### PR TITLE
fix(proxy): hide blank reasoning summary comments

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -5820,6 +5820,10 @@ def _could_be_blank_html_comment_line(text: str) -> bool:
     return not remainder[3:].strip(" \t\r")
 
 
+def _is_reasoning_summary_interleavable_event(event_type: JsonValue | None) -> bool:
+    return isinstance(event_type, str) and (event_type == "response.in_progress" or event_type.startswith("codex."))
+
+
 async def _normalize_reasoning_summary_stream(stream: AsyncIterator[str]) -> AsyncIterator[str]:
     pending: dict[tuple[str | None, int | None, int | None], list[dict[str, JsonValue]]] = {}
 
@@ -5842,8 +5846,12 @@ async def _normalize_reasoning_summary_stream(stream: AsyncIterator[str]) -> Asy
             continue
         event_type = payload.get("type")
         event_key = _reasoning_summary_delta_key(payload)
-        if pending and not (
-            event_type in _REASONING_SUMMARY_DELTA_TYPES | _REASONING_SUMMARY_DONE_TYPES and event_key in pending
+        if (
+            pending
+            and not _is_reasoning_summary_interleavable_event(event_type)
+            and not (
+                event_type in _REASONING_SUMMARY_DELTA_TYPES | _REASONING_SUMMARY_DONE_TYPES and event_key in pending
+            )
         ):
             for pending_key in tuple(pending):
                 for buffered in flush(pending_key):

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -205,7 +205,14 @@ from app.modules.usage.updater import UsageUpdater
 
 logger = logging.getLogger(__name__)
 
-_REASONING_SUMMARY_BLANK_HTML_COMMENT_RE = re.compile(r"(?m)^[ \t]*<!--\s*-->[ \t]*(?:\r?\n)?")
+_REASONING_SUMMARY_BLANK_HTML_COMMENT_RE = re.compile(r"(?m)^[ \t]*<!--\s*-->[ \t]*(?:\r?\n|\Z)")
+_REASONING_SUMMARY_DELTA_TYPES = frozenset({"response.reasoning_summary_text.delta"})
+_REASONING_SUMMARY_DONE_TYPES = frozenset(
+    {
+        "response.reasoning_summary_text.done",
+        "response.reasoning_summary_part.done",
+    }
+)
 
 _PUBLIC_RESPONSE_OUTPUT_ITEM_TYPES = frozenset(
     {
@@ -5057,6 +5064,7 @@ async def _normalize_public_responses_stream(
     *,
     enforce_openai_sdk_contract: bool = True,
 ) -> AsyncIterator[str]:
+    stream = _normalize_reasoning_summary_stream(stream)
     """Normalize the upstream SSE event stream for the public /v1 surface.
 
     Args:
@@ -5480,6 +5488,18 @@ def _normalize_public_stream_payload(
     enforce_openai_sdk_contract: bool = True,
 ) -> tuple[dict[str, JsonValue] | None, str | None]:
     event_type = payload.get("type")
+    if event_type == "response.reasoning_summary_text.done" and isinstance(payload.get("text"), str):
+        normalized_payload = dict(payload)
+        normalized_payload["text"] = _strip_blank_html_comment_lines(cast(str, payload["text"]))
+        return normalized_payload, None
+    if event_type in {"response.reasoning_summary_part.added", "response.reasoning_summary_part.done"}:
+        part = payload.get("part")
+        if is_json_mapping(part) and part.get("type") == "summary_text" and isinstance(part.get("text"), str):
+            normalized_part = dict(part)
+            normalized_part["text"] = _strip_blank_html_comment_lines(cast(str, part["text"]))
+            normalized_payload = dict(payload)
+            normalized_payload["part"] = normalized_part
+            return normalized_payload, None
     # Drop Codex-internal vendor events on the public /v1 surface only. The
     # upstream Codex backend emits non-standard events (notably
     # ``codex.rate_limits``, which is throttled per rate-limit window and so
@@ -5765,7 +5785,111 @@ def _normalize_reasoning_output_item(item: Mapping[str, JsonValue]) -> dict[str,
 
 
 def _strip_blank_html_comment_lines(text: str) -> str:
-    return _REASONING_SUMMARY_BLANK_HTML_COMMENT_RE.sub("", text).rstrip()
+    terminal_match = None
+    for match in _REASONING_SUMMARY_BLANK_HTML_COMMENT_RE.finditer(text):
+        if match.end() == len(text):
+            terminal_match = match
+    cleaned, count = _REASONING_SUMMARY_BLANK_HTML_COMMENT_RE.subn("", text)
+    if count == 0:
+        return text
+    if terminal_match is not None:
+        return cleaned.rstrip("\r\n")
+    return cleaned
+
+
+def _reasoning_summary_delta_key(payload: Mapping[str, JsonValue]) -> tuple[str | None, int | None, int | None]:
+    item_id = payload.get("item_id")
+    output_index = payload.get("output_index")
+    summary_index = payload.get("summary_index")
+    return (
+        item_id if isinstance(item_id, str) else None,
+        output_index if isinstance(output_index, int) else None,
+        summary_index if isinstance(summary_index, int) else None,
+    )
+
+
+def _could_be_blank_html_comment_line(text: str) -> bool:
+    candidate = text.rsplit("\n", 1)[-1].lstrip(" \t")
+    if not candidate:
+        return False
+    if not candidate.startswith("<!--"):
+        return "<!--".startswith(candidate)
+    remainder = candidate[4:].lstrip()
+    if not remainder.startswith("-->"):
+        return "-->".startswith(remainder)
+    return not remainder[3:].strip(" \t\r")
+
+
+async def _normalize_reasoning_summary_stream(stream: AsyncIterator[str]) -> AsyncIterator[str]:
+    pending: dict[tuple[str | None, int | None, int | None], list[dict[str, JsonValue]]] = {}
+
+    def flush(key: tuple[str | None, int | None, int | None]) -> list[str]:
+        payloads = pending.pop(key, [])
+        text = "".join(cast(str, payload.get("delta")) for payload in payloads)
+        cleaned = _strip_blank_html_comment_lines(text)
+        if cleaned == text:
+            return [format_sse_event(payload) for payload in payloads]
+        if not cleaned or not payloads:
+            return []
+        normalized = dict(payloads[0])
+        normalized["delta"] = cleaned
+        return [format_sse_event(normalized)]
+
+    async for event_block in stream:
+        payload = _parse_sse_payload(event_block)
+        if payload is None:
+            yield event_block
+            continue
+        event_type = payload.get("type")
+        event_key = _reasoning_summary_delta_key(payload)
+        if pending and not (
+            event_type in _REASONING_SUMMARY_DELTA_TYPES | _REASONING_SUMMARY_DONE_TYPES and event_key in pending
+        ):
+            for pending_key in tuple(pending):
+                for buffered in flush(pending_key):
+                    yield buffered
+        if event_type in _REASONING_SUMMARY_DELTA_TYPES:
+            delta = payload.get("delta")
+            if not isinstance(delta, str):
+                yield event_block
+                continue
+            key = event_key
+            if key in pending:
+                pending[key].append(payload)
+                buffered_text = "".join(cast(str, item.get("delta")) for item in pending[key])
+                if _strip_blank_html_comment_lines(buffered_text) != buffered_text:
+                    for buffered in flush(key):
+                        yield buffered
+                    continue
+                if _could_be_blank_html_comment_line(buffered_text):
+                    continue
+                for buffered in flush(key):
+                    yield buffered
+                continue
+            cleaned_delta = _strip_blank_html_comment_lines(delta)
+            if cleaned_delta != delta:
+                normalized_payload = dict(payload)
+                normalized_payload["delta"] = cleaned_delta
+                yield format_sse_event(normalized_payload)
+                continue
+            if _could_be_blank_html_comment_line(delta):
+                pending[key] = [payload]
+                continue
+            yield event_block
+            continue
+        if event_type in _REASONING_SUMMARY_DONE_TYPES:
+            key = event_key
+            for buffered in flush(key):
+                yield buffered
+        elif event_type in _PUBLIC_RESPONSE_STREAM_TERMINAL_TYPES:
+            for key in tuple(pending):
+                for buffered in flush(key):
+                    yield buffered
+        yield event_block
+
+    for key in tuple(pending):
+        for buffered in flush(key):
+            yield buffered
 
 
 def _is_public_passthrough_output_item_type(item_type: str) -> bool:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Mapping
 from contextlib import asynccontextmanager
@@ -203,6 +204,8 @@ from app.modules.usage.repository import AdditionalUsageRepository, UsageReposit
 from app.modules.usage.updater import UsageUpdater
 
 logger = logging.getLogger(__name__)
+
+_REASONING_SUMMARY_BLANK_HTML_COMMENT_RE = re.compile(r"(?m)^[ \t]*<!--\s*-->[ \t]*(?:\r?\n)?")
 
 _PUBLIC_RESPONSE_OUTPUT_ITEM_TYPES = frozenset(
     {
@@ -5706,6 +5709,8 @@ def _normalize_public_response_mapping(
 
 def _normalize_public_output_item(item: Mapping[str, JsonValue]) -> dict[str, JsonValue] | None:
     item_type = item.get("type")
+    if item_type == "reasoning":
+        return _normalize_reasoning_output_item(item)
     if isinstance(item_type, str) and _is_public_passthrough_output_item_type(item_type):
         return dict(item)
     text_value = _extract_public_output_item_text(item)
@@ -5721,6 +5726,46 @@ def _normalize_public_output_item(item: Mapping[str, JsonValue]) -> dict[str, Js
     if isinstance(item_id, str) and item_id:
         normalized["id"] = item_id
     return normalized
+
+
+def _normalize_reasoning_output_item(item: Mapping[str, JsonValue]) -> dict[str, JsonValue]:
+    """Remove renderer-only blank HTML comments from reasoning summaries.
+
+    Recent Codex reasoning summaries can include a standalone ``<!-- -->``
+    markdown placeholder after the visible summary heading. The Codex TUI renders
+    reasoning summary text directly, so proxying that inert marker verbatim makes
+    it visible between tool calls. Limit the cleanup to reasoning summary text so
+    assistant/user-visible content and non-empty HTML comments remain untouched.
+    """
+
+    normalized = dict(item)
+    summary = item.get("summary")
+    if not isinstance(summary, list):
+        return normalized
+
+    normalized_summary: list[JsonValue] = []
+    changed = False
+    for part in summary:
+        if not is_json_mapping(part):
+            normalized_summary.append(part)
+            continue
+        text = part.get("text")
+        if part.get("type") != "summary_text" or not isinstance(text, str):
+            normalized_summary.append(dict(part))
+            continue
+        cleaned = _strip_blank_html_comment_lines(text)
+        normalized_part = dict(part)
+        normalized_part["text"] = cleaned
+        normalized_summary.append(normalized_part)
+        changed = changed or cleaned != text
+
+    if changed:
+        normalized["summary"] = normalized_summary
+    return normalized
+
+
+def _strip_blank_html_comment_lines(text: str) -> str:
+    return _REASONING_SUMMARY_BLANK_HTML_COMMENT_RE.sub("", text).rstrip()
 
 
 def _is_public_passthrough_output_item_type(item_type: str) -> bool:

--- a/openspec/changes/strip-reasoning-summary-comments/proposal.md
+++ b/openspec/changes/strip-reasoning-summary-comments/proposal.md
@@ -1,0 +1,10 @@
+# Strip blank HTML comment placeholders from reasoning summaries
+
+## Why
+
+Recent Codex reasoning summary items can include a standalone `<!-- -->` markdown placeholder after the visible summary heading. Codex CLI renders summary text directly, so the placeholder becomes visible between tool calls.
+
+## What changes
+
+- Remove standalone blank HTML comment lines from Responses reasoning `summary_text` fields while proxying streamed and collected response items.
+- Limit cleanup to reasoning summary text; assistant-visible content and non-empty comments are preserved.

--- a/openspec/changes/strip-reasoning-summary-comments/specs/responses-api-compat/spec.md
+++ b/openspec/changes/strip-reasoning-summary-comments/specs/responses-api-compat/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Reasoning summaries omit blank HTML comment placeholders
+
+Responses reasoning output items MUST remove standalone blank HTML comment placeholder lines from `summary_text` before forwarding them to clients. This cleanup applies to both `/backend-api/codex/responses` and `/v1/responses` streamed or collected output item paths. The cleanup MUST be limited to reasoning summary text and MUST NOT rewrite assistant-visible message content or non-empty HTML comments.
+
+#### Scenario: Codex CLI route does not expose blank comment marker
+
+- **GIVEN** upstream emits a reasoning output item with `summary: [{"type":"summary_text","text":"**Planning**\n\n<!-- -->"}]`
+- **WHEN** a Codex CLI client streams `POST /backend-api/codex/responses`
+- **THEN** the forwarded reasoning summary text is `**Planning**`
+- **AND** the stream does not contain `<!-- -->`

--- a/openspec/changes/strip-reasoning-summary-comments/specs/responses-api-compat/spec.md
+++ b/openspec/changes/strip-reasoning-summary-comments/specs/responses-api-compat/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Reasoning summaries omit blank HTML comment placeholders
 
-Responses reasoning output items MUST remove standalone blank HTML comment placeholder lines from `summary_text` before forwarding them to clients. This cleanup applies to both `/backend-api/codex/responses` and `/v1/responses` streamed or collected output item paths. The cleanup MUST be limited to reasoning summary text and MUST NOT rewrite assistant-visible message content or non-empty HTML comments.
+Responses reasoning output items and summary delta/part events MUST remove standalone blank HTML comment placeholder lines from `summary_text` before forwarding them to clients, including markers split across delta boundaries. This cleanup applies to both `/backend-api/codex/responses` and `/v1/responses` streamed or collected output item paths. The cleanup MUST be limited to reasoning summary text and MUST NOT rewrite placeholder-free whitespace, assistant-visible message content, inline blank comments, or non-empty HTML comments.
 
 #### Scenario: Codex CLI route does not expose blank comment marker
 

--- a/openspec/changes/strip-reasoning-summary-comments/tasks.md
+++ b/openspec/changes/strip-reasoning-summary-comments/tasks.md
@@ -1,0 +1,5 @@
+## Implementation
+
+- [x] Strip standalone blank HTML comment placeholders from reasoning summary text.
+- [x] Cover Codex CLI route streaming output and non-streaming response reconstruction.
+- [x] Run focused tests and OpenSpec validation.

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -2064,6 +2064,45 @@ async def test_backend_codex_responses_strips_blank_html_comment_from_reasoning_
 
 
 @pytest.mark.asyncio
+async def test_backend_codex_responses_strips_split_blank_comment_from_reasoning_delta(async_client, monkeypatch):
+    email = "responses-reasoning-delta-comment@example.com"
+    raw_account_id = "acc_responses_reasoning_delta_comment"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        yield (
+            'data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_split",'
+            '"output_index":0,"summary_index":0,"delta":"**Planning fix**\\n\\n<!"}\n\n'
+        )
+        yield (
+            'data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_split",'
+            '"output_index":0,"summary_index":0,"delta":"-- -->"}\n\n'
+        )
+        yield (
+            'data: {"type":"response.reasoning_summary_text.done","item_id":"rs_split",'
+            '"output_index":0,"summary_index":0,"text":"**Planning fix**\\n\\n<!-- -->"}\n\n'
+        )
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_reasoning_delta_comment_1",'
+            '"object":"response","status":"completed","output":[],"usage":{}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "input": [{"role": "user", "content": "hi"}], "stream": True}
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        assert resp.status_code == 200
+        body = "\n".join([line async for line in resp.aiter_lines() if line])
+
+    assert "<!-- -->" not in body
+    assert "**Planning fix**" in body
+    assert "response.reasoning_summary_text.delta" in body
+
+
+@pytest.mark.asyncio
 async def test_v1_responses_non_streaming_preserves_sse_error_payload(async_client, monkeypatch):
     email = "responses-error-event@example.com"
     raw_account_id = "acc_responses_error_event"

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -2004,7 +2004,8 @@ async def test_v1_responses_non_streaming_reconstructs_reasoning_output(async_cl
     async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
         yield (
             'data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_1",'
-            '"type":"reasoning","summary":[{"type":"summary_text","text":"Need more steps"}],'
+            '"type":"reasoning","summary":[{"type":"summary_text",'
+            '"text":"Need more steps\\n\\n<!-- -->"}],'
             '"reasoning_details":{"tokens":4}}}\n\n'
         )
         yield (
@@ -2028,6 +2029,38 @@ async def test_v1_responses_non_streaming_reconstructs_reasoning_output(async_cl
             "reasoning_details": {"tokens": 4},
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_backend_codex_responses_strips_blank_html_comment_from_reasoning_summary(async_client, monkeypatch):
+    email = "responses-reasoning-summary-comment@example.com"
+    raw_account_id = "acc_responses_reasoning_summary_comment"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        yield (
+            'data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_1",'
+            '"type":"reasoning","summary":[{"type":"summary_text",'
+            '"text":"**Planning fix**\\n\\n<!-- -->"}]}}\n\n'
+        )
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_reasoning_comment_1",'
+            '"object":"response","status":"completed","output":[],'
+            '"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "input": [{"role": "user", "content": "hi"}], "stream": True}
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        assert resp.status_code == 200
+        body = "\n".join([line async for line in resp.aiter_lines() if line])
+
+    assert "<!-- -->" not in body
+    assert "**Planning fix**" in body
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -2077,6 +2077,7 @@ async def test_backend_codex_responses_strips_split_blank_comment_from_reasoning
             'data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_split",'
             '"output_index":0,"summary_index":0,"delta":"**Planning fix**\\n\\n<!"}\n\n'
         )
+        yield ('data: {"type":"codex.rate_limits","plan_type":"pro","rate_limits":{"allowed":true}}\n\n')
         yield (
             'data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_split",'
             '"output_index":0,"summary_index":0,"delta":"-- -->"}\n\n'

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -101,7 +101,7 @@ async def test_normalize_reasoning_summary_stream_does_not_delay_less_than_text(
 
 
 @pytest.mark.asyncio
-async def test_normalize_reasoning_summary_stream_flushes_partial_less_than_before_unrelated_event() -> None:
+async def test_normalize_reasoning_summary_stream_keeps_candidate_across_telemetry() -> None:
     first = proxy_api_module.format_sse_event(
         {
             "type": "response.reasoning_summary_text.delta",
@@ -117,7 +117,44 @@ async def test_normalize_reasoning_summary_stream_flushes_partial_less_than_befo
         block async for block in proxy_api_module._normalize_reasoning_summary_stream(_iter_blocks(first, second))
     ]
 
-    assert blocks == [first, second]
+    assert blocks == [second, first]
+
+
+@pytest.mark.asyncio
+async def test_normalize_reasoning_summary_stream_removes_split_placeholder_across_telemetry() -> None:
+    first = proxy_api_module.format_sse_event(
+        {
+            "type": "response.reasoning_summary_text.delta",
+            "item_id": "rs_1",
+            "output_index": 0,
+            "summary_index": 0,
+            "delta": "Plan\n\n<!",
+        }
+    )
+    telemetry = proxy_api_module.format_sse_event({"type": "codex.rate_limits", "limits": {}})
+    progress = proxy_api_module.format_sse_event({"type": "response.in_progress", "response": {"id": "resp_1"}})
+    final = proxy_api_module.format_sse_event(
+        {
+            "type": "response.reasoning_summary_text.delta",
+            "item_id": "rs_1",
+            "output_index": 0,
+            "summary_index": 0,
+            "delta": "-- -->",
+        }
+    )
+
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_reasoning_summary_stream(
+            _iter_blocks(first, telemetry, progress, final)
+        )
+    ]
+
+    assert blocks[:2] == [telemetry, progress]
+    payload = proxy_api_module._parse_sse_payload(blocks[-1])
+    assert payload is not None
+    assert payload["delta"] == "Plan"
+    assert "<!-- -->" not in "".join(blocks)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -17,6 +17,141 @@ async def _iter_blocks(*blocks: str) -> AsyncIterator[str]:
         yield block
 
 
+def test_strip_blank_reasoning_comment_preserves_unmatched_whitespace_and_inline_comments() -> None:
+    assert proxy_api_module._strip_blank_html_comment_lines("Need more steps\n") == "Need more steps\n"
+    assert proxy_api_module._strip_blank_html_comment_lines("Hard break  \n") == "Hard break  \n"
+    assert proxy_api_module._strip_blank_html_comment_lines("<!-- -->some text") == "<!-- -->some text"
+    assert proxy_api_module._strip_blank_html_comment_lines("Plan\n\n<!-- -->") == "Plan"
+
+
+@pytest.mark.asyncio
+async def test_normalize_reasoning_summary_stream_removes_split_placeholder_delta() -> None:
+    source = _iter_blocks(
+        proxy_api_module.format_sse_event(
+            {"type": "response.created", "response": {"id": "resp_1", "status": "in_progress", "output": []}}
+        ),
+        proxy_api_module.format_sse_event(
+            {
+                "type": "response.reasoning_summary_text.delta",
+                "item_id": "rs_1",
+                "output_index": 0,
+                "summary_index": 0,
+                "delta": "Plan\n\n<!",
+            }
+        ),
+        proxy_api_module.format_sse_event(
+            {
+                "type": "response.reasoning_summary_text.delta",
+                "item_id": "rs_1",
+                "output_index": 0,
+                "summary_index": 0,
+                "delta": "-- -->",
+            }
+        ),
+        proxy_api_module.format_sse_event(
+            {
+                "type": "response.reasoning_summary_text.done",
+                "item_id": "rs_1",
+                "output_index": 0,
+                "summary_index": 0,
+                "text": "Plan\n\n<!-- -->",
+            }
+        ),
+        proxy_api_module.format_sse_event(
+            {"type": "response.completed", "response": {"id": "resp_1", "status": "completed", "output": []}}
+        ),
+    )
+
+    blocks = [block async for block in proxy_api_module._normalize_public_responses_stream(source)]
+    payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
+    deltas = [
+        payload for payload in payloads if payload and payload.get("type") == "response.reasoning_summary_text.delta"
+    ]
+
+    assert [payload["delta"] for payload in deltas] == ["Plan"]
+    assert "<!-- -->" not in "".join(blocks)
+
+
+@pytest.mark.asyncio
+async def test_normalize_reasoning_summary_stream_does_not_delay_less_than_text() -> None:
+    first = proxy_api_module.format_sse_event(
+        {
+            "type": "response.reasoning_summary_text.delta",
+            "item_id": "rs_1",
+            "output_index": 0,
+            "summary_index": 0,
+            "delta": "x < y",
+        }
+    )
+    second = proxy_api_module.format_sse_event(
+        {
+            "type": "response.reasoning_summary_part.added",
+            "item_id": "rs_1",
+            "output_index": 0,
+            "summary_index": 1,
+            "part": {"type": "summary_text", "text": "next"},
+        }
+    )
+
+    blocks = [
+        block async for block in proxy_api_module._normalize_reasoning_summary_stream(_iter_blocks(first, second))
+    ]
+
+    assert blocks == [first, second]
+
+
+@pytest.mark.asyncio
+async def test_normalize_reasoning_summary_stream_flushes_partial_less_than_before_unrelated_event() -> None:
+    first = proxy_api_module.format_sse_event(
+        {
+            "type": "response.reasoning_summary_text.delta",
+            "item_id": "rs_1",
+            "output_index": 0,
+            "summary_index": 0,
+            "delta": "<",
+        }
+    )
+    second = proxy_api_module.format_sse_event({"type": "codex.rate_limits", "limits": {}})
+
+    blocks = [
+        block async for block in proxy_api_module._normalize_reasoning_summary_stream(_iter_blocks(first, second))
+    ]
+
+    assert blocks == [first, second]
+
+
+@pytest.mark.asyncio
+async def test_normalize_reasoning_summary_stream_cleans_complete_marker_inside_one_delta() -> None:
+    source = proxy_api_module.format_sse_event(
+        {
+            "type": "response.reasoning_summary_text.delta",
+            "item_id": "rs_1",
+            "output_index": 0,
+            "summary_index": 0,
+            "delta": "Plan\n<!-- -->\nNext",
+        }
+    )
+
+    blocks = [block async for block in proxy_api_module._normalize_reasoning_summary_stream(_iter_blocks(source))]
+    payload = proxy_api_module._parse_sse_payload(blocks[0])
+
+    assert payload is not None
+    assert payload["delta"] == "Plan\nNext"
+
+
+def test_normalize_reasoning_summary_part_removes_only_standalone_placeholder() -> None:
+    payload, violation = proxy_api_module._normalize_public_stream_payload(
+        {
+            "type": "response.reasoning_summary_part.done",
+            "part": {"type": "summary_text", "text": "Plan\n\n<!-- -->"},
+        }
+    )
+
+    assert violation is None
+    assert payload is not None
+    assert payload["part"] == {"type": "summary_text", "text": "Plan"}
+
+
 def test_compact_response_output_item_accepts_modeled_output_field() -> None:
     class ModeledCompactPayload(CompactResponsePayload):
         output: list[dict[str, JsonValue]] | None = None


### PR DESCRIPTION
## Summary
- strip standalone blank `<!-- -->` placeholders from reasoning `summary_text` items before forwarding Responses output
- limit the cleanup to reasoning summaries so assistant-visible message content and non-empty comments are not rewritten
- add OpenSpec coverage and regressions for Codex CLI streaming and non-streaming response reconstruction

## Tests
- `uv run pytest tests/integration/test_proxy_responses.py -k 'reasoning_output or reasoning_summary' -q`
- `openspec validate strip-reasoning-summary-comments --strict`
- `uv run ruff check app/modules/proxy/api.py tests/integration/test_proxy_responses.py`
- `uv run ruff format --check app/modules/proxy/api.py tests/integration/test_proxy_responses.py`
- `uv run ty check app/modules/proxy/api.py tests/integration/test_proxy_responses.py`
