### PR TITLE
fix(proxy): wait on local account cap pressure

### DIFF
--- a/app/modules/proxy/_service/http_bridge/owner_forwarding.py
+++ b/app/modules/proxy/_service/http_bridge/owner_forwarding.py
@@ -97,6 +97,7 @@ from app.modules.proxy._service.support import (
     _event_type_from_payload,
     _HTTPBridgeOwnerForward,
     _HTTPBridgeSessionKey,
+    _signal_propagated_capacity_startup_ready,
 )
 from app.modules.proxy._service.support import (
     _websocket_route_log_kwargs as _websocket_route_log_kwargs,
@@ -317,6 +318,7 @@ class _HTTPBridgeOwnerForwardingMixin:
                 headers=forward_headers,
                 context=forward_context,
                 request_started_at=request_started_at,
+                on_response_ready=_signal_propagated_capacity_startup_ready,
             ):
                 forwarded_any = True
                 event_payload = parse_sse_data_json(event_block)

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -217,7 +217,7 @@ def _proxy_error_code_message(exc: ProxyResponseError) -> tuple[str | None, str 
 
 def _http_bridge_account_capacity_wait_seconds(exc: ProxyResponseError) -> float | None:
     code, message = _proxy_error_code_message(exc)
-    if code in {"account_response_create_cap", "account_stream_cap", "capacity_exhausted_active_sessions"}:
+    if code == "capacity_exhausted_active_sessions":
         return None
     return _account_selection_recovery_sleep_seconds_from_message(
         message,

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -137,6 +137,7 @@ from app.modules.proxy._service.support import (
     _HTTPBridgeOwnerForward,
     _HTTPBridgeSession,
     _HTTPBridgeSessionKey,
+    _signal_propagated_capacity_startup_ready,
     _signal_propagated_capacity_startup_wait,
     _WebSocketRequestState,
 )
@@ -1039,6 +1040,7 @@ class _HTTPBridgeStreamingMixin:
                                 raise
                             continue
                         break
+                    _signal_propagated_capacity_startup_ready()
                     if downstream_turn_state is not None:
                         await self._register_http_bridge_turn_state(session, downstream_turn_state)
                     event_queue = retry_request_state.event_queue
@@ -1238,6 +1240,7 @@ class _HTTPBridgeStreamingMixin:
             queue_limit=queue_limit,
             propagate_http_errors=propagate_http_errors,
             downstream_turn_state=downstream_turn_state,
+            request_deadline=request_deadline,
         )
         request_state.file_required_preferred_account = file_required_preferred_account
         request_state.bridge_soft_capacity_reroute_allowed = (
@@ -1342,6 +1345,7 @@ class _HTTPBridgeStreamingMixin:
                     queue_limit=queue_limit,
                     propagate_http_errors=propagate_http_errors,
                     downstream_turn_state=downstream_turn_state,
+                    request_deadline=request_deadline,
                 )
                 request_state.bridge_soft_capacity_reroute_allowed = False
                 try:
@@ -1554,6 +1558,7 @@ class _HTTPBridgeStreamingMixin:
                     queue_limit=queue_limit,
                     propagate_http_errors=propagate_http_errors,
                     downstream_turn_state=downstream_turn_state,
+                    request_deadline=request_deadline,
                 )
                 try:
                     async for event_block in retry_events:
@@ -1606,8 +1611,10 @@ class _HTTPBridgeStreamingMixin:
         queue_limit: int,
         propagate_http_errors: bool,
         downstream_turn_state: str | None,
+        request_deadline: float | None = None,
     ) -> AsyncGenerator[str, None]:
-        request_deadline = request_state.started_at + _http_bridge_request_budget_seconds(_service_get_settings())
+        if request_deadline is None:
+            request_deadline = request_state.started_at + _http_bridge_request_budget_seconds(_service_get_settings())
         while True:
             try:
                 await self._submit_http_bridge_request(
@@ -1644,6 +1651,7 @@ class _HTTPBridgeStreamingMixin:
                     raise
                 continue
             break
+        _signal_propagated_capacity_startup_ready()
         if downstream_turn_state is not None:
             await self._register_http_bridge_turn_state(session, downstream_turn_state)
 

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -137,6 +137,7 @@ from app.modules.proxy._service.support import (
     _HTTPBridgeOwnerForward,
     _HTTPBridgeSession,
     _HTTPBridgeSessionKey,
+    _signal_propagated_capacity_startup_wait,
     _WebSocketRequestState,
 )
 from app.modules.proxy._service.support import (
@@ -247,6 +248,8 @@ async def _iter_account_capacity_wait_sse(
     sleep_seconds: float,
     emit_keepalives: bool,
 ) -> AsyncIterator[str]:
+    if not emit_keepalives:
+        _signal_propagated_capacity_startup_wait()
     wait_started_at = _service_time().monotonic()
     remaining_sleep_seconds = sleep_seconds
     while remaining_sleep_seconds > 0:

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -1001,12 +1001,44 @@ class _HTTPBridgeStreamingMixin:
                     retry_request_state.request_stage = "reattach"
                     retry_request_state.preferred_account_id = request_state.preferred_account_id
 
-                    await self._submit_http_bridge_request(
-                        session,
-                        request_state=retry_request_state,
-                        text_data=retry_text_data,
-                        queue_limit=queue_limit,
-                    )
+                    while True:
+                        try:
+                            await self._submit_http_bridge_request(
+                                session,
+                                request_state=retry_request_state,
+                                text_data=retry_text_data,
+                                queue_limit=queue_limit,
+                            )
+                        except ProxyResponseError as capacity_exc:
+                            wait_plan = _http_bridge_capacity_wait_plan(
+                                capacity_exc,
+                                request_deadline=request_deadline,
+                            )
+                            if wait_plan is None:
+                                raise
+                            bounded_wait_seconds, account_capacity_wait_seconds, message = wait_plan
+                            logger.info(
+                                "Waiting for account capacity before retrying HTTP bridge owner-forward recovery "
+                                "submit request_id=%s model=%s account_id=%s sleep_seconds=%.1f "
+                                "recovery_hint_seconds=%.1f error=%s",
+                                retry_request_state.request_id,
+                                retry_request_state.model,
+                                session.account.id,
+                                bounded_wait_seconds,
+                                account_capacity_wait_seconds,
+                                message,
+                            )
+                            async for line in _iter_account_capacity_wait_sse(
+                                request_id=retry_request_state.request_id,
+                                reason=message,
+                                sleep_seconds=bounded_wait_seconds,
+                                emit_keepalives=not propagate_http_errors,
+                            ):
+                                yield line
+                            if _service_time().monotonic() >= request_deadline:
+                                raise
+                            continue
+                        break
                     if downstream_turn_state is not None:
                         await self._register_http_bridge_turn_state(session, downstream_turn_state)
                     event_queue = retry_request_state.event_queue

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -245,22 +245,24 @@ async def _iter_account_capacity_wait_sse(
     request_id: str,
     reason: str | None,
     sleep_seconds: float,
+    emit_keepalives: bool,
 ) -> AsyncIterator[str]:
     wait_started_at = _service_time().monotonic()
     remaining_sleep_seconds = sleep_seconds
     while remaining_sleep_seconds > 0:
-        yield format_sse_event(
-            cast(
-                Mapping[str, JsonValue],
-                _account_capacity_wait_payload(
-                    None,
-                    request_id=request_id,
-                    reason=reason,
-                    retry_after_seconds=remaining_sleep_seconds,
-                    started_at=wait_started_at,
-                ),
+        if emit_keepalives:
+            yield format_sse_event(
+                cast(
+                    Mapping[str, JsonValue],
+                    _account_capacity_wait_payload(
+                        None,
+                        request_id=request_id,
+                        reason=reason,
+                        retry_after_seconds=remaining_sleep_seconds,
+                        started_at=wait_started_at,
+                    ),
+                )
             )
-        )
         chunk_seconds = min(
             remaining_sleep_seconds,
             _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS,
@@ -782,6 +784,7 @@ class _HTTPBridgeStreamingMixin:
                             request_id=request_id,
                             reason=message,
                             sleep_seconds=bounded_wait_seconds,
+                            emit_keepalives=not propagate_http_errors,
                         ):
                             yield line
                         if _service_time().monotonic() >= request_deadline:
@@ -937,6 +940,7 @@ class _HTTPBridgeStreamingMixin:
                             request_id=request_id,
                             reason=message,
                             sleep_seconds=bounded_wait_seconds,
+                            emit_keepalives=not propagate_http_errors,
                         ):
                             yield line
                         if _service_time().monotonic() >= request_deadline:
@@ -1200,6 +1204,12 @@ class _HTTPBridgeStreamingMixin:
             propagate_http_errors=propagate_http_errors,
             downstream_turn_state=downstream_turn_state,
         )
+        request_state.file_required_preferred_account = file_required_preferred_account
+        request_state.bridge_soft_capacity_reroute_allowed = (
+            bridge_session_key.strength == "soft"
+            and request_state.previous_response_id is None
+            and not file_required_preferred_account
+        )
         try:
             yielded_any = False
             async for event_block in session_events:
@@ -1283,6 +1293,7 @@ class _HTTPBridgeStreamingMixin:
                             request_id=request_id,
                             reason=message,
                             sleep_seconds=bounded_wait_seconds,
+                            emit_keepalives=not propagate_http_errors,
                         ):
                             yield line
                         if _service_time().monotonic() >= request_deadline:
@@ -1297,6 +1308,7 @@ class _HTTPBridgeStreamingMixin:
                     propagate_http_errors=propagate_http_errors,
                     downstream_turn_state=downstream_turn_state,
                 )
+                request_state.bridge_soft_capacity_reroute_allowed = False
                 try:
                     async for event_block in retry_events:
                         yield event_block
@@ -1466,6 +1478,7 @@ class _HTTPBridgeStreamingMixin:
                         request_id=request_id,
                         reason=message,
                         sleep_seconds=bounded_wait_seconds,
+                        emit_keepalives=not propagate_http_errors,
                     ):
                         yield line
                     if _service_time().monotonic() >= request_deadline:
@@ -1559,12 +1572,43 @@ class _HTTPBridgeStreamingMixin:
         propagate_http_errors: bool,
         downstream_turn_state: str | None,
     ) -> AsyncGenerator[str, None]:
-        await self._submit_http_bridge_request(
-            session,
-            request_state=request_state,
-            text_data=text_data,
-            queue_limit=queue_limit,
-        )
+        request_deadline = request_state.started_at + _http_bridge_request_budget_seconds(_service_get_settings())
+        while True:
+            try:
+                await self._submit_http_bridge_request(
+                    session,
+                    request_state=request_state,
+                    text_data=text_data,
+                    queue_limit=queue_limit,
+                )
+            except ProxyResponseError as exc:
+                if request_state.bridge_soft_capacity_reroute_allowed:
+                    raise
+                wait_plan = _http_bridge_capacity_wait_plan(exc, request_deadline=request_deadline)
+                if wait_plan is None:
+                    raise
+                bounded_wait_seconds, account_capacity_wait_seconds, message = wait_plan
+                logger.info(
+                    "Waiting for account capacity before retrying HTTP bridge submit request_id=%s model=%s "
+                    "account_id=%s sleep_seconds=%.1f recovery_hint_seconds=%.1f error=%s",
+                    request_state.request_id,
+                    request_state.model,
+                    session.account.id,
+                    bounded_wait_seconds,
+                    account_capacity_wait_seconds,
+                    message,
+                )
+                async for line in _iter_account_capacity_wait_sse(
+                    request_id=request_state.request_id,
+                    reason=message,
+                    sleep_seconds=bounded_wait_seconds,
+                    emit_keepalives=not propagate_http_errors,
+                ):
+                    yield line
+                if _service_time().monotonic() >= request_deadline:
+                    raise
+                continue
+            break
         if downstream_turn_state is not None:
             await self._register_http_bridge_turn_state(session, downstream_turn_state)
 

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -277,6 +277,7 @@ from app.modules.proxy._service.support import (
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
     _event_type_from_payload,
     _RequestLogFailureMetadata,
+    _signal_propagated_capacity_startup_ready,
     _StreamSettlement,
     _WebSocketRequestState,
 )
@@ -396,6 +397,14 @@ from app.modules.proxy.load_balancer import AccountSelection
 
 def _facade() -> Any:
     return sys.modules["app.modules.proxy.service"]
+
+
+def _stream_iterator_after_capacity_admission(
+    stream: AsyncIterator[str],
+) -> AsyncIterator[str]:
+    """Expose a slow stream once local response-create admission has succeeded."""
+    _signal_propagated_capacity_startup_ready()
+    return stream.__aiter__()
 
 
 _REQUEST_TRANSPORT_HTTP = "http"

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -295,6 +295,7 @@ from app.modules.proxy._service.support import (
     _event_type_from_payload,
     _RequestLogFailureMetadata,
     _RetryableStreamError,
+    _signal_propagated_capacity_startup_ready,
     _StreamSettlement,
     _TerminalStreamError,
     _TransientStreamError,
@@ -572,6 +573,10 @@ class _StreamingMixin(_StreamingRetryMixin):
                     raise_for_status=True,
                 )
             iterator = stream.__aiter__()
+            # Local account selection and both response-create admission gates
+            # have succeeded. A later retry that re-enters local capacity will
+            # clear this level before setting the paired wait signal.
+            _signal_propagated_capacity_startup_ready()
             try:
                 first = await iterator.__anext__()
             except StopAsyncIteration:

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -295,7 +295,6 @@ from app.modules.proxy._service.support import (
     _event_type_from_payload,
     _RequestLogFailureMetadata,
     _RetryableStreamError,
-    _signal_propagated_capacity_startup_ready,
     _StreamSettlement,
     _TerminalStreamError,
     _TransientStreamError,
@@ -572,11 +571,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                     },
                     raise_for_status=True,
                 )
-            iterator = stream.__aiter__()
-            # Local account selection and both response-create admission gates
-            # have succeeded. A later retry that re-enters local capacity will
-            # clear this level before setting the paired wait signal.
-            _signal_propagated_capacity_startup_ready()
+            iterator = _facade()._stream_iterator_after_capacity_admission(stream)
             try:
                 first = await iterator.__anext__()
             except StopAsyncIteration:

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -1468,11 +1468,15 @@ class _StreamingRetryMixin:
                                 if can_try_other_account:
                                     deferred_capacity_account = account
                                     deferred_capacity_lease = current_account_lease
-                                else:
-                                    await _release_tracked_stream_lease(current_account_lease)
-                                    current_account_lease = None
-                                excluded_account_ids.add(account.id)
-                                continue
+                                    excluded_account_ids.add(account.id)
+                                    continue
+                                # The same-account helper only re-raises this
+                                # neutral cap when recovery cannot continue
+                                # within the original budget. Exit the account
+                                # loop so the preserved cap is propagated or
+                                # rendered below, instead of replacing it with
+                                # a next-attempt timeout.
+                                break
                             if _facade()._is_account_neutral_error_code(error_code):
                                 raise
                             classified = await proxy._handle_stream_error(

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -573,7 +573,17 @@ class _StreamingRetryMixin:
                         if recovery_sleep_seconds is not None:
                             remaining_budget_seconds = _facade()._remaining_budget_seconds(deadline)
                             if remaining_budget_seconds <= 0:
-                                break
+                                if propagate_http_errors and last_transient_exc is not None:
+                                    raise last_transient_exc
+                                event = response_failed_event(
+                                    "account_response_create_cap",
+                                    (deferred_error.message if deferred_error else None)
+                                    or "Account response-create concurrency limit reached",
+                                    error_type=(deferred_error.type if deferred_error else None) or "server_error",
+                                    response_id=request_id,
+                                )
+                                yield format_sse_event(event)
+                                return
                             capacity_account = deferred_capacity_account
                             capacity_account_id = capacity_account.id
                             excluded_account_ids.discard(capacity_account_id)
@@ -589,7 +599,17 @@ class _StreamingRetryMixin:
                             ):
                                 yield wait_event
                             if _facade()._remaining_budget_seconds(deadline) <= 0:
-                                break
+                                if propagate_http_errors and last_transient_exc is not None:
+                                    raise last_transient_exc
+                                event = response_failed_event(
+                                    "account_response_create_cap",
+                                    (deferred_error.message if deferred_error else None)
+                                    or "Account response-create concurrency limit reached",
+                                    error_type=(deferred_error.type if deferred_error else None) or "server_error",
+                                    response_id=request_id,
+                                )
+                                yield format_sse_event(event)
+                                return
                             account = capacity_account
                             current_account_lease = deferred_capacity_lease
                             deferred_capacity_account = None

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -281,7 +281,6 @@ class _StreamingRetryMixin:
         last_security_work_retry_error: _RetryableStreamError | None = None
         excluded_account_ids: set[str] = set()
         deferred_capacity_account_id: str | None = None
-        capacity_waited_account_ids: set[str] = set()
         preferred_account_id: str | None = None
         file_preferred_account_id: str | None = rewritten_file_account_id
         require_preferred_account = False
@@ -589,7 +588,6 @@ class _StreamingRetryMixin:
                                 yield wait_event
                             if _facade()._remaining_budget_seconds(deadline) <= 0:
                                 break
-                            capacity_waited_account_ids.add(capacity_account_id)
                             deferred_capacity_account_id = None
                             continue
                     if account is not None:
@@ -1109,7 +1107,6 @@ class _StreamingRetryMixin:
                                             not require_preferred_account
                                             and account.id != file_preferred_account_id
                                             and attempt < max_attempts - 1
-                                            and account.id not in capacity_waited_account_ids
                                         )
                                         if can_try_other_account:
                                             deferred_capacity_account_id = account.id
@@ -1404,7 +1401,6 @@ class _StreamingRetryMixin:
                                 not require_preferred_account
                                 and account.id != file_preferred_account_id
                                 and attempt < max_attempts - 1
-                                and account.id not in capacity_waited_account_ids
                             )
                             async for line in _stream_post_refresh_with_capacity_recovery(
                                 account,

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -14,7 +14,7 @@ from app.core.auth.refresh import RefreshError
 from app.core.balancer import failover_decision
 from app.core.balancer.types import UpstreamError
 from app.core.clients.proxy import ProxyResponseError, _resolve_stream_transport, pop_stream_timeout_overrides
-from app.core.errors import openai_error, response_failed_event
+from app.core.errors import response_failed_event
 from app.core.openai.requests import ResponsesRequest
 from app.core.upstream_proxy import UpstreamProxyRouteError
 from app.core.utils.request_id import ensure_request_id
@@ -30,6 +30,7 @@ from app.modules.proxy._service.observability import (
 from app.modules.proxy._service.streaming.protocol import _StreamingServiceProtocol
 from app.modules.proxy._service.support import (
     _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS,
+    _LOCAL_ACCOUNT_CAP_ERROR_CODES,
     _account_capacity_wait_payload,
     _account_selection_recovery_sleep_seconds,
     _request_log_useragent_fields,
@@ -54,7 +55,7 @@ from app.modules.proxy.helpers import (
     _parse_openai_error,
     _upstream_error_from_openai,
 )
-from app.modules.proxy.load_balancer import AccountLease
+from app.modules.proxy.load_balancer import AccountLease, AccountSelection
 
 _REQUEST_TRANSPORT_HTTP = "http"
 _REQUEST_TRANSPORT_WEBSOCKET = "websocket"
@@ -437,10 +438,14 @@ class _StreamingRetryMixin:
                         continue
                     if (
                         not account
-                        and not _facade()._is_local_account_cap_code(selection.error_code)
-                        and not (propagate_http_errors and last_transient_exc is not None)
-                        and last_retryable_stream_error is None
-                        and last_security_work_retry_error is None
+                        and (
+                            selection.error_code in _LOCAL_ACCOUNT_CAP_ERROR_CODES
+                            or not (propagate_http_errors and last_transient_exc is not None)
+                        )
+                        and (
+                            selection.error_code in _LOCAL_ACCOUNT_CAP_ERROR_CODES
+                            or (last_retryable_stream_error is None and last_security_work_retry_error is None)
+                        )
                     ):
                         recovery_sleep_seconds = _account_selection_recovery_sleep_seconds(selection)
                         if recovery_sleep_seconds is not None:
@@ -480,15 +485,35 @@ class _StreamingRetryMixin:
                             continue
                     break
                 if not account:
-                    if _facade()._is_local_account_cap_code(selection.error_code):
-                        raise ProxyResponseError(
-                            429,
-                            openai_error(
-                                selection.error_code or "account_stream_cap",
-                                selection.error_message or "Account stream capacity is exhausted",
-                                error_type="rate_limit_error",
-                            ),
+                    if selection.error_code in _LOCAL_ACCOUNT_CAP_ERROR_CODES:
+                        no_accounts_msg = selection.error_message or "Local account capacity is exhausted"
+                        error_code = selection.error_code
+                        event = response_failed_event(
+                            error_code,
+                            no_accounts_msg,
+                            error_type="rate_limit_error",
+                            response_id=request_id,
                         )
+                        yield format_sse_event(event)
+                        await proxy._write_request_log(
+                            account_id=None,
+                            api_key=api_key,
+                            request_id=request_id,
+                            model=payload.model,
+                            latency_ms=int((time.monotonic() - start) * 1000),
+                            status="error",
+                            error_code=error_code,
+                            error_message=no_accounts_msg,
+                            reasoning_effort=payload.reasoning.effort if payload.reasoning else None,
+                            transport=request_transport,
+                            upstream_transport=upstream_stream_transport,
+                            service_tier=payload.service_tier,
+                            requested_service_tier=payload.service_tier,
+                            useragent=useragent,
+                            useragent_group=useragent_group,
+                            client_ip=client_ip,
+                        )
+                        return
                     if require_preferred_account and preferred_account_id is not None:
                         message = "Previous response owner account is unavailable; retry later."
                         _record_continuity_fail_closed(
@@ -590,6 +615,9 @@ class _StreamingRetryMixin:
                     event = response_failed_event(
                         error_code,
                         no_accounts_msg,
+                        error_type="rate_limit_error"
+                        if error_code in _LOCAL_ACCOUNT_CAP_ERROR_CODES
+                        else "server_error",
                         response_id=request_id,
                     )
                     yield format_sse_event(event)
@@ -918,6 +946,63 @@ class _StreamingRetryMixin:
                                     last_transient_exc = tex
                                     break
                                 if code == "account_response_create_cap":
+                                    last_transient_exc = tex
+                                    recovery_sleep_seconds = _account_selection_recovery_sleep_seconds(
+                                        AccountSelection(
+                                            account=None,
+                                            error_message=error_message,
+                                            error_code=code,
+                                        )
+                                    )
+                                    if recovery_sleep_seconds is not None:
+                                        can_try_other_account = (
+                                            not require_preferred_account
+                                            and account.id != file_preferred_account_id
+                                            and attempt < max_attempts - 1
+                                        )
+                                        if can_try_other_account:
+                                            await _release_tracked_stream_lease(current_account_lease)
+                                            current_account_lease = None
+                                            excluded_account_ids.add(account.id)
+                                            break
+                                        if propagate_http_errors:
+                                            raise
+                                        remaining_budget_seconds = _facade()._remaining_budget_seconds(deadline)
+                                        if remaining_budget_seconds <= 0:
+                                            raise
+                                        wait_started_at = time.monotonic()
+                                        remaining_sleep_seconds = min(recovery_sleep_seconds, remaining_budget_seconds)
+                                        _facade().logger.info(
+                                            "Waiting for response-create capacity before retrying stream "
+                                            "request_id=%s model=%s account_id=%s sleep_seconds=%.1f "
+                                            "recovery_hint_seconds=%.1f error=%s",
+                                            request_id,
+                                            payload.model,
+                                            account.id,
+                                            remaining_sleep_seconds,
+                                            recovery_sleep_seconds,
+                                            error_message,
+                                        )
+                                        while remaining_sleep_seconds > 0:
+                                            yield format_sse_event(
+                                                cast(
+                                                    Mapping[str, Any],
+                                                    _account_capacity_wait_payload(
+                                                        None,
+                                                        request_id=request_id,
+                                                        reason=error_message,
+                                                        retry_after_seconds=remaining_sleep_seconds,
+                                                        started_at=wait_started_at,
+                                                    ),
+                                                )
+                                            )
+                                            chunk_seconds = min(
+                                                remaining_sleep_seconds,
+                                                _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS,
+                                            )
+                                            await asyncio.sleep(chunk_seconds)
+                                            remaining_sleep_seconds -= chunk_seconds
+                                        continue
                                     last_transient_exc = tex
                                     await _release_tracked_stream_lease(current_account_lease)
                                     current_account_lease = None
@@ -1427,6 +1512,22 @@ class _StreamingRetryMixin:
                         client_ip=client_ip,
                     )
                 return
+            if last_transient_exc is not None:
+                error = _parse_openai_error(last_transient_exc.payload)
+                error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
+                if error_code == "account_response_create_cap":
+                    error_message = error.message if error else None
+                    event = response_failed_event(
+                        error_code,
+                        error_message or "Account response-create concurrency limit reached",
+                        error_type=(error.type if error else None) or "server_error",
+                        response_id=request_id,
+                        error_param=error.param if error else None,
+                    )
+                    _apply_error_metadata(event["response"]["error"], error)
+                    yield format_sse_event(event)
+                    return
+
             retries_exhausted_msg = "No available accounts after retries"
             _facade().logger.warning(
                 "Proxy streaming exhausted accounts request_id=%s model=%s transport=%s attempts=%s "

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -14,7 +14,7 @@ from app.core.auth.refresh import RefreshError
 from app.core.balancer import failover_decision
 from app.core.balancer.types import UpstreamError
 from app.core.clients.proxy import ProxyResponseError, _resolve_stream_transport, pop_stream_timeout_overrides
-from app.core.errors import response_failed_event
+from app.core.errors import openai_error, response_failed_event
 from app.core.openai.requests import ResponsesRequest
 from app.core.upstream_proxy import UpstreamProxyRouteError
 from app.core.utils.request_id import ensure_request_id
@@ -597,7 +597,6 @@ class _StreamingRetryMixin:
                             error_type="rate_limit_error",
                             response_id=request_id,
                         )
-                        yield format_sse_event(event)
                         await proxy._write_request_log(
                             account_id=None,
                             api_key=api_key,
@@ -616,6 +615,16 @@ class _StreamingRetryMixin:
                             useragent_group=useragent_group,
                             client_ip=client_ip,
                         )
+                        if propagate_http_errors:
+                            raise ProxyResponseError(
+                                429,
+                                openai_error(
+                                    error_code,
+                                    no_accounts_msg,
+                                    error_type="rate_limit_error",
+                                ),
+                            )
+                        yield format_sse_event(event)
                         return
                     if require_preferred_account and preferred_account_id is not None:
                         message = "Previous response owner account is unavailable; retry later."

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -280,7 +280,8 @@ class _StreamingRetryMixin:
         last_transient_exc: ProxyResponseError | None = None
         last_security_work_retry_error: _RetryableStreamError | None = None
         excluded_account_ids: set[str] = set()
-        deferred_capacity_account_id: str | None = None
+        deferred_capacity_account: Account | None = None
+        deferred_capacity_lease: AccountLease | None = None
         preferred_account_id: str | None = None
         file_preferred_account_id: str | None = rewritten_file_account_id
         require_preferred_account = False
@@ -560,7 +561,7 @@ class _StreamingRetryMixin:
                         )
                         require_security_work_authorized = False
                         continue
-                    if not account and deferred_capacity_account_id is not None:
+                    if not account and deferred_capacity_account is not None:
                         deferred_error = _parse_openai_error(last_transient_exc.payload) if last_transient_exc else None
                         recovery_sleep_seconds = _account_selection_recovery_sleep_seconds(
                             AccountSelection(
@@ -573,7 +574,8 @@ class _StreamingRetryMixin:
                             remaining_budget_seconds = _facade()._remaining_budget_seconds(deadline)
                             if remaining_budget_seconds <= 0:
                                 break
-                            capacity_account_id = deferred_capacity_account_id
+                            capacity_account = deferred_capacity_account
+                            capacity_account_id = capacity_account.id
                             excluded_account_ids.discard(capacity_account_id)
                             async for wait_event in _iter_account_capacity_recovery_wait(
                                 request_id=request_id,
@@ -588,10 +590,14 @@ class _StreamingRetryMixin:
                                 yield wait_event
                             if _facade()._remaining_budget_seconds(deadline) <= 0:
                                 break
-                            deferred_capacity_account_id = None
-                            continue
-                    if account is not None:
-                        deferred_capacity_account_id = None
+                            account = capacity_account
+                            current_account_lease = deferred_capacity_lease
+                            deferred_capacity_account = None
+                            deferred_capacity_lease = None
+                    if account is not None and deferred_capacity_account is not None:
+                        await _release_tracked_stream_lease(deferred_capacity_lease)
+                        deferred_capacity_account = None
+                        deferred_capacity_lease = None
                     if (
                         not account
                         and (
@@ -1109,9 +1115,8 @@ class _StreamingRetryMixin:
                                             and attempt < max_attempts - 1
                                         )
                                         if can_try_other_account:
-                                            deferred_capacity_account_id = account.id
-                                            await _release_tracked_stream_lease(current_account_lease)
-                                            current_account_lease = None
+                                            deferred_capacity_account = account
+                                            deferred_capacity_lease = current_account_lease
                                             excluded_account_ids.add(account.id)
                                             break
                                         remaining_budget_seconds = _facade()._remaining_budget_seconds(deadline)
@@ -1461,9 +1466,11 @@ class _StreamingRetryMixin:
                             if error_code == "account_response_create_cap":
                                 last_transient_exc = retry_exc
                                 if can_try_other_account:
-                                    deferred_capacity_account_id = account.id
-                                await _release_tracked_stream_lease(current_account_lease)
-                                current_account_lease = None
+                                    deferred_capacity_account = account
+                                    deferred_capacity_lease = current_account_lease
+                                else:
+                                    await _release_tracked_stream_lease(current_account_lease)
+                                    current_account_lease = None
                                 excluded_account_ids.add(account.id)
                                 continue
                             if _facade()._is_account_neutral_error_code(error_code):

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -35,6 +35,7 @@ from app.modules.proxy._service.support import (
     _account_selection_recovery_sleep_seconds,
     _request_log_useragent_fields,
     _RetryableStreamError,
+    _signal_propagated_capacity_startup_wait,
     _stream_settlement_error_payload,
     _StreamSettlement,
     _TerminalStreamError,
@@ -122,6 +123,8 @@ async def _iter_account_capacity_recovery_wait(
     emit_keepalives: bool,
     stage: str,
 ) -> AsyncIterator[str]:
+    if not emit_keepalives:
+        _signal_propagated_capacity_startup_wait()
     remaining_budget_seconds = _facade()._remaining_budget_seconds(deadline)
     if remaining_budget_seconds <= 0:
         return

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -280,6 +280,8 @@ class _StreamingRetryMixin:
         last_transient_exc: ProxyResponseError | None = None
         last_security_work_retry_error: _RetryableStreamError | None = None
         excluded_account_ids: set[str] = set()
+        deferred_capacity_account_id: str | None = None
+        capacity_waited_account_ids: set[str] = set()
         preferred_account_id: str | None = None
         file_preferred_account_id: str | None = rewritten_file_account_id
         require_preferred_account = False
@@ -559,6 +561,39 @@ class _StreamingRetryMixin:
                         )
                         require_security_work_authorized = False
                         continue
+                    if not account and deferred_capacity_account_id is not None:
+                        deferred_error = _parse_openai_error(last_transient_exc.payload) if last_transient_exc else None
+                        recovery_sleep_seconds = _account_selection_recovery_sleep_seconds(
+                            AccountSelection(
+                                account=None,
+                                error_message=deferred_error.message if deferred_error else None,
+                                error_code="account_response_create_cap",
+                            )
+                        )
+                        if recovery_sleep_seconds is not None:
+                            remaining_budget_seconds = _facade()._remaining_budget_seconds(deadline)
+                            if remaining_budget_seconds <= 0:
+                                break
+                            capacity_account_id = deferred_capacity_account_id
+                            excluded_account_ids.discard(capacity_account_id)
+                            async for wait_event in _iter_account_capacity_recovery_wait(
+                                request_id=request_id,
+                                model=payload.model,
+                                account_id=capacity_account_id,
+                                error_message=deferred_error.message if deferred_error else None,
+                                recovery_sleep_seconds=recovery_sleep_seconds,
+                                deadline=deadline,
+                                emit_keepalives=not propagate_http_errors,
+                                stage="response_create_no_alternate",
+                            ):
+                                yield wait_event
+                            if _facade()._remaining_budget_seconds(deadline) <= 0:
+                                break
+                            capacity_waited_account_ids.add(capacity_account_id)
+                            deferred_capacity_account_id = None
+                            continue
+                    if account is not None:
+                        deferred_capacity_account_id = None
                     if (
                         not account
                         and (
@@ -1074,8 +1109,10 @@ class _StreamingRetryMixin:
                                             not require_preferred_account
                                             and account.id != file_preferred_account_id
                                             and attempt < max_attempts - 1
+                                            and account.id not in capacity_waited_account_ids
                                         )
                                         if can_try_other_account:
+                                            deferred_capacity_account_id = account.id
                                             await _release_tracked_stream_lease(current_account_lease)
                                             current_account_lease = None
                                             excluded_account_ids.add(account.id)
@@ -1363,14 +1400,16 @@ class _StreamingRetryMixin:
                             yield format_sse_event(_facade()._proxy_request_timeout_event(request_id))
                             return
                         try:
+                            can_try_other_account = (
+                                not require_preferred_account
+                                and account.id != file_preferred_account_id
+                                and attempt < max_attempts - 1
+                                and account.id not in capacity_waited_account_ids
+                            )
                             async for line in _stream_post_refresh_with_capacity_recovery(
                                 account,
                                 settlement=settlement,
-                                can_try_other_account=(
-                                    not require_preferred_account
-                                    and account.id != file_preferred_account_id
-                                    and attempt < max_attempts - 1
-                                ),
+                                can_try_other_account=can_try_other_account,
                                 tool_call_dedupe=tool_call_dedupe,
                             ):
                                 yield line
@@ -1425,6 +1464,8 @@ class _StreamingRetryMixin:
                             )
                             if error_code == "account_response_create_cap":
                                 last_transient_exc = retry_exc
+                                if can_try_other_account:
+                                    deferred_capacity_account_id = account.id
                                 await _release_tracked_stream_lease(current_account_lease)
                                 current_account_lease = None
                                 excluded_account_ids.add(account.id)

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -20,7 +20,7 @@ from app.core.upstream_proxy import UpstreamProxyRouteError
 from app.core.utils.request_id import ensure_request_id
 from app.core.utils.retry import backoff_seconds
 from app.core.utils.sse import format_sse_event
-from app.db.models import StickySessionKind
+from app.db.models import Account, StickySessionKind
 from app.modules.api_keys.service import ApiKeyData, ApiKeyUsageReservationData
 from app.modules.proxy._service.observability import (
     _maybe_log_proxy_request_shape,
@@ -109,6 +109,55 @@ def _resolved_configured_stream_transport(dashboard_settings: Any, base_settings
     if configured == "default":
         configured = getattr(base_settings, "upstream_stream_transport", "auto")
     return configured, configured in ("http", "websocket")
+
+
+async def _iter_account_capacity_recovery_wait(
+    *,
+    request_id: str,
+    model: str | None,
+    account_id: str | None,
+    error_message: str | None,
+    recovery_sleep_seconds: float,
+    deadline: float,
+    emit_keepalives: bool,
+    stage: str,
+) -> AsyncIterator[str]:
+    remaining_budget_seconds = _facade()._remaining_budget_seconds(deadline)
+    if remaining_budget_seconds <= 0:
+        return
+    wait_started_at = time.monotonic()
+    remaining_sleep_seconds = min(recovery_sleep_seconds, remaining_budget_seconds)
+    _facade().logger.info(
+        "Waiting for account capacity before retrying stream request_id=%s model=%s account_id=%s "
+        "stage=%s sleep_seconds=%.1f recovery_hint_seconds=%.1f error=%s",
+        request_id,
+        model,
+        account_id,
+        stage,
+        remaining_sleep_seconds,
+        recovery_sleep_seconds,
+        error_message,
+    )
+    while remaining_sleep_seconds > 0:
+        if emit_keepalives:
+            yield format_sse_event(
+                cast(
+                    Mapping[str, Any],
+                    _account_capacity_wait_payload(
+                        None,
+                        request_id=request_id,
+                        reason=error_message,
+                        retry_after_seconds=remaining_sleep_seconds,
+                        started_at=wait_started_at,
+                    ),
+                )
+            )
+        chunk_seconds = min(
+            remaining_sleep_seconds,
+            _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS,
+        )
+        await asyncio.sleep(chunk_seconds)
+        remaining_sleep_seconds -= chunk_seconds
 
 
 def _payload_size_estimate_bytes(payload: ResponsesRequest) -> int:
@@ -246,6 +295,76 @@ class _StreamingRetryMixin:
             except ValueError:
                 pass
             await proxy._load_balancer.release_account_lease(lease)
+
+        async def _stream_post_refresh_with_capacity_recovery(
+            account: Account,
+            *,
+            settlement: _StreamSettlement,
+            can_try_other_account: bool,
+            tool_call_dedupe: _WebSocketUpstreamControl,
+        ) -> AsyncIterator[str]:
+            nonlocal last_transient_exc
+            while True:
+                stream_timeout_tokens = _facade()._push_stream_attempt_timeout_overrides(
+                    _facade()._remaining_budget_seconds(deadline)
+                )
+                try:
+                    async for line in proxy._stream_once(
+                        account,
+                        payload,
+                        headers,
+                        request_id,
+                        False,
+                        request_started_at=start,
+                        api_key=api_key,
+                        api_key_reservation=api_key_reservation,
+                        settlement=settlement,
+                        suppress_text_done_events=suppress_text_done_events,
+                        upstream_stream_transport=upstream_stream_transport,
+                        request_transport=request_transport,
+                        useragent=useragent,
+                        useragent_group=useragent_group,
+                        client_ip=client_ip,
+                        tool_call_dedupe=tool_call_dedupe,
+                        enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+                    ):
+                        yield line
+                    return
+                except ProxyResponseError as exc:
+                    error = _parse_openai_error(exc.payload)
+                    error_code = _normalize_error_code(
+                        error.code if error else None,
+                        error.type if error else None,
+                    )
+                    if error_code != "account_response_create_cap":
+                        raise
+                    last_transient_exc = exc
+                    if can_try_other_account:
+                        raise
+                    recovery_sleep_seconds = _account_selection_recovery_sleep_seconds(
+                        AccountSelection(
+                            account=None,
+                            error_message=error.message if error else None,
+                            error_code=error_code,
+                        )
+                    )
+                    if recovery_sleep_seconds is None or _facade()._remaining_budget_seconds(deadline) <= 0:
+                        raise
+                    async for wait_event in _iter_account_capacity_recovery_wait(
+                        request_id=request_id,
+                        model=payload.model,
+                        account_id=account.id,
+                        error_message=error.message if error else None,
+                        recovery_sleep_seconds=recovery_sleep_seconds,
+                        deadline=deadline,
+                        emit_keepalives=not propagate_http_errors,
+                        stage="post_refresh_response_create",
+                    ):
+                        yield wait_event
+                    if _facade()._remaining_budget_seconds(deadline) <= 0:
+                        raise
+                finally:
+                    pop_stream_timeout_overrides(stream_timeout_tokens)
 
         def _record_upstream_transport_metric_once(status: str) -> None:
             nonlocal upstream_transport_metric_recorded
@@ -452,36 +571,17 @@ class _StreamingRetryMixin:
                             remaining_budget_seconds = _facade()._remaining_budget_seconds(deadline)
                             if remaining_budget_seconds <= 0:
                                 break
-                            wait_started_at = time.monotonic()
-                            remaining_sleep_seconds = min(recovery_sleep_seconds, remaining_budget_seconds)
-                            _facade().logger.info(
-                                "Waiting for an account to recover before retrying stream selection "
-                                "request_id=%s model=%s sleep_seconds=%.1f recovery_hint_seconds=%.1f error=%s",
-                                request_id,
-                                payload.model,
-                                remaining_sleep_seconds,
-                                recovery_sleep_seconds,
-                                selection.error_message,
-                            )
-                            while remaining_sleep_seconds > 0:
-                                yield format_sse_event(
-                                    cast(
-                                        Mapping[str, Any],
-                                        _account_capacity_wait_payload(
-                                            None,
-                                            request_id=request_id,
-                                            reason=selection.error_message,
-                                            retry_after_seconds=remaining_sleep_seconds,
-                                            started_at=wait_started_at,
-                                        ),
-                                    )
-                                )
-                                chunk_seconds = min(
-                                    remaining_sleep_seconds,
-                                    _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS,
-                                )
-                                await asyncio.sleep(chunk_seconds)
-                                remaining_sleep_seconds -= chunk_seconds
+                            async for wait_event in _iter_account_capacity_recovery_wait(
+                                request_id=request_id,
+                                model=payload.model,
+                                account_id=None,
+                                error_message=selection.error_message,
+                                recovery_sleep_seconds=recovery_sleep_seconds,
+                                deadline=deadline,
+                                emit_keepalives=not propagate_http_errors,
+                                stage="selection",
+                            ):
+                                yield wait_event
                             continue
                     break
                 if not account:
@@ -965,43 +1065,22 @@ class _StreamingRetryMixin:
                                             current_account_lease = None
                                             excluded_account_ids.add(account.id)
                                             break
-                                        if propagate_http_errors:
-                                            raise
                                         remaining_budget_seconds = _facade()._remaining_budget_seconds(deadline)
                                         if remaining_budget_seconds <= 0:
                                             raise
-                                        wait_started_at = time.monotonic()
-                                        remaining_sleep_seconds = min(recovery_sleep_seconds, remaining_budget_seconds)
-                                        _facade().logger.info(
-                                            "Waiting for response-create capacity before retrying stream "
-                                            "request_id=%s model=%s account_id=%s sleep_seconds=%.1f "
-                                            "recovery_hint_seconds=%.1f error=%s",
-                                            request_id,
-                                            payload.model,
-                                            account.id,
-                                            remaining_sleep_seconds,
-                                            recovery_sleep_seconds,
-                                            error_message,
-                                        )
-                                        while remaining_sleep_seconds > 0:
-                                            yield format_sse_event(
-                                                cast(
-                                                    Mapping[str, Any],
-                                                    _account_capacity_wait_payload(
-                                                        None,
-                                                        request_id=request_id,
-                                                        reason=error_message,
-                                                        retry_after_seconds=remaining_sleep_seconds,
-                                                        started_at=wait_started_at,
-                                                    ),
-                                                )
-                                            )
-                                            chunk_seconds = min(
-                                                remaining_sleep_seconds,
-                                                _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS,
-                                            )
-                                            await asyncio.sleep(chunk_seconds)
-                                            remaining_sleep_seconds -= chunk_seconds
+                                        async for wait_event in _iter_account_capacity_recovery_wait(
+                                            request_id=request_id,
+                                            model=payload.model,
+                                            account_id=account.id,
+                                            error_message=error_message,
+                                            recovery_sleep_seconds=recovery_sleep_seconds,
+                                            deadline=deadline,
+                                            emit_keepalives=not propagate_http_errors,
+                                            stage="response_create",
+                                        ):
+                                            yield wait_event
+                                        if _facade()._remaining_budget_seconds(deadline) <= 0:
+                                            raise
                                         continue
                                     last_transient_exc = tex
                                     await _release_tracked_stream_lease(current_account_lease)
@@ -1268,28 +1347,16 @@ class _StreamingRetryMixin:
                             )
                             yield format_sse_event(_facade()._proxy_request_timeout_event(request_id))
                             return
-                        stream_timeout_tokens = _facade()._push_stream_attempt_timeout_overrides(
-                            effective_attempt_timeout
-                        )
                         try:
-                            async for line in proxy._stream_once(
+                            async for line in _stream_post_refresh_with_capacity_recovery(
                                 account,
-                                payload,
-                                headers,
-                                request_id,
-                                False,
-                                request_started_at=start,
-                                api_key=api_key,
-                                api_key_reservation=api_key_reservation,
                                 settlement=settlement,
-                                suppress_text_done_events=suppress_text_done_events,
-                                upstream_stream_transport=upstream_stream_transport,
-                                request_transport=request_transport,
-                                useragent=useragent,
-                                useragent_group=useragent_group,
-                                client_ip=client_ip,
+                                can_try_other_account=(
+                                    not require_preferred_account
+                                    and account.id != file_preferred_account_id
+                                    and attempt < max_attempts - 1
+                                ),
                                 tool_call_dedupe=tool_call_dedupe,
-                                enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                             ):
                                 yield line
                         except ProxyResponseError as retry_exc:
@@ -1394,8 +1461,6 @@ class _StreamingRetryMixin:
                             _apply_error_metadata(event["response"]["error"], error)
                             yield format_sse_event(event)
                             return
-                        finally:
-                            pop_stream_timeout_overrides(stream_timeout_tokens)
                         if settlement.account_health_error:
                             await proxy._handle_stream_error(
                                 account,

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -308,6 +308,7 @@ class _StreamingRetryMixin:
         ) -> AsyncIterator[str]:
             nonlocal last_transient_exc
             while True:
+                settlement.reset()
                 stream_timeout_tokens = _facade()._push_stream_attempt_timeout_overrides(
                     _facade()._remaining_budget_seconds(deadline)
                 )
@@ -585,6 +586,8 @@ class _StreamingRetryMixin:
                                 stage="selection",
                             ):
                                 yield wait_event
+                            if _facade()._remaining_budget_seconds(deadline) <= 0:
+                                break
                             continue
                     break
                 if not account:

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -371,6 +371,7 @@ class _WebSocketRequestState:
     preferred_account_id: str | None = None
     require_security_work_authorized: bool = False
     file_required_preferred_account: bool = False
+    bridge_soft_capacity_reroute_allowed: bool = False
     error_code_override: str | None = None
     error_message_override: str | None = None
     error_type_override: str | None = None

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -47,6 +47,10 @@ _PROPAGATED_CAPACITY_STARTUP_WAIT: ContextVar[asyncio.Event | None] = ContextVar
     "propagated_capacity_startup_wait",
     default=None,
 )
+_PROPAGATED_CAPACITY_STARTUP_READY: ContextVar[asyncio.Event | None] = ContextVar(
+    "propagated_capacity_startup_ready",
+    default=None,
+)
 
 
 def _bind_propagated_capacity_startup_wait(event: asyncio.Event) -> Token[asyncio.Event | None]:
@@ -57,8 +61,28 @@ def _reset_propagated_capacity_startup_wait(token: Token[asyncio.Event | None]) 
     _PROPAGATED_CAPACITY_STARTUP_WAIT.reset(token)
 
 
+def _bind_propagated_capacity_startup_ready(event: asyncio.Event) -> Token[asyncio.Event | None]:
+    return _PROPAGATED_CAPACITY_STARTUP_READY.set(event)
+
+
+def _reset_propagated_capacity_startup_ready(token: Token[asyncio.Event | None]) -> None:
+    _PROPAGATED_CAPACITY_STARTUP_READY.reset(token)
+
+
 def _signal_propagated_capacity_startup_wait() -> None:
+    ready_event = _PROPAGATED_CAPACITY_STARTUP_READY.get()
+    if ready_event is not None:
+        ready_event.clear()
     event = _PROPAGATED_CAPACITY_STARTUP_WAIT.get()
+    if event is not None:
+        event.set()
+
+
+def _signal_propagated_capacity_startup_ready() -> None:
+    wait_event = _PROPAGATED_CAPACITY_STARTUP_WAIT.get()
+    if wait_event is not None:
+        wait_event.clear()
+    event = _PROPAGATED_CAPACITY_STARTUP_READY.get()
     if event is not None:
         event.set()
 

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -7,6 +7,7 @@ import re
 import time
 from collections import deque
 from collections.abc import Awaitable, Callable, Coroutine, Mapping
+from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -42,6 +43,24 @@ _ACCOUNT_SELECTION_RECOVERY_MAX_SLEEP_SECONDS = 300.0
 _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS = 10.0
 _ACCOUNT_SELECTION_RETRY_HINT_RE = re.compile(r"try again in\s+([0-9]+(?:\.[0-9]+)?)s", re.IGNORECASE)
 _LOCAL_ACCOUNT_CAP_ERROR_CODES = frozenset({"account_response_create_cap", "account_stream_cap"})
+_PROPAGATED_CAPACITY_STARTUP_WAIT: ContextVar[asyncio.Event | None] = ContextVar(
+    "propagated_capacity_startup_wait",
+    default=None,
+)
+
+
+def _bind_propagated_capacity_startup_wait(event: asyncio.Event) -> Token[asyncio.Event | None]:
+    return _PROPAGATED_CAPACITY_STARTUP_WAIT.set(event)
+
+
+def _reset_propagated_capacity_startup_wait(token: Token[asyncio.Event | None]) -> None:
+    _PROPAGATED_CAPACITY_STARTUP_WAIT.reset(token)
+
+
+def _signal_propagated_capacity_startup_wait() -> None:
+    event = _PROPAGATED_CAPACITY_STARTUP_WAIT.get()
+    if event is not None:
+        event.set()
 
 
 def _account_selection_recovery_sleep_seconds_from_message(

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -41,6 +41,7 @@ _ACCOUNT_SELECTION_RECOVERY_DEFAULT_SLEEP_SECONDS = 30.0
 _ACCOUNT_SELECTION_RECOVERY_MAX_SLEEP_SECONDS = 300.0
 _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS = 10.0
 _ACCOUNT_SELECTION_RETRY_HINT_RE = re.compile(r"try again in\s+([0-9]+(?:\.[0-9]+)?)s", re.IGNORECASE)
+_LOCAL_ACCOUNT_CAP_ERROR_CODES = frozenset({"account_response_create_cap", "account_stream_cap"})
 
 
 def _account_selection_recovery_sleep_seconds_from_message(
@@ -79,6 +80,9 @@ def _account_selection_recovery_sleep_seconds_from_message(
         )
 
     if "hit your spend cap set by the owner of your workspace" in lowered:
+        return _ACCOUNT_SELECTION_RECOVERY_DEFAULT_SLEEP_SECONDS
+
+    if error_code in _LOCAL_ACCOUNT_CAP_ERROR_CODES:
         return _ACCOUNT_SELECTION_RECOVERY_DEFAULT_SLEEP_SECONDS
 
     return None

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -288,6 +288,10 @@ class _StreamSettlement:
     response_id: str | None = None
     usage_settlement_transferred: bool = False
 
+    def reset(self) -> None:
+        fresh = type(self)()
+        self.__dict__.update(fresh.__dict__)
+
 
 def _stream_settlement_error_payload(settlement: _StreamSettlement) -> UpstreamError:
     if settlement.error is not None:

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -1821,6 +1821,12 @@ class _WebSocketMixin:
                 heartbeat=_heartbeat,
             ):
                 break
+            # A wait clipped to the remaining request budget is still a
+            # completed wait. Preserve the selection error that caused it
+            # instead of performing one more selection that can only replace
+            # the original local-cap 429 with upstream_request_timeout.
+            if _facade()._remaining_budget_seconds(deadline) <= 0:
+                break
 
         account = selection.account
         if (
@@ -1857,7 +1863,7 @@ class _WebSocketMixin:
         if account:
             request_state.websocket_stream_lease = selection.lease
             return account
-        if defer_no_account_error:
+        if defer_no_account_error and not _facade()._is_local_account_cap_code(selection.error_code):
             _facade().logger.warning(
                 "Websocket account selection deferred no-account error request_id=%s model=%s "
                 "preferred_account_id=%s require_preferred=%s error_code=%s error=%s excluded_count=%s",
@@ -1882,7 +1888,7 @@ class _WebSocketMixin:
             )
             return None
         if require_preferred_account and preferred_account_id is not None:
-            if request_state.file_required_preferred_account and _facade()._is_local_account_cap_code(error_code):
+            if _facade()._is_local_account_cap_code(error_code):
                 await proxy._emit_websocket_connect_failure(
                     websocket,
                     client_send_lock=client_send_lock,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -4726,6 +4726,11 @@ async def _wait_for_first_stream_probe(
             # wait can set the shared marker again.
             capacity_wait_event.clear()
             await asyncio.wait({first_task})
+            # Another capacity sleep may have signalled while the upstream
+            # first item was still pending. That marker belongs to this same
+            # extended probe and must not leak into the next buffered startup
+            # event probe.
+            capacity_wait_event.clear()
             return True
         return first_task in done
     finally:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -161,6 +161,10 @@ from app.modules.model_sources.repository import ModelSourcesRepository
 from app.modules.proxy import affinity as proxy_affinity_module
 from app.modules.proxy import images_service as images_service_module
 from app.modules.proxy import service as proxy_service_module
+from app.modules.proxy._service.support import (
+    _bind_propagated_capacity_startup_wait,
+    _reset_propagated_capacity_startup_wait,
+)
 from app.modules.proxy.account_cache import get_account_selection_cache
 from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
 from app.modules.proxy.helpers import _rate_limit_details
@@ -4138,13 +4142,19 @@ async def _stream_responses(
             client_ip=client_ip,
             enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         )
-    stream, startup_error = await _probe_stream_startup_error(
-        stream,
-        convert_event_errors=bridge_active and enforce_openai_sdk_contract,
-        timeout_seconds=(
-            _HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS if prefer_http_bridge else _STREAM_STARTUP_ERROR_PROBE_SECONDS
-        ),
-    )
+    capacity_wait_event = asyncio.Event()
+    capacity_wait_token = _bind_propagated_capacity_startup_wait(capacity_wait_event)
+    try:
+        stream, startup_error = await _probe_stream_startup_error(
+            stream,
+            convert_event_errors=bridge_active and enforce_openai_sdk_contract,
+            timeout_seconds=(
+                _HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS if prefer_http_bridge else _STREAM_STARTUP_ERROR_PROBE_SECONDS
+            ),
+            capacity_wait_event=capacity_wait_event,
+        )
+    finally:
+        _reset_propagated_capacity_startup_wait(capacity_wait_token)
     if startup_error is not None:
         if owns_reservation:
             await _release_reservation(reservation)
@@ -4683,11 +4693,20 @@ async def _probe_stream_startup_error(
     *,
     convert_event_errors: bool = False,
     timeout_seconds: float | None = None,
+    capacity_wait_event: asyncio.Event | None = None,
 ) -> tuple[AsyncIterator[str], ProxyResponseError | OpenAIErrorEnvelopeModel | None]:
     if timeout_seconds is None:
         timeout_seconds = _STREAM_STARTUP_ERROR_PROBE_SECONDS
     first_task = _create_first_stream_probe_task(stream)
     done, _pending = await asyncio.wait({first_task}, timeout=timeout_seconds)
+    if not done and capacity_wait_event is not None:
+        # Let the producer publish a local-capacity wait marker before
+        # committing the streaming response. Once capacity recovery starts,
+        # keep startup propagation open until the bounded retry yields an
+        # upstream event or raises its structured error.
+        await asyncio.sleep(0)
+        if capacity_wait_event.is_set():
+            done, _pending = await asyncio.wait({first_task})
     if not done:
         # Probe window elapsed before the first item arrived. Hand the still-
         # running task off to be consumed by the streamed response. asyncio.wait

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -162,7 +162,9 @@ from app.modules.proxy import affinity as proxy_affinity_module
 from app.modules.proxy import images_service as images_service_module
 from app.modules.proxy import service as proxy_service_module
 from app.modules.proxy._service.support import (
+    _bind_propagated_capacity_startup_ready,
     _bind_propagated_capacity_startup_wait,
+    _reset_propagated_capacity_startup_ready,
     _reset_propagated_capacity_startup_wait,
 )
 from app.modules.proxy.account_cache import get_account_selection_cache
@@ -3040,14 +3042,18 @@ async def v1_chat_completions(
         else _CHAT_COMPLETIONS_STARTUP_ERROR_PROBE_SECONDS
     )
     capacity_wait_event = asyncio.Event()
+    capacity_ready_event = asyncio.Event()
     capacity_wait_token = _bind_propagated_capacity_startup_wait(capacity_wait_event)
+    capacity_ready_token = _bind_propagated_capacity_startup_ready(capacity_ready_event)
     try:
         stream, startup_error = await _probe_chat_stream_startup_error(
             stream,
             timeout_seconds=startup_probe_timeout,
             capacity_wait_event=capacity_wait_event,
+            capacity_ready_event=capacity_ready_event,
         )
     finally:
+        _reset_propagated_capacity_startup_ready(capacity_ready_token)
         _reset_propagated_capacity_startup_wait(capacity_wait_token)
     if startup_error is not None:
         if cursor_compat_client and _is_context_length_startup_error(startup_error):
@@ -4153,7 +4159,9 @@ async def _stream_responses(
             enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         )
     capacity_wait_event = asyncio.Event()
+    capacity_ready_event = asyncio.Event()
     capacity_wait_token = _bind_propagated_capacity_startup_wait(capacity_wait_event)
+    capacity_ready_token = _bind_propagated_capacity_startup_ready(capacity_ready_event)
     try:
         stream, startup_error = await _probe_stream_startup_error(
             stream,
@@ -4162,8 +4170,10 @@ async def _stream_responses(
                 _HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS if prefer_http_bridge else _STREAM_STARTUP_ERROR_PROBE_SECONDS
             ),
             capacity_wait_event=capacity_wait_event,
+            capacity_ready_event=capacity_ready_event,
         )
     finally:
+        _reset_propagated_capacity_startup_ready(capacity_ready_token)
         _reset_propagated_capacity_startup_wait(capacity_wait_token)
     if startup_error is not None:
         if owns_reservation:
@@ -4703,40 +4713,77 @@ async def _wait_for_first_stream_probe(
     *,
     timeout_seconds: float,
     capacity_wait_event: asyncio.Event | None,
+    capacity_ready_event: asyncio.Event | None = None,
 ) -> bool:
-    done, _pending = await asyncio.wait({first_task}, timeout=timeout_seconds)
-    if done:
-        if capacity_wait_event is not None and capacity_wait_event.is_set():
-            capacity_wait_event.clear()
-        return True
-    if capacity_wait_event is None:
-        return bool(done)
-
-    marker_task = asyncio.create_task(capacity_wait_event.wait())
     try:
-        done, _pending = await asyncio.wait(
-            {first_task, marker_task},
-            timeout=_CAPACITY_WAIT_MARKER_GRACE_SECONDS,
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-        if marker_task in done and capacity_wait_event.is_set():
-            # The marker extends this probe only. Chat-completions may probe
-            # several buffered startup events, so leaving the Event set would
-            # turn every later probe into an unbounded wait. A later capacity
-            # wait can set the shared marker again.
-            capacity_wait_event.clear()
-            await asyncio.wait({first_task})
-            # Another capacity sleep may have signalled while the upstream
-            # first item was still pending. That marker belongs to this same
-            # extended probe and must not leak into the next buffered startup
-            # event probe.
-            capacity_wait_event.clear()
+        done, _pending = await asyncio.wait({first_task}, timeout=timeout_seconds)
+        if done:
+            if capacity_wait_event is not None and capacity_wait_event.is_set():
+                capacity_wait_event.clear()
             return True
-        return first_task in done
-    finally:
-        if not marker_task.done():
-            marker_task.cancel()
-        await asyncio.gather(marker_task, return_exceptions=True)
+        if capacity_wait_event is None:
+            return False
+
+        while True:
+            if first_task.done():
+                if capacity_wait_event.is_set():
+                    capacity_wait_event.clear()
+                return True
+            if capacity_wait_event.is_set():
+                recovery_ready_task = (
+                    asyncio.create_task(capacity_ready_event.wait()) if capacity_ready_event is not None else None
+                )
+                try:
+                    recovery_waiters = {first_task}
+                    if recovery_ready_task is not None:
+                        recovery_waiters.add(recovery_ready_task)
+                    recovery_done, _pending = await asyncio.wait(
+                        recovery_waiters,
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    if first_task not in recovery_done:
+                        # Re-read the paired level state. The ready signal has
+                        # cleared the wait that recovered, but a newer wait may
+                        # already have superseded that ready before this task
+                        # resumes.
+                        continue
+                finally:
+                    if recovery_ready_task is not None and not recovery_ready_task.done():
+                        recovery_ready_task.cancel()
+                    if recovery_ready_task is not None:
+                        await asyncio.gather(recovery_ready_task, return_exceptions=True)
+                continue
+            if capacity_ready_event is not None and capacity_ready_event.is_set():
+                return False
+
+            marker_task = asyncio.create_task(capacity_wait_event.wait())
+            ready_task = asyncio.create_task(capacity_ready_event.wait()) if capacity_ready_event is not None else None
+            try:
+                signal_waiters = {first_task, marker_task}
+                if ready_task is not None:
+                    signal_waiters.add(ready_task)
+                signal_done, _pending = await asyncio.wait(
+                    signal_waiters,
+                    timeout=None if ready_task is not None else _CAPACITY_WAIT_MARKER_GRACE_SECONDS,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if not signal_done:
+                    return False
+            finally:
+                pending_signal_tasks = [
+                    task for task in (marker_task, ready_task) if task is not None and not task.done()
+                ]
+                for task in pending_signal_tasks:
+                    task.cancel()
+                await asyncio.gather(
+                    marker_task,
+                    *(task for task in (ready_task,) if task is not None),
+                    return_exceptions=True,
+                )
+    except asyncio.CancelledError:
+        first_task.cancel()
+        await asyncio.gather(first_task, return_exceptions=True)
+        raise
 
 
 async def _probe_stream_startup_error(
@@ -4745,6 +4792,7 @@ async def _probe_stream_startup_error(
     convert_event_errors: bool = False,
     timeout_seconds: float | None = None,
     capacity_wait_event: asyncio.Event | None = None,
+    capacity_ready_event: asyncio.Event | None = None,
 ) -> tuple[AsyncIterator[str], ProxyResponseError | OpenAIErrorEnvelopeModel | None]:
     if timeout_seconds is None:
         timeout_seconds = _STREAM_STARTUP_ERROR_PROBE_SECONDS
@@ -4753,6 +4801,7 @@ async def _probe_stream_startup_error(
         first_task,
         timeout_seconds=timeout_seconds,
         capacity_wait_event=capacity_wait_event,
+        capacity_ready_event=capacity_ready_event,
     )
     if not probe_done:
         # Probe window elapsed before the first item arrived. Hand the still-
@@ -5065,6 +5114,7 @@ async def _probe_chat_stream_startup_error(
     timeout_seconds: float = _CHAT_COMPLETIONS_STARTUP_ERROR_PROBE_SECONDS,
     max_startup_events: int = 8,
     capacity_wait_event: asyncio.Event | None = None,
+    capacity_ready_event: asyncio.Event | None = None,
 ) -> tuple[AsyncIterator[str], ProxyResponseError | OpenAIErrorEnvelopeModel | None]:
     buffered: list[str] = []
     for _ in range(max_startup_events):
@@ -5073,6 +5123,7 @@ async def _probe_chat_stream_startup_error(
             first_task,
             timeout_seconds=timeout_seconds,
             capacity_wait_event=capacity_wait_event,
+            capacity_ready_event=capacity_ready_event,
         )
         if not probe_done:
             return _prepend_items(buffered, _prepend_first_task(first_task, stream)), None

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -305,6 +305,7 @@ _UNAVAILABLE_SELECTION_ERROR_CODES = {
     "no_additional_quota_eligible_accounts",
 }
 _STREAM_STARTUP_ERROR_PROBE_SECONDS = 0.05
+_CAPACITY_WAIT_MARKER_GRACE_SECONDS = 0.025
 # Keep bridge startup probing above tiny event-loop scheduling jitter:
 # PostgreSQL-backed failures may need a DB round trip before the first item.
 _HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS = 2.0
@@ -3038,7 +3039,16 @@ async def v1_chat_completions(
         if cursor_compat_client
         else _CHAT_COMPLETIONS_STARTUP_ERROR_PROBE_SECONDS
     )
-    stream, startup_error = await _probe_chat_stream_startup_error(stream, timeout_seconds=startup_probe_timeout)
+    capacity_wait_event = asyncio.Event()
+    capacity_wait_token = _bind_propagated_capacity_startup_wait(capacity_wait_event)
+    try:
+        stream, startup_error = await _probe_chat_stream_startup_error(
+            stream,
+            timeout_seconds=startup_probe_timeout,
+            capacity_wait_event=capacity_wait_event,
+        )
+    finally:
+        _reset_propagated_capacity_startup_wait(capacity_wait_token)
     if startup_error is not None:
         if cursor_compat_client and _is_context_length_startup_error(startup_error):
             await _release_reservation(reservation)
@@ -4688,6 +4698,33 @@ def _create_first_stream_probe_task(stream: AsyncIterator[str]) -> asyncio.Task[
     return task
 
 
+async def _wait_for_first_stream_probe(
+    first_task: asyncio.Task[str],
+    *,
+    timeout_seconds: float,
+    capacity_wait_event: asyncio.Event | None,
+) -> bool:
+    done, _pending = await asyncio.wait({first_task}, timeout=timeout_seconds)
+    if done or capacity_wait_event is None:
+        return bool(done)
+
+    marker_task = asyncio.create_task(capacity_wait_event.wait())
+    try:
+        done, _pending = await asyncio.wait(
+            {first_task, marker_task},
+            timeout=_CAPACITY_WAIT_MARKER_GRACE_SECONDS,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if marker_task in done and capacity_wait_event.is_set():
+            await asyncio.wait({first_task})
+            return True
+        return first_task in done
+    finally:
+        if not marker_task.done():
+            marker_task.cancel()
+        await asyncio.gather(marker_task, return_exceptions=True)
+
+
 async def _probe_stream_startup_error(
     stream: AsyncIterator[str],
     *,
@@ -4698,16 +4735,12 @@ async def _probe_stream_startup_error(
     if timeout_seconds is None:
         timeout_seconds = _STREAM_STARTUP_ERROR_PROBE_SECONDS
     first_task = _create_first_stream_probe_task(stream)
-    done, _pending = await asyncio.wait({first_task}, timeout=timeout_seconds)
-    if not done and capacity_wait_event is not None:
-        # Let the producer publish a local-capacity wait marker before
-        # committing the streaming response. Once capacity recovery starts,
-        # keep startup propagation open until the bounded retry yields an
-        # upstream event or raises its structured error.
-        await asyncio.sleep(0)
-        if capacity_wait_event.is_set():
-            done, _pending = await asyncio.wait({first_task})
-    if not done:
+    probe_done = await _wait_for_first_stream_probe(
+        first_task,
+        timeout_seconds=timeout_seconds,
+        capacity_wait_event=capacity_wait_event,
+    )
+    if not probe_done:
         # Probe window elapsed before the first item arrived. Hand the still-
         # running task off to be consumed by the streamed response. asyncio.wait
         # (rather than wait_for + shield) never cancels the task on timeout,
@@ -5017,12 +5050,17 @@ async def _probe_chat_stream_startup_error(
     *,
     timeout_seconds: float = _CHAT_COMPLETIONS_STARTUP_ERROR_PROBE_SECONDS,
     max_startup_events: int = 8,
+    capacity_wait_event: asyncio.Event | None = None,
 ) -> tuple[AsyncIterator[str], ProxyResponseError | OpenAIErrorEnvelopeModel | None]:
     buffered: list[str] = []
     for _ in range(max_startup_events):
         first_task = _create_first_stream_probe_task(stream)
-        done, _pending = await asyncio.wait({first_task}, timeout=timeout_seconds)
-        if not done:
+        probe_done = await _wait_for_first_stream_probe(
+            first_task,
+            timeout_seconds=timeout_seconds,
+            capacity_wait_event=capacity_wait_event,
+        )
+        if not probe_done:
             return _prepend_items(buffered, _prepend_first_task(first_task, stream)), None
         try:
             first = first_task.result()

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -307,7 +307,7 @@ _UNAVAILABLE_SELECTION_ERROR_CODES = {
     "no_additional_quota_eligible_accounts",
 }
 _STREAM_STARTUP_ERROR_PROBE_SECONDS = 0.05
-_CAPACITY_WAIT_MARKER_GRACE_SECONDS = 0.025
+_CAPACITY_WAIT_MARKER_GRACE_SECONDS = 0.05
 # Keep bridge startup probing above tiny event-loop scheduling jitter:
 # PostgreSQL-backed failures may need a DB round trip before the first item.
 _HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS = 2.0
@@ -4764,7 +4764,7 @@ async def _wait_for_first_stream_probe(
                     signal_waiters.add(ready_task)
                 signal_done, _pending = await asyncio.wait(
                     signal_waiters,
-                    timeout=None if ready_task is not None else _CAPACITY_WAIT_MARKER_GRACE_SECONDS,
+                    timeout=_CAPACITY_WAIT_MARKER_GRACE_SECONDS,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
                 if not signal_done:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -321,6 +321,25 @@ _V1_MAX_OUTPUT_TOKEN_OVERRIDES: Final[dict[str, int]] = {
     "gpt-5.4-mini": 128_000,
     "gpt-5.3-codex": 128_000,
 }
+
+
+class _CapacityStartupReadyEvent(asyncio.Event):
+    """Track when admission became ready so its startup probe cannot reset."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.set_at: float | None = None
+
+    def set(self) -> None:
+        if not self.is_set():
+            self.set_at = time.monotonic()
+        super().set()
+
+    def clear(self) -> None:
+        self.set_at = None
+        super().clear()
+
+
 _OPPORTUNISTIC_RETRY_AFTER_SECONDS = 60
 
 # OpenAI error ``type`` -> HTTP status for the /v1/images/* non-streaming
@@ -3043,7 +3062,7 @@ async def v1_chat_completions(
         else _CHAT_COMPLETIONS_STARTUP_ERROR_PROBE_SECONDS
     )
     capacity_wait_event = asyncio.Event()
-    capacity_ready_event = asyncio.Event()
+    capacity_ready_event = _CapacityStartupReadyEvent()
     capacity_wait_token = _bind_propagated_capacity_startup_wait(capacity_wait_event)
     capacity_ready_token = _bind_propagated_capacity_startup_ready(capacity_ready_event)
     try:
@@ -4160,7 +4179,7 @@ async def _stream_responses(
             enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         )
     capacity_wait_event = asyncio.Event()
-    capacity_ready_event = asyncio.Event()
+    capacity_ready_event = _CapacityStartupReadyEvent()
     capacity_wait_token = _bind_propagated_capacity_startup_wait(capacity_wait_event)
     capacity_ready_token = _bind_propagated_capacity_startup_ready(capacity_ready_event)
     try:
@@ -4766,7 +4785,23 @@ async def _wait_for_first_stream_probe(
                         await asyncio.gather(recovery_ready_task, return_exceptions=True)
                 continue
             if capacity_ready_event is not None and capacity_ready_event.is_set():
-                return False
+                # Admission recovery only proves that local capacity is ready;
+                # the resumed upstream can still fail before its first item.
+                # Preserve the route's normal bounded startup-error window so
+                # an immediate 4xx / response.failed remains an HTTP startup
+                # error, while a slow healthy upstream is still handed off.
+                post_ready_timeout = timeout_seconds
+                if isinstance(capacity_ready_event, _CapacityStartupReadyEvent):
+                    ready_set_at = capacity_ready_event.set_at
+                    if ready_set_at is not None:
+                        post_ready_timeout = max(0.0, timeout_seconds - (time.monotonic() - ready_set_at))
+                if post_ready_timeout <= 0:
+                    return False
+                post_ready_done, _pending = await asyncio.wait(
+                    {first_task},
+                    timeout=post_ready_timeout,
+                )
+                return bool(post_ready_done)
 
             marker_task = asyncio.create_task(capacity_wait_event.wait())
             ready_task = asyncio.create_task(capacity_ready_event.wait()) if capacity_ready_event is not None else None

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -311,6 +311,7 @@ _CAPACITY_WAIT_MARKER_GRACE_SECONDS = 0.05
 # Keep bridge startup probing above tiny event-loop scheduling jitter:
 # PostgreSQL-backed failures may need a DB round trip before the first item.
 _HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS = 2.0
+_CAPACITY_STARTUP_SIGNAL_DISCOVERY_SECONDS = _HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS
 _CHAT_COMPLETIONS_STARTUP_ERROR_PROBE_SECONDS = 2.0
 _CURSOR_CHAT_COMPLETIONS_STARTUP_ERROR_PROBE_SECONDS = 15.0
 _CURSOR_CONTEXT_LIMIT_SYNTHETIC_USAGE_TOKENS: Final[int] = 1_000_000
@@ -4724,6 +4725,17 @@ async def _wait_for_first_stream_probe(
         if capacity_wait_event is None:
             return False
 
+        # Account selection can include a PostgreSQL round trip before it can
+        # report either successful admission or local capacity pressure. Give
+        # those paired signals the established bounded startup-probe window,
+        # but keep one absolute deadline so unrelated/no-marker streams cannot
+        # turn the route into a request-budget-length startup wait.
+        signal_discovery_seconds = (
+            _CAPACITY_STARTUP_SIGNAL_DISCOVERY_SECONDS
+            if capacity_ready_event is not None
+            else _CAPACITY_WAIT_MARKER_GRACE_SECONDS
+        )
+        signal_discovery_deadline = asyncio.get_running_loop().time() + signal_discovery_seconds
         while True:
             if first_task.done():
                 if capacity_wait_event.is_set():
@@ -4759,12 +4771,18 @@ async def _wait_for_first_stream_probe(
             marker_task = asyncio.create_task(capacity_wait_event.wait())
             ready_task = asyncio.create_task(capacity_ready_event.wait()) if capacity_ready_event is not None else None
             try:
+                signal_discovery_remaining = max(
+                    0.0,
+                    signal_discovery_deadline - asyncio.get_running_loop().time(),
+                )
+                if signal_discovery_remaining <= 0:
+                    return False
                 signal_waiters = {first_task, marker_task}
                 if ready_task is not None:
                     signal_waiters.add(ready_task)
                 signal_done, _pending = await asyncio.wait(
                     signal_waiters,
-                    timeout=_CAPACITY_WAIT_MARKER_GRACE_SECONDS,
+                    timeout=signal_discovery_remaining,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
                 if not signal_done:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -4705,7 +4705,11 @@ async def _wait_for_first_stream_probe(
     capacity_wait_event: asyncio.Event | None,
 ) -> bool:
     done, _pending = await asyncio.wait({first_task}, timeout=timeout_seconds)
-    if done or capacity_wait_event is None:
+    if done:
+        if capacity_wait_event is not None and capacity_wait_event.is_set():
+            capacity_wait_event.clear()
+        return True
+    if capacity_wait_event is None:
         return bool(done)
 
     marker_task = asyncio.create_task(capacity_wait_event.wait())
@@ -4716,6 +4720,11 @@ async def _wait_for_first_stream_probe(
             return_when=asyncio.FIRST_COMPLETED,
         )
         if marker_task in done and capacity_wait_event.is_set():
+            # The marker extends this probe only. Chat-completions may probe
+            # several buffered startup events, so leaving the Event set would
+            # turn every later probe into an unbounded wait. A later capacity
+            # wait can set the shared marker again.
+            capacity_wait_event.clear()
             await asyncio.wait({first_task})
             return True
         return first_task in done

--- a/app/modules/proxy/http_bridge_forwarding.py
+++ b/app/modules/proxy/http_bridge_forwarding.py
@@ -5,7 +5,7 @@ import hashlib
 import hmac
 import json
 import time
-from collections.abc import AsyncIterator, Mapping
+from collections.abc import AsyncIterator, Callable, Mapping
 from dataclasses import dataclass
 from typing import cast
 
@@ -103,6 +103,7 @@ class HTTPBridgeOwnerClient:
         headers: Mapping[str, str],
         context: HTTPBridgeForwardContext,
         request_started_at: float,
+        on_response_ready: Callable[[], None] | None = None,
     ) -> AsyncIterator[str]:
         settings = get_settings()
         timeout = _owner_forward_timeout(
@@ -125,6 +126,8 @@ class HTTPBridgeOwnerClient:
                         failure_detail="owner_forward_non_200",
                         upstream_status_code=response.status,
                     )
+                if on_response_ready is not None:
+                    on_response_ready()
                 yielded_event = False
                 try:
                     async for event_block in _iter_sse_event_blocks(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -526,6 +526,9 @@ from app.modules.proxy._service.streaming.helpers import (
     _should_retry_transient_stream_error as _should_retry_transient_stream_error,
 )
 from app.modules.proxy._service.streaming.helpers import (
+    _stream_iterator_after_capacity_admission as _stream_iterator_after_capacity_admission,
+)
+from app.modules.proxy._service.streaming.helpers import (
     _stream_request_budget_seconds as _stream_request_budget_seconds,
 )
 from app.modules.proxy._service.streaming.helpers import (

--- a/openspec/changes/wait-on-local-account-caps/proposal.md
+++ b/openspec/changes/wait-on-local-account-caps/proposal.md
@@ -4,8 +4,10 @@ Image-capable Codex requests bypass the HTTP bridge and use the streaming select
 
 ## What Changes
 
-- Treat local account stream/response-create cap selection failures as recoverable account-capacity waits.
-- Reuse the existing bounded streaming keepalive wait loop before retrying selection.
+- Treat local account stream/response-create cap failures as recoverable account-capacity waits across direct
+  streaming, HTTP bridge session submission, and downstream WebSocket account selection.
+- Reuse the original request budget while preserving stream leases for same-account retries and preferring an
+  eligible spare account when continuity does not pin the request.
 - Keep permanent no-account and local balancer `Rate limit exceeded. Try again in Ns` failures non-waitable.
 
 ## Impact

--- a/openspec/changes/wait-on-local-account-caps/proposal.md
+++ b/openspec/changes/wait-on-local-account-caps/proposal.md
@@ -1,0 +1,14 @@
+## Why
+
+Image-capable Codex requests bypass the HTTP bridge and use the streaming selection path directly. When all eligible accounts are briefly at the local per-account stream or response-create cap, that path returns an immediate local 429 (`account_stream_cap` / `account_response_create_cap`). Codex retries several subagents at once, exhausts its client retry budget, and surfaces `exceeded retry limit, last status: 429 Too Many Requests` even though capacity may free seconds later.
+
+## What Changes
+
+- Treat local account stream/response-create cap selection failures as recoverable account-capacity waits.
+- Reuse the existing bounded streaming keepalive wait loop before retrying selection.
+- Keep permanent no-account and local balancer `Rate limit exceeded. Try again in Ns` failures non-waitable.
+
+## Impact
+
+- Code: `app/modules/proxy/_service/support.py`, `app/modules/proxy/_service/streaming/retry.py`, `app/modules/proxy/_service/http_bridge/streaming.py`
+- Tests: targeted proxy unit tests

--- a/openspec/changes/wait-on-local-account-caps/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/wait-on-local-account-caps/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,9 @@
+## MODIFIED Requirements
+
+### Requirement: Streaming timeout diagnostics are emitted
+For `/v1/responses` HTTP/SSE streams, the service MUST log low-cardinality diagnostics for early heartbeat emission, keepalive emission, account-capacity recovery waits, startup wait timeout, downstream disconnect, and stream idle timeout. The diagnostics MUST include request id, route family, account id when known, timeout or wait stage, model when known, bounded sleep or elapsed seconds where available, and normalized error code/message where available, without exposing payload content, API keys, raw affinity keys, or raw account emails.
+
+#### Scenario: Local account cap wait is diagnosable
+- **WHEN** a streaming request waits because local per-account stream or response-create capacity is exhausted
+- **THEN** downstream keepalive and logs use the account-capacity wait path with normalized local cap reason fields
+- **AND** the diagnostic does not expose prompt content, API keys, raw affinity keys, or account emails

--- a/openspec/changes/wait-on-local-account-caps/specs/responses-api-compat/spec.md
+++ b/openspec/changes/wait-on-local-account-caps/specs/responses-api-compat/spec.md
@@ -8,3 +8,25 @@ When a streaming `/v1/responses` request encounters upstream instability, the pr
 - **THEN** the proxy treats the condition as a recoverable account-capacity wait within the request budget
 - **AND** it retries account selection after the bounded wait instead of returning an immediate 429
 - **AND** permanent `no_accounts` failures remain non-waitable unless they carry a distinct recoverable capacity or upstream quota signal
+
+#### Scenario: Post-selection response-create capacity preserves routing invariants
+- **WHEN** a selected account reaches `account_response_create_cap` before downstream output is visible
+- **THEN** an unpinned request MUST prefer an eligible alternate account before waiting
+- **AND** an owner-bound, file-pinned, or otherwise same-account retry MUST keep or reacquire its stream lease while waiting within the original request budget
+- **AND** the same behavior applies after a forced token refresh
+
+#### Scenario: Propagated startup errors remain observable
+- **WHEN** a route requests HTTP error propagation and waits for local account capacity before startup
+- **THEN** the route MUST perform the bounded recovery wait instead of raising the first cap error immediately
+- **AND** it MUST NOT emit an account-capacity keepalive before startup succeeds, so a terminal startup error can still use the route's structured error path
+
+#### Scenario: Existing HTTP bridge session waits on submit capacity
+- **WHEN** HTTP bridge session submission reaches `account_response_create_cap`
+- **THEN** a hard-affinity or file-pinned request MUST wait and retry submission within the bridge request budget
+- **AND** a soft-affinity request MUST retain its existing alternate-session reroute behavior before waiting on the saturated session
+
+#### Scenario: WebSocket account selection waits on local caps
+- **WHEN** downstream WebSocket account selection returns `account_stream_cap` or `account_response_create_cap`
+- **THEN** the proxy MUST emit a `codex.keepalive` with status `waiting_for_account_capacity`
+- **AND** retry selection within the original WebSocket request budget
+- **AND** return the original local-cap error if that budget is already exhausted

--- a/openspec/changes/wait-on-local-account-caps/specs/responses-api-compat/spec.md
+++ b/openspec/changes/wait-on-local-account-caps/specs/responses-api-compat/spec.md
@@ -1,0 +1,10 @@
+## MODIFIED Requirements
+
+### Requirement: Streaming Responses requests use a bounded retry budget
+When a streaming `/v1/responses` request encounters upstream instability, the proxy MUST enforce a configurable total request budget across selection, token refresh, account-capacity recovery waits, and upstream stream attempts. Each upstream stream attempt MUST clamp its connect timeout, idle timeout, and total request timeout to the remaining request budget.
+
+#### Scenario: Local account cap selection waits instead of failing immediately
+- **WHEN** account selection for a streaming Responses request fails locally with `account_stream_cap` or `account_response_create_cap`
+- **THEN** the proxy treats the condition as a recoverable account-capacity wait within the request budget
+- **AND** it retries account selection after the bounded wait instead of returning an immediate 429
+- **AND** permanent `no_accounts` failures remain non-waitable unless they carry a distinct recoverable capacity or upstream quota signal

--- a/openspec/changes/wait-on-local-account-caps/tasks.md
+++ b/openspec/changes/wait-on-local-account-caps/tasks.md
@@ -4,6 +4,8 @@
 - [x] 1.2 Let streaming selection failures for those local cap codes use the existing bounded keepalive wait/retry loop.
 - [x] 1.3 Preserve non-waitable permanent no-account selection failures.
 - [x] 1.4 Add unit coverage for helper, streaming, and HTTP bridge capacity-wait behavior.
+- [x] 1.5 Preserve direct-stream lease and propagation semantics for same-account retries, including forced refresh.
+- [x] 1.6 Apply the same bounded recovery contract to HTTP bridge submission and WebSocket selection.
 
 ## 2. Validation
 

--- a/openspec/changes/wait-on-local-account-caps/tasks.md
+++ b/openspec/changes/wait-on-local-account-caps/tasks.md
@@ -1,0 +1,11 @@
+## 1. Local account-cap recovery
+
+- [x] 1.1 Classify `account_stream_cap` and `account_response_create_cap` as recoverable account-capacity waits.
+- [x] 1.2 Let streaming selection failures for those local cap codes use the existing bounded keepalive wait/retry loop.
+- [x] 1.3 Preserve non-waitable permanent no-account selection failures.
+- [x] 1.4 Add unit coverage for helper, streaming, and HTTP bridge capacity-wait behavior.
+
+## 2. Validation
+
+- [x] 2.1 Run targeted unit tests.
+- [x] 2.2 Validate OpenSpec change strictly.

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -20,6 +20,7 @@ from app.core.utils.sse import CODEX_KEEPALIVE_FRAME, SSE_KEEPALIVE_FRAME
 from app.db.models import Account, AccountStatus, RequestLog
 from app.db.session import SessionLocal
 from app.dependencies import ProxyContext
+from app.modules.proxy._service.support import _signal_propagated_capacity_startup_ready
 
 pytestmark = pytest.mark.integration
 
@@ -1017,6 +1018,9 @@ async def test_stream_responses_starts_sse_keepalive_before_first_upstream_event
             del args
             seen_client_ip.append(kwargs.get("client_ip"))
             upstream_started.set()
+            # The real service signals this after local admission. Preserve
+            # that contract while this fake deliberately stalls upstream I/O.
+            _signal_propagated_capacity_startup_ready()
             await release_upstream.wait()
             event = {"type": "response.completed", "response": {"id": "resp_delayed"}}
             yield _sse_event(event)
@@ -1114,6 +1118,7 @@ async def test_codex_route_stream_responses_starts_event_keepalive_before_first_
         async def stream_responses(self, *args, **kwargs):
             del args, kwargs
             upstream_started.set()
+            _signal_propagated_capacity_startup_ready()
             await release_upstream.wait()
             event = {"type": "response.completed", "response": {"id": "resp_delayed"}}
             yield _sse_event(event)

--- a/tests/unit/test_http_bridge_forwarding.py
+++ b/tests/unit/test_http_bridge_forwarding.py
@@ -508,6 +508,7 @@ async def test_owner_forward_uses_direct_session_without_env_proxy(monkeypatch: 
     get_settings.cache_clear()
 
     client = HTTPBridgeOwnerClient()
+    ready_calls: list[bool] = []
     payload = _payload()
     context = HTTPBridgeForwardContext(
         origin_instance="instance-a",
@@ -524,12 +525,14 @@ async def test_owner_forward_uses_direct_session_without_env_proxy(monkeypatch: 
             headers={"Authorization": "Bearer proxy-key"},
             context=context,
             request_started_at=10.0,
+            on_response_ready=lambda: ready_calls.append(True),
         )
     ]
 
     assert len(events) == 1
     assert '"type":"response.failed"' in events[0]
     assert '"code":"stream_incomplete"' in events[0]
+    assert ready_calls == [True]
     assert captured["trust_env"] is False
     skip_auto_headers = captured["skip_auto_headers"]
     assert isinstance(skip_auto_headers, frozenset)

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -633,6 +633,66 @@ async def test_http_bridge_submit_leaves_soft_capacity_for_session_reroute(monke
     assert submit.await_count == 1
 
 
+@pytest.mark.asyncio
+async def test_http_bridge_submit_capacity_wait_uses_original_request_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="sid-submit-original-deadline")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-submit-original-deadline",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=99.5,
+        transport="http",
+        event_queue=asyncio.Queue(),
+    )
+    capacity_error = ProxyResponseError(
+        429,
+        openai_error(
+            "account_response_create_cap",
+            "Account response-create concurrency limit reached",
+            error_type="rate_limit_error",
+        ),
+    )
+    submit = AsyncMock(side_effect=capacity_error)
+    clock = [100.0]
+    waited: list[float] = []
+
+    async def fake_capacity_wait(**kwargs: object):
+        waited.append(cast(float, kwargs["sleep_seconds"]))
+        clock[0] += waited[-1]
+        if False:
+            yield ""
+
+    monkeypatch.setattr(service, "_submit_http_bridge_request", submit)
+    monkeypatch.setattr(http_bridge_streaming_module, "_http_bridge_account_capacity_wait_seconds", lambda _exc: 30.0)
+    monkeypatch.setattr(http_bridge_streaming_module, "_iter_account_capacity_wait_sse", fake_capacity_wait)
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_service_time",
+        lambda: SimpleNamespace(monotonic=lambda: clock[0]),
+    )
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        async for _ in service._stream_http_bridge_session_events(
+            session,
+            request_state=request_state,
+            text_data='{"type":"response.create"}',
+            queue_limit=4,
+            propagate_http_errors=True,
+            downstream_turn_state=None,
+            request_deadline=101.0,
+        ):
+            pass
+
+    assert exc_info.value is capacity_error
+    assert waited == [1.0]
+    assert submit.await_count == 1
+
+
 def _make_api_key(
     *,
     key_id: str,
@@ -2039,8 +2099,9 @@ async def test_stream_via_http_bridge_keeps_sse_alive_while_session_creation_wai
         queue_limit: int,
         propagate_http_errors: bool,
         downstream_turn_state: str | None,
+        request_deadline: float | None = None,
     ):
-        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state
+        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state, request_deadline
         yield (
             'data: {"type":"response.completed","response":{"id":"resp_capacity_create_ok",'
             '"usage":{"input_tokens":1,"output_tokens":2}}}\n\n'
@@ -2253,8 +2314,9 @@ async def test_stream_via_http_bridge_soft_prompt_cache_queue_full_reroutes(
         queue_limit: int,
         propagate_http_errors: bool,
         downstream_turn_state: str | None,
+        request_deadline: float | None = None,
     ):
-        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state
+        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state, request_deadline
         if session is saturated_session:
             raise ProxyResponseError(
                 429,
@@ -2346,8 +2408,17 @@ async def test_stream_via_http_bridge_file_pin_queue_full_does_not_reroute(
         queue_limit: int,
         propagate_http_errors: bool,
         downstream_turn_state: str | None,
+        request_deadline: float | None = None,
     ):
-        del session, request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state
+        del (
+            session,
+            request_state,
+            text_data,
+            queue_limit,
+            propagate_http_errors,
+            downstream_turn_state,
+            request_deadline,
+        )
         raise ProxyResponseError(
             429,
             proxy_service.openai_error(
@@ -5799,8 +5870,9 @@ async def test_stream_via_http_bridge_uses_generated_downstream_turn_state_for_o
         queue_limit: int,
         propagate_http_errors: bool,
         downstream_turn_state: str | None,
+        request_deadline: float | None = None,
     ):
-        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state
+        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state, request_deadline
         yield 'data: {"type":"response.completed"}\n\n'
 
     owner_lookup = AsyncMock(return_value="acc-owner-from-turn-state")
@@ -6430,8 +6502,9 @@ async def test_stream_via_http_bridge_reacquires_api_key_reservation_for_local_p
         queue_limit: int,
         propagate_http_errors: bool,
         downstream_turn_state: str | None,
+        request_deadline: float | None = None,
     ):
-        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state
+        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state, request_deadline
         stream_calls["count"] += 1
         if stream_calls["count"] == 1:
             raise ProxyResponseError(400, proxy_service.openai_error("previous_response_not_found", "missing"))
@@ -6563,9 +6636,18 @@ async def test_stream_via_http_bridge_does_not_rebind_after_downstream_visible(
         queue_limit: int,
         propagate_http_errors: bool,
         downstream_turn_state: str | None,
+        request_deadline: float | None = None,
     ):
         nonlocal stream_calls
-        del _session, request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state
+        del (
+            _session,
+            request_state,
+            text_data,
+            queue_limit,
+            propagate_http_errors,
+            downstream_turn_state,
+            request_deadline,
+        )
         stream_calls += 1
         yield 'data: {"type":"response.output_text.delta","delta":"already visible"}\n\n'
         raise ProxyResponseError(400, proxy_service.openai_error("previous_response_not_found", "missing"))
@@ -7345,8 +7427,9 @@ async def test_stream_via_http_bridge_local_previous_response_rebind_fails_exist
         queue_limit: int,
         propagate_http_errors: bool,
         downstream_turn_state: str | None,
+        request_deadline: float | None = None,
     ):
-        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state
+        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state, request_deadline
         stream_calls["count"] += 1
         if stream_calls["count"] == 1:
             raise ProxyResponseError(400, proxy_service.openai_error("previous_response_not_found", "missing"))
@@ -7485,8 +7568,9 @@ async def test_stream_via_http_bridge_rolls_over_session_after_context_length_ex
         queue_limit: int,
         propagate_http_errors: bool,
         downstream_turn_state: str | None,
+        request_deadline: float | None = None,
     ):
-        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state
+        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state, request_deadline
         raise ProxyResponseError(
             400,
             proxy_service.openai_error(
@@ -7620,8 +7704,9 @@ async def test_stream_via_http_bridge_context_overflow_keeps_hard_affinity_sessi
         queue_limit: int,
         propagate_http_errors: bool,
         downstream_turn_state: str | None,
+        request_deadline: float | None = None,
     ):
-        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state
+        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state, request_deadline
         raise ProxyResponseError(
             400,
             proxy_service.openai_error(
@@ -7754,9 +7839,10 @@ async def test_stream_via_http_bridge_context_overflow_does_not_retry_hard_affin
         queue_limit: int,
         propagate_http_errors: bool,
         downstream_turn_state: str | None,
+        request_deadline: float | None = None,
     ):
         nonlocal stream_attempt
-        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state
+        del request_state, text_data, queue_limit, propagate_http_errors, downstream_turn_state, request_deadline
         stream_attempt += 1
         if stream_attempt == 1:
             raise ProxyResponseError(
@@ -12369,8 +12455,9 @@ async def test_stream_via_http_bridge_replays_durable_full_resend_when_owner_is_
         queue_limit: int,
         propagate_http_errors: bool,
         downstream_turn_state: str | None,
+        request_deadline: float | None = None,
     ):
-        del queue_limit, propagate_http_errors, downstream_turn_state
+        del queue_limit, propagate_http_errors, downstream_turn_state, request_deadline
         captured_request_states.append(request_state)
         captured_text_data.append(text_data)
         yield 'data: {"type":"response.completed"}\n\n'

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -527,6 +527,112 @@ def test_http_bridge_account_capacity_wait_treats_local_account_caps_as_recovera
     assert http_bridge_streaming_module._http_bridge_account_capacity_wait_seconds(exc) == 30.0
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("propagate_http_errors", "expected_event_types"),
+    [
+        (False, ["codex.keepalive", "response.completed"]),
+        (True, ["response.completed"]),
+    ],
+)
+async def test_http_bridge_submit_waits_for_local_account_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+    propagate_http_errors: bool,
+    expected_event_types: list[str],
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="sid-submit-capacity")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-submit-capacity",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        transport="http",
+        event_queue=asyncio.Queue(),
+    )
+    assert request_state.event_queue is not None
+    request_state.event_queue.put_nowait(
+        'data: {"type":"response.completed","response":{"id":"resp_submit_capacity"}}\n\n'
+    )
+    request_state.event_queue.put_nowait(None)
+    capacity_error = ProxyResponseError(
+        429,
+        openai_error(
+            "account_response_create_cap",
+            "Account response-create concurrency limit reached",
+            error_type="rate_limit_error",
+        ),
+    )
+    submit = AsyncMock(side_effect=[capacity_error, None])
+    detach = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(http_bridge_streaming_module, "_http_bridge_account_capacity_wait_seconds", lambda _exc: 0.001)
+    monkeypatch.setattr(http_bridge_streaming_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.001)
+    monkeypatch.setattr(service, "_submit_http_bridge_request", submit)
+    monkeypatch.setattr(service, "_detach_http_bridge_request", detach)
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_http_bridge_session_events(
+            session,
+            request_state=request_state,
+            text_data='{"type":"response.create"}',
+            queue_limit=4,
+            propagate_http_errors=propagate_http_errors,
+            downstream_turn_state=None,
+        )
+    ]
+
+    event_types = [cast(dict[str, object], proxy_service.parse_sse_data_json(chunk))["type"] for chunk in chunks]
+    assert event_types == expected_event_types
+    assert submit.await_count == 2
+    detach.assert_awaited_once_with(session, request_state=request_state)
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_submit_leaves_soft_capacity_for_session_reroute(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="soft-submit-capacity")
+    session.key = proxy_service._HTTPBridgeSessionKey("prompt_cache", "soft-submit-capacity", None)
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-soft-submit-capacity",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        transport="http",
+        bridge_soft_capacity_reroute_allowed=True,
+    )
+    capacity_error = ProxyResponseError(
+        429,
+        openai_error(
+            "account_response_create_cap",
+            "Account response-create concurrency limit reached",
+            error_type="rate_limit_error",
+        ),
+    )
+    submit = AsyncMock(side_effect=capacity_error)
+    monkeypatch.setattr(service, "_submit_http_bridge_request", submit)
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        async for _ in service._stream_http_bridge_session_events(
+            session,
+            request_state=request_state,
+            text_data='{"type":"response.create"}',
+            queue_limit=4,
+            propagate_http_errors=True,
+            downstream_turn_state=None,
+        ):
+            pass
+
+    assert exc_info.value is capacity_error
+    assert submit.await_count == 1
+
+
 def _make_api_key(
     *,
     key_id: str,
@@ -2204,10 +2310,7 @@ async def test_stream_via_http_bridge_soft_prompt_cache_queue_full_reroutes(
         )
     ]
 
-    keepalive = proxy_service.parse_sse_data_json(chunks[0])
-    assert keepalive is not None
-    assert keepalive["status"] == "waiting_for_account_capacity"
-    assert chunks[-1] == 'data: {"type":"response.completed"}\n\n'
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
     assert get_or_create.await_count == 3
     reroute_key = get_or_create.await_args_list[1].args[0]
     retry_reroute_key = get_or_create.await_args_list[2].args[0]
@@ -12280,10 +12383,7 @@ async def test_stream_via_http_bridge_replays_durable_full_resend_when_owner_is_
         )
     ]
 
-    keepalive = proxy_service.parse_sse_data_json(chunks[0])
-    assert keepalive is not None
-    assert keepalive["status"] == "waiting_for_account_capacity"
-    assert chunks[-1] == 'data: {"type":"response.completed"}\n\n'
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
     assert get_or_create.await_count == 3
     first_call = get_or_create.await_args_list[0]
     second_call = get_or_create.await_args_list[1]

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -514,6 +514,19 @@ def test_http_bridge_account_capacity_wait_ignores_local_no_accounts_retry_hint(
     assert http_bridge_streaming_module._http_bridge_account_capacity_wait_seconds(exc) is None
 
 
+@pytest.mark.parametrize("error_code", ["account_stream_cap", "account_response_create_cap"])
+def test_http_bridge_account_capacity_wait_treats_local_account_caps_as_recoverable(error_code: str) -> None:
+    exc = ProxyResponseError(
+        429,
+        openai_error(
+            error_code,
+            "Account stream capacity is exhausted; per-account limit is 8.",
+        ),
+    )
+
+    assert http_bridge_streaming_module._http_bridge_account_capacity_wait_seconds(exc) == 30.0
+
+
 def _make_api_key(
     *,
     key_id: str,

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -6869,6 +6869,8 @@ async def _run_owner_forward_recovery_with_session(
     *,
     recovery_session: "proxy_service._HTTPBridgeSession",
     input_items: list[dict[str, Any]],
+    capacity_error_on_first_submit: bool = False,
+    submit_attempts: list[str] | None = None,
 ) -> list[Any]:
     """Drive owner-forward failure -> local recovery; return prepared inputs.
 
@@ -6933,6 +6935,16 @@ async def _run_owner_forward_recovery_with_session(
         queue_limit: int,
     ) -> None:
         del _session, text_data, queue_limit
+        if submit_attempts is not None:
+            submit_attempts.append(request_state.request_id)
+        if capacity_error_on_first_submit and submit_attempts is not None and len(submit_attempts) == 1:
+            raise ProxyResponseError(
+                429,
+                proxy_service.openai_error(
+                    "account_response_create_cap",
+                    "Account response-create concurrency limit reached",
+                ),
+            )
         event_queue = request_state.event_queue
         assert event_queue is not None
         await event_queue.put('data: {"type":"response.completed"}\n\n')
@@ -6958,6 +6970,7 @@ async def _run_owner_forward_recovery_with_session(
         ),
     )
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(http_bridge_streaming_module, "_http_bridge_account_capacity_wait_seconds", lambda _exc: 0.001)
     monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
     monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value="acc-1"))
     monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
@@ -6983,7 +6996,14 @@ async def _run_owner_forward_recovery_with_session(
             queue_limit=4,
         )
     ]
-    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    if capacity_error_on_first_submit:
+        keepalive = proxy_service.parse_sse_data_json(chunks[0])
+        assert keepalive is not None
+        assert keepalive["type"] == "codex.keepalive"
+        assert keepalive["status"] == "waiting_for_account_capacity"
+        assert chunks[-1] == 'data: {"type":"response.completed"}\n\n'
+    else:
+        assert chunks == ['data: {"type":"response.completed"}\n\n']
     assert get_or_create.await_count == 2
     return prepared_inputs
 
@@ -7007,6 +7027,23 @@ def _make_owner_forward_recovery_session() -> "proxy_service._HTTPBridgeSession"
         last_used_at=2.0,
         idle_ttl_seconds=120.0,
     )
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_owner_forward_recovery_waits_for_local_submit_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    submit_attempts: list[str] = []
+
+    await _run_owner_forward_recovery_with_session(
+        monkeypatch,
+        recovery_session=_make_owner_forward_recovery_session(),
+        input_items=[{"role": "user", "content": "continue"}],
+        capacity_error_on_first_submit=True,
+        submit_attempts=submit_attempts,
+    )
+
+    assert submit_attempts == ["req-2", "req-2"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -323,6 +323,39 @@ async def test_chat_startup_probe_timeout_consumes_abandoned_first_task_exceptio
     assert captured == []
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("surface", ["responses", "chat"])
+async def test_startup_probe_waits_for_late_capacity_marker(surface: str) -> None:
+    capacity_wait_event = asyncio.Event()
+
+    async def delayed_capacity_error() -> AsyncIterator[str]:
+        await asyncio.sleep(0.02)
+        capacity_wait_event.set()
+        await asyncio.sleep(0.01)
+        raise proxy_module.ProxyResponseError(
+            429,
+            openai_error("account_stream_cap", "Account stream concurrency limit reached"),
+        )
+        yield ""
+
+    if surface == "responses":
+        _stream, startup_error = await proxy_api._probe_stream_startup_error(
+            delayed_capacity_error(),
+            timeout_seconds=0.001,
+            capacity_wait_event=capacity_wait_event,
+        )
+    else:
+        _stream, startup_error = await proxy_api._probe_chat_stream_startup_error(
+            delayed_capacity_error(),
+            timeout_seconds=0.001,
+            max_startup_events=1,
+            capacity_wait_event=capacity_wait_event,
+        )
+
+    assert isinstance(startup_error, proxy_module.ProxyResponseError)
+    assert startup_error.status_code == 429
+
+
 def test_relative_availability_settings_default_when_stored_values_are_null():
     settings = cast(Any, SimpleNamespace(relative_availability_power=None, relative_availability_top_k=None))
 
@@ -1518,11 +1551,18 @@ async def test_external_stream_startup_waits_for_single_account_response_create_
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("request_budget_seconds", "recovery_sleep_seconds", "minimum_selection_calls"),
+    [(0.2, 0.1, 2), (0.1, 0.3, 1)],
+)
 async def test_responses_route_preserves_selection_cap_429_after_startup_wait(
     monkeypatch: pytest.MonkeyPatch,
+    request_budget_seconds: float,
+    recovery_sleep_seconds: float,
+    minimum_selection_calls: int,
 ) -> None:
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
-    settings.http_responses_stream_request_budget_seconds = 0.2
+    settings.http_responses_stream_request_budget_seconds = request_budget_seconds
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     selection_calls = 0
 
@@ -1548,7 +1588,7 @@ async def test_responses_route_preserves_selection_cap_429_after_startup_wait(
     monkeypatch.setattr(
         streaming_retry_module,
         "_account_selection_recovery_sleep_seconds",
-        lambda _selection: 0.1,
+        lambda _selection: recovery_sleep_seconds,
     )
     monkeypatch.setattr(streaming_retry_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.1)
     monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
@@ -1569,7 +1609,10 @@ async def test_responses_route_preserves_selection_cap_429_after_startup_wait(
     assert response.status_code == 429
     body = bytes(response.body).decode()
     assert "account_stream_cap" in body
-    assert selection_calls > 1
+    if recovery_sleep_seconds > request_budget_seconds:
+        assert selection_calls == minimum_selection_calls
+    else:
+        assert selection_calls >= minimum_selection_calls
 
 
 @pytest.mark.asyncio
@@ -8802,6 +8845,7 @@ async def test_stream_with_retry_post_refresh_response_create_cap_waits_with_str
     async def fake_stream_once(*_args: object, **_kwargs: object):
         nonlocal stream_once_calls
         stream_once_calls += 1
+        settlement = cast(proxy_service._StreamSettlement, _kwargs["settlement"])
         assert release_account_lease.await_count == 0
         if stream_once_calls == 1:
             raise proxy_module.ProxyResponseError(
@@ -8809,6 +8853,7 @@ async def test_stream_with_retry_post_refresh_response_create_cap_waits_with_str
                 proxy_module.openai_error("invalid_api_key", "expired", error_type="invalid_request_error"),
             )
         if stream_once_calls == 2:
+            settlement.record_success = False
             raise proxy_module.ProxyResponseError(
                 429,
                 proxy_module.openai_error(
@@ -8817,6 +8862,7 @@ async def test_stream_with_retry_post_refresh_response_create_cap_waits_with_str
                     error_type="rate_limit_error",
                 ),
             )
+        assert settlement.record_success is True
         yield 'data: {"type":"response.completed","response":{"id":"resp_post_refresh_capacity_ok"}}\n\n'
 
     monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
@@ -9156,7 +9202,7 @@ async def test_stream_with_retry_capacity_wait_keeps_original_request_deadline(m
 
     assert sleeps == [1.0]
     assert keepalive["retry_after_seconds"] == 1
-    assert deadlines == [1001.0, 1001.0]
+    assert deadlines == [1001.0]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1418,7 +1418,7 @@ async def test_external_stream_startup_waits_for_single_account_response_create_
     capacity_recovers: bool,
 ) -> None:
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
-    settings.http_responses_stream_request_budget_seconds = 1.0 if capacity_recovers else 0.01
+    settings.http_responses_stream_request_budget_seconds = 1.0 if capacity_recovers else 0.2
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_route_response_create_capacity")
     stream_once_calls = 0
@@ -1452,9 +1452,9 @@ async def test_external_stream_startup_waits_for_single_account_response_create_
     monkeypatch.setattr(
         streaming_retry_module,
         "_account_selection_recovery_sleep_seconds",
-        lambda _selection: 0.001,
+        lambda _selection: 0.1,
     )
-    monkeypatch.setattr(streaming_retry_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.001)
+    monkeypatch.setattr(streaming_retry_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.1)
     monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=account.id))
     monkeypatch.setattr(
         service,

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -8859,10 +8859,14 @@ async def test_stream_with_retry_prefers_other_account_before_response_create_ca
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("propagate_http_errors", [False, True])
+@pytest.mark.parametrize(
+    ("propagate_http_errors", "budget_expires"),
+    [(False, False), (True, False), (False, True)],
+)
 async def test_stream_with_retry_waits_after_response_create_cap_has_no_alternate(
     monkeypatch,
     propagate_http_errors: bool,
+    budget_expires: bool,
 ):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
@@ -8920,6 +8924,11 @@ async def test_stream_with_retry_waits_after_response_create_cap_has_no_alternat
     )
     monkeypatch.setattr(service, "_stream_once", fake_stream_once)
     monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
+    monkeypatch.setattr(
+        proxy_service,
+        "_remaining_budget_seconds",
+        lambda _deadline: 0.0 if budget_expires and stream_once_calls >= 1 and len(selection_exclusions) >= 2 else 10.0,
+    )
 
     payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
     chunks = [
@@ -8940,6 +8949,13 @@ async def test_stream_with_retry_waits_after_response_create_cap_has_no_alternat
 
     completed = json.loads(chunks[-1].split("data: ", 1)[1])
 
+    if budget_expires:
+        assert completed["type"] == "response.failed"
+        assert completed["response"]["error"]["code"] == "account_response_create_cap"
+        assert selection_exclusions == [set(), {account.id}]
+        assert stream_once_calls == 1
+        release_account_lease.assert_awaited_once_with(stream_lease)
+        return
     if propagate_http_errors:
         assert len(chunks) == 1
     else:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -445,6 +445,34 @@ async def test_startup_probe_waits_for_capacity_marker_after_legacy_grace() -> N
 
 
 @pytest.mark.asyncio
+async def test_startup_probe_without_capacity_signal_returns_within_discovery_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capacity_wait_event = asyncio.Event()
+    capacity_ready_event = asyncio.Event()
+    release_first_event = asyncio.Event()
+
+    async def slow_stream_without_capacity_signal() -> AsyncIterator[str]:
+        await release_first_event.wait()
+        yield 'data: {"type":"response.output_text.delta","delta":"hello"}\n\n'
+
+    monkeypatch.setattr(proxy_api, "_CAPACITY_STARTUP_SIGNAL_DISCOVERY_SECONDS", 0.01)
+    stream, startup_error = await asyncio.wait_for(
+        proxy_api._probe_stream_startup_error(
+            slow_stream_without_capacity_signal(),
+            timeout_seconds=0.001,
+            capacity_wait_event=capacity_wait_event,
+            capacity_ready_event=capacity_ready_event,
+        ),
+        timeout=0.1,
+    )
+
+    assert startup_error is None
+    release_first_event.set()
+    assert "response.output_text.delta" in await asyncio.wait_for(anext(stream), timeout=0.1)
+
+
+@pytest.mark.asyncio
 async def test_startup_probe_waits_for_remote_owner_headers_without_local_marker() -> None:
     capacity_wait_event = asyncio.Event()
     capacity_ready_event = asyncio.Event()
@@ -1746,14 +1774,15 @@ async def test_external_stream_startup_waits_for_single_account_response_create_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("request_budget_seconds", "recovery_sleep_seconds", "minimum_selection_calls"),
-    [(0.2, 0.1, 2), (0.1, 0.3, 1)],
+    ("request_budget_seconds", "recovery_sleep_seconds", "minimum_selection_calls", "selection_delay_seconds"),
+    [(0.2, 0.1, 2, 0.0), (0.1, 0.3, 1, 0.12)],
 )
 async def test_responses_route_preserves_selection_cap_429_after_startup_wait(
     monkeypatch: pytest.MonkeyPatch,
     request_budget_seconds: float,
     recovery_sleep_seconds: float,
     minimum_selection_calls: int,
+    selection_delay_seconds: float,
 ) -> None:
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     settings.http_responses_stream_request_budget_seconds = request_budget_seconds
@@ -1769,6 +1798,10 @@ async def test_responses_route_preserves_selection_cap_429_after_startup_wait(
     async def select_account(*_args: object, **_kwargs: object) -> AccountSelection:
         nonlocal selection_calls
         selection_calls += 1
+        if selection_delay_seconds:
+            # PostgreSQL-backed selection can legitimately exceed the old
+            # 50 ms marker grace before it discovers the local cap.
+            await asyncio.sleep(selection_delay_seconds)
         return AccountSelection(
             account=None,
             error_message="Account stream concurrency limit reached",

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -415,6 +415,139 @@ async def test_chat_startup_probe_consumes_repeated_capacity_markers_before_firs
     assert await anext(stream) == 'data: {"type":"response.created"}\n\n'
 
 
+@pytest.mark.asyncio
+async def test_startup_probe_waits_for_capacity_marker_after_legacy_grace() -> None:
+    capacity_wait_event = asyncio.Event()
+    capacity_ready_event = asyncio.Event()
+
+    async def delayed_capacity_error() -> AsyncIterator[str]:
+        await asyncio.sleep(0.04)
+        capacity_wait_event.set()
+        await asyncio.sleep(0.001)
+        raise proxy_module.ProxyResponseError(
+            429,
+            openai_error("account_stream_cap", "Account stream concurrency limit reached"),
+        )
+        yield ""
+
+    _stream, startup_error = await asyncio.wait_for(
+        proxy_api._probe_stream_startup_error(
+            delayed_capacity_error(),
+            timeout_seconds=0.001,
+            capacity_wait_event=capacity_wait_event,
+            capacity_ready_event=capacity_ready_event,
+        ),
+        timeout=0.2,
+    )
+
+    assert isinstance(startup_error, proxy_module.ProxyResponseError)
+    assert startup_error.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_startup_probe_waits_for_remote_owner_headers_without_local_marker() -> None:
+    capacity_wait_event = asyncio.Event()
+    capacity_ready_event = asyncio.Event()
+
+    async def delayed_owner_error() -> AsyncIterator[str]:
+        await asyncio.sleep(0.04)
+        raise proxy_module.ProxyResponseError(
+            429,
+            openai_error("account_response_create_cap", "Remote owner capacity is exhausted"),
+        )
+        yield ""
+
+    _stream, startup_error = await asyncio.wait_for(
+        proxy_api._probe_stream_startup_error(
+            delayed_owner_error(),
+            timeout_seconds=0.001,
+            capacity_wait_event=capacity_wait_event,
+            capacity_ready_event=capacity_ready_event,
+        ),
+        timeout=0.2,
+    )
+
+    assert isinstance(startup_error, proxy_module.ProxyResponseError)
+    assert startup_error.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_startup_probe_ready_supersedes_recovered_capacity_marker() -> None:
+    capacity_wait_event = asyncio.Event()
+    recovery_ready_wait_started = asyncio.Event()
+
+    class ObservedReadyEvent(asyncio.Event):
+        def __init__(self) -> None:
+            super().__init__()
+            self.wait_calls = 0
+
+        async def wait(self) -> bool:
+            self.wait_calls += 1
+            if self.wait_calls >= 2:
+                recovery_ready_wait_started.set()
+            return await super().wait()
+
+    capacity_ready_event = ObservedReadyEvent()
+    release_first_event = asyncio.Event()
+
+    async def recovered_slow_stream() -> AsyncIterator[str]:
+        await asyncio.sleep(0.01)
+        capacity_wait_event.set()
+        await release_first_event.wait()
+        yield 'data: {"type":"response.output_text.delta","delta":"hello"}\n\n'
+
+    probe_task = asyncio.create_task(
+        proxy_api._probe_stream_startup_error(
+            recovered_slow_stream(),
+            timeout_seconds=0.001,
+            capacity_wait_event=capacity_wait_event,
+            capacity_ready_event=capacity_ready_event,
+        )
+    )
+    try:
+        await asyncio.wait_for(recovery_ready_wait_started.wait(), timeout=0.1)
+        capacity_wait_event.clear()
+        capacity_ready_event.set()
+        stream, startup_error = await asyncio.wait_for(probe_task, timeout=0.1)
+    finally:
+        release_first_event.set()
+
+    assert startup_error is None
+    assert capacity_wait_event.is_set() is False
+    first = await asyncio.wait_for(anext(stream), timeout=0.1)
+    assert "response.output_text.delta" in first
+
+
+@pytest.mark.asyncio
+async def test_startup_probe_cancellation_stops_extended_first_item_task() -> None:
+    capacity_wait_event = asyncio.Event()
+    capacity_ready_event = asyncio.Event()
+    source_finalized = asyncio.Event()
+
+    async def blocked_capacity_stream() -> AsyncIterator[str]:
+        capacity_wait_event.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            source_finalized.set()
+        yield ""
+
+    probe_task = asyncio.create_task(
+        proxy_api._probe_stream_startup_error(
+            blocked_capacity_stream(),
+            timeout_seconds=0.001,
+            capacity_wait_event=capacity_wait_event,
+            capacity_ready_event=capacity_ready_event,
+        )
+    )
+    await asyncio.sleep(0.01)
+    probe_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await probe_task
+    await asyncio.wait_for(source_finalized.wait(), timeout=0.1)
+
+
 def test_relative_availability_settings_default_when_stored_values_are_null():
     settings = cast(Any, SimpleNamespace(relative_availability_power=None, relative_availability_top_k=None))
 
@@ -1434,6 +1567,7 @@ async def test_stream_responses_returns_before_first_upstream_event(monkeypatch)
 
     async def stream_responses(*args, **kwargs):
         del args, kwargs
+        proxy_support._signal_propagated_capacity_startup_ready()
         await asyncio.sleep(10.0)
         yield 'data: {"type":"response.completed","response":{"id":"resp_slow","status":"completed"}}\n\n'
 
@@ -1469,6 +1603,7 @@ async def test_stream_responses_streams_post_startup_proxy_error_as_sse(monkeypa
 
     async def stream_responses(*args, **kwargs):
         del args, kwargs
+        proxy_support._signal_propagated_capacity_startup_ready()
         await asyncio.sleep(0.1)
         raise proxy_module.ProxyResponseError(
             429,
@@ -9130,6 +9265,126 @@ async def test_stream_with_retry_post_refresh_response_create_cap_waits_with_str
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("propagate_http_errors", [False, True])
+async def test_stream_with_retry_post_refresh_capacity_exhaustion_preserves_original_cap(
+    monkeypatch,
+    propagate_http_errors: bool,
+):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_post_refresh_capacity_exhausts")
+    stream_lease = AccountLease(
+        lease_id="lease_post_refresh_capacity_exhausts",
+        account_id=account.id,
+        kind="stream",
+        acquired_at=time.monotonic(),
+    )
+    release_account_lease = AsyncMock()
+    select_account = AsyncMock(return_value=AccountSelection(account=account, error_message=None, lease=stream_lease))
+    budget_exhausted = False
+    stream_once_calls = 0
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=account.id))
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account, account]))
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
+    monkeypatch.setattr(
+        streaming_retry_module,
+        "_account_selection_recovery_sleep_seconds",
+        lambda _selection: 1.0,
+    )
+    monkeypatch.setattr(
+        proxy_service,
+        "_remaining_budget_seconds",
+        lambda _deadline: 0.0 if budget_exhausted else 1.0,
+    )
+
+    async def exhaust_capacity_wait(**kwargs: object):
+        nonlocal budget_exhausted
+        budget_exhausted = True
+        if kwargs["emit_keepalives"]:
+            yield 'data: {"type":"codex.keepalive","status":"waiting_for_account_capacity"}\n\n'
+
+    async def fake_stream_once(*_args: object, **kwargs: object):
+        nonlocal stream_once_calls
+        stream_once_calls += 1
+        settlement = cast(proxy_service._StreamSettlement, kwargs["settlement"])
+        assert release_account_lease.await_count == 0
+        if stream_once_calls == 1:
+            raise proxy_module.ProxyResponseError(
+                401,
+                proxy_module.openai_error("invalid_api_key", "expired", error_type="invalid_request_error"),
+            )
+        settlement.record_success = False
+        raise proxy_module.ProxyResponseError(
+            429,
+            proxy_module.openai_error(
+                "account_response_create_cap",
+                "Account response-create concurrency limit reached",
+                error_type="rate_limit_error",
+            ),
+        )
+        yield ""
+
+    monkeypatch.setattr(streaming_retry_module, "_iter_account_capacity_recovery_wait", exhaust_capacity_wait)
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [],
+            "stream": True,
+            "previous_response_id": "resp_post_refresh_capacity_exhausts",
+        }
+    )
+    chunks: list[str] = []
+
+    if propagate_http_errors:
+        with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+            async for chunk in service._stream_with_retry(
+                payload,
+                {"session_id": "sid-post-refresh-capacity-exhausts"},
+                codex_session_affinity=False,
+                propagate_http_errors=True,
+                openai_cache_affinity=False,
+                api_key=None,
+                api_key_reservation=None,
+                suppress_text_done_events=False,
+                request_transport="http",
+                upstream_stream_transport_override="http",
+            ):
+                chunks.append(chunk)
+        error = proxy_service._parse_openai_error(exc_info.value.payload)
+        assert error is not None
+        assert error.code == "account_response_create_cap"
+    else:
+        chunks = [
+            chunk
+            async for chunk in service._stream_with_retry(
+                payload,
+                {"session_id": "sid-post-refresh-capacity-exhausts"},
+                codex_session_affinity=False,
+                propagate_http_errors=False,
+                openai_cache_affinity=False,
+                api_key=None,
+                api_key_reservation=None,
+                suppress_text_done_events=False,
+                request_transport="http",
+                upstream_stream_transport_override="http",
+            )
+        ]
+        failed = json.loads(chunks[-1].split("data: ", 1)[1])
+        assert failed["response"]["error"]["code"] == "account_response_create_cap"
+
+    assert select_account.await_count == 1
+    assert stream_once_calls == 2
+    release_account_lease.assert_awaited_once_with(stream_lease)
+
+
+@pytest.mark.asyncio
 async def test_stream_with_retry_surfaces_response_create_cap_when_wait_retries_exhaust(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()
@@ -12415,6 +12670,89 @@ async def test_select_websocket_connect_account_sends_capacity_keepalive_and_ret
     assert sent_payload["type"] == "codex.keepalive"
     assert sent_payload["status"] == "waiting_for_account_capacity"
     assert sent_payload["request_id"] == "ws_req_capacity_wait"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("preferred_account_id", "require_preferred_account", "file_required", "defer_no_account_error"),
+    [
+        (None, False, False, False),
+        (None, False, False, True),
+        ("acc_ws_owner", True, False, False),
+        ("acc_ws_file", True, True, False),
+    ],
+)
+async def test_select_websocket_capacity_wait_budget_preserves_original_cap(
+    monkeypatch,
+    preferred_account_id: str | None,
+    require_preferred_account: bool,
+    file_required: bool,
+    defer_no_account_error: bool,
+):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_capacity_budget",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_ws_owner" if require_preferred_account and not file_required else None,
+        preferred_account_id=preferred_account_id,
+        file_required_preferred_account=file_required,
+    )
+    selection = AccountSelection(
+        account=None,
+        error_message="Account stream capacity is exhausted; per-account limit is 8.",
+        error_code="account_stream_cap",
+    )
+    select_account = AsyncMock(return_value=selection)
+
+    async def fake_sleep_for_account_selection_recovery(*_args: object, **kwargs: object) -> bool:
+        heartbeat = cast(Callable[[float], Any] | None, kwargs.get("heartbeat"))
+        assert heartbeat is not None
+        await heartbeat(0.0)
+        return True
+
+    remaining_budget = iter([0.001, 0.0])
+    websocket_send = AsyncMock()
+    monkeypatch.setattr(service, "_select_account_with_budget", select_account)
+    monkeypatch.setattr(
+        websocket_mixin_module,
+        "_sleep_for_account_selection_recovery",
+        fake_sleep_for_account_selection_recovery,
+    )
+    monkeypatch.setattr(
+        proxy_service,
+        "_remaining_budget_seconds",
+        lambda _deadline: next(remaining_budget, 0.0),
+    )
+
+    result = await service._select_websocket_connect_account(
+        time.monotonic() + 1.0,
+        sticky_key=None,
+        sticky_kind=None,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        model="gpt-5.1",
+        request_state=request_state,
+        api_key=None,
+        client_send_lock=anyio.Lock(),
+        websocket=cast(WebSocket, SimpleNamespace(send_text=websocket_send)),
+        reallocate_sticky=False,
+        sticky_max_age_seconds=None,
+        exclude_account_ids=set(),
+        preferred_account_id=preferred_account_id,
+        require_preferred_account=require_preferred_account,
+        defer_no_account_error=defer_no_account_error,
+    )
+
+    assert result is None
+    assert select_account.await_count == 1
+    sent_payloads = [json.loads(call.args[0]) for call in websocket_send.await_args_list]
+    assert sent_payloads[0]["status"] == "waiting_for_account_capacity"
+    assert sent_payloads[-1]["status"] == 429
+    assert sent_payloads[-1]["error"]["code"] == "account_stream_cap"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -8807,6 +8807,79 @@ async def test_stream_with_retry_waits_after_response_create_cap_has_no_alternat
 
 
 @pytest.mark.asyncio
+async def test_stream_with_retry_reprobes_alternate_after_capacity_wait(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    saturated = _make_account("acc_response_create_reprobe_saturated")
+    spare = _make_account("acc_response_create_reprobe_spare")
+    selection_exclusions: list[set[str]] = []
+    stream_accounts: list[str] = []
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        streaming_retry_module,
+        "_account_selection_recovery_sleep_seconds",
+        lambda _selection: 0.001,
+    )
+    monkeypatch.setattr(streaming_retry_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.001)
+
+    async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
+        excluded = set(cast(set[str], kwargs["exclude_account_ids"]))
+        selection_exclusions.append(excluded)
+        if saturated.id not in excluded:
+            return AccountSelection(account=saturated, error_message=None)
+        if len(selection_exclusions) == 2:
+            return AccountSelection(
+                account=None, error_message="No alternate account available", error_code="no_accounts"
+            )
+        return AccountSelection(account=spare, error_message=None)
+
+    async def fake_stream_once(account: Account, *_args: object, **_kwargs: object):
+        stream_accounts.append(account.id)
+        if account.id == saturated.id:
+            raise proxy_module.ProxyResponseError(
+                429,
+                proxy_module.openai_error(
+                    "account_response_create_cap",
+                    "Account response-create concurrency limit reached",
+                    error_type="server_error",
+                ),
+            )
+        yield 'data: {"type":"response.completed","response":{"id":"resp_response_create_reprobe_ok"}}\n\n'
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh_with_budget",
+        AsyncMock(side_effect=lambda selected, **_kwargs: selected),
+    )
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-response-create-reprobe"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    assert json.loads(chunks[0].split("data: ", 1)[1])["status"] == "waiting_for_account_capacity"
+    assert json.loads(chunks[-1].split("data: ", 1)[1])["type"] == "response.completed"
+    assert selection_exclusions == [set(), {saturated.id}, set(), {saturated.id}]
+    assert stream_accounts == [saturated.id, saturated.id, spare.id]
+
+
+@pytest.mark.asyncio
 async def test_stream_with_retry_propagation_prefers_other_account_before_response_create_cap_raise(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10,7 +10,7 @@ from collections import deque
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
-from typing import Any, AsyncIterator, Iterator, Protocol, Self, cast
+from typing import Any, AsyncIterator, Iterator, Literal, Protocol, Self, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
@@ -481,7 +481,7 @@ async def test_startup_probe_ready_supersedes_recovered_capacity_marker() -> Non
             super().__init__()
             self.wait_calls = 0
 
-        async def wait(self) -> bool:
+        async def wait(self) -> Literal[True]:
             self.wait_calls += 1
             if self.wait_calls >= 2:
                 recovery_ready_wait_started.set()

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1410,6 +1410,114 @@ async def test_stream_responses_streams_post_startup_proxy_error_as_sse(monkeypa
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("startup_surface", ["responses_route", "prime_helper"])
+@pytest.mark.parametrize("capacity_recovers", [True, False])
+async def test_external_stream_startup_waits_for_single_account_response_create_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+    startup_surface: str,
+    capacity_recovers: bool,
+) -> None:
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.http_responses_stream_request_budget_seconds = 1.0 if capacity_recovers else 0.01
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_route_response_create_capacity")
+    stream_once_calls = 0
+
+    async def skip_limits(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def no_rate_limit_headers(*_args: object, **_kwargs: object) -> dict[str, str]:
+        return {}
+
+    async def fake_stream_once(*_args: object, **_kwargs: object):
+        nonlocal stream_once_calls
+        stream_once_calls += 1
+        if capacity_recovers and stream_once_calls > 1:
+            yield 'data: {"type":"response.completed","response":{"id":"resp_route_capacity_ok"}}\n\n'
+            return
+        raise proxy_module.ProxyResponseError(
+            429,
+            proxy_module.openai_error(
+                "account_response_create_cap",
+                "Account response-create concurrency limit reached",
+                error_type="rate_limit_error",
+            ),
+        )
+        yield ""
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_api, "_enforce_request_limits", skip_limits)
+    monkeypatch.setattr(proxy_api, "_rate_limit_headers_for_request", no_rate_limit_headers)
+    monkeypatch.setattr(
+        streaming_retry_module,
+        "_account_selection_recovery_sleep_seconds",
+        lambda _selection: 0.001,
+    )
+    monkeypatch.setattr(streaming_retry_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.001)
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=account.id))
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+
+    request = Request({"type": "http", "method": "POST", "path": "/v1/responses", "headers": []})
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "test",
+            "input": "hello",
+            "previous_response_id": "resp_route_capacity_existing",
+            "stream": True,
+        }
+    )
+
+    if startup_surface == "responses_route":
+        response = await proxy_api._stream_responses(
+            request,
+            payload,
+            context=cast(proxy_api.ProxyContext, SimpleNamespace(service=service)),
+            api_key=None,
+        )
+        if capacity_recovers:
+            assert isinstance(response, StreamingResponse)
+            chunks = [chunk async for chunk in response.body_iterator]
+            body = "".join(chunk.decode() if isinstance(chunk, bytes) else str(chunk) for chunk in chunks)
+        else:
+            assert not isinstance(response, StreamingResponse)
+            body = bytes(response.body).decode()
+            assert response.status_code == 429
+    else:
+        upstream = service.stream_responses(
+            payload,
+            request.headers,
+            propagate_http_errors=True,
+        )
+        primed, error_response = await proxy_api._prime_upstream_stream(request, upstream, {})
+        if capacity_recovers:
+            assert error_response is None
+            assert primed is not None
+            body = "".join([chunk async for chunk in primed])
+        else:
+            assert primed is None
+            assert error_response is not None
+            assert error_response.status_code == 429
+            body = bytes(error_response.body).decode()
+
+    assert stream_once_calls > 1
+    assert "waiting_for_account_capacity" not in body
+    if capacity_recovers:
+        assert "response.completed" in body
+        assert "resp_route_capacity_ok" in body
+    else:
+        error_payload = json.loads(body)
+        assert error_payload["error"]["code"] == "account_response_create_cap"
+
+
+@pytest.mark.asyncio
 async def test_opportunistic_admission_uses_api_key_enforced_model():
     api_key = ApiKeyData(
         id="key_opportunistic_enforced_model",
@@ -8529,6 +8637,13 @@ async def test_stream_with_retry_waits_when_response_create_cap_fires_after_sele
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     account = _make_account("acc_response_create_capacity_recovers")
+    stream_lease = AccountLease(
+        lease_id="lease_response_create_capacity_recovers",
+        account_id=account.id,
+        kind="stream",
+        acquired_at=time.monotonic(),
+    )
+    release_account_lease = AsyncMock()
     monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=account.id))
     selections: list[dict[str, object]] = []
     stream_once_calls = 0
@@ -8544,11 +8659,12 @@ async def test_stream_with_retry_waits_when_response_create_cap_fires_after_sele
 
     async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
         selections.append(kwargs)
-        return AccountSelection(account=account, error_message=None)
+        return AccountSelection(account=account, error_message=None, lease=stream_lease)
 
     async def fake_stream_once(*_args: object, **_kwargs: object):
         nonlocal stream_once_calls
         stream_once_calls += 1
+        assert release_account_lease.await_count == 0
         if stream_once_calls == 1:
             raise proxy_module.ProxyResponseError(
                 429,
@@ -8563,6 +8679,7 @@ async def test_stream_with_retry_waits_when_response_create_cap_fires_after_sele
     monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
     monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
     monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
 
     payload = ResponsesRequest.model_validate(
         {
@@ -8598,6 +8715,92 @@ async def test_stream_with_retry_waits_when_response_create_cap_fires_after_sele
     assert completed["type"] == "response.completed"
     assert len(selections) == 1
     assert stream_once_calls == 2
+    release_account_lease.assert_awaited_once_with(stream_lease)
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_post_refresh_response_create_cap_waits_with_stream_lease(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_post_refresh_capacity_recovers")
+    stream_lease = AccountLease(
+        lease_id="lease_post_refresh_capacity_recovers",
+        account_id=account.id,
+        kind="stream",
+        acquired_at=time.monotonic(),
+    )
+    release_account_lease = AsyncMock()
+    stream_once_calls = 0
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=account.id))
+    monkeypatch.setattr(
+        streaming_retry_module,
+        "_account_selection_recovery_sleep_seconds",
+        lambda _selection: 0.001,
+    )
+    monkeypatch.setattr(streaming_retry_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.001)
+    select_account = AsyncMock(return_value=AccountSelection(account=account, error_message=None, lease=stream_lease))
+    ensure_fresh = AsyncMock(side_effect=[account, account])
+
+    async def fake_stream_once(*_args: object, **_kwargs: object):
+        nonlocal stream_once_calls
+        stream_once_calls += 1
+        assert release_account_lease.await_count == 0
+        if stream_once_calls == 1:
+            raise proxy_module.ProxyResponseError(
+                401,
+                proxy_module.openai_error("invalid_api_key", "expired", error_type="invalid_request_error"),
+            )
+        if stream_once_calls == 2:
+            raise proxy_module.ProxyResponseError(
+                429,
+                proxy_module.openai_error(
+                    "account_response_create_cap",
+                    "Account response-create concurrency limit reached",
+                    error_type="rate_limit_error",
+                ),
+            )
+        yield 'data: {"type":"response.completed","response":{"id":"resp_post_refresh_capacity_ok"}}\n\n'
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", ensure_fresh)
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [],
+            "stream": True,
+            "previous_response_id": "resp_post_refresh_existing",
+        }
+    )
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-post-refresh-capacity-recovers"},
+            codex_session_affinity=False,
+            propagate_http_errors=True,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    assert [json.loads(chunk.split("data: ", 1)[1])["type"] for chunk in chunks] == ["response.completed"]
+    assert stream_once_calls == 3
+    assert select_account.await_count == 1
+    assert ensure_fresh.await_count == 2
+    assert ensure_fresh.await_args_list[1].kwargs["force"] is True
+    release_account_lease.assert_awaited_once_with(stream_lease)
 
 
 @pytest.mark.asyncio
@@ -8686,6 +8889,7 @@ async def test_stream_with_retry_raises_response_create_cap_when_propagation_exh
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_response_create_capacity_propagates")
+    stream_once_calls = 0
     monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=account.id))
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
@@ -8710,6 +8914,8 @@ async def test_stream_with_retry_raises_response_create_cap_when_propagation_exh
     monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
 
     async def fake_stream_once(*_args: object, **_kwargs: object):
+        nonlocal stream_once_calls
+        stream_once_calls += 1
         raise proxy_module.ProxyResponseError(
             429,
             proxy_module.openai_error(
@@ -8732,26 +8938,27 @@ async def test_stream_with_retry_raises_response_create_cap_when_propagation_exh
         }
     )
 
+    chunks: list[str] = []
     with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
-        _ = [
-            chunk
-            async for chunk in service._stream_with_retry(
-                payload,
-                {"session_id": "sid-response-create-capacity-propagates"},
-                codex_session_affinity=False,
-                propagate_http_errors=True,
-                openai_cache_affinity=False,
-                api_key=None,
-                api_key_reservation=None,
-                suppress_text_done_events=False,
-                request_transport="http",
-                upstream_stream_transport_override="http",
-            )
-        ]
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-response-create-capacity-propagates"},
+            codex_session_affinity=False,
+            propagate_http_errors=True,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        ):
+            chunks.append(chunk)
 
     error = proxy_service._parse_openai_error(exc_info.value.payload)
     assert error is not None
     assert error.code == "account_response_create_cap"
+    assert stream_once_calls > 1
+    assert chunks == []
 
 
 @pytest.mark.asyncio
@@ -11802,7 +12009,22 @@ async def test_select_websocket_connect_account_stream_cap_is_local_overload(mon
 
 
 @pytest.mark.asyncio
-async def test_select_websocket_connect_account_sends_capacity_keepalive_and_retries(monkeypatch):
+@pytest.mark.parametrize(
+    ("error_code", "error_message"),
+    [
+        ("no_accounts", "Rate limit exceeded. Try again in 120s"),
+        ("account_stream_cap", "Account stream capacity is exhausted; per-account limit is 8."),
+        (
+            "account_response_create_cap",
+            "Account response-create concurrency limit reached; per-account limit is 4.",
+        ),
+    ],
+)
+async def test_select_websocket_connect_account_sends_capacity_keepalive_and_retries(
+    monkeypatch,
+    error_code: str,
+    error_message: str,
+):
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     request_state = proxy_service._WebSocketRequestState(
         request_id="ws_req_capacity_wait",
@@ -11817,8 +12039,8 @@ async def test_select_websocket_connect_account_sends_capacity_keepalive_and_ret
         side_effect=[
             AccountSelection(
                 account=None,
-                error_message="Rate limit exceeded. Try again in 120s",
-                error_code="no_accounts",
+                error_message=error_message,
+                error_code=error_code,
             ),
             AccountSelection(account=selected_account, error_message=None),
         ]

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -356,6 +356,34 @@ async def test_startup_probe_waits_for_late_capacity_marker(surface: str) -> Non
     assert startup_error.status_code == 429
 
 
+@pytest.mark.asyncio
+async def test_chat_startup_probe_consumes_capacity_marker_after_startup_event() -> None:
+    capacity_wait_event = asyncio.Event()
+    release_next_event = asyncio.Event()
+
+    async def delayed_chat_stream() -> AsyncIterator[str]:
+        capacity_wait_event.set()
+        yield 'data: {"type":"response.created"}\n\n'
+        await release_next_event.wait()
+        yield 'data: {"type":"response.output_text.delta","delta":"hello"}\n\n'
+
+    probe_task = asyncio.create_task(
+        proxy_api._probe_chat_stream_startup_error(
+            delayed_chat_stream(),
+            timeout_seconds=0.001,
+            capacity_wait_event=capacity_wait_event,
+        )
+    )
+    try:
+        stream, startup_error = await asyncio.wait_for(probe_task, timeout=0.1)
+    finally:
+        release_next_event.set()
+
+    assert startup_error is None
+    assert capacity_wait_event.is_set() is False
+    assert await anext(stream) == 'data: {"type":"response.created"}\n\n'
+
+
 def test_relative_availability_settings_default_when_stored_values_are_null():
     settings = cast(Any, SimpleNamespace(relative_availability_power=None, relative_availability_top_k=None))
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -8732,6 +8732,13 @@ async def test_stream_with_retry_waits_after_response_create_cap_has_no_alternat
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_response_create_single")
+    stream_lease = AccountLease(
+        lease_id="lease_response_create_single",
+        account_id=account.id,
+        kind="stream",
+        acquired_at=time.monotonic(),
+    )
+    release_account_lease = AsyncMock()
     selection_exclusions: list[set[str]] = []
     stream_once_calls = 0
 
@@ -8753,11 +8760,12 @@ async def test_stream_with_retry_waits_after_response_create_cap_has_no_alternat
                 error_message="No alternate account available",
                 error_code="no_accounts",
             )
-        return AccountSelection(account=account, error_message=None)
+        return AccountSelection(account=account, error_message=None, lease=stream_lease)
 
     async def fake_stream_once(*_args: object, **_kwargs: object):
         nonlocal stream_once_calls
         stream_once_calls += 1
+        assert release_account_lease.await_count == 0
         if stream_once_calls == 1:
             raise proxy_module.ProxyResponseError(
                 429,
@@ -8776,6 +8784,7 @@ async def test_stream_with_retry_waits_after_response_create_cap_has_no_alternat
         AsyncMock(side_effect=lambda selected, **_kwargs: selected),
     )
     monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
 
     payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
     chunks = [
@@ -8802,8 +8811,9 @@ async def test_stream_with_retry_waits_after_response_create_cap_has_no_alternat
         keepalive = json.loads(chunks[0].split("data: ", 1)[1])
         assert keepalive["status"] == "waiting_for_account_capacity"
     assert completed["type"] == "response.completed"
-    assert selection_exclusions == [set(), {account.id}, set()]
+    assert selection_exclusions == [set(), {account.id}]
     assert stream_once_calls == 2
+    release_account_lease.assert_awaited_once_with(stream_lease)
 
 
 @pytest.mark.asyncio
@@ -8875,7 +8885,7 @@ async def test_stream_with_retry_reprobes_alternate_after_capacity_wait(monkeypa
 
     assert json.loads(chunks[0].split("data: ", 1)[1])["status"] == "waiting_for_account_capacity"
     assert json.loads(chunks[-1].split("data: ", 1)[1])["type"] == "response.completed"
-    assert selection_exclusions == [set(), {saturated.id}, set(), {saturated.id}]
+    assert selection_exclusions == [set(), {saturated.id}, {saturated.id}]
     assert stream_accounts == [saturated.id, saturated.id, spare.id]
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -384,6 +384,37 @@ async def test_chat_startup_probe_consumes_capacity_marker_after_startup_event()
     assert await anext(stream) == 'data: {"type":"response.created"}\n\n'
 
 
+@pytest.mark.asyncio
+async def test_chat_startup_probe_consumes_repeated_capacity_markers_before_first_event() -> None:
+    capacity_wait_event = asyncio.Event()
+    release_next_event = asyncio.Event()
+
+    async def delayed_chat_stream() -> AsyncIterator[str]:
+        await asyncio.sleep(0.01)
+        capacity_wait_event.set()
+        await asyncio.sleep(0.01)
+        capacity_wait_event.set()
+        yield 'data: {"type":"response.created"}\n\n'
+        await release_next_event.wait()
+        yield 'data: {"type":"response.output_text.delta","delta":"hello"}\n\n'
+
+    probe_task = asyncio.create_task(
+        proxy_api._probe_chat_stream_startup_error(
+            delayed_chat_stream(),
+            timeout_seconds=0.001,
+            capacity_wait_event=capacity_wait_event,
+        )
+    )
+    try:
+        stream, startup_error = await asyncio.wait_for(probe_task, timeout=0.1)
+    finally:
+        release_next_event.set()
+
+    assert startup_error is None
+    assert capacity_wait_event.is_set() is False
+    assert await anext(stream) == 'data: {"type":"response.created"}\n\n'
+
+
 def test_relative_availability_settings_default_when_stored_values_are_null():
     settings = cast(Any, SimpleNamespace(relative_availability_power=None, relative_availability_top_k=None))
 
@@ -8690,6 +8721,89 @@ async def test_stream_with_retry_prefers_other_account_before_response_create_ca
     assert completed["type"] == "response.completed"
     assert stream_accounts == [saturated.id, spare.id]
     assert selections[1]["exclude_account_ids"] == {saturated.id}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("propagate_http_errors", [False, True])
+async def test_stream_with_retry_waits_after_response_create_cap_has_no_alternate(
+    monkeypatch,
+    propagate_http_errors: bool,
+):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_response_create_single")
+    selection_exclusions: list[set[str]] = []
+    stream_once_calls = 0
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        streaming_retry_module,
+        "_account_selection_recovery_sleep_seconds",
+        lambda _selection: 0.001,
+    )
+    monkeypatch.setattr(streaming_retry_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.001)
+
+    async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
+        excluded = set(cast(set[str], kwargs["exclude_account_ids"]))
+        selection_exclusions.append(excluded)
+        if account.id in excluded:
+            return AccountSelection(
+                account=None,
+                error_message="No alternate account available",
+                error_code="no_accounts",
+            )
+        return AccountSelection(account=account, error_message=None)
+
+    async def fake_stream_once(*_args: object, **_kwargs: object):
+        nonlocal stream_once_calls
+        stream_once_calls += 1
+        if stream_once_calls == 1:
+            raise proxy_module.ProxyResponseError(
+                429,
+                proxy_module.openai_error(
+                    "account_response_create_cap",
+                    "Account response-create concurrency limit reached",
+                    error_type="server_error",
+                ),
+            )
+        yield 'data: {"type":"response.completed","response":{"id":"resp_response_create_single_ok"}}\n\n'
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh_with_budget",
+        AsyncMock(side_effect=lambda selected, **_kwargs: selected),
+    )
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-response-create-single"},
+            codex_session_affinity=False,
+            propagate_http_errors=propagate_http_errors,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    completed = json.loads(chunks[-1].split("data: ", 1)[1])
+
+    if propagate_http_errors:
+        assert len(chunks) == 1
+    else:
+        keepalive = json.loads(chunks[0].split("data: ", 1)[1])
+        assert keepalive["status"] == "waiting_for_account_capacity"
+    assert completed["type"] == "response.completed"
+    assert selection_exclusions == [set(), {account.id}, set()]
+    assert stream_once_calls == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1773,6 +1773,106 @@ async def test_external_stream_startup_waits_for_single_account_response_create_
 
 
 @pytest.mark.asyncio
+async def test_responses_route_preserves_immediate_error_after_capacity_recovers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.http_responses_stream_request_budget_seconds = 1.0
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_route_capacity_then_bad_request")
+    stream_once_calls = 0
+    capacity_ready = asyncio.Event()
+    release_startup_error = asyncio.Event()
+
+    async def skip_limits(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def no_rate_limit_headers(*_args: object, **_kwargs: object) -> dict[str, str]:
+        return {}
+
+    async def fake_stream_once(*_args: object, **_kwargs: object):
+        nonlocal stream_once_calls
+        stream_once_calls += 1
+        if stream_once_calls == 1:
+            raise proxy_module.ProxyResponseError(
+                429,
+                proxy_module.openai_error(
+                    "account_response_create_cap",
+                    "Account response-create concurrency limit reached",
+                    error_type="rate_limit_error",
+                ),
+            )
+        proxy_support._signal_propagated_capacity_startup_ready()
+        capacity_ready.set()
+        await release_startup_error.wait()
+        raise proxy_module.ProxyResponseError(
+            400,
+            proxy_module.openai_error(
+                "invalid_request_error",
+                "Recovered account rejected the request",
+                error_type="invalid_request_error",
+            ),
+        )
+        yield ""
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_api, "_enforce_request_limits", skip_limits)
+    monkeypatch.setattr(proxy_api, "_rate_limit_headers_for_request", no_rate_limit_headers)
+    monkeypatch.setattr(
+        streaming_retry_module,
+        "_account_selection_recovery_sleep_seconds",
+        lambda _selection: 0.1,
+    )
+    monkeypatch.setattr(streaming_retry_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.1)
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=account.id))
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+
+    request = Request({"type": "http", "method": "POST", "path": "/v1/responses", "headers": []})
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "test",
+            "input": "hello",
+            "previous_response_id": "resp_route_capacity_then_bad_request",
+            "stream": True,
+        }
+    )
+
+    response_task = asyncio.create_task(
+        proxy_api._stream_responses(
+            request,
+            payload,
+            context=cast(proxy_api.ProxyContext, SimpleNamespace(service=service)),
+            api_key=None,
+        )
+    )
+    await asyncio.wait_for(capacity_ready.wait(), timeout=0.2)
+
+    async def release_error_on_next_startup_tick() -> None:
+        await asyncio.sleep(0.02)
+        release_startup_error.set()
+
+    release_task = asyncio.create_task(release_error_on_next_startup_tick())
+    try:
+        response = await asyncio.wait_for(response_task, timeout=0.2)
+    finally:
+        await release_task
+
+    assert not isinstance(response, StreamingResponse)
+    assert response.status_code == 400
+    error_payload = json.loads(bytes(response.body).decode())
+    assert error_payload["error"]["code"] == "invalid_request_error"
+    assert stream_once_calls == 2
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("request_budget_seconds", "recovery_sleep_seconds", "minimum_selection_calls", "selection_delay_seconds"),
     [(0.2, 0.1, 2, 0.0), (0.1, 0.3, 1, 0.12)],

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1518,6 +1518,61 @@ async def test_external_stream_startup_waits_for_single_account_response_create_
 
 
 @pytest.mark.asyncio
+async def test_responses_route_preserves_selection_cap_429_after_startup_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    settings.http_responses_stream_request_budget_seconds = 0.2
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    selection_calls = 0
+
+    async def skip_limits(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def no_rate_limit_headers(*_args: object, **_kwargs: object) -> dict[str, str]:
+        return {}
+
+    async def select_account(*_args: object, **_kwargs: object) -> AccountSelection:
+        nonlocal selection_calls
+        selection_calls += 1
+        return AccountSelection(
+            account=None,
+            error_message="Account stream concurrency limit reached",
+            error_code="account_stream_cap",
+        )
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_api, "_enforce_request_limits", skip_limits)
+    monkeypatch.setattr(proxy_api, "_rate_limit_headers_for_request", no_rate_limit_headers)
+    monkeypatch.setattr(
+        streaming_retry_module,
+        "_account_selection_recovery_sleep_seconds",
+        lambda _selection: 0.1,
+    )
+    monkeypatch.setattr(streaming_retry_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.1)
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+
+    request = Request({"type": "http", "method": "POST", "path": "/v1/responses", "headers": []})
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "test", "input": "hello", "stream": True}
+    )
+
+    response = await proxy_api._stream_responses(
+        request,
+        payload,
+        context=cast(proxy_api.ProxyContext, SimpleNamespace(service=service)),
+        api_key=None,
+    )
+
+    assert not isinstance(response, StreamingResponse)
+    assert response.status_code == 429
+    body = bytes(response.body).decode()
+    assert "account_stream_cap" in body
+    assert selection_calls > 1
+
+
+@pytest.mark.asyncio
 async def test_opportunistic_admission_uses_api_key_enforced_model():
     api_key = ApiKeyData(
         id="key_opportunistic_enforced_model",

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -116,6 +116,17 @@ def test_account_selection_recovery_sleep_ignores_uncoded_local_rate_limit_retry
     assert _account_selection_recovery_sleep_seconds(selection) is None
 
 
+@pytest.mark.parametrize("error_code", ["account_stream_cap", "account_response_create_cap"])
+def test_account_selection_recovery_sleep_treats_local_account_caps_as_recoverable(error_code: str):
+    selection = AccountSelection(
+        account=None,
+        error_message="Account stream capacity is exhausted; per-account limit is 8.",
+        error_code=error_code,
+    )
+
+    assert _account_selection_recovery_sleep_seconds(selection) == 30.0
+
+
 def test_account_selection_recovery_sleep_treats_workspace_spend_cap_as_recoverable():
     selection = AccountSelection(
         account=None,
@@ -8278,8 +8289,8 @@ async def test_stream_with_retry_keeps_sse_alive_while_account_capacity_recovers
         if len(selections) == 1:
             return AccountSelection(
                 account=None,
-                error_message="Rate limit exceeded. Try again in 120s",
-                error_code="no_accounts",
+                error_message="Account stream capacity is exhausted; per-account limit is 8.",
+                error_code="account_stream_cap",
             )
         return AccountSelection(account=account, error_message=None)
 
@@ -8318,6 +8329,429 @@ async def test_stream_with_retry_keeps_sse_alive_while_account_capacity_recovers
     assert keepalive["status"] == "waiting_for_account_capacity"
     assert completed["type"] == "response.completed"
     assert len(selections) == 2
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_preserves_stream_cap_error_type_when_wait_exhausts(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        streaming_retry_module,
+        "_account_selection_recovery_sleep_seconds",
+        lambda _selection: 0.001,
+    )
+    monkeypatch.setattr(streaming_retry_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.001)
+    remaining_budget_values = iter([1.0, 0.001, 1.0, 0.0])
+
+    def fake_remaining_budget(_deadline: float) -> float:
+        return next(remaining_budget_values, 0.0)
+
+    monkeypatch.setattr(proxy_service, "_remaining_budget_seconds", fake_remaining_budget)
+
+    async def select_account(_deadline: float, **_kwargs: object) -> AccountSelection:
+        return AccountSelection(
+            account=None,
+            error_message="Account stream capacity is exhausted; try again in 30s.",
+            error_code="account_stream_cap",
+        )
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-stream-capacity-exhausts"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    keepalives = [json.loads(chunk.split("data: ", 1)[1]) for chunk in chunks[:-1]]
+    failed = json.loads(chunks[-1].split("data: ", 1)[1])
+
+    assert keepalives
+    assert {event["status"] for event in keepalives} == {"waiting_for_account_capacity"}
+    assert failed["type"] == "response.failed"
+    assert failed["response"]["error"]["code"] == "account_stream_cap"
+    assert failed["response"]["error"]["type"] == "rate_limit_error"
+    assert request_logs.calls[0]["error_code"] == "account_stream_cap"
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_prefers_other_account_before_response_create_cap_wait(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    saturated = _make_account("acc_response_create_saturated")
+    spare = _make_account("acc_response_create_spare")
+    selections: list[dict[str, object]] = []
+    stream_accounts: list[str] = []
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        streaming_retry_module,
+        "_account_selection_recovery_sleep_seconds",
+        lambda _selection: 30.0,
+    )
+
+    async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
+        selections.append(kwargs)
+        if len(selections) == 1:
+            return AccountSelection(account=saturated, error_message=None)
+        return AccountSelection(account=spare, error_message=None)
+
+    async def ensure_fresh(account: Account, *_args: object, **_kwargs: object) -> Account:
+        return account
+
+    async def fake_stream_once(account: Account, *_args: object, **_kwargs: object):
+        stream_accounts.append(account.id)
+        if account.id == saturated.id:
+            raise proxy_module.ProxyResponseError(
+                429,
+                proxy_module.openai_error(
+                    "account_response_create_cap",
+                    "Account response-create concurrency limit reached",
+                    error_type="server_error",
+                ),
+            )
+        yield 'data: {"type":"response.completed","response":{"id":"resp_response_create_spare_ok"}}\n\n'
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", ensure_fresh)
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-response-create-capacity-spare"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    completed = json.loads(chunks[-1].split("data: ", 1)[1])
+
+    assert completed["type"] == "response.completed"
+    assert stream_accounts == [saturated.id, spare.id]
+    assert selections[1]["exclude_account_ids"] == {saturated.id}
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_propagation_prefers_other_account_before_response_create_cap_raise(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    saturated = _make_account("acc_response_create_propagate_saturated")
+    spare = _make_account("acc_response_create_propagate_spare")
+    selections: list[dict[str, object]] = []
+    stream_accounts: list[str] = []
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        streaming_retry_module,
+        "_account_selection_recovery_sleep_seconds",
+        lambda _selection: 30.0,
+    )
+
+    async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
+        selections.append(kwargs)
+        if len(selections) == 1:
+            return AccountSelection(account=saturated, error_message=None)
+        return AccountSelection(account=spare, error_message=None)
+
+    async def fake_stream_once(account: Account, *_args: object, **_kwargs: object):
+        stream_accounts.append(account.id)
+        if account.id == saturated.id:
+            raise proxy_module.ProxyResponseError(
+                429,
+                proxy_module.openai_error(
+                    "account_response_create_cap",
+                    "Account response-create concurrency limit reached",
+                    error_type="server_error",
+                ),
+            )
+        yield 'data: {"type":"response.completed","response":{"id":"resp_response_create_propagate_spare_ok"}}\n\n'
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=lambda account, *_a, **_k: account))
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-response-create-propagate-spare"},
+            codex_session_affinity=False,
+            propagate_http_errors=True,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    completed = json.loads(chunks[-1].split("data: ", 1)[1])
+
+    assert completed["type"] == "response.completed"
+    assert stream_accounts == [saturated.id, spare.id]
+    assert selections[1]["exclude_account_ids"] == {saturated.id}
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_waits_when_response_create_cap_fires_after_selection(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_response_create_capacity_recovers")
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=account.id))
+    selections: list[dict[str, object]] = []
+    stream_once_calls = 0
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        streaming_retry_module,
+        "_account_selection_recovery_sleep_seconds",
+        lambda _selection: 0.001,
+    )
+    monkeypatch.setattr(streaming_retry_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.001)
+
+    async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
+        selections.append(kwargs)
+        return AccountSelection(account=account, error_message=None)
+
+    async def fake_stream_once(*_args: object, **_kwargs: object):
+        nonlocal stream_once_calls
+        stream_once_calls += 1
+        if stream_once_calls == 1:
+            raise proxy_module.ProxyResponseError(
+                429,
+                proxy_module.openai_error(
+                    "account_response_create_cap",
+                    "Account response-create concurrency limit reached",
+                    error_type="server_error",
+                ),
+            )
+        yield 'data: {"type":"response.completed","response":{"id":"resp_response_create_capacity_ok"}}\n\n'
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [],
+            "stream": True,
+            "previous_response_id": "resp_existing",
+        }
+    )
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-response-create-capacity-recovers"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    keepalive = json.loads(chunks[0].split("data: ", 1)[1])
+    completed = json.loads(chunks[-1].split("data: ", 1)[1])
+
+    assert keepalive["type"] == "codex.keepalive"
+    assert keepalive["status"] == "waiting_for_account_capacity"
+    assert completed["type"] == "response.completed"
+    assert len(selections) == 1
+    assert stream_once_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_surfaces_response_create_cap_when_wait_retries_exhaust(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_response_create_capacity_exhausts")
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=account.id))
+    stream_once_calls = 0
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        streaming_retry_module,
+        "_account_selection_recovery_sleep_seconds",
+        lambda _selection: 0.001,
+    )
+    monkeypatch.setattr(streaming_retry_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.001)
+    remaining_budget_values = iter([1.0, 1.0, 1.0, 0.001, 1.0, 0.001, 1.0, 0.0])
+
+    def fake_remaining_budget(_deadline: float) -> float:
+        return next(remaining_budget_values, 0.0)
+
+    monkeypatch.setattr(proxy_service, "_remaining_budget_seconds", fake_remaining_budget)
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+
+    async def fake_stream_once(*_args: object, **_kwargs: object):
+        nonlocal stream_once_calls
+        stream_once_calls += 1
+        raise proxy_module.ProxyResponseError(
+            429,
+            proxy_module.openai_error(
+                "account_response_create_cap",
+                "Account response-create concurrency limit reached",
+                error_type="server_error",
+            ),
+        )
+        yield ""
+
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [],
+            "stream": True,
+            "previous_response_id": "resp_existing",
+        }
+    )
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-response-create-capacity-exhausts"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    keepalives = [json.loads(chunk.split("data: ", 1)[1]) for chunk in chunks[:-1]]
+    failed = json.loads(chunks[-1].split("data: ", 1)[1])
+
+    assert keepalives
+    assert {event["status"] for event in keepalives} == {"waiting_for_account_capacity"}
+    assert failed["type"] == "response.failed"
+    assert failed["response"]["error"]["code"] == "account_response_create_cap"
+    assert stream_once_calls > 1
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_raises_response_create_cap_when_propagation_exhausts(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_response_create_capacity_propagates")
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value=account.id))
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        streaming_retry_module,
+        "_account_selection_recovery_sleep_seconds",
+        lambda _selection: 0.001,
+    )
+    monkeypatch.setattr(streaming_retry_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.001)
+    remaining_budget_values = iter([1.0, 1.0, 1.0, 0.001, 1.0, 0.001, 1.0, 0.0])
+
+    def fake_remaining_budget(_deadline: float) -> float:
+        return next(remaining_budget_values, 0.0)
+
+    monkeypatch.setattr(proxy_service, "_remaining_budget_seconds", fake_remaining_budget)
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+
+    async def fake_stream_once(*_args: object, **_kwargs: object):
+        raise proxy_module.ProxyResponseError(
+            429,
+            proxy_module.openai_error(
+                "account_response_create_cap",
+                "Account response-create concurrency limit reached",
+                error_type="server_error",
+            ),
+        )
+        yield ""
+
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [],
+            "stream": True,
+            "previous_response_id": "resp_existing",
+        }
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        _ = [
+            chunk
+            async for chunk in service._stream_with_retry(
+                payload,
+                {"session_id": "sid-response-create-capacity-propagates"},
+                codex_session_affinity=False,
+                propagate_http_errors=True,
+                openai_cache_affinity=False,
+                api_key=None,
+                api_key_reservation=None,
+                suppress_text_done_events=False,
+                request_transport="http",
+                upstream_stream_transport_override="http",
+            )
+        ]
+
+    error = proxy_service._parse_openai_error(exc_info.value.payload)
+    assert error is not None
+    assert error.code == "account_response_create_cap"
 
 
 @pytest.mark.asyncio
@@ -11336,8 +11770,10 @@ async def test_select_websocket_connect_account_stream_cap_is_local_overload(mon
 
     monkeypatch.setattr(service, "_select_account_with_budget", select_account)
 
+    # Use an exhausted deadline so this test covers the terminal local-overload
+    # response instead of the capacity-wait recovery path.
     result = await service._select_websocket_connect_account(
-        10_000.0,
+        0.0,
         sticky_key=None,
         sticky_kind=None,
         prefer_earlier_reset=False,
@@ -11523,8 +11959,10 @@ async def test_select_websocket_file_pin_stream_cap_does_not_fall_back(monkeypat
 
     monkeypatch.setattr(service, "_select_account_with_budget", select_account)
 
+    # Use an exhausted deadline so this test covers the terminal local-overload
+    # response instead of the capacity-wait recovery path.
     result = await service._select_websocket_connect_account(
-        10_000.0,
+        0.0,
         sticky_key=None,
         sticky_kind=None,
         prefer_earlier_reset=False,


### PR DESCRIPTION
## Summary
- treat local per-account stream/response-create cap selection failures as recoverable capacity pressure
- let streaming requests emit bounded account-capacity keepalives and retry selection instead of returning an immediate local 429
- keep permanent no-account/local balancer rate-limit failures non-waitable

## Tests
- `uv run pytest tests/unit/test_proxy_utils.py -k 'account_selection_recovery_sleep or stream_with_retry_keeps_sse_alive_while_account_capacity_recovers' -q`
- `uv run pytest tests/unit/test_proxy_http_bridge.py -k 'account_capacity_wait' -q`
- `openspec validate wait-on-local-account-caps --strict`
- `uv run ruff check app/modules/proxy/_service/support.py app/modules/proxy/_service/streaming/retry.py app/modules/proxy/_service/http_bridge/streaming.py tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py`
- `uv run ruff format --check app/modules/proxy/_service/support.py app/modules/proxy/_service/streaming/retry.py app/modules/proxy/_service/http_bridge/streaming.py tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py`
- `uv run ty check app/modules/proxy/_service/support.py app/modules/proxy/_service/streaming/retry.py app/modules/proxy/_service/http_bridge/streaming.py tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py`
- `git diff --check`