### PR TITLE
fix(proxy): preserve Codex Responses Lite tools for GPT-5.6 models

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -77,6 +77,7 @@ from app.core.utils.sse import format_sse_event, parse_sse_data_json
 
 CODEX_INSTALLATION_ID_HEADER = "x-codex-installation-id"
 CODEX_RESPONSES_LITE_HEADER = "x-openai-internal-codex-responses-lite"
+CODEX_RESPONSES_LITE_WS_METADATA_KEY = "ws_request_header_x_openai_internal_codex_responses_lite"
 
 IGNORE_INBOUND_HEADERS = {
     "authorization",
@@ -449,11 +450,47 @@ class CodexControlResponse:
     headers: Mapping[str, str]
 
 
-def _should_drop_inbound_header(name: str) -> bool:
+def _truthy_header_value(value: str | None) -> bool:
+    return isinstance(value, str) and value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def responses_lite_requested_from_headers(headers: Mapping[str, str]) -> bool:
+    return any(
+        key.lower() == CODEX_RESPONSES_LITE_HEADER and _truthy_header_value(value)
+        for key, value in headers.items()
+    )
+
+
+def responses_lite_requested_from_native_headers(headers: Mapping[str, str]) -> bool:
+    return _is_native_codex_request(headers) and responses_lite_requested_from_headers(headers)
+
+
+def responses_lite_requested_from_payload(payload: Mapping[str, JsonValue]) -> bool:
+    raw_metadata = payload.get("client_metadata")
+    if not is_json_mapping(raw_metadata):
+        return False
+    value = raw_metadata.get(CODEX_RESPONSES_LITE_WS_METADATA_KEY)
+    return isinstance(value, str) and _truthy_header_value(value)
+
+
+def responses_lite_requested(payload: Mapping[str, JsonValue], headers: Mapping[str, str]) -> bool:
+    return responses_lite_requested_from_headers(headers) or responses_lite_requested_from_payload(payload)
+
+
+def apply_responses_lite_client_metadata(payload: dict[str, JsonValue]) -> None:
+    raw_metadata = payload.get("client_metadata")
+    client_metadata = dict(raw_metadata) if is_json_mapping(raw_metadata) else {}
+    client_metadata[CODEX_RESPONSES_LITE_WS_METADATA_KEY] = "true"
+    payload["client_metadata"] = client_metadata
+
+
+def _should_drop_inbound_header(name: str, *, preserve_responses_lite: bool = False) -> bool:
     normalized = name.lower()
     if normalized in IGNORE_INBOUND_HEADERS:
         return True
-    if normalized in INTERNAL_OPENAI_UPSTREAM_HEADERS:
+    if normalized in INTERNAL_OPENAI_UPSTREAM_HEADERS and not (
+        preserve_responses_lite and normalized == CODEX_RESPONSES_LITE_HEADER
+    ):
         return True
     if normalized.startswith("x-forwarded-"):
         return True
@@ -462,8 +499,17 @@ def _should_drop_inbound_header(name: str) -> bool:
     return False
 
 
-def filter_inbound_headers(headers: Mapping[str, str]) -> dict[str, str]:
-    return {key: value for key, value in headers.items() if not _should_drop_inbound_header(key)}
+def filter_inbound_headers(
+    headers: Mapping[str, str],
+    *,
+    preserve_responses_lite: bool = False,
+) -> dict[str, str]:
+    preserve_responses_lite = preserve_responses_lite and _is_native_codex_request(headers)
+    return {
+        key: value
+        for key, value in headers.items()
+        if not _should_drop_inbound_header(key, preserve_responses_lite=preserve_responses_lite)
+    }
 
 
 def apply_codex_installation_metadata(payload: dict[str, JsonValue], codex_installation_id: str | None) -> None:
@@ -586,6 +632,8 @@ def _build_upstream_headers(
     access_token: str,
     account_id: str | None,
     accept: str = "text/event-stream",
+    *,
+    responses_lite: bool = False,
 ) -> dict[str, str]:
     headers = filter_inbound_headers(inbound)
     native = _is_native_codex_request(headers)
@@ -599,6 +647,8 @@ def _build_upstream_headers(
     headers["Authorization"] = f"Bearer {access_token}"
     headers["Accept"] = accept
     headers["Content-Type"] = "application/json"
+    if responses_lite:
+        headers[CODEX_RESPONSES_LITE_HEADER] = "true"
     if account_id:
         if native:
             headers["chatgpt-account-id"] = account_id
@@ -2421,6 +2471,9 @@ async def _stream_responses_with_session(
     retryable_same_contract: bool | None = None
     client_session = session
     payload_dict = dict(payload.to_payload())
+    use_responses_lite = _is_native_codex_request(headers) and responses_lite_requested(payload_dict, headers)
+    if use_responses_lite:
+        apply_responses_lite_client_metadata(payload_dict)
     apply_codex_installation_metadata(payload_dict, codex_installation_id)
     if settings.image_inline_fetch_enabled:
         payload_dict = await _inline_input_image_urls(
@@ -2447,7 +2500,12 @@ async def _stream_responses_with_session(
         upstream_headers = _build_upstream_websocket_headers(headers, access_token, account_id)
         method = "GET"
     else:
-        upstream_headers = _build_upstream_headers(headers, access_token, account_id)
+        upstream_headers = _build_upstream_headers(
+            headers,
+            access_token,
+            account_id,
+            responses_lite=use_responses_lite,
+        )
         method = "POST"
     remaining_request_timeout = _remaining_total_timeout(
         request_total_timeout,
@@ -2695,7 +2753,12 @@ async def _stream_responses_with_session(
         )
 
         transport = "http"
-        upstream_headers = _build_upstream_headers(headers, access_token, account_id)
+        upstream_headers = _build_upstream_headers(
+            headers,
+            access_token,
+            account_id,
+            responses_lite=use_responses_lite,
+        )
         method = "POST"
         remaining_request_timeout = _remaining_total_timeout(
             request_total_timeout,
@@ -3165,16 +3228,21 @@ class _CompactCommandTransport:
         if self.route is None and self.route_trace is not None:
             self.route_trace.record_direct()
         upstream_account_id = self.chatgpt_account_id or self.account_id
+        payload_dict = self.payload.to_payload()
+        use_responses_lite = _is_native_codex_request(self.headers) and responses_lite_requested(
+            payload_dict,
+            self.headers,
+        )
         upstream_headers = _build_upstream_headers(
             self.headers,
             self.access_token,
             upstream_account_id,
             accept="application/json",
+            responses_lite=use_responses_lite,
         )
         pre_request_started_at = time.monotonic()
         compact_timeout_seconds = _effective_compact_total_timeout(settings.upstream_compact_timeout_seconds)
         effective_connect_timeout = _effective_compact_connect_timeout(settings.upstream_connect_timeout_seconds)
-        payload_dict = self.payload.to_payload()
         if settings.image_inline_fetch_enabled:
             payload_dict = await _inline_input_image_urls(
                 payload_dict,

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -284,6 +284,8 @@ def _normalize_responses_input_instructions(data: JsonValue) -> JsonValue:
     input_value = data.get("input")
     if not is_json_list(input_value):
         return data
+    if _is_responses_lite_input(input_value):
+        return data
 
     instruction_parts: list[str] = []
     input_items: list[JsonValue] = []
@@ -293,8 +295,7 @@ def _normalize_responses_input_instructions(data: JsonValue) -> JsonValue:
         if item_mapping is None:
             input_items.append(item)
             continue
-        role = item_mapping.get("role")
-        if role not in ("system", "developer"):
+        if not _is_responses_instruction_message_item(item_mapping):
             input_items.append(item)
             continue
         instruction_text, preserved_content = _split_responses_instruction_item_content(item_mapping)
@@ -319,6 +320,29 @@ def _normalize_responses_input_instructions(data: JsonValue) -> JsonValue:
     normalized["instructions"] = merged_instructions
     normalized["input"] = input_items
     return normalized
+
+
+def _is_responses_lite_input(input_value: list[JsonValue]) -> bool:
+    # Responses Lite requests carry their tool bundle as an input item with
+    # type=additional_tools and deliberately place base instructions as a
+    # developer message in input (with empty top-level instructions). That
+    # shape is exactly what the lite upstream expects, so the instruction
+    # lift must leave the whole request untouched.
+    return any(
+        (mapping := _json_mapping_or_none(item)) is not None and mapping.get("type") == "additional_tools"
+        for item in input_value
+    )
+
+
+def _is_responses_instruction_message_item(item: Mapping[str, JsonValue]) -> bool:
+    role = item.get("role")
+    if role not in ("system", "developer"):
+        return False
+    item_type = item.get("type")
+    # Responses Lite encodes tool declarations as developer input items with
+    # type=additional_tools. Only role messages should be folded into the
+    # top-level instructions field.
+    return item_type is None or item_type == "message"
 
 
 def _merge_responses_instructions(existing: str, extra_parts: list[str]) -> str:

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -427,7 +427,7 @@ class _CompactMixin:
     ) -> CompactResponsePayload:
         proxy = cast(_CompactServiceProtocol, self)
         _maybe_log_proxy_request_payload("compact", payload, headers)
-        filtered = filter_inbound_headers(headers)
+        filtered = filter_inbound_headers(headers, preserve_responses_lite=True)
         useragent, useragent_group = _request_log_useragent_fields(headers)
         request_kind = _request_kind_from_headers(headers)
         request_id = get_request_id() or ensure_request_id(None)

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -286,7 +286,7 @@ class _HTTPBridgeStreamingMixin:
     ) -> AsyncIterator[str]:
         _maybe_log_proxy_request_payload("stream_http", payload, headers)
         proxy_api_authorization = _header_value_case_insensitive(headers, "authorization")
-        filtered = filter_inbound_headers(headers)
+        filtered = filter_inbound_headers(headers, preserve_responses_lite=True)
         return self._stream_http_bridge_or_retry(
             payload,
             filtered,

--- a/app/modules/proxy/_service/response_create.py
+++ b/app/modules/proxy/_service/response_create.py
@@ -15,9 +15,11 @@ from uuid import uuid4
 
 from app.core.clients.proxy import (
     CODEX_INSTALLATION_ID_HEADER,
+    CODEX_RESPONSES_LITE_WS_METADATA_KEY,
     ImageFetchSession,
     ProxyResponseError,
     _inline_content_images,
+    responses_lite_requested_from_native_headers,
 )
 from app.core.config.settings import DEFAULT_HOME_DIR, get_settings
 from app.core.errors import OpenAIErrorEnvelope, openai_error
@@ -763,6 +765,9 @@ def _response_create_client_metadata(
                 client_metadata[key] = value
 
     normalized_headers = {key.lower(): value for key, value in headers.items()}
+    if responses_lite_requested_from_native_headers(headers):
+        client_metadata.setdefault(CODEX_RESPONSES_LITE_WS_METADATA_KEY, "true")
+
     turn_metadata = normalized_headers.get("x-codex-turn-metadata")
     if isinstance(turn_metadata, str) and turn_metadata.strip():
         client_metadata.setdefault("x-codex-turn-metadata", turn_metadata)

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -449,7 +449,7 @@ class _StreamingMixin(_StreamingRetryMixin):
     ) -> AsyncIterator[str]:
         proxy = cast(_StreamingServiceProtocol, self)
         _maybe_log_proxy_request_payload("stream", payload, headers)
-        filtered = _facade().filter_inbound_headers(headers)
+        filtered = _facade().filter_inbound_headers(headers, preserve_responses_lite=True)
         return proxy._stream_with_retry(
             payload,
             filtered,

--- a/openspec/changes/preserve-native-responses-lite-passthrough/design.md
+++ b/openspec/changes/preserve-native-responses-lite-passthrough/design.md
@@ -1,0 +1,29 @@
+# Design
+
+## Wire Contract (from openai/codex)
+
+`codex-rs/core/src/client.rs` builds lite requests as follows:
+
+- `input` starts with `ResponseItem::AdditionalTools { role: "developer", tools }` (serialized as `type: "additional_tools"`), followed by a developer `message` carrying the base instructions; top-level `instructions` is the empty string and top-level `tools` is omitted.
+- HTTP transport sets the `x-openai-internal-codex-responses-lite` header per request.
+- Websocket transport puts `ws_request_header_x_openai_internal_codex_responses_lite: "true"` into the `response.create` payload's `client_metadata` (the connection is shared across models, so the signal is per request, not per handshake).
+
+codex-lb mirrors this exactly so the upstream backend sees the same request a direct Codex client would send.
+
+## Normalization
+
+`_normalize_responses_input_instructions()` exists for OpenAI-compatible clients that place system/developer messages in `input` (change #950). A lite-shaped request is by construction already in the shape the lite upstream expects, so the lift returns the payload untouched when any input item has `type == "additional_tools"`. This also keeps the developer instructions message in `input` instead of relocating it to `instructions`, preserving byte-level fidelity (prompt caching, upstream lite parsing).
+
+As defense in depth, the lift also skips any individual `system`/`developer` item whose `type` is present and not `"message"`, so unknown future typed items are never folded into instruction text.
+
+## Header Policy
+
+`filter_inbound_headers(..., preserve_responses_lite=True)` keeps the Lite header only when the request's identity headers mark it as a native Codex client (`_is_native_codex_request`). The upstream header builders then re-emit `x-openai-internal-codex-responses-lite: true` when the request-level lite decision is set, on the initial attempt, the HTTP retry attempt, and the compact transport. Non-native requests keep the blanket strip from `strip-internal-responses-lite-header`: upstream rejects the header on non-lite models, and only native Codex clients gate it on model metadata.
+
+The websocket upstream path never sends the header; the client-metadata key is preserved (inbound websocket) or synthesized from the inbound header (HTTP-to-websocket and bridge paths) instead, matching the Codex client's own transport split.
+
+## Failure Modes
+
+- Native lite request, HTTP upstream: without the header the upstream serves a plain text response and the model reports missing tools; with it the grammar `exec` tool is active.
+- Native lite request, websocket upstream: the client-metadata key is the only signal; dropping `client_metadata` would silently disable tools, so `apply_codex_installation_metadata` preserves unrelated keys.
+- Non-native client sending the header (accidentally or copied config): header still stripped, protecting against upstream `This model is not supported when using X-OpenAI-Internal-Codex-Responses-Lite` rejections.

--- a/openspec/changes/preserve-native-responses-lite-passthrough/proposal.md
+++ b/openspec/changes/preserve-native-responses-lite-passthrough/proposal.md
@@ -1,0 +1,26 @@
+# Change: Preserve native Responses Lite passthrough
+
+## Why
+
+GPT-5.6 models with `use_responses_lite: true` (for example `gpt-5.6-sol`, `tool_mode: code_mode_only`) do not send tools in the top-level `tools` field. Codex ≥ 0.144.0 instead prepends an input item `{"type": "additional_tools", "role": "developer", "tools": [...]}` and marks the request with the internal `x-openai-internal-codex-responses-lite` header (HTTP) or the `ws_request_header_x_openai_internal_codex_responses_lite` client-metadata key (websocket).
+
+codex-lb broke this contract twice (issue #1157):
+
+1. `_normalize_responses_input_instructions()` treated every `developer`/`system` input item as instruction text. The `additional_tools` item has no `content`, so it was silently dropped and the upstream model received no shell/filesystem tools ("I can't inspect the repository because no shell/filesystem tool is available in this session.").
+2. The `strip-internal-responses-lite-header` change removes the Lite header from all upstream requests, so even an intact tool bundle would not be processed in lite mode upstream.
+
+## What Changes
+
+- Skip the instruction lift entirely for lite-shaped requests (array `input` containing an `additional_tools` item) so the upstream payload matches what Codex constructed, including the developer instructions message, `custom_tool_call`, and `custom_tool_call_output` items.
+- Detect a native Codex lite request from a truthy inbound header or the websocket client-metadata key, and reconstruct the upstream signal per transport: header for HTTP responses/compact (initial and retry attempts), client-metadata key for websocket `response.create`.
+- Keep stripping the header for non-native clients (OpenAI SDK fingerprints), preserving the protection that motivated `strip-internal-responses-lite-header` (upstream rejects the header on models that do not support lite; non-native clients cannot be trusted to send it only for lite-capable models).
+- Regression coverage at the product paths: HTTP responses route, core upstream HTTP client, and the websocket bridge.
+
+Out of scope: advertising or rewriting `use_responses_lite` / `tool_mode` model metadata (served verbatim from upstream model data), grammar validation of the lite `exec` tool bundle, and Chat Completions surfaces.
+
+## Impact
+
+- Affected specs: `responses-api-compat` (modifies "Internal Responses Lite header is not forwarded upstream"; adds "Responses Lite input payloads pass through unmodified").
+- Affected code: `app/core/openai/requests.py`, `app/core/clients/proxy.py`, `app/modules/proxy/_service/{compact,response_create,http_bridge/streaming,streaming/mixin}.py`.
+- Native Codex clients regain shell/filesystem tools on GPT-5.6 lite models; non-native client behavior is unchanged.
+- Fixes #1157.

--- a/openspec/changes/preserve-native-responses-lite-passthrough/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-native-responses-lite-passthrough/specs/responses-api-compat/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: Internal Responses Lite header is not forwarded upstream
+
+The service MUST accept inbound Responses and compact requests that include `X-OpenAI-Internal-Codex-Responses-Lite`. For requests whose identity headers do not mark them as a native Codex client, the service MUST remove that header before calling upstream Responses, compact, or websocket transports. For native Codex requests that signal Responses Lite — a truthy header value, or the `ws_request_header_x_openai_internal_codex_responses_lite` key in the request's `client_metadata` — the service MUST forward the lite signal upstream on every attempt: `x-openai-internal-codex-responses-lite: true` on upstream HTTP Responses and compact requests (including retry attempts), and `ws_request_header_x_openai_internal_codex_responses_lite: "true"` inside the `client_metadata` of upstream websocket `response.create` payloads. Header matching MUST be case-insensitive. The service MUST NOT strip unrelated OpenAI SDK telemetry headers solely because they start with `x-openai-`.
+
+#### Scenario: Non-native HTTP and compact upstream headers omit Lite
+
+- **WHEN** a non-native client (OpenAI SDK fingerprint) sends a Responses or compact request with `X-OpenAI-Internal-Codex-Responses-Lite: 1`
+- **THEN** the upstream HTTP request headers omit `x-openai-internal-codex-responses-lite`
+- **AND** unrelated headers such as `x-openai-client-version` continue through the existing fingerprint policy
+
+#### Scenario: Non-native websocket upstream headers omit Lite
+
+- **WHEN** a non-native client opens a Responses websocket with `X-OpenAI-Internal-Codex-Responses-Lite: 1`
+- **THEN** the upstream websocket connection headers omit `x-openai-internal-codex-responses-lite`
+- **AND** existing websocket beta and Codex continuity headers are preserved
+
+#### Scenario: Native Codex HTTP lite request forwards the header upstream
+
+- **WHEN** a native Codex client sends a Responses request with `X-OpenAI-Internal-Codex-Responses-Lite: true`
+- **THEN** the upstream HTTP request headers include `x-openai-internal-codex-responses-lite: true` on the initial attempt and on any HTTP retry attempt
+- **AND** the upstream payload's `client_metadata` includes `ws_request_header_x_openai_internal_codex_responses_lite: "true"` so a websocket upstream transport carries the same signal
+
+#### Scenario: Native Codex websocket lite request keeps the client-metadata key
+
+- **WHEN** a native Codex client sends a websocket `response.create` payload whose `client_metadata` contains `ws_request_header_x_openai_internal_codex_responses_lite: "true"`
+- **THEN** the upstream `response.create` payload's `client_metadata` retains that key and value
+
+## ADDED Requirements
+
+### Requirement: Responses Lite input payloads pass through unmodified
+
+When an array-shaped Responses `input` contains an item with `type = "additional_tools"`, the service MUST treat the request as Responses Lite shaped and MUST forward the `input` array unmodified to upstream HTTP and websocket transports. In particular the service MUST preserve the `additional_tools` tool bundle, developer/system `message` items (which MUST NOT be lifted into top-level `instructions`), `custom_tool_call` items, and `custom_tool_call_output` items, and MUST leave top-level `instructions` unchanged. Instruction lifting for non-lite requests MUST also skip any `system`/`developer` input item whose `type` is present and is not `"message"`.
+
+#### Scenario: additional_tools bundle reaches upstream intact
+
+- **WHEN** a Codex client sends a Responses request whose `input` starts with `{"type": "additional_tools", "role": "developer", "tools": [...]}` followed by a developer instructions message and user content
+- **THEN** the upstream request's `input` equals the inbound `input`
+- **AND** top-level `instructions` keeps its inbound value
+
+#### Scenario: Lite custom tool call items survive forwarding
+
+- **WHEN** a lite-shaped Responses request includes `custom_tool_call` and `custom_tool_call_output` input items
+- **THEN** those items reach upstream unmodified over both the HTTP route and the websocket bridge
+
+#### Scenario: Non-lite instruction lifting is unaffected
+
+- **WHEN** a request without an `additional_tools` item carries system or developer messages in `input`
+- **THEN** their text is still lifted into top-level `instructions`
+- **AND** `custom_tool_call_output` items in the same `input` are preserved

--- a/openspec/changes/preserve-native-responses-lite-passthrough/tasks.md
+++ b/openspec/changes/preserve-native-responses-lite-passthrough/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] 1. Amend the OpenSpec requirement: strip the internal Lite header for non-native clients only; forward the lite signal for native Codex requests per transport.
+- [x] 2. Preserve lite-shaped `input` in Responses request normalization (skip the instruction lift when an `additional_tools` item is present; never fold non-message typed developer items).
+- [x] 3. Detect native lite requests from the inbound header or websocket client-metadata key and reconstruct the upstream signal: HTTP/compact header (initial + retry attempts) and websocket `client_metadata` key.
+- [x] 4. Add regression coverage at the product paths: normalization unit tests (additional_tools, developer message, custom_tool_call / custom_tool_call_output), core upstream HTTP client (header + payload), HTTP responses route forwarding, and websocket bridge `response.create` forwarding; keep non-native strip coverage.
+- [x] 5. Validate focused tests and OpenSpec artifacts.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -1065,3 +1065,28 @@ When an HTTP bridge request is still pending before upstream `response.completed
 - **AND** a visible HTTP bridge request is still counted in the session queue
 - **THEN** prewarm cleanup releases its response-create gate and admission state
 - **AND** the visible request queue count is preserved
+
+### Requirement: Internal Responses Lite header is not forwarded upstream
+
+The service MUST accept inbound Responses and compact requests that include
+`X-OpenAI-Internal-Codex-Responses-Lite`, but MUST remove that header before
+calling upstream Responses, compact, or websocket transports. Header matching
+MUST be case-insensitive. The service MUST NOT strip unrelated OpenAI SDK
+telemetry headers solely because they start with `x-openai-`.
+
+#### Scenario: HTTP and compact upstream headers omit Lite
+
+- **WHEN** a client sends a Responses or compact request with
+  `X-OpenAI-Internal-Codex-Responses-Lite: 1`
+- **THEN** the upstream HTTP request headers omit
+  `x-openai-internal-codex-responses-lite`
+- **AND** unrelated headers such as `x-openai-client-version` continue through
+  the existing fingerprint policy
+
+#### Scenario: Websocket upstream headers omit Lite
+
+- **WHEN** a client opens a Responses websocket with
+  `X-OpenAI-Internal-Codex-Responses-Lite: 1`
+- **THEN** the upstream websocket connection headers omit
+  `x-openai-internal-codex-responses-lite`
+- **AND** existing websocket beta and Codex continuity headers are preserved

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -1660,6 +1660,70 @@ async def test_proxy_responses_forwards_native_codex_headers(async_client, monke
 
 
 @pytest.mark.asyncio
+async def test_proxy_responses_forwards_native_responses_lite_tools(async_client, monkeypatch):
+    email = "responses-lite@example.com"
+    raw_account_id = "acc_responses_lite"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen: dict[str, object] = {}
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kw):
+        del access_token, account_id, base_url, raise_for_status
+        seen["payload"] = payload.to_payload()
+        seen["headers"] = dict(headers)
+        yield 'data: {"type":"response.completed","response":{"id":"resp_lite_1"}}\n\n'
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    additional_tools = {
+        "type": "additional_tools",
+        "role": "developer",
+        "tools": [
+            {
+                "type": "custom",
+                "name": "exec",
+                "format": {"type": "grammar", "syntax": "lark", "definition": "start: /.*/"},
+            }
+        ],
+    }
+    lite_input = [
+        additional_tools,
+        {"type": "message", "role": "developer", "content": [{"type": "input_text", "text": "dev instructions"}]},
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        {"type": "custom_tool_call", "call_id": "call_1", "name": "exec", "input": "ls"},
+        {"type": "custom_tool_call_output", "call_id": "call_1", "output": "README.md"},
+    ]
+    payload = {"model": "gpt-5.6-sol", "instructions": "", "input": lite_input, "stream": True}
+    native_headers = {
+        "user-agent": "codex_exec/0.144.0 (Mac OS 27.0.0; arm64) unknown (codex_exec; 0.144.0)",
+        "x-openai-internal-codex-responses-lite": "true",
+        "session_id": "sid-lite",
+        "x-request-id": "req_lite_123",
+    }
+
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=payload,
+        headers=native_headers,
+    ) as resp:
+        assert resp.status_code == 200
+        _ = [line async for line in resp.aiter_lines() if line]
+
+    seen_headers = cast(dict[str, str], seen["headers"])
+    lite_values = [
+        value for key, value in seen_headers.items() if key.lower() == "x-openai-internal-codex-responses-lite"
+    ]
+    assert lite_values == ["true"]
+    seen_payload = cast(dict[str, object], seen["payload"])
+    assert seen_payload["input"] == lite_input
+    assert seen_payload["instructions"] == ""
+
+
+@pytest.mark.asyncio
 async def test_v1_responses_stream_preserves_done_text_events(async_client, monkeypatch):
     email = "done-filter@example.com"
     raw_account_id = "acc_done_filter"

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -745,6 +745,98 @@ def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_insta
     assert log["output_tokens"] == 5
 
 
+def test_backend_responses_websocket_forwards_responses_lite_tools(app_instance, monkeypatch):
+    upstream_messages = [
+        _FakeUpstreamMessage(
+            "text",
+            text=json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {"id": "resp_ws_lite_1", "object": "response", "status": "completed"},
+                },
+                separators=(",", ":"),
+            ),
+        ),
+    ]
+    fake_upstream = _FakeUpstreamWebSocket(upstream_messages)
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        return None
+
+    async def fake_connect_proxy_websocket(self, headers, **kwargs):
+        return SimpleNamespace(id="acct_ws_lite", codex_installation_id=None), fake_upstream
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+
+    additional_tools = {
+        "type": "additional_tools",
+        "role": "developer",
+        "tools": [
+            {
+                "type": "custom",
+                "name": "exec",
+                "format": {"type": "grammar", "syntax": "lark", "definition": "start: /.*/"},
+            }
+        ],
+    }
+    lite_input = [
+        additional_tools,
+        {"type": "message", "role": "developer", "content": [{"type": "input_text", "text": "dev instructions"}]},
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        {"type": "custom_tool_call", "call_id": "call_1", "name": "exec", "input": "ls"},
+        {"type": "custom_tool_call_output", "call_id": "call_1", "output": "README.md"},
+    ]
+    lite_metadata_key = "ws_request_header_x_openai_internal_codex_responses_lite"
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "client_metadata": {lite_metadata_key: "true"},
+        "input": lite_input,
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers={
+                "Authorization": "Bearer external-token",
+                "chatgpt-account-id": "external-account",
+                "session_id": "thread-ws-lite",
+                "openai-beta": "responses_websockets=2026-02-06",
+            },
+        ) as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            completed = json.loads(websocket.receive_text())
+
+    assert completed["type"] == "response.completed"
+    _assert_upstream_payloads(
+        fake_upstream.sent_text,
+        [
+            {
+                "model": "gpt-5.6-sol",
+                "instructions": "",
+                "input": lite_input,
+                "tools": [],
+                "client_metadata": {lite_metadata_key: "true"},
+                "store": False,
+                "include": [],
+                "type": "response.create",
+            }
+        ],
+    )
+
+
 def test_backend_responses_websocket_keeps_same_response_distinct_tool_call_ids(
     app_instance,
     monkeypatch,

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -82,6 +82,18 @@ def test_compact_client_metadata_is_stripped():
     assert "client_metadata" not in request.to_payload()
 
 
+def test_responses_client_metadata_is_preserved():
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": [],
+        "client_metadata": {"keep": "yes"},
+    }
+    request = ResponsesRequest.model_validate(payload)
+
+    assert request.to_payload()["client_metadata"] == {"keep": "yes"}
+
+
 def test_known_unsupported_upstream_fields_are_stripped():
     payload = {
         "model": "gpt-5.1",
@@ -561,6 +573,53 @@ def test_responses_input_system_message_moves_to_instructions():
 
     assert request.instructions == "primary\nsys\ndev"
     assert request.input == [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]}]
+
+
+def test_responses_input_preserves_responses_lite_shape_untouched():
+    additional_tools = {
+        "type": "additional_tools",
+        "role": "developer",
+        "tools": [
+            {
+                "type": "custom",
+                "name": "exec",
+                "format": {"type": "grammar", "syntax": "lark", "definition": "start: /.*/"},
+            }
+        ],
+    }
+    lite_input = [
+        additional_tools,
+        {"type": "message", "role": "developer", "content": [{"type": "input_text", "text": "dev instructions"}]},
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        {"type": "custom_tool_call", "call_id": "call_1", "name": "exec", "input": "ls"},
+        {"type": "custom_tool_call_output", "call_id": "call_1", "output": "README.md"},
+    ]
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": lite_input,
+    }
+    request = ResponsesRequest.model_validate(payload)
+
+    assert request.instructions == ""
+    assert request.to_payload()["input"] == lite_input
+
+
+def test_responses_input_custom_tool_call_output_survives_instruction_lift():
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "",
+        "input": [
+            {"type": "message", "role": "developer", "content": "dev instructions"},
+            {"type": "custom_tool_call_output", "call_id": "call_1", "output": "README.md"},
+        ],
+    }
+    request = ResponsesRequest.model_validate(payload)
+
+    assert request.instructions == "dev instructions"
+    assert request.to_payload()["input"] == [
+        {"type": "custom_tool_call_output", "call_id": "call_1", "output": "README.md"},
+    ]
 
 
 def test_responses_input_system_message_keeps_user_text_parts():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -559,6 +559,31 @@ def test_filter_inbound_headers_strips_internal_responses_lite_header():
     assert filtered["User-Agent"] == "codex-test"
 
 
+def test_filter_inbound_headers_preserves_native_responses_lite_header_when_requested():
+    headers = {
+        "X-OpenAI-Internal-Codex-Responses-Lite": "true",
+        "User-Agent": "codex_exec/0.144.0 (Mac OS 27.0.0; arm64) unknown (codex_exec; 0.144.0)",
+    }
+
+    filtered = filter_inbound_headers(headers, preserve_responses_lite=True)
+
+    assert filtered["X-OpenAI-Internal-Codex-Responses-Lite"] == "true"
+    assert filtered["User-Agent"] == headers["User-Agent"]
+
+
+def test_filter_inbound_headers_keeps_non_native_responses_lite_header_stripped_when_requested():
+    headers = {
+        "X-OpenAI-Internal-Codex-Responses-Lite": "true",
+        "User-Agent": "OpenAI/Python 2.24.0",
+    }
+
+    filtered = filter_inbound_headers(headers, preserve_responses_lite=True)
+    lowered = {key.lower() for key in filtered}
+
+    assert "x-openai-internal-codex-responses-lite" not in lowered
+    assert filtered["User-Agent"] == "OpenAI/Python 2.24.0"
+
+
 def test_request_log_useragent_fields_extract_full_value_and_group() -> None:
     assert proxy_service._request_log_useragent_fields(
         {
@@ -631,6 +656,19 @@ def test_build_upstream_headers_strips_internal_responses_lite_header():
 
     lowered = {key.lower() for key in headers}
     assert "x-openai-internal-codex-responses-lite" not in lowered
+
+
+def test_build_upstream_headers_emits_responses_lite_header_when_requested():
+    native_ua = "codex_exec/0.144.0 (Mac OS 27.0.0; arm64) unknown (codex_exec; 0.144.0)"
+    headers = _build_upstream_headers(
+        {"User-Agent": native_ua},
+        "token",
+        "acc_2",
+        responses_lite=True,
+    )
+
+    assert headers[proxy_module.CODEX_RESPONSES_LITE_HEADER] == "true"
+    assert headers["User-Agent"] == native_ua
 
 
 def test_build_upstream_headers_accept_override():
@@ -813,6 +851,54 @@ def _build_registry_with_model(slug: str, efforts: list[str]):
     registry = ModelRegistry()
     registry._snapshot = snapshot
     return registry
+
+
+def _codex_metadata_model(slug: str):
+    from app.core.openai.model_registry import ReasoningLevel, UpstreamModel
+
+    return UpstreamModel(
+        slug=slug,
+        display_name=slug,
+        description="",
+        context_window=128000,
+        input_modalities=("text",),
+        supported_reasoning_levels=(ReasoningLevel(effort="medium", description=""),),
+        default_reasoning_level="medium",
+        supports_reasoning_summaries=True,
+        support_verbosity=True,
+        default_verbosity="low",
+        prefer_websockets=True,
+        supports_parallel_tool_calls=True,
+        supported_in_api=True,
+        minimal_client_version=None,
+        priority=0,
+        available_in_plans=frozenset({"pro"}),
+        raw={
+            "use_responses_lite": True,
+            "tool_mode": "code_mode_only",
+            "multi_agent_version": "v2",
+            "shell_type": "shell_command",
+            "apply_patch_tool_type": "freeform",
+        },
+    )
+
+
+def test_codex_model_entry_preserves_gpt_5_6_lite_tool_metadata():
+    entry = proxy_api._to_codex_model_entry(_codex_metadata_model("gpt-5.6-terra")).model_dump(mode="json")
+
+    assert entry["use_responses_lite"] is True
+    assert entry["tool_mode"] == "code_mode_only"
+    assert entry["multi_agent_version"] == "v2"
+    assert entry["shell_type"] == "shell_command"
+    assert entry["apply_patch_tool_type"] == "freeform"
+
+
+def test_codex_model_entry_preserves_non_gpt_5_6_lite_tool_metadata():
+    entry = proxy_api._to_codex_model_entry(_codex_metadata_model("gpt-5.5")).model_dump(mode="json")
+
+    assert entry["use_responses_lite"] is True
+    assert entry["tool_mode"] == "code_mode_only"
+    assert entry["multi_agent_version"] == "v2"
 
 
 def test_normalize_unsupported_reasoning_effort_rewrites_minimal_to_low(caplog):
@@ -2163,6 +2249,33 @@ def test_response_create_client_metadata_reads_turn_metadata_case_insensitively(
     )
 
     assert metadata == {"x-codex-turn-metadata": '{"turn_id":"header-turn"}'}
+
+
+def test_response_create_client_metadata_sets_responses_lite_ws_metadata_from_header():
+    metadata = proxy_service._response_create_client_metadata(
+        {"client_metadata": {"keep": "yes"}},
+        headers={
+            "X-OpenAI-Internal-Codex-Responses-Lite": "true",
+            "User-Agent": "codex_exec/0.144.0 (Mac OS 27.0.0; arm64) unknown (codex_exec; 0.144.0)",
+        },
+    )
+
+    assert metadata == {
+        "keep": "yes",
+        proxy_module.CODEX_RESPONSES_LITE_WS_METADATA_KEY: "true",
+    }
+
+
+def test_response_create_client_metadata_ignores_responses_lite_header_from_non_native_client():
+    metadata = proxy_service._response_create_client_metadata(
+        {"client_metadata": {"keep": "yes"}},
+        headers={
+            "X-OpenAI-Internal-Codex-Responses-Lite": "true",
+            "User-Agent": "OpenAI/Python 2.24.0",
+        },
+    )
+
+    assert metadata == {"keep": "yes"}
 
 
 def test_has_native_codex_transport_headers_does_not_treat_session_id_as_websocket_signal():
@@ -4085,6 +4198,113 @@ async def test_stream_responses_uses_http_responses_stream_budget(monkeypatch):
     assert isinstance(timeout, proxy_module.aiohttp.ClientTimeout)
     assert timeout.total == pytest.approx(7200.0, abs=0.1)
     assert events == ['data: {"type":"response.completed","response":{"id":"resp_1"}}\n\n']
+
+
+@pytest.mark.asyncio
+async def test_stream_responses_forwards_responses_lite_header_and_tools_upstream(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 1.0
+        stream_idle_timeout_seconds = 1.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        log_upstream_request_payload = False
+        proxy_request_budget_seconds = 15.0
+        upstream_stream_transport = "http"
+        log_upstream_request_summary = False
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+
+    additional_tools = {
+        "type": "additional_tools",
+        "role": "developer",
+        "tools": [
+            {
+                "type": "custom",
+                "name": "exec",
+                "format": {"type": "grammar", "syntax": "lark", "definition": "start: /.*/"},
+            }
+        ],
+    }
+    lite_input = [
+        additional_tools,
+        {"type": "message", "role": "developer", "content": [{"type": "input_text", "text": "dev instructions"}]},
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        {"type": "custom_tool_call_output", "call_id": "call_1", "output": "README.md"},
+    ]
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.6-sol", "instructions": "", "input": lite_input})
+    session = _SseSession(_SsePostResponse([b'data: {"type":"response.completed","response":{"id":"resp_1"}}\n\n']))
+
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={
+                "User-Agent": "codex_exec/0.144.0 (Mac OS 27.0.0; arm64) unknown (codex_exec; 0.144.0)",
+                "X-OpenAI-Internal-Codex-Responses-Lite": "true",
+            },
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, session),
+        )
+    ]
+
+    assert events == ['data: {"type":"response.completed","response":{"id":"resp_1"}}\n\n']
+    call = session.calls[0]
+    upstream_headers = cast(dict[str, str], call["headers"])
+    lite_header_values = {
+        key: value for key, value in upstream_headers.items() if key.lower() == proxy_module.CODEX_RESPONSES_LITE_HEADER
+    }
+    assert list(lite_header_values.values()) == ["true"]
+    upstream_payload = cast(dict[str, JsonValue], call["json"])
+    assert upstream_payload["input"] == lite_input
+    assert upstream_payload["instructions"] == ""
+    client_metadata = cast(dict[str, JsonValue], upstream_payload["client_metadata"])
+    assert client_metadata[proxy_module.CODEX_RESPONSES_LITE_WS_METADATA_KEY] == "true"
+
+
+@pytest.mark.asyncio
+async def test_stream_responses_keeps_lite_header_stripped_for_non_native_client(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 1.0
+        stream_idle_timeout_seconds = 1.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        log_upstream_request_payload = False
+        proxy_request_budget_seconds = 15.0
+        upstream_stream_transport = "http"
+        log_upstream_request_summary = False
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.6-sol", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+    session = _SseSession(_SsePostResponse([b'data: {"type":"response.completed","response":{"id":"resp_1"}}\n\n']))
+
+    _ = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={
+                "User-Agent": "OpenAI/Python 2.24.0",
+                "X-OpenAI-Internal-Codex-Responses-Lite": "true",
+            },
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, session),
+        )
+    ]
+
+    upstream_headers = cast(dict[str, str], session.calls[0]["headers"])
+    assert proxy_module.CODEX_RESPONSES_LITE_HEADER not in {key.lower() for key in upstream_headers}
+    upstream_payload = cast(dict[str, JsonValue], session.calls[0]["json"])
+    assert "client_metadata" not in upstream_payload
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #1157.

GPT-5.6 lite models (`gpt-5.6-sol` / `-terra` / `-luna`, `use_responses_lite: true`, `tool_mode: code_mode_only`) do not send tools in the top-level `tools` field. Codex ≥ 0.144.0 prepends an input item `{"type": "additional_tools", "role": "developer", "tools": [...]}` and marks the request with the internal `x-openai-internal-codex-responses-lite` header (HTTP) or the `ws_request_header_x_openai_internal_codex_responses_lite` `client_metadata` key (websocket) — see `codex-rs/core/src/client.rs`.

codex-lb broke this contract in two places:

1. **`_normalize_responses_input_instructions()`** treated every `developer`/`system` input item as instruction text. The `additional_tools` item has no `content`, so it was silently dropped — the upstream model received no shell/filesystem tools and answered *"I can't inspect the repository because no shell/filesystem tool is available in this session."*
2. **`strip-internal-responses-lite-header`** removes the Lite header from all upstream requests, so even an intact tool bundle would never be processed in lite mode upstream.

## What changes

- **Lite-shaped requests pass through byte-identical**: when `input` contains an `additional_tools` item, the instruction lift is skipped entirely, preserving the tool bundle, the developer instructions message, and `custom_tool_call` / `custom_tool_call_output` items exactly as Codex constructed them.
- **The lite signal is forwarded for native Codex clients, per transport**: `x-openai-internal-codex-responses-lite: true` on upstream HTTP responses/compact requests (initial and retry attempts), and the `ws_request_header_x_openai_internal_codex_responses_lite` key in `client_metadata` on upstream websocket `response.create` payloads — mirroring the Codex client's own transport split.
- **Non-native clients keep the existing strip behavior**, preserving the protection that motivated `strip-internal-responses-lite-header` (upstream rejects the header on models without lite support).

## OpenSpec

- New change: `openspec/changes/preserve-native-responses-lite-passthrough/` (proposal, design, tasks, delta spec). Validates with `openspec validate --strict`.
- `openspec/specs/responses-api-compat/spec.md` gains the requirement from `strip-internal-responses-lite-header` **verbatim** — that change was implemented but never synced to the main spec, and the sync is needed to anchor this change's `MODIFIED` delta. `openspec validate --specs` passes 30/30.

## Verification

- Unit suite: 3203 passed. Touched-surface integration suites (`test_proxy_responses`, `test_proxy_websocket_responses`, `test_proxy_compact`, `test_http_responses_bridge`, `test_codex_client_compat`): 197 passed. Ruff lint/format clean.
- Regression tests at the externally failing product paths: request normalization units, core upstream HTTP client (asserts real upstream headers + payload), the `/backend-api/codex/responses` HTTP route, and the websocket bridge `response.create` forwarding — for both native and non-native clients.
- **Real end-to-end**: `codex exec` v0.144.0 against this branch with `gpt-5.6-terra` (served with truthful `use_responses_lite: true` / `tool_mode: code_mode_only` metadata, same lite protocol as `gpt-5.6-sol`) — the model invoked the shell tool (`exec /bin/bash -lc ...` succeeded) and completed the task. The currently released image only "works" by downgrading GPT-5.6 metadata to `use_responses_lite: false`, which forces the legacy tool path; this PR serves the real metadata and supports the native lite protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)