### PR TITLE
fix(proxy): preserve non-message developer input items

### DIFF
--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -297,6 +297,14 @@ def _normalize_responses_input_instructions(data: JsonValue) -> JsonValue:
         if role not in ("system", "developer"):
             input_items.append(item)
             continue
+        # Only hoist actual message items. Codex responses-lite clients (gpt-5.6+ models with
+        # use_responses_lite/tool_mode=code_mode_only) send non-message developer items such as
+        # {"type": "additional_tools", "role": "developer", "tools": [...]} inside input; those
+        # have no content, so hoisting used to drop them entirely and the model lost all tools.
+        item_type = item_mapping.get("type")
+        if item_type is not None and item_type != "message":
+            input_items.append(item)
+            continue
         instruction_text, preserved_content = _split_responses_instruction_item_content(item_mapping)
         if instruction_text:
             instruction_parts.append(instruction_text)

--- a/openspec/changes/preserve-non-message-developer-input-items/.openspec.yaml
+++ b/openspec/changes/preserve-non-message-developer-input-items/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/preserve-non-message-developer-input-items/design.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/design.md
@@ -1,0 +1,9 @@
+# Design
+
+## Approach
+
+Add a type guard to `_normalize_responses_input_instructions()` in `app/core/openai/requests.py`: before treating a `system`/`developer`-role input item as an instruction message, check the item's `type`. Items whose `type` is present and not `"message"` are appended to the preserved input list unchanged.
+
+Typeless role items (`{"role": "system", "content": ...}`, as sent by OpenAI-compatible clients) keep the existing hoisting behavior, so `/v1`-style compatibility is unaffected. The guard lives in the shared normalizer, so both `ResponsesRequest` and `ResponsesCompactRequest` validators pick it up.
+
+This keeps the codex-faithful wire format: native Codex responses-lite bodies reach upstream with their `additional_tools` prefix intact, exactly as the Codex CLI emits them.

--- a/openspec/changes/preserve-non-message-developer-input-items/proposal.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/proposal.md
@@ -1,0 +1,26 @@
+# Preserve Non-Message Developer Input Items
+
+## Summary
+
+Stop dropping non-message `input` items with a `system`/`developer` role when hoisting instruction messages into the `instructions` field.
+
+## Motivation
+
+Codex clients in responses-lite mode (gpt-5.6 models, which set `use_responses_lite=true` and `tool_mode=code_mode_only` in their model metadata) no longer send a top-level `tools` array. Instead, tool definitions are delivered as the first `input` item:
+
+```json
+{"type": "additional_tools", "role": "developer", "tools": [{"type": "custom", "name": "exec"}, ...]}
+```
+
+The instruction-hoisting normalizer treats every `system`/`developer`-role input item as an instruction message. `additional_tools` items carry no `content`, so they contributed no instruction text, produced no preserved item, and were silently removed from `input`. Upstream then received a well-formed request with no tools anywhere, and the model responded that no terminal/filesystem tool was exposed — every gpt-5.6 session through codex-lb was effectively toolless, while gpt-5.5 (classic top-level `tools`) kept working.
+
+## Scope
+
+- Only hoist input items that are actual messages (`type` omitted or `"message"`) into `instructions`.
+- Pass every other `system`/`developer`-role input item through to upstream untouched, byte-for-byte.
+- Applies to both `ResponsesRequest` and `ResponsesCompactRequest` normalization.
+
+## Out of Scope
+
+- Changing how message-shaped instruction items are hoisted or merged.
+- Modeling the `additional_tools` item shape; it is forwarded opaquely to stay codex-faithful.

--- a/openspec/changes/preserve-non-message-developer-input-items/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/specs/responses-api-compat/spec.md
@@ -1,0 +1,26 @@
+# responses-api-compat — Delta
+
+## ADDED Requirements
+
+### Requirement: Non-message developer input items are preserved
+
+When normalizing Responses or compact request `input`, the service MUST only
+hoist items that are instruction messages — items whose `type` is omitted or
+`"message"` — into the `instructions` field. Any other `system`/`developer`-role
+input item (such as the Codex responses-lite
+`{"type": "additional_tools", "role": "developer", "tools": [...]}` prefix)
+MUST be forwarded upstream in its original position and shape.
+
+#### Scenario: additional_tools input item survives normalization
+
+- **WHEN** a Codex client sends a Responses request whose `input` begins with
+  `{"type": "additional_tools", "role": "developer", "tools": [...]}` followed
+  by developer instruction messages
+- **THEN** the developer instruction messages are hoisted into `instructions`
+- **AND** the `additional_tools` item remains in `input` unchanged
+
+#### Scenario: typeless system messages keep hoisting behavior
+
+- **WHEN** an OpenAI-compatible client sends `input` containing
+  `{"role": "system", "content": "sys"}` without a `type` field
+- **THEN** that item is hoisted into `instructions` as before

--- a/openspec/changes/preserve-non-message-developer-input-items/tasks.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] 1. Add OpenSpec requirement for preserving non-message developer input items during instruction hoisting.
+- [x] 2. Guard the instruction-hoisting normalizer so only message-shaped items are hoisted.
+- [x] 3. Add regression coverage for `ResponsesRequest` and `ResponsesCompactRequest` with `additional_tools` input items.
+- [x] 4. Validate focused tests and OpenSpec artifacts.

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -563,6 +563,29 @@ def test_responses_input_system_message_moves_to_instructions():
     assert request.input == [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]}]
 
 
+def test_responses_input_additional_tools_item_is_preserved():
+    additional_tools = {
+        "type": "additional_tools",
+        "role": "developer",
+        "tools": [{"type": "custom", "name": "exec"}, {"type": "function", "name": "wait"}],
+    }
+    payload = {
+        "model": "gpt-5.6-sol",
+        "input": [
+            additional_tools,
+            {"type": "message", "role": "developer", "content": [{"type": "input_text", "text": "base"}]},
+            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        ],
+    }
+    request = ResponsesRequest.model_validate(payload)
+
+    assert request.instructions == "base"
+    assert request.input == [
+        additional_tools,
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+    ]
+
+
 def test_responses_input_system_message_keeps_user_text_parts():
     payload = {
         "model": "gpt-5.1",
@@ -671,6 +694,26 @@ def test_responses_compact_input_system_message_moves_to_instructions():
 
     assert request.instructions == "primary\nsys"
     assert request.input == [{"role": "user", "content": "compact me"}]
+
+
+def test_responses_compact_input_additional_tools_item_is_preserved():
+    additional_tools = {
+        "type": "additional_tools",
+        "role": "developer",
+        "tools": [{"type": "custom", "name": "exec"}],
+    }
+    payload = {
+        "model": "gpt-5.6-sol",
+        "input": [
+            additional_tools,
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "compact me"},
+        ],
+    }
+    request = ResponsesCompactRequest.model_validate(payload)
+
+    assert request.instructions == "sys"
+    assert request.input == [additional_tools, {"role": "user", "content": "compact me"}]
 
 
 def test_responses_compact_to_payload_strips_late_system_message():


### PR DESCRIPTION
## Summary

Codex responses-lite clients (gpt-5.6 models) deliver tool definitions inside `input` as an `additional_tools` item; the instruction-hoisting normalizer silently dropped that item, so every gpt-5.6 session through codex-lb ran without any tools.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/preserve-non-message-developer-input-items/`

## Changes

- `_normalize_responses_input_instructions()` now only hoists `system`/`developer` input items that are actual messages (`type` omitted or `"message"`); other items pass through to upstream unchanged.
- Regression tests for `ResponsesRequest` and `ResponsesCompactRequest` with an `additional_tools` input item.
- OpenSpec requirement recording that non-message developer input items must be preserved.

## Details

gpt-5.6 models advertise `use_responses_lite: true` and `tool_mode: code_mode_only`. In this mode the Codex CLI (0.144.0) sends **no top-level `tools` field** — tool definitions ride in the first input item:

```json
{"type": "additional_tools", "role": "developer", "tools": [{"type": "custom", "name": "exec"}, ...]}
```

The hoisting normalizer treats every `system`/`developer`-role input item as an instruction message. `additional_tools` has no `content`, so it contributed no instruction text, produced no preserved item, and was removed from `input` entirely. Upstream then received a well-formed request with no tools anywhere and the model would answer that no terminal/filesystem tool is exposed (or emit `to=functions.exec` as plain text). gpt-5.5 and earlier (classic top-level `tools`) were unaffected, which made this look like a model regression rather than a proxy bug.

Typeless role items (`{"role": "system", "content": "..."}` from OpenAI-compatible clients) keep the existing hoisting behavior.

## Test plan

Verified against a live proxy by asking gpt-5.6-sol to read a file with unguessable random content via shell (bluff-proof probe):

- before: model answers `TOOLLESS` (request on the wire confirmed to have lost the `additional_tools` item)
- after: model reads the file over ws and HTTP transports, at xhigh and ultra efforts; gpt-5.5 classic path unaffected

```
uv run pytest tests/unit/test_openai_requests.py -q
104 passed in 0.37s
```
