### PR TITLE
fix(proxy): support Codex image edit routes

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -907,6 +907,17 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "nazirulhafiy",
+      "name": "Hafiy",
+      "avatar_url": "https://avatars.githubusercontent.com/u/255521226?v=4",
+      "profile": "https://github.com/nazirulhafiy",
+      "contributions": [
+        "code",
+        "test",
+        "doc"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/app/core/handlers/exceptions.py
+++ b/app/core/handlers/exceptions.py
@@ -71,19 +71,32 @@ def _error_format(request: Request) -> str | None:
     return None
 
 
+# Codex-native aliases under /backend-api/codex map to the same route labels
+# as their /v1 counterparts so observability stays consistent across surfaces.
+_IMAGE_ROUTE_PATHS: dict[str, ImageRoute] = {
+    "/v1/images/generations": "generations",
+    "/backend-api/codex/images/generations": "generations",
+    "/v1/images/edits": "edits",
+    "/backend-api/codex/images/edits": "edits",
+}
+
+
 def _image_route_from_path(path: str) -> ImageRoute | None:
-    if path == "/v1/images/generations":
-        return "generations"
-    if path == "/v1/images/edits":
-        return "edits"
-    return None
+    return _IMAGE_ROUTE_PATHS.get(path)
+
+
+def _is_json_request(request: Request) -> bool:
+    content_type = request.headers.get("content-type", "")
+    return content_type.split(";", 1)[0].strip().lower() == "application/json"
 
 
 async def _image_request_model_and_stream(request: Request, route: ImageRoute) -> tuple[str | None, bool]:
     model: str | None = None
     stream = False
 
-    if route == "generations":
+    # Generations is always JSON; the codex edits alias also accepts a JSON
+    # payload (unlike the multipart /v1 edits surface).
+    if route == "generations" or _is_json_request(request):
         try:
             payload: Any = await request.json()
         except Exception:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1563,6 +1563,7 @@ async def v1_audio_transcriptions(
     )
 
 
+@router.post("/images/generations", response_model=None, include_in_schema=False)
 @v1_router.post("/images/generations", response_model=None)
 async def v1_images_generations(
     request: Request,
@@ -1743,6 +1744,138 @@ async def v1_images_edits(
         payload=form_payload,
         images=images_payload,
         mask=mask_payload,
+        context=context,
+        api_key=api_key,
+        started_at=started_at,
+    )
+
+
+@router.post("/images/edits", response_model=None, include_in_schema=False)
+async def codex_images_edits(
+    request: Request,
+    context: ProxyContext = Depends(get_proxy_context),
+    api_key: ApiKeyData | None = Security(validate_proxy_api_key),
+) -> Response:
+    """Accept Codex's JSON data-URL image-edit payload on its native base URL.
+
+    The built-in Codex image tool sends ``images: [{"image_url":
+    "data:<mime>;base64,..."}]`` rather than the multipart ``image`` parts
+    used by the public OpenAI Images API. Decode that transport shape here,
+    then delegate to the shared edit pipeline so validation and upstream
+    behavior remain identical.
+    """
+    started_at = time.perf_counter()
+    try:
+        raw_payload = await request.json()
+    except (JSONDecodeError, UnicodeDecodeError):
+        _record_images_edit_early_rejection(
+            model=None,
+            stream=False,
+            started_at=started_at,
+        )
+        return _logged_error_json_response(
+            request,
+            400,
+            images_service_module.make_invalid_request_error(
+                "Expected a JSON request body.",
+                param="prompt",
+            ),
+        )
+    if not is_json_mapping(raw_payload):
+        _record_images_edit_early_rejection(
+            model=None,
+            stream=False,
+            started_at=started_at,
+        )
+        return _logged_error_json_response(
+            request,
+            400,
+            images_service_module.make_invalid_request_error(
+                "Expected a JSON object request body.",
+                param="prompt",
+            ),
+        )
+
+    raw_model = raw_payload.get("model")
+    observability_model = raw_model if isinstance(raw_model, str) else None
+    raw_stream = raw_payload.get("stream", False)
+    observability_stream = raw_stream if isinstance(raw_stream, bool) else False
+    raw_form: dict[str, object] = {
+        "model": raw_model,
+        "prompt": raw_payload.get("prompt"),
+        "n": raw_payload.get("n", 1),
+        "size": raw_payload.get("size", "auto"),
+        "quality": raw_payload.get("quality", "auto"),
+        "background": raw_payload.get("background", "auto"),
+        "output_format": raw_payload.get("output_format", "png"),
+        "output_compression": raw_payload.get("output_compression", 100),
+        "moderation": raw_payload.get("moderation", "auto"),
+        "partial_images": raw_payload.get("partial_images"),
+        "stream": raw_payload.get("stream", False),
+        "input_fidelity": raw_payload.get("input_fidelity"),
+        "user": raw_payload.get("user"),
+    }
+    try:
+        form_payload = V1ImagesEditsForm.model_validate(raw_form)
+    except ValidationError as exc:
+        _record_images_edit_early_rejection(
+            model=observability_model,
+            stream=observability_stream,
+            started_at=started_at,
+        )
+        return _logged_error_json_response(request, 400, openai_validation_error(exc))
+
+    raw_images = raw_payload.get("images")
+    if not isinstance(raw_images, list) or not raw_images:
+        _record_images_edit_early_rejection(
+            model=form_payload.model,
+            stream=bool(form_payload.stream),
+            started_at=started_at,
+        )
+        return _logged_error_json_response(
+            request,
+            400,
+            images_service_module.make_invalid_request_error(
+                "At least one `images[].image_url` data URL is required.",
+                param="images",
+            ),
+        )
+
+    images: list[tuple[bytes, str | None]] = []
+    for index, raw_image in enumerate(raw_images):
+        if not is_json_mapping(raw_image) or not isinstance(image_url := raw_image.get("image_url"), str):
+            _record_images_edit_early_rejection(
+                model=form_payload.model,
+                stream=bool(form_payload.stream),
+                started_at=started_at,
+            )
+            return _logged_error_json_response(
+                request,
+                400,
+                images_service_module.make_invalid_request_error(
+                    f"images[{index}].image_url must be a base64 data URL.",
+                    param="images",
+                ),
+            )
+        try:
+            images.append(images_service_module.decode_data_url(image_url))
+        except ValueError as exc:
+            _record_images_edit_early_rejection(
+                model=form_payload.model,
+                stream=bool(form_payload.stream),
+                started_at=started_at,
+            )
+            return _logged_error_json_response(
+                request,
+                400,
+                images_service_module.make_invalid_request_error(str(exc), param="images"),
+            )
+
+    return await _proxy_images_edit_request(
+        request=request,
+        payload=form_payload,
+        images=images,
+        mask=None,
         context=context,
         api_key=api_key,
         started_at=started_at,

--- a/openspec/changes/add-codex-images-route-alias/context.md
+++ b/openspec/changes/add-codex-images-route-alias/context.md
@@ -1,0 +1,126 @@
+# Context: add-codex-images-route-alias
+
+## Purpose
+
+Codex's built-in `imagegen` tool performs both standalone image generation and
+reference-image edits against the model provider `base_url`, not against
+`/v1`. codex-lb documents `base_url = "http://127.0.0.1:2455/backend-api/codex"`
+for Codex clients, so the tool POSTs to `/backend-api/codex/images/generations`
+and `/backend-api/codex/images/edits`. Before this change only `/v1/images/*`
+had handlers, so Codex edit requests returned `405 Method Not Allowed`.
+
+## Verified upstream wire contract (openai/codex @ rust-v0.144.1)
+
+All citations are at tag `rust-v0.144.1` (commit
+`44918ea10c0f99151c6710411b4322c2f5c96bea`, published 2026-07-09).
+
+### Endpoint paths — relative to `base_url`, not `/v1`
+
+- `codex-rs/codex-api/src/endpoint/images.rs:33-54` posts to
+  `images/generations` and `images/edits` joined onto the provider base URL
+  (`codex-rs/codex-api/src/provider.rs:53-73`, `url_for_path`:
+  `base.trim_end_matches('/') + "/" + path.trim_start_matches('/')`).
+- Codex's own integration test asserts the joined paths
+  `/api/codex/images/{generations,edits}` when `base_url = "<server>/api/codex"`
+  (`codex-rs/app-server/tests/suite/v2/imagegen_extension.rs:160,496,550,562`).
+- The client never sends a trailing slash (`url_for_path` joins with exactly
+  one separator). In codex-lb the trailing-slash variants are not aliased:
+  they fall through to the SPA `GET /{path:path}` catch-all
+  (`app/main.py`), so a POST returns 405 with the OpenAI error envelope —
+  identically on `/v1/images/*/` and `/backend-api/codex/images/*/`.
+  Regression tests pin this parity.
+
+### Request encoding — JSON, never multipart
+
+- `EndpointSession::execute` wraps the serialized struct as
+  `RequestBody::Json` (`codex-rs/codex-api/src/endpoint/session.rs`), sent
+  with `Content-Type: application/json` and no compression
+  (`codex-rs/codex-api/src/provider.rs:83`). Multipart exists in the client
+  only for realtime calls, never for images. This is why the Codex-base edit
+  alias is a JSON adapter rather than a rebind of the multipart `/v1` handler.
+
+### Exact request shapes (`codex-rs/codex-api/src/images.rs`)
+
+- `ImageGenerationRequest`: `prompt`, `model`, optional
+  `background|n|quality|size` (omitted when `None`).
+- `ImageEditRequest`: `images: Vec<ImageUrl>` where
+  `ImageUrl { image_url: String }` carries a base64 data URL, plus `prompt`
+  and the same optional scalars. Codex's unit test pins the exact wire body
+  (`codex-rs/codex-api/src/endpoint/images.rs:259-267`):
+
+  ```json
+  {"images": [{"image_url": "data:image/png;base64,Zm9v"}],
+   "prompt": "add a red hat", "model": "gpt-image-1.5"}
+  ```
+
+- The shipped tool always sends `model: "gpt-image-2"`,
+  `background/quality/size: "auto"`, omits `n`, and caps edits at 5 images
+  (`codex-rs/ext/image-generation/src/tool.rs:57,270-327`).
+- Images are always `data:<mime>;base64,...` data URLs — files go through
+  `into_data_url()` (`codex-rs/utils/image/src/lib.rs:53-56`) and the
+  app-server rejects remote `http(s)` image URLs at input
+  (`codex-rs/app-server/src/image_url.rs:4-8`). The adapter's data-URL regex
+  (`app/modules/proxy/images_service.py`) matches this output exactly.
+- **The client has no mask capability**: `ImageEditRequest` has no mask field
+  anywhere in `codex-rs`. The adapter's hardcoded `mask=None` is therefore the
+  full contract, not a gap.
+- The client never sends `stream`, `output_format`, `response_format`,
+  `user`, `moderation`, `input_fidelity`, or `partial_images`; the adapter
+  accepts them with `/v1`-compatible defaults as a harmless superset.
+
+A captured real request from Codex Desktop 0.144.0-alpha.4 (PR #1160
+discussion) confirms the same shape live:
+`POST /backend-api/codex/images/edits`, `Content-Type: application/json`, body
+`{"model": "gpt-image-2", "prompt": ..., "images": [{"image_url":
+"data:image/png;base64,..."}]}`.
+
+### Response shape expected by the client
+
+`ImageResponse` (`codex-rs/codex-api/src/images.rs:55-70`) requires `created`
+and non-empty `data[].b64_json`; `background`, `quality`, `size` are optional
+and unknown extras (`usage`, `revised_prompt`) are ignored by serde. codex-lb's
+`V1ImageResponse` (`app/core/openai/images.py`) satisfies this. The tool
+renders `data[0].b64_json` as `data:image/png;base64,...`, matching the
+adapter's default `output_format="png"`.
+
+## Decisions
+
+- **Aliases, not new routes**: `include_in_schema=False` keeps `/v1/images/*`
+  the only OpenAPI-visible surface; the Codex-base paths are a transport
+  compatibility shim.
+- **Generation alias reuses the `/v1` handler unchanged** because Codex's
+  generation body is a strict subset of `V1ImagesGenerationsRequest`
+  (`extra="ignore"`).
+- **Edit alias adapts JSON to the shared pipeline**: decode
+  `images[].image_url` data URLs to `(bytes, mime)` tuples and delegate to
+  `_proxy_images_edit_request` so validation, auth, account routing,
+  observability, and error envelopes stay identical to `/v1`.
+- **Observability parity**: `started_at` is captured at handler entry and all
+  early-400 paths call `_record_images_edit_early_rejection`, matching the
+  `/v1` edit route's metrics contract from #1123.
+
+## Failure modes
+
+- Non-JSON or invalid-UTF-8 body → 400 `invalid_request_error` with
+  `param=prompt` (matches `/v1` envelope; `UnicodeDecodeError` is caught
+  alongside `JSONDecodeError`).
+- Missing/empty `images`, non-object entries, or non-data-URL `image_url` →
+  400 with `param=images`.
+- Theoretical divergence: `background: "transparent"` is representable in the
+  client's types but never sent by the shipped tool; codex-lb rejects it for
+  `gpt-image-2` per its validation matrix. Only reachable by non-official
+  callers.
+
+## Concrete example
+
+```http
+POST /backend-api/codex/images/edits HTTP/1.1
+Content-Type: application/json
+
+{"model": "gpt-image-2", "prompt": "make it green",
+ "images": [{"image_url": "data:image/png;base64,iVBORw0KGgo..."}],
+ "background": "auto", "quality": "auto", "size": "auto"}
+```
+
+→ 200 `{"created": ..., "data": [{"b64_json": "..."}], ...}` produced by the
+same upstream pipeline as `POST /v1/images/edits` multipart.

--- a/openspec/changes/add-codex-images-route-alias/proposal.md
+++ b/openspec/changes/add-codex-images-route-alias/proposal.md
@@ -1,0 +1,27 @@
+# Proposal: add-codex-images-route-alias
+
+## Why
+
+Codex clients configured with codex-lb use `/backend-api/codex` as their base
+URL. When Codex invokes image generation with reference images, it submits a
+JSON request containing `images[].image_url` data URLs to
+`/backend-api/codex/images/edits`. codex-lb currently registers the existing
+Images API adapter only under `/v1/images/edits`, so the Codex-base request
+reaches no POST handler and returns `405 Method Not Allowed`.
+
+## What Changes
+
+- Register the existing image generation handler and a Codex-native JSON image
+  edit adapter under the Codex-base router as non-OpenAPI aliases.
+- Keep `/v1/images/generations` and `/v1/images/edits` as the canonical public
+  OpenAI-compatible routes.
+- Decode Codex's `images[].image_url` base64 data URLs, then preserve the
+  existing validation, authentication, account routing, observability, and
+  Images response shape for both route families.
+
+## Impact
+
+- Codex can use image generation and reference-image editing through its
+  configured codex-lb provider without changing `base_url`.
+- The change is limited to routing aliases and regression coverage; it does
+  not introduce a new upstream API or alter model selection.

--- a/openspec/changes/add-codex-images-route-alias/specs/images-api-compat/spec.md
+++ b/openspec/changes/add-codex-images-route-alias/specs/images-api-compat/spec.md
@@ -26,3 +26,13 @@ surface.
   without a non-empty `images[].image_url` data URL
 - **THEN** the service returns a 400 OpenAI `invalid_request_error` with
   `param: images`, rather than `405 Method Not Allowed` or a missing-prompt error
+
+#### Scenario: Codex-base alias failures before the handler record route observability
+
+- **WHEN** a request to `POST /backend-api/codex/images/generations` or
+  `POST /backend-api/codex/images/edits` fails before the route handler runs
+  (for example API-key authentication or request-body validation handled by
+  the shared exception layer)
+- **THEN** the service records the `images_route_complete` observability entry
+  (log and metrics) with the same `generations`/`edits` route label as the
+  `/v1` counterpart, exactly once

--- a/openspec/changes/add-codex-images-route-alias/specs/images-api-compat/spec.md
+++ b/openspec/changes/add-codex-images-route-alias/specs/images-api-compat/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Codex-base Images API aliases
+
+The system SHALL expose `POST /backend-api/codex/images/generations` and
+`POST /backend-api/codex/images/edits` as Codex-base equivalents of the
+existing `/v1/images/generations` and `/v1/images/edits` handlers. The edit
+route MUST accept Codex's JSON `images` array, whose entries contain base64
+`image_url` data URLs, and decode those entries before it delegates to the
+existing edit pipeline. The aliases MUST apply the same authentication,
+validation, account-routing, observability, response-shape, and error-envelope
+behavior as their `/v1` counterparts. The aliases MUST NOT be included in the
+OpenAPI schema because `/v1/images/*` remains the canonical OpenAI-compatible
+surface.
+
+#### Scenario: Codex-base image generation uses the existing handler
+
+- **WHEN** a Codex client sends `POST /backend-api/codex/images/generations`
+  with an invalid image model
+- **THEN** the service returns the same 400 OpenAI `invalid_request_error` with
+  `param: model` as `POST /v1/images/generations`
+
+#### Scenario: Codex-base image editing uses the existing handler
+
+- **WHEN** a Codex client sends JSON `POST /backend-api/codex/images/edits`
+  without a non-empty `images[].image_url` data URL
+- **THEN** the service returns a 400 OpenAI `invalid_request_error` with
+  `param: images`, rather than `405 Method Not Allowed` or a missing-prompt error

--- a/openspec/changes/add-codex-images-route-alias/tasks.md
+++ b/openspec/changes/add-codex-images-route-alias/tasks.md
@@ -3,6 +3,7 @@
 ## 1. Specification
 
 - [x] 1.1 Define Codex-base aliases for the existing Images API handlers.
+- [x] 1.2 Record the verified upstream Codex wire contract (openai/codex @ rust-v0.144.1) with citations in `context.md`.
 
 ## 2. Implementation
 
@@ -13,5 +14,6 @@
 
 - [x] 3.1 Add route-level regression coverage for both aliases, including Codex JSON data-URL edits.
 - [x] 3.2 Run focused image compatibility tests and lint (`35 passed`; Ruff and `git diff --check` clean).
-- [ ] 3.3 Run strict OpenSpec validation (the OpenSpec CLI is not installed in this checkout's environment).
+- [x] 3.3 Run strict OpenSpec validation (`openspec validate add-codex-images-route-alias --strict` — valid).
 - [x] 3.4 Restart the local LaunchAgent-backed codex-lb service and verify the live aliases return their handlers' 400 validation responses rather than `405`.
+- [x] 3.5 Cover trailing-slash behavior: the slashed variants 405 identically on the `/v1` canonical and Codex-base alias surfaces.

--- a/openspec/changes/add-codex-images-route-alias/tasks.md
+++ b/openspec/changes/add-codex-images-route-alias/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: add-codex-images-route-alias
+
+## 1. Specification
+
+- [x] 1.1 Define Codex-base aliases for the existing Images API handlers.
+
+## 2. Implementation
+
+- [x] 2.1 Register `/backend-api/codex/images/generations` as an alias of the existing generation handler.
+- [x] 2.2 Register `/backend-api/codex/images/edits` as a Codex-native JSON adapter that delegates to the existing edit pipeline.
+
+## 3. Verification
+
+- [x] 3.1 Add route-level regression coverage for both aliases, including Codex JSON data-URL edits.
+- [x] 3.2 Run focused image compatibility tests and lint (`35 passed`; Ruff and `git diff --check` clean).
+- [ ] 3.3 Run strict OpenSpec validation (the OpenSpec CLI is not installed in this checkout's environment).
+- [x] 3.4 Restart the local LaunchAgent-backed codex-lb service and verify the live aliases return their handlers' 400 validation responses rather than `405`.

--- a/tests/integration/test_proxy_images.py
+++ b/tests/integration/test_proxy_images.py
@@ -211,6 +211,22 @@ async def test_backend_codex_images_generations_alias_uses_same_validation(async
 
 
 @pytest.mark.asyncio
+async def test_backend_codex_images_generations_alias_auth_rejection_records_route_observability(async_client, caplog):
+    await _enable_api_key_auth(async_client)
+
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/backend-api/codex/images/generations",
+            json={"model": "gpt-image-2", "prompt": "a red circle"},
+        )
+
+    assert response.status_code == 401
+    message = "images_route_complete route=generations model=gpt-image-2 stream=false status=401 outcome=auth_error"
+    assert message in caplog.text
+    assert caplog.text.count(message) == 1
+
+
+@pytest.mark.asyncio
 async def test_images_generations_trailing_slash_parity_between_v1_and_codex_alias(async_client):
     # Codex joins `base_url` + "images/generations" without a trailing slash,
     # so only the exact paths are handled. The trailing-slash variants fall
@@ -599,6 +615,26 @@ async def test_backend_codex_images_edits_requires_native_image_data_urls(async_
         "images_route_complete route=edits model=gpt-image-2 stream=false status=400 outcome=invalid_request"
         in caplog.text
     )
+
+
+@pytest.mark.asyncio
+async def test_backend_codex_images_edits_alias_auth_rejection_records_route_observability(async_client, caplog):
+    await _enable_api_key_auth(async_client)
+
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/backend-api/codex/images/edits",
+            json={
+                "model": "gpt-image-2",
+                "prompt": "make it green",
+                "images": [{"image_url": "data:image/png;base64,aGVsbG8="}],
+            },
+        )
+
+    assert response.status_code == 401
+    message = "images_route_complete route=edits model=gpt-image-2 stream=false status=401 outcome=auth_error"
+    assert message in caplog.text
+    assert caplog.text.count(message) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_images.py
+++ b/tests/integration/test_proxy_images.py
@@ -211,6 +211,21 @@ async def test_backend_codex_images_generations_alias_uses_same_validation(async
 
 
 @pytest.mark.asyncio
+async def test_images_generations_trailing_slash_parity_between_v1_and_codex_alias(async_client):
+    # Codex joins `base_url` + "images/generations" without a trailing slash,
+    # so only the exact paths are handled. The trailing-slash variants fall
+    # through to the SPA catch-all route and must fail identically (405 with
+    # the OpenAI error envelope) on the canonical and alias surfaces.
+    payload = {"model": "dall-e-3", "prompt": "a red circle"}
+    v1_response = await async_client.post("/v1/images/generations/", json=payload)
+    alias_response = await async_client.post("/backend-api/codex/images/generations/", json=payload)
+    assert v1_response.status_code == 405
+    assert alias_response.status_code == 405
+    assert v1_response.json()["error"]["type"] == "invalid_request_error"
+    assert alias_response.json() == v1_response.json()
+
+
+@pytest.mark.asyncio
 async def test_images_generations_rejects_transparent_background(async_client):
     response = await async_client.post(
         "/v1/images/generations",
@@ -584,6 +599,21 @@ async def test_backend_codex_images_edits_requires_native_image_data_urls(async_
         "images_route_complete route=edits model=gpt-image-2 stream=false status=400 outcome=invalid_request"
         in caplog.text
     )
+
+
+@pytest.mark.asyncio
+async def test_images_edits_trailing_slash_parity_between_v1_and_codex_alias(async_client):
+    # Codex joins `base_url` + "images/edits" without a trailing slash, so
+    # only the exact paths are handled. The trailing-slash variants fall
+    # through to the SPA catch-all route and must fail identically (405 with
+    # the OpenAI error envelope) on the canonical and alias surfaces.
+    payload = {"model": "gpt-image-2", "prompt": "make it green", "images": []}
+    v1_response = await async_client.post("/v1/images/edits/", json=payload)
+    alias_response = await async_client.post("/backend-api/codex/images/edits/", json=payload)
+    assert v1_response.status_code == 405
+    assert alias_response.status_code == 405
+    assert v1_response.json()["error"]["type"] == "invalid_request_error"
+    assert alias_response.json() == v1_response.json()
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_images.py
+++ b/tests/integration/test_proxy_images.py
@@ -199,6 +199,18 @@ async def test_images_generations_auth_rejection_records_route_observability(asy
 
 
 @pytest.mark.asyncio
+async def test_backend_codex_images_generations_alias_uses_same_validation(async_client):
+    response = await async_client.post(
+        "/backend-api/codex/images/generations",
+        json={"model": "dall-e-3", "prompt": "a red circle"},
+    )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"]["type"] == "invalid_request_error"
+    assert body["error"]["param"] == "model"
+
+
+@pytest.mark.asyncio
 async def test_images_generations_rejects_transparent_background(async_client):
     response = await async_client.post(
         "/v1/images/generations",
@@ -558,6 +570,41 @@ async def test_images_generations_failed_image_returns_5xx(async_client, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_backend_codex_images_edits_requires_native_image_data_urls(async_client, caplog):
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/backend-api/codex/images/edits",
+            json={"model": "gpt-image-2", "prompt": "make it green", "images": []},
+        )
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"]["type"] == "invalid_request_error"
+    assert body["error"]["param"] == "images"
+    assert (
+        "images_route_complete route=edits model=gpt-image-2 stream=false status=400 outcome=invalid_request"
+        in caplog.text
+    )
+
+
+@pytest.mark.asyncio
+async def test_backend_codex_images_edits_invalid_utf8_returns_400(async_client, caplog):
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/backend-api/codex/images/edits",
+            content=b"\xff",
+            headers={"content-type": "application/json"},
+        )
+
+    assert response.status_code == 400
+    body = response.json()
+    assert body["error"]["type"] == "invalid_request_error"
+    assert body["error"]["param"] == "prompt"
+    assert (
+        "images_route_complete route=edits model=unknown stream=false status=400 outcome=invalid_request" in caplog.text
+    )
+
+
+@pytest.mark.asyncio
 async def test_images_edits_basic_round_trip(async_client, monkeypatch):
     await _import_account(async_client, "acc_images_edit", "img-edit@example.com")
 
@@ -610,6 +657,77 @@ async def test_images_edits_basic_round_trip(async_client, monkeypatch):
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["data"] == [{"b64_json": "EDITED_B64", "revised_prompt": "edited"}]
+
+    # Verify the upstream payload contained the image as an input_image data
+    # URL alongside the prompt text.
+    input_value = cast(list[Any], captured["input"])
+    assert input_value
+    first_message = cast(dict[str, Any], input_value[0])
+    content = cast(list[Any], first_message["content"])
+    text_part = cast(dict[str, Any], content[0])
+    assert text_part["type"] == "input_text"
+    assert text_part["text"] == "make it green"
+    image_parts: list[dict[str, Any]] = [
+        cast(dict[str, Any], p) for p in content if isinstance(p, dict) and p.get("type") == "input_image"
+    ]
+    assert len(image_parts) == 1
+    image_url_value = cast(str, image_parts[0]["image_url"])
+    assert image_url_value.startswith("data:image/png;base64,")
+
+
+@pytest.mark.asyncio
+async def test_backend_codex_images_edits_json_data_urls_round_trip(async_client, monkeypatch):
+    await _import_account(async_client, "acc_images_edit_codex", "img-edit-codex@example.com")
+
+    captured: dict[str, object] = {}
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del headers, access_token, base_url, raise_for_status, kwargs
+        captured["input"] = payload.input
+        captured["tools"] = list(payload.tools)
+        captured["account_id"] = account_id
+        yield _sse(
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "image_generation_call",
+                    "id": "ig_edit_codex",
+                    "status": "completed",
+                    "result": "EDITED_B64",
+                    "revised_prompt": "edited",
+                    "size": "1024x1024",
+                    "quality": "auto",
+                    "background": "auto",
+                    "output_format": "png",
+                },
+            }
+        )
+        yield _sse({"type": "response.completed", "response": {}})
+
+    async def fake_ensure_fresh(self, account, **kwargs):
+        del self, kwargs
+        return account
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh)
+
+    image_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+    image_url = f"data:image/png;base64,{base64.b64encode(image_bytes).decode('ascii')}"
+    response = await async_client.post(
+        "/backend-api/codex/images/edits",
+        json={
+            "model": "gpt-image-2",
+            "prompt": "make it green",
+            "images": [{"image_url": image_url}],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["data"] == [{"b64_json": "EDITED_B64", "revised_prompt": "edited"}]
+    input_items = cast(list[dict[str, Any]], captured["input"])
+    content = cast(list[dict[str, Any]], input_items[0]["content"])
+    assert content[1]["type"] == "input_image"
 
     # Verify the upstream payload contained the image as an input_image data
     # URL alongside the prompt text.


### PR DESCRIPTION
## Summary

- Adds non-OpenAPI Codex-base aliases for image generation and image edits.
- Adapts Codex JSON `images[].image_url` base64 data URLs to the existing Images edit pipeline.
- Adds regression coverage and an OpenSpec proposal/spec/tasks bundle.

## Root cause

Codex-LB uses `/backend-api/codex` as Codex's base URL, but the existing Images handlers were registered only under `/v1/images/*`. Reference-image edit requests therefore returned `405 Method Not Allowed` before reaching the image pipeline.

## Maintainer review updates

- Rebased onto current `main`.
- Captures `started_at` at Codex edit-handler entry and records all early 400 rejections for Images observability parity.
- Handles invalid UTF-8 JSON bodies as OpenAI-shaped 400 responses.
- Restores the complete pre-existing `/v1/images/edits` round-trip test and keeps the Codex test separate.
- Adds `nazirulhafiy` to `.all-contributorsrc`.

## Validation

- `uv run pytest tests/integration/test_proxy_images.py -q` — 35 passed
- `uv run pre-commit run local-ci --hook-stage manual --all-files` — passed
- `.github/scripts/check_all_contributors.py` — passed
- Live local Codex-LB alias check confirms requests reach handler validation rather than returning 405.

## OpenSpec

- Change: `openspec/changes/add-codex-images-route-alias/`
- Strict OpenSpec CLI validation is documented as pending because the CLI is not installed in this checkout.

No linked issue: this is a direct Codex compatibility regression.