### PR TITLE
feat(models): add GPT-5.6 bootstrap catalog and extended reasoning efforts

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -917,6 +917,16 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "knightcn1983",
+      "name": "knightcn1983",
+      "avatar_url": "https://avatars.githubusercontent.com/u/66906018?v=4",
+      "profile": "https://github.com/knightcn1983",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -57,7 +57,13 @@ class ModelRegistrySnapshot:
     fetched_at: float
 
 
-_BOOTSTRAP_WEBSOCKET_PREFERRED_MODEL_PATTERNS = ("gpt-5.5", "gpt-5.5-*", "gpt-5.4", "gpt-5.4-*")
+_BOOTSTRAP_WEBSOCKET_PREFERRED_MODEL_PATTERNS = (
+    "gpt-5.6-*",
+    "gpt-5.5",
+    "gpt-5.5-*",
+    "gpt-5.4",
+    "gpt-5.4-*",
+)
 
 _REASONING_LEVELS_STANDARD = (
     ReasoningLevel(effort="low", description="Low reasoning effort"),
@@ -71,6 +77,27 @@ _REASONING_LEVELS_EXTENDED = (
     ReasoningLevel(effort="high", description="High reasoning effort"),
     ReasoningLevel(effort="xhigh", description="Extra high reasoning effort"),
 )
+
+_REASONING_LEVELS_MAX = (
+    ReasoningLevel(effort="low", description="Fast responses with lighter reasoning"),
+    ReasoningLevel(effort="medium", description="Balances speed and reasoning depth for everyday tasks"),
+    ReasoningLevel(effort="high", description="Greater reasoning depth for complex problems"),
+    ReasoningLevel(effort="xhigh", description="Extra high reasoning depth for complex problems"),
+    ReasoningLevel(effort="max", description="Maximum reasoning depth for the hardest problems"),
+)
+
+_REASONING_LEVELS_ULTRA = (
+    *_REASONING_LEVELS_MAX,
+    ReasoningLevel(effort="ultra", description="Maximum reasoning with automatic task delegation"),
+)
+
+_BOOTSTRAP_FAST_SERVICE_TIERS: list[JsonValue] = [
+    {
+        "id": "priority",
+        "name": "Fast",
+        "description": "1.5x speed, increased usage",
+    }
+]
 
 _BOOTSTRAP_AVAILABLE_IN_PLANS = frozenset(
     {
@@ -94,6 +121,32 @@ _BOOTSTRAP_AVAILABLE_IN_PLANS = frozenset(
     }
 )
 
+_BOOTSTRAP_GPT56_AVAILABLE_IN_PLANS = frozenset(
+    {
+        "business",
+        "edu",
+        "edu_plus",
+        "edu_pro",
+        "education",
+        "enterprise",
+        "enterprise_cbp_automation",
+        "enterprise_cbp_usage_based",
+        "finserv",
+        "free",
+        "free_workspace",
+        "go",
+        "hc",
+        "k12",
+        "plus",
+        "pro",
+        "prolite",
+        "quorum",
+        "sci",
+        "self_serve_business_usage_based",
+        "team",
+    }
+)
+
 _BOOTSTRAP_CORE_AVAILABLE_IN_PLANS = frozenset(
     plan for plan in _BOOTSTRAP_AVAILABLE_IN_PLANS if plan not in {"free", "free_workspace", "k12"}
 )
@@ -105,6 +158,7 @@ def _bootstrap_model(
     *,
     prefer_websockets: bool,
     minimal_client_version: str | None,
+    description: str | None = None,
     reasoning_levels: tuple[ReasoningLevel, ...] = _REASONING_LEVELS_EXTENDED,
     context_window: int = 272_000,
     input_modalities: tuple[str, ...] = ("text", "image"),
@@ -114,6 +168,7 @@ def _bootstrap_model(
     available_in_plans: frozenset[str] = _BOOTSTRAP_AVAILABLE_IN_PLANS,
     visibility: str = "list",
     shell_type: str = "shell_command",
+    priority: int = 0,
     raw: dict[str, JsonValue] | None = None,
 ) -> UpstreamModel:
     raw_fields: dict[str, JsonValue] = {
@@ -127,7 +182,7 @@ def _bootstrap_model(
     return UpstreamModel(
         slug=slug,
         display_name=display_name,
-        description=display_name,
+        description=description or display_name,
         context_window=context_window,
         input_modalities=input_modalities,
         supported_reasoning_levels=reasoning_levels,
@@ -139,10 +194,39 @@ def _bootstrap_model(
         supports_parallel_tool_calls=True,
         supported_in_api=supported_in_api,
         minimal_client_version=minimal_client_version,
-        priority=0,
+        priority=priority,
         available_in_plans=available_in_plans,
         raw=raw_fields,
     )
+
+
+def _gpt56_raw(
+    *,
+    multi_agent_version: str,
+    availability_nux: JsonValue = None,
+) -> dict[str, JsonValue]:
+    return {
+        "availability_nux": availability_nux,
+        "apply_patch_tool_type": "freeform",
+        "web_search_tool_type": "text_and_image",
+        "supports_image_detail_original": True,
+        "truncation_policy": {"mode": "tokens", "limit": 10_000},
+        "tool_mode": "code_mode_only",
+        "multi_agent_version": multi_agent_version,
+        "use_responses_lite": True,
+        "include_skills_usage_instructions": False,
+        "auto_review_model_override": None,
+        "auto_compact_token_limit": None,
+        "comp_hash": "3000",
+        "reasoning_summary_format": "experimental",
+        "default_reasoning_summary": "none",
+        "upgrade": None,
+        "experimental_supported_tools": [],
+        "supports_search_tool": True,
+        "default_service_tier": None,
+        "service_tiers": _BOOTSTRAP_FAST_SERVICE_TIERS,
+        "additional_speed_tiers": ["fast"],
+    }
 
 
 # Static bundled fallback models used before the first upstream registry refresh.
@@ -152,6 +236,54 @@ def _bootstrap_model(
 # explicit rather than inherited from helper defaults; every slug must exist
 # upstream, and live upstream data always takes precedence once available.
 _BOOTSTRAP_STATIC_MODELS: tuple[UpstreamModel, ...] = (
+    _bootstrap_model(
+        "gpt-5.6-sol",
+        "GPT-5.6-Sol",
+        description="Latest frontier agentic coding model.",
+        prefer_websockets=True,
+        minimal_client_version="0.144.0",
+        reasoning_levels=_REASONING_LEVELS_ULTRA,
+        context_window=372_000,
+        default_reasoning_level="low",
+        priority=1,
+        available_in_plans=_BOOTSTRAP_GPT56_AVAILABLE_IN_PLANS,
+        raw=_gpt56_raw(
+            multi_agent_version="v2",
+            availability_nux={
+                "message": (
+                    "Our most capable model yet. GPT-5.6 Sol can tackle complex code changes, dig into research, "
+                    "produce polished documents, and take on your most ambitious work. Sol is highly capable at "
+                    "lower reasoning efforts—try starting lower, then turn it up for harder jobs."
+                )
+            },
+        ),
+    ),
+    _bootstrap_model(
+        "gpt-5.6-terra",
+        "GPT-5.6-Terra",
+        description="Balanced agentic coding model for everyday work.",
+        prefer_websockets=True,
+        minimal_client_version="0.144.0",
+        reasoning_levels=_REASONING_LEVELS_ULTRA,
+        context_window=372_000,
+        default_reasoning_level="medium",
+        priority=2,
+        available_in_plans=_BOOTSTRAP_GPT56_AVAILABLE_IN_PLANS,
+        raw=_gpt56_raw(multi_agent_version="v2"),
+    ),
+    _bootstrap_model(
+        "gpt-5.6-luna",
+        "GPT-5.6-Luna",
+        description="Fast and affordable agentic coding model.",
+        prefer_websockets=True,
+        minimal_client_version="0.144.0",
+        reasoning_levels=_REASONING_LEVELS_MAX,
+        context_window=372_000,
+        default_reasoning_level="medium",
+        priority=3,
+        available_in_plans=_BOOTSTRAP_GPT56_AVAILABLE_IN_PLANS,
+        raw=_gpt56_raw(multi_agent_version="v1"),
+    ),
     _bootstrap_model(
         "gpt-5.5",
         "GPT-5.5",

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -726,6 +726,12 @@ _POISONED_LOCAL_COMPACT_FALLBACK_TEXT = "Local compact fallback preserved the la
 _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS = 100_000
 _COMPACT_UPSTREAM_HEAD_ESTIMATED_TOKENS = 12_000
 _ESTIMATED_CHARS_PER_TOKEN = 4
+_REASONING_EFFORT_WIRE_ALIASES = {"ultra": "max"}
+
+
+def normalize_reasoning_effort_for_wire(effort: str) -> str:
+    normalized = effort.strip().lower()
+    return _REASONING_EFFORT_WIRE_ALIASES.get(normalized, normalized)
 
 
 def _strip_unsupported_fields(payload: MutableJsonObject) -> MutableJsonObject:
@@ -1127,7 +1133,7 @@ def normalize_reasoning_aliases(payload: MutableJsonObject) -> None:
         reasoning_map = {}
 
     if isinstance(reasoning_effort, str) and "effort" not in reasoning_map:
-        reasoning_map["effort"] = reasoning_effort
+        reasoning_map["effort"] = normalize_reasoning_effort_for_wire(reasoning_effort)
     if isinstance(reasoning_summary, str) and "summary" not in reasoning_map:
         reasoning_map["summary"] = reasoning_summary
 
@@ -1140,6 +1146,10 @@ def normalize_reasoning_aliases(payload: MutableJsonObject) -> None:
             reasoning_map["effort"] = provider_reasoning["effort"]
         if "summary" not in reasoning_map and "summary" in provider_reasoning:
             reasoning_map["summary"] = provider_reasoning["summary"]
+
+    effective_effort = reasoning_map.get("effort")
+    if isinstance(effective_effort, str):
+        reasoning_map["effort"] = normalize_reasoning_effort_for_wire(effective_effort)
 
     if reasoning_map:
         payload["reasoning"] = reasoning_map
@@ -1154,8 +1164,8 @@ def _normalize_thinking_alias(
         return {"effort": "medium"} if thinking else None
     if isinstance(thinking, str):
         normalized = thinking.strip().lower()
-        if normalized in {"low", "medium", "high", "xhigh"}:
-            return {"effort": normalized}
+        if normalized in {"low", "medium", "high", "xhigh", "max", "ultra"}:
+            return {"effort": normalize_reasoning_effort_for_wire(normalized)}
         if normalized in {"enabled", "true", "on"}:
             return {"effort": "medium"}
         if normalized in {"disabled", "false", "off"}:
@@ -1166,7 +1176,7 @@ def _normalize_thinking_alias(
         effort = thinking_mapping.get("effort")
         summary = thinking_mapping.get("summary")
         if isinstance(effort, str) and effort.strip():
-            normalized["effort"] = effort.strip().lower()
+            normalized["effort"] = normalize_reasoning_effort_for_wire(effort)
         if isinstance(summary, str) and summary.strip():
             normalized["summary"] = summary.strip()
         if normalized:

--- a/app/modules/api_keys/schemas.py
+++ b/app/modules/api_keys/schemas.py
@@ -29,7 +29,9 @@ class ApiKeyCreateRequest(DashboardModel):
     allowed_models: list[str] | None = None
     apply_to_codex_model: bool = False
     enforced_model: str | None = Field(default=None, min_length=1)
-    enforced_reasoning_effort: str | None = Field(default=None, pattern=r"(?i)^(none|minimal|low|medium|high|xhigh)$")
+    enforced_reasoning_effort: str | None = Field(
+        default=None, pattern=r"(?i)^(none|minimal|low|medium|high|xhigh|max|ultra)$"
+    )
     enforced_service_tier: str | None = Field(default=None, pattern=r"(?i)^(auto|default|priority|flex|fast)$")
     traffic_class: str | None = Field(default=None, pattern=r"(?i)^(foreground|opportunistic)$")
     transport_policy_override: str | None = None
@@ -46,7 +48,9 @@ class ApiKeyUpdateRequest(DashboardModel):
     allowed_models: list[str] | None = None
     apply_to_codex_model: bool | None = None
     enforced_model: str | None = Field(default=None, min_length=1)
-    enforced_reasoning_effort: str | None = Field(default=None, pattern=r"(?i)^(none|minimal|low|medium|high|xhigh)$")
+    enforced_reasoning_effort: str | None = Field(
+        default=None, pattern=r"(?i)^(none|minimal|low|medium|high|xhigh|max|ultra)$"
+    )
     enforced_service_tier: str | None = Field(default=None, pattern=r"(?i)^(auto|default|priority|flex|fast)$")
     traffic_class: str | None = Field(default=None, pattern=r"(?i)^(foreground|opportunistic)$")
     transport_policy_override: str | None = None

--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -1322,7 +1322,7 @@ def _normalize_model_slug(value: str | None) -> str | None:
     return normalized
 
 
-_SUPPORTED_REASONING_EFFORTS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh"})
+_SUPPORTED_REASONING_EFFORTS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"})
 _SUPPORTED_SERVICE_TIERS = frozenset({"auto", "default", "priority", "flex"})
 
 

--- a/app/modules/automations/schemas.py
+++ b/app/modules/automations/schemas.py
@@ -11,7 +11,7 @@ AUTOMATION_SCHEDULE_TYPES = ("daily",)
 AUTOMATION_WEEKDAY_CODES = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
 AUTOMATION_RUN_STATUSES = ("running", "success", "failed", "partial")
 AUTOMATION_RUN_TRIGGERS = ("scheduled", "manual")
-AUTOMATION_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
+AUTOMATION_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max", "ultra")
 
 AutomationWeekday = Literal["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
 
@@ -42,7 +42,7 @@ class AutomationJobCreateRequest(DashboardModel):
     include_paused_accounts: bool = Field(default=False, alias="includePausedAccounts")
     schedule: AutomationScheduleRequest
     model: str = Field(min_length=1)
-    reasoning_effort: str | None = Field(default=None, pattern=r"(?i)^(minimal|low|medium|high|xhigh)$")
+    reasoning_effort: str | None = Field(default=None, pattern=r"(?i)^(minimal|low|medium|high|xhigh|max|ultra)$")
     prompt: str | None = Field(default=None, max_length=1000)
     account_ids: list[str] = Field(default_factory=list, max_length=128, alias="accountIds")
 
@@ -61,7 +61,7 @@ class AutomationJobUpdateRequest(DashboardModel):
     include_paused_accounts: bool | None = Field(default=None, alias="includePausedAccounts")
     schedule: AutomationScheduleRequest | None = None
     model: str | None = Field(default=None, min_length=1)
-    reasoning_effort: str | None = Field(default=None, pattern=r"(?i)^(minimal|low|medium|high|xhigh)$")
+    reasoning_effort: str | None = Field(default=None, pattern=r"(?i)^(minimal|low|medium|high|xhigh|max|ultra)$")
     prompt: str | None = Field(default=None, max_length=1000)
     account_ids: list[str] | None = Field(default=None, max_length=128, alias="accountIds")
 

--- a/app/modules/automations/service.py
+++ b/app/modules/automations/service.py
@@ -20,7 +20,11 @@ from app.core.clients.proxy import compact_responses as core_compact_responses
 from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
 from app.core.openai.model_registry import get_model_registry
-from app.core.openai.requests import ResponsesCompactRequest, ResponsesReasoning
+from app.core.openai.requests import (
+    ResponsesCompactRequest,
+    ResponsesReasoning,
+    normalize_reasoning_effort_for_wire,
+)
 from app.core.upstream_proxy import ResolvedUpstreamRoute, resolve_upstream_route
 from app.core.utils.time import naive_utc_to_epoch, utcnow
 from app.db.models import Account, AccountStatus
@@ -1148,7 +1152,11 @@ class AutomationsService:
                     model=run_model,
                     input=run_prompt,
                     instructions="Automation ping",
-                    reasoning=ResponsesReasoning(effort=run_reasoning_effort) if run_reasoning_effort else None,
+                    reasoning=(
+                        ResponsesReasoning(effort=normalize_reasoning_effort_for_wire(run_reasoning_effort))
+                        if run_reasoning_effort
+                        else None
+                    ),
                 )
                 request_started_at = time.monotonic()
                 compact_response = await asyncio.wait_for(
@@ -2123,7 +2131,7 @@ def _normalize_reasoning_effort(value: str | None, *, model_slug: str) -> str | 
     normalized = value.strip().lower()
     if not normalized:
         return None
-    allowed = {"minimal", "low", "medium", "high", "xhigh"}
+    allowed = {"minimal", "low", "medium", "high", "xhigh", "max", "ultra"}
     if normalized not in allowed:
         raise AutomationValidationError(
             f"Unsupported reasoning effort: {value}",

--- a/app/modules/dashboard/api.py
+++ b/app/modules/dashboard/api.py
@@ -42,7 +42,7 @@ async def list_models() -> dict:
     models_by_slug = registry.get_models_with_fallback()
     if not models_by_slug:
         return {"models": []}
-    allowed_efforts = {"minimal", "low", "medium", "high", "xhigh"}
+    allowed_efforts = {"minimal", "low", "medium", "high", "xhigh", "max", "ultra"}
 
     def _normalize_effort(value: str | None) -> str | None:
         if not isinstance(value, str):

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -165,6 +165,7 @@ from app.modules.proxy.request_policy import (
     enforce_strict_function_tools_format,
     enforce_strict_text_format,
     normalize_responses_request_payload,
+    normalize_source_reasoning_payload,
     openai_client_payload_error,
     openai_validation_error,
     resolve_model_alias,
@@ -3194,6 +3195,7 @@ async def _source_responses_response(
     )
     source_payload = payload.model_dump(mode="json", exclude_none=True)
     source_payload["stream"] = bool(payload.stream)
+    normalize_source_reasoning_payload(source_payload)
 
     if payload.stream:
         try:

--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -8,7 +8,13 @@ from app.core.errors import OpenAIErrorEnvelope, openai_error
 from app.core.exceptions import ProxyModelNotAllowed
 from app.core.openai.exceptions import ClientPayloadError
 from app.core.openai.model_registry import ModelRegistry, get_model_registry
-from app.core.openai.requests import ResponsesCompactRequest, ResponsesReasoning, ResponsesRequest
+from app.core.openai.requests import (
+    ResponsesCompactRequest,
+    ResponsesReasoning,
+    ResponsesRequest,
+    normalize_reasoning_aliases,
+    normalize_reasoning_effort_for_wire,
+)
 from app.core.openai.strict_schema import (
     validate_strict_function_tool_schema,
     validate_strict_json_schema,
@@ -183,6 +189,7 @@ def sanitize_source_chat_payload(
     empty list, so an unfiltered ``model_dump`` forwards ``"tools": []`` and any
     client-side reasoning toggles verbatim.
     """
+    normalize_source_reasoning_payload(payload)
     tools = payload.get("tools")
     if isinstance(tools, list) and not tools:
         payload.pop("tools", None)
@@ -191,6 +198,22 @@ def sanitize_source_chat_payload(
     if not allow_reasoning:
         for key in _SOURCE_REASONING_TOGGLE_KEYS:
             payload.pop(key, None)
+
+
+def normalize_source_reasoning_payload(payload: dict[str, JsonValue]) -> None:
+    """Canonicalize client reasoning aliases on direct model-source egress."""
+    reasoning_effort = payload.get("reasoning_effort")
+    if isinstance(reasoning_effort, str):
+        wire_effort = normalize_reasoning_effort_for_wire(reasoning_effort)
+        payload["reasoning_effort"] = wire_effort
+        reasoning = payload.get("reasoning")
+        if is_json_mapping(reasoning):
+            reasoning_map = dict(reasoning.items())
+            reasoning_map.setdefault("effort", wire_effort)
+            payload["reasoning"] = reasoning_map
+        elif reasoning is None:
+            payload["reasoning"] = {"effort": wire_effort}
+    normalize_reasoning_aliases(payload)
 
 
 def apply_api_key_enforcement_to_chat_payload(
@@ -208,12 +231,13 @@ def apply_api_key_enforcement_to_chat_payload(
         return
 
     if api_key.enforced_reasoning_effort is not None:
-        payload["reasoning_effort"] = api_key.enforced_reasoning_effort
+        wire_effort = normalize_reasoning_effort_for_wire(api_key.enforced_reasoning_effort)
+        payload["reasoning_effort"] = wire_effort
         reasoning = payload.get("reasoning")
         if isinstance(reasoning, dict):
-            payload["reasoning"] = {**reasoning, "effort": api_key.enforced_reasoning_effort}
+            payload["reasoning"] = {**reasoning, "effort": wire_effort}
         else:
-            payload["reasoning"] = {"effort": api_key.enforced_reasoning_effort}
+            payload["reasoning"] = {"effort": wire_effort}
 
     if api_key.enforced_service_tier is not None:
         if api_key.enforced_service_tier in _UPSTREAM_OMIT_SERVICE_TIERS:
@@ -337,6 +361,17 @@ def normalize_unsupported_reasoning_effort(
 
     requested_effort = payload.reasoning.effort
     normalized_effort = requested_effort.strip().lower()
+    wire_effort = normalize_reasoning_effort_for_wire(requested_effort)
+    if wire_effort != normalized_effort:
+        payload.reasoning.effort = wire_effort
+        logger.info(
+            "reasoning_effort_normalized request_id=%s model=%s requested_effort=%s normalized_effort=%s",
+            get_request_id(),
+            payload.model,
+            requested_effort,
+            wire_effort,
+        )
+        return
     if normalized_effort not in _UNSUPPORTED_UPSTREAM_REASONING_EFFORTS:
         return
 

--- a/frontend/src/features/api-keys/components/api-key-create-dialog.tsx
+++ b/frontend/src/features/api-keys/components/api-key-create-dialog.tsx
@@ -31,6 +31,7 @@ import { ModelSourceMultiSelect } from "@/features/model-sources/components/mode
 import type {
   ApiKeyCreateRequest,
   LimitRuleCreate,
+  ReasoningEffortType,
   ServiceTierType,
   TrafficClass,
   TransportPolicyOverride,
@@ -120,7 +121,7 @@ function ApiKeyCreateForm({ busy, onClose, onSubmit }: ApiKeyCreateFormProps) {
       enforcedReasoningEffort:
         draft.enforcedReasoningEffort === "none"
           ? null
-          : draft.enforcedReasoningEffort as "minimal" | "low" | "medium" | "high" | "xhigh",
+          : draft.enforcedReasoningEffort as ReasoningEffortType,
       enforcedServiceTier: draft.enforcedServiceTier === "none" ? null : draft.enforcedServiceTier as ServiceTierType,
       trafficClass: draft.trafficClass,
       transportPolicyOverride: draft.transportPolicyOverride,
@@ -216,6 +217,8 @@ function ApiKeyCreateForm({ busy, onClose, onSubmit }: ApiKeyCreateFormProps) {
                   <SelectItem value="medium">Medium</SelectItem>
                   <SelectItem value="high">High</SelectItem>
                   <SelectItem value="xhigh">XHigh</SelectItem>
+                  <SelectItem value="max">Max</SelectItem>
+                  <SelectItem value="ultra">Ultra</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/frontend/src/features/api-keys/components/api-key-edit-dialog.tsx
+++ b/frontend/src/features/api-keys/components/api-key-edit-dialog.tsx
@@ -34,6 +34,7 @@ import type {
   ApiKeyUpdateRequest,
   LimitRuleCreate,
   LimitType,
+  ReasoningEffortType,
   ServiceTierType,
   TrafficClass,
   TransportPolicyOverride,
@@ -160,7 +161,8 @@ function ApiKeyEditForm({ apiKey, busy, onSubmit, onClose }: ApiKeyEditFormProps
       allowedModels: draft.selectedModels.length > 0 ? draft.selectedModels : null,
       applyToCodexModel: draft.applyToCodexModel,
       enforcedModel: draft.enforcedModel.trim() ? draft.enforcedModel.trim() : null,
-      enforcedReasoningEffort: draft.enforcedReasoningEffort === "none" ? null : draft.enforcedReasoningEffort as "minimal" | "low" | "medium" | "high" | "xhigh",
+      enforcedReasoningEffort:
+        draft.enforcedReasoningEffort === "none" ? null : draft.enforcedReasoningEffort as ReasoningEffortType,
       enforcedServiceTier: draft.enforcedServiceTier === "none" ? null : draft.enforcedServiceTier as ServiceTierType,
       trafficClass: draft.trafficClass,
       transportPolicyOverride: draft.transportPolicyOverride,
@@ -284,6 +286,8 @@ function ApiKeyEditForm({ apiKey, busy, onSubmit, onClose }: ApiKeyEditFormProps
                   <SelectItem value="medium">Medium</SelectItem>
                   <SelectItem value="high">High</SelectItem>
                   <SelectItem value="xhigh">XHigh</SelectItem>
+                  <SelectItem value="max">Max</SelectItem>
+                  <SelectItem value="ultra">Ultra</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/frontend/src/features/api-keys/schemas.test.ts
+++ b/frontend/src/features/api-keys/schemas.test.ts
@@ -6,6 +6,7 @@ import {
   ApiKeySchema,
   ApiKeyUpdateRequestSchema,
   LimitRuleCreateSchema,
+  ModelItemSchema,
 } from "@/features/api-keys/schemas";
 
 const ISO = "2026-01-01T00:00:00+00:00";
@@ -135,6 +136,20 @@ describe("ApiKeyCreateResponseSchema", () => {
   });
 });
 
+describe("ModelItemSchema", () => {
+  it("accepts extended GPT-5.6 reasoning efforts", () => {
+    const parsed = ModelItemSchema.parse({
+      id: "gpt-5.6-sol",
+      name: "GPT-5.6-Sol",
+      sourceOnly: false,
+      supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+      defaultReasoningEffort: "low",
+    });
+
+    expect(parsed.supportedReasoningEfforts).toEqual(["low", "medium", "high", "xhigh", "max", "ultra"]);
+  });
+});
+
 describe("ApiKeyCreateRequestSchema", () => {
   it("accepts optional assigned accounts", () => {
     const parsed = ApiKeyCreateRequestSchema.parse({
@@ -163,6 +178,15 @@ describe("ApiKeyCreateRequestSchema", () => {
     });
 
     expect(parsed.trafficClass).toBe("opportunistic");
+  });
+
+  it("accepts extended GPT-5.6 enforced reasoning in create payload", () => {
+    const parsed = ApiKeyCreateRequestSchema.parse({
+      name: "Extended reasoning key",
+      enforcedReasoningEffort: "ultra",
+    });
+
+    expect(parsed.enforcedReasoningEffort).toBe("ultra");
   });
 
   it("rejects invalid traffic class in create payload", () => {

--- a/frontend/src/features/api-keys/schemas.ts
+++ b/frontend/src/features/api-keys/schemas.ts
@@ -37,6 +37,9 @@ export const TRAFFIC_CLASSES = ["foreground", "opportunistic"] as const;
 export type TrafficClass = (typeof TRAFFIC_CLASSES)[number];
 export const TRANSPORT_POLICY_OVERRIDES = ["smart", "always_http", "always_websocket"] as const;
 export type TransportPolicyOverride = (typeof TRANSPORT_POLICY_OVERRIDES)[number];
+export const REASONING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max", "ultra"] as const;
+export type ReasoningEffortType = (typeof REASONING_EFFORTS)[number];
+export const ENFORCED_REASONING_EFFORTS = ["none", ...REASONING_EFFORTS] as const;
 
 export const ApiKeySchema = z.object({
   id: z.string(),
@@ -49,10 +52,7 @@ export const ApiKeySchema = z.object({
     .enum(TRAFFIC_CLASSES)
     .default("foreground"),
   transportPolicyOverride: z.enum(TRANSPORT_POLICY_OVERRIDES).nullable().default(null),
-  enforcedReasoningEffort: z
-    .enum(["none", "minimal", "low", "medium", "high", "xhigh"])
-    .nullable()
-    .default(null),
+  enforcedReasoningEffort: z.enum(ENFORCED_REASONING_EFFORTS).nullable().default(null),
   enforcedServiceTier: z
     .enum(SERVICE_TIERS)
     .nullable()
@@ -88,10 +88,7 @@ export const ApiKeyCreateRequestSchema = z.object({
   trafficClass: z.enum(TRAFFIC_CLASSES).optional(),
   transportPolicyOverride: z.enum(TRANSPORT_POLICY_OVERRIDES).nullable().optional(),
   enforcedModel: z.string().min(1).nullable().optional(),
-  enforcedReasoningEffort: z
-    .enum(["none", "minimal", "low", "medium", "high", "xhigh"])
-    .nullable()
-    .optional(),
+  enforcedReasoningEffort: z.enum(ENFORCED_REASONING_EFFORTS).nullable().optional(),
   enforcedServiceTier: z
     .enum(SERVICE_TIERS)
     .nullable()
@@ -115,10 +112,7 @@ export const ApiKeyUpdateRequestSchema = z.object({
   trafficClass: z.enum(TRAFFIC_CLASSES).optional(),
   transportPolicyOverride: z.enum(TRANSPORT_POLICY_OVERRIDES).nullable().optional(),
   enforcedModel: z.string().min(1).nullable().optional(),
-  enforcedReasoningEffort: z
-    .enum(["none", "minimal", "low", "medium", "high", "xhigh"])
-    .nullable()
-    .optional(),
+  enforcedReasoningEffort: z.enum(ENFORCED_REASONING_EFFORTS).nullable().optional(),
   enforcedServiceTier: z
     .enum(SERVICE_TIERS)
     .nullable()
@@ -146,11 +140,8 @@ export const ModelItemSchema = z.object({
   id: z.string(),
   name: z.string(),
   sourceOnly: z.boolean().default(false),
-  supportedReasoningEfforts: z.array(z.enum(["minimal", "low", "medium", "high", "xhigh"])).default([]),
-  defaultReasoningEffort: z
-    .enum(["minimal", "low", "medium", "high", "xhigh"])
-    .nullable()
-    .optional(),
+  supportedReasoningEfforts: z.array(z.enum(REASONING_EFFORTS)).default([]),
+  defaultReasoningEffort: z.enum(REASONING_EFFORTS).nullable().optional(),
 });
 export const ModelsResponseSchema = z.object({ models: z.array(ModelItemSchema) });
 export type ModelItem = z.infer<typeof ModelItemSchema>;

--- a/frontend/src/features/automations/components/automation-job-dialog.tsx
+++ b/frontend/src/features/automations/components/automation-job-dialog.tsx
@@ -57,13 +57,15 @@ const DEFAULT_SCHEDULE_TIME = "05:00";
 const DEFAULT_SCHEDULE_THRESHOLD_MINUTES = 0;
 const MAX_SCHEDULE_THRESHOLD_MINUTES = 240;
 const DEFAULT_REASONING_EFFORT_VALUE = "__default__";
-const FALLBACK_REASONING_EFFORTS: AutomationReasoningEffort[] = ["low", "medium", "high", "xhigh"];
+const FALLBACK_REASONING_EFFORTS: AutomationReasoningEffort[] = ["low", "medium", "high", "xhigh", "max", "ultra"];
 const REASONING_LABELS: Record<AutomationReasoningEffort, string> = {
   minimal: "Minimal",
   low: "Low",
   medium: "Medium",
   high: "High",
   xhigh: "XHigh",
+  max: "Max",
+  ultra: "Ultra",
 };
 
 type CreateFormField = "name" | "model" | "time" | "threshold" | "accounts";

--- a/frontend/src/features/automations/components/automations-page.tsx
+++ b/frontend/src/features/automations/components/automations-page.tsx
@@ -389,7 +389,7 @@ export function AutomationsPage() {
       days: ("mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun")[];
     };
     model: string;
-    reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh" | null;
+    reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra" | null;
     prompt?: string;
     accountIds: string[];
   }) => {
@@ -408,7 +408,7 @@ export function AutomationsPage() {
       days: ("mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun")[];
     };
     model?: string;
-    reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh" | null;
+    reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra" | null;
     prompt?: string;
     accountIds?: string[];
   }) => {

--- a/frontend/src/features/automations/schemas.test.ts
+++ b/frontend/src/features/automations/schemas.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   AutomationCreateRequestSchema,
   AutomationJobSchema,
+  AutomationReasoningEffortSchema,
   AutomationRunSchema,
 } from "@/features/automations/schemas";
 
@@ -65,6 +66,11 @@ describe("automations schemas", () => {
     });
 
     expect(parsed.accountIds).toEqual([]);
+  });
+
+  it("accepts extended GPT-5.6 reasoning efforts", () => {
+    expect(AutomationReasoningEffortSchema.parse("max")).toBe("max");
+    expect(AutomationReasoningEffortSchema.parse("ultra")).toBe("ultra");
   });
 
   it("rejects duplicate schedule days", () => {

--- a/frontend/src/features/automations/schemas.ts
+++ b/frontend/src/features/automations/schemas.ts
@@ -4,7 +4,7 @@ export const AutomationScheduleTypeSchema = z.enum(["daily"]);
 export const AutomationScheduleDaySchema = z.enum(["mon", "tue", "wed", "thu", "fri", "sat", "sun"]);
 export const AutomationRunStatusSchema = z.enum(["running", "success", "failed", "partial"]);
 export const AutomationRunTriggerSchema = z.enum(["scheduled", "manual"]);
-export const AutomationReasoningEffortSchema = z.enum(["minimal", "low", "medium", "high", "xhigh"]);
+export const AutomationReasoningEffortSchema = z.enum(["minimal", "low", "medium", "high", "xhigh", "max", "ultra"]);
 
 export const AutomationScheduleDaysSchema = z
   .array(AutomationScheduleDaySchema)

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -199,7 +199,7 @@ const AutomationCreatePayloadSchema = z.object({
 	includePausedAccounts: z.boolean().optional(),
 	schedule: AutomationSchedulePayloadSchema,
 	model: z.string().min(1),
-	reasoningEffort: z.enum(["minimal", "low", "medium", "high", "xhigh"]).nullable().optional(),
+	reasoningEffort: z.enum(["minimal", "low", "medium", "high", "xhigh", "max", "ultra"]).nullable().optional(),
 	prompt: z.string().optional(),
 	accountIds: z.array(z.string().min(1)),
 });
@@ -211,7 +211,7 @@ const AutomationUpdatePayloadSchema = z
 		includePausedAccounts: z.boolean().optional(),
 		schedule: AutomationSchedulePayloadSchema.optional(),
 		model: z.string().min(1).optional(),
-		reasoningEffort: z.enum(["minimal", "low", "medium", "high", "xhigh"]).nullable().optional(),
+		reasoningEffort: z.enum(["minimal", "low", "medium", "high", "xhigh", "max", "ultra"]).nullable().optional(),
 		prompt: z.string().min(1).optional(),
 		accountIds: z.array(z.string().min(1)).optional(),
 	})
@@ -255,7 +255,7 @@ type MockState = {
       days: Array<"mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun">;
     };
     model: string;
-    reasoningEffort: "minimal" | "low" | "medium" | "high" | "xhigh" | null;
+    reasoningEffort: "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra" | null;
     prompt: string;
     accountIds: string[];
     nextRunAt: string | null;
@@ -263,7 +263,7 @@ type MockState = {
       id: string;
       jobId: string;
       model: string | null;
-      reasoningEffort: "minimal" | "low" | "medium" | "high" | "xhigh" | null;
+      reasoningEffort: "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra" | null;
       trigger: "scheduled" | "manual";
       status: "running" | "success" | "failed" | "partial";
       scheduledFor: string;
@@ -287,6 +287,8 @@ type MockState = {
         | "medium"
         | "high"
         | "xhigh"
+        | "max"
+        | "ultra"
         | null;
       trigger: "scheduled" | "manual";
       status: "running" | "success" | "failed" | "partial";
@@ -618,7 +620,7 @@ function listAutomationRunsWithContext() {
 		(MockState["automationRuns"][string][number] & {
 			jobName: string | null;
 			model: string | null;
-			reasoningEffort: "minimal" | "low" | "medium" | "high" | "xhigh" | null;
+			reasoningEffort: "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra" | null;
 			effectiveStatus: "running" | "success" | "failed" | "partial";
 			totalAccounts: number;
 			completedAccounts: number;

--- a/openspec/changes/add-gpt56-bootstrap-models/context.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/context.md
@@ -1,0 +1,39 @@
+# GPT-5.6 bootstrap and reasoning context
+
+## Purpose and scope
+
+The bootstrap catalog keeps Codex model discovery usable before the first live
+registry refresh. This change mirrors the contract-relevant GPT-5.6 metadata
+published by OpenAI in `codex-rs/models-manager/models.json` at commit
+`3380969a29134630d56feb6218e8e8dcc5e8196d`. It does not add speculative model
+aliases, pricing, or request-log filtering behavior.
+
+## Decision rationale
+
+`ultra` is a Codex client-facing effort that enables proactive multi-agent
+behavior. The Codex client converts it to `max` when constructing the upstream
+request. codex-lb therefore preserves `ultra` in catalogs, API-key policies,
+automation configuration, and dashboard controls, but uses one wire
+canonicalization rule (`ultra` to `max`) at every ChatGPT/Codex forwarding path.
+
+Dropping `ultra` would make the bootstrap catalog diverge from upstream.
+Persisting `max` in place of a selected `ultra` would lose operator intent and
+break API round trips.
+
+## Constraints and failure modes
+
+- Clients older than `0.144.0` cannot drive the GPT-5.6 code-mode/Responses-Lite
+  contract, so all three bootstrap entries retain the upstream minimum version.
+- Literal wire `ultra` may be rejected or silently degraded by upstream, so it
+  must never leave the proxy as a reasoning effort, including on direct
+  OpenAI-compatible model-source routes.
+- Responses-Lite requires preservation of `additional_tools`; this change is
+  based on main after PR #1161, which supplies that transport behavior.
+- Live registry data remains authoritative after refresh.
+
+## Example
+
+An API key may return `enforcedReasoningEffort: "ultra"` from dashboard CRUD.
+When that key handles a Responses request, codex-lb forwards
+`reasoning: {"effort": "max"}` while request logs and the stored policy continue
+to identify the operator's `ultra` selection.

--- a/openspec/changes/add-gpt56-bootstrap-models/proposal.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Codex 0.144 ships GPT-5.6 family model catalog entries (`gpt-5.6-sol`,
+`gpt-5.6-terra`, and `gpt-5.6-luna`) with extended reasoning efforts. When
+codex-lb starts before a successful upstream model refresh, its bundled
+bootstrap catalog still lacks those slugs and dashboard/API-key validation still
+rejects the new `max` and `ultra` reasoning effort values.
+
+## What Changes
+
+- Add GPT-5.6 Sol, Terra, and Luna to the static bootstrap model catalog with
+  Codex-compatible context window, speed-tier, websocket, and reasoning
+  metadata.
+- Allow `max` and `ultra` reasoning efforts where codex-lb validates model
+  reasoning choices for dashboard model metadata, automations, and API-key
+  reasoning enforcement.
+- Preserve `ultra` as the client-facing selection while canonicalizing it to
+  the upstream wire-level `max` effort for Responses, Compact, API-key
+  enforcement, and automation requests.
+- Keep refreshed upstream model registry data authoritative over the bootstrap
+  catalog.
+
+## Impact
+
+- No database migration.
+- Offline/startup model listing includes GPT-5.6 family models.
+- Dashboard and API-key forms can preserve and submit the extended reasoning
+  efforts advertised by the model catalog.
+- Upstream requests never send the client-only `ultra` effort literally.

--- a/openspec/changes/add-gpt56-bootstrap-models/specs/api-keys/spec.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/specs/api-keys/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: API keys can enforce extended reasoning efforts
+
+The dashboard API key CRUD surface MUST allow callers to persist optional
+enforced reasoning efforts advertised by the model catalog, including extended
+GPT-5.6 efforts `max` and `ultra`.
+
+#### Scenario: API key accepts extended enforced reasoning effort on create
+
+- **WHEN** a dashboard client creates an API key with `enforcedReasoningEffort: "ultra"`
+- **THEN** the request is accepted
+- **AND** the response returns `enforcedReasoningEffort: "ultra"`
+
+#### Scenario: API key accepts extended enforced reasoning effort on update
+
+- **WHEN** a dashboard client updates an API key with `enforcedReasoningEffort: "max"`
+- **THEN** the request is accepted
+- **AND** the response returns `enforcedReasoningEffort: "max"`
+
+#### Scenario: API key preserves the client-facing ultra policy
+
+- **WHEN** a dashboard client creates or updates an API key with `enforcedReasoningEffort: "ultra"`
+- **THEN** the persisted and returned API-key policy remains `ultra`
+- **AND** wire-level canonicalization does not mutate the stored policy

--- a/openspec/changes/add-gpt56-bootstrap-models/specs/chat-completions-compat/spec.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/specs/chat-completions-compat/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Chat Completions normalizes provider-specific thinking aliases
+
+The service MUST normalize provider-specific Chat Completions reasoning
+controls used by non-OpenAI SDKs into the internal Responses `reasoning` shape
+before forwarding upstream. The original provider-specific fields MUST NOT be
+forwarded upstream unchanged. String and object aliases using `max` MUST remain
+`max`, while client-facing `ultra` MUST normalize to wire-level `max`.
+
+#### Scenario: Qwen-style enable_thinking is normalized
+
+- **WHEN** a client calls `/v1/chat/completions` with `enable_thinking: true`
+- **AND** no explicit `reasoning` or `reasoning_effort` override is present
+- **THEN** the mapped Responses payload includes `reasoning.effort: "medium"`
+- **AND** the forwarded upstream payload does not include `enable_thinking`
+
+#### Scenario: Anthropic-style thinking object is normalized
+
+- **WHEN** a client calls `/v1/chat/completions` with `thinking: {"type":"enabled","budget_tokens":2048}`
+- **AND** no explicit `reasoning` or `reasoning_effort` override is present
+- **THEN** the mapped Responses payload includes `reasoning.effort: "medium"`
+- **AND** the forwarded upstream payload does not include `thinking`
+
+#### Scenario: Chat ultra thinking alias normalizes to wire max
+
+- **WHEN** a client calls `/v1/chat/completions` with `thinking: "ultra"`
+- **AND** no explicit `reasoning` or `reasoning_effort` override is present
+- **THEN** the mapped Responses payload includes `reasoning.effort: "max"`
+- **AND** the forwarded upstream payload does not include `thinking`
+
+#### Scenario: Source-routed Chat reasoning aliases send wire max
+
+- **WHEN** an OpenAI-compatible source model supports reasoning
+- **AND** a Chat Completions request includes client-facing `ultra` in top-level or nested reasoning controls
+- **THEN** the source receives only canonical `max` reasoning efforts
+- **AND** provider-specific `thinking` and camel-case reasoning aliases are absent

--- a/openspec/changes/add-gpt56-bootstrap-models/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/specs/frontend-architecture/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Settings page
+
+The Settings page SHALL include sections for: routing settings (sticky threads,
+reset priority, prompt-cache affinity TTL), password management
+(setup/change/remove), TOTP management (setup/disable), API key auth toggle,
+API key management (table, create, edit, delete, regenerate), and
+sticky-session administration. API key create/edit controls that expose
+reasoning effort choices MUST include upstream-supported extended efforts such
+as `max` and `ultra`.
+
+#### Scenario: API key dialog offers extended reasoning efforts
+
+- **WHEN** an operator opens the API key create or edit dialog
+- **THEN** the enforced reasoning control offers `Max` and `Ultra` in addition to existing reasoning efforts
+
+## ADDED Requirements
+
+### Requirement: Automations page accepts extended reasoning efforts
+
+The Automations page SHALL allow operators to create and update scheduled
+refresh jobs using any reasoning effort advertised by the selected model,
+including extended GPT-5.6 efforts such as `max` and `ultra`.
+
+#### Scenario: Automation dialog offers extended model reasoning efforts
+
+- **WHEN** a selected model advertises `max` or `ultra` in `supportedReasoningEfforts`
+- **THEN** the automation create/edit dialog offers those efforts as selectable values

--- a/openspec/changes/add-gpt56-bootstrap-models/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/specs/model-catalog-compat/spec.md
@@ -1,0 +1,47 @@
+## MODIFIED Requirements
+
+### Requirement: Bootstrap model catalog is available before refresh
+
+Before the first successful upstream model-registry refresh, the system MUST
+serve a conservative static catalog of known Codex model slugs from both
+`GET /v1/models` and `GET /backend-api/codex/models`. This static catalog is a
+bundled fallback for startup/offline paths; refreshed upstream model-registry
+data remains the authoritative source once available. The bootstrap catalog MUST
+include `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`,
+`gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`,
+`gpt-5.2`, and `codex-auto-review`, and MUST NOT invent unverified variant
+slugs such as `gpt-5.5-pro` or a bare `gpt-5.6`.
+
+#### Scenario: OpenAI-compatible models endpoint serves bootstrap slugs
+
+- **GIVEN** the model registry has no refreshed upstream snapshot
+- **WHEN** a client calls `GET /v1/models`
+- **THEN** the response contains exactly the bootstrap model slugs
+- **AND** the response includes `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`
+- **AND** the response does not include `gpt-5.5-pro` or bare `gpt-5.6`
+
+#### Scenario: Codex-native models endpoint serves GPT-5.6 bootstrap metadata
+
+- **GIVEN** the model registry has no refreshed upstream snapshot
+- **WHEN** a client calls `GET /backend-api/codex/models`
+- **THEN** the `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` entries mirror the contract-relevant upstream metadata, including `minimal_client_version: "0.144.0"`, `tool_mode: "code_mode_only"`, Responses-Lite, context-window, visibility, speed-tier, plan-availability, and reasoning fields
+- **AND** Sol and Terra advertise multi-agent metadata version `v2`
+- **AND** Luna advertises multi-agent metadata version `v1`
+- **AND** Sol and Terra advertise `low`, `medium`, `high`, `xhigh`, `max`, and `ultra`
+- **AND** Luna advertises `low`, `medium`, `high`, `xhigh`, and `max`
+
+## ADDED Requirements
+
+### Requirement: Dashboard model metadata exposes supported reasoning efforts
+
+When serving `GET /api/models`, the system MUST expose the supported reasoning
+efforts advertised by each public model catalog entry. The response MUST include
+new upstream-supported efforts such as `max` and `ultra` instead of filtering
+them out.
+
+#### Scenario: Dashboard model list exposes GPT-5.6 reasoning efforts
+
+- **WHEN** the model catalog contains `gpt-5.6-sol` with supported efforts `low`, `medium`, `high`, `xhigh`, `max`, and `ultra`
+- **WHEN** a client calls `GET /api/models`
+- **THEN** the `gpt-5.6-sol` entry's `supportedReasoningEfforts` includes `max` and `ultra`
+- **AND** `defaultReasoningEffort` reflects the catalog default

--- a/openspec/changes/add-gpt56-bootstrap-models/specs/responses-api-compat/spec.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/specs/responses-api-compat/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Client-facing ultra reasoning canonicalizes to wire max
+
+The proxy MUST preserve `ultra` as a client-facing model-catalog and policy
+value while canonicalizing it to `max` before forwarding any Responses or
+Compact request to an upstream, including OpenAI-compatible model sources. The
+canonicalization MUST apply after API-key enforcement and to
+automation-generated Compact requests.
+
+#### Scenario: API-key ultra enforcement sends wire max
+
+- **WHEN** an API key enforces `ultra` on a Responses request
+- **THEN** the API-key policy remains `ultra`
+- **AND** the forwarded upstream request uses `reasoning.effort: "max"`
+
+#### Scenario: Automation ultra selection sends wire max
+
+- **WHEN** an automation run is configured with `reasoningEffort: "ultra"`
+- **THEN** the job and run metadata retain `ultra`
+- **AND** the Compact request forwarded upstream uses `reasoning.effort: "max"`
+
+#### Scenario: Model-source Responses aliases send wire max
+
+- **WHEN** a source-routed Responses request includes `thinking: "ultra"` or `reasoningEffort: "ultra"`
+- **THEN** the OpenAI-compatible source receives `reasoning.effort: "max"`
+- **AND** the source payload does not include `thinking` or `reasoningEffort`
+
+## MODIFIED Requirements
+
+### Requirement: OpenAI-compatible Responses payload sanitation removes provider-specific thinking aliases
+
+The shared OpenAI-compatible Responses sanitation path MUST normalize
+third-party thinking aliases into the canonical `reasoning` object before
+upstream forwarding. String and object aliases using `max` MUST remain `max`,
+while aliases using client-facing `ultra` MUST normalize to wire-level `max`.
+Unknown provider-specific thinking controls MUST NOT be passed through
+unchanged to the upstream ChatGPT backend.
+
+#### Scenario: Shared payload sanitation maps enable_thinking
+
+- **WHEN** an internal Responses payload contains `enable_thinking: true`
+- **AND** no explicit `reasoning.effort` is already present
+- **THEN** the forwarded upstream payload includes `reasoning.effort: "medium"`
+- **AND** the forwarded upstream payload does not include `enable_thinking`
+
+#### Scenario: Explicit reasoning wins over provider aliases
+
+- **WHEN** an internal Responses payload contains both `reasoning: {"effort":"high"}` and `thinking: {"type":"enabled"}`
+- **THEN** the forwarded upstream payload keeps `reasoning.effort: "high"`
+- **AND** the forwarded upstream payload does not include `thinking`
+
+#### Scenario: Max thinking alias remains max
+
+- **WHEN** an internal Responses payload contains `thinking: "max"`
+- **AND** no explicit `reasoning.effort` is already present
+- **THEN** the forwarded upstream payload includes `reasoning.effort: "max"`
+- **AND** the forwarded payload does not include `thinking`
+
+#### Scenario: Ultra thinking alias normalizes to wire max
+
+- **WHEN** an internal Responses payload contains `thinking: "ultra"`
+- **AND** no explicit `reasoning.effort` is already present
+- **THEN** the forwarded upstream payload includes `reasoning.effort: "max"`
+- **AND** the forwarded payload does not include `thinking`

--- a/openspec/changes/add-gpt56-bootstrap-models/tasks.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/tasks.md
@@ -1,0 +1,12 @@
+## Tasks
+
+- [x] 1. Add regression tests for upstream-exact GPT-5.6 bootstrap metadata.
+- [x] 2. Mirror contract-relevant GPT-5.6 metadata from upstream commit `3380969a`.
+- [x] 3. Add regression tests for `max`/`ultra` thinking aliases and wire canonicalization.
+- [x] 4. Canonicalize client-facing `ultra` to wire-level `max` for Responses, API-key, chat, and automation forwarding.
+- [x] 5. Extend backend and frontend validation/controls for client-facing `max` and `ultra`.
+- [x] 6. Run targeted backend and frontend tests, lint, type checks, and builds.
+- [x] 7. Run strict change validation and all-spec OpenSpec validation.
+- [x] 8. Add contributor attribution and verify the contributor checker.
+- [x] 9. Add integration captures for source-routed Chat and Responses `ultra` egress.
+- [x] 10. Canonicalize reasoning aliases before every OpenAI-compatible model-source egress.

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -1158,7 +1158,13 @@ async def test_backend_codex_responses_routes_responses_capable_model_source(asy
     async with async_client.stream(
         "POST",
         "/backend-api/codex/responses",
-        json={"model": model, "instructions": "hi", "input": []},
+        json={
+            "model": model,
+            "instructions": "hi",
+            "input": [],
+            "reasoningEffort": "ultra",
+            "thinking": "ultra",
+        },
     ) as response:
         assert response.status_code == 200
         lines = [line async for line in response.aiter_lines() if line]
@@ -1167,6 +1173,9 @@ async def test_backend_codex_responses_routes_responses_capable_model_source(asy
     forwarded_payload = cast("dict[str, object]", observed["payload"])
     assert forwarded_payload["model"] == model
     assert forwarded_payload["stream"] is True
+    assert forwarded_payload["reasoning"] == {"effort": "max"}
+    assert "reasoningEffort" not in forwarded_payload
+    assert "thinking" not in forwarded_payload
     assert any("resp_source" in line for line in lines)
 
 
@@ -1468,6 +1477,19 @@ async def test_api_key_create_accepts_uppercase_enforced_reasoning(async_client)
 
 
 @pytest.mark.asyncio
+async def test_api_key_create_accepts_extended_enforced_reasoning(async_client):
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "extended-enforcement",
+            "enforcedReasoningEffort": "ULTRA",
+        },
+    )
+    assert created.status_code == 200
+    assert created.json()["enforcedReasoningEffort"] == "ultra"
+
+
+@pytest.mark.asyncio
 async def test_api_key_update_accepts_uppercase_enforced_reasoning(async_client):
     created = await async_client.post(
         "/api/api-keys/",
@@ -1486,6 +1508,27 @@ async def test_api_key_update_accepts_uppercase_enforced_reasoning(async_client)
     )
     assert updated.status_code == 200
     assert updated.json()["enforcedReasoningEffort"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_api_key_update_accepts_extended_enforced_reasoning(async_client):
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "extended-enforcement-update",
+        },
+    )
+    assert created.status_code == 200
+    key_id = created.json()["id"]
+
+    updated = await async_client.patch(
+        f"/api/api-keys/{key_id}",
+        json={
+            "enforcedReasoningEffort": "MAX",
+        },
+    )
+    assert updated.status_code == 200
+    assert updated.json()["enforcedReasoningEffort"] == "max"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_automations_api.py
+++ b/tests/integration/test_automations_api.py
@@ -115,6 +115,7 @@ def _make_upstream_model(slug: str, *, reasoning_efforts: tuple[str, ...]) -> Up
 async def _populate_automation_reasoning_models() -> None:
     models = [
         _make_upstream_model("automation-reasoning-xhigh", reasoning_efforts=("low", "medium", "high", "xhigh")),
+        _make_upstream_model("automation-reasoning-ultra", reasoning_efforts=("low", "max", "ultra")),
         _make_upstream_model("automation-reasoning-medium", reasoning_efforts=("medium",)),
     ]
     await get_model_registry().update({"plus": models, "pro": models})
@@ -343,6 +344,53 @@ async def test_automations_patch_model_rejects_retained_unsupported_reasoning_ef
     payload = valid_update.json()
     assert payload["model"] == "automation-reasoning-medium"
     assert payload["reasoningEffort"] is None
+
+
+@pytest.mark.asyncio
+async def test_automations_api_accepts_extended_reasoning_efforts(async_client, monkeypatch):
+    await _populate_automation_reasoning_models()
+    accounts = await _create_accounts("auto-reasoning-ultra")
+    compact_requests = []
+
+    async def _fake_compact(request, *_args, **_kwargs):
+        compact_requests.append(request)
+        return SimpleNamespace(id="resp-reasoning-ultra")
+
+    monkeypatch.setattr("app.modules.automations.service.core_compact_responses", _fake_compact)
+
+    create_response = await async_client.post(
+        "/api/automations",
+        json={
+            "name": "Extended reasoning",
+            "enabled": True,
+            "schedule": {
+                "type": "daily",
+                "time": "05:00",
+                "timezone": "UTC",
+                "days": ["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
+            },
+            "model": "automation-reasoning-ultra",
+            "reasoningEffort": "ultra",
+            "prompt": "ping",
+            "accountIds": [accounts[0].id],
+        },
+    )
+    assert create_response.status_code == 200
+    assert create_response.json()["reasoningEffort"] == "ultra"
+
+    run_response = await async_client.post(f"/api/automations/{create_response.json()['id']}/run-now")
+    assert run_response.status_code == 202
+    assert run_response.json()["reasoningEffort"] == "ultra"
+    assert len(compact_requests) == 1
+    assert compact_requests[0].reasoning is not None
+    assert compact_requests[0].reasoning.effort == "max"
+
+    update_response = await async_client.patch(
+        f"/api/automations/{create_response.json()['id']}",
+        json={"reasoningEffort": "max"},
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["reasoningEffort"] == "max"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_model_source_routing.py
+++ b/tests/integration/test_model_source_routing.py
@@ -1355,6 +1355,77 @@ async def test_source_chat_payload_keeps_reasoning_toggles_for_optin_model(async
 
 
 @pytest.mark.asyncio
+async def test_source_chat_payload_maps_ultra_to_wire_max(async_client, source_upstream):
+    captured: dict[str, object] = {}
+
+    async def capture(request: web.Request) -> web.Response:
+        captured.update(await request.json())
+        return web.json_response(_chat_completion_body("reasoning-ultra-model"))
+
+    base_url = await source_upstream(capture)
+    model = "reasoning-ultra-model"
+    await _create_model_source(
+        async_client,
+        name="reasoning-ultra",
+        model=model,
+        base_url=base_url,
+        raw_metadata_json='{"supports_reasoning": true}',
+    )
+
+    response = await async_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": model,
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning": {"effort": "ultra", "summary": "auto"},
+            "reasoning_effort": "ultra",
+            "reasoningEffort": "ultra",
+            "thinking": "ultra",
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured["reasoning"] == {"effort": "max", "summary": "auto"}
+    assert captured["reasoning_effort"] == "max"
+    assert "reasoningEffort" not in captured
+    assert "thinking" not in captured
+
+
+@pytest.mark.asyncio
+async def test_source_chat_explicit_reasoning_effort_overrides_thinking_alias(async_client, source_upstream):
+    captured: dict[str, object] = {}
+
+    async def capture(request: web.Request) -> web.Response:
+        captured.update(await request.json())
+        return web.json_response(_chat_completion_body("reasoning-precedence-model"))
+
+    base_url = await source_upstream(capture)
+    model = "reasoning-precedence-model"
+    await _create_model_source(
+        async_client,
+        name="reasoning-precedence",
+        model=model,
+        base_url=base_url,
+        raw_metadata_json='{"supports_reasoning": true}',
+    )
+
+    response = await async_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": model,
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning_effort": "high",
+            "thinking": "ultra",
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured["reasoning_effort"] == "high"
+    assert captured["reasoning"] == {"effort": "high"}
+    assert "thinking" not in captured
+
+
+@pytest.mark.asyncio
 async def test_source_chat_payload_overrides_enforced_reasoning_object(async_client, source_upstream):
     await _enable_api_key_auth(async_client)
     captured: dict[str, object] = {}

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from app.core.openai.model_registry import ReasoningLevel, UpstreamModel, get_model_registry
@@ -8,6 +10,9 @@ from app.core.types import JsonValue
 pytestmark = pytest.mark.integration
 
 BOOTSTRAP_MODEL_SLUGS = {
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
     "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
@@ -34,7 +39,34 @@ EXPECTED_CORE_MODEL_PLANS = {
     "enterprise_cbp_usage_based",
 }
 
+EXPECTED_GPT56_MODEL_PLANS = {
+    "business",
+    "edu",
+    "edu_plus",
+    "edu_pro",
+    "education",
+    "enterprise",
+    "enterprise_cbp_automation",
+    "enterprise_cbp_usage_based",
+    "finserv",
+    "free",
+    "free_workspace",
+    "go",
+    "hc",
+    "k12",
+    "plus",
+    "pro",
+    "prolite",
+    "quorum",
+    "sci",
+    "self_serve_business_usage_based",
+    "team",
+}
+
 EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS = {
+    "gpt-5.6-sol": "0.144.0",
+    "gpt-5.6-terra": "0.144.0",
+    "gpt-5.6-luna": "0.144.0",
     "gpt-5.5": "0.124.0",
     "gpt-5.4": "0.98.0",
     "gpt-5.4-mini": "0.98.0",
@@ -43,6 +75,49 @@ EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS = {
     "gpt-5.2": "0.0.1",
     "codex-auto-review": "0.98.0",
 }
+
+
+def _expected_gpt56_extra(*, multi_agent_version: str, availability_nux: object) -> dict[str, object]:
+    return {
+        "shell_type": "shell_command",
+        "availability_nux": availability_nux,
+        "max_context_window": 372_000,
+        "apply_patch_tool_type": "freeform",
+        "web_search_tool_type": "text_and_image",
+        "supports_image_detail_original": True,
+        "truncation_policy": {"mode": "tokens", "limit": 10_000},
+        "tool_mode": "code_mode_only",
+        "multi_agent_version": multi_agent_version,
+        "use_responses_lite": True,
+        "include_skills_usage_instructions": False,
+        "auto_review_model_override": None,
+        "auto_compact_token_limit": None,
+        "comp_hash": "3000",
+        "reasoning_summary_format": "experimental",
+        "default_reasoning_summary": "none",
+        "upgrade": None,
+        "experimental_supported_tools": [],
+        "supports_search_tool": True,
+        "default_service_tier": None,
+        "service_tiers": [
+            {
+                "id": "priority",
+                "name": "Fast",
+                "description": "1.5x speed, increased usage",
+            }
+        ],
+        "additional_speed_tiers": ["fast"],
+    }
+
+
+def _assert_gpt56_extra(entry: dict[str, object], *, multi_agent_version: str, availability_nux: object) -> None:
+    expected = _expected_gpt56_extra(
+        multi_agent_version=multi_agent_version,
+        availability_nux=availability_nux,
+    )
+    for key, value in expected.items():
+        assert entry[key] == value
+    assert "effective_context_window_percent" not in entry
 
 
 def _make_upstream_model(
@@ -204,6 +279,56 @@ async def test_backend_codex_models_uses_bootstrap_upstream_metadata(async_clien
     assert set(entries) == set(EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS)
     for slug, expected_version in EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS.items():
         assert entries[slug]["minimal_client_version"] == expected_version
+
+    sol = entries["gpt-5.6-sol"]
+    assert sol["display_name"] == "GPT-5.6-Sol"
+    assert sol["context_window"] == 372_000
+    assert sol["default_reasoning_level"] == "low"
+    assert {level["effort"] for level in sol["supported_reasoning_levels"]} == {
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+    }
+    assert set(sol["available_in_plans"]) == EXPECTED_GPT56_MODEL_PLANS
+    _assert_gpt56_extra(
+        sol,
+        multi_agent_version="v2",
+        availability_nux={
+            "message": (
+                "Our most capable model yet. GPT-5.6 Sol can tackle complex code changes, dig into research, "
+                "produce polished documents, and take on your most ambitious work. Sol is highly capable at "
+                "lower reasoning efforts—try starting lower, then turn it up for harder jobs."
+            )
+        },
+    )
+
+    terra = entries["gpt-5.6-terra"]
+    assert terra["default_reasoning_level"] == "medium"
+    assert {level["effort"] for level in terra["supported_reasoning_levels"]} == {
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+    }
+    assert set(terra["available_in_plans"]) == EXPECTED_GPT56_MODEL_PLANS
+    _assert_gpt56_extra(terra, multi_agent_version="v2", availability_nux=None)
+
+    luna = entries["gpt-5.6-luna"]
+    assert luna["default_reasoning_level"] == "medium"
+    assert {level["effort"] for level in luna["supported_reasoning_levels"]} == {
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    }
+    assert set(luna["available_in_plans"]) == EXPECTED_GPT56_MODEL_PLANS
+    _assert_gpt56_extra(luna, multi_agent_version="v1", availability_nux=None)
 
     gpt54 = entries["gpt-5.4"]
     assert gpt54["minimal_client_version"] == "0.98.0"
@@ -1030,6 +1155,36 @@ async def test_model_sets_are_consistent_across_api_endpoints(async_client):
     assert "gpt-hidden" not in codex_slugs
     assert dashboard_ids == v1_ids
     assert dashboard_ids.issubset(codex_slugs)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_models_exposes_extended_reasoning_efforts(async_client):
+    registry = get_model_registry()
+    models = [
+        _make_upstream_model(
+            "gpt-5.6-sol",
+            raw={
+                "shell_type": "shell_command",
+                "visibility": "list",
+            },
+        )
+    ]
+    models[0] = replace(
+        models[0],
+        supported_reasoning_levels=tuple(
+            ReasoningLevel(effort=effort, description=effort)
+            for effort in ("low", "medium", "high", "xhigh", "max", "ultra")
+        ),
+        default_reasoning_level="low",
+    )
+    await registry.update({"plus": models, "pro": models})
+
+    response = await async_client.get("/api/models")
+
+    assert response.status_code == 200
+    model = next(item for item in response.json()["models"] if item["id"] == "gpt-5.6-sol")
+    assert model["supportedReasoningEfforts"] == ["low", "medium", "high", "xhigh", "max", "ultra"]
+    assert model["defaultReasoningEffort"] == "low"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_chat_request_mapping.py
+++ b/tests/unit/test_chat_request_mapping.py
@@ -347,6 +347,23 @@ def test_chat_anthropic_thinking_alias_maps_to_default_reasoning_effort():
     assert reasoning_map.get("effort") == "medium"
 
 
+def test_chat_ultra_thinking_alias_maps_to_wire_max():
+    payload = {
+        "model": "gpt-5.6-sol",
+        "messages": [{"role": "user", "content": "hi"}],
+        "thinking": "ultra",
+    }
+    req = ChatCompletionsRequest.model_validate(payload)
+    responses = req.to_responses_request()
+    dumped = responses.to_payload()
+
+    assert "thinking" not in dumped
+    reasoning = dumped.get("reasoning")
+    assert isinstance(reasoning, Mapping)
+    reasoning_map = cast(Mapping[str, JsonValue], reasoning)
+    assert reasoning_map.get("effort") == "max"
+
+
 def test_chat_service_tier_is_preserved_in_responses_payload():
     payload = {
         "model": "gpt-5.2",

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -26,7 +26,34 @@ EXPECTED_CORE_MODEL_PLANS = {
     "enterprise_cbp_usage_based",
 }
 
+EXPECTED_GPT56_MODEL_PLANS = {
+    "business",
+    "edu",
+    "edu_plus",
+    "edu_pro",
+    "education",
+    "enterprise",
+    "enterprise_cbp_automation",
+    "enterprise_cbp_usage_based",
+    "finserv",
+    "free",
+    "free_workspace",
+    "go",
+    "hc",
+    "k12",
+    "plus",
+    "pro",
+    "prolite",
+    "quorum",
+    "sci",
+    "self_serve_business_usage_based",
+    "team",
+}
+
 EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS = {
+    "gpt-5.6-sol": "0.144.0",
+    "gpt-5.6-terra": "0.144.0",
+    "gpt-5.6-luna": "0.144.0",
     "gpt-5.5": "0.124.0",
     "gpt-5.4": "0.98.0",
     "gpt-5.4-mini": "0.98.0",
@@ -35,6 +62,40 @@ EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS = {
     "gpt-5.2": "0.0.1",
     "codex-auto-review": "0.98.0",
 }
+
+
+def _expected_gpt56_raw(*, multi_agent_version: str, availability_nux: object) -> dict[str, object]:
+    return {
+        "shell_type": "shell_command",
+        "visibility": "list",
+        "availability_nux": availability_nux,
+        "max_context_window": 372_000,
+        "apply_patch_tool_type": "freeform",
+        "web_search_tool_type": "text_and_image",
+        "supports_image_detail_original": True,
+        "truncation_policy": {"mode": "tokens", "limit": 10_000},
+        "tool_mode": "code_mode_only",
+        "multi_agent_version": multi_agent_version,
+        "use_responses_lite": True,
+        "include_skills_usage_instructions": False,
+        "auto_review_model_override": None,
+        "auto_compact_token_limit": None,
+        "comp_hash": "3000",
+        "reasoning_summary_format": "experimental",
+        "default_reasoning_summary": "none",
+        "upgrade": None,
+        "experimental_supported_tools": [],
+        "supports_search_tool": True,
+        "default_service_tier": None,
+        "service_tiers": [
+            {
+                "id": "priority",
+                "name": "Fast",
+                "description": "1.5x speed, increased usage",
+            }
+        ],
+        "additional_speed_tiers": ["fast"],
+    }
 
 
 def _model(slug: str) -> UpstreamModel:
@@ -138,6 +199,9 @@ async def test_prefers_websockets_does_not_use_bootstrap_after_snapshot():
 def test_prefers_websockets_uses_bootstrap_fallback_when_uninitialized():
     registry = ModelRegistry(ttl_seconds=60.0)
 
+    assert registry.prefers_websockets("gpt-5.6-sol") is True
+    assert registry.prefers_websockets("gpt-5.6-terra") is True
+    assert registry.prefers_websockets("gpt-5.6-luna") is True
     assert registry.prefers_websockets("gpt-5.4") is True
     assert registry.prefers_websockets("gpt-5.4-2026") is True
     assert registry.prefers_websockets("gpt-5.3-codex") is True
@@ -154,6 +218,51 @@ def test_bootstrap_models_include_representative_upstream_metadata():
     assert set(models) == set(EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS)
     for slug, expected_version in EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS.items():
         assert models[slug].minimal_client_version == expected_version
+
+    sol = models["gpt-5.6-sol"]
+    assert sol.display_name == "GPT-5.6-Sol"
+    assert sol.context_window == 372_000
+    assert sol.default_reasoning_level == "low"
+    assert {level.effort for level in sol.supported_reasoning_levels} == {
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+    }
+    assert sol.available_in_plans == EXPECTED_GPT56_MODEL_PLANS
+    assert sol.raw == _expected_gpt56_raw(
+        multi_agent_version="v2",
+        availability_nux={
+            "message": (
+                "Our most capable model yet. GPT-5.6 Sol can tackle complex code changes, dig into research, "
+                "produce polished documents, and take on your most ambitious work. Sol is highly capable at "
+                "lower reasoning efforts—try starting lower, then turn it up for harder jobs."
+            )
+        },
+    )
+
+    terra = models["gpt-5.6-terra"]
+    assert terra.display_name == "GPT-5.6-Terra"
+    assert terra.default_reasoning_level == "medium"
+    assert {level.effort for level in terra.supported_reasoning_levels} == {
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+    }
+    assert terra.available_in_plans == EXPECTED_GPT56_MODEL_PLANS
+    assert terra.raw == _expected_gpt56_raw(multi_agent_version="v2", availability_nux=None)
+
+    luna = models["gpt-5.6-luna"]
+    assert luna.display_name == "GPT-5.6-Luna"
+    assert luna.default_reasoning_level == "medium"
+    assert {level.effort for level in luna.supported_reasoning_levels} == {"low", "medium", "high", "xhigh", "max"}
+    assert luna.available_in_plans == EXPECTED_GPT56_MODEL_PLANS
+    assert luna.raw == _expected_gpt56_raw(multi_agent_version="v1", availability_nux=None)
 
     gpt54 = models["gpt-5.4"]
     assert gpt54.minimal_client_version == "0.98.0"

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -264,6 +264,30 @@ def test_provider_thinking_aliases_are_normalized():
     assert "enable_thinking" not in dumped
 
 
+@pytest.mark.parametrize(
+    ("thinking", "expected_effort"),
+    [
+        ("max", "max"),
+        ("ultra", "max"),
+        ({"effort": "max"}, "max"),
+        ({"effort": "ultra"}, "max"),
+    ],
+)
+def test_provider_thinking_extended_efforts_use_wire_max(thinking: JsonValue, expected_effort: str):
+    payload: dict[str, JsonValue] = {
+        "model": "gpt-5.6-sol",
+        "instructions": "hi",
+        "input": [],
+        "thinking": thinking,
+    }
+    request = ResponsesRequest.model_validate(payload)
+
+    dumped = request.to_payload()
+
+    assert dumped["reasoning"] == {"effort": expected_effort}
+    assert "thinking" not in dumped
+
+
 def test_explicit_reasoning_wins_over_provider_thinking_aliases():
     payload = {
         "model": "gpt-5.1",

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -707,6 +707,34 @@ def test_apply_api_key_enforcement_to_chat_payload_overrides_reasoning_object():
     assert payload["reasoning_effort"] == "high"
 
 
+def test_apply_api_key_enforcement_to_chat_payload_maps_ultra_to_wire_max():
+    payload: dict[str, JsonValue] = {
+        "model": "gpt-5.6-sol",
+        "messages": [{"role": "user", "content": "hi"}],
+        "reasoning": {"effort": "low", "summary": "auto"},
+        "reasoning_effort": "low",
+    }
+    api_key = proxy_service.ApiKeyData(
+        id="key_ultra_chat",
+        name="ultra-chat-key",
+        key_prefix="sk-clb-test",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort="ultra",
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    proxy_request_policy.apply_api_key_enforcement_to_chat_payload(payload, api_key)
+
+    assert api_key.enforced_reasoning_effort == "ultra"
+    assert payload["reasoning"] == {"effort": "max", "summary": "auto"}
+    assert payload["reasoning_effort"] == "max"
+
+
 def _service_tier_enforcement_key(enforced: str) -> proxy_service.ApiKeyData:
     return proxy_service.ApiKeyData(
         id="key_default",
@@ -873,6 +901,24 @@ def test_normalize_unsupported_reasoning_effort_preserves_supported_effort():
     assert payload.reasoning.effort == "high"
 
 
+def test_normalize_unsupported_reasoning_effort_maps_ultra_to_wire_max():
+    from app.core.openai.requests import ResponsesReasoning
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "hello",
+            "input": [],
+        }
+    )
+    payload.reasoning = ResponsesReasoning(effort="ultra")
+
+    proxy_request_policy.normalize_unsupported_reasoning_effort(payload)
+
+    assert payload.reasoning is not None
+    assert payload.reasoning.effort == "max"
+
+
 def test_apply_api_key_enforcement_normalizes_minimal_without_api_key():
     from app.core.openai.requests import ResponsesReasoning
 
@@ -889,6 +935,36 @@ def test_apply_api_key_enforcement_normalizes_minimal_without_api_key():
 
     assert payload.reasoning is not None
     assert payload.reasoning.effort == "low"
+
+
+def test_apply_api_key_enforcement_maps_enforced_ultra_to_wire_max():
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "hello",
+            "input": [],
+            "reasoning": {"effort": "low"},
+        }
+    )
+    api_key = proxy_service.ApiKeyData(
+        id="key_ultra",
+        name="ultra-key",
+        key_prefix="sk-clb-test",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort="ultra",
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    proxy_request_policy.apply_api_key_enforcement(payload, api_key)
+
+    assert api_key.enforced_reasoning_effort == "ultra"
+    assert payload.reasoning is not None
+    assert payload.reasoning.effort == "max"
 
 
 def test_normalize_responses_request_payload_preserves_backend_codex_image_generation_with_function_tools():


### PR DESCRIPTION
## Summary

- mirror the GPT-5.6 Sol, Terra, and Luna bootstrap contracts from upstream Codex commit `3380969a`, including minimum client versions, code-only tool mode, multi-agent versions, plans, NUX, truncation, and Responses-Lite flags
- expose client-facing `max` / `ultra` reasoning options while canonicalizing every `ultra` egress value to wire-level `max` across Responses, Chat, API-key enforcement, automations, and model-source forwarding
- rebase onto current `main`, which includes the Responses-Lite transport fix from #1161
- update the OpenSpec delta and contributor attribution

## Review feedback addressed

1. GPT-5.6 bootstrap metadata is verified field-for-field against upstream `models.json` (excluding the intentionally unbundled instruction/message text).
2. `ultra` remains a UI/API alias but is never forwarded literally; `thinking: max` and `thinking: ultra` are normalized consistently. Explicit Chat `reasoning_effort` takes precedence over provider aliases.
3. The branch is based on `f746a8d7`, after #1161 merged, so `use_responses_lite: true` is safe.
4. The request-log registry filter behavior was removed from this PR to preserve one-concern scope.
5. The commit/PR title is Conventional Commit format, OpenSpec tasks and strict validation are complete, and `knightcn1983` is present in `.all-contributorsrc`.

## Validation

- affected backend suite: 872 passed
- frontend suite: 827 passed; lint, typecheck, and production build passed
- OpenSpec: change validation passed; strict all-spec validation passed (30/30)
- contributor attribution check passed (71 contributors)
- broader local CI passed unit, integration, bridge, WebSocket, end-to-end, SQLite migration, package build, and wheel asset verification stages
- PostgreSQL/Docker/Helm-specific checks could not run locally because those runtimes are unavailable; GitHub CI is authoritative for those gates

Related: #1157, #1161.