### PR TITLE
fix(models): serve the Codex catalog on /v1/models for Codex clients

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -898,6 +898,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "kevinWangSheng",
+      "name": "Shawn",
+      "avatar_url": "https://avatars.githubusercontent.com/u/118158941?v=4",
+      "profile": "https://github.com/kevinWangSheng",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -823,10 +823,20 @@ async def models(
     return await _build_codex_models_response(api_key)
 
 
-@v1_router.get("/models", response_model=ModelListResponse)
+@v1_router.get("/models", response_model=None)
 async def v1_models(
+    request: Request,
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> Response:
+    # Codex clients pointed at this proxy via `openai_base_url` fetch their model
+    # catalog from `<base_url>/models` and always append a `client_version` query
+    # parameter. They require the Codex catalog shape (`{"models": [...]}`); the
+    # OpenAI-compatible list shape fails to parse client-side, and the client
+    # silently falls back to its bundled model metadata (stale tool_mode /
+    # use_responses_lite flags and context windows). Serve the Codex catalog to
+    # Codex clients and keep the OpenAI-compatible shape for everyone else.
+    if request.query_params.get("client_version"):
+        return await _build_codex_models_response(api_key)
     return await _build_models_response(api_key)
 
 

--- a/openspec/changes/serve-codex-catalog-on-v1-models/.openspec.yaml
+++ b/openspec/changes/serve-codex-catalog-on-v1-models/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/serve-codex-catalog-on-v1-models/design.md
+++ b/openspec/changes/serve-codex-catalog-on-v1-models/design.md
@@ -1,0 +1,14 @@
+# Design
+
+## Approach
+
+Branch inside the existing `v1_models` handler in `app/modules/proxy/api.py`: when `request.query_params.get("client_version")` is truthy, delegate to `_build_codex_models_response` (the `/backend-api/codex/models` builder); otherwise keep delegating to `_build_models_response`. The route's `response_model` becomes `None` because the endpoint now serves two documented shapes.
+
+`client_version` is the discriminator because the codex-rs models-manager unconditionally appends it when fetching `<base_url>/models`, while OpenAI-compatible SDKs never send it. No header sniffing or user-agent parsing is needed. An empty value (`?client_version=`) is treated as absent, so accidental empty parameters degrade to the OpenAI-compatible shape rather than surprising a non-Codex caller.
+
+`CodexModelsResponse` already includes both `models` and the OpenAI-compatible `data`/`object` fields, so a mixed consumer that hits the negotiated path still finds the list shape it expects. Codex's catalog deserializer ignores unknown fields, so the extra `data` key is harmless in the other direction.
+
+## Alternatives considered
+
+- Always returning the dual-shape catalog from `/v1/models`: rejected because `ModelListResponse` is `extra="forbid"` today and strict OpenAI-compatible consumers may validate the response shape.
+- Fixing only the docs (telling users to use the `/backend-api/codex` provider): rejected; the silent-fallback failure mode is too costly to leave, and `openai_base_url` remains the most discoverable configuration.

--- a/openspec/changes/serve-codex-catalog-on-v1-models/proposal.md
+++ b/openspec/changes/serve-codex-catalog-on-v1-models/proposal.md
@@ -1,0 +1,24 @@
+# Serve the Codex Catalog on /v1/models for Codex Clients
+
+## Summary
+
+Return the Codex model catalog shape (`{"models": [...]}`) from `GET /v1/models` when the request carries a `client_version` query parameter, keeping the OpenAI-compatible list shape for all other callers.
+
+## Motivation
+
+Codex CLI/IDE clients can be pointed at codex-lb in two ways: the `codex-lb`-style provider (`base_url = .../backend-api/codex`) or the simpler `openai_base_url = ".../v1"` override. In the second mode the client fetches its model catalog from `<base_url>/models`, i.e. `GET /v1/models?client_version=<version>` — the codex-rs models-manager always appends that query parameter.
+
+That endpoint currently returns only the OpenAI-compatible shape (`{"object": "list", "data": [...]}`), which the Codex client cannot parse as a catalog. The refresh fails silently and the client falls back to the model metadata bundled in its binary. The failure is invisible until the bundled metadata diverges from what the proxy can serve: with GPT-5.6 (`use_responses_lite = true`, `tool_mode = "code_mode_only"` in the bundled metadata), clients built lite-shaped requests that the proxy could not honor, and every session ran without tools while `/backend-api/codex/models` was serving correct(able) metadata all along.
+
+The proxy already maintains the dual-shape precedent in the opposite direction: `CodexModelsResponse` carries both `models` and `data` so OpenAI-compatible consumers can read `/backend-api/codex/models`. This change closes the remaining gap.
+
+## Scope
+
+- `GET /v1/models` with a non-empty `client_version` query parameter returns the same payload as `GET /backend-api/codex/models` (Codex catalog, which already includes the OpenAI-compatible `data` list).
+- `GET /v1/models` without the parameter (or with an empty value) is unchanged.
+- API-key model filtering and visibility rules follow whichever builder serves the request, identical to the existing endpoints.
+
+## Out of Scope
+
+- Changing the Codex catalog contents or `CodexModelsResponse` schema.
+- The responses-lite request forwarding fixes tracked in #1157.

--- a/openspec/changes/serve-codex-catalog-on-v1-models/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/serve-codex-catalog-on-v1-models/specs/model-catalog-compat/spec.md
@@ -1,0 +1,25 @@
+# model-catalog-compat — Delta
+
+## ADDED Requirements
+
+### Requirement: Codex clients receive the Codex catalog from /v1/models
+
+When `GET /v1/models` is called with a non-empty `client_version` query
+parameter, the service MUST return the same Codex catalog payload as
+`GET /backend-api/codex/models`, including its `models` entries and the
+OpenAI-compatible `object`/`data` fields. When the parameter is absent or
+empty, the service MUST return the unchanged OpenAI-compatible list shape.
+API-key model filtering and visibility rules MUST apply in both cases.
+
+#### Scenario: Codex client fetches its catalog through the /v1 base URL
+
+- **GIVEN** a Codex client configured with `openai_base_url` pointing at this proxy
+- **WHEN** it calls `GET /v1/models?client_version=0.144.1`
+- **THEN** the response contains Codex catalog entries under `models`
+- **AND** the payload equals the response of `GET /backend-api/codex/models`
+
+#### Scenario: OpenAI-compatible clients are unaffected
+
+- **GIVEN** an OpenAI-compatible client
+- **WHEN** it calls `GET /v1/models` without a `client_version` parameter (or with an empty value)
+- **THEN** the response keeps the `{"object": "list", "data": [...]}` shape

--- a/openspec/changes/serve-codex-catalog-on-v1-models/tasks.md
+++ b/openspec/changes/serve-codex-catalog-on-v1-models/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] Add the `client_version` content negotiation to the `v1_models` handler
+- [x] Add integration tests: negotiated Codex shape equals `/backend-api/codex/models`; bare and empty-parameter requests keep the OpenAI-compatible shape
+- [x] Update the model-catalog-compat spec delta
+- [x] Run targeted tests and lint

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -154,6 +154,32 @@ async def test_v1_models_list(async_client):
 
 
 @pytest.mark.asyncio
+async def test_v1_models_with_client_version_returns_codex_catalog(async_client):
+    """Codex clients configured via `openai_base_url` fetch `<base>/models` with a
+    `client_version` query parameter and can only parse the Codex catalog shape;
+    the OpenAI-compatible list shape makes them silently fall back to bundled
+    model metadata."""
+    await _populate_test_registry()
+    resp = await async_client.get("/v1/models", params={"client_version": "0.144.1"})
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert "models" in payload
+    slugs = {entry["slug"] for entry in payload["models"]}
+    assert "gpt-5.2" in slugs
+    codex_resp = await async_client.get("/backend-api/codex/models")
+    assert codex_resp.status_code == 200
+    assert payload == codex_resp.json()
+
+
+@pytest.mark.asyncio
+async def test_v1_models_with_empty_client_version_keeps_openai_shape(async_client):
+    await _populate_test_registry()
+    resp = await async_client.get("/v1/models?client_version=")
+    assert resp.status_code == 200
+    assert resp.json()["object"] == "list"
+
+
+@pytest.mark.asyncio
 async def test_v1_models_uses_bootstrap_models_when_registry_not_populated(async_client):
     registry = get_model_registry()
     registry._snapshot = None


### PR DESCRIPTION
## Summary

`GET /v1/models` only speaks the OpenAI-compatible list shape, but Codex clients configured via `openai_base_url` fetch their model catalog from that exact endpoint (always with a `client_version` query parameter). The catalog refresh fails to parse client-side and Codex silently falls back to its bundled model metadata. This PR content-negotiates on `client_version` and serves the Codex catalog to Codex clients, keeping the OpenAI-compatible shape for everyone else.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: complements #1157 (the silent metadata half; the request-forwarding half is addressed by #1158/#1159/#1161)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches a codex-faithful path (request/response shape) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/serve-codex-catalog-on-v1-models/`

## Changes

- `app/modules/proxy/api.py`: `v1_models` returns `_build_codex_models_response` when the request carries a non-empty `client_version` query parameter (codex-rs models-manager appends it unconditionally; OpenAI SDKs never send it), `_build_models_response` otherwise. `response_model=None` since the endpoint now serves two documented shapes.
- Integration tests: negotiated payload equals `GET /backend-api/codex/models`; bare and empty-parameter requests keep the `{"object": "list", "data": [...]}` shape.
- OpenSpec change with a `model-catalog-compat` delta.

## Why this matters (real-world failure)

With GPT-5.6 (`use_responses_lite: true`, `tool_mode: "code_mode_only"` in the client's bundled metadata), a Codex CLI pointed at codex-lb via `openai_base_url` builds responses-lite requests from **stale bundled metadata** no matter what the proxy serves, because its `/v1/models?client_version=…` refresh silently fails to parse. Every session runs without tools and the model reports it has no shell/filesystem access — the same symptom as #1157, but on the catalog layer, so it persists even after the request-forwarding fixes land. Reproduced with codex-cli 0.144.1 against codex-lb 1.20.1: the identical request works once the client receives catalog metadata it can parse.

`CodexModelsResponse` already carries both `models` and the OpenAI-compatible `object`/`data` fields (the dual-shape precedent in the opposite direction), so mixed consumers are unaffected in both directions.

## Test plan

```
uv run pytest tests/integration/test_v1_models.py -q                      # 33 passed
uv run pytest tests/integration/test_v1_models.py \
  tests/unit/test_path_rewrite_middleware.py \
  tests/integration/test_path_rewrite_alias.py \
  tests/integration/test_codex_client_compat.py -q                        # 55 passed
uv run ruff check / ruff format --check on touched files                  # clean
```

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant test subset locally.
- [x] CHANGELOG is not edited by hand.
