### PR TITLE
feat(models): add GPT-5.6 Responses Lite support

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -466,6 +466,32 @@ def filter_inbound_headers(headers: Mapping[str, str]) -> dict[str, str]:
     return {key: value for key, value in headers.items() if not _should_drop_inbound_header(key)}
 
 
+def responses_lite_for_model(model: str | None) -> bool:
+    """Return True when ``model`` is a Responses Lite upstream model.
+
+    GPT-5.6 models ship with ``use_responses_lite: true`` in the upstream Codex
+    catalog. The Codex CLI signals this mode to the upstream ChatGPT backend
+    with the ``x-openai-internal-codex-responses-lite: true`` header. That
+    header is stripped from inbound requests (see ``_should_drop_inbound_header``)
+    so a client cannot spoof it; codex-lb must reconstruct it from its own model
+    registry when forwarding a request for a Responses Lite model, otherwise the
+    upstream rejects the request as ``Model not found`` (issue #1157).
+    """
+    if not model:
+        return False
+    registry = get_model_registry()
+    # ``getattr`` fallback keeps unit tests that pass narrowed ``SimpleNamespace``
+    # registry fakes (only exposing ``prefers_websockets``) working without forcing
+    # every fake to redeclare ``get_models_with_fallback``.
+    get_models = getattr(registry, "get_models_with_fallback", None)
+    if get_models is None:
+        return False
+    upstream = get_models().get(model)
+    if upstream is None:
+        return False
+    return bool(upstream.raw.get("use_responses_lite"))
+
+
 def apply_codex_installation_metadata(payload: dict[str, JsonValue], codex_installation_id: str | None) -> None:
     raw_metadata = payload.get("client_metadata")
     client_metadata: dict[str, JsonValue] = {}
@@ -585,7 +611,9 @@ def _build_upstream_headers(
     inbound: Mapping[str, str],
     access_token: str,
     account_id: str | None,
+    *,
     accept: str = "text/event-stream",
+    model: str | None = None,
 ) -> dict[str, str]:
     headers = filter_inbound_headers(inbound)
     native = _is_native_codex_request(headers)
@@ -604,6 +632,8 @@ def _build_upstream_headers(
             headers["chatgpt-account-id"] = account_id
         else:
             headers[_CHATGPT_ACCOUNT_ID_HEADER] = account_id
+    if responses_lite_for_model(model):
+        headers[CODEX_RESPONSES_LITE_HEADER] = "true"
     return headers
 
 
@@ -635,6 +665,8 @@ def _build_upstream_websocket_headers(
     inbound: Mapping[str, str],
     access_token: str,
     account_id: str | None,
+    *,
+    model: str | None = None,
 ) -> dict[str, str]:
     connected_header_tokens: set[str] = set()
     for key, value in inbound.items():
@@ -666,6 +698,8 @@ def _build_upstream_websocket_headers(
             headers["chatgpt-account-id"] = account_id
         else:
             headers[_CHATGPT_ACCOUNT_ID_HEADER] = account_id
+    if responses_lite_for_model(model):
+        headers[CODEX_RESPONSES_LITE_HEADER] = "true"
     return headers
 
 
@@ -2444,10 +2478,10 @@ async def _stream_responses_with_session(
         payload_size_estimate_bytes=payload_size_estimate_bytes,
     )
     if transport == "websocket":
-        upstream_headers = _build_upstream_websocket_headers(headers, access_token, account_id)
+        upstream_headers = _build_upstream_websocket_headers(headers, access_token, account_id, model=payload.model)
         method = "GET"
     else:
-        upstream_headers = _build_upstream_headers(headers, access_token, account_id)
+        upstream_headers = _build_upstream_headers(headers, access_token, account_id, model=payload.model)
         method = "POST"
     remaining_request_timeout = _remaining_total_timeout(
         request_total_timeout,
@@ -2695,7 +2729,7 @@ async def _stream_responses_with_session(
         )
 
         transport = "http"
-        upstream_headers = _build_upstream_headers(headers, access_token, account_id)
+        upstream_headers = _build_upstream_headers(headers, access_token, account_id, model=payload.model)
         method = "POST"
         remaining_request_timeout = _remaining_total_timeout(
             request_total_timeout,
@@ -3170,6 +3204,7 @@ class _CompactCommandTransport:
             self.access_token,
             upstream_account_id,
             accept="application/json",
+            model=self.payload.model,
         )
         pre_request_started_at = time.monotonic()
         compact_timeout_seconds = _effective_compact_total_timeout(settings.upstream_compact_timeout_seconds)

--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -57,7 +57,14 @@ class ModelRegistrySnapshot:
     fetched_at: float
 
 
-_BOOTSTRAP_WEBSOCKET_PREFERRED_MODEL_PATTERNS = ("gpt-5.5", "gpt-5.5-*", "gpt-5.4", "gpt-5.4-*")
+_BOOTSTRAP_WEBSOCKET_PREFERRED_MODEL_PATTERNS = (
+    "gpt-5.6",
+    "gpt-5.6-*",
+    "gpt-5.5",
+    "gpt-5.5-*",
+    "gpt-5.4",
+    "gpt-5.4-*",
+)
 
 _REASONING_LEVELS_STANDARD = (
     ReasoningLevel(effort="low", description="Low reasoning effort"),
@@ -70,6 +77,14 @@ _REASONING_LEVELS_EXTENDED = (
     ReasoningLevel(effort="medium", description="Medium reasoning effort"),
     ReasoningLevel(effort="high", description="High reasoning effort"),
     ReasoningLevel(effort="xhigh", description="Extra high reasoning effort"),
+)
+
+_REASONING_LEVELS_MAX = (
+    ReasoningLevel(effort="low", description="Low reasoning effort"),
+    ReasoningLevel(effort="medium", description="Medium reasoning effort"),
+    ReasoningLevel(effort="high", description="High reasoning effort"),
+    ReasoningLevel(effort="xhigh", description="Extra high reasoning effort"),
+    ReasoningLevel(effort="max", description="Maximum reasoning effort"),
 )
 
 _BOOTSTRAP_AVAILABLE_IN_PLANS = frozenset(
@@ -152,6 +167,48 @@ def _bootstrap_model(
 # explicit rather than inherited from helper defaults; every slug must exist
 # upstream, and live upstream data always takes precedence once available.
 _BOOTSTRAP_STATIC_MODELS: tuple[UpstreamModel, ...] = (
+    _bootstrap_model(
+        "gpt-5.6-sol",
+        "GPT-5.6 Sol",
+        prefer_websockets=True,
+        reasoning_levels=_REASONING_LEVELS_MAX,
+        context_window=372_000,
+        minimal_client_version="0.144.0",
+        raw={
+            "use_responses_lite": True,
+            "tool_mode": "code_mode_only",
+            "shell_type": "shell_command",
+            "apply_patch_tool_type": "freeform",
+        },
+    ),
+    _bootstrap_model(
+        "gpt-5.6-terra",
+        "GPT-5.6 Terra",
+        prefer_websockets=True,
+        reasoning_levels=_REASONING_LEVELS_MAX,
+        context_window=372_000,
+        minimal_client_version="0.144.0",
+        raw={
+            "use_responses_lite": True,
+            "tool_mode": "code_mode_only",
+            "shell_type": "shell_command",
+            "apply_patch_tool_type": "freeform",
+        },
+    ),
+    _bootstrap_model(
+        "gpt-5.6-luna",
+        "GPT-5.6 Luna",
+        prefer_websockets=True,
+        reasoning_levels=_REASONING_LEVELS_MAX,
+        context_window=372_000,
+        minimal_client_version="0.144.0",
+        raw={
+            "use_responses_lite": True,
+            "tool_mode": "code_mode_only",
+            "shell_type": "shell_command",
+            "apply_patch_tool_type": "freeform",
+        },
+    ),
     _bootstrap_model(
         "gpt-5.5",
         "GPT-5.5",

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -297,6 +297,16 @@ def _normalize_responses_input_instructions(data: JsonValue) -> JsonValue:
         if role not in ("system", "developer"):
             input_items.append(item)
             continue
+        # Responses Lite (GPT-5.6) carries the custom exec tool grammar in a
+        # developer-role ``additional_tools`` input item instead of the
+        # top-level ``tools`` field. Such an item has no ``content``, so the
+        # instruction normalization below would silently drop it and leave the
+        # upstream model without any shell/filesystem tool definitions
+        # (issue #1157). Preserve it unchanged so the tool bundle reaches the
+        # upstream request intact.
+        if item_mapping.get("type") == "additional_tools":
+            input_items.append(item)
+            continue
         instruction_text, preserved_content = _split_responses_instruction_item_content(item_mapping)
         if instruction_text:
             instruction_parts.append(instruction_text)

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -27,6 +27,9 @@ EXPECTED_CORE_MODEL_PLANS = {
 }
 
 EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS = {
+    "gpt-5.6-sol": "0.144.0",
+    "gpt-5.6-terra": "0.144.0",
+    "gpt-5.6-luna": "0.144.0",
     "gpt-5.5": "0.124.0",
     "gpt-5.4": "0.98.0",
     "gpt-5.4-mini": "0.98.0",
@@ -138,6 +141,8 @@ async def test_prefers_websockets_does_not_use_bootstrap_after_snapshot():
 def test_prefers_websockets_uses_bootstrap_fallback_when_uninitialized():
     registry = ModelRegistry(ttl_seconds=60.0)
 
+    assert registry.prefers_websockets("gpt-5.6-sol") is True
+    assert registry.prefers_websockets("gpt-5.6-luna") is True
     assert registry.prefers_websockets("gpt-5.4") is True
     assert registry.prefers_websockets("gpt-5.4-2026") is True
     assert registry.prefers_websockets("gpt-5.3-codex") is True
@@ -178,6 +183,24 @@ def test_bootstrap_models_include_representative_upstream_metadata():
     assert auto_review.raw["shell_type"] == "shell_command"
     assert auto_review.raw["max_context_window"] == 1_000_000
     assert auto_review.minimal_client_version == "0.98.0"
+
+    # GPT-5.6 Responses Lite models expose max reasoning and ship with the
+    # additional_tools tool bundle (issue #1157).
+    for slug in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
+        gpt56 = models[slug]
+        assert gpt56.prefer_websockets is True
+        assert gpt56.context_window == 372_000
+        assert gpt56.minimal_client_version == "0.144.0"
+        assert gpt56.input_modalities == ("text", "image")
+        assert {level.effort for level in gpt56.supported_reasoning_levels} == {
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max",
+        }
+        assert gpt56.raw["use_responses_lite"] is True
+        assert gpt56.raw["tool_mode"] == "code_mode_only"
     assert auto_review.available_in_plans == EXPECTED_CORE_MODEL_PLANS
     assert models["gpt-5.3-codex"].available_in_plans == EXPECTED_CORE_MODEL_PLANS
 

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -1619,3 +1619,55 @@ def test_extract_input_image_file_references_collects_tool_output_paths():
         (0, None, "file_tool"),
         (0, None, "file_nested"),
     ]
+
+
+def test_responses_preserves_responses_lite_additional_tools_item():
+    """GPT-5.6 Responses Lite places the exec tool grammar in a developer-role
+    ``additional_tools`` input item with no ``content``. Normalization must keep
+    it instead of dropping it (issue #1157)."""
+    additional_tools_item = {
+        "type": "additional_tools",
+        "role": "developer",
+        "tools": [
+            {
+                "type": "custom",
+                "name": "exec",
+                "format": {"type": "grammar", "syntax": "lark"},
+            }
+        ],
+    }
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-luna",
+            "instructions": "You are Codex.",
+            "input": [
+                additional_tools_item,
+                {"role": "user", "content": "Inspect this repository."},
+            ],
+        }
+    )
+
+    input_items = cast(list[JsonValue], request.input)
+    preserved = [item for item in input_items if cast(Mapping[str, JsonValue], item).get("type") == "additional_tools"]
+    assert len(preserved) == 1, "additional_tools item was dropped during normalization"
+    assert preserved[0] == additional_tools_item
+
+
+def test_responses_still_lifts_developer_text_instructions_into_instructions_field():
+    """A regular developer text item is still merged into ``instructions`` and
+    removed from ``input`` after the additional_tools fix."""
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-luna",
+            "instructions": "Base.",
+            "input": [
+                {"role": "developer", "content": "Extra guidance."},
+                {"role": "user", "content": "Hi"},
+            ],
+        }
+    )
+
+    input_items = cast(list[JsonValue], request.input)
+    developer_items = [item for item in input_items if cast(Mapping[str, JsonValue], item).get("role") == "developer"]
+    assert developer_items == []
+    assert "Extra guidance." in request.instructions

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -633,6 +633,56 @@ def test_build_upstream_headers_strips_internal_responses_lite_header():
     assert "x-openai-internal-codex-responses-lite" not in lowered
 
 
+def _responses_lite_registry(models: dict[str, dict[str, JsonValue]]) -> object:
+    return SimpleNamespace(
+        get_models_with_fallback=lambda: {slug: SimpleNamespace(raw=raw) for slug, raw in models.items()}
+    )
+
+
+def test_build_upstream_headers_reconstructs_responses_lite_header_for_lite_model(monkeypatch):
+    monkeypatch.setattr(
+        proxy_module,
+        "get_model_registry",
+        lambda: _responses_lite_registry({"gpt-5.6-luna": {"use_responses_lite": True}}),
+    )
+    headers = _build_upstream_headers({}, "token", "acc_2", model="gpt-5.6-luna")
+    assert headers["x-openai-internal-codex-responses-lite"] == "true"
+
+
+def test_build_upstream_headers_omits_responses_lite_header_for_non_lite_model(monkeypatch):
+    monkeypatch.setattr(
+        proxy_module,
+        "get_model_registry",
+        lambda: _responses_lite_registry({"gpt-5.5": {"use_responses_lite": False}}),
+    )
+    headers = _build_upstream_headers({}, "token", "acc_2", model="gpt-5.5")
+    lowered = {key.lower() for key in headers}
+    assert "x-openai-internal-codex-responses-lite" not in lowered
+
+
+def test_build_upstream_headers_omits_responses_lite_header_for_unknown_model(monkeypatch):
+    monkeypatch.setattr(
+        proxy_module,
+        "get_model_registry",
+        lambda: _responses_lite_registry({"gpt-5.6-luna": {"use_responses_lite": True}}),
+    )
+    headers = _build_upstream_headers({}, "token", "acc_2", model="gpt-9-does-not-exist")
+    lowered = {key.lower() for key in headers}
+    assert "x-openai-internal-codex-responses-lite" not in lowered
+
+
+def test_build_upstream_websocket_headers_reconstructs_responses_lite_header(monkeypatch):
+    monkeypatch.setattr(
+        proxy_module,
+        "get_model_registry",
+        lambda: _responses_lite_registry({"gpt-5.6-sol": {"use_responses_lite": True}}),
+    )
+    headers = proxy_module._build_upstream_websocket_headers(
+        {"Connection": "Upgrade"}, "token", "acc_2", model="gpt-5.6-sol"
+    )
+    assert headers["x-openai-internal-codex-responses-lite"] == "true"
+
+
 def test_build_upstream_headers_accept_override():
     inbound = {}
     headers = _build_upstream_headers(inbound, "token", None, accept="application/json")


### PR DESCRIPTION
## Status: superseded by #1161 and #1162

Follow-up deployment testing clarified the original diagnosis:

- #1161 now preserves Responses Lite payload state and implements canonical transport-aware Lite signaling more comprehensively than this PR.
- #1162 adds GPT-5.6 Sol/Terra/Luna bootstrap metadata and extended reasoning support across the backend and dashboard more comprehensively than this PR.
- Using #1161 on a live codex-lb deployment, pi's standard `openai-completions` provider successfully used `/v1/chat/completions` with streaming for both GPT-5.6 Sol and Terra, including standard function-tool calls.
- Therefore, this PR's claim that absence of registry-derived header reconstruction rejects *all* GPT-5.6 traffic was too broad.
- GPT-5.6 Luna remained unavailable, but an exact-token direct request to ChatGPT (bypassing nginx and codex-lb) returned the same account-specific internal-model error: `gpt-5.6-luna-free-1p-codexswic-ev3`. That is not a proxy regression.

The useful areas of this PR are covered by the two narrower and more complete upstream contributions above, so this PR is being closed to avoid duplicate implementations and review overhead.

### Live compatibility verification

| Client path | Sol | Terra | Luna |
|---|---:|---:|---:|
| pi `openai-completions` → streamed `/v1/chat/completions` | ✅ text + tools | ✅ text + tools | ❌ upstream account rollout |

Superseded by #1161 and #1162. Related: #1157.
