### PR TITLE
fix(ci): ignore superseded same-head check suites

### DIFF
--- a/.github/scripts/sync_codex_ok_labels.py
+++ b/.github/scripts/sync_codex_ok_labels.py
@@ -696,14 +696,16 @@ def classify_check_state(
     named_check_runs: dict[str, dict[str, Any]] = {}
     unnamed_check_runs: list[dict[str, Any]] = []
 
-    authoritative_ci_run = authoritative_ci_workflow_run_id(check_runs)
     authoritative_ci_workflow = authoritative_ci_workflow_id(check_runs)
+    authoritative_ci_run = authoritative_ci_workflow_run_id(
+        check_runs,
+        workflow_id=authoritative_ci_workflow,
+    )
     if authoritative_ci_run is not None and authoritative_ci_workflow is not None:
         check_runs = [
             item
             for item in check_runs
-            if item.get("name") in required_check_names
-            or github_actions_workflow_id(item) != authoritative_ci_workflow
+            if github_actions_workflow_id(item) != authoritative_ci_workflow
             or github_actions_workflow_run_id(item) in {None, authoritative_ci_run}
         ]
 
@@ -764,12 +766,32 @@ def github_actions_workflow_run_id(item: dict[str, Any]) -> str | None:
     return match.group(1) if match is not None else None
 
 
-def authoritative_ci_workflow_run_id(check_runs: list[dict[str, Any]]) -> str | None:
-    required_runs = [item for item in check_runs if item.get("name") == "CI Required"]
-    if not required_runs:
+def authoritative_ci_workflow_run_id(
+    check_runs: list[dict[str, Any]],
+    *,
+    workflow_id: str | None,
+) -> str | None:
+    if workflow_id is None:
         return None
-    latest_required = max(required_runs, key=check_run_recency_key)
-    return github_actions_workflow_run_id(latest_required)
+    workflow_runs = [
+        item
+        for item in check_runs
+        if github_actions_workflow_id(item) == workflow_id
+        and github_actions_workflow_run_id(item) is not None
+    ]
+    if not workflow_runs:
+        return None
+    latest_run = max(workflow_runs, key=github_actions_workflow_run_recency_key)
+    return github_actions_workflow_run_id(latest_run)
+
+
+def github_actions_workflow_run_recency_key(item: dict[str, Any]) -> tuple[str, tuple[str, str], int]:
+    run_id = github_actions_workflow_run_id(item)
+    return (
+        str(item.get("_github_actions_run_created_at") or ""),
+        check_run_recency_key(item),
+        int(run_id) if isinstance(run_id, str) and run_id.isdigit() else 0,
+    )
 
 
 def github_actions_workflow_id(item: dict[str, Any]) -> str | None:
@@ -786,7 +808,7 @@ def authoritative_ci_workflow_id(check_runs: list[dict[str, Any]]) -> str | None
 
 
 def annotate_github_actions_workflow_ids(repo: str, check_runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    workflow_ids_by_run: dict[str, str] = {}
+    workflow_metadata_by_run: dict[str, tuple[str, str | None]] = {}
     for run_id in {github_actions_workflow_run_id(item) for item in check_runs} - {None}:
         assert run_id is not None
         try:
@@ -795,13 +817,24 @@ def annotate_github_actions_workflow_ids(repo: str, check_runs: list[dict[str, A
             continue
         workflow_id = workflow_run.get("workflow_id") if isinstance(workflow_run, dict) else None
         if isinstance(workflow_id, (int, str)):
-            workflow_ids_by_run[run_id] = str(workflow_id)
+            run_created_at = workflow_run.get("created_at") or workflow_run.get("run_started_at")
+            workflow_metadata_by_run[run_id] = (
+                str(workflow_id),
+                str(run_created_at) if isinstance(run_created_at, str) else None,
+            )
 
     annotated: list[dict[str, Any]] = []
     for item in check_runs:
         run_id = github_actions_workflow_run_id(item)
-        workflow_id = workflow_ids_by_run.get(run_id) if run_id is not None else None
-        annotated.append({**item, "_github_actions_workflow_id": workflow_id} if workflow_id is not None else item)
+        metadata = workflow_metadata_by_run.get(run_id) if run_id is not None else None
+        if metadata is None:
+            annotated.append(item)
+            continue
+        workflow_id, run_created_at = metadata
+        annotated_item = {**item, "_github_actions_workflow_id": workflow_id}
+        if run_created_at is not None:
+            annotated_item["_github_actions_run_created_at"] = run_created_at
+        annotated.append(annotated_item)
     return annotated
 
 

--- a/.github/scripts/sync_codex_ok_labels.py
+++ b/.github/scripts/sync_codex_ok_labels.py
@@ -696,6 +696,15 @@ def classify_check_state(
     named_check_runs: dict[str, dict[str, Any]] = {}
     unnamed_check_runs: list[dict[str, Any]] = []
 
+    authoritative_ci_run = authoritative_ci_workflow_run_id(check_runs)
+    if authoritative_ci_run is not None:
+        check_runs = [
+            item
+            for item in check_runs
+            if item.get("name") in required_check_names
+            or github_actions_workflow_run_id(item) in {None, authoritative_ci_run}
+        ]
+
     for item in check_runs:
         name = item.get("name")
         if isinstance(name, str):
@@ -743,6 +752,22 @@ def check_run_recency_key(item: dict[str, Any]) -> tuple[str, str]:
         ),
         str(item.get("completed_at") or item.get("completedAt") or ""),
     )
+
+
+def github_actions_workflow_run_id(item: dict[str, Any]) -> str | None:
+    details_url = item.get("details_url") or item.get("detailsUrl")
+    if not isinstance(details_url, str):
+        return None
+    match = re.search(r"/actions/runs/(\d+)(?:/|$)", details_url)
+    return match.group(1) if match is not None else None
+
+
+def authoritative_ci_workflow_run_id(check_runs: list[dict[str, Any]]) -> str | None:
+    required_runs = [item for item in check_runs if item.get("name") == "CI Required"]
+    if not required_runs:
+        return None
+    latest_required = max(required_runs, key=check_run_recency_key)
+    return github_actions_workflow_run_id(latest_required)
 
 
 def commit_checks_state(repo: str, head_sha: str) -> str:

--- a/.github/scripts/sync_codex_ok_labels.py
+++ b/.github/scripts/sync_codex_ok_labels.py
@@ -697,11 +697,13 @@ def classify_check_state(
     unnamed_check_runs: list[dict[str, Any]] = []
 
     authoritative_ci_run = authoritative_ci_workflow_run_id(check_runs)
-    if authoritative_ci_run is not None:
+    authoritative_ci_workflow = authoritative_ci_workflow_id(check_runs)
+    if authoritative_ci_run is not None and authoritative_ci_workflow is not None:
         check_runs = [
             item
             for item in check_runs
             if item.get("name") in required_check_names
+            or github_actions_workflow_id(item) != authoritative_ci_workflow
             or github_actions_workflow_run_id(item) in {None, authoritative_ci_run}
         ]
 
@@ -770,8 +772,42 @@ def authoritative_ci_workflow_run_id(check_runs: list[dict[str, Any]]) -> str | 
     return github_actions_workflow_run_id(latest_required)
 
 
+def github_actions_workflow_id(item: dict[str, Any]) -> str | None:
+    workflow_id = item.get("_github_actions_workflow_id")
+    return str(workflow_id) if isinstance(workflow_id, (int, str)) else None
+
+
+def authoritative_ci_workflow_id(check_runs: list[dict[str, Any]]) -> str | None:
+    required_runs = [item for item in check_runs if item.get("name") == "CI Required"]
+    if not required_runs:
+        return None
+    latest_required = max(required_runs, key=check_run_recency_key)
+    return github_actions_workflow_id(latest_required)
+
+
+def annotate_github_actions_workflow_ids(repo: str, check_runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    workflow_ids_by_run: dict[str, str] = {}
+    for run_id in {github_actions_workflow_run_id(item) for item in check_runs} - {None}:
+        assert run_id is not None
+        try:
+            workflow_run = gh_api(f"/repos/{repo}/actions/runs/{run_id}")
+        except GhError:
+            continue
+        workflow_id = workflow_run.get("workflow_id") if isinstance(workflow_run, dict) else None
+        if isinstance(workflow_id, (int, str)):
+            workflow_ids_by_run[run_id] = str(workflow_id)
+
+    annotated: list[dict[str, Any]] = []
+    for item in check_runs:
+        run_id = github_actions_workflow_run_id(item)
+        workflow_id = workflow_ids_by_run.get(run_id) if run_id is not None else None
+        annotated.append({**item, "_github_actions_workflow_id": workflow_id} if workflow_id is not None else item)
+    return annotated
+
+
 def commit_checks_state(repo: str, head_sha: str) -> str:
     check_runs = paged_api(f"/repos/{repo}/commits/{head_sha}/check-runs")
+    check_runs = annotate_github_actions_workflow_ids(repo, check_runs)
     combined_status = gh_api(f"/repos/{repo}/commits/{head_sha}/status")
     return classify_check_state(
         check_runs,

--- a/.github/scripts/sync_codex_ok_labels.py
+++ b/.github/scripts/sync_codex_ok_labels.py
@@ -776,8 +776,7 @@ def authoritative_ci_workflow_run_id(
     workflow_runs = [
         item
         for item in check_runs
-        if github_actions_workflow_id(item) == workflow_id
-        and github_actions_workflow_run_id(item) is not None
+        if github_actions_workflow_id(item) == workflow_id and github_actions_workflow_run_id(item) is not None
     ]
     if not workflow_runs:
         return None

--- a/openspec/changes/ignore-superseded-ci-check-suites/proposal.md
+++ b/openspec/changes/ignore-superseded-ci-check-suites/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+GitHub can start two CI workflow runs for the same pull-request head and cancel
+the older run. The cancelled suite may leave a uniquely named matrix placeholder
+check in failure even after the newer suite's `CI Required` job succeeds. The
+Codex label synchronizer currently aggregates that stale check and classifies an
+otherwise green current head as failed, so it neither labels a clean review nor
+requests the missing current-head Codex review.
+
+## What Changes
+
+- Treat the workflow run containing the most recent `CI Required` check as the
+  authoritative GitHub Actions CI suite for that head.
+- Ignore non-required GitHub Actions checks from superseded workflow runs while
+  preserving required check contexts and non-Actions status evidence.
+- Keep failures from the authoritative CI workflow blocking.
+- Add regression coverage for the cancelled matrix-placeholder shape observed
+  on a real current-head pull request.
+
+## Impact
+
+Codex review labels and review requests follow the latest completed CI suite for
+the exact head instead of remaining blocked by stale checks from a cancelled
+duplicate run.

--- a/openspec/changes/ignore-superseded-ci-check-suites/proposal.md
+++ b/openspec/changes/ignore-superseded-ci-check-suites/proposal.md
@@ -9,11 +9,14 @@ requests the missing current-head Codex review.
 
 ## What Changes
 
-- Treat the workflow run containing the most recent `CI Required` check as the
-  authoritative GitHub Actions CI suite for that head.
-- Ignore non-required GitHub Actions checks from superseded workflow runs while
-  preserving required check contexts and non-Actions status evidence.
-- Keep failures from the authoritative CI workflow blocking.
+- Identify the GitHub Actions CI workflow from the most recent `CI Required`
+  check, then treat the newest same-head run of that workflow as the
+  authoritative CI suite — keeping a newer run pending until its own
+  `CI Required` completes.
+- Ignore GitHub Actions checks (including stale required contexts) only from
+  superseded runs of that workflow, while preserving non-Actions status
+  evidence and checks from independent workflows.
+- Keep failures from the authoritative CI run blocking.
 - Add regression coverage for the cancelled matrix-placeholder shape observed
   on a real current-head pull request.
 

--- a/openspec/changes/ignore-superseded-ci-check-suites/specs/github-automation/spec.md
+++ b/openspec/changes/ignore-superseded-ci-check-suites/specs/github-automation/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Codex review labels use the authoritative current-head CI suite
+
+The Codex review label synchronizer SHALL treat the run containing the most
+recent `CI Required` check as the authoritative CI suite when multiple GitHub
+Actions CI workflow runs exist for one pull-request head. It MUST ignore
+non-required Actions checks from superseded runs, while required check contexts,
+non-Actions status evidence, and failures from the authoritative run remain
+blocking.
+
+#### Scenario: Cancelled duplicate leaves a unique failed placeholder
+
+- **GIVEN** an older CI workflow run for the current head was cancelled
+- **AND** that run left a uniquely named non-required matrix placeholder in failure
+- **AND** a newer run for the same head completed every required check including `CI Required` successfully
+- **WHEN** Codex review labels are synchronized
+- **THEN** the stale placeholder does not make the current head failed
+- **AND** the synchronizer may request or accept current-head Codex review evidence
+
+#### Scenario: Authoritative CI run has an optional failure
+
+- **GIVEN** the most recent `CI Required` check identifies the authoritative workflow run
+- **AND** another check in that same run failed
+- **WHEN** Codex review labels are synchronized
+- **THEN** the current head remains classified as failed

--- a/openspec/changes/ignore-superseded-ci-check-suites/specs/github-automation/spec.md
+++ b/openspec/changes/ignore-superseded-ci-check-suites/specs/github-automation/spec.md
@@ -3,11 +3,11 @@
 ### Requirement: Codex review labels use the authoritative current-head CI suite
 
 The Codex review label synchronizer SHALL treat the run containing the most
-recent `CI Required` check as the authoritative CI suite when multiple GitHub
-Actions CI workflow runs exist for one pull-request head. It MUST ignore
+recent `CI Required` check as the authoritative CI suite when multiple runs of
+the same GitHub Actions CI workflow exist for one pull-request head. It MUST ignore
 non-required Actions checks from superseded runs, while required check contexts,
-non-Actions status evidence, and failures from the authoritative run remain
-blocking.
+non-Actions status evidence, failures from the authoritative run, and failures
+from independent workflows remain blocking.
 
 #### Scenario: Cancelled duplicate leaves a unique failed placeholder
 
@@ -24,3 +24,10 @@ blocking.
 - **AND** another check in that same run failed
 - **WHEN** Codex review labels are synchronized
 - **THEN** the current head remains classified as failed
+
+#### Scenario: Independent workflow on the same head fails
+
+- **GIVEN** the authoritative CI workflow run is successful
+- **AND** a different GitHub Actions workflow has a failed check on the same head
+- **WHEN** Codex review labels are synchronized
+- **THEN** the independent workflow failure remains blocking

--- a/openspec/changes/ignore-superseded-ci-check-suites/specs/github-automation/spec.md
+++ b/openspec/changes/ignore-superseded-ci-check-suites/specs/github-automation/spec.md
@@ -2,12 +2,16 @@
 
 ### Requirement: Codex review labels use the authoritative current-head CI suite
 
-The Codex review label synchronizer SHALL treat the run containing the most
-recent `CI Required` check as the authoritative CI suite when multiple runs of
-the same GitHub Actions CI workflow exist for one pull-request head. It MUST ignore
-non-required Actions checks from superseded runs, while required check contexts,
-non-Actions status evidence, failures from the authoritative run, and failures
-from independent workflows remain blocking.
+The Codex review label synchronizer SHALL identify the CI workflow from the
+most recent `CI Required` check and SHALL treat the newest same-head run of
+that workflow (ordered by workflow-run creation time, then check recency, then
+run id) as the authoritative CI suite when multiple runs of the same GitHub
+Actions CI workflow exist for one pull-request head, even when that run has
+not yet produced its own `CI Required` check. It MUST ignore Actions checks —
+including stale required contexts — only from superseded (older) runs of that
+workflow, while checks from the authoritative run, checks that cannot be
+attributed to a workflow run, non-Actions status evidence, and failures from
+independent workflows remain blocking evidence.
 
 #### Scenario: Cancelled duplicate leaves a unique failed placeholder
 
@@ -20,10 +24,19 @@ from independent workflows remain blocking.
 
 #### Scenario: Authoritative CI run has an optional failure
 
-- **GIVEN** the most recent `CI Required` check identifies the authoritative workflow run
+- **GIVEN** the newest run of the CI workflow identified by the latest `CI Required` check is the authoritative run
 - **AND** another check in that same run failed
 - **WHEN** Codex review labels are synchronized
 - **THEN** the current head remains classified as failed
+
+#### Scenario: A newer run stays pending until its own CI Required completes
+
+- **GIVEN** an older run of the CI workflow completed `CI Required` successfully for the current head
+- **AND** a newer run of the same CI workflow was created for the same head
+- **AND** the newer run has started early checks but has not yet completed its own `CI Required` check
+- **WHEN** Codex review labels are synchronized
+- **THEN** the newer run is the authoritative CI suite and the older run's completed checks are ignored
+- **AND** the current head remains classified as pending until the newer run's `CI Required` completes
 
 #### Scenario: Independent workflow on the same head fails
 

--- a/openspec/changes/ignore-superseded-ci-check-suites/tasks.md
+++ b/openspec/changes/ignore-superseded-ci-check-suites/tasks.md
@@ -1,0 +1,13 @@
+## 1. Specification
+
+- [x] 1.1 Define latest-suite selection and stale-check handling for Codex label synchronization.
+
+## 2. Implementation
+
+- [x] 2.1 Identify the GitHub Actions run containing the newest `CI Required` check.
+- [x] 2.2 Exclude non-required checks from superseded Actions runs without masking current-suite failures.
+
+## 3. Verification
+
+- [x] 3.1 Add positive and negative unit regressions for duplicate same-head CI runs.
+- [x] 3.2 Run focused tests, lint, type checks, and strict OpenSpec validation.

--- a/tests/unit/test_sync_codex_ok_labels.py
+++ b/tests/unit/test_sync_codex_ok_labels.py
@@ -146,6 +146,7 @@ def test_classify_check_state_ignores_unique_failure_from_superseded_ci_run() ->
             "started_at": "2026-07-10T06:00:37Z",
             "completed_at": "2026-07-10T06:00:37Z",
             "details_url": "https://github.com/Soju06/codex-lb/actions/runs/100/job/1",
+            "_github_actions_workflow_id": "ci",
         },
         {
             "name": "CI Required",
@@ -154,6 +155,7 @@ def test_classify_check_state_ignores_unique_failure_from_superseded_ci_run() ->
             "started_at": "2026-07-10T06:00:38Z",
             "completed_at": "2026-07-10T06:00:41Z",
             "details_url": "https://github.com/Soju06/codex-lb/actions/runs/100/job/2",
+            "_github_actions_workflow_id": "ci",
         },
         {
             "name": "Tests (pytest, unit)",
@@ -162,6 +164,7 @@ def test_classify_check_state_ignores_unique_failure_from_superseded_ci_run() ->
             "started_at": "2026-07-10T06:01:00Z",
             "completed_at": "2026-07-10T06:05:00Z",
             "details_url": "https://github.com/Soju06/codex-lb/actions/runs/200/job/3",
+            "_github_actions_workflow_id": "ci",
         },
         {
             "name": "CI Required",
@@ -170,6 +173,7 @@ def test_classify_check_state_ignores_unique_failure_from_superseded_ci_run() ->
             "started_at": "2026-07-10T06:09:01Z",
             "completed_at": "2026-07-10T06:09:05Z",
             "details_url": "https://github.com/Soju06/codex-lb/actions/runs/200/job/4",
+            "_github_actions_workflow_id": "ci",
         },
     ]
 
@@ -194,6 +198,7 @@ def test_classify_check_state_keeps_optional_failure_from_authoritative_ci_run()
             "started_at": "2026-07-10T06:09:00Z",
             "completed_at": "2026-07-10T06:09:04Z",
             "details_url": "https://github.com/Soju06/codex-lb/actions/runs/200/job/3",
+            "_github_actions_workflow_id": "ci",
         },
         {
             "name": "CI Required",
@@ -202,6 +207,7 @@ def test_classify_check_state_keeps_optional_failure_from_authoritative_ci_run()
             "started_at": "2026-07-10T06:09:01Z",
             "completed_at": "2026-07-10T06:09:05Z",
             "details_url": "https://github.com/Soju06/codex-lb/actions/runs/200/job/4",
+            "_github_actions_workflow_id": "ci",
         },
     ]
 
@@ -213,6 +219,68 @@ def test_classify_check_state_keeps_optional_failure_from_authoritative_ci_run()
         )
         == "failure"
     )
+
+
+def test_classify_check_state_keeps_failure_from_independent_workflow_run() -> None:
+    module = load_sync_module()
+
+    check_runs = [
+        {
+            "name": "independent security scan",
+            "status": "completed",
+            "conclusion": "failure",
+            "started_at": "2026-07-10T06:08:00Z",
+            "completed_at": "2026-07-10T06:08:30Z",
+            "details_url": "https://github.com/Soju06/codex-lb/actions/runs/300/job/1",
+            "_github_actions_workflow_id": "security",
+        },
+        {
+            "name": "CI Required",
+            "status": "completed",
+            "conclusion": "success",
+            "started_at": "2026-07-10T06:09:01Z",
+            "completed_at": "2026-07-10T06:09:05Z",
+            "details_url": "https://github.com/Soju06/codex-lb/actions/runs/200/job/4",
+            "_github_actions_workflow_id": "ci",
+        },
+    ]
+
+    assert (
+        module.classify_check_state(
+            check_runs,
+            {"statuses": []},
+            required_check_names=frozenset({"CI Required"}),
+        )
+        == "failure"
+    )
+
+
+def test_annotate_github_actions_workflow_ids_is_conservative_when_metadata_lookup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_sync_module()
+    check_runs = [
+        {
+            "name": "CI Required",
+            "details_url": "https://github.com/Soju06/codex-lb/actions/runs/200/job/4",
+        },
+        {
+            "name": "independent scan",
+            "details_url": "https://github.com/Soju06/codex-lb/actions/runs/300/job/1",
+        },
+    ]
+
+    def workflow_run(path: str) -> dict[str, int]:
+        if path.endswith("/200"):
+            return {"workflow_id": 10}
+        raise module.GhError("metadata unavailable")
+
+    monkeypatch.setattr(module, "gh_api", workflow_run)
+
+    annotated = module.annotate_github_actions_workflow_ids("Soju06/codex-lb", check_runs)
+
+    assert annotated[0]["_github_actions_workflow_id"] == "10"
+    assert "_github_actions_workflow_id" not in annotated[1]
 
 
 def test_apply_decision_tolerates_github_app_write_denial(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_sync_codex_ok_labels.py
+++ b/tests/unit/test_sync_codex_ok_labels.py
@@ -221,6 +221,41 @@ def test_classify_check_state_keeps_optional_failure_from_authoritative_ci_run()
     )
 
 
+def test_classify_check_state_keeps_newer_same_workflow_run_pending_before_required_job_exists() -> None:
+    module = load_sync_module()
+
+    check_runs = [
+        {
+            "name": "CI Required",
+            "status": "completed",
+            "conclusion": "success",
+            "started_at": "2026-07-10T06:09:01Z",
+            "completed_at": "2026-07-10T06:09:05Z",
+            "details_url": "https://github.com/Soju06/codex-lb/actions/runs/200/job/4",
+            "_github_actions_workflow_id": "ci",
+            "_github_actions_run_created_at": "2026-07-10T06:00:43Z",
+        },
+        {
+            "name": "Detect changes",
+            "status": "in_progress",
+            "conclusion": None,
+            "started_at": "2026-07-10T06:50:20Z",
+            "details_url": "https://github.com/Soju06/codex-lb/actions/runs/300/job/1",
+            "_github_actions_workflow_id": "ci",
+            "_github_actions_run_created_at": "2026-07-10T06:50:20Z",
+        },
+    ]
+
+    assert (
+        module.classify_check_state(
+            check_runs,
+            {"statuses": []},
+            required_check_names=frozenset({"CI Required"}),
+        )
+        == "pending"
+    )
+
+
 def test_classify_check_state_keeps_failure_from_independent_workflow_run() -> None:
     module = load_sync_module()
 
@@ -270,9 +305,9 @@ def test_annotate_github_actions_workflow_ids_is_conservative_when_metadata_look
         },
     ]
 
-    def workflow_run(path: str) -> dict[str, int]:
+    def workflow_run(path: str) -> dict[str, int | str]:
         if path.endswith("/200"):
-            return {"workflow_id": 10}
+            return {"workflow_id": 10, "created_at": "2026-07-10T06:00:43Z"}
         raise module.GhError("metadata unavailable")
 
     monkeypatch.setattr(module, "gh_api", workflow_run)
@@ -280,6 +315,7 @@ def test_annotate_github_actions_workflow_ids_is_conservative_when_metadata_look
     annotated = module.annotate_github_actions_workflow_ids("Soju06/codex-lb", check_runs)
 
     assert annotated[0]["_github_actions_workflow_id"] == "10"
+    assert annotated[0]["_github_actions_run_created_at"] == "2026-07-10T06:00:43Z"
     assert "_github_actions_workflow_id" not in annotated[1]
 
 

--- a/tests/unit/test_sync_codex_ok_labels.py
+++ b/tests/unit/test_sync_codex_ok_labels.py
@@ -135,6 +135,86 @@ def test_classify_check_state_ignores_stale_duplicate_that_finishes_late() -> No
     )
 
 
+def test_classify_check_state_ignores_unique_failure_from_superseded_ci_run() -> None:
+    module = load_sync_module()
+
+    check_runs = [
+        {
+            "name": "Tests (pytest, ${{ matrix.slice.name }})",
+            "status": "completed",
+            "conclusion": "failure",
+            "started_at": "2026-07-10T06:00:37Z",
+            "completed_at": "2026-07-10T06:00:37Z",
+            "details_url": "https://github.com/Soju06/codex-lb/actions/runs/100/job/1",
+        },
+        {
+            "name": "CI Required",
+            "status": "completed",
+            "conclusion": "failure",
+            "started_at": "2026-07-10T06:00:38Z",
+            "completed_at": "2026-07-10T06:00:41Z",
+            "details_url": "https://github.com/Soju06/codex-lb/actions/runs/100/job/2",
+        },
+        {
+            "name": "Tests (pytest, unit)",
+            "status": "completed",
+            "conclusion": "success",
+            "started_at": "2026-07-10T06:01:00Z",
+            "completed_at": "2026-07-10T06:05:00Z",
+            "details_url": "https://github.com/Soju06/codex-lb/actions/runs/200/job/3",
+        },
+        {
+            "name": "CI Required",
+            "status": "completed",
+            "conclusion": "success",
+            "started_at": "2026-07-10T06:09:01Z",
+            "completed_at": "2026-07-10T06:09:05Z",
+            "details_url": "https://github.com/Soju06/codex-lb/actions/runs/200/job/4",
+        },
+    ]
+
+    assert (
+        module.classify_check_state(
+            check_runs,
+            {"statuses": []},
+            required_check_names=frozenset({"CI Required", "Tests (pytest, unit)"}),
+        )
+        == "success"
+    )
+
+
+def test_classify_check_state_keeps_optional_failure_from_authoritative_ci_run() -> None:
+    module = load_sync_module()
+
+    check_runs = [
+        {
+            "name": "optional security scan",
+            "status": "completed",
+            "conclusion": "failure",
+            "started_at": "2026-07-10T06:09:00Z",
+            "completed_at": "2026-07-10T06:09:04Z",
+            "details_url": "https://github.com/Soju06/codex-lb/actions/runs/200/job/3",
+        },
+        {
+            "name": "CI Required",
+            "status": "completed",
+            "conclusion": "success",
+            "started_at": "2026-07-10T06:09:01Z",
+            "completed_at": "2026-07-10T06:09:05Z",
+            "details_url": "https://github.com/Soju06/codex-lb/actions/runs/200/job/4",
+        },
+    ]
+
+    assert (
+        module.classify_check_state(
+            check_runs,
+            {"statuses": []},
+            required_check_names=frozenset({"CI Required"}),
+        )
+        == "failure"
+    )
+
+
 def test_apply_decision_tolerates_github_app_write_denial(monkeypatch: pytest.MonkeyPatch) -> None:
     module = load_sync_module()
 


### PR DESCRIPTION
## Summary

- identify the CI workflow from its required context, then select the newest same-head run of that workflow before suppressing older runs
- ignore checks, including stale required contexts, only from superseded runs of that same CI workflow
- keep a newer run pending until its own `CI Required` context appears and completes
- preserve failures from the authoritative run, independent workflows, non-Actions status evidence, and cases where workflow metadata cannot be loaded
- cover cancelled duplicate suites, newer pending reruns, independent red workflows, and metadata lookup failures

## Validation

- `.venv/bin/pytest -q tests/unit/test_sync_codex_ok_labels.py` — 23 passed
- `.venv/bin/ruff check .github/scripts/sync_codex_ok_labels.py tests/unit/test_sync_codex_ok_labels.py`
- `.venv/bin/ty check .github/scripts/sync_codex_ok_labels.py tests/unit/test_sync_codex_ok_labels.py`
- `openspec validate ignore-superseded-ci-check-suites --strict`
- `openspec validate --specs` — 30 specs passed
- `git diff --check`