### PR TITLE
fix(proxy): preserve all non-message system and developer input items

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -917,6 +917,15 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "kvz",
+      "name": "Kevin van Zonneveld",
+      "avatar_url": "https://avatars.githubusercontent.com/u/26752?v=4",
+      "profile": "https://github.com/kvz",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -305,6 +305,14 @@ def _normalize_responses_input_instructions(data: JsonValue) -> JsonValue:
         if role not in ("system", "developer"):
             input_items.append(item)
             continue
+        # Only hoist actual message items. Codex responses-lite clients (gpt-5.6+ models with
+        # use_responses_lite/tool_mode=code_mode_only) send non-message developer items such as
+        # {"type": "additional_tools", "role": "developer", "tools": [...]} inside input; those
+        # have no content, so hoisting used to drop them entirely and the model lost all tools.
+        item_type = item_mapping.get("type")
+        if item_type is not None and item_type != "message":
+            input_items.append(item)
+            continue
         instruction_text, preserved_content = _split_responses_instruction_item_content(item_mapping)
         if instruction_text:
             instruction_parts.append(instruction_text)

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -313,6 +313,10 @@ def _normalize_responses_input_instructions(data: JsonValue) -> JsonValue:
         item_type = item_mapping.get("type")
         if item_type is not None and item_type != "message":
             input_items.append(item)
+            # Still counts as a normalization outcome: directive-only inputs
+            # must default top-level ``instructions`` (to "") so the request
+            # validates instead of failing on the required field.
+            changed = True
             continue
         instruction_text, preserved_content = _split_responses_instruction_item_content(item_mapping)
         if instruction_text:

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -268,9 +268,27 @@ def extract_input_image_file_references(input_value: JsonValue) -> list[InputIma
     return references
 
 
+def _is_preserved_non_message_directive(item: Mapping[str, JsonValue]) -> bool:
+    # Shared preservation rule: any system/developer-role input item whose type
+    # is present and not "message" must reach upstream byte-identical. It gates
+    # instruction hoisting, input sanitization, and compact trim anchoring.
+    if item.get("role") not in ("system", "developer"):
+        return False
+    item_type = item.get("type")
+    return item_type is not None and item_type != "message"
+
+
 def _sanitize_input_items(input_items: list[JsonValue]) -> list[JsonValue]:
     sanitized_input: list[JsonValue] = []
     for item in input_items:
+        item_mapping = _json_mapping_or_none(item)
+        if item_mapping is not None and _is_preserved_non_message_directive(item_mapping):
+            # Preserved directives are forwarded unchanged; the interleaved
+            # reasoning sanitizer targets assistant-message echo fields and
+            # must not strip keys such as tool_calls or reasoning_content
+            # from a typed directive.
+            sanitized_input.append(item)
+            continue
         sanitized_item = _sanitize_interleaved_reasoning_input_item(item)
         if sanitized_item is None:
             continue
@@ -301,22 +319,21 @@ def _normalize_responses_input_instructions(data: JsonValue) -> JsonValue:
         if item_mapping is None:
             input_items.append(item)
             continue
-        role = item_mapping.get("role")
-        if role not in ("system", "developer"):
-            input_items.append(item)
-            continue
         # Only hoist actual message items (type omitted or "message"). Non-message
         # typed system/developer items (e.g. the Codex responses-lite
         # {"type": "additional_tools", "role": "developer", "tools": [...]} bundle, or
         # any future typed item) carry no instruction content; hoisting used to drop
         # them entirely, so pass them through untouched regardless of role.
-        item_type = item_mapping.get("type")
-        if item_type is not None and item_type != "message":
+        if _is_preserved_non_message_directive(item_mapping):
             input_items.append(item)
             # Still counts as a normalization outcome: directive-only inputs
             # must default top-level ``instructions`` (to "") so the request
             # validates instead of failing on the required field.
             changed = True
+            continue
+        role = item_mapping.get("role")
+        if role not in ("system", "developer"):
+            input_items.append(item)
             continue
         instruction_text, preserved_content = _split_responses_instruction_item_content(item_mapping)
         if instruction_text:
@@ -898,7 +915,7 @@ def _compact_state_anchor_indices(input_value: list[JsonValue]) -> set[int]:
                     developer_type = developer_item.get("type")
                     if developer_type is None or developer_type == "message":
                         preserved_indices.add(developer_index)
-        if _compact_item_is_preserved_non_message_directive(item_mapping):
+        if _is_preserved_non_message_directive(item_mapping):
             preserved_indices.add(index)
         if _compact_item_is_state_anchor(item_mapping):
             preserved_indices.add(index)
@@ -1001,17 +1018,6 @@ def _compact_reconciled_tool_call_indices(
             if not add_indices(matched_output_indices):
                 remove_indices([call_index, *matched_output_indices])
     return reconciled
-
-
-def _compact_item_is_preserved_non_message_directive(item: Mapping[str, JsonValue]) -> bool:
-    # Mirror the instruction-normalization guard: any system/developer-role item
-    # whose type is present and not "message" is preserved verbatim during
-    # normalization, so compact trimming must anchor it in place instead of
-    # replacing it with the trim marker.
-    if item.get("role") not in ("system", "developer"):
-        return False
-    item_type = item.get("type")
-    return item_type is not None and item_type != "message"
 
 
 def _compact_item_is_state_anchor(item: Mapping[str, JsonValue]) -> bool:

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -894,6 +894,8 @@ def _compact_state_anchor_indices(input_value: list[JsonValue]) -> set[int]:
                     developer_type = developer_item.get("type")
                     if developer_type is None or developer_type == "message":
                         preserved_indices.add(developer_index)
+        if _compact_item_is_preserved_non_message_directive(item_mapping):
+            preserved_indices.add(index)
         if _compact_item_is_state_anchor(item_mapping):
             preserved_indices.add(index)
             call_id = item_mapping.get("call_id")
@@ -995,6 +997,17 @@ def _compact_reconciled_tool_call_indices(
             if not add_indices(matched_output_indices):
                 remove_indices([call_index, *matched_output_indices])
     return reconciled
+
+
+def _compact_item_is_preserved_non_message_directive(item: Mapping[str, JsonValue]) -> bool:
+    # Mirror the instruction-normalization guard: any system/developer-role item
+    # whose type is present and not "message" is preserved verbatim during
+    # normalization, so compact trimming must anchor it in place instead of
+    # replacing it with the trim marker.
+    if item.get("role") not in ("system", "developer"):
+        return False
+    item_type = item.get("type")
+    return item_type is not None and item_type != "message"
 
 
 def _compact_item_is_state_anchor(item: Mapping[str, JsonValue]) -> bool:

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -305,10 +305,11 @@ def _normalize_responses_input_instructions(data: JsonValue) -> JsonValue:
         if role not in ("system", "developer"):
             input_items.append(item)
             continue
-        # Only hoist actual message items. Codex responses-lite clients (gpt-5.6+ models with
-        # use_responses_lite/tool_mode=code_mode_only) send non-message developer items such as
-        # {"type": "additional_tools", "role": "developer", "tools": [...]} inside input; those
-        # have no content, so hoisting used to drop them entirely and the model lost all tools.
+        # Only hoist actual message items (type omitted or "message"). Non-message
+        # typed system/developer items (e.g. the Codex responses-lite
+        # {"type": "additional_tools", "role": "developer", "tools": [...]} bundle, or
+        # any future typed item) carry no instruction content; hoisting used to drop
+        # them entirely, so pass them through untouched regardless of role.
         item_type = item_mapping.get("type")
         if item_type is not None and item_type != "message":
             input_items.append(item)

--- a/openspec/changes/preserve-non-message-developer-input-items/.openspec.yaml
+++ b/openspec/changes/preserve-non-message-developer-input-items/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/preserve-non-message-developer-input-items/design.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/design.md
@@ -1,0 +1,9 @@
+# Design
+
+## Approach
+
+Add a type guard to `_normalize_responses_input_instructions()` in `app/core/openai/requests.py`: before treating a `system`/`developer`-role input item as an instruction message, check the item's `type`. Items whose `type` is present and not `"message"` are appended to the preserved input list unchanged.
+
+Typeless role items (`{"role": "system", "content": ...}`, as sent by OpenAI-compatible clients) keep the existing hoisting behavior, so `/v1`-style compatibility is unaffected. The guard lives in the shared normalizer, so both `ResponsesRequest` and `ResponsesCompactRequest` validators pick it up.
+
+This keeps the codex-faithful wire format: native Codex responses-lite bodies reach upstream with their `additional_tools` prefix intact, exactly as the Codex CLI emits them.

--- a/openspec/changes/preserve-non-message-developer-input-items/design.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/design.md
@@ -29,9 +29,21 @@ adjacent developer instructions message) is deliberately left untouched so the
 native Codex wire shape reaches upstream byte-for-byte. The per-item type guard
 is the general safety net for every other non-message typed item.
 
-Compact upstream trimming applies the same rule: `_compact_state_anchor_indices()`
-treats any `system`/`developer`-role item whose `type` is present and not
-`"message"` as a trim anchor, so a preserved directive sitting in the trimmed
-middle of an oversized compact request is kept in place instead of being
-replaced by the trim marker. Existing anchors (`additional_tools`, compact
-state items, and reconciled tool calls) are unaffected.
+The preservation rule lives in a single predicate,
+`_is_preserved_non_message_directive()` (system/developer role, `type` present
+and not `"message"`), shared by three normalization stages:
+
+- Instruction hoisting (`_normalize_responses_input_instructions()`) passes
+  matching items through untouched.
+- Input sanitization (`_sanitize_input_items()`) skips matching items so the
+  interleaved-reasoning sanitizer — which targets assistant-message echo
+  fields — cannot strip top-level `reasoning_content`, `reasoning_details`,
+  `tool_calls`, or `function_call` keys (or reasoning-typed content parts)
+  from a preserved directive. This cannot regress prior behavior: before this
+  change, such items were dropped entirely, so nothing depended on their
+  sanitized shape.
+- Compact upstream trimming (`_compact_state_anchor_indices()`) treats
+  matching items as trim anchors, so a preserved directive sitting in the
+  trimmed middle of an oversized compact request is kept in place instead of
+  being replaced by the trim marker. Existing anchors (`additional_tools`,
+  compact state items, and reconciled tool calls) are unaffected.

--- a/openspec/changes/preserve-non-message-developer-input-items/design.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/design.md
@@ -20,3 +20,10 @@ when a Lite tool bundle is present, the entire input array (including the
 adjacent developer instructions message) is deliberately left untouched so the
 native Codex wire shape reaches upstream byte-for-byte. The per-item type guard
 is the general safety net for every other non-message typed item.
+
+Compact upstream trimming applies the same rule: `_compact_state_anchor_indices()`
+treats any `system`/`developer`-role item whose `type` is present and not
+`"message"` as a trim anchor, so a preserved directive sitting in the trimmed
+middle of an oversized compact request is kept in place instead of being
+replaced by the trim marker. Existing anchors (`additional_tools`, compact
+state items, and reconciled tool calls) are unaffected.

--- a/openspec/changes/preserve-non-message-developer-input-items/design.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/design.md
@@ -2,8 +2,21 @@
 
 ## Approach
 
-Add a type guard to `_normalize_responses_input_instructions()` in `app/core/openai/requests.py`: before treating a `system`/`developer`-role input item as an instruction message, check the item's `type`. Items whose `type` is present and not `"message"` are appended to the preserved input list unchanged.
+Add a type guard to `_normalize_responses_input_instructions()` in
+`app/core/openai/requests.py`: before treating a `system`/`developer`-role
+input item as an instruction message, check the item's `type`. Items whose
+`type` is present and not `"message"` are appended to the preserved input list
+unchanged, regardless of role.
 
-Typeless role items (`{"role": "system", "content": ...}`, as sent by OpenAI-compatible clients) keep the existing hoisting behavior, so `/v1`-style compatibility is unaffected. The guard lives in the shared normalizer, so both `ResponsesRequest` and `ResponsesCompactRequest` validators pick it up.
+Typeless role items (`{"role": "system", "content": ...}`, as sent by
+OpenAI-compatible clients) keep the existing hoisting behavior, so `/v1`-style
+compatibility is unaffected. The guard lives in the shared normalizer, so both
+`ResponsesRequest` and `ResponsesCompactRequest` validators pick it up, and the
+compact `to_payload()` path (which re-runs the normalizer via
+`_strip_compact_unsupported_fields`) applies the same rule.
 
-This keeps the codex-faithful wire format: native Codex responses-lite bodies reach upstream with their `additional_tools` prefix intact, exactly as the Codex CLI emits them.
+The Responses Lite `additional_tools` early return stays in front of the loop:
+when a Lite tool bundle is present, the entire input array (including the
+adjacent developer instructions message) is deliberately left untouched so the
+native Codex wire shape reaches upstream byte-for-byte. The per-item type guard
+is the general safety net for every other non-message typed item.

--- a/openspec/changes/preserve-non-message-developer-input-items/design.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/design.md
@@ -15,6 +15,14 @@ compatibility is unaffected. The guard lives in the shared normalizer, so both
 compact `to_payload()` path (which re-runs the normalizer via
 `_strip_compact_unsupported_fields`) applies the same rule.
 
+Preserving a directive counts as a normalization outcome (`changed = True`):
+the normalizer then merges instructions as usual, which defaults the top-level
+`instructions` field to `""` when the request carries none and no instruction
+messages are hoisted. Without this, a directive-only input would leave the
+payload untouched and fail validation on the required `instructions` field —
+the pre-change path implicitly set `instructions` to `""` while dropping the
+directive.
+
 The Responses Lite `additional_tools` early return stays in front of the loop:
 when a Lite tool bundle is present, the entire input array (including the
 adjacent developer instructions message) is deliberately left untouched so the

--- a/openspec/changes/preserve-non-message-developer-input-items/proposal.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/proposal.md
@@ -2,25 +2,43 @@
 
 ## Summary
 
-Stop dropping non-message `input` items with a `system`/`developer` role when hoisting instruction messages into the `instructions` field.
+Stop dropping non-message `input` items with a `system`/`developer` role when
+hoisting instruction messages into the `instructions` field.
 
 ## Motivation
 
-Codex clients in responses-lite mode (gpt-5.6 models, which set `use_responses_lite=true` and `tool_mode=code_mode_only` in their model metadata) no longer send a top-level `tools` array. Instead, tool definitions are delivered as the first `input` item:
+The instruction-hoisting normalizer treated every `system`/`developer`-role
+input item as an instruction message. Items that carry no `content` (such as
+the Codex responses-lite `{"type": "additional_tools", "role": "developer",
+"tools": [...]}` prefix) contributed no instruction text, produced no preserved
+item, and were silently removed from `input`. Upstream then received a
+well-formed request with no tools anywhere, and the model responded that no
+terminal/filesystem tool was exposed (issue #1157).
 
-```json
-{"type": "additional_tools", "role": "developer", "tools": [{"type": "custom", "name": "exec"}, ...]}
-```
-
-The instruction-hoisting normalizer treats every `system`/`developer`-role input item as an instruction message. `additional_tools` items carry no `content`, so they contributed no instruction text, produced no preserved item, and were silently removed from `input`. Upstream then received a well-formed request with no tools anywhere, and the model responded that no terminal/filesystem tool was exposed — every gpt-5.6 session through codex-lb was effectively toolless, while gpt-5.5 (classic top-level `tools`) kept working.
+The merged fix for #1157 preserved the `additional_tools` case by skipping
+normalization entirely for Lite-shaped requests. But the underlying hazard is
+broader: any future non-message typed item that upstream introduces with
+`role: developer/system` and no `content` would still be folded away in a
+non-Lite request, reproducing the same class of bug (issue #1171). Two of the
+duplicate fixes for #1157 (#1159, #1158) carried a more general guard — never
+fold a `system`/`developer` input item whose `type` is present and not
+`"message"` — which is better defense-in-depth.
 
 ## Scope
 
-- Only hoist input items that are actual messages (`type` omitted or `"message"`) into `instructions`.
-- Pass every other `system`/`developer`-role input item through to upstream untouched, byte-for-byte.
-- Applies to both `ResponsesRequest` and `ResponsesCompactRequest` normalization.
+- Only hoist input items that are actual messages (`type` omitted or
+  `"message"`) into `instructions`.
+- Pass every other typed `system`/`developer`-role input item through to
+  upstream untouched, byte-for-byte and in its original position.
+- Applies to both `ResponsesRequest` and `ResponsesCompactRequest`
+  normalization, at validation time and on upstream serialization
+  (`to_payload()`).
 
 ## Out of Scope
 
 - Changing how message-shaped instruction items are hoisted or merged.
-- Modeling the `additional_tools` item shape; it is forwarded opaquely to stay codex-faithful.
+- Changing the Responses Lite `additional_tools` whole-request preservation
+  rule: requests containing an `additional_tools` item still skip instruction
+  hoisting entirely so the native Lite input prefix stays byte-for-byte intact.
+- Modeling unknown item shapes; they are forwarded opaquely to stay
+  codex-faithful.

--- a/openspec/changes/preserve-non-message-developer-input-items/proposal.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/proposal.md
@@ -1,0 +1,26 @@
+# Preserve Non-Message Developer Input Items
+
+## Summary
+
+Stop dropping non-message `input` items with a `system`/`developer` role when hoisting instruction messages into the `instructions` field.
+
+## Motivation
+
+Codex clients in responses-lite mode (gpt-5.6 models, which set `use_responses_lite=true` and `tool_mode=code_mode_only` in their model metadata) no longer send a top-level `tools` array. Instead, tool definitions are delivered as the first `input` item:
+
+```json
+{"type": "additional_tools", "role": "developer", "tools": [{"type": "custom", "name": "exec"}, ...]}
+```
+
+The instruction-hoisting normalizer treats every `system`/`developer`-role input item as an instruction message. `additional_tools` items carry no `content`, so they contributed no instruction text, produced no preserved item, and were silently removed from `input`. Upstream then received a well-formed request with no tools anywhere, and the model responded that no terminal/filesystem tool was exposed — every gpt-5.6 session through codex-lb was effectively toolless, while gpt-5.5 (classic top-level `tools`) kept working.
+
+## Scope
+
+- Only hoist input items that are actual messages (`type` omitted or `"message"`) into `instructions`.
+- Pass every other `system`/`developer`-role input item through to upstream untouched, byte-for-byte.
+- Applies to both `ResponsesRequest` and `ResponsesCompactRequest` normalization.
+
+## Out of Scope
+
+- Changing how message-shaped instruction items are hoisted or merged.
+- Modeling the `additional_tools` item shape; it is forwarded opaquely to stay codex-faithful.

--- a/openspec/changes/preserve-non-message-developer-input-items/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/specs/responses-api-compat/spec.md
@@ -2,22 +2,28 @@
 
 ## ADDED Requirements
 
-### Requirement: Non-message developer input items are preserved
+### Requirement: Non-message system and developer input items are preserved
 
 When normalizing Responses or compact request `input`, the service MUST only
-hoist items that are instruction messages — items whose `type` is omitted or
-`"message"` — into the `instructions` field. Any other `system`/`developer`-role
-input item (such as the Codex responses-lite
-`{"type": "additional_tools", "role": "developer", "tools": [...]}` prefix)
-MUST be forwarded upstream in its original position and shape.
+hoist items that are instruction messages — `system`/`developer`-role items
+whose `type` is omitted or `"message"` — into the top-level `instructions`
+field. Any `system`/`developer`-role input item carrying any other `type`
+value, including item types the service does not model, MUST be forwarded
+upstream unchanged and in its original input position. This preservation MUST
+hold both when the request is validated and when the request is serialized for
+upstream delivery. Requests whose input contains an `additional_tools` item
+remain governed by the Responses Lite rule that leaves the entire input array
+and top-level `instructions` unchanged.
 
-#### Scenario: additional_tools input item survives normalization
+#### Scenario: unknown non-message developer input item survives normalization
 
-- **WHEN** a Codex client sends a Responses request whose `input` begins with
-  `{"type": "additional_tools", "role": "developer", "tools": [...]}` followed
-  by developer instruction messages
+- **WHEN** a Responses or compact request `input` contains a typed, non-message
+  item such as `{"type": "future_directive", "role": "developer", ...}`
+  alongside developer instruction messages and user messages
 - **THEN** the developer instruction messages are hoisted into `instructions`
-- **AND** the `additional_tools` item remains in `input` unchanged
+- **AND** the `future_directive` item remains in `input` unchanged, in its
+  original position
+- **AND** the upstream-serialized payload retains the item unchanged
 
 #### Scenario: typeless system messages keep hoisting behavior
 

--- a/openspec/changes/preserve-non-message-developer-input-items/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/specs/responses-api-compat/spec.md
@@ -11,9 +11,12 @@ field. Any `system`/`developer`-role input item carrying any other `type`
 value, including item types the service does not model, MUST be forwarded
 upstream unchanged and in its original input position. This preservation MUST
 hold both when the request is validated and when the request is serialized for
-upstream delivery. Requests whose input contains an `additional_tools` item
-remain governed by the Responses Lite rule that leaves the entire input array
-and top-level `instructions` unchanged.
+upstream delivery. When compact requests exceed the upstream input budget and
+the service trims the input middle, preserved non-message `system`/`developer`
+items MUST be treated as trim anchors and retained in the trimmed payload
+rather than replaced by the trim marker. Requests whose input contains an
+`additional_tools` item remain governed by the Responses Lite rule that leaves
+the entire input array and top-level `instructions` unchanged.
 
 #### Scenario: unknown non-message developer input item survives normalization
 
@@ -24,6 +27,15 @@ and top-level `instructions` unchanged.
 - **AND** the `future_directive` item remains in `input` unchanged, in its
   original position
 - **AND** the upstream-serialized payload retains the item unchanged
+
+#### Scenario: preserved directive survives compact input trimming
+
+- **WHEN** a compact request is large enough to trigger upstream input
+  trimming and its input middle contains a typed, non-message
+  `system`/`developer` item such as
+  `{"type": "future_directive", "role": "developer", ...}`
+- **THEN** the trimmed upstream payload retains the item unchanged
+- **AND** the item is not replaced by the trim marker
 
 #### Scenario: typeless system messages keep hoisting behavior
 

--- a/openspec/changes/preserve-non-message-developer-input-items/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/specs/responses-api-compat/spec.md
@@ -1,0 +1,26 @@
+# responses-api-compat — Delta
+
+## ADDED Requirements
+
+### Requirement: Non-message developer input items are preserved
+
+When normalizing Responses or compact request `input`, the service MUST only
+hoist items that are instruction messages — items whose `type` is omitted or
+`"message"` — into the `instructions` field. Any other `system`/`developer`-role
+input item (such as the Codex responses-lite
+`{"type": "additional_tools", "role": "developer", "tools": [...]}` prefix)
+MUST be forwarded upstream in its original position and shape.
+
+#### Scenario: additional_tools input item survives normalization
+
+- **WHEN** a Codex client sends a Responses request whose `input` begins with
+  `{"type": "additional_tools", "role": "developer", "tools": [...]}` followed
+  by developer instruction messages
+- **THEN** the developer instruction messages are hoisted into `instructions`
+- **AND** the `additional_tools` item remains in `input` unchanged
+
+#### Scenario: typeless system messages keep hoisting behavior
+
+- **WHEN** an OpenAI-compatible client sends `input` containing
+  `{"role": "system", "content": "sys"}` without a `type` field
+- **THEN** that item is hoisted into `instructions` as before

--- a/openspec/changes/preserve-non-message-developer-input-items/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/specs/responses-api-compat/spec.md
@@ -11,7 +11,10 @@ field. Any `system`/`developer`-role input item carrying any other `type`
 value, including item types the service does not model, MUST be forwarded
 upstream unchanged and in its original input position. This preservation MUST
 hold both when the request is validated and when the request is serialized for
-upstream delivery. When compact requests exceed the upstream input budget and
+upstream delivery, and it exempts the item from input sanitization: keys such
+as `reasoning_content`, `reasoning_details`, `tool_calls`, and `function_call`
+MUST NOT be stripped from a preserved item. When compact requests exceed the
+upstream input budget and
 the service trims the input middle, preserved non-message `system`/`developer`
 items MUST be treated as trim anchors and retained in the trimmed payload
 rather than replaced by the trim marker. When a non-message
@@ -31,6 +34,15 @@ top-level `instructions` unchanged.
 - **AND** the `future_directive` item remains in `input` unchanged, in its
   original position
 - **AND** the upstream-serialized payload retains the item unchanged
+
+#### Scenario: preserved directive keeps reasoning and tool-call keys
+
+- **WHEN** a Responses or compact request `input` contains a typed,
+  non-message `system`/`developer` item carrying keys the interleaved
+  reasoning sanitizer strips from message items (such as
+  `reasoning_content`, `reasoning_details`, `tool_calls`, or `function_call`)
+- **THEN** the item is retained byte-identical after validation
+- **AND** the upstream-serialized payload retains the item byte-identical
 
 #### Scenario: directive-only request without instructions still validates
 

--- a/openspec/changes/preserve-non-message-developer-input-items/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/specs/responses-api-compat/spec.md
@@ -14,9 +14,13 @@ hold both when the request is validated and when the request is serialized for
 upstream delivery. When compact requests exceed the upstream input budget and
 the service trims the input middle, preserved non-message `system`/`developer`
 items MUST be treated as trim anchors and retained in the trimmed payload
-rather than replaced by the trim marker. Requests whose input contains an
-`additional_tools` item remain governed by the Responses Lite rule that leaves
-the entire input array and top-level `instructions` unchanged.
+rather than replaced by the trim marker. When a non-message
+`system`/`developer` item is preserved and the request carries no top-level
+`instructions` and no hoistable instruction messages, the service MUST default
+`instructions` to the empty string so the request still validates and
+forwards. Requests whose input contains an `additional_tools` item remain
+governed by the Responses Lite rule that leaves the entire input array and
+top-level `instructions` unchanged.
 
 #### Scenario: unknown non-message developer input item survives normalization
 
@@ -27,6 +31,16 @@ the entire input array and top-level `instructions` unchanged.
 - **AND** the `future_directive` item remains in `input` unchanged, in its
   original position
 - **AND** the upstream-serialized payload retains the item unchanged
+
+#### Scenario: directive-only request without instructions still validates
+
+- **WHEN** a Responses or compact request omits top-level `instructions` and
+  its `input` contains only a typed, non-message `system`/`developer` item
+  (such as `{"type": "future_directive", "role": "developer", ...}`) alongside
+  user messages
+- **THEN** the request validates with `instructions` defaulted to `""`
+- **AND** the directive item remains in `input` unchanged, including in the
+  upstream-serialized payload
 
 #### Scenario: preserved directive survives compact input trimming
 

--- a/openspec/changes/preserve-non-message-developer-input-items/tasks.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/tasks.md
@@ -6,4 +6,5 @@
 - [x] 4. Anchor preserved non-message system/developer items in `_trim_compact_input_for_upstream()` so compact trimming does not replace them with the trim marker, with regression coverage on an oversized compact request.
 - [x] 5. Treat directive preservation as a normalization change so directive-only requests without top-level `instructions` validate with `instructions` defaulted to `""`, with regression coverage for both request models.
 - [x] 6. Exempt preserved directives from interleaved-reasoning input sanitization (`_sanitize_input_items()`) via the shared `_is_preserved_non_message_directive()` predicate, so keys like `reasoning_content` and `tool_calls` survive byte-identical, with regression coverage for both request models.
-- [x] 7. Validate focused tests and OpenSpec artifacts.
+- [x] 7. Add route-level regression coverage through `/backend-api/codex/responses`: a non-message developer directive among messages reaches the captured upstream payload byte-identical while the plain developer message is still hoisted into `instructions` (mirrors the #1161 integration test pattern in `tests/integration/test_proxy_responses.py`).
+- [x] 8. Validate focused tests and OpenSpec artifacts.

--- a/openspec/changes/preserve-non-message-developer-input-items/tasks.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/tasks.md
@@ -5,4 +5,5 @@
 - [x] 3. Add regression coverage for `ResponsesRequest` and `ResponsesCompactRequest` with a synthetic non-message item type, asserting preservation through `model_validate` and `to_payload()`.
 - [x] 4. Anchor preserved non-message system/developer items in `_trim_compact_input_for_upstream()` so compact trimming does not replace them with the trim marker, with regression coverage on an oversized compact request.
 - [x] 5. Treat directive preservation as a normalization change so directive-only requests without top-level `instructions` validate with `instructions` defaulted to `""`, with regression coverage for both request models.
-- [x] 6. Validate focused tests and OpenSpec artifacts.
+- [x] 6. Exempt preserved directives from interleaved-reasoning input sanitization (`_sanitize_input_items()`) via the shared `_is_preserved_non_message_directive()` predicate, so keys like `reasoning_content` and `tool_calls` survive byte-identical, with regression coverage for both request models.
+- [x] 7. Validate focused tests and OpenSpec artifacts.

--- a/openspec/changes/preserve-non-message-developer-input-items/tasks.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/tasks.md
@@ -3,4 +3,5 @@
 - [x] 1. Add OpenSpec requirement for preserving non-message system/developer input items during instruction hoisting.
 - [x] 2. Guard the instruction-hoisting normalizer so only message-shaped items are hoisted; keep the Responses Lite `additional_tools` whole-request preservation intact.
 - [x] 3. Add regression coverage for `ResponsesRequest` and `ResponsesCompactRequest` with a synthetic non-message item type, asserting preservation through `model_validate` and `to_payload()`.
-- [x] 4. Validate focused tests and OpenSpec artifacts.
+- [x] 4. Anchor preserved non-message system/developer items in `_trim_compact_input_for_upstream()` so compact trimming does not replace them with the trim marker, with regression coverage on an oversized compact request.
+- [x] 5. Validate focused tests and OpenSpec artifacts.

--- a/openspec/changes/preserve-non-message-developer-input-items/tasks.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/tasks.md
@@ -4,4 +4,5 @@
 - [x] 2. Guard the instruction-hoisting normalizer so only message-shaped items are hoisted; keep the Responses Lite `additional_tools` whole-request preservation intact.
 - [x] 3. Add regression coverage for `ResponsesRequest` and `ResponsesCompactRequest` with a synthetic non-message item type, asserting preservation through `model_validate` and `to_payload()`.
 - [x] 4. Anchor preserved non-message system/developer items in `_trim_compact_input_for_upstream()` so compact trimming does not replace them with the trim marker, with regression coverage on an oversized compact request.
-- [x] 5. Validate focused tests and OpenSpec artifacts.
+- [x] 5. Treat directive preservation as a normalization change so directive-only requests without top-level `instructions` validate with `instructions` defaulted to `""`, with regression coverage for both request models.
+- [x] 6. Validate focused tests and OpenSpec artifacts.

--- a/openspec/changes/preserve-non-message-developer-input-items/tasks.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] 1. Add OpenSpec requirement for preserving non-message developer input items during instruction hoisting.
+- [x] 2. Guard the instruction-hoisting normalizer so only message-shaped items are hoisted.
+- [x] 3. Add regression coverage for `ResponsesRequest` and `ResponsesCompactRequest` with `additional_tools` input items.
+- [x] 4. Validate focused tests and OpenSpec artifacts.

--- a/openspec/changes/preserve-non-message-developer-input-items/tasks.md
+++ b/openspec/changes/preserve-non-message-developer-input-items/tasks.md
@@ -1,6 +1,6 @@
 # Tasks
 
-- [x] 1. Add OpenSpec requirement for preserving non-message developer input items during instruction hoisting.
-- [x] 2. Guard the instruction-hoisting normalizer so only message-shaped items are hoisted.
-- [x] 3. Add regression coverage for `ResponsesRequest` and `ResponsesCompactRequest` with `additional_tools` input items.
+- [x] 1. Add OpenSpec requirement for preserving non-message system/developer input items during instruction hoisting.
+- [x] 2. Guard the instruction-hoisting normalizer so only message-shaped items are hoisted; keep the Responses Lite `additional_tools` whole-request preservation intact.
+- [x] 3. Add regression coverage for `ResponsesRequest` and `ResponsesCompactRequest` with a synthetic non-message item type, asserting preservation through `model_validate` and `to_payload()`.
 - [x] 4. Validate focused tests and OpenSpec artifacts.

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -244,6 +244,62 @@ async def test_backend_responses_preserves_responses_lite_tools_and_outputs(asyn
 
 
 @pytest.mark.asyncio
+async def test_backend_responses_preserves_non_message_developer_directive(async_client, monkeypatch):
+    raw_account_id = "acc_future_directive"
+    auth_json = _make_auth_json(raw_account_id, "future-directive@example.com")
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    developer_directive = {
+        "type": "future_directive",
+        "role": "developer",
+        "directive": {"mode": "strict", "budget": 3},
+        "reasoning_content": "directive-level reasoning",
+        "tool_calls": [{"id": "call_1", "name": "future_tool"}],
+    }
+    seen_payload: dict[str, object] = {}
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del headers, access_token, account_id, base_url, raise_for_status, kwargs
+        seen_payload.update(payload.to_payload())
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_future_directive",'
+            '"object":"response","status":"completed","usage":{"input_tokens":2,"output_tokens":1}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    request_payload = {
+        "model": "gpt-5.6-sol",
+        "input": [
+            developer_directive,
+            {"type": "message", "role": "developer", "content": "follow the directive"},
+            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        ],
+        "stream": True,
+    }
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=request_payload,
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    event = _extract_first_event(lines)
+    assert event["type"] == "response.completed"
+    # The plain developer message is still hoisted into instructions, while the
+    # typed directive is forwarded upstream byte-identical (including keys the
+    # interleaved-reasoning sanitizer strips from message items).
+    assert seen_payload["instructions"] == "follow the directive"
+    assert seen_payload["input"] == [
+        developer_directive,
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_proxy_responses_repeated_401_after_refresh_fails_over(async_client, monkeypatch):
     for raw_account_id, email in (
         ("acc_stream_invalidated_a", "stream-invalidated-a@example.com"),

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -1077,6 +1077,40 @@ def test_compact_trimming_preserves_codex_goal_context_anchor_from_middle():
     assert dumped_input[-1] == input_items[-1]
 
 
+def test_compact_trimming_preserves_non_message_developer_directive_from_middle():
+    developer_directive = {
+        "type": "future_directive",
+        "role": "developer",
+        "directive": {"mode": "strict", "budget": 3},
+    }
+    input_items = [
+        {"role": "user", "content": "initial instructions"},
+        {"role": "assistant", "content": "x" * 300_000},
+        developer_directive,
+        # Large enough to exhaust the tail budget on its own, so the directive
+        # in the middle survives only if it is treated as a trim anchor.
+        {"role": "assistant", "content": "y" * 500_000},
+        {"role": "user", "content": "latest request"},
+    ]
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": input_items,
+    }
+
+    request = ResponsesCompactRequest.model_validate(payload)
+    dumped = request.to_payload()
+    dumped_input = dumped["input"]
+
+    assert isinstance(dumped_input, list)
+    assert dumped_input[0] == input_items[0]
+    assert developer_directive in dumped_input
+    assert dumped_input[-1] == input_items[-1]
+    # Trimming actually occurred: the oversized filler items were dropped.
+    assert input_items[1] not in dumped_input
+    assert input_items[3] not in dumped_input
+
+
 def test_compact_trimming_preserves_plan_and_goal_tool_call_outputs():
     update_plan_call = {
         "type": "function_call",

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -646,6 +646,31 @@ def test_responses_input_non_message_system_and_developer_items_are_preserved(re
     assert request.to_payload()["input"] == request.input
 
 
+@pytest.mark.parametrize("request_type", [ResponsesRequest, ResponsesCompactRequest])
+def test_responses_input_directive_only_request_defaults_instructions(request_type):
+    developer_directive = {
+        "type": "future_directive",
+        "role": "developer",
+        "directive": {"mode": "strict", "budget": 3},
+    }
+    payload = {
+        "model": "gpt-5.1",
+        "input": [
+            developer_directive,
+            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        ],
+    }
+
+    request = request_type.model_validate(payload)
+
+    assert request.instructions == ""
+    assert request.input == [
+        developer_directive,
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+    ]
+    assert request.to_payload()["input"] == request.input
+
+
 def test_responses_input_system_message_keeps_user_text_parts():
     payload = {
         "model": "gpt-5.1",

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -647,6 +647,35 @@ def test_responses_input_non_message_system_and_developer_items_are_preserved(re
 
 
 @pytest.mark.parametrize("request_type", [ResponsesRequest, ResponsesCompactRequest])
+def test_responses_input_preserved_directive_keeps_reasoning_and_tool_call_keys(request_type):
+    developer_directive = {
+        "type": "future_directive",
+        "role": "developer",
+        "reasoning_content": "directive-level reasoning",
+        "reasoning_details": [{"type": "spec", "detail": "keep me"}],
+        "tool_calls": [{"id": "call_1", "name": "future_tool"}],
+        "function_call": {"name": "future_tool", "arguments": "{}"},
+        "content": [{"type": "reasoning", "text": "also keep me"}],
+    }
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "primary",
+        "input": [
+            developer_directive,
+            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        ],
+    }
+
+    request = request_type.model_validate(payload)
+
+    assert request.input == [
+        developer_directive,
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+    ]
+    assert request.to_payload()["input"] == request.input
+
+
+@pytest.mark.parametrize("request_type", [ResponsesRequest, ResponsesCompactRequest])
 def test_responses_input_directive_only_request_defaults_instructions(request_type):
     developer_directive = {
         "type": "future_directive",

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -613,6 +613,39 @@ def test_responses_input_additional_tools_item_is_preserved(request_type):
     assert request.to_payload()["input"] == request.input
 
 
+@pytest.mark.parametrize("request_type", [ResponsesRequest, ResponsesCompactRequest])
+def test_responses_input_non_message_system_and_developer_items_are_preserved(request_type):
+    developer_directive = {
+        "type": "future_directive",
+        "role": "developer",
+        "directive": {"mode": "strict", "budget": 3},
+    }
+    system_directive = {
+        "type": "future_directive",
+        "role": "system",
+        "directive": {"mode": "audit"},
+    }
+    payload = {
+        "model": "gpt-5.1",
+        "input": [
+            developer_directive,
+            {"type": "message", "role": "developer", "content": "dev"},
+            system_directive,
+            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        ],
+    }
+
+    request = request_type.model_validate(payload)
+
+    assert request.instructions == "dev"
+    assert request.input == [
+        developer_directive,
+        system_directive,
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+    ]
+    assert request.to_payload()["input"] == request.input
+
+
 def test_responses_input_system_message_keeps_user_text_parts():
     payload = {
         "model": "gpt-5.1",


### PR DESCRIPTION
## Summary

#1161 fixed #1157 by skipping instruction hoisting entirely for Responses Lite requests (input containing an `additional_tools` item). But the underlying hazard was broader: `_normalize_responses_input_instructions` still folded **every other** `system`/`developer`-role input item into `instructions`, so any future non-message typed item upstream introduces (with `role: developer/system` and no `content`) would be silently dropped in a non-Lite request, reproducing the same class of bug.

This PR generalizes the guard: only items whose `type` is absent or `"message"` are hoisted; every other typed item passes through untouched, regardless of role, both at `model_validate` time and on `to_payload()` serialization. All merged #1161 behavior (Lite whole-request preservation, compact trimming, websocket continuity) is unchanged.

## Credit

The core guard is @kvz's commit from #1159, cherry-picked onto current main with him retained as author (conflicting tests that predated the merged #1161 whole-request Lite preservation were resolved in favor of the merged behavior). The same approach was independently proposed by @Aminkbi in #1158.

## Changes

- `app/core/openai/requests.py`: in `_normalize_responses_input_instructions`, only hoist `system`/`developer` items whose `type` is omitted or `"message"`; append any other typed item to the preserved input unchanged. The `additional_tools` early return from #1161 stays in front as the Lite whole-request rule.
- `tests/unit/test_openai_requests.py`: new parametrized regression test (`ResponsesRequest` + `ResponsesCompactRequest`) with a synthetic `future_directive` item type on both `developer` and `system` roles, asserting preservation through `model_validate` **and** `to_payload()`. Fails on `main`, passes here.
- `openspec/changes/preserve-non-message-developer-input-items/`: new change with a normative delta on `responses-api-compat` (generalized preservation requirement, consistent with the #1161 `strip-internal-responses-lite-header` change). `openspec validate preserve-non-message-developer-input-items --strict` and `openspec validate --specs` pass.
- `.all-contributorsrc`: add @kvz.

## Test plan

- [x] New regression test fails on `origin/main` (both parametrizations), passes on this branch
- [x] `uv run pytest tests/unit` — 3208 passed, 3 skipped
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run ty check` — clean
- [x] `openspec validate preserve-non-message-developer-input-items --strict` + `openspec validate --specs` — valid
- [x] `python3 .github/scripts/check_all_contributors.py` — covers all commit authors

Fixes #1171
Refs #1157, #1158, #1159, #1161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
