### PR TITLE
feat(models): add GPT-5.6 Codex support

### DIFF
--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -48,7 +48,14 @@ class ModelRegistrySnapshot:
     fetched_at: float
 
 
-_BOOTSTRAP_WEBSOCKET_PREFERRED_MODEL_PATTERNS = ("gpt-5.5", "gpt-5.5-*", "gpt-5.4", "gpt-5.4-*")
+_BOOTSTRAP_WEBSOCKET_PREFERRED_MODEL_PATTERNS = (
+    "gpt-5.6",
+    "gpt-5.6-*",
+    "gpt-5.5",
+    "gpt-5.5-*",
+    "gpt-5.4",
+    "gpt-5.4-*",
+)
 
 _REASONING_LEVELS_STANDARD = (
     ReasoningLevel(effort="low", description="Low reasoning effort"),
@@ -61,6 +68,15 @@ _REASONING_LEVELS_EXTENDED = (
     ReasoningLevel(effort="medium", description="Medium reasoning effort"),
     ReasoningLevel(effort="high", description="High reasoning effort"),
     ReasoningLevel(effort="xhigh", description="Extra high reasoning effort"),
+)
+
+_REASONING_LEVELS_56 = (
+    ReasoningLevel(effort="low", description="Fast responses with lighter reasoning"),
+    ReasoningLevel(effort="medium", description="Balances speed and reasoning depth for everyday tasks"),
+    ReasoningLevel(effort="high", description="Greater reasoning depth for complex problems"),
+    ReasoningLevel(effort="xhigh", description="Extra high reasoning depth for complex problems"),
+    ReasoningLevel(effort="max", description="Maximum reasoning depth for the hardest problems"),
+    ReasoningLevel(effort="ultra", description="Maximum reasoning with automatic task delegation"),
 )
 
 _BOOTSTRAP_AVAILABLE_IN_PLANS = frozenset(
@@ -87,6 +103,10 @@ _BOOTSTRAP_AVAILABLE_IN_PLANS = frozenset(
 
 _BOOTSTRAP_CORE_AVAILABLE_IN_PLANS = frozenset(
     plan for plan in _BOOTSTRAP_AVAILABLE_IN_PLANS if plan not in {"free", "free_workspace", "k12"}
+)
+
+_BOOTSTRAP_56_PAID_AVAILABLE_IN_PLANS = frozenset(
+    plan for plan in _BOOTSTRAP_AVAILABLE_IN_PLANS if plan not in {"free", "free_workspace", "go", "k12"}
 )
 
 
@@ -143,6 +163,29 @@ def _bootstrap_model(
 # explicit rather than inherited from helper defaults; every slug must exist
 # upstream, and live upstream data always takes precedence once available.
 _BOOTSTRAP_STATIC_MODELS: tuple[UpstreamModel, ...] = (
+    _bootstrap_model(
+        "gpt-5.6-sol",
+        "GPT-5.6 Sol",
+        prefer_websockets=True,
+        minimal_client_version="0.144.0",
+        reasoning_levels=_REASONING_LEVELS_56,
+        available_in_plans=_BOOTSTRAP_56_PAID_AVAILABLE_IN_PLANS,
+    ),
+    _bootstrap_model(
+        "gpt-5.6-terra",
+        "GPT-5.6 Terra",
+        prefer_websockets=True,
+        minimal_client_version="0.144.0",
+        reasoning_levels=_REASONING_LEVELS_56,
+    ),
+    _bootstrap_model(
+        "gpt-5.6-luna",
+        "GPT-5.6 Luna",
+        prefer_websockets=True,
+        minimal_client_version="0.144.0",
+        reasoning_levels=_REASONING_LEVELS_56,
+        available_in_plans=_BOOTSTRAP_56_PAID_AVAILABLE_IN_PLANS,
+    ),
     _bootstrap_model(
         "gpt-5.5",
         "GPT-5.5",
@@ -213,7 +256,7 @@ class ModelRegistry:
     def get_models_with_fallback(self) -> dict[str, UpstreamModel]:
         snapshot = self._snapshot
         if snapshot is not None:
-            return snapshot.models
+            return {**self._bootstrap_models, **snapshot.models}
         return self._bootstrap_models
 
     def plan_types_for_model(self, slug: str) -> frozenset[str] | None:
@@ -221,7 +264,11 @@ class ModelRegistry:
         if self._snapshot is None:
             model = self._bootstrap_models.get(slug) or self._bootstrap_models.get(normalized_slug)
             return model.available_in_plans if model is not None else None
-        return self._snapshot.model_plans.get(slug) or self._snapshot.model_plans.get(normalized_slug, frozenset())
+        snapshot_plans = self._snapshot.model_plans.get(slug) or self._snapshot.model_plans.get(normalized_slug)
+        if snapshot_plans:
+            return snapshot_plans
+        model = self._bootstrap_models.get(slug) or self._bootstrap_models.get(normalized_slug)
+        return model.available_in_plans if model is not None else frozenset()
 
     def prefers_websockets(self, slug: str | None) -> bool:
         if not isinstance(slug, str):

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -231,11 +231,14 @@ def _request_log_reasoning_effort(
     if upstream_effort != "max" or not client_metadata:
         return upstream_effort
     raw_turn_metadata = client_metadata.get("x-codex-turn-metadata")
-    if not isinstance(raw_turn_metadata, str):
-        return upstream_effort
-    try:
-        turn_metadata = json.loads(raw_turn_metadata)
-    except json.JSONDecodeError:
+    if isinstance(raw_turn_metadata, str):
+        try:
+            turn_metadata = json.loads(raw_turn_metadata)
+        except json.JSONDecodeError:
+            return upstream_effort
+    elif isinstance(raw_turn_metadata, dict):
+        turn_metadata = raw_turn_metadata
+    else:
         return upstream_effort
     if not isinstance(turn_metadata, dict):
         return upstream_effort

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -223,6 +223,28 @@ def _request_kind_from_headers(headers: Mapping[str, str] | None) -> str:
     return "normal"
 
 
+def _request_log_reasoning_effort(
+    payload: ResponsesRequest,
+    client_metadata: Mapping[str, JsonValue] | None,
+) -> str | None:
+    upstream_effort = payload.reasoning.effort if payload.reasoning else None
+    if upstream_effort != "max" or not client_metadata:
+        return upstream_effort
+    raw_turn_metadata = client_metadata.get("x-codex-turn-metadata")
+    if not isinstance(raw_turn_metadata, str):
+        return upstream_effort
+    try:
+        turn_metadata = json.loads(raw_turn_metadata)
+    except json.JSONDecodeError:
+        return upstream_effort
+    if not isinstance(turn_metadata, dict):
+        return upstream_effort
+    metadata_effort = turn_metadata.get("reasoning_effort")
+    if isinstance(metadata_effort, str) and metadata_effort.strip().lower() == "ultra":
+        return "ultra"
+    return upstream_effort
+
+
 class _HTTPBridgeRequestSubmitMixin:
     def _prepare_http_bridge_request(
         self: Any,
@@ -234,6 +256,7 @@ class _HTTPBridgeRequestSubmitMixin:
         request_id: str | None = None,
         enforce_openai_sdk_contract: bool = True,
     ) -> tuple[_WebSocketRequestState, str]:
+        client_metadata = _response_create_client_metadata(payload.to_payload(), headers=headers)
         request_state, text_data = self._prepare_response_bridge_request_state(
             payload,
             api_key=api_key,
@@ -241,7 +264,7 @@ class _HTTPBridgeRequestSubmitMixin:
             include_type_field=True,
             attach_event_queue=True,
             transport=_REQUEST_TRANSPORT_HTTP,
-            client_metadata=_response_create_client_metadata(payload.to_payload(), headers=headers),
+            client_metadata=client_metadata,
             headers=headers,
             session_id=_owner_lookup_session_id_from_headers(headers),
             request_log_id=request_id or get_request_id() or ensure_request_id(None),
@@ -301,7 +324,7 @@ class _HTTPBridgeRequestSubmitMixin:
             request_log_id=request_log_id,
             model=payload.model,
             service_tier=forwarded_service_tier,
-            reasoning_effort=payload.reasoning.effort if payload.reasoning else None,
+            reasoning_effort=_request_log_reasoning_effort(payload, client_metadata),
             api_key_reservation=api_key_reservation,
             started_at=_service_time().monotonic(),
             requested_service_tier=forwarded_service_tier,

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -663,14 +663,14 @@ def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_insta
 
     request_payload = {
         "type": "response.create",
-        "model": "gpt-5.4",
+        "model": "gpt-5.6-sol",
         "instructions": "",
         "client_metadata": {
             "x-codex-installation-id": "client-installation",
-            "x-codex-turn-metadata": '{"turn_id":"turn_123","sandbox":"workspace-write"}',
+            "x-codex-turn-metadata": ('{"turn_id":"turn_123","sandbox":"workspace-write","reasoning_effort":"ultra"}'),
         },
         "service_tier": "fast",
-        "reasoning": {"effort": "high"},
+        "reasoning": {"effort": "max"},
         "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
         "stream": True,
     }
@@ -698,17 +698,21 @@ def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_insta
     assert seen["sticky_kind"] == proxy_module.StickySessionKind.CODEX_SESSION
     assert seen["prefer_earlier_reset"] is False
     assert seen["routing_strategy"] == "usage_weighted"
-    assert seen["model"] == "gpt-5.4"
+    assert seen["model"] == "gpt-5.6-sol"
     _assert_upstream_payloads(
         fake_upstream.sent_text,
         [
             {
-                "model": "gpt-5.4",
+                "model": "gpt-5.6-sol",
                 "instructions": "",
                 "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
                 "tools": [],
-                "reasoning": {"effort": "high"},
-                "client_metadata": {"x-codex-turn-metadata": '{"turn_id":"turn_123","sandbox":"workspace-write"}'},
+                "reasoning": {"effort": "max"},
+                "client_metadata": {
+                    "x-codex-turn-metadata": (
+                        '{"turn_id":"turn_123","sandbox":"workspace-write","reasoning_effort":"ultra"}'
+                    )
+                },
                 "service_tier": "priority",
                 "store": False,
                 "include": [],
@@ -720,7 +724,8 @@ def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_insta
     log = log_calls[0]
     assert log["account_id"] == "acct_ws_proxy"
     assert log["request_id"] == "resp_ws_1"
-    assert log["model"] == "gpt-5.4"
+    assert log["model"] == "gpt-5.6-sol"
+    assert log["reasoning_effort"] == "ultra"
     assert log["service_tier"] == "priority"
     assert log["transport"] == "websocket"
     assert log["status"] == "success"

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -27,6 +27,9 @@ EXPECTED_CORE_MODEL_PLANS = {
 }
 
 EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS = {
+    "gpt-5.6-sol": "0.144.0",
+    "gpt-5.6-terra": "0.144.0",
+    "gpt-5.6-luna": "0.144.0",
     "gpt-5.5": "0.124.0",
     "gpt-5.4": "0.98.0",
     "gpt-5.4-mini": "0.98.0",
@@ -144,6 +147,19 @@ def test_bootstrap_models_include_representative_upstream_metadata():
     for slug, expected_version in EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS.items():
         assert models[slug].minimal_client_version == expected_version
 
+    for slug in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
+        model = models[slug]
+        assert model.prefer_websockets is True
+        assert model.default_reasoning_level == "medium"
+        assert {level.effort for level in model.supported_reasoning_levels} == {
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max",
+            "ultra",
+        }
+
     gpt54 = models["gpt-5.4"]
     assert gpt54.minimal_client_version == "0.98.0"
     assert gpt54.raw["max_context_window"] == 1_000_000
@@ -186,6 +202,10 @@ async def test_update_merges_models_across_plans():
     assert set(snapshot.models.keys()) == {"shared", "plus-only", "pro-only"}
     assert snapshot.plan_models["plus"] == frozenset({"shared", "plus-only"})
     assert snapshot.plan_models["pro"] == frozenset({"shared", "pro-only"})
+
+    models = registry.get_models_with_fallback()
+    assert models["shared"].slug == "shared"
+    assert models["gpt-5.6-sol"].slug == "gpt-5.6-sol"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -327,6 +327,20 @@ def test_request_log_reasoning_effort_preserves_codex_ultra_metadata():
     assert payload.reasoning.effort == "max"
 
 
+def test_request_log_reasoning_effort_accepts_structured_codex_ultra_metadata():
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "",
+            "input": [],
+            "reasoning": {"effort": "max"},
+        }
+    )
+    client_metadata: dict[str, JsonValue] = {"x-codex-turn-metadata": {"reasoning_effort": "ultra"}}
+
+    assert proxy_http_bridge_request_submit._request_log_reasoning_effort(payload, client_metadata) == "ultra"
+
+
 @pytest.mark.parametrize(
     "client_metadata",
     [

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -311,6 +311,46 @@ def test_http_bridge_client_metadata_cannot_spoof_reserved_request_kind():
     )
 
 
+def test_request_log_reasoning_effort_preserves_codex_ultra_metadata():
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "",
+            "input": [],
+            "reasoning": {"effort": "max"},
+        }
+    )
+    client_metadata: dict[str, JsonValue] = {"x-codex-turn-metadata": json.dumps({"reasoning_effort": "ultra"})}
+
+    assert proxy_http_bridge_request_submit._request_log_reasoning_effort(payload, client_metadata) == "ultra"
+    assert payload.reasoning is not None
+    assert payload.reasoning.effort == "max"
+
+
+@pytest.mark.parametrize(
+    "client_metadata",
+    [
+        None,
+        {},
+        {"x-codex-turn-metadata": "not-json"},
+        {"x-codex-turn-metadata": json.dumps({"reasoning_effort": "max"})},
+    ],
+)
+def test_request_log_reasoning_effort_keeps_upstream_max_without_ultra_metadata(
+    client_metadata: Mapping[str, JsonValue] | None,
+):
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "",
+            "input": [],
+            "reasoning": {"effort": "max"},
+        }
+    )
+
+    assert proxy_http_bridge_request_submit._request_log_reasoning_effort(payload, client_metadata) == "max"
+
+
 def test_compact_client_metadata_cannot_spoof_reserved_request_kind():
     assert (
         proxy_compact_service._request_kind_from_headers(


### PR DESCRIPTION
## Summary
- bootstrap GPT-5.6 Sol, Terra, and Luna in the model registry
- expose low, medium, high, xhigh, max, and ultra reasoning efforts
- retain bootstrap models when live upstream snapshots lag behind
- cover the new metadata and fallback behavior with unit tests

## Verification
- `.venv/bin/pytest tests/unit/test_model_registry.py -q` (18 passed)
- live `gpt-5.6-sol` request at `max` through codex-lb
- app, CLI, and VS Code model catalogs list all three GPT-5.6 variants and all six efforts