### PR TITLE
feat(models): add GPT-5.6 bootstrap catalog with upstream-verified metadata

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -917,6 +917,16 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "knightcn1983",
+      "name": "knightcn1983",
+      "avatar_url": "https://avatars.githubusercontent.com/u/66906018?v=4",
+      "profile": "https://github.com/knightcn1983",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -257,7 +257,11 @@ class Settings(BaseSettings):
     # cap is lifted in the same change that introduces fan-out.
     model_registry_enabled: bool = True
     model_registry_refresh_interval_seconds: int = Field(default=300, gt=0)
-    model_registry_client_version: str = "0.101.0"
+    # Fallback Codex client version used when the live release lookup fails.
+    # Must stay >= the highest ``minimal_client_version`` in the bootstrap
+    # catalog (GPT-5.6 requires 0.144.0) or a degraded-startup refresh would
+    # receive an upstream catalog without those models.
+    model_registry_client_version: str = "0.144.0"
     codex_fingerprint_os: str = "Mac OS 26.5.0"
     codex_fingerprint_arch: str = "arm64"
     codex_fingerprint_terminal: str = "iTerm.app/3.6.10"

--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -57,7 +57,13 @@ class ModelRegistrySnapshot:
     fetched_at: float
 
 
-_BOOTSTRAP_WEBSOCKET_PREFERRED_MODEL_PATTERNS = ("gpt-5.5", "gpt-5.5-*", "gpt-5.4", "gpt-5.4-*")
+_BOOTSTRAP_WEBSOCKET_PREFERRED_MODEL_PATTERNS = (
+    "gpt-5.6-*",
+    "gpt-5.5",
+    "gpt-5.5-*",
+    "gpt-5.4",
+    "gpt-5.4-*",
+)
 
 _REASONING_LEVELS_STANDARD = (
     ReasoningLevel(effort="low", description="Low reasoning effort"),
@@ -71,6 +77,27 @@ _REASONING_LEVELS_EXTENDED = (
     ReasoningLevel(effort="high", description="High reasoning effort"),
     ReasoningLevel(effort="xhigh", description="Extra high reasoning effort"),
 )
+
+_REASONING_LEVELS_MAX = (
+    ReasoningLevel(effort="low", description="Fast responses with lighter reasoning"),
+    ReasoningLevel(effort="medium", description="Balances speed and reasoning depth for everyday tasks"),
+    ReasoningLevel(effort="high", description="Greater reasoning depth for complex problems"),
+    ReasoningLevel(effort="xhigh", description="Extra high reasoning depth for complex problems"),
+    ReasoningLevel(effort="max", description="Maximum reasoning depth for the hardest problems"),
+)
+
+_REASONING_LEVELS_ULTRA = (
+    *_REASONING_LEVELS_MAX,
+    ReasoningLevel(effort="ultra", description="Maximum reasoning with automatic task delegation"),
+)
+
+_BOOTSTRAP_FAST_SERVICE_TIERS: list[JsonValue] = [
+    {
+        "id": "priority",
+        "name": "Fast",
+        "description": "1.5x speed, increased usage",
+    }
+]
 
 _BOOTSTRAP_AVAILABLE_IN_PLANS = frozenset(
     {
@@ -105,6 +132,7 @@ def _bootstrap_model(
     *,
     prefer_websockets: bool,
     minimal_client_version: str | None,
+    description: str | None = None,
     reasoning_levels: tuple[ReasoningLevel, ...] = _REASONING_LEVELS_EXTENDED,
     context_window: int = 272_000,
     input_modalities: tuple[str, ...] = ("text", "image"),
@@ -114,6 +142,7 @@ def _bootstrap_model(
     available_in_plans: frozenset[str] = _BOOTSTRAP_AVAILABLE_IN_PLANS,
     visibility: str = "list",
     shell_type: str = "shell_command",
+    priority: int = 0,
     raw: dict[str, JsonValue] | None = None,
 ) -> UpstreamModel:
     raw_fields: dict[str, JsonValue] = {
@@ -127,7 +156,7 @@ def _bootstrap_model(
     return UpstreamModel(
         slug=slug,
         display_name=display_name,
-        description=display_name,
+        description=description or display_name,
         context_window=context_window,
         input_modalities=input_modalities,
         supported_reasoning_levels=reasoning_levels,
@@ -139,10 +168,21 @@ def _bootstrap_model(
         supports_parallel_tool_calls=True,
         supported_in_api=supported_in_api,
         minimal_client_version=minimal_client_version,
-        priority=0,
+        priority=priority,
         available_in_plans=available_in_plans,
         raw=raw_fields,
     )
+
+
+def _gpt56_raw() -> dict[str, JsonValue]:
+    return {
+        "additional_speed_tiers": ["fast"],
+        "service_tiers": _BOOTSTRAP_FAST_SERVICE_TIERS,
+        "effective_context_window_percent": 95,
+        "truncation_policy": {"mode": "tokens", "limit": 10_000},
+        "supports_search_tool": True,
+        "use_responses_lite": True,
+    }
 
 
 # Static bundled fallback models used before the first upstream registry refresh.
@@ -152,6 +192,42 @@ def _bootstrap_model(
 # explicit rather than inherited from helper defaults; every slug must exist
 # upstream, and live upstream data always takes precedence once available.
 _BOOTSTRAP_STATIC_MODELS: tuple[UpstreamModel, ...] = (
+    _bootstrap_model(
+        "gpt-5.6-sol",
+        "GPT-5.6-Sol",
+        description="Latest frontier agentic coding model.",
+        prefer_websockets=True,
+        minimal_client_version=None,
+        reasoning_levels=_REASONING_LEVELS_ULTRA,
+        context_window=372_000,
+        default_reasoning_level="low",
+        priority=1,
+        raw=_gpt56_raw(),
+    ),
+    _bootstrap_model(
+        "gpt-5.6-terra",
+        "GPT-5.6-Terra",
+        description="Balanced agentic coding model for everyday work.",
+        prefer_websockets=True,
+        minimal_client_version=None,
+        reasoning_levels=_REASONING_LEVELS_ULTRA,
+        context_window=372_000,
+        default_reasoning_level="medium",
+        priority=2,
+        raw=_gpt56_raw(),
+    ),
+    _bootstrap_model(
+        "gpt-5.6-luna",
+        "GPT-5.6-Luna",
+        description="Fast and affordable agentic coding model.",
+        prefer_websockets=True,
+        minimal_client_version=None,
+        reasoning_levels=_REASONING_LEVELS_MAX,
+        context_window=372_000,
+        default_reasoning_level="medium",
+        priority=3,
+        raw=_gpt56_raw(),
+    ),
     _bootstrap_model(
         "gpt-5.5",
         "GPT-5.5",

--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -125,6 +125,27 @@ _BOOTSTRAP_CORE_AVAILABLE_IN_PLANS = frozenset(
     plan for plan in _BOOTSTRAP_AVAILABLE_IN_PLANS if plan not in {"free", "free_workspace", "k12"}
 )
 
+# GPT-5.6 ships to four additional plan tiers upstream
+# (codex-rs/models-manager/models.json at rust-v0.144.1).
+_BOOTSTRAP_GPT56_AVAILABLE_IN_PLANS = frozenset(
+    {
+        *_BOOTSTRAP_AVAILABLE_IN_PLANS,
+        "edu_plus",
+        "edu_pro",
+        "enterprise_cbp_automation",
+        "sci",
+    }
+)
+
+_GPT56_SOL_AVAILABILITY_NUX: dict[str, JsonValue] = {
+    "message": (
+        "Our most capable model yet. GPT-5.6 Sol can tackle complex code changes, "
+        "dig into research, produce polished documents, and take on your most "
+        "ambitious work. Sol is highly capable at lower reasoning efforts—try "
+        "starting lower, then turn it up for harder jobs."
+    )
+}
+
 
 def _bootstrap_model(
     slug: str,
@@ -174,14 +195,43 @@ def _bootstrap_model(
     )
 
 
-def _gpt56_raw() -> dict[str, JsonValue]:
+def _gpt56_raw(
+    *,
+    multi_agent_version: str,
+    availability_nux: dict[str, JsonValue] | None = None,
+) -> dict[str, JsonValue]:
+    """Raw catalog fields for the GPT-5.6 family, mirroring the upstream
+    bundled catalog (codex-rs/models-manager/models.json at rust-v0.144.1)
+    field-for-field. The ~16.5 KB ``base_instructions`` string and the
+    personality-templated ``model_messages`` object are deliberately not
+    bundled; the live upstream registry supplies them on the first refresh.
+    """
     return {
-        "additional_speed_tiers": ["fast"],
-        "service_tiers": _BOOTSTRAP_FAST_SERVICE_TIERS,
-        "effective_context_window_percent": 95,
+        "apply_patch_tool_type": "freeform",
+        "web_search_tool_type": "text_and_image",
+        "supports_image_detail_original": True,
         "truncation_policy": {"mode": "tokens", "limit": 10_000},
-        "supports_search_tool": True,
+        # ``tool_mode`` / ``multi_agent_version`` drive Codex client tool
+        # assembly and the ``ultra`` proactive multi-agent mode; omitting them
+        # would make a bootstrap-served catalog change client behavior.
+        "tool_mode": "code_mode_only",
+        "multi_agent_version": multi_agent_version,
         "use_responses_lite": True,
+        "include_skills_usage_instructions": False,
+        "auto_review_model_override": None,
+        "auto_compact_token_limit": None,
+        "comp_hash": "3000",
+        "reasoning_summary_format": "experimental",
+        "default_reasoning_summary": "none",
+        "availability_nux": availability_nux,
+        "upgrade": None,
+        # Required (no serde default) by the Rust ``ModelInfo`` deserializer;
+        # a Codex client rejects catalog entries that omit it.
+        "experimental_supported_tools": [],
+        "supports_search_tool": True,
+        "default_service_tier": None,
+        "service_tiers": _BOOTSTRAP_FAST_SERVICE_TIERS,
+        "additional_speed_tiers": ["fast"],
     }
 
 
@@ -189,44 +239,50 @@ def _gpt56_raw() -> dict[str, JsonValue]:
 # This mirrors Codex's model-manager pattern: ship a conservative catalog so
 # startup/offline paths have usable metadata, then treat the live upstream
 # registry as authoritative once a refresh succeeds. Keep compatibility fields
-# explicit rather than inherited from helper defaults; every slug must exist
-# upstream, and live upstream data always takes precedence once available.
+# explicit rather than inherited from helper defaults; every slug must be a
+# real upstream slug (never invented), and live upstream data always takes
+# precedence once available. ``gpt-5.3-codex`` / ``gpt-5.3-codex-spark`` were
+# dropped from upstream's bundled catalog at rust-v0.144.x but are retained
+# here for older pinned clients; the upstream backend still serves them.
 _BOOTSTRAP_STATIC_MODELS: tuple[UpstreamModel, ...] = (
     _bootstrap_model(
         "gpt-5.6-sol",
         "GPT-5.6-Sol",
         description="Latest frontier agentic coding model.",
         prefer_websockets=True,
-        minimal_client_version=None,
+        minimal_client_version="0.144.0",
         reasoning_levels=_REASONING_LEVELS_ULTRA,
         context_window=372_000,
         default_reasoning_level="low",
         priority=1,
-        raw=_gpt56_raw(),
+        available_in_plans=_BOOTSTRAP_GPT56_AVAILABLE_IN_PLANS,
+        raw=_gpt56_raw(multi_agent_version="v2", availability_nux=_GPT56_SOL_AVAILABILITY_NUX),
     ),
     _bootstrap_model(
         "gpt-5.6-terra",
         "GPT-5.6-Terra",
         description="Balanced agentic coding model for everyday work.",
         prefer_websockets=True,
-        minimal_client_version=None,
+        minimal_client_version="0.144.0",
         reasoning_levels=_REASONING_LEVELS_ULTRA,
         context_window=372_000,
         default_reasoning_level="medium",
         priority=2,
-        raw=_gpt56_raw(),
+        available_in_plans=_BOOTSTRAP_GPT56_AVAILABLE_IN_PLANS,
+        raw=_gpt56_raw(multi_agent_version="v2"),
     ),
     _bootstrap_model(
         "gpt-5.6-luna",
         "GPT-5.6-Luna",
         description="Fast and affordable agentic coding model.",
         prefer_websockets=True,
-        minimal_client_version=None,
+        minimal_client_version="0.144.0",
         reasoning_levels=_REASONING_LEVELS_MAX,
         context_window=372_000,
         default_reasoning_level="medium",
         priority=3,
-        raw=_gpt56_raw(),
+        available_in_plans=_BOOTSTRAP_GPT56_AVAILABLE_IN_PLANS,
+        raw=_gpt56_raw(multi_agent_version="v1"),
     ),
     _bootstrap_model(
         "gpt-5.5",

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -1154,7 +1154,7 @@ def _normalize_thinking_alias(
         return {"effort": "medium"} if thinking else None
     if isinstance(thinking, str):
         normalized = thinking.strip().lower()
-        if normalized in {"low", "medium", "high", "xhigh"}:
+        if normalized in {"low", "medium", "high", "xhigh", "max", "ultra"}:
             return {"effort": normalized}
         if normalized in {"enabled", "true", "on"}:
             return {"effort": "medium"}

--- a/app/modules/api_keys/schemas.py
+++ b/app/modules/api_keys/schemas.py
@@ -29,7 +29,9 @@ class ApiKeyCreateRequest(DashboardModel):
     allowed_models: list[str] | None = None
     apply_to_codex_model: bool = False
     enforced_model: str | None = Field(default=None, min_length=1)
-    enforced_reasoning_effort: str | None = Field(default=None, pattern=r"(?i)^(none|minimal|low|medium|high|xhigh)$")
+    enforced_reasoning_effort: str | None = Field(
+        default=None, pattern=r"(?i)^(none|minimal|low|medium|high|xhigh|max|ultra)$"
+    )
     enforced_service_tier: str | None = Field(default=None, pattern=r"(?i)^(auto|default|priority|flex|fast)$")
     traffic_class: str | None = Field(default=None, pattern=r"(?i)^(foreground|opportunistic)$")
     transport_policy_override: str | None = None
@@ -46,7 +48,9 @@ class ApiKeyUpdateRequest(DashboardModel):
     allowed_models: list[str] | None = None
     apply_to_codex_model: bool | None = None
     enforced_model: str | None = Field(default=None, min_length=1)
-    enforced_reasoning_effort: str | None = Field(default=None, pattern=r"(?i)^(none|minimal|low|medium|high|xhigh)$")
+    enforced_reasoning_effort: str | None = Field(
+        default=None, pattern=r"(?i)^(none|minimal|low|medium|high|xhigh|max|ultra)$"
+    )
     enforced_service_tier: str | None = Field(default=None, pattern=r"(?i)^(auto|default|priority|flex|fast)$")
     traffic_class: str | None = Field(default=None, pattern=r"(?i)^(foreground|opportunistic)$")
     transport_policy_override: str | None = None

--- a/app/modules/api_keys/service.py
+++ b/app/modules/api_keys/service.py
@@ -1322,7 +1322,7 @@ def _normalize_model_slug(value: str | None) -> str | None:
     return normalized
 
 
-_SUPPORTED_REASONING_EFFORTS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh"})
+_SUPPORTED_REASONING_EFFORTS = frozenset({"none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"})
 _SUPPORTED_SERVICE_TIERS = frozenset({"auto", "default", "priority", "flex"})
 
 

--- a/app/modules/automations/schemas.py
+++ b/app/modules/automations/schemas.py
@@ -11,7 +11,7 @@ AUTOMATION_SCHEDULE_TYPES = ("daily",)
 AUTOMATION_WEEKDAY_CODES = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
 AUTOMATION_RUN_STATUSES = ("running", "success", "failed", "partial")
 AUTOMATION_RUN_TRIGGERS = ("scheduled", "manual")
-AUTOMATION_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
+AUTOMATION_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh", "max", "ultra")
 
 AutomationWeekday = Literal["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
 
@@ -42,7 +42,7 @@ class AutomationJobCreateRequest(DashboardModel):
     include_paused_accounts: bool = Field(default=False, alias="includePausedAccounts")
     schedule: AutomationScheduleRequest
     model: str = Field(min_length=1)
-    reasoning_effort: str | None = Field(default=None, pattern=r"(?i)^(minimal|low|medium|high|xhigh)$")
+    reasoning_effort: str | None = Field(default=None, pattern=r"(?i)^(minimal|low|medium|high|xhigh|max|ultra)$")
     prompt: str | None = Field(default=None, max_length=1000)
     account_ids: list[str] = Field(default_factory=list, max_length=128, alias="accountIds")
 
@@ -61,7 +61,7 @@ class AutomationJobUpdateRequest(DashboardModel):
     include_paused_accounts: bool | None = Field(default=None, alias="includePausedAccounts")
     schedule: AutomationScheduleRequest | None = None
     model: str | None = Field(default=None, min_length=1)
-    reasoning_effort: str | None = Field(default=None, pattern=r"(?i)^(minimal|low|medium|high|xhigh)$")
+    reasoning_effort: str | None = Field(default=None, pattern=r"(?i)^(minimal|low|medium|high|xhigh|max|ultra)$")
     prompt: str | None = Field(default=None, max_length=1000)
     account_ids: list[str] | None = Field(default=None, max_length=128, alias="accountIds")
 

--- a/app/modules/automations/service.py
+++ b/app/modules/automations/service.py
@@ -35,6 +35,7 @@ from app.modules.automations.repository import (
 )
 from app.modules.proxy.account_cache import get_account_selection_cache, mark_account_routing_unavailable
 from app.modules.proxy.helpers import _header_account_id
+from app.modules.proxy.request_policy import resolve_wire_reasoning_effort
 from app.modules.request_logs.repository import RequestLogsRepository
 
 AUTOMATION_SCHEDULE_DAILY = "daily"
@@ -1117,6 +1118,12 @@ class AutomationsService:
         account_ids_to_try = _prioritize_forced_account(account_ids_to_try, forced_account_id_for_priority)
         run_model = run.model or job.model
         run_reasoning_effort = run.reasoning_effort
+        # Client-plane efforts (``ultra``) must be aliased to their wire-safe
+        # value (``max``) here because the compact ping bypasses the proxy
+        # request-policy path that performs this rewrite for proxied traffic.
+        wire_reasoning_effort = (
+            resolve_wire_reasoning_effort(run_reasoning_effort) if run_reasoning_effort is not None else None
+        )
         run_prompt = run.prompt or job.prompt
 
         for account_id in account_ids_to_try:
@@ -1148,7 +1155,7 @@ class AutomationsService:
                     model=run_model,
                     input=run_prompt,
                     instructions="Automation ping",
-                    reasoning=ResponsesReasoning(effort=run_reasoning_effort) if run_reasoning_effort else None,
+                    reasoning=ResponsesReasoning(effort=wire_reasoning_effort) if wire_reasoning_effort else None,
                 )
                 request_started_at = time.monotonic()
                 compact_response = await asyncio.wait_for(
@@ -1175,7 +1182,7 @@ class AutomationsService:
                     account_id=account.id,
                     request_id=request_id,
                     model=run_model,
-                    reasoning_effort=run_reasoning_effort,
+                    reasoning_effort=wire_reasoning_effort,
                     latency_ms=latency_ms,
                     status="success",
                     input_tokens=input_tokens,
@@ -1208,7 +1215,7 @@ class AutomationsService:
                     account_id=account.id,
                     request_id=_automation_request_id(None, run.id, attempt_count),
                     model=run_model,
-                    reasoning_effort=run_reasoning_effort,
+                    reasoning_effort=wire_reasoning_effort,
                     latency_ms=_elapsed_ms(request_started_at),
                     status="error",
                     error_code=error_code,
@@ -1226,7 +1233,7 @@ class AutomationsService:
                         account_id=account.id,
                         request_id=_automation_request_id(None, run.id, attempt_count),
                         model=run_model,
-                        reasoning_effort=run_reasoning_effort,
+                        reasoning_effort=wire_reasoning_effort,
                         latency_ms=_elapsed_ms(request_started_at),
                         status="error",
                         error_code=last_error_code,

--- a/app/modules/automations/service.py
+++ b/app/modules/automations/service.py
@@ -2123,7 +2123,7 @@ def _normalize_reasoning_effort(value: str | None, *, model_slug: str) -> str | 
     normalized = value.strip().lower()
     if not normalized:
         return None
-    allowed = {"minimal", "low", "medium", "high", "xhigh"}
+    allowed = {"minimal", "low", "medium", "high", "xhigh", "max", "ultra"}
     if normalized not in allowed:
         raise AutomationValidationError(
             f"Unsupported reasoning effort: {value}",

--- a/app/modules/dashboard/api.py
+++ b/app/modules/dashboard/api.py
@@ -42,7 +42,7 @@ async def list_models() -> dict:
     models_by_slug = registry.get_models_with_fallback()
     if not models_by_slug:
         return {"models": []}
-    allowed_efforts = {"minimal", "low", "medium", "high", "xhigh"}
+    allowed_efforts = {"minimal", "low", "medium", "high", "xhigh", "max", "ultra"}
 
     def _normalize_effort(value: str | None) -> str | None:
         if not isinstance(value, str):

--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -31,6 +31,15 @@ logger = logging.getLogger(__name__)
 _UNSUPPORTED_UPSTREAM_REASONING_EFFORTS: frozenset[str] = frozenset({"minimal"})
 _DEFAULT_REASONING_EFFORT_FALLBACK = "low"
 
+# Client-plane reasoning efforts the reference Codex client never sends on the
+# wire. GPT-5.6 Sol/Terra advertise ``ultra`` in their catalog entries, but the
+# official client rewrites it to ``max`` before building the Responses request
+# (``reasoning_effort_for_request`` in codex-rs ``core/src/client.rs`` at
+# rust-v0.144.1); ``ultra``'s extra effect (proactive multi-agent mode) is
+# purely client-side. Mirror that aliasing for API-key enforcement and raw
+# API callers so the upstream backend only ever sees wire-safe values.
+_REASONING_EFFORT_WIRE_ALIASES: dict[str, str] = {"ultra": "max"}
+
 # Cursor exposes GPT-5 family model labels with UI suffixes such as "Extra
 # High Fast". The ChatGPT/Codex upstream accepts the canonical GPT-5-family
 # slug plus request fields, not those synthetic suffixes in the model name.
@@ -208,12 +217,16 @@ def apply_api_key_enforcement_to_chat_payload(
         return
 
     if api_key.enforced_reasoning_effort is not None:
-        payload["reasoning_effort"] = api_key.enforced_reasoning_effort
+        enforced_effort = _REASONING_EFFORT_WIRE_ALIASES.get(
+            api_key.enforced_reasoning_effort.strip().lower(),
+            api_key.enforced_reasoning_effort,
+        )
+        payload["reasoning_effort"] = enforced_effort
         reasoning = payload.get("reasoning")
         if isinstance(reasoning, dict):
-            payload["reasoning"] = {**reasoning, "effort": api_key.enforced_reasoning_effort}
+            payload["reasoning"] = {**reasoning, "effort": enforced_effort}
         else:
-            payload["reasoning"] = {"effort": api_key.enforced_reasoning_effort}
+            payload["reasoning"] = {"effort": enforced_effort}
 
     if api_key.enforced_service_tier is not None:
         if api_key.enforced_service_tier in _UPSTREAM_OMIT_SERVICE_TIERS:
@@ -330,6 +343,9 @@ def normalize_unsupported_reasoning_effort(
     so clients (e.g. Codex CLI's ``--reasoning-effort minimal``) keep
     working. Mapping picks the model's lowest advertised effort, falling
     back to ``low`` when the registry has no metadata yet.
+
+    Client-plane efforts the reference Codex client aliases before sending
+    (``ultra`` -> ``max``) are rewritten the same way here.
     """
 
     if payload.reasoning is None or payload.reasoning.effort is None:
@@ -337,6 +353,19 @@ def normalize_unsupported_reasoning_effort(
 
     requested_effort = payload.reasoning.effort
     normalized_effort = requested_effort.strip().lower()
+
+    wire_alias = _REASONING_EFFORT_WIRE_ALIASES.get(normalized_effort)
+    if wire_alias is not None:
+        payload.reasoning.effort = wire_alias
+        logger.info(
+            "reasoning_effort_wire_aliased request_id=%s model=%s requested_effort=%s aliased_effort=%s",
+            get_request_id(),
+            payload.model,
+            requested_effort,
+            wire_alias,
+        )
+        return
+
     if normalized_effort not in _UNSUPPORTED_UPSTREAM_REASONING_EFFORTS:
         return
 

--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -46,6 +46,9 @@ _REASONING_EFFORT_WIRE_ALIASES: dict[str, str] = {"ultra": "max"}
 # Keep this deliberately narrow: only strip known Cursor-style suffix tokens
 # from known GPT-5 base model slugs, and leave every other model untouched.
 _GPT5_ALIAS_BASE_MODELS: tuple[str, ...] = (
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
     "gpt-5.4-mini",
     "gpt-5.3-codex",
     "gpt-5.2-codex",
@@ -90,6 +93,19 @@ _MODEL_ALIAS_TOKENS: frozenset[str] = frozenset(
 # ``service_tier`` instead of sending a literal that fails upstream. See
 # https://github.com/Soju06/codex-lb/issues/546
 _UPSTREAM_OMIT_SERVICE_TIERS: frozenset[str] = frozenset({"auto", "default"})
+
+
+def resolve_wire_reasoning_effort(effort: str) -> str:
+    """Return the wire-safe value for a client-plane reasoning effort.
+
+    The reference Codex client rewrites client-plane efforts (``ultra`` ->
+    ``max``) before building the upstream Responses request; every codex-lb
+    code path that builds an upstream payload directly (proxy enforcement,
+    automation compact pings) applies the same aliasing so the upstream
+    backend never sees a client-plane literal. Unknown values pass through
+    unchanged.
+    """
+    return _REASONING_EFFORT_WIRE_ALIASES.get(effort.strip().lower(), effort)
 
 
 def validate_model_access(api_key: ApiKeyData | None, model: str | None) -> None:
@@ -217,10 +233,7 @@ def apply_api_key_enforcement_to_chat_payload(
         return
 
     if api_key.enforced_reasoning_effort is not None:
-        enforced_effort = _REASONING_EFFORT_WIRE_ALIASES.get(
-            api_key.enforced_reasoning_effort.strip().lower(),
-            api_key.enforced_reasoning_effort,
-        )
+        enforced_effort = resolve_wire_reasoning_effort(api_key.enforced_reasoning_effort)
         payload["reasoning_effort"] = enforced_effort
         reasoning = payload.get("reasoning")
         if isinstance(reasoning, dict):

--- a/frontend/src/features/api-keys/components/api-key-create-dialog.tsx
+++ b/frontend/src/features/api-keys/components/api-key-create-dialog.tsx
@@ -31,6 +31,7 @@ import { ModelSourceMultiSelect } from "@/features/model-sources/components/mode
 import type {
   ApiKeyCreateRequest,
   LimitRuleCreate,
+  ReasoningEffortType,
   ServiceTierType,
   TrafficClass,
   TransportPolicyOverride,
@@ -120,7 +121,7 @@ function ApiKeyCreateForm({ busy, onClose, onSubmit }: ApiKeyCreateFormProps) {
       enforcedReasoningEffort:
         draft.enforcedReasoningEffort === "none"
           ? null
-          : draft.enforcedReasoningEffort as "minimal" | "low" | "medium" | "high" | "xhigh",
+          : draft.enforcedReasoningEffort as ReasoningEffortType,
       enforcedServiceTier: draft.enforcedServiceTier === "none" ? null : draft.enforcedServiceTier as ServiceTierType,
       trafficClass: draft.trafficClass,
       transportPolicyOverride: draft.transportPolicyOverride,
@@ -216,6 +217,8 @@ function ApiKeyCreateForm({ busy, onClose, onSubmit }: ApiKeyCreateFormProps) {
                   <SelectItem value="medium">Medium</SelectItem>
                   <SelectItem value="high">High</SelectItem>
                   <SelectItem value="xhigh">XHigh</SelectItem>
+                  <SelectItem value="max">Max</SelectItem>
+                  <SelectItem value="ultra">Ultra</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/frontend/src/features/api-keys/components/api-key-edit-dialog.tsx
+++ b/frontend/src/features/api-keys/components/api-key-edit-dialog.tsx
@@ -34,6 +34,7 @@ import type {
   ApiKeyUpdateRequest,
   LimitRuleCreate,
   LimitType,
+  ReasoningEffortType,
   ServiceTierType,
   TrafficClass,
   TransportPolicyOverride,
@@ -160,7 +161,8 @@ function ApiKeyEditForm({ apiKey, busy, onSubmit, onClose }: ApiKeyEditFormProps
       allowedModels: draft.selectedModels.length > 0 ? draft.selectedModels : null,
       applyToCodexModel: draft.applyToCodexModel,
       enforcedModel: draft.enforcedModel.trim() ? draft.enforcedModel.trim() : null,
-      enforcedReasoningEffort: draft.enforcedReasoningEffort === "none" ? null : draft.enforcedReasoningEffort as "minimal" | "low" | "medium" | "high" | "xhigh",
+      enforcedReasoningEffort:
+        draft.enforcedReasoningEffort === "none" ? null : draft.enforcedReasoningEffort as ReasoningEffortType,
       enforcedServiceTier: draft.enforcedServiceTier === "none" ? null : draft.enforcedServiceTier as ServiceTierType,
       trafficClass: draft.trafficClass,
       transportPolicyOverride: draft.transportPolicyOverride,
@@ -284,6 +286,8 @@ function ApiKeyEditForm({ apiKey, busy, onSubmit, onClose }: ApiKeyEditFormProps
                   <SelectItem value="medium">Medium</SelectItem>
                   <SelectItem value="high">High</SelectItem>
                   <SelectItem value="xhigh">XHigh</SelectItem>
+                  <SelectItem value="max">Max</SelectItem>
+                  <SelectItem value="ultra">Ultra</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/frontend/src/features/api-keys/schemas.test.ts
+++ b/frontend/src/features/api-keys/schemas.test.ts
@@ -6,6 +6,7 @@ import {
   ApiKeySchema,
   ApiKeyUpdateRequestSchema,
   LimitRuleCreateSchema,
+  ModelItemSchema,
 } from "@/features/api-keys/schemas";
 
 const ISO = "2026-01-01T00:00:00+00:00";
@@ -135,6 +136,20 @@ describe("ApiKeyCreateResponseSchema", () => {
   });
 });
 
+describe("ModelItemSchema", () => {
+  it("accepts extended GPT-5.6 reasoning efforts", () => {
+    const parsed = ModelItemSchema.parse({
+      id: "gpt-5.6-sol",
+      name: "GPT-5.6-Sol",
+      sourceOnly: false,
+      supportedReasoningEfforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
+      defaultReasoningEffort: "low",
+    });
+
+    expect(parsed.supportedReasoningEfforts).toEqual(["low", "medium", "high", "xhigh", "max", "ultra"]);
+  });
+});
+
 describe("ApiKeyCreateRequestSchema", () => {
   it("accepts optional assigned accounts", () => {
     const parsed = ApiKeyCreateRequestSchema.parse({
@@ -163,6 +178,15 @@ describe("ApiKeyCreateRequestSchema", () => {
     });
 
     expect(parsed.trafficClass).toBe("opportunistic");
+  });
+
+  it("accepts extended GPT-5.6 enforced reasoning in create payload", () => {
+    const parsed = ApiKeyCreateRequestSchema.parse({
+      name: "Extended reasoning key",
+      enforcedReasoningEffort: "ultra",
+    });
+
+    expect(parsed.enforcedReasoningEffort).toBe("ultra");
   });
 
   it("rejects invalid traffic class in create payload", () => {

--- a/frontend/src/features/api-keys/schemas.ts
+++ b/frontend/src/features/api-keys/schemas.ts
@@ -37,6 +37,9 @@ export const TRAFFIC_CLASSES = ["foreground", "opportunistic"] as const;
 export type TrafficClass = (typeof TRAFFIC_CLASSES)[number];
 export const TRANSPORT_POLICY_OVERRIDES = ["smart", "always_http", "always_websocket"] as const;
 export type TransportPolicyOverride = (typeof TRANSPORT_POLICY_OVERRIDES)[number];
+export const REASONING_EFFORTS = ["minimal", "low", "medium", "high", "xhigh", "max", "ultra"] as const;
+export type ReasoningEffortType = (typeof REASONING_EFFORTS)[number];
+export const ENFORCED_REASONING_EFFORTS = ["none", ...REASONING_EFFORTS] as const;
 
 export const ApiKeySchema = z.object({
   id: z.string(),
@@ -49,10 +52,7 @@ export const ApiKeySchema = z.object({
     .enum(TRAFFIC_CLASSES)
     .default("foreground"),
   transportPolicyOverride: z.enum(TRANSPORT_POLICY_OVERRIDES).nullable().default(null),
-  enforcedReasoningEffort: z
-    .enum(["none", "minimal", "low", "medium", "high", "xhigh"])
-    .nullable()
-    .default(null),
+  enforcedReasoningEffort: z.enum(ENFORCED_REASONING_EFFORTS).nullable().default(null),
   enforcedServiceTier: z
     .enum(SERVICE_TIERS)
     .nullable()
@@ -88,10 +88,7 @@ export const ApiKeyCreateRequestSchema = z.object({
   trafficClass: z.enum(TRAFFIC_CLASSES).optional(),
   transportPolicyOverride: z.enum(TRANSPORT_POLICY_OVERRIDES).nullable().optional(),
   enforcedModel: z.string().min(1).nullable().optional(),
-  enforcedReasoningEffort: z
-    .enum(["none", "minimal", "low", "medium", "high", "xhigh"])
-    .nullable()
-    .optional(),
+  enforcedReasoningEffort: z.enum(ENFORCED_REASONING_EFFORTS).nullable().optional(),
   enforcedServiceTier: z
     .enum(SERVICE_TIERS)
     .nullable()
@@ -115,10 +112,7 @@ export const ApiKeyUpdateRequestSchema = z.object({
   trafficClass: z.enum(TRAFFIC_CLASSES).optional(),
   transportPolicyOverride: z.enum(TRANSPORT_POLICY_OVERRIDES).nullable().optional(),
   enforcedModel: z.string().min(1).nullable().optional(),
-  enforcedReasoningEffort: z
-    .enum(["none", "minimal", "low", "medium", "high", "xhigh"])
-    .nullable()
-    .optional(),
+  enforcedReasoningEffort: z.enum(ENFORCED_REASONING_EFFORTS).nullable().optional(),
   enforcedServiceTier: z
     .enum(SERVICE_TIERS)
     .nullable()
@@ -146,11 +140,8 @@ export const ModelItemSchema = z.object({
   id: z.string(),
   name: z.string(),
   sourceOnly: z.boolean().default(false),
-  supportedReasoningEfforts: z.array(z.enum(["minimal", "low", "medium", "high", "xhigh"])).default([]),
-  defaultReasoningEffort: z
-    .enum(["minimal", "low", "medium", "high", "xhigh"])
-    .nullable()
-    .optional(),
+  supportedReasoningEfforts: z.array(z.enum(REASONING_EFFORTS)).default([]),
+  defaultReasoningEffort: z.enum(REASONING_EFFORTS).nullable().optional(),
 });
 export const ModelsResponseSchema = z.object({ models: z.array(ModelItemSchema) });
 export type ModelItem = z.infer<typeof ModelItemSchema>;

--- a/frontend/src/features/automations/components/automation-job-dialog.tsx
+++ b/frontend/src/features/automations/components/automation-job-dialog.tsx
@@ -57,13 +57,15 @@ const DEFAULT_SCHEDULE_TIME = "05:00";
 const DEFAULT_SCHEDULE_THRESHOLD_MINUTES = 0;
 const MAX_SCHEDULE_THRESHOLD_MINUTES = 240;
 const DEFAULT_REASONING_EFFORT_VALUE = "__default__";
-const FALLBACK_REASONING_EFFORTS: AutomationReasoningEffort[] = ["low", "medium", "high", "xhigh"];
+const FALLBACK_REASONING_EFFORTS: AutomationReasoningEffort[] = ["low", "medium", "high", "xhigh", "max", "ultra"];
 const REASONING_LABELS: Record<AutomationReasoningEffort, string> = {
   minimal: "Minimal",
   low: "Low",
   medium: "Medium",
   high: "High",
   xhigh: "XHigh",
+  max: "Max",
+  ultra: "Ultra",
 };
 
 type CreateFormField = "name" | "model" | "time" | "threshold" | "accounts";

--- a/frontend/src/features/automations/components/automations-page.tsx
+++ b/frontend/src/features/automations/components/automations-page.tsx
@@ -389,7 +389,7 @@ export function AutomationsPage() {
       days: ("mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun")[];
     };
     model: string;
-    reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh" | null;
+    reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra" | null;
     prompt?: string;
     accountIds: string[];
   }) => {
@@ -408,7 +408,7 @@ export function AutomationsPage() {
       days: ("mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun")[];
     };
     model?: string;
-    reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh" | null;
+    reasoningEffort?: "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra" | null;
     prompt?: string;
     accountIds?: string[];
   }) => {

--- a/frontend/src/features/automations/schemas.test.ts
+++ b/frontend/src/features/automations/schemas.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   AutomationCreateRequestSchema,
   AutomationJobSchema,
+  AutomationReasoningEffortSchema,
   AutomationRunSchema,
 } from "@/features/automations/schemas";
 
@@ -65,6 +66,11 @@ describe("automations schemas", () => {
     });
 
     expect(parsed.accountIds).toEqual([]);
+  });
+
+  it("accepts extended GPT-5.6 reasoning efforts", () => {
+    expect(AutomationReasoningEffortSchema.parse("max")).toBe("max");
+    expect(AutomationReasoningEffortSchema.parse("ultra")).toBe("ultra");
   });
 
   it("rejects duplicate schedule days", () => {

--- a/frontend/src/features/automations/schemas.ts
+++ b/frontend/src/features/automations/schemas.ts
@@ -4,7 +4,7 @@ export const AutomationScheduleTypeSchema = z.enum(["daily"]);
 export const AutomationScheduleDaySchema = z.enum(["mon", "tue", "wed", "thu", "fri", "sat", "sun"]);
 export const AutomationRunStatusSchema = z.enum(["running", "success", "failed", "partial"]);
 export const AutomationRunTriggerSchema = z.enum(["scheduled", "manual"]);
-export const AutomationReasoningEffortSchema = z.enum(["minimal", "low", "medium", "high", "xhigh"]);
+export const AutomationReasoningEffortSchema = z.enum(["minimal", "low", "medium", "high", "xhigh", "max", "ultra"]);
 
 export const AutomationScheduleDaysSchema = z
   .array(AutomationScheduleDaySchema)

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -199,7 +199,7 @@ const AutomationCreatePayloadSchema = z.object({
 	includePausedAccounts: z.boolean().optional(),
 	schedule: AutomationSchedulePayloadSchema,
 	model: z.string().min(1),
-	reasoningEffort: z.enum(["minimal", "low", "medium", "high", "xhigh"]).nullable().optional(),
+	reasoningEffort: z.enum(["minimal", "low", "medium", "high", "xhigh", "max", "ultra"]).nullable().optional(),
 	prompt: z.string().optional(),
 	accountIds: z.array(z.string().min(1)),
 });
@@ -211,7 +211,7 @@ const AutomationUpdatePayloadSchema = z
 		includePausedAccounts: z.boolean().optional(),
 		schedule: AutomationSchedulePayloadSchema.optional(),
 		model: z.string().min(1).optional(),
-		reasoningEffort: z.enum(["minimal", "low", "medium", "high", "xhigh"]).nullable().optional(),
+		reasoningEffort: z.enum(["minimal", "low", "medium", "high", "xhigh", "max", "ultra"]).nullable().optional(),
 		prompt: z.string().min(1).optional(),
 		accountIds: z.array(z.string().min(1)).optional(),
 	})
@@ -255,7 +255,7 @@ type MockState = {
       days: Array<"mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun">;
     };
     model: string;
-    reasoningEffort: "minimal" | "low" | "medium" | "high" | "xhigh" | null;
+    reasoningEffort: "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra" | null;
     prompt: string;
     accountIds: string[];
     nextRunAt: string | null;
@@ -263,7 +263,7 @@ type MockState = {
       id: string;
       jobId: string;
       model: string | null;
-      reasoningEffort: "minimal" | "low" | "medium" | "high" | "xhigh" | null;
+      reasoningEffort: "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra" | null;
       trigger: "scheduled" | "manual";
       status: "running" | "success" | "failed" | "partial";
       scheduledFor: string;
@@ -287,6 +287,8 @@ type MockState = {
         | "medium"
         | "high"
         | "xhigh"
+        | "max"
+        | "ultra"
         | null;
       trigger: "scheduled" | "manual";
       status: "running" | "success" | "failed" | "partial";
@@ -618,7 +620,7 @@ function listAutomationRunsWithContext() {
 		(MockState["automationRuns"][string][number] & {
 			jobName: string | null;
 			model: string | null;
-			reasoningEffort: "minimal" | "low" | "medium" | "high" | "xhigh" | null;
+			reasoningEffort: "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra" | null;
 			effectiveStatus: "running" | "success" | "failed" | "partial";
 			totalAccounts: number;
 			completedAccounts: number;

--- a/openspec/changes/add-gpt56-bootstrap-models/proposal.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/proposal.md
@@ -28,6 +28,13 @@ unparseable client-side.
 - Alias `ultra` to `max` on the upstream wire (requested or enforced), exactly
   like the reference Codex client (`reasoning_effort_for_request`, codex-rs
   `core/src/client.rs` at rust-v0.144.1); `ultra` itself is never forwarded.
+  Automation compact pings, which build upstream payloads directly and bypass
+  the proxy request-policy rewrite, apply the same aliasing.
+- Recognize Cursor-style suffixed labels for the GPT-5.6 personality slugs
+  (e.g. `gpt-5.6-sol-extra-high-fast` normalizes to `gpt-5.6-sol` plus derived
+  reasoning/service-tier fields) in the model alias normalizer; `ultra`/`max`
+  stay outside the suffix grammar because not every GPT-5-family base supports
+  them.
 - Raise the fallback Codex client version (`model_registry_client_version`)
   from 0.101.0 to 0.144.0 so a degraded-startup registry refresh still
   receives GPT-5.6 from upstream.

--- a/openspec/changes/add-gpt56-bootstrap-models/proposal.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Codex 0.144 ships GPT-5.6 family model catalog entries (`gpt-5.6-sol`,
+`gpt-5.6-terra`, and `gpt-5.6-luna`) with extended reasoning efforts. When
+codex-lb starts before a successful upstream model refresh, its bundled
+bootstrap catalog still lacks those slugs and dashboard/API-key validation still
+rejects the new `max` and `ultra` reasoning effort values.
+
+## What Changes
+
+- Add GPT-5.6 Sol, Terra, and Luna to the static bootstrap model catalog with
+  Codex-compatible context window, speed-tier, websocket, and reasoning
+  metadata.
+- Allow `max` and `ultra` reasoning efforts where codex-lb validates model
+  reasoning choices for dashboard model metadata, automations, and API-key
+  reasoning enforcement.
+- Keep refreshed upstream model registry data authoritative over the bootstrap
+  catalog.
+
+## Impact
+
+- No database migration.
+- Offline/startup model listing includes GPT-5.6 family models.
+- Dashboard and API-key forms can preserve and submit the extended reasoning
+  efforts advertised by the model catalog.

--- a/openspec/changes/add-gpt56-bootstrap-models/proposal.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/proposal.md
@@ -4,22 +4,41 @@ Codex 0.144 ships GPT-5.6 family model catalog entries (`gpt-5.6-sol`,
 `gpt-5.6-terra`, and `gpt-5.6-luna`) with extended reasoning efforts. When
 codex-lb starts before a successful upstream model refresh, its bundled
 bootstrap catalog still lacks those slugs and dashboard/API-key validation still
-rejects the new `max` and `ultra` reasoning effort values.
+rejects the new `max` and `ultra` reasoning effort values. A bootstrap-served
+Codex catalog must also match the upstream bundled metadata exactly
+(`codex-rs/models-manager/models.json` at rust-v0.144.1): missing fields such
+as `tool_mode`, `multi_agent_version`, or the deserializer-required
+`experimental_supported_tools` change Codex client behavior or make the entry
+unparseable client-side.
 
 ## What Changes
 
 - Add GPT-5.6 Sol, Terra, and Luna to the static bootstrap model catalog with
-  Codex-compatible context window, speed-tier, websocket, and reasoning
-  metadata.
+  metadata that mirrors the upstream bundled catalog field-for-field
+  (context window 372000, `minimal_client_version` 0.144.0,
+  `tool_mode: code_mode_only`, per-model `multi_agent_version`,
+  `use_responses_lite`, reasoning-summary metadata, 21-plan availability,
+  Sol's `availability_nux`, speed/service tiers, websocket preference). The
+  large `base_instructions` / `model_messages` prompts are deliberately left
+  to the live refresh.
 - Allow `max` and `ultra` reasoning efforts where codex-lb validates model
   reasoning choices for dashboard model metadata, automations, and API-key
-  reasoning enforcement.
+  reasoning enforcement, and accept them in the OpenAI-compatible `thinking`
+  string alias.
+- Alias `ultra` to `max` on the upstream wire (requested or enforced), exactly
+  like the reference Codex client (`reasoning_effort_for_request`, codex-rs
+  `core/src/client.rs` at rust-v0.144.1); `ultra` itself is never forwarded.
+- Raise the fallback Codex client version (`model_registry_client_version`)
+  from 0.101.0 to 0.144.0 so a degraded-startup registry refresh still
+  receives GPT-5.6 from upstream.
 - Keep refreshed upstream model registry data authoritative over the bootstrap
   catalog.
 
 ## Impact
 
 - No database migration.
-- Offline/startup model listing includes GPT-5.6 family models.
+- Offline/startup model listing includes GPT-5.6 family models with
+  upstream-exact metadata.
 - Dashboard and API-key forms can preserve and submit the extended reasoning
-  efforts advertised by the model catalog.
+  efforts advertised by the model catalog; upstream never sees the
+  client-plane `ultra` literal.

--- a/openspec/changes/add-gpt56-bootstrap-models/specs/api-keys/spec.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/specs/api-keys/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: API keys can enforce extended reasoning efforts
+
+The dashboard API key CRUD surface MUST allow callers to persist optional
+enforced reasoning efforts advertised by the model catalog, including extended
+GPT-5.6 efforts `max` and `ultra`.
+
+#### Scenario: API key accepts extended enforced reasoning effort on create
+
+- **WHEN** a dashboard client creates an API key with `enforcedReasoningEffort: "ultra"`
+- **THEN** the request is accepted
+- **AND** the response returns `enforcedReasoningEffort: "ultra"`
+
+#### Scenario: API key accepts extended enforced reasoning effort on update
+
+- **WHEN** a dashboard client updates an API key with `enforcedReasoningEffort: "max"`
+- **THEN** the request is accepted
+- **AND** the response returns `enforcedReasoningEffort: "max"`

--- a/openspec/changes/add-gpt56-bootstrap-models/specs/frontend-architecture/spec.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/specs/frontend-architecture/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Settings page
+
+The Settings page SHALL include sections for: routing settings (sticky threads,
+reset priority, prompt-cache affinity TTL), password management
+(setup/change/remove), TOTP management (setup/disable), API key auth toggle,
+API key management (table, create, edit, delete, regenerate), and
+sticky-session administration. API key create/edit controls that expose
+reasoning effort choices MUST include upstream-supported extended efforts such
+as `max` and `ultra`.
+
+#### Scenario: API key dialog offers extended reasoning efforts
+
+- **WHEN** an operator opens the API key create or edit dialog
+- **THEN** the enforced reasoning control offers `Max` and `Ultra` in addition to existing reasoning efforts
+
+## ADDED Requirements
+
+### Requirement: Automations page accepts extended reasoning efforts
+
+The Automations page SHALL allow operators to create and update scheduled
+refresh jobs using any reasoning effort advertised by the selected model,
+including extended GPT-5.6 efforts such as `max` and `ultra`.
+
+#### Scenario: Automation dialog offers extended model reasoning efforts
+
+- **WHEN** a selected model advertises `max` or `ultra` in `supportedReasoningEfforts`
+- **THEN** the automation create/edit dialog offers those efforts as selectable values

--- a/openspec/changes/add-gpt56-bootstrap-models/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/specs/model-catalog-compat/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Bootstrap model catalog is available before refresh
+
+Before the first successful upstream model-registry refresh, the system MUST
+serve a conservative static catalog of known Codex model slugs from both
+`GET /v1/models` and `GET /backend-api/codex/models`. This static catalog is a
+bundled fallback for startup/offline paths; refreshed upstream model-registry
+data remains the authoritative source once available. The bootstrap catalog MUST
+include `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`,
+`gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`,
+`gpt-5.2`, and `codex-auto-review`, and MUST NOT invent unverified variant
+slugs such as `gpt-5.5-pro` or a bare `gpt-5.6`.
+
+#### Scenario: OpenAI-compatible models endpoint serves bootstrap slugs
+
+- **GIVEN** the model registry has no refreshed upstream snapshot
+- **WHEN** a client calls `GET /v1/models`
+- **THEN** the response contains exactly the bootstrap model slugs
+- **AND** the response includes `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`
+- **AND** the response does not include `gpt-5.5-pro` or bare `gpt-5.6`
+
+#### Scenario: Codex-native models endpoint serves GPT-5.6 bootstrap metadata
+
+- **GIVEN** the model registry has no refreshed upstream snapshot
+- **WHEN** a client calls `GET /backend-api/codex/models`
+- **THEN** the `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` entries include representative upstream metadata including context-window, visibility, speed-tier, and reasoning fields
+- **AND** Sol and Terra advertise `low`, `medium`, `high`, `xhigh`, `max`, and `ultra`
+- **AND** Luna advertises `low`, `medium`, `high`, `xhigh`, and `max`
+
+## ADDED Requirements
+
+### Requirement: Dashboard model metadata exposes supported reasoning efforts
+
+When serving `GET /api/models`, the system MUST expose the supported reasoning
+efforts advertised by each public model catalog entry. The response MUST include
+new upstream-supported efforts such as `max` and `ultra` instead of filtering
+them out.
+
+#### Scenario: Dashboard model list exposes GPT-5.6 reasoning efforts
+
+- **WHEN** the model catalog contains `gpt-5.6-sol` with supported efforts `low`, `medium`, `high`, `xhigh`, `max`, and `ultra`
+- **WHEN** a client calls `GET /api/models`
+- **THEN** the `gpt-5.6-sol` entry's `supportedReasoningEfforts` includes `max` and `ultra`
+- **AND** `defaultReasoningEffort` reflects the catalog default

--- a/openspec/changes/add-gpt56-bootstrap-models/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/specs/model-catalog-compat/spec.md
@@ -10,7 +10,10 @@ data remains the authoritative source once available. The bootstrap catalog MUST
 include `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`,
 `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`,
 `gpt-5.2`, and `codex-auto-review`, and MUST NOT invent unverified variant
-slugs such as `gpt-5.5-pro` or a bare `gpt-5.6`.
+slugs such as `gpt-5.5-pro` or a bare `gpt-5.6`. `gpt-5.3-codex` and
+`gpt-5.3-codex-spark` were dropped from upstream's bundled catalog at
+codex rust-v0.144.x but remain retained for older pinned clients because the
+upstream backend still serves them.
 
 #### Scenario: OpenAI-compatible models endpoint serves bootstrap slugs
 
@@ -29,6 +32,57 @@ slugs such as `gpt-5.5-pro` or a bare `gpt-5.6`.
 - **AND** Luna advertises `low`, `medium`, `high`, `xhigh`, and `max`
 
 ## ADDED Requirements
+
+### Requirement: GPT-5.6 bootstrap metadata matches the upstream bundled catalog
+
+The GPT-5.6 bootstrap catalog entries (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) MUST mirror the upstream bundled catalog (`codex-rs/models-manager/models.json` at codex release rust-v0.144.1) field-for-field for every metadata field codex-lb serves. In particular each
+entry MUST carry: `context_window` and `max_context_window` of `372000`;
+`minimal_client_version` `"0.144.0"`; `tool_mode` `"code_mode_only"`;
+`use_responses_lite` `true`; `apply_patch_tool_type` `"freeform"`;
+`web_search_tool_type` `"text_and_image"`; `supports_image_detail_original`
+`true`; `truncation_policy` `{"mode": "tokens", "limit": 10000}`;
+`comp_hash` `"3000"`; `reasoning_summary_format` `"experimental"`;
+`default_reasoning_summary` `"none"`; `include_skills_usage_instructions`
+`false`; `experimental_supported_tools` `[]` (a field the Codex client's
+deserializer requires); `supports_search_tool` `true`; `additional_speed_tiers`
+`["fast"]`; the `priority`/`Fast` service tier entry; `shell_type`
+`"shell_command"`; `prefer_websockets` `true`; and the 21-plan
+`available_in_plans` list upstream advertises (including `edu_plus`,
+`edu_pro`, `enterprise_cbp_automation`, and `sci`). `multi_agent_version` MUST
+be `"v2"` for Sol and Terra and `"v1"` for Luna. Sol MUST carry the upstream
+`availability_nux` message while Terra and Luna carry `null`. Default
+reasoning levels MUST be `low` for Sol and `medium` for Terra and Luna, and
+reasoning-level descriptions MUST be the verbatim upstream strings.
+
+The ~16.5 KB upstream `base_instructions` prompt and the personality-templated
+`model_messages` object are deliberately NOT bundled in the bootstrap catalog;
+the first successful live registry refresh supplies them. This is the only
+sanctioned divergence from the upstream GPT-5.6 entries.
+
+#### Scenario: GPT-5.6 entries expose upstream tool and multi-agent metadata
+
+- **GIVEN** the model registry has no refreshed upstream snapshot
+- **WHEN** a client calls `GET /backend-api/codex/models`
+- **THEN** `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` carry `tool_mode: "code_mode_only"`, `use_responses_lite: true`, `experimental_supported_tools: []`, and `minimal_client_version: "0.144.0"`
+- **AND** `multi_agent_version` is `"v2"` for Sol and Terra and `"v1"` for Luna
+
+#### Scenario: GPT-5.6 entries expose upstream reasoning-summary and plan metadata
+
+- **GIVEN** the model registry has no refreshed upstream snapshot
+- **WHEN** a client calls `GET /backend-api/codex/models`
+- **THEN** each GPT-5.6 entry carries `default_reasoning_summary: "none"`, `reasoning_summary_format: "experimental"`, and `comp_hash: "3000"`
+- **AND** each GPT-5.6 entry's `available_in_plans` includes `edu_plus`, `edu_pro`, `enterprise_cbp_automation`, and `sci`
+- **AND** only `gpt-5.6-sol` carries a non-null `availability_nux` message
+
+### Requirement: Fallback client version covers the bootstrap catalog
+
+The configured fallback Codex client version (used when the live Codex release lookup fails and no cached version exists) MUST be greater than or equal to the highest `minimal_client_version` in the bootstrap catalog, so a degraded-startup registry refresh still receives the newest bootstrap models from upstream.
+
+#### Scenario: Degraded-startup refresh still requests GPT-5.6
+
+- **GIVEN** the live Codex release lookup fails and no version is cached
+- **WHEN** the model registry refresh fetches `<base>/codex/models?client_version=<fallback>`
+- **THEN** the fallback version is at least `0.144.0` (GPT-5.6's `minimal_client_version`)
 
 ### Requirement: Dashboard model metadata exposes supported reasoning efforts
 

--- a/openspec/changes/add-gpt56-bootstrap-models/specs/responses-api-compat/spec.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/specs/responses-api-compat/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Ultra reasoning effort is aliased to max on the upstream wire
+
+The proxy MUST forward any outbound upstream Responses payload whose `reasoning.effort` resolves to `ultra` — whether requested by the client or injected by API-key reasoning enforcement — with `reasoning.effort: "max"`. `ultra` is a client-plane reasoning effort: GPT-5.6 Sol and Terra advertise it
+in their catalog entries, but the reference Codex client rewrites it to `max`
+before building the upstream Responses request
+(`reasoning_effort_for_request` in codex-rs `core/src/client.rs` at release
+rust-v0.144.1); its additional effect (proactive multi-agent mode) is purely
+client-side. Source-routed chat-completions
+payloads with an enforced `ultra` effort MUST likewise forward `max`. `max`
+and `xhigh` MUST be forwarded verbatim (no `max` → `xhigh` aliasing exists
+upstream).
+
+#### Scenario: Client-requested ultra forwards as max
+
+- **WHEN** a client sends a Responses request for `gpt-5.6-sol` with `reasoning: {"effort": "ultra"}`
+- **THEN** the forwarded upstream payload uses `reasoning.effort: "max"`
+
+#### Scenario: Enforced ultra forwards as max
+
+- **GIVEN** an API key configured with `enforcedReasoningEffort: "ultra"`
+- **WHEN** a request is proxied with that API key
+- **THEN** the forwarded upstream payload uses `reasoning.effort: "max"`
+
+#### Scenario: Max is forwarded verbatim
+
+- **WHEN** a client sends a Responses request with `reasoning: {"effort": "max"}`
+- **THEN** the forwarded upstream payload keeps `reasoning.effort: "max"`

--- a/openspec/changes/add-gpt56-bootstrap-models/specs/responses-api-compat/spec.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/specs/responses-api-compat/spec.md
@@ -8,7 +8,12 @@ before building the upstream Responses request
 (`reasoning_effort_for_request` in codex-rs `core/src/client.rs` at release
 rust-v0.144.1); its additional effect (proactive multi-agent mode) is purely
 client-side. Source-routed chat-completions
-payloads with an enforced `ultra` effort MUST likewise forward `max`. `max`
+payloads with an enforced `ultra` effort MUST likewise forward `max`. Code
+paths that build upstream Responses payloads directly instead of passing
+through the proxy request-policy rewrite — such as automation compact pings —
+MUST apply the same aliasing before dispatch, while persisted automation
+configuration and run history keep the configured client-plane `ultra` value.
+`max`
 and `xhigh` MUST be forwarded verbatim (no `max` → `xhigh` aliasing exists
 upstream).
 
@@ -23,7 +28,50 @@ upstream).
 - **WHEN** a request is proxied with that API key
 - **THEN** the forwarded upstream payload uses `reasoning.effort: "max"`
 
+#### Scenario: Automation compact ping with ultra dispatches max
+
+- **GIVEN** an automation configured with model `gpt-5.6-sol` and reasoning effort `ultra`
+- **WHEN** an automation run dispatches its compact ping upstream
+- **THEN** the dispatched compact payload uses `reasoning.effort: "max"`
+- **AND** the stored automation run history keeps the configured `ultra` effort
+
 #### Scenario: Max is forwarded verbatim
 
 - **WHEN** a client sends a Responses request with `reasoning: {"effort": "max"}`
 - **THEN** the forwarded upstream payload keeps `reasoning.effort: "max"`
+
+## MODIFIED Requirements
+
+### Requirement: Cursor GPT-5 model aliases normalize to canonical slugs
+
+For Responses proxy traffic, the service MUST recognize Cursor-style GPT-5 model aliases formed by appending known suffix tokens
+(`minimal`, `low`, `medium`, `high`, `xhigh`, `extra`, `fast`, `priority`, `reasoning`, `thinking`) to supported GPT-5 family slugs, including the GPT-5.6
+personality slugs `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`. The alias
+resolver MUST match longer qualified canonical slugs before shorter family prefixes so aliases such as `gpt-5.4-mini-high` and `gpt-5.3-codex-fast` normalize
+to the intended model. Unknown suffix tokens MUST leave the requested model unchanged; `ultra` and `max` are not suffix tokens (they are not effort levels
+every GPT-5-family base supports — `gpt-5.6-luna` advertises no `ultra`), so
+labels such as `gpt-5.6-sol-ultra` pass through unchanged.
+
+#### Scenario: Qualified mini model alias normalizes reasoning
+
+- **WHEN** a client sends a Responses request with `model: "gpt-5.4-mini-high"`
+- **THEN** the forwarded upstream request uses `model: "gpt-5.4-mini"`
+- **AND** the forwarded upstream request uses `reasoning.effort: "high"`
+
+#### Scenario: Qualified codex model alias normalizes service tier
+
+- **WHEN** a client sends a Responses request with `model: "gpt-5.3-codex-fast"`
+- **THEN** the forwarded upstream request uses `model: "gpt-5.3-codex"`
+- **AND** the forwarded upstream request uses `service_tier: "priority"`
+
+#### Scenario: GPT-5.6 personality alias normalizes reasoning and service tier
+
+- **WHEN** a client sends a Responses request with `model: "gpt-5.6-sol-extra-high-fast"`
+- **THEN** the forwarded upstream request uses `model: "gpt-5.6-sol"`
+- **AND** the forwarded upstream request uses `reasoning.effort: "high"`
+- **AND** the forwarded upstream request uses `service_tier: "priority"`
+
+#### Scenario: GPT-5.6 ultra-suffixed label is not rewritten
+
+- **WHEN** a client sends a Responses request with `model: "gpt-5.6-sol-ultra"`
+- **THEN** the forwarded upstream request keeps `model: "gpt-5.6-sol-ultra"` unchanged

--- a/openspec/changes/add-gpt56-bootstrap-models/tasks.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/tasks.md
@@ -1,7 +1,18 @@
 ## Tasks
 
 - [x] Add GPT-5.6 bootstrap model metadata and tests.
+- [x] Align GPT-5.6 bootstrap metadata field-for-field with the upstream
+      bundled catalog (`codex-rs/models-manager/models.json` at rust-v0.144.1):
+      `tool_mode`, `multi_agent_version`, `minimal_client_version` 0.144.0,
+      `experimental_supported_tools`, reasoning-summary fields, 21-plan
+      availability, Sol `availability_nux`.
 - [x] Extend backend reasoning effort validation for `max` and `ultra`.
+- [x] Alias `ultra` -> `max` on the upstream wire (request policy + chat
+      enforcement) with unit and route-level regression tests.
+- [x] Accept `max`/`ultra` in the OpenAI-compatible `thinking` string alias.
+- [x] Raise the fallback `model_registry_client_version` to 0.144.0.
 - [x] Extend frontend model/API-key/automation schemas and controls.
+- [x] Extend the Responses Lite route regression to a GPT-5.6 bootstrap slug
+      (additional_tools preserved, Lite header signaling, ultra aliased).
 - [x] Run targeted backend and frontend tests.
-- [ ] Run OpenSpec validation. (`openspec` CLI is not installed in this environment.)
+- [x] Run OpenSpec validation (`openspec validate add-gpt56-bootstrap-models --strict`).

--- a/openspec/changes/add-gpt56-bootstrap-models/tasks.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/tasks.md
@@ -9,6 +9,13 @@
 - [x] Extend backend reasoning effort validation for `max` and `ultra`.
 - [x] Alias `ultra` -> `max` on the upstream wire (request policy + chat
       enforcement) with unit and route-level regression tests.
+- [x] Apply the same `ultra` -> `max` wire aliasing to automation compact
+      pings (which bypass the proxy request-policy rewrite) with an
+      automations API regression test.
+- [x] Extend the Cursor-style model alias normalizer to the GPT-5.6
+      personality slugs (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) with
+      alias and allowlist regression tests; keep `ultra`/`max` out of the
+      suffix grammar (not every GPT-5-family base supports them).
 - [x] Accept `max`/`ultra` in the OpenAI-compatible `thinking` string alias.
 - [x] Raise the fallback `model_registry_client_version` to 0.144.0.
 - [x] Extend frontend model/API-key/automation schemas and controls.

--- a/openspec/changes/add-gpt56-bootstrap-models/tasks.md
+++ b/openspec/changes/add-gpt56-bootstrap-models/tasks.md
@@ -1,0 +1,7 @@
+## Tasks
+
+- [x] Add GPT-5.6 bootstrap model metadata and tests.
+- [x] Extend backend reasoning effort validation for `max` and `ultra`.
+- [x] Extend frontend model/API-key/automation schemas and controls.
+- [x] Run targeted backend and frontend tests.
+- [ ] Run OpenSpec validation. (`openspec` CLI is not installed in this environment.)

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -1468,6 +1468,19 @@ async def test_api_key_create_accepts_uppercase_enforced_reasoning(async_client)
 
 
 @pytest.mark.asyncio
+async def test_api_key_create_accepts_extended_enforced_reasoning(async_client):
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "extended-enforcement",
+            "enforcedReasoningEffort": "ULTRA",
+        },
+    )
+    assert created.status_code == 200
+    assert created.json()["enforcedReasoningEffort"] == "ultra"
+
+
+@pytest.mark.asyncio
 async def test_api_key_update_accepts_uppercase_enforced_reasoning(async_client):
     created = await async_client.post(
         "/api/api-keys/",
@@ -1486,6 +1499,27 @@ async def test_api_key_update_accepts_uppercase_enforced_reasoning(async_client)
     )
     assert updated.status_code == 200
     assert updated.json()["enforcedReasoningEffort"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_api_key_update_accepts_extended_enforced_reasoning(async_client):
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "extended-enforcement-update",
+        },
+    )
+    assert created.status_code == 200
+    key_id = created.json()["id"]
+
+    updated = await async_client.patch(
+        f"/api/api-keys/{key_id}",
+        json={
+            "enforcedReasoningEffort": "MAX",
+        },
+    )
+    assert updated.status_code == 200
+    assert updated.json()["enforcedReasoningEffort"] == "max"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_automations_api.py
+++ b/tests/integration/test_automations_api.py
@@ -115,6 +115,7 @@ def _make_upstream_model(slug: str, *, reasoning_efforts: tuple[str, ...]) -> Up
 async def _populate_automation_reasoning_models() -> None:
     models = [
         _make_upstream_model("automation-reasoning-xhigh", reasoning_efforts=("low", "medium", "high", "xhigh")),
+        _make_upstream_model("automation-reasoning-ultra", reasoning_efforts=("low", "max", "ultra")),
         _make_upstream_model("automation-reasoning-medium", reasoning_efforts=("medium",)),
     ]
     await get_model_registry().update({"plus": models, "pro": models})
@@ -343,6 +344,39 @@ async def test_automations_patch_model_rejects_retained_unsupported_reasoning_ef
     payload = valid_update.json()
     assert payload["model"] == "automation-reasoning-medium"
     assert payload["reasoningEffort"] is None
+
+
+@pytest.mark.asyncio
+async def test_automations_api_accepts_extended_reasoning_efforts(async_client):
+    await _populate_automation_reasoning_models()
+    accounts = await _create_accounts("auto-reasoning-ultra")
+
+    create_response = await async_client.post(
+        "/api/automations",
+        json={
+            "name": "Extended reasoning",
+            "enabled": True,
+            "schedule": {
+                "type": "daily",
+                "time": "05:00",
+                "timezone": "UTC",
+                "days": ["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
+            },
+            "model": "automation-reasoning-ultra",
+            "reasoningEffort": "ultra",
+            "prompt": "ping",
+            "accountIds": [accounts[0].id],
+        },
+    )
+    assert create_response.status_code == 200
+    assert create_response.json()["reasoningEffort"] == "ultra"
+
+    update_response = await async_client.patch(
+        f"/api/automations/{create_response.json()['id']}",
+        json={"reasoningEffort": "max"},
+    )
+    assert update_response.status_code == 200
+    assert update_response.json()["reasoningEffort"] == "max"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_automations_api.py
+++ b/tests/integration/test_automations_api.py
@@ -466,6 +466,74 @@ async def test_automations_run_history_keeps_claimed_model_snapshot(async_client
 
 
 @pytest.mark.asyncio
+async def test_automations_run_now_aliases_ultra_reasoning_to_max_on_wire(async_client, monkeypatch):
+    started_at = utcnow()
+    accounts = await _create_accounts("auto-ultra-wire-alias")
+    compact_requests = []
+
+    async def _fake_compact(request, *_args, **_kwargs):
+        compact_requests.append(request)
+        return SimpleNamespace(id="resp-ultra-wire-alias")
+
+    monkeypatch.setattr("app.modules.automations.service.core_compact_responses", _fake_compact)
+
+    # ``gpt-5.6-sol`` comes from the bootstrap catalog (registry snapshot is
+    # reset per test) and advertises the client-plane ``ultra`` effort.
+    create_response = await async_client.post(
+        "/api/automations",
+        json={
+            "name": "Ultra wire alias",
+            "enabled": False,
+            "schedule": {
+                "type": "daily",
+                "time": "05:00",
+                "timezone": "UTC",
+                "days": ["mon", "tue", "wed", "thu", "fri", "sat", "sun"],
+            },
+            "model": "gpt-5.6-sol",
+            "reasoningEffort": "ultra",
+            "prompt": "ultra ping",
+            "accountIds": [accounts[0].id],
+        },
+    )
+    assert create_response.status_code == 200
+    automation_id = create_response.json()["id"]
+    assert create_response.json()["reasoningEffort"] == "ultra"
+
+    run_response = await async_client.post(f"/api/automations/{automation_id}/run-now")
+    assert run_response.status_code == 202
+    assert run_response.json()["status"] == "success"
+
+    # The configured client-plane effort is preserved in run history...
+    runs_response = await async_client.get(f"/api/automations/{automation_id}/runs")
+    assert runs_response.status_code == 200
+    run_item = runs_response.json()["items"][0]
+    assert run_item["reasoningEffort"] == "ultra"
+
+    # ...but the compact request sent upstream carries the wire-safe alias.
+    assert len(compact_requests) == 1
+    assert compact_requests[0].model == "gpt-5.6-sol"
+    assert compact_requests[0].reasoning is not None
+    assert compact_requests[0].reasoning.effort == "max"
+
+    async with SessionLocal() as session:
+        request_logs_repository = RequestLogsRepository(session)
+        recent_logs, _ = await request_logs_repository.list_recent(limit=200, since=started_at)
+        matching_logs = [
+            log
+            for log in recent_logs
+            if (
+                log.transport == "automation"
+                and log.account_id == accounts[0].id
+                and log.request_id == "resp-ultra-wire-alias"
+            )
+        ]
+        assert len(matching_logs) == 1
+        assert matching_logs[0].model == "gpt-5.6-sol"
+        assert matching_logs[0].reasoning_effort == "max"
+
+
+@pytest.mark.asyncio
 async def test_automations_api_accepts_server_default_timezone(async_client, monkeypatch):
     accounts = await _create_accounts("auto-server-default")
     started_at = utcnow()

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -15,6 +15,7 @@ import app.modules.proxy.service as proxy_module
 from app.core.auth import generate_unique_account_id
 from app.core.config.settings import Settings
 from app.core.openai.models import CompactResponsePayload
+from app.core.types import JsonValue
 from app.db.models import Account, DashboardSettings, RequestLog
 from app.db.session import SessionLocal
 from app.modules.proxy._service.streaming import retry as streaming_retry_module
@@ -220,6 +221,7 @@ async def test_backend_responses_preserves_responses_lite_tools_and_outputs(asyn
             custom_tool_output,
             {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "inspect"}]},
         ],
+        "reasoning": {"effort": "ultra"},
         "stream": True,
     }
     async with async_client.stream(
@@ -241,6 +243,20 @@ async def test_backend_responses_preserves_responses_lite_tools_and_outputs(asyn
         custom_tool_output,
         {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "inspect"}]},
     ]
+    # Catalog-advertised ``ultra`` must be aliased to ``max`` on the wire,
+    # exactly like the reference Codex client (codex-rs core/src/client.rs
+    # ``reasoning_effort_for_request`` at rust-v0.144.1).
+    reasoning = cast("dict[str, JsonValue]", seen_payload["reasoning"])
+    assert reasoning["effort"] == "max"
+    # The forwarded payload must keep signaling Responses Lite: the upstream
+    # HTTP client derives the internal Lite header from the additional_tools
+    # input prefix that survived the round trip.
+    upstream_headers: dict[str, str] = {}
+    proxy_client_module._apply_responses_lite_http_header(
+        upstream_headers,
+        cast("Mapping[str, JsonValue]", seen_payload),
+    )
+    assert upstream_headers == {proxy_client_module.CODEX_RESPONSES_LITE_HEADER: "true"}
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -40,9 +40,9 @@ EXPECTED_CORE_MODEL_PLANS = {
 }
 
 EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS = {
-    "gpt-5.6-sol": None,
-    "gpt-5.6-terra": None,
-    "gpt-5.6-luna": None,
+    "gpt-5.6-sol": "0.144.0",
+    "gpt-5.6-terra": "0.144.0",
+    "gpt-5.6-luna": "0.144.0",
     "gpt-5.5": "0.124.0",
     "gpt-5.4": "0.98.0",
     "gpt-5.4-mini": "0.98.0",
@@ -247,6 +247,31 @@ async def test_backend_codex_models_uses_bootstrap_upstream_metadata(async_clien
         "xhigh",
         "max",
     }
+
+    # Upstream-exact GPT-5.6 metadata as served on the Codex catalog wire
+    # (codex-rs/models-manager/models.json at rust-v0.144.1).
+    for gpt56 in (sol, terra, luna):
+        assert gpt56["minimal_client_version"] == "0.144.0"
+        assert gpt56["tool_mode"] == "code_mode_only"
+        assert gpt56["use_responses_lite"] is True
+        assert gpt56["apply_patch_tool_type"] == "freeform"
+        assert gpt56["web_search_tool_type"] == "text_and_image"
+        assert gpt56["truncation_policy"] == {"mode": "tokens", "limit": 10_000}
+        assert gpt56["default_reasoning_summary"] == "none"
+        assert gpt56["reasoning_summary_format"] == "experimental"
+        assert gpt56["comp_hash"] == "3000"
+        assert gpt56["experimental_supported_tools"] == []
+        assert gpt56["max_context_window"] == 372_000
+        assert gpt56["service_tiers"] == [
+            {"id": "priority", "name": "Fast", "description": "1.5x speed, increased usage"}
+        ]
+        assert {"edu_plus", "edu_pro", "enterprise_cbp_automation", "sci"} <= set(gpt56["available_in_plans"])
+    assert sol["multi_agent_version"] == "v2"
+    assert terra["multi_agent_version"] == "v2"
+    assert luna["multi_agent_version"] == "v1"
+    assert "most capable model yet" in sol["availability_nux"]["message"]
+    assert terra["availability_nux"] is None
+    assert luna["availability_nux"] is None
 
     gpt54 = entries["gpt-5.4"]
     assert gpt54["minimal_client_version"] == "0.98.0"

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from app.core.openai.model_registry import ReasoningLevel, UpstreamModel, get_model_registry
@@ -8,6 +10,9 @@ from app.core.types import JsonValue
 pytestmark = pytest.mark.integration
 
 BOOTSTRAP_MODEL_SLUGS = {
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
     "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
@@ -35,6 +40,9 @@ EXPECTED_CORE_MODEL_PLANS = {
 }
 
 EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS = {
+    "gpt-5.6-sol": None,
+    "gpt-5.6-terra": None,
+    "gpt-5.6-luna": None,
     "gpt-5.5": "0.124.0",
     "gpt-5.4": "0.98.0",
     "gpt-5.4-mini": "0.98.0",
@@ -204,6 +212,41 @@ async def test_backend_codex_models_uses_bootstrap_upstream_metadata(async_clien
     assert set(entries) == set(EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS)
     for slug, expected_version in EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS.items():
         assert entries[slug]["minimal_client_version"] == expected_version
+
+    sol = entries["gpt-5.6-sol"]
+    assert sol["display_name"] == "GPT-5.6-Sol"
+    assert sol["context_window"] == 372_000
+    assert sol["default_reasoning_level"] == "low"
+    assert {level["effort"] for level in sol["supported_reasoning_levels"]} == {
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+    }
+    assert sol["additional_speed_tiers"] == ["fast"]
+
+    terra = entries["gpt-5.6-terra"]
+    assert terra["default_reasoning_level"] == "medium"
+    assert {level["effort"] for level in terra["supported_reasoning_levels"]} == {
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+    }
+
+    luna = entries["gpt-5.6-luna"]
+    assert luna["default_reasoning_level"] == "medium"
+    assert {level["effort"] for level in luna["supported_reasoning_levels"]} == {
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+    }
 
     gpt54 = entries["gpt-5.4"]
     assert gpt54["minimal_client_version"] == "0.98.0"
@@ -1030,6 +1073,36 @@ async def test_model_sets_are_consistent_across_api_endpoints(async_client):
     assert "gpt-hidden" not in codex_slugs
     assert dashboard_ids == v1_ids
     assert dashboard_ids.issubset(codex_slugs)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_models_exposes_extended_reasoning_efforts(async_client):
+    registry = get_model_registry()
+    models = [
+        _make_upstream_model(
+            "gpt-5.6-sol",
+            raw={
+                "shell_type": "shell_command",
+                "visibility": "list",
+            },
+        )
+    ]
+    models[0] = replace(
+        models[0],
+        supported_reasoning_levels=tuple(
+            ReasoningLevel(effort=effort, description=effort)
+            for effort in ("low", "medium", "high", "xhigh", "max", "ultra")
+        ),
+        default_reasoning_level="low",
+    )
+    await registry.update({"plus": models, "pro": models})
+
+    response = await async_client.get("/api/models")
+
+    assert response.status_code == 200
+    model = next(item for item in response.json()["models"] if item["id"] == "gpt-5.6-sol")
+    assert model["supportedReasoningEfforts"] == ["low", "medium", "high", "xhigh", "max", "ultra"]
+    assert model["defaultReasoningEffort"] == "low"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_codex_version.py
+++ b/tests/unit/test_codex_version.py
@@ -101,7 +101,7 @@ async def test_rejects_invalid_version_name():
         version = await cache.get_version()
 
     # Invalid name falls back to settings default
-    assert version == "0.101.0"
+    assert version == "0.144.0"
 
 
 @pytest.mark.asyncio
@@ -113,7 +113,7 @@ async def test_rejects_alpha_version_name():
     with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session):
         version = await cache.get_version()
 
-    assert version == "0.101.0"
+    assert version == "0.144.0"
 
 
 @pytest.mark.asyncio
@@ -149,7 +149,7 @@ async def test_fallback_to_settings_default_when_no_cache():
     with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session_fail):
         version = await cache.get_version()
 
-    assert version == "0.101.0"
+    assert version == "0.144.0"
 
 
 @pytest.mark.asyncio
@@ -162,7 +162,7 @@ async def test_fallback_on_network_exception():
     ):
         version = await cache.get_version()
 
-    assert version == "0.101.0"
+    assert version == "0.144.0"
 
 
 @pytest.mark.asyncio
@@ -193,7 +193,7 @@ async def test_missing_name_field_falls_back():
     with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session):
         version = await cache.get_version()
 
-    assert version == "0.101.0"
+    assert version == "0.144.0"
 
 
 def test_ttl_must_be_positive():
@@ -239,7 +239,7 @@ async def test_npm_invalid_version_falls_back_to_settings_default():
     with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session):
         version = await cache.get_version()
 
-    assert version == "0.101.0"
+    assert version == "0.144.0"
 
 
 @pytest.mark.asyncio
@@ -252,7 +252,7 @@ async def test_npm_missing_version_field_falls_back_to_settings_default():
     with patch("app.core.clients.codex_version.aiohttp.ClientSession", return_value=session):
         version = await cache.get_version()
 
-    assert version == "0.101.0"
+    assert version == "0.144.0"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -26,10 +26,36 @@ EXPECTED_CORE_MODEL_PLANS = {
     "enterprise_cbp_usage_based",
 }
 
+# The 21-plan list upstream advertises for GPT-5.6
+# (codex-rs/models-manager/models.json at rust-v0.144.1).
+EXPECTED_GPT56_MODEL_PLANS = {
+    "business",
+    "edu",
+    "edu_plus",
+    "edu_pro",
+    "education",
+    "enterprise",
+    "enterprise_cbp_automation",
+    "enterprise_cbp_usage_based",
+    "finserv",
+    "free",
+    "free_workspace",
+    "go",
+    "hc",
+    "k12",
+    "plus",
+    "pro",
+    "prolite",
+    "quorum",
+    "sci",
+    "self_serve_business_usage_based",
+    "team",
+}
+
 EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS = {
-    "gpt-5.6-sol": None,
-    "gpt-5.6-terra": None,
-    "gpt-5.6-luna": None,
+    "gpt-5.6-sol": "0.144.0",
+    "gpt-5.6-terra": "0.144.0",
+    "gpt-5.6-luna": "0.144.0",
     "gpt-5.5": "0.124.0",
     "gpt-5.4": "0.98.0",
     "gpt-5.4-mini": "0.98.0",
@@ -165,32 +191,61 @@ def test_bootstrap_models_include_representative_upstream_metadata():
     assert sol.display_name == "GPT-5.6-Sol"
     assert sol.context_window == 372_000
     assert sol.default_reasoning_level == "low"
-    assert {level.effort for level in sol.supported_reasoning_levels} == {
+    assert [level.effort for level in sol.supported_reasoning_levels] == [
         "low",
         "medium",
         "high",
         "xhigh",
         "max",
         "ultra",
-    }
+    ]
     assert sol.raw["additional_speed_tiers"] == ["fast"]
 
     terra = models["gpt-5.6-terra"]
     assert terra.display_name == "GPT-5.6-Terra"
     assert terra.default_reasoning_level == "medium"
-    assert {level.effort for level in terra.supported_reasoning_levels} == {
+    assert [level.effort for level in terra.supported_reasoning_levels] == [
         "low",
         "medium",
         "high",
         "xhigh",
         "max",
         "ultra",
-    }
+    ]
 
     luna = models["gpt-5.6-luna"]
     assert luna.display_name == "GPT-5.6-Luna"
     assert luna.default_reasoning_level == "medium"
-    assert {level.effort for level in luna.supported_reasoning_levels} == {"low", "medium", "high", "xhigh", "max"}
+    assert [level.effort for level in luna.supported_reasoning_levels] == ["low", "medium", "high", "xhigh", "max"]
+
+    # Upstream-exact GPT-5.6 raw metadata (codex-rs/models-manager/models.json
+    # at rust-v0.144.1).
+    for gpt56 in (sol, terra, luna):
+        assert gpt56.minimal_client_version == "0.144.0"
+        assert gpt56.raw["tool_mode"] == "code_mode_only"
+        assert gpt56.raw["use_responses_lite"] is True
+        assert gpt56.raw["apply_patch_tool_type"] == "freeform"
+        assert gpt56.raw["web_search_tool_type"] == "text_and_image"
+        assert gpt56.raw["supports_image_detail_original"] is True
+        assert gpt56.raw["truncation_policy"] == {"mode": "tokens", "limit": 10_000}
+        assert gpt56.raw["comp_hash"] == "3000"
+        assert gpt56.raw["reasoning_summary_format"] == "experimental"
+        assert gpt56.raw["default_reasoning_summary"] == "none"
+        assert gpt56.raw["include_skills_usage_instructions"] is False
+        assert gpt56.raw["experimental_supported_tools"] == []
+        assert gpt56.raw["supports_search_tool"] is True
+        assert gpt56.raw["max_context_window"] == 372_000
+        assert gpt56.raw["service_tiers"] == [
+            {"id": "priority", "name": "Fast", "description": "1.5x speed, increased usage"}
+        ]
+        assert gpt56.available_in_plans == EXPECTED_GPT56_MODEL_PLANS
+    assert sol.raw["multi_agent_version"] == "v2"
+    assert terra.raw["multi_agent_version"] == "v2"
+    assert luna.raw["multi_agent_version"] == "v1"
+    assert isinstance(sol.raw["availability_nux"], dict)
+    assert "most capable model yet" in str(sol.raw["availability_nux"]["message"])
+    assert terra.raw["availability_nux"] is None
+    assert luna.raw["availability_nux"] is None
 
     gpt54 = models["gpt-5.4"]
     assert gpt54.minimal_client_version == "0.98.0"

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -27,6 +27,9 @@ EXPECTED_CORE_MODEL_PLANS = {
 }
 
 EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS = {
+    "gpt-5.6-sol": None,
+    "gpt-5.6-terra": None,
+    "gpt-5.6-luna": None,
     "gpt-5.5": "0.124.0",
     "gpt-5.4": "0.98.0",
     "gpt-5.4-mini": "0.98.0",
@@ -138,6 +141,9 @@ async def test_prefers_websockets_does_not_use_bootstrap_after_snapshot():
 def test_prefers_websockets_uses_bootstrap_fallback_when_uninitialized():
     registry = ModelRegistry(ttl_seconds=60.0)
 
+    assert registry.prefers_websockets("gpt-5.6-sol") is True
+    assert registry.prefers_websockets("gpt-5.6-terra") is True
+    assert registry.prefers_websockets("gpt-5.6-luna") is True
     assert registry.prefers_websockets("gpt-5.4") is True
     assert registry.prefers_websockets("gpt-5.4-2026") is True
     assert registry.prefers_websockets("gpt-5.3-codex") is True
@@ -154,6 +160,37 @@ def test_bootstrap_models_include_representative_upstream_metadata():
     assert set(models) == set(EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS)
     for slug, expected_version in EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS.items():
         assert models[slug].minimal_client_version == expected_version
+
+    sol = models["gpt-5.6-sol"]
+    assert sol.display_name == "GPT-5.6-Sol"
+    assert sol.context_window == 372_000
+    assert sol.default_reasoning_level == "low"
+    assert {level.effort for level in sol.supported_reasoning_levels} == {
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+    }
+    assert sol.raw["additional_speed_tiers"] == ["fast"]
+
+    terra = models["gpt-5.6-terra"]
+    assert terra.display_name == "GPT-5.6-Terra"
+    assert terra.default_reasoning_level == "medium"
+    assert {level.effort for level in terra.supported_reasoning_levels} == {
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+        "max",
+        "ultra",
+    }
+
+    luna = models["gpt-5.6-luna"]
+    assert luna.display_name == "GPT-5.6-Luna"
+    assert luna.default_reasoning_level == "medium"
+    assert {level.effort for level in luna.supported_reasoning_levels} == {"low", "medium", "high", "xhigh", "max"}
 
     gpt54 = models["gpt-5.4"]
     assert gpt54.minimal_client_version == "0.98.0"

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -264,6 +264,24 @@ def test_provider_thinking_aliases_are_normalized():
     assert "enable_thinking" not in dumped
 
 
+def test_provider_thinking_string_alias_accepts_catalog_advertised_efforts():
+    # GPT-5.6 catalog entries advertise ``max`` and ``ultra``
+    # (codex-rs/models-manager/models.json at rust-v0.144.1); the string-form
+    # thinking alias must accept every catalog-advertised effort.
+    for effort in ("low", "medium", "high", "xhigh", "max", "ultra"):
+        payload = {
+            "model": "gpt-5.6-sol",
+            "instructions": "hi",
+            "input": [],
+            "thinking": effort,
+        }
+        request = ResponsesRequest.model_validate(payload)
+
+        dumped = request.to_payload()
+        assert dumped["reasoning"] == {"effort": effort}
+        assert "thinking" not in dumped
+
+
 def test_explicit_reasoning_wins_over_provider_thinking_aliases():
     payload = {
         "model": "gpt-5.1",

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -891,6 +891,104 @@ def test_apply_api_key_enforcement_normalizes_minimal_without_api_key():
     assert payload.reasoning.effort == "low"
 
 
+def test_normalize_unsupported_reasoning_effort_aliases_ultra_to_max(caplog):
+    # The reference Codex client never sends ``ultra`` on the wire; it
+    # rewrites it to ``max`` (``reasoning_effort_for_request`` in codex-rs
+    # ``core/src/client.rs`` at rust-v0.144.1). The proxy must mirror that
+    # aliasing so catalog-advertised ``ultra`` stays wire-safe.
+    from app.core.openai.requests import ResponsesReasoning
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "hello",
+            "input": [],
+        }
+    )
+    payload.reasoning = ResponsesReasoning(effort="ultra")
+    registry = _build_registry_with_model("gpt-5.6-sol", ["low", "medium", "high", "xhigh", "max", "ultra"])
+
+    with caplog.at_level(logging.INFO, logger="app.modules.proxy.request_policy"):
+        proxy_request_policy.normalize_unsupported_reasoning_effort(payload, registry=registry)
+
+    assert payload.reasoning is not None
+    assert payload.reasoning.effort == "max"
+    assert any("reasoning_effort_wire_aliased" in record.message for record in caplog.records)
+
+
+def test_normalize_unsupported_reasoning_effort_preserves_max():
+    # ``max`` and ``xhigh`` are sent verbatim by the reference client; no
+    # ``max`` -> ``xhigh`` aliasing exists upstream.
+    from app.core.openai.requests import ResponsesReasoning
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "hello",
+            "input": [],
+        }
+    )
+    payload.reasoning = ResponsesReasoning(effort="max")
+    registry = _build_registry_with_model("gpt-5.6-sol", ["low", "medium", "high", "xhigh", "max", "ultra"])
+
+    proxy_request_policy.normalize_unsupported_reasoning_effort(payload, registry=registry)
+
+    assert payload.reasoning.effort == "max"
+
+
+def test_apply_api_key_enforcement_aliases_enforced_ultra_to_max():
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "hello",
+            "input": [],
+        }
+    )
+    api_key = proxy_service.ApiKeyData(
+        id="key_ultra",
+        name="ultra-key",
+        key_prefix="sk-clb-test",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort="ultra",
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    proxy_request_policy.apply_api_key_enforcement(payload, api_key)
+
+    assert payload.reasoning is not None
+    assert payload.reasoning.effort == "max"
+
+
+def test_apply_api_key_enforcement_to_chat_payload_aliases_ultra_to_max():
+    payload: dict[str, JsonValue] = {
+        "model": "source-reasoning-model",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    api_key = proxy_service.ApiKeyData(
+        id="key_ultra_chat",
+        name="ultra-chat-key",
+        key_prefix="sk-clb-test",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort="ultra",
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    proxy_request_policy.apply_api_key_enforcement_to_chat_payload(payload, api_key)
+
+    assert payload["reasoning_effort"] == "max"
+    assert payload["reasoning"] == {"effort": "max"}
+
+
 def test_normalize_responses_request_payload_preserves_backend_codex_image_generation_with_function_tools():
     function_tool = {
         "type": "function",

--- a/tests/unit/test_request_policy.py
+++ b/tests/unit/test_request_policy.py
@@ -24,6 +24,12 @@ from app.modules.proxy.request_policy import apply_api_key_enforcement, validate
         ("gpt-5.1-codex-mini-extra-fast", "gpt-5.1-codex-mini", "high", "priority"),
         ("gpt-5.5-extra", "gpt-5.5", "high", None),
         ("gpt-5.5-extra-high-fast", "gpt-5.5", "high", "priority"),
+        ("gpt-5.6-sol-extra-high-fast", "gpt-5.6-sol", "high", "priority"),
+        ("gpt-5.6-sol-xhigh", "gpt-5.6-sol", "high", None),
+        ("gpt-5.6-terra-extra-high-fast", "gpt-5.6-terra", "high", "priority"),
+        ("gpt-5.6-terra-medium", "gpt-5.6-terra", "medium", None),
+        ("gpt-5.6-luna-extra-high-fast", "gpt-5.6-luna", "high", "priority"),
+        ("gpt-5.6-luna-low-fast", "gpt-5.6-luna", "low", "priority"),
     ],
 )
 def test_gpt5_cursor_aliases_target_canonical_models(
@@ -82,10 +88,36 @@ def test_unknown_gpt5_suffix_is_not_rewritten() -> None:
     assert request.service_tier is None
 
 
+def test_gpt56_ultra_suffix_is_not_rewritten() -> None:
+    # The Cursor-style suffix grammar has no ``ultra``/``max`` reasoning
+    # tokens (they are not effort levels every GPT-5-family base supports;
+    # e.g. gpt-5.6-luna has no ``ultra``), so an ``ultra``-suffixed label is
+    # an unknown alias and must pass through unchanged.
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol-ultra",
+            "instructions": "",
+            "input": [],
+        }
+    )
+
+    apply_api_key_enforcement(request, None)
+
+    assert request.model == "gpt-5.6-sol-ultra"
+    assert request.reasoning is None
+    assert request.service_tier is None
+
+
 def test_model_access_accepts_allowed_canonical_model_alias() -> None:
     api_key = cast(ApiKeyData, SimpleNamespace(allowed_models=frozenset({"gpt-5.5"})))
 
     validate_model_access(api_key, "gpt-5.5-extra-high-fast")
+
+
+def test_model_access_accepts_allowed_canonical_gpt56_model_alias() -> None:
+    api_key = cast(ApiKeyData, SimpleNamespace(allowed_models=frozenset({"gpt-5.6-sol"})))
+
+    validate_model_access(api_key, "gpt-5.6-sol-extra-high-fast")
 
 
 def test_model_access_accepts_allowed_qualified_canonical_model_alias() -> None:


### PR DESCRIPTION
## Summary

Definitive GPT-5.6 model catalog PR. Supersedes #1162 (fork branch is not maintainer-editable); @knightcn1983's model-support commit is cherry-picked with authorship preserved, followed by fix commits that make the bootstrap metadata match the **latest official codex open-source GPT-5.6 metadata exactly** — `codex-rs/models-manager/models.json` at release `rust-v0.144.1` (commit `44918ea10c`, byte-identical on upstream `main` at `1f0566d3f5`).

Refs #1162, refs #1157.

### Carried over from #1162 (authorship preserved)

- `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` bootstrap entries: verbatim display names, descriptions, 372k context window, effort lists (Sol/Terra: low→ultra, Luna: low→max) with verbatim upstream effort descriptions, defaults (Sol `low`, Terra/Luna `medium`), priorities 1/2/3, Fast tier metadata, `use_responses_lite`, websocket preference + `gpt-5.6-*` glob.
- `max`/`ultra` acceptance across API-key enforcement, automations, dashboard `/api/models`, and the frontend zod/TS schemas, dialogs, mocks, and tests.
- OpenSpec change folder `add-gpt56-bootstrap-models`.

The second commit of #1162 (request-log model filter sourced from the registry) is intentionally **dropped** as a separate concern — noted as a possible follow-up PR.

### Corrected vs upstream (`codex-rs/models-manager/models.json`, `rust-v0.144.1`)

1. **`tool_mode: "code_mode_only"` added** (all three). Without it a Codex client consuming the bootstrap catalog falls back to feature-flag defaults → `Direct` tool assembly (`codex-rs/core/src/tools/mod.rs`).
2. **`multi_agent_version` added** (`v2` Sol/Terra, `v1` Luna). Required for `ultra`'s proactive multi-agent mode (`codex-rs/core/src/session/multi_agents.rs`).
3. **`experimental_supported_tools: []` added** — a required (no serde default) field of the Rust `ModelInfo` deserializer (`codex-rs/protocol/src/openai_models.rs`); omitting it makes a real Codex client reject the entry and silently fall back to its bundled catalog.
4. **`ultra` is now wire-safe**: the reference client rewrites `ultra` → `max` before sending (`reasoning_effort_for_request`, `codex-rs/core/src/client.rs`). The proxy now mirrors that aliasing for client-requested and API-key-enforced efforts (Responses and source-routed chat paths); previously an enforced `ultra` injected the literal `"ultra"` upstream. `max`/`xhigh` are forwarded verbatim (no `max` → `xhigh` aliasing exists upstream).
5. **`minimal_client_version: "0.144.0"`** (was `null`; upstream ships `"0.144.0"` for all three).
6. **21-plan `available_in_plans`** (adds `edu_plus`, `edu_pro`, `enterprise_cbp_automation`, `sci`).
7. **`default_reasoning_summary: "none"` + `reasoning_summary_format: "experimental"` added** (Rust default for a missing summary is `Auto`, diverging from upstream behavior).
8. **Remaining raw fields matched**: `apply_patch_tool_type: "freeform"`, `web_search_tool_type: "text_and_image"`, `supports_image_detail_original: true`, `comp_hash: "3000"`, `include_skills_usage_instructions: false`, Sol's `availability_nux` message (Terra/Luna `null`), upstream null fields (`upgrade`, `auto_compact_token_limit`, `auto_review_model_override`, `default_service_tier`). Dropped the explicit `effective_context_window_percent: 95` (upstream omits it; Rust default is 95).
9. **Fallback `model_registry_client_version` raised 0.101.0 → 0.144.0** so a degraded-startup refresh (release lookup failed, cache cold) still queries upstream with a version ≥ GPT-5.6's `minimal_client_version` and actually receives the models.
10. **`thinking` string alias accepts `max`/`ultra`** so every catalog-advertised effort round-trips through the OpenAI-compatible sanitation path.

Deliberate divergence (documented in the OpenSpec delta): the ~16.5 KB `base_instructions` and personality-templated `model_messages` are not bundled; the first live registry refresh supplies them. `gpt-5.3-codex`/`gpt-5.3-codex-spark` were dropped from upstream's bundled catalog at 0.144.x but stay bootstrapped for older pinned clients (upstream backend still serves them); the spec and registry comments now say so instead of claiming every slug exists in the upstream bundle.

### Responses Lite end-to-end (builds on #1161)

With #1161 in `main`, `use_responses_lite: true` is safe to advertise. The route regression from #1161 (`test_backend_responses_preserves_responses_lite_tools_and_outputs`) now drives the real bootstrap slug `gpt-5.6-sol` through `POST /backend-api/codex/responses` with `reasoning.effort: "ultra"` and asserts the forwarded payload keeps the `additional_tools` prefix intact, still triggers the internal `x-openai-internal-codex-responses-lite` header signaling, and carries `reasoning.effort: "max"` on the wire.

### OpenSpec

`openspec/changes/add-gpt56-bootstrap-models/`: proposal/tasks updated to the final behavior; `model-catalog-compat` delta gains the upstream-exact GPT-5.6 metadata requirement + fallback-client-version requirement; new `responses-api-compat` delta covers the `ultra` → `max` wire aliasing. All tasks checked. `openspec validate add-gpt56-bootstrap-models --strict` and `openspec validate --specs` pass.

## Test plan

- `uv run ruff check .` / `uv run ruff format --check .` / `uv run ty check` — clean.
- `uv run pytest tests/unit` — 3211 passed, 3 skipped.
- `uv run pytest tests/integration/test_proxy_responses.py tests/integration/test_v1_models.py tests/integration/test_api_keys_api.py tests/integration/test_automations_api.py` — 238 passed.
- Frontend: `bun run typecheck` clean, `bun run test` — 122 files / 827 tests passed.
- `python3 .github/scripts/check_all_contributors.py` — passes with the new `knightcn1983` entry.
- `openspec validate add-gpt56-bootstrap-models --strict` — valid.

## Follow-up candidates

- Request-log model filter fed from the registry (dropped second commit of #1162).
- Removing the stale `gpt-5.3-codex(-spark)` bootstrap slugs once older pinned clients are out of support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
