### PR TITLE
fix(proxy): only hoist message items into instructions

### DIFF
--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -305,6 +305,15 @@ def _normalize_responses_input_instructions(data: JsonValue) -> JsonValue:
         if role not in ("system", "developer"):
             input_items.append(item)
             continue
+        # Only lift actual instruction messages. A typed non-message item that
+        # carries a system/developer role (like the Lite ``additional_tools``
+        # bundle, or any future upstream item type without ``content``) must
+        # keep its position and wire shape — folding it into ``instructions``
+        # silently drops it, the hazard class behind #1157.
+        item_type = item_mapping.get("type")
+        if item_type is not None and item_type != "message":
+            input_items.append(item)
+            continue
         instruction_text, preserved_content = _split_responses_instruction_item_content(item_mapping)
         if instruction_text:
             instruction_parts.append(instruction_text)

--- a/openspec/changes/generalize-input-normalization-guard/.openspec.yaml
+++ b/openspec/changes/generalize-input-normalization-guard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/generalize-input-normalization-guard/proposal.md
+++ b/openspec/changes/generalize-input-normalization-guard/proposal.md
@@ -1,0 +1,22 @@
+# Generalize Input Normalization Guard
+
+## Summary
+
+Only lift input items that are actual instruction messages into `instructions`; pass every other typed `system`/`developer` input item through untouched, regardless of request shape.
+
+## Motivation
+
+#1161 fixed #1157 by returning early from `_normalize_responses_input_instructions` when the input carries a Responses-Lite `additional_tools` bundle. The underlying hazard is broader (#1171): the hoisting loop folds **any** `system`/`developer`-role input item into `instructions`, so a future non-message item type with a developer role and no `content` — in a request without the Lite prefix — would still be silently dropped, reproducing the same class of bug.
+
+## Scope
+
+- Guard the hoisting loop: only items whose `type` is absent or `"message"` are lifted; any other typed item keeps its position and wire shape.
+- Keep the merged #1161 behavior (Lite early return, `to_payload()` round-trip) intact.
+- Regression coverage with a synthetic non-message developer item type for `ResponsesRequest` and `ResponsesCompactRequest`.
+
+Approach from #1159 / #1158, as requested in #1171.
+
+## Out of Scope
+
+- Modeling specific non-message item shapes; they are forwarded opaquely to stay codex-faithful.
+- Changing how message-shaped instruction items are hoisted or merged.

--- a/openspec/changes/generalize-input-normalization-guard/specs/responses-api-compat/spec.md
+++ b/openspec/changes/generalize-input-normalization-guard/specs/responses-api-compat/spec.md
@@ -1,0 +1,26 @@
+# responses-api-compat — Delta
+
+## ADDED Requirements
+
+### Requirement: Only message items are hoisted into instructions
+
+When normalizing Responses or compact request `input`, the service MUST only
+hoist items that are instruction messages — items whose `type` is omitted or
+`"message"` — into the `instructions` field. Any other typed
+`system`/`developer`-role input item MUST be forwarded upstream in its original
+position and shape, whether or not the request carries a Responses-Lite
+`additional_tools` prefix.
+
+#### Scenario: typed non-message developer item survives normalization
+
+- **WHEN** a client sends a Responses request whose `input` contains a typed
+  non-message item with a `developer` role (for example a future upstream item
+  type without `content`) alongside developer instruction messages
+- **THEN** the instruction messages are hoisted into `instructions`
+- **AND** the typed non-message item remains in `input` unchanged
+
+#### Scenario: typeless system messages keep hoisting behavior
+
+- **WHEN** an OpenAI-compatible client sends `input` containing
+  `{"role": "system", "content": "sys"}` without a `type` field
+- **THEN** that item is hoisted into `instructions` as before

--- a/openspec/changes/generalize-input-normalization-guard/tasks.md
+++ b/openspec/changes/generalize-input-normalization-guard/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] 1. Add OpenSpec requirement that only message-shaped instruction items are hoisted during input normalization.
+- [x] 2. Guard the hoisting loop in `_normalize_responses_input_instructions` by item type, keeping the #1161 Lite early return intact.
+- [x] 3. Add regression coverage with a synthetic non-message developer item for `ResponsesRequest` and `ResponsesCompactRequest`.
+- [x] 4. Validate focused tests and OpenSpec artifacts.

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -631,6 +631,34 @@ def test_responses_input_additional_tools_item_is_preserved(request_type):
     assert request.to_payload()["input"] == request.input
 
 
+@pytest.mark.parametrize("request_type", [ResponsesRequest, ResponsesCompactRequest])
+def test_responses_input_non_message_developer_item_is_preserved(request_type):
+    # Synthetic future item type: developer role, no content — must survive
+    # normalization untouched even without the Lite additional_tools prefix.
+    developer_state = {
+        "type": "developer_state",
+        "role": "developer",
+        "state": {"budget_remaining": 3},
+    }
+    payload = {
+        "model": "gpt-5.1",
+        "input": [
+            developer_state,
+            {"type": "message", "role": "system", "content": "sys"},
+            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        ],
+    }
+
+    request = request_type.model_validate(payload)
+
+    assert request.instructions == "sys"
+    assert request.input == [
+        developer_state,
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+    ]
+    assert request.to_payload()["input"] == request.input
+
+
 def test_responses_input_system_message_keeps_user_text_parts():
     payload = {
         "model": "gpt-5.1",


### PR DESCRIPTION
## Summary

Implements #1171: only hoist message-shaped items into `instructions`; every other typed `system`/`developer` input item passes through untouched, regardless of request shape.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: Closes #1171

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/generalize-input-normalization-guard/`

## Changes

- `_normalize_responses_input_instructions()`: the hoisting loop now skips items whose `type` is present and not `"message"`, so a future non-message developer item (no `content`, outside the Lite `additional_tools` early return) keeps its position and wire shape instead of being silently dropped — the hazard class behind #1157.
- The merged #1161 behavior is untouched: the Lite early return and `to_payload()` round-trip semantics stay exactly as merged, and typeless role items (`{"role": "system", "content": ...}`) keep the existing hoisting behavior for OpenAI-compatible clients.
- Regression test with a synthetic `developer_state` item type, parametrized over `ResponsesRequest` and `ResponsesCompactRequest`.
- OpenSpec change recording the message-only hoisting requirement.

Guard carried over from #1159 / #1158, per the maintainer's scope in #1171.

## Test plan

```
uv run pytest tests/unit/test_openai_requests.py -q
108 passed

uv run pytest tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py -q
790 passed
```
