### PR TITLE
fix(proxy): preserve model_messages in catalog response

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -947,6 +947,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "zepx",
+      "name": "Choong Jun Jin",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1377772?v=4",
+      "profile": "https://github.com/zepx",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/app/core/clients/model_fetcher.py
+++ b/app/core/clients/model_fetcher.py
@@ -22,7 +22,6 @@ from app.core.upstream_proxy import ResolvedUpstreamRoute
 logger = logging.getLogger(__name__)
 
 _FETCH_TIMEOUT_SECONDS = 15.0
-_FILTERED_FIELDS = {"model_messages"}
 
 
 class ModelFetchError(Exception):
@@ -68,7 +67,8 @@ def _parse_reasoning_level(value: JsonValue) -> ReasoningLevel | None:
 
 
 def _parse_upstream_model(data: dict[str, JsonValue]) -> UpstreamModel:
-    raw = {k: v for k, v in data.items() if k not in _FILTERED_FIELDS}
+    # preserve all upstream catalog fields verbatim
+    raw = dict(data)
 
     reasoning_levels = tuple(
         parsed_level

--- a/openspec/changes/preserve-model-messages-in-catalog/proposal.md
+++ b/openspec/changes/preserve-model-messages-in-catalog/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The Codex client model picker requires the `model_messages` field on each
+model catalog entry to display newer models (gpt-5.6-sol/terra/luna). Without
+it, the client silently drops models absent from its bundled metadata, so
+gpt-5.6 models never appear in the picker even though codex-lb is serving
+them.
+
+`model_fetcher.py` explicitly stripped `model_messages` from upstream entries
+via `_FILTERED_FIELDS = {"model_messages"}`. PR #331 already removed
+`base_instructions` from the same filter for an identical reason but left
+`model_messages` behind. The `add-gpt56-bootstrap-models` change (PR #1176)
+states that `model_messages` is "left to the live registry refresh" — this
+change makes that contract true by removing the filter that prevented it.
+
+## What Changes
+
+- Stop filtering `model_messages` from upstream model catalog entries during
+  fetch parsing. All upstream fields are now preserved verbatim in
+  `UpstreamModel.raw`.
+- Remove the now-dead `_FILTERED_FIELDS` abstraction; replace the filter
+  comprehension with a direct shallow copy (`raw = dict(data)`).
+
+## Impact
+
+- `GET /backend-api/codex/models` and `GET /v1/models?client_version=<v>` now
+  include `model_messages` on each model entry, matching the upstream ChatGPT
+  backend response field-for-field.
+- Catalog responses are larger (the `model_messages` object contains
+  instruction templates, ~16 KB per model). This is inherent to the
+  compatibility fix — the client needs the field.
+- No database migration; the registry is in-memory only.
+- No new security exposure: `model_messages` is upstream catalog content the
+  Codex client already receives when talking directly to ChatGPT's backend.

--- a/openspec/changes/preserve-model-messages-in-catalog/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/preserve-model-messages-in-catalog/specs/model-catalog-compat/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Upstream model_messages is preserved in the catalog
+
+When parsing upstream model-registry data, the system MUST preserve the
+`model_messages` field on each model entry through to the Codex-native catalog
+response. The field MUST NOT be stripped during fetch parsing, registry
+storage, or catalog serialization. `GET /backend-api/codex/models` and
+`GET /v1/models?client_version=<v>` MUST return each model's `model_messages`
+object unchanged from the upstream response once a refreshed registry snapshot
+exists.
+
+#### Scenario: model_messages survives the fetch → registry → catalog path
+
+- **GIVEN** the upstream model catalog contains a model with a `model_messages` object
+- **WHEN** the model registry refresh parses the upstream response
+- **THEN** the resulting `UpstreamModel.raw` includes `model_messages` unchanged
+
+#### Scenario: Codex-native catalog endpoint returns model_messages
+
+- **GIVEN** the model registry has a refreshed snapshot containing a model with `model_messages`
+- **WHEN** a client calls `GET /backend-api/codex/models`
+- **THEN** the model entry in the response includes `model_messages` with the same value as the upstream response
+
+#### Scenario: OpenAI-compatible catalog endpoint returns model_messages for Codex clients
+
+- **GIVEN** the model registry has a refreshed snapshot containing a model with `model_messages`
+- **WHEN** a client calls `GET /v1/models?client_version=<v>`
+- **THEN** the model entry in the response includes `model_messages` with the same value as the upstream response

--- a/openspec/changes/preserve-model-messages-in-catalog/tasks.md
+++ b/openspec/changes/preserve-model-messages-in-catalog/tasks.md
@@ -1,0 +1,15 @@
+## Tasks
+
+- [ ] Remove `_FILTERED_FIELDS` from `app/core/clients/model_fetcher.py`;
+      replace the filter comprehension with `raw = dict(data)`.
+- [ ] Add `model_messages` to the `_CodexResponse` mock in
+      `tests/unit/test_model_fetcher.py` and assert it survives in
+      `UpstreamModel.raw`.
+- [ ] Extend `test_backend_codex_models_entry_has_upstream_fields` in
+      `tests/integration/test_v1_models.py` to include `model_messages` in the
+      `raw` fixture and assert it appears in the `/backend-api/codex/models`
+      response.
+- [ ] Run `openspec validate preserve-model-messages-in-catalog --strict`.
+- [ ] Run `uv run ruff check app/core/clients/model_fetcher.py`.
+- [ ] Run focused tests: `tests/unit/test_model_fetcher.py` and
+      `tests/integration/test_v1_models.py`.

--- a/openspec/changes/preserve-model-messages-in-catalog/tasks.md
+++ b/openspec/changes/preserve-model-messages-in-catalog/tasks.md
@@ -1,15 +1,15 @@
 ## Tasks
 
-- [ ] Remove `_FILTERED_FIELDS` from `app/core/clients/model_fetcher.py`;
+- [x] Remove `_FILTERED_FIELDS` from `app/core/clients/model_fetcher.py`;
       replace the filter comprehension with `raw = dict(data)`.
-- [ ] Add `model_messages` to the `_CodexResponse` mock in
+- [x] Add `model_messages` to the `_CodexResponse` mock in
       `tests/unit/test_model_fetcher.py` and assert it survives in
       `UpstreamModel.raw`.
-- [ ] Extend `test_backend_codex_models_entry_has_upstream_fields` in
+- [x] Extend `test_backend_codex_models_entry_has_upstream_fields` in
       `tests/integration/test_v1_models.py` to include `model_messages` in the
       `raw` fixture and assert it appears in the `/backend-api/codex/models`
       response.
-- [ ] Run `openspec validate preserve-model-messages-in-catalog --strict`.
-- [ ] Run `uv run ruff check app/core/clients/model_fetcher.py`.
-- [ ] Run focused tests: `tests/unit/test_model_fetcher.py` and
+- [x] Run `openspec validate preserve-model-messages-in-catalog --strict`.
+- [x] Run `uv run ruff check app/core/clients/model_fetcher.py`.
+- [x] Run focused tests: `tests/unit/test_model_fetcher.py` and
       `tests/integration/test_v1_models.py`.

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -185,6 +185,35 @@ async def test_v1_models_with_client_version_returns_codex_catalog(async_client)
 
 
 @pytest.mark.asyncio
+async def test_v1_models_with_client_version_includes_model_messages(async_client):
+    """The Codex model picker needs `model_messages` from the live catalog to
+    display models absent from its bundled metadata; the catalog served on the
+    `client_version` path must preserve the field verbatim."""
+    registry = get_model_registry()
+    model_messages: dict[str, JsonValue] = {
+        "instructions_template": "You are a coding assistant.",
+        "instructions_variables": {"personality_default": ""},
+        "approvals": None,
+    }
+    models = [
+        _make_upstream_model(
+            "gpt-5.3-codex",
+            raw={
+                "shell_type": "shell_command",
+                "visibility": "list",
+                "model_messages": model_messages,
+            },
+        ),
+    ]
+    await registry.update({"plus": models, "pro": models})
+
+    resp = await async_client.get("/v1/models", params={"client_version": "0.144.1"})
+    assert resp.status_code == 200
+    entries = {entry["slug"]: entry for entry in resp.json()["models"]}
+    assert entries["gpt-5.3-codex"]["model_messages"] == model_messages
+
+
+@pytest.mark.asyncio
 async def test_v1_models_with_empty_client_version_keeps_openai_shape(async_client):
     await _populate_test_registry()
     resp = await async_client.get("/v1/models?client_version=")

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -722,6 +722,11 @@ async def test_backend_codex_models_entry_has_upstream_fields(async_client):
                 "visibility": "list",
                 "availability_nux": None,
                 "upgrade": {"model": "gpt-5.4", "migration_markdown": "Upgrade!"},
+                "model_messages": {
+                    "instructions_template": "You are a coding assistant.",
+                    "instructions_variables": {"personality_default": ""},
+                    "approvals": None,
+                },
             },
             base_instructions="You are a helpful coding assistant.",
         ),
@@ -742,6 +747,11 @@ async def test_backend_codex_models_entry_has_upstream_fields(async_client):
     assert entry["visibility"] == "list"
     assert entry["availability_nux"] is None
     assert entry["upgrade"] == {"model": "gpt-5.4", "migration_markdown": "Upgrade!"}
+    assert entry["model_messages"] == {
+        "instructions_template": "You are a coding assistant.",
+        "instructions_variables": {"personality_default": ""},
+        "approvals": None,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_model_fetcher.py
+++ b/tests/unit/test_model_fetcher.py
@@ -49,6 +49,11 @@ class _CodexResponse:
                     "base_instructions": "",
                     "context_window": 128000,
                     "priority": 1,
+                    "model_messages": {
+                        "instructions_template": "You are a coding assistant.",
+                        "instructions_variables": {"personality_default": ""},
+                        "approvals": None,
+                    },
                 }
             ]
         }
@@ -109,3 +114,8 @@ async def test_fetch_models_for_plan_uses_resolved_codex_route(monkeypatch: pyte
     assert client.calls[0]["route"] is route
     assert client.calls[0]["method"] == "GET"
     assert str(client.calls[0]["url"]).endswith("/codex/models?client_version=0.128.0")
+    assert models[0].raw["model_messages"] == {
+        "instructions_template": "You are a coding assistant.",
+        "instructions_variables": {"personality_default": ""},
+        "approvals": None,
+    }


### PR DESCRIPTION
## Summary

codex-lb stripped the `model_messages` field from upstream model catalog entries via `_FILTERED_FIELDS = {"model_messages"}` in `app/core/clients/model_fetcher.py`. The Codex client's model picker requires this field to display newer models (gpt-5.6-sol/terra/luna); without it the client silently drops models absent from its bundled metadata, so gpt-5.6 models never appear in the picker even though codex-lb is serving them.

PR #331 already removed `base_instructions` from the same filter for an identical reason but left `model_messages` behind by oversight. The `add-gpt56-bootstrap-models` change (#1176) states that `model_messages` is "left to the live registry refresh" — this PR makes that contract true by removing the filter that prevented it.

## What changes

- Remove the dead `_FILTERED_FIELDS` abstraction from `app/core/clients/model_fetcher.py`; replace the filter comprehension with `raw = dict(data)` to preserve all upstream fields verbatim.
- Add regression tests:
  - `tests/unit/test_model_fetcher.py`: asserts `model_messages` survives in `UpstreamModel.raw` after fetch parsing.
  - `tests/integration/test_v1_models.py`: asserts `model_messages` appears in the `/backend-api/codex/models` response after registry → HTTP serialization.
- Add OpenSpec change folder `preserve-model-messages-in-catalog` with proposal, tasks, and `model-catalog-compat` spec delta.

## Validation

- `uv run ruff check` — ✅ all checks passed
- `uv run ruff format --check` — ✅ already formatted
- `uv run pytest tests/unit/test_model_fetcher.py tests/integration/test_v1_models.py` — ✅ 36 passed
- `openspec validate preserve-model-messages-in-catalog --strict` — ✅ Change is valid
- Regression test confirmed: fails on `origin/main` (`KeyError: 'model_messages'`), passes with fix.

## Impact

- `GET /backend-api/codex/models` and `GET /v1/models?client_version=<v>` now include `model_messages` on each model entry, matching the upstream ChatGPT backend response field-for-field.
- Catalog responses are larger (~16 KB per model for the instruction template). This is inherent to the compatibility fix — the client needs the field.
- No database migration; the registry is in-memory only.
- No new security exposure: `model_messages` is upstream catalog content the Codex client already receives when talking directly to ChatGPT's backend.