### PR TITLE
ci: shard integration-core tests, PR-mode vitest without coverage

### DIFF
--- a/.github/scripts/pytest_shards.py
+++ b/.github/scripts/pytest_shards.py
@@ -1,0 +1,115 @@
+"""Deterministic pytest shard selection for the integration-core CI slice.
+
+The integration-core slice is ``tests/integration`` minus the files owned by
+the integration-bridge slice. To keep CI wallclock down the slice is split
+into ``--shard-count`` shards: every file's weight is its number of test
+functions (a cheap static proxy for runtime) and files are greedily assigned
+to the lightest shard. Assignment is a pure function of the file tree, so
+every test file maps to exactly one shard by construction and files added
+later are picked up automatically.
+
+Usage:
+    python .github/scripts/pytest_shards.py --shard-count 3 --shard 1
+        Print the file arguments for shard 1 (one per line).
+    python .github/scripts/pytest_shards.py --shard-count 3 --verify
+        Assert the shards form a complete, non-overlapping partition of the
+        integration-core selection and that the bridge exclusions still exist.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+INTEGRATION_ROOT = Path("tests/integration")
+
+# Files owned by the integration-bridge slice (see `make test-integration-bridge`).
+# They are excluded here and must keep existing so neither slice silently loses them.
+BRIDGE_FILES = (
+    INTEGRATION_ROOT / "test_http_responses_bridge.py",
+    INTEGRATION_ROOT / "test_proxy_websocket_responses.py",
+)
+
+# Default pytest collection globs (`python_files`); pyproject.toml does not override them.
+TEST_FILE_GLOBS = ("test_*.py", "*_test.py")
+
+TEST_FUNCTION_RE = re.compile(r"^\s*(?:async\s+)?def\s+test_", re.MULTILINE)
+
+
+def integration_core_files() -> list[Path]:
+    root = REPO_ROOT / INTEGRATION_ROOT
+    files: set[Path] = set()
+    for pattern in TEST_FILE_GLOBS:
+        files.update(path.relative_to(REPO_ROOT) for path in root.rglob(pattern))
+    return sorted(files - set(BRIDGE_FILES))
+
+
+def file_weight(path: Path) -> int:
+    text = (REPO_ROOT / path).read_text(encoding="utf-8")
+    # Weight 1 minimum so empty/new files still get a deterministic shard.
+    return max(1, len(TEST_FUNCTION_RE.findall(text)))
+
+
+def shard_files(files: list[Path], shard: int, shard_count: int) -> list[Path]:
+    # Greedy bin packing: heaviest file first onto the lightest shard.
+    # Deterministic tie-breaks (file name, shard index) keep assignment stable.
+    loads = [0] * shard_count
+    shards: list[list[Path]] = [[] for _ in range(shard_count)]
+    for path in sorted(files, key=lambda p: (-file_weight(p), p)):
+        target = min(range(shard_count), key=lambda i: (loads[i], i))
+        loads[target] += file_weight(path)
+        shards[target].append(path)
+    return sorted(shards[shard - 1])
+
+
+def verify(files: list[Path], shard_count: int) -> None:
+    for bridge_file in BRIDGE_FILES:
+        if not (REPO_ROOT / bridge_file).is_file():
+            raise SystemExit(
+                f"bridge exclusion {bridge_file} does not exist; "
+                "update BRIDGE_FILES and the Makefile integration slices together"
+            )
+    if not files:
+        raise SystemExit("integration-core selection is empty")
+
+    seen: dict[Path, int] = {}
+    for shard in range(1, shard_count + 1):
+        selected = shard_files(files, shard, shard_count)
+        if not selected:
+            raise SystemExit(f"shard {shard}/{shard_count} selects no files")
+        for path in selected:
+            if path in seen:
+                raise SystemExit(f"{path} assigned to both shard {seen[path]} and shard {shard}")
+            seen[path] = shard
+
+    missing = sorted(set(files) - set(seen))
+    if missing:
+        raise SystemExit("files not assigned to any shard: " + ", ".join(map(str, missing)))
+    print(f"OK: {len(files)} integration-core test files partitioned across {shard_count} shards")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--shard-count", type=int, required=True, help="total number of shards")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--shard", type=int, help="1-based shard index to print files for")
+    group.add_argument("--verify", action="store_true", help="assert shards partition the full selection")
+    args = parser.parse_args()
+
+    if args.shard_count < 1:
+        parser.error("--shard-count must be >= 1")
+    if args.shard is not None and not 1 <= args.shard <= args.shard_count:
+        parser.error("--shard must be between 1 and --shard-count")
+
+    files = integration_core_files()
+    if args.verify:
+        verify(files, args.shard_count)
+        return
+    sys.stdout.write("\n".join(str(path) for path in shard_files(files, args.shard, args.shard_count)) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,16 @@ name: CI
 on:
   push:
     branches: ["main"]
-  # No `edited` type: PR title/body edits (often made by tooling right after a
-  # push) raced the `synchronize` run for the same head SHA, so every push
-  # produced a duplicate run that concurrency immediately cancelled.
+  # `edited` must stay: release-guard evidence (validation checklist + exact
+  # head SHA) is added by editing the release PR body, and CI Required only
+  # reruns for that PR via an `edited` event (scripts/guard_beta_release.py).
+  # Known cost: a body edit right after a push starts a duplicate run for the
+  # same head SHA and concurrency cancels the older one. Do NOT "fix" this by
+  # skipping edited runs for non-release PRs: skipped or all-skipped
+  # "CI Required" check runs still satisfy branch protection, so a body-only
+  # edit could mint a passing check for a red or untested head.
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, edited, ready_for_review]
   merge_group:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,11 @@ name: CI
 on:
   push:
     branches: ["main"]
+  # No `edited` type: PR title/body edits (often made by tooling right after a
+  # push) raced the `synchronize` run for the same head SHA, so every push
+  # produced a duplicate run that concurrency immediately cancelled.
   pull_request:
-    types: [opened, reopened, synchronize, edited, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
   merge_group:
 
 concurrency:
@@ -217,7 +220,7 @@ jobs:
         run: make frontend-typecheck
 
   frontend-test:
-    name: Frontend tests (vitest + coverage)
+    name: Frontend tests (vitest)
     runs-on: ubuntu-24.04
     needs: changes
     if: needs.changes.outputs.frontend == 'true'
@@ -243,7 +246,14 @@ jobs:
           restore-keys: |
             bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-
 
+      # PRs run vitest without coverage instrumentation for a faster signal;
+      # main pushes and the merge queue keep the full coverage run.
+      - name: Run frontend tests
+        if: github.event_name == 'pull_request'
+        run: make frontend-test-fast
+
       - name: Run frontend tests with coverage
+        if: github.event_name != 'pull_request'
         run: make frontend-test
 
   frontend-build:
@@ -328,7 +338,12 @@ jobs:
       matrix:
         slice:
           - name: unit
-          - name: integration-core
+          # integration-core is split into deterministic shards; the make
+          # target verifies the shards partition the full selection before
+          # running pytest (see .github/scripts/pytest_shards.py).
+          - name: integration-core-1
+          - name: integration-core-2
+          - name: integration-core-3
           - name: integration-bridge
           - name: e2e
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,11 @@ jobs:
         run: make frontend-typecheck
 
   frontend-test:
-    name: Frontend tests (vitest)
+    # Keep this exact job name: the repository ruleset and
+    # .github/scripts/sync_codex_ok_labels.py treat "Frontend tests
+    # (vitest + coverage)" as a required check context. PR runs skip the
+    # coverage instrumentation below, but the check name must not change.
+    name: Frontend tests (vitest + coverage)
     runs-on: ubuntu-24.04
     needs: changes
     if: needs.changes.outputs.frontend == 'true'
@@ -343,12 +347,6 @@ jobs:
       matrix:
         slice:
           - name: unit
-          # integration-core is split into deterministic shards; the make
-          # target verifies the shards partition the full selection before
-          # running pytest (see .github/scripts/pytest_shards.py).
-          - name: integration-core-1
-          - name: integration-core-2
-          - name: integration-core-3
           - name: integration-bridge
           - name: e2e
     env:
@@ -392,6 +390,96 @@ jobs:
       - name: Run tests
         if: needs.changes.outputs.backend == 'true'
         run: make test-${{ matrix.slice.name }}
+
+  # integration-core is split into deterministic shards to shorten the CI
+  # critical path; each shard's make target verifies the shards partition the
+  # full selection before running pytest (see .github/scripts/pytest_shards.py).
+  test-integration-core:
+    name: Tests (pytest, integration-core-${{ matrix.shard }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    needs: changes
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    env:
+      PYTHONFAULTHANDLER: "1"
+
+    steps:
+      - name: Skip backend tests for unrelated changes
+        if: needs.changes.outputs.backend != 'true'
+        run: echo "Backend files unchanged; required pytest context satisfied."
+
+      - name: Checkout repository
+        if: needs.changes.outputs.backend == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Set up Bun
+        if: needs.changes.outputs.backend == 'true'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3.14"
+
+      - name: Cache Bun dependencies
+        if: needs.changes.outputs.backend == 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: |
+            ~/.bun/install/cache
+            frontend/node_modules
+          key: bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: |
+            bun-1.3.14-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Set up uv
+        if: needs.changes.outputs.backend == 'true'
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Run tests
+        if: needs.changes.outputs.backend == 'true'
+        run: make test-integration-core-${{ matrix.shard }}
+
+  # Aggregate for the shards above. Keep this exact job name: the repository
+  # ruleset and .github/scripts/sync_codex_ok_labels.py treat
+  # "Tests (pytest, integration-core)" as a required check context. The shard
+  # jobs never skip at job level (they use the placeholder-step pattern), so
+  # anything other than an all-success matrix result must fail here —
+  # skipped or cancelled shards are not laundered into a passing check.
+  test-integration-core-required:
+    name: Tests (pytest, integration-core)
+    runs-on: ubuntu-24.04
+    if: always()
+    needs:
+      - test-integration-core
+
+    steps:
+      - name: Require every integration-core shard to pass
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          failed = {
+              name: details["result"]
+              for name, details in sorted(needs.items())
+              if details.get("result") != "success"
+          }
+          if failed:
+              for name, result in failed.items():
+                  print(f"{name}: {result}")
+              sys.exit(1)
+          print("all integration-core shards passed")
+          PY
 
   test-postgres:
     name: Tests (pytest, PostgreSQL)
@@ -718,6 +806,8 @@ jobs:
       - lint
       - typecheck
       - test
+      - test-integration-core
+      - test-integration-core-required
       - test-postgres
       - migration-check
       - migration-check-postgres

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PYTEST_ARGS := -q -ra -o faulthandler_timeout=300 -o faulthandler_exit_on_timeout=true --timeout=180 --timeout-method=thread --durations=20
 POSTGRES_TEST_DATABASE_URL ?= postgresql+asyncpg://codex_lb:codex_lb@127.0.0.1:5432/codex_lb
+INTEGRATION_CORE_SHARD_COUNT := 3
 POSTGRES_PYTEST_TARGETS := \
 	tests/integration/test_migrations.py::test_postgresql_migration_contract_policy_and_drift_match \
 	tests/integration/test_migrations.py::test_postgresql_upgrade_head_from_empty_database \
@@ -24,7 +25,7 @@ help:
 	  '  make ci-fast                 lint/type/frontend/unit/package' \
 	  '  make ci                      full local CI gate'
 
-.PHONY: frontend-install frontend-lint frontend-typecheck frontend-test frontend-build
+.PHONY: frontend-install frontend-lint frontend-typecheck frontend-test frontend-test-fast frontend-build
 frontend-install:
 	cd frontend && bun install --frozen-lockfile
 
@@ -36,6 +37,9 @@ frontend-typecheck: frontend-install
 
 frontend-test: frontend-install
 	cd frontend && bun run test:coverage
+
+frontend-test-fast: frontend-install
+	cd frontend && bun run test
 
 frontend-build: frontend-install
 	cd frontend && bun run build
@@ -52,7 +56,9 @@ typecheck:
 	uv sync --dev --frozen
 	uv run ty check
 
-.PHONY: test-unit test-integration-core test-integration-bridge test-e2e test-postgres
+.PHONY: test-unit test-integration-core test-integration-core-shard \
+	test-integration-core-1 test-integration-core-2 test-integration-core-3 \
+	test-integration-bridge test-e2e test-postgres
 test-unit: frontend-build
 	uv sync --dev --frozen
 	PYTHONFAULTHANDLER=1 uv run pytest $(PYTEST_ARGS) tests/unit tests/test_request_logs_options_api.py
@@ -62,6 +68,24 @@ test-integration-core: frontend-build
 	PYTHONFAULTHANDLER=1 uv run pytest $(PYTEST_ARGS) tests/integration \
 	  --ignore=tests/integration/test_http_responses_bridge.py \
 	  --ignore=tests/integration/test_proxy_websocket_responses.py
+
+# CI splits integration-core into deterministic shards (test-count-weighted
+# greedy assignment; see .github/scripts/pytest_shards.py). The --verify call
+# guards that the shards always partition the full selection exactly.
+test-integration-core-shard: frontend-build
+	uv sync --dev --frozen
+	python .github/scripts/pytest_shards.py --shard-count $(INTEGRATION_CORE_SHARD_COUNT) --verify
+	PYTHONFAULTHANDLER=1 uv run pytest $(PYTEST_ARGS) \
+	  $$(python .github/scripts/pytest_shards.py --shard-count $(INTEGRATION_CORE_SHARD_COUNT) --shard $(SHARD))
+
+test-integration-core-1:
+	$(MAKE) test-integration-core-shard SHARD=1
+
+test-integration-core-2:
+	$(MAKE) test-integration-core-shard SHARD=2
+
+test-integration-core-3:
+	$(MAKE) test-integration-core-shard SHARD=3
 
 test-integration-bridge: frontend-build
 	uv sync --dev --frozen


### PR DESCRIPTION
## Why

CI wallclock on a typical backend PR is ~9 min, dominated by one job.

Measured (avg over 5 recent successful runs):

| Job | Avg duration |
|---|---|
| Tests (pytest, integration-core) | **8.3 min** (critical path) |
| Frontend tests (vitest + coverage) | 5.9 min (when frontend changes) |
| Tests (pytest, unit) | 2.6 min |
| Tests (pytest, integration-bridge) | 2.0 min |
| Everything else | <= 1.2 min |

From the latest successful main run, integration-core = ~52 s setup + 7:36 of test time over 1071 fairly uniform tests, so file-level sharding splits cleanly.

## What changed

### 1. integration-core split into 3 deterministic shards

- New `.github/scripts/pytest_shards.py` selects the integration-core file set (`tests/integration` recursive `test_*.py` / `*_test.py`, minus the two integration-bridge files) and assigns files to shards by test-function-count-weighted greedy bin packing. Assignment is a pure function of the file tree: new test files always land in exactly one shard automatically.
- New make targets `test-integration-core-{1,2,3}` (thin wrappers over `test-integration-core-shard`). The shards live in a dedicated matrix job emitting `Tests (pytest, integration-core-1/2/3)`; the original `test` matrix keeps `unit` / `integration-bridge` / `e2e`.
- **Required-check contract preserved:** the repository ruleset and `.github/scripts/sync_codex_ok_labels.py` require the exact context `Tests (pytest, integration-core)`, so an aggregate job with exactly that name `needs:` the shard matrix and succeeds only when every shard result is `success` — a skipped or cancelled shard fails the aggregate (no laundering), and on non-backend PRs the shards report success via the existing placeholder-step pattern so the required context still completes. All 18 contexts in `CODEX_LB_REQUIRED_CHECKS` were verified emitted by the workflow (matrix names expanded programmatically).
- **Completeness guard:** every shard job runs `pytest_shards.py --verify` before pytest. It fails the job if the shards do not form an exact, non-overlapping partition of the full selection, if any shard is empty, or if either bridge-slice exclusion file stops existing (rename drift protection).
- `CI Required` now also needs `test-integration-core` and the aggregate, so every shard is covered by branch protection. `make test-integration-core` (unsharded) is kept for local `make ci`.

Local proof (collection):

```
$ pytest_shards.py --shard-count 3 --verify
OK: 64 integration-core test files partitioned across 3 shards
full slice --collect-only:  1071 tests collected
shard 1: 21 files, 360 tests
shard 2: 21 files, 352 tests
shard 3: 22 files, 359 tests
sum: 1071 = full slice
```

Live proof on this PR's own CI: shards completed green in 3:32 / 2:54 / 3:32 vs the previous 8:41 integration-core job.

### 2. Duplicate PR runs: investigated, then intentionally NOT changed

An earlier revision of this PR dropped `edited` from `pull_request.types` because tooling body-edits right after a push fire `edited` alongside `synchronize` for the same head SHA, producing a duplicate run that concurrency immediately cancels (e.g. runs 29083421839 cancelled / 29083428433 success on `e48e4595`).

Codex review correctly flagged this as a P1: `scripts/guard_beta_release.py` requires the validation checklist + exact head SHA in the release PR **body**, and that evidence is added by editing the description after the first failed run. Without `edited`, CI Required never reruns and the release PR stays blocked short of a dummy push.

Gating `edited` runs to release branches only (job-level `if`) was analyzed and rejected as unsafe:

- **Shared concurrency group:** an all-skipped `edited` run arriving seconds after a push would *cancel the live synchronize run*, then its `if: always()` CI Required aggregate (which treats skipped deps as OK) reports success — a green gate for an untested head.
- **Separate concurrency group:** the all-skipped run still mints a "CI Required" check run (success or `skipped`), and GitHub branch protection treats skipped conclusions as satisfying required checks — so a body-only edit on a red head would launder it green.

So `edited` is restored unchanged, the duplicate-run cost is accepted, and the trigger block now carries a comment warning future optimizers away from the skip-based "fix". Behavior per scenario: release PR body edit → full CI rerun picks up the new evidence (guard requirement intact); non-release body edit on a green head → duplicate full run, still green (waste, but correct); non-release body edit on a red head → full rerun stays red (no laundering).

### 3. Vitest coverage main-only

`frontend-test` runs `bun run test` (no coverage instrumentation) on `pull_request`, and keeps the full `bun run test:coverage` run on main pushes and `merge_group`. The job name stays exactly `Frontend tests (vitest + coverage)` — the ruleset and the codex-ok label automation match on that context, so only the step behavior differs per event. No coverage artifact was previously uploaded, so main's coverage behavior is unchanged.

## Expected effect

Backend-PR critical path drops from ~8.6 min (integration-core) to ~3.5 min per shard (measured on this PR), i.e. **~9 min -> ~4-5 min** wallclock; frontend PRs also shed the coverage-instrumentation overhead.

## Validation

- `python -c yaml.safe_load` on `.github/workflows/ci.yml`: OK (both revisions)
- `actionlint` (via `uvx actionlint-py`, v1.7.12): clean (both revisions)
- `uvx ruff check` / `ruff format --check` on the new script: clean
- Shard partition guard run locally against the current tree (output above); per-shard `--collect-only` counts sum exactly to the original 1071
- Smoke-ran two shard-3 files end-to-end: 11 passed
- All three shards green on this PR's live CI run
- `uv run pytest tests/unit/test_sync_codex_ok_labels.py`: 18 passed
- Programmatic assertion that all 18 `CODEX_LB_REQUIRED_CHECKS` contexts are emitted by the workflow: OK

## Notes

- CI-config/dev-tooling change only — no runtime behavior, API, or schema change, so this is OpenSpec-exempt.
- Do not merge without maintainer review (no self-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
