### PR TITLE
fix(proxy): synthesize interrupted outputs for custom and apply-patch calls

### DIFF
--- a/app/modules/proxy/_service/http_bridge/service_stubs.py
+++ b/app/modules/proxy/_service/http_bridge/service_stubs.py
@@ -403,8 +403,8 @@ def _service_tier_from_event_payload(*args: Any, **kwargs: Any) -> Any:
     return _service_global("_service_tier_from_event_payload")(*args, **kwargs)
 
 
-def _response_output_item_done_function_call_id(*args: Any, **kwargs: Any) -> Any:
-    return _service_global("_response_output_item_done_function_call_id")(*args, **kwargs)
+def _response_output_item_done_tool_call(*args: Any, **kwargs: Any) -> Any:
+    return _service_global("_response_output_item_done_tool_call")(*args, **kwargs)
 
 
 def _rewrite_websocket_downstream_response_id(*args: Any, **kwargs: Any) -> Any:

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -61,7 +61,7 @@ from app.modules.proxy._service.http_bridge.service_stubs import (
     _pop_terminal_websocket_request_state,
     _previous_response_id_from_not_found_message,
     _release_websocket_response_create_gate,
-    _response_output_item_done_function_call_id,
+    _response_output_item_done_tool_call,
     _rewrite_websocket_continuity_corruption_event,
     _rewrite_websocket_downstream_response_id,
     _rewrite_websocket_previous_response_owner_unavailable_event,
@@ -408,12 +408,10 @@ class _HTTPBridgeUpstreamEventsMixin:
                 if actual_service_tier is not None:
                     matched_request_state.actual_service_tier = actual_service_tier
                     matched_request_state.service_tier = actual_service_tier
-                completed_function_call_id = _response_output_item_done_function_call_id(payload)
-                if (
-                    completed_function_call_id is not None
-                    and completed_function_call_id not in matched_request_state.pending_function_call_ids
-                ):
-                    matched_request_state.pending_function_call_ids.append(completed_function_call_id)
+                completed_tool_call = _response_output_item_done_tool_call(payload)
+                if completed_tool_call is not None:
+                    call_id, call_item_type = completed_tool_call
+                    matched_request_state.pending_tool_calls.setdefault(call_id, call_item_type)
                 if mark_duplicate_tool_call_downstream_event(
                     payload,
                     seen_tool_call_keys=matched_request_state.seen_tool_call_keys,

--- a/app/modules/proxy/_service/response_create.py
+++ b/app/modules/proxy/_service/response_create.py
@@ -266,10 +266,22 @@ def _slim_response_create_payload_for_upstream(
     }
 
 
-def _function_call_output_call_ids(input_items: list[JsonValue]) -> set[str]:
+# Tool call item types whose outputs upstream demands on the next request, and
+# the output item type each one pairs with. custom_tool_call (Responses Lite
+# shell) and apply_patch_call were previously untracked, so interrupted calls
+# produced "No tool output found for custom tool call call_..." 400s (#1168).
+_TOOL_CALL_OUTPUT_TYPE_BY_ITEM_TYPE = {
+    "function_call": "function_call_output",
+    "custom_tool_call": "custom_tool_call_output",
+    "apply_patch_call": "apply_patch_call_output",
+}
+_TOOL_CALL_OUTPUT_ITEM_TYPES = frozenset(_TOOL_CALL_OUTPUT_TYPE_BY_ITEM_TYPE.values())
+
+
+def _tool_call_output_call_ids(input_items: list[JsonValue]) -> set[str]:
     call_ids: set[str] = set()
     for item in input_items:
-        if not isinstance(item, dict) or item.get("type") != "function_call_output":
+        if not isinstance(item, dict) or item.get("type") not in _TOOL_CALL_OUTPUT_ITEM_TYPES:
             continue
         call_id = item.get("call_id")
         if isinstance(call_id, str) and call_id:
@@ -277,20 +289,24 @@ def _function_call_output_call_ids(input_items: list[JsonValue]) -> set[str]:
     return call_ids
 
 
-def _missing_function_call_outputs_for_previous_response(
+def _missing_tool_call_outputs_for_previous_response(
     input_items: list[JsonValue],
     *,
-    pending_call_ids: list[str],
-) -> list[str]:
-    if not pending_call_ids:
+    pending_calls: Mapping[str, str],
+) -> list[tuple[str, str]]:
+    if not pending_calls:
         return []
-    present_call_ids = _function_call_output_call_ids(input_items)
-    return [call_id for call_id in pending_call_ids if call_id not in present_call_ids]
+    present_call_ids = _tool_call_output_call_ids(input_items)
+    return [
+        (call_id, call_item_type)
+        for call_id, call_item_type in pending_calls.items()
+        if call_id not in present_call_ids
+    ]
 
 
-def _synthetic_interrupted_function_call_output(call_id: str) -> dict[str, JsonValue]:
+def _synthetic_interrupted_tool_call_output(call_id: str, call_item_type: str) -> dict[str, JsonValue]:
     return {
-        "type": "function_call_output",
+        "type": _TOOL_CALL_OUTPUT_TYPE_BY_ITEM_TYPE.get(call_item_type, "function_call_output"),
         "call_id": call_id,
         "output": (
             "Tool call was not executed because the previous turn was interrupted before tool output was available."
@@ -298,27 +314,36 @@ def _synthetic_interrupted_function_call_output(call_id: str) -> dict[str, JsonV
     }
 
 
-def _inject_missing_interrupted_function_call_outputs(
+def _inject_missing_interrupted_tool_call_outputs(
     input_items: list[JsonValue],
     *,
-    missing_call_ids: list[str],
+    missing_calls: list[tuple[str, str]],
 ) -> list[JsonValue]:
-    if not missing_call_ids:
+    if not missing_calls:
         return input_items
     return [
-        *[_synthetic_interrupted_function_call_output(call_id) for call_id in missing_call_ids],
+        *[
+            _synthetic_interrupted_tool_call_output(call_id, call_item_type)
+            for call_id, call_item_type in missing_calls
+        ],
         *input_items,
     ]
 
 
-def _response_output_item_done_function_call_id(payload: dict[str, JsonValue] | None) -> str | None:
+def _response_output_item_done_tool_call(payload: dict[str, JsonValue] | None) -> tuple[str, str] | None:
+    """Return ``(call_id, call_item_type)`` for a completed tool call item, if any."""
     if not isinstance(payload, dict) or payload.get("type") != "response.output_item.done":
         return None
     item = payload.get("item")
-    if not isinstance(item, dict) or item.get("type") != "function_call":
+    if not isinstance(item, dict):
+        return None
+    item_type = item.get("type")
+    if not isinstance(item_type, str) or item_type not in _TOOL_CALL_OUTPUT_TYPE_BY_ITEM_TYPE:
         return None
     call_id = item.get("call_id")
-    return call_id if isinstance(call_id, str) and call_id else None
+    if not isinstance(call_id, str) or not call_id:
+        return None
+    return call_id, item_type
 
 
 def _response_create_too_large_error_envelope(

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -383,7 +383,7 @@ class _WebSocketRequestState:
     affinity_policy: _AffinityPolicy = field(default_factory=_AffinityPolicy)
     suppressed_downstream_tool_call: bool = False
     suppressed_duplicate_tool_call: bool = False
-    pending_function_call_ids: list[str] = field(default_factory=list)
+    pending_tool_calls: dict[str, str] = field(default_factory=dict)
     seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None] = field(default_factory=dict)
     input_item_count: int = 0
     input_full_fingerprint: str | None = None
@@ -497,7 +497,7 @@ class _WebSocketContinuityState:
     last_completed_input_count: int = 0
     last_completed_response_id: str | None = None
     last_completed_input_prefix_fingerprint: str | None = None
-    last_pending_function_call_ids: list[str] = field(default_factory=list)
+    last_pending_tool_calls: dict[str, str] = field(default_factory=dict)
     responses_lite_model: str | None = None
     responses_lite_response_id: str | None = None
 

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -458,12 +458,12 @@ def _record_websocket_continuity_completion(
         continuity_state.last_completed_response_id = None
         continuity_state.last_completed_input_count = 0
         continuity_state.last_completed_input_prefix_fingerprint = None
-        continuity_state.last_pending_function_call_ids = []
+        continuity_state.last_pending_tool_calls = {}
         return
     continuity_state.last_completed_response_id = response_id
     continuity_state.last_completed_input_count = request_state.input_item_count
     continuity_state.last_completed_input_prefix_fingerprint = request_state.input_full_fingerprint
-    continuity_state.last_pending_function_call_ids = list(request_state.pending_function_call_ids)
+    continuity_state.last_pending_tool_calls = dict(request_state.pending_tool_calls)
 
 
 def _record_websocket_responses_lite_acceptance(

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -1376,27 +1376,27 @@ class _WebSocketMixin:
             continuity_state is not None
             and responses_payload.previous_response_id is not None
             and responses_payload.previous_response_id == continuity_state.last_completed_response_id
-            and continuity_state.last_pending_function_call_ids
+            and continuity_state.last_pending_tool_calls
             and isinstance(responses_payload.input, list)
         ):
             input_items = cast(list[JsonValue], responses_payload.input)
-            missing_call_ids = _facade()._missing_function_call_outputs_for_previous_response(
+            missing_calls = _facade()._missing_tool_call_outputs_for_previous_response(
                 input_items,
-                pending_call_ids=continuity_state.last_pending_function_call_ids,
+                pending_calls=continuity_state.last_pending_tool_calls,
             )
-            if missing_call_ids:
+            if missing_calls:
                 responses_payload = responses_payload.model_copy(
                     update={
-                        "input": _facade()._inject_missing_interrupted_function_call_outputs(
+                        "input": _facade()._inject_missing_interrupted_tool_call_outputs(
                             input_items,
-                            missing_call_ids=missing_call_ids,
+                            missing_calls=missing_calls,
                         )
                     }
                 )
                 _facade().logger.warning(
                     "websocket_interrupted_tool_outputs_injected previous_response_id=%s missing_call_count=%s",
                     responses_payload.previous_response_id,
-                    len(missing_call_ids),
+                    len(missing_calls),
                 )
         reservation = await proxy._reserve_websocket_api_key_usage(
             refreshed_api_key,
@@ -2889,12 +2889,10 @@ class _WebSocketMixin:
                 if actual_service_tier is not None:
                     request_state.actual_service_tier = actual_service_tier
                     request_state.service_tier = actual_service_tier
-                completed_function_call_id = _facade()._response_output_item_done_function_call_id(payload)
-                if (
-                    completed_function_call_id is not None
-                    and completed_function_call_id not in request_state.pending_function_call_ids
-                ):
-                    request_state.pending_function_call_ids.append(completed_function_call_id)
+                completed_tool_call = _facade()._response_output_item_done_tool_call(payload)
+                if completed_tool_call is not None:
+                    call_id, call_item_type = completed_tool_call
+                    request_state.pending_tool_calls.setdefault(call_id, call_item_type)
                 if mark_duplicate_tool_call_downstream_event(
                     payload,
                     seen_tool_call_keys=request_state.seen_tool_call_keys,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -388,10 +388,10 @@ from app.modules.proxy._service.response_create import (
     _fingerprint_input_items as _fingerprint_input_items,
 )
 from app.modules.proxy._service.response_create import (
-    _function_call_output_call_ids as _function_call_output_call_ids,
+    _tool_call_output_call_ids as _tool_call_output_call_ids,
 )
 from app.modules.proxy._service.response_create import (
-    _inject_missing_interrupted_function_call_outputs as _inject_missing_interrupted_function_call_outputs,
+    _inject_missing_interrupted_tool_call_outputs as _inject_missing_interrupted_tool_call_outputs,
 )
 from app.modules.proxy._service.response_create import (
     _inline_top_level_input_image_urls as _inline_top_level_input_image_urls,
@@ -412,7 +412,7 @@ from app.modules.proxy._service.response_create import (
     _maybe_dump_oversized_response_create_request as _maybe_dump_oversized_response_create_request,
 )
 from app.modules.proxy._service.response_create import (
-    _missing_function_call_outputs_for_previous_response as _missing_function_call_outputs_for_previous_response,
+    _missing_tool_call_outputs_for_previous_response as _missing_tool_call_outputs_for_previous_response,
 )
 from app.modules.proxy._service.response_create import (
     _oversized_response_create_dump_dir as _oversized_response_create_dump_dir,
@@ -445,7 +445,7 @@ from app.modules.proxy._service.response_create import (
     _response_create_too_large_error_envelope as _response_create_too_large_error_envelope,
 )
 from app.modules.proxy._service.response_create import (
-    _response_output_item_done_function_call_id as _response_output_item_done_function_call_id,
+    _response_output_item_done_tool_call as _response_output_item_done_tool_call,
 )
 from app.modules.proxy._service.response_create import (
     _responses_request_contains_input_image as _responses_request_contains_input_image,
@@ -481,7 +481,7 @@ from app.modules.proxy._service.response_create import (
     _summarize_response_create_payload as _summarize_response_create_payload,
 )
 from app.modules.proxy._service.response_create import (
-    _synthetic_interrupted_function_call_output as _synthetic_interrupted_function_call_output,
+    _synthetic_interrupted_tool_call_output as _synthetic_interrupted_tool_call_output,
 )
 from app.modules.proxy._service.response_create import (
     _write_response_create_dump as _write_response_create_dump,
@@ -2056,7 +2056,13 @@ def _is_missing_tool_output_error(
     if code != "invalid_request_error" or param != "input" or message is None:
         return False
     normalized = " ".join(message.lower().split())
-    return normalized.startswith("no tool output found for function call call_")
+    return normalized.startswith(
+        (
+            "no tool output found for function call call_",
+            "no tool output found for custom tool call call_",
+            "no tool output found for apply patch call call_",
+        )
+    )
 
 
 def _is_previous_response_not_found_error(

--- a/openspec/changes/synthesize-interrupted-custom-tool-outputs/.openspec.yaml
+++ b/openspec/changes/synthesize-interrupted-custom-tool-outputs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/synthesize-interrupted-custom-tool-outputs/proposal.md
+++ b/openspec/changes/synthesize-interrupted-custom-tool-outputs/proposal.md
@@ -1,0 +1,27 @@
+# Synthesize Interrupted Custom Tool Outputs
+
+## Summary
+
+Extend the interrupted-tool-output machinery — pending-call tracking, synthetic output injection, and the missing-tool-output error classifier — from `function_call` only to also cover `custom_tool_call` and `apply_patch_call`.
+
+## Motivation
+
+Implements #1168. When a turn ends with an unresolved `custom_tool_call` (e.g. the user interrupts Codex before the shell output is sent) and the next request references that response, upstream rejects it with:
+
+```
+{"type":"error","error":{"type":"invalid_request_error","message":"No tool output found for custom tool call call_xxx","param":"input"},"status":400}
+```
+
+Three sites only handled `function_call`: the pending-call tracker never recorded custom/apply-patch completions, the synthetic interrupted-output injection only emitted `function_call_output` items, and the error classifier only matched the function-call message variant — so the raw upstream 400 bypassed the existing masking/retry recovery and leaked to the client, permanently wedging the session. Reachable in practice since Responses-Lite custom shell tools started working (#1161); gpt-5.6 models emit `custom_tool_call` for every shell command.
+
+## Scope
+
+- Track pending tool calls as `call_id → call item type` for `function_call`, `custom_tool_call`, and `apply_patch_call`.
+- Synthesize the matching output item type (`function_call_output` / `custom_tool_call_output` / `apply_patch_call_output`) when injecting interrupted outputs.
+- Classify the custom and apply-patch variants of the upstream "No tool output found" message so existing recovery paths engage.
+- Regression coverage at the websocket surface (interrupted custom/apply-patch turn → next request with `previous_response_id` → synthetic outputs injected) and the HTTP-bridge surface (custom tool call completions are recorded as pending).
+
+## Out of Scope
+
+- Adding a new interrupted-output injection site to the HTTP bridge (it records pendings but has no injection path today; recovery there is via the extended classifier).
+- Anchor validation for stored responses ending in unanswered tool calls (tracked separately in #1167).

--- a/openspec/changes/synthesize-interrupted-custom-tool-outputs/specs/responses-api-compat/spec.md
+++ b/openspec/changes/synthesize-interrupted-custom-tool-outputs/specs/responses-api-compat/spec.md
@@ -1,0 +1,30 @@
+# responses-api-compat — Delta
+
+## ADDED Requirements
+
+### Requirement: Interrupted tool outputs are synthesized for all tool call item types
+
+When a completed upstream response contains tool call items (`function_call`,
+`custom_tool_call`, or `apply_patch_call`) whose outputs were never returned by
+the client, and a subsequent request references that response via
+`previous_response_id`, the service MUST inject synthetic interrupted-output
+items of the matching output type (`function_call_output`,
+`custom_tool_call_output`, `apply_patch_call_output`) so upstream does not
+reject the request. The upstream error message variants for all three call
+types MUST be classified as missing-tool-output errors so existing recovery
+paths apply.
+
+#### Scenario: interrupted custom tool call is synthesized
+
+- **WHEN** a turn ends with an unresolved `custom_tool_call` and the next
+  request references that response via `previous_response_id` without the
+  matching `custom_tool_call_output`
+- **THEN** the service injects a synthetic `custom_tool_call_output` for the
+  pending call id before forwarding upstream
+
+#### Scenario: custom variant of the upstream 400 is classified
+
+- **WHEN** upstream returns `invalid_request_error` with `param=input` and a
+  message starting with "No tool output found for custom tool call call_"
+- **THEN** the service treats it as a missing-tool-output error, engaging the
+  same masking and retry recovery as the function-call variant

--- a/openspec/changes/synthesize-interrupted-custom-tool-outputs/tasks.md
+++ b/openspec/changes/synthesize-interrupted-custom-tool-outputs/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] 1. Add OpenSpec requirement covering interrupted-output synthesis for all tool call item types.
+- [x] 2. Track pending tool calls with their item type in websocket and HTTP-bridge upstream event handling.
+- [x] 3. Synthesize the matching output item type when injecting interrupted outputs.
+- [x] 4. Extend the missing-tool-output error classifier to the custom and apply-patch message variants.
+- [x] 5. Add websocket and HTTP-bridge regression coverage and validate focused suites.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -11133,6 +11133,60 @@ async def test_process_http_bridge_upstream_text_scopes_tool_dedupe_to_request_s
 
 
 @pytest.mark.asyncio
+async def test_process_http_bridge_upstream_text_records_pending_custom_tool_call() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-bridge-custom-tool",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        response_id="resp_bridge_custom_tool",
+        event_queue=asyncio.Queue(),
+        transport="http",
+        skip_request_log=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-custom", None),
+        headers={"x-codex-session-id": "sid-custom"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-custom",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.6-sol",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+
+    event = json.dumps(
+        {
+            "type": "response.output_item.done",
+            "response": {"id": "resp_bridge_custom_tool", "status": "in_progress"},
+            "response_id": "resp_bridge_custom_tool",
+            "item": {
+                "type": "custom_tool_call",
+                "name": "exec",
+                "input": "pwd",
+                "call_id": "call_shell_1",
+            },
+        },
+        separators=(",", ":"),
+    )
+
+    await service._process_http_bridge_upstream_text(session, event)
+
+    assert request_state.pending_tool_calls == {"call_shell_1": "custom_tool_call"}
+
+
+@pytest.mark.asyncio
 async def test_process_http_bridge_upstream_text_marks_text_delta_downstream_visible() -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     request_state = proxy_service._WebSocketRequestState(

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12710,7 +12710,7 @@ async def test_prepare_websocket_response_create_request_fills_interrupted_pendi
 
     continuity_state = proxy_service._WebSocketContinuityState(
         last_completed_response_id="resp_pending_tool_calls",
-        last_pending_function_call_ids=["call_missing_a", "call_missing_b"],
+        last_pending_tool_calls={"call_missing_a": "function_call", "call_missing_b": "function_call"},
     )
     interrupted_input: list[JsonValue] = [
         {
@@ -12767,6 +12767,111 @@ async def test_prepare_websocket_response_create_request_fills_interrupted_pendi
     ]
     assert upstream_payload["input"][2:] == interrupted_input
     assert prepared.request_state.input_item_count == 4
+
+
+@pytest.mark.asyncio
+async def test_prepare_websocket_response_create_request_fills_interrupted_custom_tool_outputs(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    reserve_usage = AsyncMock(return_value=None)
+    api_key = ApiKeyData(
+        id="key_ws_interrupted_custom",
+        name="ws-interrupted-custom",
+        key_prefix="sk-ws-custom",
+        allowed_models=["gpt-5.6-sol"],
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    class Settings:
+        log_proxy_request_payload = False
+        log_proxy_request_shape = False
+        log_proxy_request_shape_raw_cache_key = False
+        log_proxy_service_tier_trace = False
+        openai_prompt_cache_key_derivation_enabled = True
+
+    continuity_state = proxy_service._WebSocketContinuityState(
+        last_completed_response_id="resp_pending_custom_calls",
+        last_pending_tool_calls={"call_shell_1": "custom_tool_call", "call_patch_1": "apply_patch_call"},
+    )
+    interrupted_input: list[JsonValue] = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "input_text",
+                    "text": "<turn_aborted>\nThe user interrupted the previous turn on purpose.\n</turn_aborted>",
+                }
+            ],
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: Settings())
+    monkeypatch.setattr(service, "_reserve_websocket_api_key_usage", reserve_usage)
+    monkeypatch.setattr(service, "_refresh_websocket_api_key_policy", AsyncMock(return_value=api_key))
+
+    prepared = await service._prepare_websocket_response_create_request(
+        cast(
+            dict[str, JsonValue],
+            {
+                "type": "response.create",
+                "model": "gpt-5.6-sol",
+                "previous_response_id": "resp_pending_custom_calls",
+                "input": interrupted_input,
+            },
+        ),
+        headers={"session_id": "turn_ws_interrupted_custom"},
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=300,
+        api_key=api_key,
+        continuity_state=continuity_state,
+    )
+
+    upstream_payload = json.loads(prepared.text_data)
+    assert upstream_payload["previous_response_id"] == "resp_pending_custom_calls"
+    interrupted_tool_output = (
+        "Tool call was not executed because the previous turn was interrupted before tool output was available."
+    )
+    assert upstream_payload["input"][:2] == [
+        {
+            "type": "custom_tool_call_output",
+            "call_id": "call_shell_1",
+            "output": interrupted_tool_output,
+        },
+        {
+            "type": "apply_patch_call_output",
+            "call_id": "call_patch_1",
+            "output": interrupted_tool_output,
+        },
+    ]
+    assert upstream_payload["input"][2:] == interrupted_input
+    assert prepared.request_state.input_item_count == 4
+
+
+def test_is_missing_tool_output_error_matches_custom_and_apply_patch_variants():
+    for message in (
+        "No tool output found for function call call_abc123.",
+        "No tool output found for custom tool call call_XnzBtHwdOs9bda4KP9DE44rm.",
+        "No tool output found for apply patch call call_def456.",
+    ):
+        assert proxy_service._is_missing_tool_output_error(
+            code="invalid_request_error",
+            param="input",
+            message=message,
+        )
+    assert not proxy_service._is_missing_tool_output_error(
+        code="invalid_request_error",
+        param="input",
+        message="No tool output found for web search call call_ghi789.",
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Implements #1168: extend the interrupted-tool-output machinery from `function_call` only to also cover `custom_tool_call` and `apply_patch_call`, at all three sites identified in the issue.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: Closes #1168

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/synthesize-interrupted-custom-tool-outputs/`

## Changes

- **Site 1 — pending-call tracker**: `_response_output_item_done_function_call_id` → `_response_output_item_done_tool_call`, returning `(call_id, item_type)` for `function_call` / `custom_tool_call` / `apply_patch_call`. State fields `pending_function_call_ids: list[str]` / `last_pending_function_call_ids` become `pending_tool_calls: dict[str, str]` / `last_pending_tool_calls` (call_id → item type, insertion-ordered), recorded at both the websocket and HTTP-bridge upstream event handlers.
- **Site 2 — synthetic injection**: `_synthetic_interrupted_tool_call_output(call_id, call_item_type)` emits the matching output item type (`custom_tool_call_output` / `apply_patch_call_output` / `function_call_output`); the websocket injection site passes the typed pending map through.
- **Site 3 — classifier**: `_is_missing_tool_output_error` now matches the custom and apply-patch variants of "No tool output found for … call call_", so the existing masking/retry recovery engages for them.
- Regression tests: websocket surface (interrupted custom + apply-patch turn → next request with `previous_response_id` → typed synthetic outputs injected ahead of the client input), HTTP-bridge surface (custom tool call completion recorded as pending), and classifier variants.
- OpenSpec change recording the requirement.

## Notes

- The HTTP bridge records pendings but has no injection site today; adding one felt out of scope for "extend" — recovery on that surface comes via the extended classifier. Happy to follow up if you'd rather have bridge-side injection too.
- Field observation matching the issue: a gpt-5.6 session whose turn was severed near an `exec` call wedged permanently on the custom-variant 400 (every full-resend retry got re-anchored onto the same response), which is exactly the classifier bypass this fixes.

## Test plan

```
uv run pytest tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py tests/unit/test_openai_requests.py -q
899 passed

uv run pytest tests/unit -q --ignore=tests/unit/test_helm_external_secrets.py
3180 passed, 3 skipped
```
(helm tests fail in my environment on unmodified main; excluded as pre-existing.)
