### PR TITLE
fix(db): persist security lineage markers

### DIFF
--- a/app/db/alembic/versions/20260722_000000_add_security_lineage_persistence.py
+++ b/app/db/alembic/versions/20260722_000000_add_security_lineage_persistence.py
@@ -1,0 +1,287 @@
+"""Reconcile durable security-lineage persistence without a second head.
+
+Revision ID: 20260722_000000_add_security_lineage_persistence
+Revises: 20260806_030000_add_api_key_allowed_reasoning_efforts
+Create Date: 2026-07-22 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+revision = "20260722_000000_add_security_lineage_persistence"
+down_revision = "20260806_030000_add_api_key_allowed_reasoning_efforts"
+branch_labels = None
+depends_on = None
+
+_MARKER_PREFIX = "@security-work/v2/"
+_LEGACY_MARKER_PREFIX = "security-work:"
+_CODEX_SESSION_KIND = "codex_session"
+_LINEAGE_ALIAS_KINDS = ("session_header", "turn_state", "previous_response_id")
+_ANONYMOUS_SCOPE = "__anonymous__"
+_BATCH_NAMING_CONVENTION = {
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+}
+
+
+def _columns(connection: Connection, table_name: str) -> dict[str, Mapping[str, object]]:
+    inspector = sa.inspect(connection)
+    if not inspector.has_table(table_name):
+        return {}
+    return {str(column["name"]): column for column in inspector.get_columns(table_name) if column.get("name")}
+
+
+def _account_foreign_key(connection: Connection, table_name: str) -> Mapping[str, object] | None:
+    inspector = sa.inspect(connection)
+    if not inspector.has_table(table_name):
+        return None
+    for foreign_key in inspector.get_foreign_keys(table_name):
+        if foreign_key.get("constrained_columns") == ["account_id"] and foreign_key.get("referred_table") == "accounts":
+            return foreign_key
+    return None
+
+
+def _marker_key(lineage_id: str, api_key_scope: str | None) -> str:
+    scope = (api_key_scope or "").strip() or _ANONYMOUS_SCOPE
+    digest = hashlib.sha256(f"{scope}\0{lineage_id}".encode()).hexdigest()
+    return f"{_MARKER_PREFIX}{digest}"
+
+
+def _legacy_marker_key(lineage_id: str) -> str:
+    return f"{_MARKER_PREFIX}{hashlib.sha256(lineage_id.encode()).hexdigest()}"
+
+
+def _insert_marker(bind: Connection, marker_key: str) -> None:
+    bind.execute(
+        sa.text(
+            """
+            INSERT INTO sticky_sessions (
+                key, kind, account_id, requires_security_work_authorized, created_at, updated_at
+            )
+            SELECT :key, :kind, NULL, :required, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+            WHERE NOT EXISTS (
+                SELECT 1 FROM sticky_sessions WHERE key = :key AND kind = :kind
+            )
+            """
+        ),
+        {"key": marker_key, "kind": _CODEX_SESSION_KIND, "required": True},
+    )
+    bind.execute(
+        sa.text(
+            """
+            UPDATE sticky_sessions
+            SET account_id = NULL, requires_security_work_authorized = :required,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE key = :key AND kind = :kind
+            """
+        ),
+        {"key": marker_key, "kind": _CODEX_SESSION_KIND, "required": True},
+    )
+
+
+def _backfill_marker(bind: Connection, lineage_id: str, api_key_scope: str | None, *, legacy: bool = False) -> None:
+    if lineage_id.startswith(_MARKER_PREFIX):
+        bind.execute(
+            sa.text(
+                """
+                UPDATE sticky_sessions
+                SET account_id = NULL, requires_security_work_authorized = :required, updated_at = CURRENT_TIMESTAMP
+                WHERE key = :key AND kind = :kind
+                """
+            ),
+            {"key": lineage_id, "kind": _CODEX_SESSION_KIND, "required": True},
+        )
+        return
+    if lineage_id.startswith(_LEGACY_MARKER_PREFIX):
+        lineage_id = lineage_id.removeprefix(_LEGACY_MARKER_PREFIX)
+    _insert_marker(bind, _marker_key(lineage_id, api_key_scope))
+    if legacy:
+        _insert_marker(bind, _legacy_marker_key(lineage_id))
+
+
+def _backfill_detached_markers(bind: Connection) -> None:
+    sticky_columns = _columns(bind, "sticky_sessions")
+    required_sticky = {"key", "kind", "account_id", "requires_security_work_authorized"}
+    if required_sticky.issubset(sticky_columns):
+        rows = bind.execute(
+            sa.text(
+                """
+                SELECT key FROM sticky_sessions
+                WHERE kind = :kind AND account_id IS NOT NULL AND requires_security_work_authorized = :required
+                """
+            ),
+            {"kind": _CODEX_SESSION_KIND, "required": True},
+        ).fetchall()
+        for (lineage_id,) in rows:
+            if isinstance(lineage_id, str):
+                _backfill_marker(bind, lineage_id, None, legacy=True)
+
+    bridge_columns = _columns(bind, "http_bridge_sessions")
+    required_bridge = {"session_key_kind", "session_key_value", "api_key_scope", "requires_security_work_authorized"}
+    if not required_bridge.issubset(bridge_columns):
+        return
+    turn_state = "latest_turn_state" if "latest_turn_state" in bridge_columns else "NULL"
+    rows = bind.execute(
+        sa.text(
+            f"""
+            SELECT session_key_kind, session_key_value, api_key_scope, {turn_state} AS latest_turn_state
+            FROM http_bridge_sessions
+            WHERE requires_security_work_authorized = :required
+            """
+        ),
+        {"required": True},
+    ).fetchall()
+    for kind, value, scope, latest_turn_state in rows:
+        if kind in _LINEAGE_ALIAS_KINDS and isinstance(value, str):
+            _backfill_marker(bind, value, scope if isinstance(scope, str) else None)
+        if isinstance(latest_turn_state, str):
+            _backfill_marker(bind, latest_turn_state, scope if isinstance(scope, str) else None)
+
+    alias_columns = _columns(bind, "http_bridge_session_aliases")
+    required_alias = {"session_id", "alias_kind", "alias_value"}
+    if not required_alias.issubset(alias_columns) or "id" not in bridge_columns:
+        return
+    if "api_key_scope" in alias_columns:
+        alias_scope = "COALESCE(a.api_key_scope, s.api_key_scope, :anonymous_scope)"
+    else:
+        alias_scope = "COALESCE(s.api_key_scope, :anonymous_scope)"
+    alias_rows = bind.execute(
+        sa.text(
+            f"""
+            SELECT a.alias_value, {alias_scope} AS api_key_scope
+            FROM http_bridge_session_aliases AS a
+            JOIN http_bridge_sessions AS s ON s.id = a.session_id
+            WHERE s.requires_security_work_authorized = :required
+              AND a.alias_kind IN :alias_kinds
+            """
+        ).bindparams(sa.bindparam("alias_kinds", expanding=True)),
+        {
+            "required": True,
+            "alias_kinds": list(_LINEAGE_ALIAS_KINDS),
+            "anonymous_scope": _ANONYMOUS_SCOPE,
+        },
+    ).fetchall()
+    for alias_value, scope in alias_rows:
+        if isinstance(alias_value, str):
+            _backfill_marker(bind, alias_value, scope if isinstance(scope, str) else None)
+
+
+def _add_columns(bind: Connection) -> None:
+    usage = _columns(bind, "usage_history")
+    if usage:
+        with op.batch_alter_table("usage_history") as batch:
+            if "requires_security_work_authorized" not in usage:
+                batch.add_column(
+                    sa.Column(
+                        "requires_security_work_authorized", sa.Boolean(), nullable=False, server_default=sa.false()
+                    )
+                )
+            if not bool(usage.get("account_id", {}).get("nullable", False)):
+                batch.alter_column("account_id", existing_type=sa.String(), nullable=True)
+        if bind.dialect.name == "sqlite":
+            # SQLite batch-alter rebuilds the table and does not preserve its
+            # expression indexes, which are required by the usage hot path.
+            op.execute(sa.text("DROP INDEX IF EXISTS idx_usage_window_account_latest"))
+            op.execute(sa.text("DROP INDEX IF EXISTS idx_usage_window_account_time"))
+            op.execute(
+                sa.text(
+                    "CREATE INDEX idx_usage_window_account_latest "
+                    "ON usage_history (coalesce(\"window\", 'primary'), account_id, recorded_at DESC, id DESC)"
+                )
+            )
+            op.execute(
+                sa.text(
+                    "CREATE INDEX idx_usage_window_account_time "
+                    "ON usage_history (coalesce(\"window\", 'primary'), account_id, recorded_at DESC)"
+                )
+            )
+            op.execute(
+                sa.text(
+                    "CREATE INDEX IF NOT EXISTS idx_usage_window_account_time_covering "
+                    "ON usage_history (coalesce(\"window\", 'primary'), account_id, recorded_at, "
+                    'used_percent, reset_at, window_minutes, id, "window")'
+                )
+            )
+            op.execute(
+                sa.text(
+                    "CREATE INDEX IF NOT EXISTS idx_usage_window_raw_account_time_covering "
+                    'ON usage_history ("window", account_id, recorded_at, used_percent, reset_at, '
+                    "window_minutes, id)"
+                )
+            )
+
+    sticky = _columns(bind, "sticky_sessions")
+    if sticky:
+        account_foreign_key = _account_foreign_key(bind, "sticky_sessions")
+        raw_account_foreign_key_options = account_foreign_key.get("options") if account_foreign_key else None
+        account_foreign_key_options = (
+            raw_account_foreign_key_options if isinstance(raw_account_foreign_key_options, Mapping) else {}
+        )
+        replace_account_foreign_key = (
+            account_foreign_key is None or str(account_foreign_key_options.get("ondelete", "")).upper() != "SET NULL"
+        )
+        with op.batch_alter_table(
+            "sticky_sessions",
+            naming_convention=_BATCH_NAMING_CONVENTION,
+        ) as batch:
+            if "requires_security_work_authorized" not in sticky:
+                batch.add_column(
+                    sa.Column(
+                        "requires_security_work_authorized", sa.Boolean(), nullable=False, server_default=sa.false()
+                    )
+                )
+            if not bool(sticky.get("account_id", {}).get("nullable", False)):
+                batch.alter_column("account_id", existing_type=sa.String(), nullable=True)
+            if replace_account_foreign_key:
+                if account_foreign_key is not None:
+                    constraint_name = str(account_foreign_key.get("name") or "fk_sticky_sessions_account_id_accounts")
+                    batch.drop_constraint(constraint_name, type_="foreignkey")
+                batch.create_foreign_key(
+                    "fk_sticky_sessions_account_id_accounts",
+                    "accounts",
+                    ["account_id"],
+                    ["id"],
+                    ondelete="SET NULL",
+                )
+
+    bridge = _columns(bind, "http_bridge_sessions")
+    if bridge:
+        with op.batch_alter_table("http_bridge_sessions") as batch:
+            if "requires_security_work_authorized" not in bridge:
+                batch.add_column(
+                    sa.Column(
+                        "requires_security_work_authorized", sa.Boolean(), nullable=False, server_default=sa.false()
+                    )
+                )
+
+    quota = _columns(bind, "quota_planner_settings")
+    if quota:
+        with op.batch_alter_table("quota_planner_settings") as batch:
+            if "auto_redeem_expiring_reset_credits" not in quota:
+                batch.add_column(
+                    sa.Column(
+                        "auto_redeem_expiring_reset_credits", sa.Boolean(), nullable=False, server_default=sa.false()
+                    )
+                )
+            if "reset_credit_redeem_lead_minutes" not in quota:
+                batch.add_column(
+                    sa.Column("reset_credit_redeem_lead_minutes", sa.Integer(), nullable=False, server_default="30")
+                )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    _add_columns(bind)
+    _backfill_detached_markers(bind)
+
+
+def downgrade() -> None:
+    # This revision reconciles columns and detached markers that may have been
+    # created by a previous aggregate. Their original owner cannot be inferred,
+    # so dropping them could destroy live lineage data.
+    return

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -179,7 +179,17 @@ class UsageHistory(Base):
     __tablename__ = "usage_history"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    account_id: Mapped[str] = mapped_column(String, ForeignKey("accounts.id", ondelete="CASCADE"), nullable=False)
+    account_id: Mapped[str | None] = mapped_column(
+        String,
+        ForeignKey("accounts.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    requires_security_work_authorized: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        server_default=false(),
+        nullable=False,
+    )
     recorded_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
     window: Mapped[str | None] = mapped_column(String, nullable=True)
     used_percent: Mapped[float] = mapped_column(Float, nullable=False)
@@ -794,7 +804,19 @@ class StickySession(Base):
         server_default=text("'sticky_thread'"),
         nullable=False,
     )
-    account_id: Mapped[str] = mapped_column(String, ForeignKey("accounts.id", ondelete="CASCADE"), nullable=False)
+    account_id: Mapped[str | None] = mapped_column(
+        String,
+        ForeignKey("accounts.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # Detached CODEX_SESSION markers retain a security requirement after the
+    # account that originally owned the lineage has been deleted.
+    requires_security_work_authorized: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        server_default=false(),
+        nullable=False,
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
@@ -1684,6 +1706,21 @@ class QuotaPlannerSettings(Base):
     )
     warmup_model_preference: Mapped[str | None] = mapped_column(String, nullable=True)
     dry_run: Mapped[bool] = mapped_column(Boolean, default=True, server_default=true(), nullable=False)
+    # Retain these compatibility fields for databases that previously ran the
+    # broader security-lineage aggregate. This carrier does not enable the
+    # retired planner behavior, but its schema must remain drift-free.
+    auto_redeem_expiring_reset_credits: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        server_default=false(),
+        nullable=False,
+    )
+    reset_credit_redeem_lead_minutes: Mapped[int] = mapped_column(
+        Integer,
+        default=30,
+        server_default=text("30"),
+        nullable=False,
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
@@ -1878,6 +1915,12 @@ class HttpBridgeSessionRecord(Base):
     )
     model: Mapped[str | None] = mapped_column(String, nullable=True)
     service_tier: Mapped[str | None] = mapped_column(String, nullable=True)
+    requires_security_work_authorized: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        server_default=false(),
+        nullable=False,
+    )
     latest_turn_state: Mapped[str | None] = mapped_column(Text, nullable=True)
     latest_response_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     latest_input_item_count: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -816,7 +816,7 @@ class AccountsRepository:
             if updated_id is not None and self._hard_sticky_outage_started(expected_status, status):
                 await self._refresh_hard_sticky_outage_grace(account_id)
             if updated_id is not None and status in (AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
-                await self._session.execute(delete(StickySession).where(StickySession.account_id == account_id))
+                await self._clear_account_sticky_sessions(account_id)
                 await self._close_http_bridge_sessions_for_account(account_id)
             await self._session.commit()
             return updated_id is not None
@@ -918,6 +918,22 @@ class AccountsRepository:
                 latest_input_item_count=None,
                 latest_input_full_fingerprint=None,
                 latest_pending_tool_calls_json=None,
+            )
+        )
+
+    async def _clear_account_sticky_sessions(self, account_id: str) -> None:
+        await self._session.execute(
+            update(StickySession)
+            .where(
+                StickySession.account_id == account_id,
+                StickySession.requires_security_work_authorized.is_(True),
+            )
+            .values(account_id=None, updated_at=func.now())
+        )
+        await self._session.execute(
+            delete(StickySession).where(
+                StickySession.account_id == account_id,
+                StickySession.requires_security_work_authorized.is_(False),
             )
         )
 
@@ -1178,7 +1194,7 @@ class AccountsRepository:
                 # set) into the folded buckets: move them to the orphaned
                 # deleted dimension so time-series totals are preserved.
                 await mirror_account_soft_delete_into_time_rollups(self._session, account_id)
-            await self._session.execute(delete(StickySession).where(StickySession.account_id == account_id))
+            await self._clear_account_sticky_sessions(account_id)
             await self._session.execute(delete(AccountUsageRollup).where(AccountUsageRollup.account_id == account_id))
             result = await self._session.execute(delete(Account).where(Account.id == account_id).returning(Account.id))
             deleted_id = result.scalar_one_or_none()

--- a/app/modules/proxy/_service/codex_control.py
+++ b/app/modules/proxy/_service/codex_control.py
@@ -30,10 +30,11 @@ from app.core.config.settings_cache import get_settings_cache
 from app.core.errors import openai_error
 from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteError
 from app.core.utils.request_id import ensure_request_id, get_request_id
-from app.db.models import Account
+from app.db.models import Account, StickySessionKind
 from app.modules.api_keys.service import ApiKeyData
 from app.modules.proxy._service.support import _request_log_client_fields, _RequestLogFailureMetadata
 from app.modules.proxy.affinity import _AffinityPolicy, _sticky_key_for_codex_control_request
+from app.modules.proxy.durable_bridge_repository import durable_bridge_api_key_scope
 from app.modules.proxy.helpers import _header_account_id, _normalize_error_code, _parse_openai_error
 from app.modules.proxy.load_balancer import AccountSelection, effective_account_concurrency_caps
 from app.modules.proxy.selection_errors import selection_failure_response
@@ -45,6 +46,7 @@ T = TypeVar("T")
 class _CodexControlServiceProtocol(Protocol):
     _encryptor: Any
     _load_balancer: Any
+    _repo_factory: Any
 
     async def _select_account_with_budget_compatible(self, deadline: float, **kwargs: object) -> AccountSelection: ...
     async def _select_account_with_budget(self, deadline: float, **kwargs: Any) -> AccountSelection: ...
@@ -223,6 +225,19 @@ class _CodexControlMixin:
             if scoped_account_ids is not None and selected_account_id not in scoped_account_ids:
                 return None
             scoped_account_ids = {selected_account_id}
+        # A lineage that already proved security-work authorization must keep
+        # selecting an authorized account; otherwise the follow-up silently
+        # lands somewhere the earlier turn was refused.
+        require_security_work_authorized = False
+        if affinity.kind == StickySessionKind.CODEX_SESSION and affinity.selection_key:
+            async with proxy._repo_factory() as repos:
+                require_security_work_authorized = (
+                    await repos.sticky_sessions.security_work_required(
+                        tuple(key for key in (affinity.selection_key, affinity.legacy_selection_key) if key),
+                        api_key_scope=durable_bridge_api_key_scope(api_key.id if api_key is not None else None),
+                    )
+                    is True
+                )
         selection = await proxy._load_balancer.select_account(
             sticky_key=affinity.selection_key,
             sticky_kind=affinity.kind,
@@ -241,6 +256,7 @@ class _CodexControlMixin:
             secondary_budget_threshold_pct=_sticky_reallocation_secondary_budget_threshold_pct(settings),
             traffic_class=traffic_class,
             concurrency_caps=effective_account_concurrency_caps(settings),
+            require_security_work_authorized=require_security_work_authorized,
         )
         if selection.account is None:
             return None

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -26,7 +26,7 @@ from app.core.config.settings_cache import get_settings_cache
 from app.core.errors import openai_error
 from app.core.openai.exceptions import ClientPayloadError
 from app.core.openai.models import CompactResponsePayload
-from app.core.openai.requests import ResponsesCompactRequest
+from app.core.openai.requests import ResponsesCompactRequest, extract_input_file_ids
 from app.core.resilience.network_recovery import ProcessNetworkRecovery
 from app.core.types import JsonValue
 from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteError
@@ -38,7 +38,11 @@ from app.modules.api_keys.service import (
     ApiKeyRequestUsageBudget,
     ApiKeyUsageReservationData,
 )
-from app.modules.proxy._service.support import _request_log_client_fields, _RequestLogFailureMetadata
+from app.modules.proxy._service.support import (
+    _request_log_client_fields,
+    _RequestLogFailureMetadata,
+    _security_lineage_ids,
+)
 from app.modules.proxy.affinity import (
     _affinity_with_payload_continuity,
     _AffinityPolicy,
@@ -104,6 +108,8 @@ class _CompactServiceProtocol(Protocol):
     _http_bridge_sessions: Any
     _http_bridge_turn_state_index: Any
     _durable_bridge: Any
+    _persist_security_work_lineage_markers: Any
+    _security_lineage_requires_security_work_authorized: Any
 
     def _get_work_admission(self) -> WorkAdmissionController: ...
 
@@ -863,6 +869,12 @@ class _CompactMixin:
             sticky_threads_enabled=settings.sticky_threads_enabled,
             api_key=api_key,
         )
+        security_lineage_ids = _security_lineage_ids(
+            affinity.selection_key,
+            affinity.legacy_selection_key,
+            getattr(payload, "previous_response_id", None),
+        )
+        request_contains_input_file_ids = bool(extract_input_file_ids(payload.input))
         sticky_key_source = "none"
         if affinity.codex_session_source == "thread_header":
             # The payload cache hint remains unchanged; diagnostics must not
@@ -1238,6 +1250,27 @@ class _CompactMixin:
             # account.
             owner_quota_failover_eligible = False
             require_security_work_authorized = False
+            # A warning observed during this request may be retried without an
+            # authorized pool for backwards-compatible first-turn failover.
+            # A marker that existed before this request is a durable policy
+            # decision and must never be softened that way.
+            security_requirement_preexisting = await proxy._security_lineage_requires_security_work_authorized(
+                security_lineage_ids,
+                api_key_id=api_key.id if api_key is not None else None,
+            )
+            bypass_new_security_lineage_requirement = False
+            security_lineage_persisted: bool | None = None
+
+            async def _persist_security_work_lineage_once() -> bool:
+                nonlocal security_lineage_persisted
+                if security_lineage_persisted is not None:
+                    return security_lineage_persisted
+                security_lineage_persisted = await proxy._persist_security_work_lineage_markers(
+                    security_lineage_ids,
+                    api_key_id=api_key.id if api_key is not None else None,
+                )
+                return security_lineage_persisted
+
             estimated_lease_tokens = _estimated_lease_tokens_from_request_usage_budget(
                 estimate_api_key_request_usage(payload)
             )
@@ -1256,6 +1289,8 @@ class _CompactMixin:
                     exclude_account_ids=excluded_account_ids,
                     preferred_account_id=preferred_account_id,
                     require_security_work_authorized=require_security_work_authorized,
+                    security_lineage_ids=security_lineage_ids,
+                    enforce_persisted_security_lineage=not bypass_new_security_lineage_requirement,
                     lease_kind="response_create",
                     estimated_lease_tokens=estimated_lease_tokens,
                     fallback_on_preferred_account_unavailable=preferred_account_id is None,
@@ -1265,14 +1300,16 @@ class _CompactMixin:
                     if (
                         require_security_work_authorized
                         and selection.error_code == _no_security_work_authorized_accounts_code()
+                        and not security_requirement_preexisting
                         and last_exc is not None
                     ):
                         logger.info(
-                            "No security-work-authorized account available for compact retry; "
-                            "continuing normal account failover request_id=%s",
+                            "No security-work-authorized account available for new compact classification; "
+                            "continuing ordinary failover request_id=%s",
                             request_id,
                         )
                         require_security_work_authorized = False
+                        bypass_new_security_lineage_requirement = True
                         selection = await proxy._select_account_with_budget_compatible(
                             deadline,
                             request_id=request_id,
@@ -1287,6 +1324,8 @@ class _CompactMixin:
                             exclude_account_ids=excluded_account_ids,
                             preferred_account_id=preferred_account_id,
                             require_security_work_authorized=False,
+                            security_lineage_ids=security_lineage_ids,
+                            enforce_persisted_security_lineage=False,
                             lease_kind="response_create",
                             estimated_lease_tokens=estimated_lease_tokens,
                             fallback_on_preferred_account_unavailable=preferred_account_id is None,
@@ -1426,7 +1465,7 @@ class _CompactMixin:
                         pass
                     elif last_exc is not None:
                         break
-                    else:
+                    if account is None:
                         log_error_code = selection.error_code or "no_accounts"
                         log_error_message = selection.error_message or "No active accounts available"
                         status_code, error_payload = selection_failure_response(selection)
@@ -1912,8 +1951,19 @@ class _CompactMixin:
                             safe_retry_budget -= 1
                             continue
                         if _is_security_work_authorization_required_error(code, error_message):
+                            security_requirement_persisted = await _persist_security_work_lineage_once()
+                            if not security_requirement_persisted:
+                                await proxy._settle_compact_api_key_usage(
+                                    api_key=api_key,
+                                    api_key_reservation=api_key_reservation,
+                                    response=None,
+                                    request_service_tier=request_service_tier,
+                                )
+                                raise
                             if (
-                                not account.security_work_authorized
+                                not request_contains_input_file_ids
+                                and rewritten_file_account_id is None
+                                and not account.security_work_authorized
                                 and account.id != preferred_account_id
                                 and _account_attempt < _compact_max_account_attempts() - 1
                             ):

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -357,6 +357,7 @@ class _HTTPBridgeMixin(
         preferred_account_id: str | None = None,
         preferred_account_has_continuity_provenance: bool = False,
         fallback_on_preferred_account_unavailable: bool = True,
+        require_security_work_authorized: bool = False,
         request_usage_budget: ApiKeyRequestUsageBudget | None = None,
         request_deadline: float | None = None,
         session_header_fallback_key: "_HTTPBridgeSessionKey | None" = None,
@@ -390,6 +391,7 @@ class _HTTPBridgeMixin(
         preferred_account_id: str | None = None,
         preferred_account_has_continuity_provenance: bool = False,
         fallback_on_preferred_account_unavailable: bool = True,
+        require_security_work_authorized: bool = False,
         request_usage_budget: ApiKeyRequestUsageBudget | None = None,
         request_deadline: float | None = None,
         session_header_fallback_key: "_HTTPBridgeSessionKey | None" = None,
@@ -422,6 +424,7 @@ class _HTTPBridgeMixin(
         preferred_account_id: str | None = None,
         preferred_account_has_continuity_provenance: bool = False,
         fallback_on_preferred_account_unavailable: bool = True,
+        require_security_work_authorized: bool = False,
         request_usage_budget: ApiKeyRequestUsageBudget | None = None,
         request_deadline: float | None = None,
         session_header_fallback_key: "_HTTPBridgeSessionKey | None" = None,
@@ -1512,6 +1515,7 @@ class _HTTPBridgeMixin(
                     "fallback_on_preferred_account_unavailable": (
                         fallback_on_preferred_account_unavailable and not require_preferred_account
                     ),
+                    "require_security_work_authorized": require_security_work_authorized,
                     "request_usage_budget": request_usage_budget,
                     "request_deadline": request_deadline,
                     "exclude_account_ids": exclude_account_ids,
@@ -1535,6 +1539,7 @@ class _HTTPBridgeMixin(
                         "preferred_account_is_continuity_owner",
                         "deferred_account_backoff_lifecycle",
                         "defer_account_health_writes",
+                        "require_security_work_authorized",
                     ):
                         if optional_kwarg not in create_signature.parameters:
                             create_kwargs.pop(optional_kwarg, None)
@@ -1676,6 +1681,7 @@ class _HTTPBridgeMixin(
         require_preferred_account: bool = False,
         preferred_account_is_continuity_owner: bool = False,
         fallback_on_preferred_account_unavailable: bool = True,
+        require_security_work_authorized: bool = False,
         request_usage_budget: ApiKeyRequestUsageBudget | None = None,
         request_deadline: float | None = None,
         exclude_account_ids: Collection[str] | None = None,
@@ -1732,6 +1738,7 @@ class _HTTPBridgeMixin(
                 "lease_kind": "stream",
                 "estimated_lease_tokens": _estimated_lease_tokens_from_request_usage_budget(request_usage_budget),
                 "fallback_on_preferred_account_unavailable": fallback_on_preferred_account_unavailable,
+                "require_security_work_authorized": require_security_work_authorized,
             }
             selection = await self._select_account_with_budget_for_stream(deadline, **select_kwargs)
             selected_account_lease = selection.lease

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -3397,6 +3397,53 @@ class _HTTPBridgeRequestSubmitMixin:
                 logger.warning("HTTP bridge pre-created auth retry failed", exc_info=True)
             return "failed"
 
+    async def _persist_http_bridge_security_work_requirement(
+        self: Any,
+        session: "_HTTPBridgeSession",
+        request_state: _WebSocketRequestState,
+    ) -> bool:
+        request_state.require_security_work_authorized = True
+        durable_session_id = session.durable_session_id
+        durable_persisted = False
+        if durable_session_id is not None:
+            try:
+                durable_snapshot = await self._durable_bridge.require_security_work_authorized(
+                    session_id=durable_session_id
+                )
+                durable_persisted = durable_snapshot is not None
+            except Exception:
+                logger.warning(
+                    "Failed to persist durable HTTP bridge security-work requirement session_id=%s",
+                    durable_session_id,
+                    exc_info=True,
+                )
+
+        affinity_key = request_state.affinity_policy.selection_key
+        lineage_ids = tuple(
+            dict.fromkeys(
+                value
+                for value in (
+                    session.key.affinity_key,
+                    affinity_key,
+                    session.upstream_turn_state,
+                    session.downstream_turn_state,
+                    request_state.session_id,
+                    request_state.previous_response_id,
+                )
+                if value
+            )
+        )
+        marker_persisted = await self._persist_security_work_lineage_markers(
+            lineage_ids,
+            api_key_id=session.key.api_key_id,
+        )
+        if not durable_persisted and not marker_persisted:
+            logger.error(
+                "Refusing HTTP bridge security-work retry because no durable requirement was persisted session_id=%s",
+                durable_session_id,
+            )
+        return durable_persisted or marker_persisted
+
     async def _retry_http_bridge_security_work_request(
         self: Any,
         session: "_HTTPBridgeSession",

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -47,9 +47,7 @@ from app.core.metrics.prometheus import (
     stream_idle_timeout_total,
     stream_keepalive_sent_total,
 )
-from app.core.openai.requests import (
-    ResponsesRequest,
-)
+from app.core.openai.requests import ResponsesRequest
 from app.core.types import JsonValue
 from app.core.utils.request_id import ensure_request_id, ensure_request_scope_id
 from app.core.utils.sse import format_sse_event, parse_sse_data_json
@@ -168,6 +166,7 @@ from app.modules.proxy._service.support import (
     _HTTPBridgeSession,
     _HTTPBridgeSessionKey,
     _is_local_account_cap_code,
+    _security_lineage_ids,
     _signal_propagated_capacity_startup_ready,
     _signal_propagated_capacity_startup_wait,
     _signal_propagated_responses_service_cleanup_ready,
@@ -1511,6 +1510,23 @@ class _HTTPBridgeStreamingMixin:
             if durable_lookup is not None and not _http_bridge_models_compatible(durable_lookup.model, payload.model)
             else None
         )
+        durable_security_requirement = bool(
+            (durable_lookup is not None and durable_lookup.requires_security_work_authorized)
+            or (
+                durable_model_transition_lookup is not None
+                and durable_model_transition_lookup.requires_security_work_authorized
+            )
+        )
+        if not durable_security_requirement:
+            durable_security_requirement = await self._security_lineage_requires_security_work_authorized(
+                _security_lineage_ids(
+                    bridge_session_key.affinity_key,
+                    incoming_turn_state_header,
+                    incoming_session_header,
+                    payload.previous_response_id,
+                ),
+                api_key_id=api_key.id if api_key is not None else None,
+            )
         durable_model_transition_requires_owner = durable_model_transition_lookup is not None and (
             payload.previous_response_id is not None
             or bridge_session_key.strength == "hard"
@@ -1691,6 +1707,7 @@ class _HTTPBridgeStreamingMixin:
         request_state, text_data = prepare_bridge_request(effective_payload)
         request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
         request_state.affinity_policy = affinity
+        request_state.require_security_work_authorized = durable_security_requirement
         _apply_http_bridge_downstream_turn_state(
             request_state,
             downstream_turn_state=downstream_turn_state,
@@ -1981,6 +1998,7 @@ class _HTTPBridgeStreamingMixin:
                 request_state.operation_rebind_required = True
             request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
             request_state.affinity_policy = affinity
+            request_state.require_security_work_authorized = durable_security_requirement
             request_state.excluded_account_ids.update(fresh_replay_excluded_account_ids)
             if downstream_turn_state is not None:
                 request_state.session_id = _normalize_session_id(downstream_turn_state)
@@ -2091,6 +2109,7 @@ class _HTTPBridgeStreamingMixin:
                     preferred_account_id=request_state.preferred_account_id,
                     preferred_account_has_continuity_provenance=preferred_account_has_continuity_provenance,
                     fallback_on_preferred_account_unavailable=not file_required_preferred_account,
+                    require_security_work_authorized=request_state.require_security_work_authorized,
                     request_usage_budget=request_state.request_usage_budget,
                     request_deadline=request_deadline,
                     session_header_fallback_key=session_header_fallback_key,
@@ -2365,6 +2384,7 @@ class _HTTPBridgeStreamingMixin:
                             ),
                             preferred_account_id=request_state.preferred_account_id,
                             preferred_account_has_continuity_provenance=preferred_account_has_continuity_provenance,
+                            require_security_work_authorized=request_state.require_security_work_authorized,
                             request_usage_budget=request_state.request_usage_budget,
                             session_header_fallback_key=session_header_fallback_key,
                             request_deadline=request_deadline,
@@ -2698,6 +2718,7 @@ class _HTTPBridgeStreamingMixin:
             request_state, text_data = prepare_bridge_request(effective_payload)
             request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
             request_state.affinity_policy = affinity
+            request_state.require_security_work_authorized = durable_security_requirement
             request_state.transport = _REQUEST_TRANSPORT_HTTP
             request_state.request_stage = _http_bridge_request_stage(
                 headers=headers,
@@ -2981,6 +3002,7 @@ class _HTTPBridgeStreamingMixin:
                                 file_required_preferred_account or request_state.previous_response_id is not None
                             ),
                             allow_previous_response_recovery_rebind=request_state.previous_response_id is not None,
+                            require_security_work_authorized=request_state.require_security_work_authorized,
                             request_usage_budget=request_state.request_usage_budget,
                             request_deadline=request_deadline,
                             session_header_fallback_key=session_header_fallback_key,
@@ -3088,6 +3110,7 @@ class _HTTPBridgeStreamingMixin:
                             durable_lookup=None,
                             request_stage=request_state.request_stage,
                             preferred_account_id=None,
+                            require_security_work_authorized=request_state.require_security_work_authorized,
                             request_usage_budget=request_state.request_usage_budget,
                             request_deadline=request_deadline,
                             exclude_account_ids=request_state.excluded_account_ids or None,
@@ -3343,6 +3366,7 @@ class _HTTPBridgeStreamingMixin:
                             fallback_on_preferred_account_unavailable=not (
                                 file_required_preferred_account and retry_preferred_account_id is not None
                             ),
+                            require_security_work_authorized=request_state.require_security_work_authorized,
                             request_usage_budget=estimate_api_key_request_usage(retry_payload),
                             request_deadline=request_deadline,
                             exclude_account_ids=request_state.excluded_account_ids or None,

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -2894,8 +2894,12 @@ class _HTTPBridgeUpstreamEventsMixin:
             )
             terminal_error_message = error.message if error else None
             if _is_security_work_authorization_required_error(terminal_error_code, terminal_error_message):
+                security_requirement_persisted = await self._persist_http_bridge_security_work_requirement(
+                    session, terminal_request_state
+                )
                 can_retry_security_work = (
-                    not is_http_bridge_account_neutral_replay(
+                    security_requirement_persisted
+                    and not is_http_bridge_account_neutral_replay(
                         kind=session.key.affinity_kind,
                         key=session.key.affinity_key,
                     )
@@ -2917,9 +2921,10 @@ class _HTTPBridgeUpstreamEventsMixin:
                                 message=(
                                     _SECURITY_WORK_RETRY_MESSAGE
                                     if can_retry_security_work
-                                    else "Upstream flagged this request as possible cybersecurity work. "
-                                    "codex-lb cannot safely switch accounts after this response has already started, "
-                                    "so the original upstream error is being forwarded."
+                                    else "Upstream flagged this request as possible cybersecurity work, but "
+                                    "codex-lb could not durably preserve that requirement or cannot safely "
+                                    "switch accounts after this response has already started. The original "
+                                    "upstream error is being forwarded."
                                 ),
                                 request_id=terminal_request_state.request_log_id or terminal_request_state.request_id,
                                 action=(

--- a/app/modules/proxy/_service/security_lineage.py
+++ b/app/modules/proxy/_service/security_lineage.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Collection
+from typing import Any
+
+from app.modules.proxy._service.support import _security_lineage_ids
+from app.modules.proxy.durable_bridge_repository import durable_bridge_api_key_scope
+
+logger = logging.getLogger(__name__)
+
+
+class _SecurityLineageMixin:
+    _repo_factory: Any
+
+    async def _security_lineage_requires_security_work_authorized(
+        self,
+        lineage_ids: Collection[str],
+        *,
+        api_key_id: str | None,
+    ) -> bool:
+        normalized_lineage_ids = _security_lineage_ids(*lineage_ids)
+        if not normalized_lineage_ids:
+            return False
+        try:
+            async with self._repo_factory() as repos:
+                return (
+                    await repos.sticky_sessions.security_work_required(
+                        normalized_lineage_ids,
+                        api_key_scope=durable_bridge_api_key_scope(api_key_id),
+                    )
+                    is True
+                )
+        except Exception:
+            # Unknown lineage metadata must not downgrade a previously
+            # classified security request into ordinary account selection.
+            logger.warning("Security-work lineage lookup failed; requiring an authorized account", exc_info=True)
+            return True

--- a/app/modules/proxy/_service/streaming/protocol.py
+++ b/app/modules/proxy/_service/streaming/protocol.py
@@ -13,6 +13,7 @@ class _StreamingServiceProtocol(Protocol):
     _handle_stream_error: Any
     _load_balancer: Any
     _maybe_touch_api_key_reservation: Any
+    _persist_security_work_lineage_markers: Any
     _raise_for_unsupported_input_image_references: Any
     _release_unsettled_stream_api_key_usage: Any
     _resolve_file_account_for_responses: Any
@@ -21,6 +22,7 @@ class _StreamingServiceProtocol(Protocol):
     _resolve_websocket_previous_response_owner: Any
     _run_api_key_reservation_heartbeat: Any
     _schedule_cancel_safe_cleanup: Any
+    _security_lineage_requires_security_work_authorized: Any
     _select_account_with_budget_compatible: Any
     _settle_stream_api_key_usage: Any
     _stream_once: Any

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -47,6 +47,7 @@ from app.modules.proxy._service.support import (
     _account_selection_recovery_sleep_seconds,
     _request_log_client_fields,
     _RetryableStreamError,
+    _security_lineage_ids,
     _signal_propagated_capacity_startup_wait,
     _signal_propagated_responses_service_cleanup_ready,
     _stream_settlement_error_payload,
@@ -348,6 +349,12 @@ class _StreamingRetryMixin:
             sticky_threads_enabled=settings.sticky_threads_enabled,
             api_key=api_key,
         )
+        security_lineage_ids = _security_lineage_ids(
+            affinity.selection_key,
+            affinity.legacy_selection_key,
+            payload.previous_response_id,
+        )
+        request_contains_input_file_ids = bool(extract_input_file_ids(payload.input))
         turn_state_owner_account_id: str | None = None
         turn_state = _sticky_key_from_turn_state_header(headers)
         if turn_state is not None:
@@ -403,6 +410,12 @@ class _StreamingRetryMixin:
         deferred_account_error_backoffs: dict[str, Account] = {}
         post_refresh_transient_replacement_selected = False
         require_security_work_authorized = False
+        security_requirement_preexisting = await proxy._security_lineage_requires_security_work_authorized(
+            security_lineage_ids,
+            api_key_id=api_key.id if api_key is not None else None,
+        )
+        bypass_new_security_lineage_requirement = False
+        security_lineage_persisted: bool | None = None
         account_leases: list[AccountLease] = []
         estimated_lease_tokens = _facade()._estimated_lease_tokens_from_request_usage_budget(
             estimate_api_key_request_usage(payload)
@@ -530,6 +543,16 @@ class _StreamingRetryMixin:
             _, cancellation = await _await_task_deferring_cancellation(finalize_task)
             if cancellation is not None:
                 raise cancellation
+
+        async def _persist_security_work_lineage_once() -> bool:
+            nonlocal security_lineage_persisted
+            if security_lineage_persisted is not None:
+                return security_lineage_persisted
+            security_lineage_persisted = await proxy._persist_security_work_lineage_markers(
+                security_lineage_ids,
+                api_key_id=api_key.id if api_key is not None else None,
+            )
+            return security_lineage_persisted
 
         async def _wait_for_process_network_recovery(
             account: Account,
@@ -1052,6 +1075,8 @@ class _StreamingRetryMixin:
                             exclude_account_ids=excluded_account_ids,
                             preferred_account_id=preferred_account_id,
                             require_security_work_authorized=require_security_work_authorized,
+                            security_lineage_ids=security_lineage_ids,
+                            enforce_persisted_security_lineage=not bypass_new_security_lineage_requirement,
                             lease_kind="stream",
                             estimated_lease_tokens=estimated_lease_tokens,
                             # Keep stored-object and file ownership strict. The
@@ -1104,21 +1129,34 @@ class _StreamingRetryMixin:
                         and require_security_work_authorized
                         and selection.error_code == _facade()._NO_SECURITY_WORK_AUTHORIZED_ACCOUNTS_CODE
                     ):
+                        if not security_requirement_preexisting and last_security_work_retry_error is not None:
+                            _facade().logger.info(
+                                "No security-work-authorized account available for new stream classification; "
+                                "continuing ordinary failover request_id=%s",
+                                request_id,
+                            )
+                            yield format_sse_event(
+                                _facade()._security_work_advisory_event(
+                                    code=_facade()._NO_SECURITY_WORK_AUTHORIZED_ACCOUNTS_CODE,
+                                    message=_facade()._SECURITY_WORK_NO_AUTHORIZED_ACCOUNTS_MESSAGE,
+                                    request_id=request_id,
+                                    action="continue_normal_selection",
+                                )
+                            )
+                            require_security_work_authorized = False
+                            bypass_new_security_lineage_requirement = True
+                            continue
                         _facade().logger.info(
-                            "No security-work-authorized account available for stream retry; "
-                            "continuing normal account failover request_id=%s",
+                            "No security-work-authorized account available for classified stream request_id=%s",
                             request_id,
                         )
-                        yield format_sse_event(
-                            _facade()._security_work_advisory_event(
-                                code=_facade()._NO_SECURITY_WORK_AUTHORIZED_ACCOUNTS_CODE,
-                                message=_facade()._SECURITY_WORK_NO_AUTHORIZED_ACCOUNTS_MESSAGE,
-                                request_id=request_id,
-                                action="continue_normal_selection",
-                            )
+                        event = response_failed_event(
+                            selection.error_code,
+                            selection.error_message or _facade()._SECURITY_WORK_NO_AUTHORIZED_ACCOUNTS_MESSAGE,
+                            response_id=request_id,
                         )
-                        require_security_work_authorized = False
-                        continue
+                        yield format_sse_event(event)
+                        return
                     if not account and deferred_capacity_account is not None:
                         deferred_error = _parse_openai_error(last_transient_exc.payload) if last_transient_exc else None
                         recovery_sleep_seconds = _account_selection_recovery_sleep_seconds(
@@ -2011,8 +2049,11 @@ class _StreamingRetryMixin:
                                     # already excluded by the helper.
                                     break
                                 if _facade()._is_security_work_authorization_required_error(code, error_message):
+                                    security_requirement_persisted = await _persist_security_work_lineage_once()
                                     if (
-                                        account.security_work_authorized
+                                        not security_requirement_persisted
+                                        or account.security_work_authorized
+                                        or request_contains_input_file_ids
                                         or account.id == file_preferred_account_id
                                         or require_preferred_account
                                         or attempt >= max_attempts - 1
@@ -2274,8 +2315,11 @@ class _StreamingRetryMixin:
                     continue  # outer loop: account failover after transient exhaustion
                 except _RetryableStreamError as exc:
                     if _facade()._is_security_work_authorization_required_error(exc.code, exc.error.get("message")):
+                        security_requirement_persisted = await _persist_security_work_lineage_once()
                         if (
-                            account.security_work_authorized
+                            not security_requirement_persisted
+                            or account.security_work_authorized
+                            or request_contains_input_file_ids
                             or account.id == file_preferred_account_id
                             or require_preferred_account
                             or attempt >= max_attempts - 1
@@ -2841,8 +2885,11 @@ class _StreamingRetryMixin:
                     error_type = error.type if error else None
                     error_param = error.param if error else None
                     if _facade()._is_security_work_authorization_required_error(error_code, error_message):
+                        security_requirement_persisted = await _persist_security_work_lineage_once()
                         if (
-                            not account.security_work_authorized
+                            security_requirement_persisted
+                            and not account.security_work_authorized
+                            and not request_contains_input_file_ids
                             and account.id != file_preferred_account_id
                             and not require_preferred_account
                             and attempt < max_attempts - 1

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -112,6 +112,10 @@ _PROPAGATED_RESPONSES_OWNER_FORWARD_REJECTED: ContextVar[asyncio.Event | None] =
 )
 
 
+def _security_lineage_ids(*values: object) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(value.strip() for value in values if isinstance(value, str) and value.strip()))
+
+
 def _strip_blank_html_comment_lines(text: str) -> str:
     terminal_match = None
     for match in _REASONING_SUMMARY_BLANK_HTML_COMMENT_RE.finditer(text):

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -332,6 +332,7 @@ from app.modules.proxy._service.support import (
     _record_response_event,
     _record_websocket_route_metadata,
     _request_log_client_fields,
+    _security_lineage_ids,
     _sleep_for_account_selection_recovery,
     _stream_settlement_error_payload,
     _StreamSettlement,
@@ -2192,6 +2193,7 @@ class _WebSocketMixin:
                         model=request_state.model,
                         preferred_account_id=account.id,
                         require_security_work_authorized=request_state.require_security_work_authorized,
+                        security_lineage_ids=proxy._websocket_security_lineage_ids(request_state),
                         fallback_on_preferred_account_unavailable=False,
                     )
                     if ownership_selection.account is None:
@@ -3299,6 +3301,17 @@ class _WebSocketMixin:
             affinity_policy=affinity_policy,
         )
 
+    def _websocket_security_lineage_ids(
+        self,
+        request_state: _WebSocketRequestState,
+    ) -> tuple[str, ...]:
+        return _security_lineage_ids(
+            request_state.affinity_policy.selection_key,
+            request_state.affinity_policy.legacy_selection_key,
+            request_state.session_id,
+            request_state.previous_response_id,
+        )
+
     async def _revalidate_open_websocket_account(
         self,
         account: Account,
@@ -3322,6 +3335,7 @@ class _WebSocketMixin:
             service_tier=request_state.requested_service_tier,
             preferred_account_id=account.id,
             require_security_work_authorized=request_state.require_security_work_authorized,
+            security_lineage_ids=self._websocket_security_lineage_ids(request_state),
             fallback_on_preferred_account_unavailable=False,
         )
         await proxy._load_balancer.release_account_lease(selection.lease)
@@ -3703,6 +3717,7 @@ class _WebSocketMixin:
                     exclude_account_ids=exclude_account_ids,
                     preferred_account_id=preferred_account_id,
                     require_security_work_authorized=require_security_work_authorized,
+                    security_lineage_ids=proxy._websocket_security_lineage_ids(request_state),
                     lease_kind="stream",
                     request_stage=request_state.request_stage,
                     estimated_lease_tokens=_facade()._estimated_lease_tokens_from_request_usage_budget(
@@ -5604,8 +5619,25 @@ class _WebSocketMixin:
             )
             terminal_error_message = error.message if error else None
             if _facade()._is_security_work_authorization_required_error(terminal_error_code, terminal_error_message):
+                security_lineage_ids = tuple(
+                    dict.fromkeys(
+                        value
+                        for value in (
+                            request_state.affinity_policy.selection_key,
+                            request_state.affinity_policy.legacy_selection_key,
+                            request_state.session_id,
+                            request_state.previous_response_id,
+                        )
+                        if value
+                    )
+                )
+                security_requirement_persisted = await proxy._persist_security_work_lineage_markers(
+                    security_lineage_ids,
+                    api_key_id=request_state.api_key.id if request_state.api_key is not None else None,
+                )
                 can_retry_security_work = (
-                    not account.security_work_authorized
+                    security_requirement_persisted
+                    and not account.security_work_authorized
                     and not has_other_pending_requests
                     and request_state.last_downstream_sequence_number is None
                     and request_state.response_id is None

--- a/app/modules/proxy/_service/websocket/protocol.py
+++ b/app/modules/proxy/_service/websocket/protocol.py
@@ -35,6 +35,7 @@ class _WebSocketServiceProtocol(Protocol):
     _open_upstream_websocket_with_budget: Any
     _prepare_response_bridge_request_state: Any
     _prepare_websocket_response_create_request: Any
+    _persist_security_work_lineage_markers: Any
     _process_upstream_websocket_text: Any
     _raise_for_unsupported_input_image_references: Any
     _refresh_websocket_api_key_policy: Any
@@ -63,6 +64,7 @@ class _WebSocketServiceProtocol(Protocol):
     _websocket_continuity_index: Any
     _websocket_continuity_state_for_request: Any
     _websocket_previous_response_account_index: Any
+    _websocket_security_lineage_ids: Any
     _write_request_log: Any
     _write_websocket_connect_failure: Any
     proxy_responses_websocket: Any

--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -49,6 +49,7 @@ class DurableBridgeLookup:
     model: str | None = None
     latest_pending_tool_calls: dict[str, str] | None = None
     owner_process_epoch: str | None = None
+    requires_security_work_authorized: bool = False
 
     def lease_is_active(self, *, now: datetime) -> bool:
         if self.owner_instance_id is None:
@@ -356,6 +357,17 @@ class DurableBridgeSessionCoordinator:
                 latest_pending_tool_calls=latest_pending_tool_calls,
                 state=state,
             )
+        if snapshot is None:
+            return None
+        return _to_lookup(snapshot)
+
+    async def require_security_work_authorized(
+        self,
+        *,
+        session_id: str,
+    ) -> DurableBridgeLookup | None:
+        async with self._session() as session:
+            snapshot = await DurableBridgeRepository(session).require_security_work_authorized(session_id=session_id)
         if snapshot is None:
             return None
         return _to_lookup(snapshot)
@@ -947,4 +959,5 @@ def _to_lookup(snapshot: DurableBridgeSessionSnapshot) -> DurableBridgeLookup:
         latest_input_full_fingerprint=snapshot.latest_input_full_fingerprint,
         model=snapshot.model,
         latest_pending_tool_calls=snapshot.latest_pending_tool_calls,
+        requires_security_work_authorized=snapshot.requires_security_work_authorized,
     )

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -141,6 +141,7 @@ class DurableBridgeSessionSnapshot:
     account_id: str | None
     model: str | None
     service_tier: str | None
+    requires_security_work_authorized: bool
     latest_turn_state: str | None
     latest_response_id: str | None
     latest_input_item_count: int | None
@@ -677,6 +678,7 @@ class DurableBridgeRepository:
                     latest_input_item_count=None,
                     latest_input_full_fingerprint=None,
                     latest_pending_tool_calls=None,
+                    requires_security_work_authorized=False,
                     last_seen_at=now,
                     closed_at=None,
                 )
@@ -793,6 +795,12 @@ class DurableBridgeRepository:
                     cast("str | None", written_response_id),
                     cast("str | None", written_pending_json),
                 ),
+                requires_security_work_authorized=bool(
+                    values.get(
+                        "requires_security_work_authorized",
+                        existing.requires_security_work_authorized,
+                    )
+                ),
                 last_seen_at=now,
                 closed_at=None,
             )
@@ -844,6 +852,23 @@ class DurableBridgeRepository:
             owner_epoch=owner_epoch,
             values=values,
         )
+
+    async def require_security_work_authorized(
+        self,
+        *,
+        session_id: str,
+    ) -> DurableBridgeSessionSnapshot | None:
+        statement = (
+            update(HttpBridgeSessionRecord)
+            .where(HttpBridgeSessionRecord.id == session_id)
+            .values(requires_security_work_authorized=True)
+            .returning(*_SNAPSHOT_COLUMNS)
+        )
+        async with sqlite_writer_section():
+            result = await self._session.execute(statement)
+            await self._session.commit()
+        row = result.first()
+        return _returned_row_to_snapshot(row) if row is not None else None
 
     async def rebind_session_account(
         self,
@@ -3017,6 +3042,7 @@ _SNAPSHOT_COLUMNS = (
     HttpBridgeSessionRecord.account_id,
     HttpBridgeSessionRecord.model,
     HttpBridgeSessionRecord.service_tier,
+    HttpBridgeSessionRecord.requires_security_work_authorized,
     HttpBridgeSessionRecord.latest_turn_state,
     HttpBridgeSessionRecord.latest_response_id,
     HttpBridgeSessionRecord.latest_input_item_count,
@@ -3043,6 +3069,7 @@ def _returned_row_to_snapshot(row: Row[tuple[object, ...]]) -> DurableBridgeSess
         account_id=mapping[HttpBridgeSessionRecord.account_id],
         model=mapping[HttpBridgeSessionRecord.model],
         service_tier=mapping[HttpBridgeSessionRecord.service_tier],
+        requires_security_work_authorized=bool(mapping[HttpBridgeSessionRecord.requires_security_work_authorized]),
         latest_turn_state=mapping[HttpBridgeSessionRecord.latest_turn_state],
         latest_response_id=mapping[HttpBridgeSessionRecord.latest_response_id],
         latest_input_item_count=mapping[HttpBridgeSessionRecord.latest_input_item_count],
@@ -3073,6 +3100,7 @@ def _to_snapshot(row: HttpBridgeSessionRecord | None) -> DurableBridgeSessionSna
         account_id=row.account_id,
         model=row.model,
         service_tier=row.service_tier,
+        requires_security_work_authorized=bool(row.requires_security_work_authorized),
         latest_turn_state=row.latest_turn_state,
         latest_response_id=row.latest_response_id,
         latest_input_item_count=row.latest_input_item_count,

--- a/app/modules/proxy/security_lineage.py
+++ b/app/modules/proxy/security_lineage.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+
+SECURITY_WORK_MARKER_PREFIX = "@security-work/v2/"
+ANONYMOUS_API_KEY_SCOPE = "__anonymous__"
+
+
+def security_work_marker_key(lineage_id: str, api_key_scope: str | None) -> str:
+    scope = (api_key_scope or "").strip() or ANONYMOUS_API_KEY_SCOPE
+    digest = hashlib.sha256(f"{scope}\0{lineage_id}".encode()).hexdigest()
+    return f"{SECURITY_WORK_MARKER_PREFIX}{digest}"
+
+
+def legacy_security_work_marker_key(lineage_id: str) -> str:
+    return f"{SECURITY_WORK_MARKER_PREFIX}{hashlib.sha256(lineage_id.encode()).hexdigest()}"
+
+
+def security_work_marker_keys(
+    lineage_ids: Iterable[str],
+    *,
+    api_key_scope: str | None,
+    include_legacy: bool = True,
+) -> tuple[str, ...]:
+    keys: dict[str, None] = {}
+    for lineage_id in lineage_ids:
+        stripped = lineage_id.strip()
+        if not stripped:
+            continue
+        keys[security_work_marker_key(stripped, api_key_scope)] = None
+        if include_legacy:
+            keys[legacy_security_work_marker_key(stripped)] = None
+    return tuple(keys)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -498,6 +498,7 @@ from app.modules.proxy._service.response_create import (
 from app.modules.proxy._service.response_create import (
     _write_response_create_dump as _write_response_create_dump,
 )
+from app.modules.proxy._service.security_lineage import _SecurityLineageMixin
 from app.modules.proxy._service.streaming import (
     _StreamingMixin,
 )
@@ -577,6 +578,7 @@ from app.modules.proxy._service.support import (
     _request_log_useragent_fields,  # noqa: F401
     _RequestLogFailureMetadata,
     _RetryableStreamError,  # noqa: F401
+    _security_lineage_ids,
     _selection_api_key_fair_share_threshold_pct,
     _stream_settlement_error_payload,  # noqa: F401
     _StreamSettlement,  # noqa: F401
@@ -727,6 +729,7 @@ from app.modules.proxy.durable_bridge_coordinator import (
 from app.modules.proxy.durable_bridge_coordinator import (
     DurableBridgeSessionCoordinator,
 )
+from app.modules.proxy.durable_bridge_repository import durable_bridge_api_key_scope
 from app.modules.proxy.helpers import (
     _apply_error_metadata,
     _header_account_id,
@@ -913,6 +916,7 @@ def _bounded_lease_token_estimate(value: int | None, *, default: int) -> int:
 
 
 class ProxyService(
+    _SecurityLineageMixin,
     _ApiKeyUsageMixin,
     _RequestLogMixin,
     _RateLimitMixin,
@@ -1429,6 +1433,28 @@ class ProxyService(
             **required_capability_kwargs,
         )
 
+    async def _persist_security_work_lineage_markers(
+        self,
+        lineage_ids: Collection[str],
+        *,
+        api_key_id: str | None,
+    ) -> bool:
+        normalized_lineage_ids = tuple(dict.fromkeys(value.strip() for value in lineage_ids if value.strip()))
+        if not normalized_lineage_ids:
+            # A request without a reusable lineage has no future selection to
+            # constrain. Its current in-memory retry is therefore sufficient.
+            return True
+        try:
+            async with self._repo_factory() as repos:
+                marker_keys = await repos.sticky_sessions.require_security_work_authorized(
+                    normalized_lineage_ids,
+                    api_key_scope=durable_bridge_api_key_scope(api_key_id),
+                )
+        except Exception:
+            logger.warning("Failed to persist security-work lineage markers", exc_info=True)
+            return False
+        return bool(marker_keys)
+
     @asynccontextmanager
     async def _accounts_refresh_scope(self) -> AsyncIterator[AccountsRepositoryPort]:
         # A self-contained repo prevents request cancellation from closing the
@@ -1719,6 +1745,8 @@ class ProxyService(
         preferred_account_id: str | None = None,
         preferred_account_is_continuity_owner: bool = False,
         require_security_work_authorized: bool = False,
+        security_lineage_ids: Collection[str] = (),
+        enforce_persisted_security_lineage: bool = True,
         lease_kind: Literal["response_create", "stream"] | None = None,
         estimated_lease_tokens: float = 0.0,
         fallback_on_preferred_account_unavailable: bool = True,
@@ -1771,6 +1799,19 @@ class ProxyService(
         try:
             with anyio.fail_after(remaining_budget):
                 settings = await get_settings_cache().get()
+                lineage_ids = _security_lineage_ids(
+                    *security_lineage_ids,
+                    *((sticky_key, legacy_sticky_key) if sticky_kind == StickySessionKind.CODEX_SESSION else ()),
+                )
+                if lineage_ids and enforce_persisted_security_lineage:
+                    async with self._repo_factory() as repos:
+                        persisted_security_requirement = await repos.sticky_sessions.security_work_required(
+                            lineage_ids,
+                            api_key_scope=durable_bridge_api_key_scope(api_key.id if api_key is not None else None),
+                        )
+                    require_security_work_authorized = (
+                        require_security_work_authorized or persisted_security_requirement is True
+                    )
                 concurrency_caps = effective_account_concurrency_caps(settings)
                 stream_reserve_slots = (
                     (

--- a/app/modules/proxy/sticky_repository.py
+++ b/app/modules/proxy/sticky_repository.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Literal
+from typing import Literal, cast
 
 from sqlalchemy import and_, delete, func, or_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -14,6 +14,7 @@ from sqlalchemy.sql import Insert
 from app.core.utils.time import naive_utc_to_epoch, to_utc_naive, utcnow
 from app.db.models import Account, AccountStatus, StickySession, StickySessionKind
 from app.db.session import sqlite_writer_section
+from app.modules.proxy.security_lineage import ANONYMOUS_API_KEY_SCOPE, security_work_marker_keys
 from app.modules.sticky_sessions.schemas import StickySessionSortBy, StickySessionSortDir
 
 # Each (key, kind) pair in delete_entries contributes 2 bind parameters to
@@ -99,7 +100,7 @@ def _continuity_is_abandoned_for_source(
 
 
 def _source_scoped_abandoned_account_id(
-    account_id: str,
+    account_id: str | None,
     abandonment_scope: str | None,
     continuity_source: _ContinuitySource | None,
 ) -> str | None:
@@ -239,7 +240,8 @@ class StickySessionsRepository:
         async with sqlite_writer_section():
             deleted_key = (await self._session.execute(statement)).scalar_one_or_none()
             if deleted_key is None:
-                current = (
+                current = cast(
+                    "tuple[str, datetime, datetime | None, str | None] | None",
                     (
                         await self._session.execute(
                             select(
@@ -250,11 +252,12 @@ class StickySessionsRepository:
                             ).where(
                                 StickySession.key == key,
                                 StickySession.kind == kind,
+                                StickySession.account_id.is_not(None),
                             )
                         )
                     )
                     .tuples()
-                    .one_or_none()
+                    .one_or_none(),
                 )
             await self._session.commit()
 
@@ -310,13 +313,71 @@ class StickySessionsRepository:
         result = await self._session.execute(statement)
         return result.scalar_one_or_none()
 
-    async def upsert(self, key: str, account_id: str, *, kind: StickySessionKind) -> StickySession:
+    async def security_work_required(
+        self,
+        lineage_ids: Sequence[str],
+        *,
+        api_key_scope: str | None,
+    ) -> bool:
+        marker_keys = security_work_marker_keys(lineage_ids, api_key_scope=api_key_scope)
+        normalized_scope = (api_key_scope or "").strip() or ANONYMOUS_API_KEY_SCOPE
+        raw_lineage_ids = lineage_ids if normalized_scope == ANONYMOUS_API_KEY_SCOPE else ()
+        lookup_keys = tuple(dict.fromkeys((*raw_lineage_ids, *marker_keys)))
+        if not lookup_keys:
+            return False
+        statement = select(StickySession.key).where(
+            StickySession.key.in_(lookup_keys),
+            StickySession.kind == StickySessionKind.CODEX_SESSION,
+            StickySession.requires_security_work_authorized.is_(True),
+        )
+        result = await self._session.execute(statement.limit(1))
+        return result.scalar_one_or_none() is not None
+
+    async def require_security_work_authorized(
+        self,
+        lineage_ids: Sequence[str],
+        *,
+        api_key_scope: str | None,
+    ) -> tuple[str, ...]:
+        marker_keys = security_work_marker_keys(
+            lineage_ids,
+            api_key_scope=api_key_scope,
+            include_legacy=False,
+        )
+        if not marker_keys:
+            return ()
+        async with sqlite_writer_section():
+            for marker_key in marker_keys:
+                await self._session.execute(
+                    self._build_upsert_statement(
+                        marker_key,
+                        None,
+                        StickySessionKind.CODEX_SESSION,
+                        requires_security_work_authorized=True,
+                    )
+                )
+            await self._session.commit()
+        return marker_keys
+
+    async def upsert(
+        self,
+        key: str,
+        account_id: str | None,
+        *,
+        kind: StickySessionKind,
+        requires_security_work_authorized: bool = False,
+    ) -> StickySession:
         # RETURNING collapses the previous upsert + re-select + refresh
         # (4 round trips) into one statement; this runs inline before the
         # first upstream byte on sticky requests, so round trips are TTFT.
         # populate_existing forces the returned row to overwrite any stale
         # identity-map instance the session may already hold for this key.
-        statement = self._build_upsert_statement(key, account_id, kind).returning(StickySession)
+        statement = self._build_upsert_statement(
+            key,
+            account_id,
+            kind,
+            requires_security_work_authorized=requires_security_work_authorized,
+        ).returning(StickySession)
         async with sqlite_writer_section():
             result = await self._session.execute(statement, execution_options={"populate_existing": True})
             row = result.scalar_one_or_none()
@@ -611,6 +672,13 @@ class StickySessionsRepository:
         stmt = delete(StickySession).where(StickySession.updated_at < to_utc_naive(cutoff))
         if kind is not None:
             stmt = stmt.where(StickySession.kind == kind)
+        if kind in {None, StickySessionKind.CODEX_SESSION}:
+            stmt = stmt.where(
+                or_(
+                    StickySession.account_id.is_not(None),
+                    StickySession.requires_security_work_authorized.is_(False),
+                )
+            )
         async with sqlite_writer_section():
             result = await self._session.execute(stmt.returning(StickySession.key))
             deleted = len(result.scalars().all())
@@ -738,7 +806,14 @@ class StickySessionsRepository:
             await self._session.commit()
         return tombstoned + deleted
 
-    def _build_upsert_statement(self, key: str, account_id: str, kind: StickySessionKind) -> Insert:
+    def _build_upsert_statement(
+        self,
+        key: str,
+        account_id: str | None,
+        kind: StickySessionKind,
+        *,
+        requires_security_work_authorized: bool = False,
+    ) -> Insert:
         dialect = self._session.get_bind().dialect.name
         if dialect == "postgresql":
             insert_fn = pg_insert
@@ -746,11 +821,20 @@ class StickySessionsRepository:
             insert_fn = sqlite_insert
         else:
             raise RuntimeError(f"StickySession upsert unsupported for dialect={dialect!r}")
-        statement = insert_fn(StickySession).values(key=key, account_id=account_id, kind=kind)
+        statement = insert_fn(StickySession).values(
+            key=key,
+            account_id=account_id,
+            kind=kind,
+            requires_security_work_authorized=requires_security_work_authorized,
+        )
         return statement.on_conflict_do_update(
             index_elements=[StickySession.key, StickySession.kind],
             set_={
                 "account_id": account_id,
+                "requires_security_work_authorized": or_(
+                    StickySession.requires_security_work_authorized,
+                    statement.excluded.requires_security_work_authorized,
+                ),
                 "updated_at": func.now(),
                 # A fresh pin fully re-establishes ownership, so any earlier
                 # purge tombstone (see purge_stale_hard_codex_session_mappings)

--- a/app/modules/usage/mappers.py
+++ b/app/modules/usage/mappers.py
@@ -20,8 +20,11 @@ def usage_history_to_window_row(entry: UsageHistory | AdditionalUsageHistory) ->
     All fields map by name. Callers that need a ``UsageWindowRow`` from a
     usage row should route through this helper.
     """
+    account_id = entry.account_id
+    if account_id is None:
+        raise ValueError("Detached security-lineage usage rows are not usage windows")
     return UsageWindowRow(
-        account_id=entry.account_id,
+        account_id=account_id,
         used_percent=entry.used_percent,
         reset_at=entry.reset_at,
         window_minutes=entry.window_minutes,

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -409,7 +409,8 @@ def _latest_by_account_sqlite(
             row = conn.execute(latest_sql, [account_id, *window_params]).fetchone()
             if row is not None:
                 entry = _usage_history_from_sqlite_row(row)
-                latest[entry.account_id] = entry
+                if entry.account_id is not None:
+                    latest[entry.account_id] = entry
     return latest
 
 
@@ -900,7 +901,7 @@ class UsageRepository:
             )
             stmt = select(UsageHistory).where(UsageHistory.id.in_(id_query))
             result = await self._session.execute(stmt)
-            return {entry.account_id: entry for entry in result.scalars().all()}
+            return {entry.account_id: entry for entry in result.scalars().all() if entry.account_id is not None}
 
         acct_stmt = select(Account.id)
         if account_ids is not None:
@@ -920,7 +921,7 @@ class UsageRepository:
         id_rows = select(latest_id.label("usage_id")).select_from(acct_subq).subquery("latest_ids")
         stmt = select(UsageHistory).join(id_rows, UsageHistory.id == id_rows.c.usage_id)
         result = await self._session.execute(stmt)
-        return {entry.account_id: entry for entry in result.scalars().all()}
+        return {entry.account_id: entry for entry in result.scalars().all() if entry.account_id is not None}
 
     async def history_since(
         self,

--- a/openspec/changes/persist-security-lineage-markers/proposal.md
+++ b/openspec/changes/persist-security-lineage-markers/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Security-work authorization is a monotonic property of a response lineage, but
+older schemas attach that property only to the account that happened to own the
+lineage. Deleting or replacing that account can therefore erase the requirement
+and let a durable bridge or sticky alias be reused by an unauthorized account.
+
+Deployments that ran the broader live integration stack can also contain the
+new lineage and compatibility columns without a matching focused mainline
+revision. Those databases need one idempotent Alembic carrier rather than a
+second migration head or a destructive schema rollback.
+
+## What Changes
+
+- Add one current-head Alembic revision that reconciles the security-lineage,
+  durable bridge, pending tool-call, and retained quota-planner compatibility
+  columns idempotently.
+- Persist the security-work requirement on durable bridge rows and detached
+  `codex_session` markers so it survives account deletion and reassignment.
+- Preserve detached security markers during ordinary sticky-session cleanup.
+- Keep account-less security-lineage usage rows out of normal account usage
+  windows while retaining them as migration-compatible evidence.
+- Keep the migration downgrade non-destructive because it cannot prove which
+  previous live aggregate created an existing column or marker.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `database-migrations`: reconcile and retain monotonic security-lineage state
+  across fresh databases and databases that already ran the broader live stack.
+
+## Impact
+
+- Affected code: SQLAlchemy metadata, the durable bridge and sticky-session
+  repositories, usage-row mapping, and one Alembic revision.
+- Affected data: existing security-required owners and durable aliases are
+  backfilled into detached hashed markers; no marker is downgraded or deleted.
+- APIs and configuration: none.
+

--- a/openspec/changes/persist-security-lineage-markers/specs/database-migrations/spec.md
+++ b/openspec/changes/persist-security-lineage-markers/specs/database-migrations/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Security lineage persistence survives account ownership changes
+
+The migration lineage SHALL persist the monotonic
+`requires_security_work_authorized` property independently of the account that
+currently owns a response lineage. Alembic and ORM metadata SHALL represent the
+same nullable ownership and security-marker columns, and migration reconciliation
+SHALL be idempotent for both fresh databases and databases that already ran the
+broader security-work live stack.
+
+Detached security markers SHALL NOT be returned as ordinary account usage or
+deleted by age-based sticky-session cleanup. A downgrade SHALL NOT remove
+existing compatibility columns or detached markers when their original owning
+revision cannot be proven.
+
+#### Scenario: Fresh migration creates the focused security-lineage schema
+
+- **WHEN** a fresh database upgrades to Alembic `head`
+- **THEN** usage, sticky-session, and durable bridge tables contain the focused
+  security-lineage columns represented by ORM metadata
+- **AND** migration policy reports one head with no schema drift
+
+#### Scenario: Existing live-stack schema reconciles idempotently
+
+- **GIVEN** a database already contains any subset of the security-lineage,
+  pending tool-call, or retained quota-planner compatibility columns
+- **WHEN** the focused reconciliation revision upgrades that database
+- **THEN** it adds only missing columns and markers
+- **AND** a repeated upgrade leaves the same schema and data intact
+
+#### Scenario: Security requirement survives owner deletion
+
+- **GIVEN** a sticky or durable response lineage requires a security-work
+  authorized account
+- **WHEN** its current account is deleted or ownership is cleared
+- **THEN** a detached, account-less marker retains the monotonic requirement
+- **AND** later selection cannot treat that lineage as authorization-neutral
+
+#### Scenario: Detached markers stay out of ordinary usage windows
+
+- **GIVEN** a retained security-lineage usage row has no account owner
+- **WHEN** account usage windows are queried or mapped
+- **THEN** the detached row is not exposed as an ordinary account usage window
+- **AND** the evidence row remains available to migration-compatible storage
+

--- a/openspec/changes/persist-security-lineage-markers/specs/responses-api-compat/spec.md
+++ b/openspec/changes/persist-security-lineage-markers/specs/responses-api-compat/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Persisted security-work lineage MUST be enforced across Responses transports
+
+Compact, streamed Responses, and HTTP bridge account selection MUST enforce a
+security-work-authorized requirement for every marked durable alias, including
+`previous_response_id`. The requirement MUST remain monotonic when the original
+account or durable bridge owner is no longer available.
+
+A request newly classified by upstream as security work MAY use the existing
+safe ordinary-account fallback when no authorized account is available. That
+bounded compatibility fallback MUST NOT weaken a requirement that existed
+before the request, and it MUST NOT repeatedly re-read the marker and re-enter
+authorized-account selection.
+
+#### Scenario: Previous-response continuation crosses transport
+
+- **GIVEN** a bridge, compact, or streamed request persists a security-work
+  requirement for a `previous_response_id`
+- **WHEN** a later request presents that alias through another Responses
+  transport
+- **THEN** account selection requires a security-work-authorized account
+- **AND** owner deletion or missing durable bridge state does not downgrade the
+  requirement
+
+#### Scenario: Persisted requirement has no authorized account
+
+- **GIVEN** the request lineage was marked before the current request
+- **AND** no eligible security-work-authorized account exists
+- **WHEN** compact or streamed Responses account selection runs
+- **THEN** the request fails with the no-authorized-account error or the
+  original security-work authorization failure
+- **AND** the request is not sent to an ordinary fallback account
+
+#### Scenario: Newly classified request uses bounded compatibility fallback
+
+- **GIVEN** the request lineage was not marked before the current request
+- **AND** upstream newly classifies the request as requiring security-work
+  authorization
+- **AND** no eligible security-work-authorized account exists
+- **WHEN** the transport applies its documented safe ordinary-account fallback
+- **THEN** marker enforcement is bypassed only for that fallback selection
+- **AND** selection does not loop back into the authorized-account requirement

--- a/openspec/changes/persist-security-lineage-markers/tasks.md
+++ b/openspec/changes/persist-security-lineage-markers/tasks.md
@@ -1,0 +1,17 @@
+## 1. Schema and repositories
+
+- [x] 1.1 Add one idempotent current-head revision for the focused lineage and
+  compatibility schema.
+- [x] 1.2 Persist monotonic security requirements on durable sessions and
+  detached sticky markers.
+- [x] 1.3 Preserve detached markers during cleanup and exclude them from normal
+  account usage windows.
+
+## 2. Validation
+
+- [x] 2.1 Cover fresh, partial, and repeated migration shapes.
+- [x] 2.2 Cover durable and sticky security-marker persistence.
+- [x] 2.3 Run focused unit/integration tests, type checking, migration policy,
+  schema drift, and strict OpenSpec validation.
+- [x] 2.4 Cover cross-transport `previous_response_id` enforcement, fail-closed
+  persisted requirements, and the bounded newly-classified fallback.

--- a/scripts/check_proxy_architecture.py
+++ b/scripts/check_proxy_architecture.py
@@ -26,9 +26,9 @@ STREAMING_MIXIN_PATH = PROXY_DIR / "_service" / "streaming" / "mixin.py"
 # Ruff 0.16's formatter adds blank lines around top-level definitions. Keep
 # the ratchets at the formatted baseline so whitespace normalization does not
 # consume architectural budget.
-MAX_SERVICE_LINES = 2_617
+MAX_SERVICE_LINES = 2_711
 MAX_LOAD_BALANCER_LINES = 3_260
-MAX_HTTP_BRIDGE_MIXIN_LINES = 2_436
+MAX_HTTP_BRIDGE_MIXIN_LINES = 2_443
 MAX_STREAMING_MIXIN_LINES = 1_100
 MAX_PROXY_SERVICE_METHOD_LINES = 1_200
 MAX_LOAD_BALANCER_SELECT_ACCOUNT_LINES = 699

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -897,6 +897,49 @@ async def test_accounts_delete_clears_usage_cache_after_commit(db_setup, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_accounts_delete_detaches_required_sticky_lineage_and_deletes_neutral_mapping(db_setup):
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        account = _make_account("acc-delete-security-lineage", "delete-security-lineage@example.com")
+        await repo.upsert(account, merge_by_email=False)
+        session.add_all(
+            [
+                StickySession(
+                    key="required-security-lineage",
+                    kind=StickySessionKind.CODEX_SESSION,
+                    account_id=account.id,
+                    requires_security_work_authorized=True,
+                ),
+                StickySession(
+                    key="neutral-lineage",
+                    kind=StickySessionKind.CODEX_SESSION,
+                    account_id=account.id,
+                    requires_security_work_authorized=False,
+                ),
+            ]
+        )
+        await session.commit()
+
+        deleted = await repo.delete(account.id)
+        required = await session.get(
+            StickySession,
+            ("required-security-lineage", StickySessionKind.CODEX_SESSION),
+            populate_existing=True,
+        )
+        neutral = await session.get(
+            StickySession,
+            ("neutral-lineage", StickySessionKind.CODEX_SESSION),
+            populate_existing=True,
+        )
+
+    assert deleted is True
+    assert required is not None
+    assert required.account_id is None
+    assert required.requires_security_work_authorized is True
+    assert neutral is None
+
+
+@pytest.mark.asyncio
 async def test_accounts_upsert_merge_by_chatgpt_identity_does_not_clear_workspace_on_workspace_less_reauth(db_setup):
     async with SessionLocal() as session:
         repo = AccountsRepository(session)

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import importlib
 import json
 import sqlite3
@@ -2231,7 +2232,11 @@ def test_api_key_reasoning_policy_migration_round_trips_from_current_parent(tmp_
     config = _build_alembic_config(url)
     script_directory = ScriptDirectory.from_config(config)
     assert script_directory.get_revision(target_revision).down_revision == parent_revision
-    assert target_revision in script_directory.get_heads()
+    # Assert reachability from the single head rather than "is the head": every
+    # later migration would otherwise have to edit this test.
+    heads = script_directory.get_heads()
+    assert len(heads) == 1
+    assert target_revision in {revision.revision for revision in script_directory.iterate_revisions(heads[0], "base")}
 
     engine = create_engine(to_sync_database_url(url))
     try:
@@ -2538,4 +2543,162 @@ def test_dashboard_hot_path_index_migration_drops_redundant_indexes(tmp_path: Pa
     assert "idx_logs_dash_usage_covering" in log_indexes
     assert "ix_additional_usage_distinct_labels" in usage_indexes
 
-    assert check_schema_drift(url) == ()
+
+def test_security_lineage_persistence_migration_reconciles_aggregate_schema_and_preserves_markers(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "security-lineage.db"
+    url = _db_url(db_path)
+    parent_revision = "20260720_000000_add_request_log_conversation_id"
+    target_revision = "20260722_000000_add_security_lineage_persistence"
+
+    run_upgrade(url, parent_revision, bootstrap_legacy=False)
+    sync_url = to_sync_database_url(url)
+    preexisting_marker_key = (
+        "@security-work/v2/" + hashlib.sha256("api-key-scope\0security-alias-root".encode()).hexdigest()
+    )
+    previous_response_marker_key = (
+        "@security-work/v2/" + hashlib.sha256("api-key-scope\0resp-security-alias-root".encode()).hexdigest()
+    )
+    with create_engine(sync_url, future=True).begin() as connection:
+        connection.execute(
+            text(
+                """
+                INSERT INTO accounts (id, email, plan_type, access_token_encrypted, refresh_token_encrypted,
+                    id_token_encrypted, codex_installation_id, last_refresh, status)
+                VALUES ('security-owner', 'security-owner@example.com', 'plus', X'01', X'01', X'01',
+                    'security-owner-installation', CURRENT_TIMESTAMP, 'active')
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO sticky_sessions (key, kind, account_id, created_at, updated_at)
+                VALUES ('legacy-security-root', 'codex_session', 'security-owner', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """
+            )
+        )
+        # Simulate the deployed aggregate: it already created some columns,
+        # but its revision id is not in this focused branch's graph.
+        connection.execute(
+            text("ALTER TABLE sticky_sessions ADD COLUMN requires_security_work_authorized BOOLEAN NOT NULL DEFAULT 0")
+        )
+        connection.execute(
+            text("UPDATE sticky_sessions SET requires_security_work_authorized = 1 WHERE key = 'legacy-security-root'")
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO sticky_sessions (
+                    key, kind, account_id, requires_security_work_authorized, created_at, updated_at
+                ) VALUES (
+                    :key, 'codex_session', 'security-owner', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+                )
+                """
+            ),
+            {"key": preexisting_marker_key},
+        )
+        connection.execute(
+            text(
+                "ALTER TABLE http_bridge_sessions "
+                "ADD COLUMN requires_security_work_authorized BOOLEAN NOT NULL DEFAULT 0"
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO http_bridge_sessions (
+                    id, session_key_kind, session_key_value, session_key_hash, api_key_scope,
+                    requires_security_work_authorized
+                ) VALUES (
+                    'security-bridge', 'session_header', 'security-bridge-root', 'bridge-hash',
+                    'api-key-scope', 1
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                """
+                INSERT INTO http_bridge_session_aliases (
+                    id, session_id, alias_kind, alias_value, alias_hash, api_key_scope
+                ) VALUES
+                    (
+                        'security-alias', 'security-bridge', 'turn_state', 'security-alias-root',
+                        'alias-hash', 'api-key-scope'
+                    ),
+                    (
+                        'security-previous-response-alias', 'security-bridge', 'previous_response_id',
+                        'resp-security-alias-root', 'previous-response-alias-hash', 'api-key-scope'
+                    )
+                """
+            )
+        )
+
+    result = run_upgrade(url, target_revision, bootstrap_legacy=False)
+    assert result.current_revision == target_revision
+
+    with create_engine(sync_url, future=True).connect() as connection:
+        sticky_columns = {column["name"]: column for column in inspect(connection).get_columns("sticky_sessions")}
+        usage_columns = {column["name"]: column for column in inspect(connection).get_columns("usage_history")}
+        bridge_columns = {column["name"] for column in inspect(connection).get_columns("http_bridge_sessions")}
+        quota_columns = {column["name"] for column in inspect(connection).get_columns("quota_planner_settings")}
+        detached = connection.execute(
+            text(
+                """
+                SELECT account_id, requires_security_work_authorized
+                FROM sticky_sessions
+                WHERE key LIKE '@security-work/v2/%' AND kind = 'codex_session'
+                """
+            )
+        ).fetchall()
+        alias_marker = connection.execute(
+            text(
+                "SELECT account_id, requires_security_work_authorized FROM sticky_sessions "
+                "WHERE key = :key AND kind = 'codex_session'"
+            ),
+            {"key": preexisting_marker_key},
+        ).one()
+        previous_response_marker = connection.execute(
+            text(
+                "SELECT account_id, requires_security_work_authorized FROM sticky_sessions "
+                "WHERE key = :key AND kind = 'codex_session'"
+            ),
+            {"key": previous_response_marker_key},
+        ).one()
+        sticky_foreign_keys = connection.execute(text("PRAGMA foreign_key_list('sticky_sessions')")).mappings().all()
+        usage_index_sql = {
+            name: sql
+            for name, sql in connection.execute(
+                text(
+                    "SELECT name, sql FROM sqlite_master "
+                    "WHERE type = 'index' AND name IN "
+                    "('idx_usage_window_account_latest', 'idx_usage_window_account_time')"
+                )
+            ).all()
+        }
+
+    assert sticky_columns["account_id"]["nullable"] is True
+    assert usage_columns["account_id"]["nullable"] is True
+    assert "requires_security_work_authorized" in usage_columns
+    assert "requires_security_work_authorized" in bridge_columns
+    assert {"auto_redeem_expiring_reset_credits", "reset_credit_redeem_lead_minutes"} <= quota_columns
+    assert detached
+    assert alias_marker == (None, True)
+    assert previous_response_marker == (None, True)
+    assert all(account_id is None and bool(required) for account_id, required in detached)
+    assert any(
+        foreign_key["from"] == "account_id"
+        and foreign_key["table"] == "accounts"
+        and foreign_key["on_delete"] == "SET NULL"
+        for foreign_key in sticky_foreign_keys
+    )
+    assert all("coalesce(\"window\", 'primary')" in sql for sql in usage_index_sql.values())
+
+    config = _build_alembic_config(url)
+    command.downgrade(config, parent_revision)
+    with create_engine(sync_url, future=True).connect() as connection:
+        assert connection.execute(
+            text("SELECT COUNT(*) FROM sticky_sessions WHERE key LIKE '@security-work/v2/%' AND account_id IS NULL")
+        ).scalar_one() == len(detached)

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -143,6 +143,32 @@ async def test_durable_bridge_lookup_prefers_turn_state_then_previous_response_t
 
 
 @pytest.mark.asyncio
+async def test_durable_bridge_can_persist_security_requirement(
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    claimed = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-security",
+        api_key_id="key-1",
+        instance_id="instance-a",
+        owner_process_epoch="test-process",
+        lease_ttl_seconds=120.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id=None,
+        allow_takeover=True,
+    )
+
+    updated = await coordinator.require_security_work_authorized(session_id=claimed.session_id)
+
+    assert updated is not None
+    assert updated.session_id == claimed.session_id
+    assert updated.requires_security_work_authorized is True
+
+
+@pytest.mark.asyncio
 async def test_reversible_recovery_turn_state_registration_restores_previous_owner(
     coordinator: DurableBridgeSessionCoordinator,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -17056,6 +17056,7 @@ async def test_get_or_create_http_bridge_session_preserves_explicit_forwarded_af
         preferred_account_id: str | None = None,
         require_preferred_account: bool = False,
         fallback_on_preferred_account_unavailable: bool = True,
+        require_security_work_authorized: bool = False,
     ) -> proxy_service._HTTPBridgeSession:
         del (
             headers,
@@ -17067,6 +17068,7 @@ async def test_get_or_create_http_bridge_session_preserves_explicit_forwarded_af
             preferred_account_id,
             require_preferred_account,
             fallback_on_preferred_account_unavailable,
+            require_security_work_authorized,
         )
         captured["key"] = create_key
         return created_session
@@ -17141,6 +17143,7 @@ async def test_get_or_create_http_bridge_session_falls_back_to_session_header_wh
         preferred_account_id: str | None = None,
         require_preferred_account: bool = False,
         fallback_on_preferred_account_unavailable: bool = True,
+        require_security_work_authorized: bool = False,
     ) -> proxy_service._HTTPBridgeSession:
         del (
             headers,
@@ -17152,6 +17155,7 @@ async def test_get_or_create_http_bridge_session_falls_back_to_session_header_wh
             preferred_account_id,
             require_preferred_account,
             fallback_on_preferred_account_unavailable,
+            require_security_work_authorized,
         )
         captured["key"] = create_key
         return created_session
@@ -17350,6 +17354,7 @@ async def test_get_or_create_http_bridge_session_preserves_durable_canonical_pro
         preferred_account_id: str | None = None,
         require_preferred_account: bool = False,
         fallback_on_preferred_account_unavailable: bool = True,
+        **_kwargs: Any,
     ) -> proxy_service._HTTPBridgeSession:
         del (
             headers,
@@ -24711,6 +24716,7 @@ async def test_durable_model_transition_preserves_owner_provenance_when_replacin
         latest_turn_state="http_turn_model_parent",
         latest_response_id="resp_model_parent",
         model="gpt-5.6-sol",
+        requires_security_work_authorized=True,
     )
     owner_unavailable = ProxyResponseError(
         502,
@@ -24803,6 +24809,7 @@ async def test_durable_model_transition_preserves_owner_provenance_when_replacin
     assert all(call["previous_response_id"] is None for call in creation_calls)
     assert all(call["preferred_account_id"] == "acc-model-owner" for call in creation_calls)
     assert all(call["preferred_account_has_continuity_provenance"] is True for call in creation_calls)
+    assert all(call["require_security_work_authorized"] is True for call in creation_calls)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -226,7 +226,14 @@ class StubStickySessionsRepository(StickySessionsRepository):
         )
         return StickyOwnerLookup(account_id=account_id, continuity_abandoned=False)
 
-    async def upsert(self, key: str, account_id: str, *, kind: StickySessionKind) -> StickySession:
+    async def upsert(
+        self,
+        key: str,
+        account_id: str | None,
+        *,
+        kind: StickySessionKind,
+        requires_security_work_authorized: bool = False,
+    ) -> StickySession:
         row = self._build_row(key, account_id, kind)
         self.upserts.append(row)
         return row
@@ -236,7 +243,7 @@ class StubStickySessionsRepository(StickySessionsRepository):
         return False
 
     @staticmethod
-    def _build_row(key: str, account_id: str, kind: StickySessionKind) -> StickySession:
+    def _build_row(key: str, account_id: str | None, kind: StickySessionKind) -> StickySession:
         return StickySession(key=key, account_id=account_id, kind=kind)
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -36,6 +36,7 @@ import app.core.clients.proxy as proxy_module
 import app.core.openai.requests as openai_requests_module
 import app.core.resilience.network_recovery as network_recovery_module
 import app.modules.proxy.load_balancer as load_balancer_module
+import app.modules.proxy.security_lineage as proxy_security_lineage
 from app.core import shutdown as shutdown_state
 from app.core.auth.refresh import RefreshError
 from app.core.balancer.types import UpstreamError
@@ -683,6 +684,7 @@ async def test_revalidate_open_websocket_account_uses_current_model_and_tier(mon
     assert select_account.await_args.kwargs["preferred_account_id"] == account.id
     assert select_account.await_args.kwargs["model"] == "gpt-5.6-sol"
     assert select_account.await_args.kwargs["service_tier"] == "priority"
+    assert select_account.await_args.kwargs["security_lineage_ids"] == ()
     assert select_account.await_args.kwargs["fallback_on_preferred_account_unavailable"] is False
     release_lease.assert_awaited_once_with(None)
 
@@ -5987,8 +5989,32 @@ async def test_select_codex_control_account_without_budget_uses_balancer(monkeyp
         secondary_budget_threshold_pct=100.0,
         traffic_class=proxy_service.TRAFFIC_CLASS_FOREGROUND,
         concurrency_caps=ANY,
+        require_security_work_authorized=False,
         redact_sensitive_details=False,
     )
+
+
+@pytest.mark.asyncio
+async def test_select_codex_control_account_without_budget_preserves_redaction(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    selected_account = _make_account("acc_codex_private")
+    select_account = AsyncMock(return_value=AccountSelection(account=selected_account, error_message=None))
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+
+    result = await service._select_codex_control_account_without_budget(
+        affinity=proxy_service._AffinityPolicy(
+            key="control-private-session",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        api_key=None,
+        privacy_policy=proxy_module.CodexControlRequestPrivacyPolicy.PRIVATE_REALTIME,
+    )
+
+    assert result is not None
+    assert result.id == "acc_codex_private"
+    assert select_account.await_args is not None
+    assert select_account.await_args.kwargs["redact_sensitive_details"] is True
 
 
 @pytest.mark.asyncio
@@ -17190,6 +17216,8 @@ async def test_stream_responses_retries_security_work_warning_on_authorized_acco
     monkeypatch.setattr(service._load_balancer, "record_success", AsyncMock())
     monkeypatch.setattr(service._load_balancer, "release_account_lease", release_account_lease)
     monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=lambda account, **kwargs: account))
+    persist_security_requirement = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_persist_security_work_lineage_markers", persist_security_requirement)
 
     async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
         del payload, headers, access_token, base_url, raise_for_status
@@ -17223,7 +17251,14 @@ async def test_stream_responses_retries_security_work_warning_on_authorized_acco
 
     payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
 
-    chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream"})]
+    chunks = [
+        chunk
+        async for chunk in service.stream_responses(
+            payload,
+            {"session_id": "sid-stream"},
+            codex_session_affinity=True,
+        )
+    ]
 
     assert len(chunks) == 2
     warning = json.loads(chunks[0].split("data: ", 1)[1])
@@ -17246,6 +17281,10 @@ async def test_stream_responses_retries_security_work_warning_on_authorized_acco
     assert request_logs.calls[1]["status"] == "success"
     assert regular_lease in released_leases
     assert authorized_lease in released_leases
+    persist_security_requirement.assert_awaited_once()
+    assert persist_security_requirement.await_args is not None
+    assert persist_security_requirement.await_args.args[0][-1] == "sid-stream"
+    assert persist_security_requirement.await_args.kwargs == {"api_key_id": None}
 
 
 @pytest.mark.asyncio
@@ -17337,6 +17376,63 @@ async def test_stream_responses_treats_missing_security_work_pool_as_optional(mo
     ]
     assert request_logs.calls[0]["error_code"] == "security_work_authorization_required"
     assert request_logs.calls[1]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_stream_responses_preexisting_security_lineage_never_falls_back(monkeypatch):
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    regular_account = _make_account("acc_preexisting_security_regular")
+    fallback_account = _make_account("acc_preexisting_security_fallback")
+    select_account = AsyncMock(
+        side_effect=[
+            AccountSelection(account=regular_account, error_message=None),
+            AccountSelection(
+                account=None,
+                error_message="No accounts marked as authorized for security work",
+                error_code="no_security_work_authorized_accounts",
+            ),
+            AccountSelection(account=fallback_account, error_message=None),
+        ]
+    )
+    cyber_message = (
+        "This chat was flagged for possible cybersecurity risk. "
+        "To get authorized for security work, join the Trusted Access for Cyber program. "
+        "https://chatgpt.com/cyber"
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service._load_balancer, "record_error", AsyncMock())
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=lambda account, **kwargs: account))
+    monkeypatch.setattr(service, "_security_lineage_requires_security_work_authorized", AsyncMock(return_value=True))
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        del payload, headers, access_token, account_id, base_url, raise_for_status
+        yield (
+            "data: "
+            + json.dumps(
+                {
+                    "type": "response.failed",
+                    "response": {
+                        "id": "resp_preexisting_security",
+                        "error": {"code": "invalid_request_error", "message": cyber_message},
+                    },
+                }
+            )
+            + "\n\n"
+        )
+
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+
+    chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-preexisting-security"})]
+
+    assert json.loads(chunks[-1].split("data: ", 1)[1])["response"]["error"]["code"] == (
+        "no_security_work_authorized_accounts"
+    )
+    assert select_account.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -17528,6 +17624,13 @@ async def test_stream_responses_does_not_move_file_pinned_security_work_request(
     monkeypatch.setattr(service._load_balancer, "record_success", AsyncMock())
     monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=lambda account, **kwargs: account))
     monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=regular_account.id))
+    monkeypatch.setattr(
+        service,
+        "_resolve_websocket_previous_response_owner",
+        AsyncMock(return_value=regular_account.id),
+    )
+    persist_security_requirement = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_persist_security_work_lineage_markers", persist_security_requirement)
 
     async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
         del payload, headers, access_token, base_url, raise_for_status
@@ -17556,6 +17659,7 @@ async def test_stream_responses_does_not_move_file_pinned_security_work_request(
         {
             "model": "gpt-5.1",
             "instructions": "check pinned file",
+            "previous_response_id": "resp_security_file_anchor",
             "input": [
                 {
                     "role": "user",
@@ -17571,7 +17675,14 @@ async def test_stream_responses_does_not_move_file_pinned_security_work_request(
         }
     )
 
-    chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream-file"})]
+    chunks = [
+        chunk
+        async for chunk in service.stream_responses(
+            payload,
+            {"session_id": "sid-stream-file"},
+            codex_session_affinity=True,
+        )
+    ]
 
     assert len(chunks) == 1
     event = json.loads(chunks[0].split("data: ", 1)[1])
@@ -17582,6 +17693,9 @@ async def test_stream_responses_does_not_move_file_pinned_security_work_request(
     assert only_call.kwargs["account_ids"] is None
     assert only_call.kwargs["required_account_id"] == regular_account.id
     assert only_call.kwargs["require_security_work_authorized"] is False
+    persist_security_requirement.assert_awaited_once()
+    assert persist_security_requirement.await_args is not None
+    assert {"sid-stream-file", "resp_security_file_anchor"} <= set(persist_security_requirement.await_args.args[0])
 
 
 @pytest.mark.asyncio
@@ -17651,6 +17765,12 @@ async def test_http_bridge_retries_security_work_warning_on_authorized_account(m
     monkeypatch.setattr(service, "_reconnect_http_bridge_session", fake_reconnect_http_bridge_session)
     monkeypatch.setattr(service, "_acquire_account_response_create_lease_or_overload", acquire_create_lease)
     monkeypatch.setattr(service._load_balancer, "release_account_lease", release_create_lease)
+    persist_security_requirement = AsyncMock()
+    monkeypatch.setattr(
+        service,
+        "_persist_http_bridge_security_work_requirement",
+        persist_security_requirement,
+    )
 
     request_state = proxy_service._WebSocketRequestState(
         request_id="bridge_req_security",
@@ -17704,6 +17824,7 @@ async def test_http_bridge_retries_security_work_warning_on_authorized_account(m
 
     await service._process_http_bridge_upstream_text(session, text)
 
+    persist_security_requirement.assert_awaited_once_with(session, request_state)
     assert reconnect_calls == [
         {
             "request_state": request_state,
@@ -17867,6 +17988,87 @@ async def test_http_bridge_keeps_reasoning_deltas_buffered_after_prelude(
     assert len(request_state.deferred_reasoning_downstream_texts) == 2
     assert request_state.event_queue is not None
     assert request_state.event_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_security_work_requirement_persists_durable_and_detached_lineage() -> None:
+    request_logs = _RequestLogsRecorder()
+    repo_context = _RepoContext(request_logs)
+    sticky_repository = cast(AsyncMock, repo_context._repos.sticky_sessions)
+    service = proxy_service.ProxyService(lambda: repo_context)
+    service._durable_bridge.require_security_work_authorized = AsyncMock()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="bridge-persist-security",
+        model="gpt-5.6",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        session_id="downstream-turn",
+        previous_response_id="resp-bridge-security-root",
+        affinity_policy=proxy_service._AffinityPolicy(
+            key="affinity-root",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+    )
+    session = cast(
+        proxy_service._HTTPBridgeSession,
+        SimpleNamespace(
+            key=proxy_service._HTTPBridgeSessionKey("session_header", "canonical-root", "api-key-a"),
+            durable_session_id="durable-security-root",
+            upstream_turn_state="upstream-turn",
+            downstream_turn_state="downstream-turn",
+        ),
+    )
+
+    persisted = await service._persist_http_bridge_security_work_requirement(session, request_state)
+
+    assert request_state.require_security_work_authorized is True
+    service._durable_bridge.require_security_work_authorized.assert_awaited_once_with(
+        session_id="durable-security-root"
+    )
+    sticky_repository.require_security_work_authorized.assert_awaited_once_with(
+        (
+            "canonical-root",
+            "affinity-root",
+            "upstream-turn",
+            "downstream-turn",
+            "resp-bridge-security-root",
+        ),
+        api_key_scope="api-key-a",
+    )
+    assert persisted is True
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_security_work_requirement_fails_closed_when_all_writes_miss(monkeypatch) -> None:
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    service._durable_bridge.require_security_work_authorized = AsyncMock(return_value=None)
+    marker_write = AsyncMock(return_value=False)
+    monkeypatch.setattr(service, "_persist_security_work_lineage_markers", marker_write)
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="bridge-persist-security-miss",
+        model="gpt-5.6",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+    )
+    session = cast(
+        proxy_service._HTTPBridgeSession,
+        SimpleNamespace(
+            key=proxy_service._HTTPBridgeSessionKey("session_header", "missing-root", "api-key-a"),
+            durable_session_id="missing-durable-root",
+            upstream_turn_state=None,
+            downstream_turn_state=None,
+        ),
+    )
+
+    persisted = await service._persist_http_bridge_security_work_requirement(session, request_state)
+
+    assert persisted is False
+    assert request_state.require_security_work_authorized is True
+    marker_write.assert_awaited_once_with(("missing-root",), api_key_id="api-key-a")
 
 
 @pytest.mark.asyncio
@@ -19233,6 +19435,8 @@ async def test_compact_responses_retries_security_work_warning_on_authorized_acc
     monkeypatch.setattr(service._load_balancer, "record_success", AsyncMock())
     monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=lambda account, **kwargs: account))
     monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock())
+    persist_security_requirement = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_persist_security_work_lineage_markers", persist_security_requirement)
 
     async def fake_compact(payload, headers, access_token, account_id):
         del payload, headers, access_token
@@ -19251,7 +19455,11 @@ async def test_compact_responses_retries_security_work_warning_on_authorized_acc
 
     payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
 
-    result = await service.compact_responses(payload, {"session_id": "sid-compact"})
+    result = await service.compact_responses(
+        payload,
+        {"session_id": "sid-compact"},
+        codex_session_affinity=True,
+    )
 
     assert result.model_extra == {"output": []}
     assert select_account.await_count == 2
@@ -19263,6 +19471,10 @@ async def test_compact_responses_retries_security_work_warning_on_authorized_acc
     assert [call["account_id"] for call in request_logs.calls] == [authorized_account.id]
     assert request_logs.calls[0]["status"] == "success"
     record_error.assert_not_awaited()
+    persist_security_requirement.assert_awaited_once()
+    assert persist_security_requirement.await_args is not None
+    assert persist_security_requirement.await_args.args[0][-1] == "sid-compact"
+    assert persist_security_requirement.await_args.kwargs == {"api_key_id": None}
 
 
 @pytest.mark.asyncio
@@ -19330,6 +19542,66 @@ async def test_compact_responses_treats_missing_security_work_pool_as_optional(m
 
 
 @pytest.mark.asyncio
+async def test_compact_responses_preexisting_security_lineage_never_falls_back(monkeypatch):
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    regular_account = _make_account("acc_compact_preexisting_security_regular")
+    fallback_account = _make_account("acc_compact_preexisting_security_fallback")
+    select_account = AsyncMock(
+        side_effect=[
+            AccountSelection(account=regular_account, error_message=None),
+            AccountSelection(
+                account=None,
+                error_message="No accounts marked as authorized for security work",
+                error_code="no_security_work_authorized_accounts",
+            ),
+            AccountSelection(account=fallback_account, error_message=None),
+        ]
+    )
+    cyber_message = (
+        "This chat was flagged for possible cybersecurity risk. "
+        "To get authorized for security work, join the Trusted Access for Cyber program. "
+        "https://chatgpt.com/cyber"
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service._load_balancer, "record_error", AsyncMock())
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=lambda account, **kwargs: account))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock())
+    monkeypatch.setattr(service, "_security_lineage_requires_security_work_authorized", AsyncMock(return_value=True))
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token, account_id
+        raise proxy_module.ProxyResponseError(
+            400,
+            openai_error(
+                "invalid_request_error",
+                cyber_message,
+                error_type="invalid_request_error",
+            ),
+        )
+
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+
+    payload = ResponsesCompactRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [],
+        }
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.compact_responses(payload, {"session_id": "sid-compact-preexisting-security"})
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert _proxy_error_code(exc) == "invalid_request_error"
+    assert select_account.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_connect_proxy_websocket_passes_sticky_kind_to_load_balancer(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -19371,6 +19643,51 @@ async def test_connect_proxy_websocket_passes_sticky_kind_to_load_balancer(monke
     assert await_args is not None
     assert await_args.kwargs["sticky_key"] == "codex-session-1"
     assert await_args.kwargs["sticky_kind"] == proxy_service.StickySessionKind.CODEX_SESSION
+
+
+@pytest.mark.asyncio
+async def test_select_websocket_connect_account_passes_previous_response_lineage_to_selection(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_ws_prev_resp")
+    select_account = AsyncMock(
+        return_value=AccountSelection(account=account, error_message=None, error_code=None, lease=None)
+    )
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_prev_resp",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        previous_response_id="resp_prev_only",
+    )
+
+    websocket = cast(WebSocket, SimpleNamespace(send_text=AsyncMock()))
+    selected_account = await service._select_websocket_connect_account(
+        deadline=30.0,
+        sticky_key=None,
+        sticky_kind=None,
+        prefer_earlier_reset=False,
+        prefer_earlier_reset_window="secondary",
+        routing_strategy="usage_weighted",
+        model="gpt-5.1",
+        request_state=request_state,
+        api_key=None,
+        client_send_lock=anyio.Lock(),
+        websocket=websocket,
+        downstream_activity=None,
+        reallocate_sticky=False,
+        sticky_max_age_seconds=None,
+        exclude_account_ids=set(),
+        preferred_account_id=None,
+    )
+
+    assert selected_account == account
+    await_args = select_account.await_args
+    assert await_args is not None
+    assert await_args.kwargs["security_lineage_ids"] == ("resp_prev_only",)
 
 
 @pytest.mark.asyncio
@@ -39158,6 +39475,39 @@ async def test_select_account_with_budget_times_out_during_settings_fetch(monkey
 
 
 @pytest.mark.asyncio
+async def test_select_account_with_budget_enforces_persisted_security_lineage(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    repo_context = _RepoContext(request_logs)
+    sticky_repository = cast(AsyncMock, repo_context._repos.sticky_sessions)
+    sticky_repository.security_work_required.return_value = True
+    service = proxy_service.ProxyService(lambda: repo_context)
+    account = _make_account("acc-persisted-security-lineage")
+    select_account = AsyncMock(return_value=AccountSelection(account=account, error_message=None))
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(proxy_service, "_remaining_budget_seconds", lambda _deadline: 10.0)
+
+    selection = await service._select_account_with_budget(
+        deadline=123.0,
+        request_id="req-persisted-security-lineage",
+        kind="stream",
+        sticky_key="security-lineage-root",
+        sticky_kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        model="gpt-5.6",
+    )
+
+    assert selection.account == account
+    sticky_repository.security_work_required.assert_awaited_once_with(
+        ("security-lineage-root",),
+        api_key_scope="__anonymous__",
+    )
+    assert select_account.await_args is not None
+    assert select_account.await_args.kwargs["require_security_work_authorized"] is True
+
+
+@pytest.mark.asyncio
 async def test_select_account_with_budget_forwards_estimated_lease_tokens(monkeypatch):
     settings = _make_proxy_settings()
     request_logs = _RequestLogsRecorder()
@@ -46343,7 +46693,14 @@ async def test_http_bridge_owner_forward_defers_image_inlining(monkeypatch):
         {
             "model": "gpt-5.5",
             "instructions": "describe the image",
-            "input": [{"content": [{"type": "input_image", "image_url": original_url}]}],
+            "input": [
+                {
+                    "content": [
+                        {"type": "input_image", "image_url": original_url},
+                        {"type": "input_file", "file_id": "file-owner-pinned"},
+                    ]
+                }
+            ],
             "stream": True,
         }
     )
@@ -46364,7 +46721,10 @@ async def test_http_bridge_owner_forward_defers_image_inlining(monkeypatch):
     monkeypatch.setattr(service, "_inline_http_bridge_image_urls", inline)
     monkeypatch.setattr(service, "_http_bridge_owner_client", OwnerClient())
     monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
-    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", AsyncMock(return_value=owner_forward))
+    persisted_security_lookup = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_security_lineage_requires_security_work_authorized", persisted_security_lookup)
+    get_or_create_session = AsyncMock(return_value=owner_forward)
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", get_or_create_session)
     monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
     monkeypatch.setattr(
         proxy_service,
@@ -46403,6 +46763,12 @@ async def test_http_bridge_owner_forward_defers_image_inlining(monkeypatch):
     assert forwarded_payloads
     forwarded = forwarded_payloads[0].model_dump(mode="json", exclude_none=True)
     assert forwarded["input"][0]["content"][0]["image_url"] == original_url
+    persisted_security_lookup.assert_awaited_once()
+    security_lookup_call = persisted_security_lookup.await_args
+    assert security_lookup_call is not None
+    assert "sid-forward-inline" in security_lookup_call.args[0]
+    assert get_or_create_session.await_args is not None
+    assert get_or_create_session.await_args.kwargs["require_security_work_authorized"] is True
 
 
 def test_count_external_image_urls_handles_object_content() -> None:
@@ -47391,3 +47757,26 @@ async def test_stream_with_retry_reframes_data_only_delta_frames_after_ttft(monk
     assert chunks[2] == 'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"b"}\n\n'
     assert await service.drain_persistence_tasks(timeout_seconds=1)
     assert request_logs.calls[0]["status"] == "success"
+
+
+def test_security_lineage_ids_include_previous_response_and_normalize_values() -> None:
+    assert proxy_support._security_lineage_ids(
+        " session-root ",
+        "session-root",
+        None,
+        " resp_previous ",
+        42,
+    ) == ("session-root", "resp_previous")
+
+
+def test_security_work_marker_keys_hash_reserved_looking_transport_values() -> None:
+    raw_lineage_id = "@security-work/v2/client-controlled"
+
+    marker_keys = proxy_security_lineage.security_work_marker_keys(
+        (raw_lineage_id,),
+        api_key_scope="api-scope",
+        include_legacy=False,
+    )
+
+    assert marker_keys == (proxy_security_lineage.security_work_marker_key(raw_lineage_id, "api-scope"),)
+    assert raw_lineage_id not in marker_keys

--- a/tests/unit/test_usage_mappers.py
+++ b/tests/unit/test_usage_mappers.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.unit
 
 def _entry(
     *,
-    account_id: str = "acc1",
+    account_id: str | None = "acc1",
     used_percent: float = 42.5,
     reset_at: int | None = 1_700_000_000,
     window_minutes: int | None = 60,
@@ -55,3 +55,8 @@ def test_returns_distinct_rows_per_entry() -> None:
     rows = [usage_history_to_window_row(e) for e in (a, b)]
     assert [r.account_id for r in rows] == ["acc-a", "acc-b"]
     assert [r.used_percent for r in rows] == [pytest.approx(10.0), pytest.approx(20.0)]
+
+
+def test_rejects_detached_security_lineage_row() -> None:
+    with pytest.raises(ValueError, match="Detached security-lineage"):
+        usage_history_to_window_row(_entry(account_id=None))


### PR DESCRIPTION
## Summary

Keep a security-work authorization requirement attached to the logical Codex lineage even after its selected account or ordinary sticky row disappears. Without this durable marker, a later stream, compact, WebSocket, or HTTP bridge retry could route the same security-work lineage through an account that is not Trusted Access authorized.

Current head: `b3d5400fd`.

## Changes

- add the focused Alembic revision and monotonic detached lineage markers;
- backfill markers from sticky sessions, durable bridge identities, latest turn state, and bridge aliases;
- normalize pre-existing partial-rollout marker rows to detached, security-required state;
- include `previous_response_id` in compact and streaming lineage persistence even when no session/turn-state affinity exists;
- retain security evidence when accounts and ordinary sticky rows are cleaned up;
- require a Trusted Access account on later requests in the same API-key scope;
- retain account-less usage audit rows without mapping them as live account windows.

## Scope

This is the focused durable security-lineage owner. Hard-affinity retry work remains in #1441, and the broad integration carrier remains #1442.

## Validation

- `uv run pytest tests/unit/test_db_migrate.py -q` -> 50 passed;
- `uv run pytest tests/unit/test_proxy_utils.py -q -k 'security_work or security_lineage'` -> 19 passed;
- security-focused repository/token-refresh integration selection -> 1 passed;
- focused previous-response lineage and partial-marker regression selection -> 4 passed;
- Ruff check and format check passed;
- `ty check` passed for changed proxy modules;
- proxy architecture check passed;
- strict OpenSpec validation passed for `persist-security-lineage-markers`;
- `git diff --check` passed.

Hosted checks and current-head review evidence remain authoritative for merge.
