### PR TITLE
fix(proxy): preserve multi-agent v2 passthrough

### DIFF
--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -42,6 +42,7 @@ from app.modules.proxy.affinity import (
     _prompt_cache_key_from_request_model,
     _resolve_prompt_cache_key,
     _sticky_key_from_session_header,
+    _sticky_key_from_turn_state_header,
 )
 from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
 from app.modules.proxy.helpers import _header_account_id, _normalize_error_code, _parse_openai_error
@@ -386,6 +387,12 @@ def _sticky_key_for_compact_request(
         openai_cache_affinity=openai_cache_affinity,
         api_key=api_key,
     )
+    turn_state_key = _sticky_key_from_turn_state_header(headers)
+    if turn_state_key:
+        return _AffinityPolicy(
+            key=turn_state_key,
+            kind=StickySessionKind.CODEX_SESSION,
+        )
     if codex_session_affinity:
         session_key = _sticky_key_from_session_header(headers)
         if session_key:
@@ -463,7 +470,9 @@ class _CompactMixin:
         )
         sticky_key_source = "none"
         if affinity.kind == StickySessionKind.CODEX_SESSION:
-            sticky_key_source = "session_header"
+            sticky_key_source = (
+                "turn_state_header" if _sticky_key_from_turn_state_header(headers) is not None else "session_header"
+            )
         elif affinity.key:
             sticky_key_source = "payload" if had_prompt_cache_key else "derived"
         _maybe_log_proxy_request_shape(

--- a/app/modules/proxy/_service/http_bridge/service_stubs.py
+++ b/app/modules/proxy/_service/http_bridge/service_stubs.py
@@ -24,6 +24,7 @@ from app.core.openai.requests import ResponsesRequest
 from app.core.types import JsonValue
 from app.core.utils.sse import CODEX_KEEPALIVE_FRAME
 from app.db.models import Account, DashboardSettings
+from app.modules.proxy._service.response_create import _RESPONSE_CREATE_COMPATIBILITY_METADATA_HEADERS
 from app.modules.proxy._service.support import _RequestLogFailureMetadata
 
 T = TypeVar("T")
@@ -296,7 +297,12 @@ def _headers_with_turn_state(*args: Any, **kwargs: Any) -> Any:
 
 
 def _websocket_safe_headers_with_turn_state(headers: Mapping[str, str], turn_state: str | None) -> dict[str, str]:
-    return cast(dict[str, str], _headers_with_turn_state(filter_inbound_websocket_headers(dict(headers)), turn_state))
+    filtered = {
+        key: value
+        for key, value in filter_inbound_websocket_headers(dict(headers)).items()
+        if key.lower() not in _RESPONSE_CREATE_COMPATIBILITY_METADATA_HEADERS
+    }
+    return cast(dict[str, str], _headers_with_turn_state(filtered, turn_state))
 
 
 def _headers_with_authorization(*args: Any, **kwargs: Any) -> Any:

--- a/app/modules/proxy/_service/http_bridge/service_stubs.py
+++ b/app/modules/proxy/_service/http_bridge/service_stubs.py
@@ -24,7 +24,6 @@ from app.core.openai.requests import ResponsesRequest
 from app.core.types import JsonValue
 from app.core.utils.sse import CODEX_KEEPALIVE_FRAME
 from app.db.models import Account, DashboardSettings
-from app.modules.proxy._service.response_create import _RESPONSE_CREATE_COMPATIBILITY_METADATA_HEADERS
 from app.modules.proxy._service.support import _RequestLogFailureMetadata
 
 T = TypeVar("T")
@@ -44,6 +43,13 @@ def _service_module() -> Any:
 
 def _service_global(name: str) -> Any:
     return getattr(_service_module(), name)
+
+
+def _response_create_compatibility_metadata_headers() -> tuple[str, ...]:
+    return cast(
+        tuple[str, ...],
+        _service_global("_RESPONSE_CREATE_COMPATIBILITY_METADATA_HEADERS"),
+    )
 
 
 def _service_global_or(name: str, fallback: T) -> T:
@@ -300,7 +306,7 @@ def _websocket_safe_headers_with_turn_state(headers: Mapping[str, str], turn_sta
     filtered = {
         key: value
         for key, value in filter_inbound_websocket_headers(dict(headers)).items()
-        if key.lower() not in _RESPONSE_CREATE_COMPATIBILITY_METADATA_HEADERS
+        if key.lower() not in _response_create_compatibility_metadata_headers()
     }
     return cast(dict[str, str], _headers_with_turn_state(filtered, turn_state))
 

--- a/app/modules/proxy/_service/response_create.py
+++ b/app/modules/proxy/_service/response_create.py
@@ -43,6 +43,12 @@ _RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE = (
 )
 _RESPONSE_CREATE_IMAGE_OMISSION_NOTICE = "[codex-lb omitted historical inline image to fit upstream websocket budget]"
 _OVERSIZED_RESPONSE_CREATE_DUMP_DIR: Path | None = None
+_RESPONSE_CREATE_COMPATIBILITY_METADATA_HEADERS = (
+    "x-codex-turn-metadata",
+    "x-openai-subagent",
+    "x-codex-parent-thread-id",
+    "x-codex-window-id",
+)
 
 
 def _service_module() -> Any | None:
@@ -801,9 +807,10 @@ def _response_create_client_metadata(
                 client_metadata[key] = value
 
     normalized_headers = {key.lower(): value for key, value in headers.items()}
-    turn_metadata = normalized_headers.get("x-codex-turn-metadata")
-    if isinstance(turn_metadata, str) and turn_metadata.strip():
-        client_metadata.setdefault("x-codex-turn-metadata", turn_metadata)
+    for header_name in _RESPONSE_CREATE_COMPATIBILITY_METADATA_HEADERS:
+        metadata_value = normalized_headers.get(header_name)
+        if isinstance(metadata_value, str) and metadata_value.strip():
+            client_metadata.setdefault(header_name, metadata_value)
 
     if codex_installation_id:
         client_metadata[CODEX_INSTALLATION_ID_HEADER] = codex_installation_id

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -27,6 +27,7 @@ from app.modules.api_keys.service import (
 )
 from app.modules.proxy.affinity import _AffinityPolicy
 from app.modules.proxy.load_balancer import AccountLease, AccountSelection
+from app.modules.proxy.tool_call_dedupe import ToolCallDedupeKey
 from app.modules.proxy.work_admission import AdmissionLease
 
 logger = logging.getLogger(__name__)
@@ -385,7 +386,7 @@ class _WebSocketRequestState:
     suppressed_duplicate_tool_call: bool = False
     pending_function_call_ids: list[str] = field(default_factory=list)
     pending_tool_call_types: dict[str, str] = field(default_factory=dict)
-    seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None] = field(default_factory=dict)
+    seen_tool_call_keys: dict[ToolCallDedupeKey, None] = field(default_factory=dict)
     input_item_count: int = 0
     input_full_fingerprint: str | None = None
     api_key_reservation_last_touch_at: float = field(default_factory=time.monotonic)
@@ -466,7 +467,7 @@ class _HTTPBridgeSession:
     closed: bool = False
     account_lease: AccountLease | None = None
     upstream_close_attempted: bool = False
-    seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None] = field(default_factory=dict)
+    seen_tool_call_keys: dict[ToolCallDedupeKey, None] = field(default_factory=dict)
     upstream_proxy_route_mode: str | None = None
     upstream_proxy_pool_id: str | None = None
     upstream_proxy_endpoint_id: str | None = None
@@ -518,7 +519,7 @@ class _WebSocketUpstreamControl:
     suppress_downstream_event: bool = False
     replay_request_state: _WebSocketRequestState | None = None
     downstream_texts: list[str] | None = None
-    seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None] = field(default_factory=dict)
+    seen_tool_call_keys: dict[ToolCallDedupeKey, None] = field(default_factory=dict)
 
 
 @dataclass(slots=True)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -364,6 +364,9 @@ from app.modules.proxy._service.response_create import (
     _OVERSIZED_RESPONSE_CREATE_LARGEST_ITEMS as _OVERSIZED_RESPONSE_CREATE_LARGEST_ITEMS,
 )
 from app.modules.proxy._service.response_create import (
+    _RESPONSE_CREATE_COMPATIBILITY_METADATA_HEADERS as _RESPONSE_CREATE_COMPATIBILITY_METADATA_HEADERS,
+)
+from app.modules.proxy._service.response_create import (
     _RESPONSE_CREATE_HISTORY_OMISSION_NOTICE as _RESPONSE_CREATE_HISTORY_OMISSION_NOTICE,
 )
 from app.modules.proxy._service.response_create import (

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -57,6 +57,9 @@ _PARALLEL_TOOL_USE_DEDUPE_RECIPIENT_NAMES = frozenset(
 )
 _SIDE_EFFECT_VOLATILE_ARG_KEYS = frozenset({"max_output_tokens", "timeout_ms", "yield_time_ms"})
 
+ToolCallDedupeKey = tuple[str, str, str | None, str | None, str | None, str]
+ReplayedSideEffectToolCallKey = tuple[str, str | None, str | None, str | None, str]
+
 
 def event_type_from_payload(event: OpenAIEvent | None, payload: dict[str, JsonValue] | None) -> str | None:
     if event is not None:
@@ -92,7 +95,7 @@ def response_id_from_payload(payload: dict[str, JsonValue] | None) -> str | None
 def mark_duplicate_tool_call_downstream_event(
     payload: dict[str, JsonValue] | None,
     *,
-    seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None],
+    seen_tool_call_keys: dict[ToolCallDedupeKey, None],
     response_id: str | None,
     scope_side_effects_by_response_id: bool = True,
 ) -> bool:
@@ -113,13 +116,16 @@ def mark_duplicate_tool_call_downstream_event(
         else:
             argument_value = operation_value
     else:
-        seen_tool_call_keys.clear()
+        _clear_legacy_downstream_tool_call_keys(seen_tool_call_keys)
         return False
     if not isinstance(argument_value, str):
         return False
     item_name = item.get("name")
     if item_name is not None and not isinstance(item_name, str):
         item_name = None
+    item_namespace = item.get("namespace")
+    if item_namespace is not None and not isinstance(item_namespace, str):
+        item_namespace = None
     call_id = item.get("call_id")
     if call_id is not None and not isinstance(call_id, str):
         call_id = None
@@ -128,7 +134,7 @@ def mark_duplicate_tool_call_downstream_event(
         and _tool_call_has_side_effect_arguments(item_name, argument_value)
     )
     if not is_side_effect_tool_call:
-        seen_tool_call_keys.clear()
+        _clear_legacy_downstream_tool_call_keys(seen_tool_call_keys)
         return False
     if item_name == _PARALLEL_TOOL_CALL_NAME and is_side_effect_tool_call:
         return _mark_duplicate_parallel_tool_call_downstream_event(
@@ -144,7 +150,7 @@ def mark_duplicate_tool_call_downstream_event(
     else:
         argument_key = argument_value
     dedupe_response_id = response_id if response_id is not None else ""
-    key = (dedupe_response_id, str(item_type), item_name, call_id, argument_key)
+    key = (dedupe_response_id, str(item_type), item_namespace, item_name, call_id, argument_key)
     if key in seen_tool_call_keys:
         logger.warning(
             "Suppressed duplicate downstream tool call response_id=%s item_type=%s name=%s",
@@ -154,16 +160,31 @@ def mark_duplicate_tool_call_downstream_event(
         )
         return True
     if is_side_effect_tool_call:
-        same_response_argument_key = (dedupe_response_id, str(item_type), item_name, None, argument_key)
+        same_response_argument_key = (
+            dedupe_response_id,
+            str(item_type),
+            item_namespace,
+            item_name,
+            None,
+            argument_key,
+        )
         code_mode_call = item_name in _CODE_MODE_DOWNSTREAM_SIDE_EFFECT_TOOL_CALL_NAMES
-        cross_response_call_id = call_id if code_mode_call else None
-        cross_response_argument_key = ("", str(item_type), item_name, cross_response_call_id, argument_key)
-        has_cross_response_identity = not code_mode_call or cross_response_call_id is not None
+        identity_scoped_call = code_mode_call or item_namespace is not None
+        cross_response_call_id = call_id if identity_scoped_call else None
+        cross_response_argument_key = (
+            "",
+            str(item_type),
+            item_namespace,
+            item_name,
+            cross_response_call_id,
+            argument_key,
+        )
+        has_cross_response_identity = not identity_scoped_call or cross_response_call_id is not None
         if (
             not scope_side_effects_by_response_id
             and has_cross_response_identity
             and cross_response_argument_key in seen_tool_call_keys
-            and same_response_argument_key not in seen_tool_call_keys
+            and (identity_scoped_call or same_response_argument_key not in seen_tool_call_keys)
         ):
             logger.warning(
                 "Suppressed duplicate downstream side-effect replay response_id=%s item_type=%s name=%s",
@@ -182,11 +203,19 @@ def mark_duplicate_tool_call_downstream_event(
     return False
 
 
+def _clear_legacy_downstream_tool_call_keys(seen_tool_call_keys: dict[ToolCallDedupeKey, None]) -> None:
+    for key in tuple(seen_tool_call_keys):
+        _, _, namespace, _, call_id, _ = key
+        if namespace is not None and call_id is not None:
+            continue
+        seen_tool_call_keys.pop(key, None)
+
+
 def _mark_duplicate_parallel_tool_call_downstream_event(
     item: dict[str, JsonValue],
     argument_value: str,
     *,
-    seen_tool_call_keys: dict[tuple[str, str, str | None, str | None, str], None],
+    seen_tool_call_keys: dict[ToolCallDedupeKey, None],
     response_id: str | None,
     scope_side_effects_by_response_id: bool,
 ) -> bool:
@@ -197,7 +226,7 @@ def _mark_duplicate_parallel_tool_call_downstream_event(
     if not isinstance(tool_uses, list):
         return False
 
-    candidate_keys: list[tuple[str, str, str | None, str | None, str]] = []
+    candidate_keys: list[ToolCallDedupeKey] = []
     for tool_use in tool_uses:
         if not isinstance(tool_use, dict):
             continue
@@ -209,6 +238,7 @@ def _mark_duplicate_parallel_tool_call_downstream_event(
             (
                 dedupe_response_id or "",
                 "parallel_tool_use",
+                None,
                 recipient_name,
                 None,
                 canonical_parallel_tool_use_key(cast(dict[str, JsonValue], tool_use)),
@@ -228,6 +258,7 @@ def _mark_duplicate_parallel_tool_call_downstream_event(
         key = (
             dedupe_response_id or "",
             "parallel_tool_use",
+            None,
             recipient_name,
             None,
             canonical_parallel_tool_use_key(cast(dict[str, JsonValue], tool_use)),
@@ -360,7 +391,7 @@ def dedupe_replayed_side_effect_input_items(
     *,
     sanitize_missing_outputs: bool = False,
 ) -> tuple[list[JsonValue], int]:
-    call_keys: dict[int, tuple[str, str | None, str]] = {}
+    call_keys: dict[int, ReplayedSideEffectToolCallKey] = {}
     call_ids: dict[int, str] = {}
     output_indices_by_call_id: dict[str, list[int]] = {}
     for index, item in enumerate(input_items):
@@ -382,11 +413,11 @@ def dedupe_replayed_side_effect_input_items(
 
     kept = [True] * len(input_items)
     rewritten: dict[int, JsonValue] = {}
-    first_call_id_by_key: dict[tuple[str, str | None, str], str | None] = {}
-    first_call_index_by_key: dict[tuple[str, str | None, str], int] = {}
+    first_call_id_by_key: dict[ReplayedSideEffectToolCallKey, str | None] = {}
+    first_call_index_by_key: dict[ReplayedSideEffectToolCallKey, int] = {}
     output_index_by_call_index: dict[int, int | None] = {}
     next_output_cursor_by_call_id: dict[str, int] = {}
-    last_side_effect_key: tuple[str, str | None, str] | None = None
+    last_side_effect_key: ReplayedSideEffectToolCallKey | None = None
     removed_count = 0
     for index, item in enumerate(input_items):
         if isinstance(item, dict) and replayed_input_segment_boundary(item):
@@ -402,13 +433,14 @@ def dedupe_replayed_side_effect_input_items(
                 and first_call_id_by_key.get(last_side_effect_key) == output_call_id
             ):
                 continue
-            if output_call_id is not None or (isinstance(item, dict) and replayed_tool_call_segment_boundary(item)):
-                first_call_id_by_key.clear()
-                first_call_index_by_key.clear()
-                last_side_effect_key = None
+            if isinstance(item, dict) and replayed_tool_call_segment_boundary(item):
+                _clear_legacy_replayed_side_effect_keys(first_call_id_by_key, first_call_index_by_key)
+                continue
+            if output_call_id is not None:
+                _clear_legacy_replayed_side_effect_keys(first_call_id_by_key, first_call_index_by_key)
             continue
         if last_side_effect_key is not None and key != last_side_effect_key:
-            first_call_id_by_key.clear()
+            _clear_legacy_replayed_side_effect_keys(first_call_id_by_key, first_call_index_by_key)
         last_side_effect_key = key
         call_id = call_ids.get(index)
         output_index = (
@@ -464,7 +496,7 @@ def dedupe_replayed_side_effect_input_items(
     return deduped_items, removed_count + missing_output_rewrites
 
 
-def replayed_side_effect_tool_call_key(item: Mapping[str, JsonValue]) -> tuple[str, str | None, str] | None:
+def replayed_side_effect_tool_call_key(item: Mapping[str, JsonValue]) -> ReplayedSideEffectToolCallKey | None:
     item_type_value = item.get("type")
     item_type = item_type_value if isinstance(item_type_value, str) else None
     if item_type == "function_call":
@@ -495,7 +527,27 @@ def replayed_side_effect_tool_call_key(item: Mapping[str, JsonValue]) -> tuple[s
         argument_key = canonical_json_key(operation_value)
     else:
         return None
-    return (item_type, item_name, argument_key)
+    namespace_value = item.get("namespace")
+    namespace = namespace_value if isinstance(namespace_value, str) else None
+    call_id_value = item.get("call_id")
+    call_id = call_id_value if namespace is not None and isinstance(call_id_value, str) and call_id_value else None
+    return (item_type, namespace, item_name, call_id, argument_key)
+
+
+def _replayed_side_effect_key_has_stable_identity(key: ReplayedSideEffectToolCallKey) -> bool:
+    _, namespace, _, call_id, _ = key
+    return namespace is not None and call_id is not None
+
+
+def _clear_legacy_replayed_side_effect_keys(
+    first_call_id_by_key: dict[ReplayedSideEffectToolCallKey, str | None],
+    first_call_index_by_key: dict[ReplayedSideEffectToolCallKey, int],
+) -> None:
+    for key in tuple(first_call_id_by_key):
+        if _replayed_side_effect_key_has_stable_identity(key):
+            continue
+        first_call_id_by_key.pop(key, None)
+        first_call_index_by_key.pop(key, None)
 
 
 def replayed_input_segment_boundary(item: Mapping[str, JsonValue]) -> bool:

--- a/openspec/changes/preserve-multi-agent-v2-passthrough/.openspec.yaml
+++ b/openspec/changes/preserve-multi-agent-v2-passthrough/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/preserve-multi-agent-v2-passthrough/design.md
+++ b/openspec/changes/preserve-multi-agent-v2-passthrough/design.md
@@ -41,12 +41,13 @@ namespace and call ID so distinct calls and their matching outputs survive.
 Stable namespaced identities remain tracked across intervening side-effect,
 read-only tool, ordinary assistant-output, and unmatched tool-output items
 until an explicit developer, system, or user input segment boundary. Those
-intervening items clear only legacy argument-based entries. Flat legacy
-side-effect calls continue to use consecutive argument-based replay identity
-and reset when a different side effect, read-only call, or output item
-intervenes; this preserves protection for reconnects that replay shell, patch,
-or terminal operations under a new call ID without collapsing intentional
-later repetitions.
+different side-effect, read-only tool, and unmatched tool-output items clear
+only legacy argument-based entries; ordinary assistant output preserves the
+existing consecutive legacy state. Flat legacy side-effect calls continue to
+use consecutive argument-based replay identity and reset at those legacy tool
+boundaries, preserving protection for reconnects that replay shell, patch, or
+terminal operations under a new call ID without collapsing intentional later
+repetitions.
 
 Nested `multi_tool_use.parallel` behavior is unchanged. Its existing entries
 use an explicit empty namespace slot in the expanded cache-key shape.

--- a/openspec/changes/preserve-multi-agent-v2-passthrough/design.md
+++ b/openspec/changes/preserve-multi-agent-v2-passthrough/design.md
@@ -1,0 +1,59 @@
+# Design
+
+## Request-scoped metadata projection
+
+An HTTP request can be multiplexed onto an already-open upstream WebSocket, so
+the socket handshake is not a request-scoped metadata channel. When preparing
+each `response.create` frame, project nonblank values from
+`x-codex-turn-metadata`, `x-openai-subagent`,
+`x-codex-parent-thread-id`, and `x-codex-window-id` into
+`client_metadata`.
+
+The request body remains canonical: use insert-if-absent semantics so a value
+already present in body `client_metadata` is not replaced by its compatibility
+header. Header names are matched case-insensitively. Installation identity
+continues to use the existing account-owned replacement path.
+
+## Compact affinity
+
+`x-codex-turn-state` is more specific than a session header or prompt-cache
+key. Compact classification mirrors the normal Responses classifier: resolve
+the prompt-cache key as before, then return Codex-session affinity for a
+nonblank turn-state before considering session or cache affinity. Resolving the
+cache key first preserves the existing derived-cache-key side effect used for
+upstream payload consistency.
+
+Observability labels the resulting source as `turn_state_header`, matching the
+Responses path instead of reporting it as a generic session header.
+
+## Namespaced side-effect identity
+
+The Responses API represents multi-agent v2 calls with separate `namespace`,
+`name`, and `call_id` fields. Downstream deduplication therefore adds namespace
+to every cache key. For a namespaced call, cross-response replay identity also
+retains `call_id`, as already done for code-mode `exec` and `collaboration`
+calls. An exact replay with the same namespace and call ID remains suppressed
+even when a different call was emitted earlier in the new response; a
+different namespace or call ID remains visible.
+
+History deduplication follows the same boundary. Namespaced call keys retain
+namespace and call ID so distinct calls and their matching outputs survive.
+Stable namespaced identities remain tracked across intervening side-effect,
+read-only tool, ordinary assistant-output, and unmatched tool-output items
+until an explicit developer, system, or user input segment boundary. Those
+intervening items clear only legacy argument-based entries. Flat legacy
+side-effect calls continue to use consecutive argument-based replay identity
+and reset when a different side effect, read-only call, or output item
+intervenes; this preserves protection for reconnects that replay shell, patch,
+or terminal operations under a new call ID without collapsing intentional
+later repetitions.
+
+Nested `multi_tool_use.parallel` behavior is unchanged. Its existing entries
+use an explicit empty namespace slot in the expanded cache-key shape.
+
+## Failure boundaries
+
+This change does not weaken exact-replay suppression, previous-response
+continuity checks, API-key enforcement, or account ownership. It changes only
+metadata projection, affinity classification, and the identity of namespaced
+side-effect calls.

--- a/openspec/changes/preserve-multi-agent-v2-passthrough/proposal.md
+++ b/openspec/changes/preserve-multi-agent-v2-passthrough/proposal.md
@@ -1,0 +1,42 @@
+# Preserve Multi-Agent v2 Passthrough
+
+## Summary
+
+Preserve request-scoped Codex multi-agent metadata, compact affinity, and
+namespaced tool-call identity across the Responses proxy.
+
+## Motivation
+
+Codex multi-agent v2 uses per-request subagent, parent-thread, and window
+metadata; it replays `x-codex-turn-state` on remote compaction; and it emits
+tools such as `collaboration.spawn_agent` as namespaced calls with stable call
+IDs.
+
+Three proxy boundaries currently lose those distinctions:
+
+- The HTTP-to-WebSocket bridge promotes only turn metadata into each
+  `response.create` frame, leaving other compatibility headers tied to the
+  reused socket handshake.
+- Compact affinity ignores `x-codex-turn-state` and can select an account using
+  a less-specific session or prompt-cache key.
+- Side-effect deduplication omits the tool namespace and discards call IDs for
+  non-code-mode cross-response and history keys, collapsing legitimate
+  namespaced calls.
+
+## Scope
+
+- Project subagent, parent-thread, window, and turn metadata into each upstream
+  WebSocket request without overriding canonical body metadata.
+- Give compact requests the same turn-state affinity precedence as Responses
+  requests.
+- Include namespace and stable call ID in namespaced side-effect replay
+  identity while retaining legacy flat-tool replay protection.
+- Add focused unit and integration coverage for reused bridge sessions,
+  compact account pinning, and namespaced replay/history handling.
+
+## Impact
+
+- Affected spec: `responses-api-compat`.
+- Affected code: Responses WebSocket frame preparation, compact affinity, and
+  side-effect tool-call deduplication.
+- No database, API schema, or configuration migration is required.

--- a/openspec/changes/preserve-multi-agent-v2-passthrough/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-multi-agent-v2-passthrough/specs/responses-api-compat/spec.md
@@ -1,0 +1,78 @@
+# responses-api-compat - Delta
+
+## ADDED Requirements
+
+### Requirement: Request-scoped Codex metadata survives HTTP-to-WebSocket bridging
+
+When an HTTP Responses request is translated into an upstream WebSocket
+`response.create` frame, the service MUST project nonblank
+`x-codex-turn-metadata`, `x-openai-subagent`,
+`x-codex-parent-thread-id`, and `x-codex-window-id` compatibility headers into
+that frame's `client_metadata`. This projection MUST happen for every request,
+including requests multiplexed over a reused upstream socket. A metadata value
+already supplied in the request body MUST remain authoritative over the
+compatibility header, and header matching MUST be case-insensitive.
+
+#### Scenario: Reused bridge session receives a subagent turn
+
+- **GIVEN** a parent HTTP request has opened an upstream Responses WebSocket
+- **WHEN** a subagent HTTP request reuses that socket with subagent, parent-thread, and child-window headers
+- **THEN** the subagent request's `response.create.client_metadata` contains those values
+- **AND** the earlier parent frame retains its own window metadata
+- **AND** no value is inherited solely from the socket handshake
+
+#### Scenario: Body metadata remains canonical
+
+- **WHEN** a request body and compatibility header provide different values for the same Codex metadata key
+- **THEN** the upstream `response.create.client_metadata` retains the body value
+
+### Requirement: Compact routing honors turn-state affinity
+
+When a compact request carries a nonblank `x-codex-turn-state`, the service MUST
+classify that value as Codex-session affinity before considering a session
+header, prompt-cache affinity, or sticky-thread affinity. This precedence MUST
+apply even when generic Codex session-header affinity is disabled, matching the
+normal Responses path.
+
+#### Scenario: Turn-state-only compact remains on the turn owner
+
+- **GIVEN** a Responses turn established an account mapping for an `x-codex-turn-state` value
+- **AND** another account becomes preferable under the non-sticky routing strategy
+- **WHEN** `/responses/compact` carries only that turn-state continuity value
+- **THEN** the compact request is routed to the account that owns the turn-state mapping
+
+#### Scenario: Turn-state overrides less-specific affinity
+
+- **WHEN** a compact request carries turn-state, session-header, and prompt-cache keys
+- **THEN** its affinity key is the turn-state value
+- **AND** its affinity kind is Codex session
+
+### Requirement: Namespaced side-effect replay dedupe preserves call identity
+
+For a namespaced side-effect function or custom-tool call, the service MUST use
+the call's namespace and call ID as part of downstream and replayed-history
+deduplication identity. An exact replay with the same namespace, name, call ID,
+and canonical arguments MUST remain suppressed. Calls with different
+namespaces or different nonblank call IDs MUST remain distinct, even when their
+names and canonical arguments match, and their matching outputs MUST remain in
+forwarded history.
+
+Flat legacy side-effect calls MAY continue to use argument-based replay
+identity so reconnects that change only a call ID do not repeat shell, patch,
+or terminal side effects.
+
+#### Scenario: Distinct namespaced spawns use identical arguments
+
+- **WHEN** two `collaboration.spawn_agent` calls have identical arguments and different call IDs
+- **THEN** both calls are forwarded
+- **AND** both matching outputs remain in replayed request history
+
+#### Scenario: Exact namespaced call is replayed after reconnect
+
+- **WHEN** reconnect replay emits the same namespaced call ID and canonical arguments under a new response ID
+- **THEN** the service suppresses the replayed downstream call
+
+#### Scenario: Equal call identity appears in different namespaces
+
+- **WHEN** two side-effect calls share a name, call ID, and arguments but have different namespaces
+- **THEN** the service treats them as distinct calls

--- a/openspec/changes/preserve-multi-agent-v2-passthrough/tasks.md
+++ b/openspec/changes/preserve-multi-agent-v2-passthrough/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+- [x] 1. Promote request-scoped multi-agent compatibility headers into upstream WebSocket client metadata.
+- [x] 2. Give compact requests turn-state affinity precedence matching normal Responses requests.
+- [x] 3. Preserve namespace and call ID for namespaced side-effect downstream and history deduplication.
+- [x] 4. Add unit regressions for metadata projection, compact affinity, and exact-versus-distinct namespaced calls.
+- [x] 5. Add integration regressions for reused bridge metadata and turn-state-only compact account pinning.
+- [x] 6. Run focused tests, lint, type checks, strict OpenSpec validation, and diff checks.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -3884,13 +3884,22 @@ async def test_v1_responses_http_bridge_reuses_upstream_websocket_and_preserves_
             "x-codex-installation-id": "client-spoofed-installation-id",
         },
     }
-    first = await async_client.post("/v1/responses", json=payload)
+    first = await async_client.post(
+        "/v1/responses",
+        json=payload,
+        headers={"x-codex-window-id": "parent-thread:0"},
+    )
     assert first.status_code == 200
     first_body = first.json()
 
     second = await async_client.post(
         "/v1/responses",
         json={**payload, "previous_response_id": first_body["id"]},
+        headers={
+            "x-openai-subagent": "collab_spawn",
+            "x-codex-parent-thread-id": "parent-thread",
+            "x-codex-window-id": "child-thread:0",
+        },
     )
     assert second.status_code == 200
     second_body = second.json()
@@ -3903,7 +3912,14 @@ async def test_v1_responses_http_bridge_reuses_upstream_websocket_and_preserves_
     assert first_upstream_payload["client_metadata"]["keep"] == "yes"
     assert first_upstream_payload["client_metadata"]["x-codex-installation-id"] == account.codex_installation_id
     assert first_upstream_payload["client_metadata"]["x-codex-installation-id"] != "client-spoofed-installation-id"
-    assert json.loads(fake_upstream.sent_text[1])["previous_response_id"] == "resp_bridge_1"
+    assert first_upstream_payload["client_metadata"]["x-codex-window-id"] == "parent-thread:0"
+    assert "x-openai-subagent" not in first_upstream_payload["client_metadata"]
+    assert "x-codex-parent-thread-id" not in first_upstream_payload["client_metadata"]
+    second_upstream_payload = json.loads(fake_upstream.sent_text[1])
+    assert second_upstream_payload["previous_response_id"] == "resp_bridge_1"
+    assert second_upstream_payload["client_metadata"]["x-openai-subagent"] == "collab_spawn"
+    assert second_upstream_payload["client_metadata"]["x-codex-parent-thread-id"] == "parent-thread"
+    assert second_upstream_payload["client_metadata"]["x-codex-window-id"] == "child-thread:0"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_sticky_sessions.py
+++ b/tests/integration/test_proxy_sticky_sessions.py
@@ -439,6 +439,89 @@ async def test_proxy_codex_session_id_pins_responses_and_compact_without_sticky_
 
 
 @pytest.mark.asyncio
+async def test_proxy_codex_turn_state_pins_responses_and_compact_without_sticky_threads(async_client, monkeypatch):
+    await _set_routing_settings(async_client, sticky_threads_enabled=False)
+    acc_a_id = await _import_account(async_client, "acc_turn_state_a", "turn_state_a@example.com")
+    acc_b_id = await _import_account(async_client, "acc_turn_state_b", "turn_state_b@example.com")
+
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+
+    async with SessionLocal() as session:
+        usage_repo = UsageRepository(session)
+        await usage_repo.add_entry(
+            account_id=acc_a_id,
+            used_percent=10.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+        await usage_repo.add_entry(
+            account_id=acc_b_id,
+            used_percent=20.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+
+    stream_seen: list[str] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **_kwargs):
+        stream_seen.append(account_id)
+        yield 'data: {"type":"response.completed","response":{"id":"resp_turn_state"}}\n\n'
+
+    compact_seen: list[str] = []
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        compact_seen.append(account_id)
+        return OpenAIResponsePayload.model_validate({"output": []})
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    headers = {"x-codex-turn-state": "codex-turn-state-123"}
+    stream_payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": [],
+        "stream": True,
+    }
+    response = await async_client.post("/backend-api/codex/responses", json=stream_payload, headers=headers)
+    assert response.status_code == 200
+    assert stream_seen == ["acc_turn_state_a"]
+
+    async with SessionLocal() as session:
+        usage_repo = UsageRepository(session)
+        await usage_repo.add_entry(
+            account_id=acc_a_id,
+            used_percent=95.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+        await usage_repo.add_entry(
+            account_id=acc_b_id,
+            used_percent=5.0,
+            window="primary",
+            reset_at=now_epoch + 3600,
+            window_minutes=300,
+        )
+
+    compact_payload = {
+        "model": "gpt-5.1",
+        "instructions": "summarize",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+    }
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json=compact_payload,
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert compact_seen == ["acc_turn_state_a"]
+
+
+@pytest.mark.asyncio
 async def test_proxy_codex_session_id_reallocates_when_pinned_budget_exhausted(async_client, monkeypatch):
     await _set_routing_settings(async_client, sticky_threads_enabled=False)
     acc_a_id = await _import_account(async_client, "acc_sid_budget_a", "sid_budget_a@example.com")

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -2625,6 +2625,10 @@ async def test_create_http_bridge_session_filters_http_headers_for_upstream_webs
             "transfer-encoding": "chunked",
             "upgrade": "websocket",
             "user-agent": "pi",
+            "X-Codex-Turn-Metadata": '{"turn_id":"turn-create"}',
+            "x-OpenAI-Subagent": "collab_spawn",
+            "X-Codex-Parent-Thread-ID": "parent-create",
+            "x-CODEX-window-id": "child-create:0",
             "x-handshake-debug": "1",
         },
         affinity=proxy_service._AffinityPolicy(
@@ -2656,6 +2660,10 @@ async def test_create_http_bridge_session_filters_http_headers_for_upstream_webs
     assert "trailer" not in forwarded
     assert "transfer-encoding" not in forwarded
     assert "upgrade" not in forwarded
+    assert "x-codex-turn-metadata" not in forwarded
+    assert "x-openai-subagent" not in forwarded
+    assert "x-codex-parent-thread-id" not in forwarded
+    assert "x-codex-window-id" not in forwarded
     assert "x-handshake-debug" not in forwarded
 
 
@@ -2682,6 +2690,10 @@ async def test_reconnect_http_bridge_session_filters_http_headers_for_upstream_w
         "transfer-encoding": "chunked",
         "upgrade": "websocket",
         "user-agent": "pi",
+        "X-Codex-Turn-Metadata": '{"turn_id":"turn-reconnect"}',
+        "x-OpenAI-Subagent": "collab_spawn",
+        "X-Codex-Parent-Thread-ID": "parent-reconnect",
+        "x-CODEX-window-id": "child-reconnect:0",
         "x-handshake-debug": "1",
     }
     session.upstream_turn_state = "upstream-turn-state"
@@ -2743,6 +2755,10 @@ async def test_reconnect_http_bridge_session_filters_http_headers_for_upstream_w
     assert "trailer" not in forwarded
     assert "transfer-encoding" not in forwarded
     assert "upgrade" not in forwarded
+    assert "x-codex-turn-metadata" not in forwarded
+    assert "x-openai-subagent" not in forwarded
+    assert "x-codex-parent-thread-id" not in forwarded
+    assert "x-codex-window-id" not in forwarded
     assert "x-handshake-debug" not in forwarded
 
 

--- a/tests/unit/test_proxy_tool_call_dedupe.py
+++ b/tests/unit/test_proxy_tool_call_dedupe.py
@@ -198,6 +198,158 @@ def test_mark_duplicate_tool_call_downstream_event_keeps_distinct_code_mode_exec
     )
 
 
+def test_mark_duplicate_tool_call_downstream_event_suppresses_namespaced_replay_after_distinct_call():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+
+    def payload(response_id: str, call_id: str) -> dict[str, JsonValue]:
+        return {
+            "type": "response.output_item.done",
+            "response_id": response_id,
+            "item": {
+                "type": "custom_tool_call",
+                "namespace": "collaboration",
+                "name": "spawn_agent",
+                "input": '{"message":"same task"}',
+                "call_id": call_id,
+            },
+        }
+
+    results = [
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            event,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id=response_id,
+            scope_side_effects_by_response_id=False,
+        )
+        for event, response_id in (
+            (payload("resp_namespaced_first", "call_a"), "resp_namespaced_first"),
+            (payload("resp_namespaced_second", "call_c"), "resp_namespaced_second"),
+            (payload("resp_namespaced_second", "call_a"), "resp_namespaced_second"),
+        )
+    ]
+
+    assert results == [False, False, True]
+
+
+def test_mark_duplicate_tool_call_downstream_event_suppresses_namespaced_replay_after_read_only_call():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+
+    def payload(response_id: str, call_id: str, name: str) -> dict[str, JsonValue]:
+        return {
+            "type": "response.output_item.done",
+            "response_id": response_id,
+            "item": {
+                "type": "custom_tool_call",
+                "namespace": "collaboration",
+                "name": name,
+                "input": '{"message":"same task"}' if name == "spawn_agent" else "{}",
+                "call_id": call_id,
+            },
+        }
+
+    results = [
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            event,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id=response_id,
+            scope_side_effects_by_response_id=False,
+        )
+        for event, response_id in (
+            (payload("resp_namespaced_first", "call_a", "spawn_agent"), "resp_namespaced_first"),
+            (payload("resp_namespaced_second", "call_read", "list_agents"), "resp_namespaced_second"),
+            (payload("resp_namespaced_second", "call_a", "spawn_agent"), "resp_namespaced_second"),
+        )
+    ]
+
+    assert results == [False, False, True]
+
+
+def test_mark_duplicate_tool_call_downstream_event_suppresses_namespaced_replay_after_message_item():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    spawn_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_namespaced_first",
+        "item": {
+            "type": "custom_tool_call",
+            "namespace": "collaboration",
+            "name": "spawn_agent",
+            "input": '{"message":"same task"}',
+            "call_id": "call_a",
+        },
+    }
+    message_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_namespaced_second",
+        "item": {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "still working"}],
+        },
+    }
+    replay_payload: dict[str, JsonValue] = {
+        **spawn_payload,
+        "response_id": "resp_namespaced_second",
+    }
+
+    results = [
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            event,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id=response_id,
+            scope_side_effects_by_response_id=False,
+        )
+        for event, response_id in (
+            (spawn_payload, "resp_namespaced_first"),
+            (message_payload, "resp_namespaced_second"),
+            (replay_payload, "resp_namespaced_second"),
+        )
+    ]
+
+    assert results == [False, False, True]
+
+
+def test_mark_duplicate_tool_call_downstream_event_keeps_distinct_namespaces():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    first_payload: dict[str, JsonValue] = {
+        "type": "response.output_item.done",
+        "response_id": "resp_namespace_v1",
+        "item": {
+            "type": "function_call",
+            "namespace": "multi_agent_v1",
+            "name": "spawn_agent",
+            "arguments": '{"message":"same task"}',
+            "call_id": "call_shared",
+        },
+    }
+    second_payload: dict[str, JsonValue] = {
+        **first_payload,
+        "response_id": "resp_namespace_v2",
+        "item": {
+            **cast(dict[str, JsonValue], first_payload["item"]),
+            "namespace": "collaboration",
+        },
+    }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            first_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_namespace_v1",
+            scope_side_effects_by_response_id=False,
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            second_payload,
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_namespace_v2",
+            scope_side_effects_by_response_id=False,
+        )
+        is False
+    )
+
+
 def test_mark_duplicate_tool_call_downstream_event_suppresses_direct_wait_agent_replay():
     upstream_control = proxy_service._WebSocketUpstreamControl()
     first_payload: dict[str, JsonValue] = {
@@ -1476,6 +1628,241 @@ def test_dedupe_replayed_side_effect_input_items_keeps_distinct_code_mode_calls(
             "call_id": "call_code_mode_second",
             "output": "second result",
         },
+    ]
+
+    deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)
+
+    assert removed_count == 0
+    assert deduped_items == input_items
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments"),
+    [
+        ("spawn_agent", '{"message":"same task"}'),
+        ("wait_agent", '{"targets":["agent-a"],"timeout_ms":30000}'),
+    ],
+)
+def test_dedupe_replayed_side_effect_input_items_keeps_distinct_namespaced_calls(
+    tool_name: str,
+    arguments: str,
+):
+    input_items: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "namespace": "collaboration",
+            "name": tool_name,
+            "arguments": arguments,
+            "call_id": "call_namespaced_first",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_namespaced_first",
+            "output": "first result",
+        },
+        {
+            "type": "function_call",
+            "namespace": "collaboration",
+            "name": tool_name,
+            "arguments": arguments,
+            "call_id": "call_namespaced_second",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_namespaced_second",
+            "output": "second result",
+        },
+    ]
+
+    deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)
+
+    assert removed_count == 0
+    assert deduped_items == input_items
+
+
+def test_dedupe_replayed_side_effect_input_items_suppresses_exact_namespaced_replay():
+    repeated_call: dict[str, JsonValue] = {
+        "type": "custom_tool_call",
+        "namespace": "collaboration",
+        "name": "spawn_agent",
+        "input": '{"message":"same task"}',
+        "call_id": "call_namespaced",
+    }
+    input_items: list[JsonValue] = [
+        repeated_call,
+        {
+            "type": "custom_tool_call_output",
+            "call_id": "call_namespaced",
+            "output": "first result",
+        },
+        dict(repeated_call),
+        {
+            "type": "custom_tool_call_output",
+            "call_id": "call_namespaced",
+            "output": "replayed result",
+        },
+    ]
+
+    deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)
+
+    assert removed_count == 1
+    assert sum(1 for item in deduped_items if isinstance(item, dict) and item.get("type") == "custom_tool_call") == 1
+
+
+def test_dedupe_replayed_side_effect_input_items_keeps_distinct_namespaced_custom_calls():
+    repeated_input = '{"message":"same task"}'
+    input_items: list[JsonValue] = [
+        {
+            "type": "custom_tool_call",
+            "namespace": "collaboration",
+            "name": "spawn_agent",
+            "input": repeated_input,
+            "call_id": "call_custom_namespaced_first",
+        },
+        {
+            "type": "custom_tool_call_output",
+            "call_id": "call_custom_namespaced_first",
+            "output": "first result",
+        },
+        {
+            "type": "custom_tool_call",
+            "namespace": "collaboration",
+            "name": "spawn_agent",
+            "input": repeated_input,
+            "call_id": "call_custom_namespaced_second",
+        },
+        {
+            "type": "custom_tool_call_output",
+            "call_id": "call_custom_namespaced_second",
+            "output": "second result",
+        },
+    ]
+
+    deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)
+
+    assert removed_count == 0
+    assert deduped_items == input_items
+
+
+def test_dedupe_replayed_side_effect_input_items_suppresses_namespaced_replay_after_distinct_call():
+    repeated_input = '{"message":"same task"}'
+
+    def call(call_id: str) -> dict[str, JsonValue]:
+        return {
+            "type": "custom_tool_call",
+            "namespace": "collaboration",
+            "name": "spawn_agent",
+            "input": repeated_input,
+            "call_id": call_id,
+        }
+
+    def output(call_id: str, value: str) -> dict[str, JsonValue]:
+        return {
+            "type": "custom_tool_call_output",
+            "call_id": call_id,
+            "output": value,
+        }
+
+    input_items: list[JsonValue] = [
+        call("call_a"),
+        output("call_a", "first result"),
+        call("call_c"),
+        output("call_c", "distinct result"),
+        call("call_a"),
+        output("call_a", "replayed result"),
+    ]
+
+    deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)
+
+    assert removed_count == 1
+    assert [item.get("call_id") for item in deduped_items if isinstance(item, dict) and "call_id" in item] == [
+        "call_a",
+        "call_a",
+        "call_c",
+        "call_c",
+    ]
+    replay_output = cast(dict[str, JsonValue], deduped_items[-1])
+    assert replay_output["type"] == "message"
+    assert replay_output["content"] == [{"type": "output_text", "text": "replayed result"}]
+
+
+def test_dedupe_replayed_side_effect_input_items_suppresses_namespaced_replay_after_read_only_call():
+    spawn_call: dict[str, JsonValue] = {
+        "type": "custom_tool_call",
+        "namespace": "collaboration",
+        "name": "spawn_agent",
+        "input": '{"message":"same task"}',
+        "call_id": "call_a",
+    }
+    input_items: list[JsonValue] = [
+        spawn_call,
+        {"type": "custom_tool_call_output", "call_id": "call_a", "output": "first result"},
+        {
+            "type": "custom_tool_call",
+            "namespace": "collaboration",
+            "name": "list_agents",
+            "input": "{}",
+            "call_id": "call_read",
+        },
+        {"type": "custom_tool_call_output", "call_id": "call_read", "output": "agent list"},
+        dict(spawn_call),
+        {"type": "custom_tool_call_output", "call_id": "call_a", "output": "replayed result"},
+    ]
+
+    deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)
+
+    assert removed_count == 1
+    assert [item.get("call_id") for item in deduped_items if isinstance(item, dict) and "call_id" in item] == [
+        "call_a",
+        "call_a",
+        "call_read",
+        "call_read",
+    ]
+    replay_output = cast(dict[str, JsonValue], deduped_items[-1])
+    assert replay_output["type"] == "message"
+    assert replay_output["content"] == [{"type": "output_text", "text": "replayed result"}]
+
+
+def test_dedupe_replayed_side_effect_input_items_suppresses_namespaced_replay_after_unknown_output():
+    spawn_call: dict[str, JsonValue] = {
+        "type": "custom_tool_call",
+        "namespace": "collaboration",
+        "name": "spawn_agent",
+        "input": '{"message":"same task"}',
+        "call_id": "call_a",
+    }
+    input_items: list[JsonValue] = [
+        spawn_call,
+        {"type": "custom_tool_call_output", "call_id": "call_a", "output": "first result"},
+        {"type": "custom_tool_call_output", "call_id": "call_unknown", "output": "unmatched result"},
+        dict(spawn_call),
+        {"type": "custom_tool_call_output", "call_id": "call_a", "output": "replayed result"},
+    ]
+
+    deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)
+
+    assert removed_count == 1
+    unmatched_output = cast(dict[str, JsonValue], deduped_items[2])
+    assert unmatched_output["call_id"] == "call_unknown"
+    replay_output = cast(dict[str, JsonValue], deduped_items[-1])
+    assert replay_output["type"] == "message"
+    assert replay_output["content"] == [{"type": "output_text", "text": "replayed result"}]
+
+
+def test_dedupe_replayed_side_effect_input_items_resets_namespaced_identity_at_user_boundary():
+    spawn_call: dict[str, JsonValue] = {
+        "type": "custom_tool_call",
+        "namespace": "collaboration",
+        "name": "spawn_agent",
+        "input": '{"message":"same task"}',
+        "call_id": "call_a",
+    }
+    input_items: list[JsonValue] = [
+        spawn_call,
+        {"type": "custom_tool_call_output", "call_id": "call_a", "output": "first result"},
+        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "spawn again"}]},
+        dict(spawn_call),
+        {"type": "custom_tool_call_output", "call_id": "call_a", "output": "second result"},
     ]
 
     deduped_items, removed_count = tool_call_dedupe.dedupe_replayed_side_effect_input_items(input_items)

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -2202,6 +2202,42 @@ def test_response_create_client_metadata_preserves_existing_json_values_and_turn
     }
 
 
+def test_response_create_client_metadata_promotes_multi_agent_headers_per_request():
+    metadata = proxy_service._response_create_client_metadata(
+        {
+            "client_metadata": {
+                "x-openai-subagent": "payload-subagent",
+            }
+        },
+        headers={
+            "X-OpenAI-Subagent": "header-subagent",
+            "X-Codex-Parent-Thread-Id": "parent-thread",
+            "X-Codex-Window-Id": "child-thread:0",
+            "X-Codex-Turn-Metadata": '{"turn_id":"turn-1"}',
+        },
+    )
+
+    assert metadata == {
+        "x-openai-subagent": "payload-subagent",
+        "x-codex-parent-thread-id": "parent-thread",
+        "x-codex-window-id": "child-thread:0",
+        "x-codex-turn-metadata": '{"turn_id":"turn-1"}',
+    }
+
+
+def test_response_create_client_metadata_ignores_blank_multi_agent_headers():
+    metadata = proxy_service._response_create_client_metadata(
+        {},
+        headers={
+            "x-openai-subagent": " ",
+            "x-codex-parent-thread-id": "",
+            "x-codex-window-id": "\t",
+        },
+    )
+
+    assert metadata is None
+
+
 def test_response_create_client_metadata_reconstructs_responses_lite_marker():
     marker = proxy_module.CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY
     metadata = proxy_service._response_create_client_metadata(
@@ -7105,6 +7141,37 @@ def test_sticky_key_for_compact_request_prefers_codex_session_affinity():
     )
 
     assert policy.key == "codex-session-1"
+    assert policy.kind == proxy_service.StickySessionKind.CODEX_SESSION
+    assert policy.reallocate_sticky is False
+    assert policy.max_age_seconds is None
+
+
+@pytest.mark.parametrize("codex_session_affinity", [False, True])
+def test_sticky_key_for_compact_request_prefers_turn_state_over_session_and_cache(
+    codex_session_affinity: bool,
+):
+    payload = ResponsesCompactRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "hi",
+            "input": [],
+            "prompt_cache_key": "cache-owner",
+        }
+    )
+
+    policy = proxy_service._sticky_key_for_compact_request(
+        payload,
+        headers={
+            "x-codex-turn-state": "turn-owner",
+            "session_id": "session-owner",
+        },
+        codex_session_affinity=codex_session_affinity,
+        openai_cache_affinity=True,
+        openai_cache_affinity_max_age_seconds=300,
+        sticky_threads_enabled=True,
+    )
+
+    assert policy.key == "turn-owner"
     assert policy.kind == proxy_service.StickySessionKind.CODEX_SESSION
     assert policy.reallocate_sticky is False
     assert policy.max_age_seconds is None


### PR DESCRIPTION
## Summary

Preserves Codex multi-agent v2 metadata, compact affinity, and namespaced tool-call identity across Responses proxy boundaries. This fixes the deterministic passthrough gaps reported in #1185 without changing legacy flat-tool replay protection.

## Type of change

- [x] `fix:` - bug fix (no behavior change beyond the bug)
- [ ] `feat:` - new user-facing feature or capability
- [ ] `refactor:` - internal refactor (no behavior change, no API change)
- [ ] `docs:` - documentation only
- [ ] `chore:` / `ci:` / `build:` - tooling, CI, packaging
- [ ] `test:` - test-only change
- [ ] **Breaking change**

Linked issue: Fixes #1185

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable - bug fix that matches the existing spec
- [ ] Not applicable - docs / CI / chore only
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/preserve-multi-agent-v2-passthrough/`

## Changes

- Projects per-request turn, subagent, parent-thread, and window metadata into every bridged `response.create` frame, including reused upstream sockets.
- Gives `x-codex-turn-state` compact affinity precedence over session and prompt-cache keys.
- Includes namespace and stable call ID in namespaced side-effect replay identity while retaining legacy argument-based protection for flat tools.
- Keeps stable namespaced identities across intervening side-effect, read-only, message, and unknown-output items until a real user/system/developer input boundary.
- Adds externally visible bridge and compact-routing regressions plus focused downstream/history dedupe coverage.

## Test plan

```
uv run pytest tests/unit/test_proxy_tool_call_dedupe.py tests/unit/test_proxy_utils.py -q
# 644 passed, 5 pre-existing AsyncMock warnings

uv run pytest tests/integration/test_http_responses_bridge.py::test_v1_responses_http_bridge_reuses_upstream_websocket_and_preserves_previous_response_id tests/integration/test_proxy_sticky_sessions.py::test_proxy_codex_turn_state_pins_responses_and_compact_without_sticky_threads -q
# 2 passed

uv run ruff check .
uv run ruff format --check .
uv run ty check
npx --yes @fission-ai/openspec@latest validate preserve-multi-agent-v2-passthrough --strict
npx --yes @fission-ai/openspec@latest validate --specs
git diff --check
```

All commands passed. OpenSpec validated all 30 repository specs.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local CI subset.
- [x] Strict OpenSpec change and repository spec validation pass.
- [x] CHANGELOG is not edited by hand.