### PR TITLE
fix(proxy): preserve admitted bridge waiters on upstream close

### DIFF
--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -367,9 +367,10 @@ def http_bridge_activity_snapshot_nowait(service: Any) -> dict[str, int | bool]:
     pending_unknown_sessions = 0
 
     for session in list(service._http_bridge_sessions.values()):
-        if session.closed:
+        if session.closed and not _http_bridge_session_has_admission_waiter(session):
             continue
-        live_sessions += 1
+        if not session.closed:
+            live_sessions += 1
         pending_count = _http_bridge_pending_count_nowait(session, context="drain_status")
         if pending_count is None:
             pending_unknown_sessions += 1
@@ -677,6 +678,65 @@ def _http_bridge_session_matches_preferred_account(
     if previous_response_id is None and not require_preferred_account:
         return True
     return session.account.id == preferred_account_id
+
+
+def _http_bridge_session_reusable_for_lookup(
+    *,
+    session: "_HTTPBridgeSession",
+    key: "_HTTPBridgeSessionKey",
+    api_key: ApiKeyData | None,
+    incoming_turn_state: str | None,
+    previous_response_id: str | None,
+    preferred_account_id: str | None,
+    require_preferred_account: bool,
+    service_tier_supported: bool,
+    allow_closed_admission_handoff: bool,
+) -> bool:
+    live_or_retained = _http_bridge_session_account_active(session) and (
+        not session.closed or (allow_closed_admission_handoff and _http_bridge_session_has_admission_waiter(session))
+    )
+    return (
+        live_or_retained
+        and _http_bridge_session_allows_api_key(session, api_key)
+        and _http_bridge_session_reusable_for_request(
+            session=session,
+            key=key,
+            incoming_turn_state=incoming_turn_state,
+            previous_response_id=previous_response_id,
+        )
+        and _http_bridge_session_matches_preferred_account(
+            session=session,
+            previous_response_id=previous_response_id,
+            preferred_account_id=preferred_account_id,
+            require_preferred_account=require_preferred_account,
+        )
+        and service_tier_supported
+    )
+
+
+def _require_http_bridge_bound_account_not_excluded(
+    hard_account_bound: bool,
+    account_id: str,
+    excluded_account_ids: set[str],
+) -> None:
+    if hard_account_bound and account_id in excluded_account_ids:
+        raise ProxyResponseError(
+            502,
+            openai_error(
+                "upstream_unavailable",
+                "HTTP responses session bridge continuity account is excluded",
+            ),
+        )
+
+
+def _raise_http_bridge_incompatible_admission_handoff() -> None:
+    raise ProxyResponseError(
+        503,
+        openai_error(
+            "upstream_unavailable",
+            "HTTP responses session bridge is preserving an incompatible admission handoff",
+        ),
+    )
 
 
 def _make_http_bridge_session_key(

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -588,6 +588,11 @@ def _http_bridge_request_counts_against_queue(request_state: _WebSocketRequestSt
     return not request_state.draining_until_terminal
 
 
+def _http_bridge_session_has_admission_waiter(session: object | None) -> bool:
+    """Keep a closed bridge registered while an unsent request owns its handoff."""
+    return session is not None and bool(getattr(session, "admission_waiter_count", 0))
+
+
 def _http_bridge_session_has_visible_requests(session: "_HTTPBridgeSession") -> bool:
     return session.queued_request_count > 0 or any(
         _http_bridge_request_counts_against_queue(request_state) for request_state in session.pending_requests

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -660,6 +660,12 @@ class _HTTPBridgeMixin(
                 existing = self._http_bridge_sessions.get(key)
                 if (
                     existing is not None
+                    and existing.closed
+                    and getattr(existing, "admission_waiter_count", 0) > 0
+                ):
+                    return existing
+                if (
+                    existing is not None
                     and not existing.closed
                     and _http_bridge_session_account_active(existing)
                     and _http_bridge_session_allows_api_key(existing, api_key)
@@ -2129,6 +2135,7 @@ class _HTTPBridgeMixin(
         request_state: _WebSocketRequestState,
         restart_reader: bool = False,
         require_security_work_authorized: bool = False,
+        require_same_account: bool = False,
     ) -> None:
         old_account_id = session.account.id
         old_upstream = session.upstream
@@ -2152,7 +2159,9 @@ class _HTTPBridgeMixin(
         settings = await _service_get_settings_cache().get()
         session.api_key = request_state.api_key
         close_skips_account = session.last_upstream_close_code in _UPSTREAM_CLOSE_CODES_SKIP_SAME_ACCOUNT_RETRY
-        hard_close_account_bound = session.key.strength == "hard" and close_skips_account
+        hard_close_account_bound = session.key.strength == "hard" and (
+            close_skips_account or require_same_account
+        )
         skip_same_account = session.key.strength != "hard" and close_skips_account
         forced_refresh_account_id = request_state.force_refresh_account_id
         excluded_account_ids: set[str] = set(request_state.excluded_account_ids)

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -1519,6 +1519,10 @@ class _HTTPBridgeMixin(
         now = _service_time().monotonic()
         stale_keys: list[_HTTPBridgeSessionKey] = []
         for key, session in self._http_bridge_sessions.items():
+            # An admitted request waiting for the response-create gate owns the
+            # session handoff even when the old upstream reader just closed.
+            if session.admission_waiter_count > 0:
+                continue
             if session.closed:
                 stale_keys.append(key)
                 continue

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -92,6 +92,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_session_has_admission_waiter,
     _http_bridge_session_matches_preferred_account,
     _http_bridge_session_retiring_with_visible_requests,
+    _http_bridge_session_reusable_for_lookup,
     _http_bridge_session_reusable_for_request,
     _http_bridge_should_wait_for_registration,
     _http_bridge_startup_wait_timeout_error,
@@ -100,9 +101,11 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _log_http_bridge_event,
     _log_http_bridge_startup_wait_timeout,
     _preferred_http_bridge_reconnect_turn_state,
+    _raise_http_bridge_incompatible_admission_handoff,
     _record_bridge_drain_recovery_allowed,
     _record_bridge_first_turn_timeout,
     _record_bridge_reattach,
+    _require_http_bridge_bound_account_not_excluded,
 )
 from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_pending_count_nowait as helpers_http_bridge_pending_count_nowait,
@@ -648,38 +651,32 @@ class _HTTPBridgeMixin(
                         else:
                             key = _HTTPBridgeSessionKey("turn_state_header", incoming_turn_state, api_key_id)
                             missing_turn_state_alias = True
-
                 pruned_sessions = self._prune_http_bridge_sessions_locked()
                 if pruned_sessions:
                     if any(session.key == key for session in pruned_sessions):
                         force_durable_takeover = True
                     self._schedule_http_bridge_session_closes(pruned_sessions, reason="registry_detach")
                 existing = self._http_bridge_sessions.get(key)
-                if existing is not None and existing.closed and _http_bridge_session_has_admission_waiter(existing):
-                    return existing
-                if (
-                    existing is not None
-                    and not existing.closed
-                    and _http_bridge_session_account_active(existing)
-                    and _http_bridge_session_allows_api_key(existing, api_key)
-                    and _http_bridge_session_reusable_for_request(
-                        session=existing,
-                        key=key,
-                        incoming_turn_state=incoming_turn_state,
-                        previous_response_id=previous_response_id,
-                    )
-                    and _http_bridge_session_matches_preferred_account(
-                        session=existing,
-                        previous_response_id=previous_response_id,
-                        preferred_account_id=preferred_account_id,
-                        require_preferred_account=require_preferred_account,
-                    )
-                    and _http_bridge_session_supports_service_tier(
-                        existing,
-                        request_model=request_model,
-                        request_service_tier=request_service_tier,
-                    )
-                ):
+                retained_handoff = bool(
+                    existing and existing.closed and _http_bridge_session_has_admission_waiter(existing)
+                )
+                reusable = existing is not None and _http_bridge_session_reusable_for_lookup(
+                    session=existing,
+                    key=key,
+                    api_key=api_key,
+                    incoming_turn_state=incoming_turn_state,
+                    previous_response_id=previous_response_id,
+                    preferred_account_id=preferred_account_id,
+                    require_preferred_account=require_preferred_account,
+                    service_tier_supported=_http_bridge_session_supports_service_tier(
+                        existing, request_model=request_model, request_service_tier=request_service_tier
+                    ),
+                    allow_closed_admission_handoff=retained_handoff,
+                )
+                if retained_handoff and not reusable:
+                    _raise_http_bridge_incompatible_admission_handoff()
+                if reusable:
+                    assert existing is not None
                     current_instance = settings.http_responses_session_bridge_instance_id
                     if _durable_bridge_lookup_allows_local_reuse(durable_lookup, current_instance=current_instance):
                         existing.api_key = api_key
@@ -2154,6 +2151,9 @@ class _HTTPBridgeMixin(
         skip_same_account = session.key.strength != "hard" and close_skips_account
         forced_refresh_account_id = request_state.force_refresh_account_id
         excluded_account_ids: set[str] = set(request_state.excluded_account_ids)
+        _require_http_bridge_bound_account_not_excluded(
+            hard_close_account_bound, session.account.id, excluded_account_ids
+        )
         if skip_same_account:
             excluded_account_ids.add(session.account.id)
         retry_same_account_once = not skip_same_account and session.account.id not in excluded_account_ids
@@ -2245,6 +2245,9 @@ class _HTTPBridgeMixin(
                     excluded_account_ids.update(request_state.excluded_account_ids)
                     if skip_same_account:
                         excluded_account_ids.add(session.account.id)
+                    _require_http_bridge_bound_account_not_excluded(
+                        hard_close_account_bound, session.account.id, excluded_account_ids
+                    )
                     retry_same_account_once = not skip_same_account and session.account.id not in excluded_account_ids
                     if skip_same_account:
                         preferred_candidate_id = None

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -89,6 +89,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_request_counts_against_queue,
     _http_bridge_session_account_active,
     _http_bridge_session_allows_api_key,
+    _http_bridge_session_has_admission_waiter,
     _http_bridge_session_matches_preferred_account,
     _http_bridge_session_retiring_with_visible_requests,
     _http_bridge_session_reusable_for_request,
@@ -652,17 +653,9 @@ class _HTTPBridgeMixin(
                 if pruned_sessions:
                     if any(session.key == key for session in pruned_sessions):
                         force_durable_takeover = True
-                    self._schedule_http_bridge_session_closes(
-                        pruned_sessions,
-                        reason="registry_detach",
-                    )
-
+                    self._schedule_http_bridge_session_closes(pruned_sessions, reason="registry_detach")
                 existing = self._http_bridge_sessions.get(key)
-                if (
-                    existing is not None
-                    and existing.closed
-                    and getattr(existing, "admission_waiter_count", 0) > 0
-                ):
+                if existing is not None and existing.closed and _http_bridge_session_has_admission_waiter(existing):
                     return existing
                 if (
                     existing is not None
@@ -1525,9 +1518,7 @@ class _HTTPBridgeMixin(
         now = _service_time().monotonic()
         stale_keys: list[_HTTPBridgeSessionKey] = []
         for key, session in self._http_bridge_sessions.items():
-            # An admitted request waiting for the response-create gate owns the
-            # session handoff even when the old upstream reader just closed.
-            if getattr(session, "admission_waiter_count", 0) > 0:
+            if _http_bridge_session_has_admission_waiter(session):
                 continue
             if session.closed:
                 stale_keys.append(key)
@@ -2159,9 +2150,7 @@ class _HTTPBridgeMixin(
         settings = await _service_get_settings_cache().get()
         session.api_key = request_state.api_key
         close_skips_account = session.last_upstream_close_code in _UPSTREAM_CLOSE_CODES_SKIP_SAME_ACCOUNT_RETRY
-        hard_close_account_bound = session.key.strength == "hard" and (
-            close_skips_account or require_same_account
-        )
+        hard_close_account_bound = session.key.strength == "hard" and (close_skips_account or require_same_account)
         skip_same_account = session.key.strength != "hard" and close_skips_account
         forced_refresh_account_id = request_state.force_refresh_account_id
         excluded_account_ids: set[str] = set(request_state.excluded_account_ids)

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -1521,7 +1521,7 @@ class _HTTPBridgeMixin(
         for key, session in self._http_bridge_sessions.items():
             # An admitted request waiting for the response-create gate owns the
             # session handoff even when the old upstream reader just closed.
-            if session.admission_waiter_count > 0:
+            if getattr(session, "admission_waiter_count", 0) > 0:
                 continue
             if session.closed:
                 stale_keys.append(key)

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -576,6 +576,7 @@ class _HTTPBridgeRequestSubmitMixin:
         )
         gate_acquired = False
         request_enqueued = False
+        admission_waiter_registered = False
         async with session.pending_lock:
             if session.queued_request_count >= queue_limit:
                 _log_http_bridge_event(
@@ -596,6 +597,8 @@ class _HTTPBridgeRequestSubmitMixin:
                     ),
                 )
             session.queued_request_count += 1
+            session.admission_waiter_count += 1
+            admission_waiter_registered = True
         try:
             text_data = await self._inline_http_bridge_image_urls(text_data, request_state)
             text_data = self._http_bridge_text_with_account_installation_id(session, request_state, text_data)
@@ -630,6 +633,15 @@ class _HTTPBridgeRequestSubmitMixin:
                     current_session = http_bridge_sessions.get(session.key)
                 session_unregistered = current_session is None and _http_bridge_key_strength(session.key) == "hard"
                 session_replaced = current_session is not None and current_session is not session
+                if session.closed and current_session is session:
+                    recovered = await self._retry_http_bridge_request_on_fresh_upstream(
+                        session,
+                        request_state=request_state,
+                        text_data=text_data,
+                        send_request=False,
+                    )
+                    if recovered:
+                        session.closed = False
                 if session.closed or session_unregistered or session_replaced:
                     _log_http_bridge_event(
                         "submit_on_closed",
@@ -654,6 +666,8 @@ class _HTTPBridgeRequestSubmitMixin:
                     )
                 async with session.pending_lock:
                     session.pending_requests.append(request_state)
+                    session.admission_waiter_count = max(0, session.admission_waiter_count - 1)
+                    admission_waiter_registered = False
                 request_enqueued = True
                 await _send_http_bridge_request_text_with_archive_id(session, request_state, text_data)
                 session.last_used_at = _service_time().monotonic()
@@ -664,6 +678,7 @@ class _HTTPBridgeRequestSubmitMixin:
                 gate_acquired=gate_acquired,
                 request_enqueued=request_enqueued,
                 counted_in_queue=True,
+                admission_waiter_registered=admission_waiter_registered,
             )
             raise
         except asyncio.CancelledError:
@@ -673,6 +688,7 @@ class _HTTPBridgeRequestSubmitMixin:
                 gate_acquired=gate_acquired,
                 request_enqueued=request_enqueued,
                 counted_in_queue=True,
+                admission_waiter_registered=admission_waiter_registered,
             )
             raise
         except Exception as exc:
@@ -698,6 +714,7 @@ class _HTTPBridgeRequestSubmitMixin:
                 gate_acquired=gate_acquired,
                 request_enqueued=request_enqueued,
                 counted_in_queue=True,
+                admission_waiter_registered=admission_waiter_registered,
             )
             await self._fail_pending_websocket_requests(
                 account=session.account,
@@ -942,12 +959,17 @@ class _HTTPBridgeRequestSubmitMixin:
         gate_acquired: bool,
         request_enqueued: bool,
         counted_in_queue: bool,
+        admission_waiter_registered: bool = False,
     ) -> None:
+        retire_closed_session = False
         async with session.pending_lock:
             if request_enqueued and request_state in session.pending_requests:
                 session.pending_requests.remove(request_state)
             if counted_in_queue:
                 session.queued_request_count = max(0, session.queued_request_count - 1)
+            if admission_waiter_registered:
+                session.admission_waiter_count = max(0, session.admission_waiter_count - 1)
+            retire_closed_session = session.closed and session.admission_waiter_count == 0
         self._cancel_request_state_api_key_reservation_heartbeat(request_state)
         if request_state.response_create_gate is not None:
             if gate_acquired or request_state.response_create_gate_acquired:
@@ -967,6 +989,11 @@ class _HTTPBridgeRequestSubmitMixin:
                 request_state.response_create_gate_acquired = False
         elif gate_acquired:
             await _release_websocket_response_create_gate(request_state, session.response_create_gate)
+        if retire_closed_session:
+            await self._retire_stale_pending_http_bridge_session(
+                session,
+                detail="last_admission_waiter_cancelled",
+            )
 
     async def _detach_http_bridge_request(
         self: Any,

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -545,6 +545,7 @@ class _HTTPBridgeRequestSubmitMixin:
                         request_state=request_state,
                         text_data=text_data,
                         send_request=False,
+                        require_same_account=_http_bridge_key_strength(session.key) == "hard",
                     )
                     if recovered:
                         session.closed = False
@@ -639,6 +640,7 @@ class _HTTPBridgeRequestSubmitMixin:
                         request_state=request_state,
                         text_data=text_data,
                         send_request=False,
+                        require_same_account=_http_bridge_key_strength(session.key) == "hard",
                     )
                     if recovered:
                         session.closed = False
@@ -1095,6 +1097,7 @@ class _HTTPBridgeRequestSubmitMixin:
         request_state: _WebSocketRequestState,
         text_data: str,
         send_request: bool = True,
+        require_same_account: bool = False,
     ) -> bool:
         retry_text_data = text_data
         using_fresh_replay = False
@@ -1135,6 +1138,7 @@ class _HTTPBridgeRequestSubmitMixin:
                 session,
                 request_state=request_state,
                 restart_reader=True,
+                require_same_account=require_same_account,
             )
             if send_request:
                 retry_text_data = self._http_bridge_text_with_account_installation_id(

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -212,32 +212,38 @@ class _HTTPBridgeUpstreamEventsMixin:
     ) -> bool:
         session.closed = True
         async with session.pending_lock:
-            failed_pending_count = len(session.pending_requests)
-            session.queued_request_count = max(0, session.queued_request_count - failed_pending_count)
-        await self._fail_pending_websocket_requests(
-            account=session.account,
-            account_id_value=session.account.id,
-            pending_requests=session.pending_requests,
-            pending_lock=session.pending_lock,
-            error_code=error_code,
-            error_message=error_message,
-            api_key=None,
-            response_create_gate=session.response_create_gate,
-        )
-        if session.admission_waiter_count > 0:
-            _log_http_bridge_event(
-                "retire_deferred_for_admission_waiter",
-                session.key,
-                account_id=session.account.id,
-                model=session.request_model,
-                pending_count=session.admission_waiter_count,
-                detail=error_code,
-                cache_key_family=session.key.affinity_kind,
-                model_class=_extract_model_class(session.request_model) if session.request_model else None,
+            failed_pending_count = sum(
+                1
+                for request_state in session.pending_requests
+                if _http_bridge_request_counts_against_queue(request_state)
             )
-            return False
-        await self._retire_stale_pending_http_bridge_session(session, detail=error_code)
-        return True
+            session.queued_request_count = max(0, session.queued_request_count - failed_pending_count)
+        try:
+            await self._fail_pending_websocket_requests(
+                account=session.account,
+                account_id_value=session.account.id,
+                pending_requests=session.pending_requests,
+                pending_lock=session.pending_lock,
+                error_code=error_code,
+                error_message=error_message,
+                api_key=None,
+                response_create_gate=session.response_create_gate,
+            )
+        finally:
+            if session.admission_waiter_count > 0:
+                _log_http_bridge_event(
+                    "retire_deferred_for_admission_waiter",
+                    session.key,
+                    account_id=session.account.id,
+                    model=session.request_model,
+                    pending_count=session.admission_waiter_count,
+                    detail=error_code,
+                    cache_key_family=session.key.affinity_kind,
+                    model_class=_extract_model_class(session.request_model) if session.request_model else None,
+                )
+            else:
+                await self._retire_stale_pending_http_bridge_session(session, detail=error_code)
+        return session.admission_waiter_count == 0
 
     async def _relay_http_bridge_upstream_messages(
         self: Any,

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -250,6 +250,7 @@ class _HTTPBridgeUpstreamEventsMixin:
         session: "_HTTPBridgeSession",
     ) -> None:
         runtime_settings = _service_get_settings()
+        relay_upstream = session.upstream
         try:
             while True:
                 receive_timeout = await self._next_websocket_receive_timeout(
@@ -319,7 +320,8 @@ class _HTTPBridgeUpstreamEventsMixin:
                     error_message="HTTP bridge upstream reader crashed before response.completed",
                 )
         finally:
-            session.closed = True
+            if session.upstream is relay_upstream:
+                session.closed = True
 
     async def _process_http_bridge_upstream_text(
         self: Any,

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -203,6 +203,42 @@ def _archive_http_bridge_upstream_message(
 
 
 class _HTTPBridgeUpstreamEventsMixin:
+    async def _fail_http_bridge_reader_and_maybe_retire(
+        self: Any,
+        session: "_HTTPBridgeSession",
+        *,
+        error_code: str,
+        error_message: str,
+    ) -> bool:
+        session.closed = True
+        async with session.pending_lock:
+            failed_pending_count = len(session.pending_requests)
+            session.queued_request_count = max(0, session.queued_request_count - failed_pending_count)
+        await self._fail_pending_websocket_requests(
+            account=session.account,
+            account_id_value=session.account.id,
+            pending_requests=session.pending_requests,
+            pending_lock=session.pending_lock,
+            error_code=error_code,
+            error_message=error_message,
+            api_key=None,
+            response_create_gate=session.response_create_gate,
+        )
+        if session.admission_waiter_count > 0:
+            _log_http_bridge_event(
+                "retire_deferred_for_admission_waiter",
+                session.key,
+                account_id=session.account.id,
+                model=session.request_model,
+                pending_count=session.admission_waiter_count,
+                detail=error_code,
+                cache_key_family=session.key.affinity_kind,
+                model_class=_extract_model_class(session.request_model) if session.request_model else None,
+            )
+            return False
+        await self._retire_stale_pending_http_bridge_session(session, detail=error_code)
+        return True
+
     async def _relay_http_bridge_upstream_messages(
         self: Any,
         session: "_HTTPBridgeSession",
@@ -233,25 +269,11 @@ class _HTTPBridgeUpstreamEventsMixin:
                     if retried:
                         continue
                     async with session.lifecycle_lock:
-                        try:
-                            session.closed = True
-                            async with session.pending_lock:
-                                session.queued_request_count = 0
-                            await self._fail_pending_websocket_requests(
-                                account=session.account,
-                                account_id_value=session.account.id,
-                                pending_requests=session.pending_requests,
-                                pending_lock=session.pending_lock,
-                                error_code=receive_timeout.error_code,
-                                error_message=receive_timeout.error_message,
-                                api_key=None,
-                                response_create_gate=session.response_create_gate,
-                            )
-                        finally:
-                            await self._retire_stale_pending_http_bridge_session(
-                                session,
-                                detail=receive_timeout.error_code,
-                            )
+                        await self._fail_http_bridge_reader_and_maybe_retire(
+                            session,
+                            error_code=receive_timeout.error_code,
+                            error_message=receive_timeout.error_message,
+                        )
                     break
 
                 if message.kind == "text" and message.text is not None:
@@ -269,25 +291,11 @@ class _HTTPBridgeUpstreamEventsMixin:
                 if retried:
                     continue
                 async with session.lifecycle_lock:
-                    try:
-                        session.closed = True
-                        async with session.pending_lock:
-                            session.queued_request_count = 0
-                        await self._fail_pending_websocket_requests(
-                            account=session.account,
-                            account_id_value=session.account.id,
-                            pending_requests=session.pending_requests,
-                            pending_lock=session.pending_lock,
-                            error_code="stream_incomplete",
-                            error_message=_upstream_websocket_disconnect_message(message),
-                            api_key=None,
-                            response_create_gate=session.response_create_gate,
-                        )
-                    finally:
-                        await self._retire_stale_pending_http_bridge_session(
-                            session,
-                            detail="stream_incomplete",
-                        )
+                    await self._fail_http_bridge_reader_and_maybe_retire(
+                        session,
+                        error_code="stream_incomplete",
+                        error_message=_upstream_websocket_disconnect_message(message),
+                    )
                 break
         except asyncio.CancelledError:
             raise
@@ -299,25 +307,11 @@ class _HTTPBridgeUpstreamEventsMixin:
                 exc_info=True,
             )
             async with session.lifecycle_lock:
-                try:
-                    session.closed = True
-                    async with session.pending_lock:
-                        session.queued_request_count = 0
-                    await self._fail_pending_websocket_requests(
-                        account=session.account,
-                        account_id_value=session.account.id,
-                        pending_requests=session.pending_requests,
-                        pending_lock=session.pending_lock,
-                        error_code="stream_incomplete",
-                        error_message="HTTP bridge upstream reader crashed before response.completed",
-                        api_key=None,
-                        response_create_gate=session.response_create_gate,
-                    )
-                finally:
-                    await self._retire_stale_pending_http_bridge_session(
-                        session,
-                        detail="reader_crash",
-                    )
+                await self._fail_http_bridge_reader_and_maybe_retire(
+                    session,
+                    error_code="stream_incomplete",
+                    error_message="HTTP bridge upstream reader crashed before response.completed",
+                )
         finally:
             session.closed = True
 

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -445,6 +445,7 @@ class _HTTPBridgeSession:
     queued_request_count: int
     last_used_at: float
     idle_ttl_seconds: float
+    admission_waiter_count: int = 0
     request_service_tier: str | None = None
     lifecycle_lock: anyio.Lock = field(default_factory=anyio.Lock)
     api_key: ApiKeyData | None = None

--- a/openspec/changes/preserve-http-bridge-admission-waiters/proposal.md
+++ b/openspec/changes/preserve-http-bridge-admission-waiters/proposal.md
@@ -1,0 +1,20 @@
+## Why
+
+An upstream HTTP bridge websocket can close while the next request is already
+waiting on the session response-create gate. The reader currently retires the
+session before that unsent request acquires the gate, so the request receives an
+internal `HTTP responses session bridge is closed` error even though it can be
+safely sent once on a fresh same-session upstream connection.
+
+## What Changes
+
+- Track unsent admission waiters explicitly.
+- Defer session retirement and pruning while a waiter owns the handoff.
+- Reconnect the retained same-account session before sending the waiter once.
+- Retire the closed session when its last waiter is cancelled or fails.
+
+## Impact
+
+Long Codex turns can continue across the upstream-close/admission race without
+exposing an internal bridge lifecycle error. Unsafe or ambiguous sends remain
+fail-closed.

--- a/openspec/changes/preserve-http-bridge-admission-waiters/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-http-bridge-admission-waiters/specs/responses-api-compat/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: HTTP bridge admission waiters survive upstream replacement
+
+The proxy MUST preserve an HTTP bridge session when its upstream connection
+terminates while an unsent request is already waiting for that session's
+response-create admission. It MUST fail the requests that were pending on the
+terminated upstream but MUST NOT retire, unregister, prune, or release the
+retained session while the unsent waiter owns the handoff.
+
+After the waiter acquires admission, the proxy MUST reconnect the retained
+session before sending the request. A waiter that has not entered the pending
+request queue and has no upstream send timestamp MAY be sent exactly once on
+that fresh connection. Hard-affinity sessions MUST retain their account and
+continuity ownership during this handoff. If the session was replaced or
+unregistered, or reconnection fails, the proxy MUST fail closed without sending
+the waiter. Cancelling or failing the last waiter MUST allow the closed session
+to retire and release its resources.
+
+#### Scenario: admitted follow-up survives an upstream close
+
+- **GIVEN** one HTTP bridge request is pending upstream
+- **AND** a follow-up request is unsent and waiting on the same response-create gate
+- **WHEN** the upstream connection closes before the follow-up acquires the gate
+- **THEN** the pending request receives its terminal continuity failure
+- **AND** the session remains registered and protected from pruning for the waiter
+- **AND** the waiter reconnects the retained session and is sent exactly once
+- **AND** the waiter does not receive an internal bridge-closed error
+
+#### Scenario: unsafe handoff fails closed
+
+- **GIVEN** an unsent waiter whose prior session was replaced or unregistered
+- **OR** the retained session cannot reconnect
+- **WHEN** the waiter acquires admission
+- **THEN** the waiter is not sent
+- **AND** the request receives an explicit retryable proxy error

--- a/openspec/changes/preserve-http-bridge-admission-waiters/tasks.md
+++ b/openspec/changes/preserve-http-bridge-admission-waiters/tasks.md
@@ -1,0 +1,5 @@
+- [x] Track and clean up unsent HTTP bridge admission waiters.
+- [x] Defer reader retirement and pruning while a waiter owns the handoff.
+- [x] Reconnect the retained session before sending an admitted waiter.
+- [x] Add regression coverage for the upstream-close/admission race.
+- [x] Run focused tests, lint, and OpenSpec validation.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -12759,7 +12759,7 @@ async def test_http_bridge_reader_failed_precreated_replay_retires_registered_se
 
 
 @pytest.mark.asyncio
-async def test_http_bridge_reader_retirement_rejects_concurrent_gate_waiter(
+async def test_http_bridge_reader_retirement_recovers_concurrent_gate_waiter(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
@@ -12829,6 +12829,8 @@ async def test_http_bridge_reader_retirement_rejects_concurrent_gate_waiter(
 
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
     monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", fail_replay)
+    reconnect_waiter = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_retry_http_bridge_request_on_fresh_upstream", reconnect_waiter)
 
     submit_task = asyncio.create_task(
         service._submit_http_bridge_request(
@@ -12845,19 +12847,29 @@ async def test_http_bridge_reader_retirement_rejects_concurrent_gate_waiter(
 
         await service._relay_http_bridge_upstream_messages(session)
 
-        with pytest.raises(proxy_service.ProxyResponseError) as exc_info:
-            await submit_task
+        await submit_task
 
-        assert exc_info.value.status_code == 502
-        assert exc_info.value.payload["error"]["code"] == "upstream_unavailable"
-        assert send_text.await_count == 0
-        assert list(session.pending_requests) == []
-        assert session.queued_request_count == 0
-        assert session.closed is True
-        assert key not in service._http_bridge_sessions
-        assert new_request_state.response_create_gate is None
-        assert new_request_state.response_create_gate_acquired is False
-        assert gate.locked() is False
+        reconnect_waiter.assert_awaited_once_with(
+            session,
+            request_state=new_request_state,
+            text_data=new_request_state.request_text,
+            send_request=False,
+        )
+        send_text.assert_awaited_once_with(new_request_state.request_text)
+        assert await old_event_queue.get() is not None
+        assert await old_event_queue.get() is None
+        assert list(session.pending_requests) == [new_request_state]
+        assert session.queued_request_count == 1
+        assert session.admission_waiter_count == 0
+        assert session.closed is False
+        assert service._http_bridge_sessions[key] is session
+        await service._cleanup_http_bridge_submit_interruption(
+            session,
+            request_state=new_request_state,
+            gate_acquired=True,
+            request_enqueued=True,
+            counted_in_queue=True,
+        )
     finally:
         if not submit_task.done():
             submit_task.cancel()

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -1233,6 +1233,39 @@ async def test_get_or_create_http_bridge_session_reuses_live_local_session_witho
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_preserves_closed_admission_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "bridge-handoff", None)
+    existing = _make_bridge_session(key_value="bridge-handoff")
+    existing.key = key
+    existing.closed = True
+    existing.admission_waiter_count = 1
+    service._http_bridge_sessions[key] = existing
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    create = AsyncMock()
+    monkeypatch.setattr(service, "_create_http_bridge_session", create)
+
+    resolved = await service._get_or_create_http_bridge_session(
+        key,
+        headers={"x-codex-session-id": "bridge-handoff"},
+        affinity=proxy_service._AffinityPolicy(
+            key="bridge-handoff",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        api_key=None,
+        request_model="gpt-5.4",
+        idle_ttl_seconds=120.0,
+        max_sessions=8,
+    )
+
+    assert resolved is existing
+    assert service._http_bridge_sessions[key] is existing
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_replaces_routing_unavailable_account(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2434,11 +2467,17 @@ async def test_reconnect_http_bridge_session_passes_dashboard_reset_window_to_se
     monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
 
     with pytest.raises(ProxyResponseError):
-        await service._reconnect_http_bridge_session(session, request_state=request_state)
+        await service._reconnect_http_bridge_session(
+            session,
+            request_state=request_state,
+            require_same_account=True,
+        )
 
     assert selection_kwargs[0]["prefer_earlier_reset_accounts"] is True
     assert selection_kwargs[0]["prefer_earlier_reset_window"] == "primary"
     assert selection_kwargs[0]["service_tier"] == "priority"
+    assert selection_kwargs[0]["preferred_account_id"] == session.account.id
+    assert selection_kwargs[0]["fallback_on_preferred_account_unavailable"] is False
 
 
 @pytest.mark.asyncio
@@ -11160,6 +11199,7 @@ async def test_retry_http_bridge_request_on_fresh_upstream_reconnects_without_re
         session,
         request_state=request_state,
         restart_reader=True,
+        require_same_account=False,
     )
     send_text.assert_not_awaited()
 
@@ -12798,16 +12838,19 @@ async def test_http_bridge_reader_retirement_recovers_concurrent_gate_waiter(
     upstream = cast(
         UpstreamResponsesWebSocket,
         SimpleNamespace(
-            receive=AsyncMock(return_value=UpstreamWebSocketMessage(kind="close", close_code=1011)),
+            receive=AsyncMock(return_value=UpstreamWebSocketMessage(kind="close", close_code=1006)),
             send_text=send_text,
             close=AsyncMock(),
         ),
     )
-    key = proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key-concurrent-retire", None)
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "bridge-key-concurrent-retire", None)
     session = proxy_service._HTTPBridgeSession(
         key=key,
-        headers={},
-        affinity=proxy_service._AffinityPolicy(key="bridge-key-concurrent-retire"),
+        headers={"x-codex-session-id": "bridge-key-concurrent-retire"},
+        affinity=proxy_service._AffinityPolicy(
+            key="bridge-key-concurrent-retire",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
         request_model="gpt-5.4",
         account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
         upstream=upstream,
@@ -12854,6 +12897,7 @@ async def test_http_bridge_reader_retirement_recovers_concurrent_gate_waiter(
             request_state=new_request_state,
             text_data=new_request_state.request_text,
             send_request=False,
+            require_same_account=True,
         )
         send_text.assert_awaited_once_with(new_request_state.request_text)
         assert await old_event_queue.get() is not None
@@ -12875,6 +12919,53 @@ async def test_http_bridge_reader_retirement_recovers_concurrent_gate_waiter(
             submit_task.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await submit_task
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_reader_failure_keeps_waiter_count_when_draining_request_is_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    normal = cast(Any, SimpleNamespace(draining_until_terminal=False))
+    draining = cast(Any, SimpleNamespace(draining_until_terminal=True))
+    session = _make_bridge_session(
+        key_value="bridge-draining-accounting",
+        pending_requests=deque([normal, draining]),
+        queued_request_count=2,
+    )
+    session.admission_waiter_count = 1
+    fail_pending = AsyncMock()
+    monkeypatch.setattr(service, "_fail_pending_websocket_requests", fail_pending)
+
+    retired = await service._fail_http_bridge_reader_and_maybe_retire(
+        session,
+        error_code="stream_incomplete",
+        error_message="closed",
+    )
+
+    assert retired is False
+    assert session.queued_request_count == 1
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_reader_failure_retires_without_waiters_when_notification_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="bridge-failure-finally")
+    fail_pending = AsyncMock(side_effect=RuntimeError("notify failed"))
+    retire = AsyncMock()
+    monkeypatch.setattr(service, "_fail_pending_websocket_requests", fail_pending)
+    monkeypatch.setattr(service, "_retire_stale_pending_http_bridge_session", retire)
+
+    with pytest.raises(RuntimeError, match="notify failed"):
+        await service._fail_http_bridge_reader_and_maybe_retire(
+            session,
+            error_code="stream_incomplete",
+            error_message="closed",
+        )
+
+    retire.assert_awaited_once_with(session, detail="stream_incomplete")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -236,6 +236,22 @@ async def test_http_bridge_activity_snapshot_counts_pending_and_inflight_session
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_activity_snapshot_counts_closed_admission_waiter_as_restart_blocking() -> None:
+    service = proxy_service.ProxyService(cast(Any, SimpleNamespace()))
+    session = _make_bridge_session(queued_request_count=1)
+    session.closed = True
+    session.admission_waiter_count = 1
+    service._http_bridge_sessions[session.key] = session
+
+    snapshot = service.http_bridge_activity_snapshot_nowait()
+
+    assert snapshot["http_bridge_live_sessions"] == 0
+    assert snapshot["http_bridge_pending_or_queued_requests"] == 1
+    assert snapshot["http_bridge_active"] is True
+    assert snapshot["http_bridge_restart_blocking"] is True
+
+
+@pytest.mark.asyncio
 async def test_response_create_gate_timeout_retires_session_with_old_pending_visible_request(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1261,6 +1277,39 @@ async def test_get_or_create_http_bridge_session_preserves_closed_admission_hand
     )
 
     assert resolved is existing
+    assert service._http_bridge_sessions[key] is existing
+    assert existing.request_model == "gpt-5.4"
+    create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_rejects_incompatible_closed_admission_handoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "bridge-handoff", None)
+    existing = _make_bridge_session(key_value="bridge-handoff")
+    existing.key = key
+    existing.closed = True
+    existing.admission_waiter_count = 1
+    service._http_bridge_sessions[key] = existing
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    create = AsyncMock()
+    monkeypatch.setattr(service, "_create_http_bridge_session", create)
+
+    with pytest.raises(proxy_service.ProxyResponseError) as exc_info:
+        await service._get_or_create_http_bridge_session(
+            key,
+            headers={"x-codex-session-id": "bridge-handoff"},
+            affinity=proxy_service._AffinityPolicy(key="bridge-handoff"),
+            api_key=None,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
+            max_sessions=8,
+            preferred_account_id="different-account",
+        )
+
+    assert exc_info.value.status_code == 503
     assert service._http_bridge_sessions[key] is existing
     create.assert_not_awaited()
 
@@ -2837,6 +2886,52 @@ async def test_reconnect_http_bridge_session_preserves_hard_account_after_1011(
     assert "acc-bridge" not in exclude_account_ids
     assert session.account.id == "acc-bridge"
     assert session.last_upstream_close_code is None
+
+
+@pytest.mark.asyncio
+async def test_reconnect_http_bridge_session_fails_closed_when_bound_account_is_excluded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-hard-excluded", None),
+        key_value="sid-hard-excluded",
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-hard-excluded",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        excluded_account_ids={session.account.id},
+    )
+    select_account = AsyncMock()
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(
+            get=AsyncMock(
+                return_value=SimpleNamespace(
+                    prefer_earlier_reset_accounts=False,
+                    routing_strategy=None,
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "_select_account_with_budget_for_stream", select_account)
+
+    with pytest.raises(proxy_service.ProxyResponseError) as exc_info:
+        await service._reconnect_http_bridge_session(
+            session,
+            request_state=request_state,
+            require_same_account=True,
+        )
+
+    assert exc_info.value.status_code == 502
+    assert session.account.id == "acc-bridge"
+    select_account.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -12578,6 +12673,34 @@ async def test_http_bridge_reader_marks_session_closed_before_reconnect_close(
 
     assert session.closed is True
     close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_stale_reader_does_not_close_reconnected_upstream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    old_upstream = cast(
+        UpstreamResponsesWebSocket,
+        SimpleNamespace(receive=AsyncMock(return_value=UpstreamWebSocketMessage(kind="close", close_code=1011))),
+    )
+    new_upstream = cast(UpstreamResponsesWebSocket, SimpleNamespace())
+    session = _make_bridge_session(key_value="bridge-stale-reader")
+    session.upstream = old_upstream
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", AsyncMock(return_value=False))
+
+    async def reconnect_during_failure(*_args: object, **_kwargs: object) -> bool:
+        session.upstream = new_upstream
+        session.closed = False
+        return False
+
+    monkeypatch.setattr(service, "_fail_http_bridge_reader_and_maybe_retire", reconnect_during_failure)
+
+    await service._relay_http_bridge_upstream_messages(session)
+
+    assert session.upstream is new_upstream
+    assert session.closed is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -25132,7 +25132,12 @@ async def test_retry_http_bridge_request_on_fresh_upstream_uses_archive_request_
         reset_request_id(token)
 
     assert retried is True
-    reconnect.assert_awaited_once_with(session, request_state=request_state, restart_reader=True)
+    reconnect.assert_awaited_once_with(
+        session,
+        request_state=request_state,
+        restart_reader=True,
+        require_same_account=False,
+    )
     send_text.assert_awaited_once_with('{"type":"response.create","model":"gpt-5.1","input":"retry"}')
     assert send_request_ids == ["archive_bridge_retry_fresh"]
 


### PR DESCRIPTION
## Summary

Preserve an unsent HTTP bridge admission waiter when the current upstream websocket closes, then reconnect the retained same-account session before sending the waiter exactly once. This prevents a client-visible `HTTP responses session bridge is closed` error during the reader-close/response-create admission race.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: References Soju06/codex-lb#554

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/preserve-http-bridge-admission-waiters/`

## Changes

- track unsent response-create admission waiters and pin their bridge session against pruning
- fail only requests sent on the terminated upstream while deferring session retirement for an unsent waiter
- reconnect the retained session before the waiter is enqueued and sent once
- retire the closed session if its last waiter is cancelled or fails

## Test plan

```text
uv run pytest -q tests/unit/test_proxy_http_bridge.py tests/unit/test_http_bridge_forwarding.py
# 240 passed
uv run ruff check app/modules/proxy/_service/http_bridge/upstream_events.py app/modules/proxy/_service/http_bridge/request_submit.py app/modules/proxy/_service/http_bridge/mixin.py app/modules/proxy/_service/support.py tests/unit/test_proxy_http_bridge.py
# All checks passed
openspec validate preserve-http-bridge-admission-waiters --strict
# valid
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local CI subset.
- [x] If touching specs: strict OpenSpec validation passes.
- [x] CHANGELOG is **not** edited by hand.
