### PR TITLE
fix(proxy): preserve responses turn-state fidelity

### DIFF
--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -459,12 +459,9 @@ class _CompactMixin:
                 ),
             )
         api_key_id = api_key.id if api_key is not None else None
-        from app.modules.proxy._service.http_bridge.helpers import _http_bridge_turn_state_alias_key
-
+        owner_account_ids: set[str] = set()
         async with proxy._http_bridge_lock:
-            session_key = proxy._http_bridge_turn_state_index.get(
-                _http_bridge_turn_state_alias_key(normalized_turn_state, api_key_id)
-            )
+            session_key = proxy._http_bridge_turn_state_index.get((normalized_turn_state, api_key_id))
             session = proxy._http_bridge_sessions.get(session_key) if session_key is not None else None
             account = getattr(session, "account", None)
             account_id = getattr(account, "id", None)
@@ -487,7 +484,36 @@ class _CompactMixin:
             ) from exc
         account_id = getattr(durable_lookup, "account_id", None)
         if isinstance(account_id, str) and account_id.strip():
-            return account_id
+            owner_account_ids.add(account_id)
+        if api_key is None:
+            try:
+                async with proxy._repo_factory() as repos:
+                    sticky_account_id = await repos.sticky_sessions.get_account_id(
+                        normalized_turn_state,
+                        kind=StickySessionKind.CODEX_SESSION,
+                    )
+            except Exception as exc:
+                raise ProxyResponseError(
+                    502,
+                    openai_error(
+                        "turn_state_owner_unavailable",
+                        "Turn-state owner account is unavailable; retry the logical turn.",
+                        error_type="server_error",
+                    ),
+                ) from exc
+            if isinstance(sticky_account_id, str) and sticky_account_id.strip():
+                owner_account_ids.add(sticky_account_id)
+        if len(owner_account_ids) == 1:
+            return next(iter(owner_account_ids))
+        if len(owner_account_ids) > 1:
+            raise ProxyResponseError(
+                502,
+                openai_error(
+                    "turn_state_owner_conflict",
+                    "Turn-state continuity resolved to conflicting upstream accounts; retry the logical turn.",
+                    error_type="server_error",
+                ),
+            )
         raise ProxyResponseError(
             502,
             openai_error(

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -494,24 +494,6 @@ class _CompactMixin:
         account_id = getattr(durable_lookup, "account_id", None)
         if isinstance(account_id, str) and account_id.strip():
             owner_account_ids.add(account_id)
-        if api_key is None:
-            try:
-                async with proxy._repo_factory() as repos:
-                    sticky_account_id = await repos.sticky_sessions.get_account_id(
-                        normalized_turn_state,
-                        kind=StickySessionKind.CODEX_SESSION,
-                    )
-            except Exception as exc:
-                raise ProxyResponseError(
-                    502,
-                    openai_error(
-                        "turn_state_owner_unavailable",
-                        "Turn-state owner account is unavailable; retry the logical turn.",
-                        error_type="server_error",
-                    ),
-                ) from exc
-            if isinstance(sticky_account_id, str) and sticky_account_id.strip():
-                owner_account_ids.add(sticky_account_id)
         if len(owner_account_ids) == 1:
             return next(iter(owner_account_ids))
         if len(owner_account_ids) > 1:

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -63,6 +63,10 @@ class _CompactServiceProtocol(Protocol):
     _encryptor: Any
     _load_balancer: Any
     _repo_factory: Any
+    _http_bridge_lock: Any
+    _http_bridge_sessions: Any
+    _http_bridge_turn_state_index: Any
+    _durable_bridge: Any
 
     def _get_work_admission(self) -> WorkAdmissionController: ...
 
@@ -90,6 +94,13 @@ class _CompactServiceProtocol(Protocol):
         session_id: str | None = None,
         surface: str,
     ) -> str | None: ...
+
+    async def _resolve_compact_turn_state_owner(
+        self,
+        *,
+        turn_state: str,
+        api_key: ApiKeyData | None,
+    ) -> str: ...
 
     async def _ensure_fresh_with_budget(
         self, account: Account, *, force: bool = False, timeout_seconds: float | None = None
@@ -421,6 +432,71 @@ def _service_tier_from_compact_payload(payload: ResponsesCompactRequest) -> str 
 
 
 class _CompactMixin:
+    async def _resolve_compact_turn_state_owner(
+        self,
+        *,
+        turn_state: str,
+        api_key: ApiKeyData | None,
+    ) -> str:
+        """Resolve a turn-state token to its API-key-scoped HTTP bridge owner.
+
+        A compact request cannot safely fall back to generic sticky routing: an
+        opaque turn-state is valid only on the account that created it.  The
+        local alias index is the fast path; the durable lookup covers a request
+        that arrives on another replica.  Both lookup surfaces are keyed by the
+        exact API key id, so a token observed under one key cannot select an
+        account for another key.
+        """
+        proxy = cast(_CompactServiceProtocol, self)
+        normalized_turn_state = turn_state.strip()
+        if not normalized_turn_state:
+            raise ProxyResponseError(
+                502,
+                openai_error(
+                    "turn_state_owner_unavailable",
+                    "Turn-state owner account is unavailable; retry the logical turn.",
+                    error_type="server_error",
+                ),
+            )
+        api_key_id = api_key.id if api_key is not None else None
+        from app.modules.proxy._service.http_bridge.helpers import _http_bridge_turn_state_alias_key
+
+        async with proxy._http_bridge_lock:
+            session_key = proxy._http_bridge_turn_state_index.get(
+                _http_bridge_turn_state_alias_key(normalized_turn_state, api_key_id)
+            )
+            session = proxy._http_bridge_sessions.get(session_key) if session_key is not None else None
+            account = getattr(session, "account", None)
+            account_id = getattr(account, "id", None)
+            if isinstance(account_id, str) and account_id.strip():
+                return account_id
+
+        try:
+            durable_lookup = await proxy._durable_bridge.lookup_turn_state_target(
+                turn_state=normalized_turn_state,
+                api_key_id=api_key_id,
+            )
+        except Exception as exc:
+            raise ProxyResponseError(
+                502,
+                openai_error(
+                    "turn_state_owner_unavailable",
+                    "Turn-state owner account is unavailable; retry the logical turn.",
+                    error_type="server_error",
+                ),
+            ) from exc
+        account_id = getattr(durable_lookup, "account_id", None)
+        if isinstance(account_id, str) and account_id.strip():
+            return account_id
+        raise ProxyResponseError(
+            502,
+            openai_error(
+                "turn_state_owner_unavailable",
+                "Turn-state owner account is unavailable; retry the logical turn.",
+                error_type="server_error",
+            ),
+        )
+
     async def compact_responses(
         self,
         payload: ResponsesCompactRequest,
@@ -484,6 +560,13 @@ class _CompactMixin:
             prompt_cache_key_set=_prompt_cache_key_from_request_model(payload) is not None,
         )
         routing_strategy = _routing_strategy(settings)
+        turn_state_owner_account_id: str | None = None
+        turn_state = _sticky_key_from_turn_state_header(headers)
+        if turn_state is not None:
+            turn_state_owner_account_id = await proxy._resolve_compact_turn_state_owner(
+                turn_state=turn_state,
+                api_key=api_key,
+            )
         previous_response_id = getattr(payload, "previous_response_id", None)
         previous_response_preferred_account_id: str | None = None
         previous_response_lookup_session_id: str | None = None
@@ -527,9 +610,24 @@ class _CompactMixin:
         # returns ``None`` when stronger affinity signals are present
         # (prompt_cache_key / session header / turn_state header /
         # previous_response_id), so existing routing wins.
-        file_preferred_account_id = previous_response_preferred_account_id or rewritten_file_account_id
-        if file_preferred_account_id is None:
-            file_preferred_account_id = await proxy._resolve_file_account_for_responses(payload, headers)
+        if (
+            turn_state_owner_account_id is not None
+            and previous_response_preferred_account_id is not None
+            and turn_state_owner_account_id != previous_response_preferred_account_id
+        ):
+            raise ProxyResponseError(
+                502,
+                openai_error(
+                    "turn_state_owner_conflict",
+                    "Turn-state continuity resolved to conflicting upstream accounts; retry the logical turn.",
+                    error_type="server_error",
+                ),
+            )
+        preferred_account_id = (
+            turn_state_owner_account_id or previous_response_preferred_account_id or rewritten_file_account_id
+        )
+        if preferred_account_id is None:
+            preferred_account_id = await proxy._resolve_file_account_for_responses(payload, headers)
         try:
 
             async def _call_compact(
@@ -698,11 +796,11 @@ class _CompactMixin:
                     model=payload.model,
                     service_tier=payload.service_tier,
                     exclude_account_ids=excluded_account_ids,
-                    preferred_account_id=file_preferred_account_id,
+                    preferred_account_id=preferred_account_id,
                     require_security_work_authorized=require_security_work_authorized,
                     lease_kind="response_create",
                     estimated_lease_tokens=estimated_lease_tokens,
-                    fallback_on_preferred_account_unavailable=file_preferred_account_id is None,
+                    fallback_on_preferred_account_unavailable=preferred_account_id is None,
                 )
                 account = selection.account
                 if not account:
@@ -732,11 +830,11 @@ class _CompactMixin:
                             model=payload.model,
                             service_tier=payload.service_tier,
                             exclude_account_ids=excluded_account_ids,
-                            preferred_account_id=file_preferred_account_id,
+                            preferred_account_id=preferred_account_id,
                             require_security_work_authorized=False,
                             lease_kind="response_create",
                             estimated_lease_tokens=estimated_lease_tokens,
-                            fallback_on_preferred_account_unavailable=file_preferred_account_id is None,
+                            fallback_on_preferred_account_unavailable=preferred_account_id is None,
                         )
                         account = selection.account
                     if account is not None:
@@ -800,7 +898,7 @@ class _CompactMixin:
                     )
                     if not _should_retry_transient_stream_error("upstream_unavailable", message):
                         _raise_proxy_unavailable(message)
-                    if file_preferred_account_id is not None:
+                    if preferred_account_id is not None:
                         _raise_proxy_unavailable(message)
                     await proxy._handle_stream_error(
                         account,
@@ -918,7 +1016,7 @@ class _CompactMixin:
                                         request_service_tier=request_service_tier,
                                     )
                                     _raise_proxy_unavailable(message)
-                                if file_preferred_account_id is not None:
+                                if preferred_account_id is not None:
                                     await proxy._settle_compact_api_key_usage(
                                         api_key=api_key,
                                         api_key_reservation=api_key_reservation,
@@ -983,7 +1081,7 @@ class _CompactMixin:
                         if _is_security_work_authorization_required_error(code, error_message):
                             if (
                                 not account.security_work_authorized
-                                and account.id != file_preferred_account_id
+                                and account.id != preferred_account_id
                                 and _account_attempt < _compact_max_account_attempts() - 1
                             ):
                                 last_exc = exc

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -101,7 +101,8 @@ class _CompactServiceProtocol(Protocol):
         *,
         turn_state: str,
         api_key: ApiKeyData | None,
-    ) -> str: ...
+        fail_on_missing: bool = True,
+    ) -> str | None: ...
 
     async def _ensure_fresh_with_budget(
         self, account: Account, *, force: bool = False, timeout_seconds: float | None = None
@@ -438,7 +439,8 @@ class _CompactMixin:
         *,
         turn_state: str,
         api_key: ApiKeyData | None,
-    ) -> str:
+        fail_on_missing: bool = True,
+    ) -> str | None:
         """Resolve a turn-state token to its API-key-scoped HTTP bridge owner.
 
         A compact request cannot safely fall back to generic sticky routing: an
@@ -447,6 +449,12 @@ class _CompactMixin:
         that arrives on another replica.  Both lookup surfaces are keyed by the
         exact API key id, so a token observed under one key cannot select an
         account for another key.
+
+        Synthetic-shaped ``turn_*`` / ``http_turn_*`` values can be real
+        registered bridge aliases on later turns.  Callers may pass
+        ``fail_on_missing=False`` only for those synthetic placeholders so an
+        unregistered first-turn placeholder still allows weaker routing signals
+        such as file ownership to run.
         """
         proxy = cast(_CompactServiceProtocol, self)
         normalized_turn_state = turn_state.strip()
@@ -515,6 +523,8 @@ class _CompactMixin:
                     error_type="server_error",
                 ),
             )
+        if not fail_on_missing:
+            return None
         raise ProxyResponseError(
             502,
             openai_error(
@@ -589,10 +599,11 @@ class _CompactMixin:
         routing_strategy = _routing_strategy(settings)
         turn_state_owner_account_id: str | None = None
         turn_state = _sticky_key_from_turn_state_header(headers)
-        if turn_state is not None and not _is_synthesized_turn_state(turn_state):
+        if turn_state is not None:
             turn_state_owner_account_id = await proxy._resolve_compact_turn_state_owner(
                 turn_state=turn_state,
                 api_key=api_key,
+                fail_on_missing=not _is_synthesized_turn_state(turn_state),
             )
         previous_response_id = getattr(payload, "previous_response_id", None)
         previous_response_preferred_account_id: str | None = None

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -38,6 +38,7 @@ from app.modules.api_keys.service import (
 from app.modules.proxy._service.support import _request_log_useragent_fields, _RequestLogFailureMetadata
 from app.modules.proxy.affinity import (
     _AffinityPolicy,
+    _is_synthesized_turn_state,
     _owner_lookup_session_id_from_headers,
     _prompt_cache_key_from_request_model,
     _resolve_prompt_cache_key,
@@ -588,7 +589,7 @@ class _CompactMixin:
         routing_strategy = _routing_strategy(settings)
         turn_state_owner_account_id: str | None = None
         turn_state = _sticky_key_from_turn_state_header(headers)
-        if turn_state is not None:
+        if turn_state is not None and not _is_synthesized_turn_state(turn_state):
             turn_state_owner_account_id = await proxy._resolve_compact_turn_state_owner(
                 turn_state=turn_state,
                 api_key=api_key,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -4375,7 +4375,7 @@ async def _collect_responses(
             request,
             status_code,
             error.model_dump(mode="json", exclude_none=True),
-            headers={**turn_state_headers, **captured_turn_state_headers, **rate_limit_headers},
+            headers={**captured_turn_state_headers, **rate_limit_headers},
         )
     if isinstance(response_payload, OpenAIResponsePayload):
         if response_payload.status == "failed":

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -4375,7 +4375,7 @@ async def _collect_responses(
             request,
             status_code,
             error.model_dump(mode="json", exclude_none=True),
-            headers=rate_limit_headers,
+            headers={**turn_state_headers, **captured_turn_state_headers, **rate_limit_headers},
         )
     if isinstance(response_payload, OpenAIResponsePayload):
         if response_payload.status == "failed":

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -4361,8 +4361,12 @@ async def _collect_responses(
             suppress_text_done_events=suppress_text_done_events,
             client_ip=client_ip,
         )
+    captured_turn_state_headers: dict[str, str] = {}
     try:
-        response_payload = await _collect_responses_payload(stream)
+        response_payload = await _collect_responses_payload(
+            stream,
+            captured_turn_state_headers=captured_turn_state_headers,
+        )
     except ProxyResponseError as exc:
         await _release_reservation(reservation)
         error = _parse_error_envelope(exc.payload)
@@ -4381,18 +4385,18 @@ async def _collect_responses(
                 request,
                 status_code,
                 error_payload.model_dump(mode="json", exclude_none=True),
-                headers={**turn_state_headers, **rate_limit_headers},
+                headers={**turn_state_headers, **captured_turn_state_headers, **rate_limit_headers},
             )
         return JSONResponse(
             content=response_payload.model_dump(mode="json", exclude_none=True),
-            headers={**turn_state_headers, **rate_limit_headers},
+            headers={**turn_state_headers, **captured_turn_state_headers, **rate_limit_headers},
         )
     status_code, response_payload = _mask_previous_response_not_found_error(response_payload)
     return _logged_error_json_response(
         request,
         status_code,
         response_payload.model_dump(mode="json", exclude_none=True),
-        headers={**turn_state_headers, **rate_limit_headers},
+        headers={**turn_state_headers, **captured_turn_state_headers, **rate_limit_headers},
     )
 
 
@@ -5801,7 +5805,30 @@ def _compact_request_service_tier(payload: ResponsesCompactRequest) -> str | Non
     return stripped or None
 
 
-async def _collect_responses_payload(stream: AsyncIterator[str]) -> OpenAIResponseResult:
+def _capture_response_metadata_turn_state(
+    payload: Mapping[str, JsonValue],
+    captured_turn_state_headers: dict[str, str],
+) -> None:
+    """Keep the first real upstream turn-state metadata header for the HTTP response."""
+    if captured_turn_state_headers or payload.get("type") != "response.metadata":
+        return
+    headers = payload.get("headers")
+    if not is_json_mapping(headers):
+        return
+    for name, value in headers.items():
+        if str(name).lower() != "x-codex-turn-state" or not isinstance(value, str):
+            continue
+        turn_state = value.strip()
+        if turn_state:
+            captured_turn_state_headers["x-codex-turn-state"] = turn_state
+        return
+
+
+async def _collect_responses_payload(
+    stream: AsyncIterator[str],
+    *,
+    captured_turn_state_headers: dict[str, str] | None = None,
+) -> OpenAIResponseResult:
     output_items: dict[int, dict[str, JsonValue]] = {}
     terminal_result: OpenAIResponseResult | None = None
     contract_violation_kind: str | None = None
@@ -5811,6 +5838,8 @@ async def _collect_responses_payload(stream: AsyncIterator[str]) -> OpenAIRespon
             if _looks_like_sse_data_block(line):
                 contract_violation_kind = contract_violation_kind or "invalid_json"
             continue
+        if captured_turn_state_headers is not None:
+            _capture_response_metadata_turn_state(payload, captured_turn_state_headers)
         event_type = payload.get("type")
         _collect_output_item_event(payload, output_items)
         if terminal_result is not None:

--- a/openspec/changes/preserve-residual-turn-state-fidelity/proposal.md
+++ b/openspec/changes/preserve-residual-turn-state-fidelity/proposal.md
@@ -1,0 +1,14 @@
+# Preserve residual turn-state fidelity
+
+## Why
+
+Turn-state continuity must retain the exact account boundary when a terminal
+turn is compacted, and a collected failed response must not discard a real
+upstream turn-state token that arrived before the failure.
+
+## What changes
+
+- Resolve compact requests carrying `x-codex-turn-state` through the
+  API-key-scoped bridge owner and fail closed when the owner is unavailable.
+- Keep the established compatibility metadata-header allowlist intact.
+- Surface captured upstream turn-state metadata on collected failed responses.

--- a/openspec/changes/preserve-residual-turn-state-fidelity/proposal.md
+++ b/openspec/changes/preserve-residual-turn-state-fidelity/proposal.md
@@ -8,7 +8,9 @@ upstream turn-state token that arrived before the failure.
 
 ## What changes
 
-- Resolve compact requests carrying `x-codex-turn-state` through the
-  API-key-scoped bridge owner and fail closed when the owner is unavailable.
+- Resolve compact requests carrying a real client-supplied
+  `x-codex-turn-state` through the API-key-scoped bridge owner and fail closed
+  when that owner is unavailable, while letting proxy-synthesized first-turn
+  placeholders fall through to file-owner routing.
 - Keep the established compatibility metadata-header allowlist intact.
 - Surface captured upstream turn-state metadata on collected failed responses.

--- a/openspec/changes/preserve-residual-turn-state-fidelity/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-residual-turn-state-fidelity/specs/responses-api-compat/spec.md
@@ -4,10 +4,13 @@
 
 ### Requirement: Compact requests preserve scoped turn-state ownership
 
-When a compact request contains `x-codex-turn-state`, the system MUST resolve
-the token only in the requesting API key scope and select only that owner
-account. If the owner cannot be resolved or selected, the request MUST fail
-closed and MUST NOT fall back to a generic sticky or load-balanced account.
+When a compact request contains a real client-supplied `x-codex-turn-state`,
+the system MUST resolve the token only in the requesting API key scope and
+select only that owner account. If the owner cannot be resolved or selected,
+the request MUST fail closed and MUST NOT fall back to a generic sticky or
+load-balanced account. Proxy-synthesized first-turn placeholders (the
+`turn_*` / `http_turn_*` values codex-lb injects when the client did not supply
+one) are not real continuity tokens and MUST NOT block file-owner routing.
 
 #### Scenario: Token belongs to the requesting API key
 
@@ -21,6 +24,14 @@ closed and MUST NOT fall back to a generic sticky or load-balanced account.
 - **WHEN** the client submits a compact request with that token
 - **THEN** the request fails with `turn_state_owner_unavailable`
 - **AND** no generic account is selected
+
+#### Scenario: Synthesized first-turn placeholder does not override file-owner routing
+
+- **GIVEN** the request carries only a proxy-synthesized `x-codex-turn-state`
+- **AND** the payload references an `input_file.file_id` pinned to an account
+- **WHEN** the client submits the compact request
+- **THEN** compact routing may use the pinned file owner
+- **AND** the synthesized placeholder does not trigger `turn_state_owner_unavailable`
 
 ### Requirement: Collected failures retain upstream turn-state metadata
 

--- a/openspec/changes/preserve-residual-turn-state-fidelity/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-residual-turn-state-fidelity/specs/responses-api-compat/spec.md
@@ -10,7 +10,9 @@ select only that owner account. If the owner cannot be resolved or selected,
 the request MUST fail closed and MUST NOT fall back to a generic sticky or
 load-balanced account. Proxy-synthesized first-turn placeholders (the
 `turn_*` / `http_turn_*` values codex-lb injects when the client did not supply
-one) are not real continuity tokens and MUST NOT block file-owner routing.
+one) are not real continuity tokens until registered as bridge aliases; an
+unregistered placeholder MUST NOT block file-owner routing, but a registered
+placeholder MUST still resolve to its owner account.
 
 #### Scenario: Token belongs to the requesting API key
 
@@ -24,6 +26,12 @@ one) are not real continuity tokens and MUST NOT block file-owner routing.
 - **WHEN** the client submits a compact request with that token
 - **THEN** the request fails with `turn_state_owner_unavailable`
 - **AND** no generic account is selected
+
+#### Scenario: Registered synthesized placeholder belongs to the requesting API key
+
+- **GIVEN** a proxy-synthesized `http_turn_*` token has been registered as a bridge alias
+- **WHEN** the client later submits a compact request with that token
+- **THEN** compact selection is constrained to the registered owner account
 
 #### Scenario: Synthesized first-turn placeholder does not override file-owner routing
 

--- a/openspec/changes/preserve-residual-turn-state-fidelity/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-residual-turn-state-fidelity/specs/responses-api-compat/spec.md
@@ -20,6 +20,13 @@ placeholder MUST still resolve to its owner account.
 - **WHEN** the client submits a compact request with that token
 - **THEN** compact selection is constrained to that owner account
 
+#### Scenario: Unscoped sticky state cannot supply a turn-state owner
+
+- **GIVEN** a turn-state token has no owner in the requesting API-key-scoped local or durable bridge indexes
+- **WHEN** an unscoped sticky-session mapping exists for the same token
+- **THEN** compact owner resolution fails closed
+- **AND** the unscoped sticky-session mapping is not consulted
+
 #### Scenario: Token belongs to a different API key or is unavailable
 
 - **GIVEN** the token has no owner in the requesting API key scope

--- a/openspec/changes/preserve-residual-turn-state-fidelity/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-residual-turn-state-fidelity/specs/responses-api-compat/spec.md
@@ -1,0 +1,35 @@
+# Responses API compatibility delta
+
+## ADDED Requirements
+
+### Requirement: Compact requests preserve scoped turn-state ownership
+
+When a compact request contains `x-codex-turn-state`, the system MUST resolve
+the token only in the requesting API key scope and select only that owner
+account. If the owner cannot be resolved or selected, the request MUST fail
+closed and MUST NOT fall back to a generic sticky or load-balanced account.
+
+#### Scenario: Token belongs to the requesting API key
+
+- **GIVEN** an active turn-state owner exists for the requesting API key
+- **WHEN** the client submits a compact request with that token
+- **THEN** compact selection is constrained to that owner account
+
+#### Scenario: Token belongs to a different API key or is unavailable
+
+- **GIVEN** the token has no owner in the requesting API key scope
+- **WHEN** the client submits a compact request with that token
+- **THEN** the request fails with `turn_state_owner_unavailable`
+- **AND** no generic account is selected
+
+### Requirement: Collected failures retain upstream turn-state metadata
+
+The system MUST copy a real `x-codex-turn-state` received in a
+`response.metadata` event into the HTTP headers of a collected response,
+including when the later terminal event is `response.failed`.
+
+#### Scenario: Metadata precedes a failed response
+
+- **GIVEN** a collected response stream emits turn-state metadata
+- **AND** the terminal response is failed
+- **THEN** the returned HTTP error includes the captured turn-state header

--- a/openspec/changes/preserve-residual-turn-state-fidelity/tasks.md
+++ b/openspec/changes/preserve-residual-turn-state-fidelity/tasks.md
@@ -1,0 +1,12 @@
+# Tasks
+
+## Implementation
+
+- [x] Bind compact selection to the API-key-scoped turn-state owner.
+- [x] Preserve the shared compatibility metadata-header promotion contract.
+- [x] Return captured turn-state metadata for collected failed responses.
+
+## Verification
+
+- [x] Add focused regression coverage for owner scope, header preservation, and failure metadata.
+- [x] Run focused and relevant full tests, Ruff, type checks, and strict OpenSpec validation.

--- a/tests/integration/test_proxy_sticky_sessions.py
+++ b/tests/integration/test_proxy_sticky_sessions.py
@@ -440,7 +440,10 @@ async def test_proxy_codex_session_id_pins_responses_and_compact_without_sticky_
 
 
 @pytest.mark.asyncio
-async def test_proxy_codex_turn_state_pins_responses_and_compact_without_sticky_threads(async_client, monkeypatch):
+async def test_proxy_unregistered_turn_state_does_not_pin_compact_via_unscoped_sticky_state(
+    async_client,
+    monkeypatch,
+):
     await _set_routing_settings(async_client, sticky_threads_enabled=False)
     acc_a_id = await _import_account(async_client, "acc_turn_state_a", "turn_state_a@example.com")
     acc_b_id = await _import_account(async_client, "acc_turn_state_b", "turn_state_b@example.com")
@@ -518,8 +521,9 @@ async def test_proxy_codex_turn_state_pins_responses_and_compact_without_sticky_
         json=compact_payload,
         headers=headers,
     )
-    assert response.status_code == 200
-    assert compact_seen == ["acc_turn_state_a"]
+    assert response.status_code == 502
+    assert response.json()["error"]["code"] == "turn_state_owner_unavailable"
+    assert compact_seen == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -269,6 +269,47 @@ async def test_collect_responses_payload_captures_turn_state_metadata_before_fai
 
 
 @pytest.mark.asyncio
+async def test_collect_responses_preserves_captured_turn_state_when_stream_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    from app.core.clients.proxy import ProxyResponseError
+    from app.core.openai.requests import ResponsesRequest
+
+    async def failing_stream():
+        yield 'data: {"type":"response.metadata","headers":{"X-Codex-Turn-State":"turn-owner"}}\n\n'
+        raise ProxyResponseError(
+            502,
+            {"error": {"code": "upstream_error", "message": "failed", "type": "server_error"}},
+        )
+
+    service = SimpleNamespace(stream_responses=lambda *_args, **_kwargs: failing_stream())
+    context = SimpleNamespace(service=service)
+    request = SimpleNamespace(
+        headers={},
+        method="POST",
+        url=SimpleNamespace(path="/backend-api/codex/responses"),
+        client=None,
+    )
+    monkeypatch.setattr(proxy_api_module, "_opportunistic_admission_denial", AsyncMock(return_value=None))
+    monkeypatch.setattr(proxy_api_module, "_enforce_request_limits", AsyncMock(return_value=None))
+    monkeypatch.setattr(proxy_api_module, "_rate_limit_headers_for_request", AsyncMock(return_value={}))
+    monkeypatch.setattr(proxy_api_module, "_release_reservation", AsyncMock())
+
+    response = await proxy_api_module._collect_responses(
+        cast(Any, request),
+        ResponsesRequest.model_validate({"model": "gpt-5.5", "instructions": "test", "input": []}),
+        cast(Any, context),
+        None,
+    )
+
+    assert response.status_code == 502
+    assert response.headers["x-codex-turn-state"] == "turn-owner"
+
+
+@pytest.mark.asyncio
 async def test_collect_responses_payload_normalizes_unknown_output_item_to_message() -> None:
     result = await proxy_api_module._collect_responses_payload(
         _iter_blocks(

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -252,6 +252,23 @@ async def test_collect_responses_payload_returns_contract_error_on_truncated_str
 
 
 @pytest.mark.asyncio
+async def test_collect_responses_payload_captures_turn_state_metadata_before_failed_response() -> None:
+    captured_headers: dict[str, str] = {}
+
+    result = await proxy_api_module._collect_responses_payload(
+        _iter_blocks(
+            'data: {"type":"response.metadata","headers":{"X-Codex-Turn-State":" turn-owner "}}\n\n',
+            'data: {"type":"response.failed","response":{"error":{"code":"upstream_error",'
+            '"message":"failed","type":"server_error"}}}\n\n',
+        ),
+        captured_turn_state_headers=captured_headers,
+    )
+
+    assert result.error is not None
+    assert captured_headers == {"x-codex-turn-state": "turn-owner"}
+
+
+@pytest.mark.asyncio
 async def test_collect_responses_payload_normalizes_unknown_output_item_to_message() -> None:
     result = await proxy_api_module._collect_responses_payload(
         _iter_blocks(

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -1230,6 +1230,7 @@ async def test_internal_bridge_responses_disables_openai_sdk_contract(
         AsyncMock(return_value=(None, None)),
     )
     monkeypatch.setattr(proxy_api_module, "_strip_internal_bridge_headers", lambda h: dict(h))
+    monkeypatch.setattr(proxy_api_module, "_prohibit_fast_mode_enabled", AsyncMock(return_value=False))
 
     # Minimal payload + request stubs.
     from app.core.openai.requests import ResponsesRequest

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -2801,6 +2801,23 @@ async def test_compact_turn_state_owner_lookup_is_api_key_scoped_and_fails_close
 
 
 @pytest.mark.asyncio
+async def test_compact_turn_state_owner_never_falls_back_to_unscoped_sticky_sessions() -> None:
+    def fail_repo_factory():
+        raise AssertionError("turn-state owner resolution must not query unscoped sticky sessions")
+
+    service = proxy_service.ProxyService(fail_repo_factory)
+    service._durable_bridge = SimpleNamespace(lookup_turn_state_target=AsyncMock(return_value=None))
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service._resolve_compact_turn_state_owner(
+            turn_state="turn-from-another-api-key-scope",
+            api_key=None,
+        )
+
+    assert _proxy_error_code(exc_info.value) == "turn_state_owner_unavailable"
+
+
+@pytest.mark.asyncio
 async def test_compact_turn_state_owner_is_a_strict_selection_constraint(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -2833,6 +2833,82 @@ async def test_compact_turn_state_owner_is_a_strict_selection_constraint(monkeyp
     assert seen_selection["fallback_on_preferred_account_unavailable"] is False
 
 
+@pytest.mark.asyncio
+async def test_compact_synthesized_turn_state_allows_file_pin_routing(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_compact_file_pin_synth")
+    seen_selection: dict[str, object] = {}
+
+    async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
+        seen_selection.update(kwargs)
+        return AccountSelection(account=account, error_message=None)
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(
+        service,
+        "_resolve_compact_turn_state_owner",
+        AsyncMock(side_effect=AssertionError("synthetic turn-state must not trigger owner resolution")),
+    )
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=account.id))
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock())
+    monkeypatch.setattr(
+        proxy_service,
+        "core_compact_responses",
+        AsyncMock(return_value=CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})),
+    )
+
+    payload = ResponsesCompactRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"type": "input_file", "file_id": "file_pinned"}],
+        }
+    )
+
+    result = await service.compact_responses(
+        payload,
+        {"x-codex-turn-state": proxy_affinity.ensure_http_downstream_turn_state({})},
+    )
+
+    assert result.model_extra == {"output": []}
+    assert seen_selection["preferred_account_id"] == account.id
+    assert seen_selection["fallback_on_preferred_account_unavailable"] is False
+    assert request_logs.calls[0]["status"] == "success"
+    assert request_logs.calls[0]["account_id"] == account.id
+
+
+@pytest.mark.asyncio
+async def test_compact_real_turn_state_still_blocks_file_pin_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_compact_file_pin_real")
+    selection = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", selection)
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=account.id))
+
+    payload = ResponsesCompactRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"type": "input_file", "file_id": "file_pinned"}],
+        }
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.compact_responses(payload, {"x-codex-turn-state": "client-turn-state-123"})
+
+    assert _proxy_error_code(exc_info.value) == "turn_state_owner_unavailable"
+    selection.assert_not_awaited()
+
+
 def test_response_create_client_metadata_ignores_blank_multi_agent_headers():
     metadata = proxy_service._response_create_client_metadata(
         {},

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -2834,6 +2834,41 @@ async def test_compact_turn_state_owner_is_a_strict_selection_constraint(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_compact_registered_synthesized_turn_state_is_a_strict_selection_constraint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    owner = _make_account("acc_compact_http_turn_owner")
+    turn_state = "http_turn_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    alias_key = proxy_service._http_bridge_turn_state_alias_key(turn_state, None)
+    service._http_bridge_turn_state_index[alias_key] = "bridge-owner"  # type: ignore[assignment]
+    service._http_bridge_sessions["bridge-owner"] = SimpleNamespace(account=owner)  # type: ignore[index]
+    seen_selection: dict[str, object] = {}
+
+    async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
+        seen_selection.update(kwargs)
+        return AccountSelection(account=owner, error_message=None)
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=owner))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock())
+    monkeypatch.setattr(
+        proxy_service,
+        "core_compact_responses",
+        AsyncMock(return_value=CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})),
+    )
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    await service.compact_responses(payload, {"x-codex-turn-state": turn_state})
+
+    assert seen_selection["preferred_account_id"] == owner.id
+    assert seen_selection["fallback_on_preferred_account_unavailable"] is False
+
+
+@pytest.mark.asyncio
 async def test_compact_synthesized_turn_state_allows_file_pin_routing(monkeypatch: pytest.MonkeyPatch) -> None:
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()
@@ -2848,10 +2883,11 @@ async def test_compact_synthesized_turn_state_allows_file_pin_routing(monkeypatc
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
     monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    owner_lookup = AsyncMock(return_value=None)
     monkeypatch.setattr(
         service,
         "_resolve_compact_turn_state_owner",
-        AsyncMock(side_effect=AssertionError("synthetic turn-state must not trigger owner resolution")),
+        owner_lookup,
     )
     monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=account.id))
     monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
@@ -2870,14 +2906,17 @@ async def test_compact_synthesized_turn_state_allows_file_pin_routing(monkeypatc
         }
     )
 
-    result = await service.compact_responses(
-        payload,
-        {"x-codex-turn-state": proxy_affinity.ensure_http_downstream_turn_state({})},
-    )
+    turn_state = proxy_affinity.ensure_http_downstream_turn_state({})
+    result = await service.compact_responses(payload, {"x-codex-turn-state": turn_state})
 
     assert result.model_extra == {"output": []}
     assert seen_selection["preferred_account_id"] == account.id
     assert seen_selection["fallback_on_preferred_account_unavailable"] is False
+    owner_lookup.assert_awaited_once_with(
+        turn_state=turn_state,
+        api_key=None,
+        fail_on_missing=False,
+    )
     assert request_logs.calls[0]["status"] == "success"
     assert request_logs.calls[0]["account_id"] == account.id
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -2770,6 +2770,69 @@ def test_response_create_client_metadata_promotes_multi_agent_headers_per_reques
     }
 
 
+@pytest.mark.asyncio
+async def test_compact_turn_state_owner_lookup_is_api_key_scoped_and_fails_closed() -> None:
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    turn_state = "turn-owner"
+    owner_key = proxy_service._http_bridge_turn_state_alias_key(turn_state, "key-owner")
+    service._http_bridge_turn_state_index[owner_key] = "bridge-owner"  # type: ignore[assignment]
+    service._http_bridge_sessions["bridge-owner"] = SimpleNamespace(account=SimpleNamespace(id="account-owner"))  # type: ignore[index]
+    service._durable_bridge = SimpleNamespace(lookup_turn_state_target=AsyncMock(return_value=None))
+
+    assert (
+        await service._resolve_compact_turn_state_owner(
+            turn_state=turn_state,
+            api_key=cast(Any, SimpleNamespace(id="key-owner")),
+        )
+        == "account-owner"
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service._resolve_compact_turn_state_owner(
+            turn_state=turn_state,
+            api_key=cast(Any, SimpleNamespace(id="key-other")),
+        )
+
+    assert _proxy_error_code(exc_info.value) == "turn_state_owner_unavailable"
+    service._durable_bridge.lookup_turn_state_target.assert_awaited_once_with(
+        turn_state=turn_state,
+        api_key_id="key-other",
+    )
+
+
+@pytest.mark.asyncio
+async def test_compact_turn_state_owner_is_a_strict_selection_constraint(monkeypatch: pytest.MonkeyPatch) -> None:
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    owner = _make_account("acc_compact_turn_owner")
+    turn_state = "turn-compact-owner"
+    alias_key = proxy_service._http_bridge_turn_state_alias_key(turn_state, None)
+    service._http_bridge_turn_state_index[alias_key] = "bridge-owner"  # type: ignore[assignment]
+    service._http_bridge_sessions["bridge-owner"] = SimpleNamespace(account=owner)  # type: ignore[index]
+    seen_selection: dict[str, object] = {}
+
+    async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
+        seen_selection.update(kwargs)
+        return AccountSelection(account=owner, error_message=None)
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=owner))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock())
+    monkeypatch.setattr(
+        proxy_service,
+        "core_compact_responses",
+        AsyncMock(return_value=CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})),
+    )
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    await service.compact_responses(payload, {"x-codex-turn-state": turn_state})
+
+    assert seen_selection["preferred_account_id"] == owner.id
+    assert seen_selection["fallback_on_preferred_account_unavailable"] is False
+
+
 def test_response_create_client_metadata_ignores_blank_multi_agent_headers():
     metadata = proxy_service._response_create_client_metadata(
         {},


### PR DESCRIPTION
## Summary

Preserve the remaining Responses turn-state fidelity behavior after the overlapping signature-v2 forwarding work landed on `main`.

The branch is rebuilt on current `main`; the previous 47-file aggregate is reduced to a 7-file residual change.

## Changes

- resolve compact-request `x-codex-turn-state` through the exact API-key-scoped local or durable bridge owner;
- use that owner as a strict account constraint and fail closed when turn-state and previous-response ownership conflict or cannot be resolved;
- preserve the shared compatibility metadata allowlist, including `x-codex-turn-metadata`, `x-openai-subagent`, `x-codex-parent-thread-id`, and `x-codex-window-id`;
- capture upstream `response.metadata` turn-state and include it on later collected JSON failures;
- retain current-main signature-v2 owner-forwarding behavior.

## Validation

- `723 passed` in the relevant unit suites;
- `7 passed` in the relevant integration selection;
- `ruff check`, `ruff format --check`, `ty check`, and `git diff --check` passed;
- the focused OpenSpec change and all 31 specs validate strictly.

Fixes Soju06/codex-lb#1186
