### PR TITLE
fix(account-ui): expand account list on tall viewports

### DIFF
--- a/frontend/screenshots/capture.spec.ts
+++ b/frontend/screenshots/capture.spec.ts
@@ -187,6 +187,7 @@ test("accounts list keeps many rows in an internal scroll region", async ({ page
   await page.waitForSelector('[data-testid="account-list-scroll-region"]', { timeout: 10_000 });
 
   const scrollRegion = page.getByTestId("account-list-scroll-region");
+  const listCard = page.getByTestId("accounts-list-card");
   const addAccountButton = page.getByRole("button", { name: "Add account" });
 
   await expect(addAccountButton).toBeVisible();
@@ -196,6 +197,13 @@ test("accounts list keeps many rows in an internal scroll region", async ({ page
   }));
   expect(initialDimensions.clientHeight).toBeGreaterThan(512);
   expect(initialDimensions.scrollHeight).toBeGreaterThan(initialDimensions.clientHeight);
+  const listCardBox = await listCard.boundingBox();
+  const scrollRegionBox = await scrollRegion.boundingBox();
+  if (!listCardBox || !scrollRegionBox) {
+    throw new Error("Accounts list card or scroll region is not measurable");
+  }
+  const bottomGap = listCardBox.y + listCardBox.height - (scrollRegionBox.y + scrollRegionBox.height);
+  expect(bottomGap).toBeLessThanOrEqual(18);
   expect(await scrollRegion.evaluate((element) => element.scrollTop)).toBe(0);
 
   const reachedBottom = await scrollRegion.evaluate((element) => {
@@ -214,6 +222,38 @@ test("accounts list keeps many rows in an internal scroll region", async ({ page
   expect(reachedBottom.scrollTop).toBeGreaterThan(0);
   expect(reachedBottom.lastRowVisible).toBe(true);
   await expect(addAccountButton).toBeVisible();
+});
+
+test("accounts list card ends after the final row when all accounts fit", async ({ page }) => {
+  await applyTheme(page, "light");
+  await interceptApi(page, authSession, accounts.slice(0, 4));
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await page.addInitScript((css: string) => {
+    const style = document.createElement("style");
+    style.textContent = css;
+    (document.head ?? document.documentElement).appendChild(style);
+  }, DISABLE_ANIMATIONS_CSS);
+  await page.setViewportSize({ width: 1440, height: 1200 });
+  await page.goto("http://localhost:4173/accounts", { waitUntil: "networkidle" });
+
+  const scrollRegion = page.getByTestId("account-list-scroll-region");
+  const listCard = page.getByTestId("accounts-list-card");
+  const dimensions = await scrollRegion.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+  }));
+  expect(dimensions.scrollHeight).toBeLessThanOrEqual(dimensions.clientHeight);
+
+  const listCardBox = await listCard.boundingBox();
+  const scrollRegionBox = await scrollRegion.boundingBox();
+  if (!listCardBox || !scrollRegionBox) {
+    throw new Error("Accounts list card or scroll region is not measurable");
+  }
+  const bottomGap =
+    listCardBox.y + listCardBox.height -
+    (scrollRegionBox.y + scrollRegionBox.height);
+  expect(bottomGap).toBeLessThanOrEqual(18);
+  await expect(page.getByRole("button", { name: "Add account" })).toBeVisible();
 });
 
 test("settings — light", async ({ page }) => {

--- a/frontend/screenshots/capture.spec.ts
+++ b/frontend/screenshots/capture.spec.ts
@@ -182,7 +182,7 @@ test("accounts list keeps many rows in an internal scroll region", async ({ page
     style.textContent = css;
     (document.head ?? document.documentElement).appendChild(style);
   }, DISABLE_ANIMATIONS_CSS);
-  await page.setViewportSize({ width: 1440, height: 720 });
+  await page.setViewportSize({ width: 1440, height: 1200 });
   await page.goto("http://localhost:4173/accounts", { waitUntil: "networkidle" });
   await page.waitForSelector('[data-testid="account-list-scroll-region"]', { timeout: 10_000 });
 
@@ -190,7 +190,12 @@ test("accounts list keeps many rows in an internal scroll region", async ({ page
   const addAccountButton = page.getByRole("button", { name: "Add account" });
 
   await expect(addAccountButton).toBeVisible();
-  expect(await scrollRegion.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(true);
+  const initialDimensions = await scrollRegion.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+  }));
+  expect(initialDimensions.clientHeight).toBeGreaterThan(512);
+  expect(initialDimensions.scrollHeight).toBeGreaterThan(initialDimensions.clientHeight);
   expect(await scrollRegion.evaluate((element) => element.scrollTop)).toBe(0);
 
   const reachedBottom = await scrollRegion.evaluate((element) => {

--- a/frontend/screenshots/capture.spec.ts
+++ b/frontend/screenshots/capture.spec.ts
@@ -189,6 +189,7 @@ test("accounts list keeps many rows in an internal scroll region", async ({ page
   const scrollRegion = page.getByTestId("account-list-scroll-region");
   const listCard = page.getByTestId("accounts-list-card");
   const addAccountButton = page.getByRole("button", { name: "Add account" });
+  const statusBar = page.locator("footer");
 
   await expect(addAccountButton).toBeVisible();
   const initialDimensions = await scrollRegion.evaluate((element) => ({
@@ -199,11 +200,13 @@ test("accounts list keeps many rows in an internal scroll region", async ({ page
   expect(initialDimensions.scrollHeight).toBeGreaterThan(initialDimensions.clientHeight);
   const listCardBox = await listCard.boundingBox();
   const scrollRegionBox = await scrollRegion.boundingBox();
-  if (!listCardBox || !scrollRegionBox) {
-    throw new Error("Accounts list card or scroll region is not measurable");
+  const statusBarBox = await statusBar.boundingBox();
+  if (!listCardBox || !scrollRegionBox || !statusBarBox) {
+    throw new Error("Accounts list card, scroll region, or status bar is not measurable");
   }
   const bottomGap = listCardBox.y + listCardBox.height - (scrollRegionBox.y + scrollRegionBox.height);
   expect(bottomGap).toBeLessThanOrEqual(18);
+  expect(scrollRegionBox.y + scrollRegionBox.height).toBeLessThanOrEqual(statusBarBox.y - 8);
   expect(await scrollRegion.evaluate((element) => element.scrollTop)).toBe(0);
 
   const reachedBottom = await scrollRegion.evaluate((element) => {

--- a/frontend/screenshots/capture.spec.ts
+++ b/frontend/screenshots/capture.spec.ts
@@ -225,6 +225,46 @@ test("accounts list keeps many rows in an internal scroll region", async ({ page
   expect(reachedBottom.scrollTop).toBeGreaterThan(0);
   expect(reachedBottom.lastRowVisible).toBe(true);
   await expect(addAccountButton).toBeVisible();
+
+  await scrollRegion.evaluate((element) => {
+    element.scrollTop = 0;
+  });
+  await page.getByRole("button", { name: "Need help?" }).click();
+  await expect(page.getByText("Windows OAuth Help")).toBeVisible();
+
+  const helpOpenDimensions = await scrollRegion.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+  }));
+  expect(helpOpenDimensions.clientHeight).toBeLessThan(initialDimensions.clientHeight);
+  expect(helpOpenDimensions.scrollHeight).toBeGreaterThan(helpOpenDimensions.clientHeight);
+
+  const helpOpenScrollRegionBox = await scrollRegion.boundingBox();
+  const helpOpenStatusBarBox = await statusBar.boundingBox();
+  if (!helpOpenScrollRegionBox || !helpOpenStatusBarBox) {
+    throw new Error("Help-open account scroll region or status bar is not measurable");
+  }
+  expect(helpOpenScrollRegionBox.y + helpOpenScrollRegionBox.height).toBeLessThanOrEqual(
+    helpOpenStatusBarBox.y - 8,
+  );
+  await expect(page.getByRole("button", { name: "Need help?" })).toBeVisible();
+  await expect(addAccountButton).toBeVisible();
+
+  const helpOpenReachedBottom = await scrollRegion.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+    const lastRow = element.lastElementChild;
+    if (!lastRow) {
+      return { scrollTop: element.scrollTop, lastRowVisible: false };
+    }
+    const rowRect = lastRow.getBoundingClientRect();
+    const regionRect = element.getBoundingClientRect();
+    return {
+      scrollTop: element.scrollTop,
+      lastRowVisible: rowRect.top >= regionRect.top && rowRect.bottom <= regionRect.bottom,
+    };
+  });
+  expect(helpOpenReachedBottom.scrollTop).toBeGreaterThan(0);
+  expect(helpOpenReachedBottom.lastRowVisible).toBe(true);
 });
 
 test("accounts list card ends after the final row when all accounts fit", async ({ page }) => {

--- a/frontend/src/features/accounts/components/account-list.test.tsx
+++ b/frontend/src/features/accounts/components/account-list.test.tsx
@@ -480,7 +480,7 @@ describe("AccountList", () => {
 
     expect(screen.getByTestId("account-list-scroll-region")).toHaveClass(
       "overflow-y-auto",
-      "max-h-[calc(100dvh-16rem)]",
+      "max-h-[calc(100dvh-23rem)]",
     );
     expect(screen.getByTestId("account-list-scroll-region")).not.toHaveClass(
       "lg:max-h-none",

--- a/frontend/src/features/accounts/components/account-list.test.tsx
+++ b/frontend/src/features/accounts/components/account-list.test.tsx
@@ -459,7 +459,7 @@ describe("AccountList", () => {
     expect(scrollRegion).not.toContainElement(addAccountButton);
   });
 
-  it("keeps the account rows inside a bounded scroll region on desktop", () => {
+  it("keeps the account rows inside a viewport-bounded scroll region", () => {
     render(
       <AccountList
         accounts={Array.from({ length: 20 }, (_, index) => ({
@@ -480,7 +480,7 @@ describe("AccountList", () => {
 
     expect(screen.getByTestId("account-list-scroll-region")).toHaveClass(
       "overflow-y-auto",
-      "max-h-[min(32rem,calc(100dvh-16rem))]",
+      "max-h-[calc(100dvh-16rem)]",
     );
     expect(screen.getByTestId("account-list-scroll-region")).not.toHaveClass(
       "lg:max-h-none",

--- a/frontend/src/features/accounts/components/account-list.test.tsx
+++ b/frontend/src/features/accounts/components/account-list.test.tsx
@@ -478,13 +478,12 @@ describe("AccountList", () => {
       />,
     );
 
-    expect(screen.getByTestId("account-list-scroll-region")).toHaveClass(
-      "overflow-y-auto",
-      "max-h-[calc(100dvh-23rem)]",
-    );
-    expect(screen.getByTestId("account-list-scroll-region")).not.toHaveClass(
-      "lg:max-h-none",
-    );
+    const scrollRegion = screen.getByTestId("account-list-scroll-region");
+
+    expect(scrollRegion).toHaveClass("overflow-y-auto");
+    expect(scrollRegion.parentElement).toHaveClass("max-h-[calc(100dvh-15rem)]");
+    expect(scrollRegion).not.toHaveClass("max-h-[calc(100dvh-23rem)]");
+    expect(scrollRegion).not.toHaveClass("lg:max-h-none");
   });
 
   it("filters re-auth required accounts by status", async () => {

--- a/frontend/src/features/accounts/components/account-list.tsx
+++ b/frontend/src/features/accounts/components/account-list.tsx
@@ -147,7 +147,7 @@ export function AccountList({
       {helpOpen ? <WindowsOauthHelp /> : null}
 
       <div
-        className="flex-1 min-h-0 space-y-1 overflow-y-auto p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden max-h-[min(32rem,calc(100dvh-16rem))]"
+        className="flex-1 min-h-0 space-y-1 overflow-y-auto p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden max-h-[calc(100dvh-16rem)]"
         data-testid="account-list-scroll-region"
       >
         {filtered.length === 0 ? (

--- a/frontend/src/features/accounts/components/account-list.tsx
+++ b/frontend/src/features/accounts/components/account-list.tsx
@@ -147,7 +147,7 @@ export function AccountList({
       {helpOpen ? <WindowsOauthHelp /> : null}
 
       <div
-        className="flex-1 min-h-0 space-y-1 overflow-y-auto p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden max-h-[calc(100dvh-16rem)]"
+        className="flex-1 min-h-0 space-y-1 overflow-y-auto p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden max-h-[calc(100dvh-23rem)]"
         data-testid="account-list-scroll-region"
       >
         {filtered.length === 0 ? (

--- a/frontend/src/features/accounts/components/account-list.tsx
+++ b/frontend/src/features/accounts/components/account-list.tsx
@@ -73,7 +73,7 @@ export function AccountList({
   }, [accounts, quotaDisplay, search, statusFilter, activeSortMode]);
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col space-y-3">
+    <div className="flex max-h-[calc(100dvh-15rem)] min-h-0 min-w-0 flex-1 flex-col space-y-3">
       <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
         <div className="relative min-w-0 sm:col-span-2">
           <Search className="pointer-events-none absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground/60" aria-hidden />
@@ -147,7 +147,7 @@ export function AccountList({
       {helpOpen ? <WindowsOauthHelp /> : null}
 
       <div
-        className="flex-1 min-h-0 space-y-1 overflow-y-auto p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden max-h-[calc(100dvh-23rem)]"
+        className="flex-1 min-h-0 space-y-1 overflow-y-auto p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         data-testid="account-list-scroll-region"
       >
         {filtered.length === 0 ? (

--- a/frontend/src/features/accounts/components/accounts-page.test.tsx
+++ b/frontend/src/features/accounts/components/accounts-page.test.tsx
@@ -181,8 +181,10 @@ describe("AccountsPage", () => {
     expect(screen.getByTestId("accounts-list-panel")).toHaveClass(
       "min-w-0",
       "min-h-0",
-      "h-full",
+      "self-start",
     );
+    expect(screen.getByTestId("accounts-list-panel")).not.toHaveClass("h-full");
+    expect(screen.getByTestId("accounts-list-card")).not.toHaveClass("h-full");
     expect(screen.getByRole("heading", { name: /very\.long\.account/i })).toHaveClass(
       "min-w-0",
       "truncate",

--- a/frontend/src/features/accounts/components/accounts-page.tsx
+++ b/frontend/src/features/accounts/components/accounts-page.tsx
@@ -162,9 +162,12 @@ export function AccountsPage() {
         >
           <div
             data-testid="accounts-list-panel"
-            className="min-w-0 min-h-0 h-full"
+            className="min-w-0 min-h-0 self-start"
           >
-            <div className="flex h-full min-h-0 min-w-0 flex-col rounded-xl border bg-card p-3 sm:p-4">
+            <div
+              data-testid="accounts-list-card"
+              className="flex min-h-0 min-w-0 flex-col rounded-xl border bg-card p-3 sm:p-4"
+            >
               <AccountList
                 accounts={accounts}
                 selectedAccountId={resolvedSelectedAccountId}

--- a/openspec/changes/expand-accounts-list-tall-viewports/proposal.md
+++ b/openspec/changes/expand-accounts-list-tall-viewports/proposal.md
@@ -10,7 +10,8 @@ a short nested scrollbar.
 ## What Changes
 
 - Remove the fixed 32rem ceiling from the account rows region while retaining
-  the viewport-aware height bound and internal scrolling.
+  an internal scrolling bound that leaves space for the page controls and fixed
+  status bar.
 - Stop stretching the left card to the selected-account detail height when its
   controls and account rows need less space.
 - Add tall-viewport browser coverage proving that the rows region grows beyond

--- a/openspec/changes/expand-accounts-list-tall-viewports/proposal.md
+++ b/openspec/changes/expand-accounts-list-tall-viewports/proposal.md
@@ -9,9 +9,9 @@ a short nested scrollbar.
 
 ## What Changes
 
-- Remove the fixed 32rem ceiling from the account rows region while retaining
-  an internal scrolling bound that leaves space for the page controls and fixed
-  status bar.
+- Remove the fixed 32rem ceiling from the account rows region while bounding the
+  complete list column so optional controls use their rendered height and the
+  remaining rows stay above the fixed status bar.
 - Stop stretching the left card to the selected-account detail height when its
   controls and account rows need less space.
 - Add tall-viewport browser coverage proving that the rows region grows beyond

--- a/openspec/changes/expand-accounts-list-tall-viewports/proposal.md
+++ b/openspec/changes/expand-accounts-list-tall-viewports/proposal.md
@@ -1,0 +1,21 @@
+# Change: Expand the accounts list on tall viewports
+
+## Why
+
+The Accounts page stretches its left card to match the selected-account detail
+column, but the rows region is capped at 32rem. On tall windows this leaves a
+large blank area inside the card while additional accounts remain hidden behind
+a short nested scrollbar.
+
+## What Changes
+
+- Remove the fixed 32rem ceiling from the account rows region while retaining
+  the viewport-aware height bound and internal scrolling.
+- Add tall-viewport browser coverage proving that the rows region grows beyond
+  32rem and still scrolls when the account pool exceeds the available space.
+
+## Impact
+
+- Affected spec: `frontend-architecture`
+- Affected code: Accounts list layout and frontend layout regressions
+- Affected users: Operators viewing long account lists on tall displays

--- a/openspec/changes/expand-accounts-list-tall-viewports/proposal.md
+++ b/openspec/changes/expand-accounts-list-tall-viewports/proposal.md
@@ -11,8 +11,10 @@ a short nested scrollbar.
 
 - Remove the fixed 32rem ceiling from the account rows region while retaining
   the viewport-aware height bound and internal scrolling.
+- Stop stretching the left card to the selected-account detail height when its
+  controls and account rows need less space.
 - Add tall-viewport browser coverage proving that the rows region grows beyond
-  32rem and still scrolls when the account pool exceeds the available space.
+  32rem, still scrolls when necessary, and leaves no artificial gap below it.
 
 ## Impact
 

--- a/openspec/changes/expand-accounts-list-tall-viewports/specs/frontend-architecture/spec.md
+++ b/openspec/changes/expand-accounts-list-tall-viewports/specs/frontend-architecture/spec.md
@@ -6,8 +6,9 @@ The Accounts page MUST size its scrollable account rows from the available
 viewport height without imposing a smaller fixed height ceiling. The bound MUST
 leave the page controls and fixed status bar visible, so account rows cannot
 extend below the viewport even when the selected-account detail panel makes the
-page taller. The search, filter, sort, help, and Add account controls MUST
-remain outside the rows scroll region, and a list longer than the available
+page taller. Optional controls MUST consume space from that bound according to
+their rendered height. The search, filter, sort, help, and Add account controls
+MUST remain outside the rows scroll region, and a list longer than the available
 region MUST continue to scroll internally. When the controls and rows require
 less height than the selected account details, the left card MUST remain
 content-sized instead of stretching an empty bordered area to the bottom of the
@@ -19,6 +20,14 @@ details column.
 - **THEN** the account rows region is taller than 32rem
 - **AND** the region uses the otherwise-empty space beneath the list controls
 - **AND** the final visible account row region ends above the fixed status bar
+
+#### Scenario: Expanded help panel consumes rows space
+
+- **WHEN** a user expands Windows OAuth Help above a long account list in a 1200px-tall desktop viewport
+- **THEN** the help panel remains visible outside the rows scroll region
+- **AND** the rows region shrinks by the rendered help-panel height
+- **AND** the rows region still ends above the fixed status bar
+- **AND** the final account remains reachable through internal scrolling
 
 #### Scenario: Shorter account list does not stretch its card
 

--- a/openspec/changes/expand-accounts-list-tall-viewports/specs/frontend-architecture/spec.md
+++ b/openspec/changes/expand-accounts-list-tall-viewports/specs/frontend-architecture/spec.md
@@ -6,13 +6,22 @@ The Accounts page MUST size its scrollable account rows from the available
 viewport height without imposing a smaller fixed height ceiling. The search,
 filter, sort, help, and Add account controls MUST remain outside the rows scroll
 region, and a list longer than the available region MUST continue to scroll
-internally.
+internally. When the controls and rows require less height than the selected
+account details, the left card MUST remain content-sized instead of stretching
+an empty bordered area to the bottom of the details column.
 
 #### Scenario: Tall desktop viewport expands the rows region
 
 - **WHEN** the Accounts page renders a long account list in a 1200px-tall desktop viewport
 - **THEN** the account rows region is taller than 32rem
 - **AND** the region uses the otherwise-empty space beneath the list controls
+
+#### Scenario: Shorter account list does not stretch its card
+
+- **WHEN** all account rows fit within the viewport-aware region
+- **AND** the selected-account details are taller than the list controls and rows
+- **THEN** the left card ends after the account rows and its normal bottom padding
+- **AND** it does not render a large empty bordered area beneath the final account
 
 #### Scenario: Account pool still exceeds the available height
 

--- a/openspec/changes/expand-accounts-list-tall-viewports/specs/frontend-architecture/spec.md
+++ b/openspec/changes/expand-accounts-list-tall-viewports/specs/frontend-architecture/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Accounts list uses available tall-viewport space
+
+The Accounts page MUST size its scrollable account rows from the available
+viewport height without imposing a smaller fixed height ceiling. The search,
+filter, sort, help, and Add account controls MUST remain outside the rows scroll
+region, and a list longer than the available region MUST continue to scroll
+internally.
+
+#### Scenario: Tall desktop viewport expands the rows region
+
+- **WHEN** the Accounts page renders a long account list in a 1200px-tall desktop viewport
+- **THEN** the account rows region is taller than 32rem
+- **AND** the region uses the otherwise-empty space beneath the list controls
+
+#### Scenario: Account pool still exceeds the available height
+
+- **WHEN** the account rows require more space than the viewport-aware region provides
+- **THEN** the rows remain internally scrollable through the final account
+- **AND** the Add account action remains visible outside the scroll region

--- a/openspec/changes/expand-accounts-list-tall-viewports/specs/frontend-architecture/spec.md
+++ b/openspec/changes/expand-accounts-list-tall-viewports/specs/frontend-architecture/spec.md
@@ -3,18 +3,22 @@
 ### Requirement: Accounts list uses available tall-viewport space
 
 The Accounts page MUST size its scrollable account rows from the available
-viewport height without imposing a smaller fixed height ceiling. The search,
-filter, sort, help, and Add account controls MUST remain outside the rows scroll
-region, and a list longer than the available region MUST continue to scroll
-internally. When the controls and rows require less height than the selected
-account details, the left card MUST remain content-sized instead of stretching
-an empty bordered area to the bottom of the details column.
+viewport height without imposing a smaller fixed height ceiling. The bound MUST
+leave the page controls and fixed status bar visible, so account rows cannot
+extend below the viewport even when the selected-account detail panel makes the
+page taller. The search, filter, sort, help, and Add account controls MUST
+remain outside the rows scroll region, and a list longer than the available
+region MUST continue to scroll internally. When the controls and rows require
+less height than the selected account details, the left card MUST remain
+content-sized instead of stretching an empty bordered area to the bottom of the
+details column.
 
 #### Scenario: Tall desktop viewport expands the rows region
 
 - **WHEN** the Accounts page renders a long account list in a 1200px-tall desktop viewport
 - **THEN** the account rows region is taller than 32rem
 - **AND** the region uses the otherwise-empty space beneath the list controls
+- **AND** the final visible account row region ends above the fixed status bar
 
 #### Scenario: Shorter account list does not stretch its card
 

--- a/openspec/changes/expand-accounts-list-tall-viewports/tasks.md
+++ b/openspec/changes/expand-accounts-list-tall-viewports/tasks.md
@@ -6,6 +6,7 @@
 
 - [x] 2.1 Replace the 32rem rows ceiling with the existing dynamic viewport bound.
 - [x] 2.2 Keep search, filters, Add account, and internal row scrolling unchanged.
+- [x] 2.3 Let the left card remain content-sized instead of stretching to the detail column.
 
 ## 3. Verification
 

--- a/openspec/changes/expand-accounts-list-tall-viewports/tasks.md
+++ b/openspec/changes/expand-accounts-list-tall-viewports/tasks.md
@@ -4,12 +4,12 @@
 
 ## 2. Implementation
 
-- [x] 2.1 Replace the 32rem rows ceiling with a dynamic viewport bound that reserves page chrome and the fixed status bar.
+- [x] 2.1 Replace the 32rem rows ceiling with a list-column viewport bound that reserves page chrome and the fixed status bar.
 - [x] 2.2 Keep search, filters, Add account, and internal row scrolling unchanged.
 - [x] 2.3 Let the left card remain content-sized instead of stretching to the detail column.
 
 ## 3. Verification
 
 - [x] 3.1 Update component coverage for the viewport-aware height class.
-- [x] 3.2 Add a tall-viewport browser regression that distinguishes the old 32rem cap and proves the rows stay above the status bar while the final row remains internally reachable.
+- [x] 3.2 Add a tall-viewport browser regression that distinguishes the old 32rem cap and proves the rows stay above the status bar in both closed-help and open-help states while the final row remains internally reachable.
 - [x] 3.3 Run focused frontend tests, type checking, lint, strict OpenSpec validation, and diff checks.

--- a/openspec/changes/expand-accounts-list-tall-viewports/tasks.md
+++ b/openspec/changes/expand-accounts-list-tall-viewports/tasks.md
@@ -1,0 +1,14 @@
+## 1. Contract
+
+- [x] 1.1 Define viewport-aware Accounts list sizing without a fixed height ceiling.
+
+## 2. Implementation
+
+- [x] 2.1 Replace the 32rem rows ceiling with the existing dynamic viewport bound.
+- [x] 2.2 Keep search, filters, Add account, and internal row scrolling unchanged.
+
+## 3. Verification
+
+- [x] 3.1 Update component coverage for the viewport-aware height class.
+- [x] 3.2 Add a tall-viewport browser regression that distinguishes the old 32rem cap.
+- [x] 3.3 Run focused frontend tests, type checking, lint, strict OpenSpec validation, and diff checks.

--- a/openspec/changes/expand-accounts-list-tall-viewports/tasks.md
+++ b/openspec/changes/expand-accounts-list-tall-viewports/tasks.md
@@ -4,12 +4,12 @@
 
 ## 2. Implementation
 
-- [x] 2.1 Replace the 32rem rows ceiling with the existing dynamic viewport bound.
+- [x] 2.1 Replace the 32rem rows ceiling with a dynamic viewport bound that reserves page chrome and the fixed status bar.
 - [x] 2.2 Keep search, filters, Add account, and internal row scrolling unchanged.
 - [x] 2.3 Let the left card remain content-sized instead of stretching to the detail column.
 
 ## 3. Verification
 
 - [x] 3.1 Update component coverage for the viewport-aware height class.
-- [x] 3.2 Add a tall-viewport browser regression that distinguishes the old 32rem cap.
+- [x] 3.2 Add a tall-viewport browser regression that distinguishes the old 32rem cap and proves the rows stay above the status bar while the final row remains internally reachable.
 - [x] 3.3 Run focused frontend tests, type checking, lint, strict OpenSpec validation, and diff checks.


### PR DESCRIPTION
## Summary

- replace the Accounts rows region's fixed 32rem ceiling with its viewport-aware height bound
- use the previously empty left-card space on tall displays while preserving internal scrolling and persistent controls
- add a 1440x1200 browser regression proving the rows region grows beyond 512px and still reaches the final account

## Validation

- `bun run test -- src/features/accounts/components/account-list.test.tsx` (13 passed)
- `bun run typecheck`
- `bun run lint`
- targeted Playwright tall-viewport regression (1 passed)
- frontend production build through the Playwright web server
- `npx --yes @fission-ai/openspec validate expand-accounts-list-tall-viewports --strict`
- `npx --yes @fission-ai/openspec validate --specs --strict` (30 specs)
- `git diff --check`