### PR TITLE
fix(proxy): send complete Codex identity headers

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -570,9 +570,8 @@ def _is_native_codex_request(headers: Mapping[str, str]) -> bool:
 def _normalize_non_native_upstream_fingerprint(headers: dict[str, str]) -> None:
     """Rewrite a non-native request's outbound fingerprint to the Codex CLI
     persona in place: set ``User-Agent`` to a ``codex_cli_rs`` string, strip
-    SDK-only ``x-openai-client-*`` and ``x-stainless-*`` headers, and strip any
-    inbound ``originator`` header (the real Codex CLI omits it for the default
-    originator and lets the backend read it from the User-Agent prefix)."""
+    SDK-only ``x-openai-client-*`` and ``x-stainless-*`` headers, and replace
+    any inbound ``originator`` or ``version`` with the canonical Codex values."""
     version = get_codex_version_cache().cached_version_or_default()
     codex_user_agent = build_codex_user_agent(version)
     for key in list(headers.keys()):
@@ -582,9 +581,12 @@ def _normalize_non_native_upstream_fingerprint(headers: dict[str, str]) -> None:
             or lowered in _SDK_FINGERPRINT_HEADER_KEYS
             or lowered.startswith(_SDK_FINGERPRINT_HEADER_PREFIXES)
             or lowered == "originator"
+            or lowered == "version"
         ):
             del headers[key]
     headers["User-Agent"] = codex_user_agent
+    headers["originator"] = _CODEX_CLI_ORIGINATOR
+    headers["version"] = version
 
 
 def _build_upstream_headers(

--- a/openspec/changes/normalize-upstream-codex-fingerprint/proposal.md
+++ b/openspec/changes/normalize-upstream-codex-fingerprint/proposal.md
@@ -61,20 +61,21 @@ official Codex CLI sends (`get_codex_user_agent()` in
 2. Strip SDK-only fingerprint headers (`x-openai-client-version`,
    `x-openai-client-os`, `x-openai-client-arch`, `x-openai-client-id`,
    `x-openai-client-user-agent`).
-3. Do **not** add an `originator` header: the real Codex CLI omits the
-   `originator` header when the originator equals the default (`codex_cli_rs`)
-   and lets the backend read it from the `User-Agent` prefix. Strip any
-   inbound `originator` header so no SDK-supplied value leaks through.
+3. Strip any inbound `originator` and `version` headers, then install the
+   canonical Codex identity pair: `originator: codex_cli_rs` and
+   `version: <version>`, using the same cached version embedded in the
+   `User-Agent`. The official Codex client installs the default originator on
+   its shared HTTP client and adds the package version through its model
+   provider headers; omitting either header does not match its wire identity.
 4. Use PascalCase `ChatGPT-Account-Id` for the account header, matching Codex
    CLI (`codex-rs/backend-client/src/client.rs`).
 
 A request is **native** (left untouched) when its User-Agent already begins
 with a known Codex client token (`codex_cli_rs`, `codex-tui`, `codex_exec`,
-`codex_vscode`, `Codex Desktop`, or `Codex ...`) **or** it already carries
-native Codex transport headers (`originator` in the native set, or any
-`x-codex-*` stream header). websocket requests are unaffected because they use
-`_build_upstream_websocket_headers` and already connect as native Codex
-clients.
+`codex_vscode`, `Codex Desktop`, or `Codex ...`) **or** it carries an
+`originator` in the native Codex set. Continuity-only `x-codex-*` headers do
+not make a request native. The same normalization applies to non-native HTTP,
+internal websocket, and client-facing Responses websocket egress.
 
 ## Why this is correct as a behavior change
 
@@ -94,7 +95,7 @@ clients.
 
 ### Spec deltas
 - `outbound-http-clients`: ADD a Requirement covering non-native upstream http
-  request fingerprint normalization (User-Agent, originator omission, SDK
+  request fingerprint normalization (User-Agent, canonical identity, SDK
   header stripping, account-header casing, native-client exemption).
 
 ### Code
@@ -103,19 +104,21 @@ clients.
   hot header-build path; background refresh stays on the existing async
   `get_version()` already called every model-registry refresh cycle.
 - `app/core/clients/proxy.py` — add `build_codex_user_agent(version)` helper
-  and a `_normalize_non_native_upstream_fingerprint()` step; call it from
-  `_build_upstream_headers` for non-native http requests. Add native-client
-  detection by User-Agent prefix combined with the existing
-  `_has_native_codex_transport_headers`.
+  and a shared `_normalize_non_native_upstream_fingerprint()` step; call it
+  from HTTP and internal websocket builders for non-native requests. Replace
+  untrusted `originator` / `version` values with canonical Codex identity
+  headers. Add native-client detection by User-Agent prefix or allowlisted
+  first-party originator. The client-facing Responses websocket builder reuses
+  the same normalization.
 - `app/core/config/settings.py` — add `codex_fingerprint_os`,
   `codex_fingerprint_arch`, `codex_fingerprint_terminal` settings (defaults
   `Mac OS 26.5.0` / `arm64` / `iTerm.app/3.6.10`).
 
 ### Tests
 - `tests/unit/test_proxy_upstream_fingerprint.py` (new) — non-native http UA
-  rewritten to `codex_cli_rs/...`; native UA + websocket unchanged;
-  `x-openai-client-*` and inbound `originator` stripped; no `originator` header
-  added; PascalCase `ChatGPT-Account-Id`; version sourced from cache with
+  and websocket UAs rewritten to `codex_cli_rs/...`; native identities
+  unchanged; SDK identity stripped and canonical `originator` / `version`
+  installed; PascalCase `ChatGPT-Account-Id`; version sourced from cache with
   settings-default fallback.
 - `tests/unit/test_codex_version_cache.py` — `cached_version_or_default()`
   returns the cached version when present and the settings default when empty,
@@ -123,7 +126,6 @@ clients.
 
 ## Out of scope
 
-- Changing websocket upstream headers (`_build_upstream_websocket_headers`).
 - Changing native Codex client requests.
 - Per-key rate limiting, account-pool sizing, or retry/backoff policy for
   `auto`-tier overloads (separate concerns).

--- a/openspec/changes/normalize-upstream-codex-fingerprint/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/normalize-upstream-codex-fingerprint/specs/outbound-http-clients/spec.md
@@ -42,9 +42,9 @@ For a non-native request, the service MUST:
   `x-openai-client-os`, `x-openai-client-arch`, `x-openai-client-id`, and
   `x-openai-client-user-agent`, as well as every `x-stainless-*` header (the
   OpenAI SDK fingerprint family the API layer uses to detect SDK callers).
-- Remove any inbound `originator` header and MUST NOT add an `originator`
-  header, matching the Codex CLI behavior of omitting the header when the
-  originator equals the default `codex_cli_rs`.
+- Remove inbound `originator` and `version` headers case-insensitively, then
+  set `originator: codex_cli_rs` and `version: <version>`, where `<version>` is
+  the same cached Codex client version used in the outbound `User-Agent`.
 - Emit the upstream account header as PascalCase `ChatGPT-Account-Id`.
 - Preserve continuity headers (`x-codex-turn-state` and other `x-codex-*`
   stream headers) on the outbound request so sticky routing is unaffected.
@@ -55,14 +55,16 @@ in-process cache that is refreshed by existing background refresh paths.
 
 #### Scenario: non-native SDK http request is rewritten to the Codex CLI fingerprint
 
-- **WHEN** an http upstream request arrives with `User-Agent: OpenAI/Python 2.24.0`
-  and `x-openai-client-version` / `x-openai-client-os` / `x-stainless-os` headers
+- **WHEN** an http upstream request arrives with `User-Agent: OpenAI/Python 2.24.0`,
+  untrusted `originator` / mixed-case `Version` values, and
+  `x-openai-client-version` / `x-openai-client-os` / `x-stainless-os` headers
 - **THEN** the outbound `User-Agent` is `codex_cli_rs/<version> (Mac OS 26.5.0; arm64) iTerm.app/3.6.10`
 - **AND** the `x-openai-client-version`, `x-openai-client-os`,
   `x-openai-client-arch`, `x-openai-client-id`, and `x-openai-client-user-agent`
   headers are absent from the outbound request
 - **AND** every `x-stainless-*` header is absent from the outbound request
-- **AND** no `originator` header is present on the outbound request
+- **AND** the only outbound identity values are `originator: codex_cli_rs` and
+  `version: <version>` matching the version embedded in `User-Agent`
 
 #### Scenario: native Codex http request is left unchanged
 
@@ -91,8 +93,8 @@ in-process cache that is refreshed by existing background refresh paths.
   header, and an `x-codex-turn-state` continuity header
 - **THEN** the outbound websocket `User-Agent` is
   `codex_cli_rs/<version> (Mac OS 26.5.0; arm64) iTerm.app/3.6.10`
-- **AND** the `x-openai-client-*` and `originator` headers are absent from the
-  outbound request
+- **AND** SDK identity headers are absent and the outbound request carries
+  `originator: codex_cli_rs` and `version: <version>`
 - **AND** the upstream account id is carried under the PascalCase header name
   `ChatGPT-Account-Id`
 - **AND** the `x-codex-turn-state` header is preserved on the outbound request
@@ -111,8 +113,8 @@ in-process cache that is refreshed by existing background refresh paths.
   and `x-stainless-*` headers
 - **THEN** the upstream responses websocket `User-Agent` is
   `codex_cli_rs/<version> (Mac OS 26.5.0; arm64) iTerm.app/3.6.10`
-- **AND** the `x-openai-client-*`, `x-stainless-*`, and `originator` headers are
-  absent from the outbound request
+- **AND** the `x-openai-client-*` and `x-stainless-*` headers are absent while
+  `originator: codex_cli_rs` and `version: <version>` are present
 - **AND** the upstream account id is carried under the PascalCase header name
   `ChatGPT-Account-Id`
 - **AND** the required responses websocket beta header is still present
@@ -137,4 +139,5 @@ in-process cache that is refreshed by existing background refresh paths.
 - **AND** a non-native http request is normalized
 - **THEN** the outbound `User-Agent` uses the configured client-version default
   for `<version>`
+- **AND** the outbound `version` header uses that same configured default
 - **AND** resolving the version does not perform a network call on the request path

--- a/openspec/changes/normalize-upstream-codex-fingerprint/tasks.md
+++ b/openspec/changes/normalize-upstream-codex-fingerprint/tasks.md
@@ -15,8 +15,9 @@
   existing `_has_native_codex_transport_headers`.
 - [x] T5: Add `_normalize_non_native_upstream_fingerprint(headers)` and call it
   from `_build_upstream_headers` for non-native http requests: rewrite
-  `User-Agent`, strip `x-openai-client-*`, strip inbound `originator`, set
-  PascalCase `ChatGPT-Account-Id`.
+  `User-Agent`, strip SDK fingerprints and untrusted `originator` / `version`,
+  install canonical Codex identity headers, and set PascalCase
+  `ChatGPT-Account-Id`.
 
 ## Tests
 - [x] T6: `tests/unit/test_codex_version.py` — `cached_version_or_default()`
@@ -25,10 +26,11 @@
 - [x] T7: `tests/unit/test_proxy_upstream_fingerprint.py` — non-native http UA
   (`OpenAI/Python 2.24.0`) rewritten to `codex_cli_rs/<ver> (...)`.
 - [x] T8: native UA (`codex_exec/...`, `Codex Desktop/...`) left unchanged.
-- [x] T9: `x-openai-client-*` headers and inbound `originator` stripped on
-  non-native http; no `originator` header added.
+- [x] T9: `x-openai-client-*` headers and inbound identity values stripped on
+  non-native HTTP; canonical `originator` and `version` headers added.
 - [x] T10: account header emitted as PascalCase `ChatGPT-Account-Id`.
-- [x] T11: websocket header builder untouched (native path regression guard).
+- [x] T11: internal and client-facing websocket builders reuse the same
+  normalization; native websocket identity remains untouched.
 
 ## Spec
 - [x] T12: Add the delta in
@@ -40,3 +42,14 @@
 - [x] T15: Broader proxy-client sweep (1006 passed, 3 skipped, 0 new failures;
   18 pre-existing assertions updated for the intended behavior change).
 - [x] T16: `uvx ruff check .` + `uvx ruff format --check .` + `uv run ty check` clean.
+
+## Issue #1194 follow-up
+- [x] T17: Replace case-insensitive inbound `originator` and `version` values
+  with `codex_cli_rs` and the cached version on every non-native egress path.
+- [x] T18: Add HTTP, internal websocket, client-facing websocket, and
+  stream-level wire regressions proving both canonical headers are emitted.
+- [x] T19: Preserve native Codex identity headers unchanged.
+- [x] T20: Run the focused identity and wire regressions (15 + 2 passed) plus
+  the full proxy utility suite (589 passed).
+- [x] T21: Run Ruff, `ty`, proxy architecture checks, focused strict OpenSpec
+  validation, all-spec strict validation, and `git diff --check`.

--- a/tests/unit/test_proxy_upstream_fingerprint.py
+++ b/tests/unit/test_proxy_upstream_fingerprint.py
@@ -27,6 +27,7 @@ def test_non_native_sdk_http_request_is_rewritten_to_codex_cli_fingerprint():
         "x-openai-client-id": "abc",
         "x-openai-client-user-agent": "OpenAI/Python 2.24.0",
         "originator": "sdk",
+        "Version": "9.9.9",
     }
     with patch.object(proxy_module.get_codex_version_cache(), "cached_version_or_default", return_value="0.142.0"):
         headers = _build_upstream_headers(inbound, "tok", "acct-123")
@@ -38,8 +39,11 @@ def test_non_native_sdk_http_request_is_rewritten_to_codex_cli_fingerprint():
     assert "x-openai-client-arch" not in lowered
     assert "x-openai-client-id" not in lowered
     assert "x-openai-client-user-agent" not in lowered
-    # No originator header is added; inbound SDK originator is stripped.
-    assert "originator" not in lowered
+    assert headers["originator"] == "codex_cli_rs"
+    assert headers["version"] == "0.142.0"
+    assert "Version" not in headers
+    assert sum(key.lower() == "originator" for key in headers) == 1
+    assert sum(key.lower() == "version" for key in headers) == 1
 
 
 def test_non_native_request_uses_pascalcase_account_header():
@@ -62,13 +66,21 @@ def test_non_native_request_version_falls_back_to_settings_default():
     from app.core.config.settings import get_settings
 
     assert get_settings().model_registry_client_version in ua
+    assert headers["version"] == get_settings().model_registry_client_version
+    assert headers["originator"] == "codex_cli_rs"
 
 
 def test_native_codex_http_request_is_left_unchanged():
     native_ua = "codex_exec/0.142.1 (Mac OS 27.0.0; arm64) unknown (codex_exec; 0.142.1)"
-    headers = _build_upstream_headers({"User-Agent": native_ua}, "tok", "acct-1")
+    headers = _build_upstream_headers(
+        {"User-Agent": native_ua, "originator": "codex_exec", "version": "0.142.1"},
+        "tok",
+        "acct-1",
+    )
 
     assert headers["User-Agent"] == native_ua
+    assert headers["originator"] == "codex_exec"
+    assert headers["version"] == "0.142.1"
     # Native requests keep the existing lowercase account header.
     assert headers["chatgpt-account-id"] == "acct-1"
     assert "ChatGPT-Account-Id" not in headers
@@ -101,8 +113,8 @@ def test_sdk_request_replaying_turn_state_is_still_normalized():
 
 
 def test_native_originator_header_marks_request_native():
-    # A native Codex originator header (not the default codex_cli_rs, which the
-    # CLI omits) identifies a first-party client and is left unchanged.
+    # A native Codex originator identifies a first-party client and is left
+    # unchanged.
     inbound = {"User-Agent": "OpenAI/Python 2.24.0", "originator": "codex_vscode"}
     headers = _build_upstream_headers(inbound, "tok", None)
     assert headers["User-Agent"] == "OpenAI/Python 2.24.0"
@@ -141,6 +153,7 @@ def test_websocket_non_native_sdk_request_is_normalized():
         "x-openai-client-version": "2.24.0",
         "x-codex-turn-state": "abc",
         "originator": "sdk",
+        "Version": "9.9.9",
     }
     with patch.object(proxy_module.get_codex_version_cache(), "cached_version_or_default", return_value="0.142.0"):
         headers = _build_upstream_websocket_headers(inbound, "tok", "acct-1")
@@ -148,7 +161,9 @@ def test_websocket_non_native_sdk_request_is_normalized():
     assert headers["User-Agent"] == "codex_cli_rs/0.142.0 (Mac OS 26.5.0; arm64) iTerm.app/3.6.10"
     lowered = _lower_keys(headers)
     assert "x-openai-client-version" not in lowered
-    assert "originator" not in lowered
+    assert headers["originator"] == "codex_cli_rs"
+    assert headers["version"] == "0.142.0"
+    assert "Version" not in headers
     # Non-native uses the PascalCase account header, mirroring the HTTP builder.
     assert headers["ChatGPT-Account-Id"] == "acct-1"
     assert "chatgpt-account-id" not in headers

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4700,6 +4700,11 @@ async def test_stream_responses_falls_back_to_http_post_without_native_codex_hea
     monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
     monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
     monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+    monkeypatch.setattr(
+        proxy_module.get_codex_version_cache(),
+        "cached_version_or_default",
+        lambda: "0.142.0",
+    )
 
     payload = ResponsesRequest.model_validate(
         {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
@@ -4713,7 +4718,7 @@ async def test_stream_responses_falls_back_to_http_post_without_native_codex_hea
         event
         async for event in proxy_module.stream_responses(
             payload,
-            headers={},
+            headers={"originator": "sdk", "Version": "9.9.9"},
             access_token="token",
             account_id="acc_1",
             session=cast(proxy_module.aiohttp.ClientSession, session),
@@ -4722,6 +4727,11 @@ async def test_stream_responses_falls_back_to_http_post_without_native_codex_hea
 
     assert session.ws_calls == []
     assert len(session.post_calls) == 1
+    upstream_headers = cast(dict[str, str], session.post_calls[0]["headers"])
+    assert upstream_headers["User-Agent"].startswith("codex_cli_rs/0.142.0 ")
+    assert upstream_headers["originator"] == "codex_cli_rs"
+    assert upstream_headers["version"] == "0.142.0"
+    assert "Version" not in upstream_headers
     assert events == ['data: {"type":"response.completed","response":{"id":"resp_1"}}\n\n']
 
 

--- a/tests/unit/test_proxy_websocket_client.py
+++ b/tests/unit/test_proxy_websocket_client.py
@@ -1048,6 +1048,7 @@ def test_responses_websocket_builder_normalizes_non_native_sdk_fingerprint():
         "x-openai-client-version": "2.24.0",
         "x-stainless-os": "MacOS",
         "originator": "sdk",
+        "Version": "9.9.9",
         "openai-beta": "responses_websockets=2026-02-06",
     }
     with patch.object(proxy_module.get_codex_version_cache(), "cached_version_or_default", return_value="0.142.0"):
@@ -1057,7 +1058,9 @@ def test_responses_websocket_builder_normalizes_non_native_sdk_fingerprint():
     lowered = {key.lower() for key in headers}
     assert "x-openai-client-version" not in lowered
     assert not any(key.lower().startswith("x-stainless-") for key in headers)
-    assert "originator" not in lowered
+    assert headers["originator"] == "codex_cli_rs"
+    assert headers["version"] == "0.142.0"
+    assert "Version" not in headers
     assert headers["ChatGPT-Account-Id"] == "acct-1"
     assert "chatgpt-account-id" not in headers
     # The responses websocket beta header is still appended.


### PR DESCRIPTION
## Summary

- replace client-supplied `originator` and `version` headers case-insensitively on normalized non-native requests
- send the complete Codex CLI identity: canonical `User-Agent`, `originator: codex_cli_rs`, and a matching cached `version`
- cover HTTP, internal WebSocket, and client-facing Responses WebSocket egress through the shared helper while leaving native Codex requests unchanged
- correct the active OpenSpec requirement that previously documented the default originator as omitted

## Scope

This is intentionally small: the runtime change is 5 added / 3 removed lines in one shared helper. The remaining diff is focused regression coverage and OpenSpec synchronization.

## Validation

- `uv run pytest tests/unit/test_proxy_upstream_fingerprint.py -q` (15 passed)
- direct WebSocket + stream-level outgoing-header regressions (2 passed)
- `uv run pytest tests/unit/test_proxy_utils.py -q` (589 passed)
- Ruff format/check
- `uv run ty check`
- proxy architecture checks
- strict OpenSpec change validation
- strict validation of all 30 specs
- `git diff --check`

Fixes #1194