### PR TITLE
fix(ui): keep API key dialogs open for dropdown interactions

### DIFF
--- a/frontend/src/features/api-keys/components/account-multi-select.tsx
+++ b/frontend/src/features/api-keys/components/account-multi-select.tsx
@@ -191,7 +191,7 @@ export function AccountMultiSelect({
 
   return (
     <div className="space-y-1.5">
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <Button
             type="button"

--- a/frontend/src/features/api-keys/components/api-key-create-dialog.tsx
+++ b/frontend/src/features/api-keys/components/api-key-create-dialog.tsx
@@ -44,6 +44,8 @@ const TRANSPORT_POLICY_LABELS = {
   always_websocket: "Prefer persistent sessions",
 } as const;
 
+import { preventApiKeyDialogDropdownDismiss } from "./api-key-dialog-interactions";
+
 const formSchema = z.object({
   name: z.string().min(1, "Name is required"),
 });
@@ -303,7 +305,10 @@ export function ApiKeyCreateDialog({ open, busy, onOpenChange, onSubmit }: ApiKe
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {open ? (
-        <DialogContent className="sm:max-w-3xl">
+        <DialogContent
+          className="sm:max-w-3xl"
+          onInteractOutside={preventApiKeyDialogDropdownDismiss}
+        >
           <DialogHeader>
             <DialogTitle>Create API key</DialogTitle>
             <DialogDescription>Set restrictions and expiration for this key.</DialogDescription>

--- a/frontend/src/features/api-keys/components/api-key-dialog-interactions.test.ts
+++ b/frontend/src/features/api-keys/components/api-key-dialog-interactions.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { preventApiKeyDialogDropdownDismiss } from "./api-key-dialog-interactions";
+
+describe("preventApiKeyDialogDropdownDismiss", () => {
+  it("prevents dismissal for portalled dropdown content", () => {
+    const content = document.createElement("div");
+    content.dataset.slot = "dropdown-menu-content";
+    const item = document.createElement("div");
+    content.append(item);
+    const preventDefault = vi.fn();
+
+    preventApiKeyDialogDropdownDismiss({ target: item, preventDefault });
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+
+  it("allows ordinary outside interactions", () => {
+    const preventDefault = vi.fn();
+
+    preventApiKeyDialogDropdownDismiss({
+      target: document.createElement("div"),
+      preventDefault,
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/features/api-keys/components/api-key-dialog-interactions.ts
+++ b/frontend/src/features/api-keys/components/api-key-dialog-interactions.ts
@@ -1,0 +1,13 @@
+type OutsideInteractionEvent = {
+  target: EventTarget | null;
+  preventDefault(): void;
+};
+
+export function preventApiKeyDialogDropdownDismiss(event: OutsideInteractionEvent): void {
+  if (
+    event.target instanceof Element &&
+    event.target.closest('[data-slot="dropdown-menu-content"]')
+  ) {
+    event.preventDefault();
+  }
+}

--- a/frontend/src/features/api-keys/components/api-key-edit-dialog.test.tsx
+++ b/frontend/src/features/api-keys/components/api-key-edit-dialog.test.tsx
@@ -347,6 +347,43 @@ describe("ApiKeyEditDialog", () => {
     expect(payload.assignedAccountIds).toEqual([]);
   });
 
+  it("keeps the dialog open while selecting a model and submits the selection", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const onOpenChange = vi.fn();
+    server.use(
+      http.get("/api/models", () =>
+        HttpResponse.json({
+          models: [
+            { id: "gpt-5.5", name: "GPT 5.5" },
+            { id: "gpt-5.6-sol", name: "GPT 5.6 SOL" },
+          ],
+        }),
+      ),
+    );
+
+    renderWithProviders(
+      <ApiKeyEditDialog
+        open
+        busy={false}
+        apiKey={createApiKey({ allowedModels: ["gpt-5.5"] })}
+        onOpenChange={onOpenChange}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: "1 model selected" }));
+    await user.click(screen.getByRole("menuitemcheckbox", { name: "gpt-5.6-sol" }));
+
+    expect(screen.getByRole("dialog", { name: "Edit API key" })).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0].allowedModels).toEqual(["gpt-5.5", "gpt-5.6-sol"]);
+  });
+
   it("keeps a deny-all source scope when editing an unrelated field", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn().mockResolvedValue(undefined);

--- a/frontend/src/features/api-keys/components/api-key-edit-dialog.test.tsx
+++ b/frontend/src/features/api-keys/components/api-key-edit-dialog.test.tsx
@@ -374,6 +374,7 @@ describe("ApiKeyEditDialog", () => {
 
     await user.click(await screen.findByRole("button", { name: "1 model selected" }));
     await user.click(screen.getByRole("menuitemcheckbox", { name: "gpt-5.6-sol" }));
+    await user.keyboard("{Escape}");
 
     expect(screen.getByRole("dialog", { name: "Edit API key" })).toBeInTheDocument();
     expect(onOpenChange).not.toHaveBeenCalledWith(false);

--- a/frontend/src/features/api-keys/components/api-key-edit-dialog.tsx
+++ b/frontend/src/features/api-keys/components/api-key-edit-dialog.tsx
@@ -41,6 +41,7 @@ import type {
 } from "@/features/api-keys/schemas";
 import { parseDate } from "@/utils/formatters";
 
+import { preventApiKeyDialogDropdownDismiss } from "./api-key-dialog-interactions";
 import { hasLimitRuleChanges, normalizeLimitRules } from "./limit-rules-utils";
 
 const TRANSPORT_POLICY_FOLLOW_GLOBAL = "follow_global";
@@ -442,7 +443,10 @@ function formatTokenCount(n: number): string {
 export function ApiKeyEditDialog({ open, busy, apiKey, onOpenChange, onSubmit }: ApiKeyEditDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-3xl">
+      <DialogContent
+        className="sm:max-w-3xl"
+        onInteractOutside={preventApiKeyDialogDropdownDismiss}
+      >
         <DialogHeader>
           <DialogTitle>Edit API key</DialogTitle>
           <DialogDescription>Update restrictions and lifecycle settings.</DialogDescription>

--- a/frontend/src/features/api-keys/components/model-multi-select.tsx
+++ b/frontend/src/features/api-keys/components/model-multi-select.tsx
@@ -64,7 +64,7 @@ export function ModelMultiSelect({
 
   return (
     <div className="space-y-1.5">
-      <DropdownMenu>
+      <DropdownMenu modal={false}>
         <DropdownMenuTrigger asChild>
           <Button
             type="button"

--- a/openspec/changes/fix-api-key-dialog-dropdown-dismiss/design.md
+++ b/openspec/changes/fix-api-key-dialog-dropdown-dismiss/design.md
@@ -1,0 +1,31 @@
+## Context
+
+`ModelMultiSelect` and `AccountMultiSelect` use Radix dropdown menus whose content is portalled outside the API-key dialog DOM subtree. In the deployed 1.20.1 dashboard, selecting a model reproducibly closes the parent edit dialog before Save. The selection state therefore cannot be persisted through the GUI.
+
+## Goals
+
+- A model or account dropdown interaction inside an API-key dialog must not dismiss that dialog.
+- The operator must be able to select several models and submit the resulting allowlist.
+- Clicking outside both the dialog and its owned dropdown content must continue to dismiss the dialog.
+- The live repair must preserve the existing `codex-lb-data` volume and container runtime configuration.
+
+## Non-goals
+
+- Redesigning the multi-select controls.
+- Changing API-key enforcement semantics or database schemas.
+- Disabling all outside-click dismissal.
+- Refactoring unrelated dialog or dropdown components.
+
+## Decision
+
+Add a narrowly scoped outside-interaction guard to the API-key create and edit dialog content. The guard prevents dialog dismissal only when the event target belongs to portalled dropdown content owned by the dialog. It does not globally disable outside interactions and does not change the dropdowns' modal/focus behavior.
+
+The implementation will reuse the same guard for both API-key dialogs because both embed the same portalled selectors. A regression test will exercise the externally failing edit path: open the dialog, open Allowed models, select a model, assert that the dialog remains open, submit, and assert that the selected allowlist is present in the update payload.
+
+## Deployment
+
+Build a patched container from the exact deployed 1.20.1 revision. Before replacement, capture the existing container inspection and maintain the named `codex-lb-data` mount, published ports, restart policy, environment, and command. Replace only the application image, then verify health, persisted API-key state, and the original browser interaction.
+
+## Failure handling
+
+If the focused regression test does not fail before the code change, stop and refine the test rather than implementing. If the custom image does not become healthy, restore the prior container/image using the captured runtime configuration; the persistent volume remains untouched.

--- a/openspec/changes/fix-api-key-dialog-dropdown-dismiss/design.md
+++ b/openspec/changes/fix-api-key-dialog-dropdown-dismiss/design.md
@@ -20,7 +20,7 @@
 
 Add a narrowly scoped outside-interaction guard to the API-key create and edit dialog content. The guard prevents dialog dismissal only when the event target belongs to portalled dropdown content owned by the dialog. It does not globally disable outside interactions.
 
-Configure the nested model dropdown as non-modal. Radix otherwise composes two modal layers—a dropdown portal inside a dialog—and Chrome can dismiss the parent dialog during a checkbox selection even after the outside-interaction guard runs. The parent API-key dialog remains modal, so page content outside the editor is still protected.
+Configure the nested model and account dropdowns as non-modal. Radix otherwise composes two modal layers—a dropdown portal inside a dialog—and Chrome can dismiss the parent dialog during a checkbox selection even after the outside-interaction guard runs. The parent API-key dialog remains modal, so page content outside the editor is still protected.
 
 The implementation will reuse the same guard for both API-key dialogs because both embed the same portalled selectors. A regression test will exercise the externally failing edit path: open the dialog, open Allowed models, select a model, assert that the dialog remains open, submit, and assert that the selected allowlist is present in the update payload.
 

--- a/openspec/changes/fix-api-key-dialog-dropdown-dismiss/design.md
+++ b/openspec/changes/fix-api-key-dialog-dropdown-dismiss/design.md
@@ -18,7 +18,9 @@
 
 ## Decision
 
-Add a narrowly scoped outside-interaction guard to the API-key create and edit dialog content. The guard prevents dialog dismissal only when the event target belongs to portalled dropdown content owned by the dialog. It does not globally disable outside interactions and does not change the dropdowns' modal/focus behavior.
+Add a narrowly scoped outside-interaction guard to the API-key create and edit dialog content. The guard prevents dialog dismissal only when the event target belongs to portalled dropdown content owned by the dialog. It does not globally disable outside interactions.
+
+Configure the nested model dropdown as non-modal. Radix otherwise composes two modal layers—a dropdown portal inside a dialog—and Chrome can dismiss the parent dialog during a checkbox selection even after the outside-interaction guard runs. The parent API-key dialog remains modal, so page content outside the editor is still protected.
 
 The implementation will reuse the same guard for both API-key dialogs because both embed the same portalled selectors. A regression test will exercise the externally failing edit path: open the dialog, open Allowed models, select a model, assert that the dialog remains open, submit, and assert that the selected allowlist is present in the update payload.
 

--- a/openspec/changes/fix-api-key-dialog-dropdown-dismiss/implementation-plan.md
+++ b/openspec/changes/fix-api-key-dialog-dropdown-dismiss/implementation-plan.md
@@ -1,0 +1,303 @@
+# API Key Dialog Dropdown Dismissal Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep API-key create/edit dialogs open during interactions with their portalled dropdowns while preserving ordinary outside-click dismissal, then deploy and verify the fix on the Ubuntu host.
+
+**Architecture:** A small API-key-specific event guard recognizes Radix dropdown content by its stable `data-slot="dropdown-menu-content"` marker. Both API-key dialogs pass the guard to `DialogContent.onInteractOutside`; integration coverage exercises the real edit flow rather than only testing the helper.
+
+**Tech Stack:** React 19, TypeScript 6, Radix UI, Testing Library, Vitest, Bun, Docker, FastAPI static frontend packaging.
+
+## Global Constraints
+
+- Preserve normal click-outside dismissal outside owned dropdown content.
+- Do not change API-key API, schema, authentication, routing, or enforcement semantics.
+- Preserve the live `codex-lb-data` named volume and the existing container runtime configuration.
+- Base the live image on deployed revision `17c1762d254b2f328b882d417adeb8ded2726ec4` (`v1.20.1`).
+- Keep the patch limited to API-key dialogs, their regression tests, and required OpenSpec artifacts.
+
+---
+
+### Task 1: Add a product-path regression test
+
+**Files:**
+- Modify: `frontend/src/features/api-keys/components/api-key-edit-dialog.test.tsx`
+
+**Interfaces:**
+- Consumes: `ApiKeyEditDialog` and existing `/api/models` MSW fixture.
+- Produces: regression test `keeps the dialog open while selecting a model and submits the selection`.
+
+- [ ] **Step 1: Add the failing integration test**
+
+Add a test that renders an open edit dialog with `allowedModels: ["gpt-5.5"]`, opens the `1 model selected` control, selects `gpt-5.6-sol`, asserts `Edit API key` remains present, clicks Save, and asserts `onSubmit.mock.calls[0][0].allowedModels` equals `["gpt-5.5", "gpt-5.6-sol"]`.
+
+```tsx
+it("keeps the dialog open while selecting a model and submits the selection", async () => {
+  const user = userEvent.setup();
+  const onSubmit = vi.fn().mockResolvedValue(undefined);
+  const onOpenChange = vi.fn();
+
+  renderWithProviders(
+    <ApiKeyEditDialog
+      open
+      busy={false}
+      apiKey={createApiKey({ allowedModels: ["gpt-5.5"] })}
+      onOpenChange={onOpenChange}
+      onSubmit={onSubmit}
+    />,
+  );
+
+  await user.click(await screen.findByRole("button", { name: "1 model selected" }));
+  await user.click(screen.getByRole("menuitemcheckbox", { name: "gpt-5.6-sol" }));
+
+  expect(screen.getByRole("dialog", { name: "Edit API key" })).toBeInTheDocument();
+  expect(onOpenChange).not.toHaveBeenCalledWith(false);
+
+  await user.click(screen.getByRole("button", { name: "Save" }));
+  await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+  expect(onSubmit.mock.calls[0][0].allowedModels).toEqual(["gpt-5.5", "gpt-5.6-sol"]);
+});
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run:
+
+```bash
+cd frontend
+bun test src/features/api-keys/components/api-key-edit-dialog.test.tsx -t "keeps the dialog open while selecting a model"
+```
+
+Expected: FAIL because the parent dialog closes or `onOpenChange(false)` is called after the portalled menu interaction.
+
+- [ ] **Step 3: Commit the red regression test**
+
+```bash
+git add frontend/src/features/api-keys/components/api-key-edit-dialog.test.tsx
+git commit -m "test(ui): reproduce API key dropdown dismissal"
+```
+
+### Task 2: Implement the targeted portal guard
+
+**Files:**
+- Create: `frontend/src/features/api-keys/components/api-key-dialog-interactions.ts`
+- Create: `frontend/src/features/api-keys/components/api-key-dialog-interactions.test.ts`
+- Modify: `frontend/src/features/api-keys/components/api-key-create-dialog.tsx`
+- Modify: `frontend/src/features/api-keys/components/api-key-edit-dialog.tsx`
+
+**Interfaces:**
+- Produces: `preventApiKeyDialogDropdownDismiss(event: { target: EventTarget | null; preventDefault(): void }): void`.
+- Consumes: Radix dropdown content marker `[data-slot="dropdown-menu-content"]`.
+
+- [ ] **Step 1: Add focused helper tests**
+
+Test that the helper calls `preventDefault` when the target is inside dropdown content and does not call it for an ordinary outside element.
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { preventApiKeyDialogDropdownDismiss } from "./api-key-dialog-interactions";
+
+describe("preventApiKeyDialogDropdownDismiss", () => {
+  it("prevents dismissal for portalled dropdown content", () => {
+    const content = document.createElement("div");
+    content.dataset.slot = "dropdown-menu-content";
+    const item = document.createElement("div");
+    content.append(item);
+    const preventDefault = vi.fn();
+
+    preventApiKeyDialogDropdownDismiss({ target: item, preventDefault });
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+
+  it("allows ordinary outside interactions", () => {
+    const preventDefault = vi.fn();
+
+    preventApiKeyDialogDropdownDismiss({
+      target: document.createElement("div"),
+      preventDefault,
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the helper test and verify RED**
+
+Run:
+
+```bash
+cd frontend
+bun test src/features/api-keys/components/api-key-dialog-interactions.test.ts
+```
+
+Expected: FAIL because `api-key-dialog-interactions.ts` does not exist.
+
+- [ ] **Step 3: Add the minimal helper**
+
+```ts
+type OutsideInteractionEvent = {
+  target: EventTarget | null;
+  preventDefault(): void;
+};
+
+export function preventApiKeyDialogDropdownDismiss(event: OutsideInteractionEvent): void {
+  if (
+    event.target instanceof Element &&
+    event.target.closest('[data-slot="dropdown-menu-content"]')
+  ) {
+    event.preventDefault();
+  }
+}
+```
+
+- [ ] **Step 4: Wire both API-key dialogs**
+
+Import the helper into `api-key-create-dialog.tsx` and `api-key-edit-dialog.tsx`, then pass it to each dialog content:
+
+```tsx
+<DialogContent
+  className="sm:max-w-3xl"
+  onInteractOutside={preventApiKeyDialogDropdownDismiss}
+>
+```
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+cd frontend
+bun test \
+  src/features/api-keys/components/api-key-dialog-interactions.test.ts \
+  src/features/api-keys/components/api-key-edit-dialog.test.tsx \
+  src/features/api-keys/components/api-key-create-dialog.test.tsx
+```
+
+Expected: all selected test files PASS, including the product-path regression.
+
+- [ ] **Step 6: Commit the implementation**
+
+```bash
+git add frontend/src/features/api-keys/components/api-key-dialog-interactions.ts \
+  frontend/src/features/api-keys/components/api-key-dialog-interactions.test.ts \
+  frontend/src/features/api-keys/components/api-key-create-dialog.tsx \
+  frontend/src/features/api-keys/components/api-key-edit-dialog.tsx
+git commit -m "fix(ui): keep API key dialogs open for dropdown interactions"
+```
+
+### Task 3: Run repository verification
+
+**Files:**
+- Modify: `openspec/changes/fix-api-key-dialog-dropdown-dismiss/tasks.md`
+
+**Interfaces:**
+- Consumes: completed frontend patch and OpenSpec change.
+- Produces: verified build artifacts suitable for image packaging.
+
+- [ ] **Step 1: Run the frontend quality gate**
+
+```bash
+cd frontend
+bun test src/features/api-keys/components
+bun run typecheck
+bun run lint
+bun run build
+```
+
+Expected: all commands exit 0 with no failing tests, type errors, lint errors, or build errors.
+
+- [ ] **Step 2: Validate OpenSpec**
+
+From the repository root:
+
+```bash
+openspec validate --specs
+```
+
+Expected: validation exits 0. If the CLI is unavailable, install/use the repository-documented OpenSpec runner and record that exact command in verification evidence.
+
+- [ ] **Step 3: Mark completed OpenSpec tasks and commit**
+
+Update only completed checkboxes in `tasks.md`, then:
+
+```bash
+git add openspec/changes/fix-api-key-dialog-dropdown-dismiss
+git commit -m "docs(openspec): record dropdown fix verification"
+```
+
+### Task 4: Build and deploy the patched 1.20.1 image
+
+**Files:**
+- No repository file changes.
+- Runtime target: `jianan@192.168.50.10`, container `codex-lb`.
+
+**Interfaces:**
+- Consumes: verified repository checkout and current container inspection.
+- Produces: local image `codex-lb:gpt56-dropdown-fix` and a healthy replacement container using `codex-lb-data`.
+
+- [ ] **Step 1: Capture rollback metadata**
+
+```bash
+ssh jianan@192.168.50.10 'docker inspect codex-lb' > work/codex-lb-container-before.json
+ssh jianan@192.168.50.10 'docker image inspect ghcr.io/soju06/codex-lb:latest --format "{{.Id}}"'
+```
+
+Expected: inspection JSON is non-empty and the prior image ID is recorded.
+
+- [ ] **Step 2: Build the patched image for the Ubuntu host architecture**
+
+Use the repository Dockerfile and the host's reported architecture. Build/tag `codex-lb:gpt56-dropdown-fix`; transfer it with `docker save | ssh ... docker load` if building on macOS, or build from the verified source on the Ubuntu Docker host.
+
+Expected: `docker image inspect codex-lb:gpt56-dropdown-fix` succeeds on Ubuntu.
+
+- [ ] **Step 3: Replace the container without changing runtime configuration**
+
+Recreate `codex-lb` from the captured inspection, preserving published ports `1455` and `2455`, restart policy, environment, command, and `codex-lb-data:/var/lib/codex-lb`. Do not delete or recreate the named volume.
+
+Expected: the new container reports image `codex-lb:gpt56-dropdown-fix` and the same volume/ports as the inspection snapshot.
+
+- [ ] **Step 4: Verify service and data**
+
+```bash
+curl -fsS http://192.168.50.10:2455/health
+ssh jianan@192.168.50.10 'docker inspect codex-lb --format "{{.Config.Image}} {{json .Mounts}} {{json .HostConfig.PortBindings}}"'
+```
+
+Expected: health returns `{"status":"ok"}`, the named volume remains `codex-lb-data`, and both port bindings remain present.
+
+### Task 5: Verify the original browser symptom and publish the upstream patch
+
+**Files:**
+- No additional code files unless verification exposes a regression.
+
+**Interfaces:**
+- Consumes: healthy live patched container and committed branch.
+- Produces: browser evidence and an upstream pull request.
+
+- [ ] **Step 1: Re-run the live browser reproduction**
+
+Open `/settings`, edit `ubuntu-hermes-agent-gpt55-active`, open Allowed models, toggle one model off and back on, and verify the dialog remains visible after each click. Save and verify the table still lists `gpt-5.5`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
+
+Expected: dialog stays open, Save completes, and the four-model allowlist persists after reload.
+
+- [ ] **Step 2: Verify normal outside dismissal**
+
+Reopen the edit dialog, click the overlay outside both the dialog and dropdown content, and verify the dialog closes.
+
+Expected: ordinary click-outside dismissal remains functional.
+
+- [ ] **Step 3: Push the branch and open the PR**
+
+Push `fix/api-key-dialog-dropdown-dismiss` to the authenticated contributor fork/remote and create a draft PR against `Soju06/codex-lb:main`. The PR title is:
+
+```text
+fix(ui): keep API key dialogs open for dropdown interactions
+```
+
+The body must include the exact 1.20.1 reproduction, regression-test evidence, frontend gate results, OpenSpec validation, live deployment verification, and a linked issue using `Fixes #N` if an issue exists; otherwise state that no issue was filed and keep the PR draft until maintainer guidance.
+
+- [ ] **Step 4: Report handoff and rollback**
+
+Provide the PR URL, live image tag/ID, prior image ID, health result, GUI verification result, and the exact rollback command derived from `work/codex-lb-container-before.json`.

--- a/openspec/changes/fix-api-key-dialog-dropdown-dismiss/proposal.md
+++ b/openspec/changes/fix-api-key-dialog-dropdown-dismiss/proposal.md
@@ -1,0 +1,15 @@
+## Why
+
+The API-key create and edit dialogs contain portalled model and account dropdowns. Interacting with a dropdown item is currently treated as an outside interaction by the parent dialog, which dismisses the dialog before the operator can save the changed selection.
+
+## What Changes
+
+- Keep API-key dialogs open while the operator interacts with their portalled dropdown content.
+- Preserve normal click-outside dismissal for interactions that do not originate in owned dropdown content.
+- Add product-path regression coverage for selecting models in the edit dialog and then saving the resulting allowlist.
+
+## Impact
+
+- Dashboard-only behavior change in API-key create/edit dialogs.
+- No API, database, authentication, or routing contract changes.
+- Existing keyboard and ordinary outside-click dismissal behavior remains in scope for regression verification.

--- a/openspec/changes/fix-api-key-dialog-dropdown-dismiss/tasks.md
+++ b/openspec/changes/fix-api-key-dialog-dropdown-dismiss/tasks.md
@@ -1,24 +1,24 @@
 ## 1. Regression coverage
 
-- [ ] Add an edit-dialog integration test that reproduces dropdown selection dismissing the parent dialog.
-- [ ] Run the focused test and confirm it fails for the expected dismissal behavior.
+- [x] Add an edit-dialog integration test that reproduces dropdown selection dismissing the parent dialog.
+- [x] Run the focused test and confirm it fails for the expected dismissal behavior.
 
 ## 2. Implementation
 
-- [ ] Add the smallest shared guard needed by the API-key create and edit dialogs.
-- [ ] Preserve ordinary outside-click dismissal and existing keyboard behavior.
+- [x] Add the smallest shared guard needed by the API-key create and edit dialogs.
+- [x] Preserve ordinary outside-click dismissal and existing keyboard behavior.
 
 ## 3. Verification
 
-- [ ] Run focused component and integration tests.
-- [ ] Run frontend typecheck, lint, and build checks.
-- [ ] Validate OpenSpec artifacts.
+- [x] Run focused component and integration tests.
+- [x] Run frontend typecheck, lint, and build checks.
+- [x] Validate OpenSpec artifacts.
 
 ## 4. Live deployment
 
-- [ ] Capture the current container runtime configuration and build a patched 1.20.1 image.
-- [ ] Replace the live container without changing the persistent data volume.
-- [ ] Verify health, API-key data, and the original multi-model GUI save flow.
+- [x] Capture the current container runtime configuration and build a patched 1.20.1 image.
+- [x] Replace the live container without changing the persistent data volume.
+- [x] Verify health, API-key data, and the original multi-model GUI save flow.
 
 ## 5. Upstream handoff
 

--- a/openspec/changes/fix-api-key-dialog-dropdown-dismiss/tasks.md
+++ b/openspec/changes/fix-api-key-dialog-dropdown-dismiss/tasks.md
@@ -1,0 +1,26 @@
+## 1. Regression coverage
+
+- [ ] Add an edit-dialog integration test that reproduces dropdown selection dismissing the parent dialog.
+- [ ] Run the focused test and confirm it fails for the expected dismissal behavior.
+
+## 2. Implementation
+
+- [ ] Add the smallest shared guard needed by the API-key create and edit dialogs.
+- [ ] Preserve ordinary outside-click dismissal and existing keyboard behavior.
+
+## 3. Verification
+
+- [ ] Run focused component and integration tests.
+- [ ] Run frontend typecheck, lint, and build checks.
+- [ ] Validate OpenSpec artifacts.
+
+## 4. Live deployment
+
+- [ ] Capture the current container runtime configuration and build a patched 1.20.1 image.
+- [ ] Replace the live container without changing the persistent data volume.
+- [ ] Verify health, API-key data, and the original multi-model GUI save flow.
+
+## 5. Upstream handoff
+
+- [ ] Commit the focused patch and push the branch.
+- [ ] Open an upstream-ready PR that reports the live reproduction and verification evidence.

--- a/openspec/changes/fix-api-key-dialog-dropdown-dismiss/tasks.md
+++ b/openspec/changes/fix-api-key-dialog-dropdown-dismiss/tasks.md
@@ -22,5 +22,5 @@
 
 ## 5. Upstream handoff
 
-- [ ] Commit the focused patch and push the branch.
-- [ ] Open an upstream-ready PR that reports the live reproduction and verification evidence.
+- [x] Commit the focused patch and push the branch.
+- [x] Open an upstream-ready PR that reports the live reproduction and verification evidence.


### PR DESCRIPTION
## Summary

- keep API-key create/edit dialogs open when a Radix dropdown portal receives an interaction
- preserve ordinary outside-click and keyboard dismissal
- add focused regression coverage and OpenSpec artifacts

## Exact 1.20.1 reproduction

On the deployed v1.20.1 dashboard, open Settings, edit the API key named ubuntu-hermes-agent-gpt55-active, open Allowed models, and select a model. Before this patch, the portalled dropdown interaction was treated as outside the parent dialog and dismissed the editor before Save.

The submitted branch is rebased onto current upstream main; the separate live deployment remains the exact verified v1.20.1-based build.

## Current-head regression evidence

Commands were run after refreshing this branch onto current upstream main:

- bun run test src/features/api-keys/components/api-key-dialog-interactions.test.ts src/features/api-keys/components/api-key-edit-dialog.test.tsx src/features/api-keys/components/api-key-create-dialog.test.tsx — 3 files, 28 tests passed
- bun run test src/features/api-keys/components — 12 files, 81 tests passed
- bun run typecheck — passed
- bun run lint — passed
- bun run build — passed; 1,764 modules transformed
- npx --yes @fission-ai/openspec@1.6.0 validate --specs — 30 specs passed, 0 failed

The first test attempt after switching to current main failed before test collection because the existing dependency install lacked current-main's new i18next dependency. bun install --frozen-lockfile aligned node_modules to the committed lockfile; every gate above then passed.

## Live deployment verification

Built and deployed the exact v1.20.1-based patch as codex-lb:gpt56-dropdown-fix (image sha256:51d5aaf496711337488cb798e82d6db75c8f2b0dccbad0cd73139e3521a1efd9) while preserving the codex-lb-data volume and runtime configuration.

At http://192.168.50.10:2455/settings:

- edited ubuntu-hermes-agent-gpt55-active
- toggled gpt-5.6-sol off and back on; the edit dialog remained open after both interactions
- added gpt-5.5, closed the dropdown with Escape, and saved
- reloaded and verified the four-model allowlist: gpt-5.5, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna
- verified enforced_model remains blank/null in the persisted api_keys row
- separately reopened the editor and verified an ordinary overlay click closes it
- external health returned {"status":"ok"}

## Issue

No matching issue was found or filed. This PR remains a draft pending maintainer guidance.
