### PR TITLE
fix(proxy): preserve native capability routing across failover

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -81,6 +81,7 @@ from app.core.utils.request_id import get_request_id
 from app.core.utils.sse import format_sse_event, parse_sse_data_json
 
 CODEX_INSTALLATION_ID_HEADER = "x-codex-installation-id"
+CODEX_TURN_METADATA_HEADER = "x-codex-turn-metadata"
 CODEX_RESPONSES_LITE_HEADER = "x-openai-internal-codex-responses-lite"
 CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY = "ws_request_header_x_openai_internal_codex_responses_lite"
 
@@ -472,19 +473,58 @@ def filter_inbound_headers(headers: Mapping[str, str]) -> dict[str, str]:
     return {key: value for key, value in headers.items() if not _should_drop_inbound_header(key)}
 
 
+def _rewrite_turn_metadata_installation_id(value: JsonValue, codex_installation_id: str | None) -> JsonValue:
+    if not codex_installation_id or not isinstance(value, str):
+        return value
+    try:
+        metadata = json.loads(value)
+    except json.JSONDecodeError:
+        return value
+    if not isinstance(metadata, dict):
+        return value
+    if "installation_id" not in metadata:
+        return value
+    metadata["installation_id"] = codex_installation_id
+    return json.dumps(metadata, ensure_ascii=True, separators=(",", ":"))
+
+
 def apply_codex_installation_metadata(payload: dict[str, JsonValue], codex_installation_id: str | None) -> None:
     raw_metadata = payload.get("client_metadata")
     client_metadata: dict[str, JsonValue] = {}
     if is_json_mapping(raw_metadata):
         for key, value in raw_metadata.items():
-            if isinstance(key, str) and key.lower() != CODEX_INSTALLATION_ID_HEADER:
-                client_metadata[key] = value
+            if not isinstance(key, str) or key.lower() == CODEX_INSTALLATION_ID_HEADER:
+                continue
+            client_metadata[key] = (
+                _rewrite_turn_metadata_installation_id(value, codex_installation_id)
+                if key.lower() == CODEX_TURN_METADATA_HEADER
+                else value
+            )
     if codex_installation_id:
         client_metadata[CODEX_INSTALLATION_ID_HEADER] = codex_installation_id
     if client_metadata:
         payload["client_metadata"] = client_metadata
     else:
         payload.pop("client_metadata", None)
+
+
+def apply_codex_installation_headers(
+    headers: Mapping[str, str],
+    codex_installation_id: str | None,
+) -> dict[str, str]:
+    """Keep canonical turn metadata consistent with the selected account."""
+    updated = dict(headers)
+    if not codex_installation_id:
+        return updated
+    for key, value in list(updated.items()):
+        lowered = key.lower()
+        if lowered == CODEX_INSTALLATION_ID_HEADER:
+            updated[key] = codex_installation_id
+        elif lowered == CODEX_TURN_METADATA_HEADER:
+            rewritten = _rewrite_turn_metadata_installation_id(value, codex_installation_id)
+            if isinstance(rewritten, str):
+                updated[key] = rewritten
+    return updated
 
 
 _NATIVE_CODEX_USER_AGENT_PREFIXES: tuple[str, ...] = (
@@ -2465,6 +2505,7 @@ async def _stream_responses_with_session(
     enforce_openai_sdk_contract: bool = True,
 ) -> AsyncIterator[str]:
     settings = get_settings()
+    headers = apply_codex_installation_headers(headers, codex_installation_id)
     upstream_base = (base_url or settings.upstream_base_url).rstrip("/")
     url = f"{upstream_base}/codex/responses"
     require_route_or_direct_egress_opt_in(

--- a/app/core/openai/model_refresh_scheduler.py
+++ b/app/core/openai/model_refresh_scheduler.py
@@ -91,7 +91,8 @@ class ModelRefreshScheduler:
                 detach_session_objects(session)
             grouped = _group_by_plan(accounts)
             if not grouped:
-                logger.debug("No active accounts for model registry refresh")
+                await get_model_registry().clear()
+                logger.info("Model registry cleared because no active accounts remain")
                 return
 
             encryptor = TokenEncryptor()
@@ -250,20 +251,18 @@ def _merge_same_plan_model_results(successful_results: list[list[UpstreamModel]]
     if not successful_results:
         return []
 
-    models_by_slug = [{model.slug: model for model in models} for models in successful_results]
-    common_slugs = set(models_by_slug[0])
-    for models in models_by_slug[1:]:
-        common_slugs.intersection_update(models)
-
-    merged_models: list[UpstreamModel] = []
-    for model in models_by_slug[0].values():
-        if model.slug not in common_slugs:
-            continue
-        merged_model = model
-        for models in models_by_slug[1:]:
-            merged_model = _merge_service_tier_metadata(merged_model, models[model.slug])
-        merged_models.append(merged_model)
-    return merged_models
+    # Catalog visibility can differ between accounts on the same plan because
+    # of staged rollouts, account capabilities, or experiments. Keep the union
+    # here and let ModelRegistry.model_accounts constrain request routing to the
+    # accounts whose own catalog actually advertised each model. Intersecting
+    # the slugs made one ineligible account erase a native model (and all of its
+    # reasoning/service-tier metadata) for every eligible account.
+    merged_by_slug: dict[str, UpstreamModel] = {}
+    for models in successful_results:
+        for model in models:
+            existing = merged_by_slug.get(model.slug)
+            merged_by_slug[model.slug] = model if existing is None else _merge_service_tier_metadata(existing, model)
+    return list(merged_by_slug.values())
 
 
 async def _ensure_fresh_with_transport_recovery(

--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -55,6 +55,8 @@ class ModelRegistrySnapshot:
     model_service_tier_accounts: dict[str, dict[str, frozenset[str]]]
     account_plans: dict[str, str]
     fetched_at: float
+    model_accounts: dict[str, frozenset[str]] = field(default_factory=dict)
+    account_catalogs_authoritative: bool = False
 
 
 _BOOTSTRAP_WEBSOCKET_PREFERRED_MODEL_PATTERNS = (
@@ -537,8 +539,32 @@ class ModelRegistry:
             slug
         ) or self._snapshot.model_service_tier_accounts.get(normalized_slug)
         if tier_accounts is None:
+            # Once per-account catalogs are populated, absence of tier metadata
+            # is authoritative: no discovered account advertised this tier.
+            # Returning None would fail open to plan-level routing.
+            if self._snapshot.account_catalogs_authoritative:
+                return frozenset()
             return None
         return tier_accounts.get(normalized_service_tier, frozenset())
+
+    def account_ids_for_model(self, slug: str) -> frozenset[str] | None:
+        """Return accounts whose own upstream catalog advertises ``slug``.
+
+        ``None`` means account-level catalog data is unavailable, so callers
+        should retain the older plan-level fallback. An empty set means the
+        account-level catalog is authoritative and no active account supports
+        the model.
+        """
+        if self._snapshot is None:
+            return None
+        normalized_slug = slug.strip().lower()
+        if not normalized_slug:
+            return None
+        if not self._snapshot.account_catalogs_authoritative:
+            return None
+        return self._snapshot.model_accounts.get(slug) or self._snapshot.model_accounts.get(
+            normalized_slug, frozenset()
+        )
 
     def prefers_websockets(self, slug: str | None) -> bool:
         if not isinstance(slug, str):
@@ -564,6 +590,21 @@ class ModelRegistry:
             return True
         return (time.monotonic() - self._snapshot.fetched_at) >= self._ttl_seconds
 
+    async def clear(self) -> None:
+        """Publish an authoritative empty snapshot when no active accounts exist."""
+        async with self._lock:
+            self._snapshot = ModelRegistrySnapshot(
+                models={},
+                model_plans={},
+                plan_models={},
+                model_service_tier_plans={},
+                model_service_tier_accounts={},
+                account_plans={},
+                fetched_at=time.monotonic(),
+                model_accounts={},
+                account_catalogs_authoritative=True,
+            )
+
     async def update(
         self,
         per_plan_results: dict[str, list[UpstreamModel]],
@@ -582,6 +623,7 @@ class ModelRegistry:
                 model_plans: dict[str, set[str]] = {}
                 model_service_tier_plans: dict[str, dict[str, set[str]]] = {}
                 model_service_tier_accounts: dict[str, dict[str, set[str]]] = {}
+                model_accounts: dict[str, set[str]] = {}
                 account_plans: dict[str, str] = {}
 
                 # Carry over data from plans not present in per_plan_results
@@ -589,18 +631,25 @@ class ModelRegistry:
                     previous_plans = set(previous.plan_models.keys())
                     refreshed_plans = set(per_plan_results.keys())
                     stale_plans = previous_plans - refreshed_plans
-                    stale_account_ids = {
-                        account_id
-                        for account_id, plan_type in previous.account_plans.items()
-                        if plan_type in stale_plans
-                    }
                     if active_account_plans is not None:
+                        stale_plans.intersection_update(active_account_plans.values())
+                        stale_account_ids = {
+                            account_id
+                            for account_id, plan_type in previous.account_plans.items()
+                            if account_id in active_account_plans and plan_type in stale_plans
+                        }
                         refreshed_account_ids = set(per_account_results or {})
                         stale_account_ids.update(
                             account_id
                             for account_id in previous.account_plans
                             if account_id in active_account_plans and account_id not in refreshed_account_ids
                         )
+                    else:
+                        stale_account_ids = {
+                            account_id
+                            for account_id, plan_type in previous.account_plans.items()
+                            if plan_type in stale_plans
+                        }
 
                     for plan_type in stale_plans:
                         stale_slugs = previous.plan_models.get(plan_type, frozenset())
@@ -622,6 +671,10 @@ class ModelRegistry:
                         )
                         if plan_type is not None:
                             account_plans[account_id] = plan_type
+                    for slug, account_ids in previous.model_accounts.items():
+                        stale_model_accounts = account_ids & stale_account_ids
+                        if stale_model_accounts:
+                            model_accounts.setdefault(slug, set()).update(stale_model_accounts)
                     for slug, tier_accounts in previous.model_service_tier_accounts.items():
                         for service_tier, account_ids in tier_accounts.items():
                             stale_tier_accounts = account_ids & stale_account_ids
@@ -652,6 +705,7 @@ class ModelRegistry:
                     for account_id, (plan_type, account_models) in per_account_results.items():
                         account_plans[account_id] = plan_type
                         for model in account_models:
+                            model_accounts.setdefault(model.slug, set()).add(account_id)
                             for service_tier in _model_service_tier_keys(model):
                                 model_service_tier_accounts.setdefault(model.slug, {}).setdefault(
                                     service_tier, set()
@@ -667,6 +721,9 @@ class ModelRegistry:
                 frozen_model_service_tier_accounts: dict[str, dict[str, frozenset[str]]] = {
                     slug: {service_tier: frozenset(account_ids) for service_tier, account_ids in tier_accounts.items()}
                     for slug, tier_accounts in model_service_tier_accounts.items()
+                }
+                frozen_model_accounts: dict[str, frozenset[str]] = {
+                    slug: frozenset(account_ids) for slug, account_ids in model_accounts.items()
                 }
 
                 # Build reverse index: plan_type -> set of slugs
@@ -687,6 +744,8 @@ class ModelRegistry:
                     model_service_tier_accounts=frozen_model_service_tier_accounts,
                     account_plans=account_plans,
                     fetched_at=time.monotonic(),
+                    model_accounts=frozen_model_accounts,
+                    account_catalogs_authoritative=per_account_results is not None,
                 )
             except Exception:
                 self._snapshot = previous

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -1363,11 +1363,17 @@ class _HTTPBridgeMixin(
                         preferred_account_id=preferred_account_id,
                         require_preferred_account=require_preferred_account,
                     )
+                    and _http_bridge_session_supports_service_tier(
+                        session,
+                        request_model=request_model,
+                        request_service_tier=request_service_tier,
+                    )
                 ):
                     current_instance = settings.http_responses_session_bridge_instance_id
                     if _durable_bridge_lookup_allows_local_reuse(durable_lookup, current_instance=current_instance):
                         session.api_key = api_key
                         session.request_model = request_model
+                        session.request_service_tier = request_service_tier
                         session.last_used_at = _service_time().monotonic()
                         return session
                 if not session.closed and session.account.status == AccountStatus.ACTIVE:

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -1076,16 +1076,11 @@ class _HTTPBridgeRequestSubmitMixin:
             # upstream already accepted the continuation. Re-sending the same
             # previous_response_id request can fork continuity with duplicate
             # child responses, so only reconnect-without-resend is allowed.
-            # The single exception is proxy-injected anchors on trim-safe
-            # full-resend payloads: dropping the anchor and replaying the
-            # original unanchored request is equivalent to the client's own
-            # retry. Session-level injections do not opt in because their
-            # payload may depend on the anchor for context preservation.
-            if (
-                not request_state.proxy_injected_previous_response_id
-                or not request_state.fresh_upstream_request_text
-                or not request_state.fresh_upstream_request_is_retry_safe
-            ):
+            # The exception is a verified full-resend payload with a prepared
+            # unanchored body. Dropping the anchor and replaying that body is
+            # equivalent to the client's own fresh retry. Short continuations
+            # do not opt in because they depend on owner-scoped context.
+            if not (request_state.fresh_upstream_request_text and request_state.fresh_upstream_request_is_retry_safe):
                 return False
             retry_text_data = request_state.fresh_upstream_request_text
             using_fresh_replay = True
@@ -1139,15 +1134,13 @@ class _HTTPBridgeRequestSubmitMixin:
                 return False
             request_state = retryable_requests[0]
             if request_state.previous_response_id is not None and not (
-                request_state.proxy_injected_previous_response_id
-                and request_state.fresh_upstream_request_is_retry_safe
-                and request_state.fresh_upstream_request_text
+                request_state.fresh_upstream_request_is_retry_safe and request_state.fresh_upstream_request_text
             ):
                 # Once a continuation is pending upstream, reconnecting without
                 # replay cannot complete the current request, while replaying it
                 # is unsafe without upstream idempotency guarantees. Proxy-
-                # injected retry-safe anchors are equivalent to the client's own
-                # full resend once the anchor is stripped.
+                # retry-safe full resends are equivalent to the client's own
+                # fresh retry once the owner-scoped anchor is stripped.
                 return False
             close_classification = _classify_upstream_close(
                 session.last_upstream_close_code,

--- a/app/modules/proxy/_service/http_bridge/service_stubs.py
+++ b/app/modules/proxy/_service/http_bridge/service_stubs.py
@@ -351,6 +351,10 @@ def _prepare_websocket_request_state_for_visible_output_replay(*args: Any, **kwa
     return _service_global("_prepare_websocket_request_state_for_visible_output_replay")(*args, **kwargs)
 
 
+def _websocket_client_previous_response_full_resend_is_retry_safe(*args: Any, **kwargs: Any) -> Any:
+    return _service_global("_websocket_client_previous_response_full_resend_is_retry_safe")(*args, **kwargs)
+
+
 def _prepare_websocket_request_state_for_auth_replay(*args: Any, **kwargs: Any) -> Any:
     return _service_global("_prepare_websocket_request_state_for_auth_replay")(*args, **kwargs)
 

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -106,6 +106,7 @@ from app.modules.proxy._service.http_bridge.service_stubs import (
     _service_get_settings_cache,
     _service_time,
     _stream_keepalive_max_count,
+    _websocket_client_previous_response_full_resend_is_retry_safe,
     _websocket_downstream_response_id,
     _websocket_event_error_code,
     _websocket_event_error_message,
@@ -568,6 +569,7 @@ class _HTTPBridgeStreamingMixin:
         untrimmed_effective_payload = payload
         proxy_injected_previous_response_id = False
         fresh_upstream_request_text: str | None = None
+        fresh_replay_payload: ResponsesRequest | None = None
         previous_response_trimmed_input_count: int | None = None
         previous_response_trimmed_input_fingerprint: str | None = None
         durable_full_resend_anchor_count: int | None = None
@@ -629,6 +631,14 @@ class _HTTPBridgeStreamingMixin:
                     )
         if effective_payload.previous_response_id is not None and isinstance(effective_payload.input, list):
             previous_response_input_items = cast(list[JsonValue], effective_payload.input)
+            if _websocket_client_previous_response_full_resend_is_retry_safe(
+                previous_response_id=effective_payload.previous_response_id,
+                input_value=effective_payload.input,
+                continuity_state=None,
+            ):
+                fresh_replay_payload = effective_payload.model_copy(update={"previous_response_id": None})
+                _fresh_request_state, fresh_upstream_request_text = prepare_bridge_request(fresh_replay_payload)
+                del _fresh_request_state
             trimmed_input_items = _trim_http_bridge_previous_response_input_items(previous_response_input_items)
             if len(trimmed_input_items) != len(previous_response_input_items):
                 previous_response_trimmed_input_count = len(previous_response_input_items)
@@ -652,6 +662,9 @@ class _HTTPBridgeStreamingMixin:
                 else None,
                 effective_payload.previous_response_id,
             )
+        if fresh_replay_payload is not None and fresh_upstream_request_text is not None:
+            request_state.fresh_upstream_request_text = fresh_upstream_request_text
+            request_state.fresh_upstream_request_is_retry_safe = True
         request_state.transport = _REQUEST_TRANSPORT_HTTP
         request_state.request_stage = _http_bridge_request_stage(
             headers=headers,
@@ -689,18 +702,44 @@ class _HTTPBridgeStreamingMixin:
                 surface="http_bridge",
             )
         if request_state.previous_response_id is not None and request_state.preferred_account_id is None:
-            message = "Previous response owner account is unavailable; retry later."
-            _record_continuity_fail_closed(
-                surface="http_bridge",
-                reason="owner_account_unavailable",
-                previous_response_id=request_state.previous_response_id,
-                session_id=request_state.session_id,
-                upstream_error_code="owner_lookup_miss",
-            )
-            raise ProxyResponseError(
-                502,
-                openai_error("previous_response_owner_unavailable", message),
-            )
+            if fresh_replay_payload is not None:
+                _log_http_bridge_event(
+                    "owner_lookup_miss_fresh_resend",
+                    bridge_session_key,
+                    account_id=None,
+                    model=payload.model,
+                    detail="outcome=fresh_full_resend_without_anchor",
+                    cache_key_family=bridge_session_key.affinity_kind,
+                    model_class=_extract_model_class(payload.model) if payload.model else None,
+                )
+                effective_payload = fresh_replay_payload
+                untrimmed_effective_payload = fresh_replay_payload
+                request_state, text_data = prepare_bridge_request(fresh_replay_payload)
+                request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
+                request_state.affinity_policy = affinity
+                if downstream_turn_state is not None:
+                    request_state.session_id = _normalize_session_id(downstream_turn_state)
+                request_state.transport = _REQUEST_TRANSPORT_HTTP
+                request_state.request_stage = _http_bridge_request_stage(
+                    headers=headers,
+                    payload=fresh_replay_payload,
+                    durable_lookup=None,
+                )
+                fresh_replay_payload = None
+                fresh_upstream_request_text = None
+            else:
+                message = "Previous response owner account is unavailable; retry later."
+                _record_continuity_fail_closed(
+                    surface="http_bridge",
+                    reason="owner_account_unavailable",
+                    previous_response_id=request_state.previous_response_id,
+                    session_id=request_state.session_id,
+                    upstream_error_code="owner_lookup_miss",
+                )
+                raise ProxyResponseError(
+                    502,
+                    openai_error("previous_response_owner_unavailable", message),
+                )
         file_required_preferred_account = False
         if request_state.preferred_account_id is None:
             # ``input_file.file_id`` references must land on the account
@@ -759,13 +798,19 @@ class _HTTPBridgeStreamingMixin:
                     request_deadline=request_deadline,
                 )
             except ProxyResponseError as exc:
-                if not (
+                retry_safe_fresh_resend = bool(
                     _http_bridge_is_previous_response_owner_unavailable(exc)
-                    and proxy_injected_previous_response_id
+                    and fresh_replay_payload is not None
                     and fresh_upstream_request_text is not None
-                    and durable_full_resend_anchor_count is not None
-                    and durable_full_resend_anchor_fingerprint is not None
-                ):
+                    and (
+                        not proxy_injected_previous_response_id
+                        or (
+                            durable_full_resend_anchor_count is not None
+                            and durable_full_resend_anchor_fingerprint is not None
+                        )
+                    )
+                )
+                if not retry_safe_fresh_resend:
                     wait_plan = _http_bridge_capacity_wait_plan(exc, request_deadline=request_deadline)
                     if wait_plan is not None:
                         bounded_wait_seconds, account_capacity_wait_seconds, message = wait_plan
@@ -797,14 +842,15 @@ class _HTTPBridgeStreamingMixin:
                     cache_key_family=bridge_session_key.affinity_kind,
                     model_class=_extract_model_class(payload.model) if payload.model else None,
                 )
-                request_state, text_data = prepare_bridge_request(payload)
+                assert fresh_replay_payload is not None
+                request_state, text_data = prepare_bridge_request(fresh_replay_payload)
                 request_state.affinity_policy = affinity
                 if downstream_turn_state is not None:
                     request_state.session_id = _normalize_session_id(downstream_turn_state)
                 request_state.transport = _REQUEST_TRANSPORT_HTTP
                 request_state.request_stage = _http_bridge_request_stage(
                     headers=headers,
-                    payload=payload,
+                    payload=fresh_replay_payload,
                     durable_lookup=None,
                 )
                 file_required_preferred_account = False
@@ -816,9 +862,11 @@ class _HTTPBridgeStreamingMixin:
                     if resolved_file_account_id is not None:
                         request_state.preferred_account_id = resolved_file_account_id
                         file_required_preferred_account = True
-                effective_payload = payload
-                untrimmed_effective_payload = payload
+                effective_payload = fresh_replay_payload
+                untrimmed_effective_payload = fresh_replay_payload
                 proxy_injected_previous_response_id = False
+                fresh_replay_payload = None
+                fresh_upstream_request_text = None
                 previous_response_trimmed_input_count = None
                 previous_response_trimmed_input_fingerprint = None
                 durable_full_resend_anchor_count = None

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -685,6 +685,14 @@ class _HTTPBridgeUpstreamEventsMixin:
                 setattr(status_request_state, "account_health_error_handled", True)
             if (
                 status_request_state is not None
+                and status_request_state.fresh_upstream_request_is_retry_safe
+                and status_request_state.fresh_upstream_request_text
+            ):
+                retried = await self._retry_http_bridge_precreated_request(session)
+                if retried:
+                    return
+            if (
+                status_request_state is not None
                 and status_request_state.previous_response_id is not None
                 and status_request_state.preferred_account_id is not None
             ):

--- a/app/modules/proxy/_service/response_create.py
+++ b/app/modules/proxy/_service/response_create.py
@@ -19,6 +19,7 @@ from app.core.clients.proxy import (
     ProxyResponseError,
     _inline_content_images,
     _normalize_responses_lite_websocket_client_metadata,
+    apply_codex_installation_metadata,
 )
 from app.core.config.settings import DEFAULT_HOME_DIR, get_settings
 from app.core.errors import OpenAIErrorEnvelope, openai_error
@@ -217,12 +218,7 @@ def _response_create_text_with_account_installation_id(
         return text_data
     upstream_payload = cast(dict[str, JsonValue], raw_payload)
 
-    raw_metadata = upstream_payload.get("client_metadata")
-    client_metadata: dict[str, JsonValue] = {}
-    if is_json_mapping(raw_metadata):
-        client_metadata.update({key: value for key, value in raw_metadata.items() if isinstance(key, str)})
-    client_metadata["x-codex-installation-id"] = installation_id
-    upstream_payload["client_metadata"] = client_metadata
+    apply_codex_installation_metadata(upstream_payload, installation_id)
     return json.dumps(upstream_payload, ensure_ascii=True, separators=(",", ":"))
 
 
@@ -805,8 +801,10 @@ def _response_create_client_metadata(
     if isinstance(turn_metadata, str) and turn_metadata.strip():
         client_metadata.setdefault("x-codex-turn-metadata", turn_metadata)
 
-    if codex_installation_id:
-        client_metadata[CODEX_INSTALLATION_ID_HEADER] = codex_installation_id
+    metadata_container: dict[str, JsonValue] = {"client_metadata": client_metadata}
+    apply_codex_installation_metadata(metadata_container, codex_installation_id)
+    normalized_metadata = metadata_container.get("client_metadata")
+    client_metadata = dict(normalized_metadata) if is_json_mapping(normalized_metadata) else {}
     client_metadata = _normalize_responses_lite_websocket_client_metadata(
         payload,
         client_metadata,

--- a/app/modules/proxy/_service/streaming/protocol.py
+++ b/app/modules/proxy/_service/streaming/protocol.py
@@ -12,6 +12,7 @@ class _StreamingServiceProtocol(Protocol):
     _handle_stream_error: Any
     _load_balancer: Any
     _maybe_touch_api_key_reservation: Any
+    _remember_websocket_previous_response_owner: Any
     _raise_for_unsupported_input_image_references: Any
     _release_unsettled_stream_api_key_usage: Any
     _resolve_file_account_for_responses: Any

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -230,12 +230,43 @@ class _StreamingRetryMixin:
         preferred_account_id: str | None = None
         file_preferred_account_id: str | None = rewritten_file_account_id
         require_preferred_account = False
+        fresh_replay_payload: ResponsesRequest | None = None
+        if (
+            payload.previous_response_id is not None
+            and rewritten_file_account_id is None
+            and _facade()._websocket_client_previous_response_full_resend_is_retry_safe(
+                previous_response_id=payload.previous_response_id,
+                input_value=payload.input,
+                continuity_state=None,
+            )
+        ):
+            fresh_replay_payload = payload.model_copy(update={"previous_response_id": None})
         last_retryable_stream_error: _RetryableStreamError | None = None
         require_security_work_authorized = False
         account_leases: list[AccountLease] = []
         estimated_lease_tokens = _facade()._estimated_lease_tokens_from_request_usage_budget(
             estimate_api_key_request_usage(payload)
         )
+
+        def activate_fresh_replay() -> bool:
+            nonlocal payload, preferred_account_id, require_preferred_account, fresh_replay_payload
+            if fresh_replay_payload is None or file_preferred_account_id is not None:
+                return False
+            payload = fresh_replay_payload
+            fresh_replay_payload = None
+            preferred_account_id = None
+            require_preferred_account = False
+            return True
+
+        def remember_success_owner(account_id: str) -> None:
+            if not settlement.record_success or settlement.response_id is None:
+                return
+            proxy._remember_websocket_previous_response_owner(
+                previous_response_id=settlement.response_id,
+                api_key_id=api_key.id if api_key is not None else None,
+                account_id=account_id,
+                session_id=_owner_lookup_session_id_from_headers(headers),
+            )
 
         async def _release_tracked_stream_lease(lease: AccountLease | None) -> None:
             if lease is None:
@@ -279,7 +310,7 @@ class _StreamingRetryMixin:
                         additional_limit_name=None,
                         account_ids=None,
                     )
-                    if len(selection_inputs.accounts) != 1:
+                    if len(selection_inputs.accounts) != 1 and not activate_fresh_replay():
                         message = "Previous response owner account is unavailable; retry later."
                         _record_continuity_fail_closed(
                             surface="http_stream",
@@ -490,6 +521,8 @@ class _StreamingRetryMixin:
                             ),
                         )
                     if require_preferred_account and preferred_account_id is not None:
+                        if activate_fresh_replay():
+                            continue
                         message = "Previous response owner account is unavailable; retry later."
                         _record_continuity_fail_closed(
                             surface="http_stream",
@@ -619,6 +652,10 @@ class _StreamingRetryMixin:
                     and preferred_account_id is not None
                     and account.id != preferred_account_id
                 ):
+                    if activate_fresh_replay():
+                        await _release_tracked_stream_lease(current_account_lease)
+                        current_account_lease = None
+                        continue
                     message = "Previous response owner account is unavailable; retry later."
                     _record_continuity_fail_closed(
                         surface="http_stream",
@@ -816,7 +853,9 @@ class _StreamingRetryMixin:
                                 useragent=useragent,
                                 useragent_group=useragent_group,
                                 client_ip=client_ip,
-                                preferred_account_id=preferred_account_id,
+                                preferred_account_id=(
+                                    None if fresh_replay_payload is not None else preferred_account_id
+                                ),
                                 tool_call_dedupe=tool_call_dedupe,
                                 enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                             ):
@@ -953,6 +992,8 @@ class _StreamingRetryMixin:
                                     await _release_tracked_stream_lease(current_account_lease)
                                     current_account_lease = None
                                     excluded_account_ids.add(account.id)
+                                    if require_preferred_account:
+                                        activate_fresh_replay()
                                     break
                                 raise
                             transient_retries += 1
@@ -1010,6 +1051,7 @@ class _StreamingRetryMixin:
                             )
                         elif settlement.record_success:
                             await proxy._load_balancer.record_success(account)
+                            remember_success_owner(account.id)
                         settled = await proxy._settle_stream_api_key_usage(
                             api_key,
                             api_key_reservation,
@@ -1061,6 +1103,8 @@ class _StreamingRetryMixin:
                         await _release_tracked_stream_lease(current_account_lease)
                         current_account_lease = None
                         excluded_account_ids.add(account.id)
+                    if require_preferred_account:
+                        activate_fresh_replay()
                     continue
                 except _TerminalStreamError as exc:
                     if _facade()._should_penalize_stream_error(exc.code):
@@ -1319,6 +1363,7 @@ class _StreamingRetryMixin:
                             )
                         elif settlement.record_success:
                             await proxy._load_balancer.record_success(account)
+                            remember_success_owner(account.id)
                         settled = await proxy._settle_stream_api_key_usage(
                             api_key,
                             api_key_reservation,

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -480,10 +480,17 @@ def _http_bridge_session_supports_service_tier(
     request_model: str | None,
     request_service_tier: str | None,
 ) -> bool:
-    if request_model is None or request_service_tier is None:
+    if request_model is None:
         return True
 
     registry = get_model_registry()
+    account_ids_for_model = getattr(registry, "account_ids_for_model", None)
+    model_account_ids = account_ids_for_model(request_model) if callable(account_ids_for_model) else None
+    if model_account_ids is not None and session.account.id not in model_account_ids:
+        return False
+    if request_service_tier is None:
+        return True
+
     allowed_account_ids = registry.account_ids_for_model_service_tier(request_model, request_service_tier)
     if allowed_account_ids is not None:
         return session.account.id in allowed_account_ids

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -348,6 +348,7 @@ def _prepare_websocket_request_state_for_visible_output_replay(
     if request_state.fresh_upstream_request_is_retry_safe and request_state.fresh_upstream_request_text:
         request_state.request_text = request_state.fresh_upstream_request_text
         request_state.previous_response_id = None
+        request_state.preferred_account_id = None
         request_state.proxy_injected_previous_response_id = False
         request_state.fresh_upstream_request_is_retry_safe = False
         request_state.responses_lite_model = request_state.fresh_upstream_request_responses_lite_model

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -36,6 +36,7 @@ from app.core.clients.proxy import (  # noqa: F401  # noqa: F401
     _payload_has_responses_lite_websocket_marker,
     _payload_uses_responses_lite,
     _ws_transport_payload_budget_bytes,
+    apply_codex_installation_headers,
     apply_codex_installation_metadata,
     filter_inbound_headers,
     pop_compact_timeout_overrides,
@@ -580,6 +581,25 @@ def _websocket_enforce_response_create_text_size(
         request_state.request_text = original_request_text
 
 
+def _prepare_websocket_request_state_for_account_switch(
+    request_state: _WebSocketRequestState,
+) -> str | None:
+    """Return an unsent request body that is safe to move to another account."""
+
+    if request_state.previous_response_id is None:
+        return request_state.request_text
+    if not (request_state.fresh_upstream_request_is_retry_safe and request_state.fresh_upstream_request_text):
+        return None
+
+    request_state.request_text = request_state.fresh_upstream_request_text
+    request_state.previous_response_id = None
+    request_state.preferred_account_id = None
+    request_state.proxy_injected_previous_response_id = False
+    request_state.fresh_upstream_request_is_retry_safe = False
+    request_state.responses_lite_model = request_state.fresh_upstream_request_responses_lite_model
+    return request_state.request_text
+
+
 class _WebSocketMixin:
     def _websocket_continuity_state_for_request(
         self,
@@ -649,6 +669,28 @@ class _WebSocketMixin:
             nonlocal account_lease
             await proxy._load_balancer.release_account_lease(account_lease)
             account_lease = None
+
+        async def retire_current_upstream() -> None:
+            nonlocal account, upstream, upstream_control, upstream_reader
+            if upstream_control is not None:
+                # The reader's cancellation finalizer must not close the
+                # downstream socket while the unsent request is still queued.
+                upstream_control.reconnect_requested = True
+            if upstream_reader is not None:
+                await _facade()._await_cancelled_task(
+                    upstream_reader,
+                    label="proxy websocket upstream reader",
+                )
+                upstream_reader = None
+            upstream_control = None
+            if upstream is not None:
+                try:
+                    await upstream.close()
+                except Exception:
+                    _facade().logger.debug("Failed to retire upstream websocket", exc_info=True)
+            upstream = None
+            await release_current_account_lease()
+            account = None
 
         try:
             while True:
@@ -1038,6 +1080,81 @@ class _WebSocketMixin:
                                     pending_requests.remove(request_state)
                         await _release_websocket_response_create_gate(request_state, response_create_gate)
                         raise
+
+                if (
+                    request_state is not None
+                    and request_state_registered
+                    and text_data is not None
+                    and payload is not None
+                    and _is_websocket_response_create(payload)
+                    and upstream is not None
+                    and account is not None
+                ):
+                    (
+                        validated_account,
+                        validation_code,
+                        validation_message,
+                    ) = await proxy._revalidate_open_websocket_account(
+                        account,
+                        request_state=request_state,
+                        api_key=request_state.api_key or api_key,
+                    )
+                    if validated_account is not None:
+                        account = validated_account
+                    else:
+                        current_account_id = account.id
+                        safe_request_text = _prepare_websocket_request_state_for_account_switch(request_state)
+                        await retire_current_upstream()
+                        if safe_request_text is None:
+                            message = "Previous response owner account is unavailable; retry later."
+                            _record_continuity_fail_closed(
+                                surface="websocket_revalidate",
+                                reason=validation_code or "owner_account_unavailable",
+                                previous_response_id=request_state.previous_response_id,
+                                session_id=request_state.session_id,
+                                upstream_error_code="previous_response_owner_unavailable",
+                            )
+                            async with pending_lock:
+                                if request_state in pending_requests:
+                                    pending_requests.remove(request_state)
+                            await proxy._emit_websocket_connect_failure(
+                                websocket,
+                                client_send_lock=client_send_lock,
+                                account_id=current_account_id,
+                                api_key=request_state.api_key or api_key,
+                                request_state=request_state,
+                                status_code=502,
+                                payload=openai_error(
+                                    "previous_response_owner_unavailable",
+                                    message,
+                                    error_type="server_error",
+                                ),
+                                error_code="previous_response_owner_unavailable",
+                                error_message=message,
+                            )
+                            continue
+                        text_data = safe_request_text
+                        payload = _parse_websocket_payload(text_data)
+                        if payload is None:
+                            async with pending_lock:
+                                if request_state in pending_requests:
+                                    pending_requests.remove(request_state)
+                            await proxy._emit_websocket_connect_failure(
+                                websocket,
+                                client_send_lock=client_send_lock,
+                                account_id=current_account_id,
+                                api_key=request_state.api_key or api_key,
+                                request_state=request_state,
+                                status_code=503,
+                                payload=openai_error(
+                                    "websocket_account_unavailable",
+                                    validation_message or "Current websocket account is unavailable",
+                                    error_type="server_error",
+                                ),
+                                error_code="websocket_account_unavailable",
+                                error_message=validation_message or "Current websocket account is unavailable",
+                            )
+                            continue
 
                 if upstream is None:
                     if text_data is not None and payload is None:
@@ -1575,6 +1692,46 @@ class _WebSocketMixin:
             request_state=request_state,
             affinity_policy=affinity_policy,
         )
+
+    async def _revalidate_open_websocket_account(
+        self,
+        account: Account,
+        *,
+        request_state: _WebSocketRequestState,
+        api_key: ApiKeyData | None,
+    ) -> tuple[Account | None, str | None, str | None]:
+        """Revalidate an already-open upstream socket for the next unsent turn."""
+
+        proxy = cast(_WebSocketServiceProtocol, self)
+        preferred_account_id = request_state.preferred_account_id
+        if preferred_account_id is not None and preferred_account_id != account.id:
+            return (
+                None,
+                "preferred_account_mismatch",
+                "Current websocket account does not own this request's continuity state",
+            )
+
+        deadline = _websocket_connect_deadline(
+            request_state,
+            _facade().get_settings().proxy_request_budget_seconds,
+        )
+        selection = await proxy._select_account_with_budget_compatible(
+            deadline,
+            request_id=request_state.request_log_id or request_state.request_id,
+            kind="websocket_revalidate",
+            request_stage=request_state.request_stage,
+            api_key=api_key,
+            model=request_state.model,
+            service_tier=request_state.requested_service_tier,
+            preferred_account_id=account.id,
+            require_security_work_authorized=request_state.require_security_work_authorized,
+            fallback_on_preferred_account_unavailable=False,
+        )
+        await proxy._load_balancer.release_account_lease(selection.lease)
+        selected_account = selection.account
+        if selected_account is None or selected_account.id != account.id:
+            return None, selection.error_code, selection.error_message
+        return selected_account, None, None
 
     async def _connect_proxy_websocket(
         self,
@@ -2266,6 +2423,7 @@ class _WebSocketMixin:
         proxy = cast(_WebSocketServiceProtocol, self)
         _ = proxy
         access_token = proxy._encryptor.decrypt(account.access_token_encrypted)
+        headers = apply_codex_installation_headers(headers, getattr(account, "codex_installation_id", None))
         account_id = _header_account_id(account.chatgpt_account_id)
         connect_lease = await proxy._get_work_admission().acquire_websocket_connect()
         try:
@@ -3111,11 +3269,19 @@ class _WebSocketMixin:
                 payload=payload,
                 has_other_pending_requests=has_other_pending_requests,
             )
+        retry_safe_owner_replay = bool(
+            retry_error_code in _facade()._WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES
+            and request_state.previous_response_id is not None
+            and request_state.preferred_account_id is not None
+            and request_state.fresh_upstream_request_is_retry_safe
+            and request_state.fresh_upstream_request_text
+        )
         if (
             retry_error_code in _facade()._WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES
             and request_state.previous_response_id is not None
             and request_state.preferred_account_id is not None
             and not retry_safe_previous_response_not_found
+            and not retry_safe_owner_replay
         ):
             await proxy._handle_stream_error(
                 account,
@@ -3126,6 +3292,12 @@ class _WebSocketMixin:
                 request_state=request_state,
             )
             retry_error_code = None
+        if retry_safe_owner_replay and not retry_safe_previous_response_not_found:
+            safe_request_text = _prepare_websocket_request_state_for_account_switch(request_state)
+            if safe_request_text is None:
+                retry_error_code = None
+            else:
+                request_state.request_text = safe_request_text
         if retry_error_code is not None:
             if retry_is_previous_response_not_found:
                 if not (

--- a/app/modules/proxy/_service/websocket/protocol.py
+++ b/app/modules/proxy/_service/websocket/protocol.py
@@ -35,6 +35,7 @@ class _WebSocketServiceProtocol(Protocol):
     _process_upstream_websocket_text: Any
     _raise_for_unsupported_input_image_references: Any
     _refresh_websocket_api_key_policy: Any
+    _revalidate_open_websocket_account: Any
     _relay_upstream_websocket_messages: Any
     _release_websocket_request_state_reservation: Any
     _release_websocket_reservation: Any

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -2213,18 +2213,23 @@ def _filter_accounts_for_model(
     service_tier: str | None = None,
 ) -> list[Account]:
     registry = get_model_registry()
+    account_ids_for_model = getattr(registry, "account_ids_for_model", None)
+    model_account_ids = account_ids_for_model(model) if callable(account_ids_for_model) else None
+    model_accounts = (
+        accounts if model_account_ids is None else [account for account in accounts if account.id in model_account_ids]
+    )
     normalized_service_tier = service_tier.strip().lower() if service_tier is not None else None
     effective_service_tier = None if normalized_service_tier in {"auto", "default"} else service_tier
     if effective_service_tier is not None:
         allowed_account_ids = registry.account_ids_for_model_service_tier(model, effective_service_tier)
         if allowed_account_ids is not None:
-            return [account for account in accounts if account.id in allowed_account_ids]
+            return [account for account in model_accounts if account.id in allowed_account_ids]
         allowed_plans = registry.plan_types_for_model_service_tier(model, effective_service_tier)
     else:
         allowed_plans = registry.plan_types_for_model(model)
     if allowed_plans is None:
-        return accounts
-    return [a for a in accounts if account_plan_matches_allowed(a.plan_type, allowed_plans)]
+        return model_accounts
+    return [a for a in model_accounts if account_plan_matches_allowed(a.plan_type, allowed_plans)]
 
 
 def _selectable_accounts(accounts: list[Account]) -> list[Account]:
@@ -2246,7 +2251,15 @@ def _mapped_model_has_registry_entry(model: str | None) -> bool:
     plan_types_for_model = getattr(registry, "plan_types_for_model", None)
     if not callable(plan_types_for_model):
         return False
-    return bool(plan_types_for_model(model))
+    if plan_types_for_model(model):
+        return True
+    # A populated account-level catalog is authoritative even when the model
+    # is absent. In that case ``account_ids_for_model`` returns an empty set,
+    # which must trigger filtering instead of forwarding an unknown model to
+    # every active account. ``None`` preserves the legacy/degraded fallback
+    # when account-level discovery is unavailable.
+    account_ids_for_model = getattr(registry, "account_ids_for_model", None)
+    return callable(account_ids_for_model) and account_ids_for_model(model) is not None
 
 
 def _clone_account(account: Account) -> Account:

--- a/openspec/changes/harden-native-codex-capability-routing/context.md
+++ b/openspec/changes/harden-native-codex-capability-routing/context.md
@@ -1,0 +1,61 @@
+# Native capability routing context
+
+## Purpose
+
+Pooled Codex accounts must preserve Codex Responses semantics rather than
+rotating accounts blindly. Model catalog visibility, account eligibility,
+continuity ownership, service-tier intent, and actual upstream execution are
+separate facts and must remain observable as such.
+
+## Native semantics boundary
+
+The Codex client continues to own the local harness: tool execution, sandbox,
+approvals, skills, MCP, compaction decisions, and multi-agent workflow. The
+proxy owns upstream account selection and transport compatibility. Changing
+the selected account must not orphan a tool output, lose prior conversation
+state, or send an account-scoped file reference to a different owner.
+
+A `previous_response_id` is an upstream stored-object reference owned by the
+account that created it. Therefore:
+
+- a short continuation remains pinned to that owner;
+- a verified full resend can drop the owner-scoped anchor and start fresh on a
+  different eligible account;
+- a full resend is not safe when it contains a tool output without its matching
+  tool call, or when an account-scoped file reference still requires the old
+  owner;
+- no replay occurs after visible downstream output, because doing so could
+  duplicate or fork the response.
+
+This is why per-request round-robin routing is not equivalent to native Codex
+continuity. Rotation is safe only at a fresh or reconstructable boundary.
+
+## Model and Fast routing
+
+The merged model catalog is a discovery union, not proof that every account can
+serve every advertised model or tier. Selection uses the refreshed per-account
+catalog and fails closed when no account advertises the requested capability.
+
+`service_tier = "priority"` records Fast intent. It does not prove Fast was
+granted. The completed response's actual `service_tier` remains authoritative;
+`default` or `auto` means priority execution was not confirmed for that turn.
+
+## Transport continuity
+
+Direct WebSocket, HTTP-to-WebSocket bridge, and HTTP streaming/image bypass all
+use the same replay-safety boundary. A successful HTTP-stream response records
+its creator account so later owner lookup remains correct. If the upstream
+anchor is unavailable across transports, a self-contained full resend may
+recover without the anchor; a delta-only continuation fails closed.
+
+The focused live validation sequence is:
+
+1. WebSocket response that emits a function call.
+2. HTTP image request containing the call and tool output as full resend.
+3. WebSocket continuation containing self-contained history.
+4. HTTP compact request.
+5. WebSocket request consuming the compact output.
+
+Success across this sequence demonstrates preserved tool and context semantics,
+but it does not by itself prove that upstream granted Fast. Requested and actual
+service tiers must still be checked separately.

--- a/openspec/changes/harden-native-codex-capability-routing/proposal.md
+++ b/openspec/changes/harden-native-codex-capability-routing/proposal.md
@@ -1,0 +1,39 @@
+# Harden native Codex capability routing
+
+## Why
+
+The shared Codex model catalog can advertise a model or Fast tier when only a
+subset of pooled accounts actually exposes that capability. Routing by plan
+alone can then select an account that rejects the model, and a long-lived
+downstream WebSocket can keep using an account after it is paused or becomes
+ineligible. In addition, the selected account installation identity must stay
+consistent across the canonical Codex metadata carriers.
+
+## What changes
+
+- Preserve the union of account-specific model catalogs for picker visibility,
+  while retaining an account-level capability index for request selection.
+- Fail closed when an authoritative refreshed catalog has no account for the
+  requested model or service tier.
+- Revalidate an open direct-WebSocket account before each unsent
+  `response.create` turn. Fresh requests and verified self-contained full
+  resends may reconnect on another eligible account after quota failure; short
+  `previous_response_id` deltas remain pinned and fail with a retryable
+  continuity error when their owner is unavailable.
+- Apply the same replay-safety boundary to direct WebSocket, HTTP bridge, and
+  HTTP streaming/image-bypass paths, and remember the account that created a
+  successful HTTP-stream response for later continuity lookup.
+- Rewrite both `x-codex-installation-id` and an existing
+  `x-codex-turn-metadata.installation_id` to the selected account identity on
+  HTTP, HTTP-to-WebSocket, retry, and direct-WebSocket paths.
+- Remove stale model capability data when accounts are paused or no active
+  account remains.
+
+## Impact
+
+- Model registry and refresh scheduling.
+- Account selection and HTTP bridge session reuse.
+- Direct Responses WebSocket lifecycle and continuity behavior.
+- HTTP bridge and HTTP streaming failover behavior.
+- Codex installation metadata normalization.
+- No schema migration and no credential-format change.

--- a/openspec/changes/harden-native-codex-capability-routing/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/harden-native-codex-capability-routing/specs/model-catalog-compat/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Refreshed account catalogs constrain pooled routing
+
+When per-account upstream model catalogs have been refreshed, the system MUST
+treat those account-level results as authoritative for pooled request routing.
+The merged catalog MAY expose the union of models and service tiers for client
+discovery, but a request MUST be routed only to an active account whose own
+catalog advertised the requested model and non-default service tier.
+
+#### Scenario: One account lacks a unioned model
+
+- **GIVEN** one active account advertises `gpt-5.6-sol` and another active
+  account does not
+- **WHEN** a request selects `gpt-5.6-sol`
+- **THEN** only the advertising account is eligible
+
+#### Scenario: No account advertises requested Fast tier
+
+- **GIVEN** refreshed account catalogs are authoritative
+- **AND** no active account advertises `priority` for the requested model
+- **WHEN** a request selects `service_tier = "priority"`
+- **THEN** selection fails closed instead of falling back to plan-only routing
+
+#### Scenario: Active pool becomes empty
+
+- **WHEN** all accounts are paused, deactivated, or otherwise excluded from
+  model refresh
+- **THEN** the refreshed registry publishes an authoritative empty snapshot
+- **AND** stale models from inactive accounts are not served or routed
+

--- a/openspec/changes/harden-native-codex-capability-routing/specs/responses-api-compat/spec.md
+++ b/openspec/changes/harden-native-codex-capability-routing/specs/responses-api-compat/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: Direct WebSocket turns revalidate account capabilities
+
+Before forwarding each unsent direct-WebSocket `response.create` frame on an
+already-open upstream socket, the service MUST revalidate that the selected
+account remains active, remains in the API-key scope, supports the requested
+model and service tier, and still satisfies any preferred-owner constraint.
+
+#### Scenario: Account is paused after the socket opens
+
+- **GIVEN** a direct upstream WebSocket was opened on an active account
+- **AND** that account is paused before the next fresh turn
+- **WHEN** the next `response.create` is ready to send
+- **THEN** the service does not send that frame on the paused account
+- **AND** it reconnects to another eligible account when the request is safe to
+  start fresh
+
+#### Scenario: Short previous-response continuation remains owner-bound
+
+- **GIVEN** a turn contains a client-owned `previous_response_id`
+- **AND** its input contains only a delta that depends on the stored response
+- **AND** its owner account is unavailable or no longer supports the request
+- **WHEN** the turn is ready to send
+- **THEN** the service fails with a retryable continuity error
+- **AND** it does not move the hard chain to another account
+
+#### Scenario: Verified client full resend survives owner quota exhaustion
+
+- **GIVEN** a turn contains a client-owned `previous_response_id`
+- **AND** its input is a verified self-contained full resend, including every
+  tool call required by any included tool output
+- **AND** the owner account reports a retryable quota failure before visible
+  output
+- **WHEN** another model- and tier-eligible account is available
+- **THEN** the service removes the owner-scoped `previous_response_id`
+- **AND** it replays the full request on the other eligible account
+- **AND** it does not expose the first account's quota error downstream
+
+#### Scenario: HTTP image bypass uses the same safe replay boundary
+
+- **GIVEN** an HTTP Responses request bypasses the WebSocket bridge because it
+  contains an input image
+- **AND** it carries a verified self-contained full resend
+- **WHEN** its previous-response owner reports a retryable quota failure before
+  visible output
+- **THEN** the HTTP streaming retry path may remove the anchor and select
+  another eligible account
+- **AND** a successful response is associated with the account that created it
+  for subsequent owner lookup
+
+#### Scenario: Proxy-injected continuity has a safe fresh form
+
+- **GIVEN** the proxy injected a previous-response anchor for optimization
+- **AND** it retained a semantically equivalent fresh request body
+- **WHEN** the current account becomes ineligible before send
+- **THEN** the service may retire the drained socket and reconnect using the
+  fresh request body without the injected anchor
+
+### Requirement: Cross-transport failover preserves semantic continuity
+
+The service MUST apply one replay-safety rule across direct WebSocket, HTTP
+bridge, and HTTP streaming transports. It MUST NOT treat a transport change as
+permission to reroute an owner-bound delta, and it MAY reroute only when a
+fresh request body is independently sufficient to preserve conversation and
+tool semantics.
+
+#### Scenario: Tool output without its call cannot move accounts
+
+- **GIVEN** a continuation contains a tool output whose corresponding tool call
+  exists only in an owner-scoped previous response
+- **WHEN** the owner is unavailable
+- **THEN** the service fails closed instead of replaying the orphaned tool
+  output on another account
+
+#### Scenario: Self-contained tool history may move accounts
+
+- **GIVEN** a full resend includes a tool call before every corresponding tool
+  output
+- **AND** no account-scoped file reference requires the old owner
+- **WHEN** the old owner is unavailable before visible output
+- **THEN** the service may replay that history as a fresh request on another
+  eligible account
+
+### Requirement: Selected Codex installation identity is internally consistent
+
+For native Codex requests, when an account-specific installation id is applied,
+the service MUST use that same id in `x-codex-installation-id` and in an
+existing `x-codex-turn-metadata.installation_id`. Missing or malformed turn
+metadata MUST be preserved rather than invented or discarded.
+
+#### Scenario: Both canonical metadata carriers are present
+
+- **WHEN** a native request contains both installation metadata carriers
+- **AND** the proxy selects a pooled account
+- **THEN** both outbound values contain the selected account installation id

--- a/openspec/changes/harden-native-codex-capability-routing/tasks.md
+++ b/openspec/changes/harden-native-codex-capability-routing/tasks.md
@@ -1,0 +1,17 @@
+# Tasks
+
+- [x] Track model and service-tier support per refreshed account catalog.
+- [x] Route only to accounts whose authoritative catalog supports the request.
+- [x] Drop stale capability entries for paused/inactive accounts and publish an
+      authoritative empty snapshot when the active pool is empty.
+- [x] Normalize the selected installation identity across canonical Codex
+      metadata carriers.
+- [x] Revalidate direct WebSocket account/model/tier/owner eligibility before
+      every unsent `response.create` frame.
+- [x] Preserve safe fresh-turn and verified full-resend reconnect while failing
+      closed for hard continuity that lacks replayable state.
+- [x] Add focused regression coverage for pause-after-open, model/tier changes,
+      safe reconnect, hard continuity, and installation metadata.
+- [x] Run focused and broad Python test suites.
+- [x] Run strict OpenSpec validation for the change and all main specs.
+- [x] Deploy only after backup and verify the live native catalog and requests.

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -393,6 +393,61 @@ async def test_stream_connect_phase_429_usage_limit_transparent_failover(async_c
 
 
 @pytest.mark.asyncio
+async def test_stream_owner_quota_replays_safe_full_resend_without_anchor(async_client, monkeypatch):
+    account_a = await _import_account(async_client, "acc_owner_quota_a", "ownerquotaa@example.com")
+    account_b = await _import_account(async_client, "acc_owner_quota_b", "ownerquotab@example.com")
+
+    async def resolve_owner(self, **kwargs):
+        del self, kwargs
+        return account_a
+
+    seen_requests: list[tuple[str | None, str | None]] = []
+    remembered_owners: list[tuple[str | None, str | None]] = []
+
+    def remember_owner(self, **kwargs):
+        del self
+        remembered_owners.append((kwargs.get("previous_response_id"), kwargs.get("account_id")))
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        del headers, access_token, base_url, raise_for_status
+        seen_requests.append((account_id, payload.previous_response_id))
+        if account_id == "acc_owner_quota_a":
+            raise ProxyResponseError(
+                429,
+                openai_error("usage_limit_reached", "usage limit reached"),
+                failure_phase="status",
+            )
+        yield _success_sse_event("resp_owner_rotated")
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_resolve_websocket_previous_response_owner", resolve_owner)
+    monkeypatch.setattr(proxy_module.ProxyService, "_remember_websocket_previous_response_owner", remember_owner)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "previous_response_id": "resp_owner",
+        "input": [
+            {"role": "user", "content": [{"type": "input_text", "text": "first"}]},
+            {"role": "assistant", "content": [{"type": "output_text", "text": "answer"}]},
+            {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+        ],
+        "stream": True,
+    }
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    events = _extract_events(lines)
+    assert len([event for event in events if event.get("type") == "response.completed"]) == 1
+    assert seen_requests[:2] == [
+        ("acc_owner_quota_a", "resp_owner"),
+        ("acc_owner_quota_b", None),
+    ]
+    assert remembered_owners == [("resp_owner_rotated", account_b)]
+
+
+@pytest.mark.asyncio
 async def test_stream_http_502_unknown_code_fails_over_to_second_account(async_client, monkeypatch):
     await _import_account(async_client, "acc_h502_a", "h502_a@example.com")
     await _import_account(async_client, "acc_h502_b", "h502_b@example.com")

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -7382,6 +7382,124 @@ def test_backend_responses_websocket_previous_response_usage_limit_returns_upstr
     assert handled_error_codes == ["usage_limit_reached"]
 
 
+def test_backend_responses_websocket_replays_safe_full_resend_after_owner_usage_limit(
+    app_instance,
+    monkeypatch,
+):
+    first_upstream = _FakeUpstreamWebSocket(
+        [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "error",
+                        "status": 429,
+                        "error": {"code": "usage_limit_reached", "message": "usage limit reached"},
+                    },
+                    separators=(",", ":"),
+                ),
+            )
+        ]
+    )
+    second_upstream = _FakeUpstreamWebSocket(
+        [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {"type": "response.created", "response": {"id": "resp_rotated", "status": "in_progress"}},
+                    separators=(",", ":"),
+                ),
+            ),
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_rotated",
+                            "status": "completed",
+                            "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+        ]
+    )
+    upstreams = [first_upstream, second_upstream]
+    connected_accounts: list[str] = []
+    handled_error_codes: list[str] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
+        return None
+
+    async def fake_resolve_previous_response_owner(self, **kwargs):
+        del self, kwargs
+        return "acct_owner"
+
+    async def fake_connect_proxy_websocket(self, headers, **kwargs):
+        del self, headers, kwargs
+        index = len(connected_accounts)
+        account_id = "acct_owner" if index == 0 else "acct_rotated"
+        connected_accounts.append(account_id)
+        return SimpleNamespace(id=account_id), upstreams[index]
+
+    async def fake_handle_stream_error(self, account, error, code):
+        del self, account, error
+        handled_error_codes.append(code)
+
+    async def fake_write_request_log(self, **kwargs):
+        del self, kwargs
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_resolve_websocket_previous_response_owner",
+        fake_resolve_previous_response_owner,
+    )
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(proxy_module.ProxyService, "_handle_stream_error", fake_handle_stream_error)
+    monkeypatch.setattr(proxy_module.ProxyService, "_write_request_log", fake_write_request_log)
+
+    full_resend_input = [
+        {"role": "user", "content": [{"type": "input_text", "text": "first"}]},
+        {"role": "assistant", "content": [{"type": "output_text", "text": "answer"}]},
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(
+                json.dumps(
+                    {
+                        "type": "response.create",
+                        "model": "gpt-5.6-sol",
+                        "previous_response_id": "resp_owner",
+                        "input": full_resend_input,
+                        "stream": True,
+                    }
+                )
+            )
+            created = json.loads(websocket.receive_text())
+            completed = json.loads(websocket.receive_text())
+
+    assert created["type"] == "response.created"
+    assert completed["type"] == "response.completed"
+    assert connected_accounts == ["acct_owner", "acct_rotated"]
+    assert handled_error_codes == ["usage_limit_reached"]
+    replay_payload = json.loads(second_upstream.sent_text[0])
+    assert "previous_response_id" not in replay_payload
+    assert replay_payload["input"] == full_resend_input
+
+
 def test_backend_responses_websocket_transparent_replay_emits_no_accounts_when_reconnect_fails(
     app_instance,
     monkeypatch,

--- a/tests/unit/test_model_refresh_scheduler.py
+++ b/tests/unit/test_model_refresh_scheduler.py
@@ -302,7 +302,7 @@ async def test_fetch_with_failover_unions_same_plan_tiers(
 
 
 @pytest.mark.asyncio
-async def test_fetch_with_failover_excludes_same_plan_private_model_slug(
+async def test_fetch_with_failover_unions_same_plan_account_specific_model_slug(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     accounts = [_account("account-1"), _account("account-2")]
@@ -319,7 +319,11 @@ async def test_fetch_with_failover_excludes_same_plan_private_model_slug(
     result = await scheduler_module._fetch_with_failover(accounts, encryptor, MagicMock())
 
     assert result is not None
-    assert [model.slug for model in result.models] == ["gpt-5.4"]
+    assert [model.slug for model in result.models] == ["gpt-5.4", "private-alpha"]
+    assert result.account_models == {
+        accounts[0].id: (accounts[0].plan_type, first_models),
+        accounts[1].id: (accounts[1].plan_type, second_models),
+    }
     assert fetch_models_for_plan.await_count == 2
 
 

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -408,6 +408,37 @@ async def test_account_ids_for_model_service_tier_tracks_account_catalogs():
 
 
 @pytest.mark.asyncio
+async def test_account_ids_for_model_service_tier_is_empty_when_authoritative_catalog_has_no_tier():
+    standard = _model("gpt-5.5")
+    registry = ModelRegistry(ttl_seconds=60.0)
+    await registry.update(
+        {"plus": [standard]},
+        per_account_results={"account-standard": ("plus", [standard])},
+    )
+
+    assert registry.account_ids_for_model_service_tier("gpt-5.5", "priority") == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_account_ids_for_model_tracks_account_catalogs():
+    shared = _model("gpt-5.4")
+    sol = _model("gpt-5.6-sol")
+
+    registry = ModelRegistry(ttl_seconds=60.0)
+    await registry.update(
+        {"pro": [shared, sol]},
+        per_account_results={
+            "account-sol": ("pro", [shared, sol]),
+            "account-default": ("pro", [shared]),
+        },
+    )
+
+    assert registry.account_ids_for_model("gpt-5.6-sol") == frozenset({"account-sol"})
+    assert registry.account_ids_for_model("gpt-5.4") == frozenset({"account-sol", "account-default"})
+    assert registry.account_ids_for_model("unknown") == frozenset()
+
+
+@pytest.mark.asyncio
 async def test_account_ids_for_model_service_tier_preserves_missing_active_accounts():
     fast = replace(_model("gpt-5.5"), raw={"service_tiers": [{"slug": "fast"}], "additional_speed_tiers": ["fast"]})
     no_fast = replace(_model("gpt-5.5"), raw={"service_tiers": [{"slug": "default"}]})
@@ -485,6 +516,59 @@ async def test_partial_update_preserves_stale_plans():
     # plus-new should be present
     assert "plus-new" in snapshot.models
     assert "plus" in snapshot.model_plans["plus-new"]
+
+
+@pytest.mark.asyncio
+async def test_partial_update_drops_stale_plan_with_no_active_accounts():
+    registry = ModelRegistry(ttl_seconds=60.0)
+    sol = _model("gpt-5.6-sol")
+    shared = _model("gpt-5.4")
+    await registry.update(
+        {"pro": [sol], "plus": [shared]},
+        per_account_results={
+            "account-pro": ("pro", [sol]),
+            "account-plus": ("plus", [shared]),
+        },
+        active_account_plans={"account-pro": "pro", "account-plus": "plus"},
+    )
+
+    await registry.update(
+        {"plus": [shared]},
+        per_account_results={"account-plus": ("plus", [shared])},
+        active_account_plans={"account-plus": "plus"},
+    )
+
+    snapshot = registry.get_snapshot()
+    assert snapshot is not None
+    assert "gpt-5.6-sol" not in snapshot.models
+    assert registry.account_ids_for_model("gpt-5.6-sol") == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_clear_publishes_authoritative_empty_snapshot():
+    registry = ModelRegistry(ttl_seconds=60.0)
+    await registry.update({"plus": [_model("gpt-5.4")]})
+
+    await registry.clear()
+
+    assert registry.get_models_with_fallback() == {}
+    assert registry.plan_types_for_model("gpt-5.4") == frozenset()
+    assert registry.account_ids_for_model("gpt-5.4") == frozenset()
+    assert registry.account_ids_for_model_service_tier("gpt-5.4", "priority") == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_empty_per_account_catalog_is_authoritative():
+    registry = ModelRegistry(ttl_seconds=60.0)
+    shared = _model("gpt-5.4")
+
+    await registry.update(
+        {"plus": [shared]},
+        per_account_results={"account-empty": ("plus", [])},
+    )
+
+    assert registry.account_ids_for_model("gpt-5.4") == frozenset()
+    assert registry.account_ids_for_model_service_tier("gpt-5.4", "priority") == frozenset()
 
 
 def test_needs_refresh_true_initially():

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -10201,6 +10201,69 @@ async def test_process_http_bridge_upstream_text_masks_previous_response_usage_l
 
 
 @pytest.mark.asyncio
+async def test_process_http_bridge_replays_safe_full_resend_after_owner_usage_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-prev-limit-replay",
+        model="gpt-5.6-sol",
+        service_tier="priority",
+        reasoning_effort="high",
+        api_key_reservation=None,
+        started_at=1.0,
+        previous_response_id="resp_owner",
+        preferred_account_id="acc-limited",
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","previous_response_id":"resp_owner"}',
+        fresh_upstream_request_text='{"type":"response.create","model":"gpt-5.6-sol","input":[]}',
+        fresh_upstream_request_is_retry_safe=True,
+        transport="http",
+        skip_request_log=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_prev_replay", None),
+        headers={"x-codex-turn-state": "http_turn_prev_replay"},
+        affinity=proxy_service._AffinityPolicy(
+            key="http_turn_prev_replay",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.6-sol",
+        account=cast(Any, SimpleNamespace(id="acc-limited", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+    handle_stream_error = AsyncMock()
+    retry_request = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_request)
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 429,
+                "error": {"type": "usage_limit_reached", "message": "usage limit reached"},
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    handle_stream_error.assert_awaited_once()
+    retry_request.assert_awaited_once_with(session)
+    assert request_state.event_queue is not None
+    assert request_state.event_queue.empty()
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_masks_owner_pinned_quota_error_with_queued_requests(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -2677,6 +2677,38 @@ async def test_select_account_skips_plan_filter_when_registry_snapshot_lacks_mod
 
 
 @pytest.mark.asyncio
+async def test_select_account_rejects_model_absent_from_authoritative_account_catalog(monkeypatch) -> None:
+    account = _make_account("acc-authoritative-registry", "authoritative-registry@example.com")
+    now = utcnow()
+    primary_entry = UsageHistory(
+        id=1,
+        account_id=account.id,
+        recorded_at=now,
+        window="primary",
+        used_percent=5.0,
+        reset_at=int(now.replace(tzinfo=timezone.utc).timestamp()) + 300,
+        window_minutes=5,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(primary={account.id: primary_entry}, secondary={})
+    sticky_repo = StubStickySessionsRepository()
+
+    monkeypatch.setattr(
+        "app.modules.proxy.load_balancer.get_model_registry",
+        lambda: SimpleNamespace(
+            plan_types_for_model=lambda _model: frozenset(),
+            account_ids_for_model=lambda _model: frozenset(),
+        ),
+    )
+
+    balancer = LoadBalancer(lambda: _repo_factory(accounts_repo, usage_repo, sticky_repo))
+    selection = await balancer.select_account(model="gpt-5.6-sol")
+
+    assert selection.account is None
+    assert selection.error_code == NO_PLAN_SUPPORT_FOR_MODEL
+
+
+@pytest.mark.asyncio
 async def test_select_account_empty_pool_preserves_no_accounts_for_modeled_request(monkeypatch) -> None:
     accounts_repo = StubAccountsRepository([])
     usage_repo = StubUsageRepository(primary={}, secondary={})

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -86,6 +86,160 @@ def test_websocket_archive_request_context_clears_unmatched_frame_request_id():
         reset_request_id(token)
 
 
+def test_websocket_account_switch_keeps_fresh_request_body():
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_ws_fresh_switch",
+        model="gpt-5.6-sol",
+        service_tier="priority",
+        reasoning_effort="high",
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        request_text='{"type":"response.create","model":"gpt-5.6-sol"}',
+    )
+
+    assert websocket_mixin._prepare_websocket_request_state_for_account_switch(request_state) == (
+        request_state.request_text
+    )
+
+
+def test_websocket_account_switch_rejects_client_owned_previous_response_chain():
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_ws_hard_chain",
+        model="gpt-5.6-sol",
+        service_tier="priority",
+        reasoning_effort="high",
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        request_text='{"type":"response.create","previous_response_id":"resp_hard"}',
+        previous_response_id="resp_hard",
+        preferred_account_id="acc_owner",
+    )
+
+    assert websocket_mixin._prepare_websocket_request_state_for_account_switch(request_state) is None
+    assert request_state.previous_response_id == "resp_hard"
+    assert request_state.preferred_account_id == "acc_owner"
+
+
+def test_websocket_account_switch_restores_safe_fresh_form_for_proxy_anchor():
+    fresh_text = '{"type":"response.create","model":"gpt-5.6-sol","input":[]}'
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_ws_proxy_chain",
+        model="gpt-5.6-sol",
+        service_tier="priority",
+        reasoning_effort="high",
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        request_text='{"type":"response.create","previous_response_id":"resp_proxy"}',
+        previous_response_id="resp_proxy",
+        preferred_account_id="acc_old",
+        proxy_injected_previous_response_id=True,
+        fresh_upstream_request_is_retry_safe=True,
+        fresh_upstream_request_text=fresh_text,
+        fresh_upstream_request_responses_lite_model="gpt-5.6-sol",
+    )
+
+    assert websocket_mixin._prepare_websocket_request_state_for_account_switch(request_state) == fresh_text
+    assert request_state.previous_response_id is None
+    assert request_state.preferred_account_id is None
+    assert request_state.proxy_injected_previous_response_id is False
+    assert request_state.fresh_upstream_request_is_retry_safe is False
+    assert request_state.responses_lite_model == "gpt-5.6-sol"
+
+
+def test_websocket_account_switch_restores_safe_client_full_resend():
+    fresh_text = '{"type":"response.create","model":"gpt-5.6-sol","input":[{"role":"user"}]}'
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_ws_client_full_resend",
+        model="gpt-5.6-sol",
+        service_tier="priority",
+        reasoning_effort="high",
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        request_text='{"type":"response.create","previous_response_id":"resp_client"}',
+        previous_response_id="resp_client",
+        preferred_account_id="acc_old",
+        fresh_upstream_request_is_retry_safe=True,
+        fresh_upstream_request_text=fresh_text,
+    )
+
+    assert websocket_mixin._prepare_websocket_request_state_for_account_switch(request_state) == fresh_text
+    assert request_state.previous_response_id is None
+    assert request_state.preferred_account_id is None
+
+
+@pytest.mark.asyncio
+async def test_revalidate_open_websocket_account_uses_current_model_and_tier(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_ws_revalidate")
+    refreshed_account = _make_account("acc_ws_revalidate")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_ws_revalidate",
+        request_log_id="log_ws_revalidate",
+        model="gpt-5.6-sol",
+        service_tier="priority",
+        requested_service_tier="priority",
+        reasoning_effort="high",
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        preferred_account_id=account.id,
+    )
+    select_account = AsyncMock(
+        return_value=AccountSelection(
+            account=refreshed_account,
+            error_message=None,
+            error_code=None,
+            lease=None,
+        )
+    )
+    release_lease = AsyncMock()
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_lease)
+
+    selected, error_code, error_message = await service._revalidate_open_websocket_account(
+        account,
+        request_state=request_state,
+        api_key=None,
+    )
+
+    assert selected is refreshed_account
+    assert error_code is None
+    assert error_message is None
+    assert select_account.await_args is not None
+    assert select_account.await_args.kwargs["preferred_account_id"] == account.id
+    assert select_account.await_args.kwargs["model"] == "gpt-5.6-sol"
+    assert select_account.await_args.kwargs["service_tier"] == "priority"
+    assert select_account.await_args.kwargs["fallback_on_preferred_account_unavailable"] is False
+    release_lease.assert_awaited_once_with(None)
+
+
+@pytest.mark.asyncio
+async def test_revalidate_open_websocket_account_rejects_changed_owner(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_ws_current")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_ws_owner_changed",
+        model="gpt-5.6-sol",
+        service_tier="priority",
+        reasoning_effort="high",
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        preferred_account_id="acc_ws_required_owner",
+    )
+    select_account = AsyncMock()
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+
+    selected, error_code, error_message = await service._revalidate_open_websocket_account(
+        account,
+        request_state=request_state,
+        api_key=None,
+    )
+
+    assert selected is None
+    assert error_code == "preferred_account_mismatch"
+    assert error_message is not None
+    select_account.assert_not_awaited()
+
+
 def test_account_selection_recovery_sleep_uses_retry_hint_with_bounds():
     selection = AccountSelection(
         account=None,
@@ -2253,7 +2407,7 @@ def test_response_create_client_metadata_replaces_installation_id():
         {
             "client_metadata": {
                 "x-codex-installation-id": "client-installation",
-                "x-codex-turn-metadata": '{"turn_id":"payload-turn"}',
+                "x-codex-turn-metadata": '{"installation_id":"client-installation","turn_id":"payload-turn"}',
             }
         },
         headers={},
@@ -2262,7 +2416,23 @@ def test_response_create_client_metadata_replaces_installation_id():
 
     assert metadata == {
         "x-codex-installation-id": "account-installation",
-        "x-codex-turn-metadata": '{"turn_id":"payload-turn"}',
+        "x-codex-turn-metadata": '{"installation_id":"account-installation","turn_id":"payload-turn"}',
+    }
+
+
+def test_installation_headers_rewrite_canonical_turn_metadata():
+    headers = proxy_module.apply_codex_installation_headers(
+        {
+            "x-codex-installation-id": "client-installation",
+            "x-codex-turn-metadata": '{"installation_id":"client-installation","turn_id":"turn-1"}',
+        },
+        "account-installation",
+    )
+
+    assert headers["x-codex-installation-id"] == "account-installation"
+    assert json.loads(headers["x-codex-turn-metadata"]) == {
+        "installation_id": "account-installation",
+        "turn_id": "turn-1",
     }
 
 
@@ -17028,6 +17198,11 @@ async def test_proxy_responses_websocket_replays_precreated_request_after_upstre
         return _make_account("acc_ws_race_2"), second_upstream
 
     monkeypatch.setattr(proxy_service.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(
+        proxy_service.ProxyService,
+        "_revalidate_open_websocket_account",
+        AsyncMock(side_effect=lambda current_account, **_: (current_account, None, None)),
+    )
 
     first_request = {
         "type": "response.create",
@@ -24348,6 +24523,102 @@ async def test_http_bridge_reselects_sticky_session_for_new_service_tier(monkeyp
 
     assert result is replacement
     assert existing.closed is True
+    create_session.assert_awaited_once()
+    assert create_session.await_args is not None
+    assert create_session.await_args.kwargs["request_service_tier"] == "priority"
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_inflight_waiter_reselects_for_new_service_tier(monkeypatch):
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account_a = _make_account("acc_bridge_inflight_default")
+    account_b = _make_account("acc_bridge_inflight_priority")
+    key = proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-inflight-tier-key", None)
+    incompatible = proxy_service._HTTPBridgeSession(
+        key=key,
+        headers={},
+        affinity=proxy_service._AffinityPolicy(key="bridge-inflight-tier-key"),
+        request_model="gpt-5.5",
+        request_service_tier=None,
+        account=account_a,
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    replacement = proxy_service._HTTPBridgeSession(
+        key=key,
+        headers={},
+        affinity=proxy_service._AffinityPolicy(key="bridge-inflight-tier-key"),
+        request_model="gpt-5.5",
+        request_service_tier="priority",
+        account=account_b,
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    inflight_future = asyncio.get_running_loop().create_future()
+    service._http_bridge_inflight_sessions[key] = inflight_future
+
+    class Registry:
+        def account_ids_for_model_service_tier(self, slug: str, service_tier: str | None) -> frozenset[str] | None:
+            if slug == "gpt-5.5" and service_tier == "priority":
+                return frozenset({account_b.id})
+            return None
+
+        def plan_types_for_model_service_tier(self, slug: str, service_tier: str | None) -> frozenset[str] | None:
+            return None
+
+    create_session = AsyncMock(return_value=replacement)
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr("app.modules.proxy._service.support.get_model_registry", lambda: Registry())
+    monkeypatch.setattr(
+        "app.modules.proxy._service.http_bridge.mixin._http_bridge_owner_instance",
+        AsyncMock(return_value=settings.http_responses_session_bridge_instance_id),
+    )
+    monkeypatch.setattr(
+        "app.modules.proxy._service.http_bridge.mixin._active_http_bridge_instance_ring",
+        AsyncMock(
+            return_value=(
+                settings.http_responses_session_bridge_instance_id,
+                (settings.http_responses_session_bridge_instance_id,),
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "_create_http_bridge_session", create_session)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+
+    waiter = asyncio.create_task(
+        service._get_or_create_http_bridge_session(
+            key,
+            headers={},
+            affinity=proxy_service._AffinityPolicy(key="bridge-inflight-tier-key"),
+            api_key=None,
+            request_model="gpt-5.5",
+            request_service_tier="priority",
+            idle_ttl_seconds=30.0,
+            max_sessions=10,
+        )
+    )
+    await asyncio.sleep(0)
+    service._http_bridge_sessions[key] = incompatible
+    service._http_bridge_inflight_sessions.pop(key, None)
+    inflight_future.set_result(incompatible)
+
+    result = await waiter
+
+    assert result is replacement
+    assert incompatible.closed is True
     create_session.assert_awaited_once()
     assert create_session.await_args is not None
     assert create_session.await_args.kwargs["request_service_tier"] == "priority"


### PR DESCRIPTION
## What changed

- retain per-account model and service-tier capabilities while exposing the merged catalog union;
- fail closed when no refreshed account catalog supports the requested model or non-default tier;
- revalidate account, model, tier, and continuity ownership before every unsent direct-WebSocket turn;
- rotate retry-safe fresh requests and verified self-contained full resends after pre-visible quota failures;
- keep delta-only `previous_response_id` chains and account-scoped files pinned to their owner;
- apply the same replay-safety rule to direct WebSocket, HTTP bridge, and HTTP streaming/image bypass;
- normalize selected Codex installation metadata across HTTP, bridge, WebSocket, and retry paths;
- add OpenSpec requirements and regression coverage for capability routing, quota failover, continuity, and metadata.

## Why

The merged upstream model catalog can advertise a model or Fast tier that only a subset of pooled accounts supports. Plan-only routing may select an incompatible account. Separately, blindly changing accounts for every request can break upstream-owned `previous_response_id` continuity, orphan tool outputs, and misroute account-scoped files.

This change separates discovery from eligibility and permits account rotation only when the request is independently replayable. Short owner-dependent continuations still fail closed.

Fast intent and actual execution also remain distinct: forwarding `service_tier = "priority"` does not claim Fast unless the completed upstream response reports the priority tier.

No linked issue; this was reproduced through live Codex App/CLI compatibility testing against the native backend route.

## Validation

- `npx --yes @fission-ai/openspec@latest validate harden-native-codex-capability-routing --strict`
- `npx --yes @fission-ai/openspec@latest validate --specs --strict` — 30 specs passed
- `uv run ruff check ...`
- `uv run ty check`
- 694 focused backend/unit tests passed, 3 skipped before deployment
- 196 Responses/bridge/files/compact/transient integration tests passed after final changes
- live sequence passed: WebSocket tool call → HTTP image full resend → WebSocket continuation → HTTP compact → WebSocket continuation from compact output

## Notes

- One unrelated WebSocket Lite test can hang when run independently in this local environment; it is not reported as passing.
- The pull request is intentionally draft pending upstream CI and review.
