### PR TITLE
fix(proxy): stop synthesizing top-level tools for upstream Codex requests

### DIFF
--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -701,6 +701,18 @@ class ResponsesRequest(BaseModel):
 
     def to_payload(self) -> JsonObject:
         payload: MutableJsonObject = self.model_dump(mode="json", exclude_none=True)
+        if "tools" not in self.model_fields_set:
+            # ``tools`` is declared with ``default_factory=list``, so
+            # ``model_dump(exclude_none=True)`` synthesizes an explicit
+            # ``"tools": []`` even when the client omitted the field. Codex
+            # Responses-Lite clients omit top-level ``tools`` entirely (the
+            # bundle rides in the ``additional_tools`` input item), and models
+            # with reserved model tools (e.g. ``collaboration.spawn_agent`` on
+            # gpt-5.6 ``multi_agent_version: v2``) reject any explicit
+            # ``tools`` param that cannot match the reserved schema. Only
+            # forward the field when the client actually sent it — including
+            # an explicit client-sent ``[]``. See issue #1184.
+            payload.pop("tools", None)
         return _strip_unsupported_fields(payload)
 
 
@@ -777,7 +789,11 @@ def _strip_unsupported_fields(payload: MutableJsonObject) -> MutableJsonObject:
     _normalize_service_tier_aliases(payload)
     _sanitize_interleaved_reasoning_input(payload)
     _strip_poisoned_local_compact_fallback_items(payload)
-    _canonicalize_tools(payload)
+    # ``tools`` is deliberately NOT canonicalized here: the wire payload must
+    # forward client tool entries byte-preserved (array order, key order, and
+    # unknown keys untouched) so reserved model tools survive upstream
+    # byte/structural-equality checks. Order-insensitive canonicalization is
+    # cache-affinity/observability-only; see ``canonicalized_tools``.
     for key in _UNSUPPORTED_UPSTREAM_FIELDS:
         payload.pop(key, None)
     return payload
@@ -828,15 +844,18 @@ def _is_poisoned_local_compact_fallback_message(item: JsonValue) -> bool:
     return False
 
 
-def _canonicalize_tools(payload: MutableJsonObject) -> None:
-    tools = payload.get("tools")
-    if not is_json_list(tools):
-        return
-    tool_list = tools
-    if not tool_list:
-        return
-    sorted_tools = sorted(tool_list, key=_tool_sort_key)
-    payload["tools"] = [_sort_keys_recursive(t) for t in sorted_tools]
+def canonicalized_tools(tools: list[JsonValue]) -> list[JsonValue]:
+    """Return an order- and key-order-insensitive canonical form of ``tools``.
+
+    Used only for prompt-cache affinity/observability hashing (change #228):
+    two requests that differ solely in tool array order or object key order
+    hash identically. The result MUST NOT feed the upstream wire payload —
+    outgoing requests forward the client's tool entries byte-preserved (see
+    issue #1184). Array values (e.g. ``parameters.required``) are never
+    reordered; only mapping keys are sorted.
+    """
+    sorted_tools = sorted(tools, key=_tool_sort_key)
+    return [_sort_keys_recursive(t) for t in sorted_tools]
 
 
 def _tool_sort_key(tool: JsonValue) -> str:

--- a/app/core/openai/v1_requests.py
+++ b/app/core/openai/v1_requests.py
@@ -66,6 +66,14 @@ class V1ResponsesRequest(BaseModel):
 
     def to_responses_request(self) -> ResponsesRequest:
         data = self.model_dump(mode="json", exclude_none=True)
+        if "tools" not in self.model_fields_set:
+            # ``tools`` defaults to ``[]`` via ``default_factory``, so
+            # ``model_dump`` would hand ``ResponsesRequest`` an explicit
+            # ``"tools": []`` the client never sent, marking the field as set
+            # and forwarding a synthesized empty array upstream. Drop it here
+            # so field omission propagates through ``to_payload()``
+            # (issue #1184); an explicit client-sent ``[]`` stays intact.
+            data.pop("tools", None)
         messages = data.pop("messages", None)
         instructions = data.get("instructions")
         instruction_text = instructions if isinstance(instructions, str) else ""

--- a/app/modules/proxy/_service/observability.py
+++ b/app/modules/proxy/_service/observability.py
@@ -14,8 +14,9 @@ from app.core.metrics.prometheus import (
     continuity_owner_resolution_total,
     upstream_transport_decisions_total,
 )
-from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest
+from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest, canonicalized_tools
 from app.core.types import JsonValue
+from app.core.utils.json_guards import is_json_list
 from app.core.utils.request_id import get_request_id
 from app.modules.proxy.affinity import (
     _extract_model_class,
@@ -248,9 +249,17 @@ def _truncate_identifier(value: str, *, max_length: int = 96) -> str:
 
 def _tools_hash(payload: ResponsesRequest | ResponsesCompactRequest) -> str | None:
     payload_tools = payload.to_payload().get("tools")
-    if not isinstance(payload_tools, list) or not payload_tools:
+    if not is_json_list(payload_tools) or not payload_tools:
         return None
-    serialized = json.dumps(payload_tools, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+    # The wire payload keeps client tool entries byte-preserved (issue #1184),
+    # so the affinity/observability hash canonicalizes locally to stay
+    # insensitive to tool array order and object key order (change #228).
+    serialized = json.dumps(
+        canonicalized_tools(payload_tools),
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
     return _hash_identifier(serialized)
 
 

--- a/openspec/changes/omit-synthesized-top-level-tools/proposal.md
+++ b/openspec/changes/omit-synthesized-top-level-tools/proposal.md
@@ -1,0 +1,60 @@
+# Stop Synthesizing Top-Level Tools for Upstream Codex Requests
+
+## Summary
+
+Forward the top-level `tools` field to upstream only when the client actually
+sent it, and forward client-sent tool entries byte-preserved. Tool
+canonicalization (sorting the array and object keys) becomes a
+cache-affinity/observability-only computation and no longer mutates the wire
+payload.
+
+## Motivation
+
+Under Responses Lite the Codex client omits top-level `tools` entirely
+(codex-rs `build_responses_request` sends `tools = None`) and ships the tool
+bundle in the `additional_tools` input item. `ResponsesRequest.tools` is
+declared with `default_factory=list`, so `to_payload()` synthesized an
+explicit `"tools": []` on every Lite request. gpt-5.6 Sol/Terra
+(`multi_agent_version: v2`) configure a reserved `collaboration` namespace
+tool (flattened to `collaboration.spawn_agent` in error messages); an explicit
+`tools` param triggers reserved-tool schema reconciliation, and `[]` cannot
+match, producing `400 invalid_request_error` with `param: "tools"`
+(issue #1184).
+
+Secondary hazard: `_canonicalize_tools` (from #228, prompt-cache affinity)
+re-sorted every tool and every object key **in the wire payload**, which would
+break any byte/structural-equality check upstream performs on a client-sent
+reserved tool entry.
+
+## Scope
+
+- `ResponsesRequest.to_payload()` omits `tools` when the field is not in
+  `model_fields_set`; an explicit client-sent `[]` is still forwarded.
+- `V1ResponsesRequest.to_responses_request()` propagates field omission so the
+  OpenAI-compatible route inherits the same behavior.
+- Wire payloads forward client tool entries byte-preserved (array order,
+  object key order, unknown keys, array-value order). Canonicalization moves
+  to `canonicalized_tools()` and feeds only the `_tools_hash`
+  affinity/observability consumer, which stays order-insensitive.
+- Regression coverage at the product paths: websocket `response.create`
+  frame, HTTP-bridge body, and legacy HTTP stream path.
+
+## Sibling-field audit
+
+- `tool_choice` and `parallel_tool_calls` default to `None` and are already
+  dropped by `model_dump(exclude_none=True)` when unset; explicit values
+  (including Lite's explicit `parallel_tool_calls: false`) keep forwarding.
+  No change needed.
+- `store: false` is a deliberate proxy invariant (coerced by validator) and
+  keeps being emitted.
+- `include` shares the `default_factory=list` pattern but a synthesized
+  `"include": []` is semantically identical to omission upstream and is not a
+  reserved-schema hazard; left unchanged to keep this change one concern wide.
+
+## Out of Scope
+
+- Chat-completions conversion (`ChatCompletionsRequest.to_responses_request`)
+  constructs `tools` deliberately; the chat-source path already drops empty
+  tool lists (`sanitize_source_chat_payload`).
+- Compact requests, which strip `tools` entirely by design.
+- Any change to `include`/`store` emission.

--- a/openspec/changes/omit-synthesized-top-level-tools/specs/responses-api-compat/spec.md
+++ b/openspec/changes/omit-synthesized-top-level-tools/specs/responses-api-compat/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: Upstream Responses payloads omit client-omitted request fields
+
+The service MUST NOT emit top-level request fields the client omitted onto
+upstream Responses payloads when the field's absence is meaningful upstream.
+In particular, the proxy MUST NOT synthesize a top-level `"tools": []` from
+the request model's default for clients that did not send the `tools` field,
+on any upstream transport (websocket `response.create` frames, HTTP-bridge
+bodies, and direct HTTP stream requests). An explicit client-sent
+`"tools": []` MUST be forwarded as `[]`. `tool_choice` and
+`parallel_tool_calls` MUST be forwarded only when the client sent them;
+an explicit client-sent `parallel_tool_calls: false` MUST reach upstream.
+The OpenAI-compatible `/v1/responses` conversion MUST propagate `tools`
+omission into the native request so both routes behave identically.
+
+#### Scenario: Responses Lite request reaches upstream without a tools key
+
+- **WHEN** a `/backend-api/codex/responses` request omits top-level `tools`
+  and carries its tool bundle in an `additional_tools` input item
+- **THEN** the upstream websocket `response.create` frame contains no
+  top-level `tools` key
+- **AND** the HTTP-bridge request body contains no top-level `tools` key
+
+#### Scenario: Explicit empty tools array is forwarded
+
+- **WHEN** a client sends `"tools": []` explicitly
+- **THEN** the upstream payload contains `"tools": []`
+
+#### Scenario: Unset optional tool fields stay absent
+
+- **WHEN** a client omits `tool_choice` and `parallel_tool_calls`
+- **THEN** the upstream payload contains neither field
+
+### Requirement: Client tool entries are forwarded byte-preserved
+
+The service MUST forward client-sent top-level `tools` entries to upstream
+byte-preserved: the tool array order, per-object key order, unknown keys
+(including unknown tool types such as `namespace` entries and non-standard
+schema markers), and array-value order (for example `parameters.required`)
+MUST reach upstream exactly as the client sent them. Tool canonicalization
+(array sorting and recursive key sorting) MUST be used only for prompt-cache
+affinity and observability hashing and MUST NOT mutate the outgoing payload.
+The affinity/observability hash MUST remain insensitive to tool array order
+and object key order.
+
+#### Scenario: Reserved namespace tool survives byte-identical
+
+- **WHEN** a client sends top-level `tools` containing a reserved
+  `{"type": "namespace", "name": "collaboration", ...}` entry with nested
+  function entries, `strict: false`, unknown property markers, and a
+  non-alphabetical `required` array
+- **THEN** the upstream `response.create` frame serializes that `tools` array
+  byte-identical to the client's serialization
+
+#### Scenario: Affinity hash ignores tool ordering
+
+- **WHEN** two requests differ only in tool array order or tool object key
+  order
+- **THEN** their tools affinity/observability hash is identical

--- a/openspec/changes/omit-synthesized-top-level-tools/tasks.md
+++ b/openspec/changes/omit-synthesized-top-level-tools/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [x] 1. Add OpenSpec requirements: omit client-omitted request fields (`tools` and audited siblings), forward client tool entries byte-preserved, keep canonicalization cache-affinity-only.
+- [x] 2. `ResponsesRequest.to_payload()`: pop `tools` when the client did not send the field; preserve explicit client-sent `[]`.
+- [x] 3. Audit `tool_choice` / `parallel_tool_calls` for the same default-injection pattern (result: `None` defaults already dropped by `exclude_none`; no change needed).
+- [x] 4. `V1ResponsesRequest.to_responses_request()`: propagate `tools` omission into the converted `ResponsesRequest`.
+- [x] 5. Remove `_canonicalize_tools` from the wire path; expose `canonicalized_tools()` and use it only in the `_tools_hash` affinity/observability consumer.
+- [x] 6. Regression tests (fail-before/pass-after): Lite websocket frame and HTTP-bridge body carry no top-level `tools` key; client-sent reserved namespace tool reaches the upstream frame byte-identical; explicit `[]` still forwarded; affinity hash stays order-insensitive.
+- [x] 7. Run focused tests, lint, type check, and strict OpenSpec validation.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -4418,6 +4418,113 @@ async def test_v1_responses_http_bridge_trims_replayed_apply_patch_previous_resp
 
 
 @pytest.mark.asyncio
+async def test_backend_responses_http_bridge_lite_request_omits_synthesized_tools(
+    async_client,
+    monkeypatch,
+):
+    # Regression for issue #1184: Responses-Lite clients omit top-level
+    # ``tools`` entirely (the bundle rides in the ``additional_tools`` input
+    # item). The HTTP-bridge body must not synthesize ``"tools": []`` from the
+    # model default; gpt-5.6 reserved model tools reject any explicit
+    # ``tools`` param that cannot match the reserved schema.
+    _install_bridge_settings(monkeypatch, enabled=True)
+    account_id = await _import_account(
+        async_client,
+        "acc_backend_http_bridge_lite_no_tools",
+        "backend-http-bridge-lite-no-tools@example.com",
+    )
+    account = await _get_account(account_id)
+    fake_upstream = _FakeBridgeUpstreamWebSocket()
+
+    async def fake_select_account_with_budget(
+        self,
+        deadline,
+        *,
+        request_id,
+        kind,
+        request_stage="first_turn",
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset_accounts,
+        routing_strategy,
+        model,
+        exclude_account_ids=None,
+        additional_limit_name=None,
+        api_key=None,
+        preferred_account_id=None,
+    ):
+        del (
+            self,
+            deadline,
+            request_id,
+            kind,
+            request_stage,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset_accounts,
+            routing_strategy,
+            model,
+            exclude_account_ids,
+            additional_limit_name,
+            api_key,
+            preferred_account_id,
+        )
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        return fake_upstream
+
+    async def fail_legacy_stream(*args, **kwargs):
+        raise AssertionError("legacy core_stream_responses path must not be used when HTTP bridge is enabled")
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fail_legacy_stream)
+
+    payload = {
+        "model": "gpt-5.6",
+        "instructions": "",
+        "input": [
+            {
+                "type": "additional_tools",
+                "role": "developer",
+                "tools": [{"type": "custom", "name": "shell"}],
+            },
+            {"type": "message", "role": "developer", "content": "use repository tools"},
+            {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+        ],
+        "stream": True,
+    }
+    events = await _collect_sse_events(async_client, "/backend-api/codex/responses", json_body=payload)
+
+    _assert_created_text_delta_completed(events)
+    assert len(fake_upstream.sent_text) == 1
+    bridge_body = json.loads(fake_upstream.sent_text[0])
+    assert "tools" not in bridge_body
+    # The Lite input prefix must survive and keep signaling Responses Lite.
+    assert bridge_body["input"][0]["type"] == "additional_tools"
+    client_metadata = bridge_body["client_metadata"]
+    assert client_metadata["ws_request_header_x_openai_internal_codex_responses_lite"] == "true"
+
+
+@pytest.mark.asyncio
 async def test_backend_responses_http_bridge_reuses_upstream_websocket_and_preserves_previous_response_id(
     async_client,
     monkeypatch,

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -237,6 +237,9 @@ async def test_backend_responses_preserves_responses_lite_tools_and_outputs(asyn
     event = _extract_first_event(lines)
     assert event["type"] == "response.completed"
     assert seen_payload["instructions"] == ""
+    # The Lite client omitted top-level ``tools``; the proxy must not
+    # synthesize ``"tools": []`` from the model default (issue #1184).
+    assert "tools" not in seen_payload
     assert seen_payload["input"] == [
         additional_tools,
         {"type": "message", "role": "developer", "content": "use repository tools"},
@@ -258,6 +261,49 @@ async def test_backend_responses_preserves_responses_lite_tools_and_outputs(asyn
         cast("Mapping[str, JsonValue]", seen_payload),
     )
     assert upstream_headers == {proxy_client_module.CODEX_RESPONSES_LITE_HEADER: "true"}
+
+
+@pytest.mark.asyncio
+async def test_backend_responses_forwards_explicit_empty_tools(async_client, monkeypatch):
+    # An explicit client-sent ``"tools": []`` is a real request field and must
+    # keep reaching upstream as ``[]`` (issue #1184 only suppresses the
+    # synthesized default for clients that omitted the field).
+    raw_account_id = "acc_responses_explicit_empty_tools"
+    auth_json = _make_auth_json(raw_account_id, "responses-explicit-empty-tools@example.com")
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payload: dict[str, object] = {}
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del headers, access_token, account_id, base_url, raise_for_status, kwargs
+        seen_payload.update(payload.to_payload())
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_explicit_empty_tools",'
+            '"object":"response","status":"completed","usage":{"input_tokens":2,"output_tokens":1}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    request_payload = {
+        "model": "gpt-5.6",
+        "instructions": "hi",
+        "input": [{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        "tools": [],
+        "stream": True,
+    }
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=request_payload,
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    event = _extract_first_event(lines)
+    assert event["type"] == "response.completed"
+    assert seen_payload["tools"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -749,7 +749,6 @@ def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_insta
                     custom_tool_output,
                     {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
                 ],
-                "tools": [],
                 "reasoning": {"effort": "high"},
                 "client_metadata": {
                     "x-codex-turn-metadata": '{"turn_id":"turn_123","sandbox":"workspace-write"}',
@@ -775,6 +774,147 @@ def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_insta
     assert log["status"] == "success"
     assert log["input_tokens"] == 3
     assert log["output_tokens"] == 5
+
+
+def test_backend_responses_websocket_forwards_client_tools_byte_identical(app_instance, monkeypatch):
+    # Regression for issue #1184: client-sent top-level tools must reach the
+    # upstream ``response.create`` frame byte-identical — array order, object
+    # key order, unknown keys, and array-value order all preserved. The
+    # fixture mirrors the gpt-5.6 ``multi_agent_version: v2`` reserved
+    # collaboration namespace tool (codex-rs rust-v0.144.1): ``strict: false``,
+    # a non-standard ``encrypted`` marker, non-alphabetical ``required`` order,
+    # and leading whitespace in the description.
+    upstream_messages = [
+        _FakeUpstreamMessage(
+            "text",
+            text=json.dumps(
+                {
+                    "type": "response.created",
+                    "response": {"id": "resp_ws_tools_bytes", "object": "response", "status": "in_progress"},
+                },
+                separators=(",", ":"),
+            ),
+        ),
+        _FakeUpstreamMessage(
+            "text",
+            text=json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_tools_bytes",
+                        "object": "response",
+                        "status": "completed",
+                        "usage": {"input_tokens": 3, "output_tokens": 5, "total_tokens": 8},
+                    },
+                },
+                separators=(",", ":"),
+            ),
+        ),
+    ]
+    fake_upstream = _FakeUpstreamWebSocket(upstream_messages)
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        del authorization, request
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        prefer_earlier_reset_window,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            prefer_earlier_reset_window,
+            routing_strategy,
+            model,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        return SimpleNamespace(id="acct_ws_tools_bytes", codex_installation_id="account-installation"), fake_upstream
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+
+    client_tools = [
+        {
+            "type": "namespace",
+            "name": "collaboration",
+            "description": "Tools for spawning and managing sub-agents.",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "spawn_agent",
+                    "strict": False,
+                    "description": "\n        \n        Spawn a sub-agent for the given task.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "message": {"type": "string", "encrypted": True},
+                            "task_name": {"type": "string"},
+                        },
+                        "required": ["task_name", "message"],
+                        "additionalProperties": False,
+                    },
+                }
+            ],
+        },
+        {
+            "type": "function",
+            "name": "zeta_tool",
+            "parameters": {"required": [], "type": "object", "properties": {}},
+            "description": "later",
+        },
+    ]
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.6",
+        "instructions": "hi",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        "tools": client_tools,
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            first = json.loads(websocket.receive_text())
+            second = json.loads(websocket.receive_text())
+
+    assert first["type"] == "response.created"
+    assert second["type"] == "response.completed"
+    assert len(fake_upstream.sent_text) == 1
+    frame = fake_upstream.sent_text[0]
+    expected_tools_bytes = '"tools":' + json.dumps(client_tools, ensure_ascii=True, separators=(",", ":"))
+    assert expected_tools_bytes in frame
 
 
 def test_backend_responses_websocket_lite_marker_requires_previous_response_linkage(app_instance, monkeypatch):
@@ -2109,7 +2249,6 @@ def test_v1_responses_websocket_reuses_upstream_for_sequential_requests(app_inst
                 "model": "gpt-5.4",
                 "instructions": "",
                 "input": [{"role": "user", "content": [{"type": "input_text", "text": "first"}]}],
-                "tools": [],
                 "store": False,
                 "include": [],
                 "prompt_cache_key": "thread_a",
@@ -2119,7 +2258,6 @@ def test_v1_responses_websocket_reuses_upstream_for_sequential_requests(app_inst
                 "model": "gpt-5.5",
                 "instructions": "",
                 "input": [{"role": "user", "content": [{"type": "input_text", "text": "second"}]}],
-                "tools": [],
                 "store": False,
                 "include": [],
                 "prompt_cache_key": "thread_b",
@@ -2637,7 +2775,6 @@ def test_backend_responses_websocket_forwards_previous_response_id(app_instance,
                 "model": "gpt-5.4",
                 "instructions": "",
                 "input": [{"role": "user", "content": [{"type": "input_text", "text": "continue"}]}],
-                "tools": [],
                 "store": False,
                 "include": [],
                 "previous_response_id": "resp_prev_123",
@@ -2822,7 +2959,6 @@ def test_backend_responses_websocket_injects_interrupted_custom_tool_output_on_f
                 "model": "gpt-5.4",
                 "instructions": "",
                 "input": [first_user_message],
-                "tools": [],
                 "store": False,
                 "include": [],
                 "type": "response.create",
@@ -2838,7 +2974,6 @@ def test_backend_responses_websocket_injects_interrupted_custom_tool_output_on_f
                     },
                     interrupted_user_message,
                 ],
-                "tools": [],
                 "store": False,
                 "include": [],
                 "previous_response_id": "resp_ws_custom_interrupt",
@@ -3050,7 +3185,6 @@ def test_backend_responses_websocket_injects_interrupted_custom_tool_output_afte
                 "model": "gpt-5.4",
                 "instructions": "",
                 "input": expected_first_upstream_input,
-                "tools": [],
                 "store": False,
                 "include": [],
                 "type": "response.create",
@@ -3066,7 +3200,6 @@ def test_backend_responses_websocket_injects_interrupted_custom_tool_output_afte
                     },
                     interrupted_user_message,
                 ],
-                "tools": [],
                 "store": False,
                 "include": [],
                 "previous_response_id": first_response_id,
@@ -3271,7 +3404,6 @@ def test_v1_responses_websocket_forwards_previous_response_id(app_instance, monk
                 "model": "gpt-5.4",
                 "instructions": "",
                 "input": [{"role": "user", "content": [{"type": "input_text", "text": "continue"}]}],
-                "tools": [],
                 "store": False,
                 "include": [],
                 "previous_response_id": "resp_prev_v1_123",
@@ -6964,7 +7096,6 @@ def test_backend_responses_websocket_reconnects_after_account_health_failure(app
                 "model": "gpt-5.1",
                 "instructions": "",
                 "input": [{"role": "user", "content": [{"type": "input_text", "text": "first"}]}],
-                "tools": [],
                 "store": False,
                 "include": [],
                 "type": "response.create",
@@ -6978,7 +7109,6 @@ def test_backend_responses_websocket_reconnects_after_account_health_failure(app
                 "model": "gpt-5.2",
                 "instructions": "",
                 "input": [{"role": "user", "content": [{"type": "input_text", "text": "second"}]}],
-                "tools": [],
                 "store": False,
                 "include": [],
                 "type": "response.create",

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -203,36 +203,189 @@ def test_settings_default_prompt_cache_affinity_ttl_is_1800():
     assert settings.openai_cache_affinity_max_age_seconds == 1800
 
 
-def test_responses_to_payload_canonicalizes_tool_order_and_object_keys():
+def test_responses_to_payload_preserves_tool_order_and_object_keys():
+    # Wire payload byte-preservation (issue #1184): the client's tool array
+    # order and per-object key order must reach upstream untouched. The
+    # previously asserted wire canonicalization is now cache-affinity-only.
+    client_tools: list[JsonValue] = [
+        {
+            "type": "function",
+            "name": "zeta",
+            "parameters": {"required": [], "type": "object", "properties": {}},
+            "description": "later",
+        },
+        {
+            "description": "first",
+            "parameters": {"properties": {}, "required": [], "type": "object"},
+            "type": "function",
+            "name": "alpha",
+        },
+    ]
     request = ResponsesRequest.model_validate(
         {
             "model": "gpt-5.1",
             "instructions": "hi",
             "input": [],
-            "tools": [
-                {
-                    "type": "function",
-                    "name": "zeta",
-                    "parameters": {"required": [], "type": "object", "properties": {}},
-                    "description": "later",
-                },
-                {
-                    "description": "first",
-                    "parameters": {"properties": {}, "required": [], "type": "object"},
-                    "type": "function",
-                    "name": "alpha",
-                },
-            ],
+            "tools": client_tools,
         }
     )
 
     dumped = request.to_payload()
-    tools = cast(list[JsonValue], dumped["tools"])
-    first_tool = cast(Mapping[str, JsonValue], tools[0])
-    parameters = cast(Mapping[str, JsonValue], first_tool["parameters"])
-    assert first_tool["name"] == "alpha"
-    assert list(first_tool.keys()) == ["description", "name", "parameters", "type"]
-    assert list(parameters.keys()) == ["properties", "required", "type"]
+    assert json.dumps(dumped["tools"], ensure_ascii=True, separators=(",", ":")) == json.dumps(
+        client_tools, ensure_ascii=True, separators=(",", ":")
+    )
+
+
+def test_responses_to_payload_omits_unset_tools():
+    # Codex Responses-Lite clients omit top-level ``tools`` entirely; the
+    # proxy must not synthesize ``"tools": []`` from the model default
+    # (issue #1184).
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6",
+            "instructions": "",
+            "input": [
+                {
+                    "type": "additional_tools",
+                    "role": "developer",
+                    "tools": [{"type": "custom", "name": "shell"}],
+                },
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
+            ],
+            "stream": True,
+        }
+    )
+
+    assert "tools" not in request.to_payload()
+
+
+def test_responses_to_payload_omits_unset_tool_choice_and_parallel_tool_calls():
+    # Sibling-field audit for issue #1184: ``tool_choice`` and
+    # ``parallel_tool_calls`` default to ``None`` and are dropped by
+    # ``model_dump(exclude_none=True)`` when the client omits them, while
+    # explicit values (including ``false``) keep forwarding.
+    unset = ResponsesRequest.model_validate({"model": "gpt-5.6", "instructions": "hi", "input": []})
+    explicit = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6",
+            "instructions": "hi",
+            "input": [],
+            "tool_choice": "auto",
+            "parallel_tool_calls": False,
+        }
+    )
+
+    unset_payload = unset.to_payload()
+    explicit_payload = explicit.to_payload()
+
+    assert "tool_choice" not in unset_payload
+    assert "parallel_tool_calls" not in unset_payload
+    assert explicit_payload["tool_choice"] == "auto"
+    assert explicit_payload["parallel_tool_calls"] is False
+
+
+def test_responses_to_payload_preserves_explicit_empty_tools():
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [],
+            "tools": [],
+        }
+    )
+
+    assert request.to_payload()["tools"] == []
+
+
+def test_responses_to_payload_preserves_reserved_namespace_tool_byte_identical():
+    # gpt-5.6 ``multi_agent_version: v2`` reserved collaboration tool shape
+    # (codex-rs rust-v0.144.1): namespace-typed entry with nested function
+    # entries, unknown keys (``encrypted``), non-alphabetical ``required``
+    # array order, leading whitespace in descriptions, and ``strict: false``.
+    reserved_namespace_tool: JsonValue = {
+        "type": "namespace",
+        "name": "collaboration",
+        "description": "Tools for spawning and managing sub-agents.",
+        "tools": [
+            {
+                "type": "function",
+                "name": "spawn_agent",
+                "strict": False,
+                "description": "\n        \n        Spawn a sub-agent for the given task.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "message": {"type": "string", "encrypted": True},
+                        "task_name": {"type": "string"},
+                    },
+                    "required": ["task_name", "message"],
+                    "additionalProperties": False,
+                },
+            }
+        ],
+    }
+    client_tools: list[JsonValue] = [reserved_namespace_tool]
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6",
+            "instructions": "hi",
+            "input": [],
+            "tools": client_tools,
+        }
+    )
+
+    dumped = request.to_payload()
+    assert json.dumps(dumped["tools"], ensure_ascii=True, separators=(",", ":")) == json.dumps(
+        client_tools, ensure_ascii=True, separators=(",", ":")
+    )
+
+
+def test_canonicalized_tools_is_order_insensitive_and_non_mutating():
+    from app.core.openai.requests import canonicalized_tools
+
+    tools_one: list[JsonValue] = [
+        {"type": "function", "name": "zeta", "parameters": {"required": ["b", "a"], "type": "object"}},
+        {"name": "alpha", "type": "function"},
+    ]
+    tools_two: list[JsonValue] = [
+        {"type": "function", "name": "alpha"},
+        {"parameters": {"type": "object", "required": ["b", "a"]}, "type": "function", "name": "zeta"},
+    ]
+    snapshot = json.dumps(tools_one, ensure_ascii=True, separators=(",", ":"))
+
+    canonical_one = json.dumps(canonicalized_tools(tools_one), sort_keys=True, separators=(",", ":"))
+    canonical_two = json.dumps(canonicalized_tools(tools_two), sort_keys=True, separators=(",", ":"))
+
+    assert canonical_one == canonical_two
+    # Array values (e.g. ``required``) must never be reordered.
+    assert '"required": ["b", "a"]' in json.dumps(canonicalized_tools(tools_one))
+    # The input list is left untouched.
+    assert json.dumps(tools_one, ensure_ascii=True, separators=(",", ":")) == snapshot
+
+
+def test_v1_responses_to_responses_request_propagates_unset_tools():
+    request = V1ResponsesRequest.model_validate(
+        {"model": "gpt-5.6", "input": [{"type": "message", "role": "user", "content": "hi"}]}
+    )
+
+    converted = request.to_responses_request()
+
+    assert "tools" not in converted.model_fields_set
+    assert "tools" not in converted.to_payload()
+
+
+def test_v1_responses_to_responses_request_preserves_explicit_empty_tools():
+    request = V1ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6",
+            "input": [{"type": "message", "role": "user", "content": "hi"}],
+            "tools": [],
+        }
+    )
+
+    converted = request.to_responses_request()
+
+    assert converted.to_payload()["tools"] == []
 
 
 def test_openai_compatible_reasoning_aliases_are_normalized():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -3955,6 +3955,48 @@ def test_log_proxy_request_shape_includes_affinity_metadata(monkeypatch, caplog)
     assert "tools_hash=sha256:" in caplog.text
 
 
+def test_tools_hash_is_insensitive_to_tool_and_key_order():
+    # Wire payloads forward client tool entries byte-preserved (issue #1184),
+    # so the affinity/observability hash must canonicalize locally: tool array
+    # order and object key order must not change the hash (change #228).
+    base = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+    }
+    payload_one = ResponsesRequest.model_validate(
+        {
+            **base,
+            "tools": [
+                {"type": "function", "name": "b_tool", "parameters": {"type": "object", "properties": {}}},
+                {"type": "function", "name": "a_tool"},
+            ],
+        }
+    )
+    payload_two = ResponsesRequest.model_validate(
+        {
+            **base,
+            "tools": [
+                {"name": "a_tool", "type": "function"},
+                {"parameters": {"properties": {}, "type": "object"}, "name": "b_tool", "type": "function"},
+            ],
+        }
+    )
+    payload_other = ResponsesRequest.model_validate(
+        {
+            **base,
+            "tools": [{"type": "function", "name": "c_tool"}],
+        }
+    )
+
+    hash_one = proxy_service._tools_hash(payload_one)
+    hash_two = proxy_service._tools_hash(payload_two)
+
+    assert hash_one is not None
+    assert hash_one == hash_two
+    assert hash_one != proxy_service._tools_hash(payload_other)
+
+
 def test_log_proxy_request_shape_hashes_prompt_cache_key_without_raw_value(monkeypatch, caplog):
     payload = ResponsesRequest.model_validate(
         {


### PR DESCRIPTION
Fixes #1184

## Root cause

Under Responses Lite the Codex client omits top-level `tools` entirely (codex-rs `build_responses_request`: `(instructions, tools) = (String::new(), None)`), shipping the tool bundle in the `additional_tools` input item. `ResponsesRequest.tools` is declared with `default_factory=list`, so `to_payload()` synthesized an explicit `"tools": []` on every Lite request across all upstream transports (websocket `response.create` frames via `_response_create_text`, HTTP-bridge bodies via `_prepare_http_bridge_request`, and the direct HTTP stream path). gpt-5.6 Sol/Terra (`multi_agent_version: v2`) configure `collaboration.spawn_agent` as a reserved model tool; any explicit `tools` param triggers reserved-tool schema reconciliation, and `[]` cannot match — hence the intermittent `400 invalid_request_error` with `param: "tools"`.

Secondary hazard from the same trace: `_canonicalize_tools` (#228, prompt-cache affinity) re-sorted every tool and every object key **in the wire payload**, which would break any byte/structural-equality check upstream performs on a client-sent reserved tool entry.

## Changes

- `ResponsesRequest.to_payload()` pops `tools` when `"tools" not in model_fields_set`; an explicit client-sent `[]` is still forwarded. Websocket/bridge/HTTP paths inherit the fix because they all serialize via `to_payload()`.
- `V1ResponsesRequest.to_responses_request()` drops the synthesized default before constructing the native request, so `/v1/responses` propagates client omission (its own `model_dump` would otherwise mark `tools` as set).
- `_canonicalize_tools` is replaced by a non-mutating `canonicalized_tools()` used only by the `_tools_hash` affinity/observability consumer; the wire payload keeps the client's tool entries byte-preserved (array order, object key order, unknown keys, array-value order).
- OpenSpec change `omit-synthesized-top-level-tools` with normative deltas on `responses-api-compat` (strict validation passes).

## Sibling-field audit

- `tool_choice` / `parallel_tool_calls`: default `None`, already dropped by `model_dump(exclude_none=True)` when unset; explicit values — including Lite's explicit `parallel_tool_calls: false` — keep forwarding. No code change needed; behavior locked by a new unit test.
- `store: false` is a deliberate proxy invariant (validator-coerced) and keeps being emitted.
- `include` shares the `default_factory=list` pattern, but `"include": []` is semantically identical to omission upstream and not a reserved-schema hazard; left unchanged to keep this PR one concern wide.
- `validate_tool_types` passes `{"type": "namespace"}` entries through untouched (no alias, not an unsupported type), verified by the byte-identity tests which run through the field validator.

## Byte-diff evidence

- Lite request (input contains `additional_tools`, no top-level `tools`): before — upstream websocket frame and HTTP-bridge body both contained `"tools":[]`; after — no `tools` key on either transport (`additional_tools` passthrough stays byte-identical per #1161/#1172).
- Client-sent reserved namespace tool (`collaboration` namespace wrapping `spawn_agent` with `strict: false`, non-standard `"encrypted": true` marker, non-alphabetical `required` order, leading description whitespace): before — array re-sorted and every key alphabetized on the wire; after — the upstream frame contains the tools array byte-identical to the client serialization (asserted as an exact `"tools":<json>` substring of the raw frame).
- Explicit client-sent `"tools": []` — forwarded as `[]` before and after (unchanged).

## Test plan

All new regression tests verified fail-before/pass-after by stashing the `app/` changes:

- `tests/unit/test_openai_requests.py` — unset tools omitted; explicit `[]` preserved; reserved namespace tool byte-identical; tool order/key order preserved; `canonicalized_tools` order-insensitive and non-mutating (never reorders array values like `required`); V1 conversion propagates omission and preserves explicit `[]`; unset `tool_choice`/`parallel_tool_calls` absent while explicit values forward.
- `tests/unit/test_proxy_utils.py` — `_tools_hash` identical across tool-array reorder and key reorder, different for different tools.
- `tests/integration/test_proxy_websocket_responses.py` — Lite frame exact-payload assertion no longer contains `tools` (fails pre-fix); new byte-identity test on the raw upstream `response.create` frame with the reserved namespace fixture.
- `tests/integration/test_http_responses_bridge.py` — new Lite bridge test: bridge body has no `tools` key while the Lite client-metadata marker survives.
- `tests/integration/test_proxy_responses.py` — Lite HTTP path payload has no `tools` key; new explicit-`[]` forwarding test.

Quality gate: `uv run ruff check .` + `uv run ruff format --check .` + `uv run ty check` all clean; `tests/unit` 3276 passed; touched integration files (`test_proxy_responses.py`, `test_http_responses_bridge.py`, `test_proxy_websocket_responses.py`, `test_proxy_compact.py`) 212 passed, plus `test_openai_compat_features.py` / `test_proxy_sticky_sessions.py` green; `openspec validate omit-synthesized-top-level-tools --strict` valid.

Refs #1157, #1176, #228, #1161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)