### PR TITLE
chore: release v1.21.0-beta.2

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.21.0-beta.1"  # x-release-please-version
+__version__ = "1.21.0-beta.2"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.21.0-beta.1
-appVersion: 1.21.0-beta.1
+version: 1.21.0-beta.2
+appVersion: 1.21.0-beta.2
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.21.0-beta.1",
+  "version": "1.21.0-beta.2",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.21.0-beta.1"
+version = "1.21.0-beta.2"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.21.0-beta.1"
+version = "1.21.0-beta.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.21.0-beta.2 for the 1.21.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.21.0-beta.2 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1087; no manual beta workflow dispatch is required.

## Changes since v1.21.0-beta.1
- fix(proxy): preserve multi-agent v2 passthrough (#1189) (9bbc5cd)
- fix(proxy): stop synthesizing top-level tools for upstream Codex requests (#1200) (
fc57c9)

## Release-candidate validation
Validated candidate: aec536ad5276775376e617a086f947ea112657c6

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates
- [x] Frontend tests/build
- [x] Wheel/package validation
- [x] Docker/container smoke
- [x] Live upstream/account smoke
- [ ] Live upstream/account smoke not required

Validation evidence (2026-07-11, candidate aec536ad):
- CI matrix green on the candidate SHA (31 checks; only the guard pending this checklist).
- Wheel `codex_lb-1.21.0b2` built (`make package`), fresh-venv install, `codex-lb --help` OK, metadata version `1.21.0b2`, frontend assets verified; `verify_release_version --require-channel beta` → tag v1.21.0-beta.2.
- Docker image built at the SHA; container `GET /health/live` 200, dashboard root 200, zero tracebacks; container/image cleaned up.
- `uv run pytest tests/unit -q` at the SHA: 3292 passed, 3 skipped; ruff + ty (frozen) clean.
- **Live upstream/account smoke PERFORMED** with real Codex CLI v0.144.1 + a real ChatGPT account against a scratch instance running the identical code tree (main @ fc57c9ca; the candidate differs only by release version files): gpt-5.6-sol catalog fetch (model_messages present), shell tool execution, and `collaboration.spawn_agent` multi-agent v2 flow all succeeded — 8/8 upstream requests success, zero 400s. This directly re-verifies the beta.1 field regressions (#1184, #1185).

## Install after publish
```bash
uvx --from "codex-lb==1.21.0b2" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.21.0-beta.2
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.21.0-beta.2 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.21.0.

