### PR TITLE
chore: release v1.21.0-beta.3

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.21.0-beta.2"  # x-release-please-version
+__version__ = "1.21.0-beta.3"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.21.0-beta.2
-appVersion: 1.21.0-beta.2
+version: 1.21.0-beta.3
+appVersion: 1.21.0-beta.3
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.21.0-beta.2",
+  "version": "1.21.0-beta.3",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.21.0-beta.2"
+version = "1.21.0-beta.3"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.21.0-beta.2"
+version = "1.21.0-beta.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.21.0-beta.3 for the 1.21.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.21.0-beta.3 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1087; no manual beta workflow dispatch is required.

## Changes since v1.21.0-beta.2
- fix(proxy): send complete Codex identity headers (#1197) (d57307b)
- fix(account-ui): expand account list on tall viewports (#1195) (
d5cef8)
- fix(proxy): hide blank reasoning summary comments (#1154) (
b62e03)
- fix(proxy): wait on local account cap pressure (#1155) (
689c6d)
- fix(proxy): preserve admitted bridge waiters on upstream close (#1191) (
03b777)
- feat(proxy): add Fast Mode prohibition setting (#1190) (
cab7ef)
- fix(proxy): isolate unanchored parallel bridge requests (#1169) (
cea524)
- fix(proxy): reserve stream capacity for recovery (#1188) (
bf0345)
- fix(proxy): omit synthesized tools on owner-forward and source egress (#1203) (
e94e07)
- fix(proxy): normalize selected installation metadata (#1204) (
2d52ff)
- fix(accounts): sync free-to-paid plan upgrades (#1217) (
57ebc3)
- fix(ci): keep manual rerun attempts authoritative (#1216) (
87b590)
- fix(proxy): preserve responses turn-state fidelity (#1193) (
88540b)
- fix(models): retain hidden metadata across partial refreshes (#1221) (
cf8723)
- fix(proxy): preserve websocket reconnect affinity (#1220) (
ca1043)
- fix(proxy): preserve websocket incomplete reasons (#1219) (
b962b3)
- fix(proxy): reselect only safe websocket turns (#1207) (
4c3d10)
- fix(proxy): route by complete account capability catalogs (#1205) (
f8815b)
- fix(proxy): keep native capacity waits alive (#1218) (
0b0d43)
- fix(ui): make routing strategy guide clickable cards (#1229) (
534d95)
- fix(oauth): isolate reauth by Team seat identity (#1224) (
64b9f7)
- fix(proxy): prevent sequenced websocket replay (#1223) (
4f891a)
- feat(proxy): configure account concurrency caps (#1214) (
88807e)
- feat(dashboard): show request log speed metrics (#1210) (
3de4dd)
- fix(warmup): separate idle threshold, fix jitter, redesign warm-up UI (#1230) (
1c6355)

## Release-candidate validation
Validated candidate: bad6fd2b08a55f2ba5ef15cee1fcbbc872f18cad

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates
- [x] Frontend tests/build
- [x] Wheel/package validation
- [x] Docker/container smoke
- [x] Live upstream/account smoke
- [ ] Live upstream/account smoke not required

Validation evidence (2026-07-12, candidate bad6fd2b = main 1c635501 + version bump; bundles all round-3/4/5 merges):
- CI matrix green on the candidate (31 checks; only the guard pending this checklist).
- Wheel codex_lb-1.21.0b3 built, fresh-venv install OK, `codex-lb --help` exit 0, metadata version 1.21.0b3; verify_release_version → tag v1.21.0-beta.3 / pypi 1.21.0b3.
- Docker: fresh-start applies Alembic to head 20260711_030000, drift-check clean, /health/live + / = 200, no tracebacks. **Upgrade path verified**: seeded DB at 20260711_000000 → startup applied the 3-step chain 010000→020000→030000 (chatgpt_user_id, concurrency caps nullable, idle_threshold FLOAT NOT NULL default 1.0) cleanly with drift-check passing.
- `pytest tests/unit` at the SHA: 3511 passed, 3 skipped; ruff + ty (frozen) clean.
- **Live upstream/account smoke PERFORMED** (real Codex CLI 0.144.1 + real ChatGPT account, scratch instance on identical code): gpt-5.6 catalog (model_messages + correct efforts incl ultra on sol/terra), shell tool execution, and collaboration.spawn_agent multi-agent-v2 flow (subagent returned correct sha256) — 7/7 gpt-5.6 upstream requests success, ZERO 400s.
- ⚠️ Operator note (not a release blocker): production DBs that predate accounts.codex_installation_id must apply a manual column-add + uuid backfill + NOT-NULL alter before the beta.3 startup drift-check passes; the migration chain does not self-heal that pre-existing gap. Reproduced and remediated on a prod-DB copy during E2E.

## Install after publish
```bash
uvx --from "codex-lb==1.21.0b3" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.21.0-beta.3
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.21.0-beta.3 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.21.0.

