### PR TITLE
fix(ci): keep manual rerun attempts authoritative

### DIFF
--- a/.github/scripts/sync_codex_ok_labels.py
+++ b/.github/scripts/sync_codex_ok_labels.py
@@ -787,7 +787,7 @@ def authoritative_ci_workflow_run_id(
 def github_actions_workflow_run_recency_key(item: dict[str, Any]) -> tuple[str, tuple[str, str], int]:
     run_id = github_actions_workflow_run_id(item)
     return (
-        str(item.get("_github_actions_run_created_at") or ""),
+        str(item.get("_github_actions_run_started_at") or item.get("_github_actions_run_created_at") or ""),
         check_run_recency_key(item),
         int(run_id) if isinstance(run_id, str) and run_id.isdigit() else 0,
     )
@@ -816,10 +816,12 @@ def annotate_github_actions_workflow_ids(repo: str, check_runs: list[dict[str, A
             continue
         workflow_id = workflow_run.get("workflow_id") if isinstance(workflow_run, dict) else None
         if isinstance(workflow_id, (int, str)):
-            run_created_at = workflow_run.get("created_at") or workflow_run.get("run_started_at")
+            # GitHub preserves ``created_at`` when an existing run id is rerun,
+            # while ``run_started_at`` advances to the current attempt.
+            run_started_at = workflow_run.get("run_started_at") or workflow_run.get("created_at")
             workflow_metadata_by_run[run_id] = (
                 str(workflow_id),
-                str(run_created_at) if isinstance(run_created_at, str) else None,
+                str(run_started_at) if isinstance(run_started_at, str) else None,
             )
 
     annotated: list[dict[str, Any]] = []
@@ -829,10 +831,10 @@ def annotate_github_actions_workflow_ids(repo: str, check_runs: list[dict[str, A
         if metadata is None:
             annotated.append(item)
             continue
-        workflow_id, run_created_at = metadata
+        workflow_id, run_started_at = metadata
         annotated_item = {**item, "_github_actions_workflow_id": workflow_id}
-        if run_created_at is not None:
-            annotated_item["_github_actions_run_created_at"] = run_created_at
+        if run_started_at is not None:
+            annotated_item["_github_actions_run_started_at"] = run_started_at
         annotated.append(annotated_item)
     return annotated
 

--- a/openspec/changes/ignore-superseded-ci-check-suites/proposal.md
+++ b/openspec/changes/ignore-superseded-ci-check-suites/proposal.md
@@ -17,6 +17,8 @@ requests the missing current-head Codex review.
   superseded runs of that workflow, while preserving non-Actions status
   evidence and checks from independent workflows.
 - Keep failures from the authoritative CI run blocking.
+- Treat a manually re-run older workflow `run_id` as newer evidence when its
+  current attempt started after a later-created run.
 - Add regression coverage for the cancelled matrix-placeholder shape observed
   on a real current-head pull request.
 

--- a/openspec/changes/ignore-superseded-ci-check-suites/specs/github-automation/spec.md
+++ b/openspec/changes/ignore-superseded-ci-check-suites/specs/github-automation/spec.md
@@ -4,10 +4,11 @@
 
 The Codex review label synchronizer SHALL identify the CI workflow from the
 most recent `CI Required` check and SHALL treat the newest same-head run of
-that workflow (ordered by workflow-run creation time, then check recency, then
-run id) as the authoritative CI suite when multiple runs of the same GitHub
-Actions CI workflow exist for one pull-request head, even when that run has
-not yet produced its own `CI Required` check. It MUST ignore Actions checks —
+that workflow (ordered by the current attempt's start time, falling back to
+workflow-run creation time, then check recency and run id) as the authoritative
+CI suite when multiple runs of the same GitHub Actions CI workflow exist for
+one pull-request head, even when that run has not yet produced its own
+`CI Required` check. It MUST ignore Actions checks —
 including stale required contexts — only from superseded (older) runs of that
 workflow, while checks from the authoritative run, checks that cannot be
 attributed to a workflow run, non-Actions status evidence, and failures from
@@ -37,6 +38,14 @@ independent workflows remain blocking evidence.
 - **WHEN** Codex review labels are synchronized
 - **THEN** the newer run is the authoritative CI suite and the older run's completed checks are ignored
 - **AND** the current head remains classified as pending until the newer run's `CI Required` completes
+
+#### Scenario: An older workflow run id is manually rerun
+
+- **GIVEN** a newer-created CI workflow run completed successfully for the current head
+- **AND** an older workflow `run_id` is manually rerun afterward
+- **WHEN** the older run's new attempt has the latest `run_started_at`
+- **THEN** that rerun is the authoritative CI suite
+- **AND** its pending or failed checks remain blocking evidence
 
 #### Scenario: Independent workflow on the same head fails
 

--- a/openspec/changes/ignore-superseded-ci-check-suites/tasks.md
+++ b/openspec/changes/ignore-superseded-ci-check-suites/tasks.md
@@ -11,3 +11,11 @@
 
 - [x] 3.1 Add positive and negative unit regressions for duplicate same-head CI runs.
 - [x] 3.2 Run focused tests, lint, type checks, and strict OpenSpec validation.
+
+## 4. Issue #1182 follow-up
+
+- [x] 4.1 Order workflow runs by the current attempt's `run_started_at`, with
+  workflow creation time as a compatibility fallback.
+- [x] 4.2 Cover pending and failed manual reruns of an older workflow `run_id`.
+- [x] 4.3 Run the 25-test synchronizer suite, Ruff format/check, `ty`, strict
+  change validation, all-spec strict validation, and `git diff --check`.

--- a/tests/unit/test_sync_codex_ok_labels.py
+++ b/tests/unit/test_sync_codex_ok_labels.py
@@ -256,6 +256,81 @@ def test_classify_check_state_keeps_newer_same_workflow_run_pending_before_requi
     )
 
 
+def test_classify_check_state_keeps_manual_rerun_of_older_run_pending() -> None:
+    module = load_sync_module()
+
+    check_runs = [
+        {
+            "name": "CI Required",
+            "status": "completed",
+            "conclusion": "success",
+            "started_at": "2026-07-10T06:50:20Z",
+            "completed_at": "2026-07-10T06:59:05Z",
+            "details_url": "https://github.com/Soju06/codex-lb/actions/runs/200/job/4",
+            "_github_actions_workflow_id": "ci",
+            "_github_actions_run_created_at": "2026-07-10T06:50:00Z",
+            "_github_actions_run_started_at": "2026-07-10T06:50:00Z",
+        },
+        {
+            "name": "Detect changes",
+            "status": "in_progress",
+            "conclusion": None,
+            "started_at": "2026-07-10T07:10:20Z",
+            "details_url": "https://github.com/Soju06/codex-lb/actions/runs/100/job/1",
+            "_github_actions_workflow_id": "ci",
+            "_github_actions_run_created_at": "2026-07-10T06:00:00Z",
+            "_github_actions_run_started_at": "2026-07-10T07:10:00Z",
+        },
+    ]
+
+    assert (
+        module.classify_check_state(
+            check_runs,
+            {"statuses": []},
+            required_check_names=frozenset({"CI Required"}),
+        )
+        == "pending"
+    )
+
+
+def test_classify_check_state_keeps_failure_from_manual_rerun_of_older_run() -> None:
+    module = load_sync_module()
+
+    check_runs = [
+        {
+            "name": "CI Required",
+            "status": "completed",
+            "conclusion": "success",
+            "started_at": "2026-07-10T06:50:20Z",
+            "completed_at": "2026-07-10T06:59:05Z",
+            "details_url": "https://github.com/Soju06/codex-lb/actions/runs/200/job/4",
+            "_github_actions_workflow_id": "ci",
+            "_github_actions_run_created_at": "2026-07-10T06:50:00Z",
+            "_github_actions_run_started_at": "2026-07-10T06:50:00Z",
+        },
+        {
+            "name": "CI Required",
+            "status": "completed",
+            "conclusion": "failure",
+            "started_at": "2026-07-10T07:10:20Z",
+            "completed_at": "2026-07-10T07:15:05Z",
+            "details_url": "https://github.com/Soju06/codex-lb/actions/runs/100/job/4",
+            "_github_actions_workflow_id": "ci",
+            "_github_actions_run_created_at": "2026-07-10T06:00:00Z",
+            "_github_actions_run_started_at": "2026-07-10T07:10:00Z",
+        },
+    ]
+
+    assert (
+        module.classify_check_state(
+            check_runs,
+            {"statuses": []},
+            required_check_names=frozenset({"CI Required"}),
+        )
+        == "failure"
+    )
+
+
 def test_classify_check_state_keeps_failure_from_independent_workflow_run() -> None:
     module = load_sync_module()
 
@@ -307,7 +382,11 @@ def test_annotate_github_actions_workflow_ids_is_conservative_when_metadata_look
 
     def workflow_run(path: str) -> dict[str, int | str]:
         if path.endswith("/200"):
-            return {"workflow_id": 10, "created_at": "2026-07-10T06:00:43Z"}
+            return {
+                "workflow_id": 10,
+                "created_at": "2026-07-10T06:00:43Z",
+                "run_started_at": "2026-07-10T07:10:00Z",
+            }
         raise module.GhError("metadata unavailable")
 
     monkeypatch.setattr(module, "gh_api", workflow_run)
@@ -315,7 +394,7 @@ def test_annotate_github_actions_workflow_ids_is_conservative_when_metadata_look
     annotated = module.annotate_github_actions_workflow_ids("Soju06/codex-lb", check_runs)
 
     assert annotated[0]["_github_actions_workflow_id"] == "10"
-    assert annotated[0]["_github_actions_run_created_at"] == "2026-07-10T06:00:43Z"
+    assert annotated[0]["_github_actions_run_started_at"] == "2026-07-10T07:10:00Z"
     assert "_github_actions_workflow_id" not in annotated[1]
 
 


### PR DESCRIPTION
## Summary

- order same-workflow CI runs by the current attempt's `run_started_at`, falling back to immutable workflow creation time only when needed
- keep a manually rerun older `run_id` authoritative when its new attempt starts after a newer-created successful run
- preserve pending and failed rerun checks as blocking Codex-label evidence
- update the active GitHub automation OpenSpec change and add regressions for both states

## Why

GitHub reuses a workflow `run_id` for manual reruns. Its `created_at` remains tied to the original run, while `run_started_at` advances for the new attempt. Selecting solely by creation time can therefore filter out the genuinely newest pending or failing CI evidence.

A current repository run with `run_attempt: 2` confirmed this shape: its `created_at` remained `2026-07-11T13:52:03Z`, while `run_started_at` advanced to `2026-07-11T14:43:45Z`.

## Scope

The runtime script diff is 6 additions / 6 removals. The remaining diff is focused regression coverage and OpenSpec synchronization.

## Validation

- `uv run pytest tests/unit/test_sync_codex_ok_labels.py -q` (25 passed)
- Ruff format/check
- `uv run ty check .github/scripts/sync_codex_ok_labels.py tests/unit/test_sync_codex_ok_labels.py`
- strict OpenSpec change validation
- strict validation of all 31 specs
- `git diff --check`

Fixes #1182