### PR TITLE
fix(accounts): sync free-to-paid plan upgrades

### DIFF
--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -847,20 +847,20 @@ def _payload_mismatches_account_slot(account: Account, payload: UsagePayload) ->
         normalized_payload_plan_type = normalize_account_plan_type(payload.plan_type)
         stored_plan_type = coerce_account_plan_type(account.plan_type, "free")
         recognized_paid_plans = ACCOUNT_PLAN_TYPES - {"free"}
-        # A transition between two recognized paid plans (e.g. Plus -> Pro) is a
-        # legitimate upgrade/downgrade, not an identity mismatch: the usage
-        # payload carries no independent account identifier and is fetched per
-        # account token, so plan_type alone cannot establish identity. Persist
-        # those via _sync_identity_metadata (issue #1086). A workspace-less
-        # payload that instead introduces "free" or an unrecognized plan stays
-        # untrusted -- the signature of a degraded or wrong-identity usage
-        # response that must not silently rewrite the stored plan.
+        # A transition from free into a recognized paid plan (e.g. Free -> Plus)
+        # or between paid plans (e.g. Plus -> Pro) is a legitimate plan change,
+        # not an identity mismatch: the usage payload carries no independent
+        # account identifier and is fetched per-account token, so plan_type alone
+        # cannot establish identity. A workspace-less payload that instead
+        # introduces "free" or an unrecognized plan stays untrusted -- the
+        # signature of a degraded or wrong-identity usage response that must not
+        # silently rewrite the stored plan.
         if payload_plan_type != stored_plan_type and not (
             stored_plan_type == "unknown"
             and normalized_payload_plan_type in recognized_paid_plans
             or (
                 not account.workspace_id
-                and stored_plan_type in recognized_paid_plans
+                and stored_plan_type in ACCOUNT_PLAN_TYPES
                 and payload_plan_type in recognized_paid_plans
             )
         ):

--- a/openspec/changes/sync-paid-plan-upgrade-without-workspace/proposal.md
+++ b/openspec/changes/sync-paid-plan-upgrade-without-workspace/proposal.md
@@ -17,11 +17,16 @@ carries no independent account identifier and is fetched per-account token, so
 paid plans (Plus -> Pro) is a legitimate upgrade, not a mismatch, so the guard
 wrongly blocks it and the stored plan never updates until a manual re-import.
 
+Issue #1215 exposes the same guard on a Free -> Plus upgrade. The payload is
+fetched with that account's token and reports a recognized paid plan, but the
+guard only trusts paid -> paid transitions, so Force probe discards the new
+plan until the operator signs in again.
+
 ## What Changes
 
-- Allow background usage refresh to persist a plan transition between two
-  recognized paid plans (e.g. Plus -> Pro) for a workspace-less account, instead
-  of rejecting it as an identity mismatch.
+- Allow background and forced usage refresh to persist a transition from Free
+  to a recognized paid plan (e.g. Free -> Plus), as well as transitions between
+  recognized paid plans, for a workspace-less account.
 - Keep refusing workspace-less payloads that introduce `free` or an unrecognized
   plan for an account that currently holds a different plan, since those remain
   the signature of a degraded or wrong-identity usage response.
@@ -31,7 +36,7 @@ wrongly blocks it and the stored plan never updates until a manual re-import.
 ## Impact
 
 - Affected capability: `usage-refresh-policy`.
-- Plus/Pro (and other paid-tier) upgrades and downgrades now reflect on the next
-  usage refresh without a manual re-import.
+- Free-to-paid and paid-tier transitions now reflect on the next usage refresh
+  or Force probe without a manual re-import.
 - No change for workspace-bound accounts or for payloads that would drop a plan
   to `free`/unknown without workspace identity; those still skip the mutation.

--- a/openspec/changes/sync-paid-plan-upgrade-without-workspace/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/sync-paid-plan-upgrade-without-workspace/specs/usage-refresh-policy/spec.md
@@ -1,14 +1,15 @@
 ## ADDED Requirements
 
-### Requirement: Usage refresh trusts paid-plan transitions without workspace identity
+### Requirement: Usage refresh trusts recognized paid-plan transitions without workspace identity
 
-Background usage refresh MUST persist a stored account's `plan_type` change when
-a usage payload that omits a `workspace_id` reports a different but recognized
-paid plan than the one currently stored (for example, an upgrade from `plus` to
-`pro`). Because the usage payload carries no independent account identifier and
-is fetched per-account token, a transition between two recognized paid plans
-MUST be treated as a legitimate upgrade or downgrade rather than an account-slot
-identity mismatch.
+Usage refresh MUST persist a stored account's `plan_type` change when
+a usage payload that omits a `workspace_id` reports a recognized paid plan and
+the stored plan is either `free` or another recognized paid plan (for example,
+an upgrade from `free` to `plus` or from `plus` to `pro`). Because the usage
+payload carries no independent account identifier and is fetched per-account
+token, these transitions MUST be treated as legitimate plan changes rather than
+account-slot identity mismatches. This requirement applies to scheduled usage
+refresh and the forced refresh performed after an operator's Force probe.
 
 A workspace-less usage payload MUST still be rejected, leaving the stored plan
 unchanged, when it reports `free` or an unrecognized plan that differs from the
@@ -21,6 +22,12 @@ account is bound to MUST continue to be rejected as a slot mismatch.
 - **GIVEN** an active account with stored `plan_type` `plus` and no `workspace_id`
 - **WHEN** background usage refresh returns a payload with `plan_type` `pro` and no `workspace_id`
 - **THEN** the account's stored `plan_type` becomes `pro` and the usage sample is written
+
+#### Scenario: Force probe persists a Free to Plus upgrade
+
+- **GIVEN** an active account with stored `plan_type` `free` and no `workspace_id`
+- **WHEN** Force probe refreshes usage and the payload reports `plan_type` `plus`
+- **THEN** the account's stored `plan_type` becomes `plus` without reauthentication
 
 #### Scenario: Free downgrade without a workspace is rejected
 

--- a/openspec/changes/sync-paid-plan-upgrade-without-workspace/tasks.md
+++ b/openspec/changes/sync-paid-plan-upgrade-without-workspace/tasks.md
@@ -4,3 +4,14 @@
 - [x] Add product-path regression coverage in `tests/unit/test_usage_updater.py` asserting a Plus -> Pro refresh persists the new plan for a workspace-less account.
 - [x] Confirm the existing workspace-mismatch / taken-slot / free-downgrade guard tests still pass.
 - [x] Document the plan-mutation trust rule under the `usage-refresh-policy` capability.
+
+## Issue #1215 follow-up
+
+- [x] Trust a workspace-less Free -> recognized-paid transition from the
+  per-account usage payload.
+- [x] Cover the Force probe refresh path while retaining paid -> Free and
+  unrecognized-plan rejection.
+- [x] Run 10 focused plan/workspace tests, the 11-test Force probe suite, the
+  remaining 81 usage-updater tests, Ruff, `ty`, strict change/all-spec
+  validation, and `git diff --check`; the excluded Windows-local monthly-row
+  freshness test reproduces unchanged on `upstream/main`.

--- a/tests/integration/test_accounts_api_probe.py
+++ b/tests/integration/test_accounts_api_probe.py
@@ -7,6 +7,7 @@ import pytest
 
 from app.core.auth import generate_unique_account_id
 from app.core.auth.refresh import RefreshError
+from app.core.usage.models import UsagePayload
 from app.modules.accounts.service import AccountsService
 
 pytestmark = pytest.mark.integration
@@ -18,11 +19,11 @@ def _encode_jwt(payload: dict) -> str:
     return f"header.{body}.sig"
 
 
-async def _import_test_account(async_client, *, email: str, account_id: str) -> str:
+async def _import_test_account(async_client, *, email: str, account_id: str, plan_type: str = "pro") -> str:
     payload = {
         "email": email,
         "chatgpt_account_id": account_id,
-        "https://api.openai.com/auth": {"chatgpt_plan_type": "pro"},
+        "https://api.openai.com/auth": {"chatgpt_plan_type": plan_type},
     }
     auth_json = {
         "tokens": {
@@ -120,6 +121,33 @@ async def test_probe_active_account_returns_snapshot(async_client, monkeypatch):
     assert captured["model"] == "gpt-5.5-test"
     assert captured["chatgpt_account_id"] == "acc_probe_active"
     assert captured["had_token"] is True
+
+
+@pytest.mark.asyncio
+async def test_force_probe_persists_free_to_plus_plan_upgrade(async_client, monkeypatch):
+    async def _fake_probe(self, *, access_token, chatgpt_account_id, model):  # noqa: ARG001
+        return 200
+
+    async def _fake_fetch_usage(**_kwargs):
+        return UsagePayload.model_validate({"plan_type": "plus"})
+
+    monkeypatch.setattr(AccountsService, "_send_probe_request", _fake_probe)
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", _fake_fetch_usage)
+
+    account_id = await _import_test_account(
+        async_client,
+        email="probe-plan-upgrade@example.com",
+        account_id="acc_probe_plan_upgrade",
+        plan_type="free",
+    )
+
+    response = await async_client.post(f"/api/accounts/{account_id}/probe")
+    assert response.status_code == 200, response.text
+
+    listing = await async_client.get("/api/accounts")
+    assert listing.status_code == 200
+    account = next(item for item in listing.json()["accounts"] if item["accountId"] == account_id)
+    assert account["planType"] == "plus"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -2367,7 +2367,7 @@ async def test_usage_updater_persists_primary_and_secondary_usage(monkeypatch) -
 
 
 @pytest.mark.asyncio
-async def test_usage_updater_does_not_sync_conflicting_plan_without_workspace_identity(monkeypatch) -> None:
+async def test_forced_usage_refresh_syncs_free_to_plus_upgrade_without_workspace(monkeypatch) -> None:
     monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
     from app.core.config.settings import get_settings
 
@@ -2385,10 +2385,11 @@ async def test_usage_updater_does_not_sync_conflicting_plan_without_workspace_id
     accounts_repo.accounts_by_id[acc.id] = acc
     acc.plan_type = "free"
 
-    await updater.refresh_accounts([acc], latest_usage={})
+    usage_written = await updater.force_refresh(acc, ignore_refresh_disabled=True)
 
-    assert acc.plan_type == "free"
-    assert accounts_repo.token_updates == []
+    assert usage_written is False
+    assert acc.plan_type == "plus"
+    assert accounts_repo.token_updates[0]["plan_type"] == "plus"
     assert usage_repo.entries == []
 
 


### PR DESCRIPTION
## Summary

- trust a workspace-less Free ? recognized-paid transition from the per-account usage payload
- let the forced usage refresh behind **Force probe** persist Free ? Plus without requiring logout/relogin
- retain the existing guards against paid ? Free, unrecognized-plan rewrites, and conflicting workspace identity
- update the active usage-refresh OpenSpec change and convert the former rejection test into a Force-probe-path regression

## Root cause

The usage payload already reports the new plan and `_sync_identity_metadata()` can persist it. `_payload_mismatches_account_slot()` allowed paid ? paid changes but classified `stored_plan_type=free payload_plan_type=plus` as an identity mismatch, so Force probe discarded a legitimate upgrade.

## Scope

The behavior change is one condition in the existing plan-trust guard. The remaining runtime diff is explanatory comment reflow; all other changes are focused tests and OpenSpec synchronization.

## Validation

- `uv run pytest tests/unit/test_usage_updater.py -k "plan or workspace" -q` (10 passed)
- `uv run pytest tests/unit/test_accounts_service_probe.py -q` (11 passed)
- remaining usage-updater tests (81 passed)
- Ruff format/check
- `uv run ty check app/modules/usage/updater.py tests/unit/test_usage_updater.py`
- strict OpenSpec change validation
- strict validation of all 31 specs
- `git diff --check`

Local note: one unrelated Windows-only monthly-row freshness test fails identically on `upstream/main` because its naive local `datetime.now()` fixture is not fresh against UTC; it is not touched by this diff.

Fixes #1215