### PR TITLE
fix(proxy): keep native capacity waits alive

### DIFF
--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -363,7 +363,7 @@ class _StreamingRetryMixin:
                         error_message=error.message if error else None,
                         recovery_sleep_seconds=recovery_sleep_seconds,
                         deadline=deadline,
-                        emit_keepalives=not propagate_http_errors,
+                        emit_keepalives=not propagate_http_errors or not enforce_openai_sdk_contract,
                         stage="post_refresh_response_create",
                     ):
                         yield wait_event
@@ -594,7 +594,7 @@ class _StreamingRetryMixin:
                                 error_message=deferred_error.message if deferred_error else None,
                                 recovery_sleep_seconds=recovery_sleep_seconds,
                                 deadline=deadline,
-                                emit_keepalives=not propagate_http_errors,
+                                emit_keepalives=not propagate_http_errors or not enforce_openai_sdk_contract,
                                 stage="response_create_no_alternate",
                             ):
                                 yield wait_event
@@ -641,7 +641,7 @@ class _StreamingRetryMixin:
                                 error_message=selection.error_message,
                                 recovery_sleep_seconds=recovery_sleep_seconds,
                                 deadline=deadline,
-                                emit_keepalives=not propagate_http_errors,
+                                emit_keepalives=not propagate_http_errors or not enforce_openai_sdk_contract,
                                 stage="selection",
                             ):
                                 yield wait_event
@@ -1149,7 +1149,8 @@ class _StreamingRetryMixin:
                                             error_message=error_message,
                                             recovery_sleep_seconds=recovery_sleep_seconds,
                                             deadline=deadline,
-                                            emit_keepalives=not propagate_http_errors,
+                                            emit_keepalives=not propagate_http_errors
+                                            or not enforce_openai_sdk_contract,
                                             stage="response_create",
                                         ):
                                             yield wait_event

--- a/openspec/changes/emit-native-sse-capacity-heartbeats/proposal.md
+++ b/openspec/changes/emit-native-sse-capacity-heartbeats/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Image-capable native Codex requests bypass the HTTP responses bridge and wait
+for local account capacity in the direct streaming path. That route propagates
+HTTP errors but disables the OpenAI SDK stream contract, so suppressing
+keepalives solely because error propagation is enabled leaves Codex with no SSE
+bytes during a recoverable wait and allows its startup idle timeout to fire.
+
+The earlier local-cap change described keepalive suppression too broadly for
+all propagated startup errors. The actual compatibility boundary is whether the
+downstream stream must obey the OpenAI SDK contract.
+
+## What Changes
+
+- Emit `codex.keepalive` during direct account-capacity waits when the OpenAI
+  SDK stream contract is disabled, even if HTTP errors are propagated.
+- Preserve the no-keepalive startup behavior when HTTP errors are propagated
+  under the OpenAI SDK stream contract.
+- Reconcile the active local-cap wording with that contract-mode boundary and
+  add a native image-bypass regression.
+
+## Impact
+
+- Native Codex image-capable requests remain alive while local stream or
+  response-create capacity recovers.
+- OpenAI SDK-compatible routes retain structured startup 429 behavior without
+  receiving non-standard `codex.*` events.

--- a/openspec/changes/emit-native-sse-capacity-heartbeats/specs/responses-api-compat/spec.md
+++ b/openspec/changes/emit-native-sse-capacity-heartbeats/specs/responses-api-compat/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Direct capacity-wait progress follows the downstream stream contract
+
+When direct HTTP/SSE streaming waits for recoverable local account capacity, the proxy MUST emit `codex.keepalive` progress events if the OpenAI SDK stream contract is disabled, regardless of whether the route propagates HTTP errors.
+The proxy MUST continue suppressing those non-standard progress events before
+startup when both HTTP error propagation and the OpenAI SDK stream contract are
+enabled.
+
+#### Scenario: Native image-capable bypass emits capacity progress
+
+- **GIVEN** an image-capable native Codex request bypasses the HTTP responses bridge
+- **AND** the route propagates HTTP errors with `enforce_openai_sdk_contract = false`
+- **WHEN** direct account selection waits for `account_stream_cap` or `account_response_create_cap` to recover
+- **THEN** the stream emits `codex.keepalive` with `status = "waiting_for_account_capacity"` before capacity is released
+- **AND** no upstream response attempt or terminal event occurs before capacity is released
+- **AND** account selection retries and the real upstream completion is forwarded after capacity becomes available
+
+#### Scenario: OpenAI SDK startup error remains structured
+
+- **GIVEN** a route propagates HTTP errors with `enforce_openai_sdk_contract = true`
+- **WHEN** a local account-capacity wait occurs before stream startup
+- **THEN** the proxy MUST NOT emit `codex.keepalive` before startup
+- **AND** a terminal local-cap failure remains available to the route's structured HTTP error path

--- a/openspec/changes/emit-native-sse-capacity-heartbeats/tasks.md
+++ b/openspec/changes/emit-native-sse-capacity-heartbeats/tasks.md
@@ -1,0 +1,10 @@
+## 1. Contract
+
+- [x] Reconcile local-cap startup wording around the OpenAI SDK contract boundary.
+- [x] Add a focused native backend SSE capacity-heartbeat requirement.
+
+## 2. Implementation and coverage
+
+- [x] Emit direct-stream capacity keepalives when HTTP errors are not propagated or the OpenAI SDK contract is disabled.
+- [x] Add a native image-bypass regression that proves keepalive-before-release, no premature upstream attempt, and completion after release.
+- [x] Run focused and broader proxy tests, Ruff, ty, and strict OpenSpec validation.

--- a/openspec/changes/wait-on-local-account-caps/specs/responses-api-compat/spec.md
+++ b/openspec/changes/wait-on-local-account-caps/specs/responses-api-compat/spec.md
@@ -15,8 +15,8 @@ When a streaming `/v1/responses` request encounters upstream instability, the pr
 - **AND** an owner-bound, file-pinned, or otherwise same-account retry MUST keep or reacquire its stream lease while waiting within the original request budget
 - **AND** the same behavior applies after a forced token refresh
 
-#### Scenario: Propagated startup errors remain observable
-- **WHEN** a route requests HTTP error propagation and waits for local account capacity before startup
+#### Scenario: SDK-contract propagated startup errors remain observable
+- **WHEN** a route requests HTTP error propagation, enforces the OpenAI SDK stream contract, and waits for local account capacity before startup
 - **THEN** the route MUST perform the bounded recovery wait instead of raising the first cap error immediately
 - **AND** it MUST NOT emit an account-capacity keepalive before startup succeeds, so a terminal startup error can still use the route's structured error path
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -2572,6 +2572,114 @@ async def test_stream_http_bridge_or_retry_bypasses_bridge_for_image_generation_
 
 
 @pytest.mark.asyncio
+async def test_native_image_bypass_emits_capacity_keepalive_before_upstream_start(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    account = _make_account("acc_native_image_capacity")
+    capacity_released = asyncio.Event()
+    selection_calls = 0
+    upstream_calls = 0
+    bridge_calls = 0
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        proxy_service,
+        "_http_bridge_runtime_config",
+        lambda _dashboard_settings, _app_settings: proxy_service._HTTPBridgeRuntimeConfig(
+            enabled=True,
+            idle_ttl_seconds=30.0,
+            codex_idle_ttl_seconds=30.0,
+            max_sessions=8,
+            queue_limit=16,
+            prompt_cache_idle_ttl_seconds=30.0,
+            gateway_safe_mode=False,
+        ),
+    )
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+
+    async def select_account(_deadline: float, **_kwargs: object) -> AccountSelection:
+        nonlocal selection_calls
+        selection_calls += 1
+        if not capacity_released.is_set():
+            return AccountSelection(
+                account=None,
+                error_message="Account stream capacity is exhausted; per-account limit is 8.",
+                error_code="account_stream_cap",
+            )
+        return AccountSelection(account=account, error_message=None)
+
+    async def wait_for_capacity(**kwargs: object):
+        assert kwargs["stage"] == "selection"
+        if kwargs["emit_keepalives"]:
+            yield 'data: {"type":"codex.keepalive","status":"waiting_for_account_capacity"}\n\n'
+        await capacity_released.wait()
+
+    async def core_stream_responses(*_args: object, **_kwargs: object):
+        nonlocal upstream_calls
+        upstream_calls += 1
+        yield 'data: {"type":"response.completed","response":{"id":"resp_native_image_capacity_ok"}}\n\n'
+
+    async def forbidden_http_bridge(*_args: object, **_kwargs: object):
+        nonlocal bridge_calls
+        bridge_calls += 1
+        yield "data: bridge\n\n"
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    monkeypatch.setattr(streaming_retry_module, "_iter_account_capacity_recovery_wait", wait_for_capacity)
+    monkeypatch.setattr(proxy_service, "core_stream_responses", core_stream_responses)
+    monkeypatch.setattr(service, "_stream_via_http_bridge", forbidden_http_bridge)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "describe the image",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "describe"},
+                        {"type": "input_image", "image_url": "data:image/png;base64,iVBORw0KGgo="},
+                    ],
+                }
+            ],
+            "stream": True,
+        }
+    )
+    stream = service._stream_http_bridge_or_retry(
+        payload,
+        {"originator": "Codex Desktop"},
+        codex_session_affinity=True,
+        propagate_http_errors=True,
+        openai_cache_affinity=False,
+        api_key=None,
+        api_key_reservation=None,
+        suppress_text_done_events=False,
+        enforce_openai_sdk_contract=False,
+    )
+
+    first = await asyncio.wait_for(anext(stream), timeout=0.2)
+    first_payload = json.loads(first.split("data: ", 1)[1])
+
+    assert first_payload["type"] == "codex.keepalive"
+    assert first_payload["status"] == "waiting_for_account_capacity"
+    assert selection_calls == 1
+    assert upstream_calls == 0
+    assert bridge_calls == 0
+
+    capacity_released.set()
+    remaining = [chunk async for chunk in stream]
+    completed = json.loads(remaining[-1].split("data: ", 1)[1])
+
+    assert completed["type"] == "response.completed"
+    assert completed["response"]["id"] == "resp_native_image_capacity_ok"
+    assert selection_calls == 2
+    assert upstream_calls == 1
+    assert bridge_calls == 0
+
+
+@pytest.mark.asyncio
 async def test_stream_http_bridge_or_retry_forces_http_for_input_image_when_bridge_disabled(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))


### PR DESCRIPTION
## Summary

- keep native Codex SSE requests alive while they wait for recoverable local account capacity
- preserve structured startup errors for OpenAI SDK-compatible streams
- cover the image-capable path that bypasses the HTTP responses bridge

## Problem

Image-capable native Codex requests use the direct streaming path. When local
account capacity was exhausted, that path suppressed capacity progress because
HTTP error propagation was enabled. The response startup probe therefore had no
SSE bytes to return, so a client could hit its idle timeout while the proxy was
still waiting and retrying normally.

## Behavior

Native streams with the OpenAI SDK contract disabled now receive the existing
nonterminal `codex.keepalive` event during a capacity wait. The event does not
claim that an upstream response exists, consume a stream lease, or synthesize a
`response.*` lifecycle event. SDK-compatible streams continue to suppress this
extension before startup so they can return structured local-capacity errors.

## Verification

- new image-bypass regression failed before the fix with no initial SSE byte
- `12` focused tests passed
- `641` proxy utility tests passed
- `51` OpenAI compatibility integration tests passed
- Ruff, ty, strict OpenSpec validation, and the main OpenSpec suite passed
