### PR TITLE
fix(proxy): preserve websocket incomplete reasons

### DIFF
--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -862,6 +862,25 @@ def _websocket_event_error_payload(
     return None
 
 
+def _websocket_event_incomplete_reason(
+    event_type: str | None,
+    payload: dict[str, JsonValue] | None,
+) -> str | None:
+    if event_type != "response.incomplete" or not isinstance(payload, dict):
+        return None
+    response = payload.get("response")
+    if not isinstance(response, dict):
+        return None
+    incomplete_details = response.get("incomplete_details")
+    if not isinstance(incomplete_details, dict):
+        return None
+    reason = incomplete_details.get("reason")
+    if not isinstance(reason, str):
+        return None
+    stripped = reason.strip()
+    return stripped or None
+
+
 def _maybe_rewrite_websocket_previous_response_not_found_event(
     *,
     request_state: _WebSocketRequestState,

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -394,6 +394,7 @@ from app.modules.proxy._service.websocket.helpers import (
     _websocket_event_error_message,
     _websocket_event_error_param,
     _websocket_event_error_type,
+    _websocket_event_incomplete_reason,
     _websocket_full_resend_conflicts_with_visible_pending,
     _websocket_input_items_are_self_contained_fresh_replay,
     _websocket_precreated_auth_error_code,
@@ -3480,6 +3481,10 @@ class _WebSocketMixin:
             error = event.response.error if event and event.response else None
             error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
             error_message = error.message if error else None
+            incomplete_reason = _websocket_event_incomplete_reason(event_type, payload)
+            if incomplete_reason is not None:
+                error_code = incomplete_reason
+                error_message = incomplete_reason
             if event_type == "response.failed":
                 error_payload = _upstream_error_from_openai(error)
             usage = event.response.usage if event and event.response else None

--- a/openspec/changes/preserve-websocket-incomplete-reasons/.openspec.yaml
+++ b/openspec/changes/preserve-websocket-incomplete-reasons/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/preserve-websocket-incomplete-reasons/context.md
+++ b/openspec/changes/preserve-websocket-incomplete-reasons/context.md
@@ -1,0 +1,11 @@
+# Context
+
+The upstream event already reaches the downstream client unchanged. This
+change is deliberately limited to the proxy's terminal request-log settlement:
+it does not retry an incomplete response, penalize the account, or expose a
+new client-facing error format.
+
+For example, an upstream terminal event with
+`incomplete_details.reason = "max_output_tokens"` is logged with status
+`error`, error code `max_output_tokens`, and error message
+`max_output_tokens` instead of `upstream_error` and no message.

--- a/openspec/changes/preserve-websocket-incomplete-reasons/proposal.md
+++ b/openspec/changes/preserve-websocket-incomplete-reasons/proposal.md
@@ -1,0 +1,21 @@
+# Preserve WebSocket incomplete-response reasons
+
+## Why
+
+Upstream Responses WebSocket streams can terminate with `response.incomplete`
+and a machine-readable `incomplete_details.reason`. The proxy currently stores
+these terminal requests as a generic `upstream_error` with no message, which
+makes an upstream `max_output_tokens` limit indistinguishable from unrelated
+failures in request logs.
+
+## What Changes
+
+- Preserve a valid upstream incomplete reason in the WebSocket request log.
+- Record the reason as both the terminal error code and error message while
+  retaining the existing non-penalizing handling of incomplete responses.
+
+## Impact
+
+- **Spec**: `responses-api-compat`
+- **Behavior**: request logs for WebSocket `response.incomplete` events become
+  diagnostically accurate; downstream event forwarding is unchanged.

--- a/openspec/changes/preserve-websocket-incomplete-reasons/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-websocket-incomplete-reasons/specs/responses-api-compat/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: WebSocket incomplete responses preserve the upstream reason in request logs
+
+When an upstream Responses WebSocket terminal `response.incomplete` event
+contains a non-empty string at `response.incomplete_details.reason`, the
+service SHALL persist the request log with status `error` and SHALL preserve
+that reason as both `error_code` and `error_message`. The terminal event sent
+to the downstream client and the account-health treatment of an incomplete
+response SHALL remain unchanged.
+
+#### Scenario: max-output limit is identifiable in a WebSocket request log
+
+- **WHEN** the upstream emits `response.incomplete` with
+  `incomplete_details.reason` equal to `max_output_tokens`
+- **THEN** the corresponding WebSocket request log has status `error`,
+  `error_code` equal to `max_output_tokens`, and `error_message` equal to
+  `max_output_tokens`
+- **AND** the account is not marked unhealthy solely because of that
+  incomplete event

--- a/openspec/changes/preserve-websocket-incomplete-reasons/tasks.md
+++ b/openspec/changes/preserve-websocket-incomplete-reasons/tasks.md
@@ -1,0 +1,15 @@
+## 1. Specification
+
+- [x] 1.1 Define the WebSocket incomplete-reason request-log contract.
+
+## 2. Implementation
+
+- [x] 2.1 Extract a valid incomplete reason from terminal WebSocket payloads.
+- [x] 2.2 Record the extracted reason in WebSocket request-log settlement.
+
+## 3. Verification
+
+- [x] 3.1 Add regression coverage for `max_output_tokens` logging and
+  non-penalizing incomplete handling.
+- [x] 3.2 Run targeted tests, lint, type checks, and OpenSpec validation when
+  the CLI is available.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -15873,6 +15873,7 @@ async def test_finalize_websocket_request_state_updates_balancer_state(monkeypat
         "response": {
             "id": "resp_ws_incomplete",
             "status": "incomplete",
+            "incomplete_details": {"reason": "max_output_tokens"},
             "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
         },
     }
@@ -15904,6 +15905,8 @@ async def test_finalize_websocket_request_state_updates_balancer_state(monkeypat
     handle_stream_error.assert_not_awaited()
     assert incomplete_upstream_control.reconnect_requested is False
     assert request_logs.calls[-1]["status"] == "error"
+    assert request_logs.calls[-1]["error_code"] == "max_output_tokens"
+    assert request_logs.calls[-1]["error_message"] == "max_output_tokens"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- preserve `response.incomplete.incomplete_details.reason` in WebSocket request logs
- retain the existing non-penalizing account-health behavior for incomplete responses
- add the OpenSpec contract and regression coverage

## Validation
- `uv run pytest tests/unit/test_proxy_utils.py -k finalize_websocket_request_state_updates_balancer_state`
- `uv run ruff check app/modules/proxy/_service/websocket/helpers.py app/modules/proxy/_service/websocket/mixin.py tests/unit/test_proxy_utils.py`
- `uv run ty check app/modules/proxy/_service/websocket/helpers.py app/modules/proxy/_service/websocket/mixin.py`
- `npx --yes @fission-ai/openspec@latest validate preserve-websocket-incomplete-reasons --strict`

Note: the full `tests/unit/test_proxy_utils.py` run has an unrelated existing timing assertion failure in `test_stream_responses_honors_timeout_overrides` (constructed timeout is about 12ms below the expected 4.5 seconds). The new regression passes.