### PR TITLE
fix(proxy): preserve websocket reconnect affinity

### DIFF
--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -595,21 +595,27 @@ class _WebSocketMixin:
         if not codex_session_affinity:
             return _WebSocketContinuityState()
         session_id = _owner_lookup_session_id_from_headers(headers, synthesized_turn_state=synthesized_turn_state)
-        # The generated value is deliberately not the first connection's
-        # routing key, but it is the only continuity key when the client did
-        # not supply a session header.  Save the state under it so a later
-        # reconnect that echoes the accepted turn state can recover the
-        # completed-response anchor and pending tool outputs.
-        if session_id is None:
-            session_id = synthesized_turn_state
-        if session_id is None:
+        api_key_id = api_key.id if api_key is not None else None
+        cache_keys: list[tuple[str, str | None]] = []
+        if session_id is not None:
+            cache_keys.append((session_id, api_key_id))
+        if synthesized_turn_state is not None:
+            generated_key = (synthesized_turn_state, api_key_id)
+            if generated_key not in cache_keys:
+                cache_keys.append(generated_key)
+        if not cache_keys:
             return _WebSocketContinuityState()
-        key = (session_id, api_key.id if api_key is not None else None)
-        continuity_state = proxy._websocket_continuity_index.get(key)
+        continuity_state = next(
+            (
+                existing_state
+                for key in cache_keys
+                if (existing_state := proxy._websocket_continuity_index.get(key)) is not None
+            ),
+            None,
+        )
         if continuity_state is None:
             continuity_state = _WebSocketContinuityState()
-            proxy._websocket_continuity_index[key] = continuity_state
-        else:
+        for key in cache_keys:
             proxy._websocket_continuity_index.pop(key, None)
             proxy._websocket_continuity_index[key] = continuity_state
         while len(proxy._websocket_continuity_index) > _facade()._WEBSOCKET_CONTINUITY_CACHE_LIMIT:

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -588,12 +588,13 @@ class _WebSocketMixin:
         *,
         api_key: ApiKeyData | None,
         codex_session_affinity: bool,
+        synthesized_turn_state: str | None = None,
     ) -> "_WebSocketContinuityState":
         proxy = cast(_WebSocketServiceProtocol, self)
         _ = proxy
         if not codex_session_affinity:
             return _WebSocketContinuityState()
-        session_id = _owner_lookup_session_id_from_headers(headers)
+        session_id = _owner_lookup_session_id_from_headers(headers, synthesized_turn_state=synthesized_turn_state)
         if session_id is None:
             return _WebSocketContinuityState()
         key = (session_id, api_key.id if api_key is not None else None)
@@ -617,6 +618,7 @@ class _WebSocketMixin:
         openai_cache_affinity: bool,
         api_key: ApiKeyData | None,
         client_ip: str | None = None,
+        synthesized_turn_state: str | None = None,
     ) -> None:
         proxy = cast(_WebSocketServiceProtocol, self)
         _ = proxy
@@ -640,6 +642,7 @@ class _WebSocketMixin:
             headers,
             api_key=api_key,
             codex_session_affinity=codex_session_affinity,
+            synthesized_turn_state=synthesized_turn_state,
         )
         account: Account | None = None
         account_lease: AccountLease | None = None
@@ -790,6 +793,7 @@ class _WebSocketMixin:
                                     useragent=useragent,
                                     useragent_group=useragent_group,
                                     client_ip=client_ip,
+                                    synthesized_turn_state=synthesized_turn_state,
                                 )
                                 if await _websocket_full_replay_should_wait_for_continuity(
                                     prepared_request.request_state,
@@ -826,6 +830,7 @@ class _WebSocketMixin:
                                         useragent=useragent,
                                         useragent_group=useragent_group,
                                         client_ip=client_ip,
+                                        synthesized_turn_state=synthesized_turn_state,
                                     )
                                 request_state = prepared_request.request_state
                                 request_affinity = prepared_request.affinity_policy
@@ -838,7 +843,10 @@ class _WebSocketMixin:
                                     _error_message,
                                 ) = _sanitize_websocket_previous_response_error(
                                     previous_response_id=_facade()._previous_response_id_from_payload(payload),
-                                    session_id=_owner_lookup_session_id_from_headers(headers),
+                                    session_id=_owner_lookup_session_id_from_headers(
+                                        headers,
+                                        synthesized_turn_state=synthesized_turn_state,
+                                    ),
                                     status_code=exc.status_code,
                                     payload=exc.payload,
                                     error_code="upstream_error",
@@ -1287,6 +1295,7 @@ class _WebSocketMixin:
         useragent: str | None = None,
         useragent_group: str | None = None,
         client_ip: str | None = None,
+        synthesized_turn_state: str | None = None,
     ) -> _PreparedWebSocketRequest:
         proxy = cast(_WebSocketServiceProtocol, self)
         _ = proxy
@@ -1418,7 +1427,7 @@ class _WebSocketMixin:
             request_usage_budget=estimate_api_key_request_usage(responses_payload),
         )
         try:
-            session_id = _owner_lookup_session_id_from_headers(headers)
+            session_id = _owner_lookup_session_id_from_headers(headers, synthesized_turn_state=synthesized_turn_state)
             request_state, text_data = proxy._prepare_response_bridge_request_state(
                 responses_payload,
                 api_key=refreshed_api_key,
@@ -1524,12 +1533,17 @@ class _WebSocketMixin:
             openai_cache_affinity_max_age_seconds=openai_cache_affinity_max_age_seconds,
             sticky_threads_enabled=sticky_threads_enabled,
             api_key=api_key,
+            synthesized_turn_state=synthesized_turn_state,
         )
         sticky_key_source = "none"
         if affinity_policy.kind == StickySessionKind.CODEX_SESSION:
-            sticky_key_source = (
-                "turn_state_header" if _sticky_key_from_turn_state_header(headers) is not None else "session_header"
-            )
+            turn_state_key = _sticky_key_from_turn_state_header(headers)
+            if turn_state_key is not None and turn_state_key == synthesized_turn_state:
+                sticky_key_source = "generated_turn_state"
+            elif turn_state_key is not None:
+                sticky_key_source = "turn_state_header"
+            else:
+                sticky_key_source = "session_header"
         elif affinity_policy.key:
             sticky_key_source = "payload" if had_prompt_cache_key else "derived"
         _maybe_log_proxy_request_shape(

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -595,6 +595,13 @@ class _WebSocketMixin:
         if not codex_session_affinity:
             return _WebSocketContinuityState()
         session_id = _owner_lookup_session_id_from_headers(headers, synthesized_turn_state=synthesized_turn_state)
+        # The generated value is deliberately not the first connection's
+        # routing key, but it is the only continuity key when the client did
+        # not supply a session header.  Save the state under it so a later
+        # reconnect that echoes the accepted turn state can recover the
+        # completed-response anchor and pending tool outputs.
+        if session_id is None:
+            session_id = synthesized_turn_state
         if session_id is None:
             return _WebSocketContinuityState()
         key = (session_id, api_key.id if api_key is not None else None)

--- a/app/modules/proxy/affinity.py
+++ b/app/modules/proxy/affinity.py
@@ -214,11 +214,18 @@ def _sticky_key_for_codex_control_request(
     return _AffinityPolicy()
 
 
-def _owner_lookup_session_id_from_headers(headers: Mapping[str, str]) -> str | None:
+def _owner_lookup_session_id_from_headers(
+    headers: Mapping[str, str],
+    *,
+    synthesized_turn_state: str | None = None,
+) -> str | None:
     # `x-codex-turn-state` is per conversation turn/thread and is more specific
-    # than `session_id`, which may be shared across multiple terminals.
+    # than `session_id`, which may be shared across multiple terminals. A turn
+    # state generated for the current downstream connection is only an
+    # upstream-forwarding placeholder, however; it must not hide a durable
+    # client session on reconnect.
     turn_state = _sticky_key_from_turn_state_header(headers)
-    if turn_state is not None:
+    if turn_state is not None and turn_state != synthesized_turn_state:
         return turn_state
     return _sticky_key_from_session_header(headers)
 
@@ -293,6 +300,7 @@ def _sticky_key_for_responses_request(
     openai_cache_affinity_max_age_seconds: int,
     sticky_threads_enabled: bool,
     api_key: ApiKeyData | None = None,
+    synthesized_turn_state: str | None = None,
 ) -> _AffinityPolicy:
     # This helper only classifies locality keys. Stored-object continuity such
     # as `previous_response_id` is resolved later by ProxyService and must stay
@@ -303,7 +311,7 @@ def _sticky_key_for_responses_request(
         api_key=api_key,
     )
     turn_state_key = _sticky_key_from_turn_state_header(headers)
-    if turn_state_key:
+    if turn_state_key and turn_state_key != synthesized_turn_state:
         return _AffinityPolicy(
             key=turn_state_key,
             kind=StickySessionKind.CODEX_SESSION,
@@ -326,5 +334,10 @@ def _sticky_key_for_responses_request(
             key=cache_key,
             kind=StickySessionKind.STICKY_THREAD,
             reallocate_sticky=True,
+        )
+    if turn_state_key is not None and turn_state_key == synthesized_turn_state:
+        return _AffinityPolicy(
+            key=turn_state_key,
+            kind=StickySessionKind.CODEX_SESSION,
         )
     return _AffinityPolicy()

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -684,10 +684,12 @@ async def responses_websocket(
     if denial is not None:
         await websocket.send_denial_response(denial)
         return
+    client_turn_state = proxy_affinity_module._sticky_key_from_turn_state_header(websocket.headers)
     turn_state = proxy_affinity_module.ensure_downstream_turn_state(websocket.headers)
     await websocket.accept(headers=proxy_affinity_module.build_downstream_turn_state_accept_headers(turn_state))
     forwarded_headers = dict(websocket.headers)
-    forwarded_headers.setdefault("x-codex-turn-state", turn_state)
+    if client_turn_state is None:
+        forwarded_headers["x-codex-turn-state"] = turn_state
     await context.service.proxy_responses_websocket(
         websocket,
         forwarded_headers,
@@ -695,6 +697,7 @@ async def responses_websocket(
         openai_cache_affinity=True,
         api_key=api_key,
         client_ip=resolve_request_client_host(websocket),
+        synthesized_turn_state=turn_state if client_turn_state is None else None,
     )
 
 
@@ -872,10 +875,12 @@ async def v1_responses_websocket(
     if denial is not None:
         await websocket.send_denial_response(denial)
         return
+    client_turn_state = proxy_affinity_module._sticky_key_from_turn_state_header(websocket.headers)
     turn_state = proxy_affinity_module.ensure_downstream_turn_state(websocket.headers)
     await websocket.accept(headers=proxy_affinity_module.build_downstream_turn_state_accept_headers(turn_state))
     forwarded_headers = dict(websocket.headers)
-    forwarded_headers.setdefault("x-codex-turn-state", turn_state)
+    if client_turn_state is None:
+        forwarded_headers["x-codex-turn-state"] = turn_state
     await context.service.proxy_responses_websocket(
         websocket,
         forwarded_headers,
@@ -883,6 +888,7 @@ async def v1_responses_websocket(
         openai_cache_affinity=True,
         api_key=api_key,
         client_ip=resolve_request_client_host(websocket),
+        synthesized_turn_state=turn_state if client_turn_state is None else None,
     )
 
 

--- a/openspec/changes/preserve-websocket-reconnect-affinity/.openspec.yaml
+++ b/openspec/changes/preserve-websocket-reconnect-affinity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/preserve-websocket-reconnect-affinity/context.md
+++ b/openspec/changes/preserve-websocket-reconnect-affinity/context.md
@@ -11,6 +11,11 @@ connection. Consequently, if a client receives that value in the handshake
 response and sends it on its next connection, it is again treated as a
 client-supplied continuation key.
 
+If the first handshake has no accepted session header, its generated turn
+state is also the continuity-cache key. This preserves the prior completed
+response anchor for a later client-echoed reconnect without changing the
+first handshake's routing precedence.
+
 Example: two backend WebSocket connections both send `session_id: session-a`
 without a turn-state header. The proxy may forward a different `turn_*` value
 on each connection, but both account selections use `session-a`.

--- a/openspec/changes/preserve-websocket-reconnect-affinity/context.md
+++ b/openspec/changes/preserve-websocket-reconnect-affinity/context.md
@@ -1,0 +1,16 @@
+# Context
+
+A turn state supplied by a client represents a specific conversation turn and
+rightly outranks a broader session header. A turn state synthesized by the
+proxy solely because the current WebSocket handshake lacked one has different
+semantics: it is an upstream continuity header, not a durable client routing
+choice.
+
+The implementation carries the exact synthesized value only for the active
+connection. Consequently, if a client receives that value in the handshake
+response and sends it on its next connection, it is again treated as a
+client-supplied continuation key.
+
+Example: two backend WebSocket connections both send `session_id: session-a`
+without a turn-state header. The proxy may forward a different `turn_*` value
+on each connection, but both account selections use `session-a`.

--- a/openspec/changes/preserve-websocket-reconnect-affinity/proposal.md
+++ b/openspec/changes/preserve-websocket-reconnect-affinity/proposal.md
@@ -1,0 +1,26 @@
+# Preserve WebSocket reconnect affinity
+
+## Why
+
+When a downstream Responses WebSocket handshake has no
+`x-codex-turn-state`, the proxy generates one and forwards it upstream. The
+generated per-connection value currently takes precedence over a stable Codex
+session header or prompt-cache key during account selection. A reconnect then
+creates a new affinity key and can rotate accounts despite a durable client
+continuity signal.
+
+## What Changes
+
+- Track whether a turn state was generated for the current downstream
+  WebSocket handshake.
+- Keep forwarding that generated turn state upstream, but let durable
+  client-supplied session or prompt-cache affinity take precedence.
+- Preserve client-supplied (including previously echoed) turn states as the
+  most-specific affinity and continuity key.
+
+## Impact
+
+- **Spec**: `responses-api-compat`
+- **Behavior**: backend Codex WebSocket reconnects with a stable session
+  header keep the same account affinity even when each connection receives a
+  newly generated turn state.

--- a/openspec/changes/preserve-websocket-reconnect-affinity/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-websocket-reconnect-affinity/specs/responses-api-compat/spec.md
@@ -19,6 +19,11 @@ forward that synthesized turn state upstream. A turn state sent by the client,
 including one that the proxy generated and the client later echoed, remains a
 client-supplied turn-state affinity key.
 
+When a WebSocket handshake has neither a client-supplied turn state nor an
+accepted session header, the proxy MUST store its generated turn state as the
+WebSocket continuity key. A later connection that echoes that accepted value
+MUST recover the same continuity state.
+
 #### Scenario: backend WebSocket reconnect retains session affinity despite a generated turn state
 
 - **WHEN** two backend Codex Responses WebSocket connections include the same
@@ -34,3 +39,13 @@ client-supplied turn-state affinity key.
   received from an earlier proxy handshake
 - **THEN** that turn state remains the routing and WebSocket continuity key
   ahead of a broader accepted session header
+
+#### Scenario: generated turn state seeds continuity without a session header
+
+- **WHEN** a backend Codex Responses WebSocket handshake omits both an
+  accepted session header and `x-codex-turn-state`
+- **AND** the proxy generates and returns a turn state for that handshake
+- **THEN** the proxy stores its WebSocket continuity state under that generated
+  value
+- **AND WHEN** a later connection sends that value in `x-codex-turn-state`
+- **THEN** it recovers the stored continuity state

--- a/openspec/changes/preserve-websocket-reconnect-affinity/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-websocket-reconnect-affinity/specs/responses-api-compat/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Codex backend session_id preserves account affinity
+
+When a backend Codex Responses or compact request includes a non-empty
+accepted session header, the service MUST use that value as the routing
+affinity key for upstream account selection unless the client supplied a
+non-empty `x-codex-turn-state` header. If the request lacks a
+client-supplied `prompt_cache_key`, the service MUST derive and attach a
+stable `prompt_cache_key` before upstream forwarding so account affinity and
+upstream prompt-cache routing can coexist. Accepted session headers are
+`session_id`, `session-id`, `x-codex-session-id`,
+`x-codex-conversation-id`, and `thread-id`, in that priority order.
+
+A turn state synthesized by the proxy for the current downstream WebSocket
+handshake MUST NOT override a client-supplied session header or prompt-cache
+key for routing or WebSocket continuity selection. The proxy MUST continue to
+forward that synthesized turn state upstream. A turn state sent by the client,
+including one that the proxy generated and the client later echoed, remains a
+client-supplied turn-state affinity key.
+
+#### Scenario: backend WebSocket reconnect retains session affinity despite a generated turn state
+
+- **WHEN** two backend Codex Responses WebSocket connections include the same
+  accepted session header and omit `x-codex-turn-state`
+- **AND** the proxy generates a distinct turn state for each handshake
+- **THEN** both account selections use the session header as the durable
+  `codex_session` affinity key
+- **AND** each generated turn state is still forwarded to the upstream
+
+#### Scenario: echoed generated turn state remains a client continuation key
+
+- **WHEN** a client reconnects with a non-empty `x-codex-turn-state` value it
+  received from an earlier proxy handshake
+- **THEN** that turn state remains the routing and WebSocket continuity key
+  ahead of a broader accepted session header

--- a/openspec/changes/preserve-websocket-reconnect-affinity/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-websocket-reconnect-affinity/specs/responses-api-compat/spec.md
@@ -14,7 +14,9 @@ upstream prompt-cache routing can coexist. Accepted session headers are
 
 A turn state synthesized by the proxy for the current downstream WebSocket
 handshake MUST NOT override a client-supplied session header or prompt-cache
-key for routing or WebSocket continuity selection. The proxy MUST continue to
+key for routing or WebSocket continuity selection. The proxy MUST seed
+WebSocket continuity storage under that synthesized turn state so a later
+client echo can reuse the completed-turn owner. The proxy MUST continue to
 forward that synthesized turn state upstream. A turn state sent by the client,
 including one that the proxy generated and the client later echoed, remains a
 client-supplied turn-state affinity key.
@@ -39,6 +41,8 @@ MUST recover the same continuity state.
   received from an earlier proxy handshake
 - **THEN** that turn state remains the routing and WebSocket continuity key
   ahead of a broader accepted session header
+- **AND** full-resend continuity for that echoed turn state can reuse the
+  earlier completed response anchor
 
 #### Scenario: generated turn state seeds continuity without a session header
 

--- a/openspec/changes/preserve-websocket-reconnect-affinity/tasks.md
+++ b/openspec/changes/preserve-websocket-reconnect-affinity/tasks.md
@@ -1,0 +1,18 @@
+## 1. Specification
+
+- [x] 1.1 Define the distinction between current-handshake generated and
+  client-supplied turn states.
+
+## 2. Implementation
+
+- [x] 2.1 Carry generated-turn-state provenance from the WebSocket routes to
+  affinity and continuity selection.
+- [x] 2.2 Prefer durable session or prompt-cache affinity over only a
+  current-handshake generated turn state.
+- [x] 2.3 Preserve upstream forwarding and client-echoed turn-state behavior.
+
+## 3. Verification
+
+- [x] 3.1 Add unit and integration reconnect regressions.
+- [x] 3.2 Run targeted tests, lint, type checks, and strict OpenSpec
+  validation.

--- a/openspec/changes/preserve-websocket-reconnect-affinity/tasks.md
+++ b/openspec/changes/preserve-websocket-reconnect-affinity/tasks.md
@@ -10,6 +10,7 @@
 - [x] 2.2 Prefer durable session or prompt-cache affinity over only a
   current-handshake generated turn state.
 - [x] 2.3 Preserve upstream forwarding and client-echoed turn-state behavior.
+- [x] 2.4 Seed generated turn states for client-echoed reconnect continuity.
 
 ## 3. Verification
 

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -734,7 +734,8 @@ def test_backend_responses_websocket_proxies_upstream_and_persists_log(app_insta
     seen_headers = cast(dict[str, str], seen["headers"])
     assert seen_headers["session_id"] == "thread-ws-1"
     assert seen_headers["openai-beta"] == "responses_websockets=2026-02-06"
-    assert seen_headers["x-codex-turn-state"] == cast(str, seen["sticky_key"])
+    assert seen_headers["x-codex-turn-state"] != cast(str, seen["sticky_key"])
+    assert seen["sticky_key"] == "thread-ws-1"
     assert seen["sticky_kind"] == proxy_module.StickySessionKind.CODEX_SESSION
     assert seen["prefer_earlier_reset"] is False
     assert seen["routing_strategy"] == "usage_weighted"
@@ -1987,7 +1988,10 @@ def test_backend_responses_websocket_accepts_and_reuses_generated_turn_state(app
     with TestClient(app_instance) as client:
         with client.websocket_connect(
             "/backend-api/codex/responses",
-            headers={"Authorization": "Bearer external-token"},
+            headers={
+                "Authorization": "Bearer external-token",
+                "session_id": "session-generated-turn-state",
+            },
         ) as websocket:
             raw_extra_headers = cast(list[tuple[bytes, bytes]], websocket.extra_headers)
             extra_headers = {key.decode(): value.decode() for key, value in raw_extra_headers}
@@ -2000,8 +2004,125 @@ def test_backend_responses_websocket_accepts_and_reuses_generated_turn_state(app
     seen_headers = cast(dict[str, str], seen["headers"])
     assert turn_state
     assert seen_headers["x-codex-turn-state"] == turn_state
-    assert seen["sticky_key"] == turn_state
+    assert seen["sticky_key"] == "session-generated-turn-state"
     assert seen["sticky_kind"] == proxy_module.StickySessionKind.CODEX_SESSION
+
+
+def test_backend_responses_websocket_reconnect_keeps_session_affinity_with_fresh_generated_turn_states(
+    app_instance,
+    monkeypatch,
+):
+    def upstream_messages(response_id: str) -> list[_FakeUpstreamMessage]:
+        return [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {"type": "response.created", "response": {"id": response_id, "status": "in_progress"}},
+                    separators=(",", ":"),
+                ),
+            ),
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": response_id,
+                            "status": "completed",
+                            "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+        ]
+
+    upstreams = deque(
+        [
+            _FakeUpstreamWebSocket(upstream_messages("resp_reconnect_one")),
+            _FakeUpstreamWebSocket(upstream_messages("resp_reconnect_two")),
+        ]
+    )
+    selections: list[dict[str, object]] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        assert authorization == "Bearer external-token"
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        prefer_earlier_reset_window,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            prefer_earlier_reset_window,
+            routing_strategy,
+            model,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        selections.append({"headers": dict(headers), "key": sticky_key, "kind": sticky_kind})
+        return SimpleNamespace(id=f"acct_reconnect_{len(selections)}"), upstreams.popleft()
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "reconnect"}]}],
+        "stream": True,
+    }
+    turn_states: list[str] = []
+
+    with TestClient(app_instance) as client:
+        for _ in range(2):
+            with client.websocket_connect(
+                "/backend-api/codex/responses",
+                headers={"Authorization": "Bearer external-token", "session_id": "session-reconnect"},
+            ) as websocket:
+                raw_extra_headers = cast(list[tuple[bytes, bytes]], websocket.extra_headers)
+                extra_headers = {key.decode(): value.decode() for key, value in raw_extra_headers}
+                turn_states.append(extra_headers["x-codex-turn-state"])
+                websocket.send_text(json.dumps(request_payload))
+                assert json.loads(websocket.receive_text())["type"] == "response.created"
+                assert json.loads(websocket.receive_text())["type"] == "response.completed"
+
+    assert turn_states[0] != turn_states[1]
+    assert [selection["key"] for selection in selections] == ["session-reconnect", "session-reconnect"]
+    assert [selection["kind"] for selection in selections] == [
+        proxy_module.StickySessionKind.CODEX_SESSION,
+        proxy_module.StickySessionKind.CODEX_SESSION,
+    ]
+    assert [cast(dict[str, str], selection["headers"])["x-codex-turn-state"] for selection in selections] == turn_states
 
 
 def test_backend_responses_websocket_echoes_existing_turn_state_header(app_instance, monkeypatch):
@@ -2089,7 +2210,7 @@ def test_backend_responses_websocket_echoes_existing_turn_state_header(app_insta
         "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
         "stream": True,
     }
-    existing_turn_state = "turn_state_existing_123"
+    existing_turn_state = "turn_0123456789abcdef0123456789abcdef"
 
     with TestClient(app_instance) as client:
         with client.websocket_connect(
@@ -2097,6 +2218,7 @@ def test_backend_responses_websocket_echoes_existing_turn_state_header(app_insta
             headers={
                 "Authorization": "Bearer external-token",
                 "x-codex-turn-state": existing_turn_state,
+                "session_id": "broader-session-id",
             },
         ) as websocket:
             raw_extra_headers = cast(list[tuple[bytes, bytes]], websocket.extra_headers)
@@ -2232,9 +2354,6 @@ def test_v1_responses_websocket_reuses_upstream_for_sequential_requests(app_inst
 
     with TestClient(app_instance) as client:
         with client.websocket_connect("/v1/responses") as websocket:
-            raw_extra_headers = cast(list[tuple[bytes, bytes]], websocket.extra_headers)
-            extra_headers = {key.decode(): value.decode() for key, value in raw_extra_headers}
-            turn_state = extra_headers["x-codex-turn-state"]
             websocket.send_text(json.dumps(first_request))
             first_events = [json.loads(websocket.receive_text()) for _ in range(2)]
 
@@ -2244,8 +2363,8 @@ def test_v1_responses_websocket_reuses_upstream_for_sequential_requests(app_inst
     assert [event["type"] for event in first_events] == ["response.created", "response.completed"]
     assert [event["type"] for event in second_events] == ["response.created", "response.completed"]
     assert len(connect_calls) == 1
-    assert connect_calls[0]["sticky_key"] == turn_state
-    assert connect_calls[0]["sticky_kind"] == proxy_module.StickySessionKind.CODEX_SESSION
+    assert connect_calls[0]["sticky_key"] == "thread_a"
+    assert connect_calls[0]["sticky_kind"] == proxy_module.StickySessionKind.PROMPT_CACHE
     assert connect_calls[0]["model"] == "gpt-5.4"
     _assert_upstream_payloads(
         first_upstream.sent_text,
@@ -2523,8 +2642,8 @@ def test_v1_responses_websocket_accepts_and_reuses_generated_turn_state(app_inst
     seen_headers = cast(dict[str, str], seen["headers"])
     assert turn_state
     assert seen_headers["x-codex-turn-state"] == turn_state
-    assert seen["sticky_key"] == turn_state
-    assert seen["sticky_kind"] == proxy_module.StickySessionKind.CODEX_SESSION
+    assert seen["sticky_key"] != turn_state
+    assert seen["sticky_kind"] == proxy_module.StickySessionKind.PROMPT_CACHE
 
 
 def test_v1_responses_websocket_normalizes_payload_before_forwarding(app_instance, monkeypatch):
@@ -2614,19 +2733,16 @@ def test_v1_responses_websocket_normalizes_payload_before_forwarding(app_instanc
 
     with TestClient(app_instance) as client:
         with client.websocket_connect("/v1/responses") as websocket:
-            raw_extra_headers = cast(list[tuple[bytes, bytes]], websocket.extra_headers)
-            extra_headers = {key.decode(): value.decode() for key, value in raw_extra_headers}
-            turn_state = extra_headers["x-codex-turn-state"]
             websocket.send_text(json.dumps(request_payload))
             first = json.loads(websocket.receive_text())
             second = json.loads(websocket.receive_text())
 
     assert first["type"] == "response.created"
     assert second["type"] == "response.completed"
-    assert seen["sticky_key"] == turn_state
-    assert seen["sticky_kind"] == proxy_module.StickySessionKind.CODEX_SESSION
+    assert seen["sticky_key"] == "thread_alias"
+    assert seen["sticky_kind"] == proxy_module.StickySessionKind.PROMPT_CACHE
     assert seen["reallocate_sticky"] is False
-    assert seen["sticky_max_age_seconds"] is None
+    assert seen["sticky_max_age_seconds"] == 300
     assert seen["prefer_earlier_reset_window"] == "secondary"
     assert seen["model"] == "gpt-5.4"
     _assert_upstream_payloads(

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -2021,6 +2021,143 @@ def test_backend_responses_websocket_accepts_and_reuses_generated_turn_state(app
     assert second_payload["input"] == [second_input]
 
 
+def test_backend_responses_websocket_echoed_generated_turn_state_reuses_continuity_anchor(
+    app_instance,
+    monkeypatch,
+):
+    def upstream_messages(response_id: str) -> list[_FakeUpstreamMessage]:
+        return [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {"type": "response.created", "response": {"id": response_id, "status": "in_progress"}},
+                    separators=(",", ":"),
+                ),
+            ),
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": response_id,
+                            "status": "completed",
+                            "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+        ]
+
+    first_upstream = _FakeUpstreamWebSocket(upstream_messages("resp_generated_anchor"))
+    second_upstream = _FakeUpstreamWebSocket(upstream_messages("resp_generated_followup"))
+    upstreams = deque([first_upstream, second_upstream])
+    selections: list[dict[str, object]] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        assert authorization == "Bearer external-token"
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        prefer_earlier_reset_window,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            prefer_earlier_reset_window,
+            routing_strategy,
+            model,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        selections.append({"headers": dict(headers), "key": sticky_key, "kind": sticky_kind})
+        return SimpleNamespace(id=f"acct_generated_echo_{len(selections)}"), upstreams.popleft()
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+
+    first_input = {"role": "user", "content": [{"type": "input_text", "text": "first"}]}
+    second_input = {"role": "user", "content": [{"type": "input_text", "text": "second"}]}
+    first_payload = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [first_input],
+        "stream": True,
+    }
+    echoed_full_resend_payload = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [first_input, second_input],
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers={"Authorization": "Bearer external-token"},
+        ) as websocket:
+            raw_extra_headers = cast(list[tuple[bytes, bytes]], websocket.extra_headers)
+            extra_headers = {key.decode(): value.decode() for key, value in raw_extra_headers}
+            turn_state = extra_headers["x-codex-turn-state"]
+            websocket.send_text(json.dumps(first_payload))
+            assert json.loads(websocket.receive_text())["type"] == "response.created"
+            assert json.loads(websocket.receive_text())["type"] == "response.completed"
+
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers={
+                "Authorization": "Bearer external-token",
+                "x-codex-turn-state": turn_state,
+            },
+        ) as websocket:
+            raw_extra_headers = cast(list[tuple[bytes, bytes]], websocket.extra_headers)
+            extra_headers = {key.decode(): value.decode() for key, value in raw_extra_headers}
+            assert extra_headers["x-codex-turn-state"] == turn_state
+            websocket.send_text(json.dumps(echoed_full_resend_payload))
+            assert json.loads(websocket.receive_text())["type"] == "response.created"
+            assert json.loads(websocket.receive_text())["type"] == "response.completed"
+
+    first_upstream_payload = json.loads(first_upstream.sent_text[0])
+    second_upstream_payload = json.loads(second_upstream.sent_text[0])
+    assert "previous_response_id" not in first_upstream_payload
+    assert second_upstream_payload["previous_response_id"] == "resp_generated_anchor"
+    assert second_upstream_payload["input"] == [second_input]
+    assert [cast(dict[str, str], selection["headers"])["x-codex-turn-state"] for selection in selections] == [
+        turn_state,
+        turn_state,
+    ]
+
+
 def test_backend_responses_websocket_reconnect_keeps_session_affinity_with_fresh_generated_turn_states(
     app_instance,
     monkeypatch,

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -1900,31 +1900,35 @@ def test_backend_responses_websocket_preserves_image_generation_tool_advertiseme
 
 
 def test_backend_responses_websocket_accepts_and_reuses_generated_turn_state(app_instance, monkeypatch):
-    upstream_messages = [
-        _FakeUpstreamMessage(
-            "text",
-            text=json.dumps(
-                {"type": "response.created", "response": {"id": "resp_turn_state", "status": "in_progress"}},
-                separators=(",", ":"),
+    def upstream_messages(response_id: str) -> list[_FakeUpstreamMessage]:
+        return [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {"type": "response.created", "response": {"id": response_id, "status": "in_progress"}},
+                    separators=(",", ":"),
+                ),
             ),
-        ),
-        _FakeUpstreamMessage(
-            "text",
-            text=json.dumps(
-                {
-                    "type": "response.completed",
-                    "response": {
-                        "id": "resp_turn_state",
-                        "status": "completed",
-                        "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": response_id,
+                            "status": "completed",
+                            "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                        },
                     },
-                },
-                separators=(",", ":"),
+                    separators=(",", ":"),
+                ),
             ),
-        ),
-    ]
-    fake_upstream = _FakeUpstreamWebSocket(upstream_messages)
-    seen: dict[str, object] = {}
+        ]
+
+    first_upstream = _FakeUpstreamWebSocket(upstream_messages("resp_turn_state_first"))
+    second_upstream = _FakeUpstreamWebSocket(upstream_messages("resp_turn_state_second"))
+    upstreams = deque([first_upstream, second_upstream])
+    selections: list[dict[str, object]] = []
 
     class _FakeSettingsCache:
         async def get(self):
@@ -1967,45 +1971,54 @@ def test_backend_responses_websocket_accepts_and_reuses_generated_turn_state(app
             client_send_lock,
             websocket,
         )
-        seen["headers"] = dict(headers)
-        seen["sticky_key"] = sticky_key
-        seen["sticky_kind"] = sticky_kind
-        return SimpleNamespace(id="acct_turn_state"), fake_upstream
+        selections.append({"headers": dict(headers), "sticky_key": sticky_key, "sticky_kind": sticky_kind})
+        return SimpleNamespace(id="acct_turn_state"), upstreams.popleft()
 
     monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
     monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
     monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
     monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
 
+    first_input = {"role": "user", "content": [{"type": "input_text", "text": "hi"}]}
+    second_input = {"role": "user", "content": [{"type": "input_text", "text": "continue"}]}
     request_payload = {
         "type": "response.create",
         "model": "gpt-5.4",
         "instructions": "",
-        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        "input": [first_input],
         "stream": True,
     }
 
     with TestClient(app_instance) as client:
         with client.websocket_connect(
             "/backend-api/codex/responses",
-            headers={
-                "Authorization": "Bearer external-token",
-                "session_id": "session-generated-turn-state",
-            },
+            headers={"Authorization": "Bearer external-token"},
         ) as websocket:
             raw_extra_headers = cast(list[tuple[bytes, bytes]], websocket.extra_headers)
             extra_headers = {key.decode(): value.decode() for key, value in raw_extra_headers}
             turn_state = extra_headers["x-codex-turn-state"]
             websocket.send_text(json.dumps(request_payload))
-            completed = json.loads(websocket.receive_text())
-            assert completed["type"] == "response.created"
-            _ = json.loads(websocket.receive_text())
+            assert json.loads(websocket.receive_text())["type"] == "response.created"
+            assert json.loads(websocket.receive_text())["type"] == "response.completed"
 
-    seen_headers = cast(dict[str, str], seen["headers"])
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers={"Authorization": "Bearer external-token", "x-codex-turn-state": turn_state},
+        ) as websocket:
+            websocket.send_text(json.dumps({**request_payload, "input": [first_input, second_input]}))
+            assert json.loads(websocket.receive_text())["type"] == "response.created"
+            assert json.loads(websocket.receive_text())["type"] == "response.completed"
+
     assert turn_state
-    assert seen_headers["x-codex-turn-state"] == turn_state
-    assert seen["sticky_key"] == "session-generated-turn-state"
-    assert seen["sticky_kind"] == proxy_module.StickySessionKind.CODEX_SESSION
+    assert [cast(dict[str, str], selection["headers"])["x-codex-turn-state"] for selection in selections] == [
+        turn_state,
+        turn_state,
+    ]
+    assert selections[1]["sticky_key"] == turn_state
+    assert selections[1]["sticky_kind"] == proxy_module.StickySessionKind.CODEX_SESSION
+    second_payload = json.loads(second_upstream.sent_text[0])
+    assert second_payload["previous_response_id"] == "resp_turn_state_first"
+    assert second_payload["input"] == [second_input]
 
 
 def test_backend_responses_websocket_reconnect_keeps_session_affinity_with_fresh_generated_turn_states(

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -7892,6 +7892,50 @@ def test_owner_lookup_session_id_from_headers_prefers_turn_state_then_session_al
     assert proxy_service._owner_lookup_session_id_from_headers({}) is None
 
 
+def test_owner_lookup_session_id_from_headers_ignores_current_handshake_generated_turn_state():
+    headers = {
+        "x-codex-turn-state": "turn_0123456789abcdef0123456789abcdef",
+        "session_id": "sid_1",
+    }
+
+    assert proxy_service._owner_lookup_session_id_from_headers(headers) == headers["x-codex-turn-state"]
+    assert (
+        proxy_service._owner_lookup_session_id_from_headers(
+            headers,
+            synthesized_turn_state=headers["x-codex-turn-state"],
+        )
+        == "sid_1"
+    )
+
+
+def test_sticky_key_for_responses_request_prefers_session_over_current_handshake_generated_turn_state():
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "hi",
+            "input": [],
+            "prompt_cache_key": "cache-owner",
+        }
+    )
+    headers = {
+        "x-codex-turn-state": "turn_0123456789abcdef0123456789abcdef",
+        "session_id": "session-owner",
+    }
+
+    policy = proxy_service._sticky_key_for_responses_request(
+        payload,
+        headers=headers,
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        openai_cache_affinity_max_age_seconds=300,
+        sticky_threads_enabled=True,
+        synthesized_turn_state=headers["x-codex-turn-state"],
+    )
+
+    assert policy.key == "session-owner"
+    assert policy.kind == proxy_service.StickySessionKind.CODEX_SESSION
+
+
 def test_sticky_key_for_responses_request_derives_prompt_cache_before_codex_session_return():
     payload = ResponsesRequest.model_validate(
         {

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14851,6 +14851,50 @@ def test_websocket_continuity_state_reuses_codex_session_scope():
     assert unscoped is not first
 
 
+def test_websocket_continuity_state_seeds_generated_turn_state_alias():
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    generated_turn_state = "turn_0123456789abcdef0123456789abcdef"
+
+    first = service._websocket_continuity_state_for_request(
+        {"x-codex-turn-state": generated_turn_state},
+        api_key=None,
+        codex_session_affinity=True,
+        synthesized_turn_state=generated_turn_state,
+    )
+    first.last_completed_response_id = "resp_generated_anchor"
+
+    echoed = service._websocket_continuity_state_for_request(
+        {"x-codex-turn-state": generated_turn_state},
+        api_key=None,
+        codex_session_affinity=True,
+    )
+
+    assert echoed is first
+    assert echoed.last_completed_response_id == "resp_generated_anchor"
+
+
+def test_websocket_continuity_state_does_not_seed_generated_turn_state_when_affinity_disabled():
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    generated_turn_state = "turn_0123456789abcdef0123456789abcdef"
+
+    unscoped = service._websocket_continuity_state_for_request(
+        {"x-codex-turn-state": generated_turn_state},
+        api_key=None,
+        codex_session_affinity=False,
+        synthesized_turn_state=generated_turn_state,
+    )
+    unscoped.last_completed_response_id = "resp_unscoped"
+
+    echoed = service._websocket_continuity_state_for_request(
+        {"x-codex-turn-state": generated_turn_state},
+        api_key=None,
+        codex_session_affinity=True,
+    )
+
+    assert echoed is not unscoped
+    assert echoed.last_completed_response_id is None
+
+
 def test_record_websocket_continuity_completion_keeps_anchor_fields_in_sync():
     continuity_state = proxy_service._WebSocketContinuityState(
         last_completed_input_count=2,


### PR DESCRIPTION
## Summary
- distinguish a turn state generated for the current WebSocket handshake from a client-supplied continuation key
- retain generated turn-state forwarding while preferring durable session or prompt-cache affinity
- preserve echoed turn states as the most-specific client continuity key
- add an OpenSpec contract plus unit and two-connection WebSocket integration regressions

## Validation
- `uv run pytest tests/integration/test_proxy_websocket_responses.py` (59 passed)
- `uv run pytest tests/unit/test_proxy_utils.py -k "not stream_responses_honors_timeout_overrides"` (641 passed)
- `uv run ruff check app/modules/proxy/affinity.py app/modules/proxy/api.py app/modules/proxy/_service/websocket/mixin.py tests/unit/test_proxy_utils.py tests/integration/test_proxy_websocket_responses.py`
- `uv run ty check app/modules/proxy/affinity.py app/modules/proxy/api.py app/modules/proxy/_service/websocket/mixin.py`
- `npx --yes @fission-ai/openspec@latest validate preserve-websocket-reconnect-affinity --strict`

Note: the excluded timeout test has an unrelated existing assertion failure in this environment: `test_stream_responses_honors_timeout_overrides` observes about 4.488 seconds against an expected `4.50 ± 0.01`.