### PR TITLE
fix(models): retain hidden metadata across partial refreshes

### DIFF
--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -690,6 +690,13 @@ class ModelRegistry:
                     for slug, model in (self._metadata_models or self._bootstrap_models).items()
                     if slug in self._bootstrap_models
                 }
+                if per_account_results is not None:
+                    account_metadata_models: dict[str, UpstreamModel] = {}
+                    for _account_id, (_plan_type, account_models) in per_account_results.items():
+                        for model in account_models:
+                            if model.slug in self._bootstrap_models:
+                                account_metadata_models.setdefault(model.slug, model)
+                    metadata_models.update(account_metadata_models)
                 metadata_models.update(models)
                 self._snapshot = ModelRegistrySnapshot(
                     models=models,

--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -484,6 +484,7 @@ class ModelRegistry:
         self._ttl_seconds = ttl_seconds
         self._snapshot: ModelRegistrySnapshot | None = None
         self._bootstrap_models: dict[str, UpstreamModel] = {m.slug: m for m in _BOOTSTRAP_STATIC_MODELS}
+        self._metadata_models: dict[str, UpstreamModel] | None = None
         self._lock = anyio.Lock()
 
     def get_snapshot(self) -> ModelRegistrySnapshot | None:
@@ -493,6 +494,11 @@ class ModelRegistry:
         snapshot = self._snapshot
         if snapshot is not None:
             return snapshot.models
+        return self._bootstrap_models
+
+    def get_models_for_metadata(self) -> dict[str, UpstreamModel]:
+        if self._metadata_models is not None:
+            return self._metadata_models
         return self._bootstrap_models
 
     def plan_types_for_model(self, slug: str) -> frozenset[str] | None:
@@ -679,6 +685,10 @@ class ModelRegistry:
                     plan_type: frozenset(slugs) for plan_type, slugs in plan_models_index.items()
                 }
 
+                metadata_models = dict(self._metadata_models or self._bootstrap_models)
+                metadata_models.update(
+                    (slug, model) for slug, model in models.items() if slug in self._bootstrap_models
+                )
                 self._snapshot = ModelRegistrySnapshot(
                     models=models,
                     model_plans=frozen_model_plans,
@@ -688,6 +698,7 @@ class ModelRegistry:
                     account_plans=account_plans,
                     fetched_at=time.monotonic(),
                 )
+                self._metadata_models = metadata_models
             except Exception:
                 self._snapshot = previous
                 logger.warning("Model registry refresh failed; keeping cached snapshot", exc_info=True)

--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -685,10 +685,12 @@ class ModelRegistry:
                     plan_type: frozenset(slugs) for plan_type, slugs in plan_models_index.items()
                 }
 
-                metadata_models = dict(self._metadata_models or self._bootstrap_models)
-                metadata_models.update(
-                    (slug, model) for slug, model in models.items() if slug in self._bootstrap_models
-                )
+                metadata_models = {
+                    slug: model
+                    for slug, model in (self._metadata_models or self._bootstrap_models).items()
+                    if slug in self._bootstrap_models
+                }
+                metadata_models.update(models)
                 self._snapshot = ModelRegistrySnapshot(
                     models=models,
                     model_plans=frozen_model_plans,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2646,13 +2646,14 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
 
     registry = get_model_registry()
     models = registry.get_models_with_fallback()
+    metadata_models = registry.get_models_for_metadata()
     source_models = [
         model
         for model in await _list_enabled_source_catalog_models(api_key, require_responses=True)
         if model.raw.get("supports_streaming") is True
     ]
 
-    if not models and not source_models:
+    if not models and not metadata_models and not source_models:
         await _release_reservation(reservation)
         return JSONResponse(content=CodexModelsResponse(models=[], data=[]).model_dump(mode="json"))
 
@@ -2679,6 +2680,13 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
         seen_slugs.add(slug)
         if model.supported_in_api and entry.visibility == "list":
             data.append(_to_model_list_item(slug, model, created=_model_list_created_at(model)))
+    for slug, model in metadata_models.items():
+        if slug in models or not _is_codex_backend_catalog_model(model):
+            continue
+        if visibility_allowed_models is None and allowed_models is not None and slug not in allowed_models:
+            continue
+        entries.append(_to_codex_model_entry(model, visibility="hide"))
+        seen_slugs.add(slug)
     for model in source_models:
         if model.slug in seen_slugs:
             continue

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2652,7 +2652,16 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
         for model in await _list_enabled_source_catalog_models(api_key, require_responses=True)
         if model.raw.get("supports_streaming") is True
     ]
-    source_model_slugs = {model.slug for model in source_models}
+    visible_source_models = []
+    for source_model in source_models:
+        if visibility_allowed_models is None:
+            if exact_source_allowed_models is not None:
+                if source_model.slug not in exact_source_allowed_models:
+                    continue
+            elif not is_public_model(source_model, allowed_models):
+                continue
+        visible_source_models.append(source_model)
+    source_model_slugs = {model.slug for model in visible_source_models}
 
     if not models and not metadata_models and not source_models:
         await _release_reservation(reservation)
@@ -2688,15 +2697,10 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
             continue
         entries.append(_to_codex_model_entry(model, visibility="hide"))
         seen_slugs.add(slug)
-    for model in source_models:
+    for model in visible_source_models:
         if model.slug in seen_slugs:
             continue
         if visibility_allowed_models is None:
-            if exact_source_allowed_models is not None:
-                if model.slug not in exact_source_allowed_models:
-                    continue
-            elif not is_public_model(model, allowed_models):
-                continue
             entry = _to_codex_model_entry(model)
             entries.append(entry)
             seen_slugs.add(model.slug)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2661,6 +2661,16 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
             elif not is_public_model(source_model, allowed_models):
                 continue
         visible_source_models.append(source_model)
+    visible_source_models.sort(
+        key=lambda model: (
+            _effective_source_codex_visibility(
+                model,
+                visibility_allowed_models=visibility_allowed_models,
+                exact_source_allowed_models=exact_source_allowed_models,
+            )
+            != "list"
+        )
+    )
     source_model_slugs = {
         model.slug
         for model in visible_source_models

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2652,6 +2652,7 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
         for model in await _list_enabled_source_catalog_models(api_key, require_responses=True)
         if model.raw.get("supports_streaming") is True
     ]
+    source_model_slugs = {model.slug for model in source_models}
 
     if not models and not metadata_models and not source_models:
         await _release_reservation(reservation)
@@ -2681,7 +2682,7 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
         if model.supported_in_api and entry.visibility == "list":
             data.append(_to_model_list_item(slug, model, created=_model_list_created_at(model)))
     for slug, model in metadata_models.items():
-        if slug in models or not _is_codex_backend_catalog_model(model):
+        if slug in models or slug in source_model_slugs or not _is_codex_backend_catalog_model(model):
             continue
         if visibility_allowed_models is None and allowed_models is not None and slug not in allowed_models:
             continue

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2664,9 +2664,12 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
     source_model_slugs = {
         model.slug
         for model in visible_source_models
-        if visibility_allowed_models is None
-        or exact_source_allowed_models is None
-        or model.slug in exact_source_allowed_models
+        if _effective_source_codex_visibility(
+            model,
+            visibility_allowed_models=visibility_allowed_models,
+            exact_source_allowed_models=exact_source_allowed_models,
+        )
+        == "list"
     }
 
     if not models and not metadata_models and not source_models:
@@ -2715,8 +2718,10 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
             continue
         entry = _to_codex_model_entry(
             model,
-            visibility=(
-                "list" if exact_source_allowed_models is None or model.slug in exact_source_allowed_models else "hide"
+            visibility=_effective_source_codex_visibility(
+                model,
+                visibility_allowed_models=visibility_allowed_models,
+                exact_source_allowed_models=exact_source_allowed_models,
             ),
         )
         entries.append(entry)
@@ -2981,6 +2986,24 @@ def _v1_supports_vision(model: UpstreamModel) -> bool:
 def _model_visibility(model: UpstreamModel) -> str:
     visibility = model.raw.get("visibility")
     return visibility if isinstance(visibility, str) else "list"
+
+
+def _effective_source_codex_visibility(
+    model: UpstreamModel,
+    *,
+    visibility_allowed_models: set[str] | None,
+    exact_source_allowed_models: set[str] | None,
+) -> str:
+    raw_visibility = _model_visibility(model)
+    if raw_visibility != "list":
+        return raw_visibility
+    if (
+        visibility_allowed_models is not None
+        and exact_source_allowed_models is not None
+        and model.slug not in exact_source_allowed_models
+    ):
+        return "hide"
+    return "list"
 
 
 def _to_model_metadata(model: UpstreamModel) -> ModelMetadata:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2661,7 +2661,13 @@ async def _build_codex_models_response(api_key: ApiKeyData | None) -> Response:
             elif not is_public_model(source_model, allowed_models):
                 continue
         visible_source_models.append(source_model)
-    source_model_slugs = {model.slug for model in visible_source_models}
+    source_model_slugs = {
+        model.slug
+        for model in visible_source_models
+        if visibility_allowed_models is None
+        or exact_source_allowed_models is None
+        or model.slug in exact_source_allowed_models
+    }
 
     if not models and not metadata_models and not source_models:
         await _release_reservation(reservation)

--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -212,7 +212,7 @@ def _model_responses_lite_capability(
     registry: ModelRegistry,
 ) -> bool | None:
     normalized_model = model.strip().lower()
-    models = registry.get_models_with_fallback()
+    models = registry.get_models_for_metadata()
     model_entry = models.get(model) or models.get(normalized_model)
     if model_entry is None:
         return None

--- a/openspec/changes/retain-last-known-codex-model-metadata/proposal.md
+++ b/openspec/changes/retain-last-known-codex-model-metadata/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+An otherwise successful upstream model refresh can temporarily omit a model
+during a staged rollout. The live registry currently replaces the whole model
+map, so Codex loses metadata for an explicitly configured model even while
+codex-lb can still route requests to it. Codex then falls back to generic
+metadata, degrading tool, context, and instruction behavior.
+
+## What Changes
+
+- Retain the last complete live metadata for bundled Codex models omitted by a
+  later refresh.
+- Return retained-only entries as hidden in the Codex catalog.
+- Keep active availability, entitlement indexes, routing, and `/v1/models`
+  based only on the current live snapshot.
+- Use retained metadata for Responses Lite capability validation.
+
+## Impact
+
+- Affected capability: `model-catalog-compat`.
+- Partial upstream catalogs no longer erase metadata for configured Codex
+  models.
+- Retained metadata cannot advertise or authorize a model that is absent from
+  the current live catalog.
+- Models outside the bundled Codex catalog are never retained, avoiding stale
+  cross-account metadata exposure.

--- a/openspec/changes/retain-last-known-codex-model-metadata/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/retain-last-known-codex-model-metadata/specs/model-catalog-compat/spec.md
@@ -15,6 +15,11 @@ MUST replace the retained entry when the model appears again.
 Models outside the bundled Codex catalog MUST NOT be retained after they leave
 the current live availability snapshot.
 
+OpenAI-compatible source entries that share a slug with retained Codex metadata
+MUST replace retained metadata only when the source entry is visible/listed for
+the requesting API key. A same-slug source entry hidden by the API key's exact
+source allowlist MUST NOT shadow the retained metadata.
+
 #### Scenario: Sol metadata remains resolvable after a partial refresh
 
 - **GIVEN** a successful live catalog refresh returned complete metadata for `gpt-5.6-sol`
@@ -27,3 +32,11 @@ the current live availability snapshot.
 - **GIVEN** metadata was retained for a model omitted by a previous refresh
 - **WHEN** a later live refresh returns that model with updated metadata
 - **THEN** the updated live metadata is used and the model follows its current live visibility
+
+#### Scenario: Hidden source entry does not replace retained metadata
+
+- **GIVEN** metadata was retained for `gpt-5.6-sol`
+- **AND** an OpenAI-compatible source exposes the same `gpt-5.6-sol` slug
+- **AND** an API key's exact source allowlist hides that source entry from the Codex catalog
+- **WHEN** a client calls `GET /backend-api/codex/models` with that API key
+- **THEN** the hidden Sol catalog entry uses the retained Codex metadata

--- a/openspec/changes/retain-last-known-codex-model-metadata/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/retain-last-known-codex-model-metadata/specs/model-catalog-compat/spec.md
@@ -49,3 +49,10 @@ shadow the retained metadata.
 - **WHEN** the Codex catalog is rendered
 - **THEN** the list-visible source entry MUST take precedence for that slug
 - **AND** the earlier hidden source MUST NOT suppress or replace it
+
+#### Scenario: Bundled model appears on only one account in a plan
+
+- **GIVEN** a same-plan refresh returns a bundled Codex model from one successful account but omits it from another
+- **WHEN** the availability intersection excludes that model
+- **THEN** the model MUST remain absent from live availability indexes
+- **AND** its complete per-account live entry MUST refresh the metadata-only catalog

--- a/openspec/changes/retain-last-known-codex-model-metadata/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/retain-last-known-codex-model-metadata/specs/model-catalog-compat/spec.md
@@ -41,3 +41,11 @@ shadow the retained metadata.
 - **AND** that source entry is hidden from the effective Codex catalog by raw visibility or an API key's exact source allowlist
 - **WHEN** a client calls `GET /backend-api/codex/models` with that API key
 - **THEN** the hidden Sol catalog entry uses the retained Codex metadata
+
+#### Scenario: Visible same-slug source follows an earlier hidden source
+
+- **GIVEN** multiple enabled sources expose the same model slug
+- **AND** an earlier source is hidden while a later source is list-visible
+- **WHEN** the Codex catalog is rendered
+- **THEN** the list-visible source entry MUST take precedence for that slug
+- **AND** the earlier hidden source MUST NOT suppress or replace it

--- a/openspec/changes/retain-last-known-codex-model-metadata/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/retain-last-known-codex-model-metadata/specs/model-catalog-compat/spec.md
@@ -16,9 +16,10 @@ Models outside the bundled Codex catalog MUST NOT be retained after they leave
 the current live availability snapshot.
 
 OpenAI-compatible source entries that share a slug with retained Codex metadata
-MUST replace retained metadata only when the source entry is visible/listed for
-the requesting API key. A same-slug source entry hidden by the API key's exact
-source allowlist MUST NOT shadow the retained metadata.
+MUST replace retained metadata only when the source entry's effective Codex
+visibility is `list` for the requesting client. A same-slug source entry hidden
+by raw catalog visibility or by the API key's exact source allowlist MUST NOT
+shadow the retained metadata.
 
 #### Scenario: Sol metadata remains resolvable after a partial refresh
 
@@ -37,6 +38,6 @@ source allowlist MUST NOT shadow the retained metadata.
 
 - **GIVEN** metadata was retained for `gpt-5.6-sol`
 - **AND** an OpenAI-compatible source exposes the same `gpt-5.6-sol` slug
-- **AND** an API key's exact source allowlist hides that source entry from the Codex catalog
+- **AND** that source entry is hidden from the effective Codex catalog by raw visibility or an API key's exact source allowlist
 - **WHEN** a client calls `GET /backend-api/codex/models` with that API key
 - **THEN** the hidden Sol catalog entry uses the retained Codex metadata

--- a/openspec/changes/retain-last-known-codex-model-metadata/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/retain-last-known-codex-model-metadata/specs/model-catalog-compat/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Codex metadata survives a partial live catalog refresh
+
+The proxy MUST retain the last successfully fetched complete metadata for a
+bundled Codex model when a later successful live catalog refresh omits that
+model. A retained model that is absent from the current live availability snapshot MUST be
+returned through the Codex model catalog with hidden visibility so an explicitly
+configured client can resolve its metadata without advertising it in the model
+picker.
+
+Retained metadata MUST NOT add the model to current plan, account, service-tier,
+routing, dashboard, warmup, or `/v1/models` availability. A current live entry
+MUST replace the retained entry when the model appears again.
+Models outside the bundled Codex catalog MUST NOT be retained after they leave
+the current live availability snapshot.
+
+#### Scenario: Sol metadata remains resolvable after a partial refresh
+
+- **GIVEN** a successful live catalog refresh returned complete metadata for `gpt-5.6-sol`
+- **WHEN** a later successful refresh omits `gpt-5.6-sol`
+- **THEN** the Codex catalog includes the last complete Sol metadata with hidden visibility
+- **AND** `/v1/models` and live availability indexes omit Sol
+
+#### Scenario: A later live entry replaces retained metadata
+
+- **GIVEN** metadata was retained for a model omitted by a previous refresh
+- **WHEN** a later live refresh returns that model with updated metadata
+- **THEN** the updated live metadata is used and the model follows its current live visibility

--- a/openspec/changes/retain-last-known-codex-model-metadata/tasks.md
+++ b/openspec/changes/retain-last-known-codex-model-metadata/tasks.md
@@ -1,0 +1,6 @@
+- [x] Preserve last-known complete live model metadata across partial refreshes.
+- [x] Keep live availability and plan indexes authoritative to the current refresh.
+- [x] Emit retained-only Codex catalog entries with hidden visibility.
+- [x] Keep `/v1/models` limited to currently available models.
+- [x] Resolve Responses Lite capability from the metadata view.
+- [x] Add unit and integration regression coverage.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,8 +118,10 @@ def _reset_model_registry():
 
     registry = get_model_registry()
     registry._snapshot = None
+    registry._metadata_models = None
     yield
     registry._snapshot = None
+    registry._metadata_models = None
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -1562,6 +1562,60 @@ async def test_raw_hidden_same_slug_source_does_not_shadow_retained_metadata(asy
 
 
 @pytest.mark.asyncio
+async def test_list_visible_same_slug_source_wins_over_earlier_hidden_source(async_client):
+    registry = get_model_registry()
+    sol = _make_upstream_model("gpt-5.6-sol", base_instructions="retained sol metadata")
+    terra = _make_upstream_model("gpt-5.6-terra")
+    await registry.update({"plus": [sol, terra]})
+    await registry.update({"plus": [terra]})
+    await _create_model_source(
+        async_client,
+        name="first-hidden-same-slug-source",
+        model="gpt-5.6-sol",
+        supports_responses=True,
+        raw_metadata_json=json.dumps({"visibility": "hide", "use_responses_lite": False}),
+    )
+    await _create_model_source(
+        async_client,
+        name="second-visible-same-slug-source",
+        model="gpt-5.6-sol",
+        supports_responses=True,
+        raw_metadata_json=json.dumps({"visibility": "list", "use_responses_lite": True}),
+    )
+    enable = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": False,
+            "preferEarlierResetAccounts": False,
+            "totpRequiredOnLogin": False,
+            "apiKeyAuthEnabled": True,
+        },
+    )
+    assert enable.status_code == 200
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "visible-source-precedence",
+            "allowedModels": ["gpt-5.6-sol"],
+            "applyToCodexModel": True,
+        },
+    )
+    assert created.status_code == 200
+
+    response = await async_client.get(
+        "/backend-api/codex/models",
+        headers={"Authorization": f"Bearer {created.json()['key']}"},
+    )
+
+    assert response.status_code == 200
+    entries = [item for item in response.json()["models"] if item["slug"] == "gpt-5.6-sol"]
+    assert len(entries) == 1
+    assert entries[0]["visibility"] == "list"
+    assert entries[0]["use_responses_lite"] is True
+    assert "gpt-5.6-sol" in {item["id"] for item in response.json()["data"]}
+
+
+@pytest.mark.asyncio
 async def test_first_partial_refresh_serves_hidden_bootstrap_metadata(async_client):
     registry = get_model_registry()
     await registry.update({"plus": [_make_upstream_model("gpt-5.6-terra")]})

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -1425,6 +1425,47 @@ async def test_codex_catalog_hides_last_known_metadata_omitted_by_live_refresh(a
 
 
 @pytest.mark.asyncio
+async def test_source_model_shadows_retained_metadata_with_the_same_slug(async_client):
+    registry = get_model_registry()
+    sol = _make_upstream_model("gpt-5.6-sol", base_instructions="retained subscription metadata")
+    terra = _make_upstream_model("gpt-5.6-terra")
+    await registry.update({"plus": [sol, terra]})
+    await registry.update({"plus": [terra]})
+    await _create_model_source(
+        async_client,
+        name="live-sol-source",
+        model="gpt-5.6-sol",
+        supports_responses=True,
+    )
+
+    settings = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": False,
+            "preferEarlierResetAccounts": False,
+            "totpRequiredOnLogin": False,
+            "apiKeyAuthEnabled": True,
+        },
+    )
+    assert settings.status_code == 200
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={"name": "exact live sol source", "allowedModels": ["gpt-5.6-sol"]},
+    )
+    assert created.status_code == 200
+
+    response = await async_client.get(
+        "/backend-api/codex/models",
+        headers={"Authorization": f"Bearer {created.json()['key']}"},
+    )
+    assert response.status_code == 200
+    entries = [item for item in response.json()["models"] if item["slug"] == "gpt-5.6-sol"]
+    assert len(entries) == 1
+    assert entries[0]["visibility"] == "list"
+    assert "gpt-5.6-sol" in {item["id"] for item in response.json()["data"]}
+
+
+@pytest.mark.asyncio
 async def test_first_partial_refresh_serves_hidden_bootstrap_metadata(async_client):
     registry = get_model_registry()
     await registry.update({"plus": [_make_upstream_model("gpt-5.6-terra")]})

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -1560,3 +1560,56 @@ async def test_codex_visibility_allowlist_keeps_retained_metadata_hidden(async_c
     assert entries["gpt-5.6-terra"]["visibility"] == "list"
     assert entries["gpt-5.6-sol"]["visibility"] == "hide"
     assert entries["gpt-5.6-sol"]["base_instructions"] == "retained sol"
+
+
+@pytest.mark.asyncio
+async def test_hidden_same_slug_source_does_not_shadow_retained_metadata_for_codex_visibility_allowlist(
+    async_client,
+):
+    registry = get_model_registry()
+    sol = _make_upstream_model(
+        "gpt-5.6-sol",
+        base_instructions="retained sol metadata",
+        raw={"use_responses_lite": True},
+    )
+    terra = _make_upstream_model("gpt-5.6-terra")
+    await registry.update({"plus": [sol, terra]})
+    await registry.update({"plus": [terra]})
+    await _create_model_source(
+        async_client,
+        name="hidden-same-slug-sol-source",
+        model="gpt-5.6-sol",
+        supports_responses=True,
+    )
+
+    enable = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": False,
+            "preferEarlierResetAccounts": False,
+            "totpRequiredOnLogin": False,
+            "apiKeyAuthEnabled": True,
+        },
+    )
+    assert enable.status_code == 200
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "retained-codex-visibility-alias",
+            "allowedModels": ["gpt-5.6-sol-extra-high-fast"],
+            "applyToCodexModel": True,
+        },
+    )
+    assert created.status_code == 200
+
+    resp = await async_client.get(
+        "/backend-api/codex/models",
+        headers={"Authorization": f"Bearer {created.json()['key']}"},
+    )
+
+    assert resp.status_code == 200
+    entries = {item["slug"]: item for item in resp.json()["models"]}
+    assert entries["gpt-5.6-sol"]["visibility"] == "hide"
+    assert entries["gpt-5.6-sol"]["base_instructions"] == "retained sol metadata"
+    assert entries["gpt-5.6-sol"]["use_responses_lite"] is True
+    assert "gpt-5.6-sol" not in {item["id"] for item in resp.json()["data"]}

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -1511,6 +1511,57 @@ async def test_filtered_same_slug_source_does_not_hide_allowed_retained_metadata
 
 
 @pytest.mark.asyncio
+async def test_raw_hidden_same_slug_source_does_not_shadow_retained_metadata(async_client):
+    registry = get_model_registry()
+    sol = _make_upstream_model(
+        "gpt-5.6-sol",
+        base_instructions="retained sol metadata",
+        raw={"use_responses_lite": True},
+    )
+    terra = _make_upstream_model("gpt-5.6-terra")
+    await registry.update({"plus": [sol, terra]})
+    await registry.update({"plus": [terra]})
+    await _create_model_source(
+        async_client,
+        name="raw-hidden-same-slug-sol-source",
+        model="gpt-5.6-sol",
+        supports_responses=True,
+        raw_metadata_json=json.dumps({"visibility": "hide", "use_responses_lite": False}),
+    )
+    enable = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": False,
+            "preferEarlierResetAccounts": False,
+            "totpRequiredOnLogin": False,
+            "apiKeyAuthEnabled": True,
+        },
+    )
+    assert enable.status_code == 200
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "raw-hidden-source-codex-visibility",
+            "allowedModels": ["gpt-5.6-sol"],
+            "applyToCodexModel": True,
+        },
+    )
+    assert created.status_code == 200
+
+    response = await async_client.get(
+        "/backend-api/codex/models",
+        headers={"Authorization": f"Bearer {created.json()['key']}"},
+    )
+
+    assert response.status_code == 200
+    entries = {item["slug"]: item for item in response.json()["models"]}
+    assert entries["gpt-5.6-sol"]["visibility"] == "hide"
+    assert entries["gpt-5.6-sol"]["base_instructions"] == "retained sol metadata"
+    assert entries["gpt-5.6-sol"]["use_responses_lite"] is True
+    assert "gpt-5.6-sol" not in {item["id"] for item in response.json()["data"]}
+
+
+@pytest.mark.asyncio
 async def test_first_partial_refresh_serves_hidden_bootstrap_metadata(async_client):
     registry = get_model_registry()
     await registry.update({"plus": [_make_upstream_model("gpt-5.6-terra")]})

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -1390,3 +1390,87 @@ async def test_v1_models_does_not_promote_raw_max_context_window(async_client):
     assert entry["metadata"]["context_window"] == 272_000
     assert entry["metadata"]["input_context_window"] == 272_000
     assert entry["metadata"].get("max_output_tokens") is None
+
+
+@pytest.mark.asyncio
+async def test_codex_catalog_hides_last_known_metadata_omitted_by_live_refresh(async_client):
+    registry = get_model_registry()
+    sol = _make_upstream_model(
+        "gpt-5.6-sol",
+        base_instructions="full live sol instructions",
+        raw={
+            "shell_type": "shell_command",
+            "visibility": "list",
+            "use_responses_lite": True,
+        },
+    )
+    terra = _make_upstream_model("gpt-5.6-terra")
+    await registry.update({"plus": [sol, terra]})
+    await registry.update({"plus": [terra]})
+
+    codex_resp = await async_client.get(
+        "/backend-api/codex/models",
+        params={"client_version": "0.144.1"},
+    )
+    assert codex_resp.status_code == 200
+    entries = {item["slug"]: item for item in codex_resp.json()["models"]}
+    assert entries["gpt-5.6-sol"]["visibility"] == "hide"
+    assert entries["gpt-5.6-sol"]["base_instructions"] == "full live sol instructions"
+    assert entries["gpt-5.6-sol"]["use_responses_lite"] is True
+    assert entries["gpt-5.6-terra"]["visibility"] == "list"
+
+    v1_resp = await async_client.get("/v1/models")
+    assert v1_resp.status_code == 200
+    assert "gpt-5.6-sol" not in {item["id"] for item in v1_resp.json()["data"]}
+
+
+@pytest.mark.asyncio
+async def test_first_partial_refresh_serves_hidden_bootstrap_metadata(async_client):
+    registry = get_model_registry()
+    await registry.update({"plus": [_make_upstream_model("gpt-5.6-terra")]})
+
+    codex_resp = await async_client.get("/backend-api/codex/models")
+    entries = {item["slug"]: item for item in codex_resp.json()["models"]}
+    assert entries["gpt-5.6-sol"]["visibility"] == "hide"
+    assert entries["gpt-5.6-sol"]["use_responses_lite"] is True
+
+    v1_resp = await async_client.get("/v1/models")
+    assert "gpt-5.6-sol" not in {item["id"] for item in v1_resp.json()["data"]}
+
+
+@pytest.mark.asyncio
+async def test_codex_visibility_allowlist_keeps_retained_metadata_hidden(async_client):
+    registry = get_model_registry()
+    sol = _make_upstream_model("gpt-5.6-sol", base_instructions="retained sol")
+    terra = _make_upstream_model("gpt-5.6-terra")
+    await registry.update({"plus": [sol, terra]})
+    await registry.update({"plus": [terra]})
+
+    enable = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": False,
+            "preferEarlierResetAccounts": False,
+            "totpRequiredOnLogin": False,
+            "apiKeyAuthEnabled": True,
+        },
+    )
+    assert enable.status_code == 200
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "retained-codex-visibility",
+            "allowedModels": ["gpt-5.6-terra"],
+            "applyToCodexModel": True,
+        },
+    )
+    assert created.status_code == 200
+
+    resp = await async_client.get(
+        "/backend-api/codex/models",
+        headers={"Authorization": f"Bearer {created.json()['key']}"},
+    )
+    entries = {item["slug"]: item for item in resp.json()["models"]}
+    assert entries["gpt-5.6-terra"]["visibility"] == "list"
+    assert entries["gpt-5.6-sol"]["visibility"] == "hide"
+    assert entries["gpt-5.6-sol"]["base_instructions"] == "retained sol"

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -1466,6 +1466,51 @@ async def test_source_model_shadows_retained_metadata_with_the_same_slug(async_c
 
 
 @pytest.mark.asyncio
+async def test_filtered_same_slug_source_does_not_hide_allowed_retained_metadata(async_client):
+    registry = get_model_registry()
+    sol = _make_upstream_model("gpt-5.6-sol", base_instructions="retained subscription metadata")
+    terra = _make_upstream_model("gpt-5.6-terra")
+    await registry.update({"plus": [sol, terra]})
+    await registry.update({"plus": [terra]})
+    await _create_model_source(
+        async_client,
+        name="filtered-live-sol-source",
+        model="gpt-5.6-sol",
+        supports_responses=True,
+    )
+
+    settings = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": False,
+            "preferEarlierResetAccounts": False,
+            "totpRequiredOnLogin": False,
+            "apiKeyAuthEnabled": True,
+        },
+    )
+    assert settings.status_code == 200
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "canonical retained sol alias",
+            "allowedModels": ["gpt-5.6-sol-extra-high-fast"],
+        },
+    )
+    assert created.status_code == 200
+
+    response = await async_client.get(
+        "/backend-api/codex/models",
+        headers={"Authorization": f"Bearer {created.json()['key']}"},
+    )
+    assert response.status_code == 200
+    entries = [item for item in response.json()["models"] if item["slug"] == "gpt-5.6-sol"]
+    assert len(entries) == 1
+    assert entries[0]["visibility"] == "hide"
+    assert entries[0]["base_instructions"] == "retained subscription metadata"
+    assert "gpt-5.6-sol" not in {item["id"] for item in response.json()["data"]}
+
+
+@pytest.mark.asyncio
 async def test_first_partial_refresh_serves_hidden_bootstrap_metadata(async_client):
     registry = get_model_registry()
     await registry.update({"plus": [_make_upstream_model("gpt-5.6-terra")]})

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -457,6 +457,31 @@ async def test_account_ids_for_model_service_tier_tracks_account_catalogs():
 
 
 @pytest.mark.asyncio
+async def test_per_account_bundled_model_refreshes_metadata_without_availability():
+    live_sol = replace(
+        _model("gpt-5.6-sol"),
+        base_instructions="live per-account sol metadata",
+        raw={"use_responses_lite": False},
+    )
+    registry = ModelRegistry(ttl_seconds=60.0)
+
+    await registry.update(
+        {"pro": []},
+        per_account_results={
+            "account-sol": ("pro", [live_sol]),
+            "account-without-sol": ("pro", [_model("gpt-5.6-terra")]),
+        },
+    )
+
+    snapshot = registry.get_snapshot()
+    assert snapshot is not None
+    assert "gpt-5.6-sol" not in snapshot.models
+    metadata_sol = registry.get_models_for_metadata()["gpt-5.6-sol"]
+    assert metadata_sol.base_instructions == "live per-account sol metadata"
+    assert metadata_sol.raw["use_responses_lite"] is False
+
+
+@pytest.mark.asyncio
 async def test_account_ids_for_model_service_tier_preserves_missing_active_accounts():
     fast = replace(_model("gpt-5.5"), raw={"service_tiers": [{"slug": "fast"}], "additional_speed_tiers": ["fast"]})
     no_fast = replace(_model("gpt-5.5"), raw={"service_tiers": [{"slug": "default"}]})

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -171,8 +171,14 @@ async def test_first_partial_refresh_keeps_bootstrap_metadata_hidden_from_availa
 @pytest.mark.asyncio
 async def test_metadata_does_not_retain_non_bundled_models():
     registry = ModelRegistry(ttl_seconds=60.0)
+    workspace_model = replace(
+        _model("workspace-private"),
+        raw={"use_responses_lite": False},
+    )
 
-    await registry.update({"enterprise": [_model("workspace-private")]})
+    await registry.update({"enterprise": [workspace_model]})
+    assert registry.get_models_for_metadata()["workspace-private"].raw["use_responses_lite"] is False
+
     await registry.update({"enterprise": [_model("gpt-5.6-terra")]})
 
     assert "workspace-private" not in registry.get_models_for_metadata()

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -135,6 +135,49 @@ async def test_plan_types_for_model_returns_plans():
     assert registry.plan_types_for_model("model-c") == frozenset({"pro"})
 
 
+@pytest.mark.asyncio
+async def test_metadata_retains_full_live_model_after_later_catalog_omits_it():
+    registry = ModelRegistry(ttl_seconds=60.0)
+    sol = replace(
+        _model("gpt-5.6-sol"),
+        base_instructions="full live instructions",
+        raw={"use_responses_lite": True},
+    )
+    terra_v1 = replace(_model("gpt-5.6-terra"), description="old terra")
+    terra_v2 = replace(_model("gpt-5.6-terra"), description="new terra")
+
+    await registry.update({"plus": [sol, terra_v1]})
+    await registry.update({"plus": [terra_v2]})
+
+    assert set(registry.get_models_with_fallback()) == {"gpt-5.6-terra"}
+    assert registry.plan_types_for_model("gpt-5.6-sol") == frozenset()
+    metadata = registry.get_models_for_metadata()
+    assert metadata["gpt-5.6-sol"].base_instructions == "full live instructions"
+    assert metadata["gpt-5.6-sol"].raw["use_responses_lite"] is True
+    assert metadata["gpt-5.6-terra"].description == "new terra"
+
+
+@pytest.mark.asyncio
+async def test_first_partial_refresh_keeps_bootstrap_metadata_hidden_from_availability():
+    registry = ModelRegistry(ttl_seconds=60.0)
+
+    await registry.update({"plus": [_model("gpt-5.6-terra")]})
+
+    assert set(registry.get_models_with_fallback()) == {"gpt-5.6-terra"}
+    assert "gpt-5.6-sol" in registry.get_models_for_metadata()
+    assert registry.plan_types_for_model("gpt-5.6-sol") == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_metadata_does_not_retain_non_bundled_models():
+    registry = ModelRegistry(ttl_seconds=60.0)
+
+    await registry.update({"enterprise": [_model("workspace-private")]})
+    await registry.update({"enterprise": [_model("gpt-5.6-terra")]})
+
+    assert "workspace-private" not in registry.get_models_for_metadata()
+
+
 @pytest.mark.parametrize("model_slug", ["gpt-5.5", "gpt-5.3-codex-spark"])
 @pytest.mark.asyncio
 async def test_plan_types_for_bootstrap_model_uses_live_snapshot_after_refresh(model_slug: str):

--- a/tests/unit/test_request_policy.py
+++ b/tests/unit/test_request_policy.py
@@ -167,7 +167,7 @@ def test_enforced_non_lite_model_rejects_responses_lite_payload() -> None:
     registry = cast(
         ModelRegistry,
         SimpleNamespace(
-            get_models_with_fallback=lambda: {"gpt-5.5": SimpleNamespace(raw={"use_responses_lite": False})}
+            get_models_for_metadata=lambda: {"gpt-5.5": SimpleNamespace(raw={"use_responses_lite": False})}
         ),
     )
 
@@ -203,7 +203,7 @@ def test_alias_equivalent_enforced_non_lite_model_rejects_responses_lite_payload
     registry = cast(
         ModelRegistry,
         SimpleNamespace(
-            get_models_with_fallback=lambda: {"gpt-5.5": SimpleNamespace(raw={"use_responses_lite": False})}
+            get_models_for_metadata=lambda: {"gpt-5.5": SimpleNamespace(raw={"use_responses_lite": False})}
         ),
     )
 


### PR DESCRIPTION
## Summary

- retain last-known complete metadata for bundled Codex models when a later upstream catalog refresh omits them
- expose retained-only entries as hidden in the Codex catalog while keeping live routing, plan indexes, dashboard, warmup, and /v1/models authoritative
- use the retained metadata view for Responses Lite capability checks
- do not retain arbitrary/workspace-only models, avoiding stale cross-account metadata exposure

## Root cause

codex-lb treats a successful live model registry snapshot as a complete replacement for its bootstrap catalog. On July 11, 2026, the local registry refreshed from eight models to a successful six-model catalog that omitted gpt-5.6-sol, although Sol requests continued routing successfully. The Codex catalog then omitted Sol, so Codex warned that metadata was missing and used degraded fallback metadata.

A simple bootstrap overlay is insufficient because bundled metadata intentionally lacks the full live base instructions. This change preserves the complete last-known live entry when available, and uses bundled metadata only for a first partial refresh after restart.

## Safety invariants

- retained-only models are always hidden
- /v1/models and current plan/account/service-tier indexes exclude retained-only models
- live metadata replaces retained metadata when a model reappears
- only bundled Codex slugs are retained
- API-key filtering and applyToCodexModel hidden-entry behavior remain intact

## Validation

- 57 focused unit tests passed
- 40 focused integration tests passed
- focused ruff and ty checks passed
- git diff --check passed
- OpenSpec CLI is unavailable locally; canonical CI validation remains authoritative

OpenSpec: openspec/changes/retain-last-known-codex-model-metadata/