### PR TITLE
test(usage): use UTC clock for freshness fixture

### DIFF
--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -1525,7 +1525,7 @@ async def test_usage_refresh_uses_fresh_monthly_row_for_quota_freshness(monkeypa
         account.id,
         100.0,
         window="monthly",
-        recorded_at=datetime.now(),
+        recorded_at=usage_updater_module.utcnow(),
         reset_at=int(time.time()) + 3600,
         window_minutes=43_200,
     )


### PR DESCRIPTION
## Summary

- make the monthly quota-freshness fixture use the same naive-UTC clock as `UsageUpdater`
- fix a deterministic failure for contributors running the suite outside UTC
- no runtime behavior changes

## Root cause

The test inserted `recorded_at=datetime.now()`, which is naive local time. Production computes freshness with `app.core.utils.time.utcnow()`, a naive UTC timestamp. In `America/New_York`, the inserted row therefore appeared roughly four hours old and the updater incorrectly performed the mocked upstream refresh instead of treating the row as fresh.

Using `usage_updater_module.utcnow()` matches the exact clock and timestamp convention consumed by the code under test, including future clock monkeypatching.

## Validation

- targeted regression: 1 passed
- complete `tests/unit/test_usage_updater.py`: 82 passed
- Ruff passed
- `git diff --check` passed

This is a test-only portability correction, so no OpenSpec change is required.