### PR TITLE
chore: release v1.21.0-beta.4

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.21.0-beta.3"  # x-release-please-version
+__version__ = "1.21.0-beta.4"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.21.0-beta.3
-appVersion: 1.21.0-beta.3
+version: 1.21.0-beta.4
+appVersion: 1.21.0-beta.4
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.21.0-beta.3",
+  "version": "1.21.0-beta.4",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.21.0-beta.3"
+version = "1.21.0-beta.4"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.21.0b3"
+version = "1.21.0-beta.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.21.0-beta.4 for the 1.21.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.21.0-beta.4 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1087; no manual beta workflow dispatch is required.

## Changes since v1.21.0-beta.3
- fix(proxy): accept large websocket response.create and fail fast with 400 (#1236) (02f1784)
- perf(request-logs): skip-scan unfiltered filter-option facets (#1239) (
7c2cd9)
- perf(proxy): cut pre-upstream DB round trips on interactive turns (#1241) (
b62797)
- perf(proxy): make SSE event framing linear instead of quadratic (#1242) (
ed9d4d)
- perf(clients): keep upstream connections and DNS across interactive turns (#1245) (
08e7a9)
- perf(dashboard): compress responses, cache assets, lazy-load charts (#1243) (
c01abc)
- perf(usage): aggregate the summary window in SQL, drop dead log refresh (#1244) (
22544b)
- perf(accounts): serve request-usage summaries from persistent rollup (#1238) (
f8d4be)
- feat(retention): opt-in pruning for request logs and usage history (#1240) (
637c7c)
- fix(db): serialize startup migrations across replicas (#1256) (
0a7f35)
- fix(quota-planner): atomic warmup budget claims (#1260) (
a8e12f)
- fix(balancer): persist rate-limit cooldowns so peer replicas honor them (#1261) (
991be8)
- fix(deploy): repair broken multi-replica deployment artifacts (#1263) (
282192)
- fix(proxy): fence bridge lease writes, evict fenced-out replicas, purge orphaned ring state (#1259) (
53f7b4)
- fix(caching): extend cross-replica cache invalidation bus to routing, selection, and settings caches (#1255) (
b7bf87)
- feat(replica-ops): document replica topology contract and land startup guardrails (#1264) (
e9392f)
- feat(proxy): partition account concurrency caps across live replicas (#1258) (
d4f254)
- fix(reset-credits): make redemption replica-safe with durable ledger and claim (#1257) (
01188e)
- fix(proxy): queue bridged requests through response-create gate contention (#1266) (
87fae4)
- feat(balancer): adapt selection and refresh to absent short-window quotas (#1267) (
9c1486)
- feat(planner): derive phase planning from observed short windows (#1268) (
7fdbdc)
- perf(proxy): parse each SSE event once per layer, skip no-op reserialization (#1270) (
f3cc5b)
- perf(proxy): detach stream-end persistence from the response path (#1269) (
0b4363)
- perf(request-logs): cache the listing total per filter signature (#1277) (
27b982)
- perf(frontend): code-split dashboard routes (#1278) (
3e4479)
- perf(frontend): self-host JetBrains Mono, drop Google Fonts (#1279) (
acfb29)
- feat(models): replicate leader-refreshed model registry via persisted snapshots (#1262) (
fa3906)
- fix(automation): fall back to github.token when label sync hits rate limits (#1272) (
3ce5ba)
- feat(usage): ingest live rate-limit snapshots from proxied traffic (#1273) (
75e7c2)
- feat(dashboard): hide expired primary windows instead of freezing them (#1301) (
165aa9)
- feat(ci): mint a dedicated GitHub App token for codex label sync (#1302) (
5470a5)
- fix(scheduling): harden scheduler leader election for multi-replica safety (#1253) (
13d3a3)

## Release-candidate validation
Validated candidate: 3b3a93d0885c978b83440316a37da9f206fbe40b

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates
- [x] Frontend tests/build
- [x] Wheel/package validation
- [x] Docker/container smoke
- [x] Live upstream/account smoke
- [ ] Live upstream/account smoke not required

### Validation evidence (candidate 3b3a93d0, validated 2026-07-15)
- **Backend gates**: full local suite on the exact candidate SHA — 5,218 passed, 9 skipped, 0 failed; ruff/format/ty/architecture-cap/openspec (43 specs) all clean. CI `integration-bridge` failure on attempt 1 (`reconnects_after_clean_upstream_close`, 409 vs 200) reproduced 0/13 locally and passed on rerun attempt 2 — flake, not a regression.
- **Frontend**: vitest 841/841 passed; production build clean on the candidate.
- **Wheel**: `uv build` → `codex_lb-1.21.0b4` wheel+sdist; fresh-venv install reports `__version__ 1.21.0-beta.4`, server boots against sqlite, `/health` + `/health/ready` (db ok) + dashboard 200.
- **Docker smoke**: image built from candidate; booted against a migrated copy of an existing sqlite volume (Alembic upgraded to `20260713_020000_add_model_registry_snapshot`), `/health/ready` ok. (The copied scratch volume was pre-corrupted — stamped past `20260613_000000` without the `codex_installation_id` column — repaired manually; not a candidate defect since the migration graph correctly skips already-stamped revisions.)
- **Live upstream/account smoke PERFORMED** (real Codex CLI 0.144.1 + real ChatGPT pro account, scratch beta4 container on the candidate image): WebSocket transport (`/backend-api/codex/responses` accepted), capacity_weighted selection + sticky codex_session + previous_response continuity resolution, `gpt-5.4-mini` and `gpt-5.6-luna` round trips both succeeded (exact-match replies, 1,296 + 7,468 tokens), request logs recorded, weekly-only (10080-min) usage normalized to primary and ingested — the adaptive-window path exercised live.

## Install after publish
```bash
uvx --from "codex-lb==1.21.0b4" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.21.0-beta.4
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.21.0-beta.4 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.21.0.

