### PR TITLE
perf(request-logs): skip-scan unfiltered filter-option facets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ POSTGRES_PYTEST_TARGETS := \
 	tests/integration/test_repositories.py::test_accounts_upsert_with_merge_enabled_serializes_concurrent_same_email \
 	tests/integration/test_sticky_sessions_api.py::test_durable_bridge_owned_alias_registration_is_epoch_fenced \
 	tests/integration/test_proxy_api_extended.py::test_proxy_stream_usage_limit_returns_http_error \
-	tests/integration/test_repositories.py::test_accounts_upsert_with_merge_disabled_uses_identity_lock_on_postgresql
+	tests/integration/test_repositories.py::test_accounts_upsert_with_merge_disabled_uses_identity_lock_on_postgresql \
+	tests/test_request_logs_options_api.py
 SHELL := /bin/bash
 
 .PHONY: help

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -8,6 +8,7 @@ import anyio
 from sqlalchemy import Integer, String, and_, cast, func, literal_column, or_, select
 from sqlalchemy import exc as sa_exc
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.sql.elements import ColumnElement
 
 from app.core.usage.logs import RequestLogLike, calculated_cost_from_log
@@ -480,6 +481,23 @@ class RequestLogsRepository:
             exclude_soft_deleted=True,
         )
 
+        unfiltered = not any((since, until, account_ids, api_key_ids, model_options, models, reasoning_efforts))
+        if unfiltered:
+            # PostgreSQL has no loose index scan: with no user filters each
+            # DISTINCT below is a full pass over request_logs, four times per
+            # filter-panel load. Emulate the skip scan instead — one indexed
+            # probe per distinct value.
+            return (
+                [value for value in await self._distinct_skip_scan(RequestLog.account_id, filters.conditions) if value],
+                await self._pair_facet_skip_scan(RequestLog.model, RequestLog.reasoning_effort, filters.conditions),
+                [
+                    value
+                    for value in await self._distinct_skip_scan(RequestLog.api_key_id, api_key_facet_filters.conditions)
+                    if value
+                ],
+                await self._pair_facet_skip_scan(RequestLog.status, RequestLog.error_code, filters.conditions),
+            )
+
         account_stmt = select(RequestLog.account_id).distinct().order_by(RequestLog.account_id.asc())
         model_stmt = (
             select(RequestLog.model, RequestLog.reasoning_effort)
@@ -510,6 +528,51 @@ class RequestLogsRepository:
         api_key_ids = [row[0] for row in api_key_rows.all() if row[0]]
         status_values = [(row[0], row[1]) for row in status_rows.all() if row[0]]
         return account_ids, model_options, api_key_ids, status_values
+
+    async def _distinct_skip_scan(
+        self,
+        column: InstrumentedAttribute[str] | InstrumentedAttribute[str | None],
+        conditions: list,
+    ) -> list[str]:
+        """Loose-index-scan emulation: seed min(column), then min(column) >
+        previous, one btree probe per distinct value. NULLs never seed or
+        chain (min() skips them); empty strings are preserved — the legacy
+        DISTINCT path only drops falsy values per facet, in the callers."""
+        seed = select(func.min(column).label("val")).where(*conditions)
+        skip = seed.cte("facet_skip", recursive=True)
+        successor = select(func.min(column)).where(*conditions, column > skip.c.val).scalar_subquery()
+        skip = skip.union_all(select(successor).where(skip.c.val.is_not(None)))
+        stmt = select(skip.c.val).where(skip.c.val.is_not(None)).order_by(skip.c.val.asc())
+        rows = await self._session.execute(stmt)
+        return [value for (value,) in rows.all() if value is not None]
+
+    async def _pair_facet_skip_scan(
+        self,
+        leading: InstrumentedAttribute[str] | InstrumentedAttribute[str | None],
+        second: InstrumentedAttribute[str] | InstrumentedAttribute[str | None],
+        conditions: list,
+    ) -> list[tuple[str, str | None]]:
+        """(leading, second) facet: skip-scan the leading column, then per
+        value probe a `(value, NULL)` pair and skip-scan the non-NULL second
+        values. NULL pair placement follows the backend's ORDER BY ASC NULL
+        ordering (SQLite: first, PostgreSQL: last) so results match the
+        legacy DISTINCT path exactly."""
+        nulls_first = self._session.get_bind().dialect.name == "sqlite"
+        pairs: list[tuple[str, str | None]] = []
+        for value in await self._distinct_skip_scan(leading, conditions):
+            if not value:
+                # Legacy DISTINCT drops falsy leading values in Python.
+                continue
+            value_conditions = [*conditions, leading == value]
+            null_probe = select(RequestLog.id).where(*value_conditions, second.is_(None)).limit(1)
+            has_null = (await self._session.execute(null_probe)).scalar_one_or_none() is not None
+            second_values = await self._distinct_skip_scan(second, value_conditions)
+            if has_null and nulls_first:
+                pairs.append((value, None))
+            pairs.extend((value, second_value) for second_value in second_values)
+            if has_null and not nulls_first:
+                pairs.append((value, None))
+        return pairs
 
     async def get_api_key_names_by_ids(self, api_key_ids: list[str]) -> dict[str, str]:
         unique_ids = sorted({key_id for key_id in api_key_ids if key_id})

--- a/openspec/changes/optimize-request-log-filter-options/.openspec.yaml
+++ b/openspec/changes/optimize-request-log-filter-options/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/optimize-request-log-filter-options/design.md
+++ b/openspec/changes/optimize-request-log-filter-options/design.md
@@ -1,0 +1,40 @@
+## Context
+
+The options endpoint feeds the request-log filter panel. `list_filter_options` builds always-on conditions (`deleted_at IS NULL`) plus optional user filters, then runs four `DISTINCT` selects. PostgreSQL cannot skip-scan a btree for `DISTINCT`, so with no user filters each select reads the entire index (`idx_logs_account_id_requested_at`, `idx_logs_model_reasoning_requested_at`, `idx_logs_api_key_requested_at`, `idx_logs_status_error_requested_at`). Facet cardinalities are tiny (tens), table cardinality is unbounded.
+
+## Goals / Non-Goals
+
+**Goals:** unfiltered options load in O(distinct values × log n); identical results and ordering; both backends.
+
+**Non-Goals:** changing filtered-request query shapes (bounded by the user's filters); caching; dimension tables (write-path cost and drift risk are not justified at these cardinalities).
+
+## Decisions
+
+### D1. Recursive-CTE loose index scan, gated to unfiltered requests
+
+The classic emulation: seed with `min(col)` under the facet conditions, then repeatedly select `min(col) WHERE col > previous`; every step is one btree probe on the existing facet index. Chosen over:
+
+- *Default time window*: changes visible option sets (older accounts/models vanish) — a behavior change the compatibility rules disallow without need.
+- *Dimension tables maintained at insert*: adds hot-path write cost and a drift/backfill liability for four dropdowns.
+- *Applying skip scan to filtered requests too*: with selective residual filters (e.g. one account), each probe may scan far into a facet block to find a matching row — asymptotically worse than the bounded `DISTINCT` it replaces. Filtered requests keep the current shape; the gate is "no user-supplied filters", the exact case that is pathological today.
+
+### D2. Pair facets via nested skip scan plus NULL-presence probe
+
+`(model, reasoning_effort)` and `(status, error_code)` iterate the leading column by skip scan; for each value, the second column's distinct non-NULL values come from a nested skip scan under `leading = value`, and a `LIMIT 1` probe detects a `(value, NULL)` pair. All probes are prefix matches on the existing composite indexes. Portable lexicographic row-value stepping over a nullable second column was rejected: SQLite orders NULL first, PostgreSQL last, making one CTE per pair facet dialect-divergent and error-prone. NULL pairs are emitted before non-NULL pairs per leading value, matching SQLite's (the default backend's) historical ordering; existing API tests pin this.
+
+### D3. Empty-string handling stays in Python
+
+The legacy code dropped falsy first-column values (`if row[0]`) after the query; the skip-scan path keeps that exact post-filter so empty-string ids behave identically.
+
+## Risks / Trade-offs
+
+- [A facet with pathologically many distinct values (e.g. api_key_id in the thousands) makes thousands of probes] → still strictly cheaper than the full pass it replaces (k probes of log n vs full index scan); cardinalities here are operator-bounded.
+- [Recursive CTE dialect quirks] → the seed/successor shape used is supported by PostgreSQL and SQLite (≥3.8.3); covered by tests on both backends in CI (`POSTGRES_PYTEST_TARGETS`).
+
+## Migration Plan
+
+Code-only; no schema change. Rollback = revert.
+
+## Open Questions
+
+None.

--- a/openspec/changes/optimize-request-log-filter-options/proposal.md
+++ b/openspec/changes/optimize-request-log-filter-options/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`GET /api/request-logs/options` runs four unbounded `SELECT DISTINCT` statements over `request_logs` (`app/modules/request_logs/repository.py:483-506`) — account ids, `(model, reasoning_effort)`, api-key ids, `(status, error_code)`. When the dashboard's filter panel loads with no active filters (the default), each statement is a full index/table pass on PostgreSQL, which has no loose index scan — four whole-table passes per options load, polled every 30 s while the logs page is open, degrading forever as logs accumulate.
+
+## What Changes
+
+- When the options request carries no user-supplied filters (no `since`/`until`/account/api-key/model/effort constraints), each facet is computed with a recursive-CTE loose index scan (skip scan): O(distinct values) indexed probes instead of a full pass. Pair facets iterate the leading column via skip scan and resolve the second column per value (including a NULL-presence probe), matching the existing facet indexes.
+- Filtered requests keep the existing `DISTINCT` shape — user filters already bound those scans.
+- Result sets, filtering semantics (`deleted_at IS NULL`, status self-filter exemption), and response ordering are unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `query-caching`: extend the hot-path query-shape contract — unfiltered request-log filter-option facets MUST NOT perform full DISTINCT passes over `request_logs`; they MUST use loose-index-scan probes while returning identical option sets.
+
+## Impact
+
+- **Code**: `app/modules/request_logs/repository.py` (`list_filter_options` + skip-scan helpers). No API/schema change, no migration.
+- **APIs**: `GET /api/request-logs/options` responses byte-identical; latency improves on large tables.
+- **Tests**: existing options API tests remain the parity oracle; add cases exercising the skip-scan path with multi-value facets, NULL second columns, and empty tables.

--- a/openspec/changes/optimize-request-log-filter-options/specs/query-caching/spec.md
+++ b/openspec/changes/optimize-request-log-filter-options/specs/query-caching/spec.md
@@ -1,0 +1,25 @@
+# query-caching Delta
+
+## ADDED Requirements
+
+### Requirement: Unfiltered request-log filter options avoid full DISTINCT passes
+
+When `GET /api/request-logs/options` is requested without user-supplied filters, each facet (account ids, model/reasoning-effort pairs, api-key ids, status/error-code pairs) MUST be computed with loose-index-scan probes bounded by the facet's distinct-value count, not by the size of `request_logs`. The returned option sets, their ordering, and the soft-delete/status-facet semantics MUST be identical to the unbounded `DISTINCT` results.
+
+#### Scenario: Unfiltered facets return identical option sets via bounded probes
+
+- **GIVEN** request logs spanning multiple accounts, models with and without reasoning effort, api keys, and statuses with and without error codes
+- **WHEN** the options endpoint is called with no filters
+- **THEN** each facet MUST be produced by per-distinct-value index probes (recursive skip scan) rather than a full `DISTINCT` pass
+- **AND** the response MUST equal the legacy `DISTINCT` results, including `(value, NULL)` pairs and ordering
+
+#### Scenario: Soft-deleted rows stay excluded from skip-scanned facets
+
+- **GIVEN** request-log rows with `deleted_at` set
+- **WHEN** the options endpoint is called with no filters
+- **THEN** values appearing only on soft-deleted rows MUST NOT appear in any facet
+
+#### Scenario: Filtered requests keep bounded DISTINCT semantics
+
+- **WHEN** the options endpoint is called with any user filter (`since`, `until`, account, api-key, model, or reasoning-effort constraints)
+- **THEN** the facets MUST apply those filters with unchanged semantics and results

--- a/openspec/changes/optimize-request-log-filter-options/tasks.md
+++ b/openspec/changes/optimize-request-log-filter-options/tasks.md
@@ -1,0 +1,14 @@
+## 1. Implementation
+
+- [x] 1.1 Add `_distinct_skip_scan(column, conditions)` (recursive-CTE loose index scan) and `_facet_null_exists(column, conditions)` helpers to `RequestLogsRepository`
+- [x] 1.2 In `list_filter_options`, detect the no-user-filter case and compute all four facets via skip scan (nested for pair facets, NULL pairs first per leading value); keep the legacy `DISTINCT` path for filtered requests
+
+## 2. Tests
+
+- [x] 2.1 Extend `tests/test_request_logs_options_api.py`: multi-value facets incl. reasoning-effort pairs (NULL and non-NULL for the same model), error-code pairs, soft-deleted exclusion, empty table, and parity between unfiltered (skip-scan) and equivalent filtered (legacy) responses
+- [x] 2.2 Ensure the suite runs against PostgreSQL in CI (add to `POSTGRES_PYTEST_TARGETS` if absent)
+
+## 3. Validation & docs
+
+- [x] 3.1 Update `openspec/specs/query-caching/context.md` with the skip-scan decision and its gate
+- [x] 3.2 `openspec validate --specs`, `ruff`, `ty`, pytest on SQLite + PostgreSQL

--- a/openspec/specs/query-caching/context.md
+++ b/openspec/specs/query-caching/context.md
@@ -9,6 +9,7 @@ The query-caching capability is broader than cache TTLs. It also owns the databa
 - Avoid related-table joins on request-log listing unless search actually needs `accounts.email` or `api_keys.name`.
 - Avoid full window-ranking scans on hot selector and dashboard aggregate reads; prefer grouped latest-id or PostgreSQL `DISTINCT ON` shapes backed by matching indexes.
 - Keep hot-path index migrations idempotent so manual production hotfix indexes do not break later schema upgrades.
+- Compute unfiltered request-log filter-option facets with recursive-CTE loose index scans (one btree probe per distinct value) instead of full `DISTINCT` passes; PostgreSQL has no native skip scan, so an unfiltered facet is otherwise a whole-index pass per facet per panel load. The gate is "no user-supplied filters": filtered requests keep the legacy `DISTINCT` shape because selective residual filters can make per-value probes degenerate. NULL second-column pair placement follows each backend's ASC NULL ordering to preserve exact result parity.
 
 ## Operational Notes
 

--- a/tests/test_request_logs_options_api.py
+++ b/tests/test_request_logs_options_api.py
@@ -7,7 +7,7 @@ import pytest
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, ApiKey
-from app.db.session import SessionLocal
+from app.db.session import SessionLocal, engine
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.request_logs.repository import RequestLogsRepository
 
@@ -277,3 +277,243 @@ async def test_request_logs_options_return_api_keys_and_ignore_api_key_self_filt
         {"id": "key_opt_a", "name": "Alpha Key", "keyPrefix": "sk-alpha"},
         {"id": "key_opt_b", "name": "Beta Key", "keyPrefix": "sk-beta"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_request_logs_options_unfiltered_skip_scan_covers_pair_facets(async_client, db_setup):
+    """Unfiltered options use the skip-scan path; pair facets must include
+    NULL and non-NULL second columns for the same leading value, in order."""
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_pair", "pair@example.com"))
+
+        for request_id, model, effort, status, error_code in (
+            ("req_pair_1", "gpt-5.1", None, "success", None),
+            ("req_pair_2", "gpt-5.1", "high", "error", "rate_limit_exceeded"),
+            ("req_pair_3", "gpt-5.1", "low", "error", "insufficient_quota"),
+            ("req_pair_4", "gpt-4o", "medium", "success", None),
+        ):
+            await logs_repo.add_log(
+                account_id="acc_pair",
+                request_id=request_id,
+                model=model,
+                reasoning_effort=effort,
+                input_tokens=10,
+                output_tokens=10,
+                latency_ms=100,
+                status=status,
+                error_code=error_code,
+                requested_at=now,
+            )
+
+    response = await async_client.get("/api/request-logs/options")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["accountIds"] == ["acc_pair"]
+    # NULL pair placement follows the backend's ASC NULL ordering, matching
+    # the legacy DISTINCT path (SQLite: first, PostgreSQL: last).
+    null_pair = {"model": "gpt-5.1", "reasoningEffort": None}
+    non_null_pairs = [
+        {"model": "gpt-5.1", "reasoningEffort": "high"},
+        {"model": "gpt-5.1", "reasoningEffort": "low"},
+    ]
+    gpt51_pairs = [null_pair, *non_null_pairs] if engine.dialect.name == "sqlite" else [*non_null_pairs, null_pair]
+    assert payload["modelOptions"] == [{"model": "gpt-4o", "reasoningEffort": "medium"}, *gpt51_pairs]
+    assert payload["statuses"] == ["ok", "rate_limit", "quota"]
+
+
+@pytest.mark.asyncio
+async def test_request_logs_options_unfiltered_excludes_soft_deleted(async_client, db_setup):
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_live", "live@example.com"))
+        await logs_repo.add_log(
+            account_id="acc_live",
+            request_id="req_live",
+            model="gpt-5.1",
+            input_tokens=10,
+            output_tokens=10,
+            latency_ms=100,
+            status="success",
+            error_code=None,
+            requested_at=now,
+        )
+        deleted = await logs_repo.add_log(
+            account_id="acc_live",
+            request_id="req_deleted",
+            model="gpt-ghost",
+            input_tokens=10,
+            output_tokens=10,
+            latency_ms=100,
+            status="error",
+            error_code="ghost_error",
+            requested_at=now,
+        )
+        deleted.deleted_at = utcnow()
+        await session.commit()
+
+    response = await async_client.get("/api/request-logs/options")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["modelOptions"] == [{"model": "gpt-5.1", "reasoningEffort": None}]
+    assert payload["statuses"] == ["ok"]
+
+
+@pytest.mark.asyncio
+async def test_request_logs_options_empty_table(async_client, db_setup):
+    response = await async_client.get("/api/request-logs/options")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["accountIds"] == []
+    assert payload["modelOptions"] == []
+    assert payload["apiKeys"] == []
+    assert payload["statuses"] == []
+
+
+@pytest.mark.asyncio
+async def test_request_logs_options_unfiltered_matches_wide_since_filter(async_client, db_setup):
+    """Parity oracle: the unfiltered (skip-scan) response must equal a
+    since-filtered (legacy DISTINCT) response covering all rows."""
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_par_a", "par-a@example.com"))
+        await accounts_repo.upsert(_make_account("acc_par_b", "par-b@example.com"))
+        for index, (account_id, model, effort, status, error_code) in enumerate(
+            (
+                ("acc_par_a", "gpt-5.1", "high", "success", None),
+                ("acc_par_a", "gpt-5.1", None, "error", "rate_limit_exceeded"),
+                ("acc_par_b", "gpt-4o", "low", "error", "insufficient_quota"),
+                ("acc_par_b", "o4-mini", None, "success", None),
+            )
+        ):
+            await logs_repo.add_log(
+                account_id=account_id,
+                request_id=f"req_par_{index}",
+                model=model,
+                reasoning_effort=effort,
+                input_tokens=10,
+                output_tokens=10,
+                latency_ms=100,
+                status=status,
+                error_code=error_code,
+                requested_at=now - timedelta(minutes=index),
+            )
+
+    unfiltered = await async_client.get("/api/request-logs/options")
+    filtered = await async_client.get(f"/api/request-logs/options?since={(now - timedelta(days=1)).isoformat()}")
+    assert unfiltered.status_code == 200
+    assert filtered.status_code == 200
+    assert unfiltered.json() == filtered.json()
+
+
+@pytest.mark.asyncio
+async def test_request_logs_options_unfiltered_preserves_empty_string_second_column(async_client, db_setup):
+    """Legacy DISTINCT drops falsy leading values but preserves empty-string
+    second columns; the skip-scan path must match."""
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_empty", "empty@example.com"))
+        await logs_repo.add_log(
+            account_id="acc_empty",
+            request_id="req_empty_effort",
+            model="gpt-5.1",
+            reasoning_effort="",
+            input_tokens=10,
+            output_tokens=10,
+            latency_ms=100,
+            status="success",
+            error_code=None,
+            requested_at=now,
+        )
+
+    unfiltered = await async_client.get("/api/request-logs/options")
+    filtered = await async_client.get(f"/api/request-logs/options?since={(now - timedelta(days=1)).isoformat()}")
+    assert unfiltered.status_code == 200
+    assert unfiltered.json() == filtered.json()
+    assert unfiltered.json()["modelOptions"] == [{"model": "gpt-5.1", "reasoningEffort": ""}]
+
+
+@pytest.mark.asyncio
+async def test_request_logs_options_unfiltered_returns_api_key_facet(async_client, db_setup):
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_key_skip", "key-skip@example.com"))
+        session.add_all(
+            [
+                ApiKey(id="key_skip_a", name="Alpha", key_hash="hash_skip_a", key_prefix="sk-a"),
+                ApiKey(id="key_skip_b", name="Beta", key_hash="hash_skip_b", key_prefix="sk-b"),
+            ]
+        )
+        await session.commit()
+        for index, key_id in enumerate(("key_skip_a", "key_skip_b", None)):
+            await logs_repo.add_log(
+                account_id="acc_key_skip",
+                request_id=f"req_key_skip_{index}",
+                model="gpt-5.1",
+                input_tokens=10,
+                output_tokens=10,
+                latency_ms=100,
+                status="success",
+                error_code=None,
+                requested_at=now,
+                api_key_id=key_id,
+            )
+
+    response = await async_client.get("/api/request-logs/options")
+    assert response.status_code == 200
+    assert [key["id"] for key in response.json()["apiKeys"]] == ["key_skip_a", "key_skip_b"]
+
+
+@pytest.mark.asyncio
+async def test_request_logs_options_unfiltered_issues_no_distinct_statements(async_client, db_setup):
+    """The spec requires bounded probes for unfiltered facets: no facet may
+    run a DISTINCT pass over request_logs."""
+    import re
+
+    from sqlalchemy import event
+
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_shape", "shape@example.com"))
+        for index, model in enumerate(("gpt-4o", "gpt-5.1", "o4-mini")):
+            await logs_repo.add_log(
+                account_id="acc_shape",
+                request_id=f"req_shape_{index}",
+                model=model,
+                input_tokens=10,
+                output_tokens=10,
+                latency_ms=100,
+                status="success",
+                error_code=None,
+                requested_at=now,
+            )
+
+    statements: list[str] = []
+
+    def _capture(conn, cursor, statement, parameters, context, executemany):
+        statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", _capture)
+    try:
+        response = await async_client.get("/api/request-logs/options")
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _capture)
+
+    assert response.status_code == 200
+    assert len(response.json()["modelOptions"]) == 3
+    options_statements = [stmt for stmt in statements if "request_logs" in stmt]
+    assert options_statements, "expected captured facet statements"
+    assert not any(re.search(r"SELECT\s+DISTINCT\b", stmt, re.IGNORECASE) for stmt in options_statements)
+    assert any("facet_skip" in stmt for stmt in options_statements)


### PR DESCRIPTION
## Summary

`GET /api/request-logs/options` runs four unbounded `SELECT DISTINCT` statements over `request_logs` when the filter panel loads with no active filters (the default state) — account ids, `(model, reasoning_effort)`, api-key ids, `(status, error_code)`. PostgreSQL has no loose index scan, so each is a full pass over the corresponding index, re-run by the dashboard's 30s options poll while the logs page is open, and growing with table size forever.

Unfiltered requests now emulate the loose index scan with recursive CTEs (`WITH RECURSIVE facet_skip`): seed `min(col)`, then repeatedly probe `min(col) WHERE col > previous` — one btree probe per distinct value against the existing composite facet indexes. Pair facets iterate the leading column by skip scan and per value resolve the second column (nested skip scan + a `LIMIT 1` NULL-presence probe).

Result parity is exact, per backend:
- NULL pair placement follows each backend's `ORDER BY ASC` NULL ordering (SQLite first, PostgreSQL last), matching the legacy `DISTINCT` output.
- Empty-string values keep the legacy per-facet falsy post-filter semantics (leading values dropped, second columns preserved).
- `deleted_at IS NULL` and the status-facet self-filter exemption are unchanged.
- **Filtered** requests keep the legacy `DISTINCT` shape — user filters already bound those scans, and per-value probes can degenerate under selective residual filters.

## OpenSpec

`openspec/changes/optimize-request-log-filter-options/` — delta on `query-caching`. `openspec validate --specs`: 31/31 pass.

## Tests

- Pair facets with NULL + non-NULL efforts for one model; soft-delete exclusion; empty table; unfiltered↔filtered parity oracle; empty-string second-column parity; unfiltered api-key facet.
- A statement-capture test pins the contract: the unfiltered options call issues **no** `SELECT DISTINCT` against `request_logs` and does use the recursive skip scan.
- Suite added to `POSTGRES_PYTEST_TARGETS`; all 12 tests pass on SQLite and PostgreSQL 16 locally. `ruff` / `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)