### PR TITLE
perf(proxy): cut pre-upstream DB round trips on interactive turns

### DIFF
--- a/app/core/auth/api_key_cache.py
+++ b/app/core/auth/api_key_cache.py
@@ -52,7 +52,13 @@ class ApiKeyCache(Generic[_CacheValueT]):
         self._version += 1
 
 
-_api_key_cache: ApiKeyCache[object] = ApiKeyCache(ttl_seconds=2)
+# Key mutations bump the api_key cache-invalidation namespace, and every
+# instance's poller (0.5s interval) clears this cache, so revocation latency
+# is poller-bound, not TTL-bound. The TTL only limits staleness if the poller
+# is broken; keeping it short instead forced interactive Codex turns (which
+# are usually more than a few seconds apart) to re-read the key row from the
+# database before every upstream call.
+_api_key_cache: ApiKeyCache[object] = ApiKeyCache(ttl_seconds=60)
 
 
 def get_api_key_cache() -> ApiKeyCache[object]:

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -950,11 +950,12 @@ class LoadBalancer:
                 )
                 return selection_inputs
 
-            standard_latest_primary, standard_latest_secondary, latest_monthly = await asyncio.gather(
-                repos.usage.latest_by_account(),
-                repos.usage.latest_by_account(window="secondary"),
-                repos.usage.latest_by_account(window="monthly"),
-            )
+            # These share one AsyncSession: concurrent execution on a single
+            # session is unsafe (asyncpg) and gains nothing — the driver
+            # serializes statements per connection anyway.
+            standard_latest_primary = await repos.usage.latest_by_account()
+            standard_latest_secondary = await repos.usage.latest_by_account(window="secondary")
+            latest_monthly = await repos.usage.latest_by_account(window="monthly")
             if effective_limit_name:
                 model_allowed_plans = get_model_registry().plan_types_for_model(model) if model else None
                 latest_primary = additional_filter.latest_primary

--- a/app/modules/proxy/sticky_repository.py
+++ b/app/modules/proxy/sticky_repository.py
@@ -65,14 +65,16 @@ class StickySessionsRepository:
         return result.scalar_one_or_none()
 
     async def upsert(self, key: str, account_id: str, *, kind: StickySessionKind) -> StickySession:
-        statement = self._build_upsert_statement(key, account_id, kind)
+        # RETURNING collapses the previous upsert + re-select + refresh
+        # (4 round trips) into one statement; this runs inline before the
+        # first upstream byte on sticky requests, so round trips are TTFT.
+        statement = self._build_upsert_statement(key, account_id, kind).returning(StickySession)
         async with sqlite_writer_section():
-            await self._session.execute(statement)
+            result = await self._session.execute(statement)
+            row = result.scalar_one_or_none()
             await self._session.commit()
-        row = await self.get_entry(key, kind=kind)
         if row is None:
             raise RuntimeError(f"StickySession upsert failed for key={key!r} kind={kind.value!r}")
-        await self._session.refresh(row)
         return row
 
     async def delete(self, key: str, *, kind: StickySessionKind) -> bool:

--- a/app/modules/proxy/sticky_repository.py
+++ b/app/modules/proxy/sticky_repository.py
@@ -68,9 +68,11 @@ class StickySessionsRepository:
         # RETURNING collapses the previous upsert + re-select + refresh
         # (4 round trips) into one statement; this runs inline before the
         # first upstream byte on sticky requests, so round trips are TTFT.
+        # populate_existing forces the returned row to overwrite any stale
+        # identity-map instance the session may already hold for this key.
         statement = self._build_upsert_statement(key, account_id, kind).returning(StickySession)
         async with sqlite_writer_section():
-            result = await self._session.execute(statement)
+            result = await self._session.execute(statement, execution_options={"populate_existing": True})
             row = result.scalar_one_or_none()
             await self._session.commit()
         if row is None:

--- a/openspec/changes/optimize-proxy-preupstream-reads/.openspec.yaml
+++ b/openspec/changes/optimize-proxy-preupstream-reads/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/optimize-proxy-preupstream-reads/design.md
+++ b/openspec/changes/optimize-proxy-preupstream-reads/design.md
@@ -1,0 +1,27 @@
+## Context
+
+Proxy hot-path audit findings: the API-key auth cache TTL (2 s) is shorter than typical Codex CLI think-time, so interactive turns miss the cache and re-read the key row (plus lazy-reset writes) before every upstream call; sticky upserts cost 4 round trips inline pre-upstream; and three selection-input usage reads run through `asyncio.gather` on one `AsyncSession`, which the project's own async rules forbid.
+
+## Goals / Non-Goals
+
+**Goals:** fewer pre-upstream DB round trips on interactive turns with byte-identical behavior; remove the shared-session concurrency hazard.
+
+**Non-Goals:** upstream-route resolution caching and stream-end write detachment (separate changes — routing and settlement invariants deserve their own review scope); `pool_pre_ping` tuning; rate-limit header cache changes.
+
+## Decisions
+
+- **TTL 60 s, not removal**: the poller (0.5 s) is the real invalidation path — registered in `app/main.py` (`cache_poller.on_invalidation(NAMESPACE_API_KEY, get_api_key_cache().clear)`) and bumped by every key mutation site. The TTL stays as a bounded backstop for a broken poller rather than being removed outright. Per-key expiry (`expires_at`) is still checked on every cache hit, so key expiration is unaffected by the TTL.
+- **RETURNING upsert**: `expire_on_commit=False` on both session factories keeps the returned ORM entity readable after commit; PostgreSQL and SQLite (≥ 3.35) both support `ON CONFLICT ... RETURNING` for insert and update arms. The happy-path `updated_at` bump is intentionally kept per-request (it feeds the TTL purge cutoff); only the redundant re-select/refresh round trips are removed.
+- **Sequential awaits**: per-connection drivers serialize statements anyway; gather on one session risks `InterfaceError`/state corruption on asyncpg for zero gain.
+
+## Risks / Trade-offs
+
+- [Poller outage extends stale-auth window from 2 s to 60 s] → the poller is process-critical infrastructure already (firewall allowlist relies on it); 60 s remains a bounded backstop and per-key `expires_at` enforcement is unaffected.
+
+## Migration Plan
+
+Code-only; rollback = revert.
+
+## Open Questions
+
+None.

--- a/openspec/changes/optimize-proxy-preupstream-reads/proposal.md
+++ b/openspec/changes/optimize-proxy-preupstream-reads/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Interactive Codex turns pay avoidable database round trips before the first upstream byte: the proxy API-key auth cache expires every 2 seconds (shorter than typical think-time, so effectively every turn re-reads the key row) even though key mutations already propagate cross-instance via the cache-invalidation poller in ~0.5 s; every sticky-session (re)assignment runs an upsert as four round trips (INSERT ON CONFLICT + COMMIT + re-SELECT + `session.refresh`); and account selection issues three usage queries through `asyncio.gather` on one shared `AsyncSession` — unsafe on asyncpg and with zero parallelism gain.
+
+## What Changes
+
+- Raise the proxy API-key auth cache TTL from 2 s to 60 s. Revocation/update latency is unchanged (poller-driven invalidation remains the binding mechanism, ~0.5 s cross-instance); the TTL is only the backstop when the poller is broken.
+- Collapse the sticky-session upsert to a single `INSERT ... ON CONFLICT ... RETURNING` statement (plus commit) — identical row contents and `updated_at` bump semantics, three fewer round trips on the sticky hot path.
+- Replace the same-session `asyncio.gather` over the three selection-input usage reads with sequential awaits (correctness: one `AsyncSession` must not run concurrent statements).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `query-caching`: hot-path contracts extended — proxy API-key auth caching MUST be invalidation-driven with a TTL backstop of at least 60 s; sticky-session upserts MUST complete in one statement; selection-input reads MUST NOT execute concurrently on a shared session.
+
+## Impact
+
+- **Code**: `app/core/auth/api_key_cache.py`, `app/modules/proxy/sticky_repository.py`, `app/modules/proxy/load_balancer.py`. No schema change, no API change.
+- **Behavior**: none observable — auth results, sticky rows, and selection inputs are byte-identical; only latency and statement counts change.

--- a/openspec/changes/optimize-proxy-preupstream-reads/specs/query-caching/spec.md
+++ b/openspec/changes/optimize-proxy-preupstream-reads/specs/query-caching/spec.md
@@ -1,0 +1,39 @@
+# query-caching Delta
+
+## ADDED Requirements
+
+### Requirement: Proxy API-key auth caching is invalidation-driven with a TTL backstop
+
+The proxy API-key auth cache MUST be invalidated through the cross-instance cache-invalidation mechanism on every key mutation (create/update/delete/reassignment), and its TTL MUST be at least 60 seconds so interactive request turns do not re-read unchanged key rows from the database.
+
+#### Scenario: Key mutations invalidate cached auth promptly
+
+- **GIVEN** an API key validated and cached on an instance
+- **WHEN** the key is updated or deleted (on any instance)
+- **THEN** the mutation MUST bump the api_key invalidation namespace
+- **AND** cached auth data for that key MUST be cleared via the poller, independent of the TTL
+
+#### Scenario: Unchanged keys are served from cache across interactive turns
+
+- **GIVEN** a key validated less than 60 seconds ago with no intervening mutation
+- **WHEN** another request authenticates with the same key
+- **THEN** validation MUST be served from the cache without a database read
+
+### Requirement: Sticky-session upsert completes in one statement
+
+Sticky-session upserts on the request path MUST persist and return the row with a single `INSERT ... ON CONFLICT ... RETURNING` statement, with unchanged row contents and `updated_at` semantics.
+
+#### Scenario: Upsert issues no follow-up selects
+
+- **WHEN** a sticky session is created or re-affirmed
+- **THEN** the repository MUST execute exactly one data statement (the returning upsert) plus the commit
+- **AND** the returned row MUST reflect the persisted state for both the insert and update arms
+
+### Requirement: Selection-input reads never run concurrently on a shared session
+
+Account-selection input loading MUST NOT execute multiple statements concurrently on one `AsyncSession`.
+
+#### Scenario: Usage window reads execute sequentially
+
+- **WHEN** selection inputs load primary, secondary, and monthly usage windows
+- **THEN** the three reads MUST be awaited sequentially on the shared session

--- a/openspec/changes/optimize-proxy-preupstream-reads/tasks.md
+++ b/openspec/changes/optimize-proxy-preupstream-reads/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Raise `_api_key_cache` TTL to 60 s with the poller-invalidation rationale documented in code
+- [x] 1.2 Collapse `StickySessionsRepository.upsert` to `INSERT ... ON CONFLICT ... RETURNING` (drop re-select + refresh)
+- [x] 1.3 Replace the same-session `asyncio.gather` usage reads in `load_balancer._load_selection_inputs` with sequential awaits
+
+## 2. Tests
+
+- [x] 2.1 Statement-capture test: sticky upsert issues exactly one data statement and returns correct rows on both insert and update arms
+- [x] 2.2 Cache test: mutation-driven invalidation still clears cached auth within the poller path; unchanged key served from cache without DB read
+- [x] 2.3 Existing sticky/load-balancer suites green on SQLite + PostgreSQL
+
+## 3. Validation & docs
+
+- [x] 3.1 Update `openspec/specs/query-caching/context.md`
+- [x] 3.2 `openspec validate --specs`, `ruff`, `ty`, pytest

--- a/openspec/specs/query-caching/context.md
+++ b/openspec/specs/query-caching/context.md
@@ -10,6 +10,8 @@ The query-caching capability is broader than cache TTLs. It also owns the databa
 - Avoid full window-ranking scans on hot selector and dashboard aggregate reads; prefer grouped latest-id or PostgreSQL `DISTINCT ON` shapes backed by matching indexes.
 - Keep hot-path index migrations idempotent so manual production hotfix indexes do not break later schema upgrades.
 
+- Proxy API-key auth caching is invalidation-driven: every key mutation bumps the `api_key` invalidation namespace and each instance's poller (0.5 s) clears the local cache, so the 60 s TTL is only a backstop for a broken poller. Sticky-session upserts persist and return the row in one `INSERT ... ON CONFLICT ... RETURNING` statement. Never run multiple statements concurrently on one `AsyncSession` (selection-input usage reads are awaited sequentially).
+
 ## Operational Notes
 
 - Primary-window usage reads should normalize on `coalesce(window, 'primary')`.

--- a/tests/integration/test_proxy_sticky_sessions.py
+++ b/tests/integration/test_proxy_sticky_sessions.py
@@ -1466,3 +1466,39 @@ async def test_sticky_upsert_single_statement_insert_and_update(db_setup):
     # One INSERT ... RETURNING per upsert; no follow-up SELECT/refresh.
     assert len(statements) == 2
     assert all("INSERT" in stmt.upper() and "RETURNING" in stmt.upper() for stmt in statements)
+
+
+@pytest.mark.asyncio
+async def test_sticky_upsert_returning_refreshes_identity_map_instance(db_setup):
+    """Rebinding a key within one session must return the NEW account even
+    when the session's identity map already holds the row from an earlier
+    upsert (populate_existing on the RETURNING execute)."""
+    from app.db.models import StickySessionKind
+    from app.modules.proxy.sticky_repository import StickySessionsRepository
+
+    encryptor = TokenEncryptor()
+    async with SessionLocal() as session:
+        repo_accounts = AccountsRepository(session)
+        for account_id in ("acc_rebind_a", "acc_rebind_b"):
+            await repo_accounts.upsert(
+                Account(
+                    id=account_id,
+                    email=f"{account_id}@example.com",
+                    plan_type="plus",
+                    access_token_encrypted=encryptor.encrypt("access"),
+                    refresh_token_encrypted=encryptor.encrypt("refresh"),
+                    id_token_encrypted=encryptor.encrypt("id"),
+                    last_refresh=utcnow(),
+                    status=AccountStatus.ACTIVE,
+                    deactivation_reason=None,
+                )
+            )
+
+    async with SessionLocal() as session:
+        repo = StickySessionsRepository(session)
+        first = await repo.upsert("key_rebind", "acc_rebind_a", kind=StickySessionKind.PROMPT_CACHE)
+        assert first.account_id == "acc_rebind_a"
+        # Same session, same identity-map row: rebinding must not return the
+        # stale in-memory account_id.
+        second = await repo.upsert("key_rebind", "acc_rebind_b", kind=StickySessionKind.PROMPT_CACHE)
+        assert second.account_id == "acc_rebind_b"

--- a/tests/integration/test_proxy_sticky_sessions.py
+++ b/tests/integration/test_proxy_sticky_sessions.py
@@ -1415,3 +1415,54 @@ async def test_reallocate_sticky_respects_existing_session_then_falls_back(async
     await async_client.post("/backend-api/codex/responses", json=payload)
     assert len(seen) == 3
     assert seen[2] == "acc_realloc_b"
+
+
+@pytest.mark.asyncio
+async def test_sticky_upsert_single_statement_insert_and_update(db_setup):
+    """The upsert must persist and return the row with one data statement
+    (RETURNING), for both the insert and the conflict-update arms."""
+    from sqlalchemy import event
+
+    from app.db.models import StickySessionKind
+    from app.db.session import engine
+    from app.modules.proxy.sticky_repository import StickySessionsRepository
+
+    encryptor = TokenEncryptor()
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(
+            Account(
+                id="acc_sticky_rt",
+                email="sticky-rt@example.com",
+                plan_type="plus",
+                access_token_encrypted=encryptor.encrypt("access"),
+                refresh_token_encrypted=encryptor.encrypt("refresh"),
+                id_token_encrypted=encryptor.encrypt("id"),
+                last_refresh=utcnow(),
+                status=AccountStatus.ACTIVE,
+                deactivation_reason=None,
+            )
+        )
+
+    statements: list[str] = []
+
+    def _capture(conn, cursor, statement, parameters, context, executemany):
+        if "sticky_sessions" in statement:
+            statements.append(statement)
+
+    async with SessionLocal() as session:
+        repo = StickySessionsRepository(session)
+        event.listen(engine.sync_engine, "before_cursor_execute", _capture)
+        try:
+            inserted = await repo.upsert("key_rt", "acc_sticky_rt", kind=StickySessionKind.PROMPT_CACHE)
+            updated = await repo.upsert("key_rt", "acc_sticky_rt", kind=StickySessionKind.PROMPT_CACHE)
+        finally:
+            event.remove(engine.sync_engine, "before_cursor_execute", _capture)
+
+    assert inserted.key == "key_rt"
+    assert inserted.account_id == "acc_sticky_rt"
+    assert updated.key == "key_rt"
+    assert updated.account_id == "acc_sticky_rt"
+    assert updated.updated_at >= inserted.updated_at
+    # One INSERT ... RETURNING per upsert; no follow-up SELECT/refresh.
+    assert len(statements) == 2
+    assert all("INSERT" in stmt.upper() and "RETURNING" in stmt.upper() for stmt in statements)

--- a/tests/unit/test_api_key_cache.py
+++ b/tests/unit/test_api_key_cache.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core.auth.api_key_cache import ApiKeyCache, get_api_key_cache
+
+pytestmark = pytest.mark.unit
+
+
+def test_auth_cache_ttl_is_invalidation_backstop_not_per_turn_expiry() -> None:
+    """Key mutations clear the cache via the invalidation poller; the TTL is
+    only a backstop and must exceed typical interactive turn gaps so
+    unchanged keys are not re-read from the database every turn."""
+    assert get_api_key_cache()._ttl >= 60
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_within_ttl_and_invalidation_clears() -> None:
+    cache: ApiKeyCache[str] = ApiKeyCache(ttl_seconds=60)
+    await cache.set("hash_a", "data_a")
+    assert await cache.get("hash_a") == "data_a"
+
+    await cache.invalidate("hash_a")
+    assert await cache.get("hash_a") is None
+
+
+@pytest.mark.asyncio
+async def test_clear_bumps_version_and_blocks_stale_set() -> None:
+    """The poller's clear() must prevent a concurrent stale validation result
+    (read before the mutation) from repopulating the cache."""
+    cache: ApiKeyCache[str] = ApiKeyCache(ttl_seconds=60)
+    version_before_read = cache.version
+    cache.clear()
+    await cache.set("hash_a", "stale", if_version=version_before_read)
+    assert await cache.get("hash_a") is None


### PR DESCRIPTION
## Summary

Hot-path audit findings between request arrival and the first upstream byte, all behavior-preserving:

1. **API-key auth cache TTL 2s → 60s.** The 2s TTL is shorter than typical Codex CLI think-time, so interactive turns effectively always missed the cache and re-read the key row (plus lazy-reset writes) before every upstream call. Key mutations already bump the `api_key` invalidation namespace and every instance's poller (0.5s) clears the cache (`app/main.py` registration), so revocation latency is poller-bound and unchanged; the TTL is only the backstop for a broken poller. Per-key `expires_at` is still enforced on every cache hit.
2. **Sticky upsert 4 round trips → 1 + commit.** `INSERT ... ON CONFLICT ... RETURNING` replaces upsert + re-SELECT + `session.refresh`. Row contents and the per-request `updated_at` bump (which feeds the TTL purge cutoff) are unchanged; `expire_on_commit=False` keeps the returned entity readable. Sticky requests pay these round trips inline pre-upstream, so this is direct TTFT.
3. **Same-session `asyncio.gather` removed** in selection-input loading (three `latest_by_account` reads on one `AsyncSession`) — the async/session-ownership rules forbid concurrent statements on a shared session (asyncpg hazard), and the connection serializes statements anyway. Sequential awaits, same results.

## OpenSpec

`openspec/changes/optimize-proxy-preupstream-reads/` — `query-caching` delta (invalidation-driven auth caching with ≥60s TTL backstop, single-statement sticky upsert, no shared-session concurrency). `openspec validate --specs`: 31/31.

## Tests

- New statement-capture test: sticky upsert issues exactly one `INSERT ... RETURNING` per call (insert and conflict-update arms), no follow-up selects.
- New cache tests: poller-style `clear()` blocks stale repopulation via the existing `if_version` guard; TTL floor pinned.
- Sticky + load-balancer + proxy suites green: 3,519 unit; sticky/proxy integration on SQLite and PostgreSQL 16. `ruff`/`ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)