### PR TITLE
perf(dashboard): compress responses, cache assets, lazy-load charts

### DIFF
--- a/app/core/middleware/dashboard_gzip.py
+++ b/app/core/middleware/dashboard_gzip.py
@@ -18,10 +18,21 @@ class DashboardGZipMiddleware:
         self._gzip = GZipMiddleware(app, minimum_size=minimum_size)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] == "http" and scope.get("path", "").startswith(_COMPRESSED_PATH_PREFIXES):
+        if (
+            scope["type"] == "http"
+            and scope.get("path", "").startswith(_COMPRESSED_PATH_PREFIXES)
+            and not _has_range_header(scope)
+        ):
             await self._gzip(scope, receive, send)
             return
         await self._plain(scope, receive, send)
+
+
+def _has_range_header(scope: Scope) -> bool:
+    """Ranged requests bypass gzip: FileResponse builds the 206 and its
+    Content-Range against the uncompressed file, so compressing the body
+    afterwards would describe offsets the encoded bytes no longer match."""
+    return any(name == b"range" for name, _ in scope.get("headers", ()))
 
 
 def add_dashboard_gzip_middleware(app) -> None:

--- a/app/core/middleware/dashboard_gzip.py
+++ b/app/core/middleware/dashboard_gzip.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from starlette.middleware.gzip import GZipMiddleware
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+# Only dashboard-facing paths are compressed. Proxy paths (/backend-api,
+# /v1, websockets) stream SSE and must never pass through a compressing
+# wrapper; dashboard API responses are JSON and the built SPA assets are
+# text-heavy (the uncompressed JS bundle alone is ~1.7 MB).
+_COMPRESSED_PATH_PREFIXES = ("/api/", "/assets/")
+
+
+class DashboardGZipMiddleware:
+    """Apply gzip to dashboard API and static-asset responses only."""
+
+    def __init__(self, app: ASGIApp, minimum_size: int = 1024) -> None:
+        self._plain = app
+        self._gzip = GZipMiddleware(app, minimum_size=minimum_size)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http" and scope.get("path", "").startswith(_COMPRESSED_PATH_PREFIXES):
+            await self._gzip(scope, receive, send)
+            return
+        await self._plain(scope, receive, send)
+
+
+def add_dashboard_gzip_middleware(app) -> None:
+    app.add_middleware(DashboardGZipMiddleware)

--- a/app/core/middleware/dashboard_gzip.py
+++ b/app/core/middleware/dashboard_gzip.py
@@ -31,8 +31,10 @@ class DashboardGZipMiddleware:
 def _has_range_header(scope: Scope) -> bool:
     """Ranged requests bypass gzip: FileResponse builds the 206 and its
     Content-Range against the uncompressed file, so compressing the body
-    afterwards would describe offsets the encoded bytes no longer match."""
-    return any(name == b"range" for name, _ in scope.get("headers", ()))
+    afterwards would describe offsets the encoded bytes no longer match.
+    Header-name casing is normalized because not every ASGI server
+    lowercases request header names."""
+    return any(name.lower() == b"range" for name, _ in scope.get("headers", ()))
 
 
 def add_dashboard_gzip_middleware(app) -> None:

--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ import sys
 import time
 from collections.abc import Awaitable
 from contextlib import asynccontextmanager
+from functools import lru_cache
 from importlib import import_module
 from ipaddress import ip_address
 from pathlib import Path, PurePosixPath
@@ -35,6 +36,7 @@ from app.core.middleware import (
     add_request_decompression_middleware,
     add_request_id_middleware,
 )
+from app.core.middleware.dashboard_gzip import add_dashboard_gzip_middleware
 from app.core.middleware.inflight import InFlightMiddleware
 from app.core.openai.model_refresh_scheduler import build_model_refresh_scheduler
 from app.core.resilience.backpressure import BackpressureMiddleware
@@ -96,12 +98,17 @@ class _RingMembershipReader(Protocol):
     ) -> Awaitable[list[str]]: ...
 
 
+@lru_cache(maxsize=4)
+def _static_files_for_root(static_root: Path) -> StaticFiles:
+    return StaticFiles(directory=static_root, check_dir=False)
+
+
 def _resolve_static_asset_path(static_root: Path, requested_path: str) -> Path | None:
     """Return a filesystem path for a SPA asset only when it stays under static_root."""
     normalized = PurePosixPath(requested_path)
     if normalized.is_absolute() or ".." in normalized.parts:
         return None
-    full_path, stat_result = StaticFiles(directory=static_root, check_dir=False).lookup_path(normalized.as_posix())
+    full_path, stat_result = _static_files_for_root(static_root).lookup_path(normalized.as_posix())
     if stat_result is None or not stat.S_ISREG(stat_result.st_mode):
         return None
     return Path(full_path)
@@ -359,6 +366,7 @@ def create_app() -> FastAPI:
     )
 
     app.add_middleware(cast(Any, InFlightMiddleware))
+    add_dashboard_gzip_middleware(app)
     add_dashboard_auth_proxy_middleware(app)
     add_request_decompression_middleware(app)
     add_request_id_middleware(app)
@@ -442,6 +450,15 @@ def create_app() -> FastAPI:
         if normalized:
             candidate = _resolve_static_asset_path(static_root, normalized)
             if candidate is not None:
+                if normalized.startswith("assets/"):
+                    # Vite content-hashes everything under assets/, so the
+                    # response for a given URL can never change: immutable
+                    # caching makes repeat dashboard loads skip ~1.7 MB of
+                    # re-downloads/revalidations. index.html stays no-cache
+                    # below, so deploys still pick up new hashes.
+                    return FileResponse(
+                        candidate, headers={"Cache-Control": "public, max-age=31536000, immutable"}
+                    )
                 return FileResponse(candidate)
             if _is_static_asset_path(normalized):
                 raise HTTPException(status_code=404, detail="Not Found")

--- a/app/main.py
+++ b/app/main.py
@@ -456,9 +456,7 @@ def create_app() -> FastAPI:
                     # caching makes repeat dashboard loads skip ~1.7 MB of
                     # re-downloads/revalidations. index.html stays no-cache
                     # below, so deploys still pick up new hashes.
-                    return FileResponse(
-                        candidate, headers={"Cache-Control": "public, max-age=31536000, immutable"}
-                    )
+                    return FileResponse(candidate, headers={"Cache-Control": "public, max-age=31536000, immutable"})
                 return FileResponse(candidate)
             if _is_static_asset_path(normalized):
                 raise HTTPException(status_code=404, detail="Not Found")

--- a/frontend/src/components/lazy-recharts.ts
+++ b/frontend/src/components/lazy-recharts.ts
@@ -1,5 +1,4 @@
 import { createElement, lazy, Suspense, type ComponentType } from "react";
-import { Cell as RechartsCell } from "recharts";
 
 type RechartsModule = typeof import("recharts");
 type LazyRechartsWrapper = ComponentType<Record<string, unknown>> & { displayName: string };
@@ -26,7 +25,7 @@ function lazyRechartsComponent(name: keyof RechartsModule) {
 export const Area = lazyRechartsComponent("Area");
 export const AreaChart = lazyRechartsComponent("AreaChart");
 export const CartesianGrid = lazyRechartsComponent("CartesianGrid");
-export const Cell = RechartsCell;
+export const Cell = lazyRechartsComponent("Cell");
 export const Line = lazyRechartsComponent("Line");
 export const Pie = lazyRechartsComponent("Pie");
 export const PieChart = lazyRechartsComponent("PieChart");

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,7 +12,10 @@ const appVersion = packageJson.version ?? "0.0.0";
 const manualChunkPackages: Record<string, string[]> = {
   "vendor-react": ["react", "react-dom", "react-router-dom"],
   "vendor-query": ["@tanstack/react-query"],
-  "vendor-charts": ["recharts"],
+  // recharts is intentionally NOT a manual chunk: forcing it into one made
+  // the bundler hoist shared helper modules into that group, which turned
+  // the (lazy-only) 580 KB chart bundle into a static import of the entry
+  // chunk, modulepreloaded before first paint.
   "vendor-ui": ["radix-ui"],
 };
 

--- a/openspec/changes/optimize-dashboard-serving/.openspec.yaml
+++ b/openspec/changes/optimize-dashboard-serving/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/optimize-dashboard-serving/design.md
+++ b/openspec/changes/optimize-dashboard-serving/design.md
@@ -1,0 +1,29 @@
+## Context
+
+Frontend audit (patch-build-revert verified): every chart component is behind `React.lazy`, but the forced `vendor-charts` rolldown group swallowed shared helper modules (CJS interop, `use-sync-external-store`, `es-toolkit`, `clsx`), so any entry-chunk module using those helpers dragged the full 572 KB chart bundle in statically, and Vite modulepreloaded it. Separately, `lazy-recharts.ts` still statically imported `Cell`, and the backend served everything uncompressed with no asset cache headers.
+
+## Goals / Non-Goals
+
+**Goals:** cut first-load transfer (~1.7 MB → ~307 KB gzipped critical path) and make repeat loads near-instant, with zero visual/API change and zero risk to proxy streaming.
+
+**Non-Goals:** route-level code splitting of the six pages (separate follow-up; entry is still one chunk), self-hosting Google Fonts, pre-compressed (.br/.gz) build artifacts.
+
+## Decisions
+
+- **Path-gated gzip wrapper** around Starlette's `GZipMiddleware` instead of a global one: compression must never touch SSE/websocket proxy responses, and a whitelist (`/api/`, `/assets/`) is simpler to reason about than content-type sniffing. Verified live: assets gzip, `/backend-api/*` has no `content-encoding`.
+- **Immutable asset caching keyed on the `assets/` prefix**: Vite content-hashes every file there, so a URL's body can never change; `index.html` keeps `no-cache` (existing behavior) so new deploys swap hashes.
+- **Lazy `Cell`**: recharts v3's `findAllByType` matches children via `type.displayName`, and the lazy wrapper carries `displayName = "Cell"`, so Pie/Donut cell detection keeps working (839 frontend tests green, donut tests included).
+- **No manual chunk for recharts**: letting the bundler place it produces an async-only chunk reachable solely via the dynamic `import("recharts")` in `lazy-recharts.ts` (verified in build output and dep maps).
+
+## Risks / Trade-offs
+
+- [First chart render pays one async chunk fetch] → intended; charts already rendered behind lazy boundaries with null fallbacks.
+- [Gzip CPU on dashboard responses] → bounded to dashboard paths; assets are the dominant win and compress once per request (level 9 default of Starlette ≈ fine at these sizes).
+
+## Migration Plan
+
+Code-only; rollback = revert. Users' cached assets remain valid (hash-addressed).
+
+## Open Questions
+
+None.

--- a/openspec/changes/optimize-dashboard-serving/proposal.md
+++ b/openspec/changes/optimize-dashboard-serving/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The dashboard's first uncached load ships ~1.7 MB of JavaScript on the critical path, uncompressed: codex-lb serves the SPA with no response compression anywhere, the 572 KB recharts chunk is modulepreloaded and statically imported by the entry chunk even though every chart component is lazy (the forced `vendor-charts` manual chunk swallowed shared helper modules), and content-hashed assets are served with no `Cache-Control`, so even repeat visits renegotiate or re-download everything.
+
+## What Changes
+
+- Add a `DashboardGZipMiddleware` that gzips responses only for `/api/` and `/assets/` paths — proxy streaming paths (`/backend-api`, `/v1`, websockets) are never wrapped.
+- Serve `/assets/*` (content-hashed by Vite) with `Cache-Control: public, max-age=31536000, immutable`; `index.html` keeps `no-cache` so deploys pick up new hashes. The per-request `StaticFiles` construction is hoisted behind an `lru_cache`.
+- Drop the forced `vendor-charts` manual chunk and make the last static recharts export (`Cell`) lazy like the rest, so recharts lands in an async-only chunk loaded when a chart first renders. Verified on the built output: no modulepreload of the charts chunk, no static import from the entry chunk; recharts v3 detects the lazy `Cell` wrapper via `displayName`.
+- Net effect measured on the build: critical-path JS 1.70 MB → ~1.13 MB raw, ~307 KB gzip-transferred; repeat loads serve assets from the browser cache.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `frontend-architecture`: dashboard serving MUST compress dashboard responses, serve hashed assets immutably, and keep chart vendor code off the first-paint critical path.
+
+## Impact
+
+- **Code**: `app/core/middleware/dashboard_gzip.py` (new), `app/main.py` (middleware + asset headers + StaticFiles hoist), `frontend/vite.config.ts`, `frontend/src/components/lazy-recharts.ts`.
+- **Behavior**: response bytes/headers only; no API or visual change. Proxy paths untouched (verified live: no `content-encoding` on `/backend-api/*`).

--- a/openspec/changes/optimize-dashboard-serving/specs/frontend-architecture/spec.md
+++ b/openspec/changes/optimize-dashboard-serving/specs/frontend-architecture/spec.md
@@ -1,0 +1,29 @@
+# frontend-architecture Delta
+
+## ADDED Requirements
+
+### Requirement: Dashboard serving is compressed, cache-correct, and chart-lazy
+
+Dashboard API and static-asset responses MUST be served gzip-compressed when the client accepts it, while proxy paths MUST NOT pass through a compressing wrapper. Content-hashed assets under `/assets/` MUST be served with immutable year-long `Cache-Control`; `index.html` MUST remain `no-cache`. Chart vendor code MUST NOT load before first paint: it MUST live in an async-only chunk that is neither statically imported by the entry chunk nor modulepreloaded.
+
+#### Scenario: Assets are compressed and immutable
+
+- **WHEN** a browser requests a hashed asset under `/assets/` with `Accept-Encoding: gzip`
+- **THEN** the response is gzip-encoded
+- **AND** carries `Cache-Control: public, max-age=31536000, immutable`
+
+#### Scenario: index.html stays fresh across deploys
+
+- **WHEN** the SPA shell is requested
+- **THEN** the response carries `Cache-Control: no-cache`
+
+#### Scenario: Proxy streaming paths are never compressed by the dashboard wrapper
+
+- **WHEN** a request targets a proxy path (`/backend-api/*`, `/v1/*`)
+- **THEN** the dashboard gzip middleware passes it through untouched
+
+#### Scenario: Chart vendor code loads lazily
+
+- **WHEN** the built dashboard entry page loads
+- **THEN** the recharts chunk is not statically imported by the entry chunk and not modulepreloaded
+- **AND** charts render correctly once their async chunk loads

--- a/openspec/changes/optimize-dashboard-serving/specs/frontend-architecture/spec.md
+++ b/openspec/changes/optimize-dashboard-serving/specs/frontend-architecture/spec.md
@@ -22,6 +22,11 @@ Dashboard API and static-asset responses MUST be served gzip-compressed when the
 - **WHEN** a request targets a proxy path (`/backend-api/*`, `/v1/*`)
 - **THEN** the dashboard gzip middleware passes it through untouched
 
+#### Scenario: Ranged asset requests bypass compression
+
+- **WHEN** an asset request carries a `Range` header
+- **THEN** the response is served uncompressed with a valid 206 `Content-Range` over unencoded bytes
+
 #### Scenario: Chart vendor code loads lazily
 
 - **WHEN** the built dashboard entry page loads

--- a/openspec/changes/optimize-dashboard-serving/tasks.md
+++ b/openspec/changes/optimize-dashboard-serving/tasks.md
@@ -1,0 +1,12 @@
+## 1. Implementation
+
+- [x] 1.1 `DashboardGZipMiddleware` gated to `/api/` + `/assets/`; wire in `create_app`
+- [x] 1.2 Immutable `Cache-Control` for `/assets/*`; hoist `StaticFiles` behind `lru_cache`
+- [x] 1.3 Drop `vendor-charts` manual chunk; make `Cell` lazy in `lazy-recharts.ts`
+
+## 2. Verification
+
+- [x] 2.1 Frontend suite green (839 tests incl. donut/cell paths)
+- [x] 2.2 Build inspection: charts chunk absent from modulepreload and entry static imports; critical path 1.70 MB → ~1.13 MB raw
+- [x] 2.3 Live curl checks: asset gzip + immutable headers, index no-cache, `/backend-api/*` untouched
+- [x] 2.4 Backend static/spa unit tests green; `ruff`/`ty`; `openspec validate --specs`

--- a/tests/integration/test_dashboard_gzip.py
+++ b/tests/integration/test_dashboard_gzip.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _built_asset_name() -> str | None:
+    assets_dir = Path("app/static/assets")
+    if not assets_dir.is_dir():
+        return None
+    for candidate in sorted(assets_dir.glob("*.js")):
+        if candidate.stat().st_size > 2048:
+            return candidate.name
+    return None
+
+
+@pytest.mark.asyncio
+async def test_asset_gzip_and_immutable_cache(async_client):
+    asset = _built_asset_name()
+    if asset is None:
+        pytest.skip("frontend build output not present")
+    response = await async_client.get(f"/assets/{asset}", headers={"Accept-Encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.headers.get("content-encoding") == "gzip"
+    assert response.headers.get("cache-control") == "public, max-age=31536000, immutable"
+
+
+@pytest.mark.asyncio
+async def test_ranged_asset_requests_bypass_gzip(async_client):
+    """A Range request must not pass through the compressing wrapper:
+    FileResponse builds the 206/Content-Range against uncompressed bytes,
+    so gzipping the body afterwards would corrupt resumable fetches."""
+    asset = _built_asset_name()
+    if asset is None:
+        pytest.skip("frontend build output not present")
+    response = await async_client.get(
+        f"/assets/{asset}",
+        headers={"Accept-Encoding": "gzip", "Range": "bytes=0-99"},
+    )
+    assert response.status_code == 206
+    assert "content-encoding" not in response.headers
+    assert response.headers.get("content-range", "").startswith("bytes 0-99/")
+    assert len(response.content) == 100
+
+
+@pytest.mark.asyncio
+async def test_proxy_paths_never_gzipped(async_client):
+    response = await async_client.get("/backend-api/codex/models", headers={"Accept-Encoding": "gzip"})
+    assert "content-encoding" not in response.headers

--- a/tests/integration/test_dashboard_gzip.py
+++ b/tests/integration/test_dashboard_gzip.py
@@ -50,3 +50,15 @@ async def test_ranged_asset_requests_bypass_gzip(async_client):
 async def test_proxy_paths_never_gzipped(async_client):
     response = await async_client.get("/backend-api/codex/models", headers={"Accept-Encoding": "gzip"})
     assert "content-encoding" not in response.headers
+
+
+@pytest.mark.asyncio
+async def test_range_header_detection_is_case_insensitive():
+    """ASGI servers are not guaranteed to lowercase header names; a
+    mixed-case Range header must still bypass the compressing wrapper."""
+    from app.core.middleware.dashboard_gzip import _has_range_header
+
+    assert _has_range_header({"headers": ((b"Range", b"bytes=0-99"),)})
+    assert _has_range_header({"headers": ((b"RANGE", b"bytes=0-99"),)})
+    assert _has_range_header({"headers": ((b"range", b"bytes=0-99"),)})
+    assert not _has_range_header({"headers": ((b"accept-encoding", b"gzip"),)})


### PR DESCRIPTION
## Summary

First uncached dashboard load shipped **~1.7 MB of uncompressed JS** on the critical path. Three fixes, no visual or API change:

1. **Response compression** — new `DashboardGZipMiddleware` gzips `/api/` and `/assets/` responses only. Proxy paths (`/backend-api`, `/v1`, websockets) are never wrapped in a compressor; verified live that they carry no `content-encoding`.
2. **Immutable asset caching** — Vite content-hashes everything under `/assets/`, so those responses now carry `Cache-Control: public, max-age=31536000, immutable`; `index.html` keeps its existing `no-cache` so deploys swap hashes. Also hoists the per-request `StaticFiles(...)` construction behind an `lru_cache`.
3. **Charts off the critical path** — every chart component was already `React.lazy`, but the forced `vendor-charts` manual chunk swallowed shared helper modules (CJS interop, `use-sync-external-store`, `es-toolkit`, `clsx`), which made the 572 KB recharts chunk a **static** import of the entry chunk and modulepreloaded before first paint; `lazy-recharts.ts` also still statically imported `Cell`. The manual chunk is removed and `Cell` is lazy like the rest — recharts v3 resolves cells via `type.displayName`, which the lazy wrapper carries.

**Measured on the build:** critical path 1.70 MB → ~1.13 MB raw (charts chunk is async-only: absent from `modulepreload` and from entry static imports — verified in the built output and dep maps), ~307 KB transferred with gzip; repeat loads are served from browser cache.

## Verification

- Live curl checks: asset responses gzip + immutable; `index.html` `no-cache`; `/backend-api/*` untouched.
- Frontend: 839 tests green (incl. donut/cell rendering paths). Backend: static/spa unit tests green; `ruff`/`ty` clean.
- OpenSpec: `openspec/changes/optimize-dashboard-serving/` (`frontend-architecture` delta), `openspec validate --specs` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)