### PR TITLE
perf(clients): keep upstream connections and DNS across interactive turns

### DIFF
--- a/app/core/clients/http.py
+++ b/app/core/clients/http.py
@@ -136,6 +136,13 @@ async def _build_http_client() -> HttpClient:
             limit=settings.http_connector_limit,
             limit_per_host=settings.http_connector_limit_per_host,
             ssl=ssl_context,
+            # aiohttp defaults (15s keepalive, 10s DNS TTL) are shorter than
+            # typical interactive Codex turn gaps, so nearly every turn paid a
+            # fresh DNS lookup + TCP/TLS handshake to the upstream host
+            # (~100-300ms of TTFT). Keep idle connections and resolved names
+            # around across turns instead.
+            keepalive_timeout=90,
+            ttl_dns_cache=300,
         )
     session = aiohttp.ClientSession(
         connector=connector,
@@ -151,7 +158,7 @@ async def _build_http_client() -> HttpClient:
             )
             ws_trust_env = False
         else:
-            ws_connector = aiohttp.TCPConnector(ssl=ssl_context)
+            ws_connector = aiohttp.TCPConnector(ssl=ssl_context, keepalive_timeout=90, ttl_dns_cache=300)
             ws_trust_env = settings.upstream_websocket_trust_env
         try:
             websocket_session = aiohttp.ClientSession(

--- a/openspec/changes/tune-upstream-connection-reuse/.openspec.yaml
+++ b/openspec/changes/tune-upstream-connection-reuse/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/tune-upstream-connection-reuse/proposal.md
+++ b/openspec/changes/tune-upstream-connection-reuse/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+The shared upstream connectors used aiohttp defaults: 15 s connection keepalive and 10 s DNS TTL. Interactive Codex turns are usually further apart than that, so nearly every turn paid a fresh DNS lookup plus TCP/TLS handshake to the upstream host (~100–300 ms of time-to-first-token) instead of reusing the pooled connection.
+
+## What Changes
+
+- Shared HTTP and websocket-handshake connectors set `keepalive_timeout=90` and `ttl_dns_cache=300`, so idle upstream connections and resolved names survive across interactive turns. No other connector behavior changes; SOCKS-proxied connectors are untouched (proxy connector library manages its own reuse).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `outbound-http-clients`: shared upstream connectors MUST keep idle connections and DNS results alive across typical interactive turn gaps.
+
+## Impact
+
+`app/core/clients/http.py` only; behavior-preserving beyond connection reuse timing.

--- a/openspec/changes/tune-upstream-connection-reuse/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/tune-upstream-connection-reuse/specs/outbound-http-clients/spec.md
@@ -1,0 +1,12 @@
+# outbound-http-clients Delta
+
+## ADDED Requirements
+
+### Requirement: Upstream connectors persist across interactive turn gaps
+
+The shared upstream TCP connectors MUST configure connection keepalive of at least 90 seconds and a DNS cache TTL of at least 300 seconds, so consecutive interactive requests reuse pooled connections and resolved names instead of re-handshaking per turn.
+
+#### Scenario: Connector construction pins reuse settings
+
+- **WHEN** the shared HTTP client initializes its direct TCP connectors
+- **THEN** they are constructed with `keepalive_timeout >= 90` and `ttl_dns_cache >= 300`

--- a/openspec/changes/tune-upstream-connection-reuse/tasks.md
+++ b/openspec/changes/tune-upstream-connection-reuse/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation
+
+- [x] 1.1 Set `keepalive_timeout=90`, `ttl_dns_cache=300` on the shared HTTP and websocket-handshake `TCPConnector`s
+
+## 2. Validation
+
+- [x] 2.1 Connector-construction unit assertions updated; suite green; `ruff`/`ty`; `openspec validate --specs`

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -88,8 +88,14 @@ async def test_init_http_client_creates_tcp_connector_with_limits() -> None:
         "limit": 100,
         "limit_per_host": 50,
         "ssl": ssl_context,
+        "keepalive_timeout": 90,
+        "ttl_dns_cache": 300,
     }
-    assert tcp_connector_cls.call_args_list[1].kwargs == {"ssl": ssl_context}
+    assert tcp_connector_cls.call_args_list[1].kwargs == {
+        "ssl": ssl_context,
+        "keepalive_timeout": 90,
+        "ttl_dns_cache": 300,
+    }
     assert client_session_cls.call_args_list[0].kwargs["connector"] is connector
     assert client_session_cls.call_args_list[1].kwargs["connector"] is websocket_connector
 


### PR DESCRIPTION
## Summary

The shared upstream connectors ran on aiohttp defaults: **15 s connection keepalive and 10 s DNS TTL**. Interactive Codex turns are usually further apart than that, so nearly every turn paid a fresh DNS lookup + TCP/TLS handshake to chatgpt.com (~100–300 ms of time-to-first-token) even though the `ClientSession` itself is pooled and shared.

Both direct `TCPConnector`s (HTTP + websocket handshake) now set `keepalive_timeout=90` and `ttl_dns_cache=300`. SOCKS-proxied connectors are untouched. No other behavior changes.

## OpenSpec

`openspec/changes/tune-upstream-connection-reuse/` — `outbound-http-clients` delta pinning the reuse floors. `openspec validate --specs` green.

## Tests

Connector-construction unit assertions updated to pin the new kwargs; `tests/unit/test_http_client.py` (16) green; `ruff`/`ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)