### PR TITLE
fix(db): serialize startup migrations across replicas and report schema-ahead correctly

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -153,6 +153,7 @@ class Settings(BaseSettings):
     database_sqlite_pre_migrate_backup_max_files: int = Field(default=5, ge=1)
     database_sqlite_startup_check_mode: Literal["quick", "full", "off"] = "quick"
     database_alembic_auto_remap_enabled: bool = True
+    database_migration_lock_timeout_seconds: float = Field(default=300.0, gt=0)
     upstream_base_url: str = "https://chatgpt.com/backend-api"
     upstream_stream_transport: Literal["http", "websocket", "auto"] = "auto"
     http_downstream_transport_policy: Literal["smart", "always_http", "always_websocket", "pinned"] = "smart"

--- a/app/db/migrate.py
+++ b/app/db/migrate.py
@@ -21,6 +21,7 @@ from sqlalchemy.engine import Connection
 
 from app.core.config.settings import get_settings
 from app.db.alembic.revision_ids import LEGACY_MIGRATION_TO_NEW_REVISION, OLD_TO_NEW_REVISION_MAP, REVISION_ID_PATTERN
+from app.db.migration_lock import migration_lock
 from app.db.migration_url import to_sync_database_url
 from app.db.models import Base
 
@@ -127,6 +128,8 @@ class MigrationState:
     has_alembic_version_table: bool
     has_legacy_migrations_table: bool
     needs_upgrade: bool
+    unknown_revisions: tuple[str, ...]
+    is_ahead: bool
 
 
 class MigrationBootstrapError(RuntimeError):
@@ -335,11 +338,14 @@ def _ensure_alembic_version_table_capacity_for_connection(connection: Connection
 
     inspector = inspect(connection)
     if not inspector.has_table(_ALEMBIC_VERSION_TABLE):
+        # IF NOT EXISTS is defense-in-depth against concurrent out-of-band
+        # `alembic upgrade` invocations that bypass run_upgrade's migration
+        # lock; the product paths are already serialized by migration_lock.
         connection.execute(
             text(
                 " ".join(
                     (
-                        f"CREATE TABLE {_ALEMBIC_VERSION_TABLE} (",
+                        f"CREATE TABLE IF NOT EXISTS {_ALEMBIC_VERSION_TABLE} (",
                         f"{_ALEMBIC_VERSION_COLUMN} VARCHAR({required_length}) NOT NULL,",
                         f"PRIMARY KEY ({_ALEMBIC_VERSION_COLUMN})",
                         ")",
@@ -481,7 +487,23 @@ def inspect_migration_state(database_url: str) -> MigrationState:
         tables = _read_table_names(connection)
         has_alembic = _ALEMBIC_VERSION_TABLE in tables
         has_legacy = _LEGACY_MIGRATIONS_TABLE in tables
-        current = _read_current_revision_from_connection(connection) if has_alembic else None
+        current_revisions = _read_current_revisions_from_connection(connection) if has_alembic else ()
+
+    if not current_revisions:
+        current = None
+    elif len(current_revisions) == 1:
+        current = current_revisions[0]
+    else:
+        current = ",".join(current_revisions)
+
+    known_revisions = _known_revisions(config)
+    unknown_revisions = tuple(
+        sorted(
+            revision
+            for revision in current_revisions
+            if revision not in known_revisions and revision not in OLD_TO_NEW_REVISION_MAP
+        )
+    )
 
     if has_alembic:
         needs_upgrade = current != head_revision
@@ -495,6 +517,8 @@ def inspect_migration_state(database_url: str) -> MigrationState:
         has_alembic_version_table=has_alembic,
         has_legacy_migrations_table=has_legacy,
         needs_upgrade=needs_upgrade,
+        unknown_revisions=unknown_revisions,
+        is_ahead=bool(unknown_revisions),
     )
 
 
@@ -601,27 +625,85 @@ def check_schema_drift(database_url: str) -> tuple[str, ...]:
     return tuple(repr(diff) for diff in diffs) + manual_diffs
 
 
+_NO_LEGACY_BOOTSTRAP = LegacyBootstrapResult(
+    stamped_revision=None,
+    legacy_row_count=0,
+    unknown_migrations=(),
+    had_non_contiguous_entries=False,
+)
+
+
+def _resolved_lock_timeout_seconds(lock_timeout_seconds: float | None) -> float:
+    if lock_timeout_seconds is not None:
+        return lock_timeout_seconds
+    return get_settings().database_migration_lock_timeout_seconds
+
+
+def _schema_ahead_error(state: MigrationState) -> MigrationBootstrapError:
+    return MigrationBootstrapError(
+        f"Database schema revision(s) {','.join(state.unknown_revisions)} are not known to this build "
+        f"(head={state.head_revision}); the schema was likely migrated by a newer version. "
+        "Deploy a matching or newer image, or run an Alembic downgrade to a revision this build knows."
+    )
+
+
 def run_upgrade(
     database_url: str,
     revision: str = "head",
     *,
     bootstrap_legacy: bool,
     auto_remap_legacy_revisions: bool = True,
+    lock_timeout_seconds: float | None = None,
 ) -> MigrationRunResult:
     config = _build_alembic_config(database_url)
+    sync_database_url = _required_sqlalchemy_url(config)
+    with migration_lock(
+        sync_database_url,
+        timeout_seconds=_resolved_lock_timeout_seconds(lock_timeout_seconds),
+    ):
+        return _run_upgrade_locked(
+            config,
+            database_url,
+            revision,
+            bootstrap_legacy=bootstrap_legacy,
+            auto_remap_legacy_revisions=auto_remap_legacy_revisions,
+        )
+
+
+def _run_upgrade_locked(
+    config: Config,
+    database_url: str,
+    revision: str,
+    *,
+    bootstrap_legacy: bool,
+    auto_remap_legacy_revisions: bool,
+) -> MigrationRunResult:
     state_before = inspect_migration_state(database_url)
+    if state_before.is_ahead:
+        raise _schema_ahead_error(state_before)
+
+    # Post-acquire re-check: a peer holding the lock first may already have
+    # migrated to head. When alembic_version exists the legacy bootstrap never
+    # stamps, and current == head means no legacy remap is pending, so skipping
+    # is safe and lets the losing replica complete startup successfully.
+    if revision == "head" and state_before.has_alembic_version_table and not state_before.needs_upgrade:
+        logger.info(
+            "Database schema already at Alembic head revision=%s; skipping upgrade "
+            "(migrations were applied by this or another replica)",
+            state_before.current_revision,
+        )
+        return MigrationRunResult(
+            current_revision=state_before.current_revision,
+            bootstrap=_NO_LEGACY_BOOTSTRAP,
+        )
+
     config.attributes["codex_lb_fresh_install"] = (
         state_before.current_revision is None
         and not state_before.has_alembic_version_table
         and not state_before.has_legacy_migrations_table
     )
 
-    bootstrap_result = LegacyBootstrapResult(
-        stamped_revision=None,
-        legacy_row_count=0,
-        unknown_migrations=(),
-        had_non_contiguous_entries=False,
-    )
+    bootstrap_result = _NO_LEGACY_BOOTSTRAP
 
     if bootstrap_legacy:
         bootstrap_result = _bootstrap_legacy_history(config)
@@ -664,10 +746,15 @@ def current_revision(database_url: str) -> str | None:
     return state.current_revision
 
 
-def stamp_revision(database_url: str, revision: str) -> None:
+def stamp_revision(database_url: str, revision: str, *, lock_timeout_seconds: float | None = None) -> None:
     config = _build_alembic_config(database_url)
-    _ensure_alembic_version_table_capacity(config)
-    command.stamp(config, revision)
+    sync_database_url = _required_sqlalchemy_url(config)
+    with migration_lock(
+        sync_database_url,
+        timeout_seconds=_resolved_lock_timeout_seconds(lock_timeout_seconds),
+    ):
+        _ensure_alembic_version_table_capacity(config)
+        command.stamp(config, revision)
 
 
 def wait_for_connection(

--- a/app/db/migration_lock.py
+++ b/app/db/migration_lock.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Callable, Iterator
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import make_url
+
+from app.db.sqlite_utils import sqlite_db_path_from_url
+
+logger = logging.getLogger(__name__)
+
+MIGRATION_LOCK_KEY = "codex_lb:migrations"
+SQLITE_MIGRATION_LOCK_SUFFIX = ".migrate-lock"
+_POLL_INTERVAL_SECONDS = 2.0
+_WAIT_LOG_INTERVAL_SECONDS = 10.0
+_TIMEOUT_SETTING_HINT = "database_migration_lock_timeout_seconds (CODEX_LB_DATABASE_MIGRATION_LOCK_TIMEOUT_SECONDS)"
+
+
+def sqlite_migration_lock_path(db_path: Path) -> Path:
+    return db_path.with_name(db_path.name + SQLITE_MIGRATION_LOCK_SUFFIX)
+
+
+def _timeout_message(description: str, timeout_seconds: float) -> str:
+    return (
+        f"Timed out after {timeout_seconds:.1f}s waiting for the {description} "
+        f"(key={MIGRATION_LOCK_KEY!r}). Another process is migrating the same database and has not "
+        f"finished; if its migrations legitimately take longer, raise {_TIMEOUT_SETTING_HINT}."
+    )
+
+
+def _acquire_with_timeout(
+    try_acquire: Callable[[], bool],
+    *,
+    timeout_seconds: float,
+    description: str,
+) -> None:
+    if timeout_seconds <= 0:
+        raise ValueError("timeout_seconds must be greater than 0")
+
+    started_at = time.monotonic()
+    next_log_after = _WAIT_LOG_INTERVAL_SECONDS
+    while True:
+        if try_acquire():
+            return
+        elapsed = time.monotonic() - started_at
+        if elapsed >= timeout_seconds:
+            raise TimeoutError(_timeout_message(description, timeout_seconds))
+        if elapsed >= next_log_after:
+            logger.info(
+                "Waiting for %s held by another process elapsed=%.1fs timeout=%.1fs",
+                description,
+                elapsed,
+                timeout_seconds,
+            )
+            next_log_after += _WAIT_LOG_INTERVAL_SECONDS
+        time.sleep(min(_POLL_INTERVAL_SECONDS, timeout_seconds - elapsed))
+
+
+@contextmanager
+def _postgresql_migration_lock(sync_database_url: str, *, timeout_seconds: float) -> Iterator[None]:
+    # A dedicated session-level advisory lock connection: run_upgrade spans many
+    # transactions across several short-lived engines, so the lock must outlive
+    # any single transaction and is held on this connection for the whole
+    # sequence. AUTOCOMMIT keeps the holder out of "idle in transaction".
+    # PostgreSQL releases session advisory locks automatically if the holder
+    # dies, so a crashed migrator never wedges its peers.
+    engine = create_engine(sync_database_url, future=True)
+    try:
+        with engine.connect() as connection:
+            connection = connection.execution_options(isolation_level="AUTOCOMMIT")
+
+            def _try_acquire() -> bool:
+                acquired = connection.execute(
+                    text("SELECT pg_try_advisory_lock(hashtext(:key))"),
+                    {"key": MIGRATION_LOCK_KEY},
+                ).scalar()
+                return bool(acquired)
+
+            _acquire_with_timeout(
+                _try_acquire,
+                timeout_seconds=timeout_seconds,
+                description="PostgreSQL advisory migration lock",
+            )
+            try:
+                yield
+            finally:
+                connection.execute(
+                    text("SELECT pg_advisory_unlock(hashtext(:key))"),
+                    {"key": MIGRATION_LOCK_KEY},
+                )
+    finally:
+        engine.dispose()
+
+
+@contextmanager
+def _sqlite_migration_lock(db_path: Path, *, timeout_seconds: float) -> Iterator[None]:
+    # Holding a BEGIN IMMEDIATE write transaction on a sentinel SQLite file is
+    # the mutex: SQLite's RESERVED lock is exclusive across processes sharing
+    # the volume and vanishes on process death. The sentinel must be a separate
+    # file — a write transaction on the main database would deadlock against
+    # Alembic's own DDL connection and block concurrent app reads. It is never
+    # unlinked (avoids unlink/reopen races) and stays behind as a harmless
+    # zero-row SQLite file.
+    lock_path = sqlite_migration_lock_path(db_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(str(lock_path), timeout=0, isolation_level=None)
+    try:
+
+        def _try_acquire() -> bool:
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+            except sqlite3.OperationalError as exc:
+                message = str(exc).lower()
+                if "locked" in message or "busy" in message:
+                    return False
+                raise
+            return True
+
+        _acquire_with_timeout(
+            _try_acquire,
+            timeout_seconds=timeout_seconds,
+            description=f"SQLite sentinel migration lock ({lock_path})",
+        )
+        try:
+            yield
+        finally:
+            connection.rollback()
+    finally:
+        connection.close()
+
+
+@contextmanager
+def migration_lock(sync_database_url: str, *, timeout_seconds: float) -> Iterator[None]:
+    """Cross-process mutex serializing schema upgrades/stamps for one database.
+
+    PostgreSQL: session-level advisory lock held on a dedicated connection.
+    File-backed SQLite: exclusive write transaction on a sentinel SQLite file
+    adjacent to the database. In-memory SQLite is a no-op (the database is
+    process-private, there is no peer), as are dialects without a portable
+    cross-process primitive.
+    """
+    backend = make_url(sync_database_url).get_backend_name()
+    if backend == "postgresql":
+        with _postgresql_migration_lock(sync_database_url, timeout_seconds=timeout_seconds):
+            yield
+        return
+    if backend == "sqlite":
+        db_path = sqlite_db_path_from_url(sync_database_url)
+        if db_path is None:
+            yield
+            return
+        with _sqlite_migration_lock(db_path, timeout_seconds=timeout_seconds):
+            yield
+        return
+    yield

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -335,11 +335,20 @@ async def init_db() -> None:
         )
         if migration_state.needs_upgrade:
             current_revision = migration_state.current_revision or "none"
-            message = (
-                "Startup database migration is disabled but database schema is behind Alembic head "
-                f"(current={current_revision}, head={migration_state.head_revision}). "
-                "Run the dedicated migration job or `python -m app.db.migrate upgrade` before starting the app."
-            )
+            if migration_state.is_ahead:
+                unknown_revisions = ",".join(migration_state.unknown_revisions)
+                message = (
+                    "Startup database migration is disabled and database schema revision(s) "
+                    f"{unknown_revisions} are not known to this build (head={migration_state.head_revision}). "
+                    "The schema was likely migrated by a newer version; deploy a matching or newer image, "
+                    "or run an Alembic downgrade to a revision this build knows."
+                )
+            else:
+                message = (
+                    "Startup database migration is disabled but database schema is behind Alembic head "
+                    f"(current={current_revision}, head={migration_state.head_revision}). "
+                    "Run the dedicated migration job or `python -m app.db.migrate upgrade` before starting the app."
+                )
             logger.error(message)
             raise RuntimeError(message)
 

--- a/openspec/changes/serialize-startup-migrations/design.md
+++ b/openspec/changes/serialize-startup-migrations/design.md
@@ -1,0 +1,144 @@
+# Design: serialize-startup-migrations
+
+## Decisions
+
+### Lock placement — `run_upgrade()`, not `env.py`
+
+`run_upgrade` is the single product entrypoint for both the app startup path
+(`init_db -> run_startup_migrations -> run_upgrade`, executed in a worker
+thread via `to_thread`) and the container entrypoint
+(`python -m app.db.migrate upgrade`). The racy steps outside `command.upgrade`
+— `_bootstrap_legacy_history`'s stamp, `_ensure_alembic_version_table_capacity`'s
+check-then-CREATE, `_remap_legacy_alembic_revisions`' DELETE+INSERT, and the
+`state_before` inspection that computes `codex_lb_fresh_install` — each open
+their own engine/connection, so an `env.py`-level lock would cover only
+`command.upgrade` and miss them all. Critically, we must NOT also lock in
+`env.py`: `run_upgrade` holds the session advisory lock on a dedicated
+connection, and Alembic's `env.py` runs on a different connection, so a second
+acquire there would self-deadlock.
+
+- Rejected: locking in `env.py` only (misses helpers and bootstrap).
+- Rejected: locking in both (self-deadlock).
+
+### PostgreSQL: session-level advisory lock on a dedicated connection
+
+`SELECT pg_try_advisory_lock(hashtext('codex_lb:migrations'))` — the same
+`hashtext` idiom as `pg_advisory_xact_lock(hashtext(:key))` in
+`app/core/rate_limiter/db_rate_limiter.py`, but session-scoped, because
+`run_upgrade` spans many transactions across several short-lived engines (each
+`_sync_transaction` creates its own engine) and the Alembic connection is not
+ours to wrap. The lock connection runs in AUTOCOMMIT, is opened first, held
+open (doing nothing) for the whole upgrade, and released via
+`pg_advisory_unlock` + `engine.dispose()` in `finally`; PostgreSQL also
+releases session locks automatically if the holder dies — no stale-lock GC.
+Acquisition is a try-lock poll loop (2s interval) with periodic wait logging
+and a bounded timeout.
+
+- Rejected: `pg_advisory_xact_lock` (transaction-scoped; cannot span the
+  multi-connection sequence).
+- Rejected: a lease row like `scheduler_leader` (chicken-and-egg — the table it
+  needs is created by the very migrations being serialized; lease expiry needs
+  clock arbitration the advisory lock gets for free).
+- Rejected: `LOCK TABLE alembic_version` (table absent on fresh databases —
+  the fresh-install race is exactly the worst case).
+- Rejected: reusing the cache-invalidation bus/poller (requires schema and an
+  event loop; this is pre-schema, sync, pre-app).
+
+### SQLite: `BEGIN IMMEDIATE` on a sentinel SQLite file, not `flock`
+
+For file-backed SQLite, open `sqlite3.connect("<db_path>.migrate-lock",
+timeout=0, isolation_level=None)` and execute `BEGIN IMMEDIATE`; holding that
+write transaction is the mutex (SQLite's RESERVED lock is exclusive across
+processes sharing the volume). Release = rollback + close; OS file locks
+vanish on process death, so a SIGKILLed migrator never wedges peers. Same
+poll/timeout/logging as PostgreSQL. The sentinel must be a *separate* file:
+`BEGIN IMMEDIATE` on the main database would deadlock against Alembic's own
+connection doing DDL and would block concurrent app reads. The sentinel is
+never unlinked (avoids unlink/reopen races); it is a harmless zero-row SQLite
+file. In-memory SQLite is a no-op — the database is process-private.
+
+- Rejected: `fcntl.flock` on a lockfile (unavailable on Windows — runtime
+  portability is a first-class capability — and unreliable on NFS; the
+  sentinel inherits exactly the SQLite locking semantics the main DB already
+  depends on).
+- Rejected: `O_CREAT|O_EXCL` pidfile (needs stale-lock recovery after SIGKILL).
+- Rejected: anyio-based `sqlite_writer_section` (process-local only).
+
+### Post-acquire re-check (wait-and-skip)
+
+After acquiring, `run_upgrade` re-runs `inspect_migration_state` on a fresh
+connection. If the requested revision is `head`, the `alembic_version` table
+exists, and the current revision equals head, it logs at INFO and returns a
+`MigrationRunResult` without invoking `command.upgrade`. (When current == head
+the legacy bootstrap is structurally a no-op — it only stamps when
+`alembic_version` is absent — and no remap is pending, so the simplified skip
+condition is equivalent to "no legacy bootstrap/remap pending".) This is what
+makes the losing replica's startup succeed instead of crash-looping; the
+entrypoint needs no change because `python -m app.db.migrate upgrade` exits 0
+on the skip path. Explicit non-head CLI targets never skip. The pre-lock steps
+in `init_db` (SQLite integrity check, pre-migration backup) stay outside the
+lock — a duplicate backup from a losing replica is harmless and bounded by
+`database_sqlite_pre_migrate_backup_max_files`.
+
+### Ahead-of-build detection
+
+`inspect_migration_state` computes `unknown_revisions` = current revisions not
+in `_known_revisions(config)` and not keys of `OLD_TO_NEW_REVISION_MAP`, and
+`is_ahead = bool(unknown_revisions)`. `needs_upgrade` stays `current != head`
+(fail-closed exact-head gating is intentional per the existing spec); only the
+*diagnostics* change: `init_db`'s migrate-disabled branch emits "revision(s)
+… are not known to this build — the schema was likely migrated by a newer
+version; deploy a matching or newer image, or run an Alembic downgrade"
+instead of "schema is behind Alembic head", and `run_upgrade` raises the same
+guidance as a `MigrationBootstrapError` before
+`_remap_legacy_alembic_revisions` can emit its misleading "Unsupported
+alembic_version revision ids detected" error. `wait-for-head` timeout behavior
+is unchanged (fail-closed by design).
+
+### No CAS, no new schema
+
+Mutual exclusion plus post-acquire re-inspection replaces any compare-and-swap
+on `alembic_version`; `CREATE TABLE IF NOT EXISTS` in the capacity helper is
+pure hardening for out-of-band `alembic upgrade` invocations. No new Alembic
+revision is added, so the single-head invariant is untouched.
+
+### Performance
+
+Zero hot-path impact — the lock exists only during startup migration/stamp.
+Cost is one extra connection + one try-lock query per boot on the winner; the
+loser waits up to the timeout (default 300s, matching `wait-for-head`).
+
+## Deviations from the approved design
+
+- The wait-and-skip condition is implemented as `revision == "head" and
+  has_alembic_version_table and current == head` rather than separately
+  re-checking "no legacy bootstrap/remap pending": when `alembic_version`
+  exists the bootstrap never stamps, and when current equals head exactly no
+  remap is pending, so the extra checks are structurally redundant (see
+  post-acquire re-check above).
+- `run_upgrade`/`stamp_revision` accept an optional `lock_timeout_seconds`
+  override (defaulting to the setting) so tests and future callers can bound
+  waits without mutating global settings.
+- The pre-existing unit test
+  `test_run_upgrade_fails_for_unsupported_alembic_version_id` asserted the old
+  misleading "Unsupported alembic_version revision ids" message on the
+  `run_upgrade` path; it now asserts the ahead-specific message. The generic
+  remap error remains for direct `_remap_legacy_alembic_revisions` callers.
+- Likewise, the pre-existing unit test
+  `test_ensure_alembic_version_table_capacity_creates_table_when_missing` now
+  asserts the `CREATE TABLE IF NOT EXISTS` SQL the design mandates for the
+  capacity helper.
+
+## Risks / trade-offs
+
+- PgBouncer/transaction-pooled endpoints break session advisory locks;
+  migrations open their own direct sync engine, but operators pointing
+  `CODEX_LB_DATABASE_URL` at a transaction-pooling proxy lose the guarantee
+  (documented in context.md).
+- Advisory-lock key collision via `hashtext` with rate-limiter keys would only
+  cause spurious brief serialization (namespaced key; rate-limiter locks are
+  xact-scoped and short).
+- SQLite sentinel on NFS inherits SQLite's known NFS locking unreliability —
+  no worse than the main DB itself (documented in context.md).
+- A hung migrator holds peers until the timeout, then they fail fast with an
+  actionable error — same crash-loop as today but explicit and tunable.

--- a/openspec/changes/serialize-startup-migrations/proposal.md
+++ b/openspec/changes/serialize-startup-migrations/proposal.md
@@ -1,0 +1,20 @@
+# Serialize Startup Migrations
+
+## Why
+
+Every replica runs Alembic `upgrade head` at boot (and `docker-entrypoint.sh` runs `python -m app.db.migrate upgrade` unconditionally) with no cross-process mutual exclusion. Two replicas starting concurrently both read the same current revision and race DDL: the loser dies on duplicate-object errors — including the non-idempotent `CREATE TABLE alembic_version` in the capacity helper and the DELETE+INSERT legacy remap — and crash-loops under the entrypoint's `set -eu`. Separately, migration state inspection is direction-blind (`needs_upgrade = current != head`), so an old binary restarting against a schema migrated by a newer build reports "schema is behind Alembic head" or a misleading "Unsupported alembic_version revision ids" remap error, sending operators the wrong way during rollouts.
+
+## What Changes
+
+- New `app/db/migration_lock.py`: a sync `migration_lock(sync_database_url, *, timeout_seconds)` context manager providing a cross-process mutex — PostgreSQL: session-level `pg_try_advisory_lock(hashtext('codex_lb:migrations'))` polled on a dedicated connection held for the whole upgrade; file-backed SQLite: an exclusive `BEGIN IMMEDIATE` write transaction held on a sentinel SQLite file `<db_path>.migrate-lock` adjacent to the database; in-memory SQLite and unknown dialects: no-op.
+- `run_upgrade()` acquires the lock around its entire sequence (state inspection, legacy bootstrap, capacity ensure, remap, `command.upgrade`); after acquiring it re-inspects migration state and, when the target is `head` and the schema is already at head, logs that migrations were already applied and returns without applying — the losing replica's startup succeeds. Covers both the app startup path and the container-entrypoint CLI path, which share `run_upgrade`.
+- `stamp_revision()` takes the same lock; `_ensure_alembic_version_table_capacity_for_connection` switches to `CREATE TABLE IF NOT EXISTS` as defense-in-depth for direct `alembic` CLI invocations that bypass `run_upgrade`.
+- New setting `database_migration_lock_timeout_seconds` (default `300.0`, env `CODEX_LB_DATABASE_MIGRATION_LOCK_TIMEOUT_SECONDS`); on timeout, a `TimeoutError` names the migration lock and the setting (startup honors `database_migrations_fail_fast` as today; the CLI always fails).
+- `MigrationState` gains `unknown_revisions: tuple[str, ...]` and `is_ahead: bool` (any current revision not in the local Alembic script directory and not legacy-remappable). `init_db()`'s migrate-disabled branch and `run_upgrade()` (before the generic unsupported-revision remap error) raise a direction-correct "schema revision(s) are not known to this build; deploy a matching or newer image, or downgrade the schema" message instead of claiming the schema is behind head.
+- Spec deltas in `openspec/specs/database-migrations/` (two ADDED requirements) plus `context.md` ops notes documenting the per-backend lock mechanism, sentinel-file lifecycle, PgBouncer/NFS caveats, and the migrate-on-startup vs migration-Job + `wait-for-head` deployment contract.
+- No new DB table and no new Alembic revision (the mechanism is a lock, not schema).
+
+## Non-goals
+
+- Serializing direct `alembic upgrade` CLI invocations that bypass `app.db.migrate` (out of the product path; `env.py` deliberately stays lock-free to avoid self-deadlock with the held session lock).
+- Changing the exact-head fail-closed gating semantics of `needs_upgrade` or `wait-for-head`.

--- a/openspec/changes/serialize-startup-migrations/specs/database-migrations/spec.md
+++ b/openspec/changes/serialize-startup-migrations/specs/database-migrations/spec.md
@@ -1,0 +1,46 @@
+# database-migrations Delta
+
+## ADDED Requirements
+
+### Requirement: Startup migrations are mutually exclusive across processes
+
+The system SHALL serialize schema upgrades and stamps across all processes sharing a database using a backend-appropriate cross-process mutex: a PostgreSQL session-level advisory lock held on a dedicated connection for the full upgrade sequence, or an exclusive write transaction on a sentinel SQLite file adjacent to a file-backed SQLite database (no-op for in-memory SQLite). After acquiring the mutex, the upgrader MUST re-inspect migration state and MUST skip applying revisions when the target is head and the schema is already at head with no legacy bootstrap or revision remap pending, completing startup successfully. Waiting for the mutex MUST be bounded by `database_migration_lock_timeout_seconds` (default 300); on timeout the system SHALL raise an explicit error naming the migration lock and the timeout setting, honoring `database_migrations_fail_fast` on the startup path.
+
+#### Scenario: Two processes upgrade a fresh database concurrently
+
+- **WHEN** two processes concurrently run upgrade to head against the same fresh database
+- **THEN** each pending revision is applied exactly once
+- **AND** both processes report the head revision
+- **AND** neither process fails with duplicate-object errors
+
+#### Scenario: A process starts while a peer is migrating
+
+- **GIVEN** a peer process holds the migration lock while upgrading to head
+- **WHEN** the peer completes to head and releases the lock
+- **THEN** the waiting process proceeds without applying revisions
+- **AND** it logs that the database is already at head
+
+#### Scenario: Lock wait exceeds the timeout
+
+- **GIVEN** another process holds the migration lock for longer than `database_migration_lock_timeout_seconds`
+- **WHEN** an upgrade or stamp attempts to acquire the lock
+- **THEN** it fails with an error that names the migration lock and the `database_migration_lock_timeout_seconds` setting
+
+### Requirement: Schema newer than build is reported distinctly from schema behind head
+
+Migration state inspection SHALL classify `alembic_version` revisions that are neither present in the local Alembic script directory nor legacy-remappable as schema-ahead, and startup diagnostics MUST report schema-ahead databases as newer than or unknown to the running build — directing the operator to deploy a matching or newer image or downgrade the schema — rather than claiming the schema is behind Alembic head. Exact-head fail-closed gating itself is unchanged.
+
+#### Scenario: Startup migration disabled against a newer schema
+
+- **GIVEN** `database_migrate_on_startup=false`
+- **AND** `alembic_version` contains a revision unknown to the running build
+- **WHEN** the application starts
+- **THEN** startup fails with an error stating the schema revision is not known to this build and directing the operator to deploy a matching or newer image or downgrade the schema
+- **AND** the error does not claim the schema is behind Alembic head
+
+#### Scenario: Startup migration enabled against a newer schema
+
+- **GIVEN** startup migration is enabled
+- **AND** `alembic_version` contains a revision unknown to the running build
+- **WHEN** the upgrade runs
+- **THEN** it fails with the ahead-specific guidance rather than a generic unsupported-revision remap error

--- a/openspec/changes/serialize-startup-migrations/tasks.md
+++ b/openspec/changes/serialize-startup-migrations/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: serialize-startup-migrations
+
+## 1. OpenSpec
+
+- [x] 1.1 Create change artifacts (proposal, design, tasks, database-migrations spec deltas) and pass `openspec validate serialize-startup-migrations`.
+
+## 2. Cross-process migration lock
+
+- [x] 2.1 Add `database_migration_lock_timeout_seconds: float = 300.0` (env `CODEX_LB_DATABASE_MIGRATION_LOCK_TIMEOUT_SECONDS`) to `app/core/config/settings.py`.
+- [x] 2.2 Implement `app/db/migration_lock.py`: `migration_lock(sync_database_url, *, timeout_seconds)` — PostgreSQL `pg_try_advisory_lock(hashtext('codex_lb:migrations'))` poll loop on a dedicated AUTOCOMMIT connection with `pg_advisory_unlock` + dispose in `finally`; file-backed SQLite `BEGIN IMMEDIATE` poll loop on a `<db_path>.migrate-lock` sentinel connection; in-memory/other dialects no-op; INFO wait logging every ~10s; `TimeoutError` naming the lock and the setting.
+- [x] 2.3 Wrap `run_upgrade()`'s whole body (state inspection, legacy bootstrap, capacity ensure, remap, `command.upgrade`) in `migration_lock`; add the post-acquire re-inspection that skips `command.upgrade` and returns early when the target is head and the schema is already at head, logging the already-migrated skip; wrap `stamp_revision()` in the same lock.
+- [x] 2.4 Change `_ensure_alembic_version_table_capacity_for_connection` to `CREATE TABLE IF NOT EXISTS`.
+
+## 3. Ahead-of-build diagnostics
+
+- [x] 3.1 Extend `MigrationState` with `unknown_revisions`/`is_ahead` computed in `inspect_migration_state` (unknown = not in `_known_revisions` and not in `OLD_TO_NEW_REVISION_MAP`).
+- [x] 3.2 Raise the ahead-specific `MigrationBootstrapError` in `run_upgrade` before the legacy remap can emit the generic unsupported-revision error.
+- [x] 3.3 Branch `init_db`'s migrate-disabled error message on `is_ahead` with "not known to this build" guidance instead of "behind Alembic head".
+
+## 4. Tests
+
+- [x] 4.1 Concurrent-upgrade race: two barrier-aligned `run_upgrade` calls on a fresh database (SQLite tmp file; PostgreSQL when `CODEX_LB_TEST_DATABASE_URL` is set) — both succeed, single head row, no duplicate-object errors.
+- [x] 4.2 Wait-and-skip: hold `migration_lock` on an at-head database, assert a second `run_upgrade` blocks, then returns without applying and logs the skip.
+- [x] 4.3 Timeout: held lock + `lock_timeout_seconds=0.5` raises `TimeoutError` naming `database_migration_lock_timeout_seconds` (SQLite and PostgreSQL variants).
+- [x] 4.4 Entrypoint path: two concurrent `python -m app.db.migrate upgrade` subprocesses on one tmp SQLite file both exit 0 with head applied once.
+- [x] 4.5 Ahead-of-build regression: fabricated future revision in `alembic_version` — `inspect_migration_state.is_ahead`, `init_db()` with `database_migrate_on_startup=false` raises "not known to this build" (not "behind Alembic head"), and `run_upgrade` raises the ahead-specific error.
+
+## 5. Docs & verification
+
+- [x] 5.1 Update `openspec/specs/database-migrations/context.md`: per-backend lock mechanism, sentinel file lifecycle, PgBouncer/NFS caveats, migrate-on-startup vs migration-Job + `wait-for-head` deployment contract, timeout tuning.
+- [x] 5.2 Run focused pytest (migration suites), ruff check/format, and strict OpenSpec validation.

--- a/openspec/specs/database-migrations/context.md
+++ b/openspec/specs/database-migrations/context.md
@@ -20,12 +20,14 @@
 - Revision IDs use `YYYYMMDD_HHMMSS_slug` for readability and merge-conflict reduction.
 - Legacy IDs are auto-remapped at startup to avoid manual DB patching during cutover.
 - CI checks both policy (head/naming) and drift in one command path.
+- Schema upgrades and stamps are serialized across processes by a cross-process migration lock (see Operational Notes); losing replicas wait, re-inspect, and skip when the schema is already at head.
+- `alembic_version` revisions unknown to the running build are reported as schema-ahead ("not known to this build") rather than "behind Alembic head".
 
 ## Constraints
 
 - Legacy `schema_migrations` rows are historical input only.
-- Production rollout assumes one migration executor at a time.
-- Unsupported `alembic_version` IDs fail fast to avoid silent divergence.
+- One migration executor at a time is enforced by the migration lock (`run_upgrade`/`stamp_revision` paths); direct `alembic` CLI invocations bypass it and remain the operator's responsibility.
+- Unsupported `alembic_version` IDs fail fast to avoid silent divergence, with direction-correct diagnostics (schema-ahead vs schema-behind).
 - Startup also verifies post-upgrade schema drift before the app begins normal work.
 
 ## Failure Modes and Mitigations
@@ -43,7 +45,16 @@
 ## Operational Notes
 
 - Startup path:
-  - inspect state -> (optional SQLite backup) -> bootstrap legacy `schema_migrations` -> remap legacy Alembic IDs -> `upgrade head` -> schema drift check
+  - (SQLite integrity check, optional SQLite backup) -> acquire migration lock -> inspect state (skip if already at head) -> bootstrap legacy `schema_migrations` -> remap legacy Alembic IDs -> `upgrade head` -> release lock -> schema drift check
+- Migration lock (serializes `run_upgrade` and `stamp_revision` across replicas):
+  - PostgreSQL: session-level `pg_try_advisory_lock(hashtext('codex_lb:migrations'))` polled every 2s on a dedicated AUTOCOMMIT connection held for the whole upgrade; released explicitly and automatically on holder death. Caveat: transaction-pooling proxies (PgBouncer in transaction mode) break session advisory locks — point `CODEX_LB_DATABASE_URL` at the database directly, or at a session-pooling endpoint, if replicas migrate on startup.
+  - File-backed SQLite: an exclusive `BEGIN IMMEDIATE` write transaction on a sentinel SQLite file `<db_path>.migrate-lock` adjacent to the database. The sentinel is created on first use and intentionally never deleted (a harmless zero-row SQLite file); OS-level SQLite locks vanish on process death. Caveat: on NFS this inherits SQLite's known NFS locking unreliability — no worse than the main database itself.
+  - In-memory SQLite: no-op (the database is process-private).
+  - Direct `alembic upgrade` (bypassing `python -m app.db.migrate`) does not take the lock; `alembic_version` capacity bootstrap uses `CREATE TABLE IF NOT EXISTS` as defense-in-depth, but out-of-band invocations should still be serialized by the operator.
+- Lock timeout tuning:
+  - `CODEX_LB_DATABASE_MIGRATION_LOCK_TIMEOUT_SECONDS` (default 300, matching `wait-for-head`) bounds how long a replica waits for a peer's migration. On timeout the error names the lock and this setting; the startup path honors `database_migrations_fail_fast`, the CLI always exits non-zero. Raise it for deployments whose migrations legitimately run long.
+- Multi-replica deployment contract:
+  - Either keep `database_migrate_on_startup=true` on every replica (the lock makes concurrent boots safe: one replica applies, the rest wait and skip), or disable it and run a dedicated migration Job while app replicas use `python -m app.db.migrate wait-for-head` before starting.
 - CLI checks:
   - `codex-lb-db check` validates head count, revision naming/filename policy, and schema drift.
 - Emergency toggle:

--- a/tests/integration/test_migration_serialization.py
+++ b/tests/integration/test_migration_serialization.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+import subprocess
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+import app.db.migrate as migrate_module
+from app.core.config.settings import get_settings
+from app.db.migrate import MigrationBootstrapError, inspect_migration_state, run_upgrade
+from app.db.migration_lock import migration_lock
+from app.db.migration_url import to_sync_database_url
+
+pytestmark = pytest.mark.integration
+
+_DATABASE_URL = get_settings().database_url
+_HEAD_REVISION = inspect_migration_state(_DATABASE_URL).head_revision
+_FUTURE_REVISION = "20991231_000000_revision_from_a_newer_build"
+_REPO_ROOT = Path(migrate_module.__file__).resolve().parents[2]
+_LOCK_HOLD_TIMEOUT_SECONDS = 60.0
+
+
+def _is_postgresql_database_url(url: str) -> bool:
+    return url.startswith("postgresql+")
+
+
+def _sqlite_alembic_revisions(db_path: Path) -> list[str]:
+    with sqlite3.connect(str(db_path)) as connection:
+        rows = connection.execute("SELECT version_num FROM alembic_version").fetchall()
+    return sorted(str(row[0]) for row in rows)
+
+
+def test_concurrent_upgrades_on_fresh_sqlite_database_apply_head_exactly_once(tmp_path: Path) -> None:
+    db_path = tmp_path / "race.sqlite"
+    db_url = f"sqlite+aiosqlite:///{db_path}"
+    barrier = threading.Barrier(2)
+
+    def _upgrade() -> migrate_module.MigrationRunResult:
+        # Align both "replicas" right before run_upgrade so they race the full
+        # inspect -> bootstrap -> upgrade sequence, as two containers booting
+        # simultaneously against one shared database file would.
+        barrier.wait(timeout=30)
+        return run_upgrade(db_url, "head", bootstrap_legacy=True)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(_upgrade) for _ in range(2)]
+        results = [future.result(timeout=300) for future in futures]
+
+    assert [result.current_revision for result in results] == [_HEAD_REVISION, _HEAD_REVISION]
+    assert _sqlite_alembic_revisions(db_path) == [_HEAD_REVISION]
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    not _is_postgresql_database_url(_DATABASE_URL),
+    reason="PostgreSQL-only concurrent migration test",
+)
+async def test_concurrent_upgrades_on_fresh_postgresql_database_apply_head_exactly_once(db_setup) -> None:
+    from app.db.session import SessionLocal
+
+    async with SessionLocal() as session:
+        await session.execute(text("DROP SCHEMA public CASCADE"))
+        await session.execute(text("CREATE SCHEMA public"))
+        await session.commit()
+
+    barrier = threading.Barrier(2)
+
+    def _upgrade() -> migrate_module.MigrationRunResult:
+        barrier.wait(timeout=30)
+        return run_upgrade(_DATABASE_URL, "head", bootstrap_legacy=True)
+
+    results = await asyncio.gather(asyncio.to_thread(_upgrade), asyncio.to_thread(_upgrade))
+    assert [result.current_revision for result in results] == [_HEAD_REVISION, _HEAD_REVISION]
+
+    async with SessionLocal() as session:
+        revision_rows = await session.execute(text("SELECT version_num FROM alembic_version"))
+        revisions = sorted(str(row[0]) for row in revision_rows.fetchall())
+        assert revisions == [_HEAD_REVISION]
+
+
+def test_run_upgrade_waits_for_lock_holder_then_skips_when_already_at_head(tmp_path: Path, caplog) -> None:
+    db_path = tmp_path / "skip.sqlite"
+    db_url = f"sqlite+aiosqlite:///{db_path}"
+    run_upgrade(db_url, "head", bootstrap_legacy=True)
+
+    caplog.set_level(logging.INFO, logger="app.db.migrate")
+    sync_url = to_sync_database_url(db_url)
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        with migration_lock(sync_url, timeout_seconds=_LOCK_HOLD_TIMEOUT_SECONDS):
+            future = pool.submit(
+                run_upgrade,
+                db_url,
+                "head",
+                bootstrap_legacy=True,
+                lock_timeout_seconds=_LOCK_HOLD_TIMEOUT_SECONDS,
+            )
+            with pytest.raises(TimeoutError):
+                # Blocked on the migration lock while the holder is migrating.
+                future.result(timeout=1.0)
+        result = future.result(timeout=_LOCK_HOLD_TIMEOUT_SECONDS)
+
+    assert result.current_revision == _HEAD_REVISION
+    assert result.bootstrap.stamped_revision is None
+    assert any("skipping upgrade" in record.getMessage() for record in caplog.records)
+
+
+def test_run_upgrade_times_out_with_actionable_error_when_lock_is_held(tmp_path: Path) -> None:
+    db_path = tmp_path / "timeout.sqlite"
+    db_url = f"sqlite+aiosqlite:///{db_path}"
+    run_upgrade(db_url, "head", bootstrap_legacy=True)
+
+    sync_url = to_sync_database_url(db_url)
+    with migration_lock(sync_url, timeout_seconds=_LOCK_HOLD_TIMEOUT_SECONDS):
+        with pytest.raises(TimeoutError) as excinfo:
+            run_upgrade(db_url, "head", bootstrap_legacy=True, lock_timeout_seconds=0.5)
+
+    message = str(excinfo.value)
+    assert "migration lock" in message
+    assert "database_migration_lock_timeout_seconds" in message
+
+
+@pytest.mark.skipif(
+    not _is_postgresql_database_url(_DATABASE_URL),
+    reason="PostgreSQL-only advisory migration lock test",
+)
+def test_postgresql_run_upgrade_times_out_when_advisory_lock_is_held() -> None:
+    sync_url = to_sync_database_url(_DATABASE_URL)
+    with migration_lock(sync_url, timeout_seconds=_LOCK_HOLD_TIMEOUT_SECONDS):
+        with pytest.raises(TimeoutError) as excinfo:
+            run_upgrade(_DATABASE_URL, "head", bootstrap_legacy=True, lock_timeout_seconds=0.5)
+
+    message = str(excinfo.value)
+    assert "migration lock" in message
+    assert "database_migration_lock_timeout_seconds" in message
+
+
+def test_migration_lock_is_noop_for_in_memory_sqlite() -> None:
+    # In-memory databases are process-private; nested acquisition proves no-op.
+    with migration_lock("sqlite:///:memory:", timeout_seconds=0.1):
+        with migration_lock("sqlite:///:memory:", timeout_seconds=0.1):
+            pass
+
+
+def test_concurrent_cli_upgrades_share_one_sqlite_database(tmp_path: Path) -> None:
+    db_path = tmp_path / "cli-race.sqlite"
+    db_url = f"sqlite+aiosqlite:///{db_path}"
+
+    def _run_cli() -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, "-m", "app.db.migrate", "--db-url", db_url, "upgrade"],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            cwd=_REPO_ROOT,
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(_run_cli) for _ in range(2)]
+        completed = [future.result(timeout=300) for future in futures]
+
+    for process in completed:
+        assert process.returncode == 0, f"stdout={process.stdout}\nstderr={process.stderr}"
+        assert f"current_revision={_HEAD_REVISION}" in process.stdout
+    assert _sqlite_alembic_revisions(db_path) == [_HEAD_REVISION]
+
+
+@pytest.mark.asyncio
+async def test_schema_ahead_of_build_reports_newer_not_behind(tmp_path: Path, monkeypatch) -> None:
+    db_path = tmp_path / "ahead.sqlite"
+    db_url = f"sqlite+aiosqlite:///{db_path}"
+    run_upgrade(db_url, "head", bootstrap_legacy=True)
+
+    engine = create_async_engine(db_url, future=True)
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(
+                text("UPDATE alembic_version SET version_num = :revision"),
+                {"revision": _FUTURE_REVISION},
+            )
+    finally:
+        await engine.dispose()
+
+    state = inspect_migration_state(db_url)
+    assert state.is_ahead
+    assert state.unknown_revisions == (_FUTURE_REVISION,)
+    assert state.needs_upgrade
+
+    with pytest.raises(MigrationBootstrapError) as upgrade_error:
+        run_upgrade(db_url, "head", bootstrap_legacy=True)
+    upgrade_message = str(upgrade_error.value)
+    assert "not known to this build" in upgrade_message
+    assert _FUTURE_REVISION in upgrade_message
+    assert "Unsupported alembic_version" not in upgrade_message
+
+    import app.db.session as session_module
+
+    monkeypatch.setattr(session_module._settings, "database_url", db_url)
+    monkeypatch.setattr(session_module._settings, "database_migrate_on_startup", False)
+    with pytest.raises(RuntimeError) as startup_error:
+        await session_module.init_db()
+    startup_message = str(startup_error.value)
+    assert "not known to this build" in startup_message
+    assert _FUTURE_REVISION in startup_message
+    assert "behind Alembic head" not in startup_message

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -1662,7 +1662,7 @@ def test_run_upgrade_fails_for_unsupported_alembic_version_id(tmp_path: Path) ->
     with create_engine(sync_url, future=True).begin() as connection:
         connection.execute(text("UPDATE alembic_version SET version_num = 'legacy_custom_999'"))
 
-    with pytest.raises(MigrationBootstrapError, match="Unsupported alembic_version revision ids"):
+    with pytest.raises(MigrationBootstrapError, match="not known to this build"):
         run_upgrade(url, "head", bootstrap_legacy=False)
 
 
@@ -1817,7 +1817,7 @@ def test_ensure_alembic_version_table_capacity_creates_table_when_missing(monkey
     _ensure_alembic_version_table_capacity_for_connection(cast(Connection, connection), required_length=64)
 
     assert connection.executed_sql == [
-        "CREATE TABLE alembic_version ( version_num VARCHAR(64) NOT NULL, PRIMARY KEY (version_num) )"
+        "CREATE TABLE IF NOT EXISTS alembic_version ( version_num VARCHAR(64) NOT NULL, PRIMARY KEY (version_num) )"
     ]
 
 

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -42,6 +42,8 @@ class _FakeMigrationState:
     has_alembic_version_table: bool
     has_legacy_migrations_table: bool
     needs_upgrade: bool
+    unknown_revisions: tuple[str, ...] = ()
+    is_ahead: bool = False
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Why

Every replica runs Alembic `upgrade head` at boot with no cross-process mutual exclusion. Two replicas starting concurrently both read the same current revision and race DDL: the loser dies on duplicate-object errors — including the non-idempotent `CREATE TABLE alembic_version` in the capacity helper and the DELETE+INSERT legacy remap — and crash-loops under the entrypoint's `set -eu`. Separately, migration state inspection is direction-blind (`needs_upgrade = current != head`), so an old binary restarting against a schema migrated by a newer build reports a misleading "schema is behind Alembic head" error, sending operators the wrong way during rollouts.

## What Changes

- New `app/db/migration_lock.py`: a sync `migration_lock(...)` context manager providing a cross-process mutex — PostgreSQL: session-level `pg_try_advisory_lock(hashtext('codex_lb:migrations'))` polled on a dedicated connection held for the whole upgrade; file-backed SQLite: an exclusive `BEGIN IMMEDIATE` transaction on a sentinel `<db_path>.migrate-lock` file; in-memory SQLite/unknown dialects: no-op.
- `run_upgrade()` acquires the lock around its entire sequence; after acquiring it re-inspects migration state and, when the schema is already at head, logs and returns — the losing replica's startup succeeds. Covers both app startup and the container-entrypoint CLI path.
- `stamp_revision()` takes the same lock; the alembic_version capacity helper switches to `CREATE TABLE IF NOT EXISTS` as defense-in-depth.
- New setting `database_migration_lock_timeout_seconds` (default 300.0, env `CODEX_LB_DATABASE_MIGRATION_LOCK_TIMEOUT_SECONDS`); on timeout, a `TimeoutError` names the lock and the setting.
- `MigrationState` gains `unknown_revisions` and `is_ahead`; the schema-ahead case now raises a direction-correct "schema revision(s) are not known to this build" message instead of claiming the schema is behind head.
- Spec deltas in `database-migrations` (two ADDED requirements) plus `context.md` ops notes (per-backend lock mechanism, sentinel-file lifecycle, PgBouncer/NFS caveats).
- No new DB table and no new Alembic revision (the mechanism is a lock, not schema).

## Testing

- `uv run pytest tests/integration/test_migration_serialization.py tests/integration/test_migrations.py tests/unit/test_db_migrate.py tests/unit/test_db_session.py -q` → 90 passed, 5 skipped (PG-only under SQLite).
- PostgreSQL run (`CODEX_LB_TEST_DATABASE_URL=postgresql+asyncpg://...`): `tests/integration/test_migration_serialization.py tests/integration/test_migrations.py -q` → 25 passed, 0 skipped — includes the PG concurrent-race and advisory-lock timeout tests.
- `uv run pytest tests/unit/test_otel.py tests/unit/test_settings_cache.py tests/unit/test_settings_multi_replica.py tests/unit/test_settings_service.py -q` → 62 passed. One pre-existing test failure (capacity CREATE TABLE assertion, missed by an interrupted earlier run) was found and fixed.
- `ruff check` / `ruff format --check` clean; `openspec validate serialize-startup-migrations` valid; `openspec validate --specs` → 31 passed.

## Merge ordering / notes

- Depends on #1252 (OpenSpec SSOT sync) — MODIFIED spec deltas target the synced spec headers.
- No Alembic revision added; safe to land in any order relative to the sibling migration-bearing PRs (and makes their concurrent-startup application safer).
- Part of the 12-change multi-replica reliability effort; resolves no filed issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
