### PR TITLE
fix(quota-planner): make warmup budget and dedup claims atomic across replicas

### DIFF
--- a/app/modules/limit_warmup/repository.py
+++ b/app/modules/limit_warmup/repository.py
@@ -2,17 +2,21 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import func, select, update
+from sqlalchemy import func, insert, literal, select, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db.models import Account, AccountLimitWarmup
+from app.db.models import AccountLimitWarmup
 from app.db.session import sqlite_writer_section
 
 
 class LimitWarmupRepository:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
+
+    def _dialect_name(self) -> str:
+        bind = self._session.get_bind()
+        return bind.dialect.name if bind else "sqlite"
 
     async def latest_by_account(self, account_ids: list[str]) -> dict[str, AccountLimitWarmup]:
         if not account_ids:
@@ -60,35 +64,59 @@ class LimitWarmupRepository:
         reset_at_tolerance_seconds: int = 0,
     ) -> AccountLimitWarmup | None:
         tolerance = max(0, reset_at_tolerance_seconds)
+        table = AccountLimitWarmup.__table__
+        # Single atomic conditional insert: the tolerance-window existence guard
+        # and the insert execute as one statement, so the dedup is effective
+        # across processes and replicas. On SQLite the statement is atomic under
+        # the database-level single-writer lock (the process-local
+        # sqlite_writer_section is kept only as a local write throttle). On
+        # PostgreSQL a single INSERT .. SELECT is not self-sufficient under READ
+        # COMMITTED, so an advisory transaction lock keyed on (account, window)
+        # serializes concurrent attempts first.
+        duplicate_in_tolerance_window = (
+            select(AccountLimitWarmup.id)
+            .where(
+                AccountLimitWarmup.account_id == account_id,
+                AccountLimitWarmup.window == window,
+                AccountLimitWarmup.reset_at.between(reset_at - tolerance, reset_at + tolerance),
+            )
+            .exists()
+        )
+        insert_stmt = (
+            insert(AccountLimitWarmup)
+            .from_select(
+                ["account_id", "window", "reset_at", "status", "model", "attempted_at"],
+                select(
+                    literal(account_id, type_=table.c.account_id.type),
+                    literal(window, type_=table.c.window.type),
+                    literal(reset_at, type_=table.c.reset_at.type),
+                    literal(status, type_=table.c.status.type),
+                    literal(model, type_=table.c.model.type),
+                    literal(attempted_at, type_=table.c.attempted_at.type),
+                ).where(~duplicate_in_tolerance_window),
+            )
+            .returning(AccountLimitWarmup.id)
+        )
         try:
             async with sqlite_writer_section():
-                # Serialize tolerant check-and-insert by account on databases
-                # where the SQLite process-local writer lock does not apply.
-                await self._session.execute(select(Account.id).where(Account.id == account_id).with_for_update())
-                existing = await self._existing_attempt(
-                    account_id=account_id,
-                    window=window,
-                    reset_at=reset_at,
-                    reset_at_tolerance_seconds=tolerance,
-                )
-                if existing is not None:
-                    await self._session.rollback()
-                    return None
-
-                row = AccountLimitWarmup(
-                    account_id=account_id,
-                    window=window,
-                    reset_at=reset_at,
-                    status=status,
-                    model=model,
-                    attempted_at=attempted_at,
-                )
-                self._session.add(row)
+                if self._dialect_name() == "postgresql":
+                    await self._session.execute(
+                        text("SELECT pg_advisory_xact_lock(hashtext(:key))"),
+                        {"key": f"limit_warmup:{account_id}:{window}"},
+                    )
+                inserted_id = await self._session.scalar(insert_stmt)
                 await self._session.commit()
-                await self._session.refresh(row)
         except IntegrityError:
+            # Backstop: the exact-tuple unique constraint
+            # uq_account_limit_warmups_account_window_reset still catches any
+            # duplicate the guard could not see.
             await self._session.rollback()
             return None
+        if inserted_id is None:
+            return None
+        row = await self._session.get(AccountLimitWarmup, inserted_id)
+        if row is not None:
+            await self._session.refresh(row)
         return row
 
     async def complete_attempt(
@@ -121,24 +149,3 @@ class LimitWarmupRepository:
         if row is not None:
             await self._session.refresh(row)
         return row
-
-    async def _existing_attempt(
-        self,
-        *,
-        account_id: str,
-        window: str,
-        reset_at: int,
-        reset_at_tolerance_seconds: int = 0,
-    ) -> AccountLimitWarmup | None:
-        tolerance = max(0, reset_at_tolerance_seconds)
-        stmt = (
-            select(AccountLimitWarmup)
-            .where(
-                AccountLimitWarmup.account_id == account_id,
-                AccountLimitWarmup.window == window,
-                AccountLimitWarmup.reset_at.between(reset_at - tolerance, reset_at + tolerance),
-            )
-            .limit(1)
-        )
-        result = await self._session.execute(stmt)
-        return result.scalar_one_or_none()

--- a/app/modules/quota_planner/repository.py
+++ b/app/modules/quota_planner/repository.py
@@ -4,7 +4,7 @@ from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
-from sqlalchemy import Integer, and_, cast, func, literal, or_, select, text, update
+from sqlalchemy import ColumnElement, Integer, and_, cast, func, literal, or_, select, text, update
 from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -54,6 +54,40 @@ class DemandBin:
 
 
 _WARMUP_BUDGET_LOCK_KEY = "quota_planner:warmup_budget"
+
+
+def _active_warmup_budget_clause(since: datetime) -> ColumnElement[bool]:
+    """Filter warmup decisions consuming the daily count budget since ``since``.
+
+    ``executed`` decisions count by ``executed_at`` (completion time).
+    In-flight ``executing`` decisions count by the claim timestamp that
+    ``claim_warmup_decision`` stamps into ``executed_at`` at the
+    planned -> executing transition — not by ``created_at``, because the
+    scheduler persists future-scheduled decisions whose ``created_at`` can
+    precede the daily boundary; a decision planned before midnight but claimed
+    after midnight must consume the claim day's budget. Executing rows without
+    a claim timestamp (claimed by a version that predates claim stamping) fall
+    back to ``created_at``.
+    """
+    return and_(
+        QuotaPlannerDecision.action == "warmup",
+        or_(
+            and_(
+                QuotaPlannerDecision.status == "executed",
+                QuotaPlannerDecision.executed_at >= since,
+            ),
+            and_(
+                QuotaPlannerDecision.status == "executing",
+                or_(
+                    QuotaPlannerDecision.executed_at >= since,
+                    and_(
+                        QuotaPlannerDecision.executed_at.is_(None),
+                        QuotaPlannerDecision.created_at >= since,
+                    ),
+                ),
+            ),
+        ),
+    )
 
 
 class QuotaPlannerRepository:
@@ -175,8 +209,13 @@ class QuotaPlannerRepository:
         The planned -> executing transition is the single authoritative budget
         enforcement point: one conditional UPDATE whose WHERE clause embeds both
         daily guards. The count budget includes in-flight ``executing`` decisions
-        (by ``created_at``) in addition to ``executed`` ones (by ``executed_at``)
-        so a probe reserves budget the moment it is claimed.
+        in addition to ``executed`` ones so a probe reserves budget the moment it
+        is claimed. The claim stamps its own timestamp into ``executed_at``
+        (overwritten with the completion time when the probe finishes), and
+        executing rows count against the day they were claimed: a decision the
+        scheduler planned before midnight but that is claimed after midnight
+        consumes the new day's budget even though its ``created_at`` is
+        yesterday.
 
         PostgreSQL serializes concurrent claims with ``pg_advisory_xact_lock`` on
         a fixed warmup-budget key (released at commit); under READ COMMITTED two
@@ -191,21 +230,7 @@ class QuotaPlannerRepository:
         """
         since = to_utc_naive(since)
         active_warmups = (
-            select(func.count(QuotaPlannerDecision.id))
-            .where(
-                QuotaPlannerDecision.action == "warmup",
-                or_(
-                    and_(
-                        QuotaPlannerDecision.status == "executed",
-                        QuotaPlannerDecision.executed_at >= since,
-                    ),
-                    and_(
-                        QuotaPlannerDecision.status == "executing",
-                        QuotaPlannerDecision.created_at >= since,
-                    ),
-                ),
-            )
-            .scalar_subquery()
+            select(func.count(QuotaPlannerDecision.id)).where(_active_warmup_budget_clause(since)).scalar_subquery()
         )
         warmup_cost = (
             select(func.coalesce(func.sum(RequestLog.cost_usd), 0.0))
@@ -226,7 +251,7 @@ class QuotaPlannerRepository:
                 active_warmups < max_warmups,
                 warmup_cost < max_credits,
             )
-            .values(status="executing", reason="warmup_executing")
+            .values(status="executing", reason="warmup_executing", executed_at=to_utc_naive(utcnow()))
             .returning(QuotaPlannerDecision.id)
         )
         async with sqlite_writer_section():
@@ -284,25 +309,12 @@ class QuotaPlannerRepository:
         """Count warmup decisions consuming the daily count budget.
 
         Includes ``executed`` decisions (by ``executed_at``) and in-flight
-        ``executing`` decisions (by ``created_at``, which is server-defaulted and
-        always present, unlike ``scheduled_at`` on manual warm-now decisions).
+        ``executing`` decisions by the claim timestamp stamped into
+        ``executed_at`` when they were claimed (see
+        ``_active_warmup_budget_clause``).
         """
         since = to_utc_naive(since)
-        stmt = select(func.count(QuotaPlannerDecision.id)).where(
-            and_(
-                QuotaPlannerDecision.action == "warmup",
-                or_(
-                    and_(
-                        QuotaPlannerDecision.status == "executed",
-                        QuotaPlannerDecision.executed_at >= since,
-                    ),
-                    and_(
-                        QuotaPlannerDecision.status == "executing",
-                        QuotaPlannerDecision.created_at >= since,
-                    ),
-                ),
-            )
-        )
+        stmt = select(func.count(QuotaPlannerDecision.id)).where(_active_warmup_budget_clause(since))
         return int(await self._session.scalar(stmt) or 0)
 
     async def count_executed_warmups_since(self, since: datetime) -> int:

--- a/app/modules/quota_planner/repository.py
+++ b/app/modules/quota_planner/repository.py
@@ -4,7 +4,8 @@ from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
-from sqlalchemy import Integer, and_, cast, func, literal, select, update
+from sqlalchemy import Integer, and_, cast, func, literal, or_, select, text, update
+from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.utils.time import to_utc_naive, utcnow
@@ -52,9 +53,16 @@ class DemandBin:
     request_count: int
 
 
+_WARMUP_BUDGET_LOCK_KEY = "quota_planner:warmup_budget"
+
+
 class QuotaPlannerRepository:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
+
+    def _dialect_name(self) -> str:
+        bind = self._session.get_bind()
+        return bind.dialect.name if bind else "sqlite"
 
     async def get_settings(self) -> PlannerSettings:
         row = await self._session.get(QuotaPlannerSettings, _SETTINGS_ID)
@@ -106,30 +114,41 @@ class QuotaPlannerRepository:
         status: str = "planned",
         executed_at: datetime | None = None,
     ) -> QuotaPlannerDecision:
-        existing = await self._session.scalar(
+        values = {
+            "mode": mode,
+            "action": action,
+            "account_id": account_id,
+            "scheduled_at": _to_db_naive_utc(scheduled_at),
+            "executed_at": _to_db_naive_utc(executed_at),
+            "score": score,
+            "reason": reason,
+            "forecast_snapshot_hash": forecast_snapshot_hash,
+            "state_before_json": state_before_json,
+            "state_after_json": state_after_json,
+            "status": status,
+            "idempotency_key": idempotency_key,
+        }
+        # Idempotency-key upsert: concurrent writers (e.g. overlapping planner
+        # leaders during a leadership handover) converge on the surviving row
+        # instead of raising IntegrityError and aborting the planning tick.
+        if self._dialect_name() == "postgresql":
+            insert_stmt = postgresql.insert(QuotaPlannerDecision).values(**values)
+        else:
+            insert_stmt = sqlite.insert(QuotaPlannerDecision).values(**values)
+        stmt = insert_stmt.on_conflict_do_nothing(index_elements=["idempotency_key"]).returning(QuotaPlannerDecision.id)
+        async with sqlite_writer_section():
+            inserted_id = await self._session.scalar(stmt)
+            await self._session.commit()
+        if inserted_id is not None:
+            row = await self._session.get(QuotaPlannerDecision, inserted_id)
+            if row is not None:
+                return row
+        surviving = await self._session.scalar(
             select(QuotaPlannerDecision).where(QuotaPlannerDecision.idempotency_key == idempotency_key)
         )
-        if existing is not None:
-            return existing
-        row = QuotaPlannerDecision(
-            mode=mode,
-            action=action,
-            account_id=account_id,
-            scheduled_at=_to_db_naive_utc(scheduled_at),
-            executed_at=_to_db_naive_utc(executed_at),
-            score=score,
-            reason=reason,
-            forecast_snapshot_hash=forecast_snapshot_hash,
-            state_before_json=state_before_json,
-            state_after_json=state_after_json,
-            status=status,
-            idempotency_key=idempotency_key,
-        )
-        self._session.add(row)
-        async with sqlite_writer_section():
-            await self._session.commit()
-            await self._session.refresh(row)
-        return row
+        if surviving is None:
+            raise RuntimeError(f"Quota planner decision vanished for idempotency key {idempotency_key!r}")
+        return surviving
 
     async def recent_decisions(self, limit: int = 50) -> list[QuotaPlannerDecision]:
         stmt = select(QuotaPlannerDecision).order_by(QuotaPlannerDecision.created_at.desc()).limit(limit)
@@ -138,6 +157,93 @@ class QuotaPlannerRepository:
 
     async def get_decision(self, decision_id: str) -> QuotaPlannerDecision | None:
         return await self._session.get(QuotaPlannerDecision, decision_id)
+
+    async def get_decision_fresh(self, decision_id: str) -> QuotaPlannerDecision | None:
+        """Re-read a decision bypassing the identity map (fresh DB state)."""
+        return await self._session.get(QuotaPlannerDecision, decision_id, populate_existing=True)
+
+    async def claim_warmup_decision(
+        self,
+        decision_id: str,
+        *,
+        since: datetime,
+        max_warmups: int,
+        max_credits: float,
+    ) -> QuotaPlannerDecision | None:
+        """Atomically claim a planned warmup decision within the daily budgets.
+
+        The planned -> executing transition is the single authoritative budget
+        enforcement point: one conditional UPDATE whose WHERE clause embeds both
+        daily guards. The count budget includes in-flight ``executing`` decisions
+        (by ``created_at``) in addition to ``executed`` ones (by ``executed_at``)
+        so a probe reserves budget the moment it is claimed.
+
+        PostgreSQL serializes concurrent claims with ``pg_advisory_xact_lock`` on
+        a fixed warmup-budget key (released at commit); under READ COMMITTED two
+        concurrent UPDATEs on different decision rows would otherwise each
+        evaluate the count subquery against their own snapshot and could both
+        pass. SQLite needs no lock: the whole UPDATE (subqueries included)
+        executes atomically under SQLite's database-level single-writer lock,
+        safe across processes sharing one file.
+
+        Returns the claimed decision, or ``None`` when the claim was refused
+        (already claimed elsewhere, or a budget guard failed).
+        """
+        since = to_utc_naive(since)
+        active_warmups = (
+            select(func.count(QuotaPlannerDecision.id))
+            .where(
+                QuotaPlannerDecision.action == "warmup",
+                or_(
+                    and_(
+                        QuotaPlannerDecision.status == "executed",
+                        QuotaPlannerDecision.executed_at >= since,
+                    ),
+                    and_(
+                        QuotaPlannerDecision.status == "executing",
+                        QuotaPlannerDecision.created_at >= since,
+                    ),
+                ),
+            )
+            .scalar_subquery()
+        )
+        warmup_cost = (
+            select(func.coalesce(func.sum(RequestLog.cost_usd), 0.0))
+            .where(
+                and_(
+                    RequestLog.request_kind == "warmup",
+                    RequestLog.requested_at >= since,
+                    RequestLog.deleted_at.is_(None),
+                )
+            )
+            .scalar_subquery()
+        )
+        stmt = (
+            update(QuotaPlannerDecision)
+            .where(
+                QuotaPlannerDecision.id == decision_id,
+                QuotaPlannerDecision.status == "planned",
+                active_warmups < max_warmups,
+                warmup_cost < max_credits,
+            )
+            .values(status="executing", reason="warmup_executing")
+            .returning(QuotaPlannerDecision.id)
+        )
+        async with sqlite_writer_section():
+            # Issue the claim at the start of a fresh transaction so its
+            # statement snapshot (and, on PostgreSQL, the advisory lock scope)
+            # is not tied to earlier reads on this session.
+            await self._session.commit()
+            if self._dialect_name() == "postgresql":
+                await self._session.execute(
+                    text("SELECT pg_advisory_xact_lock(hashtext(:key))"),
+                    {"key": _WARMUP_BUDGET_LOCK_KEY},
+                )
+            claimed_id = await self._session.scalar(stmt)
+            await self._session.commit()
+        if claimed_id is None:
+            return None
+        return await self._session.get(QuotaPlannerDecision, claimed_id, populate_existing=True)
 
     async def update_decision_status(
         self,
@@ -173,6 +279,31 @@ class QuotaPlannerRepository:
             return None
         await self._session.refresh(row)
         return row
+
+    async def count_active_warmups_since(self, since: datetime) -> int:
+        """Count warmup decisions consuming the daily count budget.
+
+        Includes ``executed`` decisions (by ``executed_at``) and in-flight
+        ``executing`` decisions (by ``created_at``, which is server-defaulted and
+        always present, unlike ``scheduled_at`` on manual warm-now decisions).
+        """
+        since = to_utc_naive(since)
+        stmt = select(func.count(QuotaPlannerDecision.id)).where(
+            and_(
+                QuotaPlannerDecision.action == "warmup",
+                or_(
+                    and_(
+                        QuotaPlannerDecision.status == "executed",
+                        QuotaPlannerDecision.executed_at >= since,
+                    ),
+                    and_(
+                        QuotaPlannerDecision.status == "executing",
+                        QuotaPlannerDecision.created_at >= since,
+                    ),
+                ),
+            )
+        )
+        return int(await self._session.scalar(stmt) or 0)
 
     async def count_executed_warmups_since(self, since: datetime) -> int:
         since = to_utc_naive(since)

--- a/app/modules/quota_planner/warmup.py
+++ b/app/modules/quota_planner/warmup.py
@@ -126,22 +126,14 @@ class QuotaWarmupService:
             )
         assert account is not None
 
-        claimed = await self._planner.update_decision_status(
+        claimed = await self._planner.claim_warmup_decision(
             decision.id,
-            status="executing",
-            reason="warmup_executing",
-            expected_status="planned",
+            since=_local_midnight(),
+            max_warmups=settings.max_warmups_per_day,
+            max_credits=settings.max_warmup_credits_per_day,
         )
         if claimed is None:
-            current = await self._planner.get_decision(decision.id)
-            if current is None:
-                return WarmupExecutionResult(decision_id=decision.id, status="skipped", reason="decision_missing")
-            return WarmupExecutionResult(
-                decision_id=current.id,
-                status=current.status,
-                reason=current.reason or f"decision_{current.status}",
-                executed_at=current.executed_at,
-            )
+            return await self._resolve_refused_claim(decision_id=decision.id, settings=settings)
 
         reservation_id: str | None = None
         if api_key_id is not None:
@@ -314,6 +306,49 @@ class QuotaWarmupService:
         except Exception:
             logger.exception("Failed to record quota warmup effect", extra={"account_id": account.id, "model": model})
 
+    async def _resolve_refused_claim(
+        self,
+        *,
+        decision_id: str,
+        settings: PlannerSettings,
+    ) -> WarmupExecutionResult:
+        """Map a refused planned -> executing claim to a decision outcome.
+
+        The claim UPDATE returns no row either because a concurrent worker
+        already moved the decision out of ``planned`` or because a daily budget
+        guard failed. Re-read the decision fresh (the identity map may hold a
+        stale snapshot) to distinguish the two, then re-run the budget counts to
+        pick the matching budget-exhausted reason.
+        """
+        current = await self._planner.get_decision_fresh(decision_id)
+        if current is None:
+            return WarmupExecutionResult(decision_id=decision_id, status="skipped", reason="decision_missing")
+        if current.status != "planned":
+            return WarmupExecutionResult(
+                decision_id=current.id,
+                status=current.status,
+                reason=current.reason or f"decision_{current.status}",
+                executed_at=current.executed_at,
+            )
+        today = _local_midnight()
+        active_today = await self._planner.count_active_warmups_since(today)
+        if active_today >= settings.max_warmups_per_day:
+            reason = "daily_warmup_count_budget_exhausted"
+        else:
+            reason = "daily_warmup_credit_budget_exhausted"
+        row = await self._planner.update_decision_status(
+            decision_id,
+            status="skipped",
+            reason=reason,
+            expected_status="planned",
+        )
+        return await self._result_from_update_or_current(
+            decision_id=decision_id,
+            row=row,
+            fallback_status="skipped",
+            fallback_reason=reason,
+        )
+
     async def _result_from_update_or_current(
         self,
         *,
@@ -379,9 +414,11 @@ class QuotaWarmupService:
         if latest is not None and latest.reset_at is not None and latest.reset_at > int(utcnow().timestamp()):
             return False, "account_window_already_active"
 
-        today = utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
-        executed_today = await self._planner.count_executed_warmups_since(today)
-        if executed_today >= settings.max_warmups_per_day:
+        # Advisory pre-check only: the authoritative budget enforcement happens
+        # inside the atomic planned -> executing claim (claim_warmup_decision).
+        today = _local_midnight()
+        active_today = await self._planner.count_active_warmups_since(today)
+        if active_today >= settings.max_warmups_per_day:
             return False, "daily_warmup_count_budget_exhausted"
         spent_today = await self._planner.warmup_cost_since(today)
         if settings.max_warmup_credits_per_day <= 0 or spent_today >= settings.max_warmup_credits_per_day:
@@ -453,6 +490,10 @@ class QuotaWarmupService:
             primary_reset_at=observed_after.reset_at if observed_after else None,
             confidence=effective_confidence,
         )
+
+
+def _local_midnight() -> datetime:
+    return utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
 
 
 def _usage_history_is_fresh(before: object | None, after: object | None) -> bool:

--- a/openspec/changes/atomic-quota-warmup-claims/design.md
+++ b/openspec/changes/atomic-quota-warmup-claims/design.md
@@ -1,0 +1,165 @@
+# Design: atomic-quota-warmup-claims
+
+## Context
+
+Three verified race conditions in warmup execution paths, all triggered by
+multi-replica (or multi-process SQLite) deployments:
+
+1. `QuotaWarmupService._execution_gate` reads
+   `count_executed_warmups_since(today)` and `warmup_cost_since(today)` and
+   compares them to `max_warmups_per_day` / `max_warmup_credits_per_day`
+   before executing. Nothing serializes this across replicas, and decisions
+   currently `executing` are invisible to the gate.
+2. `LimitWarmupRepository.try_create_attempt` serializes its tolerant
+   check-and-insert with `SELECT .. FOR UPDATE` (a no-op on SQLite) plus a
+   per-process anyio lock; two processes sharing one SQLite file can both
+   insert near-duplicate attempts within the reset_at tolerance window.
+3. `QuotaPlannerRepository.log_decision` is SELECT-then-INSERT on a UNIQUE
+   `idempotency_key`; a concurrent writer raises an unhandled
+   `IntegrityError` that aborts the rest of `run_once`.
+
+## Decisions
+
+### 1. Budget claim = conditional UPDATE with embedded guards (no ledger table)
+
+`QuotaWarmupService.warm_now` claims via a new repo method
+`claim_warmup_decision(decision_id, *, since, max_warmups, max_credits)`:
+
+```sql
+UPDATE quota_planner_decisions
+SET status='executing', reason='warmup_executing'
+WHERE id=:id AND status='planned'
+  AND (SELECT count(*) FROM quota_planner_decisions d
+       WHERE d.action='warmup'
+         AND ((d.status='executed' AND d.executed_at >= :since)
+           OR (d.status='executing' AND d.created_at >= :since))) < :max_warmups
+  AND (SELECT coalesce(sum(cost_usd), 0.0) FROM request_logs
+       WHERE request_kind='warmup' AND requested_at >= :since
+         AND deleted_at IS NULL) < :max_credits
+RETURNING id
+```
+
+Backend split:
+
+- **PostgreSQL**: `SELECT pg_advisory_xact_lock(hashtext('quota_planner:warmup_budget'))`
+  executes in the same transaction immediately before the UPDATE. Required
+  because under READ COMMITTED two concurrent UPDATEs on *different* decision
+  rows each evaluate the count subquery against their own snapshot and could
+  both pass; the xact lock serializes claims and releases at commit, so the
+  second claimant's statement snapshot sees the first's committed
+  `executing` row.
+- **SQLite**: no lock needed — the whole UPDATE (subqueries included)
+  executes atomically under SQLite's database-level single-writer lock, safe
+  across processes sharing the file (same argument as
+  `DatabaseRateLimiter.check_and_increment`). The claim is issued at the
+  start of a fresh transaction (any open transaction on the session is
+  committed first) and committed immediately, matching the existing
+  `update_decision_status` commit-per-op pattern and avoiding stale-snapshot
+  BUSY errors under WAL.
+
+Rejected alternatives: (a) budget-ledger row with CAS — new table +
+migration + midnight-rollover logic for no added safety; (b) advisory lock
+around the existing separate gate reads — fixes PG but leaves SQLite
+cross-process racy since plain SELECTs take no write lock; (c) counting
+`executing` rows by `scheduled_at` — executing rows may have NULL
+`scheduled_at` on manual warm-now; `created_at` is server-defaulted and
+always present.
+
+Failure-reason mapping: when the claim UPDATE returns no row, re-read the
+decision with `populate_existing` (the identity map may hold a stale
+snapshot); if `status != 'planned'` it was a concurrent claim (return that
+status, existing behavior); if still `planned`, re-run the count to pick
+`daily_warmup_count_budget_exhausted` vs
+`daily_warmup_credit_budget_exhausted` and CAS the decision to `skipped`
+with `expected_status='planned'`.
+
+`_execution_gate` keeps its cheap non-budget checks and an advisory
+(non-authoritative) budget pre-check for friendly early skips; the pre-check
+now uses `count_active_warmups_since` (executing + executed) so in-flight
+probes are visible even before the claim. `count_executed_warmups_since`
+stays for display.
+
+Accepted residuals (documented in context.md):
+
+- A replica that crashes mid-probe leaves an `executing` decision consuming
+  one count-budget slot until local midnight — conservative direction
+  (under-spend, never over-spend).
+- The credit budget still cannot see cost of in-flight probes (rows land
+  post-completion); the read-check race is closed on both backends and
+  overshoot is bounded by remaining count budget x per-probe cost
+  (~32 input / 8 output tokens).
+
+### 2. try_create_attempt = single conditional INSERT..SELECT
+
+Replace the FOR UPDATE + `_existing_attempt` + add with:
+
+```sql
+INSERT INTO account_limit_warmups (account_id, window, reset_at, status, model, attempted_at)
+SELECT :vals WHERE NOT EXISTS (
+  SELECT 1 FROM account_limit_warmups
+  WHERE account_id=:a AND window=:w
+    AND reset_at BETWEEN :reset_at - :tol AND :reset_at + :tol)
+RETURNING id
+```
+
+- **SQLite**: atomic under the single-writer lock across processes, fixing
+  the FOR UPDATE no-op without relying on the per-process
+  `sqlite_writer_section` (kept only as a local write-throttle).
+- **PostgreSQL**: a single INSERT..SELECT is NOT self-sufficient under READ
+  COMMITTED (two concurrent statements can both pass NOT EXISTS), so take
+  `pg_advisory_xact_lock(hashtext('limit_warmup:' || :account_id || ':' || :window))`
+  first — replacing the per-account-row FOR UPDATE with the repo's
+  established advisory-lock idiom, narrowed to (account, window).
+
+Keep the IntegrityError -> rollback -> None fallback (exact-key constraint
+`uq_account_limit_warmups_account_window_reset` remains the backstop).
+Rejected: bucketed generated-column unique constraint — needs a migration on
+both backends and fails when reset_at values straddle a bucket boundary
+while still inside the tolerance (e.g. R=999, R'=1001, tolerance 5); the
+BETWEEN guard has no boundary hole.
+
+### 3. log_decision = ON CONFLICT DO NOTHING upsert
+
+Use `sqlalchemy.dialects.postgresql.insert` / `sqlite.insert`
+(dialect-dispatched like `aggregate_demand_bins` already does) with
+`on_conflict_do_nothing(index_elements=['idempotency_key'])` + RETURNING id;
+when no row returns, SELECT the surviving row by `idempotency_key`. Both
+backends support this natively (SQLite >= 3.24). Concurrent leaders converge
+on one row; `run_once` no longer aborts mid-tick. Rejected: try/except
+IntegrityError retry — leaves the session in a rolled-back state mid-tick.
+
+### 4. No migration, no new tables
+
+This change adds no Alembic revision; existing tables/columns suffice, so
+there is no chaining or single-head risk with parallel branches.
+
+### 5. Performance
+
+Zero hot-proxy-path impact — all touched code runs in the quota-planner
+scheduler tick (300s), the dashboard warm-now route, and the usage-refresh
+warmup evaluation. PG adds one advisory-lock round-trip per warmup claim /
+per attempt insert; log_decision goes from 2 statements to 1-2.
+
+## Deviations from the reviewed design
+
+- The original reviewed design artifact (scratchpad JSON) was lost when the
+  first implementation session was interrupted; this design.md, written by
+  that session from the same artifact, is the surviving authoritative record
+  and the implementation follows it.
+- Test plan item (e) called for an additional service-level limit-warmup
+  test asserting only one `_send_warmup` task is spawned; the repository is
+  the enforcement point and is covered with two-replica regression tests at
+  the repository product path (the scheduler wrapper delegates 1:1), so the
+  service-level duplicate-task assertion is left as a follow-up.
+- The concurrent count-budget race test lets the second replica be refused
+  at the (now in-flight-aware) gate rather than forcing both legs past the
+  gate simultaneously; a separate claim-level test patches the gate to
+  simulate simultaneous stale gate reads so the UPDATE guard itself is
+  exercised for the credit budget, and an in-flight-`executing` test
+  exercises the count guard directly at the claim.
+- Regression tests simulate two processes by patching the module-level
+  `sqlite_writer_section` binding to a no-op (separate processes never share
+  that lock); the three product-path tests were verified to fail against the
+  pre-change code (two near-duplicate warm-up attempts persisted, both
+  replicas' probes sent past the count budget, duplicate idempotency-key
+  insert raised).

--- a/openspec/changes/atomic-quota-warmup-claims/design.md
+++ b/openspec/changes/atomic-quota-warmup-claims/design.md
@@ -27,17 +27,29 @@ multi-replica (or multi-process SQLite) deployments:
 
 ```sql
 UPDATE quota_planner_decisions
-SET status='executing', reason='warmup_executing'
+SET status='executing', reason='warmup_executing', executed_at=:claimed_at
 WHERE id=:id AND status='planned'
   AND (SELECT count(*) FROM quota_planner_decisions d
        WHERE d.action='warmup'
          AND ((d.status='executed' AND d.executed_at >= :since)
-           OR (d.status='executing' AND d.created_at >= :since))) < :max_warmups
+           OR (d.status='executing'
+               AND (d.executed_at >= :since
+                 OR (d.executed_at IS NULL AND d.created_at >= :since))))) < :max_warmups
   AND (SELECT coalesce(sum(cost_usd), 0.0) FROM request_logs
        WHERE request_kind='warmup' AND requested_at >= :since
          AND deleted_at IS NULL) < :max_credits
 RETURNING id
 ```
+
+The claim stamps its own timestamp into `executed_at` (no new column; the
+completion/failure transition overwrites it with the final execution time), so
+in-flight `executing` rows count against the day they were **claimed**. The
+scheduler persists future-scheduled decisions whose `created_at` can precede
+the daily boundary; counting executing rows by `created_at` let a decision
+planned before midnight but claimed after midnight escape the new day's count
+budget and reopen the double-spend window. The `executed_at IS NULL AND
+created_at >= :since` arm only covers legacy executing rows claimed by a
+version that predates claim stamping (e.g. during a rolling upgrade).
 
 Backend split:
 
@@ -62,8 +74,12 @@ migration + midnight-rollover logic for no added safety; (b) advisory lock
 around the existing separate gate reads — fixes PG but leaves SQLite
 cross-process racy since plain SELECTs take no write lock; (c) counting
 `executing` rows by `scheduled_at` — executing rows may have NULL
-`scheduled_at` on manual warm-now; `created_at` is server-defaulted and
-always present.
+`scheduled_at` on manual warm-now; (d) counting `executing` rows by
+`created_at` — server-defaulted and always present, but keyed to the decision
+creation day rather than the claim day, so scheduler-planned decisions
+crossing midnight escaped the count guard; (e) a dedicated `claimed_at`
+column — needs a migration for a timestamp `executed_at` already represents
+once the claim stamps it.
 
 Failure-reason mapping: when the claim UPDATE returns no row, re-read the
 decision with `populate_existing` (the identity map may hold a stale

--- a/openspec/changes/atomic-quota-warmup-claims/proposal.md
+++ b/openspec/changes/atomic-quota-warmup-claims/proposal.md
@@ -1,0 +1,48 @@
+# Atomic Quota and Warmup Budget Claims
+
+## Why
+
+Warmup execution can double-spend real account quota and operator credit
+budgets in multi-replica deployments. The quota-planner daily budget gate is a
+non-atomic check-then-act that counts only `executed` decisions and cost rows
+written after completion, so concurrent claims (leader scheduler plus
+`POST /api/quota-planner/warm-now` on any replica) both pass at budget-1 and
+in-flight `executing` probes are invisible. Limit-warmup dedup relies on
+`SELECT .. FOR UPDATE` (a no-op on SQLite) plus a per-process lock, so two
+processes sharing one SQLite file can insert near-duplicate attempts whose
+`reset_at` drifted within the tolerance window and both send real probes.
+Finally, `QuotaPlannerRepository.log_decision` is SELECT-then-INSERT on a
+UNIQUE `idempotency_key`; concurrent leaders raise an unhandled
+`IntegrityError` that aborts the rest of the planning tick, dropping due
+warmups for other accounts.
+
+## What Changes
+
+- Make the quota-planner planned->executing claim the single authoritative
+  budget enforcement point: one conditional UPDATE whose WHERE clause embeds
+  both daily budget guards, serialized on PostgreSQL by
+  `pg_advisory_xact_lock` on a fixed warmup-budget key and on SQLite by
+  single-statement single-writer atomicity.
+- Count in-flight work: the budget count includes `status='executing'`
+  decisions (by `created_at >= since`) in addition to `status='executed'`
+  (by `executed_at >= since`), so a probe reserves budget when claimed, not
+  after it finishes.
+- Replace `LimitWarmupRepository.try_create_attempt`'s FOR UPDATE +
+  SELECT-then-INSERT with a single conditional
+  `INSERT .. SELECT .. WHERE NOT EXISTS(tolerance-window match)`;
+  PostgreSQL additionally takes `pg_advisory_xact_lock` keyed on
+  `(account_id, window)`. No new unique constraint.
+- Convert `QuotaPlannerRepository.log_decision` to a dialect upsert
+  (`INSERT .. ON CONFLICT (idempotency_key) DO NOTHING` plus a fetch of the
+  surviving row) so concurrent writers converge instead of raising and
+  aborting the tick.
+- No Alembic migration: existing tables and columns suffice.
+
+## Impact
+
+- Affected specs: `quota-phase-planner`, `usage-refresh-policy`
+- Affected code: `app/modules/quota_planner/repository.py`,
+  `app/modules/quota_planner/warmup.py`,
+  `app/modules/limit_warmup/repository.py`
+- Operator-visible: daily warmup count/credit caps hold under concurrent
+  replicas; duplicate-key planner ticks no longer abort mid-tick.

--- a/openspec/changes/atomic-quota-warmup-claims/proposal.md
+++ b/openspec/changes/atomic-quota-warmup-claims/proposal.md
@@ -24,9 +24,13 @@ warmups for other accounts.
   `pg_advisory_xact_lock` on a fixed warmup-budget key and on SQLite by
   single-statement single-writer atomicity.
 - Count in-flight work: the budget count includes `status='executing'`
-  decisions (by `created_at >= since`) in addition to `status='executed'`
-  (by `executed_at >= since`), so a probe reserves budget when claimed, not
-  after it finishes.
+  decisions in addition to `status='executed'` (by `executed_at >= since`),
+  so a probe reserves budget when claimed, not after it finishes. The claim
+  stamps its own timestamp into `executed_at` (overwritten with the completion
+  time when the probe finishes), and executing rows count against the day they
+  were claimed, with a `created_at` fallback for legacy executing rows claimed
+  before stamping existed — `created_at` alone would let a decision planned
+  before midnight but claimed after midnight escape the new day's budget.
 - Replace `LimitWarmupRepository.try_create_attempt`'s FOR UPDATE +
   SELECT-then-INSERT with a single conditional
   `INSERT .. SELECT .. WHERE NOT EXISTS(tolerance-window match)`;

--- a/openspec/changes/atomic-quota-warmup-claims/specs/quota-phase-planner/spec.md
+++ b/openspec/changes/atomic-quota-warmup-claims/specs/quota-phase-planner/spec.md
@@ -1,0 +1,89 @@
+# Delta Specification: quota-phase-planner
+
+## MODIFIED Requirements
+
+### Requirement: Warmup decisions are claimed before synthetic traffic
+
+Warmup execution SHALL atomically transition a planned decision to `executing`
+before reserving API-key budget or sending synthetic probe traffic, and that
+transition SHALL be the single authoritative enforcement point for the daily
+warmup count and credit budgets: the claim statement MUST evaluate the
+`planned` status precondition and both budget guards atomically, so concurrent
+claimants on other replicas or processes cannot exceed either budget. The
+count-budget guard MUST include in-flight `executing` warmup decisions in
+addition to `executed` ones, so a probe reserves budget when it is claimed
+rather than after it completes. On PostgreSQL, concurrent claims MUST be
+serialized (a transaction-scoped advisory lock on a fixed warmup-budget key)
+so two claims cannot both evaluate the budget against a stale snapshot; on
+SQLite the claim MUST execute as a single statement under the database-level
+writer lock. When a claim is refused because a budget guard failed, the
+decision MUST be skipped with a reason that distinguishes the exhausted count
+budget from the exhausted credit budget. Final outcomes such as `executed`,
+`failed`, or API-key skip reasons MUST only update decisions that are still
+`executing`. Cancellation MUST only update decisions that are still queued or
+skipped and MUST NOT cancel an in-flight `executing` decision.
+
+#### Scenario: Planned warmup is claimed before probe send
+
+- **GIVEN** a planned warmup decision is eligible to run
+- **WHEN** warm-now starts sending the synthetic probe
+- **THEN** the persisted decision status is already `executing`
+- **AND** a concurrent worker cannot claim the same planned decision
+
+#### Scenario: Concurrent claims cannot exceed the daily count budget
+
+- **GIVEN** two replicas each hold a planned warmup decision
+- **AND** one warmup remains in the daily count budget
+- **WHEN** both replicas execute warm-now concurrently
+- **THEN** exactly one decision transitions to `executing` and sends a probe
+- **AND** the other decision is skipped with reason
+  `daily_warmup_count_budget_exhausted`
+
+#### Scenario: In-flight executing warmups reserve count budget
+
+- **GIVEN** a warmup decision claimed today is still `executing`
+- **AND** the daily count budget allows one warmup
+- **WHEN** another replica attempts to claim a planned warmup decision
+- **THEN** the claim is refused
+- **AND** the planned decision does not transition to `executing`
+
+#### Scenario: Claim is refused when the credit budget is spent
+
+- **GIVEN** warmup request logs recorded today already meet the daily credit
+  budget
+- **WHEN** a planned warmup decision is claimed after its execution gate read
+  stale budget state
+- **THEN** the claim is refused before any probe is sent
+- **AND** the decision is skipped with reason
+  `daily_warmup_credit_budget_exhausted`
+
+#### Scenario: Executing warmup cannot be canceled
+
+- **GIVEN** a warmup decision is already `executing`
+- **WHEN** an operator requests cancellation
+- **THEN** the decision remains `executing`
+- **AND** the response reports that the decision is not cancelable
+
+## ADDED Requirements
+
+### Requirement: Concurrent decision logging converges on idempotency keys
+
+The planner decision log SHALL treat `idempotency_key` as a convergence point:
+when multiple writers concurrently record a decision with the same idempotency
+key, exactly one decision row SHALL persist and every writer MUST receive that
+surviving row. A duplicate-key collision MUST NOT surface as an unhandled
+integrity error that aborts the remainder of a planning tick.
+
+#### Scenario: Two replicas log the same decision key concurrently
+
+- **GIVEN** two planner replicas derive the same decision idempotency key
+- **WHEN** both log the decision concurrently against one database
+- **THEN** exactly one decision row persists for that key
+- **AND** both replicas receive the surviving decision without raising
+
+#### Scenario: Duplicate keys do not abort the planning tick
+
+- **GIVEN** a planning tick logs decisions for several due accounts
+- **WHEN** one decision's idempotency key was concurrently inserted by another
+  writer
+- **THEN** the tick continues logging the remaining accounts' decisions

--- a/openspec/changes/atomic-quota-warmup-claims/specs/quota-phase-planner/spec.md
+++ b/openspec/changes/atomic-quota-warmup-claims/specs/quota-phase-planner/spec.md
@@ -12,7 +12,11 @@ warmup count and credit budgets: the claim statement MUST evaluate the
 claimants on other replicas or processes cannot exceed either budget. The
 count-budget guard MUST include in-flight `executing` warmup decisions in
 addition to `executed` ones, so a probe reserves budget when it is claimed
-rather than after it completes. On PostgreSQL, concurrent claims MUST be
+rather than after it completes. The claim MUST record its own timestamp on the
+decision, and in-flight `executing` decisions MUST count against the budget
+day in which they were claimed — not the day the decision row was created —
+so a decision planned before the daily boundary but claimed after it consumes
+the claim day's budget. On PostgreSQL, concurrent claims MUST be
 serialized (a transaction-scoped advisory lock on a fixed warmup-budget key)
 so two claims cannot both evaluate the budget against a stale snapshot; on
 SQLite the claim MUST execute as a single statement under the database-level
@@ -46,6 +50,16 @@ skipped and MUST NOT cancel an in-flight `executing` decision.
 - **WHEN** another replica attempts to claim a planned warmup decision
 - **THEN** the claim is refused
 - **AND** the planned decision does not transition to `executing`
+
+#### Scenario: Warmup planned yesterday but claimed today consumes today's budget
+
+- **GIVEN** a warmup decision the scheduler persisted before the daily boundary
+  with a future `scheduled_at`
+- **AND** the daily count budget allows one warmup
+- **WHEN** the decision is claimed after the daily boundary
+- **THEN** the claimed `executing` decision counts against the new day's budget
+- **AND** a subsequent claim of another planned decision on the same day is
+  refused
 
 #### Scenario: Claim is refused when the credit budget is spent
 

--- a/openspec/changes/atomic-quota-warmup-claims/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/atomic-quota-warmup-claims/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,33 @@
+# Delta Specification: usage-refresh-policy
+
+## ADDED Requirements
+
+### Requirement: Warm-up attempt dedup is atomic across processes
+
+Limit warm-up attempt deduplication SHALL be enforced by the database as a
+single atomic statement so that it holds across replicas and across processes
+sharing one SQLite file: the tolerance-window duplicate check and the attempt
+insert MUST NOT be separable into a check-then-act sequence observable by
+concurrent writers, and on PostgreSQL concurrent attempt inserts for the same
+account and window MUST be serialized. Two warm-up attempts whose `reset_at`
+values differ by no more than the configured tolerance MUST NOT both persist
+for the same account and window. Per-process locks MAY additionally throttle
+local writes but MUST NOT be the mechanism that guarantees dedup.
+
+#### Scenario: Two processes observe near-duplicate reset candidates
+
+- **GIVEN** two refresh workers in separate processes share one database
+- **AND** both observe the same account and window with `reset_at` values that
+  differ by less than the configured tolerance
+- **WHEN** both record a warm-up attempt concurrently
+- **THEN** at most one attempt row persists for that account/window tolerance
+  window
+- **AND** the losing worker receives no attempt and sends no warm-up probe
+
+#### Scenario: Exact-tuple duplicates remain constrained
+
+- **GIVEN** a warm-up attempt already persists for an account, window, and
+  `reset_at` tuple
+- **WHEN** another worker inserts the identical tuple despite the atomic guard
+- **THEN** the unique constraint rejects the duplicate
+- **AND** the worker treats the rejection as a dedup skip rather than an error

--- a/openspec/changes/atomic-quota-warmup-claims/tasks.md
+++ b/openspec/changes/atomic-quota-warmup-claims/tasks.md
@@ -9,8 +9,10 @@
       on single-statement single-writer atomicity; issue the claim in a fresh
       transaction and commit immediately.
 - [x] 1.2 Add `count_active_warmups_since(since)` counting `executed` (by
-      `executed_at`) plus in-flight `executing` (by `created_at`) warmup
-      decisions; keep `count_executed_warmups_since` for display.
+      `executed_at`) plus in-flight `executing` warmup decisions by the claim
+      timestamp the claim stamps into `executed_at` (with a `created_at`
+      fallback for legacy executing rows without a claim stamp); keep
+      `count_executed_warmups_since` for display.
 - [x] 1.3 Add `get_decision_fresh(decision_id)` (identity-map bypass via
       `populate_existing`) for post-refusal re-reads.
 - [x] 1.4 Convert `log_decision` to a dialect-dispatched
@@ -45,6 +47,9 @@
       concurrent `log_decision` on one idempotency key converges without
       aborting, and two-process limit-warmup attempts within the reset_at
       tolerance dedup to a single row.
+- [x] 4.3 Cross-midnight regression: a warmup decision created before the
+      daily boundary but claimed after it counts against the claim day's
+      budget and blocks a second same-day claim.
 - [x] 4.2 Update the existing bound-parameter regression test for
       `log_decision`'s new insert construct.
 

--- a/openspec/changes/atomic-quota-warmup-claims/tasks.md
+++ b/openspec/changes/atomic-quota-warmup-claims/tasks.md
@@ -1,0 +1,56 @@
+# Tasks: atomic-quota-warmup-claims
+
+## 1. Quota planner repository
+
+- [x] 1.1 Add `claim_warmup_decision(decision_id, *, since, max_warmups, max_credits)`:
+      one conditional `UPDATE .. SET status='executing'` whose WHERE clause embeds
+      the `planned` precondition plus both daily budget guards; PostgreSQL takes
+      `pg_advisory_xact_lock` on the fixed warmup-budget key first, SQLite relies
+      on single-statement single-writer atomicity; issue the claim in a fresh
+      transaction and commit immediately.
+- [x] 1.2 Add `count_active_warmups_since(since)` counting `executed` (by
+      `executed_at`) plus in-flight `executing` (by `created_at`) warmup
+      decisions; keep `count_executed_warmups_since` for display.
+- [x] 1.3 Add `get_decision_fresh(decision_id)` (identity-map bypass via
+      `populate_existing`) for post-refusal re-reads.
+- [x] 1.4 Convert `log_decision` to a dialect-dispatched
+      `INSERT .. ON CONFLICT (idempotency_key) DO NOTHING` upsert that returns
+      the surviving row instead of raising `IntegrityError` mid-tick.
+
+## 2. Warmup service
+
+- [x] 2.1 Replace the unguarded `update_decision_status(planned -> executing)`
+      in `warm_now` with `claim_warmup_decision`.
+- [x] 2.2 Downgrade the `_execution_gate` budget reads to an advisory pre-check
+      that uses `count_active_warmups_since` so in-flight probes are visible.
+- [x] 2.3 Add `_resolve_refused_claim`: fresh re-read to distinguish a
+      concurrent claim from a budget refusal, then CAS the decision to
+      `skipped` with `daily_warmup_count_budget_exhausted` vs
+      `daily_warmup_credit_budget_exhausted`.
+
+## 3. Limit warmup repository
+
+- [x] 3.1 Replace `try_create_attempt`'s FOR UPDATE + SELECT-then-INSERT with a
+      single conditional `INSERT .. SELECT .. WHERE NOT EXISTS(tolerance-window
+      match)`; PostgreSQL additionally takes `pg_advisory_xact_lock` keyed on
+      `(account_id, window)`; keep the exact-tuple unique constraint
+      IntegrityError -> None backstop.
+
+## 4. Tests
+
+- [x] 4.1 Two-replica regression tests over the shared test database:
+      concurrent `warm_now` respects the daily count budget (at most one probe),
+      claim guard counts in-flight `executing` decisions, claim guard refuses on
+      spent credit budget at the service path with the credit-specific reason,
+      concurrent `log_decision` on one idempotency key converges without
+      aborting, and two-process limit-warmup attempts within the reset_at
+      tolerance dedup to a single row.
+- [x] 4.2 Update the existing bound-parameter regression test for
+      `log_decision`'s new insert construct.
+
+## 5. OpenSpec
+
+- [x] 5.1 Spec deltas for `quota-phase-planner` (atomic budget claim,
+      idempotency-key convergence) and `usage-refresh-policy` (cross-process
+      warm-up dedup).
+- [x] 5.2 `openspec validate atomic-quota-warmup-claims` passes.

--- a/tests/integration/test_atomic_quota_warmup_claims.py
+++ b/tests/integration/test_atomic_quota_warmup_claims.py
@@ -1,0 +1,344 @@
+"""Multi-replica regression tests for atomic quota/warmup budget claims.
+
+Each test simulates two replicas (or two processes sharing one SQLite file) as
+two independent sessions over the shared test database. The process-local
+``sqlite_writer_section`` lock is patched to a no-op where the scenario models
+separate processes, because separate processes never share that lock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import pytest
+from sqlalchemy import func, select
+
+from app.core.crypto import TokenEncryptor
+from app.core.utils.time import utcnow
+from app.db.models import Account, AccountLimitWarmup, AccountStatus, QuotaPlannerDecision, RequestLog
+from app.db.session import SessionLocal
+from app.modules.limit_warmup import repository as limit_warmup_repository_module
+from app.modules.limit_warmup.repository import LimitWarmupRepository
+from app.modules.quota_planner import repository as quota_planner_repository_module
+from app.modules.quota_planner.logic import PlannerSettings
+from app.modules.quota_planner.repository import QuotaPlannerRepository
+from app.modules.quota_planner.warmup import QuotaWarmupService, WarmupUsage
+
+pytestmark = pytest.mark.integration
+
+
+@asynccontextmanager
+async def _noop_writer_section() -> AsyncIterator[None]:
+    yield
+
+
+def _simulate_separate_processes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Disable the process-local SQLite writer lock shared by both replicas.
+
+    Two real processes each have their own lock, so it provides no cross-process
+    serialization; removing it in-test reproduces that topology.
+    """
+    monkeypatch.setattr(limit_warmup_repository_module, "sqlite_writer_section", _noop_writer_section)
+    monkeypatch.setattr(quota_planner_repository_module, "sqlite_writer_section", _noop_writer_section)
+
+
+def _account(account_id: str) -> Account:
+    encryptor = TokenEncryptor()
+    return Account(
+        id=account_id,
+        email=f"{account_id}@example.test",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access"),
+        refresh_token_encrypted=encryptor.encrypt("refresh"),
+        id_token_encrypted=encryptor.encrypt("id"),
+        last_refresh=utcnow(),
+        status=AccountStatus.ACTIVE,
+    )
+
+
+def _midnight():
+    return utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+async def _seed_planner(*accounts: Account, max_warmups_per_day: int = 1) -> None:
+    async with SessionLocal() as session:
+        for account in accounts:
+            session.add(account)
+        await QuotaPlannerRepository(session).upsert_settings(
+            PlannerSettings(
+                mode="auto",
+                allow_synthetic_traffic=True,
+                dry_run=False,
+                max_warmups_per_day=max_warmups_per_day,
+                max_warmup_credits_per_day=1.0,
+                warmup_model_preference="gpt-5.4-mini",
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_warm_now_sends_at_most_one_probe_within_count_budget(monkeypatch, db_setup):
+    """Two replicas run warm-now with one warmup left in the daily budget.
+
+    Before this change both replicas' gates read the executed-only count (0),
+    both unguarded planned->executing transitions succeeded, and both probes
+    were sent, double-spending the budget.
+    """
+    del db_setup
+    await _seed_planner(_account("acc-claim-a"), _account("acc-claim-b"), max_warmups_per_day=1)
+
+    probes: list[str] = []
+
+    async def fake_send(self, *, account, model, request_id):
+        del self, model, request_id
+        probes.append(account.id)
+        return WarmupUsage(input_tokens=3, output_tokens=1, cached_input_tokens=0, reasoning_tokens=None)
+
+    async def noop_record_effect(self, account, model, *, source, confidence):
+        del self, account, model, source, confidence
+
+    monkeypatch.setattr(QuotaWarmupService, "_send_warmup_probe", fake_send)
+    monkeypatch.setattr(QuotaWarmupService, "_record_warmup_effect", noop_record_effect)
+
+    async def replica_warm_now(account_id: str):
+        async with SessionLocal() as session:
+            return await QuotaWarmupService(session).warm_now(
+                account_id=account_id,
+                model="gpt-5.4-mini",
+                force_probe=True,
+            )
+
+    results = await asyncio.gather(replica_warm_now("acc-claim-a"), replica_warm_now("acc-claim-b"))
+
+    assert len(probes) == 1
+    statuses = sorted(result.status for result in results)
+    assert statuses == ["executed", "skipped"]
+    refused = next(result for result in results if result.status == "skipped")
+    assert refused.reason == "daily_warmup_count_budget_exhausted"
+    async with SessionLocal() as session:
+        executed = await session.scalar(
+            select(func.count(QuotaPlannerDecision.id)).where(QuotaPlannerDecision.status == "executed")
+        )
+        executing = await session.scalar(
+            select(func.count(QuotaPlannerDecision.id)).where(QuotaPlannerDecision.status == "executing")
+        )
+    assert (executed, executing) == (1, 0)
+
+
+@pytest.mark.asyncio
+async def test_claim_counts_in_flight_executing_decisions(db_setup):
+    """An in-flight executing probe reserves count budget at claim time.
+
+    Before this change budget checks counted only ``status='executed'`` rows,
+    so a probe that another replica had claimed but not yet finished was
+    invisible and a second probe was admitted past the budget.
+    """
+    del db_setup
+    await _seed_planner(_account("acc-inflight"), max_warmups_per_day=1)
+    async with SessionLocal() as session:
+        repo = QuotaPlannerRepository(session)
+        await repo.log_decision(
+            mode="auto",
+            action="warmup",
+            idempotency_key="inflight-executing",
+            account_id="acc-inflight",
+            status="executing",
+        )
+        planned = await repo.log_decision(
+            mode="auto",
+            action="warmup",
+            idempotency_key="inflight-planned",
+            account_id="acc-inflight",
+            status="planned",
+        )
+        assert await repo.count_active_warmups_since(_midnight()) == 1
+        assert await repo.count_executed_warmups_since(_midnight()) == 0
+
+    async with SessionLocal() as replica_session:
+        replica_repo = QuotaPlannerRepository(replica_session)
+        claimed = await replica_repo.claim_warmup_decision(
+            planned.id,
+            since=_midnight(),
+            max_warmups=1,
+            max_credits=1.0,
+        )
+
+    assert claimed is None
+    async with SessionLocal() as session:
+        status = await session.scalar(select(QuotaPlannerDecision.status).where(QuotaPlannerDecision.id == planned.id))
+    assert status == "planned"
+
+
+@pytest.mark.asyncio
+async def test_claim_refuses_spent_credit_budget_after_stale_gate_read(monkeypatch, db_setup):
+    """The claim itself refuses a spent credit budget even if the gate passed.
+
+    The gate is patched to always allow, simulating a replica whose budget
+    pre-check read stale state. Before this change the planned->executing
+    transition had no budget guard, so the probe was sent anyway.
+    """
+    del db_setup
+    await _seed_planner(_account("acc-credits"), max_warmups_per_day=5)
+    async with SessionLocal() as session:
+        session.add(
+            RequestLog(
+                account_id="acc-credits",
+                request_id="warmup-cost-today",
+                model="gpt-5.4-mini",
+                status="success",
+                request_kind="warmup",
+                requested_at=utcnow(),
+                cost_usd=2.0,
+            )
+        )
+        await session.commit()
+        decision = await QuotaPlannerRepository(session).log_decision(
+            mode="auto",
+            action="warmup",
+            idempotency_key="credit-budget-claim",
+            account_id="acc-credits",
+            status="planned",
+        )
+
+    async def gate_always_allows(self, *, settings, account, model, force_probe):
+        del self, settings, account, model, force_probe
+        return True, "ready"
+
+    async def fail_send(self, *, account, model, request_id):
+        del self, account, model, request_id
+        raise AssertionError("claim must refuse the spent credit budget before any probe is sent")
+
+    monkeypatch.setattr(QuotaWarmupService, "_execution_gate", gate_always_allows)
+    monkeypatch.setattr(QuotaWarmupService, "_send_warmup_probe", fail_send)
+
+    async with SessionLocal() as session:
+        result = await QuotaWarmupService(session).warm_now(
+            account_id="acc-credits",
+            model="gpt-5.4-mini",
+            decision_id=decision.id,
+        )
+
+    assert result.status == "skipped"
+    assert result.reason == "daily_warmup_credit_budget_exhausted"
+    async with SessionLocal() as session:
+        status = await session.scalar(select(QuotaPlannerDecision.status).where(QuotaPlannerDecision.id == decision.id))
+    assert status == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_log_decision_converges_on_idempotency_key(monkeypatch, db_setup):
+    """Two replicas logging one idempotency key converge on a single row.
+
+    Before this change ``log_decision`` was SELECT-then-INSERT on the unique
+    key: when both replicas passed the SELECT before either inserted, the
+    second INSERT raised an unhandled IntegrityError that aborted its
+    planning tick.
+    """
+    del db_setup
+    _simulate_separate_processes(monkeypatch)
+
+    async def replica_log():
+        async with SessionLocal() as session:
+            decision = await QuotaPlannerRepository(session).log_decision(
+                mode="auto",
+                action="warmup",
+                idempotency_key="converging-key",
+                status="planned",
+                reason="tick",
+            )
+            return decision.id
+
+    first_id, second_id = await asyncio.gather(replica_log(), replica_log())
+
+    assert first_id == second_id
+    async with SessionLocal() as session:
+        row_count = await session.scalar(
+            select(func.count(QuotaPlannerDecision.id)).where(QuotaPlannerDecision.idempotency_key == "converging-key")
+        )
+    assert row_count == 1
+
+
+@pytest.mark.asyncio
+async def test_limit_warmup_attempts_dedup_within_tolerance_across_processes(monkeypatch, db_setup):
+    """Two processes recording near-duplicate reset candidates keep one attempt.
+
+    Before this change the dedup was SELECT .. FOR UPDATE (a no-op on SQLite)
+    plus a per-process lock: two processes sharing one SQLite file could both
+    pass the tolerant existence check and insert two near-duplicate attempts
+    whose ``reset_at`` drifted within the tolerance window, sending two real
+    probes.
+    """
+    del db_setup
+    _simulate_separate_processes(monkeypatch)
+    async with SessionLocal() as session:
+        session.add(_account("acc-limit-warm"))
+        await session.commit()
+
+    reset_at = int(utcnow().timestamp()) + 600
+
+    async def replica_attempt(observed_reset_at: int):
+        async with SessionLocal() as session:
+            return await LimitWarmupRepository(session).try_create_attempt(
+                account_id="acc-limit-warm",
+                window="primary",
+                reset_at=observed_reset_at,
+                model="gpt-5.4-mini",
+                attempted_at=utcnow(),
+                reset_at_tolerance_seconds=60,
+            )
+
+    results = await asyncio.gather(replica_attempt(reset_at), replica_attempt(reset_at + 2))
+
+    winners = [attempt for attempt in results if attempt is not None]
+    assert len(winners) == 1
+    assert winners[0].account_id == "acc-limit-warm"
+    assert winners[0].status == "pending"
+    async with SessionLocal() as session:
+        row_count = await session.scalar(
+            select(func.count(AccountLimitWarmup.id)).where(AccountLimitWarmup.account_id == "acc-limit-warm")
+        )
+    assert row_count == 1
+
+
+@pytest.mark.asyncio
+async def test_limit_warmup_attempt_outside_tolerance_still_inserts(db_setup):
+    """The atomic guard only blocks near-duplicates inside the tolerance."""
+    del db_setup
+    async with SessionLocal() as session:
+        session.add(_account("acc-limit-far"))
+        await session.commit()
+
+    reset_at = int(utcnow().timestamp()) + 600
+    async with SessionLocal() as session:
+        repo = LimitWarmupRepository(session)
+        first = await repo.try_create_attempt(
+            account_id="acc-limit-far",
+            window="primary",
+            reset_at=reset_at,
+            model="gpt-5.4-mini",
+            attempted_at=utcnow(),
+            reset_at_tolerance_seconds=60,
+        )
+        duplicate = await repo.try_create_attempt(
+            account_id="acc-limit-far",
+            window="primary",
+            reset_at=reset_at + 30,
+            model="gpt-5.4-mini",
+            attempted_at=utcnow(),
+            reset_at_tolerance_seconds=60,
+        )
+        far = await repo.try_create_attempt(
+            account_id="acc-limit-far",
+            window="primary",
+            reset_at=reset_at + 3600,
+            model="gpt-5.4-mini",
+            attempted_at=utcnow(),
+            reset_at_tolerance_seconds=60,
+        )
+
+    assert first is not None
+    assert duplicate is None
+    assert far is not None
+    assert far.id != first.id

--- a/tests/integration/test_atomic_quota_warmup_claims.py
+++ b/tests/integration/test_atomic_quota_warmup_claims.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from datetime import timedelta
 
 import pytest
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
@@ -168,6 +169,74 @@ async def test_claim_counts_in_flight_executing_decisions(db_setup):
     assert claimed is None
     async with SessionLocal() as session:
         status = await session.scalar(select(QuotaPlannerDecision.status).where(QuotaPlannerDecision.id == planned.id))
+    assert status == "planned"
+
+
+@pytest.mark.asyncio
+async def test_claim_counts_cross_midnight_claim_against_claim_day(db_setup):
+    """A decision planned yesterday but claimed today consumes today's budget.
+
+    ``QuotaPlannerScheduler.run_once`` persists future-scheduled decisions, so
+    ``created_at`` can precede the daily boundary. Before this fix the
+    executing-row budget guard filtered by ``created_at >= since``: a row
+    claimed today from a yesterday-created decision escaped today's count and
+    a second same-day claim was admitted past ``max_warmups_per_day=1``.
+    """
+    del db_setup
+    await _seed_planner(_account("acc-cross-midnight"), max_warmups_per_day=1)
+    midnight = _midnight()
+    async with SessionLocal() as session:
+        repo = QuotaPlannerRepository(session)
+        planned_yesterday = await repo.log_decision(
+            mode="auto",
+            action="warmup",
+            idempotency_key="cross-midnight-yesterday",
+            account_id="acc-cross-midnight",
+            scheduled_at=midnight + timedelta(minutes=5),
+            status="planned",
+        )
+        planned_today = await repo.log_decision(
+            mode="auto",
+            action="warmup",
+            idempotency_key="cross-midnight-today",
+            account_id="acc-cross-midnight",
+            status="planned",
+        )
+        await session.execute(
+            update(QuotaPlannerDecision)
+            .where(QuotaPlannerDecision.id == planned_yesterday.id)
+            .values(created_at=midnight - timedelta(hours=1))
+        )
+        await session.commit()
+
+    async with SessionLocal() as session:
+        repo = QuotaPlannerRepository(session)
+        claimed = await repo.claim_warmup_decision(
+            planned_yesterday.id,
+            since=midnight,
+            max_warmups=1,
+            max_credits=1.0,
+        )
+        assert claimed is not None
+        assert claimed.status == "executing"
+        assert claimed.executed_at is not None
+        assert claimed.executed_at >= midnight
+        assert await repo.count_active_warmups_since(midnight) == 1
+
+    async with SessionLocal() as replica_session:
+        replica_repo = QuotaPlannerRepository(replica_session)
+        refused = await replica_repo.claim_warmup_decision(
+            planned_today.id,
+            since=midnight,
+            max_warmups=1,
+            max_credits=1.0,
+        )
+
+    assert refused is None
+    async with SessionLocal() as session:
+        status = await session.scalar(
+            select(QuotaPlannerDecision.status).where(QuotaPlannerDecision.id == planned_today.id)
+        )
     assert status == "planned"
 
 

--- a/tests/integration/test_quota_planner_api.py
+++ b/tests/integration/test_quota_planner_api.py
@@ -119,14 +119,17 @@ async def test_quota_planner_repository_persists_naive_utc_decision_datetimes(mo
     # raises "can't subtract offset-naive and offset-aware datetimes" if these are aware,
     # so the repository MUST sanitize them before persistence.
     bound_scheduled: list[object] = []
-    original_add = AsyncSession.add
+    original_insert_scalar = AsyncSession.scalar
 
-    def capture_add(self, instance, *args, **kwargs):
-        if isinstance(instance, QuotaPlannerDecision):
-            bound_scheduled.append(instance.scheduled_at)
-        return original_add(self, instance, *args, **kwargs)
+    async def capture_insert_scalar(self, statement, *args, **kwargs):
+        values = getattr(statement, "_values", None)
+        if values:
+            for col, bind in values.items():
+                if getattr(col, "name", None) == "scheduled_at":
+                    bound_scheduled.append(getattr(bind, "value", bind))
+        return await original_insert_scalar(self, statement, *args, **kwargs)
 
-    monkeypatch.setattr(AsyncSession, "add", capture_add)
+    monkeypatch.setattr(AsyncSession, "scalar", capture_insert_scalar)
 
     async with SessionLocal() as session:
         repo = QuotaPlannerRepository(session)
@@ -141,7 +144,7 @@ async def test_quota_planner_repository_persists_naive_utc_decision_datetimes(mo
             status="planned",
         )
 
-    assert bound_scheduled, "log_decision should construct a decision row"
+    assert bound_scheduled, "log_decision should bind scheduled_at on its insert"
     bound_value = bound_scheduled[-1]
     assert isinstance(bound_value, datetime)
     # Guards the Postgres path: timezone-naive columns must not receive aware datetimes.


### PR DESCRIPTION
## Why

Warmup execution can double-spend real account quota and operator credit budgets in multi-replica deployments. The quota-planner daily budget gate is a non-atomic check-then-act that counts only `executed` decisions, so concurrent claims (leader scheduler plus `POST /api/quota-planner/warm-now` on any replica) both pass at budget-1 and in-flight `executing` probes are invisible. Limit-warmup dedup relies on `SELECT .. FOR UPDATE` (a no-op on SQLite) plus a per-process lock, so two processes sharing one SQLite file can both send real probes. Finally, `QuotaPlannerRepository.log_decision` is SELECT-then-INSERT on a UNIQUE key; concurrent leaders raise an unhandled `IntegrityError` that aborts the rest of the planning tick, dropping due warmups for other accounts.

## What Changes

- Make the quota-planner planned->executing claim the single authoritative budget enforcement point: one conditional UPDATE whose WHERE clause embeds both daily budget guards, serialized on PostgreSQL by `pg_advisory_xact_lock` on a fixed warmup-budget key and on SQLite by single-statement single-writer atomicity.
- Count in-flight work: the budget count includes `status='executing'` decisions in addition to `status='executed'`, so a probe reserves budget when claimed, not after it finishes.
- Replace `LimitWarmupRepository.try_create_attempt`'s FOR UPDATE + SELECT-then-INSERT with a single conditional `INSERT .. SELECT .. WHERE NOT EXISTS(tolerance-window match)`; PostgreSQL additionally takes `pg_advisory_xact_lock` keyed on `(account_id, window)`.
- Convert `QuotaPlannerRepository.log_decision` to a dialect upsert (`INSERT .. ON CONFLICT (idempotency_key) DO NOTHING` + fetch of the surviving row) so concurrent writers converge instead of aborting the tick.
- No Alembic migration: existing tables and columns suffice. Affected specs: `quota-phase-planner`, `usage-refresh-policy`.

## Testing

- `uv run pytest tests/integration/test_atomic_quota_warmup_claims.py tests/integration/test_quota_planner_api.py tests/unit/test_quota_planner.py tests/unit/test_limit_warmup.py tests/integration/test_warmup_accounting_exclusions.py tests/integration/test_proxy_warmup.py -q` → 93 passed.
- Pre-change failure verification via git stash of `app/`: 3 product-path tests fail as expected on main's code.
- `ruff check app tests` + `ruff format --check` clean; `openspec validate atomic-quota-warmup-claims` valid.

## Merge ordering / notes

- Depends on #1252 (OpenSpec SSOT sync) — MODIFIED spec deltas target the synced spec headers.
- No Alembic migration.
- Complements `harden-scheduler-leader-election` (bounded leader-overlap windows are backstopped by these DB-level atomic claims); no ordering requirement between them.
- Part of the 12-change multi-replica reliability effort; resolves no filed issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
