### PR TITLE
fix(deploy): repair broken multi-replica deployment artifacts

### DIFF
--- a/deploy/helm/codex-lb/README.md
+++ b/deploy/helm/codex-lb/README.md
@@ -318,7 +318,7 @@ config:
   sessionBridgeInstanceRing: "codex-lb-workload-0,codex-lb-workload-1"
 ```
 
-A static ring is incompatible with autoscaling and must list at least `replicaCount` pod names; the chart refuses to render when `autoscaling.enabled=true` or when `replicaCount` exceeds the number of ring entries. This is rarely needed in production; the database-backed discovery is preferred.
+A static ring is incompatible with autoscaling and must list exactly the StatefulSet pod names (`<workload-name>-0` through `<workload-name>-<replicaCount - 1>`); the chart refuses to render when `autoscaling.enabled=true`, when any expected pod name is missing from the ring, or when a ring entry does not match any expected pod name (for example FQDN-style entries). This is rarely needed in production; the database-backed discovery is preferred.
 
 ### Connection Pool Budget
 

--- a/deploy/helm/codex-lb/README.md
+++ b/deploy/helm/codex-lb/README.md
@@ -235,6 +235,8 @@ networkPolicy:
     kubernetes.io/metadata.name: ingress-nginx
 ```
 
+`values-prod.yaml` ships this allowlist by default (matching an ingress-nginx controller in the `ingress-nginx` namespace); adjust the labels if your controller runs elsewhere. If you enable `networkPolicy` together with `ingress` in a hand-rolled overlay and omit the allowlist, external traffic through the controller is denied on port `2455` while pods stay Ready — the rendered install NOTES warn about this combination.
+
 ## Connection Pool Sizing
 
 Each pod keeps its own SQLAlchemy pool.
@@ -296,25 +298,27 @@ The chart configures each pod with:
 clusterDomain: corp.internal
 ```
 
-In most clusters no extra values are required for `/responses` owner handoff. If pods must be reached through a different internal address, override:
+In most clusters no extra values are required for `/responses` owner handoff. If pods must be reached through a different internal address, the override must stay **per-pod**: the application refuses to start when the advertise hostname is not replica-specific, so a shared Service hostname crashloops every replica. Use the kubelet `$(POD_NAME)` expansion — the chart defines `POD_NAME` earlier in the container env list, so the kubelet expands it per pod:
 
 ```yaml
 config:
-  sessionBridgeAdvertiseBaseUrl: "http://codex-lb-internal.default.svc.cluster.local:2455"
+  sessionBridgeAdvertiseBaseUrl: "http://$(POD_NAME).codex-lb-bridge.default.svc.cluster.local:2455"
 ```
+
+Replace `codex-lb-bridge`, `default`, and `cluster.local` with your headless service name (`<release>-bridge` by default), namespace, and cluster domain. For a release named `codex-lb` the first pod then advertises `http://codex-lb-workload-0.codex-lb-bridge.default.svc.cluster.local:2455`.
 
 When `networkPolicy.enabled=true`, the chart also allows port `2455` traffic between codex-lb pods so owner handoff can work without extra rules.
 
 **Manual Ring Override (Advanced)**
 
-If you need to manually specify the pod ring (e.g., for testing or debugging):
+If you need to manually specify the pod ring (e.g., for testing or debugging), list the **bare StatefulSet pod names**. Each pod's bridge instance id is `$(POD_NAME)`, and the application requires its instance id to appear literally in the ring — FQDN entries fail Settings validation and crashloop the pods:
 
 ```yaml
 config:
-  sessionBridgeInstanceRing: "codex-lb-0.codex-lb.default.svc.cluster.local,codex-lb-1.codex-lb.default.svc.cluster.local"
+  sessionBridgeInstanceRing: "codex-lb-workload-0,codex-lb-workload-1"
 ```
 
-This is rarely needed in production; the database-backed discovery is preferred.
+A static ring is incompatible with autoscaling and must list at least `replicaCount` pod names; the chart refuses to render when `autoscaling.enabled=true` or when `replicaCount` exceeds the number of ring entries. This is rarely needed in production; the database-backed discovery is preferred.
 
 ### Connection Pool Budget
 
@@ -365,6 +369,12 @@ topologySpreadConstraints:
     topologyKey: topology.kubernetes.io/zone  # Spread across zones
 networkPolicy:
   enabled: true                    # Restrict ingress/egress
+  ingressNSMatchLabels:            # REQUIRED with ingress: allow the controller namespace
+    kubernetes.io/metadata.name: ingress-nginx
+ingress:
+  enabled: true
+  nginx:
+    enabled: true                  # Streaming-safety + sticky-hash annotations as one set
 metrics:
   serviceMonitor:
     enabled: true                  # Prometheus scraping
@@ -490,6 +500,23 @@ gatewayApi:
   hostnames:
     - codex-lb.example.com
 ```
+
+### nginx annotations and responses sticky routing
+
+All nginx-specific annotations are gated behind `ingress.nginx.enabled=true` and render as **one coherent set**: the streaming-safety annotations (proxy buffering off, 3600s read/send timeouts, 50m body size, HTTP/1.1) and the sticky-hash annotations always appear together. Enabling ingress on an nginx class without `ingress.nginx.enabled=true` renders no nginx annotations at all — which means the controller's defaults (60s read timeout, 1m body cap) apply and will cut long-lived SSE/WebSocket streams.
+
+The dedicated responses ingress defaults to a snippet-free sticky key:
+
+```yaml
+ingress:
+  responses:
+    nginx:
+      upstreamHashBy: "$http_x_codex_session_id$http_authorization"
+```
+
+Undefined nginx `$http_*` variables render empty, so requests carrying `x-codex-session-id` hash by session (+API key) and requests without it hash by the Authorization header alone. This is admitted by stock ingress-nginx at the default `annotations-risk-level`.
+
+Advanced snippet-based keys via `ingress.responses.nginx.configurationSnippet` are opt-in only: stock ingress-nginx >= 1.12 rejects `configuration-snippet` at admission unless the controller runs with `--allow-snippet-annotations=true` and `annotations-risk-level: Critical`.
 
 ## Upgrade Contract
 

--- a/deploy/helm/codex-lb/templates/NOTES.txt
+++ b/deploy/helm/codex-lb/templates/NOTES.txt
@@ -31,6 +31,19 @@ codex-lb has been installed successfully.
   Metrics: http://{{ include "codex-lb.fullname" . }}-metrics:{{ .Values.metrics.port }}/metrics
 {{- end }}
 
+{{- if and .Values.networkPolicy.enabled .Values.ingress.enabled (not .Values.networkPolicy.ingressNSMatchLabels) (not .Values.networkPolicy.extraIngress) }}
+
+WARNING: networkPolicy.enabled=true and ingress.enabled=true, but neither
+  networkPolicy.ingressNSMatchLabels nor networkPolicy.extraIngress is set.
+  The rendered NetworkPolicy DENIES all ingress-controller traffic to port
+  {{ .Values.service.port }}: external requests will time out while pods stay
+  Ready and probes stay green. Allow your ingress controller namespace, e.g.:
+
+    networkPolicy:
+      ingressNSMatchLabels:
+        kubernetes.io/metadata.name: ingress-nginx
+{{- end }}
+
 IMPORTANT:
   1. Set your encryption key in the Secret (key: encryption-key)
      Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"

--- a/deploy/helm/codex-lb/templates/deployment.yaml
+++ b/deploy/helm/codex-lb/templates/deployment.yaml
@@ -1,3 +1,23 @@
+{{- /*
+Static bridge ring guard: a manual config.sessionBridgeInstanceRing must list every
+pod or Settings validation crashloops pods at startup. Fail loudly at render time
+instead of shipping a stalled rollout.
+*/}}
+{{- if .Values.config.sessionBridgeInstanceRing }}
+{{- $ringEntries := list }}
+{{- range splitList "," .Values.config.sessionBridgeInstanceRing }}
+{{- $entry := trim . }}
+{{- if $entry }}
+{{- $ringEntries = append $ringEntries $entry }}
+{{- end }}
+{{- end }}
+{{- if .Values.autoscaling.enabled }}
+{{- fail "config.sessionBridgeInstanceRing is a static ring and is incompatible with autoscaling.enabled=true: the HPA can create pods that are missing from the ring and crashloop at startup. Remove the static ring (database-backed ring discovery is automatic) or disable autoscaling." }}
+{{- end }}
+{{- if gt (int .Values.replicaCount) (len $ringEntries) }}
+{{- fail (printf "config.sessionBridgeInstanceRing lists %d entries but replicaCount is %d: every pod name must be present in the static ring or the missing pods fail Settings validation at startup. List every pod or remove the static ring (database-backed ring discovery is automatic)." (len $ringEntries) (int .Values.replicaCount)) }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/deploy/helm/codex-lb/templates/deployment.yaml
+++ b/deploy/helm/codex-lb/templates/deployment.yaml
@@ -1,7 +1,8 @@
 {{- /*
-Static bridge ring guard: a manual config.sessionBridgeInstanceRing must list every
-pod or Settings validation crashloops pods at startup. Fail loudly at render time
-instead of shipping a stalled rollout.
+Static bridge ring guard: a manual config.sessionBridgeInstanceRing must list exactly
+the StatefulSet pod names or Settings validation crashloops pods at startup (each pod
+requires its own $(POD_NAME) to appear literally in the ring). Fail loudly at render
+time instead of shipping a stalled rollout.
 */}}
 {{- if .Values.config.sessionBridgeInstanceRing }}
 {{- $ringEntries := list }}
@@ -14,8 +15,28 @@ instead of shipping a stalled rollout.
 {{- if .Values.autoscaling.enabled }}
 {{- fail "config.sessionBridgeInstanceRing is a static ring and is incompatible with autoscaling.enabled=true: the HPA can create pods that are missing from the ring and crashloop at startup. Remove the static ring (database-backed ring discovery is automatic) or disable autoscaling." }}
 {{- end }}
-{{- if gt (int .Values.replicaCount) (len $ringEntries) }}
-{{- fail (printf "config.sessionBridgeInstanceRing lists %d entries but replicaCount is %d: every pod name must be present in the static ring or the missing pods fail Settings validation at startup. List every pod or remove the static ring (database-backed ring discovery is automatic)." (len $ringEntries) (int .Values.replicaCount)) }}
+{{- $workloadName := include "codex-lb.workloadName" . }}
+{{- $expectedPodNames := list }}
+{{- range $ordinal := until (int .Values.replicaCount) }}
+{{- $expectedPodNames = append $expectedPodNames (printf "%s-%d" $workloadName $ordinal) }}
+{{- end }}
+{{- $missingPodNames := list }}
+{{- range $expectedPodNames }}
+{{- if not (has . $ringEntries) }}
+{{- $missingPodNames = append $missingPodNames . }}
+{{- end }}
+{{- end }}
+{{- $unexpectedEntries := list }}
+{{- range $ringEntries }}
+{{- if not (has . $expectedPodNames) }}
+{{- $unexpectedEntries = append $unexpectedEntries . }}
+{{- end }}
+{{- end }}
+{{- if $missingPodNames }}
+{{- fail (printf "config.sessionBridgeInstanceRing is missing pod name(s) %q: every pod name must be present in the static ring or the missing pods fail Settings validation at startup. With replicaCount=%d the ring must list exactly %q. List every pod or remove the static ring (database-backed ring discovery is automatic)." (join "," $missingPodNames) (int .Values.replicaCount) (join "," $expectedPodNames)) }}
+{{- end }}
+{{- if $unexpectedEntries }}
+{{- fail (printf "config.sessionBridgeInstanceRing entry(ies) %q do not match any StatefulSet pod name: ring entries must be bare pod names (not FQDNs or other identifiers) or the rendered ring routes to members that do not exist. With replicaCount=%d the ring must list exactly %q. Fix the entries or remove the static ring (database-backed ring discovery is automatic)." (join "," $unexpectedEntries) (int .Values.replicaCount) (join "," $expectedPodNames)) }}
 {{- end }}
 {{- end }}
 apiVersion: apps/v1

--- a/deploy/helm/codex-lb/templates/ingress.yaml
+++ b/deploy/helm/codex-lb/templates/ingress.yaml
@@ -18,12 +18,14 @@
 {{- $_ := set $baseAnnotations $key $value }}
 {{- end }}
 {{- $apiAnnotations := deepCopy $baseAnnotations }}
+{{- if .Values.ingress.nginx.enabled }}
 {{- if .Values.ingress.nginx.upstreamHashBy }}
 {{- $_ := set $apiAnnotations "nginx.ingress.kubernetes.io/upstream-hash-by" .Values.ingress.nginx.upstreamHashBy }}
 {{- end }}
 {{- if .Values.ingress.nginx.upstreamHashBySubset }}
 {{- $_ := set $apiAnnotations "nginx.ingress.kubernetes.io/upstream-hash-by-subset" "true" }}
 {{- $_ := set $apiAnnotations "nginx.ingress.kubernetes.io/upstream-hash-by-subset-size" (.Values.ingress.nginx.upstreamHashBySubsetSize | toString) }}
+{{- end }}
 {{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -62,6 +64,7 @@ spec:
 {{- if .Values.ingress.responses.enabled }}
 ---
 {{- $responsesAnnotations := deepCopy $baseAnnotations }}
+{{- if .Values.ingress.nginx.enabled }}
 {{- if .Values.ingress.responses.nginx.upstreamHashBy }}
 {{- $_ := set $responsesAnnotations "nginx.ingress.kubernetes.io/upstream-hash-by" .Values.ingress.responses.nginx.upstreamHashBy }}
 {{- end }}
@@ -77,6 +80,7 @@ spec:
 {{- end }}
 {{- if .Values.ingress.responses.nginx.proxyNextUpstreamTries }}
 {{- $_ := set $responsesAnnotations "nginx.ingress.kubernetes.io/proxy-next-upstream-tries" (.Values.ingress.responses.nginx.proxyNextUpstreamTries | toString) }}
+{{- end }}
 {{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/deploy/helm/codex-lb/values-prod.yaml
+++ b/deploy/helm/codex-lb/values-prod.yaml
@@ -24,6 +24,12 @@ topologySpreadConstraints:
       matchLabels: {}
 networkPolicy:
   enabled: true
+  # Allow ingress-controller traffic to the HTTP port. Without this allowlist the
+  # fail-closed NetworkPolicy denies all external traffic while probes stay green.
+  # Adjust the label to the namespace your ingress controller runs in
+  # (this default matches ingress-nginx installed in the "ingress-nginx" namespace).
+  ingressNSMatchLabels:
+    kubernetes.io/metadata.name: ingress-nginx
 metrics:
   serviceMonitor:
     enabled: true
@@ -33,6 +39,9 @@ metrics:
     enabled: true
 ingress:
   enabled: true
+  # Render the full nginx annotation set (streaming safety + sticky hashing).
+  nginx:
+    enabled: true
   certManager:
     enabled: true
 config:

--- a/deploy/helm/codex-lb/values-staging.yaml
+++ b/deploy/helm/codex-lb/values-staging.yaml
@@ -16,6 +16,9 @@ metrics:
 
 ingress:
   enabled: true
+  # Render the full nginx annotation set (streaming safety + sticky hashing).
+  nginx:
+    enabled: true
   hosts:
     - host: codex-lb.staging.example.com
       paths:

--- a/deploy/helm/codex-lb/values.yaml
+++ b/deploy/helm/codex-lb/values.yaml
@@ -321,14 +321,23 @@ ingress:
       - /v1/responses
       - /backend-api/codex/responses
     nginx:
-      # @param ingress.responses.nginx.upstreamHashBy Continuity-aware sticky key variable for responses traffic
-      upstreamHashBy: "$codex_responses_hash_key"
-      # @param ingress.responses.nginx.configurationSnippet NGINX snippet that uses x-codex-session-id when present and a per-request fallback otherwise
-      configurationSnippet: |
-        set $codex_responses_hash_key "$http_authorization:$request_id";
-        if ($http_x_codex_session_id != "") {
-          set $codex_responses_hash_key $http_x_codex_session_id;
-        }
+      # @param ingress.responses.nginx.upstreamHashBy Continuity-aware sticky key for responses traffic
+      #        Snippet-free default: undefined nginx $http_* variables render empty, so the composite
+      #        key hashes by x-codex-session-id (+Authorization) when the session header is present
+      #        and by the Authorization header alone otherwise. Admitted on stock ingress-nginx.
+      upstreamHashBy: "$http_x_codex_session_id$http_authorization"
+      # @param ingress.responses.nginx.configurationSnippet Optional NGINX snippet for advanced sticky keys. Empty = disabled.
+      #        Opt-in only: nginx.ingress.kubernetes.io/configuration-snippet is REJECTED at admission by
+      #        stock ingress-nginx >= 1.12 unless the controller runs with
+      #        --allow-snippet-annotations=true and annotations-risk-level=Critical.
+      #        When set, also point upstreamHashBy at the variable the snippet defines, e.g.:
+      #          upstreamHashBy: "$codex_responses_hash_key"
+      #          configurationSnippet: |
+      #            set $codex_responses_hash_key "$http_authorization:$request_id";
+      #            if ($http_x_codex_session_id != "") {
+      #              set $codex_responses_hash_key $http_x_codex_session_id;
+      #            }
+      configurationSnippet: ""
       # @param ingress.responses.nginx.upstreamHashBySubset Enable subset mode for responses ingress
       upstreamHashBySubset: false
       # @param ingress.responses.nginx.upstreamHashBySubsetSize Subset size for responses ingress

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,6 +5,11 @@
 #
 # Requires external PostgreSQL. Set CODEX_LB_DATABASE_URL in .env.local:
 #   CODEX_LB_DATABASE_URL=postgresql+asyncpg://user:password@host:5432/codexlb
+#
+# NOTE: This Compose file defines a SINGLE-REPLICA topology.
+# Do not use `docker compose up --scale server=N` — the published host ports collide
+# and Compose provides no per-replica bridge identity. Multi-replica deployments
+# require the Helm chart with PostgreSQL and leader election (deploy/helm/codex-lb).
 services:
   server:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,7 @@
+# NOTE: This Compose file defines a SINGLE-REPLICA topology.
+# Do not use `docker compose up --scale server=N` — the SQLite default supports
+# only one writer and the published host ports collide. Multi-replica deployments
+# require the Helm chart with PostgreSQL and leader election (deploy/helm/codex-lb).
 services:
   server:
     build:

--- a/openspec/changes/fix-replica-deployment-artifacts/context.md
+++ b/openspec/changes/fix-replica-deployment-artifacts/context.md
@@ -1,0 +1,35 @@
+# Context: fix-replica-deployment-artifacts
+
+## Verified defects this change fixes
+
+All six were adversarially verified against rendered chart output (`helm template`) and `Settings()` behavior:
+
+1. **values-prod.yaml NetworkPolicy outage (high)**: `networkPolicy.enabled=true` + `ingress.enabled=true` with empty `ingressNSMatchLabels` renders a fail-closed policy that denies the ingress controller on port 2455. Kubelet probes bypass NetworkPolicy on mainstream CNIs and the helm-test pod is explicitly allowed, so pods stay Ready and `helm test` passes while every external request times out — a day-one fleet-wide outage with green signals on any policy-enforcing CNI.
+2. **README advertise-URL example crashloops pods (medium)**: the shared-service-hostname example fails `Settings._validate_http_bridge_instance_configuration` ("must be replica-specific for bridge routing") on every pod that receives it; the rollout stalls at the first crashlooping pod.
+3. **Responses sticky ingress admission-rejected (medium)**: the default `configuration-snippet` is refused by stock ingress-nginx >= 1.12 (`allow-snippet-annotations=false` since v1.9; `annotations-risk-level=High` since v1.12, snippet is Critical), so `helm install` of the prod overlay fails at the admission webhook.
+4. **README manual-ring example crashloops pods + static ring bricks HPA scale-up (medium)**: FQDN ring entries never match the bare `$(POD_NAME)` instance id (literal membership check); with a correct N-name ring, any HPA scale-up beyond N creates pods that die at Settings load while the HPA keeps them desired.
+5. **Split nginx annotation set (medium)**: streaming-safety annotations were gated on `ingress.nginx.enabled` while hash annotations rendered unconditionally; `values-staging.yaml` therefore got sticky routing with controller defaults — 60s `proxy-read-timeout` and 1m body cap — on an SSE/WebSocket proxy (the repo's WS-413 incident showed real bodies up to 128MiB).
+6. **No CI coverage of the default two-replica topology (low)**: the chart defaults to `replicaCount=2` and readiness gates on bridge ring membership, yet both kind smoke paths ran one replica, so parallel dual registration, headless-DNS advertise reachability, and `publishNotReadyAddresses` handoff were never exercised pre-release.
+
+## Sticky-key trade-off (accepted)
+
+The new default `upstream-hash-by "$http_x_codex_session_id$http_authorization"` relies on undefined nginx `$http_*` variables rendering as empty strings: requests carrying `x-codex-session-id` hash by session (+API key); requests without it hash by the Authorization header alone. Compared with the old snippet (`$http_authorization:$request_id` fallback), no-session-header traffic loses the per-request spread and pins one API key to one pod (hot-key concentration). Correctness is unaffected in both directions: the DB-backed bridge ring owner-forwarding handles non-sticky arrivals — ingress stickiness is an optimization, the ring is the correctness mechanism. Upgrading re-hashes existing sessions once (one owner-forward hop per warm session).
+
+## Snippet-mode controller requirements (opt-in)
+
+Setting `ingress.responses.nginx.configurationSnippet` requires the ingress-nginx controller to run with `--allow-snippet-annotations=true` AND `annotations-risk-level: Critical`. When using a snippet-defined variable, also point `upstreamHashBy` at that variable (example preserved in `values.yaml` comments).
+
+## Annotation-gating migration note (release-notable)
+
+Operators who set `ingress.enabled=true` on an nginx class WITHOUT `ingress.nginx.enabled=true` previously received `upstream-hash-by` unconditionally. After this change they receive no nginx annotations until they set `ingress.nginx.enabled=true`. Session correctness is preserved by ring owner-forwarding; the cost is a forwarding hop per non-sticky arrival. Shipped overlays (`values-staging.yaml`, `values-prod.yaml`) now set the flag.
+
+## NetworkPolicy allowlist assumption
+
+`values-prod.yaml` ships `ingressNSMatchLabels: {kubernetes.io/metadata.name: ingress-nginx}` — the namespace-name well-known label for an ingress-nginx controller installed in the `ingress-nginx` namespace. Operators running a different controller or namespace must override the labels (documented in the values comment, README, and the new NOTES warning).
+
+## Residual risks
+
+- `upstream-hash-by` admission at the default `annotations-risk-level=High` is asserted from ingress-nginx documentation, not exercised in CI (the kind smoke does not run a real ingress-nginx admission webhook).
+- The two-replica external-db kind smoke roughly doubles that mode's pod resources and adds ring-convergence timing; mitigated by keeping bundled mode at 1 replica, bounded `kubectl wait` timeouts, and the existing `dump_namespace_debug` ERR trap.
+- The static-ring render guard turns a previously renderable (but crashlooping) config into a `helm upgrade` error — intended, but loud.
+- Runtime multi-writer enforcement for compose/SQLite is deliberately out of scope (see sibling changes `document-replica-topology-contract` and `harden-scheduler-leader-election`).

--- a/openspec/changes/fix-replica-deployment-artifacts/design.md
+++ b/openspec/changes/fix-replica-deployment-artifacts/design.md
@@ -32,7 +32,7 @@ The chart injects `config.sessionBridgeAdvertiseBaseUrl` via the container `env:
 
 ### 5. Static-ring render guard is a template `fail`, not a NOTES warning
 
-`sessionBridgeInstanceRing` non-empty with `autoscaling.enabled` (prod overlay: maxReplicas=20) or `replicaCount` > ring length deterministically crashloops pods at Settings load; failing at `helm template`/`upgrade` time is strictly better than a stalled rollout. The guard only fires on the opt-in manual-override path, so default installs are unaffected.
+`sessionBridgeInstanceRing` non-empty with `autoscaling.enabled` (prod overlay: maxReplicas=20), or with entries that do not exactly match the expected StatefulSet pod names (missing pods crashloop at Settings load; count alone is insufficient since a right-count/wrong-values ring crashloops too); failing at `helm template`/`upgrade` time is strictly better than a stalled rollout. The guard only fires on the opt-in manual-override path, so default installs are unaffected.
 
 ### 6. Two-replica smoke goes in external-db mode only
 

--- a/openspec/changes/fix-replica-deployment-artifacts/design.md
+++ b/openspec/changes/fix-replica-deployment-artifacts/design.md
@@ -1,0 +1,54 @@
+# Design: fix-replica-deployment-artifacts
+
+## Decisions
+
+### 1. NetworkPolicy fix is overlay values + NOTES warning, not a template default
+
+The synced `deployment-networking` spec requires fail-closed rendering (no `namespaceSelector: {}` when the allowlist is empty) — that requirement stays intact.
+
+- **Rejected**: auto-rendering an allow-all or defaulting `ingressNSMatchLabels` in `values.yaml` (would weaken the fail-closed contract for operators who enable networkPolicy without ingress).
+- **Chosen**: `values-prod.yaml` ships the documented working label (`kubernetes.io/metadata.name: ingress-nginx`, exactly what the chart README already recommends) plus a NOTES.txt warning for the mis-combination, so the shipped prod overlay works out of the box and hand-rolled overlays get a loud install-time signal.
+
+### 2. Sticky routing default: snippet-free `upstream-hash-by "$http_x_codex_session_id$http_authorization"`
+
+ingress-nginx ships `allow-snippet-annotations=false` since v1.9 and `annotations-risk-level=High` since v1.12 (`configuration-snippet` is risk Critical, so it is admission-rejected), meaning the current default blocks `helm install` of the prod overlay on stock controllers. `upstream-hash-by` is admitted at the default risk level, and undefined nginx `$http_*` variables evaluate to empty string, so the composite key hashes by session id (+auth) when the header is present and by Authorization alone otherwise — the same key the main API ingress already uses.
+
+Accepted trade-off (documented in context.md): requests without `x-codex-session-id` lose the old per-request `$request_id` spread and pin one API key to one pod; correctness is unaffected either way because the DB-backed bridge ring owner-forwarding handles non-sticky arrivals — stickiness is an optimization, and the ring is the correctness mechanism. Snippet mode remains available by explicitly setting `configurationSnippet`, with required controller flags documented.
+
+- **Rejected**: nginx cookie-based session affinity (Codex CLI clients do not retain cookies); keeping the snippet default + docs-only (leaves the default prod install broken).
+
+### 3. Annotation coherence: one gate (`ingress.nginx.enabled`) for the whole nginx annotation set
+
+Today streaming-safety annotations are gated but hash annotations render unconditionally, producing the staging overlay's wrong-half combination (sticky routing + 60s `proxy-read-timeout` + 1m body cap on a streaming proxy).
+
+- **Rejected**: un-gating everything (dumps nginx annotations on non-nginx controllers); leaving templates alone and only fixing overlays (the trap remains for user values).
+- **Chosen**: gate both halves together and set `ingress.nginx.enabled=true` in `values-staging.yaml` and `values-prod.yaml`. This is a behavior change for operators who enabled `ingress.enabled` and relied on the unconditional hash annotation without setting `ingress.nginx.enabled` — captured as a normative spec delta and release-notable risk.
+
+### 4. README examples fixed to shapes that provably pass `Settings._validate_http_bridge_instance_configuration`
+
+The chart injects `config.sessionBridgeAdvertiseBaseUrl` via the container `env:` list AFTER defining `POD_NAME`/`POD_NAMESPACE`/`POD_IP`, so `$(POD_NAME)` kubelet expansion already works with zero chart changes — the README just never used it. The advertise example becomes `http://$(POD_NAME).<headless>.<ns>.svc.<clusterDomain>:2455` (first hostname label == instance id, so `_bridge_advertise_hostname_is_replica_specific` passes); the ring example becomes bare pod names matching `$(POD_NAME)` (Settings requires the literal `instance_id in ring`).
+
+- **Rejected**: relaxing settings.py validation — the validation is correct and the examples were wrong.
+
+### 5. Static-ring render guard is a template `fail`, not a NOTES warning
+
+`sessionBridgeInstanceRing` non-empty with `autoscaling.enabled` (prod overlay: maxReplicas=20) or `replicaCount` > ring length deterministically crashloops pods at Settings load; failing at `helm template`/`upgrade` time is strictly better than a stalled rollout. The guard only fires on the opt-in manual-override path, so default installs are unaffected.
+
+### 6. Two-replica smoke goes in external-db mode only
+
+External-db is the PostgreSQL/multi-replica-shaped path (bundled stays 1 replica to bound kind CI cost). `helm --wait` on the StatefulSet already requires both pods Ready; we add an explicit ring assertion (`kubectl exec` pod-0 -> GET `/health/ready`, parse `bridge_ring.ring_size==2 && is_member`) because readiness gating on ring membership is precisely the machinery (parallel dual registration, headless-DNS advertise reachability, `publishNotReadyAddresses` handoff) that has never been exercised pre-release. This IS the two-replica simulation for this change: two real app instances sharing one PostgreSQL, at the actual product path (helm chart bring-up). The existing synced spec scenario "External DB smoke uses a single app replica" is MODIFIED to its two-replica replacement.
+
+### 7. Compose guardrail is documentation-only
+
+Both compose files publish host ports, so `docker compose up --scale server=2` already fails loudly on port collision; the guardrail comment (single-replica topology; multi-replica requires Helm + PostgreSQL) closes the operator-guidance gap without inventing runtime detection. Runtime SQLite multi-writer enforcement belongs to the sibling `document-replica-topology-contract` / leader-election changes — deliberately out of scope here to keep one concern per PR.
+
+## Non-goals / zero-impact notes
+
+- **Tables/columns/migrations**: none — zero schema impact.
+- **Locks/CAS**: none needed.
+- **SQLite vs PostgreSQL**: no runtime behavior change on either backend; the chart remains a PostgreSQL-only topology (bundled subchart or external DB) and the compose/README guardrails restate SQLite as single-instance-only.
+- **Hot-path overhead**: zero — no per-request or app-code changes at all.
+
+## Deviations from the reviewed design
+
+None. Implementation follows the design as written. (`make helm-check` could not run `kubeconform` locally — the binary is not installed in this environment; `helm-lint` and `helm-template` across all overlays pass, and CI runs the full `helm-check`.)

--- a/openspec/changes/fix-replica-deployment-artifacts/proposal.md
+++ b/openspec/changes/fix-replica-deployment-artifacts/proposal.md
@@ -1,0 +1,26 @@
+# Fix Replica Deployment Artifacts
+
+## Why
+
+The shipped multi-replica deployment artifacts are broken in ways that either take the fleet down or silently degrade it while every probe stays green: `values-prod.yaml` enables a fail-closed NetworkPolicy with no ingress-controller allow rule (day-one external outage on any policy-enforcing CNI), both chart README bridge-ring examples deterministically fail Settings validation and crashloop pods, the responses sticky ingress depends on a `configuration-snippet` that stock ingress-nginx >= 1.12 rejects at admission, and the staging/prod overlays get sticky-hash routing without the streaming-safety annotations (60s read timeout / 1m body cap on SSE/WS paths). None of this is caught before release because both helm-kind-smoke paths run one replica while the chart defaults to two. All six defects were adversarially verified against rendered chart output and Settings() behavior.
+
+## What Changes
+
+- **values-prod.yaml**: add `networkPolicy.ingressNSMatchLabels` (`kubernetes.io/metadata.name: ingress-nginx`, with an adjust-for-your-controller comment) and set `ingress.nginx.enabled: true`.
+- **values-staging.yaml**: set `ingress.nginx.enabled: true`.
+- **templates/NOTES.txt**: render a loud WARNING when `networkPolicy.enabled` and `ingress.enabled` are set while both `ingressNSMatchLabels` and `extraIngress` are empty — external traffic will be denied on the HTTP port while probes stay green.
+- **templates/ingress.yaml**: gate ALL nginx annotations (streaming-safety base set AND `upstream-hash-by` AND the responses sticky set) behind the single `ingress.nginx.enabled` flag so the two halves of the nginx contract can never be split again.
+- **values.yaml**: default `ingress.responses.nginx.configurationSnippet` to `""` and `ingress.responses.nginx.upstreamHashBy` to `"$http_x_codex_session_id$http_authorization"` (snippet-free consistent hash; undefined nginx header vars render empty, so it degrades to Authorization-key hashing when no session header). Snippet mode stays available as an explicit opt-in with the required controller flags documented.
+- **templates/deployment.yaml**: `fail` at render time when `config.sessionBridgeInstanceRing` is non-empty AND (`autoscaling.enabled=true` OR `replicaCount` > ring entry count) — turning the HPA-scale-up crashloop into a loud helm error.
+- **chart README.md**: fix the advertise-URL override example to the per-pod pattern `http://$(POD_NAME).<headless-svc>.<ns>.svc.<clusterDomain>:2455`; fix the Manual Ring Override example to bare StatefulSet pod names; document static-ring/autoscaling incompatibility; document NetworkPolicy + snippet-mode controller requirements.
+- **scripts/helm-kind-smoke.sh**: external-db mode installs with `--set replicaCount=2`, then asserts 2 Ready pods and, from inside pod 0, that `/health/ready` reports `bridge_ring.ring_size == 2` and `is_member == true`.
+- **docker-compose.yml / docker-compose.prod.yml**: header-comment guardrail stating compose is a single-replica topology (do not `--scale`; multi-replica requires the Helm chart + PostgreSQL + leader election).
+- **New regression tests** `tests/unit/test_helm_replica_artifacts.py` (chart render assertions, render-guard failures, README-example-passes-Settings-validation, smoke-script topology assertion).
+- Spec deltas in `deployment-networking` (4 ADDED) and `deployment-installation` (1 MODIFIED, 3 ADDED).
+- No app runtime code, no migrations, no settings.py changes.
+
+## Impact
+
+- Affected specs: `deployment-networking`, `deployment-installation`
+- Affected code: `deploy/helm/codex-lb/**` (values overlays, ingress/deployment/NOTES templates, README), `scripts/helm-kind-smoke.sh`, `docker-compose.yml`, `docker-compose.prod.yml`, `tests/unit/test_helm_external_secrets.py`, new `tests/unit/test_helm_replica_artifacts.py`
+- Behavior change for operators who set `ingress.enabled=true` on an nginx class without `ingress.nginx.enabled=true`: they previously received `upstream-hash-by` unconditionally and now receive no nginx annotations until they set the flag (session correctness is preserved by DB-backed bridge ring owner-forwarding; the cost is a forwarding hop). Called out in change notes.

--- a/openspec/changes/fix-replica-deployment-artifacts/specs/deployment-installation/spec.md
+++ b/openspec/changes/fix-replica-deployment-artifacts/specs/deployment-installation/spec.md
@@ -25,6 +25,7 @@ The project MUST run automated Helm smoke installs for the easy-setup install mo
 - **THEN** the application release is installed with two replicas
 - **AND** both application pods become Ready
 - **AND** `/health/ready` served by an application pod reports a bridge ring of size 2 with the probed pod an active member
+- **AND** the smoke fails when the bridge ring probe emits no confirmation output, so a probe that silently no-ops cannot pass
 - **AND** the smoke still validates external database mode by using an external PostgreSQL release
 
 #### Scenario: Bundled smoke remains single-replica

--- a/openspec/changes/fix-replica-deployment-artifacts/specs/deployment-installation/spec.md
+++ b/openspec/changes/fix-replica-deployment-artifacts/specs/deployment-installation/spec.md
@@ -48,7 +48,7 @@ The project MUST run automated Helm smoke installs for the easy-setup install mo
 
 ### Requirement: Static bridge ring overrides are guarded at render time
 
-WHEN `config.sessionBridgeInstanceRing` is non-empty AND (`autoscaling.enabled=true` OR `replicaCount` exceeds the number of ring entries), chart rendering MUST fail with an error explaining that a static ring is incompatible with autoscaling / must list every pod.
+WHEN `config.sessionBridgeInstanceRing` is non-empty, chart rendering MUST fail with a helpful error if `autoscaling.enabled=true`, OR if the trimmed ring entries do not exactly match the set of expected StatefulSet pod names (`<workload-name>-0` through `<workload-name>-<replicaCount - 1>`). The guard MUST validate entry values, not merely entry count: a ring with the right number of entries but wrong values (for example FQDN-style entries or a wrong name prefix) MUST be rejected, naming the missing or unexpected entries and the exact expected pod names.
 
 #### Scenario: Static ring with autoscaling fails to render
 
@@ -57,12 +57,22 @@ WHEN `config.sessionBridgeInstanceRing` is non-empty AND (`autoscaling.enabled=t
 
 #### Scenario: Static ring smaller than replicaCount fails to render
 
-- **WHEN** the chart is rendered with `replicaCount=3` and a `config.sessionBridgeInstanceRing` listing 2 entries
-- **THEN** `helm template` fails with an error stating every pod name must be present in the static ring
+- **WHEN** the chart is rendered with `replicaCount=3` and a `config.sessionBridgeInstanceRing` listing 2 of the 3 expected pod names
+- **THEN** `helm template` fails with an error naming the missing pod name
+
+#### Scenario: Static ring with correct count but wrong values fails to render
+
+- **WHEN** the chart is rendered with `replicaCount=2` and a `config.sessionBridgeInstanceRing` listing 2 entries that are not the expected StatefulSet pod names (for example FQDN-style entries or `codex-lb-0,codex-lb-1`)
+- **THEN** `helm template` fails with an error naming the missing expected pod names and the exact ring the chart requires
+
+#### Scenario: Static ring with an unexpected extra entry fails to render
+
+- **WHEN** the chart is rendered with `replicaCount=2` and a `config.sessionBridgeInstanceRing` listing both expected pod names plus an entry that matches no StatefulSet pod
+- **THEN** `helm template` fails with an error naming the unexpected entry
 
 #### Scenario: Static ring covering every replica renders
 
-- **WHEN** the chart is rendered with `replicaCount=2` and a `config.sessionBridgeInstanceRing` listing both pod names
+- **WHEN** the chart is rendered with `replicaCount=2` and a `config.sessionBridgeInstanceRing` listing exactly both expected pod names
 - **THEN** rendering succeeds
 
 ### Requirement: Documented bridge ring and advertise URL examples pass application validation

--- a/openspec/changes/fix-replica-deployment-artifacts/specs/deployment-installation/spec.md
+++ b/openspec/changes/fix-replica-deployment-artifacts/specs/deployment-installation/spec.md
@@ -1,0 +1,83 @@
+# deployment-installation Delta
+
+## MODIFIED Requirements
+
+### Requirement: Helm install modes are smoke-tested
+
+The project MUST run automated Helm smoke installs for the easy-setup install modes in CI. CI Helm smoke installs MUST avoid avoidable external image pulls for chart test pods when the application image has already been built and loaded into the disposable cluster. Smoke scripts MUST emit timestamped logs for major phases so CI output identifies where time is spent. Smoke scripts MUST bound Helm test waits with a configurable timeout.
+
+#### Scenario: Bundled and external DB modes are smoke tested
+
+- **WHEN** CI runs Helm smoke installation checks
+- **THEN** it installs the chart on a disposable Kubernetes cluster in bundled mode
+- **AND** it installs the chart on a disposable Kubernetes cluster in external DB mode
+- **AND** both installs reach a healthy testable state
+
+#### Scenario: CI Helm test uses the loaded application image
+
+- **WHEN** CI runs kind-based Helm smoke checks after loading the application image into the cluster
+- **THEN** the Helm test pod image is overridden to the loaded application image
+- **AND** the chart default test pod image remains equivalent to `docker.io/library/busybox:1.37` for normal installs
+
+#### Scenario: External DB smoke exercises the default two-replica topology
+
+- **WHEN** CI runs the external DB smoke installation
+- **THEN** the application release is installed with two replicas
+- **AND** both application pods become Ready
+- **AND** `/health/ready` served by an application pod reports a bridge ring of size 2 with the probed pod an active member
+- **AND** the smoke still validates external database mode by using an external PostgreSQL release
+
+#### Scenario: Bundled smoke remains single-replica
+
+- **WHEN** CI runs the bundled smoke installation
+- **THEN** the application release is installed with one replica to bound disposable-cluster resource cost
+
+#### Scenario: Helm smoke phases are timestamped
+
+- **WHEN** CI runs kind-based Helm smoke checks
+- **THEN** major phases emit UTC timestamped log lines
+
+#### Scenario: Helm test wait is bounded
+
+- **WHEN** CI runs kind-based Helm smoke checks
+- **THEN** each `helm test` invocation uses the configured Helm test timeout
+- **AND** the default timeout is shorter than Helm's default wait window
+
+## ADDED Requirements
+
+### Requirement: Static bridge ring overrides are guarded at render time
+
+WHEN `config.sessionBridgeInstanceRing` is non-empty AND (`autoscaling.enabled=true` OR `replicaCount` exceeds the number of ring entries), chart rendering MUST fail with an error explaining that a static ring is incompatible with autoscaling / must list every pod.
+
+#### Scenario: Static ring with autoscaling fails to render
+
+- **WHEN** the chart is rendered with a non-empty `config.sessionBridgeInstanceRing` and `autoscaling.enabled=true`
+- **THEN** `helm template` fails with an error stating the static ring is incompatible with autoscaling
+
+#### Scenario: Static ring smaller than replicaCount fails to render
+
+- **WHEN** the chart is rendered with `replicaCount=3` and a `config.sessionBridgeInstanceRing` listing 2 entries
+- **THEN** `helm template` fails with an error stating every pod name must be present in the static ring
+
+#### Scenario: Static ring covering every replica renders
+
+- **WHEN** the chart is rendered with `replicaCount=2` and a `config.sessionBridgeInstanceRing` listing both pod names
+- **THEN** rendering succeeds
+
+### Requirement: Documented bridge ring and advertise URL examples pass application validation
+
+Bridge advertise-base-URL and manual instance-ring examples in the chart README MUST, after kubelet-style `$(POD_NAME)`/`$(POD_IP)` expansion with the chart's pod naming, satisfy the application's Settings validation (instance id literally present in the ring; advertise hostname replica-specific). Shared-service-hostname advertise examples and FQDN ring entries MUST NOT appear as recommended examples.
+
+#### Scenario: README examples construct valid Settings
+
+- **WHEN** the README example values are extracted and applied to Settings with a simulated StatefulSet pod name substituted for `$(POD_NAME)`
+- **THEN** Settings construction succeeds without validation errors
+
+### Requirement: Docker Compose deployments are declared single-replica
+
+The shipped docker-compose files MUST document that they define a single-replica topology, that `docker compose up --scale` is unsupported, and that multi-replica deployments require the Helm chart with PostgreSQL.
+
+#### Scenario: Compose files carry the guardrail statement
+
+- **WHEN** `docker-compose.yml` and `docker-compose.prod.yml` are inspected
+- **THEN** each carries the single-replica guardrail statement referencing the Helm chart path

--- a/openspec/changes/fix-replica-deployment-artifacts/specs/deployment-networking/spec.md
+++ b/openspec/changes/fix-replica-deployment-artifacts/specs/deployment-networking/spec.md
@@ -1,0 +1,56 @@
+# deployment-networking Delta
+
+## ADDED Requirements
+
+### Requirement: Shipped overlays that enable NetworkPolicy with Ingress allow ingress-controller traffic
+
+Any values overlay shipped with the chart that sets `networkPolicy.enabled=true` together with `ingress.enabled=true` MUST configure `networkPolicy.ingressNSMatchLabels` (or an equivalent `networkPolicy.extraIngress` rule) so the rendered NetworkPolicy admits ingress-controller traffic to the HTTP port.
+
+#### Scenario: values-prod.yaml admits the ingress controller on the HTTP port
+
+- **WHEN** the chart is rendered with `values-prod.yaml`
+- **THEN** the NetworkPolicy contains an ingress rule for port `2455` from a `namespaceSelector` matching the configured ingress-controller namespace labels
+- **AND** no rule on the HTTP port uses an empty `namespaceSelector` (the fail-closed requirement is preserved)
+
+### Requirement: Missing NetworkPolicy ingress allowlist warns at install time
+
+WHEN `networkPolicy.enabled=true` AND `ingress.enabled=true` AND both `networkPolicy.ingressNSMatchLabels` and `networkPolicy.extraIngress` are empty, the rendered install NOTES MUST contain a warning that external traffic through the ingress controller will be denied on the HTTP port while pods stay Ready.
+
+#### Scenario: Warning renders for the denying combination
+
+- **WHEN** the chart is installed with `networkPolicy.enabled=true`, `ingress.enabled=true`, and no ingress allowlist configured
+- **THEN** the rendered NOTES contain a WARNING naming `networkPolicy.ingressNSMatchLabels` and the denied HTTP port
+
+#### Scenario: Warning absent when an allowlist is configured
+
+- **WHEN** the chart is installed with `networkPolicy.ingressNSMatchLabels` set (for example via `values-prod.yaml`)
+- **THEN** the rendered NOTES do not contain the ingress-denied warning
+
+### Requirement: nginx ingress annotations render as a coherent set
+
+All nginx-specific annotations — the streaming-safety set (`proxy-buffering: off`, `proxy-request-buffering: off`, `proxy-read-timeout`/`proxy-send-timeout: 3600`, `proxy-body-size`, `proxy-http-version: 1.1`) AND the sticky-routing set (`upstream-hash-by`, subset options, and the responses sticky/retry annotations) — MUST render only when `ingress.nginx.enabled=true`, and MUST render together. Shipped overlays that enable ingress on an nginx class (`values-staging.yaml`, `values-prod.yaml`) MUST set `ingress.nginx.enabled=true`.
+
+#### Scenario: No nginx annotations without the nginx flag
+
+- **WHEN** the chart is rendered with `ingress.enabled=true` and `ingress.nginx.enabled=false`
+- **THEN** neither the main nor the responses Ingress carries any `nginx.ingress.kubernetes.io/*` annotation
+
+#### Scenario: Staging and prod overlays carry the full annotation set
+
+- **WHEN** the chart is rendered with `values-staging.yaml` or `values-prod.yaml`
+- **THEN** both Ingress resources carry the streaming-safety annotations AND the sticky-hash annotations
+
+### Requirement: Responses sticky routing defaults are admission-safe on stock ingress-nginx
+
+The default responses-ingress sticky mechanism MUST NOT rely on `nginx.ingress.kubernetes.io/configuration-snippet` (rejected by stock ingress-nginx >= 1.12 at the default `annotations-risk-level`). The default MUST be a snippet-free `upstream-hash-by` key that prefers `x-codex-session-id` and falls back to the `Authorization` header (`$http_x_codex_session_id$http_authorization`). `configuration-snippet` MUST render only when the operator explicitly sets `ingress.responses.nginx.configurationSnippet`.
+
+#### Scenario: Default render is snippet-free
+
+- **WHEN** the chart is rendered with `ingress.enabled=true` and `ingress.nginx.enabled=true` and default values
+- **THEN** the responses Ingress carries `nginx.ingress.kubernetes.io/upstream-hash-by: $http_x_codex_session_id$http_authorization`
+- **AND** no `nginx.ingress.kubernetes.io/configuration-snippet` annotation is rendered
+
+#### Scenario: Explicit snippet opt-in renders
+
+- **WHEN** the operator sets a non-empty `ingress.responses.nginx.configurationSnippet`
+- **THEN** the `configuration-snippet` annotation renders with the configured content

--- a/openspec/changes/fix-replica-deployment-artifacts/tasks.md
+++ b/openspec/changes/fix-replica-deployment-artifacts/tasks.md
@@ -14,7 +14,7 @@
 - [x] 3.1 templates/NOTES.txt: WARNING block for `networkPolicy.enabled && ingress.enabled && empty ingressNSMatchLabels && empty extraIngress`
 - [x] 3.2 templates/ingress.yaml: move `upstream-hash-by` / responses sticky annotation emission under the `ingress.nginx.enabled` gate (single coherent gate for all nginx annotations)
 - [x] 3.3 values.yaml: default `ingress.responses.nginx.configurationSnippet` to `""` and `ingress.responses.nginx.upstreamHashBy` to `"$http_x_codex_session_id$http_authorization"`; update @param comments documenting the opt-in snippet mode and its required controller flags
-- [x] 3.4 templates/deployment.yaml: render-time `fail` when `config.sessionBridgeInstanceRing` is non-empty and (`autoscaling.enabled` or `replicaCount` > ring entry count), with actionable error message
+- [x] 3.4 templates/deployment.yaml: render-time `fail` when `config.sessionBridgeInstanceRing` is non-empty and (`autoscaling.enabled` or the trimmed ring entries do not exactly match the expected StatefulSet pod names `<workload-name>-0..<replicaCount-1>`), with actionable error messages naming missing/unexpected entries (value validation, not just entry count)
 
 ## 4. Documentation
 

--- a/openspec/changes/fix-replica-deployment-artifacts/tasks.md
+++ b/openspec/changes/fix-replica-deployment-artifacts/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: fix-replica-deployment-artifacts
+
+## 1. OpenSpec artifacts
+
+- [x] 1.1 Create proposal.md, design.md, tasks.md, context.md, and delta specs for `deployment-networking` and `deployment-installation`; run `openspec validate fix-replica-deployment-artifacts`
+
+## 2. Chart values overlays
+
+- [x] 2.1 values-prod.yaml: add `networkPolicy.ingressNSMatchLabels` (`kubernetes.io/metadata.name: ingress-nginx`, with adjust-for-your-controller comment) and `ingress.nginx.enabled=true`
+- [x] 2.2 values-staging.yaml: add `ingress.nginx.enabled=true`
+
+## 3. Chart templates
+
+- [x] 3.1 templates/NOTES.txt: WARNING block for `networkPolicy.enabled && ingress.enabled && empty ingressNSMatchLabels && empty extraIngress`
+- [x] 3.2 templates/ingress.yaml: move `upstream-hash-by` / responses sticky annotation emission under the `ingress.nginx.enabled` gate (single coherent gate for all nginx annotations)
+- [x] 3.3 values.yaml: default `ingress.responses.nginx.configurationSnippet` to `""` and `ingress.responses.nginx.upstreamHashBy` to `"$http_x_codex_session_id$http_authorization"`; update @param comments documenting the opt-in snippet mode and its required controller flags
+- [x] 3.4 templates/deployment.yaml: render-time `fail` when `config.sessionBridgeInstanceRing` is non-empty and (`autoscaling.enabled` or `replicaCount` > ring entry count), with actionable error message
+
+## 4. Documentation
+
+- [x] 4.1 deploy/helm/codex-lb/README.md: fix `sessionBridgeAdvertiseBaseUrl` example to `http://$(POD_NAME).<headless-svc>.<ns>.svc.<clusterDomain>:2455` with env-expansion explanation; fix Manual Ring Override example to bare `<release>-workload-N` pod names; document static-ring vs autoscaling incompatibility; document snippet-mode controller requirements and the snippet-free default; cross-reference the NetworkPolicy `ingressNSMatchLabels` requirement from the prod overlay section
+- [x] 4.2 docker-compose.yml + docker-compose.prod.yml: add single-replica guardrail header comment (no `--scale`; multi-replica requires Helm chart + PostgreSQL + leader election)
+
+## 5. Smoke coverage
+
+- [x] 5.1 scripts/helm-kind-smoke.sh: external-db mode `--set replicaCount=2`; assert 2 Ready pods (kubectl wait) and kubectl-exec pod-0 GET `/health/ready` asserting `bridge_ring.ring_size==2` and `is_member==true`
+
+## 6. Tests
+
+- [x] 6.1 Add tests/unit/test_helm_replica_artifacts.py: NetworkPolicy allow rule + fail-closed invariant; NOTES warning present/absent; coherent nginx annotation set on staging/prod; no nginx annotations without the flag; snippet-free default + explicit snippet opt-in; render-guard failure and success cases; README examples pass Settings validation; smoke-script two-replica assertion; compose guardrail grep
+- [x] 6.2 Update tests/unit/test_helm_external_secrets.py for the snippet-free default and two-replica smoke topology
+- [x] 6.3 Run `make helm-lint helm-template` and `uv run pytest tests/unit/test_helm_replica_artifacts.py tests/unit/test_helm_external_secrets.py tests/unit/test_k8s_version_policy.py`
+
+## 7. Follow-up (post-verification)
+
+- [ ] 7.1 Sync delta specs into main specs via `/opsx:sync` after the openspec-sot-sync PR lands (this change's MODIFIED requirement targets the synced SSOT text)

--- a/scripts/helm-kind-smoke.sh
+++ b/scripts/helm-kind-smoke.sh
@@ -42,7 +42,8 @@ assert_bridge_ring() {
   done
 
   log_step "asserting bridge ring size ${expected_replicas} via /health/ready on ${workload}-0"
-  kubectl --context "${KUBE_CONTEXT}" -n "${namespace}" exec "${workload}-0" -c codex-lb -- \
+  local probe_output
+  probe_output=$(kubectl --context "${KUBE_CONTEXT}" -n "${namespace}" exec -i "${workload}-0" -c codex-lb -- \
     python - "${expected_replicas}" <<'PY'
 import json
 import sys
@@ -55,6 +56,12 @@ assert ring.get("ring_size") == expected, f"bridge ring size {ring.get('ring_siz
 assert ring.get("is_member") is True, f"probed pod is not an active ring member: {ring}"
 print(f"bridge ring ok: {ring}")
 PY
+)
+  if [[ "${probe_output}" != "bridge ring ok:"* ]]; then
+    echo "[helm-kind-smoke] bridge ring probe emitted no confirmation (stdin not forwarded to python?): '${probe_output}'" >&2
+    return 1
+  fi
+  log_step "${probe_output}"
 }
 
 dump_namespace_debug() {

--- a/scripts/helm-kind-smoke.sh
+++ b/scripts/helm-kind-smoke.sh
@@ -28,6 +28,35 @@ wait_for_release() {
   helm test "${release}" --namespace "${namespace}" --kube-context "${KUBE_CONTEXT}" --timeout "${HELM_TEST_TIMEOUT}"
 }
 
+assert_bridge_ring() {
+  local release="$1"
+  local namespace="$2"
+  local expected_replicas="$3"
+  local workload="${release}-workload"
+
+  log_step "asserting ${expected_replicas} Ready pods for ${workload}"
+  local ordinal
+  for ((ordinal = 0; ordinal < expected_replicas; ordinal++)); do
+    kubectl --context "${KUBE_CONTEXT}" -n "${namespace}" wait \
+      --for=condition=Ready "pod/${workload}-${ordinal}" --timeout=300s
+  done
+
+  log_step "asserting bridge ring size ${expected_replicas} via /health/ready on ${workload}-0"
+  kubectl --context "${KUBE_CONTEXT}" -n "${namespace}" exec "${workload}-0" -c codex-lb -- \
+    python - "${expected_replicas}" <<'PY'
+import json
+import sys
+import urllib.request
+
+expected = int(sys.argv[1])
+payload = json.loads(urllib.request.urlopen("http://127.0.0.1:2455/health/ready", timeout=10).read())
+ring = payload.get("bridge_ring") or {}
+assert ring.get("ring_size") == expected, f"bridge ring size {ring.get('ring_size')} != {expected}: {ring}"
+assert ring.get("is_member") is True, f"probed pod is not an active ring member: {ring}"
+print(f"bridge ring ok: {ring}")
+PY
+}
+
 dump_namespace_debug() {
   local namespace="$1"
   echo "[helm-kind-smoke] dumping namespace state for ${namespace}" >&2
@@ -131,10 +160,11 @@ PY
     --set test.image.tag="${IMAGE_TAG}" \
     --set test.image.pullPolicy=IfNotPresent \
     --set auth.existingSecret="${app_secret}" \
-    --set replicaCount=1 \
+    --set replicaCount=2 \
     --wait \
     --timeout 10m
 
+  assert_bridge_ring "${release}" "${namespace}" 2
   wait_for_release "${release}" "${namespace}"
   trap - ERR
 }

--- a/tests/unit/test_helm_external_secrets.py
+++ b/tests/unit/test_helm_external_secrets.py
@@ -366,10 +366,8 @@ def test_ingress_renders_dedicated_responses_ingress_with_session_hash() -> None
 
     assert rendered.count("kind: Ingress") == 2
     assert "name: codex-lb-responses" in rendered
-    assert "nginx.ingress.kubernetes.io/upstream-hash-by: $codex_responses_hash_key" in rendered
-    assert "nginx.ingress.kubernetes.io/configuration-snippet:" in rendered
-    assert 'set $codex_responses_hash_key "$http_authorization:$request_id";' in rendered
-    assert "set $codex_responses_hash_key $http_x_codex_session_id;" in rendered
+    assert "nginx.ingress.kubernetes.io/upstream-hash-by: $http_x_codex_session_id$http_authorization" in rendered
+    assert "nginx.ingress.kubernetes.io/configuration-snippet:" not in rendered
     assert "nginx.ingress.kubernetes.io/upstream-hash-by: $http_authorization" in rendered
     assert "nginx.ingress.kubernetes.io/proxy-next-upstream: error timeout http_502 http_503 http_504" in rendered
     assert "invalid_header" in rendered
@@ -439,8 +437,8 @@ def test_kind_smoke_overrides_helm_test_image_and_external_db_replicas() -> None
     assert '--set test.image.repository="${IMAGE_REPOSITORY}"' in script
     assert '--set test.image.tag="${IMAGE_TAG}"' in script
     assert "--set test.image.pullPolicy=IfNotPresent" in script
-    assert _command_sets_value(external_db_install, "replicaCount=1")
-    assert not _command_sets_value(bundled_install, "replicaCount=1")
+    assert _command_sets_value(external_db_install, "replicaCount=2")
+    assert not _command_sets_value(bundled_install, "replicaCount=2")
 
 
 def test_kind_smoke_logs_timestamped_major_steps() -> None:

--- a/tests/unit/test_helm_replica_artifacts.py
+++ b/tests/unit/test_helm_replica_artifacts.py
@@ -1,0 +1,360 @@
+"""Regression tests for the multi-replica deployment artifacts.
+
+Covers the artifact-level defects that shipped broken multi-replica deployments:
+- values-prod.yaml enabling a fail-closed NetworkPolicy without an ingress-controller allow rule
+- nginx ingress annotations rendering as an incoherent split set
+- the responses sticky default relying on an admission-rejected configuration-snippet
+- chart README bridge examples that fail application Settings validation
+- static-ring values that crashloop pods instead of failing at render time
+- kind smoke never exercising the default two-replica topology
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from app.core.config.settings import Settings
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CHART_DIR = _REPO_ROOT / "deploy" / "helm" / "codex-lb"
+_CHART_README = _CHART_DIR / "README.md"
+_SMOKE_SCRIPT = _REPO_ROOT / "scripts" / "helm-kind-smoke.sh"
+_HTTP_PORT = 2455
+_DEPENDENCY_BUILD_COMPLETE = False
+
+
+def _ensure_chart_dependencies() -> None:
+    global _DEPENDENCY_BUILD_COMPLETE
+    if _DEPENDENCY_BUILD_COMPLETE:
+        return
+
+    if shutil.which("helm") is None:
+        pytest.skip("helm is required for chart rendering tests")
+
+    subprocess.run(
+        ["helm", "dependency", "build", str(_CHART_DIR)],
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    _DEPENDENCY_BUILD_COMPLETE = True
+
+
+def _helm_template(*args: str) -> str:
+    _ensure_chart_dependencies()
+    completed = subprocess.run(
+        ["helm", "template", "codex-lb", str(_CHART_DIR), *args],
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout
+
+
+def _helm_template_error(*args: str) -> str:
+    _ensure_chart_dependencies()
+    completed = subprocess.run(
+        ["helm", "template", "codex-lb", str(_CHART_DIR), *args],
+        cwd=_REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0, "expected helm template to fail"
+    return completed.stderr
+
+
+def _helm_notes(*args: str) -> str:
+    _ensure_chart_dependencies()
+    completed = subprocess.run(
+        ["helm", "install", "codex-lb", str(_CHART_DIR), "--dry-run=client", *args],
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout
+
+
+def _helm_documents(rendered: str) -> list[dict]:
+    return [document for document in yaml.safe_load_all(rendered) if document]
+
+
+def _prod_overlay_args(*args: str) -> tuple[str, ...]:
+    return (
+        "-f",
+        str(_CHART_DIR / "values-prod.yaml"),
+        "--set",
+        "externalSecrets.secretStoreRef.name=test-store",
+        *args,
+    )
+
+
+def _staging_overlay_args(*args: str) -> tuple[str, ...]:
+    return (
+        "-f",
+        str(_CHART_DIR / "values-staging.yaml"),
+        "--set",
+        "externalDatabase.url=postgresql+asyncpg://test:test@localhost/test",
+        *args,
+    )
+
+
+def _http_port_rules(policy: dict) -> list[dict]:
+    rules = []
+    for rule in policy["spec"].get("ingress", []):
+        ports = rule.get("ports", [])
+        if any(port.get("port") == _HTTP_PORT for port in ports):
+            rules.append(rule)
+    return rules
+
+
+def test_prod_overlay_network_policy_allows_ingress_controller_on_http_port() -> None:
+    rendered = _helm_template(*_prod_overlay_args("--show-only", "templates/networkpolicy.yaml"))
+    (policy,) = _helm_documents(rendered)
+
+    http_rules = _http_port_rules(policy)
+    assert http_rules, "no NetworkPolicy ingress rule opens the HTTP port"
+
+    controller_selectors = [
+        peer["namespaceSelector"] for rule in http_rules for peer in rule.get("from", []) if "namespaceSelector" in peer
+    ]
+    assert {"matchLabels": {"kubernetes.io/metadata.name": "ingress-nginx"}} in controller_selectors
+
+    # Fail-closed invariant: no allow-all namespaceSelector on the HTTP port.
+    assert {} not in controller_selectors
+
+
+def test_notes_warn_when_network_policy_denies_ingress_controller() -> None:
+    notes = _helm_notes(
+        "--set",
+        "postgresql.auth.password=test-password",
+        "--set",
+        "networkPolicy.enabled=true",
+        "--set",
+        "ingress.enabled=true",
+    )
+
+    assert "WARNING" in notes
+    assert "DENIES all ingress-controller traffic to port" in notes
+    assert "networkPolicy.ingressNSMatchLabels" in notes
+
+
+def test_notes_warning_absent_when_ingress_allowlist_is_configured() -> None:
+    # ServiceMonitor/PrometheusRule CRDs are not resolvable in a clusterless dry run.
+    notes = _helm_notes(
+        *_prod_overlay_args(
+            "--set",
+            "metrics.serviceMonitor.enabled=false",
+            "--set",
+            "metrics.prometheusRule.enabled=false",
+        )
+    )
+
+    assert "DENIES all ingress-controller traffic" not in notes
+
+
+def test_staging_and_prod_overlays_render_coherent_nginx_annotation_set() -> None:
+    for overlay_args in (_staging_overlay_args(), _prod_overlay_args()):
+        rendered = _helm_template(*overlay_args, "--show-only", "templates/ingress.yaml")
+        documents = _helm_documents(rendered)
+        assert len(documents) == 2, "expected the main and responses Ingress"
+
+        for document in documents:
+            annotations = document["metadata"]["annotations"]
+            assert annotations["nginx.ingress.kubernetes.io/proxy-buffering"] == "off"
+            assert annotations["nginx.ingress.kubernetes.io/proxy-request-buffering"] == "off"
+            assert annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"] == "3600"
+            assert annotations["nginx.ingress.kubernetes.io/proxy-send-timeout"] == "3600"
+            assert annotations["nginx.ingress.kubernetes.io/proxy-body-size"] == "50m"
+            assert "nginx.ingress.kubernetes.io/upstream-hash-by" in annotations
+            assert "nginx.ingress.kubernetes.io/configuration-snippet" not in annotations
+
+
+def test_responses_sticky_default_is_snippet_free_session_hash() -> None:
+    rendered = _helm_template(
+        "--set",
+        "postgresql.auth.password=test-password",
+        "--set",
+        "ingress.enabled=true",
+        "--set",
+        "ingress.nginx.enabled=true",
+        "--show-only",
+        "templates/ingress.yaml",
+    )
+
+    responses = next(
+        document for document in _helm_documents(rendered) if document["metadata"]["name"].endswith("-responses")
+    )
+    annotations = responses["metadata"]["annotations"]
+    assert annotations["nginx.ingress.kubernetes.io/upstream-hash-by"] == "$http_x_codex_session_id$http_authorization"
+    assert "nginx.ingress.kubernetes.io/configuration-snippet" not in annotations
+
+
+def test_ingress_without_nginx_flag_renders_no_nginx_annotations() -> None:
+    rendered = _helm_template(
+        "--set",
+        "postgresql.auth.password=test-password",
+        "--set",
+        "ingress.enabled=true",
+        "--show-only",
+        "templates/ingress.yaml",
+    )
+
+    assert rendered.count("kind: Ingress") == 2
+    assert "nginx.ingress.kubernetes.io/" not in rendered
+
+
+def test_explicit_configuration_snippet_still_renders() -> None:
+    rendered = _helm_template(
+        "--set",
+        "postgresql.auth.password=test-password",
+        "--set",
+        "ingress.enabled=true",
+        "--set",
+        "ingress.nginx.enabled=true",
+        "--set-string",
+        'ingress.responses.nginx.configurationSnippet=set $codex_key "$http_authorization";',
+        "--show-only",
+        "templates/ingress.yaml",
+    )
+
+    assert "nginx.ingress.kubernetes.io/configuration-snippet:" in rendered
+    assert 'set $codex_key "$http_authorization";' in rendered
+
+
+def test_static_ring_with_autoscaling_fails_at_render_time() -> None:
+    stderr = _helm_template_error(
+        "--set",
+        "postgresql.auth.password=test-password",
+        "--set-string",
+        "config.sessionBridgeInstanceRing=codex-lb-workload-0\\,codex-lb-workload-1",
+        "--set",
+        "autoscaling.enabled=true",
+    )
+
+    assert "incompatible with autoscaling.enabled=true" in stderr
+
+
+def test_static_ring_smaller_than_replica_count_fails_at_render_time() -> None:
+    stderr = _helm_template_error(
+        "--set",
+        "postgresql.auth.password=test-password",
+        "--set-string",
+        "config.sessionBridgeInstanceRing=codex-lb-workload-0\\,codex-lb-workload-1",
+        "--set",
+        "replicaCount=3",
+    )
+
+    assert "lists 2 entries but replicaCount is 3" in stderr
+
+
+def test_static_ring_covering_every_replica_renders() -> None:
+    rendered = _helm_template(
+        "--set",
+        "postgresql.auth.password=test-password",
+        "--set-string",
+        "config.sessionBridgeInstanceRing=codex-lb-workload-0\\,codex-lb-workload-1",
+        "--set",
+        "replicaCount=2",
+        "--show-only",
+        "templates/deployment.yaml",
+    )
+
+    assert "kind: StatefulSet" in rendered
+
+
+def _readme_config_examples() -> list[dict]:
+    readme = _CHART_README.read_text()
+    examples = []
+    for fence in re.findall(r"```yaml\n(.*?)```", readme, re.DOTALL):
+        parsed = yaml.safe_load(fence)
+        if isinstance(parsed, dict) and isinstance(parsed.get("config"), dict):
+            examples.append(parsed["config"])
+    return examples
+
+
+def _clear_pod_identity_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("POD_NAME", "POD_NAMESPACE", "POD_IP", "HOSTNAME"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.delenv("CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_INSTANCE_RING", raising=False)
+    monkeypatch.delenv("CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_ADVERTISE_BASE_URL", raising=False)
+
+
+def test_readme_advertise_base_url_example_passes_settings_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    examples = [
+        config["sessionBridgeAdvertiseBaseUrl"]
+        for config in _readme_config_examples()
+        if "sessionBridgeAdvertiseBaseUrl" in config
+    ]
+    assert examples, "README no longer documents a sessionBridgeAdvertiseBaseUrl example"
+
+    pod_name = "codex-lb-workload-0"
+    _clear_pod_identity_env(monkeypatch)
+    monkeypatch.setenv("CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_INSTANCE_ID", pod_name)
+
+    for example in examples:
+        # The chart injects the value through the container env list after POD_NAME,
+        # so the kubelet expands $(POD_NAME) per pod before the app reads it.
+        assert "$(POD_NAME)" in example, f"README advertise example is not per-pod: {example}"
+        expanded = example.replace("$(POD_NAME)", pod_name)
+        monkeypatch.setenv("CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_ADVERTISE_BASE_URL", expanded)
+
+        settings = Settings()
+
+        assert settings.http_responses_session_bridge_advertise_base_url == expanded.rstrip("/")
+
+
+def test_readme_manual_ring_example_passes_settings_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    examples = [
+        config["sessionBridgeInstanceRing"]
+        for config in _readme_config_examples()
+        if "sessionBridgeInstanceRing" in config
+    ]
+    assert examples, "README no longer documents a sessionBridgeInstanceRing example"
+
+    _clear_pod_identity_env(monkeypatch)
+
+    for example in examples:
+        entries = [entry.strip() for entry in example.split(",") if entry.strip()]
+        assert entries, f"README ring example is empty: {example}"
+        for entry in entries:
+            # Instance ids are bare $(POD_NAME) values; FQDN entries never match them.
+            assert "." not in entry, f"README ring example uses a non-pod-name entry: {entry}"
+
+        monkeypatch.setenv("CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_INSTANCE_ID", entries[0])
+        monkeypatch.setenv("CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_INSTANCE_RING", example)
+
+        settings = Settings()
+
+        assert settings.http_responses_session_bridge_instance_ring == entries
+
+
+def test_kind_smoke_external_db_mode_exercises_two_replica_bridge_ring() -> None:
+    script = _SMOKE_SCRIPT.read_text()
+
+    assert "--set replicaCount=2" in script
+    assert "--set replicaCount=1" not in script
+    assert 'assert_bridge_ring "${release}" "${namespace}" 2' in script
+    assert "/health/ready" in script
+    assert 'ring.get("ring_size") == expected' in script
+    assert 'ring.get("is_member") is True' in script
+    assert "--for=condition=Ready" in script
+
+
+def test_compose_files_declare_single_replica_topology() -> None:
+    for compose_path in (_REPO_ROOT / "docker-compose.yml", _REPO_ROOT / "docker-compose.prod.yml"):
+        content = compose_path.read_text()
+        assert "SINGLE-REPLICA topology" in content, compose_path.name
+        assert "--scale server=N" in content, compose_path.name
+        assert "deploy/helm/codex-lb" in content, compose_path.name

--- a/tests/unit/test_helm_replica_artifacts.py
+++ b/tests/unit/test_helm_replica_artifacts.py
@@ -384,6 +384,11 @@ def test_kind_smoke_external_db_mode_exercises_two_replica_bridge_ring() -> None
     assert 'ring.get("ring_size") == expected' in script
     assert 'ring.get("is_member") is True' in script
     assert "--for=condition=Ready" in script
+    # kubectl exec only forwards the heredoc probe program when -i/--stdin is set;
+    # without it `python -` sees EOF and exits 0 without running any assertion.
+    assert 'exec -i "${workload}-0"' in script
+    # The probe result must be checked so a silent no-op cannot pass smoke again.
+    assert 'if [[ "${probe_output}" != "bridge ring ok:"* ]]; then' in script
 
 
 def test_compose_files_declare_single_replica_topology() -> None:

--- a/tests/unit/test_helm_replica_artifacts.py
+++ b/tests/unit/test_helm_replica_artifacts.py
@@ -290,7 +290,51 @@ def test_static_ring_smaller_than_replica_count_fails_at_render_time() -> None:
         "replicaCount=3",
     )
 
-    assert "lists 2 entries but replicaCount is 3" in stderr
+    assert 'missing pod name(s) "codex-lb-workload-2"' in stderr
+
+
+def test_static_ring_with_wrong_pod_names_fails_at_render_time() -> None:
+    """Right entry count, wrong values: the pods would still crashloop at startup."""
+    stderr = _helm_template_error(
+        "--set",
+        "postgresql.auth.password=test-password",
+        "--set-string",
+        "config.sessionBridgeInstanceRing=codex-lb-0\\,codex-lb-1",
+        "--set",
+        "replicaCount=2",
+    )
+
+    assert 'missing pod name(s) "codex-lb-workload-0,codex-lb-workload-1"' in stderr
+    assert 'must list exactly "codex-lb-workload-0,codex-lb-workload-1"' in stderr
+
+
+def test_static_ring_with_fqdn_entries_fails_at_render_time() -> None:
+    fqdn_ring = "\\,".join(
+        f"codex-lb-workload-{ordinal}.codex-lb-bridge.default.svc.cluster.local" for ordinal in range(2)
+    )
+    stderr = _helm_template_error(
+        "--set",
+        "postgresql.auth.password=test-password",
+        "--set-string",
+        f"config.sessionBridgeInstanceRing={fqdn_ring}",
+        "--set",
+        "replicaCount=2",
+    )
+
+    assert "missing pod name(s)" in stderr
+
+
+def test_static_ring_with_extra_unknown_entry_fails_at_render_time() -> None:
+    stderr = _helm_template_error(
+        "--set",
+        "postgresql.auth.password=test-password",
+        "--set-string",
+        "config.sessionBridgeInstanceRing=codex-lb-workload-0\\,codex-lb-workload-1\\,codex-lb-workload-9",
+        "--set",
+        "replicaCount=2",
+    )
+
+    assert 'entry(ies) "codex-lb-workload-9" do not match any StatefulSet pod name' in stderr
 
 
 def test_static_ring_covering_every_replica_renders() -> None:

--- a/tests/unit/test_helm_replica_artifacts.py
+++ b/tests/unit/test_helm_replica_artifacts.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import re
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -74,16 +75,49 @@ def _helm_template_error(*args: str) -> str:
     return completed.stderr
 
 
+_NOTES_WRAPPER_TEMPLATE = """\
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rendered-notes
+data:
+  notes: {{ include "codex-lb/templates/NOTES.txt" . | toJson }}
+"""
+
+
 def _helm_notes(*args: str) -> str:
+    """Render the chart NOTES.txt without a Kubernetes cluster.
+
+    ``helm install --dry-run=client`` still requires a reachable cluster
+    (the install action checks API-server reachability before rendering),
+    so it fails on CI runners that have no kubeconfig. Instead, render the
+    NOTES.txt template through ``helm template`` by including it from a
+    wrapper ConfigMap manifest in a throwaway copy of the chart.
+    """
     _ensure_chart_dependencies()
-    completed = subprocess.run(
-        ["helm", "install", "codex-lb", str(_CHART_DIR), "--dry-run=client", *args],
-        cwd=_REPO_ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return completed.stdout
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        chart_copy = Path(tmp_dir) / "codex-lb"
+        shutil.copytree(_CHART_DIR, chart_copy)
+        (chart_copy / "templates" / "zz-rendered-notes.yaml").write_text(_NOTES_WRAPPER_TEMPLATE)
+        completed = subprocess.run(
+            [
+                "helm",
+                "template",
+                "codex-lb",
+                str(chart_copy),
+                "--show-only",
+                "templates/zz-rendered-notes.yaml",
+                *args,
+            ],
+            cwd=_REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    (document,) = _helm_documents(completed.stdout)
+    notes = document["data"]["notes"]
+    assert isinstance(notes, str)
+    return notes
 
 
 def _helm_documents(rendered: str) -> list[dict]:


### PR DESCRIPTION
## Why

The shipped multi-replica deployment artifacts are broken in ways that either take the fleet down or silently degrade it while every probe stays green: `values-prod.yaml` enables a fail-closed NetworkPolicy with no ingress-controller allow rule (day-one external outage on any policy-enforcing CNI), both chart README bridge-ring examples deterministically fail Settings validation and crashloop pods, the responses sticky ingress depends on a `configuration-snippet` that stock ingress-nginx >= 1.12 rejects at admission, and the staging/prod overlays get sticky-hash routing without the streaming-safety annotations. None of this is caught before release because both helm-kind-smoke paths run one replica while the chart defaults to two. All six defects were adversarially verified against rendered chart output and Settings() behavior.

## What Changes

- **values-prod.yaml**: add `networkPolicy.ingressNSMatchLabels` (`kubernetes.io/metadata.name: ingress-nginx`) and set `ingress.nginx.enabled: true`; **values-staging.yaml**: set `ingress.nginx.enabled: true`.
- **templates/NOTES.txt**: loud WARNING when NetworkPolicy + ingress are enabled but both `ingressNSMatchLabels` and `extraIngress` are empty.
- **templates/ingress.yaml**: gate ALL nginx annotations (streaming-safety base set AND `upstream-hash-by` AND the responses sticky set) behind the single `ingress.nginx.enabled` flag.
- **values.yaml**: default the responses `configurationSnippet` to `""` and `upstreamHashBy` to `"$http_x_codex_session_id$http_authorization"` (snippet-free consistent hash); snippet mode stays an explicit opt-in.
- **templates/deployment.yaml**: `fail` at render time when `config.sessionBridgeInstanceRing` is non-empty AND (`autoscaling.enabled=true` OR `replicaCount` > ring entry count).
- **chart README.md**: fix the advertise-URL and Manual Ring Override examples; document static-ring/autoscaling incompatibility and NetworkPolicy/snippet-mode controller requirements.
- **scripts/helm-kind-smoke.sh**: external-db mode installs with `--set replicaCount=2`, asserts 2 Ready pods and `bridge_ring.ring_size == 2` / `is_member == true` from inside pod 0.
- **docker-compose{,.prod}.yml**: header-comment guardrail that compose is single-replica topology.
- New regression tests `tests/unit/test_helm_replica_artifacts.py`; spec deltas in `deployment-networking` (4 ADDED) and `deployment-installation` (1 MODIFIED, 3 ADDED). No app runtime code, no migrations.

## Testing

- `uv run pytest tests/unit/test_helm_replica_artifacts.py tests/unit/test_helm_external_secrets.py tests/unit/test_k8s_version_policy.py -q -x` → 59 passed.
- `make helm-lint helm-template` → all 7 overlay renders pass; `bash -n scripts/helm-kind-smoke.sh` clean.
- `ruff check app tests` + `ruff format --check` clean; `openspec validate fix-replica-deployment-artifacts` valid.

## Merge ordering / notes

- Depends on #1252 (OpenSpec SSOT sync) — MODIFIED spec deltas target the synced spec headers.
- No Alembic migration, no app runtime code.
- Operator-visible behavior change: `ingress.enabled=true` without `ingress.nginx.enabled=true` previously received `upstream-hash-by` unconditionally and now receives no nginx annotations until the flag is set (session correctness preserved via DB-backed bridge-ring owner-forwarding at the cost of a forwarding hop).
- Part of the 12-change multi-replica reliability effort; resolves no filed issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
