### PR TITLE
feat(planner): derive phase planning from observed short windows

### DIFF
--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -114,6 +114,7 @@ class AccountState:
     used_percent: float | None = None
     reset_at: float | None = None
     primary_reset_at: int | None = None
+    primary_window_minutes: int | None = None
     blocked_at: float | None = None
     cooldown_until: float | None = None
     secondary_used_percent: float | None = None

--- a/app/modules/limit_warmup/service.py
+++ b/app/modules/limit_warmup/service.py
@@ -712,9 +712,12 @@ def _build_staggered_idle_candidate(
         return None
     if usage_core.is_weekly_window_minutes(after.window_minutes):
         return None
+    if usage_core.is_monthly_window_minutes(after.window_minutes):
+        return None
     if after.used_percent > idle_threshold_percent:
         return None
 
+    window_seconds = _rolling_window_seconds(after)
     due = _staggered_idle_due(
         account.id,
         [candidate.id for candidate in accounts],
@@ -722,6 +725,7 @@ def _build_staggered_idle_candidate(
         reset_at=after.reset_at,
         interval_started_at=refresh_started_at,
         usage_refresh_interval_seconds=usage_refresh_interval_seconds,
+        window_seconds=window_seconds,
     )
     if due is None:
         return None
@@ -729,6 +733,7 @@ def _build_staggered_idle_candidate(
         after,
         refresh_started_at=refresh_started_at,
         cycle_end=due.cycle_end,
+        window_seconds=window_seconds,
     ):
         return None
     return _WarmupCandidate(reset_at=after.reset_at, window=_IDLE_PRIMARY_WINDOW)
@@ -740,6 +745,15 @@ class _StaggeredIdleDue:
     slot_offset_seconds: int
 
 
+def _rolling_window_seconds(entry: UsageHistory) -> int:
+    # Derive the rolling cycle from the observed primary window duration so
+    # the stagger tracks whatever short window upstream reports; 300 minutes
+    # remains the fallback when duration metadata is missing.
+    if entry.window_minutes is not None and entry.window_minutes > 0:
+        return int(entry.window_minutes) * 60
+    return _ROLLING_WINDOW_SECONDS
+
+
 def _staggered_idle_due(
     account_id: str,
     account_ids: list[str],
@@ -748,6 +762,7 @@ def _staggered_idle_due(
     reset_at: int,
     interval_started_at: datetime | None = None,
     usage_refresh_interval_seconds: int = _STAGGER_SLOT_GRACE_SECONDS,
+    window_seconds: int = _ROLLING_WINDOW_SECONDS,
 ) -> _StaggeredIdleDue | None:
     if not account_ids:
         return None
@@ -758,11 +773,11 @@ def _staggered_idle_due(
         return None
 
     now_epoch = naive_utc_to_epoch(now)
-    cycle_start = reset_at - _ROLLING_WINDOW_SECONDS
+    cycle_start = reset_at - window_seconds
     if now_epoch < cycle_start or now_epoch >= reset_at:
         return None
     elapsed = now_epoch - cycle_start
-    slot_offset = int(account_index * _ROLLING_WINDOW_SECONDS / len(ordered_account_ids))
+    slot_offset = int(account_index * window_seconds / len(ordered_account_ids))
     grace_seconds = max(_STAGGER_SLOT_GRACE_SECONDS, usage_refresh_interval_seconds)
     interval_start_epoch = naive_utc_to_epoch(interval_started_at) if interval_started_at is not None else now_epoch
     interval_start_epoch = min(interval_start_epoch, now_epoch)
@@ -772,7 +787,7 @@ def _staggered_idle_due(
     if slot_offset + grace_seconds <= interval_start_elapsed:
         return None
     return _StaggeredIdleDue(
-        cycle_end=cycle_start + _ROLLING_WINDOW_SECONDS,
+        cycle_end=cycle_start + window_seconds,
         slot_offset_seconds=slot_offset,
     )
 
@@ -782,11 +797,12 @@ def _usage_entry_refreshed_for_cycle(
     *,
     refresh_started_at: datetime | None,
     cycle_end: int | None,
+    window_seconds: int = _ROLLING_WINDOW_SECONDS,
 ) -> bool:
     if entry.recorded_at is None:
         return False
     if cycle_end is not None:
-        cycle_start = cycle_end - _ROLLING_WINDOW_SECONDS
+        cycle_start = cycle_end - window_seconds
         if entry.recorded_at < datetime.fromtimestamp(cycle_start, tz=timezone.utc).replace(tzinfo=None):
             return False
         if entry.reset_at is not None and entry.reset_at <= cycle_start:

--- a/app/modules/limit_warmup/service.py
+++ b/app/modules/limit_warmup/service.py
@@ -35,6 +35,7 @@ _TERMINAL_ERROR_EVENTS = {"response.failed", "response.incomplete", "error"}
 _QUOTA_ERROR_CODES = {"insufficient_quota", "quota_exceeded", "rate_limit_exceeded", "usage_limit_reached"}
 _MAX_CONCURRENT_WARMUP_SENDS = 4
 _ROLLING_WINDOW_SECONDS = 300 * 60
+_SHORT_WINDOW_MAX_MINUTES = 24 * 60
 _STAGGER_SLOT_GRACE_SECONDS = 60
 _IDLE_PRIMARY_WINDOW = "primary_idle"
 # Minimum reset_at forward jump (in seconds) to confirm a real quota window reset.
@@ -710,9 +711,9 @@ def _build_staggered_idle_candidate(
         return None
     if after.reset_at is None:
         return None
-    if usage_core.is_weekly_window_minutes(after.window_minutes):
-        return None
-    if usage_core.is_monthly_window_minutes(after.window_minutes):
+    if after.window_minutes is not None and after.window_minutes > _SHORT_WINDOW_MAX_MINUTES:
+        # Any long window (weekly, monthly, or a nonstandard duration over
+        # 24h) has no short phase to pre-start.
         return None
     if after.used_percent > idle_threshold_percent:
         return None

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -2212,6 +2212,7 @@ def _state_from_account(
         used_percent=effective_used_percent,
         reset_at=reset_at,
         primary_reset_at=primary_reset,
+        primary_window_minutes=primary_window_minutes,
         blocked_at=next_blocked_at,
         cooldown_until=runtime.cooldown_until,
         secondary_used_percent=effective_secondary_used_percent,

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -76,6 +76,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Rows written by the same upstream fetch land within milliseconds of each
+# other; a sibling row only proves a *later* fetch (one that no longer
+# reported the stale window) when it is newer by more than this margin.
+_SIBLING_FETCH_MARGIN_SECONDS = 5.0
+
 _UsageWindowEntry = UsageHistory | AdditionalUsageHistory
 
 _MAX_SELECTION_ATTEMPTS = 4
@@ -1971,6 +1976,18 @@ def _state_from_account(
     if primary_used is not None and primary_reset is not None and primary_reset <= now_epoch:
         primary_used = 0.0
         primary_reset = None
+        # A strictly newer long-window row proves a later fetch no longer
+        # reported the short window: drop the stale duration so phase
+        # planning does not keep treating the account as a cold
+        # short-window warmup candidate.
+        if (
+            primary_entry is not None
+            and effective_secondary_entry is not None
+            and effective_secondary_entry is not primary_entry
+            and (effective_secondary_entry.recorded_at - primary_entry.recorded_at).total_seconds()
+            > _SIBLING_FETCH_MARGIN_SECONDS
+        ):
+            primary_window_minutes = None
     if secondary_used is not None and secondary_reset is not None and secondary_reset <= now_epoch:
         secondary_used = 0.0
         secondary_reset = None

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1976,18 +1976,19 @@ def _state_from_account(
     if primary_used is not None and primary_reset is not None and primary_reset <= now_epoch:
         primary_used = 0.0
         primary_reset = None
-        # A strictly newer long-window row proves a later fetch no longer
-        # reported the short window: drop the stale duration so phase
-        # planning does not keep treating the account as a cold
-        # short-window warmup candidate.
-        if (
-            primary_entry is not None
-            and effective_secondary_entry is not None
-            and effective_secondary_entry is not primary_entry
-            and (effective_secondary_entry.recorded_at - primary_entry.recorded_at).total_seconds()
-            > _SIBLING_FETCH_MARGIN_SECONDS
-        ):
-            primary_window_minutes = None
+    # A strictly newer long-window row proves a later fetch no longer
+    # reported the short window: drop the stale duration — whether or not
+    # the stale row's reset has elapsed — so phase planning stops treating
+    # the account as having a short phase window.
+    if (
+        primary_window_minutes is not None
+        and primary_entry is not None
+        and effective_secondary_entry is not None
+        and effective_secondary_entry is not primary_entry
+        and (effective_secondary_entry.recorded_at - primary_entry.recorded_at).total_seconds()
+        > _SIBLING_FETCH_MARGIN_SECONDS
+    ):
+        primary_window_minutes = None
     if secondary_used is not None and secondary_reset is not None and secondary_reset <= now_epoch:
         secondary_used = 0.0
         secondary_reset = None

--- a/app/modules/quota_planner/logic.py
+++ b/app/modules/quota_planner/logic.py
@@ -539,7 +539,12 @@ def _plannable_window_seconds(state: AccountState) -> float | None:
 
 def _is_active_window(state: AccountState, current_ts: float) -> bool:
     # Healthy accounts never carry a blocked-status reset_at; the live phase
-    # state comes from the primary usage sample's reset timestamp.
+    # state comes from the primary usage sample's reset timestamp. Only
+    # phase-plannable (short-window) accounts count: a long unremapped
+    # primary window must not feed expiring bonuses, active-reset stagger
+    # math, or simulated pool capacity.
+    if _plannable_window_seconds(state) is None:
+        return False
     return state.primary_reset_at is not None and float(state.primary_reset_at) > current_ts
 
 

--- a/app/modules/quota_planner/logic.py
+++ b/app/modules/quota_planner/logic.py
@@ -186,7 +186,11 @@ def plan_shadow_actions(
     actions: list[PlannerAction] = []
     skipped_candidates = 0
     current_ts = current.timestamp()
-    active_resets = [float(state.primary_reset_at) for state in states if _is_active_window(state, current_ts)]
+    active_resets = [
+        float(state.primary_reset_at)
+        for state in states
+        if state.primary_reset_at is not None and _is_active_window(state, current_ts)
+    ]
     for state in states:
         if not _is_warmup_candidate(state, current_ts):
             continue

--- a/app/modules/quota_planner/logic.py
+++ b/app/modules/quota_planner/logic.py
@@ -12,6 +12,10 @@ from app.core.balancer import AccountState, RoutingCost, RoutingCostsByAccount
 from app.db.models import AccountStatus
 
 FIVE_HOUR_WINDOW_SECONDS = 5 * 60 * 60
+# Phase planning only makes sense for short rolling windows; weekly (10080)
+# and monthly (43200) windows have no phase to align, and samples without
+# duration metadata are not plannable.
+SHORT_WINDOW_MAX_MINUTES = 24 * 60
 EXPIRING_WINDOW_SECONDS = 60 * 60
 STALE_USAGE_SECONDS = 15 * 60
 DEFAULT_SLOT_SECONDS = 15 * 60
@@ -50,6 +54,7 @@ class PlannerAction:
     expected_gain: float = 0.0
     expected_cost: float = 0.0
     warmup_cycle_key: str | None = None
+    window_seconds: float = float(FIVE_HOUR_WINDOW_SECONDS)
 
 
 class DemandBinLike(Protocol):
@@ -135,12 +140,12 @@ def build_routing_costs(
         reasons: list[str] = []
 
         if _is_active_window(state, current_ts):
-            seconds_left = float(state.reset_at or 0) - current_ts
+            seconds_left = float(state.primary_reset_at or 0) - current_ts
             if seconds_left <= EXPIRING_WINDOW_SECONDS:
                 bonus = 20.0 * (1.0 - max(0.0, seconds_left) / EXPIRING_WINDOW_SECONDS)
                 cost -= bonus
                 reasons.append("expiring_active_window")
-        elif _is_cold_window(state, current_ts):
+        elif _plannable_window_seconds(state) is not None and _is_cold_window(state, current_ts):
             if _inside_work_block(current, settings):
                 # In work hours, availability wins. The planner only nudges
                 # routing toward already-active windows; it must not block work
@@ -181,23 +186,24 @@ def plan_shadow_actions(
     actions: list[PlannerAction] = []
     skipped_candidates = 0
     current_ts = current.timestamp()
-    active_resets = [
-        float(state.reset_at) for state in states if state.reset_at is not None and _is_active_window(state, current_ts)
-    ]
+    active_resets = [float(state.primary_reset_at) for state in states if _is_active_window(state, current_ts)]
     for state in states:
         if not _is_warmup_candidate(state, current_ts):
             continue
+        window_seconds = _plannable_window_seconds(state)
+        if window_seconds is None:
+            continue
         candidate_times = candidate_start_times(
             now=current,
-            account=state,
             settings=settings,
             demand_forecast=demand_forecast,
             existing_reset_epochs=active_resets,
+            window_seconds=window_seconds,
         )
         if not candidate_times:
             continue
         selected_reset_epochs = [
-            (action.scheduled_at + timedelta(seconds=FIVE_HOUR_WINDOW_SECONDS)).timestamp()
+            (action.scheduled_at + timedelta(seconds=action.window_seconds)).timestamp()
             for action in actions
             if action.scheduled_at is not None
         ]
@@ -209,6 +215,7 @@ def plan_shadow_actions(
                     settings=settings,
                     demand_forecast=demand_forecast,
                     existing_reset_epochs=[*active_resets, *selected_reset_epochs],
+                    window_seconds=window_seconds,
                 ),
             )
             for candidate in candidate_times
@@ -217,12 +224,13 @@ def plan_shadow_actions(
         if score < settings.min_expected_gain:
             skipped_candidates += 1
             continue
-        reset_at = scheduled_at + timedelta(seconds=FIVE_HOUR_WINDOW_SECONDS)
+        reset_at = scheduled_at + timedelta(seconds=window_seconds)
         target_peak_at = demand_forecast.peak_slot_start if demand_forecast else None
         expected_cost = _candidate_cost(
             scheduled_at=scheduled_at,
             settings=settings,
             existing_reset_epochs=[*active_resets, *selected_reset_epochs],
+            window_seconds=window_seconds,
         )
         actions.append(
             PlannerAction(
@@ -242,6 +250,7 @@ def plan_shadow_actions(
                 expected_gain=score + expected_cost,
                 expected_cost=expected_cost,
                 warmup_cycle_key=_warmup_cycle_key(scheduled_at, settings),
+                window_seconds=window_seconds,
             )
         )
     if skipped_candidates and not actions:
@@ -334,13 +343,17 @@ def simulate_pool(
         if _is_active_window(state, current_ts):
             remaining_pct = _remaining_percent(state)
             active_windows.append(
-                (current_ts, float(state.reset_at or 0), DEFAULT_ACCOUNT_WINDOW_CAPACITY * remaining_pct / 100.0)
+                (
+                    current_ts,
+                    float(state.primary_reset_at or 0),
+                    DEFAULT_ACCOUNT_WINDOW_CAPACITY * remaining_pct / 100.0,
+                )
             )
     for action in warmups:
         if action.scheduled_at is None:
             continue
         start = action.scheduled_at.timestamp()
-        active_windows.append((start, start + FIVE_HOUR_WINDOW_SECONDS, DEFAULT_ACCOUNT_WINDOW_CAPACITY))
+        active_windows.append((start, start + action.window_seconds, DEFAULT_ACCOUNT_WINDOW_CAPACITY))
 
     unmet = 0.0
     served = 0.0
@@ -389,24 +402,23 @@ def simulate_pool(
 def candidate_start_times(
     *,
     now: datetime,
-    account: AccountState,
     settings: PlannerSettings,
     demand_forecast: PlannerForecast | None,
     existing_reset_epochs: list[float] | None = None,
+    window_seconds: float = float(FIVE_HOUR_WINDOW_SECONDS),
 ) -> list[datetime]:
-    del account
     candidates: list[datetime] = []
     if _inside_work_block(now, settings):
         candidates.append(now)
     candidates.extend(_next_work_starts(now, settings, count=2, offsets=(-4, -3, -2)))
     if demand_forecast and demand_forecast.peak_slot_start is not None:
-        peak_start = demand_forecast.peak_slot_start - timedelta(seconds=FIVE_HOUR_WINDOW_SECONDS)
+        peak_start = demand_forecast.peak_slot_start - timedelta(seconds=window_seconds)
         candidates.extend(peak_start + timedelta(minutes=offset) for offset in (-60, -30, 0, 30, 60))
-        candidates.extend(_demand_capacity_crossing_starts(demand_forecast))
+        candidates.extend(_demand_capacity_crossing_starts(demand_forecast, window_seconds=window_seconds))
     for reset_epoch in existing_reset_epochs or []:
         reset_at = datetime.fromtimestamp(reset_epoch, tz=timezone.utc)
-        candidates.append(reset_at + timedelta(minutes=30) - timedelta(seconds=FIVE_HOUR_WINDOW_SECONDS))
-        candidates.append(reset_at - timedelta(minutes=30) - timedelta(seconds=FIVE_HOUR_WINDOW_SECONDS))
+        candidates.append(reset_at + timedelta(minutes=30) - timedelta(seconds=window_seconds))
+        candidates.append(reset_at - timedelta(minutes=30) - timedelta(seconds=window_seconds))
 
     normalized: list[datetime] = []
     seen: set[int] = set()
@@ -432,11 +444,13 @@ def score_candidate_start(
     settings: PlannerSettings,
     demand_forecast: PlannerForecast | None,
     existing_reset_epochs: list[float] | None = None,
+    window_seconds: float = float(FIVE_HOUR_WINDOW_SECONDS),
 ) -> float:
     candidate_cost = _candidate_cost(
         scheduled_at=scheduled_at,
         settings=settings,
         existing_reset_epochs=existing_reset_epochs,
+        window_seconds=window_seconds,
     )
     if demand_forecast is None:
         return 0.0
@@ -444,6 +458,7 @@ def score_candidate_start(
         scheduled_at=scheduled_at,
         settings=settings,
         demand_forecast=demand_forecast,
+        window_seconds=window_seconds,
     )
     return max(0.0, peak_gain - candidate_cost)
 
@@ -453,8 +468,9 @@ def _candidate_cost(
     scheduled_at: datetime,
     settings: PlannerSettings,
     existing_reset_epochs: list[float] | None = None,
+    window_seconds: float = float(FIVE_HOUR_WINDOW_SECONDS),
 ) -> float:
-    window_end = scheduled_at + timedelta(seconds=FIVE_HOUR_WINDOW_SECONDS)
+    window_end = scheduled_at + timedelta(seconds=window_seconds)
     sync_cost = _synchronization_penalty([*(existing_reset_epochs or []), window_end.timestamp()])
     synthetic_cost = 0.5 if settings.allow_synthetic_traffic and not settings.dry_run else 0.0
     return sync_cost + synthetic_cost
@@ -465,6 +481,7 @@ def _peak_aligned_gain(
     scheduled_at: datetime,
     settings: PlannerSettings,
     demand_forecast: PlannerForecast,
+    window_seconds: float = float(FIVE_HOUR_WINDOW_SECONDS),
 ) -> float:
     work_slots = [slot for slot in demand_forecast.slots if _inside_work_block(slot.slot_start, settings)]
     if not work_slots or demand_forecast.peak_slot_start is None:
@@ -474,7 +491,7 @@ def _peak_aligned_gain(
     if peak_excess < MIN_PEAK_EXCESS_UNITS:
         return 0.0
 
-    window_end = scheduled_at + timedelta(seconds=FIVE_HOUR_WINDOW_SECONDS)
+    window_end = scheduled_at + timedelta(seconds=window_seconds)
     window_slots = [slot for slot in work_slots if scheduled_at <= slot.slot_start < window_end]
     reset_aligns_peak = (
         abs((window_end - demand_forecast.peak_slot_start).total_seconds()) <= demand_forecast.slot_seconds
@@ -492,7 +509,11 @@ def _peak_aligned_gain(
     return window_excess + peak_excess + reset_bonus
 
 
-def _demand_capacity_crossing_starts(demand_forecast: PlannerForecast) -> list[datetime]:
+def _demand_capacity_crossing_starts(
+    demand_forecast: PlannerForecast,
+    *,
+    window_seconds: float = float(FIVE_HOUR_WINDOW_SECONDS),
+) -> list[datetime]:
     candidates: list[datetime] = []
     cumulative = 0.0
     next_bucket = DEFAULT_ACCOUNT_WINDOW_CAPACITY
@@ -500,21 +521,32 @@ def _demand_capacity_crossing_starts(demand_forecast: PlannerForecast) -> list[d
         cumulative += slot.demand_units
         if cumulative < next_bucket:
             continue
-        candidates.append(slot.slot_start - timedelta(seconds=FIVE_HOUR_WINDOW_SECONDS))
+        candidates.append(slot.slot_start - timedelta(seconds=window_seconds))
         next_bucket += DEFAULT_ACCOUNT_WINDOW_CAPACITY
     return candidates[:4]
 
 
+def _plannable_window_seconds(state: AccountState) -> float | None:
+    minutes = state.primary_window_minutes
+    if minutes is None or minutes <= 0 or minutes > SHORT_WINDOW_MAX_MINUTES:
+        return None
+    return float(minutes) * 60.0
+
+
 def _is_active_window(state: AccountState, current_ts: float) -> bool:
-    return state.reset_at is not None and float(state.reset_at) > current_ts
+    # Healthy accounts never carry a blocked-status reset_at; the live phase
+    # state comes from the primary usage sample's reset timestamp.
+    return state.primary_reset_at is not None and float(state.primary_reset_at) > current_ts
 
 
 def _is_cold_window(state: AccountState, current_ts: float) -> bool:
-    return state.reset_at is None or float(state.reset_at) <= current_ts
+    return state.primary_reset_at is None or float(state.primary_reset_at) <= current_ts
 
 
 def _is_warmup_candidate(state: AccountState, current_ts: float) -> bool:
     if state.status != AccountStatus.ACTIVE:
+        return False
+    if _plannable_window_seconds(state) is None:
         return False
     return _is_cold_window(state, current_ts)
 

--- a/app/modules/quota_planner/warmup.py
+++ b/app/modules/quota_planner/warmup.py
@@ -447,6 +447,12 @@ class QuotaWarmupService:
         # capacity — lingering rows from a former plan are not applicable.
         if latest is None:
             return False
+        latest_window_minutes = getattr(latest, "window_minutes", None)
+        if latest_window_minutes is None or int(latest_window_minutes) > SHORT_WINDOW_MAX_MINUTES:
+            # Only samples that positively report a short duration are
+            # eligible for supersession rejection; metadata-less samples
+            # keep the legacy bootstrap behavior.
+            return False
         latest_recorded_at = getattr(latest, "recorded_at", None)
         if latest_recorded_at is None:
             return False

--- a/app/modules/quota_planner/warmup.py
+++ b/app/modules/quota_planner/warmup.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core import usage as usage_core
 from app.core.clients.proxy import stream_responses
 from app.core.crypto import TokenEncryptor
 from app.core.openai.parsing import parse_sse_event
@@ -417,7 +418,7 @@ class QuotaWarmupService:
         latest = (await self._usage.latest_by_account()).get(account.id)
         if _sample_blocks_short_window_planning(latest):
             return False, "no_short_window"
-        if await self._short_window_superseded(account.id, latest):
+        if await self._short_window_superseded(account, latest):
             return False, "no_short_window"
         if latest is not None and latest.reset_at is not None and latest.reset_at > int(utcnow().timestamp()):
             return False, "account_window_already_active"
@@ -437,19 +438,22 @@ class QuotaWarmupService:
             return False, "warmup_effect_unknown"
         return True, "ready"
 
-    async def _short_window_superseded(self, account_id: str, latest: object | None) -> bool:
+    async def _short_window_superseded(self, account: Account, latest: object | None) -> bool:
         # A strictly newer long-window row proves a later refresh no longer
         # reported the short window: the stale short primary sample is not
         # evidence of a current short window, so warm-up traffic would open
         # nothing. Same-fetch rows land within milliseconds and stay inside
-        # the margin.
+        # the margin. Monthly rows only count for plans with monthly
+        # capacity — lingering rows from a former plan are not applicable.
         if latest is None:
             return False
         latest_recorded_at = getattr(latest, "recorded_at", None)
         if latest_recorded_at is None:
             return False
         for window in ("secondary", "monthly"):
-            sibling = (await self._usage.latest_by_account(window=window)).get(account_id)
+            if window == "monthly" and usage_core.capacity_for_plan(account.plan_type, "monthly") is None:
+                continue
+            sibling = (await self._usage.latest_by_account(window=window)).get(account.id)
             if sibling is None:
                 continue
             if (sibling.recorded_at - latest_recorded_at).total_seconds() > _SIBLING_FETCH_MARGIN_SECONDS:

--- a/app/modules/quota_planner/warmup.py
+++ b/app/modules/quota_planner/warmup.py
@@ -32,6 +32,10 @@ from .logic import SHORT_WINDOW_MAX_MINUTES, PlannerSettings
 from .repository import QuotaPlannerRepository
 
 WARMUP_REQUEST_KIND = "warmup"
+# Rows written by the same upstream fetch land within milliseconds of each
+# other; a sibling row only proves a later fetch when it is newer by more
+# than this margin.
+_SIBLING_FETCH_MARGIN_SECONDS = 5.0
 WARMUP_DEFAULT_INPUT_BUDGET = 32
 WARMUP_DEFAULT_OUTPUT_BUDGET = 8
 
@@ -413,6 +417,8 @@ class QuotaWarmupService:
         latest = (await self._usage.latest_by_account()).get(account.id)
         if _sample_blocks_short_window_planning(latest):
             return False, "no_short_window"
+        if await self._short_window_superseded(account.id, latest):
+            return False, "no_short_window"
         if latest is not None and latest.reset_at is not None and latest.reset_at > int(utcnow().timestamp()):
             return False, "account_window_already_active"
 
@@ -430,6 +436,25 @@ class QuotaWarmupService:
         if not force_probe and (effect is None or effect.confidence not in {"observed", "known", "high"}):
             return False, "warmup_effect_unknown"
         return True, "ready"
+
+    async def _short_window_superseded(self, account_id: str, latest: object | None) -> bool:
+        # A strictly newer long-window row proves a later refresh no longer
+        # reported the short window: the stale short primary sample is not
+        # evidence of a current short window, so warm-up traffic would open
+        # nothing. Same-fetch rows land within milliseconds and stay inside
+        # the margin.
+        if latest is None:
+            return False
+        latest_recorded_at = getattr(latest, "recorded_at", None)
+        if latest_recorded_at is None:
+            return False
+        for window in ("secondary", "monthly"):
+            sibling = (await self._usage.latest_by_account(window=window)).get(account_id)
+            if sibling is None:
+                continue
+            if (sibling.recorded_at - latest_recorded_at).total_seconds() > _SIBLING_FETCH_MARGIN_SECONDS:
+                return True
+        return False
 
     async def _send_warmup_probe(self, *, account: Account, model: str, request_id: str) -> WarmupUsage:
         payload = ResponsesRequest.model_validate(

--- a/app/modules/quota_planner/warmup.py
+++ b/app/modules/quota_planner/warmup.py
@@ -28,7 +28,7 @@ from app.modules.request_logs.repository import RequestLogsRepository
 from app.modules.usage.repository import UsageRepository
 from app.modules.usage.updater import UsageUpdater
 
-from .logic import PlannerSettings
+from .logic import SHORT_WINDOW_MAX_MINUTES, PlannerSettings
 from .repository import QuotaPlannerRepository
 
 WARMUP_REQUEST_KIND = "warmup"
@@ -411,6 +411,8 @@ class QuotaWarmupService:
             return False, f"account_status_{account.status.value}"
 
         latest = (await self._usage.latest_by_account()).get(account.id)
+        if _sample_blocks_short_window_planning(latest):
+            return False, "no_short_window"
         if latest is not None and latest.reset_at is not None and latest.reset_at > int(utcnow().timestamp()):
             return False, "account_window_already_active"
 
@@ -480,7 +482,12 @@ class QuotaWarmupService:
         latest_before_by_account = {account.id: latest_before} if latest_before else {}
         await UsageUpdater(self._usage, self._accounts).refresh_accounts([account], latest_before_by_account)
         latest_after = (await self._usage.latest_by_account()).get(account.id)
-        observed_after = latest_after if _usage_history_is_fresh(latest_before, latest_after) else None
+        observed_after = (
+            latest_after
+            if _usage_history_is_fresh(latest_before, latest_after)
+            and not _sample_blocks_short_window_planning(latest_after)
+            else None
+        )
         effective_confidence = confidence if observed_after is not None else "unknown"
         await self._planner.add_window_observation(
             account_id=account.id,
@@ -494,6 +501,20 @@ class QuotaWarmupService:
 
 def _local_midnight() -> datetime:
     return utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def _sample_blocks_short_window_planning(entry: object | None) -> bool:
+    # Phase planning only applies to short rolling windows. Only positive
+    # evidence of a long (weekly or monthly) window in the primary slot
+    # blocks warm-up execution — weekly-only plans surface the weekly window
+    # there. Absent samples or samples without duration metadata keep the
+    # legacy bootstrap behavior.
+    if entry is None:
+        return False
+    window_minutes = getattr(entry, "window_minutes", None)
+    if window_minutes is None:
+        return False
+    return int(window_minutes) > SHORT_WINDOW_MAX_MINUTES
 
 
 def _usage_history_is_fresh(before: object | None, after: object | None) -> bool:

--- a/openspec/changes/planner-window-generalization/proposal.md
+++ b/openspec/changes/planner-window-generalization/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The quota phase planner and the staggered idle limit warm-up hardcode the 5-hour primary window (`FIVE_HOUR_WINDOW_SECONDS`, `_ROLLING_WINDOW_SECONDS = 300 * 60`) and derive window state from the wrong field: `AccountState.reset_at` is only set for blocked statuses, so every healthy account looks permanently "cold" to the planner. With OpenAI's temporary removal of the 5h Codex limit (2026-07-12) and upstream codex's duration-driven window model, both assumptions now misfire:
+
+- Cold/active detection never sees a healthy account's live primary window, so expiring-window bonuses never apply and cold-start costs land uniformly (accidentally inert), and warmup candidacy treats every healthy account as cold — including accounts that no longer have a short window to pre-start.
+- Warmup planning subtracts exactly 5 hours from demand peaks and models every planned window as 5 hours, which is wrong for any other server-reported duration.
+- The warm-up execution gate and effect observations accept weekly-only or window-less usage samples as if a short window existed.
+
+## What Changes
+
+- Phase planning is scoped to accounts whose latest primary sample reports a short rolling window (duration metadata present and at most 24 hours): warmup candidates, cold-start routing costs, the warm-up execution gate, and warmup-effect observed confidence are all limited to such accounts.
+- Cold/active window detection derives from the primary window sample (`AccountState.primary_reset_at`), not the blocked-status `reset_at`; `AccountState` gains a `primary_window_minutes` carrier populated from selection state.
+- All phase math (candidate start times, planned resets, pool-simulation spans, synchronization penalties) uses each account's observed window duration; planner actions carry their window duration.
+- Routing cost nudges keep their existing mode behavior (the spec requires them enabled by default); fixing cold/active detection activates the intended active-vs-cold differentiation that the wrong field previously masked.
+- The staggered idle limit warm-up derives its rolling cycle from the account's observed primary window duration, keeping 300 minutes only as the fallback when duration metadata is missing.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `quota-phase-planner`: short-window plannability scoping, duration-derived phase math, audit-only shadow routing.
+- `usage-refresh-policy`: staggered idle warm-up cycles become duration-neutral.
+
+## Impact
+
+- Code: `app/core/balancer/logic.py`, `app/modules/proxy/load_balancer.py`, `app/modules/quota_planner/logic.py`, `app/modules/quota_planner/warmup.py`, `app/modules/limit_warmup/service.py`
+- Tests: `tests/unit/test_quota_planner.py`, `tests/unit/test_limit_warmup.py`, `tests/unit/test_load_balancer.py`
+- Specs: `openspec/specs/quota-phase-planner/spec.md`, `openspec/specs/usage-refresh-policy/spec.md`

--- a/openspec/changes/planner-window-generalization/specs/quota-phase-planner/spec.md
+++ b/openspec/changes/planner-window-generalization/specs/quota-phase-planner/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Phase planning is scoped to short rolling windows
 
-An account SHALL be phase-plannable for scheduler warmup candidacy and cold-start routing costs only when its selection state carries a primary window sample with duration metadata of at most 24 hours (weekly and monthly windows are not phase-plannable; samples without duration metadata are not phase-plannable). The warm-up execution gate and warmup-effect observed confidence SHALL treat positive evidence of a long window in the primary slot as disqualifying, while absent samples or samples without duration metadata keep legacy bootstrap behavior. Active/cold window state SHALL derive from the primary window sample's reset timestamp, not from blocked-status reset markers.
+An account SHALL be phase-plannable for scheduler warmup candidacy and cold-start routing costs only when its selection state carries a primary window sample with duration metadata of at most 24 hours (weekly and monthly windows are not phase-plannable; samples without duration metadata are not phase-plannable). The warm-up execution gate and warmup-effect observed confidence SHALL treat positive evidence of a long window in the primary slot as disqualifying, while absent samples or samples without duration metadata keep legacy bootstrap behavior. Active/cold window state SHALL derive from the primary window sample's reset timestamp, not from blocked-status reset markers, and only phase-plannable accounts SHALL count as having active phase windows — a long unremapped primary sample MUST NOT feed expiring-window bonuses, active-reset stagger anchors, or simulated pool capacity.
 
 #### Scenario: Weekly-only account is not planned
 

--- a/openspec/changes/planner-window-generalization/specs/quota-phase-planner/spec.md
+++ b/openspec/changes/planner-window-generalization/specs/quota-phase-planner/spec.md
@@ -28,6 +28,20 @@ An account SHALL be phase-plannable for scheduler warmup candidacy and cold-star
 - **WHEN** a warm-now request targets an account whose latest primary-slot sample reports a weekly or monthly window duration
 - **THEN** the execution gate refuses with a stable `no_short_window` reason
 
+#### Scenario: Execution gate refuses superseded short-window samples
+
+- **GIVEN** an account whose latest primary-slot sample reports a short window
+- **AND** a strictly newer long-window row proves a later refresh no longer reported the short window
+- **WHEN** a warm-now request targets that account
+- **THEN** the execution gate refuses with `no_short_window`
+
+#### Scenario: Superseded short-window samples lose plannability
+
+- **GIVEN** an account whose expired primary sample is strictly older than its long-window row
+- **WHEN** selection state is built
+- **THEN** the derived short-window duration is cleared
+- **AND** the planner does not treat the account as a cold short-window warmup candidate
+
 ### Requirement: Phase math derives from observed window durations
 
 Candidate warmup start times, planned window resets, pool-simulation window spans, and synchronization penalties SHALL use each account's observed primary window duration. Planner actions SHALL carry the window duration they were planned with, and cross-account reset math SHALL use each action's own duration.

--- a/openspec/changes/planner-window-generalization/specs/quota-phase-planner/spec.md
+++ b/openspec/changes/planner-window-generalization/specs/quota-phase-planner/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Phase planning is scoped to short rolling windows
+
+An account SHALL be phase-plannable for scheduler warmup candidacy and cold-start routing costs only when its selection state carries a primary window sample with duration metadata of at most 24 hours (weekly and monthly windows are not phase-plannable; samples without duration metadata are not phase-plannable). The warm-up execution gate and warmup-effect observed confidence SHALL treat positive evidence of a long window in the primary slot as disqualifying, while absent samples or samples without duration metadata keep legacy bootstrap behavior. Active/cold window state SHALL derive from the primary window sample's reset timestamp, not from blocked-status reset markers.
+
+#### Scenario: Weekly-only account is not planned
+
+- **GIVEN** an account whose usage reports only a weekly window
+- **WHEN** the planner evaluates warmup candidates and routing costs
+- **THEN** the account receives no warmup actions and no cold-start costs
+
+#### Scenario: Mixed pool plans only short-window accounts
+
+- **GIVEN** one account with a 300-minute primary window sample and one account with only weekly usage
+- **WHEN** the planner plans warmups during the prewarm band
+- **THEN** only the short-window account is considered
+
+#### Scenario: Healthy active window is not treated as cold
+
+- **GIVEN** a healthy `active` account whose primary window sample has an unexpired reset timestamp
+- **WHEN** the planner builds routing costs
+- **THEN** the account is treated as having an active window
+- **AND** it receives no cold-start cost
+
+#### Scenario: Execution gate refuses accounts with a long-window primary sample
+
+- **WHEN** a warm-now request targets an account whose latest primary-slot sample reports a weekly or monthly window duration
+- **THEN** the execution gate refuses with a stable `no_short_window` reason
+
+### Requirement: Phase math derives from observed window durations
+
+Candidate warmup start times, planned window resets, pool-simulation window spans, and synchronization penalties SHALL use each account's observed primary window duration. Planner actions SHALL carry the window duration they were planned with, and cross-account reset math SHALL use each action's own duration.
+
+#### Scenario: Peak alignment uses the observed duration
+
+- **GIVEN** an account whose primary window sample reports a 60-minute duration
+- **WHEN** the planner derives candidate start times for a forecast peak
+- **THEN** peak-aligned candidates subtract 60 minutes rather than 5 hours
+- **AND** the planned action records a 60-minute window duration

--- a/openspec/changes/planner-window-generalization/specs/quota-phase-planner/spec.md
+++ b/openspec/changes/planner-window-generalization/specs/quota-phase-planner/spec.md
@@ -37,10 +37,10 @@ An account SHALL be phase-plannable for scheduler warmup candidacy and cold-star
 
 #### Scenario: Superseded short-window samples lose plannability
 
-- **GIVEN** an account whose expired primary sample is strictly older than its long-window row
+- **GIVEN** an account whose primary sample is strictly older than its long-window row
 - **WHEN** selection state is built
-- **THEN** the derived short-window duration is cleared
-- **AND** the planner does not treat the account as a cold short-window warmup candidate
+- **THEN** the derived short-window duration is cleared whether or not the stale sample's reset has elapsed
+- **AND** the planner does not treat the account as having a short phase window
 
 ### Requirement: Phase math derives from observed window durations
 

--- a/openspec/changes/planner-window-generalization/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/planner-window-generalization/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,47 @@
+## MODIFIED Requirements
+
+### Requirement: Reset-confirmed limit warm-up
+
+The system SHALL support an optional limit warm-up mechanism that is disabled by default. When enabled globally and for an account, background usage refresh MAY send one minimal upstream Responses request after it confirms that a selected quota window has moved from an exhausted sample to a newly available reset window.
+
+#### Scenario: Warm-up is skipped unless reset is confirmed
+- **GIVEN** limit warm-up is enabled globally and for an account
+- **AND** the account's previous usage sample for a selected window was exhausted
+- **WHEN** background usage refresh records a newer sample for that window with `used_percent < 100` and a later `reset_at`
+- **THEN** the system sends at most one warm-up request for that account/window/reset tuple
+
+#### Scenario: Warm-up is opt-in and safe by default
+- **GIVEN** background usage refresh is preparing to evaluate limit warm-up candidates
+- **WHEN** global limit warm-up is disabled
+- **OR** the account is not opted in
+- **THEN** background usage refresh MUST NOT send warm-up traffic
+
+#### Scenario: Warm-up uses fresh opt-in state after usage refresh
+- **GIVEN** an account was loaded before a background usage refresh cycle
+- **AND** the account's limit warm-up opt-in changes while the refresh cycle is running
+- **WHEN** the scheduler evaluates warm-up candidates after writing usage samples
+- **THEN** the scheduler MUST evaluate the latest persisted opt-in value rather than the stale in-session account object
+
+#### Scenario: Warm-up respects unsafe account states
+- **WHEN** an account is paused, deactivated, rate-limited, quota-exceeded, or in an auth-refresh failure path
+- **THEN** limit warm-up MUST NOT send traffic for that account
+
+#### Scenario: Warm-up attempts are durable and deduplicated
+- **WHEN** multiple refresh workers observe the same account/window/reset candidate
+- **THEN** the database permits at most one persisted attempt for that tuple
+- **AND** later refresh cycles skip that tuple after a prior attempt exists
+
+#### Scenario: Staggered idle warm-up pre-starts rolling primary windows
+- **GIVEN** limit warm-up and staggered idle warm-up are enabled globally
+- **AND** multiple active accounts are opted into limit warm-up
+- **AND** an opted-in account has a healthy idle short-window primary usage sample
+- **WHEN** background usage refresh evaluates that account inside its deterministic stagger slot
+- **THEN** the system MAY send one minimal upstream warm-up request for that account's current rolling-window cycle, whose length is the account's observed primary window duration (defaulting to 300 minutes when duration metadata is missing)
+- **AND** the system MUST NOT send another staggered idle warm-up for that same account/cycle tuple
+- **AND** account slots MUST be spread deterministically across the account's rolling window so restarts do not align all opted-in accounts into the same phase
+
+#### Scenario: Staggered idle warm-up remains opt-in
+- **GIVEN** limit warm-up is enabled globally and for an account
+- **AND** staggered idle warm-up is disabled
+- **WHEN** background usage refresh observes an idle short-window primary sample that is not a reset-confirmed transition
+- **THEN** limit warm-up MUST NOT send synthetic traffic for that idle sample

--- a/openspec/changes/planner-window-generalization/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/planner-window-generalization/specs/usage-refresh-policy/spec.md
@@ -34,7 +34,7 @@ The system SHALL support an optional limit warm-up mechanism that is disabled by
 #### Scenario: Staggered idle warm-up pre-starts rolling primary windows
 - **GIVEN** limit warm-up and staggered idle warm-up are enabled globally
 - **AND** multiple active accounts are opted into limit warm-up
-- **AND** an opted-in account has a healthy idle short-window primary usage sample
+- **AND** an opted-in account has a healthy idle short-window primary usage sample (any sample reporting a duration over 24 hours is not eligible)
 - **WHEN** background usage refresh evaluates that account inside its deterministic stagger slot
 - **THEN** the system MAY send one minimal upstream warm-up request for that account's current rolling-window cycle, whose length is the account's observed primary window duration (defaulting to 300 minutes when duration metadata is missing)
 - **AND** the system MUST NOT send another staggered idle warm-up for that same account/cycle tuple

--- a/openspec/changes/planner-window-generalization/tasks.md
+++ b/openspec/changes/planner-window-generalization/tasks.md
@@ -1,0 +1,21 @@
+## 1. Window carrier
+
+- [x] 1.1 Add `primary_window_minutes` to `AccountState` and populate it from `_state_from_account` (cleared alongside the weekly-primary remap and zero-capacity handling).
+
+## 2. Planner scoping and duration math
+
+- [x] 2.1 Derive active/cold window state from `AccountState.primary_reset_at` instead of blocked-status `reset_at`.
+- [x] 2.2 Gate warmup candidacy and cold-start routing costs on short-window plannability (duration metadata present and <= 24h).
+- [x] 2.3 Thread per-account window duration through candidate start times, scoring, planned resets, and pool simulation; add `window_seconds` to `PlannerAction`.
+
+## 3. Warm-up gates
+
+- [x] 3.1 Execution gate refuses accounts whose latest primary-slot sample positively reports a long (weekly/monthly) window (`no_short_window`); absent or metadata-less samples keep legacy bootstrap behavior.
+- [x] 3.2 Warmup-effect observations do not reach observed confidence from a long-window primary-slot sample.
+- [x] 3.3 Staggered idle limit warm-up derives its rolling cycle from the observed primary window duration (300-minute fallback for missing metadata).
+
+## 4. Validation
+
+- [x] 4.1 Unit coverage: weekly-only accounts get no warmups/cold costs; mixed pools plan only short-window accounts; healthy active windows are not cold; per-account duration math; idle warm-up stagger uses observed duration.
+- [x] 4.2 Run targeted planner, limit-warmup, and load-balancer suites.
+- [x] 4.3 Validate the OpenSpec change with `openspec validate planner-window-generalization --strict`.

--- a/tests/integration/test_quota_planner_api.py
+++ b/tests/integration/test_quota_planner_api.py
@@ -299,6 +299,94 @@ async def test_quota_planner_warm_now_refuses_weekly_only_account(async_client, 
 
 
 @pytest.mark.asyncio
+async def test_quota_planner_warm_now_keeps_bootstrap_for_metadata_less_primary_rows(
+    monkeypatch, async_client, db_setup
+):
+    del db_setup
+    encryptor = TokenEncryptor()
+    now_epoch = int(utcnow().replace(tzinfo=timezone.utc).timestamp())
+    async with SessionLocal() as session:
+        account = Account(
+            id="acc-metadata-less",
+            email="metadata-less@example.test",
+            plan_type="plus",
+            access_token_encrypted=encryptor.encrypt("access"),
+            refresh_token_encrypted=encryptor.encrypt("refresh"),
+            id_token_encrypted=encryptor.encrypt("id"),
+            last_refresh=utcnow(),
+            status=AccountStatus.ACTIVE,
+        )
+        session.add(account)
+        # A legacy primary row without duration metadata plus a newer weekly
+        # row: the metadata-less sample keeps the legacy bootstrap path and
+        # must not be rejected as a superseded short window.
+        session.add(
+            UsageHistory(
+                account_id="acc-metadata-less",
+                used_percent=0.0,
+                recorded_at=utcnow() - timedelta(hours=3),
+                window="primary",
+                reset_at=now_epoch - 7200,
+                window_minutes=None,
+            )
+        )
+        session.add(
+            UsageHistory(
+                account_id="acc-metadata-less",
+                used_percent=40.0,
+                recorded_at=utcnow(),
+                window="secondary",
+                reset_at=now_epoch + 5 * 24 * 3600,
+                window_minutes=10080,
+            )
+        )
+        repo = QuotaPlannerRepository(session)
+        await repo.upsert_settings(
+            PlannerSettings(
+                mode="auto",
+                timezone="UTC",
+                working_days=(0, 1, 2, 3, 4),
+                working_hours_start="09:00",
+                working_hours_end="18:00",
+                prewarm_enabled=True,
+                prewarm_lead_minutes=300,
+                max_warmups_per_day=3,
+                max_warmup_credits_per_day=1.0,
+                min_expected_gain=1.0,
+                forecast_quantile="p75",
+                allow_synthetic_traffic=True,
+                warmup_model_preference="gpt-5.4-mini",
+                dry_run=False,
+            )
+        )
+        await repo.add_window_observation(
+            account_id="acc-metadata-less",
+            model="gpt-5.4-mini",
+            source="warmup_probe",
+            confidence="observed",
+        )
+
+    async def fake_send(self, *, account, model, request_id):
+        del self, account, model, request_id
+        return WarmupUsage(input_tokens=3, output_tokens=1, cached_input_tokens=0, reasoning_tokens=None)
+
+    async def noop_record_effect(self, account, model, *, source, confidence):
+        del self, account, model, source, confidence
+
+    monkeypatch.setattr(QuotaWarmupService, "_send_warmup_probe", fake_send)
+    monkeypatch.setattr(QuotaWarmupService, "_record_warmup_effect", noop_record_effect)
+
+    response = await async_client.post(
+        "/api/quota-planner/warm-now",
+        json={"accountId": "acc-metadata-less", "model": "gpt-5.4-mini"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "executed"
+
+
+@pytest.mark.asyncio
 async def test_quota_planner_warm_now_refuses_superseded_short_window(async_client, db_setup):
     del db_setup
     encryptor = TokenEncryptor()

--- a/tests/integration/test_quota_planner_api.py
+++ b/tests/integration/test_quota_planner_api.py
@@ -240,6 +240,65 @@ async def test_quota_planner_warm_now_defaults_to_safe_skip(async_client, db_set
 
 
 @pytest.mark.asyncio
+async def test_quota_planner_warm_now_refuses_weekly_only_account(async_client, db_setup):
+    del db_setup
+    encryptor = TokenEncryptor()
+    async with SessionLocal() as session:
+        account = Account(
+            id="acc-weekly-only",
+            email="weekly-only@example.test",
+            plan_type="free",
+            access_token_encrypted=encryptor.encrypt("access"),
+            refresh_token_encrypted=encryptor.encrypt("refresh"),
+            id_token_encrypted=encryptor.encrypt("id"),
+            last_refresh=utcnow(),
+            status=AccountStatus.ACTIVE,
+        )
+        session.add(account)
+        # Weekly-only plans surface the weekly window in the primary slot:
+        # positive evidence that there is no short window to pre-start.
+        session.add(
+            UsageHistory(
+                account_id="acc-weekly-only",
+                used_percent=20.0,
+                recorded_at=utcnow(),
+                window="primary",
+                reset_at=int(utcnow().replace(tzinfo=timezone.utc).timestamp()) - 60,
+                window_minutes=10080,
+            )
+        )
+        repo = QuotaPlannerRepository(session)
+        await repo.upsert_settings(
+            PlannerSettings(
+                mode="auto",
+                timezone="UTC",
+                working_days=(0, 1, 2, 3, 4),
+                working_hours_start="09:00",
+                working_hours_end="18:00",
+                prewarm_enabled=True,
+                prewarm_lead_minutes=300,
+                max_warmups_per_day=3,
+                max_warmup_credits_per_day=1.0,
+                min_expected_gain=1.0,
+                forecast_quantile="p75",
+                allow_synthetic_traffic=True,
+                warmup_model_preference="gpt-5.4-mini",
+                dry_run=False,
+            )
+        )
+
+    response = await async_client.post(
+        "/api/quota-planner/warm-now",
+        json={"accountId": "acc-weekly-only", "model": "gpt-5.4-mini"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "skipped"
+    assert payload["reason"] == "no_short_window"
+
+
+@pytest.mark.asyncio
 async def test_quota_planner_cancel_decision(async_client, db_setup):
     del db_setup
     async with SessionLocal() as session:

--- a/tests/integration/test_quota_planner_api.py
+++ b/tests/integration/test_quota_planner_api.py
@@ -299,6 +299,77 @@ async def test_quota_planner_warm_now_refuses_weekly_only_account(async_client, 
 
 
 @pytest.mark.asyncio
+async def test_quota_planner_warm_now_refuses_superseded_short_window(async_client, db_setup):
+    del db_setup
+    encryptor = TokenEncryptor()
+    now_epoch = int(utcnow().replace(tzinfo=timezone.utc).timestamp())
+    async with SessionLocal() as session:
+        account = Account(
+            id="acc-superseded",
+            email="superseded@example.test",
+            plan_type="plus",
+            access_token_encrypted=encryptor.encrypt("access"),
+            refresh_token_encrypted=encryptor.encrypt("refresh"),
+            id_token_encrypted=encryptor.encrypt("id"),
+            last_refresh=utcnow(),
+            status=AccountStatus.ACTIVE,
+        )
+        session.add(account)
+        # The stale short-window primary row was never rewritten; a later
+        # refresh recorded only the weekly row, proving upstream no longer
+        # reports the short window.
+        session.add(
+            UsageHistory(
+                account_id="acc-superseded",
+                used_percent=40.0,
+                recorded_at=utcnow() - timedelta(hours=3),
+                window="primary",
+                reset_at=now_epoch - 7200,
+                window_minutes=300,
+            )
+        )
+        session.add(
+            UsageHistory(
+                account_id="acc-superseded",
+                used_percent=40.0,
+                recorded_at=utcnow(),
+                window="secondary",
+                reset_at=now_epoch + 5 * 24 * 3600,
+                window_minutes=10080,
+            )
+        )
+        repo = QuotaPlannerRepository(session)
+        await repo.upsert_settings(
+            PlannerSettings(
+                mode="auto",
+                timezone="UTC",
+                working_days=(0, 1, 2, 3, 4),
+                working_hours_start="09:00",
+                working_hours_end="18:00",
+                prewarm_enabled=True,
+                prewarm_lead_minutes=300,
+                max_warmups_per_day=3,
+                max_warmup_credits_per_day=1.0,
+                min_expected_gain=1.0,
+                forecast_quantile="p75",
+                allow_synthetic_traffic=True,
+                warmup_model_preference="gpt-5.4-mini",
+                dry_run=False,
+            )
+        )
+
+    response = await async_client.post(
+        "/api/quota-planner/warm-now",
+        json={"accountId": "acc-superseded", "model": "gpt-5.4-mini"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "skipped"
+    assert payload["reason"] == "no_short_window"
+
+
+@pytest.mark.asyncio
 async def test_quota_planner_cancel_decision(async_client, db_setup):
     del db_setup
     async with SessionLocal() as session:

--- a/tests/unit/test_limit_warmup.py
+++ b/tests/unit/test_limit_warmup.py
@@ -1099,6 +1099,43 @@ async def test_staggered_idle_warmup_skips_when_reset_at_is_missing(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_staggered_idle_warmup_skips_long_nonstandard_windows(monkeypatch) -> None:
+    monkeypatch.setattr(
+        limit_warmup_service,
+        "utcnow",
+        lambda: datetime.fromtimestamp(6000, tz=timezone.utc).replace(tzinfo=None),
+    )
+    repo = FakeWarmupRepo()
+    sender = FakeSender()
+    service = LimitWarmupService(repo, FakeRequestLogsRepo(), sender=sender)
+    accounts = [_account("acc_1"), _account("acc_2"), _account("acc_3")]
+    account = accounts[1]
+
+    await service.run_after_usage_refresh(
+        accounts=accounts,
+        settings=_settings(limit_warmup_staggered_idle_enabled=True),
+        before_primary={account.id: _usage(account.id, used_percent=0, reset_at=18_000)},
+        before_secondary={},
+        after_primary={
+            account.id: UsageHistory(
+                account_id=account.id,
+                used_percent=0,
+                reset_at=90_000,
+                window="primary",
+                # A 25h window is neither the weekly nor monthly default but
+                # is still too long to phase-plan.
+                window_minutes=1500,
+                recorded_at=utcnow(),
+            )
+        },
+        after_secondary={},
+    )
+
+    assert sender.calls == []
+    assert repo.rows == []
+
+
+@pytest.mark.asyncio
 async def test_staggered_idle_warmup_ignores_selected_reset_windows(monkeypatch) -> None:
     monkeypatch.setattr(
         limit_warmup_service,

--- a/tests/unit/test_limit_warmup.py
+++ b/tests/unit/test_limit_warmup.py
@@ -928,6 +928,43 @@ def test_staggered_idle_slot_is_stable_and_spread() -> None:
     assert other.slot_offset_seconds == 6000
 
 
+def test_staggered_idle_slot_uses_observed_window_duration() -> None:
+    # A 60-minute observed window spreads slots across 3600 seconds instead
+    # of the 300-minute fallback.
+    reset_at = 10_000
+    window_seconds = 3_600
+    window_start = reset_at - window_seconds
+
+    first = limit_warmup_service._staggered_idle_due(
+        "acc_1",
+        ["acc_1", "acc_2", "acc_3"],
+        now=datetime.fromtimestamp(window_start, tz=timezone.utc).replace(tzinfo=None),
+        reset_at=reset_at,
+        window_seconds=window_seconds,
+    )
+    second = limit_warmup_service._staggered_idle_due(
+        "acc_2",
+        ["acc_1", "acc_2", "acc_3"],
+        now=datetime.fromtimestamp(window_start + 1_200, tz=timezone.utc).replace(tzinfo=None),
+        reset_at=reset_at,
+        window_seconds=window_seconds,
+    )
+    outside = limit_warmup_service._staggered_idle_due(
+        "acc_1",
+        ["acc_1", "acc_2", "acc_3"],
+        now=datetime.fromtimestamp(window_start - 1, tz=timezone.utc).replace(tzinfo=None),
+        reset_at=reset_at,
+        window_seconds=window_seconds,
+    )
+
+    assert first is not None
+    assert first.cycle_end == reset_at
+    assert first.slot_offset_seconds == 0
+    assert second is not None
+    assert second.slot_offset_seconds == 1_200
+    assert outside is None
+
+
 def test_staggered_idle_slot_uses_account_reset_window() -> None:
     reset_at = 20_000
     window_start = reset_at - 18_000

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -1764,6 +1764,52 @@ def test_state_from_account_expires_stale_partial_secondary_usage_after_reset(mo
     assert state.secondary_reset_at is None
 
 
+def test_state_from_account_carries_primary_window_minutes(monkeypatch):
+    now = 1_700_000_000.0
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    state = _state_from_account(
+        account=_make_test_account(status=AccountStatus.ACTIVE),
+        primary_entry=_make_test_usage(
+            window="primary",
+            used_percent=10.0,
+            reset_at=int(now + 3600),
+            recorded_at=_epoch_to_naive_utc(now - 30),
+            window_minutes=300,
+        ),
+        secondary_entry=None,
+        runtime=RuntimeState(),
+    )
+
+    assert state.primary_window_minutes == 300
+    assert state.primary_reset_at == int(now + 3600)
+
+
+def test_state_from_account_clears_primary_window_minutes_for_weekly_only(monkeypatch):
+    now = 1_700_000_000.0
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    state = _state_from_account(
+        account=_make_test_account(status=AccountStatus.ACTIVE, plan_type="free"),
+        primary_entry=_make_test_usage(
+            window="primary",
+            used_percent=20.0,
+            reset_at=int(now + 5 * 24 * 3600),
+            recorded_at=_epoch_to_naive_utc(now - 30),
+            window_minutes=10080,
+        ),
+        secondary_entry=None,
+        runtime=RuntimeState(),
+    )
+
+    # The weekly-primary remap moves the row to the secondary slot; the
+    # account has no short window and must not look phase-plannable.
+    assert state.primary_window_minutes is None
+    assert state.secondary_used_percent == 20.0
+
+
 def test_state_from_account_treats_monthly_usage_as_advisory_long_window_pressure(monkeypatch):
     now = 1_700_000_000.0
     future_reset = int(now + 30 * 24 * 3600)

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -1743,6 +1743,62 @@ def test_state_from_account_expires_stale_partial_primary_usage_after_reset(monk
     assert state.secondary_used_percent == 40.0
 
 
+def test_state_from_account_drops_stale_window_duration_when_superseded(monkeypatch):
+    now = 1_700_000_000.0
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    state = _state_from_account(
+        account=_make_test_account(status=AccountStatus.ACTIVE),
+        # Upstream stopped reporting the short window: the primary row is
+        # hours older than the weekly row written by later fetches.
+        primary_entry=_make_test_usage(
+            window="primary",
+            used_percent=40.0,
+            reset_at=int(now - 7200),
+            recorded_at=_epoch_to_naive_utc(now - 3 * 3600),
+            window_minutes=300,
+        ),
+        secondary_entry=_make_test_usage(
+            window="secondary",
+            used_percent=40.0,
+            reset_at=int(now + 5 * 24 * 3600),
+            recorded_at=_epoch_to_naive_utc(now - 30),
+        ),
+        runtime=RuntimeState(),
+    )
+
+    assert state.primary_window_minutes is None
+
+
+def test_state_from_account_keeps_window_duration_for_same_fetch_rows(monkeypatch):
+    now = 1_700_000_000.0
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    state = _state_from_account(
+        account=_make_test_account(status=AccountStatus.ACTIVE),
+        # Both rows came from the same fetch; the reset elapsed between
+        # refreshes, which does not mean the short window disappeared.
+        primary_entry=_make_test_usage(
+            window="primary",
+            used_percent=40.0,
+            reset_at=int(now - 10),
+            recorded_at=_epoch_to_naive_utc(now - 60),
+            window_minutes=300,
+        ),
+        secondary_entry=_make_test_usage(
+            window="secondary",
+            used_percent=40.0,
+            reset_at=int(now + 5 * 24 * 3600),
+            recorded_at=_epoch_to_naive_utc(now - 59),
+        ),
+        runtime=RuntimeState(),
+    )
+
+    assert state.primary_window_minutes == 300
+
+
 def test_state_from_account_expires_stale_partial_secondary_usage_after_reset(monkeypatch):
     now = 1_700_000_000.0
     monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -1771,6 +1771,35 @@ def test_state_from_account_drops_stale_window_duration_when_superseded(monkeypa
     assert state.primary_window_minutes is None
 
 
+def test_state_from_account_drops_superseded_window_duration_before_expiry(monkeypatch):
+    now = 1_700_000_000.0
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    state = _state_from_account(
+        account=_make_test_account(status=AccountStatus.ACTIVE),
+        # Upstream stopped reporting the short window while the stale row's
+        # reset is still in the future: the newer weekly row proves the
+        # short window is gone, so plannability must drop immediately.
+        primary_entry=_make_test_usage(
+            window="primary",
+            used_percent=40.0,
+            reset_at=int(now + 3600),
+            recorded_at=_epoch_to_naive_utc(now - 3 * 3600),
+            window_minutes=300,
+        ),
+        secondary_entry=_make_test_usage(
+            window="secondary",
+            used_percent=40.0,
+            reset_at=int(now + 5 * 24 * 3600),
+            recorded_at=_epoch_to_naive_utc(now - 30),
+        ),
+        runtime=RuntimeState(),
+    )
+
+    assert state.primary_window_minutes is None
+
+
 def test_state_from_account_keeps_window_duration_for_same_fetch_rows(monkeypatch):
     now = 1_700_000_000.0
     monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)

--- a/tests/unit/test_quota_planner.py
+++ b/tests/unit/test_quota_planner.py
@@ -72,8 +72,14 @@ def test_build_routing_costs_penalizes_cold_accounts_outside_work() -> None:
     )
     now = datetime(2026, 5, 18, 3, 0, tzinfo=timezone.utc)
     states = [
-        AccountState("cold", AccountStatus.ACTIVE, used_percent=0.0, reset_at=None),
-        AccountState("active", AccountStatus.ACTIVE, used_percent=50.0, reset_at=now.timestamp() + 1800),
+        AccountState("cold", AccountStatus.ACTIVE, used_percent=0.0, primary_window_minutes=300),
+        AccountState(
+            "active",
+            AccountStatus.ACTIVE,
+            used_percent=50.0,
+            primary_reset_at=int(now.timestamp() + 1800),
+            primary_window_minutes=300,
+        ),
     ]
 
     costs = build_routing_costs(settings=settings, states=states, now=now)
@@ -82,6 +88,119 @@ def test_build_routing_costs_penalizes_cold_accounts_outside_work() -> None:
     assert costs["cold"].reason == "cold_start_outside_work"
     assert costs["active"].total < 0.0
     assert costs["active"].reason == "expiring_active_window"
+
+
+def test_build_routing_costs_skips_accounts_without_short_windows() -> None:
+    settings = PlannerSettings(
+        mode="shadow",
+        timezone="UTC",
+        working_days=(0,),
+        working_hours_start="09:00",
+        working_hours_end="18:00",
+    )
+    now = datetime(2026, 5, 18, 3, 0, tzinfo=timezone.utc)
+    states = [
+        # Weekly-only account: the weekly-primary remap clears primary fields.
+        AccountState("weekly-only", AccountStatus.ACTIVE, secondary_used_percent=40.0),
+        # Short-window account stays cold-costed.
+        AccountState("cold-5h", AccountStatus.ACTIVE, used_percent=0.0, primary_window_minutes=300),
+    ]
+
+    costs = build_routing_costs(settings=settings, states=states, now=now)
+
+    assert "weekly-only" not in costs
+    assert costs["cold-5h"].total == 40.0
+
+
+def test_build_routing_costs_treats_live_primary_window_as_active() -> None:
+    settings = PlannerSettings(
+        mode="shadow",
+        timezone="UTC",
+        working_days=(0,),
+        working_hours_start="09:00",
+        working_hours_end="18:00",
+    )
+    now = datetime(2026, 5, 18, 3, 0, tzinfo=timezone.utc)
+    # A healthy ACTIVE account mid-way through a live window carries the
+    # window state in primary_reset_at (reset_at is blocked-status only).
+    states = [
+        AccountState(
+            "mid-window",
+            AccountStatus.ACTIVE,
+            used_percent=50.0,
+            primary_reset_at=int(now.timestamp() + 4 * 3600),
+            primary_window_minutes=300,
+        ),
+    ]
+
+    costs = build_routing_costs(settings=settings, states=states, now=now)
+
+    assert "mid-window" not in costs
+
+
+def test_plan_shadow_actions_skips_weekly_only_accounts() -> None:
+    settings = PlannerSettings(
+        mode="shadow",
+        timezone="UTC",
+        working_days=(0,),
+        working_hours_start="09:00",
+        working_hours_end="18:00",
+        prewarm_enabled=True,
+        prewarm_lead_minutes=300,
+        max_warmups_per_day=2,
+        min_expected_gain=1.0,
+    )
+    now = datetime(2026, 5, 18, 5, 0, tzinfo=timezone.utc)
+    peak_at = datetime(2026, 5, 18, 13, 0, tzinfo=timezone.utc)
+    states = [
+        AccountState("weekly-only", AccountStatus.ACTIVE, secondary_used_percent=10.0),
+        AccountState("cold-5h", AccountStatus.ACTIVE, used_percent=0.0, primary_window_minutes=300),
+    ]
+
+    actions = plan_shadow_actions(
+        settings=settings,
+        states=states,
+        demand_forecast=_forecast(now, peak_at=peak_at),
+        now=now,
+    )
+
+    assert actions
+    assert {action.account_id for action in actions} == {"cold-5h"}
+
+
+def test_plan_shadow_actions_uses_observed_window_duration() -> None:
+    settings = PlannerSettings(
+        mode="shadow",
+        timezone="UTC",
+        working_days=(0,),
+        working_hours_start="09:00",
+        working_hours_end="18:00",
+        prewarm_enabled=True,
+        prewarm_lead_minutes=300,
+        max_warmups_per_day=2,
+        min_expected_gain=1.0,
+    )
+    now = datetime(2026, 5, 18, 5, 0, tzinfo=timezone.utc)
+    peak_at = datetime(2026, 5, 18, 13, 0, tzinfo=timezone.utc)
+    states = [
+        AccountState("cold-1h", AccountStatus.ACTIVE, used_percent=0.0, primary_window_minutes=60),
+    ]
+
+    actions = plan_shadow_actions(
+        settings=settings,
+        states=states,
+        demand_forecast=_forecast(now, peak_at=peak_at),
+        now=now,
+    )
+
+    assert actions
+    action = actions[0]
+    assert action.window_seconds == pytest.approx(3600.0)
+    assert action.scheduled_at is not None
+    planned_reset = action.scheduled_at + timedelta(seconds=action.window_seconds)
+    # The one-hour window is planned so its span or reset aligns with the
+    # peak, which a 5h assumption could not do from these candidates.
+    assert abs((planned_reset - peak_at).total_seconds()) <= 3600.0
 
 
 def test_planner_settings_default_to_nonblocking_shadow_mode() -> None:
@@ -193,7 +312,6 @@ def test_candidate_start_times_do_not_floor_now_into_the_past() -> None:
 
     candidates = candidate_start_times(
         now=now,
-        account=AccountState("cold", AccountStatus.ACTIVE, used_percent=0.0, reset_at=None),
         settings=settings,
         demand_forecast=None,
     )
@@ -223,8 +341,8 @@ def test_simulation_sums_capacity_for_matching_reset_epochs() -> None:
         ),
     )
     states = [
-        AccountState("a", AccountStatus.ACTIVE, used_percent=40.0, reset_at=reset_at),
-        AccountState("b", AccountStatus.ACTIVE, used_percent=40.0, reset_at=reset_at),
+        AccountState("a", AccountStatus.ACTIVE, used_percent=40.0, primary_reset_at=int(reset_at)),
+        AccountState("b", AccountStatus.ACTIVE, used_percent=40.0, primary_reset_at=int(reset_at)),
     ]
 
     simulation = simulate_pool(settings=settings, states=states, demand_forecast=forecast, now=now)
@@ -295,9 +413,21 @@ def test_plan_shadow_actions_reserves_cold_accounts_for_peak_aligned_staggered_w
     now = datetime(2026, 5, 18, 5, 0, tzinfo=timezone.utc)
     peak_at = datetime(2026, 5, 18, 13, 0, tzinfo=timezone.utc)
     states = [
-        AccountState("cold-a", AccountStatus.ACTIVE, used_percent=0.0, reset_at=None),
-        AccountState("cold-b", AccountStatus.ACTIVE, used_percent=0.0, reset_at=now.timestamp() - 1),
-        AccountState("active", AccountStatus.ACTIVE, used_percent=10.0, reset_at=now.timestamp() + 60),
+        AccountState("cold-a", AccountStatus.ACTIVE, used_percent=0.0, primary_window_minutes=300),
+        AccountState(
+            "cold-b",
+            AccountStatus.ACTIVE,
+            used_percent=0.0,
+            primary_reset_at=int(now.timestamp() - 1),
+            primary_window_minutes=300,
+        ),
+        AccountState(
+            "active",
+            AccountStatus.ACTIVE,
+            used_percent=10.0,
+            primary_reset_at=int(now.timestamp() + 60),
+            primary_window_minutes=300,
+        ),
     ]
 
     actions = plan_shadow_actions(
@@ -339,8 +469,8 @@ def test_plan_shadow_actions_keeps_accounts_cold_when_flat_demand_has_no_peak_ga
     now = datetime(2026, 5, 18, 5, 0, tzinfo=timezone.utc)
     peak_at = datetime(2026, 5, 18, 13, 0, tzinfo=timezone.utc)
     states = [
-        AccountState("cold-a", AccountStatus.ACTIVE, used_percent=0.0, reset_at=None),
-        AccountState("cold-b", AccountStatus.ACTIVE, used_percent=0.0, reset_at=None),
+        AccountState("cold-a", AccountStatus.ACTIVE, used_percent=0.0, primary_window_minutes=300),
+        AccountState("cold-b", AccountStatus.ACTIVE, used_percent=0.0, primary_window_minutes=300),
     ]
 
     actions = plan_shadow_actions(
@@ -367,7 +497,7 @@ def test_plan_shadow_actions_rejects_start_that_misses_peak() -> None:
     )
     now = datetime(2026, 5, 18, 5, 0, tzinfo=timezone.utc)
     peak_at = datetime(2026, 5, 18, 23, 0, tzinfo=timezone.utc)
-    states = [AccountState("cold", AccountStatus.ACTIVE, used_percent=0.0, reset_at=None)]
+    states = [AccountState("cold", AccountStatus.ACTIVE, used_percent=0.0, primary_window_minutes=300)]
 
     actions = plan_shadow_actions(
         settings=settings,
@@ -408,8 +538,14 @@ def test_forecast_and_simulation_use_history_without_requiring_user_input() -> N
         )
     ]
     states = [
-        AccountState("cold", AccountStatus.ACTIVE, used_percent=0.0, reset_at=None),
-        AccountState("active", AccountStatus.ACTIVE, used_percent=40.0, reset_at=now.timestamp() + 3600),
+        AccountState("cold", AccountStatus.ACTIVE, used_percent=0.0, primary_window_minutes=300),
+        AccountState(
+            "active",
+            AccountStatus.ACTIVE,
+            used_percent=40.0,
+            primary_reset_at=int(now.timestamp() + 3600),
+            primary_window_minutes=300,
+        ),
     ]
 
     forecast = build_demand_forecast(settings=settings, bins=bins, now=now, horizon_hours=12)

--- a/tests/unit/test_quota_planner.py
+++ b/tests/unit/test_quota_planner.py
@@ -138,6 +138,77 @@ def test_build_routing_costs_treats_live_primary_window_as_active() -> None:
     assert "mid-window" not in costs
 
 
+def test_build_routing_costs_ignores_long_window_primary_samples() -> None:
+    settings = PlannerSettings(
+        mode="shadow",
+        timezone="UTC",
+        working_days=(0,),
+        working_hours_start="09:00",
+        working_hours_end="18:00",
+    )
+    now = datetime(2026, 5, 18, 3, 0, tzinfo=timezone.utc)
+    # A long unremapped primary window (25h) is not phase-plannable: it must
+    # neither earn an expiring-active-window bonus nor a cold-start cost.
+    states = [
+        AccountState(
+            "long-window",
+            AccountStatus.ACTIVE,
+            used_percent=50.0,
+            primary_reset_at=int(now.timestamp() + 1800),
+            primary_window_minutes=1500,
+        ),
+    ]
+
+    costs = build_routing_costs(settings=settings, states=states, now=now)
+
+    assert "long-window" not in costs
+
+
+def test_plan_shadow_actions_excludes_long_window_resets_from_stagger_math() -> None:
+    settings = PlannerSettings(
+        mode="shadow",
+        timezone="UTC",
+        working_days=(0,),
+        working_hours_start="09:00",
+        working_hours_end="18:00",
+        prewarm_enabled=True,
+        prewarm_lead_minutes=300,
+        max_warmups_per_day=2,
+        min_expected_gain=1.0,
+    )
+    now = datetime(2026, 5, 18, 5, 0, tzinfo=timezone.utc)
+    peak_at = datetime(2026, 5, 18, 13, 0, tzinfo=timezone.utc)
+    long_reset = int(now.timestamp() + 1800)
+    states = [
+        AccountState(
+            "long-window",
+            AccountStatus.ACTIVE,
+            used_percent=50.0,
+            primary_reset_at=long_reset,
+            primary_window_minutes=1500,
+        ),
+        AccountState("cold-5h", AccountStatus.ACTIVE, used_percent=0.0, primary_window_minutes=300),
+    ]
+
+    actions = plan_shadow_actions(
+        settings=settings,
+        states=states,
+        demand_forecast=_forecast(now, peak_at=peak_at),
+        now=now,
+    )
+
+    assert actions
+    assert {action.account_id for action in actions} == {"cold-5h"}
+    # The long window's reset must not act as an active-reset stagger
+    # anchor: no candidate is derived from it.
+    for action in actions:
+        assert action.scheduled_at is not None
+        anchored = abs((action.scheduled_at + timedelta(seconds=action.window_seconds)).timestamp() - long_reset) in (
+            1800.0,
+        )
+        assert not anchored
+
+
 def test_plan_shadow_actions_skips_weekly_only_accounts() -> None:
     settings = PlannerSettings(
         mode="shadow",
@@ -341,8 +412,20 @@ def test_simulation_sums_capacity_for_matching_reset_epochs() -> None:
         ),
     )
     states = [
-        AccountState("a", AccountStatus.ACTIVE, used_percent=40.0, primary_reset_at=int(reset_at)),
-        AccountState("b", AccountStatus.ACTIVE, used_percent=40.0, primary_reset_at=int(reset_at)),
+        AccountState(
+            "a",
+            AccountStatus.ACTIVE,
+            used_percent=40.0,
+            primary_reset_at=int(reset_at),
+            primary_window_minutes=300,
+        ),
+        AccountState(
+            "b",
+            AccountStatus.ACTIVE,
+            used_percent=40.0,
+            primary_reset_at=int(reset_at),
+            primary_window_minutes=300,
+        ),
     ]
 
     simulation = simulate_pool(settings=settings, states=states, demand_forecast=forecast, now=now)


### PR DESCRIPTION
## Why

Stacked on #1267. The quota phase planner and staggered idle limit warm-up hardcode the 5-hour primary window (`FIVE_HOUR_WINDOW_SECONDS`, `_ROLLING_WINDOW_SECONDS = 300 * 60`) and derive window state from the wrong field: `AccountState.reset_at` is only populated for blocked statuses, so every healthy account looked permanently "cold" — expiring-window bonuses never fired and cold-start costs landed uniformly (accidentally inert). With the temporary 5h-limit removal and upstream codex's duration-driven model, warmup candidacy also treated accounts with no short window (weekly-only) as pre-startable, and all phase math assumed exactly 5 hours.

## What

- `AccountState` gains a `primary_window_minutes` carrier (populated in `_state_from_account`, cleared by the weekly-primary remap and zero-capacity handling).
- Active/cold detection derives from `primary_reset_at` (the primary usage sample), activating the intended active-vs-cold differentiation.
- Warmup candidacy and cold-start routing costs require short-window plannability (duration metadata present and <= 24h); weekly-only accounts are never planned or cold-costed.
- Candidate start times, planned resets, pool-simulation spans, and synchronization penalties use each account's observed window duration; `PlannerAction` records its `window_seconds`.
- The warm-now execution gate refuses accounts whose primary-slot sample positively reports a long window (`no_short_window`), and long-window samples cannot produce observed warmup-effect confidence; absent or metadata-less samples keep legacy bootstrap behavior.
- Staggered idle limit warm-up spreads slots across the observed primary window duration (300-minute fallback for missing metadata).

Routing-cost mode behavior is unchanged: the spec requires routing costs enabled by default, so shadow keeps emitting them; only their inputs are now correct.

## OpenSpec

`openspec/changes/planner-window-generalization/` — adds short-window plannability and duration-derived phase math requirements to `quota-phase-planner`; makes the staggered idle warm-up scenarios in `usage-refresh-policy` duration-neutral. `openspec validate planner-window-generalization --strict` passes.

## Testing

- New unit coverage: weekly-only accounts get no warmups/cold costs; mixed pools plan only short-window accounts; a healthy mid-window account is treated as active (not cold); a 60-minute window plans peak alignment with its own duration and records `window_seconds=3600`; idle warm-up stagger spreads across the observed duration; `_state_from_account` carries and clears `primary_window_minutes`.
- New integration coverage: warm-now against a weekly-only account skips with `no_short_window`.
- Suites: planner, limit-warmup, load-balancer, planner API, proxy warmup flows — green; full unit suite 3,534 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
