### PR TITLE
fix(automation): fall back to github.token when label sync hits rate limits

### DIFF
--- a/.github/scripts/sync_codex_ok_labels.py
+++ b/.github/scripts/sync_codex_ok_labels.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -168,6 +169,28 @@ class GhError(RuntimeError):
     """A GitHub CLI call failed."""
 
 
+_RATE_LIMIT_MARKER = "API rate limit exceeded"
+_fallback_token_active = False
+
+
+def _activate_fallback_token() -> bool:
+    """Switch gh calls to GH_FALLBACK_TOKEN once after a rate-limit failure.
+
+    The primary token is typically a user PAT whose quota is shared with
+    other consumers; github.token carries a separate per-repository quota,
+    so a single runtime switch keeps the sync alive through PAT exhaustion.
+    """
+    global _fallback_token_active
+    if _fallback_token_active:
+        return False
+    fallback = os.environ.get("GH_FALLBACK_TOKEN", "").strip()
+    if not fallback or fallback == os.environ.get("GH_TOKEN", ""):
+        return False
+    os.environ["GH_TOKEN"] = fallback
+    _fallback_token_active = True
+    return True
+
+
 @dataclass(frozen=True)
 class SyncDecision:
     repo: str
@@ -207,6 +230,12 @@ def run_gh(args: list[str], *, input_json: Any | None = None, timeout_seconds: i
 
     if proc.returncode != 0:
         detail = proc.stderr.strip() or proc.stdout.strip()
+        if _RATE_LIMIT_MARKER in detail and _activate_fallback_token():
+            print(
+                "warning: active token rate-limited; retrying with GH_FALLBACK_TOKEN",
+                file=sys.stderr,
+            )
+            return run_gh(args, input_json=input_json, timeout_seconds=timeout_seconds)
         raise GhError(f"{' '.join(command)}: {detail}")
 
     text = proc.stdout.strip()

--- a/.github/workflows/codex-review-labels.yml
+++ b/.github/workflows/codex-review-labels.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Sync labels
         env:
           GH_TOKEN: ${{ secrets.CODEX_LABEL_SYNC_TOKEN || secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          GH_FALLBACK_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
@@ -77,6 +78,7 @@ jobs:
       - name: Sync labels
         env:
           GH_TOKEN: ${{ secrets.CODEX_LABEL_SYNC_TOKEN || secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          GH_FALLBACK_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
           if [ ! -f .github/scripts/sync_codex_ok_labels.py ]; then

--- a/openspec/changes/label-sync-rate-limit-fallback/proposal.md
+++ b/openspec/changes/label-sync-rate-limit-fallback/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The Codex label sync workflow authenticates with a user PAT (`CODEX_LABEL_SYNC_TOKEN`), whose 5,000/hr REST quota is shared with every other consumer of that user's token (interactive sessions, agents, other automations). During busy review cycles the quota exhausts and every label sync run fails with `API rate limit exceeded (HTTP 403)`, painting spurious CI failures on open PRs for up to an hour — observed repeatedly on 2026-07-13 during the adaptive-windows review cycle (#1266/#1267/#1268).
+
+## What Changes
+
+- The sync script detects rate-limit exhaustion on any `gh` call and switches once to a fallback token (`GH_FALLBACK_TOKEN`), retrying the failed call; the workflow provides `github.token` as that fallback, which carries a separate per-repository Actions quota.
+- When no distinct fallback is available (or it is also exhausted), behavior is unchanged: the run fails per the read/classification failure contract.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `github-automation`: label sync gains a runtime rate-limit token fallback on top of the existing configuration-time token preference.
+
+## Impact
+
+- Code: `.github/scripts/sync_codex_ok_labels.py`, `.github/workflows/codex-review-labels.yml`
+- Tests: `tests/unit/test_sync_codex_ok_labels.py`
+- Specs: `openspec/specs/github-automation/spec.md`

--- a/openspec/changes/label-sync-rate-limit-fallback/specs/github-automation/spec.md
+++ b/openspec/changes/label-sync-rate-limit-fallback/specs/github-automation/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Codex review label sync write-token fallback
+
+The `Codex review labels` workflow MUST execute the label synchronization script from the trusted default branch and MUST prefer a repository-provided write token before falling back to the default `github.token`. When the active token's API quota is exhausted at runtime, the script MUST switch once to a configured fallback token and retry the failed call instead of failing the run outright.
+
+#### Scenario: Privileged token is configured
+
+- **WHEN** the workflow synchronizes Codex review labels
+- **THEN** it uses `CODEX_LABEL_SYNC_TOKEN` when present
+- **AND** it falls back to `RELEASE_PLEASE_TOKEN` before `github.token`
+- **AND** it checks out the default branch with persisted checkout credentials disabled
+
+#### Scenario: Active token hits its rate limit
+
+- **GIVEN** the workflow provides `github.token` as `GH_FALLBACK_TOKEN`
+- **WHEN** a gh call fails with `API rate limit exceeded`
+- **THEN** the script switches to the fallback token once and retries the failed call
+- **AND** subsequent calls in the run keep using the fallback token
+
+#### Scenario: No usable fallback token
+
+- **WHEN** a gh call fails with `API rate limit exceeded`
+- **AND** no fallback token is configured, or it matches the active token, or it is also exhausted
+- **THEN** the run fails as a read/classification failure per the existing contract

--- a/openspec/changes/label-sync-rate-limit-fallback/tasks.md
+++ b/openspec/changes/label-sync-rate-limit-fallback/tasks.md
@@ -1,0 +1,10 @@
+## 1. Runtime token fallback
+
+- [x] 1.1 Detect `API rate limit exceeded` failures in the gh wrapper and switch once to `GH_FALLBACK_TOKEN`, retrying the failed call.
+- [x] 1.2 Provide `github.token` as `GH_FALLBACK_TOKEN` in both label-sync workflow jobs.
+- [x] 1.3 Unit coverage: fallback activates once and retries; no-op when the fallback is absent or identical; exhausted fallback still fails.
+
+## 2. Validation
+
+- [x] 2.1 Run the sync-script unit suite.
+- [x] 2.2 Validate with `openspec validate label-sync-rate-limit-fallback --strict`.

--- a/tests/unit/test_sync_codex_ok_labels.py
+++ b/tests/unit/test_sync_codex_ok_labels.py
@@ -840,3 +840,66 @@ def test_unresolved_inline_codex_finding_counts_as_review_news(
 
     assert len(nodes) == 1
     assert nodes[0]["url"] == url
+
+
+def _rate_limited_proc() -> Any:
+    class _Proc:
+        returncode = 1
+        stdout = ""
+        stderr = "gh: API rate limit exceeded for user ID 34199905 (HTTP 403)"
+
+    return _Proc()
+
+
+def _ok_proc(payload: str = "{}") -> Any:
+    class _Proc:
+        returncode = 0
+        stdout = payload
+        stderr = ""
+
+    return _Proc()
+
+
+def test_run_gh_switches_to_fallback_token_on_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_sync_module()
+    monkeypatch.setenv("GH_TOKEN", "primary-token")
+    monkeypatch.setenv("GH_FALLBACK_TOKEN", "fallback-token")
+
+    calls: list[str] = []
+
+    def fake_run(command: Any, **kwargs: Any) -> Any:
+        import os
+
+        calls.append(os.environ["GH_TOKEN"])
+        if len(calls) == 1:
+            return _rate_limited_proc()
+        return _ok_proc()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    result = module.run_gh(["api", "/rate-limited-path"])
+
+    assert result == {}
+    assert calls == ["primary-token", "fallback-token"]
+
+
+def test_run_gh_fails_without_distinct_fallback_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_sync_module()
+    monkeypatch.setenv("GH_TOKEN", "primary-token")
+    monkeypatch.setenv("GH_FALLBACK_TOKEN", "primary-token")
+
+    monkeypatch.setattr(module.subprocess, "run", lambda command, **kwargs: _rate_limited_proc())
+
+    with pytest.raises(module.GhError):
+        module.run_gh(["api", "/rate-limited-path"])
+
+
+def test_run_gh_fails_when_fallback_token_is_also_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_sync_module()
+    monkeypatch.setenv("GH_TOKEN", "primary-token")
+    monkeypatch.setenv("GH_FALLBACK_TOKEN", "fallback-token")
+
+    monkeypatch.setattr(module.subprocess, "run", lambda command, **kwargs: _rate_limited_proc())
+
+    with pytest.raises(module.GhError):
+        module.run_gh(["api", "/rate-limited-path"])


### PR DESCRIPTION
## Why

`CODEX_LABEL_SYNC_TOKEN` is a user PAT whose 5,000/hr REST quota is shared with every other consumer of that user's token. During the 2026-07-13 adaptive-windows review cycle the quota exhausted repeatedly, failing every "Sync Codex labels" run (HTTP 403) and painting spurious CI failures on #1266–#1268 for up to an hour at a time.

## What

- The gh wrapper in `sync_codex_ok_labels.py` detects `API rate limit exceeded` failures, switches once to `GH_FALLBACK_TOKEN`, and retries the failed call; subsequent calls keep the fallback.
- Both workflow jobs provide `github.token` as `GH_FALLBACK_TOKEN` — it carries a separate per-repository Actions quota (1,000/hr), ample for label sync.
- No usable distinct fallback (absent, identical, or also exhausted) keeps the existing fail-on-read contract.

Longer-term the PAT should move to a machine account or GitHub App to fully decouple quotas; this PR removes the recurring failure mode either way.

## OpenSpec

`openspec/changes/label-sync-rate-limit-fallback/` — modifies the `github-automation` write-token fallback requirement with runtime rate-limit scenarios. Strict validation passes.

## Testing

- New unit tests: fallback activates once and retries; identical fallback fails; exhausted fallback fails (`tests/unit/test_sync_codex_ok_labels.py`, 28 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)