### PR TITLE
feat(usage): ingest live rate-limit snapshots from proxied traffic

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -2494,6 +2494,7 @@ async def stream_responses(
     codex_installation_id: str | None = None,
     enforce_openai_sdk_contract: bool = True,
     codex_lb_account_id: str | None = None,
+    suppress_live_usage: bool = False,
 ) -> AsyncIterator[str]:
     effective_allow_direct_egress = allow_direct_egress or (route is None and session is not None)
     async with lease_http_session(session) as client_session:
@@ -2513,8 +2514,9 @@ async def stream_responses(
             codex_installation_id=codex_installation_id,
             enforce_openai_sdk_contract=enforce_openai_sdk_contract,
             codex_lb_account_id=codex_lb_account_id,
+            suppress_live_usage=suppress_live_usage,
         ):
-            if (codex_lb_account_id or account_id) and EVENT_MARKER in event_block:
+            if not suppress_live_usage and (codex_lb_account_id or account_id) and EVENT_MARKER in event_block:
                 publish_live_usage(
                     parse_rate_limit_event_text(event_block),
                     account_id=codex_lb_account_id,
@@ -2539,6 +2541,7 @@ async def _stream_responses_with_session(
     codex_installation_id: str | None = None,
     enforce_openai_sdk_contract: bool = True,
     codex_lb_account_id: str | None = None,
+    suppress_live_usage: bool = False,
 ) -> AsyncIterator[str]:
     settings = get_settings()
     headers = apply_codex_installation_headers(headers, codex_installation_id)
@@ -2655,7 +2658,7 @@ async def _stream_responses_with_session(
                 resp = _CodexSSEResponse(raw_resp)
                 status_code = resp.status
                 last_stream_activity_at = time.monotonic()
-                if resp.status < 400:
+                if resp.status < 400 and not suppress_live_usage:
                     publish_live_usage(
                         parse_rate_limit_headers(getattr(raw_resp, "headers", None)),
                         account_id=codex_lb_account_id,
@@ -2749,7 +2752,7 @@ async def _stream_responses_with_session(
         ) as resp:
             status_code = resp.status
             last_stream_activity_at = time.monotonic()
-            if resp.status < 400:
+            if resp.status < 400 and not suppress_live_usage:
                 publish_live_usage(
                     parse_rate_limit_headers(getattr(resp, "headers", None)),
                     account_id=codex_lb_account_id,

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -2658,7 +2658,10 @@ async def _stream_responses_with_session(
                 resp = _CodexSSEResponse(raw_resp)
                 status_code = resp.status
                 last_stream_activity_at = time.monotonic()
-                if resp.status < 400 and not suppress_live_usage:
+                # Error responses (429/403) carry the saturated-window
+                # snapshot — exactly when freshness matters most — so headers
+                # are ingested regardless of status.
+                if not suppress_live_usage:
                     publish_live_usage(
                         parse_rate_limit_headers(getattr(raw_resp, "headers", None)),
                         account_id=codex_lb_account_id,
@@ -2752,7 +2755,7 @@ async def _stream_responses_with_session(
         ) as resp:
             status_code = resp.status
             last_stream_activity_at = time.monotonic()
-            if resp.status < 400 and not suppress_live_usage:
+            if not suppress_live_usage:
                 publish_live_usage(
                     parse_rate_limit_headers(getattr(resp, "headers", None)),
                     account_id=codex_lb_account_id,

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -76,6 +76,8 @@ from app.core.resilience.circuit_breaker import (
 )
 from app.core.types import JsonObject, JsonValue
 from app.core.upstream_proxy import ResolvedUpstreamRoute
+from app.core.usage.live_hub import publish_live_usage
+from app.core.usage.live_snapshots import EVENT_MARKER, parse_rate_limit_event_text, parse_rate_limit_headers
 from app.core.utils.json_guards import is_json_mapping
 from app.core.utils.request_id import get_request_id
 from app.core.utils.sse import format_sse_event, parse_sse_data_json
@@ -2510,6 +2512,11 @@ async def stream_responses(
             codex_installation_id=codex_installation_id,
             enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         ):
+            if account_id and EVENT_MARKER in event_block:
+                publish_live_usage(
+                    parse_rate_limit_event_text(event_block),
+                    chatgpt_account_id=account_id,
+                )
             yield event_block
 
 
@@ -2644,6 +2651,11 @@ async def _stream_responses_with_session(
                 resp = _CodexSSEResponse(raw_resp)
                 status_code = resp.status
                 last_stream_activity_at = time.monotonic()
+                if resp.status < 400:
+                    publish_live_usage(
+                        parse_rate_limit_headers(getattr(raw_resp, "headers", None)),
+                        chatgpt_account_id=account_id,
+                    )
                 if resp.status >= 400:
                     if raise_for_status:
                         error_payload = await _error_payload_from_response(resp)

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -2493,6 +2493,7 @@ async def stream_responses(
     allow_direct_egress: bool = True,
     codex_installation_id: str | None = None,
     enforce_openai_sdk_contract: bool = True,
+    codex_lb_account_id: str | None = None,
 ) -> AsyncIterator[str]:
     effective_allow_direct_egress = allow_direct_egress or (route is None and session is not None)
     async with lease_http_session(session) as client_session:
@@ -2511,11 +2512,13 @@ async def stream_responses(
             allow_direct_egress=effective_allow_direct_egress,
             codex_installation_id=codex_installation_id,
             enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+            codex_lb_account_id=codex_lb_account_id,
         ):
-            if account_id and EVENT_MARKER in event_block:
+            if (codex_lb_account_id or account_id) and EVENT_MARKER in event_block:
                 publish_live_usage(
                     parse_rate_limit_event_text(event_block),
-                    chatgpt_account_id=account_id,
+                    account_id=codex_lb_account_id,
+                    chatgpt_account_id=None if codex_lb_account_id else account_id,
                 )
             yield event_block
 
@@ -2535,6 +2538,7 @@ async def _stream_responses_with_session(
     allow_direct_egress: bool = True,
     codex_installation_id: str | None = None,
     enforce_openai_sdk_contract: bool = True,
+    codex_lb_account_id: str | None = None,
 ) -> AsyncIterator[str]:
     settings = get_settings()
     headers = apply_codex_installation_headers(headers, codex_installation_id)
@@ -2654,7 +2658,8 @@ async def _stream_responses_with_session(
                 if resp.status < 400:
                     publish_live_usage(
                         parse_rate_limit_headers(getattr(raw_resp, "headers", None)),
-                        chatgpt_account_id=account_id,
+                        account_id=codex_lb_account_id,
+                        chatgpt_account_id=None if codex_lb_account_id else account_id,
                     )
                 if resp.status >= 400:
                     if raise_for_status:
@@ -2744,6 +2749,12 @@ async def _stream_responses_with_session(
         ) as resp:
             status_code = resp.status
             last_stream_activity_at = time.monotonic()
+            if resp.status < 400:
+                publish_live_usage(
+                    parse_rate_limit_headers(getattr(resp, "headers", None)),
+                    account_id=codex_lb_account_id,
+                    chatgpt_account_id=None if codex_lb_account_id else account_id,
+                )
             if resp.status >= 400:
                 if raise_for_status:
                     error_payload = await _error_payload_from_response(resp)

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -195,6 +195,9 @@ class Settings(BaseSettings):
     usage_fetch_max_retries: int = 2
     usage_refresh_enabled: bool = True
     usage_refresh_interval_seconds: int = Field(default=60, gt=0)
+    live_usage_ingestion_enabled: bool = True
+    live_usage_write_min_interval_seconds: float = Field(default=5.0, ge=0)
+    live_usage_queue_size: int = Field(default=512, gt=0)
     rate_limit_reset_credits_refresh_interval_seconds: int = Field(default=60, gt=0)
     openai_cache_affinity_max_age_seconds: int = Field(default=1800, gt=0)
     warmup_model: str = "gpt-5.4-mini"

--- a/app/core/usage/live_hub.py
+++ b/app/core/usage/live_hub.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Callable, Protocol
+
+from app.core.usage.live_snapshots import LiveRateLimitSnapshot
+
+
+class LiveUsagePublisher(Protocol):
+    def __call__(
+        self,
+        snapshot: LiveRateLimitSnapshot,
+        *,
+        account_id: str | None = None,
+        chatgpt_account_id: str | None = None,
+    ) -> None: ...
+
+
+# The core client layer publishes through this hub so it never imports the
+# module layer; until startup registers an ingestor every publish is a no-op.
+_publisher: Callable[..., None] | None = None
+
+
+def register_live_usage_publisher(publisher: LiveUsagePublisher | None) -> None:
+    global _publisher
+    _publisher = publisher
+
+
+def publish_live_usage(
+    snapshot: LiveRateLimitSnapshot | None,
+    *,
+    account_id: str | None = None,
+    chatgpt_account_id: str | None = None,
+) -> None:
+    if snapshot is None or not snapshot.has_windows:
+        return
+    if not account_id and not chatgpt_account_id:
+        return
+    publisher = _publisher
+    if publisher is None:
+        return
+    publisher(snapshot, account_id=account_id, chatgpt_account_id=chatgpt_account_id)

--- a/app/core/usage/live_snapshots.py
+++ b/app/core/usage/live_snapshots.py
@@ -120,6 +120,14 @@ def parse_rate_limit_event(payload: Mapping[str, Any]) -> LiveRateLimitSnapshot 
     """Parse a ``codex.rate_limits`` stream event payload."""
     if payload.get("type") != _EVENT_TYPE:
         return None
+    # Only the default ``codex`` limit family maps onto the account's main
+    # usage rows; events for model-specific or individual limit buckets
+    # (discriminated by limit_id / metered_limit_name / limit_name) must not
+    # corrupt global selection state.
+    for discriminator in ("limit_id", "metered_limit_name", "limit_name"):
+        value = payload.get(discriminator)
+        if value is not None and value != "codex":
+            return None
     rate_limits = payload.get("rate_limits")
     if not isinstance(rate_limits, dict):
         return None

--- a/app/core/usage/live_snapshots.py
+++ b/app/core/usage/live_snapshots.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass
 from typing import Any, Mapping
 
@@ -37,9 +38,15 @@ def _parse_float(value: object) -> float | None:
     if not isinstance(value, (int, float, str)):
         return None
     try:
-        return float(value)
+        parsed = float(value)
     except ValueError:
         return None
+    # Live signals run synchronously on the serving path; non-finite values
+    # (NaN/Infinity strings) must degrade to "unparseable", not raise later
+    # in int() coercion.
+    if not math.isfinite(parsed):
+        return None
+    return parsed
 
 
 def _parse_int(value: object) -> int | None:

--- a/app/core/usage/live_snapshots.py
+++ b/app/core/usage/live_snapshots.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+_HEADER_PREFIX = "x-codex-"
+_EVENT_TYPE = "codex.rate_limits"
+# Cheap containment probe so stream hot paths can skip JSON parsing for the
+# overwhelming majority of event blocks.
+EVENT_MARKER = '"codex.rate_limits"'
+
+
+@dataclass(frozen=True, slots=True)
+class LiveUsageWindow:
+    used_percent: float
+    window_minutes: int | None
+    reset_at: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class LiveRateLimitSnapshot:
+    primary: LiveUsageWindow | None
+    secondary: LiveUsageWindow | None
+    credits_has: bool | None
+    credits_unlimited: bool | None
+    credits_balance: float | None
+
+    @property
+    def has_windows(self) -> bool:
+        return self.primary is not None or self.secondary is not None
+
+
+def _parse_float(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if not isinstance(value, (int, float, str)):
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _parse_int(value: object) -> int | None:
+    parsed = _parse_float(value)
+    if parsed is None:
+        return None
+    return int(parsed)
+
+
+def _parse_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1"}:
+            return True
+        if lowered in {"false", "0"}:
+            return False
+    return None
+
+
+def _header_window(headers: Mapping[str, str], slot: str) -> LiveUsageWindow | None:
+    used = _parse_float(headers.get(f"{_HEADER_PREFIX}{slot}-used-percent"))
+    if used is None:
+        return None
+    return LiveUsageWindow(
+        used_percent=used,
+        window_minutes=_parse_int(headers.get(f"{_HEADER_PREFIX}{slot}-window-minutes")),
+        reset_at=_parse_int(headers.get(f"{_HEADER_PREFIX}{slot}-reset-at")),
+    )
+
+
+def parse_rate_limit_headers(headers: Mapping[str, str] | None) -> LiveRateLimitSnapshot | None:
+    """Parse upstream ``x-codex-*`` rate-limit response headers.
+
+    Only the default ``codex`` limit family is consumed; additional
+    ``x-<limit-id>-*`` families are out of scope for live ingestion.
+    """
+    if not headers:
+        return None
+    lowered = {key.lower(): value for key, value in headers.items()}
+    primary = _header_window(lowered, "primary")
+    secondary = _header_window(lowered, "secondary")
+    if primary is None and secondary is None:
+        return None
+    return LiveRateLimitSnapshot(
+        primary=primary,
+        secondary=secondary,
+        credits_has=_parse_bool(lowered.get(f"{_HEADER_PREFIX}credits-has-credits")),
+        credits_unlimited=_parse_bool(lowered.get(f"{_HEADER_PREFIX}credits-unlimited")),
+        credits_balance=_parse_float(lowered.get(f"{_HEADER_PREFIX}credits-balance")),
+    )
+
+
+def _event_window(payload: object) -> LiveUsageWindow | None:
+    if not isinstance(payload, dict):
+        return None
+    used = _parse_float(payload.get("used_percent"))
+    if used is None:
+        return None
+    return LiveUsageWindow(
+        used_percent=used,
+        window_minutes=_parse_int(payload.get("window_minutes")),
+        reset_at=_parse_int(
+            payload.get("reset_at") if payload.get("reset_at") is not None else payload.get("resets_at")
+        ),
+    )
+
+
+def parse_rate_limit_event(payload: Mapping[str, Any]) -> LiveRateLimitSnapshot | None:
+    """Parse a ``codex.rate_limits`` stream event payload."""
+    if payload.get("type") != _EVENT_TYPE:
+        return None
+    rate_limits = payload.get("rate_limits")
+    if not isinstance(rate_limits, dict):
+        return None
+    primary = _event_window(rate_limits.get("primary"))
+    secondary = _event_window(rate_limits.get("secondary"))
+    if primary is None and secondary is None:
+        return None
+    credits = payload.get("credits")
+    if not isinstance(credits, dict):
+        credits = rate_limits.get("credits")
+    if not isinstance(credits, dict):
+        credits = {}
+    return LiveRateLimitSnapshot(
+        primary=primary,
+        secondary=secondary,
+        credits_has=_parse_bool(credits.get("has_credits")),
+        credits_unlimited=_parse_bool(credits.get("unlimited")),
+        credits_balance=_parse_float(credits.get("balance")),
+    )
+
+
+def parse_rate_limit_event_text(text: str) -> LiveRateLimitSnapshot | None:
+    """Parse a raw stream chunk that may contain a rate-limit event.
+
+    Accepts either a bare JSON object or an SSE ``data:`` block. Callers
+    should gate on :data:`EVENT_MARKER` first to keep hot paths cheap.
+    """
+    if EVENT_MARKER not in text:
+        return None
+    for line in text.splitlines():
+        candidate = line.strip()
+        if candidate.startswith("data:"):
+            candidate = candidate[5:].strip()
+        if not candidate.startswith("{") or EVENT_MARKER not in candidate:
+            continue
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            snapshot = parse_rate_limit_event(payload)
+            if snapshot is not None:
+                return snapshot
+    return None

--- a/app/main.py
+++ b/app/main.py
@@ -83,6 +83,7 @@ from app.modules.sticky_sessions import api as sticky_sessions_api
 from app.modules.sticky_sessions.cleanup_scheduler import build_sticky_session_cleanup_scheduler
 from app.modules.usage import api as usage_api
 from app.modules.usage.additional_quota_keys import reload_additional_quota_registry
+from app.modules.usage.live_ingest import start_live_usage_ingestor, stop_live_usage_ingestor
 
 logger = logging.getLogger(__name__)
 
@@ -277,6 +278,7 @@ async def lifespan(app: FastAPI):
     rate_limit_reset_credits_scheduler = build_rate_limit_reset_credits_scheduler()
     account_usage_rollup_scheduler = build_account_usage_rollup_scheduler()
     data_retention_scheduler = build_data_retention_scheduler()
+    start_live_usage_ingestor()
     await usage_scheduler.start()
     await api_key_limit_reset_scheduler.start()
     await model_scheduler.start()
@@ -458,6 +460,7 @@ async def lifespan(app: FastAPI):
             set_cache_invalidation_poller(None)
         await api_key_limit_reset_scheduler.stop()
         await usage_scheduler.stop()
+        await stop_live_usage_ingestor()
         await rate_limit_reset_credits_scheduler.stop()
         await account_usage_rollup_scheduler.stop()
         await data_retention_scheduler.stop()

--- a/app/modules/limit_warmup/service.py
+++ b/app/modules/limit_warmup/service.py
@@ -227,6 +227,7 @@ class StreamingLimitWarmupSender:
                 route=route,
                 route_trace=route_trace,
                 allow_direct_egress=route is None,
+                codex_lb_account_id=fresh_account.id,
             ):
                 event = parse_sse_event(event_block)
                 if event is None:

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -29,6 +29,8 @@ from app.core.clients.proxy import compact_responses as core_compact_responses  
 from app.core.clients.proxy import transcribe_audio as core_transcribe_audio  # noqa: F401
 from app.core.clients.proxy_websocket import UpstreamWebSocketMessage
 from app.core.openai.parsing import parse_sse_event_payload
+from app.core.usage.live_hub import publish_live_usage
+from app.core.usage.live_snapshots import EVENT_MARKER, parse_rate_limit_event_text
 from app.core.utils.request_id import reset_request_id, set_request_id
 from app.core.utils.sse import format_sse_event, parse_sse_data_json
 from app.modules.proxy._service.api_key_usage import (
@@ -288,6 +290,11 @@ class _HTTPBridgeUpstreamEventsMixin:
 
                 if message.kind == "text" and message.text is not None:
                     session.last_upstream_close_code = None
+                    if EVENT_MARKER in message.text:
+                        publish_live_usage(
+                            parse_rate_limit_event_text(message.text),
+                            account_id=session.account.id,
+                        )
                     await self._process_http_bridge_upstream_text(session, message.text)
                     if await self._retire_http_bridge_after_drain_if_ready(session):
                         break

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -553,6 +553,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                         "codex_installation_id": account.codex_installation_id,
                         "enforce_openai_sdk_contract": enforce_openai_sdk_contract,
                         "upstream_stream_transport_override": upstream_stream_transport,
+                        "codex_lb_account_id": account.id,
                     },
                     raise_for_status=True,
                 )
@@ -569,6 +570,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                         "route_trace": route_trace,
                         "codex_installation_id": account.codex_installation_id,
                         "enforce_openai_sdk_contract": enforce_openai_sdk_contract,
+                        "codex_lb_account_id": account.id,
                     },
                     raise_for_status=True,
                 )

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -539,41 +539,25 @@ class _StreamingMixin(_StreamingRetryMixin):
                 concurrency_caps=concurrency_caps or _facade().effective_account_concurrency_caps(),
             )
             response_create_lease = await proxy._get_work_admission().acquire_response_create()
+            stream_optional_kwargs: dict[str, object] = {
+                "route": route,
+                "allow_direct_egress": route is None,
+                "route_trace": route_trace,
+                "codex_installation_id": account.codex_installation_id,
+                "enforce_openai_sdk_contract": enforce_openai_sdk_contract,
+                "codex_lb_account_id": account.id,
+            }
             if upstream_stream_transport is not None:
-                stream = _facade()._call_stream_with_supported_optional_kwargs(
-                    _facade().core_stream_responses,
-                    payload,
-                    headers,
-                    access_token,
-                    account_id,
-                    optional_kwargs={
-                        "route": route,
-                        "allow_direct_egress": route is None,
-                        "route_trace": route_trace,
-                        "codex_installation_id": account.codex_installation_id,
-                        "enforce_openai_sdk_contract": enforce_openai_sdk_contract,
-                        "upstream_stream_transport_override": upstream_stream_transport,
-                        "codex_lb_account_id": account.id,
-                    },
-                    raise_for_status=True,
-                )
-            else:
-                stream = _facade()._call_stream_with_supported_optional_kwargs(
-                    _facade().core_stream_responses,
-                    payload,
-                    headers,
-                    access_token,
-                    account_id,
-                    optional_kwargs={
-                        "route": route,
-                        "allow_direct_egress": route is None,
-                        "route_trace": route_trace,
-                        "codex_installation_id": account.codex_installation_id,
-                        "enforce_openai_sdk_contract": enforce_openai_sdk_contract,
-                        "codex_lb_account_id": account.id,
-                    },
-                    raise_for_status=True,
-                )
+                stream_optional_kwargs["upstream_stream_transport_override"] = upstream_stream_transport
+            stream = _facade()._call_stream_with_supported_optional_kwargs(
+                _facade().core_stream_responses,
+                payload,
+                headers,
+                access_token,
+                account_id,
+                optional_kwargs=stream_optional_kwargs,
+                raise_for_status=True,
+            )
             iterator = _facade()._stream_iterator_after_capacity_admission(stream)
             try:
                 first = await iterator.__anext__()

--- a/app/modules/quota_planner/warmup.py
+++ b/app/modules/quota_planner/warmup.py
@@ -487,6 +487,7 @@ class QuotaWarmupService:
             access_token,
             upstream_account_id,
             raise_for_status=True,
+            codex_lb_account_id=account.id,
         ):
             event = parse_sse_event(event_block)
             if event is None or event.response is None or event.response.usage is None:

--- a/app/modules/quota_planner/warmup.py
+++ b/app/modules/quota_planner/warmup.py
@@ -487,7 +487,11 @@ class QuotaWarmupService:
             access_token,
             upstream_account_id,
             raise_for_status=True,
-            codex_lb_account_id=account.id,
+            # The probe's own live signals must not pre-write fresh usage
+            # rows: _record_warmup_effect measures the post-probe window via
+            # its controlled refresh, which would otherwise skip as fresh
+            # and downgrade the observation to unknown.
+            suppress_live_usage=True,
         ):
             event = parse_sse_event(event_block)
             if event is None or event.response is None or event.response.usage is None:

--- a/app/modules/usage/live_ingest.py
+++ b/app/modules/usage/live_ingest.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+
+from sqlalchemy import select
+
+from app.core.config.settings import get_settings
+from app.core.usage.live_hub import register_live_usage_publisher
+from app.core.usage.live_snapshots import LiveRateLimitSnapshot, LiveUsageWindow
+from app.db.models import Account
+from app.db.session import get_background_session
+from app.modules.proxy.account_cache import get_account_selection_cache
+from app.modules.usage.repository import UsageRepository
+
+logger = logging.getLogger(__name__)
+
+_RESOLUTION_TTL_SECONDS = 300.0
+_CACHE_INVALIDATION_MIN_INTERVAL_SECONDS = 5.0
+
+
+@dataclass(frozen=True, slots=True)
+class _QueuedSnapshot:
+    account_id: str | None
+    chatgpt_account_id: str | None
+    snapshot: LiveRateLimitSnapshot
+
+
+def _fingerprint(snapshot: LiveRateLimitSnapshot) -> tuple[object, ...]:
+    def window_key(window: LiveUsageWindow | None) -> tuple[object, ...] | None:
+        if window is None:
+            return None
+        return (round(window.used_percent, 2), window.window_minutes, window.reset_at)
+
+    return (
+        window_key(snapshot.primary),
+        window_key(snapshot.secondary),
+        snapshot.credits_has,
+        snapshot.credits_unlimited,
+        snapshot.credits_balance,
+    )
+
+
+class LiveUsageIngestor:
+    """Fire-and-forget sink for per-turn rate-limit snapshots.
+
+    Snapshots ride the serving path, so enqueueing must stay O(1) and never
+    raise; a single consumer task owns its own background sessions and writes
+    usage-history rows with the same shape the background poller produces.
+    """
+
+    def __init__(
+        self,
+        *,
+        queue_size: int,
+        write_min_interval_seconds: float,
+    ) -> None:
+        self._queue: asyncio.Queue[_QueuedSnapshot] = asyncio.Queue(maxsize=max(1, queue_size))
+        self._write_min_interval_seconds = write_min_interval_seconds
+        self._last_write: dict[str, tuple[tuple[object, ...], float]] = {}
+        self._resolution_cache: dict[str, tuple[str | None, float]] = {}
+        self._consumer: asyncio.Task[None] | None = None
+        self._dropped = 0
+        self._last_cache_invalidation = 0.0
+
+    def publish(
+        self,
+        snapshot: LiveRateLimitSnapshot,
+        *,
+        account_id: str | None = None,
+        chatgpt_account_id: str | None = None,
+    ) -> None:
+        item = _QueuedSnapshot(account_id=account_id, chatgpt_account_id=chatgpt_account_id, snapshot=snapshot)
+        if account_id is not None and self._should_skip(account_id, snapshot):
+            return
+        try:
+            self._queue.put_nowait(item)
+        except asyncio.QueueFull:
+            try:
+                self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+            self._dropped += 1
+            if self._dropped % 100 == 1:
+                logger.warning("Live usage ingest queue full; dropped_total=%d", self._dropped)
+            try:
+                self._queue.put_nowait(item)
+            except asyncio.QueueFull:
+                pass
+
+    def start(self) -> None:
+        if self._consumer is None or self._consumer.done():
+            self._consumer = asyncio.create_task(self._run(), name="live-usage-ingestor")
+
+    async def stop(self) -> None:
+        consumer = self._consumer
+        self._consumer = None
+        if consumer is not None:
+            consumer.cancel()
+            try:
+                await consumer
+            except asyncio.CancelledError:
+                pass
+
+    def _should_skip(self, account_id: str, snapshot: LiveRateLimitSnapshot) -> bool:
+        last = self._last_write.get(account_id)
+        if last is None:
+            return False
+        fingerprint, written_at = last
+        if fingerprint != _fingerprint(snapshot):
+            return False
+        return time.monotonic() - written_at < self._write_min_interval_seconds
+
+    async def _run(self) -> None:
+        while True:
+            item = await self._queue.get()
+            try:
+                await self._ingest(item)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "Live usage ingest failed account_id=%s chatgpt_account_id=%s",
+                    item.account_id,
+                    item.chatgpt_account_id,
+                    exc_info=True,
+                )
+
+    async def _ingest(self, item: _QueuedSnapshot) -> None:
+        account_id = item.account_id
+        if account_id is None:
+            account_id = await self._resolve_account_id(item.chatgpt_account_id)
+        if account_id is None:
+            return
+        if self._should_skip(account_id, item.snapshot):
+            return
+
+        snapshot = item.snapshot
+        async with get_background_session() as session:
+            repo = UsageRepository(session)
+            if snapshot.primary is not None:
+                await repo.add_entry(
+                    account_id=account_id,
+                    used_percent=float(snapshot.primary.used_percent),
+                    input_tokens=None,
+                    output_tokens=None,
+                    window="primary",
+                    reset_at=snapshot.primary.reset_at,
+                    window_minutes=snapshot.primary.window_minutes,
+                    credits_has=snapshot.credits_has,
+                    credits_unlimited=snapshot.credits_unlimited,
+                    credits_balance=snapshot.credits_balance,
+                )
+            if snapshot.secondary is not None:
+                await repo.add_entry(
+                    account_id=account_id,
+                    used_percent=float(snapshot.secondary.used_percent),
+                    input_tokens=None,
+                    output_tokens=None,
+                    window="secondary",
+                    reset_at=snapshot.secondary.reset_at,
+                    window_minutes=snapshot.secondary.window_minutes,
+                )
+        self._last_write[account_id] = (_fingerprint(snapshot), time.monotonic())
+        now = time.monotonic()
+        if now - self._last_cache_invalidation >= _CACHE_INVALIDATION_MIN_INTERVAL_SECONDS:
+            self._last_cache_invalidation = now
+            get_account_selection_cache().invalidate()
+
+    async def _resolve_account_id(self, chatgpt_account_id: str | None) -> str | None:
+        if not chatgpt_account_id:
+            return None
+        cached = self._resolution_cache.get(chatgpt_account_id)
+        now = time.monotonic()
+        if cached is not None and now - cached[1] < _RESOLUTION_TTL_SECONDS:
+            return cached[0]
+        async with get_background_session() as session:
+            rows = (
+                (await session.execute(select(Account.id).where(Account.chatgpt_account_id == chatgpt_account_id)))
+                .scalars()
+                .all()
+            )
+        # Ambiguous identities (multiple workspace slots) are dropped rather
+        # than guessed; the poller stays authoritative for them.
+        resolved = rows[0] if len(rows) == 1 else None
+        self._resolution_cache[chatgpt_account_id] = (resolved, now)
+        return resolved
+
+
+_ingestor: LiveUsageIngestor | None = None
+
+
+def start_live_usage_ingestor() -> LiveUsageIngestor | None:
+    global _ingestor
+    settings = get_settings()
+    if not getattr(settings, "live_usage_ingestion_enabled", True):
+        register_live_usage_publisher(None)
+        return None
+    ingestor = LiveUsageIngestor(
+        queue_size=getattr(settings, "live_usage_queue_size", 512),
+        write_min_interval_seconds=getattr(settings, "live_usage_write_min_interval_seconds", 5.0),
+    )
+    ingestor.start()
+    register_live_usage_publisher(ingestor.publish)
+    _ingestor = ingestor
+    return ingestor
+
+
+async def stop_live_usage_ingestor() -> None:
+    global _ingestor
+    ingestor = _ingestor
+    _ingestor = None
+    register_live_usage_publisher(None)
+    if ingestor is not None:
+        await ingestor.stop()

--- a/app/modules/usage/live_ingest.py
+++ b/app/modules/usage/live_ingest.py
@@ -154,6 +154,10 @@ class LiveUsageIngestor:
                     credits_balance=snapshot.credits_balance,
                 )
             if snapshot.secondary is not None:
+                # Mirror the poller: credits normally ride the primary row.
+                # A secondary-only snapshot (e.g. the short window is not
+                # being reported) must still carry the fresh credit state.
+                secondary_carries_credits = snapshot.primary is None
                 await repo.add_entry(
                     account_id=account_id,
                     used_percent=float(snapshot.secondary.used_percent),
@@ -162,6 +166,9 @@ class LiveUsageIngestor:
                     window="secondary",
                     reset_at=snapshot.secondary.reset_at,
                     window_minutes=snapshot.secondary.window_minutes,
+                    credits_has=snapshot.credits_has if secondary_carries_credits else None,
+                    credits_unlimited=snapshot.credits_unlimited if secondary_carries_credits else None,
+                    credits_balance=snapshot.credits_balance if secondary_carries_credits else None,
                 )
         self._last_write[account_id] = (_fingerprint(snapshot), time.monotonic())
         now = time.monotonic()

--- a/app/modules/usage/live_ingest.py
+++ b/app/modules/usage/live_ingest.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from sqlalchemy import select
 
+from app.core import usage as usage_core
 from app.core.config.settings import get_settings
 from app.core.usage.live_hub import register_live_usage_publisher
 from app.core.usage.live_snapshots import LiveRateLimitSnapshot, LiveUsageWindow
@@ -143,37 +144,62 @@ class LiveUsageIngestor:
             return
 
         snapshot = item.snapshot
+        primary = snapshot.primary
+        secondary = snapshot.secondary
+        monthly: LiveUsageWindow | None = None
+        # Mirror the poller's write-time normalization: a lone primary window
+        # with the monthly duration is the monthly-only free-plan shape and
+        # belongs in the monthly slot, not the primary one.
+        if (
+            primary is not None
+            and secondary is None
+            and primary.window_minutes == usage_core.DEFAULT_WINDOW_MINUTES_MONTHLY
+        ):
+            monthly, primary = primary, None
         async with get_background_session() as session:
             repo = UsageRepository(session)
-            if snapshot.primary is not None:
+            if primary is not None:
                 await repo.add_entry(
                     account_id=account_id,
-                    used_percent=float(snapshot.primary.used_percent),
+                    used_percent=float(primary.used_percent),
                     input_tokens=None,
                     output_tokens=None,
                     window="primary",
-                    reset_at=snapshot.primary.reset_at,
-                    window_minutes=snapshot.primary.window_minutes,
+                    reset_at=primary.reset_at,
+                    window_minutes=primary.window_minutes,
                     credits_has=snapshot.credits_has,
                     credits_unlimited=snapshot.credits_unlimited,
                     credits_balance=snapshot.credits_balance,
                 )
-            if snapshot.secondary is not None:
+            if secondary is not None:
                 # Mirror the poller: credits normally ride the primary row.
                 # A secondary-only snapshot (e.g. the short window is not
                 # being reported) must still carry the fresh credit state.
-                secondary_carries_credits = snapshot.primary is None
+                secondary_carries_credits = primary is None
                 await repo.add_entry(
                     account_id=account_id,
-                    used_percent=float(snapshot.secondary.used_percent),
+                    used_percent=float(secondary.used_percent),
                     input_tokens=None,
                     output_tokens=None,
                     window="secondary",
-                    reset_at=snapshot.secondary.reset_at,
-                    window_minutes=snapshot.secondary.window_minutes,
+                    reset_at=secondary.reset_at,
+                    window_minutes=secondary.window_minutes,
                     credits_has=snapshot.credits_has if secondary_carries_credits else None,
                     credits_unlimited=snapshot.credits_unlimited if secondary_carries_credits else None,
                     credits_balance=snapshot.credits_balance if secondary_carries_credits else None,
+                )
+            if monthly is not None:
+                await repo.add_entry(
+                    account_id=account_id,
+                    used_percent=float(monthly.used_percent),
+                    input_tokens=None,
+                    output_tokens=None,
+                    window="monthly",
+                    reset_at=monthly.reset_at,
+                    window_minutes=monthly.window_minutes,
+                    credits_has=snapshot.credits_has,
+                    credits_unlimited=snapshot.credits_unlimited,
+                    credits_balance=snapshot.credits_balance,
                 )
         self._last_write[account_id] = (_fingerprint(snapshot), time.monotonic())
         await self._invalidate_caches_throttled()

--- a/app/modules/usage/live_ingest.py
+++ b/app/modules/usage/live_ingest.py
@@ -65,6 +65,7 @@ class LiveUsageIngestor:
         self._consumer: asyncio.Task[None] | None = None
         self._dropped = 0
         self._last_cache_invalidation = 0.0
+        self._trailing_invalidation: asyncio.Task[None] | None = None
 
     def publish(
         self,
@@ -98,12 +99,15 @@ class LiveUsageIngestor:
     async def stop(self) -> None:
         consumer = self._consumer
         self._consumer = None
-        if consumer is not None:
-            consumer.cancel()
-            try:
-                await consumer
-            except asyncio.CancelledError:
-                pass
+        trailing = self._trailing_invalidation
+        self._trailing_invalidation = None
+        for task in (consumer, trailing):
+            if task is not None:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
 
     def _should_skip(self, account_id: str, snapshot: LiveRateLimitSnapshot) -> bool:
         last = self._last_write.get(account_id)
@@ -172,14 +176,33 @@ class LiveUsageIngestor:
                     credits_balance=snapshot.credits_balance if secondary_carries_credits else None,
                 )
         self._last_write[account_id] = (_fingerprint(snapshot), time.monotonic())
+        await self._invalidate_caches_throttled()
+
+    async def _invalidate_caches_throttled(self) -> None:
+        # Invalidations are throttled, but every write must still be covered:
+        # a write inside the throttle window schedules one trailing
+        # invalidation at window expiry, so cached selection inputs and
+        # downstream x-codex-* headers are stale for at most the throttle
+        # interval rather than the header cache TTL.
         now = time.monotonic()
-        if now - self._last_cache_invalidation >= _CACHE_INVALIDATION_MIN_INTERVAL_SECONDS:
-            self._last_cache_invalidation = now
-            get_account_selection_cache().invalidate()
-            # Downstream x-codex-* headers are served from a TTL cache that
-            # only the poller invalidates otherwise; drop it so clients see
-            # the live values before the TTL expires.
-            await get_rate_limit_headers_cache().invalidate()
+        remaining = _CACHE_INVALIDATION_MIN_INTERVAL_SECONDS - (now - self._last_cache_invalidation)
+        if remaining <= 0:
+            await self._invalidate_caches_now()
+            return
+        if self._trailing_invalidation is None or self._trailing_invalidation.done():
+            self._trailing_invalidation = asyncio.create_task(self._trailing_invalidate(remaining))
+
+    async def _trailing_invalidate(self, delay_seconds: float) -> None:
+        await asyncio.sleep(delay_seconds)
+        await self._invalidate_caches_now()
+
+    async def _invalidate_caches_now(self) -> None:
+        self._last_cache_invalidation = time.monotonic()
+        get_account_selection_cache().invalidate()
+        # Downstream x-codex-* headers are served from a TTL cache that only
+        # the poller invalidates otherwise; drop it so clients see the live
+        # values before the TTL expires.
+        await get_rate_limit_headers_cache().invalidate()
 
     async def _resolve_account_id(self, chatgpt_account_id: str | None) -> str | None:
         if not chatgpt_account_id:

--- a/app/modules/usage/live_ingest.py
+++ b/app/modules/usage/live_ingest.py
@@ -13,6 +13,7 @@ from app.core.usage.live_snapshots import LiveRateLimitSnapshot, LiveUsageWindow
 from app.db.models import Account
 from app.db.session import get_background_session
 from app.modules.proxy.account_cache import get_account_selection_cache
+from app.modules.proxy.rate_limit_cache import get_rate_limit_headers_cache
 from app.modules.usage.repository import UsageRepository
 
 logger = logging.getLogger(__name__)
@@ -175,6 +176,10 @@ class LiveUsageIngestor:
         if now - self._last_cache_invalidation >= _CACHE_INVALIDATION_MIN_INTERVAL_SECONDS:
             self._last_cache_invalidation = now
             get_account_selection_cache().invalidate()
+            # Downstream x-codex-* headers are served from a TTL cache that
+            # only the poller invalidates otherwise; drop it so clients see
+            # the live values before the TTL expires.
+            await get_rate_limit_headers_cache().invalidate()
 
     async def _resolve_account_id(self, chatgpt_account_id: str | None) -> str | None:
         if not chatgpt_account_id:

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -424,7 +424,11 @@ class UsageUpdater:
             return False
         latest_at = await self._additional_usage_repo.latest_recorded_at_for_account(account_id)
         if latest_at is None:
-            return False
+            # No additional rows ever fetched: live rows alone must not
+            # suppress the fetch, or a first gated-model use would never be
+            # discovered. Non-gated accounts simply keep the pre-live poll
+            # cadence.
+            return True
         return (now - latest_at).total_seconds() >= interval_seconds
 
     async def _freshness_usage_entry(self, account: Account, latest: UsageHistory | None) -> UsageHistory | None:

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -415,6 +415,18 @@ class UsageUpdater:
             usage_account_id=usage_account_id,
         )
 
+    async def _additional_usage_is_stale(self, account_id: str, *, now: datetime, interval_seconds: int) -> bool:
+        # The upstream fetch is the only path that syncs additional
+        # (per-model) rate limits; live main-window rows must not keep an
+        # account "fresh" while its additional rows age past the interval,
+        # or gated-model routing starves on additional_quota_data_unavailable.
+        if self._additional_usage_repo is None:
+            return False
+        latest_at = await self._additional_usage_repo.latest_recorded_at_for_account(account_id)
+        if latest_at is None:
+            return False
+        return (now - latest_at).total_seconds() >= interval_seconds
+
     async def _freshness_usage_entry(self, account: Account, latest: UsageHistory | None) -> UsageHistory | None:
         if latest is not None:
             return latest
@@ -431,7 +443,7 @@ class UsageUpdater:
         interval_seconds: int,
     ) -> bool:
         if _latest_usage_is_fresh(latest, now=now, interval_seconds=interval_seconds):
-            return True
+            return not await self._additional_usage_is_stale(account.id, now=now, interval_seconds=interval_seconds)
         # A stale (or elapsed-reset) newest row of one window must not
         # permanently defeat freshness once upstream stops reporting that
         # window: a strictly newer sibling-window row proves a later fetch
@@ -458,7 +470,9 @@ class UsageUpdater:
             and (newest.recorded_at - latest.recorded_at).total_seconds() <= _SIBLING_FETCH_MARGIN_SECONDS
         ):
             return False
-        return _latest_usage_is_fresh(newest, now=now, interval_seconds=interval_seconds)
+        if not _latest_usage_is_fresh(newest, now=now, interval_seconds=interval_seconds):
+            return False
+        return not await self._additional_usage_is_stale(account.id, now=now, interval_seconds=interval_seconds)
 
     async def _refresh_account_if_stale_with_owned_session(
         self,

--- a/openspec/changes/live-rate-limit-ingestion/proposal.md
+++ b/openspec/changes/live-rate-limit-ingestion/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+codex-lb learns account quota state exclusively by polling `/backend-api/wham/usage` (default every 60s, one account per scheduler tick). Upstream codex clients have long consumed fresher signals that ride on the traffic itself: `x-codex-{primary,secondary}-*` response headers and `codex.rate_limits` stream events carry the same windows on every proxied turn. Because codex-lb discards them, selection state lags real usage by up to a refresh interval, in-flight pressure is approximated with a synthetic penalty, and bursty traffic can exhaust a window well before the poller notices. With the 5h window temporarily removed upstream, per-turn signals are also the fastest way to observe when short windows disappear or return.
+
+## What Changes
+
+- Proxied upstream responses become a passive usage source: rate-limit response headers and `codex.rate_limits` stream events observed on the HTTP/SSE path and the upstream WebSocket bridge are parsed into snapshots and written through the existing usage-history semantics.
+- A per-account ingest throttle (change fingerprint + minimum write interval) bounds write volume; ingestion never blocks or fails the serving path, and publishes through a startup-registered hub so the core client layer stays decoupled from module-layer persistence.
+- The background poller remains authoritative for accounts without live traffic and for payload-only fields; live rows naturally satisfy its freshness gate, so polling pressure drops on busy accounts without configuration changes.
+- Ingestion is enabled by default with an env kill switch.
+
+## Capabilities
+
+### New Capabilities
+
+- `live-usage-ingestion`: passive per-turn usage snapshots from proxied traffic.
+
+### Modified Capabilities
+
+None (usage-refresh-policy semantics are unchanged; live rows flow through the same storage contract).
+
+## Impact
+
+- Code: `app/core/usage/live_snapshots.py` (new), `app/core/usage/live_hub.py` (new), `app/modules/usage/live_ingest.py` (new), `app/core/clients/proxy.py`, `app/modules/proxy/_service/http_bridge/upstream_events.py`, `app/main.py`, `app/core/config/settings.py`
+- Tests: parser/ingestor unit suites, SSE and bridge integration coverage
+- Specs: `openspec/specs/live-usage-ingestion/spec.md` (new)

--- a/openspec/changes/live-rate-limit-ingestion/specs/live-usage-ingestion/spec.md
+++ b/openspec/changes/live-rate-limit-ingestion/specs/live-usage-ingestion/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Proxied responses feed passive usage snapshots
+
+The proxy SHALL parse upstream rate-limit signals from proxied traffic — `x-codex-{primary,secondary}-used-percent`, `-window-minutes`, `-reset-at`, and `x-codex-credits-*` response headers, and `codex.rate_limits` stream events — into per-account usage snapshots attributed to the account that served the request. Snapshots SHALL be persisted through the same usage-history storage contract the background poller uses (per-window rows with used percent, reset timestamp, window duration, and credits fields).
+
+#### Scenario: Stream event updates usage rows
+
+- **WHEN** a proxied response stream carries a `codex.rate_limits` event for an account
+- **THEN** the account's primary and secondary usage rows reflect the event's used percentages, reset timestamps, and window durations without waiting for the next poll
+
+#### Scenario: Response headers update usage rows
+
+- **WHEN** an upstream response carries `x-codex-*` rate-limit headers
+- **THEN** an equivalent snapshot is ingested for the serving account
+
+#### Scenario: Snapshots without any window are ignored
+
+- **WHEN** a response carries no rate-limit headers and no rate-limit stream event
+- **THEN** nothing is ingested
+
+### Requirement: Live ingestion never impairs the serving path
+
+Live usage ingestion MUST be fire-and-forget: parsing failures, storage failures, and backpressure MUST NOT fail, block, or slow the proxied request beyond enqueueing a snapshot. When the ingest queue is full, the oldest snapshot SHALL be dropped and the drop counted in logs.
+
+#### Scenario: Storage failure does not affect the stream
+
+- **WHEN** persisting a live snapshot fails
+- **THEN** the proxied response continues unaffected
+- **AND** the failure is logged with the account id
+
+#### Scenario: Queue overflow drops oldest
+
+- **WHEN** the ingest queue is at capacity
+- **THEN** the oldest queued snapshot is dropped in favor of the newest
+
+### Requirement: Live writes are throttled per account
+
+Live snapshot writes SHALL be throttled per account by a change fingerprint and a minimum write interval: a snapshot identical to the last persisted one is skipped, and unchanged-window writes within the interval are coalesced. A changed snapshot MAY be written immediately.
+
+#### Scenario: Duplicate snapshots are coalesced
+
+- **WHEN** consecutive turns observe identical rate-limit values within the minimum write interval
+- **THEN** at most one usage row set is written
+
+#### Scenario: Changed usage writes promptly
+
+- **WHEN** a snapshot's used percentage or reset timestamp differs from the last persisted values
+- **THEN** the write is not deferred by the unchanged-write interval
+
+### Requirement: Live ingestion is decoupled and switchable
+
+The core client layer SHALL publish snapshots through a hub that no-ops until the module layer registers an ingestor at startup. Ingestion SHALL be enabled by default and disableable via `CODEX_LB_LIVE_USAGE_INGESTION_ENABLED`.
+
+#### Scenario: Kill switch disables ingestion
+
+- **WHEN** `CODEX_LB_LIVE_USAGE_INGESTION_ENABLED` is false
+- **THEN** proxied responses do not produce usage writes
+- **AND** the background poller remains the only usage source
+
+#### Scenario: Unregistered hub is inert
+
+- **WHEN** snapshots are published before an ingestor is registered
+- **THEN** they are discarded without error

--- a/openspec/changes/live-rate-limit-ingestion/tasks.md
+++ b/openspec/changes/live-rate-limit-ingestion/tasks.md
@@ -1,0 +1,20 @@
+## 1. Core parsing and hub
+
+- [x] 1.1 `app/core/usage/live_snapshots.py`: typed snapshot dataclass + parsers for x-codex response headers and `codex.rate_limits` event payloads.
+- [x] 1.2 `app/core/usage/live_hub.py`: publish/no-op hub with startup registration.
+
+## 2. Ingestor
+
+- [x] 2.1 `app/modules/usage/live_ingest.py`: bounded queue (drop-oldest), single consumer with its own background sessions, per-account fingerprint + min-interval throttle, usage-history writes with credits fields, selection-cache invalidation on write.
+- [x] 2.2 Settings: `live_usage_ingestion_enabled` (default true), `live_usage_write_min_interval_seconds` (default 5), queue size; startup wiring in main.py.
+
+## 3. Tap points
+
+- [x] 3.1 HTTP/SSE: publish header snapshots when upstream response headers arrive and event snapshots on `codex.rate_limits` blocks in `_stream_responses_with_session`.
+- [x] 3.2 WS bridge: publish event snapshots for `codex.rate_limits` frames in the upstream relay.
+
+## 4. Validation
+
+- [x] 4.1 Unit: parser edge cases; throttle fingerprint/interval; queue overflow drop-oldest; hub no-op.
+- [x] 4.2 Integration: SSE stream with rate-limit event writes rows for the serving account; kill switch produces no writes.
+- [x] 4.3 `openspec validate live-rate-limit-ingestion --strict`; targeted proxy/usage suites.

--- a/tests/integration/test_live_usage_ingest.py
+++ b/tests/integration/test_live_usage_ingest.py
@@ -8,7 +8,7 @@ from app.core.crypto import TokenEncryptor
 from app.core.usage import live_hub
 from app.core.usage.live_snapshots import LiveRateLimitSnapshot, LiveUsageWindow
 from app.core.utils.time import utcnow
-from app.db.models import Account, AccountStatus
+from app.db.models import Account, AccountStatus, UsageHistory
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.usage import live_ingest
@@ -43,7 +43,7 @@ def _snapshot() -> LiveRateLimitSnapshot:
     )
 
 
-async def _wait_for_rows(account_id: str, *, timeout: float = 5.0) -> tuple[object | None, object | None]:
+async def _wait_for_rows(account_id: str, *, timeout: float = 5.0) -> tuple[UsageHistory | None, UsageHistory | None]:
     deadline = asyncio.get_event_loop().time() + timeout
     while True:
         async with SessionLocal() as session:

--- a/tests/integration/test_live_usage_ingest.py
+++ b/tests/integration/test_live_usage_ingest.py
@@ -182,6 +182,45 @@ async def test_live_ingestor_carries_credits_on_secondary_only_snapshots(db_setu
 
 
 @pytest.mark.asyncio
+async def test_live_ingestor_normalizes_monthly_only_snapshots(db_setup) -> None:
+    del db_setup
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(_make_account("acc_live_monthly", "live-monthly@example.com"))
+
+    now_epoch = int(utcnow().timestamp())
+    # The monthly-only free-plan shape: a lone primary window with the
+    # monthly duration must land in the monthly slot like the poller does.
+    snapshot = LiveRateLimitSnapshot(
+        primary=LiveUsageWindow(used_percent=42.0, window_minutes=43200, reset_at=now_epoch + 30 * 24 * 3600),
+        secondary=None,
+        credits_has=True,
+        credits_unlimited=False,
+        credits_balance=8.75,
+    )
+
+    ingestor = live_ingest.LiveUsageIngestor(queue_size=8, write_min_interval_seconds=0.0)
+    ingestor.start()
+    try:
+        ingestor.publish(snapshot, account_id="acc_live_monthly")
+        deadline = asyncio.get_event_loop().time() + 5.0
+        monthly = None
+        while monthly is None and asyncio.get_event_loop().time() < deadline:
+            async with SessionLocal() as session:
+                monthly = await UsageRepository(session).latest_entry_for_account("acc_live_monthly", window="monthly")
+            if monthly is None:
+                await asyncio.sleep(0.05)
+        async with SessionLocal() as session:
+            primary = await UsageRepository(session).latest_entry_for_account("acc_live_monthly", window="primary")
+    finally:
+        await ingestor.stop()
+
+    assert monthly is not None
+    assert monthly.used_percent == pytest.approx(42.0)
+    assert monthly.credits_has is True
+    assert primary is None
+
+
+@pytest.mark.asyncio
 async def test_live_ingestor_resolves_chatgpt_account_id(db_setup) -> None:
     del db_setup
     async with SessionLocal() as session:

--- a/tests/integration/test_live_usage_ingest.py
+++ b/tests/integration/test_live_usage_ingest.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from app.core.crypto import TokenEncryptor
+from app.core.usage import live_hub
+from app.core.usage.live_snapshots import LiveRateLimitSnapshot, LiveUsageWindow
+from app.core.utils.time import utcnow
+from app.db.models import Account, AccountStatus
+from app.db.session import SessionLocal
+from app.modules.accounts.repository import AccountsRepository
+from app.modules.usage import live_ingest
+from app.modules.usage.repository import UsageRepository
+
+pytestmark = pytest.mark.integration
+
+
+def _make_account(account_id: str, email: str, *, chatgpt_account_id: str | None = None) -> Account:
+    encryptor = TokenEncryptor()
+    return Account(
+        id=account_id,
+        chatgpt_account_id=chatgpt_account_id,
+        email=email,
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access"),
+        refresh_token_encrypted=encryptor.encrypt("refresh"),
+        id_token_encrypted=encryptor.encrypt("id"),
+        last_refresh=utcnow(),
+        status=AccountStatus.ACTIVE,
+    )
+
+
+def _snapshot() -> LiveRateLimitSnapshot:
+    now_epoch = int(utcnow().timestamp())
+    return LiveRateLimitSnapshot(
+        primary=LiveUsageWindow(used_percent=33.0, window_minutes=300, reset_at=now_epoch + 300),
+        secondary=LiveUsageWindow(used_percent=44.0, window_minutes=10080, reset_at=now_epoch + 5 * 24 * 3600),
+        credits_has=True,
+        credits_unlimited=False,
+        credits_balance=7.5,
+    )
+
+
+async def _wait_for_rows(account_id: str, *, timeout: float = 5.0) -> tuple[object | None, object | None]:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while True:
+        async with SessionLocal() as session:
+            repo = UsageRepository(session)
+            primary = await repo.latest_entry_for_account(account_id, window="primary")
+            secondary = await repo.latest_entry_for_account(account_id, window="secondary")
+        if primary is not None and secondary is not None:
+            return primary, secondary
+        if asyncio.get_event_loop().time() >= deadline:
+            return primary, secondary
+        await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_live_ingestor_writes_usage_rows_for_internal_account(db_setup) -> None:
+    del db_setup
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(_make_account("acc_live_internal", "live-internal@example.com"))
+
+    ingestor = live_ingest.LiveUsageIngestor(queue_size=8, write_min_interval_seconds=0.0)
+    ingestor.start()
+    try:
+        ingestor.publish(_snapshot(), account_id="acc_live_internal")
+        primary, secondary = await _wait_for_rows("acc_live_internal")
+    finally:
+        await ingestor.stop()
+
+    assert primary is not None and secondary is not None
+    assert primary.used_percent == pytest.approx(33.0)
+    assert primary.window_minutes == 300
+    assert primary.credits_has is True
+    assert primary.credits_balance == pytest.approx(7.5)
+    assert secondary.used_percent == pytest.approx(44.0)
+    assert secondary.window_minutes == 10080
+
+
+@pytest.mark.asyncio
+async def test_live_ingestor_resolves_chatgpt_account_id(db_setup) -> None:
+    del db_setup
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(
+            _make_account("acc_live_resolved", "live-resolved@example.com", chatgpt_account_id="workspace-live-1")
+        )
+
+    ingestor = live_ingest.LiveUsageIngestor(queue_size=8, write_min_interval_seconds=0.0)
+    ingestor.start()
+    try:
+        ingestor.publish(_snapshot(), chatgpt_account_id="workspace-live-1")
+        primary, secondary = await _wait_for_rows("acc_live_resolved")
+    finally:
+        await ingestor.stop()
+
+    assert primary is not None and secondary is not None
+
+
+@pytest.mark.asyncio
+async def test_live_ingestion_kill_switch_disables_publishing(monkeypatch, db_setup) -> None:
+    del db_setup
+    from app.core.config.settings import get_settings
+
+    monkeypatch.setenv("CODEX_LB_LIVE_USAGE_INGESTION_ENABLED", "false")
+    get_settings.cache_clear()
+    try:
+        assert live_ingest.start_live_usage_ingestor() is None
+        captured: list[object] = []
+        live_hub.register_live_usage_publisher(None)
+        live_hub.publish_live_usage(_snapshot(), account_id="acc-any")
+        assert captured == []
+    finally:
+        await live_ingest.stop_live_usage_ingestor()
+        get_settings.cache_clear()

--- a/tests/integration/test_live_usage_ingest.py
+++ b/tests/integration/test_live_usage_ingest.py
@@ -81,6 +81,44 @@ async def test_live_ingestor_writes_usage_rows_for_internal_account(db_setup) ->
 
 
 @pytest.mark.asyncio
+async def test_live_ingestor_carries_credits_on_secondary_only_snapshots(db_setup) -> None:
+    del db_setup
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(
+            _make_account("acc_live_secondary_only", "live-secondary-only@example.com")
+        )
+
+    now_epoch = int(utcnow().timestamp())
+    snapshot = LiveRateLimitSnapshot(
+        primary=None,
+        secondary=LiveUsageWindow(used_percent=44.0, window_minutes=10080, reset_at=now_epoch + 5 * 24 * 3600),
+        credits_has=True,
+        credits_unlimited=False,
+        credits_balance=9.25,
+    )
+
+    ingestor = live_ingest.LiveUsageIngestor(queue_size=8, write_min_interval_seconds=0.0)
+    ingestor.start()
+    try:
+        ingestor.publish(snapshot, account_id="acc_live_secondary_only")
+        deadline = asyncio.get_event_loop().time() + 5.0
+        secondary = None
+        while secondary is None and asyncio.get_event_loop().time() < deadline:
+            async with SessionLocal() as session:
+                secondary = await UsageRepository(session).latest_entry_for_account(
+                    "acc_live_secondary_only", window="secondary"
+                )
+            if secondary is None:
+                await asyncio.sleep(0.05)
+    finally:
+        await ingestor.stop()
+
+    assert secondary is not None
+    assert secondary.credits_has is True
+    assert secondary.credits_balance == pytest.approx(9.25)
+
+
+@pytest.mark.asyncio
 async def test_live_ingestor_resolves_chatgpt_account_id(db_setup) -> None:
     del db_setup
     async with SessionLocal() as session:

--- a/tests/integration/test_live_usage_ingest.py
+++ b/tests/integration/test_live_usage_ingest.py
@@ -109,6 +109,41 @@ async def test_live_ingestor_invalidates_rate_limit_header_cache(monkeypatch, db
 
 
 @pytest.mark.asyncio
+async def test_live_ingestor_trailing_invalidation_covers_throttled_writes(monkeypatch, db_setup) -> None:
+    del db_setup
+    from app.modules.usage import live_ingest as live_ingest_module
+
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        await repo.upsert(_make_account("acc_live_trail_a", "live-trail-a@example.com"))
+        await repo.upsert(_make_account("acc_live_trail_b", "live-trail-b@example.com"))
+
+    invalidations: list[float] = []
+
+    class _SpyHeadersCache:
+        async def invalidate(self) -> None:
+            invalidations.append(asyncio.get_event_loop().time())
+
+    monkeypatch.setattr(live_ingest_module, "get_rate_limit_headers_cache", lambda: _SpyHeadersCache())
+    monkeypatch.setattr(live_ingest_module, "_CACHE_INVALIDATION_MIN_INTERVAL_SECONDS", 0.2)
+
+    ingestor = live_ingest.LiveUsageIngestor(queue_size=8, write_min_interval_seconds=0.0)
+    ingestor.start()
+    try:
+        # Two accounts write inside one throttle window: the second write
+        # must still be covered by a trailing invalidation.
+        ingestor.publish(_snapshot(), account_id="acc_live_trail_a")
+        ingestor.publish(_snapshot(), account_id="acc_live_trail_b")
+        deadline = asyncio.get_event_loop().time() + 5.0
+        while len(invalidations) < 2 and asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(0.05)
+    finally:
+        await ingestor.stop()
+
+    assert len(invalidations) >= 2
+
+
+@pytest.mark.asyncio
 async def test_live_ingestor_carries_credits_on_secondary_only_snapshots(db_setup) -> None:
     del db_setup
     async with SessionLocal() as session:

--- a/tests/integration/test_live_usage_ingest.py
+++ b/tests/integration/test_live_usage_ingest.py
@@ -81,6 +81,34 @@ async def test_live_ingestor_writes_usage_rows_for_internal_account(db_setup) ->
 
 
 @pytest.mark.asyncio
+async def test_live_ingestor_invalidates_rate_limit_header_cache(monkeypatch, db_setup) -> None:
+    del db_setup
+    from app.modules.usage import live_ingest as live_ingest_module
+
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(_make_account("acc_live_headers", "live-headers@example.com"))
+
+    invalidations: list[int] = []
+
+    class _SpyHeadersCache:
+        async def invalidate(self) -> None:
+            invalidations.append(1)
+
+    monkeypatch.setattr(live_ingest_module, "get_rate_limit_headers_cache", lambda: _SpyHeadersCache())
+
+    ingestor = live_ingest.LiveUsageIngestor(queue_size=8, write_min_interval_seconds=0.0)
+    ingestor.start()
+    try:
+        ingestor.publish(_snapshot(), account_id="acc_live_headers")
+        primary, secondary = await _wait_for_rows("acc_live_headers")
+    finally:
+        await ingestor.stop()
+
+    assert primary is not None and secondary is not None
+    assert invalidations == [1]
+
+
+@pytest.mark.asyncio
 async def test_live_ingestor_carries_credits_on_secondary_only_snapshots(db_setup) -> None:
     del db_setup
     async with SessionLocal() as session:

--- a/tests/unit/test_live_usage_ingest.py
+++ b/tests/unit/test_live_usage_ingest.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from typing import Any
+
+import pytest
+
+from app.core.usage import live_hub
+from app.core.usage.live_snapshots import (
+    EVENT_MARKER,
+    LiveRateLimitSnapshot,
+    LiveUsageWindow,
+    parse_rate_limit_event_text,
+    parse_rate_limit_headers,
+)
+from app.modules.usage import live_ingest
+
+pytestmark = pytest.mark.unit
+
+
+def _snapshot(primary_used: float = 25.0, reset_at: int = 1_700_000_300) -> LiveRateLimitSnapshot:
+    return LiveRateLimitSnapshot(
+        primary=LiveUsageWindow(used_percent=primary_used, window_minutes=300, reset_at=reset_at),
+        secondary=LiveUsageWindow(used_percent=40.0, window_minutes=10080, reset_at=reset_at + 3600),
+        credits_has=True,
+        credits_unlimited=False,
+        credits_balance=12.5,
+    )
+
+
+def test_parse_rate_limit_headers_reads_both_windows_and_credits() -> None:
+    headers = {
+        "X-Codex-Primary-Used-Percent": "25.5",
+        "X-Codex-Primary-Window-Minutes": "300",
+        "X-Codex-Primary-Reset-At": "1700000300",
+        "x-codex-secondary-used-percent": "40",
+        "x-codex-secondary-window-minutes": "10080",
+        "x-codex-secondary-reset-at": "1700003900",
+        "x-codex-credits-has-credits": "true",
+        "x-codex-credits-unlimited": "false",
+        "x-codex-credits-balance": "12.50",
+    }
+
+    snapshot = parse_rate_limit_headers(headers)
+
+    assert snapshot is not None
+    assert snapshot.primary == LiveUsageWindow(used_percent=25.5, window_minutes=300, reset_at=1_700_000_300)
+    assert snapshot.secondary == LiveUsageWindow(used_percent=40.0, window_minutes=10080, reset_at=1_700_003_900)
+    assert snapshot.credits_has is True
+    assert snapshot.credits_unlimited is False
+    assert snapshot.credits_balance == pytest.approx(12.5)
+
+
+def test_parse_rate_limit_headers_without_windows_returns_none() -> None:
+    assert parse_rate_limit_headers({"content-type": "text/event-stream"}) is None
+    assert parse_rate_limit_headers({"x-codex-credits-balance": "5"}) is None
+    assert parse_rate_limit_headers(None) is None
+
+
+def test_parse_rate_limit_event_text_reads_sse_block() -> None:
+    payload = {
+        "type": "codex.rate_limits",
+        "rate_limits": {
+            "primary": {"used_percent": 61, "window_minutes": 300, "reset_at": 1_700_000_300},
+            "secondary": {"used_percent": 12.5, "window_minutes": 10080, "resets_at": 1_700_003_900},
+        },
+        "credits": {"has_credits": False, "unlimited": False, "balance": "0"},
+    }
+    block = f"event: codex.rate_limits\ndata: {json.dumps(payload)}\n\n"
+
+    snapshot = parse_rate_limit_event_text(block)
+
+    assert snapshot is not None
+    assert snapshot.primary == LiveUsageWindow(used_percent=61.0, window_minutes=300, reset_at=1_700_000_300)
+    assert snapshot.secondary == LiveUsageWindow(used_percent=12.5, window_minutes=10080, reset_at=1_700_003_900)
+    assert snapshot.credits_has is False
+
+
+def test_parse_rate_limit_event_text_ignores_other_events_and_garbage() -> None:
+    assert parse_rate_limit_event_text('data: {"type":"response.completed"}\n\n') is None
+    assert parse_rate_limit_event_text('data: {"type":"codex.rate_limits","rate_limits":{}}\n\n') is None
+    assert parse_rate_limit_event_text('data: {"type":"codex.rate_limits" broken\n\n') is None
+    assert EVENT_MARKER not in 'data: {"type":"response.completed"}'
+
+
+def test_live_hub_is_inert_until_registered() -> None:
+    captured: list[Any] = []
+    live_hub.register_live_usage_publisher(None)
+    live_hub.publish_live_usage(_snapshot(), account_id="acc-1")
+
+    live_hub.register_live_usage_publisher(
+        lambda snapshot, *, account_id=None, chatgpt_account_id=None: captured.append(
+            (snapshot, account_id, chatgpt_account_id)
+        )
+    )
+    try:
+        live_hub.publish_live_usage(_snapshot(), account_id="acc-1")
+        live_hub.publish_live_usage(None, account_id="acc-1")
+        live_hub.publish_live_usage(_snapshot(), account_id=None, chatgpt_account_id=None)
+        windowless = LiveRateLimitSnapshot(
+            primary=None,
+            secondary=None,
+            credits_has=True,
+            credits_unlimited=None,
+            credits_balance=None,
+        )
+        live_hub.publish_live_usage(windowless, account_id="acc-1")
+    finally:
+        live_hub.register_live_usage_publisher(None)
+
+    assert len(captured) == 1
+    assert captured[0][1] == "acc-1"
+
+
+@pytest.mark.asyncio
+async def test_ingestor_throttles_identical_snapshots(monkeypatch: pytest.MonkeyPatch) -> None:
+    ingestor = live_ingest.LiveUsageIngestor(queue_size=8, write_min_interval_seconds=60.0)
+    writes: list[tuple[str, LiveRateLimitSnapshot]] = []
+
+    async def fake_ingest(item: live_ingest._QueuedSnapshot) -> None:
+        assert item.account_id is not None
+        writes.append((item.account_id, item.snapshot))
+        ingestor._last_write[item.account_id] = (live_ingest._fingerprint(item.snapshot), time.monotonic())
+
+    monkeypatch.setattr(ingestor, "_ingest", fake_ingest)
+    ingestor.start()
+    try:
+        ingestor.publish(_snapshot(), account_id="acc-throttle")
+        await asyncio.sleep(0.05)
+        # Identical snapshot inside the interval is coalesced.
+        ingestor.publish(_snapshot(), account_id="acc-throttle")
+        await asyncio.sleep(0.05)
+        # A changed snapshot writes promptly despite the interval.
+        ingestor.publish(_snapshot(primary_used=90.0), account_id="acc-throttle")
+        await asyncio.sleep(0.05)
+    finally:
+        await ingestor.stop()
+
+    assert [snap.primary.used_percent for _, snap in writes if snap.primary is not None] == [25.0, 90.0]
+
+
+@pytest.mark.asyncio
+async def test_ingestor_queue_overflow_drops_oldest() -> None:
+    ingestor = live_ingest.LiveUsageIngestor(queue_size=2, write_min_interval_seconds=60.0)
+    # Consumer not started: queue fills up.
+    ingestor.publish(_snapshot(primary_used=1.0), account_id="acc-a")
+    ingestor.publish(_snapshot(primary_used=2.0), account_id="acc-b")
+    ingestor.publish(_snapshot(primary_used=3.0), account_id="acc-c")
+
+    remaining = []
+    while True:
+        try:
+            remaining.append(ingestor._queue.get_nowait())
+        except asyncio.QueueEmpty:
+            break
+
+    assert [item.snapshot.primary.used_percent for item in remaining if item.snapshot.primary is not None] == [
+        2.0,
+        3.0,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stream_responses_tap_publishes_rate_limit_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    import app.core.clients.proxy as proxy_client_module
+
+    payload = {
+        "type": "codex.rate_limits",
+        "rate_limits": {"primary": {"used_percent": 55, "window_minutes": 300, "reset_at": 1_700_000_300}},
+    }
+    blocks = [
+        'data: {"type":"response.created","response":{"id":"resp_live"}}\n\n',
+        f"data: {json.dumps(payload)}\n\n",
+        'data: {"type":"response.completed","response":{"id":"resp_live"}}\n\n',
+    ]
+
+    async def fake_stream(**kwargs: Any):
+        for block in blocks:
+            yield block
+
+    monkeypatch.setattr(proxy_client_module, "_stream_responses_with_session", lambda **kwargs: fake_stream(**kwargs))
+
+    import contextlib
+
+    @contextlib.asynccontextmanager
+    async def fake_lease(session: Any = None):
+        yield session
+
+    monkeypatch.setattr(proxy_client_module, "lease_http_session", fake_lease)
+
+    captured: list[tuple[Any, str | None]] = []
+    live_hub.register_live_usage_publisher(
+        lambda snapshot, *, account_id=None, chatgpt_account_id=None: captured.append((snapshot, chatgpt_account_id))
+    )
+    try:
+        request = proxy_client_module.ResponsesRequest.model_validate(
+            {"model": "gpt-5.1", "instructions": "hi", "input": "live", "stream": True}
+        )
+        seen = [
+            block
+            async for block in proxy_client_module.stream_responses(
+                request,
+                {},
+                "access-token",
+                "workspace-live",
+            )
+        ]
+    finally:
+        live_hub.register_live_usage_publisher(None)
+
+    assert seen == blocks
+    assert len(captured) == 1
+    snapshot, chatgpt_account_id = captured[0]
+    assert chatgpt_account_id == "workspace-live"
+    assert snapshot.primary is not None
+    assert snapshot.primary.used_percent == pytest.approx(55.0)

--- a/tests/unit/test_live_usage_ingest.py
+++ b/tests/unit/test_live_usage_ingest.py
@@ -53,6 +53,22 @@ def test_parse_rate_limit_headers_reads_both_windows_and_credits() -> None:
     assert snapshot.credits_balance == pytest.approx(12.5)
 
 
+def test_parse_rate_limit_headers_rejects_non_finite_values() -> None:
+    # Non-finite numeric strings must degrade to unparseable fields, never
+    # raise on the serving path.
+    snapshot = parse_rate_limit_headers(
+        {
+            "x-codex-primary-used-percent": "25.0",
+            "x-codex-primary-window-minutes": "NaN",
+            "x-codex-primary-reset-at": "Infinity",
+        }
+    )
+    assert snapshot is not None
+    assert snapshot.primary == LiveUsageWindow(used_percent=25.0, window_minutes=None, reset_at=None)
+
+    assert parse_rate_limit_headers({"x-codex-primary-used-percent": "NaN"}) is None
+
+
 def test_parse_rate_limit_headers_without_windows_returns_none() -> None:
     assert parse_rate_limit_headers({"content-type": "text/event-stream"}) is None
     assert parse_rate_limit_headers({"x-codex-credits-balance": "5"}) is None
@@ -190,9 +206,11 @@ async def test_stream_responses_tap_publishes_rate_limit_events(monkeypatch: pyt
 
     monkeypatch.setattr(proxy_client_module, "lease_http_session", fake_lease)
 
-    captured: list[tuple[Any, str | None]] = []
+    captured: list[tuple[Any, str | None, str | None]] = []
     live_hub.register_live_usage_publisher(
-        lambda snapshot, *, account_id=None, chatgpt_account_id=None: captured.append((snapshot, chatgpt_account_id))
+        lambda snapshot, *, account_id=None, chatgpt_account_id=None: captured.append(
+            (snapshot, account_id, chatgpt_account_id)
+        )
     )
     try:
         request = proxy_client_module.ResponsesRequest.model_validate(
@@ -207,12 +225,27 @@ async def test_stream_responses_tap_publishes_rate_limit_events(monkeypatch: pyt
                 "workspace-live",
             )
         ]
+        seen_internal = [
+            block
+            async for block in proxy_client_module.stream_responses(
+                request,
+                {},
+                "access-token",
+                "workspace-live",
+                codex_lb_account_id="acc-internal",
+            )
+        ]
     finally:
         live_hub.register_live_usage_publisher(None)
 
     assert seen == blocks
-    assert len(captured) == 1
-    snapshot, chatgpt_account_id = captured[0]
-    assert chatgpt_account_id == "workspace-live"
+    assert seen_internal == blocks
+    assert len(captured) == 2
+    snapshot, account_id, chatgpt_account_id = captured[0]
+    assert (account_id, chatgpt_account_id) == (None, "workspace-live")
     assert snapshot.primary is not None
     assert snapshot.primary.used_percent == pytest.approx(55.0)
+    # When the caller knows the selected internal account, attribution
+    # prefers it so multi-seat workspaces are not dropped as ambiguous.
+    _, account_id_internal, chatgpt_internal = captured[1]
+    assert (account_id_internal, chatgpt_internal) == ("acc-internal", None)

--- a/tests/unit/test_live_usage_ingest.py
+++ b/tests/unit/test_live_usage_ingest.py
@@ -94,6 +94,20 @@ def test_parse_rate_limit_event_text_reads_sse_block() -> None:
     assert snapshot.credits_has is False
 
 
+def test_parse_rate_limit_event_rejects_non_default_limit_families() -> None:
+    base = {
+        "type": "codex.rate_limits",
+        "rate_limits": {"primary": {"used_percent": 55, "window_minutes": 300, "reset_at": 1_700_000_300}},
+    }
+    from app.core.usage.live_snapshots import parse_rate_limit_event
+
+    assert parse_rate_limit_event({**base, "metered_limit_name": "gpt-5.2-codex-sonic"}) is None
+    assert parse_rate_limit_event({**base, "limit_id": "codex_other"}) is None
+    assert parse_rate_limit_event({**base, "limit_name": "gpt-gated"}) is None
+    assert parse_rate_limit_event({**base, "limit_id": "codex"}) is not None
+    assert parse_rate_limit_event(base) is not None
+
+
 def test_parse_rate_limit_event_text_ignores_other_events_and_garbage() -> None:
     assert parse_rate_limit_event_text('data: {"type":"response.completed"}\n\n') is None
     assert parse_rate_limit_event_text('data: {"type":"codex.rate_limits","rate_limits":{}}\n\n') is None

--- a/tests/unit/test_live_usage_ingest.py
+++ b/tests/unit/test_live_usage_ingest.py
@@ -238,8 +238,30 @@ async def test_stream_responses_tap_publishes_rate_limit_events(monkeypatch: pyt
     finally:
         live_hub.register_live_usage_publisher(None)
 
+    live_hub.register_live_usage_publisher(
+        lambda snapshot, *, account_id=None, chatgpt_account_id=None: captured.append(
+            (snapshot, account_id, chatgpt_account_id)
+        )
+    )
+    try:
+        suppressed = [
+            block
+            async for block in proxy_client_module.stream_responses(
+                request,
+                {},
+                "access-token",
+                "workspace-live",
+                codex_lb_account_id="acc-internal",
+                suppress_live_usage=True,
+            )
+        ]
+    finally:
+        live_hub.register_live_usage_publisher(None)
+
     assert seen == blocks
     assert seen_internal == blocks
+    # Suppressed callers (e.g. quota-planner probes) produce no publishes.
+    assert suppressed == blocks
     assert len(captured) == 2
     snapshot, account_id, chatgpt_account_id = captured[0]
     assert (account_id, chatgpt_account_id) == (None, "workspace-live")

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -1693,6 +1693,53 @@ async def test_http_bridge_upstream_non_text_archives_with_request_archive_id(
     assert session.last_upstream_close_code == 1000
 
 
+@pytest.mark.asyncio
+async def test_http_bridge_relay_publishes_live_rate_limit_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.core.usage import live_hub
+
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="bridge-live-rate-limits")
+    rate_limit_text = (
+        '{"type":"codex.rate_limits","rate_limits":{"primary":'
+        '{"used_percent":72,"window_minutes":300,"reset_at":1700000300}}}'
+    )
+    messages = [
+        UpstreamWebSocketMessage(kind="text", text=rate_limit_text),
+        UpstreamWebSocketMessage(kind="close", close_code=1000),
+    ]
+    session.upstream = cast(
+        UpstreamResponsesWebSocket,
+        SimpleNamespace(
+            receive=AsyncMock(side_effect=messages),
+            close=AsyncMock(),
+            archive_received=lambda message: None,
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service, "_process_http_bridge_upstream_text", AsyncMock())
+    monkeypatch.setattr(service, "_retire_http_bridge_after_drain_if_ready", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_fail_http_bridge_reader_and_maybe_retire", AsyncMock())
+    monkeypatch.setattr(service, "_fail_pending_websocket_requests", AsyncMock())
+
+    captured: list[tuple[Any, str | None]] = []
+    live_hub.register_live_usage_publisher(
+        lambda snapshot, *, account_id=None, chatgpt_account_id=None: captured.append((snapshot, account_id))
+    )
+    try:
+        await service._relay_http_bridge_upstream_messages(session)
+    finally:
+        live_hub.register_live_usage_publisher(None)
+
+    assert len(captured) == 1
+    snapshot, account_id = captured[0]
+    assert account_id == session.account.id
+    assert snapshot.primary is not None
+    assert snapshot.primary.used_percent == pytest.approx(72.0)
+
+
 def test_pop_terminal_websocket_request_state_precreated_completed_does_not_guess_with_ambiguous_pending() -> None:
     draining = proxy_service._WebSocketRequestState(
         request_id="req-draining",

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -3499,6 +3499,113 @@ def test_latest_usage_is_fresh_returns_false_when_reset_at_has_passed() -> None:
 
 
 @pytest.mark.asyncio
+async def test_refresh_accounts_fetches_when_additional_usage_ages_despite_fresh_main_rows(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.config.settings import get_settings
+    from app.core.utils.time import utcnow
+
+    get_settings.cache_clear()
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+
+    fetch_calls = 0
+
+    async def stub_fetch_usage(**_: Any) -> UsagePayload:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return UsagePayload.model_validate({"rate_limit": {}})
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    usage_repo = StubUsageRepository()
+    # Live traffic keeps the main rows fresh...
+    await usage_repo.add_entry(
+        "acc_gated",
+        30.0,
+        recorded_at=now - timedelta(seconds=5),
+        window="primary",
+        reset_at=now_epoch + 300,
+        window_minutes=300,
+    )
+    latest = await usage_repo.latest_entry_for_account("acc_gated", window="primary")
+    assert latest is not None
+
+    # ...but the additional (per-model) rows have aged past the interval:
+    # only the upstream fetch syncs them, so the fetch must still happen.
+    additional_repo = StubAdditionalUsageRepository()
+    await additional_repo.add_entry(
+        "acc_gated",
+        limit_name="codex_other",
+        metered_feature="gpt-gated",
+        window="primary",
+        used_percent=10.0,
+        recorded_at=now - timedelta(minutes=10),
+    )
+    stale_recorded_at = now - timedelta(minutes=10)
+
+    async def aged_latest_recorded_at(account_id: str):
+        return stale_recorded_at if account_id == "acc_gated" else None
+
+    monkeypatch.setattr(additional_repo, "latest_recorded_at_for_account", aged_latest_recorded_at)
+
+    acc = _make_account("acc_gated", "workspace_gated", email="gated@example.com")
+
+    updater = UsageUpdater(usage_repo, accounts_repo=None, additional_usage_repo=additional_repo)
+    await updater.refresh_accounts([acc], latest_usage={"acc_gated": latest})
+
+    assert fetch_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_accounts_skips_fetch_when_additional_usage_is_fresh(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.config.settings import get_settings
+    from app.core.utils.time import utcnow
+
+    get_settings.cache_clear()
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+
+    fetch_calls = 0
+
+    async def stub_fetch_usage(**_: Any) -> UsagePayload:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return UsagePayload.model_validate({"rate_limit": {}})
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    usage_repo = StubUsageRepository()
+    await usage_repo.add_entry(
+        "acc_gated_fresh",
+        30.0,
+        recorded_at=now - timedelta(seconds=5),
+        window="primary",
+        reset_at=now_epoch + 300,
+        window_minutes=300,
+    )
+    latest = await usage_repo.latest_entry_for_account("acc_gated_fresh", window="primary")
+    assert latest is not None
+
+    additional_repo = StubAdditionalUsageRepository()
+    await additional_repo.add_entry(
+        "acc_gated_fresh",
+        limit_name="codex_other",
+        metered_feature="gpt-gated",
+        window="primary",
+        used_percent=10.0,
+        recorded_at=now - timedelta(seconds=5),
+    )
+
+    acc = _make_account("acc_gated_fresh", "workspace_gated_fresh", email="gated-fresh@example.com")
+
+    updater = UsageUpdater(usage_repo, accounts_repo=None, additional_usage_repo=additional_repo)
+    await updater.refresh_accounts([acc], latest_usage={"acc_gated_fresh": latest})
+
+    assert fetch_calls == 0
+
+
+@pytest.mark.asyncio
 async def test_refresh_accounts_skips_fetch_when_newer_sibling_row_supersedes_elapsed_primary(monkeypatch) -> None:
     monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
     from app.core.config.settings import get_settings

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -3557,6 +3557,49 @@ async def test_refresh_accounts_fetches_when_additional_usage_ages_despite_fresh
 
 
 @pytest.mark.asyncio
+async def test_refresh_accounts_fetches_when_no_additional_rows_were_ever_synced(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.config.settings import get_settings
+    from app.core.utils.time import utcnow
+
+    get_settings.cache_clear()
+    now = utcnow()
+    now_epoch = int(now.replace(tzinfo=timezone.utc).timestamp())
+
+    fetch_calls = 0
+
+    async def stub_fetch_usage(**_: Any) -> UsagePayload:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return UsagePayload.model_validate({"rate_limit": {}})
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    usage_repo = StubUsageRepository()
+    await usage_repo.add_entry(
+        "acc_undiscovered",
+        30.0,
+        recorded_at=now - timedelta(seconds=5),
+        window="primary",
+        reset_at=now_epoch + 300,
+        window_minutes=300,
+    )
+    latest = await usage_repo.latest_entry_for_account("acc_undiscovered", window="primary")
+    assert latest is not None
+
+    # An additional-usage repo is configured but no rows were ever synced:
+    # live rows alone must not suppress the discovery fetch.
+    additional_repo = StubAdditionalUsageRepository()
+
+    acc = _make_account("acc_undiscovered", "workspace_undiscovered", email="undiscovered@example.com")
+
+    updater = UsageUpdater(usage_repo, accounts_repo=None, additional_usage_repo=additional_repo)
+    await updater.refresh_accounts([acc], latest_usage={"acc_undiscovered": latest})
+
+    assert fetch_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_refresh_accounts_skips_fetch_when_additional_usage_is_fresh(monkeypatch) -> None:
     monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
     from app.core.config.settings import get_settings


### PR DESCRIPTION
## Why

codex-lb learns account quota state exclusively by polling `/backend-api/wham/usage` (default 60s, one account per tick), while upstream codex clients have long consumed fresher signals riding on the traffic itself. Because codex-lb discards them, selection state lags real usage by up to a refresh interval and bursty traffic can exhaust a window before the poller notices. With the 5h window temporarily removed upstream, per-turn signals are also the fastest way to observe short windows disappearing or returning.

## What

Proxied upstream responses become a passive usage source:

- **Parser + hub** (`app/core/usage/live_snapshots.py`, `live_hub.py`): `x-codex-{primary,secondary}-*` headers and `codex.rate_limits` stream events parse into typed snapshots; the client layer publishes through a startup-registered hub (no-op until the module layer registers), so core never imports modules.
- **Ingestor** (`app/modules/usage/live_ingest.py`): fire-and-forget — bounded drop-oldest queue, per-account change-fingerprint + min-interval throttle, single consumer with its own background sessions writing the same usage-history row shape the poller produces, throttled selection-cache invalidation, chatgpt-account-id resolution that drops ambiguous identities.
- **Taps**: SSE response headers at response start, stream events at the transport-agnostic `stream_responses` choke point, and `codex.rate_limits` frames in the HTTP-bridge upstream relay. All gated by a cheap marker probe; failures never touch the serving path.
- Enabled by default; `CODEX_LB_LIVE_USAGE_INGESTION_ENABLED=false` kill switch. The background poller stays authoritative for idle accounts, and its sibling-freshness gate (#1267) automatically skips accounts kept fresh by live traffic — polling pressure drops with no configuration.

## OpenSpec

New capability `live-usage-ingestion` (`openspec/changes/live-rate-limit-ingestion/`): passive snapshots, serving-path isolation, per-account throttling, decoupled hub + kill switch. Strict validation passes.

## Testing

- Unit: header/event parser edge cases, hub inertness, throttle coalescing vs prompt changed-write, queue overflow drop-oldest, `stream_responses` tap, bridge relay tap (`tests/unit/test_live_usage_ingest.py`, `test_proxy_http_bridge.py`).
- Integration: ingestor writes real usage rows for internal ids and resolved chatgpt ids; kill switch produces no publisher (`tests/integration/test_live_usage_ingest.py`).
- Full unit sweep: 3,681 passed; ty/ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)