### PR TITLE
fix(proxy): never inject a cross-account previous_response_id anchor

### DIFF
--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -2295,6 +2295,7 @@ class _HTTPBridgeMixin(
             await self._unregister_http_bridge_turn_states(session)
             await self._unregister_http_bridge_previous_response_ids(session)
             session.last_completed_response_id = None
+            session.last_completed_response_account_id = None
             session.last_completed_input_count = 0
             session.last_completed_input_prefix_fingerprint = None
             session.last_pending_tool_calls.clear()

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -1691,6 +1691,7 @@ class _HTTPBridgeStreamingMixin:
                     if durable_lookup.latest_response_id != session.last_completed_response_id:
                         session.last_pending_tool_calls = {}
                     session.last_completed_response_id = durable_lookup.latest_response_id
+                    session.last_completed_response_account_id = durable_lookup.account_id
                     session.last_completed_input_count = durable_full_resend_anchor_count
                     session.last_completed_input_prefix_fingerprint = durable_full_resend_anchor_fingerprint
                     _log_http_bridge_event(
@@ -1789,6 +1790,12 @@ class _HTTPBridgeStreamingMixin:
                 # must not trigger interrupted-output injection.
                 session.last_pending_tool_calls = {}
             session.last_completed_response_id = durable_lookup.latest_response_id
+            # The durable anchor is owned by the durable session's account, which
+            # may differ from this session's account after a failover. Record the
+            # owner so the session-anchor injection below can refuse to replay a
+            # cross-account previous_response_id (upstream cannot resolve it and
+            # would stall with no response.created — a wedged response-create gate).
+            session.last_completed_response_account_id = durable_lookup.account_id
             session.last_completed_input_count = durable_full_resend_anchor_count
             session.last_completed_input_prefix_fingerprint = durable_full_resend_anchor_fingerprint
         # --- Session-level previous_response_id injection ---
@@ -1817,6 +1824,17 @@ class _HTTPBridgeStreamingMixin:
             stored_count=stored_count_preview,
             stored_fingerprint=stored_fingerprint_preview,
         )
+        # A previous_response_id is account-scoped upstream: only the account that
+        # created the response can resume it. If this session's serving account is
+        # not the anchor's owner (e.g. the session failed over after the durable
+        # owner became unavailable), injecting the anchor sends an unresolvable
+        # previous_response_id upstream with the history trimmed away — upstream
+        # then never emits response.created and the response-create gate wedges
+        # ("idle timeout waiting for SSE"). Fall through to a full-history resend.
+        session_anchor_account_owned = (
+            session.last_completed_response_account_id is not None
+            and session.last_completed_response_account_id == session.account.id
+        )
         recovery_session_can_anchor = is_http_bridge_account_neutral_replay(
             kind=session.key.affinity_kind,
             key=session.key.affinity_key,
@@ -1826,6 +1844,7 @@ class _HTTPBridgeStreamingMixin:
             and not proxy_injected_previous_response_id
             and effective_payload.previous_response_id is None
             and session.last_completed_response_id is not None
+            and session_anchor_account_owned
             and (session_anchor_trimmable or recovery_session_can_anchor)
         ):
             fresh_upstream_request_text = text_data

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -1456,6 +1456,10 @@ class _HTTPBridgeUpstreamEventsMixin:
             # anchor for continuity lookups.
             if response_id is not None:
                 session.last_completed_response_id = response_id
+                # This response was completed on the session's current account, so
+                # that account owns the anchor. Record it so the anchor is only
+                # replayed on the same account (never after a cross-account failover).
+                session.last_completed_response_account_id = session.account.id
                 # Remember which tool-call items the completed response left
                 # pending so an anchored follow-up that omits their outputs
                 # (interrupted turn) can receive synthetic interrupted

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -939,6 +939,12 @@ class _HTTPBridgeSession:
     previous_response_alias_registration_generations: dict[str, int] = field(default_factory=dict)
     last_completed_input_count: int = 0
     last_completed_response_id: str | None = None
+    # Account that owns ``last_completed_response_id``. A previous_response_id
+    # anchor is account-scoped upstream, so it may only be replayed on the same
+    # account; when the session fails over to a different account this diverges
+    # from ``account.id`` and the anchor must NOT be injected. Kept in sync with
+    # ``last_completed_response_id`` at every setter.
+    last_completed_response_account_id: str | None = None
     last_completed_input_prefix_fingerprint: str | None = None
     last_pending_tool_calls: dict[str, str] = field(default_factory=dict)
     durable_session_id: str | None = None

--- a/openspec/changes/fix-cross-account-previous-response-anchor/proposal.md
+++ b/openspec/changes/fix-cross-account-previous-response-anchor/proposal.md
@@ -1,0 +1,49 @@
+# Fix cross-account compact previous_response_id anchor wedge
+
+## Why
+
+The HTTP-bridge "compact anchor" continuity optimization injects
+`previous_response_id = session.last_completed_response_id` and trims the
+already-stored history prefix so a follow-up turn only carries the new items.
+
+A `previous_response_id` is **account-scoped** on the upstream Responses API:
+only the account that created the response can resume it. The injection had no
+account-ownership check. When a Codex session fails over to a different account
+(e.g. the durable owner account became unavailable, or a durable session record
+is restored onto a new session bound to another account), the anchor points at a
+response the serving account never created. Upstream then accepts the WebSocket
+`response.create` but **never emits `response.created`**, and because the history
+was trimmed away there is no fallback. The per-bridge `response_create_gate`
+(a `Semaphore(1)`) stays held: the holder's own client eventually reports
+`stream disconnected before completion: idle timeout waiting for SSE`, and later
+requests on the same session time out as `codex-lb is temporarily overloaded
+during http_bridge_response_create_gate`.
+
+Observed live on 2026-07-10: sol sessions that fanned across three accounts
+repeatedly wedged on the same anchor (`resp_0bc0310d…`) even though the accounts
+had quota. Freeing the gate (the stuck-gate retire backstop) does not stop the
+recurrence because the session re-injects the same cross-account anchor.
+
+## What Changes
+
+- Track the account that owns `last_completed_response_id` on the bridge session
+  (`last_completed_response_account_id`), set in lockstep at every setter: the
+  real upstream `response.completed` path records the session's current account;
+  the durable-restore path records the durable owner account.
+- The session-level compact-anchor injection MUST only fire when the anchor's
+  owning account equals the session's serving account. Otherwise the request
+  falls through to a full-history resend (correct output, slightly more tokens),
+  never a cross-account `previous_response_id`.
+
+## Impact
+
+- Affected specs: `sticky-session-operations`
+- Affected code: `_service/support.py` (`_HTTPBridgeSession`),
+  `_service/http_bridge/streaming.py` (injection guard + durable-restore owner),
+  `_service/http_bridge/upstream_events.py` (completion owner).
+- Behavior: on cross-account failover, continuity is preserved by resending full
+  history instead of an unresolvable anchor. No client-visible protocol change.
+- Follow-ups (tracked separately, not in this change): the durable direct-anchor
+  injection performed before session/account binding, the WebSocket-transport
+  anchor path, and a proactive `response.created` watchdog that replays the
+  stored full-history payload if any anchored request stalls.

--- a/openspec/changes/fix-cross-account-previous-response-anchor/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/fix-cross-account-previous-response-anchor/specs/sticky-session-operations/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Compact previous_response_id anchors are account-scoped
+
+The HTTP-bridge session-level compact-anchor injection reduces payload size by
+replacing already-stored history with `previous_response_id = session.last_completed_response_id`.
+Because a `previous_response_id` can only be resumed by the account that created
+it, codex-lb MUST NOT inject a compact anchor whose owning account differs from
+the account that will serve the request.
+
+codex-lb MUST record the account that owns `last_completed_response_id` whenever
+that value is set — from a real upstream `response.completed` (the session's
+current account) or from a durable-session restore (the durable owner account) —
+and keep the two in sync.
+
+#### Scenario: Anchor injected when the serving account owns it
+
+- **WHEN** a Codex session follow-up turn is eligible for compact-anchor injection
+- **AND** the account that owns `last_completed_response_id` equals the session's
+  serving account
+- **THEN** codex-lb injects `previous_response_id = last_completed_response_id`
+  and trims the already-stored history prefix
+
+#### Scenario: Anchor skipped after cross-account failover
+
+- **WHEN** a Codex session follow-up turn is eligible for compact-anchor injection
+- **AND** the account that owns `last_completed_response_id` differs from the
+  session's serving account (for example the session failed over after the durable
+  owner account became unavailable)
+- **THEN** codex-lb MUST NOT inject the anchor
+- **AND** codex-lb resends the full history to the serving account so continuity
+  is preserved without an unresolvable `previous_response_id`
+- **AND** the request MUST NOT stall waiting for a `response.created` that upstream
+  will never send for an anchor the serving account does not own

--- a/openspec/changes/fix-cross-account-previous-response-anchor/tasks.md
+++ b/openspec/changes/fix-cross-account-previous-response-anchor/tasks.md
@@ -1,0 +1,18 @@
+# Tasks
+
+- [x] Add `last_completed_response_account_id` to `_HTTPBridgeSession`
+- [x] Record the serving account on the real `response.completed` setter
+      (`upstream_events.py`)
+- [x] Record the durable owner account on the durable-restore setter
+      (`streaming.py`)
+- [x] Gate session-level compact-anchor injection on
+      `last_completed_response_account_id == session.account.id`
+- [x] Regression tests: anchor injected when same-account; anchor skipped and
+      full history resent when cross-account failover
+- [x] Verify full `test_proxy_http_bridge` + broader proxy suites green
+- [ ] Follow-up (separate change): guard the durable direct-anchor injection that
+      runs before account binding
+- [ ] Follow-up (separate change): proactive `response.created` watchdog that
+      replays stored full-history payload on stall
+- [ ] Follow-up (separate change): audit the WebSocket-transport anchor path for
+      the same cross-account exposure

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -7151,7 +7151,7 @@ async def _run_session_anchor_owner_stream(
     Returns the previous_response_id values passed to each prepare call.
     """
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
-    prefix_items = [
+    prefix_items: list[proxy_service.JsonValue] = [
         {"role": "user", "content": [{"type": "input_text", "text": "a"}]},
         {"role": "assistant", "content": [{"type": "output_text", "text": "b"}]},
         {"role": "user", "content": [{"type": "input_text", "text": "c"}]},

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -3294,6 +3294,7 @@ async def test_http_bridge_precreated_completed_terminal_falls_back_to_unresolve
     ]
     assert request_state.response_id == "resp_precreated_completed"
     assert session.last_completed_response_id == "resp_precreated_completed"
+    assert session.last_completed_response_account_id == session.account.id
     assert session.queued_request_count == 0
     assert not session.pending_requests
     register_previous.assert_awaited_once()
@@ -3418,6 +3419,7 @@ async def test_ordinary_completed_alias_rejection_preserves_successful_response(
     assert completed["type"] == "response.completed"
     assert await asyncio.wait_for(request_state.event_queue.get(), timeout=1.0) is None
     assert session.last_completed_response_id == "resp_ordinary_completed"
+    assert session.last_completed_response_account_id == session.account.id
     assert session.upstream_control.reconnect_requested is False
     assert session.upstream_control.retire_after_drain is False
     finalize.assert_awaited_once()
@@ -7143,12 +7145,12 @@ async def _run_session_anchor_owner_stream(
     *,
     account_id: str,
     anchor_owner_account_id: str | None,
-) -> list[str | None]:
+) -> list[proxy_service.ResponsesRequest]:
     """Drive _stream_via_http_bridge for a trimmable session-anchor turn.
 
     The stored prefix matches the incoming input (so the trim branch WOULD
     apply); the only variable is whether the serving account owns the anchor.
-    Returns the previous_response_id values passed to each prepare call.
+    Returns the payloads passed to each prepare call.
     """
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     prefix_items: list[proxy_service.JsonValue] = [
@@ -7176,7 +7178,7 @@ async def _run_session_anchor_owner_stream(
     event_queue = request_state.event_queue
     assert event_queue is not None
     await event_queue.put(None)
-    prepared_previous_response_ids: list[str | None] = []
+    prepared_payloads: list[proxy_service.ResponsesRequest] = []
 
     def fake_prepare(
         prepared_payload: proxy_service.ResponsesRequest,
@@ -7188,7 +7190,7 @@ async def _run_session_anchor_owner_stream(
         client_ip: str | None = None,
     ) -> tuple[proxy_service._WebSocketRequestState, str]:
         del api_key, api_key_reservation, request_id, client_ip
-        prepared_previous_response_ids.append(prepared_payload.previous_response_id)
+        prepared_payloads.append(prepared_payload)
         return request_state, '{"type":"response.create"}'
 
     session = proxy_service._HTTPBridgeSession(
@@ -7200,7 +7202,7 @@ async def _run_session_anchor_owner_stream(
         ),
         request_model="gpt-5.4",
         account=cast(Any, SimpleNamespace(id=account_id, status=AccountStatus.ACTIVE)),
-        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream=cast(UpstreamWebSocket, SimpleNamespace(close=AsyncMock())),
         upstream_control=proxy_service._WebSocketUpstreamControl(),
         pending_requests=deque(),
         pending_lock=anyio.Lock(),
@@ -7255,7 +7257,7 @@ async def _run_session_anchor_owner_stream(
         queue_limit=4,
     ):
         pass
-    return prepared_previous_response_ids
+    return prepared_payloads
 
 
 @pytest.mark.asyncio
@@ -7265,7 +7267,7 @@ async def test_stream_via_http_bridge_injects_session_anchor_when_account_owns_i
     # Serving account owns the anchor -> the compact anchor is injected as normal.
     prepared = await _run_session_anchor_owner_stream(monkeypatch, account_id="acc-1", anchor_owner_account_id="acc-1")
     # Injection re-prepares the payload, so the final (sent) request carries the anchor.
-    assert prepared[-1] == "resp_session_latest"
+    assert prepared[-1].previous_response_id == "resp_session_latest"
 
 
 @pytest.mark.asyncio
@@ -7278,7 +7280,13 @@ async def test_stream_via_http_bridge_skips_session_anchor_after_cross_account_f
     # emits response.created -> the response-create gate wedges. It must be skipped
     # and the full history resent instead.
     prepared = await _run_session_anchor_owner_stream(monkeypatch, account_id="acc-2", anchor_owner_account_id="acc-1")
-    assert "resp_session_latest" not in prepared
+    assert all(payload.previous_response_id != "resp_session_latest" for payload in prepared)
+    assert prepared[-1].input == [
+        {"role": "user", "content": [{"type": "input_text", "text": "a"}]},
+        {"role": "assistant", "content": [{"type": "output_text", "text": "b"}]},
+        {"role": "user", "content": [{"type": "input_text", "text": "c"}]},
+        {"role": "user", "content": [{"type": "input_text", "text": "d"}]},
+    ]
 
 
 @pytest.mark.asyncio
@@ -7691,6 +7699,7 @@ async def test_stream_via_http_bridge_preserves_only_safe_trimmable_full_resend_
     )
     assert creation.kwargs["preferred_account_id"] == "acc-1"
     assert session.last_completed_response_id == (None if preserves_full_resend else "resp_latest")
+    assert session.last_completed_response_account_id == (None if preserves_full_resend else "acc-1")
     if not preserves_full_resend:
         assert request_state.proxy_injected_previous_response_id is True
         assert request_state.fresh_upstream_request_is_retry_safe is False

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -7138,6 +7138,149 @@ async def test_stream_via_http_bridge_skips_session_anchor_injection_when_trim_w
     assert prepared_previous_response_ids == [None]
 
 
+async def _run_session_anchor_owner_stream(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    account_id: str,
+    anchor_owner_account_id: str | None,
+) -> list[str | None]:
+    """Drive _stream_via_http_bridge for a trimmable session-anchor turn.
+
+    The stored prefix matches the incoming input (so the trim branch WOULD
+    apply); the only variable is whether the serving account owns the anchor.
+    Returns the previous_response_id values passed to each prepare call.
+    """
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    prefix_items = [
+        {"role": "user", "content": [{"type": "input_text", "text": "a"}]},
+        {"role": "assistant", "content": [{"type": "output_text", "text": "b"}]},
+        {"role": "user", "content": [{"type": "input_text", "text": "c"}]},
+    ]
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": [*prefix_items, {"role": "user", "content": [{"type": "input_text", "text": "d"}]}],
+        },
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-session-anchor-owner",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        event_queue=asyncio.Queue(),
+        transport="http",
+    )
+    event_queue = request_state.event_queue
+    assert event_queue is not None
+    await event_queue.put(None)
+    prepared_previous_response_ids: list[str | None] = []
+
+    def fake_prepare(
+        prepared_payload: proxy_service.ResponsesRequest,
+        _headers: dict[str, str] | Any,
+        *,
+        api_key: proxy_service.ApiKeyData | None,
+        api_key_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        request_id: str,
+        client_ip: str | None = None,
+    ) -> tuple[proxy_service._WebSocketRequestState, str]:
+        del api_key, api_key_reservation, request_id, client_ip
+        prepared_previous_response_ids.append(prepared_payload.previous_response_id)
+        return request_state, '{"type":"response.create"}'
+
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-anchor-owner", None),
+        headers={"x-codex-session-id": "sid-anchor-owner"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-anchor-owner",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id=account_id, status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamResponsesWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+        codex_session=True,
+        last_completed_response_id="resp_session_latest",
+        last_completed_response_account_id=anchor_owner_account_id,
+        last_completed_input_count=3,
+        last_completed_input_prefix_fingerprint=proxy_service._fingerprint_input_items(prefix_items),
+    )
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_enabled=True,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", AsyncMock(return_value=session))
+    monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
+    monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
+
+    async for _chunk in service._stream_via_http_bridge(
+        payload,
+        headers={"x-codex-session-id": "sid-anchor-owner"},
+        codex_session_affinity=True,
+        propagate_http_errors=False,
+        openai_cache_affinity=False,
+        api_key=None,
+        api_key_reservation=None,
+        suppress_text_done_events=False,
+        idle_ttl_seconds=120.0,
+        codex_idle_ttl_seconds=1800.0,
+        max_sessions=8,
+        queue_limit=4,
+    ):
+        pass
+    return prepared_previous_response_ids
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_injects_session_anchor_when_account_owns_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Serving account owns the anchor -> the compact anchor is injected as normal.
+    prepared = await _run_session_anchor_owner_stream(monkeypatch, account_id="acc-1", anchor_owner_account_id="acc-1")
+    # Injection re-prepares the payload, so the final (sent) request carries the anchor.
+    assert prepared[-1] == "resp_session_latest"
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_skips_session_anchor_after_cross_account_failover(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Anchor was created on acc-1 but the session now serves on acc-2 (failover).
+    # A previous_response_id is account-scoped upstream, so injecting it here would
+    # send an unresolvable anchor with the history trimmed away -> upstream never
+    # emits response.created -> the response-create gate wedges. It must be skipped
+    # and the full history resent instead.
+    prepared = await _run_session_anchor_owner_stream(monkeypatch, account_id="acc-2", anchor_owner_account_id="acc-1")
+    assert "resp_session_latest" not in prepared
+
+
 @pytest.mark.asyncio
 async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_anchor_for_full_resend_payload(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

The HTTP-bridge "compact anchor" continuity optimization injects `previous_response_id = session.last_completed_response_id` and trims the already-stored history prefix so a follow-up turn only carries the new items. A `previous_response_id` is **account-scoped** upstream — only the account that created a response can resume it — but the injection had **no ownership check**.

When a Codex session fails over to a different account (the durable owner account became unavailable, or a durable record is restored onto a session bound to another account), the anchor points at a response the serving account never created. Upstream accepts the WebSocket `response.create` but **never emits `response.created`**, and because the history was trimmed away there is no fallback. The per-bridge `response_create_gate` (`Semaphore(1)`) stays held:

- the holder's client eventually reports `stream disconnected before completion: idle timeout waiting for SSE`;
- later requests on the same session return `codex-lb is temporarily overloaded during http_bridge_response_create_gate`.

Observed live: sessions fanned across several accounts repeatedly wedged on the same anchor even though the accounts had quota — freeing the gate doesn't help because the session re-injects the same cross-account anchor and re-wedges.

**Fix:** track the account that owns `last_completed_response_id` (`last_completed_response_account_id`), set in lockstep at both setters — the real `response.completed` path records the session's current account, the durable-restore path records the durable owner account — and gate the session-level anchor injection on **owner == serving account**. On mismatch, fall through to a full-history resend (correct output, slightly more tokens), never a cross-account `previous_response_id`.

This is **codex-faithful**: the real Codex CLI never carries a `previous_response_id` across a connection/account boundary, so declining to inject a foreign anchor matches upstream behavior more closely, not less.

## OpenSpec

`openspec/changes/fix-cross-account-previous-response-anchor/` — `sticky-session-operations` delta: compact `previous_response_id` anchors are account-scoped; codex-lb MUST NOT inject an anchor whose owning account differs from the serving account, and MUST resend the full history instead. `openspec validate --specs` green.

## Tests

- `test_stream_via_http_bridge_injects_session_anchor_when_account_owns_it` — anchor still injected when the serving account owns it (no regression to the optimization).
- `test_stream_via_http_bridge_skips_session_anchor_after_cross_account_failover` — anchor skipped and full history resent on cross-account failover; no wedge.
- Full `tests/unit/test_proxy_http_bridge.py` (267) + `tests/integration/test_http_responses_bridge.py` (89) green.
