### PR TITLE
perf(request-logs): cache the listing total per filter signature

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -226,6 +226,8 @@ class Settings(BaseSettings):
     sticky_session_cleanup_interval_seconds: int = Field(default=300, gt=0)
     # Data retention (0 = disabled). Non-zero values have safety floors so
     # every in-product consumer window stays inside retained data.
+    # Display-only pagination total for the request-log listing; 0 disables.
+    request_log_count_cache_ttl_seconds: float = Field(default=30.0, ge=0)
     request_log_retention_days: int = Field(default=0, ge=0, le=3650)
     usage_history_retention_days: int = Field(default=0, ge=0, le=3650)
     quota_planner_scheduler_enabled: bool = True

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from datetime import datetime
 from typing import cast as typing_cast
@@ -11,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.sql.elements import ColumnElement
 
+from app.core.config.settings import get_settings
 from app.core.usage.logs import RequestLogLike, calculated_cost_from_log
 from app.core.usage.types import BucketModelAggregate, RequestActivityAggregate, UsageSummaryLogsAggregate
 from app.core.utils.request_id import ensure_request_id
@@ -23,6 +25,38 @@ from app.db.session import sqlite_writer_section
 class _RequestLogFilters:
     conditions: list
     needs_related_search_joins: bool
+
+
+# The exact COUNT(*) behind the request-log listing's "X-Y of N" scans the
+# whole filtered set on PostgreSQL; the dashboard re-runs it on every 30s
+# poll and every pagination click even though the displayed total is
+# tolerant of short staleness. Cache it per filter signature for a small
+# TTL (configurable; 0 disables, which the test suite uses so totals stay
+# exact within a test).
+_COUNT_CACHE_MAX_ENTRIES = 256
+_recent_count_cache: dict[tuple, tuple[int, float]] = {}
+
+
+def _clear_recent_count_cache() -> None:
+    _recent_count_cache.clear()
+
+
+def _cached_recent_count(key: tuple) -> int | None:
+    entry = _recent_count_cache.get(key)
+    if entry is None:
+        return None
+    total, expires_at = entry
+    if time.monotonic() >= expires_at:
+        _recent_count_cache.pop(key, None)
+        return None
+    return total
+
+
+def _store_recent_count(key: tuple, total: int, ttl_seconds: float) -> None:
+    if len(_recent_count_cache) >= _COUNT_CACHE_MAX_ENTRIES:
+        oldest = min(_recent_count_cache, key=lambda existing: _recent_count_cache[existing][1])
+        _recent_count_cache.pop(oldest, None)
+    _recent_count_cache[key] = (total, time.monotonic() + ttl_seconds)
 
 
 class RequestLogsRepository:
@@ -511,7 +545,28 @@ class RequestLogsRepository:
             stmt = stmt.limit(limit)
         result = await self._session.execute(stmt)
         logs = list(result.scalars().all())
-        total = await self._count_recent(filters)
+
+        ttl_seconds = get_settings().request_log_count_cache_ttl_seconds
+        if ttl_seconds <= 0:
+            return logs, await self._count_recent(filters)
+        cache_key = (
+            search,
+            since,
+            until,
+            tuple(account_ids or ()),
+            tuple(api_key_ids or ()),
+            tuple(model_options or ()),
+            tuple(models or ()),
+            tuple(reasoning_efforts or ()),
+            include_success,
+            include_error_other,
+            tuple(sorted(error_codes_in)) if error_codes_in else None,
+            tuple(sorted(error_codes_excluding)) if error_codes_excluding else None,
+        )
+        total = _cached_recent_count(cache_key)
+        if total is None:
+            total = await self._count_recent(filters)
+            _store_recent_count(cache_key, total, ttl_seconds)
         return logs, total
 
     async def _count_recent(self, filters: _RequestLogFilters) -> int:

--- a/openspec/changes/cache-request-log-count/.openspec.yaml
+++ b/openspec/changes/cache-request-log-count/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/cache-request-log-count/proposal.md
+++ b/openspec/changes/cache-request-log-count/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+Every request-log page load and pagination click runs an exact `COUNT(*)` over the filtered set; with default filters that is effectively the whole table on every 30-second dashboard poll. The count only feeds the display-only "X–Y of N" total and last-page jump, which tolerate short staleness.
+
+## What Changes
+
+- Cache the listing total per filter signature (all filter params except limit/offset) with a configurable TTL: `CODEX_LB_REQUEST_LOG_COUNT_CACHE_TTL_SECONDS`, default 30 s, `0` disables (the test suite disables it so totals stay exact within a test). Bounded LRU-ish eviction at 256 entries; per-instance.
+- API contract unchanged: `total` and `has_more` keep their exact semantics up to ≤TTL staleness of a monotonically-growing display figure; new rows always appear on page 1 (newest-first ordering) regardless.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `query-caching`: the request-log listing total MUST be served from a short-TTL per-filter cache instead of re-counting the filtered set on every page request.
+
+## Impact
+
+`app/modules/request_logs/repository.py`, `app/core/config/settings.py`, `tests/conftest.py` (suite disables the TTL). No schema/API change.

--- a/openspec/changes/cache-request-log-count/specs/query-caching/spec.md
+++ b/openspec/changes/cache-request-log-count/specs/query-caching/spec.md
@@ -1,0 +1,23 @@
+# query-caching Delta
+
+## ADDED Requirements
+
+### Requirement: Request-log listing totals are cached per filter signature
+
+The request-log listing MUST NOT execute an exact `COUNT(*)` over the filtered set on every page request; the total MUST be reused from a per-filter-signature cache within a configurable TTL (default 30 s), with `0` disabling the cache entirely. Cached totals are display-only: page contents themselves MUST remain exact and newest-first.
+
+#### Scenario: Repeated pages reuse the cached total
+
+- **GIVEN** two listing requests with the same filters but different offsets within the TTL
+- **WHEN** both pages are served
+- **THEN** the filtered set is counted once and both responses report the same total
+
+#### Scenario: Distinct filter signatures count independently
+
+- **WHEN** a listing request arrives with different filters
+- **THEN** its total comes from its own count, not another signature's cache entry
+
+#### Scenario: TTL zero disables caching
+
+- **WHEN** the TTL setting is `0`
+- **THEN** every listing request executes an exact count

--- a/openspec/changes/cache-request-log-count/tasks.md
+++ b/openspec/changes/cache-request-log-count/tasks.md
@@ -1,0 +1,9 @@
+## 1. Implementation
+
+- [x] 1.1 Per-filter-signature TTL cache around `_count_recent` (bounded entries; TTL from settings; 0 disables)
+- [x] 1.2 Suite disables the TTL via conftest env so in-test totals stay exact
+
+## 2. Validation
+
+- [x] 2.1 Statement-capture regression test: shared signature counts once across pages, distinct signature counts separately
+- [x] 2.2 request-log suites green; `ruff`/`ty`; `openspec validate --specs`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ os.environ["CODEX_LB_MODEL_REGISTRY_ENABLED"] = "false"
 os.environ["CODEX_LB_STICKY_SESSION_CLEANUP_ENABLED"] = "false"
 os.environ["CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_ENABLED"] = "false"
 os.environ["CODEX_LB_QUOTA_PLANNER_SCHEDULER_ENABLED"] = "false"
+os.environ["CODEX_LB_REQUEST_LOG_COUNT_CACHE_TTL_SECONDS"] = "0"
 
 from app.db.models import Base  # noqa: E402
 from app.db.session import engine  # noqa: E402

--- a/tests/integration/test_request_logs_api.py
+++ b/tests/integration/test_request_logs_api.py
@@ -293,3 +293,42 @@ async def test_request_logs_api_lists_limit_warmup_rows(async_client, db_setup):
     assert options_response.status_code == 200
     option_models = [entry["model"] for entry in options_response.json()["modelOptions"]]
     assert "gpt-5.1-codex-mini" in option_models
+
+
+@pytest.mark.asyncio
+async def test_request_log_total_count_is_cached_per_filter_signature(async_client, db_setup, monkeypatch):
+    """With the TTL enabled, repeated listings reuse the cached COUNT(*) for
+    the same filter signature; distinct signatures count separately."""
+    from sqlalchemy import event
+
+    from app.core.config.settings import get_settings
+    from app.db.session import engine
+    from app.modules.request_logs import repository as logs_repository_module
+
+    monkeypatch.setenv("CODEX_LB_REQUEST_LOG_COUNT_CACHE_TTL_SECONDS", "30")
+    get_settings.cache_clear()
+    logs_repository_module._clear_recent_count_cache()
+
+    count_statements: list[str] = []
+
+    def _capture(conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT COUNT") and "request_logs" in statement:
+            count_statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", _capture)
+    try:
+        first = await async_client.get("/api/request-logs?limit=5")
+        second = await async_client.get("/api/request-logs?limit=5&offset=5")
+        filtered = await async_client.get("/api/request-logs?limit=5&status=ok")
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _capture)
+        logs_repository_module._clear_recent_count_cache()
+        get_settings.cache_clear()
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert filtered.status_code == 200
+    assert first.json()["total"] == second.json()["total"]
+    # One COUNT for the shared default signature (page 2 reuses it), one for
+    # the status-filtered signature.
+    assert len(count_statements) == 2


### PR DESCRIPTION
## Summary

The last remaining dashboard full-scan from the perf audit: every request-log page load **and every pagination click** ran an exact `COUNT(*)` over the filtered set — effectively the whole table under default filters, re-executed by the dashboard's 30s poll.

The exact total only feeds the display-only "X–Y of N" figure and the last-page jump (verified in `pagination-controls.tsx`), which tolerate short staleness — so instead of changing the API contract to `has_more` (a UX regression), the total is now cached **per filter signature** (all filters except limit/offset):

- `CODEX_LB_REQUEST_LOG_COUNT_CACHE_TTL_SECONDS` — default 30 s, `0` disables. The test suite disables it globally so in-test totals stay exact; a dedicated statement-capture test re-enables it and pins one count per signature (page 2 reuses page 1's count; a different filter counts separately).
- Bounded at 256 entries, per-instance, display-only; page contents remain exact and newest-first, so fresh rows always appear on page 1 regardless of a ≤30 s-stale total.

## OpenSpec

`openspec/changes/cache-request-log-count/` — `query-caching` delta. Validation green.

## Tests

3,694 unit + request-log suites green; `ruff`/`ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)