### PR TITLE
perf(frontend): code-split dashboard routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from "react";
 import { Navigate, Outlet, Route, Routes } from "react-router-dom";
 
 import { AppHeader } from "@/components/layout/app-header";
@@ -6,13 +7,26 @@ import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthGate } from "@/features/auth/components/auth-gate";
 import { useAuthStore } from "@/features/auth/hooks/use-auth";
-import { AccountsPage } from "@/features/accounts/components/accounts-page";
-import { AutomationsPage } from "@/features/automations/components/automations-page";
-import { ApisPage } from "@/features/apis/components/apis-page";
-import { DashboardPage } from "@/features/dashboard/components/dashboard-page";
-import { ReportsPage } from "@/features/reports/components/reports-page";
-import { SettingsPage } from "@/features/settings/components/settings-page";
 import { useTimeFormatStore } from "@/hooks/use-time-format";
+
+// Route-level code splitting: only the visited page's chunk loads, instead
+// of one entry bundle carrying all six pages' code.
+const DashboardPage = lazy(() =>
+  import("@/features/dashboard/components/dashboard-page").then((m) => ({ default: m.DashboardPage })),
+);
+const ReportsPage = lazy(() =>
+  import("@/features/reports/components/reports-page").then((m) => ({ default: m.ReportsPage })),
+);
+const AccountsPage = lazy(() =>
+  import("@/features/accounts/components/accounts-page").then((m) => ({ default: m.AccountsPage })),
+);
+const AutomationsPage = lazy(() =>
+  import("@/features/automations/components/automations-page").then((m) => ({ default: m.AutomationsPage })),
+);
+const ApisPage = lazy(() => import("@/features/apis/components/apis-page").then((m) => ({ default: m.ApisPage })));
+const SettingsPage = lazy(() =>
+  import("@/features/settings/components/settings-page").then((m) => ({ default: m.SettingsPage })),
+);
 
 function AppLayout() {
   const logout = useAuthStore((state) => state.logout);
@@ -34,7 +48,9 @@ function AppLayout() {
         showLogout={(role === "admin" && passwordRequired) || (isGuest && guestPasswordRequired)}
       />
       <main className="mx-auto w-full max-w-[1500px] flex-1 px-4 py-8 sm:px-6">
-        <Outlet />
+        <Suspense fallback={null}>
+          <Outlet />
+        </Suspense>
       </main>
       <StatusBar />
     </div>

--- a/openspec/changes/split-dashboard-routes/.openspec.yaml
+++ b/openspec/changes/split-dashboard-routes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/split-dashboard-routes/proposal.md
+++ b/openspec/changes/split-dashboard-routes/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+All six dashboard pages were statically imported by `App.tsx`, so the entry chunk carried every page's code (807 KB raw / 214 KB gzip after the chart split); an operator opening `/dashboard` parsed and executed the settings, reports, accounts, automations, and APIs pages too.
+
+## What Changes
+
+- Each route's page component loads via `React.lazy` behind one `<Suspense>` in the app layout; the entry chunk drops to 360 KB raw / 112 KB gzip, with per-page chunks (dashboard 71 KB, settings 133 KB, accounts 52 KB, automations 54 KB, ...) fetched on first visit.
+- No visual change: the suspense fallback is null and page data loading already gates rendering.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `frontend-architecture`: dashboard routes MUST be code-split so the entry chunk excludes unvisited pages' code.
+
+## Impact
+
+`frontend/src/App.tsx` only. Verified on the built output: no page chunk is statically imported or modulepreloaded by the entry; 841 frontend tests green.

--- a/openspec/changes/split-dashboard-routes/specs/frontend-architecture/spec.md
+++ b/openspec/changes/split-dashboard-routes/specs/frontend-architecture/spec.md
@@ -1,0 +1,13 @@
+# frontend-architecture Delta
+
+## ADDED Requirements
+
+### Requirement: Dashboard routes are code-split
+
+Each dashboard route's page component MUST load lazily so the entry chunk excludes the code of pages the operator has not visited; the built entry chunk MUST NOT statically import or modulepreload page chunks.
+
+#### Scenario: Entry chunk excludes unvisited pages
+
+- **WHEN** the dashboard entry page loads
+- **THEN** only the visited route's page chunk is fetched
+- **AND** the built entry chunk neither statically imports nor modulepreloads the other pages' chunks

--- a/openspec/changes/split-dashboard-routes/tasks.md
+++ b/openspec/changes/split-dashboard-routes/tasks.md
@@ -1,0 +1,8 @@
+## 1. Implementation
+
+- [x] 1.1 `React.lazy` per route + one `<Suspense>` in the app layout
+
+## 2. Validation
+
+- [x] 2.1 Build inspection: entry 807→360 KB raw (214→112 KB gzip); page chunks absent from entry imports/modulepreload
+- [x] 2.2 Frontend suite green (841); `openspec validate --specs`


### PR DESCRIPTION
## Summary

Follow-up to #1243 (which took charts off the critical path): the entry chunk still carried **all six pages'** code because `App.tsx` imported them statically. Each route now loads via `React.lazy` behind a single `<Suspense fallback={null}>` in the app layout.

**Measured on the build:**

| | Before | After |
|---|---|---|
| Entry chunk (raw) | 807 KB | **360 KB** |
| Entry chunk (gzip) | 214 KB | **112 KB** |

Per-page chunks (dashboard 71 KB, settings 133 KB, accounts 52 KB, automations 54 KB, …) fetch on first visit. Verified in the built output that the entry neither statically imports nor modulepreloads any page chunk, and the recharts chunk stays async-only.

No visual change — the fallback is null and page data loading already gates rendering.

## OpenSpec

`openspec/changes/split-dashboard-routes/` — `frontend-architecture` delta. Validation green.

## Tests

Frontend suite: 841 passed (122 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)