### PR TITLE
perf(proxy): cache upstream-route resolution per account

### DIFF
--- a/app/core/cache/invalidation.py
+++ b/app/core/cache/invalidation.py
@@ -28,6 +28,7 @@ NAMESPACE_ACCOUNT_SELECTION = "account_selection"
 NAMESPACE_SETTINGS = "settings"
 NAMESPACE_RESET_CREDITS = "reset_credits"
 NAMESPACE_MODEL_REGISTRY = "model_registry"
+NAMESPACE_UPSTREAM_ROUTE = "upstream_route"
 # Callback return values are ignored; awaitables are awaited for their side
 # effects only, so callbacks may return a status (e.g. bool) for other callers.
 type InvalidationCallback = Callable[[], object | Awaitable[object]]
@@ -45,6 +46,7 @@ _NAMESPACE_LOG_LABELS: dict[str, str] = {
     "settings": "settings",
     "reset_credits": "reset_credits",
     "model_registry": "model_registry",
+    "upstream_route": "upstream_route",
 }
 
 _BUMP_RETRY_ATTEMPTS = 3

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -304,6 +304,10 @@ class Settings(BaseSettings):
     http_responses_session_bridge_instance_ring: Annotated[list[str], NoDecode] = Field(default_factory=list)
     http_responses_session_bridge_advertise_base_url: str | None = None
     sticky_session_cleanup_enabled: bool = True
+    # TTL backstop for the per-account upstream-route resolution cache; 0
+    # disables caching. Admin mutations invalidate durably through the
+    # cache-invalidation bus, so this only bounds out-of-band database edits.
+    upstream_route_cache_ttl_seconds: float = Field(default=60.0, ge=0)
     # Data retention (0 = disabled). Non-zero values have safety floors so
     # every in-product consumer window stays inside retained data.
     # DEPRECATED: retention is managed from the dashboard runtime settings

--- a/app/core/upstream_proxy/cache.py
+++ b/app/core/upstream_proxy/cache.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from app.core.cache.invalidation import NAMESPACE_UPSTREAM_ROUTE, get_cache_invalidation_poller
+from app.core.config.settings import get_settings
+from app.core.upstream_proxy.resolver import UpstreamProxyRouteError
+from app.core.upstream_proxy.types import ResolvedUpstreamRoute
+
+
+@dataclass(frozen=True, slots=True)
+class CachedRouteOutcome:
+    """Terminal resolver outcome for one account, reproduced verbatim on a hit.
+
+    Exactly one of the resolver's three outcomes is held: a resolved route, a
+    permitted direct-egress ``None`` (``route is None`` with no error), or a
+    fail-closed error reason. ``unwrap`` re-raises errors with the original
+    reason and pool so a cache hit can never change the degradation path the
+    resolver chose.
+    """
+
+    route: ResolvedUpstreamRoute | None
+    error_reason: str | None
+    error_pool_id: str | None
+    expires_at: float
+
+    def unwrap(self, account_id: str | None) -> ResolvedUpstreamRoute | None:
+        if self.error_reason is not None:
+            raise UpstreamProxyRouteError(self.error_reason, account_id=account_id, pool_id=self.error_pool_id)
+        return self.route
+
+
+class UpstreamRouteCache:
+    """Per-account cache of upstream proxy route resolution outcomes.
+
+    Admin mutations of resolver inputs (account bindings, pool members, the
+    upstream-proxy dashboard settings) invalidate durably through the
+    ``upstream_route`` / ``settings`` cache-invalidation namespaces; the TTL is
+    only a backstop for out-of-band database edits. A TTL of 0 disables the
+    cache entirely (the test-suite default).
+    """
+
+    def __init__(self) -> None:
+        self._entries: dict[str, CachedRouteOutcome] = {}
+        self._generation = 0
+
+    @property
+    def generation(self) -> int:
+        return self._generation
+
+    @staticmethod
+    def _ttl_seconds() -> float:
+        return get_settings().upstream_route_cache_ttl_seconds
+
+    def get(self, account_id: str) -> CachedRouteOutcome | None:
+        if self._ttl_seconds() <= 0:
+            return None
+        entry = self._entries.get(account_id)
+        if entry is None:
+            return None
+        if time.monotonic() >= entry.expires_at:
+            self._entries.pop(account_id, None)
+            return None
+        return entry
+
+    def store_route(self, account_id: str, route: ResolvedUpstreamRoute | None, *, generation: int) -> None:
+        self._store(account_id, route=route, error_reason=None, error_pool_id=None, generation=generation)
+
+    def store_error(self, account_id: str, error: UpstreamProxyRouteError, *, generation: int) -> None:
+        self._store(
+            account_id,
+            route=None,
+            error_reason=error.reason,
+            error_pool_id=error.pool_id,
+            generation=generation,
+        )
+
+    def _store(
+        self,
+        account_id: str,
+        *,
+        route: ResolvedUpstreamRoute | None,
+        error_reason: str | None,
+        error_pool_id: str | None,
+        generation: int,
+    ) -> None:
+        ttl = self._ttl_seconds()
+        if ttl <= 0:
+            return
+        if generation != self._generation:
+            # An invalidation landed while this outcome was being resolved; the
+            # outcome may predate the mutation, so drop it.
+            return
+        self._entries[account_id] = CachedRouteOutcome(
+            route=route,
+            error_reason=error_reason,
+            error_pool_id=error_pool_id,
+            expires_at=time.monotonic() + ttl,
+        )
+
+    def clear(self) -> None:
+        self._generation += 1
+        self._entries.clear()
+
+    async def invalidate(self, *, propagate: bool = True) -> None:
+        """Clear locally and, unless ``propagate`` is False, durably bump the
+        cross-replica ``upstream_route`` namespace before returning.
+
+        Route mutations are security-bearing (a stale entry could keep an
+        account on direct egress after a binding lands), so mutation paths
+        await the bump rather than coalescing it. Poller callbacks use
+        ``clear`` directly, so a remote bump never re-bumps.
+        """
+        self.clear()
+        if propagate:
+            poller = get_cache_invalidation_poller()
+            if poller is not None and not await poller.bump(NAMESPACE_UPSTREAM_ROUTE):
+                # bump() never raises; on failure the coalesced pending-set
+                # retries on every poll cycle until the write lands, so peers
+                # still converge once the database recovers. The TTL backstop
+                # bounds staleness in the interim.
+                poller.request_bump(NAMESPACE_UPSTREAM_ROUTE)
+
+
+_upstream_route_cache = UpstreamRouteCache()
+
+
+def get_upstream_route_cache() -> UpstreamRouteCache:
+    return _upstream_route_cache

--- a/app/main.py
+++ b/app/main.py
@@ -230,11 +230,13 @@ async def lifespan(app: FastAPI):
         NAMESPACE_MODEL_REGISTRY,
         NAMESPACE_RESET_CREDITS,
         NAMESPACE_SETTINGS,
+        NAMESPACE_UPSTREAM_ROUTE,
         CacheInvalidationPoller,
         get_cache_invalidation_poller,
         set_cache_invalidation_poller,
     )
     from app.core.middleware.firewall_cache import get_firewall_ip_cache
+    from app.core.upstream_proxy.cache import get_upstream_route_cache
     from app.modules.proxy.account_cache import get_account_selection_cache, get_routing_availability_cache
     from app.modules.rate_limit_reset_credits.store import get_rate_limit_reset_credits_store
 
@@ -258,6 +260,10 @@ async def lifespan(app: FastAPI):
         NAMESPACE_SETTINGS,
         lambda: get_settings_cache().invalidate(propagate=False),
     )
+    cache_poller.on_invalidation(NAMESPACE_UPSTREAM_ROUTE, get_upstream_route_cache().clear)
+    # The route resolver also reads the dashboard settings row (routing enabled
+    # + default pool id), so settings bumps clear resolved routes as well.
+    cache_poller.on_invalidation(NAMESPACE_SETTINGS, get_upstream_route_cache().clear)
     # The bus carries no payload, so a peer redeem clears this replica's whole
     # reset-credits store; the refresh scheduler repopulates it on its next tick.
     cache_poller.on_invalidation(NAMESPACE_RESET_CREDITS, get_rate_limit_reset_credits_store().invalidate)

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -11,6 +11,7 @@ from sqlalchemy import delete, or_, select, text, update
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.upstream_proxy.cache import get_upstream_route_cache
 from app.core.utils.time import utcnow
 from app.db.models import (
     Account,
@@ -247,6 +248,11 @@ class AccountsRepository:
                 await self._session.commit()
                 if usage_cache_dirty:
                     _clear_bulk_history_since_sqlite_cache()
+                    # Duplicate reconciliation deletes Account rows, cascading
+                    # any account_proxy_bindings they owned. The route cache is
+                    # keyed by deterministic account id, so stale duplicate-id
+                    # outcomes must not survive the commit.
+                    await get_upstream_route_cache().invalidate()
                 await self._session.refresh(canonical)
                 return canonical
 

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -33,6 +33,7 @@ from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
 from app.core.plan_types import coerce_account_plan_type
 from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteError, resolve_upstream_route
+from app.core.upstream_proxy.cache import get_upstream_route_cache
 from app.core.upstream_proxy.resolver import _is_missing_upstream_proxy_schema
 from app.core.usage.models import UsagePayload
 from app.core.utils.time import naive_utc_to_epoch, to_utc_naive, utcnow
@@ -663,6 +664,10 @@ class AccountsService:
             mark_account_routing_unavailable(account_id)
             get_account_selection_cache().invalidate()
             get_api_key_cache().clear()
+            # Deletion cascades the account_proxy_bindings row away, and account
+            # ids are deterministic (delete-then-re-import regenerates the same
+            # id), so the cached route outcome must not survive the deletion.
+            await get_upstream_route_cache().invalidate()
             await propagate_account_routing_change()
             poller = get_cache_invalidation_poller()
             if poller is not None:

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -51,7 +51,8 @@ from app.core.resilience.network_recovery import (
     PROCESS_NETWORK_UNAVAILABLE_CODE,
 )
 from app.core.types import JsonValue
-from app.core.upstream_proxy import ResolvedUpstreamRoute
+from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteError
+from app.core.upstream_proxy.cache import get_upstream_route_cache
 from app.core.utils.request_id import get_request_id
 from app.core.utils.sse import CODEX_KEEPALIVE_FRAME as CODEX_KEEPALIVE_FRAME  # noqa: F401
 from app.core.utils.sse import format_sse_event, parse_sse_data_json
@@ -727,14 +728,28 @@ async def _resolve_upstream_route_for_account(
     *,
     operation: str,
 ) -> ResolvedUpstreamRoute | None:
+    # Outcomes (route / direct-egress None / fail-closed error) are cached
+    # verbatim, so a hit can never change the degradation path the resolver
+    # chose; errors re-raise with their original reason.
+    cache = get_upstream_route_cache()
+    cached = cache.get(account.id)
+    if cached is not None:
+        return cached.unwrap(account.id)
+    generation = cache.generation
     async with _facade().SessionLocal() as session:
-        return await _facade().resolve_upstream_route(
-            session,
-            account_id=account.id,
-            operation=operation,
-            scope="account",
-            encryptor=proxy._encryptor,
-        )
+        try:
+            route = await _facade().resolve_upstream_route(
+                session,
+                account_id=account.id,
+                operation=operation,
+                scope="account",
+                encryptor=proxy._encryptor,
+            )
+        except UpstreamProxyRouteError as exc:
+            cache.store_error(account.id, exc, generation=generation)
+            raise
+    cache.store_route(account.id, route, generation=generation)
+    return route
 
 
 async def _select_account_with_budget_for_stream(proxy: Any, deadline: float, **kwargs: Any) -> AccountSelection:

--- a/app/modules/settings/api.py
+++ b/app/modules/settings/api.py
@@ -24,6 +24,7 @@ from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.exceptions import DashboardBadRequestError, DashboardSettingsConflictError
 from app.core.upstream_proxy import resolve_proxy_endpoint
+from app.core.upstream_proxy.cache import get_upstream_route_cache
 from app.db.models import Account, AccountProxyBinding, AccountStatus, ProxyEndpoint, ProxyPool, ProxyPoolMember
 from app.dependencies import SettingsContext, get_proxy_service_for_app, get_settings_context
 from app.modules.proxy.account_cache import (
@@ -346,6 +347,9 @@ async def add_upstream_proxy_pool_member(
         if _is_duplicate_proxy_pool_member_error(exc):
             raise _duplicate_proxy_pool_member_error()
         raise
+    # Pool membership is a route-resolver input: clear + durably bump before
+    # responding (same contract as the account-binding upsert).
+    await get_upstream_route_cache().invalidate()
     endpoint_ids = (
         (
             await context.session.execute(
@@ -468,6 +472,10 @@ async def put_account_proxy_binding(
         account.blocked_at = None
         reactivated = True
     await context.session.commit()
+    # Binding rows are a route-resolver input: clear this replica's route
+    # cache and durably bump ``upstream_route`` before responding so no
+    # request on the mutating replica resolves the pre-mutation binding.
+    await get_upstream_route_cache().invalidate()
     if reactivated:
         # Invalidate + bump only after the status commit so peers (and this
         # replica's poller) never rebuild selection/routing inputs from the
@@ -815,6 +823,14 @@ async def update_settings(
     except ValueError as exc:
         raise DashboardBadRequestError(str(exc), code="invalid_totp_config") from exc
 
+    upstream_route_inputs_changed = (
+        current.upstream_proxy_routing_enabled != updated.upstream_proxy_routing_enabled
+        or current.upstream_proxy_default_pool_id != updated.upstream_proxy_default_pool_id
+    )
+    # ``SettingsRepository.commit_refresh`` already cleared the route cache
+    # synchronously between the commit and its refresh await (no concurrent
+    # request can see the committed row alongside the stale cache); only the
+    # durable cross-replica signals remain here.
     await get_settings_cache().invalidate()
     changed_fields = [
         field_name
@@ -867,6 +883,14 @@ async def update_settings(
         )
         if getattr(current, field_name) != getattr(updated, field_name)
     ]
+    if upstream_route_inputs_changed:
+        # Durably bump ``upstream_route`` (with the coalesced retry fallback)
+        # rather than relying solely on the ``settings`` bump issued above:
+        # that bump is non-raising and enqueues no retry, so a transient write
+        # failure would leave peers on the stale route outcome until the TTL
+        # instead of the first recovered poll cycle. The re-clear inside
+        # ``invalidate`` is harmless; the guarding clear already ran pre-await.
+        await get_upstream_route_cache().invalidate()
     AuditService.log_async(
         "settings_changed",
         actor_ip=request.client.host if request.client else None,

--- a/app/modules/settings/repository.py
+++ b/app/modules/settings/repository.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
@@ -8,6 +10,7 @@ from sqlalchemy.orm.exc import StaleDataError
 from app.core.auth.dashboard_session_ttl import DEFAULT_DASHBOARD_SESSION_TTL_SECONDS
 from app.core.config.settings import get_settings
 from app.core.exceptions import DashboardSettingsConflictError
+from app.core.upstream_proxy.cache import get_upstream_route_cache
 from app.db.models import DashboardSettings
 
 _SETTINGS_ID = 1
@@ -146,6 +149,10 @@ class SettingsRepository:
             raise DashboardSettingsConflictError(
                 "Settings were modified since this form was loaded; reload and retry",
             )
+        upstream_route_inputs_changed = (
+            upstream_proxy_routing_enabled is not None
+            and upstream_proxy_routing_enabled != settings.upstream_proxy_routing_enabled
+        ) or (upstream_proxy_default_pool_id or None) != settings.upstream_proxy_default_pool_id
         if sticky_threads_enabled is not None:
             settings.sticky_threads_enabled = sticky_threads_enabled
         if upstream_stream_transport is not None:
@@ -255,10 +262,20 @@ class SettingsRepository:
         # `UPDATE ... SET version = version + 1 WHERE version = :expected`, so a
         # stale no-op save still surfaces the conflict.
         flag_modified(settings, "sticky_threads_enabled")
-        await self.commit_refresh(settings)
+        # The route cache must be cleared synchronously between the commit and
+        # the refresh await: the committed row is visible to concurrent
+        # requests as soon as the commit returns, and any await before the
+        # clear would let them resolve from the stale per-account route cache
+        # (e.g. cached direct egress immediately after routing was enabled).
+        await self.commit_refresh(
+            settings,
+            on_committed=get_upstream_route_cache().clear if upstream_route_inputs_changed else None,
+        )
         return settings
 
-    async def commit_refresh(self, settings: DashboardSettings) -> None:
+    async def commit_refresh(
+        self, settings: DashboardSettings, *, on_committed: Callable[[], None] | None = None
+    ) -> None:
         try:
             await self._session.commit()
         except StaleDataError as exc:
@@ -266,4 +283,9 @@ class SettingsRepository:
             # zero rows: another writer (replica or request) committed first.
             await self._session.rollback()
             raise DashboardSettingsConflictError() from exc
+        if on_committed is not None:
+            # Runs synchronously between the commit and the refresh await so
+            # concurrent requests cannot observe the committed row alongside
+            # stale state the hook is meant to reset.
+            on_committed()
         await self._session.refresh(settings)

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -7,7 +7,7 @@ Regenerate with `uv run python scripts/generate_settings_reference.py`;
 `tests/unit/test_settings_reference.py` fails when this page drifts from
 `app/core/config/settings.py`.
 
-codex-lb currently exposes 114 settings. Every setting is an environment
+codex-lb currently exposes 115 settings. Every setting is an environment
 variable with the `CODEX_LB_` prefix (process environment or `.env` /
 `.env.local` next to the process). All defaults work with zero configuration —
 start from [Configuration](../configuration.md) for the handful that matter,
@@ -57,6 +57,7 @@ the host side of the compose `ports` mapping instead.
 | `CODEX_LB_UPSTREAM_COMPACT_TIMEOUT_SECONDS` | `float \| None` | `None` |
 | `CODEX_LB_UPSTREAM_CONNECT_TIMEOUT_SECONDS` | `float` | `8.0` |
 | `CODEX_LB_UPSTREAM_RESPONSE_CREATE_MAX_BYTES` | `int` | `15728640` |
+| `CODEX_LB_UPSTREAM_ROUTE_CACHE_TTL_SECONDS` | `float` | `60.0` |
 | `CODEX_LB_UPSTREAM_STREAM_TRANSPORT` | `'http' \| 'websocket' \| 'auto'` | `'auto'` |
 | `CODEX_LB_UPSTREAM_WEBSOCKET_TRUST_ENV` | `bool` | auto-detected from outbound proxy env vars |
 

--- a/openspec/changes/add-upstream-route-cache/.openspec.yaml
+++ b/openspec/changes/add-upstream-route-cache/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/add-upstream-route-cache/design.md
+++ b/openspec/changes/add-upstream-route-cache/design.md
@@ -1,0 +1,78 @@
+# Design: upstream-route resolution cache
+
+## Context
+
+`resolve_upstream_route` reads five tables that only change through rare admin
+mutations: `account_proxy_bindings`, `dashboard_settings`
+(`upstream_proxy_routing_enabled`, `upstream_proxy_default_pool_id`),
+`proxy_pools`, `proxy_pool_members`, `proxy_endpoints`. The proxy hot path
+(`streaming/helpers._resolve_upstream_route_for_account`, shared by streaming,
+websocket, file ops, compact, transcribe, codex-control, warmup) opens a fresh
+session per request purely for this resolution.
+
+## Decisions
+
+### Outcome-verbatim caching (the security invariant)
+
+The cache stores the resolver's terminal outcome per account id: a
+`ResolvedUpstreamRoute`, `None` (direct egress permitted), or the
+`UpstreamProxyRouteError` reason/pool. A hit reproduces that outcome exactly —
+a cached fail-closed error re-raises with the same reason and never falls back
+to the default pool or direct egress. This is what keeps the CLAUDE.md
+trapdoor ("security/trusted-access routing must degrade only along the
+documented path") intact: caching can delay a transition between outcomes
+(bounded below), but can never invent a new degradation path.
+
+`OperationalError` (including the tolerated missing-schema rollout path) is
+NOT cached: the tolerated branch returns `None` through the resolver, and that
+`None` is cached like any direct-egress outcome, bounded by the TTL; a strict
+schema error propagates uncached.
+
+### Invalidation map (every resolver input, one mechanism each)
+
+| Mutation | Path | Invalidation |
+|---|---|---|
+| Account binding upsert | `PUT /settings/upstream-proxy/accounts/{id}/binding` | local clear + durable `upstream_route` bump before response |
+| Pool member add | `POST /settings/upstream-proxy/pools/{id}/members` | local clear + durable `upstream_route` bump before response |
+| Upstream settings fields | `PUT /settings` | synchronous local clear inside `SettingsRepository.commit_refresh`, between the commit and the refresh await (the committed row must never be observable alongside the stale cache) + durable `upstream_route` bump when either upstream field changed (the existing `settings` bump also clears peers, but it enqueues no retry on a failed write; the `upstream_route` bump carries the coalesced-retry fallback) |
+| Account deletion | `DELETE /accounts/{id}` (service layer) | local clear + durable `upstream_route` bump — deletion cascades the binding row away, and account ids are deterministic, so delete-then-re-import regenerates the same cache key |
+| Endpoint create | `POST /settings/upstream-proxy/endpoints` | none needed — a new endpoint is not a member of any pool yet, so no cached outcome can reference it |
+| Pool create | `POST /settings/upstream-proxy/pools` | none needed — bindings and the default-pool setting validate pool existence, so no cached outcome can reference a pool that did not exist when it was cached |
+| Out-of-band DB edits (e.g. manual `is_active` toggles) | — | TTL backstop (60 s default) |
+
+The binding/member/deletion bumps use the awaited durable `bump()` (not the
+coalesced `request_bump()`), matching the settings cache: route changes are
+security-bearing, so the cross-replica signal is written before the mutating
+response returns. Peers converge within one poll interval (~0.5 s). `bump()`
+is non-raising; when it reports failure, `invalidate()` enqueues the coalesced
+`request_bump()` fallback, which retries on every poll cycle until the write
+lands — the TTL bounds peer staleness in the interim.
+
+### Placement and test-transparency
+
+The consult lives in `streaming/helpers._resolve_upstream_route_for_account`
+(the single funnel for all proxy-service operations). The miss path still goes
+through `_facade().SessionLocal()` / `_facade().resolve_upstream_route`, so
+existing tests that monkeypatch the service facade keep working. The test
+suite sets `CODEX_LB_UPSTREAM_ROUTE_CACHE_TTL_SECONDS=0` globally (cache
+transparent); cache-specific tests opt in explicitly. Background callers
+(usage refresh, model discovery, oauth, automations, auth dependencies) keep
+their existing fresh reads — they are not hot paths.
+
+### Staleness bounds
+
+- Admin mutation, same replica: 0 (cleared before the response returns).
+- Admin mutation, peer replica: ≤ 1 poll interval (~0.5 s); if the durable
+  bump write fails, the coalesced retry converges peers on the first poll
+  cycle after the database recovers, bounded by the TTL in the interim.
+- Out-of-band DB edit: ≤ TTL (60 s default).
+
+A `generation` counter guards repopulation: an outcome resolved concurrently
+with an invalidation is dropped rather than stored (same pattern as the
+API-key cache version guard).
+
+### Credential residency
+
+Cached routes hold decrypted proxy credentials in process memory for up to the
+TTL (today they live in memory for the request duration). Types are frozen
+dataclasses shared safely across requests; credentials never appear in logs.

--- a/openspec/changes/add-upstream-route-cache/proposal.md
+++ b/openspec/changes/add-upstream-route-cache/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Every proxy request pays an upstream-route resolution before the first upstream byte: `_resolve_upstream_route_for_account` opens a fresh `SessionLocal` and issues 1–3 uncached SELECTs (account proxy binding, dashboard settings row, proxy pool + members + endpoints). Route inputs change only through rare admin mutations, yet the hot path re-reads them on every turn. This is the last unaddressed item from the 2026-07-12 performance audit.
+
+## What Changes
+
+- Add a per-account upstream-route resolution cache consulted by the proxy hot path. A cache hit skips the session open and all resolver SELECTs.
+- Cache the resolver's outcome **verbatim**: a resolved route, `None` (direct egress permitted), or the fail-closed `UpstreamProxyRouteError` reason. A hit can therefore never change the degradation path the resolver chose — fail-closed outcomes keep failing closed and never fall back to the default pool or direct egress.
+- Add an `upstream_route` cache-invalidation namespace. Account-binding upserts and pool-member additions clear the local cache and durably bump the namespace before their HTTP response returns. Dashboard settings changes already bump the durable `settings` namespace; the route cache also subscribes to it, and the settings update path clears the local cache immediately when either upstream-proxy field changed.
+- Add `CODEX_LB_UPSTREAM_ROUTE_CACHE_TTL_SECONDS` (default 60, `0` disables caching) as a TTL backstop for out-of-band database edits; invalidation bumps remain the binding freshness mechanism (~0.5 s cross-replica).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `query-caching`: upstream-route resolution on the proxy hot path becomes invalidation-driven with a TTL backstop, mirroring the API-key auth cache contract.
+- `upstream-proxy-routing`: cached resolution MUST preserve fail-closed semantics — a cache hit reproduces the resolver's outcome exactly and mutations of route inputs invalidate before the mutating response returns.
+
+## Impact
+
+- **Code**: new `app/core/upstream_proxy/cache.py`; `app/core/cache/invalidation.py` (namespace), `app/core/config/settings.py` (TTL setting), `app/modules/proxy/_service/streaming/helpers.py` (hot-path consult), `app/main.py` (poller wiring), `app/modules/settings/api.py` (mutation invalidation hooks). No schema change.
+- **Behavior**: resolution outcomes are unchanged; only their freshness window changes. Admin mutations through the API invalidate locally before the response returns and cross-replica within one poll interval; direct database edits are bounded by the 60 s TTL backstop.

--- a/openspec/changes/add-upstream-route-cache/specs/query-caching/spec.md
+++ b/openspec/changes/add-upstream-route-cache/specs/query-caching/spec.md
@@ -1,0 +1,45 @@
+# query-caching Delta
+
+## ADDED Requirements
+
+### Requirement: Upstream-route resolution is invalidation-driven with a TTL backstop
+
+Proxy hot-path upstream-route resolution MUST be served from a per-account cache of resolver outcomes. Admin mutations of any resolver input (account proxy bindings, proxy pool membership, upstream-proxy dashboard settings, account deletion cascading a binding away) MUST invalidate the cache on the mutating replica before the mutating response returns and durably bump a cache-invalidation namespace so peer replicas converge within one poll interval. If the durable bump write fails (the bump primitive is non-raising), the implementation MUST enqueue the coalesced retry so peers still converge on the first poll cycle after the write path recovers. The cache TTL MUST default to 60 seconds as a backstop for out-of-band database edits, and a TTL of 0 MUST disable caching entirely.
+
+#### Scenario: Repeat turns skip route re-resolution
+
+- **GIVEN** an account whose route resolved less than the TTL ago with no intervening route-input mutation
+- **WHEN** another proxy request uses that account
+- **THEN** the route MUST be served from the cache without opening a database session
+
+#### Scenario: Binding change invalidates before the response returns
+
+- **GIVEN** a cached route outcome for an account
+- **WHEN** an operator upserts that account's proxy binding
+- **THEN** the mutating replica's cache MUST be cleared before the HTTP response returns
+- **AND** the `upstream_route` namespace MUST be durably bumped so peers clear their caches via the poller
+
+#### Scenario: Pool membership change invalidates
+
+- **GIVEN** a cached route outcome resolved from a pool
+- **WHEN** an operator adds a member to any proxy pool
+- **THEN** the local cache MUST be cleared and the `upstream_route` namespace durably bumped before the response returns
+
+#### Scenario: Account deletion invalidates
+
+- **GIVEN** a cached route outcome for an account
+- **WHEN** an operator deletes the account (cascading its proxy binding away)
+- **THEN** the local cache MUST be cleared and the `upstream_route` namespace durably bumped before the response returns
+
+#### Scenario: Peer replicas converge through the poller
+
+- **GIVEN** a cached route outcome on a replica that did not perform the mutation
+- **WHEN** the `upstream_route` or `settings` namespace version advances
+- **THEN** that replica's cache-invalidation poller MUST clear its route cache within one poll interval
+
+#### Scenario: Upstream settings change invalidates
+
+- **GIVEN** a cached route outcome
+- **WHEN** an operator changes `upstream_proxy_routing_enabled` or `upstream_proxy_default_pool_id`
+- **THEN** the mutating replica's route cache MUST be cleared and the `upstream_route` namespace durably bumped (with the coalesced retry on write failure) before the response returns
+- **AND** peers MUST also clear theirs via the durable `settings` namespace bump

--- a/openspec/changes/add-upstream-route-cache/specs/upstream-proxy-routing/spec.md
+++ b/openspec/changes/add-upstream-route-cache/specs/upstream-proxy-routing/spec.md
@@ -1,0 +1,20 @@
+# upstream-proxy-routing Delta
+
+## ADDED Requirements
+
+### Requirement: Cached route resolution preserves fail-closed semantics
+
+Any cache in front of upstream-route resolution MUST store the resolver's outcome verbatim — a resolved route, a permitted direct-egress `None`, or a fail-closed error with its reason. A cache hit MUST reproduce that outcome exactly: it MUST NOT convert a fail-closed outcome or a routed outcome into direct egress, and it MUST NOT substitute a different pool or endpoint than the resolver chose. Cache staleness MUST be bounded by invalidation on admin mutations (same-replica: before the mutating response returns; peers: within one cache-invalidation poll interval) with a TTL backstop for out-of-band edits.
+
+#### Scenario: Cached fail-closed outcome keeps failing closed
+
+- **GIVEN** an account-bound pool with no active usable endpoint whose fail-closed resolution outcome is cached
+- **WHEN** further upstream operations are attempted for that account
+- **THEN** each operation MUST fail before opening an upstream network connection with the same fail-closed reason
+- **AND** it MUST NOT use the default pool, environment proxy, or direct egress
+
+#### Scenario: New binding takes effect without a direct-egress window on the mutating replica
+
+- **GIVEN** an account whose cached resolution outcome is direct-egress `None`
+- **WHEN** an operator saves an active proxy binding for that account
+- **THEN** the mutating replica's cached outcome MUST be invalidated before the binding response returns, so subsequent requests on that replica resolve the bound pool

--- a/openspec/changes/add-upstream-route-cache/tasks.md
+++ b/openspec/changes/add-upstream-route-cache/tasks.md
@@ -1,0 +1,21 @@
+## 1. Implementation
+
+- [x] 1.1 Add `NAMESPACE_UPSTREAM_ROUTE` to the cache-invalidation bus (constant + log label)
+- [x] 1.2 Add `upstream_route_cache_ttl_seconds` setting (default 60, ge=0, 0 disables)
+- [x] 1.3 Add `app/core/upstream_proxy/cache.py`: outcome-verbatim per-account cache with generation guard, TTL backstop, `invalidate()` (local clear + durable bump)
+- [x] 1.4 Consult the cache in `streaming/helpers._resolve_upstream_route_for_account`; miss path keeps the facade session/resolver calls
+- [x] 1.5 Wire poller callbacks in `app/main.py` (`upstream_route` + `settings` namespaces clear the route cache)
+- [x] 1.6 Invalidate on mutations in `app/modules/settings/api.py`: binding PUT and pool-member POST (`invalidate()` after commit), settings PUT (local clear when either upstream field changed)
+- [x] 1.7 Disable the cache globally in the test suite (`CODEX_LB_UPSTREAM_ROUTE_CACHE_TTL_SECONDS=0`) and reset it in `_reset_global_state`
+
+## 2. Tests
+
+- [x] 2.1 Unit: cache primitives — TTL expiry, 0-disables, generation guard drops stale repopulation, cached error re-raises the same reason
+- [x] 2.2 Unit: hot-path helper — second call served from cache without resolver/session calls; cached fail-closed error keeps raising without default-pool/direct fallback (trapdoor)
+- [x] 2.3 Integration: binding PUT and pool-member POST clear the local cache and durably bump `upstream_route`; settings PUT with an upstream field change clears the local cache
+- [x] 2.4 Namespace log-label sync test stays green (new namespace labeled)
+
+## 3. Validation & docs
+
+- [x] 3.1 `openspec validate --specs`, ruff, ty, architecture check, pytest (SQLite + PostgreSQL)
+- [x] 3.2 Change-level context recorded; sync stable notes into `openspec/specs/query-caching/context.md` at archive time

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,9 @@ os.environ["CODEX_LB_MODEL_REGISTRY_ENABLED"] = "false"
 os.environ["CODEX_LB_STICKY_SESSION_CLEANUP_ENABLED"] = "false"
 os.environ["CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_ENABLED"] = "false"
 os.environ["CODEX_LB_QUOTA_PLANNER_SCHEDULER_ENABLED"] = "false"
+# Route-resolution caching is opt-in per test (cache-specific tests set a TTL
+# explicitly); keeping it off preserves fresh-read semantics everywhere else.
+os.environ["CODEX_LB_UPSTREAM_ROUTE_CACHE_TTL_SECONDS"] = "0"
 # The app-level automations scheduler ticks on the real clock; with leader
 # election enabled its startup tick runs as a background task and can land
 # inside a test that stages its own due-now jobs, racing the test's
@@ -304,6 +307,12 @@ def _reset_global_state() -> None:
         settings_cache = get_settings_cache()
         settings_cache._cached_settings = None
         settings_cache._cached_at = 0.0
+    except Exception:
+        pass
+    try:
+        from app.core.upstream_proxy.cache import get_upstream_route_cache
+
+        get_upstream_route_cache().clear()
     except Exception:
         pass
     try:

--- a/tests/integration/test_cache_invalidation_bus.py
+++ b/tests/integration/test_cache_invalidation_bus.py
@@ -28,6 +28,7 @@ from app.core.cache.invalidation import (
     NAMESPACE_MODEL_REGISTRY,
     NAMESPACE_RESET_CREDITS,
     NAMESPACE_SETTINGS,
+    NAMESPACE_UPSTREAM_ROUTE,
     CacheInvalidationPoller,
     get_cache_invalidation_poller,
     set_cache_invalidation_poller,
@@ -325,6 +326,7 @@ def test_namespace_log_labels_cover_all_namespaces() -> None:
             NAMESPACE_SETTINGS,
             NAMESPACE_RESET_CREDITS,
             NAMESPACE_MODEL_REGISTRY,
+            NAMESPACE_UPSTREAM_ROUTE,
         )
     }
 

--- a/tests/integration/test_replica_guardrails.py
+++ b/tests/integration/test_replica_guardrails.py
@@ -213,7 +213,7 @@ async def test_concurrent_settings_put_loser_receives_409(async_client, monkeypa
     second_writer_committed = asyncio.Event()
     call_count = 0
 
-    async def racing_commit(self, settings):
+    async def racing_commit(self, settings, *, on_committed=None):
         nonlocal call_count
         call_count += 1
         if call_count == 1:
@@ -222,7 +222,7 @@ async def test_concurrent_settings_put_loser_receives_409(async_client, monkeypa
             # same version) commit first — the cross-replica interleaving.
             first_writer_reached_commit.set()
             await asyncio.wait_for(second_writer_committed.wait(), timeout=10)
-        return await original_commit(self, settings)
+        return await original_commit(self, settings, on_committed=on_committed)
 
     monkeypatch.setattr(SettingsRepository, "commit_refresh", racing_commit)
 
@@ -252,7 +252,7 @@ async def test_concurrent_no_op_settings_put_loser_receives_409(async_client, mo
     second_writer_committed = asyncio.Event()
     call_count = 0
 
-    async def racing_commit(self, settings):
+    async def racing_commit(self, settings, *, on_committed=None):
         nonlocal call_count
         call_count += 1
         if call_count == 1:
@@ -261,7 +261,7 @@ async def test_concurrent_no_op_settings_put_loser_receives_409(async_client, mo
             # commit a real change first.
             first_writer_reached_commit.set()
             await asyncio.wait_for(second_writer_committed.wait(), timeout=10)
-        return await original_commit(self, settings)
+        return await original_commit(self, settings, on_committed=on_committed)
 
     monkeypatch.setattr(SettingsRepository, "commit_refresh", racing_commit)
 

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -7,7 +7,14 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.cache.invalidation import (
+    NAMESPACE_UPSTREAM_ROUTE,
+    CacheInvalidationPoller,
+    set_cache_invalidation_poller,
+)
+from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
+from app.core.upstream_proxy.cache import get_upstream_route_cache
 from app.core.utils.time import utcnow
 from app.db.models import (
     Account,
@@ -16,6 +23,7 @@ from app.db.models import (
     AdditionalUsageHistory,
     ApiKey,
     ApiKeyAccountAssignment,
+    CacheInvalidation,
     HttpBridgeSessionAlias,
     HttpBridgeSessionRecord,
     HttpBridgeSessionState,
@@ -916,7 +924,10 @@ async def test_accounts_upsert_merge_by_chatgpt_identity_prefers_matching_worksp
 
 
 @pytest.mark.asyncio
-async def test_accounts_upsert_merge_by_chatgpt_identity_reconciles_duplicate_rows(db_setup):
+async def test_accounts_upsert_merge_by_chatgpt_identity_reconciles_duplicate_rows(db_setup, monkeypatch):
+    monkeypatch.setenv("CODEX_LB_UPSTREAM_ROUTE_CACHE_TTL_SECONDS", "60")
+    get_settings.cache_clear()
+    set_cache_invalidation_poller(CacheInvalidationPoller(SessionLocal))
     async with SessionLocal() as session:
         repo = AccountsRepository(session)
 
@@ -1014,12 +1025,30 @@ async def test_accounts_upsert_merge_by_chatgpt_identity_reconciles_duplicate_ro
         )
         await session.commit()
 
+        route_cache = get_upstream_route_cache()
+        route_cache.store_route(duplicate_row.id, None, generation=route_cache.generation)
+        assert route_cache.get(duplicate_row.id) is not None
+        version_before = (
+            await session.scalar(
+                select(CacheInvalidation.version).where(CacheInvalidation.namespace == NAMESPACE_UPSTREAM_ROUTE)
+            )
+            or 0
+        )
+
         reauth = _make_account_with_chatgpt_id("acc_merge_main", "merge@example.com", "chatgpt_merge")
         reauth.plan_type = "team"
         saved = await repo.upsert(reauth, merge_by_email=False, merge_by_chatgpt_identity=True)
 
         assert saved.id == "acc_merge_main"
         assert saved.plan_type == "team"
+        assert route_cache.get(duplicate_row.id) is None
+        version_after = (
+            await session.scalar(
+                select(CacheInvalidation.version).where(CacheInvalidation.namespace == NAMESPACE_UPSTREAM_ROUTE)
+            )
+            or 0
+        )
+        assert version_after > version_before
 
         rows = list(
             (await session.execute(select(Account).where(Account.chatgpt_account_id == "chatgpt_merge")))

--- a/tests/integration/test_upstream_route_cache_invalidation.py
+++ b/tests/integration/test_upstream_route_cache_invalidation.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+
+import pytest
+from sqlalchemy import select
+
+from app.core.auth import generate_unique_account_id
+from app.core.cache.invalidation import (
+    NAMESPACE_SETTINGS,
+    NAMESPACE_UPSTREAM_ROUTE,
+    get_cache_invalidation_poller,
+)
+from app.core.config.settings import get_settings
+from app.core.upstream_proxy.cache import get_upstream_route_cache
+from app.db.models import CacheInvalidation
+from app.db.session import SessionLocal
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def route_cache_ttl(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_UPSTREAM_ROUTE_CACHE_TTL_SECONDS", "60")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _encode_jwt(payload: dict) -> str:
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    body = base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+    return f"header.{body}.sig"
+
+
+async def _import_account(async_client, account_id: str, email: str) -> str:
+    auth_json = {
+        "tokens": {
+            "idToken": _encode_jwt(
+                {
+                    "email": email,
+                    "chatgpt_account_id": account_id,
+                    "https://api.openai.com/auth": {"chatgpt_plan_type": "plus"},
+                }
+            ),
+            "accessToken": "access-token",
+            "refreshToken": "refresh-token",
+            "accountId": account_id,
+        },
+    }
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+    return generate_unique_account_id(account_id, email)
+
+
+async def _create_pool_with_endpoint(async_client) -> str:
+    endpoint = await async_client.post(
+        "/api/settings/upstream-proxy/endpoints",
+        json={"name": "Proxy A", "scheme": "http", "host": "proxy.internal", "port": 8080},
+    )
+    assert endpoint.status_code == 200
+    pool = await async_client.post(
+        "/api/settings/upstream-proxy/pools",
+        json={"name": "Pool A", "endpointIds": [endpoint.json()["id"]]},
+    )
+    assert pool.status_code == 200
+    return pool.json()["id"]
+
+
+async def _upstream_route_namespace_version() -> int:
+    async with SessionLocal() as session:
+        version = await session.scalar(
+            select(CacheInvalidation.version).where(CacheInvalidation.namespace == NAMESPACE_UPSTREAM_ROUTE)
+        )
+    return version or 0
+
+
+def _seed_dummy_entry() -> None:
+    cache = get_upstream_route_cache()
+    cache.store_route("seeded-account", None, generation=cache.generation)
+    assert cache.get("seeded-account") is not None
+
+
+async def test_binding_upsert_clears_cache_and_bumps_namespace(async_client, route_cache_ttl) -> None:
+    account_id = await _import_account(async_client, "acc-route-cache-binding", "route-cache-binding@example.com")
+    pool_id = await _create_pool_with_endpoint(async_client)
+    version_before = await _upstream_route_namespace_version()
+    _seed_dummy_entry()
+
+    response = await async_client.put(
+        f"/api/settings/upstream-proxy/accounts/{account_id}/binding",
+        json={"poolId": pool_id, "isActive": True},
+    )
+
+    assert response.status_code == 200
+    assert get_upstream_route_cache().get("seeded-account") is None
+    assert await _upstream_route_namespace_version() > version_before
+
+
+async def test_pool_member_add_clears_cache_and_bumps_namespace(async_client, route_cache_ttl) -> None:
+    endpoint = await async_client.post(
+        "/api/settings/upstream-proxy/endpoints",
+        json={"name": "Proxy B", "scheme": "http", "host": "proxy-b.internal", "port": 8081},
+    )
+    assert endpoint.status_code == 200
+    pool = await async_client.post(
+        "/api/settings/upstream-proxy/pools",
+        json={"name": "Pool B", "endpointIds": []},
+    )
+    assert pool.status_code == 200
+    # Endpoint/pool creation cannot be referenced by any cached outcome yet, so
+    # neither bumps the namespace.
+    assert await _upstream_route_namespace_version() == 0
+    version_before = await _upstream_route_namespace_version()
+    _seed_dummy_entry()
+
+    response = await async_client.post(
+        f"/api/settings/upstream-proxy/pools/{pool.json()['id']}/members",
+        json={"endpointId": endpoint.json()["id"]},
+    )
+
+    assert response.status_code == 200
+    assert get_upstream_route_cache().get("seeded-account") is None
+    assert await _upstream_route_namespace_version() > version_before
+
+
+async def test_account_delete_clears_cache_and_bumps_namespace(async_client, route_cache_ttl) -> None:
+    # Deletion cascades the binding row away, and account ids are
+    # deterministic, so delete-then-re-import must not replay the deleted
+    # account's cached outcome.
+    account_id = await _import_account(async_client, "acc-route-cache-delete", "route-cache-delete@example.com")
+    version_before = await _upstream_route_namespace_version()
+    _seed_dummy_entry()
+
+    response = await async_client.delete(f"/api/accounts/{account_id}")
+
+    assert response.status_code == 200
+    assert get_upstream_route_cache().get("seeded-account") is None
+    assert await _upstream_route_namespace_version() > version_before
+
+
+@pytest.mark.parametrize("namespace", [NAMESPACE_UPSTREAM_ROUTE, NAMESPACE_SETTINGS])
+async def test_namespace_bump_clears_route_cache_via_lifespan_poller(async_client, route_cache_ttl, namespace) -> None:
+    # Peer replicas converge exclusively through the poller callbacks
+    # registered in app/main.py; a durable bump observed by the running
+    # lifespan poller must clear the route cache within one poll interval.
+    _seed_dummy_entry()
+    poller = get_cache_invalidation_poller()
+    assert poller is not None
+    assert await poller.bump(namespace)
+
+    deadline = asyncio.get_event_loop().time() + 5.0
+    while asyncio.get_event_loop().time() < deadline:
+        if get_upstream_route_cache().get("seeded-account") is None:
+            break
+        await asyncio.sleep(0.05)
+    assert get_upstream_route_cache().get("seeded-account") is None
+
+
+async def test_settings_upstream_field_change_clears_local_cache(async_client, route_cache_ttl) -> None:
+    settings_response = await async_client.get("/api/settings")
+    assert settings_response.status_code == 200
+    body = settings_response.json()
+    body["upstreamProxyRoutingEnabled"] = True
+    version_before = await _upstream_route_namespace_version()
+    _seed_dummy_entry()
+
+    response = await async_client.put("/api/settings", json=body)
+
+    assert response.status_code == 200
+    assert get_upstream_route_cache().get("seeded-account") is None
+    # The settings-namespace bump alone enqueues no retry on write failure, so
+    # the upstream field change must also durably bump ``upstream_route``.
+    assert await _upstream_route_namespace_version() > version_before
+
+
+async def test_settings_change_clears_route_cache_before_first_post_commit_await(
+    async_client, route_cache_ttl, monkeypatch
+) -> None:
+    # The settings row is committed before the durable bumps are awaited; a
+    # concurrent request served during those awaits must not resolve from the
+    # stale route cache, so the clear must precede the settings-cache
+    # invalidation await.
+    from app.core.config.settings_cache import get_settings_cache
+
+    settings_response = await async_client.get("/api/settings")
+    body = settings_response.json()
+    body["upstreamProxyRoutingEnabled"] = True
+    _seed_dummy_entry()
+
+    settings_cache = get_settings_cache()
+    real_invalidate = settings_cache.invalidate
+    observed: dict[str, bool] = {}
+
+    async def spying_invalidate(*, propagate: bool = True) -> None:
+        observed.setdefault(
+            "route_cache_cleared_first",
+            get_upstream_route_cache().get("seeded-account") is None,
+        )
+        await real_invalidate(propagate=propagate)
+
+    monkeypatch.setattr(settings_cache, "invalidate", spying_invalidate)
+
+    response = await async_client.put("/api/settings", json=body)
+
+    assert response.status_code == 200
+    assert observed["route_cache_cleared_first"] is True
+
+
+async def test_repository_update_clears_route_cache_before_refresh_await(
+    db_setup, route_cache_ttl, monkeypatch
+) -> None:
+    # The committed settings row is visible to concurrent requests as soon as
+    # the commit returns; the clear must therefore run before the refresh
+    # await inside SettingsRepository.commit_refresh, not after the repository
+    # call returns.
+    from app.modules.settings.repository import SettingsRepository
+
+    async with SessionLocal() as session:
+        repo = SettingsRepository(session)
+        await repo.get_or_create()
+        _seed_dummy_entry()
+        real_refresh = session.refresh
+        observed: dict[str, bool] = {}
+
+        async def spying_refresh(instance, *args, **kwargs):
+            observed.setdefault(
+                "cleared_before_refresh",
+                get_upstream_route_cache().get("seeded-account") is None,
+            )
+            return await real_refresh(instance, *args, **kwargs)
+
+        monkeypatch.setattr(session, "refresh", spying_refresh)
+        await repo.update(upstream_proxy_routing_enabled=True)
+
+    assert observed["cleared_before_refresh"] is True

--- a/tests/unit/test_upstream_route_cache.py
+++ b/tests/unit/test_upstream_route_cache.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from app.core.cache.invalidation import (
+    NAMESPACE_UPSTREAM_ROUTE,
+    CacheInvalidationPoller,
+    set_cache_invalidation_poller,
+)
+from app.core.config.settings import get_settings
+from app.core.upstream_proxy.cache import UpstreamRouteCache
+from app.core.upstream_proxy.resolver import UpstreamProxyRouteError
+from app.core.upstream_proxy.types import ResolvedProxyEndpoint, ResolvedUpstreamRoute
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def route_cache_ttl(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_UPSTREAM_ROUTE_CACHE_TTL_SECONDS", "60")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _route(endpoint_id: str = "ep-1") -> ResolvedUpstreamRoute:
+    return ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="pool-1",
+        endpoint=ResolvedProxyEndpoint(id=endpoint_id, scheme="http", host="proxy.internal", port=8080),
+    )
+
+
+def test_store_and_get_roundtrip(route_cache_ttl) -> None:
+    cache = UpstreamRouteCache()
+    route = _route()
+    cache.store_route("acct-1", route, generation=cache.generation)
+    cache.store_route("acct-2", None, generation=cache.generation)
+
+    hit = cache.get("acct-1")
+    assert hit is not None
+    assert hit.unwrap("acct-1") is route
+    direct = cache.get("acct-2")
+    assert direct is not None
+    assert direct.unwrap("acct-2") is None
+    assert cache.get("acct-3") is None
+
+
+def test_ttl_zero_disables_cache() -> None:
+    cache = UpstreamRouteCache()
+    cache.store_route("acct-1", _route(), generation=cache.generation)
+    assert cache.get("acct-1") is None
+
+
+def test_entry_expires_after_ttl(route_cache_ttl, monkeypatch) -> None:
+    import app.core.upstream_proxy.cache as cache_module
+
+    now = 1000.0
+    monkeypatch.setattr(cache_module.time, "monotonic", lambda: now)
+    cache = UpstreamRouteCache()
+    cache.store_route("acct-1", _route(), generation=cache.generation)
+    assert cache.get("acct-1") is not None
+
+    now = 1061.0
+    assert cache.get("acct-1") is None
+
+
+def test_generation_guard_drops_stale_repopulation(route_cache_ttl) -> None:
+    cache = UpstreamRouteCache()
+    generation = cache.generation
+    cache.clear()
+    cache.store_route("acct-1", _route(), generation=generation)
+    assert cache.get("acct-1") is None
+
+
+def test_cached_error_reraises_same_reason(route_cache_ttl) -> None:
+    cache = UpstreamRouteCache()
+    error = UpstreamProxyRouteError("pool_has_no_active_endpoints", account_id="acct-1", pool_id="pool-1")
+    cache.store_error("acct-1", error, generation=cache.generation)
+
+    entry = cache.get("acct-1")
+    assert entry is not None
+    for _ in range(2):
+        with pytest.raises(UpstreamProxyRouteError) as excinfo:
+            entry.unwrap("acct-1")
+        assert excinfo.value.reason == "pool_has_no_active_endpoints"
+        assert excinfo.value.account_id == "acct-1"
+        assert excinfo.value.pool_id == "pool-1"
+        assert excinfo.value is not error
+
+
+async def test_invalidate_falls_back_to_coalesced_bump_on_failure(route_cache_ttl) -> None:
+    class _FakePoller:
+        def __init__(self) -> None:
+            self.bumped: list[str] = []
+            self.requested: list[str] = []
+
+        async def bump(self, namespace: str) -> bool:
+            self.bumped.append(namespace)
+            return False
+
+        def request_bump(self, namespace: str) -> None:
+            self.requested.append(namespace)
+
+    poller = _FakePoller()
+    set_cache_invalidation_poller(cast(CacheInvalidationPoller, poller))
+    try:
+        cache = UpstreamRouteCache()
+        cache.store_route("acct-1", _route(), generation=cache.generation)
+        await cache.invalidate()
+        assert cache.get("acct-1") is None
+        assert poller.bumped == [NAMESPACE_UPSTREAM_ROUTE]
+        # bump() never raises; a failed durable bump must enqueue the coalesced
+        # retry so peers still converge once the write path recovers.
+        assert poller.requested == [NAMESPACE_UPSTREAM_ROUTE]
+    finally:
+        set_cache_invalidation_poller(None)
+
+
+def test_clear_empties_and_advances_generation(route_cache_ttl) -> None:
+    cache = UpstreamRouteCache()
+    cache.store_route("acct-1", _route(), generation=cache.generation)
+    generation = cache.generation
+    cache.clear()
+    assert cache.get("acct-1") is None
+    assert cache.generation == generation + 1

--- a/tests/unit/test_upstream_route_cache_hot_path.py
+++ b/tests/unit/test_upstream_route_cache_hot_path.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+import app.modules.proxy.service as proxy_service
+from app.core.config.settings import get_settings
+from app.core.upstream_proxy.cache import get_upstream_route_cache
+from app.core.upstream_proxy.resolver import UpstreamProxyRouteError
+from app.core.upstream_proxy.types import ResolvedProxyEndpoint, ResolvedUpstreamRoute
+from app.db.models import Account
+from app.modules.proxy._service.streaming import helpers
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def route_cache_ttl(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_UPSTREAM_ROUTE_CACHE_TTL_SECONDS", "60")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+class _FakeSession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+
+def _route() -> ResolvedUpstreamRoute:
+    return ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="pool-1",
+        endpoint=ResolvedProxyEndpoint(id="ep-1", scheme="http", host="proxy.internal", port=8080),
+    )
+
+
+def _wire_resolver(monkeypatch, outcome):
+    calls = {"count": 0}
+
+    async def fake_resolve(session, *, account_id, operation, scope, encryptor):
+        calls["count"] += 1
+        assert scope == "account"
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(proxy_service, "SessionLocal", lambda: _FakeSession())
+    monkeypatch.setattr(proxy_service, "resolve_upstream_route", fake_resolve)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_second_resolution_served_from_cache(route_cache_ttl, monkeypatch) -> None:
+    route = _route()
+    calls = _wire_resolver(monkeypatch, route)
+    proxy = SimpleNamespace(_encryptor=None)
+    account = cast(Account, SimpleNamespace(id="acct-1"))
+
+    first = await helpers._resolve_upstream_route_for_account(proxy, account, operation="responses")
+    second = await helpers._resolve_upstream_route_for_account(proxy, account, operation="responses")
+
+    assert first is route
+    assert second is route
+    assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_direct_egress_none_is_cached(route_cache_ttl, monkeypatch) -> None:
+    calls = _wire_resolver(monkeypatch, None)
+    proxy = SimpleNamespace(_encryptor=None)
+    account = cast(Account, SimpleNamespace(id="acct-1"))
+
+    assert await helpers._resolve_upstream_route_for_account(proxy, account, operation="responses") is None
+    assert await helpers._resolve_upstream_route_for_account(proxy, account, operation="responses") is None
+    assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cached_fail_closed_error_keeps_failing_closed(route_cache_ttl, monkeypatch) -> None:
+    error = UpstreamProxyRouteError("pool_has_no_active_endpoints", account_id="acct-1", pool_id="pool-1")
+    calls = _wire_resolver(monkeypatch, error)
+    proxy = SimpleNamespace(_encryptor=None)
+    account = cast(Account, SimpleNamespace(id="acct-1"))
+
+    for _ in range(2):
+        with pytest.raises(UpstreamProxyRouteError) as excinfo:
+            await helpers._resolve_upstream_route_for_account(proxy, account, operation="responses")
+        assert excinfo.value.reason == "pool_has_no_active_endpoints"
+        assert excinfo.value.pool_id == "pool-1"
+    # The second failure must come from the cache, not a re-resolution — and
+    # it must never degrade to the default pool or direct egress (no further
+    # resolver calls that could take a different branch).
+    assert calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_invalidation_forces_re_resolution(route_cache_ttl, monkeypatch) -> None:
+    route = _route()
+    calls = _wire_resolver(monkeypatch, route)
+    proxy = SimpleNamespace(_encryptor=None)
+    account = cast(Account, SimpleNamespace(id="acct-1"))
+
+    await helpers._resolve_upstream_route_for_account(proxy, account, operation="responses")
+    get_upstream_route_cache().clear()
+    await helpers._resolve_upstream_route_for_account(proxy, account, operation="responses")
+
+    assert calls["count"] == 2


### PR DESCRIPTION
## Why

Every proxy request pays an upstream-route resolution before the first upstream byte: `_resolve_upstream_route_for_account` opens a fresh `SessionLocal` and issues 1–3 uncached SELECTs (account proxy binding, dashboard settings row, proxy pool + members + endpoints). Route inputs only change through rare admin mutations. This is the last unaddressed item from the 2026-07-12 performance audit (follow-up to #1241).

## What

- **New `app/core/upstream_proxy/cache.py`**: per-account cache of resolver **outcomes, verbatim** — a resolved route, direct-egress `None`, or the fail-closed `UpstreamProxyRouteError` reason. A hit reproduces the resolver's outcome exactly, so caching can never turn a fail-closed or routed outcome into direct egress (the documented degradation paths are preserved; cached errors re-raise with the original reason/pool).
- **Hot path** (`streaming/helpers._resolve_upstream_route_for_account`, the funnel for streaming/ws/file-ops/compact/transcribe/codex-control/warmup): consult the cache; the miss path keeps the existing facade session + resolver calls. Background callers (usage refresh, model discovery, oauth, automations) keep fresh reads.
- **Invalidation** (new `upstream_route` bus namespace):
  - binding PUT, pool-member POST, account deletion (cascades the binding row; account ids are deterministic so delete→re-import regenerates the same key): local clear + awaited durable bump **before the response returns**; when the non-raising bump write fails, the coalesced `request_bump` fallback retries every poll cycle.
  - upstream settings fields: existing durable `settings` bump for peers + immediate local clear when either field changed.
  - endpoint/pool **creation** intentionally does not bump — a new endpoint/pool cannot be referenced by any cached outcome yet (bindings and the default-pool setting validate existence).
- **TTL backstop**: `CODEX_LB_UPSTREAM_ROUTE_CACHE_TTL_SECONDS` (default 60 s, `0` disables) bounds out-of-band DB edits only; bumps remain the binding freshness mechanism. Test suite sets `0` globally; cache tests opt in.
- Generation counter guards stale repopulation (outcome resolved concurrently with an invalidation is dropped).

## Staleness bounds

| Path | Bound |
|---|---|
| Admin mutation, same replica | 0 (cleared pre-response) |
| Admin mutation, peer replica | ≤ 1 poll interval (~0.5 s); coalesced retry after bump-write failure |
| Out-of-band DB edit | ≤ TTL (60 s default) |

## Tests

- Unit: cache primitives (TTL expiry, 0-disables, generation guard, error re-raise verbatim, coalesced-bump fallback on durable-bump failure).
- Unit: hot-path helper — second call served from cache without resolver/session; **cached fail-closed error keeps failing closed with no default-pool/direct fallback**; invalidation forces re-resolution.
- Integration: binding PUT / pool-member POST / account DELETE clear the local cache and durably bump `upstream_route`; settings PUT clears locally; **peer-side poller-driven clears pinned through the real lifespan wiring** for both `upstream_route` and `settings` namespaces; namespace log-label sync test extended.
- Suites green on SQLite (full: 5095 passed) and PostgreSQL 16 (affected integration/unit suites).

## OpenSpec

`openspec/changes/add-upstream-route-cache/` — proposal, design (invalidation map, trapdoor analysis, staleness bounds, credential-residency note), delta specs for `query-caching` and `upstream-proxy-routing`. `openspec validate --specs`: 42/42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)