### PR TITLE
fix(proxy): recover stale response-create gates

### DIFF
--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -275,6 +275,36 @@ def _http_bridge_capacity_wait_plan(
     return bounded_wait_seconds, account_capacity_wait_seconds, message
 
 
+def _http_bridge_can_replace_retired_gate_session(
+    exc: ProxyResponseError,
+    *,
+    session: "_HTTPBridgeSession",
+    request_state: _WebSocketRequestState,
+    request_was_enqueued: bool,
+) -> bool:
+    # A gate timeout happens before this waiter is appended or sent.  Once the
+    # stale owner has retired the session, only that fully cleaned pre-submit
+    # state is safe to carry to a replacement; any response/replay/downstream
+    # marker makes the upstream acceptance boundary ambiguous.
+    code, _message = _proxy_error_code_message(exc)
+    return (
+        code == "response_create_gate_timeout"
+        and session.closed
+        and session.key.strength == "hard"
+        and not request_was_enqueued
+        and request_state.request_text is not None
+        and request_state.event_queue is not None
+        and request_state.response_id is None
+        and request_state.response_event_count == 0
+        and request_state.replay_count == 0
+        and request_state.last_downstream_sequence_number is None
+        and not request_state.downstream_visible
+        and not request_state.awaiting_response_created
+        and request_state.response_create_gate is None
+        and not request_state.response_create_gate_acquired
+    )
+
+
 async def _iter_account_capacity_wait_sse(
     *,
     request_id: str,
@@ -1520,6 +1550,112 @@ class _HTTPBridgeStreamingMixin:
                     default_code="upstream_error",
                     default_message="Upstream error",
                 )
+                return
+            async with session.pending_lock:
+                request_was_enqueued = request_state in session.pending_requests
+            if _http_bridge_can_replace_retired_gate_session(
+                exc,
+                session=session,
+                request_state=request_state,
+                request_was_enqueued=request_was_enqueued,
+            ):
+                _log_http_bridge_event(
+                    "replace_retired_gate",
+                    session.key,
+                    account_id=session.account.id,
+                    model=effective_payload.model,
+                    detail="reason=response_create_gate_timeout_stuck_pending",
+                    cache_key_family=session.key.affinity_kind,
+                    model_class=_extract_model_class(effective_payload.model) if effective_payload.model else None,
+                    owner_check_applied=True,
+                )
+                replacement_preferred_account_id = request_state.preferred_account_id
+                if request_state.previous_response_id is not None and replacement_preferred_account_id is None:
+                    replacement_preferred_account_id = session.account.id
+                while True:
+                    try:
+                        replacement_session = await self._get_or_create_http_bridge_session(
+                            bridge_session_key,
+                            headers=dict(headers),
+                            affinity=affinity,
+                            api_key=api_key,
+                            request_model=effective_payload.model,
+                            request_service_tier=request_state.requested_service_tier,
+                            idle_ttl_seconds=_effective_http_bridge_idle_ttl_seconds(
+                                affinity=affinity,
+                                idle_ttl_seconds=idle_ttl_seconds,
+                                codex_idle_ttl_seconds=codex_idle_ttl_seconds,
+                                prompt_cache_idle_ttl_seconds=prompt_cache_idle_ttl_seconds,
+                            ),
+                            max_sessions=max_sessions,
+                            previous_response_id=request_state.previous_response_id,
+                            gateway_safe_mode=runtime_config.gateway_safe_mode,
+                            allow_forward_to_owner=False,
+                            forwarded_request=forwarded_request,
+                            forwarded_original_request_unanchored=original_request_unanchored,
+                            durable_lookup=durable_lookup,
+                            request_stage=request_state.request_stage,
+                            preferred_account_id=replacement_preferred_account_id,
+                            fallback_on_preferred_account_unavailable=not (
+                                file_required_preferred_account or request_state.previous_response_id is not None
+                            ),
+                            allow_previous_response_recovery_rebind=request_state.previous_response_id is not None,
+                            request_usage_budget=request_state.request_usage_budget,
+                            request_deadline=request_deadline,
+                            session_header_fallback_key=session_header_fallback_key,
+                        )
+                    except ProxyResponseError as capacity_exc:
+                        wait_plan = _http_bridge_capacity_wait_plan(capacity_exc, request_deadline=request_deadline)
+                        if wait_plan is None:
+                            raise
+                        bounded_wait_seconds, account_capacity_wait_seconds, message = wait_plan
+                        logger.info(
+                            "Waiting for an account to recover before replacing retired HTTP bridge gate "
+                            "request_id=%s model=%s sleep_seconds=%.1f recovery_hint_seconds=%.1f error=%s",
+                            request_id,
+                            effective_payload.model,
+                            bounded_wait_seconds,
+                            account_capacity_wait_seconds,
+                            message,
+                        )
+                        async for line in _iter_account_capacity_wait_sse(
+                            request_id=request_id,
+                            reason=message,
+                            sleep_seconds=bounded_wait_seconds,
+                            emit_keepalives=not propagate_http_errors,
+                        ):
+                            yield line
+                        if _service_time().monotonic() >= request_deadline:
+                            raise
+                        continue
+                    break
+                if initial_handoff_scope_id is not None:
+                    _release_http_bridge_unanchored_handoff(
+                        initial_handoff_session,
+                        request_scope_id=initial_handoff_scope_id,
+                    )
+                    _reserve_http_bridge_unanchored_handoff(
+                        replacement_session,
+                        request_scope_id=initial_handoff_scope_id,
+                    )
+                    initial_handoff_session = replacement_session
+                replacement_events: AsyncGenerator[str, None] = self._stream_http_bridge_session_events(
+                    replacement_session,
+                    request_state=request_state,
+                    text_data=text_data,
+                    queue_limit=queue_limit,
+                    propagate_http_errors=propagate_http_errors,
+                    downstream_turn_state=downstream_turn_state,
+                    request_deadline=request_deadline,
+                )
+                try:
+                    async for event_block in replacement_events:
+                        yield event_block
+                finally:
+                    try:
+                        await replacement_events.aclose()
+                    except Exception:
+                        pass
                 return
             if (
                 _http_bridge_should_attempt_soft_affinity_reroute(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1343,6 +1343,7 @@ class ProxyService(
                     and state.awaiting_response_created
                     and not state.downstream_visible
                     and state.latency_response_created_ms is None
+                    and state.response_event_count == 0
                     and max(0.0, now - state.started_at) >= threshold_seconds
                     for state in pending_states
                 )

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1334,10 +1334,8 @@ class ProxyService(
                         300.0,
                     )
                 )
-                # Leading telemetry such as ``codex.rate_limits`` records
-                # first-upstream-event latency but does not assign a response
-                # or release this gate.  Only the response-created milestone
-                # proves that a pre-created gate owner made protocol progress.
+                # Leading telemetry records latency without assigning a response
+                # or releasing this gate; only response-created proves progress.
                 should_retire_stuck_session = any(
                     state.transport == _REQUEST_TRANSPORT_HTTP
                     and not state.skip_request_log

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1334,13 +1334,16 @@ class ProxyService(
                         300.0,
                     )
                 )
+                # Leading telemetry such as ``codex.rate_limits`` records
+                # first-upstream-event latency but does not assign a response
+                # or release this gate.  Only the response-created milestone
+                # proves that a pre-created gate owner made protocol progress.
                 should_retire_stuck_session = any(
                     state.transport == _REQUEST_TRANSPORT_HTTP
                     and not state.skip_request_log
                     and state.response_create_gate_acquired
                     and state.awaiting_response_created
                     and not state.downstream_visible
-                    and state.latency_first_upstream_event_ms is None
                     and state.latency_response_created_ms is None
                     and max(0.0, now - state.started_at) >= threshold_seconds
                     for state in pending_states

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -7,7 +7,6 @@ import re
 import time
 from collections.abc import Awaitable, Callable, Collection
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
 from typing import Any, AsyncIterator, Literal, Mapping, NoReturn, TypeVar, cast
 
 import aiohttp
@@ -281,6 +280,9 @@ from app.modules.proxy._service.http_bridge.helpers import (
 )
 from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_turn_state_alias_key as _http_bridge_turn_state_alias_key,
+)
+from app.modules.proxy._service.http_bridge.helpers import (
+    _HTTPBridgeRuntimeConfig as _HTTPBridgeRuntimeConfig,
 )
 from app.modules.proxy._service.http_bridge.helpers import (
     _is_http_bridge_previous_response_output_item as _is_http_bridge_previous_response_output_item,
@@ -895,17 +897,6 @@ _SECURITY_WORK_NO_AUTHORIZED_ACCOUNTS_MESSAGE = (
     "security work. codex-lb is continuing with normal account selection; the upstream request may still fail until "
     "an account with Trusted Access for Cyber is marked as security-work-authorized."
 )
-
-
-@dataclass(frozen=True, slots=True)
-class _HTTPBridgeRuntimeConfig:
-    enabled: bool
-    idle_ttl_seconds: float
-    codex_idle_ttl_seconds: float
-    max_sessions: int
-    queue_limit: int
-    prompt_cache_idle_ttl_seconds: float
-    gateway_safe_mode: bool
 
 
 def _estimated_lease_tokens_from_request_usage_budget(budget: ApiKeyRequestUsageBudget | None) -> float:

--- a/openspec/changes/retire-precreated-gates-after-telemetry/proposal.md
+++ b/openspec/changes/retire-precreated-gates-after-telemetry/proposal.md
@@ -20,6 +20,9 @@ blocked until process restart.
   even before text becomes visible.
 - Keep the existing transport, visible-request, gate-ownership, downstream
   visibility, response-created, and age safeguards unchanged.
+- Transparently submit the still-unsubmitted hard-affinity waiter on a fresh
+  bridge after it retires the stale owner, while preserving its original
+  request deadline and any previous-response account pin.
 - Add a bridge-path regression that processes real leading rate-limit telemetry
   before exercising the stale-gate timeout.
 
@@ -32,3 +35,6 @@ blocked until process restart.
   retirement.
 - Pre-created streams emitting response lifecycle events remain protected from
   retirement.
+- The waiter that discovers and retires a stale hard-affinity owner no longer
+  needs a client reconnect when its upstream acceptance boundary is provably
+  untouched.

--- a/openspec/changes/retire-precreated-gates-after-telemetry/proposal.md
+++ b/openspec/changes/retire-precreated-gates-after-telemetry/proposal.md
@@ -16,6 +16,8 @@ blocked until process restart.
   milestone that owns the gate: whether `response.created` arrived.
 - Do not let leading non-visible telemetry such as `codex.rate_limits` suppress
   stale-gate retirement.
+- Keep pre-created `response.*` lifecycle activity protected from retirement,
+  even before text becomes visible.
 - Keep the existing transport, visible-request, gate-ownership, downstream
   visibility, response-created, and age safeguards unchanged.
 - Add a bridge-path regression that processes real leading rate-limit telemetry
@@ -27,4 +29,6 @@ blocked until process restart.
 - HTTP bridge sessions whose upstream sends telemetry but never creates a
   response self-heal after the configured retirement threshold.
 - Healthy created or downstream-visible streams remain protected from
+  retirement.
+- Pre-created streams emitting response lifecycle events remain protected from
   retirement.

--- a/openspec/changes/retire-precreated-gates-after-telemetry/proposal.md
+++ b/openspec/changes/retire-precreated-gates-after-telemetry/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Issue #1206 shows HTTP bridge sessions remaining wedged behind a
+`response_create_gate` for more than 800 seconds even though the configured
+stuck-gate retirement threshold is 300 seconds. The upstream Codex protocol can
+emit `codex.rate_limits` before `response.created`. That telemetry is attributed
+to the sole pending request and records first-upstream-event latency, but it
+does not assign a response ID or release the response-create gate. The current
+retirement predicate incorrectly treats that latency marker as proof of request
+progress, so every later gate waiter skips retirement and the session remains
+blocked until process restart.
+
+## What Changes
+
+- Treat a pre-created HTTP bridge request as stuck based on the protocol
+  milestone that owns the gate: whether `response.created` arrived.
+- Do not let leading non-visible telemetry such as `codex.rate_limits` suppress
+  stale-gate retirement.
+- Keep the existing transport, visible-request, gate-ownership, downstream
+  visibility, response-created, and age safeguards unchanged.
+- Add a bridge-path regression that processes real leading rate-limit telemetry
+  before exercising the stale-gate timeout.
+
+## Impact
+
+- Affected capability: `proxy-admission-control`.
+- HTTP bridge sessions whose upstream sends telemetry but never creates a
+  response self-heal after the configured retirement threshold.
+- Healthy created or downstream-visible streams remain protected from
+  retirement.

--- a/openspec/changes/retire-precreated-gates-after-telemetry/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/retire-precreated-gates-after-telemetry/specs/proxy-admission-control/spec.md
@@ -11,7 +11,9 @@ non-visible upstream event before `response.created`, including
 `codex.rate_limits`, MUST NOT by itself suppress retirement because such an
 event neither assigns the response nor releases the gate. The retirement MUST
 emit a structured low-cardinality log and a Prometheus counter without raw keys
-or prompt content.
+or prompt content. Pre-created `response.*` lifecycle activity MUST count as
+response progress and suppress stuck-gate retirement even when it has not yet
+produced downstream-visible text.
 
 #### Scenario: Leading rate-limit telemetry does not mask a stuck pre-created request
 
@@ -27,3 +29,10 @@ or prompt content.
 - **GIVEN** a pending HTTP bridge request has received `response.created` or produced downstream-visible output
 - **WHEN** another visible request times out waiting for the gate
 - **THEN** the proxy does not classify the active stream as a stuck pre-created gate owner
+
+#### Scenario: Pre-created response lifecycle activity is not retired
+
+- **GIVEN** a pending HTTP bridge request has not received `response.created`
+- **BUT** upstream is emitting `response.*` lifecycle events for that request
+- **WHEN** another visible request times out waiting for the gate
+- **THEN** the proxy does not retire the actively progressing request

--- a/openspec/changes/retire-precreated-gates-after-telemetry/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/retire-precreated-gates-after-telemetry/specs/proxy-admission-control/spec.md
@@ -13,7 +13,13 @@ event neither assigns the response nor releases the gate. The retirement MUST
 emit a structured low-cardinality log and a Prometheus counter without raw keys
 or prompt content. Pre-created `response.*` lifecycle activity MUST count as
 response progress and suppress stuck-gate retirement even when it has not yet
-produced downstream-visible text.
+produced downstream-visible text. If the timing-out waiter has hard affinity
+and remains definitively unsubmitted, with no upstream response, replay, or
+downstream sequence markers, the proxy MUST acquire a fresh bridge and submit
+that waiter once within its original request deadline. An anchored waiter MUST
+remain pinned to the previous-response owner account. The proxy MUST NOT reuse
+the retired session object or transparently retry an ambiguously submitted
+request.
 
 #### Scenario: Leading rate-limit telemetry does not mask a stuck pre-created request
 
@@ -22,7 +28,14 @@ produced downstream-visible text.
 - **AND** the pending request becomes older than the configured stuck-gate retirement threshold
 - **WHEN** another visible request times out waiting for that gate
 - **THEN** the proxy retires the stuck bridge session
-- **AND** the waiter is rejected cleanly with `response_create_gate_timeout`
+- **AND** if the waiter has hard affinity and is still definitively unsubmitted, the proxy submits it once on a fresh bridge
+- **AND** the waiter keeps its original deadline and any previous-response account pin
+
+#### Scenario: Ambiguous waiter is not moved to a replacement bridge
+
+- **GIVEN** a gate waiter has a response event, downstream sequence, visible output, replay marker, or pending-queue membership
+- **WHEN** its bridge is retired during gate contention
+- **THEN** the proxy does not transparently submit that waiter on another bridge
 
 #### Scenario: Healthy active stream is not retired during a normal wait
 

--- a/openspec/changes/retire-precreated-gates-after-telemetry/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/retire-precreated-gates-after-telemetry/specs/proxy-admission-control/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Stuck HTTP bridge response-create gate sessions are retired
+
+When a visible HTTP bridge request times out waiting for a per-session
+response-create gate, the proxy MUST retire the bridge session only if a
+pending visible request still owns the gate, is still awaiting
+`response.created`, has not produced downstream-visible output, and its age
+meets or exceeds the configured stuck-gate retirement threshold. Receiving a
+non-visible upstream event before `response.created`, including
+`codex.rate_limits`, MUST NOT by itself suppress retirement because such an
+event neither assigns the response nor releases the gate. The retirement MUST
+emit a structured low-cardinality log and a Prometheus counter without raw keys
+or prompt content.
+
+#### Scenario: Leading rate-limit telemetry does not mask a stuck pre-created request
+
+- **GIVEN** a visible HTTP bridge request owns the response-create gate
+- **AND** upstream emits `codex.rate_limits` but never emits `response.created`
+- **AND** the pending request becomes older than the configured stuck-gate retirement threshold
+- **WHEN** another visible request times out waiting for that gate
+- **THEN** the proxy retires the stuck bridge session
+- **AND** the waiter is rejected cleanly with `response_create_gate_timeout`
+
+#### Scenario: Healthy active stream is not retired during a normal wait
+
+- **GIVEN** a pending HTTP bridge request has received `response.created` or produced downstream-visible output
+- **WHEN** another visible request times out waiting for the gate
+- **THEN** the proxy does not classify the active stream as a stuck pre-created gate owner

--- a/openspec/changes/retire-precreated-gates-after-telemetry/tasks.md
+++ b/openspec/changes/retire-precreated-gates-after-telemetry/tasks.md
@@ -2,4 +2,7 @@
 - [x] Prove the telemetry records first-event latency without releasing the response-create gate.
 - [x] Retire the old pre-created session when a later gate attempt times out past the threshold.
 - [x] Preserve the existing healthy-created-stream non-retirement coverage.
+- [x] Replace the retired session for a definitively unsubmitted hard-affinity waiter.
+- [x] Preserve the original request deadline and previous-response account ownership on replacement.
+- [x] Add negative guards for every upstream/downstream ambiguity marker.
 - [x] Run focused unit/integration, lint, type, and strict OpenSpec validation.

--- a/openspec/changes/retire-precreated-gates-after-telemetry/tasks.md
+++ b/openspec/changes/retire-precreated-gates-after-telemetry/tasks.md
@@ -1,0 +1,5 @@
+- [x] Add a regression that feeds leading `codex.rate_limits` through the HTTP bridge event processor.
+- [x] Prove the telemetry records first-event latency without releasing the response-create gate.
+- [x] Retire the old pre-created session when a later gate attempt times out past the threshold.
+- [x] Preserve the existing healthy-created-stream non-retirement coverage.
+- [x] Run focused unit/integration, lint, type, and strict OpenSpec validation.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -7041,6 +7041,128 @@ async def test_http_bridge_stale_gate_retires_after_leading_rate_limit_telemetry
 
 
 @pytest.mark.asyncio
+async def test_codex_responses_http_bridge_replaces_retired_gate_without_client_retry(
+    async_client,
+    app_instance,
+    monkeypatch,
+):
+    _install_bridge_settings_with_limits(
+        monkeypatch,
+        enabled=True,
+        admission_wait_timeout_seconds=0.001,
+    )
+    proxy_module.get_settings().http_responses_session_bridge_stuck_gate_retire_after_seconds = 0.01
+    account_id = await _import_account(
+        async_client,
+        "acc-http-bridge-retired-gate-replace",
+        "http-bridge-retired-gate-replace@example.com",
+    )
+    account = await _get_account(account_id)
+    service = get_proxy_service_for_app(app_instance)
+    replacement_upstream = _FakeBridgeUpstreamWebSocket()
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None, error_code=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        return replacement_upstream
+
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    request_headers = {
+        "session_id": "retired-gate-replace",
+        "x-codex-turn-state": "http_turn_retired_gate_replace",
+        "user-agent": "codex_cli_rs/0.145.0",
+    }
+    payload = proxy_module.ResponsesRequest(
+        model="gpt-5.6-sol",
+        instructions="Return exactly OK.",
+        input="continue after stale gate",
+    )
+    affinity = proxy_module._sticky_key_for_responses_request(
+        payload,
+        request_headers,
+        codex_session_affinity=True,
+        openai_cache_affinity=True,
+        openai_cache_affinity_max_age_seconds=300,
+        sticky_threads_enabled=False,
+        api_key=None,
+    )
+    key = proxy_module._HTTPBridgeSessionKey("session_header", "retired-gate-replace", None)
+    stale_upstream = _SilentUpstreamWebSocket()
+    gate = asyncio.Semaphore(1)
+    await gate.acquire()
+    stale_request = proxy_module._WebSocketRequestState(
+        request_id="req-stale-gate-owner",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort="high",
+        api_key_reservation=None,
+        started_at=time.monotonic() - 1.0,
+        transport="http",
+        response_create_gate=gate,
+        response_create_gate_acquired=True,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.6-sol"}',
+    )
+    stale_session = proxy_module._HTTPBridgeSession(
+        key=key,
+        headers=request_headers,
+        affinity=affinity,
+        request_model="gpt-5.6-sol",
+        account=account,
+        upstream=cast(proxy_module.UpstreamResponsesWebSocket, stale_upstream),
+        upstream_control=proxy_module._WebSocketUpstreamControl(),
+        pending_requests=deque([stale_request]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=gate,
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+        codex_session=True,
+    )
+    stale_session.downstream_turn_state_aliases.add("http_turn_retired_gate_replace")
+    service._http_bridge_sessions[key] = stale_session
+    service._http_bridge_turn_state_index[
+        proxy_module._http_bridge_turn_state_alias_key("http_turn_retired_gate_replace", None)
+    ] = key
+
+    try:
+        response = await asyncio.wait_for(
+            async_client.post(
+                "/backend-api/codex/responses",
+                json=payload.to_payload(),
+                headers=request_headers,
+            ),
+            timeout=_TEST_SYNC_TIMEOUT_SECONDS,
+        )
+    finally:
+        if gate.locked():
+            gate.release()
+
+    assert response.status_code == 200
+    assert stale_session.closed is True
+    assert stale_upstream.closed is True
+    assert len(replacement_upstream.sent_text) == 1
+    assert any(
+        current_session is not stale_session and current_session.upstream is replacement_upstream
+        for current_session in service._http_bridge_sessions.values()
+    )
+
+
+@pytest.mark.asyncio
 async def test_v1_responses_http_bridge_enforces_queue_limit_atomically_for_same_session(
     async_client,
     app_instance,

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -6946,6 +6946,101 @@ async def test_v1_responses_http_bridge_gate_contention_waits_and_completes_afte
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_stale_gate_retires_after_leading_rate_limit_telemetry(
+    app_instance,
+    monkeypatch,
+):
+    app_settings = _make_app_settings(
+        enabled=True,
+        admission_wait_timeout_seconds=0.001,
+    )
+    app_settings.http_responses_session_bridge_stuck_gate_retire_after_seconds = 0.01
+    _install_proxy_settings(
+        monkeypatch,
+        app_settings=app_settings,
+        dashboard_settings=_make_dashboard_settings(),
+    )
+    service = get_proxy_service_for_app(app_instance)
+    upstream = _SilentUpstreamWebSocket()
+    key = proxy_module._HTTPBridgeSessionKey("session_header", "stale-after-rate-limits", None)
+    gate = asyncio.Semaphore(1)
+    await gate.acquire()
+    request_state = proxy_module._WebSocketRequestState(
+        request_id="req-stale-after-rate-limits",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort="high",
+        api_key_reservation=None,
+        started_at=time.monotonic() - 1.0,
+        transport="http",
+        response_create_gate=gate,
+        response_create_gate_acquired=True,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+    )
+    session = proxy_module._HTTPBridgeSession(
+        key=key,
+        headers={},
+        affinity=proxy_module._AffinityPolicy(key="stale-after-rate-limits"),
+        request_model="gpt-5.6-sol",
+        account=cast(Account, SimpleNamespace(id="acct-stale-rate-limits", status=AccountStatus.ACTIVE)),
+        upstream=cast(proxy_module.UpstreamResponsesWebSocket, upstream),
+        upstream_control=proxy_module._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=gate,
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+    )
+    service._http_bridge_sessions[key] = session
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "codex.rate_limits",
+                "plan_type": "pro",
+                "rate_limits": {"allowed": True, "limit_reached": False},
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    assert request_state.latency_first_upstream_event_ms is not None
+    assert request_state.latency_response_created_ms is None
+    assert request_state.response_id is None
+    assert request_state.awaiting_response_created is True
+    assert gate.locked() is True
+
+    waiter = proxy_module._WebSocketRequestState(
+        request_id="req-waiting-after-rate-limits",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort="high",
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        transport="http",
+        downstream_visible=True,
+    )
+    try:
+        with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+            await service._acquire_request_state_response_create_admission(
+                waiter,
+                response_create_gate=gate,
+                bridge_session=session,
+            )
+    finally:
+        if gate.locked():
+            gate.release()
+
+    assert exc_info.value.payload["error"]["code"] == "response_create_gate_timeout"
+    assert session.closed is True
+    assert key not in service._http_bridge_sessions
+    assert upstream.closed is True
+
+
+@pytest.mark.asyncio
 async def test_v1_responses_http_bridge_enforces_queue_limit_atomically_for_same_session(
     async_client,
     app_instance,

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -742,6 +742,96 @@ async def test_response_create_gate_timeout_retires_session_with_old_pending_vis
 
 
 @pytest.mark.asyncio
+async def test_response_create_gate_timeout_retires_old_precreated_request_after_rate_limit_telemetry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _make_app_settings(
+        proxy_admission_wait_timeout_seconds=0.001,
+        http_responses_session_bridge_stuck_gate_retire_after_seconds=300.0,
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    service = proxy_service.ProxyService(cast(Any, SimpleNamespace()))
+    session = _make_bridge_session()
+    service._http_bridge_sessions[session.key] = session
+    await session.response_create_gate.acquire()
+    old_pending = proxy_service._WebSocketRequestState(
+        request_id="req-old-pending-after-telemetry",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort="high",
+        api_key_reservation=None,
+        started_at=time.monotonic() - 301.0,
+        transport="http",
+        response_create_gate=session.response_create_gate,
+        response_create_gate_acquired=True,
+        awaiting_response_created=True,
+        downstream_visible=False,
+        event_queue=asyncio.Queue(),
+    )
+    waiter = proxy_service._WebSocketRequestState(
+        request_id="req-visible-waiter-after-telemetry",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort="high",
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        transport="http",
+        downstream_visible=True,
+    )
+    async with session.pending_lock:
+        session.pending_requests.append(old_pending)
+        session.queued_request_count = 1
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "codex.rate_limits",
+                "plan_type": "pro",
+                "rate_limits": {"allowed": True, "limit_reached": False},
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    assert old_pending.latency_first_upstream_event_ms is not None
+    assert old_pending.latency_response_created_ms is None
+    assert old_pending.awaiting_response_created is True
+    assert old_pending.response_id is None
+    assert old_pending.downstream_visible is False
+    assert session.response_create_gate.locked() is True
+
+    retire_calls: list[str] = []
+
+    async def fake_retire(
+        retire_session: proxy_service._HTTPBridgeSession,
+        *,
+        detail: str,
+    ) -> None:
+        retire_calls.append(detail)
+        retire_session.closed = True
+
+    monkeypatch.setattr(service, "_retire_stale_pending_http_bridge_session", fake_retire)
+
+    try:
+        with pytest.raises(ProxyResponseError) as exc_info:
+            await service._acquire_request_state_response_create_admission(
+                waiter,
+                response_create_gate=session.response_create_gate,
+                account_id=session.account.id,
+                surface="http_bridge",
+                bridge_session=session,
+            )
+    finally:
+        if session.response_create_gate.locked():
+            session.response_create_gate.release()
+
+    assert exc_info.value.payload["error"]["code"] == "response_create_gate_timeout"
+    assert retire_calls == ["response_create_gate_timeout_stuck_pending"]
+    assert session.closed is True
+
+
+@pytest.mark.asyncio
 async def test_response_create_gate_timeout_does_not_retire_visible_active_stream(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -1426,6 +1426,89 @@ async def test_http_bridge_gate_contention_does_not_retry_retired_session(
     assert submit.await_count == 1
 
 
+@pytest.mark.parametrize(
+    ("unsafe_state", "unsafe_value"),
+    [
+        ("response_id", "resp-already-created"),
+        ("response_event_count", 1),
+        ("replay_count", 1),
+        ("last_downstream_sequence_number", 0),
+        ("downstream_visible", True),
+        ("awaiting_response_created", True),
+        ("response_create_gate_acquired", True),
+    ],
+)
+def test_http_bridge_retired_gate_replacement_requires_unsubmitted_waiter(
+    unsafe_state: str,
+    unsafe_value: object,
+) -> None:
+    session = _make_bridge_session(key_value="sid-gate-replacement-guard")
+    session.closed = True
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-gate-replacement-guard",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        transport="http",
+        request_text='{"type":"response.create"}',
+        event_queue=asyncio.Queue(),
+    )
+    setattr(request_state, unsafe_state, unsafe_value)
+    gate_timeout_error = http_bridge_helpers_module._http_bridge_startup_wait_timeout_error(
+        "http_bridge_response_create_gate",
+        code="response_create_gate_timeout",
+    )
+
+    assert not http_bridge_streaming_module._http_bridge_can_replace_retired_gate_session(
+        gate_timeout_error,
+        session=session,
+        request_state=request_state,
+        request_was_enqueued=False,
+    )
+
+
+def test_http_bridge_retired_gate_replacement_accepts_cleaned_hard_affinity_waiter() -> None:
+    session = _make_bridge_session(key_value="sid-gate-replacement-safe")
+    session.closed = True
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-gate-replacement-safe",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        transport="http",
+        request_text='{"type":"response.create"}',
+        event_queue=asyncio.Queue(),
+    )
+    gate_timeout_error = http_bridge_helpers_module._http_bridge_startup_wait_timeout_error(
+        "http_bridge_response_create_gate",
+        code="response_create_gate_timeout",
+    )
+
+    assert http_bridge_streaming_module._http_bridge_can_replace_retired_gate_session(
+        gate_timeout_error,
+        session=session,
+        request_state=request_state,
+        request_was_enqueued=False,
+    )
+    assert not http_bridge_streaming_module._http_bridge_can_replace_retired_gate_session(
+        gate_timeout_error,
+        session=session,
+        request_state=request_state,
+        request_was_enqueued=True,
+    )
+    session.key = proxy_service._HTTPBridgeSessionKey("prompt_cache", "soft-gate-replacement", None)
+    assert not http_bridge_streaming_module._http_bridge_can_replace_retired_gate_session(
+        gate_timeout_error,
+        session=session,
+        request_state=request_state,
+        request_was_enqueued=False,
+    )
+
+
 @pytest.mark.asyncio
 async def test_http_bridge_submit_gate_contention_still_reroutes_soft_sessions(
     monkeypatch: pytest.MonkeyPatch,
@@ -3324,6 +3407,131 @@ def test_http_bridge_owner_check_required_enables_sticky_thread_in_gateway_safe_
 
     assert proxy_service._http_bridge_owner_check_required(key, gateway_safe_mode=False) is False
     assert proxy_service._http_bridge_owner_check_required(key, gateway_safe_mode=True) is True
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_replaces_retired_hard_gate_before_submit(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "hi",
+            "input": "continue",
+            "previous_response_id": "resp-before-retired-gate",
+        }
+    )
+    retired_session = _make_bridge_session(key_value="sid-retired-gate-replace")
+    replacement_session = _make_bridge_session(key_value="sid-retired-gate-replace")
+    get_or_create = AsyncMock(side_effect=[retired_session, replacement_session])
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-retired-gate-replace",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        transport="http",
+        request_text=(
+            '{"type":"response.create","model":"gpt-5.6-sol","previous_response_id":"resp-before-retired-gate"}'
+        ),
+        previous_response_id="resp-before-retired-gate",
+        event_queue=asyncio.Queue(),
+    )
+    gate_timeout_error = http_bridge_helpers_module._http_bridge_startup_wait_timeout_error(
+        "http_bridge_response_create_gate",
+        code="response_create_gate_timeout",
+    )
+
+    def fake_prepare(
+        _prepared_payload: proxy_service.ResponsesRequest,
+        _headers: dict[str, str] | Any,
+        **_kwargs: object,
+    ) -> tuple[proxy_service._WebSocketRequestState, str]:
+        return request_state, request_state.request_text or "{}"
+
+    async def fake_submit(
+        session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        queue_limit: int,
+    ) -> None:
+        del text_data, queue_limit
+        if session is retired_session:
+            retired_session.closed = True
+            request_state.awaiting_response_created = False
+            request_state.response_create_gate = None
+            request_state.response_create_gate_acquired = False
+            raise gate_timeout_error
+        assert session is replacement_session
+        assert request_state.event_queue is not None
+        request_state.event_queue.put_nowait(
+            'data: {"type":"response.completed","response":{"id":"resp-replaced-gate"}}\n\n'
+        )
+        request_state.event_queue.put_nowait(None)
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value="acc-bridge"))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", get_or_create)
+    submit = AsyncMock(side_effect=fake_submit)
+    detach = AsyncMock()
+    monkeypatch.setattr(service, "_submit_http_bridge_request", submit)
+    monkeypatch.setattr(service, "_detach_http_bridge_request", detach)
+
+    caplog.set_level(logging.INFO, logger="app.modules.proxy.service")
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={"session_id": "sid-retired-gate-replace"},
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed","response":{"id":"resp-replaced-gate"}}\n\n']
+    assert get_or_create.await_count == 2
+    initial_call, replacement_call = get_or_create.await_args_list
+    assert initial_call.args[0] == replacement_call.args[0]
+    assert replacement_call.kwargs["allow_forward_to_owner"] is False
+    assert replacement_call.kwargs["allow_previous_response_recovery_rebind"] is True
+    assert replacement_call.kwargs["preferred_account_id"] == retired_session.account.id
+    assert replacement_call.kwargs["fallback_on_preferred_account_unavailable"] is False
+    assert replacement_call.kwargs["request_deadline"] == initial_call.kwargs["request_deadline"]
+    assert submit.await_count == 2
+    detach.assert_awaited_once_with(replacement_session, request_state=request_state)
+    assert "event=replace_retired_gate" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -832,8 +832,26 @@ async def test_response_create_gate_timeout_retires_old_precreated_request_after
 
 
 @pytest.mark.asyncio
-async def test_response_create_gate_timeout_does_not_retire_visible_active_stream(
+@pytest.mark.parametrize(
+    (
+        "awaiting_response_created",
+        "downstream_visible",
+        "latency_first_upstream_event_ms",
+        "latency_response_created_ms",
+        "response_event_count",
+    ),
+    [
+        (False, True, 100, 100, 1),
+        (True, False, 25, None, 1),
+    ],
+)
+async def test_response_create_gate_timeout_does_not_retire_active_response_progress(
     monkeypatch: pytest.MonkeyPatch,
+    awaiting_response_created: bool,
+    downstream_visible: bool,
+    latency_first_upstream_event_ms: int,
+    latency_response_created_ms: int | None,
+    response_event_count: int,
 ) -> None:
     settings = _make_app_settings(
         proxy_admission_wait_timeout_seconds=0.001,
@@ -853,10 +871,11 @@ async def test_response_create_gate_timeout_does_not_retire_visible_active_strea
         started_at=time.monotonic() - 301.0,
         transport="http",
         response_create_gate_acquired=True,
-        awaiting_response_created=False,
-        downstream_visible=True,
-        latency_response_created_ms=100,
-        response_event_count=1,
+        awaiting_response_created=awaiting_response_created,
+        downstream_visible=downstream_visible,
+        latency_first_upstream_event_ms=latency_first_upstream_event_ms,
+        latency_response_created_ms=latency_response_created_ms,
+        response_event_count=response_event_count,
     )
     waiter = proxy_service._WebSocketRequestState(
         request_id="req-visible-waiter",


### PR DESCRIPTION
## Summary

- retire an old HTTP bridge gate owner that is still waiting for `response.created`, even when upstream emitted non-visible `codex.rate_limits` telemetry first;
- preserve every existing protection for real `response.*` progress;
- when the timing-out hard-affinity waiter is provably still unsubmitted, acquire a fresh bridge and submit it once instead of surfacing `http_bridge_response_create_gate` to Codex;
- preserve the original request deadline and pin anchored/file-backed recovery to its required account.

## Root cause

There were two independent gaps in the stale-gate recovery path.

First, the retirement predicate treated `latency_first_upstream_event_ms` as response progress. Codex can emit `codex.rate_limits` before `response.created`; that telemetry records first-event latency but neither assigns a response ID nor releases `response_create_gate`. A request could therefore hold the gate indefinitely while every later turn failed.

Second, after a waiter correctly retired that stale session, `_stream_http_bridge_session_events()` deliberately raised rather than retrying the retired session object. Avoiding that object is correct, but the waiter had not yet been appended to `pending_requests` or sent upstream. The outer bridge path now recognizes only that fully cleaned pre-submit state, creates a new session, and submits the waiter there.

## Safety invariants

Transparent replacement is allowed only for a closed hard-affinity session when the waiter:

- is absent from the retired session's pending queue;
- has no response ID or `response.*` events;
- has no replay count, downstream sequence number, or visible output;
- no longer owns or waits on the retired response-create gate;
- still owns a live downstream event queue.

Any ambiguous marker fails closed. The retired session object is never reconnected. A waiter carrying `previous_response_id` remains pinned to the old owner account, file pins remain strict, and the original bridge request deadline is reused.

## Regression evidence

The endpoint-level regression exercises `/backend-api/codex/responses` through the real bridge lifecycle: reuse an aged hard-affinity holder, time out at its gate, retire it, create a replacement bridge, submit exactly once, and return HTTP 200 without a client retry. Unit regressions cover every refusal guard and the real submit/cleanup boundary.

## Validation

- HTTP bridge unit suite: **276 passed**
- HTTP bridge integration suite: **91 passed**
- Ruff check + format check: passed
- `ty check`: passed
- proxy architecture check: passed
- strict OpenSpec change validation: passed
- all OpenSpec specs: **42 passed, 0 failed**
- `git diff --check`: passed

PR size is **777 additions / 6 deletions** total: about **140 production-code lines**; the remainder is regression coverage and OpenSpec artifacts. Net change is 771 lines, within the repository's scoped ~800-line ceiling.

OpenSpec: `openspec/changes/retire-precreated-gates-after-telemetry/`

Fixes #1206