### PR TITLE
fix(models): complete required Codex catalog fields

### DIFF
--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -187,6 +187,8 @@ def _bootstrap_model(
         "visibility": visibility,
         "availability_nux": None,
         "max_context_window": context_window,
+        "truncation_policy": {"mode": "tokens", "limit": 10_000},
+        "experimental_supported_tools": [],
     }
     if raw:
         raw_fields.update(raw)
@@ -342,6 +344,7 @@ _BOOTSTRAP_STATIC_MODELS: tuple[UpstreamModel, ...] = (
         "GPT-5.2",
         prefer_websockets=True,
         minimal_client_version="0.0.1",
+        raw={"truncation_policy": {"mode": "bytes", "limit": 10_000}},
     ),
     _bootstrap_model(
         "codex-auto-review",

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2964,12 +2964,10 @@ def _codex_model_truncation_policy(model: UpstreamModel) -> CodexTruncationPolic
 
 
 def _codex_model_experimental_supported_tools(model: UpstreamModel) -> list[str]:
-    if "experimental_supported_tools" not in model.raw:
+    tools = model.raw.get("experimental_supported_tools")
+    if not is_json_list(tools):
         return []
-    tools = model.raw["experimental_supported_tools"]
-    if not isinstance(tools, list) or not all(isinstance(tool, str) for tool in tools):
-        raise ValueError("experimental_supported_tools must be a list of strings")
-    return cast(list[str], tools)
+    return [tool for tool in tools if isinstance(tool, str)]
 
 
 def _to_codex_model_entry(model: UpstreamModel, *, visibility: str | None = None) -> CodexModelEntry:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -195,6 +195,7 @@ from app.modules.proxy.schemas import (
     AccountPoolUsageResponse,
     CodexModelEntry,
     CodexModelsResponse,
+    CodexTruncationPolicy,
     ConsumeRateLimitResetCreditRequest,
     ConsumeRateLimitResetCreditResponse,
     FileCreateRequest,
@@ -2955,6 +2956,22 @@ def _is_codex_backend_catalog_model(model: UpstreamModel) -> bool:
     return model.raw.get("shell_type") == "shell_command"
 
 
+def _codex_model_truncation_policy(model: UpstreamModel) -> CodexTruncationPolicy:
+    if "truncation_policy" in model.raw:
+        return CodexTruncationPolicy.model_validate(model.raw["truncation_policy"])
+    mode = "bytes" if model.slug == "gpt-5.2" else "tokens"
+    return CodexTruncationPolicy(mode=mode, limit=10_000)
+
+
+def _codex_model_experimental_supported_tools(model: UpstreamModel) -> list[str]:
+    if "experimental_supported_tools" not in model.raw:
+        return []
+    tools = model.raw["experimental_supported_tools"]
+    if not isinstance(tools, list) or not all(isinstance(tool, str) for tool in tools):
+        raise ValueError("experimental_supported_tools must be a list of strings")
+    return cast(list[str], tools)
+
+
 def _to_codex_model_entry(model: UpstreamModel, *, visibility: str | None = None) -> CodexModelEntry:
     raw = model.raw
 
@@ -2978,6 +2995,8 @@ def _to_codex_model_entry(model: UpstreamModel, *, visibility: str | None = None
         "available_in_plans",
         "prefer_websockets",
         "visibility",
+        "truncation_policy",
+        "experimental_supported_tools",
     }
     for key, value in raw.items():
         if key not in skip_keys and isinstance(value, (bool, int, float, str, type(None), list, Mapping)):
@@ -3010,6 +3029,11 @@ def _to_codex_model_entry(model: UpstreamModel, *, visibility: str | None = None
         available_in_plans=sorted(model.available_in_plans),
         prefer_websockets=model.prefer_websockets,
         visibility=visibility or _model_visibility(model),
+        # Codex deserializes the complete catalog atomically. Repair legacy
+        # bootstrap/retained metadata at this final wire boundary so one hidden
+        # entry cannot invalidate otherwise-current live model metadata.
+        truncation_policy=_codex_model_truncation_policy(model),
+        experimental_supported_tools=_codex_model_experimental_supported_tools(model),
         **extra,
     )
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -2958,7 +2958,10 @@ def _is_codex_backend_catalog_model(model: UpstreamModel) -> bool:
 
 def _codex_model_truncation_policy(model: UpstreamModel) -> CodexTruncationPolicy:
     if "truncation_policy" in model.raw:
-        return CodexTruncationPolicy.model_validate(model.raw["truncation_policy"])
+        try:
+            return CodexTruncationPolicy.model_validate(model.raw["truncation_policy"])
+        except ValidationError:
+            pass
     mode = "bytes" if model.slug == "gpt-5.2" else "tokens"
     return CodexTruncationPolicy(mode=mode, limit=10_000)
 

--- a/app/modules/proxy/schemas.py
+++ b/app/modules/proxy/schemas.py
@@ -166,6 +166,13 @@ class ReasoningLevelSchema(BaseModel):
     description: str
 
 
+class CodexTruncationPolicy(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    mode: str
+    limit: int
+
+
 class CodexModelEntry(BaseModel):
     model_config = ConfigDict(extra="allow")
 
@@ -187,6 +194,8 @@ class CodexModelEntry(BaseModel):
     available_in_plans: list[str] = []
     prefer_websockets: bool = False
     visibility: str = "list"
+    truncation_policy: CodexTruncationPolicy
+    experimental_supported_tools: list[str]
 
 
 class ModelMetadata(BaseModel):

--- a/app/modules/proxy/schemas.py
+++ b/app/modules/proxy/schemas.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -169,8 +170,8 @@ class ReasoningLevelSchema(BaseModel):
 class CodexTruncationPolicy(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    mode: str
-    limit: int
+    mode: Literal["bytes", "tokens"]
+    limit: int = Field(strict=True, ge=-(2**63), le=2**63 - 1)
 
 
 class CodexModelEntry(BaseModel):

--- a/openspec/changes/fix-codex-catalog-required-fields/context.md
+++ b/openspec/changes/fix-codex-catalog-required-fields/context.md
@@ -2,10 +2,10 @@
 
 ## Decision
 
-The final Codex catalog mapper is the compatibility boundary. It fills only
-fields that are absent, so the repair also covers metadata restored from an
-older persisted registry snapshot without rewriting the snapshot or replacing
-newer upstream values.
+The final Codex catalog mapper is the compatibility boundary. It fills fields
+that are absent, so the repair also covers metadata restored from an older
+persisted registry snapshot without rewriting the snapshot or replacing newer
+wire-valid upstream values.
 
 `experimental_supported_tools` defaults to an empty list. Bundled models use
 their known truncation mode: `gpt-5.2` uses the upstream-compatible 10,000-byte
@@ -13,6 +13,13 @@ limit, while the other bundled Codex models use the upstream-compatible
 10,000-token limit. Other missing policies use the same 10,000-token default as
 codex-lb's Responses-capable model-source catalog. Explicit upstream or
 operator-provided policies take precedence unchanged.
+
+Model-source metadata is an operator-extensible JSON object. Its existing tool
+capability reader accepts mixed `experimental_supported_tools` lists and
+ignores non-string members. Catalog rendering follows that same compatibility
+rule: for example, `["custom", 42, {"type": "bad"}]` becomes `["custom"]`,
+while a non-list value becomes `[]`. This keeps one malformed optional value
+from turning the atomically decoded catalog into a 500 response.
 
 ## Failure mode
 

--- a/openspec/changes/fix-codex-catalog-required-fields/context.md
+++ b/openspec/changes/fix-codex-catalog-required-fields/context.md
@@ -1,0 +1,22 @@
+# Codex model-catalog required-field compatibility
+
+## Decision
+
+The final Codex catalog mapper is the compatibility boundary. It fills only
+fields that are absent, so the repair also covers metadata restored from an
+older persisted registry snapshot without rewriting the snapshot or replacing
+newer upstream values.
+
+`experimental_supported_tools` defaults to an empty list. Bundled models use
+their known truncation mode: `gpt-5.2` uses the upstream-compatible 10,000-byte
+limit, while the other bundled Codex models use the upstream-compatible
+10,000-token limit. Other missing policies use the same 10,000-token default as
+codex-lb's Responses-capable model-source catalog. Explicit upstream or
+operator-provided policies take precedence unchanged.
+
+## Failure mode
+
+Codex parses the complete `models` array atomically. For example, a visible
+`gpt-5.6-sol` entry can be complete while a hidden retained `gpt-5.2` entry lacks
+`truncation_policy`; Codex then rejects the whole response at the hidden entry
+and reports that model refresh could not be decoded.

--- a/openspec/changes/fix-codex-catalog-required-fields/context.md
+++ b/openspec/changes/fix-codex-catalog-required-fields/context.md
@@ -21,6 +21,11 @@ rule: for example, `["custom", 42, {"type": "bad"}]` becomes `["custom"]`,
 while a non-list value becomes `[]`. This keeps one malformed optional value
 from turning the atomically decoded catalog into a 500 response.
 
+The same boundary validates explicit truncation policies. Operator metadata
+such as `{"truncation_policy": null}` or an object missing `limit` falls back
+to the model-compatible byte/token policy described above. Valid complete
+policies, including forward-compatible extra fields, remain authoritative.
+
 ## Failure mode
 
 Codex parses the complete `models` array atomically. For example, a visible

--- a/openspec/changes/fix-codex-catalog-required-fields/context.md
+++ b/openspec/changes/fix-codex-catalog-required-fields/context.md
@@ -26,6 +26,11 @@ such as `{"truncation_policy": null}` or an object missing `limit` falls back
 to the model-compatible byte/token policy described above. Valid complete
 policies, including forward-compatible extra fields, remain authoritative.
 
+Codex's upstream protocol defines `TruncationMode` as the closed snake-case
+`bytes | tokens` enum and `limit` as an `i64`. The mapper mirrors that wire
+shape exactly: it rejects coercible-but-invalid JSON values such as a numeric
+string and falls back when an integer is outside the signed 64-bit range.
+
 ## Failure mode
 
 Codex parses the complete `models` array atomically. For example, a visible

--- a/openspec/changes/fix-codex-catalog-required-fields/proposal.md
+++ b/openspec/changes/fix-codex-catalog-required-fields/proposal.md
@@ -1,0 +1,20 @@
+# Change: Complete required Codex model-catalog fields
+
+## Why
+
+Codex 0.144.3 deserializes every entry in the native model catalog as one
+`ModelsResponse`. Hidden metadata retained from codex-lb's older bootstrap
+entries can omit the non-defaulted `truncation_policy` and
+`experimental_supported_tools` fields. One such hidden entry makes Codex reject
+the entire otherwise-valid catalog, retry model refresh continuously, and use
+fallback metadata.
+
+## What Changes
+
+- Make the Codex-native catalog rendering boundary complete the required wire
+  fields when legacy bootstrap, retained, or persisted metadata omits them.
+- Use model-appropriate conservative truncation defaults for bundled models and
+  an empty experimental-tool list, while preserving every value supplied by a
+  live upstream or model source.
+- Add route-level regressions for a partial refresh that leaves older bundled
+  models as hidden metadata and for the uninitialized bootstrap catalog.

--- a/openspec/changes/fix-codex-catalog-required-fields/proposal.md
+++ b/openspec/changes/fix-codex-catalog-required-fields/proposal.md
@@ -14,7 +14,7 @@ fallback metadata.
 - Make the Codex-native catalog rendering boundary complete the required wire
   fields when legacy bootstrap, retained, or persisted metadata omits them.
 - Use model-appropriate conservative truncation defaults for bundled models and
-  an empty experimental-tool list, while preserving every value supplied by a
-  live upstream or model source.
+  an empty experimental-tool list, while preserving wire-valid values supplied
+  by a live upstream or model source and sanitizing invalid tool-list members.
 - Add route-level regressions for a partial refresh that leaves older bundled
   models as hidden metadata and for the uninitialized bootstrap catalog.

--- a/openspec/changes/fix-codex-catalog-required-fields/proposal.md
+++ b/openspec/changes/fix-codex-catalog-required-fields/proposal.md
@@ -15,6 +15,7 @@ fallback metadata.
   fields when legacy bootstrap, retained, or persisted metadata omits them.
 - Use model-appropriate conservative truncation defaults for bundled models and
   an empty experimental-tool list, while preserving wire-valid values supplied
-  by a live upstream or model source and sanitizing invalid tool-list members.
+  by a live upstream or model source and repairing malformed required-field
+  shapes.
 - Add route-level regressions for a partial refresh that leaves older bundled
   models as hidden metadata and for the uninitialized bootstrap catalog.

--- a/openspec/changes/fix-codex-catalog-required-fields/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/fix-codex-catalog-required-fields/specs/model-catalog-compat/spec.md
@@ -9,9 +9,12 @@ Every model entry returned by `GET /backend-api/codex/models` or the equivalent
 Codex wire fields `truncation_policy` and `experimental_supported_tools`, even
 when the entry comes from hidden retained bootstrap metadata or a persisted
 legacy registry snapshot. When either field is absent from stored raw metadata,
-the mapper MUST provide a conservative model-compatible default. Values
-provided by a live upstream catalog or model source MUST remain authoritative
-and MUST NOT be overwritten by the compatibility defaults.
+the mapper MUST provide a conservative model-compatible default. Wire-valid
+values provided by a live upstream catalog or model source MUST remain
+authoritative and MUST NOT be overwritten by the compatibility defaults. When
+`experimental_supported_tools` is not a list, the mapper MUST emit an empty
+list. When it contains non-string members, the mapper MUST omit those members
+rather than failing the complete catalog.
 
 #### Scenario: Hidden bootstrap metadata cannot invalidate the live catalog
 
@@ -24,12 +27,27 @@ and MUST NOT be overwritten by the compatibility defaults.
 - **AND** the complete catalog can be deserialized instead of falling back to
   bundled client metadata
 
-#### Scenario: Explicit upstream compatibility values win
+#### Scenario: Explicit valid upstream compatibility values win
 
 - **GIVEN** a live catalog or model source provides `truncation_policy` or
   `experimental_supported_tools`
 - **WHEN** codex-lb renders the Codex-native catalog entry
 - **THEN** it preserves those explicit values unchanged
+
+#### Scenario: Invalid source tool members cannot fail the catalog
+
+- **GIVEN** a model source provides `experimental_supported_tools` with both
+  string and non-string members
+- **WHEN** codex-lb renders the Codex-native catalog entry
+- **THEN** it retains the string tool names
+- **AND** it omits non-string members instead of returning a server error
+
+#### Scenario: Non-list source tool metadata cannot fail the catalog
+
+- **GIVEN** a model source provides a non-list value for
+  `experimental_supported_tools`
+- **WHEN** codex-lb renders the Codex-native catalog entry
+- **THEN** it emits an empty list instead of returning a server error
 
 #### Scenario: Client-version alias has the same complete contract
 

--- a/openspec/changes/fix-codex-catalog-required-fields/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/fix-codex-catalog-required-fields/specs/model-catalog-compat/spec.md
@@ -14,7 +14,9 @@ values provided by a live upstream catalog or model source MUST remain
 authoritative and MUST NOT be overwritten by the compatibility defaults. When
 `experimental_supported_tools` is not a list, the mapper MUST emit an empty
 list. When it contains non-string members, the mapper MUST omit those members
-rather than failing the complete catalog.
+rather than failing the complete catalog. When an explicit `truncation_policy`
+cannot be parsed into the required wire shape, the mapper MUST emit the same
+conservative model-compatible policy used when the field is absent.
 
 #### Scenario: Hidden bootstrap metadata cannot invalidate the live catalog
 
@@ -48,6 +50,14 @@ rather than failing the complete catalog.
   `experimental_supported_tools`
 - **WHEN** codex-lb renders the Codex-native catalog entry
 - **THEN** it emits an empty list instead of returning a server error
+
+#### Scenario: Malformed source truncation policy cannot fail the catalog
+
+- **GIVEN** a model source provides an invalid `truncation_policy`, such as a
+  null, non-object, or incomplete object value
+- **WHEN** codex-lb renders the Codex-native catalog entry
+- **THEN** it emits the conservative model-compatible truncation policy
+- **AND** it does not return a server error
 
 #### Scenario: Client-version alias has the same complete contract
 

--- a/openspec/changes/fix-codex-catalog-required-fields/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/fix-codex-catalog-required-fields/specs/model-catalog-compat/spec.md
@@ -1,0 +1,38 @@
+# model-catalog-compat delta: fix-codex-catalog-required-fields
+
+## ADDED Requirements
+
+### Requirement: Every Codex-native catalog entry is wire-parseable
+
+Every model entry returned by `GET /backend-api/codex/models` or the equivalent
+`GET /v1/models?client_version=<version>` route MUST include the non-defaulted
+Codex wire fields `truncation_policy` and `experimental_supported_tools`, even
+when the entry comes from hidden retained bootstrap metadata or a persisted
+legacy registry snapshot. When either field is absent from stored raw metadata,
+the mapper MUST provide a conservative model-compatible default. Values
+provided by a live upstream catalog or model source MUST remain authoritative
+and MUST NOT be overwritten by the compatibility defaults.
+
+#### Scenario: Hidden bootstrap metadata cannot invalidate the live catalog
+
+- **GIVEN** a successful live refresh omits an older bundled model
+- **AND** codex-lb retains that model as hidden metadata whose raw payload lacks
+  required Codex wire fields
+- **WHEN** a Codex client requests the native model catalog
+- **THEN** the hidden entry includes a valid `truncation_policy`
+- **AND** it includes `experimental_supported_tools` as a list
+- **AND** the complete catalog can be deserialized instead of falling back to
+  bundled client metadata
+
+#### Scenario: Explicit upstream compatibility values win
+
+- **GIVEN** a live catalog or model source provides `truncation_policy` or
+  `experimental_supported_tools`
+- **WHEN** codex-lb renders the Codex-native catalog entry
+- **THEN** it preserves those explicit values unchanged
+
+#### Scenario: Client-version alias has the same complete contract
+
+- **WHEN** Codex requests `GET /v1/models` with a non-empty `client_version`
+- **THEN** every returned `models` entry satisfies the same required-field
+  contract as `GET /backend-api/codex/models`

--- a/openspec/changes/fix-codex-catalog-required-fields/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/fix-codex-catalog-required-fields/specs/model-catalog-compat/spec.md
@@ -14,9 +14,11 @@ values provided by a live upstream catalog or model source MUST remain
 authoritative and MUST NOT be overwritten by the compatibility defaults. When
 `experimental_supported_tools` is not a list, the mapper MUST emit an empty
 list. When it contains non-string members, the mapper MUST omit those members
-rather than failing the complete catalog. When an explicit `truncation_policy`
-cannot be parsed into the required wire shape, the mapper MUST emit the same
-conservative model-compatible policy used when the field is absent.
+rather than failing the complete catalog. A wire-valid `truncation_policy` MUST
+use the `bytes` or `tokens` mode and a JSON integer representable by Codex's
+signed 64-bit `limit` field. When an explicit policy does not satisfy that wire
+shape, the mapper MUST emit the same conservative model-compatible policy used
+when the field is absent.
 
 #### Scenario: Hidden bootstrap metadata cannot invalidate the live catalog
 
@@ -54,7 +56,8 @@ conservative model-compatible policy used when the field is absent.
 #### Scenario: Malformed source truncation policy cannot fail the catalog
 
 - **GIVEN** a model source provides an invalid `truncation_policy`, such as a
-  null, non-object, or incomplete object value
+  null, non-object, incomplete object, unknown mode, non-integer limit, or
+  out-of-range limit
 - **WHEN** codex-lb renders the Codex-native catalog entry
 - **THEN** it emits the conservative model-compatible truncation policy
 - **AND** it does not return a server error

--- a/openspec/changes/fix-codex-catalog-required-fields/tasks.md
+++ b/openspec/changes/fix-codex-catalog-required-fields/tasks.md
@@ -13,3 +13,5 @@
   boundary and cover both native catalog aliases.
 - [x] 7. Fall back from malformed model-source truncation policies without
   failing the complete Codex catalog.
+- [x] 8. Match Codex's closed truncation-mode enum and signed 64-bit limit wire
+  types while preserving forward-compatible extra fields.

--- a/openspec/changes/fix-codex-catalog-required-fields/tasks.md
+++ b/openspec/changes/fix-codex-catalog-required-fields/tasks.md
@@ -1,0 +1,11 @@
+# Tasks: fix-codex-catalog-required-fields
+
+- [x] 1. Reproduce the Codex 0.144.3 catalog decode failure and identify every
+  non-defaulted field missing from retained bootstrap metadata.
+- [x] 2. Add the OpenSpec proposal, context, tasks, and model-catalog contract
+  delta.
+- [x] 3. Add route-level regressions for hidden retained metadata, bootstrap
+  metadata, and preservation of explicit upstream values.
+- [x] 4. Complete missing required Codex wire fields at the catalog mapper.
+- [x] 5. Run focused model-catalog tests, lint/type checks, strict OpenSpec
+  validation, and the relevant broader gates.

--- a/openspec/changes/fix-codex-catalog-required-fields/tasks.md
+++ b/openspec/changes/fix-codex-catalog-required-fields/tasks.md
@@ -9,3 +9,5 @@
 - [x] 4. Complete missing required Codex wire fields at the catalog mapper.
 - [x] 5. Run focused model-catalog tests, lint/type checks, strict OpenSpec
   validation, and the relevant broader gates.
+- [x] 6. Sanitize malformed model-source tool metadata at the Codex wire
+  boundary and cover both native catalog aliases.

--- a/openspec/changes/fix-codex-catalog-required-fields/tasks.md
+++ b/openspec/changes/fix-codex-catalog-required-fields/tasks.md
@@ -11,3 +11,5 @@
   validation, and the relevant broader gates.
 - [x] 6. Sanitize malformed model-source tool metadata at the Codex wire
   boundary and cover both native catalog aliases.
+- [x] 7. Fall back from malformed model-source truncation policies without
+  failing the complete Codex catalog.

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 
 import pytest
 
-from app.core.openai.model_registry import ReasoningLevel, UpstreamModel, get_model_registry
+from app.core.openai.model_registry import ModelRegistryExport, ReasoningLevel, UpstreamModel, get_model_registry
 from app.core.types import JsonValue
 
 pytestmark = pytest.mark.integration
@@ -246,6 +246,10 @@ async def test_backend_codex_models_uses_bootstrap_upstream_metadata(async_clien
     assert set(entries) == set(EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS)
     for slug, expected_version in EXPECTED_BOOTSTRAP_MINIMAL_CLIENT_VERSIONS.items():
         assert entries[slug]["minimal_client_version"] == expected_version
+        assert entries[slug]["shell_type"] == "shell_command"
+        assert isinstance(entries[slug]["experimental_supported_tools"], list)
+        assert entries[slug]["truncation_policy"]["mode"] in {"bytes", "tokens"}
+        assert isinstance(entries[slug]["truncation_policy"]["limit"], int)
 
     sol = entries["gpt-5.6-sol"]
     assert sol["display_name"] == "GPT-5.6-Sol"
@@ -1422,6 +1426,57 @@ async def test_codex_catalog_hides_last_known_metadata_omitted_by_live_refresh(a
     v1_resp = await async_client.get("/v1/models")
     assert v1_resp.status_code == 200
     assert "gpt-5.6-sol" not in {item["id"] for item in v1_resp.json()["data"]}
+
+
+@pytest.mark.asyncio
+async def test_codex_catalog_completes_required_fields_for_hidden_bootstrap_metadata(async_client):
+    registry = get_model_registry()
+    live_sol = _make_upstream_model(
+        "gpt-5.6-sol",
+        raw={
+            "shell_type": "shell_command",
+            "visibility": "list",
+            "truncation_policy": {"mode": "tokens", "limit": 4_096},
+            "experimental_supported_tools": ["live-tool"],
+        },
+    )
+    await registry.update({"pro": [live_sol]})
+    registry_state = await registry.export_state()
+    legacy_metadata = dict(registry_state.metadata_models or {})
+    legacy_raw: dict[str, JsonValue] = {
+        "shell_type": "shell_command",
+        "visibility": "list",
+        "availability_nux": None,
+    }
+    legacy_metadata["gpt-5.2"] = _make_upstream_model("gpt-5.2", raw=legacy_raw)
+    legacy_metadata["gpt-5.3-codex"] = _make_upstream_model("gpt-5.3-codex", raw=legacy_raw)
+    await registry.import_state(
+        ModelRegistryExport(snapshot=registry_state.snapshot, metadata_models=legacy_metadata),
+        content_hash="legacy-metadata-without-required-fields",
+    )
+
+    response = await async_client.get(
+        "/backend-api/codex/models",
+        params={"client_version": "0.144.3"},
+    )
+
+    assert response.status_code == 200
+    entries = {entry["slug"]: entry for entry in response.json()["models"]}
+    assert entries["gpt-5.2"]["visibility"] == "hide"
+    assert entries["gpt-5.2"]["truncation_policy"] == {"mode": "bytes", "limit": 10_000}
+    assert entries["gpt-5.2"]["experimental_supported_tools"] == []
+    assert entries["gpt-5.3-codex"]["visibility"] == "hide"
+    assert entries["gpt-5.3-codex"]["truncation_policy"] == {"mode": "tokens", "limit": 10_000}
+    assert entries["gpt-5.3-codex"]["experimental_supported_tools"] == []
+    assert entries["gpt-5.6-sol"]["truncation_policy"] == {"mode": "tokens", "limit": 4_096}
+    assert entries["gpt-5.6-sol"]["experimental_supported_tools"] == ["live-tool"]
+
+    alias_response = await async_client.get(
+        "/v1/models",
+        params={"client_version": "0.144.3"},
+    )
+    assert alias_response.status_code == 200
+    assert alias_response.json() == response.json()
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -594,6 +594,44 @@ async def test_backend_codex_models_defaults_source_model_context_window(async_c
     assert source_entry["prefer_websockets"] is False
 
 
+@pytest.mark.parametrize(
+    ("case", "raw_tools", "expected_tools"),
+    [
+        ("mixed", ["custom", 42, {"type": "bad"}], ["custom"]),
+        ("non-list", "custom", []),
+    ],
+)
+@pytest.mark.asyncio
+async def test_codex_catalog_sanitizes_invalid_source_tool_metadata(
+    async_client,
+    case: str,
+    raw_tools: JsonValue,
+    expected_tools: list[str],
+):
+    model = f"external-{case}-tool-metadata"
+    await _create_model_source(
+        async_client,
+        name=f"codex-source-{case}-tool-metadata",
+        model=model,
+        supports_responses=True,
+        raw_metadata_json=json.dumps({"experimental_supported_tools": raw_tools}),
+    )
+
+    response = await async_client.get("/backend-api/codex/models")
+
+    assert response.status_code == 200
+    entry = next(item for item in response.json()["models"] if item["slug"] == model)
+    assert entry["experimental_supported_tools"] == expected_tools
+
+    alias_response = await async_client.get(
+        "/v1/models",
+        params={"client_version": "0.144.3"},
+    )
+    assert alias_response.status_code == 200
+    alias_entry = next(item for item in alias_response.json()["models"] if item["slug"] == model)
+    assert alias_entry["experimental_supported_tools"] == expected_tools
+
+
 @pytest.mark.asyncio
 async def test_backend_codex_models_never_exposes_source_request_overrides(async_client):
     await _create_model_source(

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -632,6 +632,44 @@ async def test_codex_catalog_sanitizes_invalid_source_tool_metadata(
     assert alias_entry["experimental_supported_tools"] == expected_tools
 
 
+@pytest.mark.parametrize(
+    ("case", "raw_policy"),
+    [
+        ("null", None),
+        ("non-object", "tokens"),
+        ("missing-limit", {"mode": "tokens"}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_codex_catalog_defaults_invalid_source_truncation_policy(
+    async_client,
+    case: str,
+    raw_policy: JsonValue,
+):
+    model = f"external-{case}-truncation-policy"
+    await _create_model_source(
+        async_client,
+        name=f"codex-source-{case}-truncation-policy",
+        model=model,
+        supports_responses=True,
+        raw_metadata_json=json.dumps({"truncation_policy": raw_policy}),
+    )
+
+    response = await async_client.get("/backend-api/codex/models")
+
+    assert response.status_code == 200
+    entry = next(item for item in response.json()["models"] if item["slug"] == model)
+    assert entry["truncation_policy"] == {"mode": "tokens", "limit": 10_000}
+
+    alias_response = await async_client.get(
+        "/v1/models",
+        params={"client_version": "0.144.3"},
+    )
+    assert alias_response.status_code == 200
+    alias_entry = next(item for item in alias_response.json()["models"] if item["slug"] == model)
+    assert alias_entry["truncation_policy"] == {"mode": "tokens", "limit": 10_000}
+
+
 @pytest.mark.asyncio
 async def test_backend_codex_models_never_exposes_source_request_overrides(async_client):
     await _create_model_source(

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -638,6 +638,9 @@ async def test_codex_catalog_sanitizes_invalid_source_tool_metadata(
         ("null", None),
         ("non-object", "tokens"),
         ("missing-limit", {"mode": "tokens"}),
+        ("invalid-mode", {"mode": "characters", "limit": 1_234}),
+        ("string-limit", {"mode": "tokens", "limit": "4096"}),
+        ("limit-overflow", {"mode": "tokens", "limit": 2**63}),
     ],
 )
 @pytest.mark.asyncio
@@ -1512,7 +1515,7 @@ async def test_codex_catalog_completes_required_fields_for_hidden_bootstrap_meta
         raw={
             "shell_type": "shell_command",
             "visibility": "list",
-            "truncation_policy": {"mode": "tokens", "limit": 4_096},
+            "truncation_policy": {"mode": "tokens", "limit": 4_096, "future_setting": "preserved"},
             "experimental_supported_tools": ["live-tool"],
         },
     )
@@ -1544,7 +1547,11 @@ async def test_codex_catalog_completes_required_fields_for_hidden_bootstrap_meta
     assert entries["gpt-5.3-codex"]["visibility"] == "hide"
     assert entries["gpt-5.3-codex"]["truncation_policy"] == {"mode": "tokens", "limit": 10_000}
     assert entries["gpt-5.3-codex"]["experimental_supported_tools"] == []
-    assert entries["gpt-5.6-sol"]["truncation_policy"] == {"mode": "tokens", "limit": 4_096}
+    assert entries["gpt-5.6-sol"]["truncation_policy"] == {
+        "mode": "tokens",
+        "limit": 4_096,
+        "future_setting": "preserved",
+    }
     assert entries["gpt-5.6-sol"]["experimental_supported_tools"] == ["live-tool"]
 
     alias_response = await async_client.get(


### PR DESCRIPTION
## Summary

- declare Codex's required `truncation_policy` and `experimental_supported_tools` catalog fields in the typed model contract
- include both fields in newly bootstrapped registry entries
- repair those fields at the final catalog boundary for legacy persisted snapshots, while preserving wire-valid source/upstream values
- sanitize malformed source tool metadata and validate truncation policies against Codex's exact enum/i64 wire shape so one optional value cannot fail the complete catalog
- cover the persisted-snapshot path with a route-level regression test and document the compatibility contract in OpenSpec

## Root cause

Codex 0.144.3 treats both fields as required on every `/backend-api/codex/models` entry. Older registry snapshots can contain hidden entries such as `gpt-5.2` and `gpt-5.3-codex` without them. A single malformed entry makes Codex reject the entire response, emit `Model metadata ... not found`, and fall back to degraded built-in metadata.

The repair belongs at the final catalog mapping boundary because merely fixing new bootstrap rows leaves existing databases broken. `gpt-5.2` receives its upstream-compatible byte truncation policy; the other bundled fallback entries use the token policy. Wire-valid source values remain authoritative; malformed required-field metadata is repaired to keep the complete response parseable.

## Validation

- 54 model-route integration tests passed
- 58 model registry/source unit tests passed
- 22 snapshot codec tests passed
- 30 registry replication integration tests passed
- Ruff check and format passed repository-wide
- `ty check` passed
- strict OpenSpec change validation passed, plus all 42 main OpenSpec specs
- broad unit run: 3,646 passed, 55 skipped; 12 unrelated Windows/environment failures remained around POSIX permission/executable behavior, SQLite sidecar locking, and inherited proxy variables

Fixes #1297