### PR TITLE
feat(ci): mint a dedicated GitHub App token for codex label sync

### DIFF
--- a/.github/workflows/codex-review-labels.yml
+++ b/.github/workflows/codex-review-labels.yml
@@ -51,6 +51,12 @@ jobs:
         with:
           app-id: ${{ vars.CODEX_LABEL_SYNC_APP_ID }}
           private-key: ${{ secrets.CODEX_LABEL_SYNC_APP_PRIVATE_KEY }}
+          permission-actions: write
+          permission-checks: read
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: read
+          permission-statuses: read
 
       - name: Sync labels
         env:
@@ -92,6 +98,12 @@ jobs:
         with:
           app-id: ${{ vars.CODEX_LABEL_SYNC_APP_ID }}
           private-key: ${{ secrets.CODEX_LABEL_SYNC_APP_PRIVATE_KEY }}
+          permission-actions: write
+          permission-checks: read
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: read
+          permission-statuses: read
 
       - name: Sync labels
         env:

--- a/.github/workflows/codex-review-labels.yml
+++ b/.github/workflows/codex-review-labels.yml
@@ -43,9 +43,18 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.repository.default_branch }}
 
+      - name: Mint label sync App token
+        id: app-token
+        if: ${{ vars.CODEX_LABEL_SYNC_APP_ID != '' }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ vars.CODEX_LABEL_SYNC_APP_ID }}
+          private-key: ${{ secrets.CODEX_LABEL_SYNC_APP_PRIVATE_KEY }}
+
       - name: Sync labels
         env:
-          GH_TOKEN: ${{ secrets.CODEX_LABEL_SYNC_TOKEN || secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.CODEX_LABEL_SYNC_TOKEN || secrets.RELEASE_PLEASE_TOKEN || github.token }}
           GH_FALLBACK_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           REPO: ${{ github.repository }}
@@ -75,9 +84,18 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.repository.default_branch }}
 
+      - name: Mint label sync App token
+        id: app-token
+        if: ${{ vars.CODEX_LABEL_SYNC_APP_ID != '' }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349
+        with:
+          app-id: ${{ vars.CODEX_LABEL_SYNC_APP_ID }}
+          private-key: ${{ secrets.CODEX_LABEL_SYNC_APP_PRIVATE_KEY }}
+
       - name: Sync labels
         env:
-          GH_TOKEN: ${{ secrets.CODEX_LABEL_SYNC_TOKEN || secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.CODEX_LABEL_SYNC_TOKEN || secrets.RELEASE_PLEASE_TOKEN || github.token }}
           GH_FALLBACK_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |

--- a/openspec/changes/label-sync-app-token/proposal.md
+++ b/openspec/changes/label-sync-app-token/proposal.md
@@ -1,0 +1,36 @@
+# Change: label-sync-app-token
+
+## Why
+
+The Codex review label sync workflow currently authenticates with a personal
+access token (`CODEX_LABEL_SYNC_TOKEN`), which shares the token owner's global
+5,000/hr REST quota with every other consumer of that PAT. Quota exhaustion by
+unrelated automation repeatedly broke label sync until the `github.token`
+fallback (change `label-sync-token-fallback`) papered over it at 1,000/hr.
+A dedicated GitHub App installation token gets its own isolated 5,000/hr
+quota, expires hourly, needs no machine account or collaborator seat, and can
+be scoped to exactly the permissions the sync script uses.
+
+## What Changes
+
+- The `Codex review labels` workflow mints a short-lived GitHub App
+  installation token (via `actions/create-github-app-token`, SHA-pinned) when
+  the repository defines the `CODEX_LABEL_SYNC_APP_ID` variable and the
+  `CODEX_LABEL_SYNC_APP_PRIVATE_KEY` secret, and prefers that token ahead of
+  the existing `CODEX_LABEL_SYNC_TOKEN` → `RELEASE_PLEASE_TOKEN` →
+  `github.token` chain.
+- A failed or skipped mint never fails the job: the sync step falls back to
+  the next token in the chain, and `GH_FALLBACK_TOKEN` (`github.token`)
+  remains the script-level rate-limit escape hatch.
+- No script changes: `sync_codex_ok_labels.py` already tolerates
+  App-token write denials (`--tolerate-write-permission-errors`).
+
+## Impact
+
+- Affected specs: `github-automation` (write-token fallback requirement)
+- Affected code: `.github/workflows/codex-review-labels.yml` (both jobs)
+- Operator action: create the App (permissions: Actions RW, Checks R,
+  Contents R, Issues RW, Pull requests R, Commit statuses R), install it on
+  the repository, set the `CODEX_LABEL_SYNC_APP_ID` repository variable and
+  `CODEX_LABEL_SYNC_APP_PRIVATE_KEY` secret. Until then the workflow behaves
+  exactly as today.

--- a/openspec/changes/label-sync-app-token/specs/github-automation/spec.md
+++ b/openspec/changes/label-sync-app-token/specs/github-automation/spec.md
@@ -10,6 +10,7 @@ The `Codex review labels` workflow MUST execute the label synchronization script
 
 - **WHEN** the repository defines the `CODEX_LABEL_SYNC_APP_ID` variable and the `CODEX_LABEL_SYNC_APP_PRIVATE_KEY` secret
 - **THEN** the workflow mints a short-lived installation token for that App before the sync step
+- **AND** the mint requests only the label-sync permission subset (actions write, checks read, contents read, issues write, pull requests read, statuses read) rather than inheriting all installation permissions
 - **AND** the sync step uses that token ahead of `CODEX_LABEL_SYNC_TOKEN`, `RELEASE_PLEASE_TOKEN`, and `github.token`
 
 #### Scenario: App token mint fails or is not configured

--- a/openspec/changes/label-sync-app-token/specs/github-automation/spec.md
+++ b/openspec/changes/label-sync-app-token/specs/github-automation/spec.md
@@ -1,0 +1,26 @@
+# github-automation delta
+
+## MODIFIED Requirements
+
+### Requirement: Codex review label sync write-token fallback
+
+The `Codex review labels` workflow MUST execute the label synchronization script from the trusted default branch and MUST prefer a dedicated GitHub App installation token, then a repository-provided write token, before falling back to the default `github.token`.
+
+#### Scenario: GitHub App credentials are configured
+
+- **WHEN** the repository defines the `CODEX_LABEL_SYNC_APP_ID` variable and the `CODEX_LABEL_SYNC_APP_PRIVATE_KEY` secret
+- **THEN** the workflow mints a short-lived installation token for that App before the sync step
+- **AND** the sync step uses that token ahead of `CODEX_LABEL_SYNC_TOKEN`, `RELEASE_PLEASE_TOKEN`, and `github.token`
+
+#### Scenario: App token mint fails or is not configured
+
+- **WHEN** the mint step fails, or the `CODEX_LABEL_SYNC_APP_ID` variable is absent
+- **THEN** the job does not fail because of the mint step
+- **AND** the sync step falls back to the next available token in the chain
+
+#### Scenario: Privileged token is configured
+
+- **WHEN** the workflow synchronizes Codex review labels and no App token was minted
+- **THEN** it uses `CODEX_LABEL_SYNC_TOKEN` when present
+- **AND** it falls back to `RELEASE_PLEASE_TOKEN` before `github.token`
+- **AND** it checks out the default branch with persisted checkout credentials disabled

--- a/openspec/changes/label-sync-app-token/tasks.md
+++ b/openspec/changes/label-sync-app-token/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: label-sync-app-token
+
+## 1. Workflow
+
+- [x] 1.1 Add a SHA-pinned `actions/create-github-app-token` mint step to both
+      `sync-pr` and `sync-after-ci`, gated on the `CODEX_LABEL_SYNC_APP_ID`
+      repository variable and marked `continue-on-error` so a failed mint
+      falls back instead of failing the job
+- [x] 1.2 Prefer the minted token at the head of the `GH_TOKEN` chain in both
+      sync steps, keeping `CODEX_LABEL_SYNC_TOKEN` → `RELEASE_PLEASE_TOKEN` →
+      `github.token` and the `GH_FALLBACK_TOKEN` escape hatch unchanged
+
+## 2. Spec
+
+- [x] 2.1 Extend the `github-automation` write-token fallback requirement with
+      the App-token preference and mint-failure fallback scenario
+
+## 3. Validation
+
+- [x] 3.1 `openspec validate label-sync-app-token --strict`
+- [x] 3.2 `actionlint` on the workflow (or CI equivalent)


### PR DESCRIPTION
## Why

`CODEX_LABEL_SYNC_TOKEN` is a personal access token, so label sync shares its owner's global 5,000/hr REST quota with every other consumer of that PAT — unrelated automation repeatedly starved the sync until the `github.token` fallback (#1272) caught it at the per-repo 1,000/hr. A dedicated GitHub App installation token gets its own isolated 5,000/hr quota, expires hourly, needs no machine account or collaborator seat, and is scoped to exactly the permissions the sync script uses.

## What

- Both `sync-pr` and `sync-after-ci` mint a short-lived installation token via `actions/create-github-app-token` (SHA-pinned to v2.2.2) when the `CODEX_LABEL_SYNC_APP_ID` repository variable and `CODEX_LABEL_SYNC_APP_PRIVATE_KEY` secret are set.
- The minted token heads the `GH_TOKEN` chain; the existing `CODEX_LABEL_SYNC_TOKEN` → `RELEASE_PLEASE_TOKEN` → `github.token` chain and the script-level `GH_FALLBACK_TOKEN` escape hatch are unchanged.
- The mint step is `continue-on-error` and gated on the variable, so a failed or unconfigured mint degrades to today's behavior exactly — no operator action is required for this PR to be safe.
- No script changes: `sync_codex_ok_labels.py` already tolerates App-token write denials.

## Operator setup (after merge)

1. Create a GitHub App (Settings → Developer settings → GitHub Apps): no webhook, repository permissions **Actions RW, Checks R, Contents R, Issues RW, Pull requests R, Commit statuses R**.
2. Install it on `Soju06/codex-lb` and generate a private key.
3. Set repository variable `CODEX_LABEL_SYNC_APP_ID` (the App ID) and secret `CODEX_LABEL_SYNC_APP_PRIVATE_KEY` (the PEM).

## OpenSpec

`openspec/changes/label-sync-app-token/` — modifies the github-automation write-token fallback requirement. Strict validation passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)