### PR TITLE
fix(proxy): preserve encrypted compaction item ids

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -4715,25 +4715,32 @@ def _compact_response_output_item(payload: CompactResponsePayload) -> dict[str, 
             if item is None:
                 continue
             item_type = item.get("type")
-            encrypted_content = item.get("encrypted_content")
             if isinstance(item_type, str) and item_type in {"compaction", "compaction_summary"}:
-                if isinstance(encrypted_content, str):
-                    return {
-                        "type": "compaction",
-                        "encrypted_content": encrypted_content,
-                    }
+                normalized_item = _normalize_compaction_output_item(item)
+                if normalized_item is not None:
+                    return normalized_item
     summary = getattr(payload, "compaction_summary", None)
     if summary is None:
         summary = extra.get("compaction_summary")
     summary_mapping = _json_mapping_from_model_or_mapping(summary)
     if summary_mapping is not None:
-        encrypted_content = summary_mapping.get("encrypted_content")
-        if isinstance(encrypted_content, str):
-            return {
-                "type": "compaction",
-                "encrypted_content": encrypted_content,
-            }
+        return _normalize_compaction_output_item(summary_mapping)
     return None
+
+
+def _normalize_compaction_output_item(item: Mapping[str, JsonValue]) -> dict[str, JsonValue] | None:
+    encrypted_content = item.get("encrypted_content")
+    if not isinstance(encrypted_content, str):
+        return None
+
+    normalized: dict[str, JsonValue] = {
+        "type": "compaction",
+        "encrypted_content": encrypted_content,
+    }
+    item_id = item.get("id")
+    if isinstance(item_id, str) and item_id.strip():
+        normalized["id"] = item_id
+    return normalized
 
 
 def _json_mapping_from_model_or_mapping(value: object) -> Mapping[str, JsonValue] | None:

--- a/openspec/changes/archive/2026-07-14-fix-compaction-item-id-fidelity/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-14-fix-compaction-item-id-fidelity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/archive/2026-07-14-fix-compaction-item-id-fidelity/design.md
+++ b/openspec/changes/archive/2026-07-14-fix-compaction-item-id-fidelity/design.md
@@ -1,0 +1,30 @@
+## Context
+
+The compact endpoint can return a remote-compaction-v2 item such as `{"id":"cmp_...","type":"compaction_summary","encrypted_content":"..."}`. Codex-compatible normalization converts that record to `type="compaction"`, but currently rebuilds it from only `type` and `encrypted_content`. The encrypted payload remains bound to the discarded upstream ID, while the client later assigns and replays a different ID.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve the authoritative non-empty upstream compaction item ID wherever the encrypted item is normalized or streamed.
+- Keep the item identical between `response.output_item.done.item` and `response.completed.response.output[0]`.
+- Cover both explicit upstream `output` items and `compaction_summary` fallback payloads.
+
+**Non-Goals:**
+
+- Decrypt, inspect, or rewrite encrypted compaction content.
+- Generate a compaction item ID when upstream omits one.
+- Change account-affinity, compact routing, or OpenAI-style compact responses.
+
+## Decisions
+
+1. `_compact_response_output_item` will copy a non-empty string `id` from the selected upstream item into the normalized `compaction` record. The synthetic stream already reuses that normalized mapping in both events, so preserving the ID at this boundary keeps all downstream representations consistent.
+
+2. Missing or invalid IDs retain the existing no-ID behavior. Synthesizing an ID is rejected because a generated value cannot satisfy ciphertext that is bound to an upstream item ID.
+
+3. The normalizer will continue selecting only the compact contract fields (`id`, `type`, and `encrypted_content`). Forwarding all upstream summary fields is rejected because it would broaden the Codex-facing response contract without evidence that those fields are accepted.
+
+## Risks / Trade-offs
+
+- [Risk] An upstream response without an exposed item ID cannot be repaired locally. -> Mitigation: preserve existing behavior for that legacy shape and test the authoritative v2 output shape that supplies an ID.
+- [Risk] A malformed whitespace-only ID could still cause an invalid replay. -> Mitigation: only forward non-empty IDs after trimming for the validity check, while preserving the original non-empty value byte-for-byte.

--- a/openspec/changes/archive/2026-07-14-fix-compaction-item-id-fidelity/proposal.md
+++ b/openspec/changes/archive/2026-07-14-fix-compaction-item-id-fidelity/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Codex compaction-trigger responses currently discard the upstream compaction item's `id` while preserving its `encrypted_content`. The client assigns a replacement `cmp_*` ID, so the next replay fails upstream verification because the ciphertext is cryptographically bound to the original item ID.
+
+## What Changes
+
+- Preserve a non-empty upstream compaction item `id` when normalizing remote compaction-v2 output.
+- Emit the same ID with the encrypted compaction item in both synthetic SSE events.
+- Add product-path regression coverage proving the ID survives compact normalization and compaction-trigger streaming unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: Require encrypted compaction output to retain its authoritative upstream item ID across Codex-compatible normalization and synthetic streaming.
+
+## Impact
+
+- Affected code: `app/modules/proxy/api.py` compaction output normalization.
+- Affected API surfaces: `POST /backend-api/codex/responses` compaction triggers and Codex-affinity `POST /backend-api/codex/responses/compact`.
+- No schema, dependency, configuration, or OpenAI-style `/v1/responses/compact` behavior changes.

--- a/openspec/changes/archive/2026-07-14-fix-compaction-item-id-fidelity/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-07-14-fix-compaction-item-id-fidelity/specs/responses-api-compat/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: Codex compaction triggers are bridged into compact output
+
+When `POST /backend-api/codex/responses` receives a request whose top-level `input` array contains exactly one `{"type":"compaction_trigger"}` item as its final element, the proxy SHALL remove that trigger before calling upstream compaction handling and SHALL emit a raw SSE stream that contains exactly one compaction output item.
+
+The stream MUST include a `response.output_item.done` event whose `item` is a `compaction` record, and the terminal `response.completed` event MUST carry the same single compaction item in `response.output`. When the selected encrypted upstream compaction item carries a non-empty `id`, both events MUST preserve that exact ID with its `encrypted_content` so a later replay retains the ciphertext's item binding.
+
+For Codex-affinity standalone compact requests, `POST /backend-api/codex/responses/compact` SHALL normalize an upstream remote-compaction-v2 response that includes historical message output plus a compaction summary into the single compact output item required by Codex clients. A non-empty upstream compaction item `id` MUST be preserved in that normalized output item.
+
+OpenAI-style `/v1/responses/compact` is unchanged by this requirement.
+
+#### Scenario: terminal trigger is converted into a compact stream
+- **WHEN** a `POST /backend-api/codex/responses` request ends with exactly one top-level `compaction_trigger`
+- **THEN** the proxy strips the trigger, invokes compact handling, and streams one `response.output_item.done` event containing a `compaction` item
+- **AND** the terminal `response.completed` event carries that same item in `response.output`
+
+#### Scenario: encrypted compaction item ID survives trigger streaming
+- **WHEN** compaction handling for a terminal trigger returns encrypted content in an item with a non-empty `cmp_*` ID
+- **THEN** the `response.output_item.done` item preserves that exact ID
+- **AND** the `response.completed` output item preserves the same ID with the same encrypted content
+
+#### Scenario: malformed trigger placement is rejected
+- **WHEN** a `POST /backend-api/codex/responses` request contains a duplicated or non-terminal top-level `compaction_trigger` item
+- **THEN** the proxy returns HTTP 400 with `invalid_request_error`
+- **AND** it does not attempt upstream compaction handling
+
+#### Scenario: Codex-affinity standalone compact normalizes remote v2 output
+- **WHEN** a Codex-affinity `POST /backend-api/codex/responses/compact` request receives upstream output that contains historical message items and one compaction summary item
+- **THEN** the JSON response body contains exactly one `output` item for that compaction summary
+- **AND** the normalized item preserves the compaction summary's non-empty upstream ID
+- **AND** it does not expose historical message items as standalone compact output

--- a/openspec/changes/archive/2026-07-14-fix-compaction-item-id-fidelity/tasks.md
+++ b/openspec/changes/archive/2026-07-14-fix-compaction-item-id-fidelity/tasks.md
@@ -1,0 +1,14 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Update the compaction-trigger integration test to require the upstream `cmp_*` ID in both synthetic SSE events.
+- [x] 1.2 Add focused contract coverage for ID preservation from remote-compaction-v2 `output` and `compaction_summary` shapes.
+
+## 2. Implementation
+
+- [x] 2.1 Preserve a valid upstream compaction item ID in Codex-compatible compact output normalization.
+- [x] 2.2 Confirm standalone compact normalization and trigger streaming emit the same item contract.
+
+## 3. Verification
+
+- [x] 3.1 Run focused unit and integration tests for compact response normalization and compaction-trigger streaming.
+- [x] 3.2 Run lint, type checking, strict change validation, and the full OpenSpec spec validation suite.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -1551,9 +1551,9 @@ requests MUST NOT wait on an orphaned creation future that can never complete.
 
 When `POST /backend-api/codex/responses` receives a request whose top-level `input` array contains exactly one `{"type":"compaction_trigger"}` item as its final element, the proxy SHALL remove that trigger before calling upstream compaction handling and SHALL emit a raw SSE stream that contains exactly one compaction output item.
 
-The stream MUST include a `response.output_item.done` event whose `item` is a `compaction` record, and the terminal `response.completed` event MUST carry the same single compaction item in `response.output`.
+The stream MUST include a `response.output_item.done` event whose `item` is a `compaction` record, and the terminal `response.completed` event MUST carry the same single compaction item in `response.output`. When the selected encrypted upstream compaction item carries a non-empty `id`, both events MUST preserve that exact ID with its `encrypted_content` so a later replay retains the ciphertext's item binding.
 
-For Codex-affinity standalone compact requests, `POST /backend-api/codex/responses/compact` SHALL normalize an upstream remote-compaction-v2 response that includes historical message output plus a compaction summary into the single compact output item required by Codex clients.
+For Codex-affinity standalone compact requests, `POST /backend-api/codex/responses/compact` SHALL normalize an upstream remote-compaction-v2 response that includes historical message output plus a compaction summary into the single compact output item required by Codex clients. A non-empty upstream compaction item `id` MUST be preserved in that normalized output item.
 
 OpenAI-style `/v1/responses/compact` is unchanged by this requirement.
 
@@ -1561,6 +1561,11 @@ OpenAI-style `/v1/responses/compact` is unchanged by this requirement.
 - **WHEN** a `POST /backend-api/codex/responses` request ends with exactly one top-level `compaction_trigger`
 - **THEN** the proxy strips the trigger, invokes compact handling, and streams one `response.output_item.done` event containing a `compaction` item
 - **AND** the terminal `response.completed` event carries that same item in `response.output`
+
+#### Scenario: encrypted compaction item ID survives trigger streaming
+- **WHEN** compaction handling for a terminal trigger returns encrypted content in an item with a non-empty `cmp_*` ID
+- **THEN** the `response.output_item.done` item preserves that exact ID
+- **AND** the `response.completed` output item preserves the same ID with the same encrypted content
 
 #### Scenario: malformed trigger placement is rejected
 - **WHEN** a `POST /backend-api/codex/responses` request contains a duplicated or non-terminal top-level `compaction_trigger` item
@@ -1570,6 +1575,7 @@ OpenAI-style `/v1/responses/compact` is unchanged by this requirement.
 #### Scenario: Codex-affinity standalone compact normalizes remote v2 output
 - **WHEN** a Codex-affinity `POST /backend-api/codex/responses/compact` request receives upstream output that contains historical message items and one compaction summary item
 - **THEN** the JSON response body contains exactly one `output` item for that compaction summary
+- **AND** the normalized item preserves the compaction summary's non-empty upstream ID
 - **AND** it does not expose historical message items as standalone compact output
 
 ### Requirement: Request logs expose upstream Responses transport

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -326,7 +326,13 @@ async def test_proxy_compact_normalizes_summary_output_for_codex_remote_v2(async
     assert response.status_code == 200
     compact_json = response.json()
     assert compact_json["object"] == "response.compaction"
-    assert compact_json["output"] == [{"type": "compaction", "encrypted_content": "enc_compact_v2"}]
+    assert compact_json["output"] == [
+        {
+            "id": "cmp_compact_v2",
+            "type": "compaction",
+            "encrypted_content": "enc_compact_v2",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -555,6 +555,7 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
             {
                 "object": "response.compaction",
                 "compaction_summary": {
+                    "id": "cmp_trigger_summary",
                     "encrypted_content": "ENCRYPTED_CONTEXT_COMPACTION_SUMMARY",
                     "summary_text": "condensed thread state",
                 },
@@ -598,11 +599,13 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
     assert "include" not in compact_payload
     assert "stream" not in compact_payload
     assert events[0]["item"] == {
+        "id": "cmp_trigger_summary",
         "type": "compaction",
         "encrypted_content": "ENCRYPTED_CONTEXT_COMPACTION_SUMMARY",
     }
     assert events[1]["response"]["output"] == [
         {
+            "id": "cmp_trigger_summary",
             "type": "compaction",
             "encrypted_content": "ENCRYPTED_CONTEXT_COMPACTION_SUMMARY",
         }

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -198,6 +198,7 @@ def test_compact_response_output_item_accepts_modeled_output_field() -> None:
             "object": "response.compaction",
             "output": [
                 {
+                    "id": "cmp_modeled_context",
                     "type": "compaction",
                     "encrypted_content": "MODELED_CONTEXT",
                 }
@@ -206,8 +207,27 @@ def test_compact_response_output_item_accepts_modeled_output_field() -> None:
     )
 
     assert proxy_api_module._compact_response_output_item(payload) == {
+        "id": "cmp_modeled_context",
         "type": "compaction",
         "encrypted_content": "MODELED_CONTEXT",
+    }
+
+
+def test_compact_response_output_item_preserves_summary_item_id() -> None:
+    payload = CompactResponsePayload.model_validate(
+        {
+            "object": "response.compaction",
+            "compaction_summary": {
+                "id": "cmp_summary_context",
+                "encrypted_content": "SUMMARY_CONTEXT",
+            },
+        }
+    )
+
+    assert proxy_api_module._compact_response_output_item(payload) == {
+        "id": "cmp_summary_context",
+        "type": "compaction",
+        "encrypted_content": "SUMMARY_CONTEXT",
     }
 
 


### PR DESCRIPTION
## Summary

Preserve the authoritative upstream `cmp_*` item ID whenever encrypted compaction output is normalized. This keeps ciphertext paired with the item identity used to encrypt it and prevents replay failures such as `Encrypted content item_id did not match the target item id`.

## Type of change

- [x] `fix:` - bug fix
- [ ] `feat:` - new user-facing feature or capability
- [ ] `refactor:` - internal refactor
- [ ] **Breaking change**

Related to #1167

## OpenSpec

- [x] This PR includes an archived OpenSpec change.
- [x] This PR touches a Codex-faithful path and preserves upstream-compatible behavior.

Change directory: `openspec/changes/archive/2026-07-14-fix-compaction-item-id-fidelity/`

## Changes

- Preserve a non-empty upstream compaction item `id` alongside `encrypted_content` for modeled `output` and `compaction_summary` responses.
- Apply the same normalized item to standalone compact responses and both synthetic terminal `compaction_trigger` SSE events.
- Add unit and integration regressions for exact item-ID fidelity and record the compatibility requirement in OpenSpec.

## Test plan

```text
uv run pytest tests/unit/test_proxy_api_responses_contract.py tests/integration/test_proxy_compact.py tests/integration/test_proxy_responses.py
# 131 passed

PATH=.venv/bin:$PATH make lint
# Architecture, ruff check, and ruff format checks passed

uv run ty check
# All checks passed

openspec validate --specs
# 47 passed, 0 failed

git diff --check upstream/main...HEAD
# Passed
```

## Checklist

- [x] Title uses Conventional Commits format.
- [x] PR is one concern wide.
- [x] Added product-path regression coverage.
- [x] OpenSpec is synced, validated, and archived.
- [x] `CHANGELOG.md` was not edited manually.
