### PR TITLE
docs(readme): update examples for GPT-5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,19 +248,19 @@ You can clean the config by using this one-liner
           "name": "GPT-5.6 Sol",
           "reasoning": true,
           "options": { "reasoningEffort": "high", "reasoningSummary": "detailed" },
-          "limit": { "context": 1050000, "output": 128000 }
+          "limit": { "context": 372000, "output": 128000 }
         },
         "gpt-5.6-terra": {
           "name": "GPT-5.6 Terra",
           "reasoning": true,
           "options": { "reasoningEffort": "high", "reasoningSummary": "detailed" },
-          "limit": { "context": 1050000, "output": 128000 }
+          "limit": { "context": 372000, "output": 128000 }
         },
         "gpt-5.6-luna": {
           "name": "GPT-5.6 Luna",
           "reasoning": true,
           "options": { "reasoningEffort": "high", "reasoningSummary": "detailed" },
-          "limit": { "context": 1050000, "output": 128000 }
+          "limit": { "context": 372000, "output": 128000 }
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Point any OpenAI-compatible client at codex-lb. If [API key auth](#api-key-authe
 
 Model availability is discovered from the upstream Codex model catalog and can vary by account plan, workspace, rollout, and upstream deprecation state. Prefer the live `GET /v1/models` or `GET /backend-api/codex/models` response over a copied static table when configuring clients or API-key model allowlists.
 
+The examples below default to `gpt-5.6-sol`. When present in your live catalog, use `gpt-5.6-terra` for balanced everyday work or `gpt-5.6-luna` for faster, lower-cost workloads.
+
 | Logo | Client | Endpoint | Config |
 |---|--------|----------|--------|
 | <img src="https://avatars.githubusercontent.com/u/14957082?s=200" width="32" alt="OpenAI"> | **Codex CLI** | `http://127.0.0.1:2455/backend-api/codex` | `~/.codex/config.toml` |
@@ -126,8 +128,8 @@ Model availability is discovered from the upstream Codex model catalog and can v
 `~/.codex/config.toml`:
 
 ```toml
-model = "gpt-5.3-codex"
-model_reasoning_effort = "xhigh"
+model = "gpt-5.6-sol"
+model_reasoning_effort = "max"
 model_provider = "codex-lb"
 
 [model_providers.codex-lb]
@@ -242,34 +244,28 @@ You can clean the config by using this one-liner
         "apiKey": "{env:CODEX_LB_API_KEY}"
       },
       "models": {
-        "gpt-5.4": {
-          "name": "GPT-5.4",
+        "gpt-5.6-sol": {
+          "name": "GPT-5.6 Sol",
           "reasoning": true,
           "options": { "reasoningEffort": "high", "reasoningSummary": "detailed" },
           "limit": { "context": 1050000, "output": 128000 }
         },
-        "gpt-5.3-codex": {
-          "name": "GPT-5.3 Codex",
+        "gpt-5.6-terra": {
+          "name": "GPT-5.6 Terra",
           "reasoning": true,
           "options": { "reasoningEffort": "high", "reasoningSummary": "detailed" },
-          "limit": { "context": 272000, "output": 65536 }
+          "limit": { "context": 1050000, "output": 128000 }
         },
-        "gpt-5.1-codex-mini": {
-          "name": "GPT-5.1 Codex Mini",
+        "gpt-5.6-luna": {
+          "name": "GPT-5.6 Luna",
           "reasoning": true,
           "options": { "reasoningEffort": "high", "reasoningSummary": "detailed" },
-          "limit": { "context": 272000, "output": 65536 }
-        },
-        "gpt-5.3-codex-spark": {
-          "name": "GPT-5.3 Codex Spark",
-          "reasoning": true,
-          "options": { "reasoningEffort": "xhigh", "reasoningSummary": "detailed" },
-          "limit": { "context": 128000, "output": 65536 }
+          "limit": { "context": 1050000, "output": 128000 }
         }
       }
     }
   },
-  "model": "openai/gpt-5.3-codex"
+  "model": "openai/gpt-5.6-sol"
 }
 ```
 
@@ -292,11 +288,11 @@ opencode
 {
   "agents": {
     "defaults": {
-      "model": { "primary": "codex-lb/gpt-5.4" },
+      "model": { "primary": "codex-lb/gpt-5.6-sol" },
       "models": {
-        "codex-lb/gpt-5.4": { "params": { "cacheRetention": "short" } }
-        "codex-lb/gpt-5.4-mini": { "params": { "cacheRetention": "short" } }
-        "codex-lb/gpt-5.3-codex": { "params": { "cacheRetention": "short" } }
+        "codex-lb/gpt-5.6-sol": { "params": { "cacheRetention": "short" } },
+        "codex-lb/gpt-5.6-terra": { "params": { "cacheRetention": "short" } },
+        "codex-lb/gpt-5.6-luna": { "params": { "cacheRetention": "short" } }
       }
     }
   },
@@ -309,28 +305,28 @@ opencode
         "api": "openai-responses",
         "models": [
           {
-            "id": "gpt-5.4",
-            "name": "gpt-5.4 (codex-lb)",
+            "id": "gpt-5.6-sol",
+            "name": "gpt-5.6-sol (codex-lb)",
             "contextWindow": 1050000,
-            "contextTokens": 272000,
+            "contextTokens": 372000,
             "maxTokens": 4096,
             "input": ["text"],
             "reasoning": false
           },
           {
-            "id": "gpt-5.4-mini",
-            "name": "gpt-5.4-mini (codex-lb)",
-            "contextWindow": 400000,
-            "contextTokens": 272000,
+            "id": "gpt-5.6-terra",
+            "name": "gpt-5.6-terra (codex-lb)",
+            "contextWindow": 1050000,
+            "contextTokens": 372000,
             "maxTokens": 4096,
             "input": ["text"],
             "reasoning": false
           },
           {
-            "id": "gpt-5.3-codex",
-            "name": "gpt-5.3-codex (codex-lb)",
-            "contextWindow": 400000,
-            "contextTokens": 272000,
+            "id": "gpt-5.6-luna",
+            "name": "gpt-5.6-luna (codex-lb)",
+            "contextWindow": 1050000,
+            "contextTokens": 372000,
             "maxTokens": 4096,
             "input": ["text"],
             "reasoning": false
@@ -362,7 +358,7 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="gpt-5.3-codex",
+    model="gpt-5.6-sol",
     messages=[{"role": "user", "content": "Hello!"}],
 )
 print(response.choices[0].message.content)

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ opencode
           {
             "id": "gpt-5.6-sol",
             "name": "gpt-5.6-sol (codex-lb)",
-            "contextWindow": 1050000,
+            "contextWindow": 372000,
             "contextTokens": 372000,
             "maxTokens": 4096,
             "input": ["text"],
@@ -316,7 +316,7 @@ opencode
           {
             "id": "gpt-5.6-terra",
             "name": "gpt-5.6-terra (codex-lb)",
-            "contextWindow": 1050000,
+            "contextWindow": 372000,
             "contextTokens": 372000,
             "maxTokens": 4096,
             "input": ["text"],
@@ -325,7 +325,7 @@ opencode
           {
             "id": "gpt-5.6-luna",
             "name": "gpt-5.6-luna (codex-lb)",
-            "contextWindow": 1050000,
+            "contextWindow": 372000,
             "contextTokens": 372000,
             "maxTokens": 4096,
             "input": ["text"],

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -284,7 +284,7 @@ opencode
           {
             "id": "gpt-5.6-sol",
             "name": "gpt-5.6-sol (codex-lb)",
-            "contextWindow": 1050000,
+            "contextWindow": 372000,
             "contextTokens": 372000,
             "maxTokens": 4096,
             "input": ["text"],
@@ -293,7 +293,7 @@ opencode
           {
             "id": "gpt-5.6-terra",
             "name": "gpt-5.6-terra (codex-lb)",
-            "contextWindow": 1050000,
+            "contextWindow": 372000,
             "contextTokens": 372000,
             "maxTokens": 4096,
             "input": ["text"],
@@ -302,7 +302,7 @@ opencode
           {
             "id": "gpt-5.6-luna",
             "name": "gpt-5.6-luna (codex-lb)",
-            "contextWindow": 1050000,
+            "contextWindow": 372000,
             "contextTokens": 372000,
             "maxTokens": 4096,
             "input": ["text"],

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -225,19 +225,19 @@ sqlite3 ~/.codex/state_5.sqlite \
           "name": "GPT-5.6 Sol",
           "reasoning": true,
           "options": { "reasoningEffort": "high", "reasoningSummary": "detailed" },
-          "limit": { "context": 1050000, "output": 128000 }
+          "limit": { "context": 372000, "output": 128000 }
         },
         "gpt-5.6-terra": {
           "name": "GPT-5.6 Terra",
           "reasoning": true,
           "options": { "reasoningEffort": "high", "reasoningSummary": "detailed" },
-          "limit": { "context": 1050000, "output": 128000 }
+          "limit": { "context": 372000, "output": 128000 }
         },
         "gpt-5.6-luna": {
           "name": "GPT-5.6 Luna",
           "reasoning": true,
           "options": { "reasoningEffort": "high", "reasoningSummary": "detailed" },
-          "limit": { "context": 1050000, "output": 128000 }
+          "limit": { "context": 372000, "output": 128000 }
         }
       }
     }

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -155,7 +155,7 @@ responses_websockets_v2 = true
 
 ```toml
 [model_providers.codex-lb]
-name = "OpenAI"
+name = "openai"
 base_url = "http://127.0.0.1:2455/backend-api/codex"
 wire_api = "responses"
 env_key = "CODEX_LB_API_KEY"

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -91,6 +91,10 @@ docker run -d --name codex-lb \
 
 将任意 OpenAI 兼容客户端指向 codex-lb 即可。如果启用了 [API Key 鉴权](#api-key-鉴权)，需要将仪表盘中创建的 key 作为 Bearer token 传入。
 
+模型可用性来自上游 Codex 模型目录，并可能因账号套餐、工作区、灰度发布和上游弃用状态而变化。配置客户端或 API Key 模型白名单时，请优先使用实时的 `GET /v1/models` 或 `GET /backend-api/codex/models` 响应，而不是复制的静态表格。
+
+以下示例默认使用 `gpt-5.6-sol`。当实时目录中提供相应模型时，可使用 `gpt-5.6-terra` 处理均衡的日常任务，或使用 `gpt-5.6-luna` 获得更快、成本更低的处理能力。
+
 | Logo | 客户端 | 端点 | 配置 |
 |---|--------|----------|--------|
 | <img src="https://avatars.githubusercontent.com/u/14957082?s=200" width="32" alt="OpenAI"> | **Codex CLI** | `http://127.0.0.1:2455/backend-api/codex` | `~/.codex/config.toml` |
@@ -105,12 +109,12 @@ docker run -d --name codex-lb \
 `~/.codex/config.toml`：
 
 ```toml
-model = "gpt-5.3-codex"
-model_reasoning_effort = "xhigh"
+model = "gpt-5.6-sol"
+model_reasoning_effort = "max"
 model_provider = "codex-lb"
 
 [model_providers.codex-lb]
-name = "OpenAI"  # 必填 —— 启用远程 /responses/compact
+name = "openai"  # 必填 —— 启用远程 /responses/compact
 base_url = "http://127.0.0.1:2455/backend-api/codex"
 wire_api = "responses"
 supports_websockets = true
@@ -217,34 +221,28 @@ sqlite3 ~/.codex/state_5.sqlite \
         "apiKey": "{env:CODEX_LB_API_KEY}"
       },
       "models": {
-        "gpt-5.4": {
-          "name": "GPT-5.4",
+        "gpt-5.6-sol": {
+          "name": "GPT-5.6 Sol",
           "reasoning": true,
           "options": { "reasoningEffort": "high", "reasoningSummary": "detailed" },
           "limit": { "context": 1050000, "output": 128000 }
         },
-        "gpt-5.3-codex": {
-          "name": "GPT-5.3 Codex",
+        "gpt-5.6-terra": {
+          "name": "GPT-5.6 Terra",
           "reasoning": true,
           "options": { "reasoningEffort": "high", "reasoningSummary": "detailed" },
-          "limit": { "context": 272000, "output": 65536 }
+          "limit": { "context": 1050000, "output": 128000 }
         },
-        "gpt-5.1-codex-mini": {
-          "name": "GPT-5.1 Codex Mini",
+        "gpt-5.6-luna": {
+          "name": "GPT-5.6 Luna",
           "reasoning": true,
           "options": { "reasoningEffort": "high", "reasoningSummary": "detailed" },
-          "limit": { "context": 272000, "output": 65536 }
-        },
-        "gpt-5.3-codex-spark": {
-          "name": "GPT-5.3 Codex Spark",
-          "reasoning": true,
-          "options": { "reasoningEffort": "xhigh", "reasoningSummary": "detailed" },
-          "limit": { "context": 128000, "output": 65536 }
+          "limit": { "context": 1050000, "output": 128000 }
         }
       }
     }
   },
-  "model": "openai/gpt-5.3-codex"
+  "model": "openai/gpt-5.6-sol"
 }
 ```
 
@@ -267,11 +265,11 @@ opencode
 {
   "agents": {
     "defaults": {
-      "model": { "primary": "codex-lb/gpt-5.4" },
+      "model": { "primary": "codex-lb/gpt-5.6-sol" },
       "models": {
-        "codex-lb/gpt-5.4": { "params": { "cacheRetention": "short" } }
-        "codex-lb/gpt-5.4-mini": { "params": { "cacheRetention": "short" } }
-        "codex-lb/gpt-5.3-codex": { "params": { "cacheRetention": "short" } }
+        "codex-lb/gpt-5.6-sol": { "params": { "cacheRetention": "short" } },
+        "codex-lb/gpt-5.6-terra": { "params": { "cacheRetention": "short" } },
+        "codex-lb/gpt-5.6-luna": { "params": { "cacheRetention": "short" } }
       }
     }
   },
@@ -284,28 +282,28 @@ opencode
         "api": "openai-responses",
         "models": [
           {
-            "id": "gpt-5.4",
-            "name": "gpt-5.4 (codex-lb)",
+            "id": "gpt-5.6-sol",
+            "name": "gpt-5.6-sol (codex-lb)",
             "contextWindow": 1050000,
-            "contextTokens": 272000,
+            "contextTokens": 372000,
             "maxTokens": 4096,
             "input": ["text"],
             "reasoning": false
           },
           {
-            "id": "gpt-5.4-mini",
-            "name": "gpt-5.4-mini (codex-lb)",
-            "contextWindow": 400000,
-            "contextTokens": 272000,
+            "id": "gpt-5.6-terra",
+            "name": "gpt-5.6-terra (codex-lb)",
+            "contextWindow": 1050000,
+            "contextTokens": 372000,
             "maxTokens": 4096,
             "input": ["text"],
             "reasoning": false
           },
           {
-            "id": "gpt-5.3-codex",
-            "name": "gpt-5.3-codex (codex-lb)",
-            "contextWindow": 400000,
-            "contextTokens": 272000,
+            "id": "gpt-5.6-luna",
+            "name": "gpt-5.6-luna (codex-lb)",
+            "contextWindow": 1050000,
+            "contextTokens": 372000,
             "maxTokens": 4096,
             "input": ["text"],
             "reasoning": false
@@ -335,7 +333,7 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="gpt-5.3-codex",
+    model="gpt-5.6-sol",
     messages=[{"role": "user", "content": "Hello!"}],
 )
 print(response.choices[0].message.content)


### PR DESCRIPTION
## Summary

Update the English and Chinese client configuration examples to the GPT-5.6 Sol, Terra, and Luna models already supported by codex-lb after #1176. The examples now default to Sol and distinguish the official 1.05M API context from the 372k Codex catalog context.

Official model references:
- https://developers.openai.com/api/docs/guides/latest-model
- https://developers.openai.com/api/docs/models/gpt-5.6-sol
- https://developers.openai.com/api/docs/models/gpt-5.6-terra
- https://developers.openai.com/api/docs/models/gpt-5.6-luna

## Merge dependency

- [ ] #1275 must merge first so GPT-5.6 usage is priced and cost-based API-key limits remain enforced. After #1275 lands, refresh this branch against `main` before merge.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [x] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Related to #1176

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [x] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: N/A

## Changes

- Default Codex CLI, OpenCode, OpenClaw, and Python examples to `gpt-5.6-sol`.
- Replace stale static model examples with `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`, including current API and Codex context limits.
- Keep English and Chinese READMEs aligned, and fix the Chinese lowercase provider name plus invalid missing JSONC commas.

## Test plan

- Machine-parsed every edited JSONC block and the Codex TOML block in both READMEs.
- Asserted the GPT-5.6 IDs, default model, reasoning effort, API limits, and Codex limits.
- `openspec validate --specs` — 43 passed, 0 failed.
- `git diff --check` — passed.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related merged model-support PR above.
- [x] Documentation snippets are machine-validated; no runtime logic changed.
- [x] Ran the relevant documentation-only validation subset locally.
- [x] `openspec validate --specs` passes.
- [x] CHANGELOG is not edited by hand.
