### PR TITLE
fix(proxy): retry stale per-account model rejections

### DIFF
--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -445,16 +445,24 @@ def _log_http_bridge_startup_wait_timeout(
     )
 
 
-def _http_bridge_precreated_retry_failure_error(exc: BaseException) -> tuple[str, str]:
+def _http_bridge_precreated_retry_failure_error(exc: BaseException) -> tuple[int, str, str, str, str | None]:
     if isinstance(exc, ProxyResponseError):
         parsed = _parse_openai_error(exc.payload)
         code = _normalize_error_code(parsed.code if parsed else None, parsed.type if parsed else None)
         message = parsed.message if parsed and parsed.message else "HTTP bridge pre-created retry failed"
-        return code, message
+        error_type = parsed.type if parsed and parsed.type else "server_error"
+        error_param = parsed.param if parsed else None
+        return exc.status_code, code, message, error_type, error_param
     if isinstance(exc, TimeoutError):
-        return "upstream_unavailable", "HTTP bridge pre-created retry failed: upstream websocket reconnect timed out"
+        return (
+            502,
+            "upstream_unavailable",
+            "HTTP bridge pre-created retry failed: upstream websocket reconnect timed out",
+            "server_error",
+            None,
+        )
     message = str(exc).strip() or "HTTP bridge pre-created retry failed"
-    return "upstream_unavailable", message
+    return 502, "upstream_unavailable", message, "server_error", None
 
 
 def _trim_http_bridge_previous_response_input_items(input_items: list[JsonValue]) -> list[JsonValue]:
@@ -563,6 +571,17 @@ def _normalize_http_bridge_error_event(
             resets_in = raw_error.get("resets_in_seconds")
             if isinstance(resets_in, int | float):
                 rate_limit_metadata["resets_in_seconds"] = resets_in
+
+    if request_state is not None:
+        if request_state.error_code_override is not None:
+            error_code_value = request_state.error_code_override
+            explicit_error_code = True
+        if request_state.error_type_override is not None:
+            error_type_value = request_state.error_type_override
+        if request_state.error_message_override is not None:
+            error_message_value = request_state.error_message_override
+        if request_state.error_param_override is not None:
+            error_param_value = request_state.error_param_override
 
     normalized_error_code = _normalize_error_code(error_code_value, error_type_value) or "upstream_error"
     if not explicit_error_code and normalized_error_code == "error":

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -2154,6 +2154,14 @@ class _HTTPBridgeMixin(
         selected_account_lease: AccountLease | None = None
         selected_account_model_replacement = False
 
+        def record_selected_account_takeover(
+            selected_account_id: str | None, preferred_account_id: str | None = session.account.id
+        ) -> None:
+            _record_same_account_takeover(
+                preferred_account_id=preferred_account_id,
+                selected_account_id=selected_account_id,
+            )
+
         async def release_selected_account_lease() -> None:
             nonlocal selected_account_lease
             lease = selected_account_lease
@@ -2249,10 +2257,7 @@ class _HTTPBridgeMixin(
                     else:
                         preferred_candidate_id = None
                     continue
-                _record_same_account_takeover(
-                    preferred_account_id=session.account.id,
-                    selected_account_id=None,
-                )
+                record_selected_account_takeover(None)
                 status_code = 429 if _is_local_account_cap_code(selection.error_code) else 503
                 raise ProxyResponseError(
                     status_code,
@@ -2265,10 +2270,7 @@ class _HTTPBridgeMixin(
             if required_preferred_account_id is not None and account.id != required_preferred_account_id:
                 if selection.lease is not None:
                     await self._load_balancer.release_account_lease(selection.lease)
-                _record_same_account_takeover(
-                    preferred_account_id=required_preferred_account_id,
-                    selected_account_id=account.id,
-                )
+                record_selected_account_takeover(account.id, required_preferred_account_id)
                 raise _http_bridge_previous_response_owner_unavailable_error()
             selected_account_lease = (
                 session.account_lease
@@ -2305,10 +2307,7 @@ class _HTTPBridgeMixin(
                     request_state=request_state,
                 )
                 _copy_websocket_route_metadata_to_session(session, request_state)
-                _record_same_account_takeover(
-                    preferred_account_id=session.account.id,
-                    selected_account_id=account.id,
-                )
+                record_selected_account_takeover(account.id)
                 break
             except ProxyResponseError as exc:
                 if exc.status_code != 401 or _remaining_budget_seconds(deadline) <= 0:
@@ -2330,10 +2329,7 @@ class _HTTPBridgeMixin(
                         request_state=request_state,
                     )
                     _copy_websocket_route_metadata_to_session(session, request_state)
-                    _record_same_account_takeover(
-                        preferred_account_id=session.account.id,
-                        selected_account_id=account.id,
-                    )
+                    record_selected_account_takeover(account.id)
                     break
                 except ProxyResponseError as retry_exc:
                     if retry_exc.status_code != 401:
@@ -2376,9 +2372,7 @@ class _HTTPBridgeMixin(
         if selected_account_lease is not session.account_lease:
             await self._load_balancer.release_account_lease(session.account_lease)
         session.account_lease = selected_account_lease
-        session.account = account
-        session.headers = connect_headers
-        session.upstream = upstream
+        session.account, session.headers, session.upstream = account, connect_headers, upstream
         session.upstream_control = _WebSocketUpstreamControl()
         session.closed = False
         session.last_upstream_close_code = None

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -2162,14 +2162,11 @@ class _HTTPBridgeMixin(
                 session.account_lease = None
             await self._load_balancer.release_account_lease(lease)
 
-        async def release_selected_account_lease_and_reraise_if_hard_close_bound() -> None:
+        async def abandon_selected_account_retry(selected_account: Any) -> None:
+            nonlocal preferred_candidate_id
             if hard_close_account_bound:
                 await release_selected_account_lease()
                 raise
-
-        async def abandon_selected_account_retry(selected_account: Any) -> None:
-            nonlocal preferred_candidate_id
-            await release_selected_account_lease_and_reraise_if_hard_close_bound()
             excluded_account_ids.add(selected_account.id)
             preferred_candidate_id = None
             await release_selected_account_lease()

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -165,6 +165,7 @@ from app.modules.proxy._service.observability import (
 from app.modules.proxy._service.support import (
     _HARD_HTTP_BRIDGE_AFFINITY_KINDS,  # noqa: F401
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
+    _clear_websocket_precreated_replay_fallback,
     _copy_websocket_route_metadata_to_session,
     _http_bridge_session_supports_service_tier,
     _HTTPBridgeOwnerForward,
@@ -2275,6 +2276,8 @@ class _HTTPBridgeMixin(
                 if reuse_current_account_lease and account.id == session.account.id
                 else selection.lease
             )
+            if account.id != request_state.precreated_replay_account_id:
+                _clear_websocket_precreated_replay_fallback(request_state)
             selected_is_preferred = account.id == session.account.id
             force_refresh = forced_refresh_account_id == account.id
             if forced_refresh_account_id is not None and account.id != forced_refresh_account_id:

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -163,6 +163,7 @@ from app.modules.proxy._service.observability import (
     _truncate_identifier as _truncate_identifier,
 )
 from app.modules.proxy._service.support import (
+    _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE,
     _HARD_HTTP_BRIDGE_AFFINITY_KINDS,  # noqa: F401
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
     _clear_websocket_precreated_replay_fallback,
@@ -2151,6 +2152,7 @@ class _HTTPBridgeMixin(
         else:
             preferred_candidate_id = None
         selected_account_lease: AccountLease | None = None
+        selected_account_model_replacement = False
 
         async def release_selected_account_lease() -> None:
             nonlocal selected_account_lease
@@ -2164,7 +2166,7 @@ class _HTTPBridgeMixin(
 
         async def abandon_selected_account_retry(selected_account: Any) -> None:
             nonlocal preferred_candidate_id
-            if hard_close_account_bound:
+            if hard_close_account_bound or selected_account_model_replacement:
                 await release_selected_account_lease()
                 raise
             excluded_account_ids.add(selected_account.id)
@@ -2273,7 +2275,11 @@ class _HTTPBridgeMixin(
                 if reuse_current_account_lease and account.id == session.account.id
                 else selection.lease
             )
-            if account.id != request_state.precreated_replay_account_id:
+            selected_account_model_replacement = (
+                request_state.precreated_replay_reason == _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE
+                and account.id != request_state.precreated_replay_account_id
+            )
+            if selected_account_model_replacement:
                 _clear_websocket_precreated_replay_fallback(request_state)
             selected_is_preferred = account.id == session.account.id
             force_refresh = forced_refresh_account_id == account.id

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -91,6 +91,7 @@ from app.modules.proxy._service.http_bridge.service_stubs import (
     _security_work_advisory_event,
     _service_as_image_fetch_session,
     _service_get_settings,
+    _service_get_settings_cache,
     _service_inline_input_image_urls,
     _service_lease_http_session,
     _service_time,
@@ -167,6 +168,7 @@ from app.modules.proxy.helpers import (
     _normalize_error_code,
     _parse_openai_error,
 )
+from app.modules.proxy.load_balancer import effective_account_concurrency_caps
 from app.modules.proxy.tool_call_dedupe import (
     dedupe_replayed_side_effect_input_items,
 )
@@ -1299,6 +1301,17 @@ class _HTTPBridgeRequestSubmitMixin:
                 )
             else:
                 await self._reconnect_http_bridge_session(session, request_state=request_state)
+            if request_state.account_response_create_lease is None:
+                current_settings = await _service_get_settings_cache().get()
+                request_state.account_response_create_lease = (
+                    await self._acquire_account_response_create_lease_or_overload(
+                        account_id=session.account.id,
+                        request_id=request_state.request_log_id or request_state.request_id,
+                        surface="http_bridge",
+                        concurrency_caps=effective_account_concurrency_caps(current_settings),
+                    )
+                )
+                request_state.account_response_create_release = self._load_balancer.release_account_lease
             request_text = self._http_bridge_text_with_account_installation_id(session, request_state, request_text)
             await _send_http_bridge_request_text_with_archive_id(session, request_state, request_text)
             session.last_used_at = _service_time().monotonic()
@@ -1306,9 +1319,13 @@ class _HTTPBridgeRequestSubmitMixin:
         except UpstreamWebSocketTransportError:
             raise
         except Exception as exc:
-            request_state.error_code_override, request_state.error_message_override = (
-                _http_bridge_precreated_retry_failure_error(exc)
-            )
+            (
+                request_state.error_http_status_override,
+                request_state.error_code_override,
+                request_state.error_message_override,
+                request_state.error_type_override,
+                request_state.error_param_override,
+            ) = _http_bridge_precreated_retry_failure_error(exc)
             if isinstance(exc, ProxyResponseError):
                 logger.info(
                     "HTTP bridge pre-created retry failed with terminal proxy error code=%s message=%s",
@@ -1375,9 +1392,13 @@ class _HTTPBridgeRequestSubmitMixin:
         except UpstreamWebSocketTransportError:
             raise
         except Exception as exc:
-            request_state.error_code_override, request_state.error_message_override = (
-                _http_bridge_precreated_retry_failure_error(exc)
-            )
+            (
+                request_state.error_http_status_override,
+                request_state.error_code_override,
+                request_state.error_message_override,
+                request_state.error_type_override,
+                request_state.error_param_override,
+            ) = _http_bridge_precreated_retry_failure_error(exc)
             if isinstance(exc, ProxyResponseError):
                 logger.info(
                     "HTTP bridge pre-created auth retry failed with terminal proxy error code=%s message=%s",

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -28,6 +28,7 @@ from app.core.clients.proxy import codex_control_request as core_codex_control_r
 from app.core.clients.proxy import compact_responses as core_compact_responses  # noqa: F401
 from app.core.clients.proxy import transcribe_audio as core_transcribe_audio  # noqa: F401
 from app.core.clients.proxy_websocket import UpstreamWebSocketMessage, UpstreamWebSocketTransportError
+from app.core.errors import response_failed_event
 from app.core.openai.parsing import parse_sse_event_payload
 from app.core.usage.live_hub import publish_live_usage
 from app.core.usage.live_snapshots import EVENT_MARKER, parse_rate_limit_event_text
@@ -792,13 +793,33 @@ class _HTTPBridgeUpstreamEventsMixin:
                     status_request_state.model,
                 )
                 return
-            session.upstream_turn_state = previous_upstream_turn_state
-            session.downstream_turn_state = previous_downstream_turn_state
-            session.headers = previous_headers
+            replacement_session_selected = session.account.id != rejected_account_id
+            if not replacement_session_selected:
+                session.upstream_turn_state = previous_upstream_turn_state
+                session.downstream_turn_state = previous_downstream_turn_state
+                session.headers = previous_headers
             async with session.pending_lock:
                 if status_request_state in session.pending_requests:
                     session.pending_requests.remove(status_request_state)
                     session.queued_request_count = max(0, session.queued_request_count - 1)
+            if replacement_session_selected:
+                # Reconnect may have committed the session to a replacement
+                # account before its replacement lease or send failed.  Never
+                # graft the rejected account's turn metadata back onto that
+                # socket; retire the now-unused replacement session instead.
+                session.upstream_control.reconnect_requested = True
+                session.upstream_control.retire_after_drain = True
+                await self._retire_http_bridge_after_drain_if_ready(session)
+                payload = response_failed_event(
+                    status_request_state.error_code_override or "upstream_unavailable",
+                    status_request_state.error_message_override or "HTTP bridge replacement retry failed",
+                    error_type=status_request_state.error_type_override or "server_error",
+                    response_id=status_request_state.request_id,
+                    error_param=status_request_state.error_param_override,
+                )
+                event_block = format_sse_event(payload)
+                event = parse_sse_event_payload(payload)
+                event_type = "response.failed"
             if status_request_state.precreated_replay_reason == _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE:
                 _clear_websocket_precreated_replay_fallback(status_request_state)
         elif (

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -101,8 +101,10 @@ from app.modules.proxy._service.observability import (
     _truncate_identifier as _truncate_identifier,
 )
 from app.modules.proxy._service.support import (
+    _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE,
     _HARD_HTTP_BRIDGE_AFFINITY_KINDS,  # noqa: F401
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
+    _clear_websocket_request_error_overrides,
     _event_type_from_payload,
     _HTTPBridgeSession,
     _record_response_event,
@@ -761,7 +763,45 @@ class _HTTPBridgeUpstreamEventsMixin:
                         )
                     )
                     event_block = f"data: {rewritten_text}\n\n"
-        elif retry_error_code is not None and not is_previous_response_not_found_event:
+        elif (
+            retry_error_code == _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE
+            and not is_previous_response_not_found_event
+            and status_request_state is not None
+            and _websocket_auth_request_can_switch_account(status_request_state)
+        ):
+            rejected_account_id = session.account.id
+            previous_upstream_turn_state = session.upstream_turn_state
+            previous_downstream_turn_state = session.downstream_turn_state
+            previous_headers = session.headers
+            async with session.pending_lock:
+                if status_request_state not in session.pending_requests:
+                    session.pending_requests.appendleft(status_request_state)
+                    session.queued_request_count += 1
+                status_request_state.awaiting_response_created = True
+                status_request_state.response_id = None
+            retried = await self._retry_http_bridge_precreated_request(session)
+            if retried:
+                logger.info(
+                    "Retried HTTP bridge request after account/model rejection "
+                    "request_id=%s rejected_account_id=%s model=%s",
+                    status_request_state.request_log_id or status_request_state.request_id,
+                    rejected_account_id,
+                    status_request_state.model,
+                )
+                return
+            session.upstream_turn_state = previous_upstream_turn_state
+            session.downstream_turn_state = previous_downstream_turn_state
+            session.headers = previous_headers
+            async with session.pending_lock:
+                if status_request_state in session.pending_requests:
+                    session.pending_requests.remove(status_request_state)
+                    session.queued_request_count = max(0, session.queued_request_count - 1)
+            _clear_websocket_request_error_overrides(status_request_state)
+        elif (
+            retry_error_code is not None
+            and retry_error_code != _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE
+            and not is_previous_response_not_found_event
+        ):
             await self._handle_stream_error(
                 session.account,
                 {"message": _websocket_event_error_message(event_type, payload) or "Upstream error"},

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import replace
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from app.core.clients.files import create_file as core_create_file  # noqa: F401
 from app.core.clients.files import finalize_file as core_finalize_file  # noqa: F401
@@ -30,6 +30,7 @@ from app.core.clients.proxy import transcribe_audio as core_transcribe_audio  # 
 from app.core.clients.proxy_websocket import UpstreamWebSocketMessage, UpstreamWebSocketTransportError
 from app.core.errors import response_failed_event
 from app.core.openai.parsing import parse_sse_event_payload
+from app.core.types import JsonValue
 from app.core.usage.live_hub import publish_live_usage
 from app.core.usage.live_snapshots import EVENT_MARKER, parse_rate_limit_event_text
 from app.core.utils.request_id import reset_request_id, set_request_id
@@ -810,12 +811,17 @@ class _HTTPBridgeUpstreamEventsMixin:
                 session.upstream_control.reconnect_requested = True
                 session.upstream_control.retire_after_drain = True
                 await self._retire_http_bridge_after_drain_if_ready(session)
-                payload = response_failed_event(
-                    status_request_state.error_code_override or "upstream_unavailable",
-                    status_request_state.error_message_override or "HTTP bridge replacement retry failed",
-                    error_type=status_request_state.error_type_override or "server_error",
-                    response_id=status_request_state.request_id,
-                    error_param=status_request_state.error_param_override,
+                payload = cast(
+                    dict[str, JsonValue],
+                    dict(
+                        response_failed_event(
+                            status_request_state.error_code_override or "upstream_unavailable",
+                            status_request_state.error_message_override or "HTTP bridge replacement retry failed",
+                            error_type=status_request_state.error_type_override or "server_error",
+                            response_id=status_request_state.request_id,
+                            error_param=status_request_state.error_param_override,
+                        )
+                    ),
                 )
                 event_block = format_sse_event(payload)
                 event = parse_sse_event_payload(payload)

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -873,7 +873,7 @@ class _HTTPBridgeUpstreamEventsMixin:
         settlement_event_type = event_type
         if event_type == "error" and normalize_error_event:
             http_status = _http_error_status_from_payload(payload)
-            if status_request_state is not None:
+            if status_request_state is not None and status_request_state.error_http_status_override is None:
                 status_request_state.error_http_status_override = http_status
             (
                 event_block,
@@ -890,7 +890,7 @@ class _HTTPBridgeUpstreamEventsMixin:
             settlement_event_type = event_type
         elif event_type == "error":
             http_status = _http_error_status_from_payload(payload)
-            if status_request_state is not None:
+            if status_request_state is not None and status_request_state.error_http_status_override is None:
                 status_request_state.error_http_status_override = http_status
             (
                 _settlement_event_block,

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -104,7 +104,7 @@ from app.modules.proxy._service.support import (
     _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE,
     _HARD_HTTP_BRIDGE_AFFINITY_KINDS,  # noqa: F401
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
-    _clear_websocket_request_error_overrides,
+    _clear_websocket_precreated_replay_fallback,
     _event_type_from_payload,
     _HTTPBridgeSession,
     _record_response_event,
@@ -770,9 +770,12 @@ class _HTTPBridgeUpstreamEventsMixin:
             and _websocket_auth_request_can_switch_account(status_request_state)
         ):
             rejected_account_id = session.account.id
+            status_request_state.precreated_replay_reason = _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE
+            status_request_state.precreated_replay_account_id = rejected_account_id
             previous_upstream_turn_state = session.upstream_turn_state
             previous_downstream_turn_state = session.downstream_turn_state
             previous_headers = session.headers
+            await self._release_request_state_account_response_create_lease(status_request_state)
             async with session.pending_lock:
                 if status_request_state not in session.pending_requests:
                     session.pending_requests.appendleft(status_request_state)
@@ -796,7 +799,8 @@ class _HTTPBridgeUpstreamEventsMixin:
                 if status_request_state in session.pending_requests:
                     session.pending_requests.remove(status_request_state)
                     session.queued_request_count = max(0, session.queued_request_count - 1)
-            _clear_websocket_request_error_overrides(status_request_state)
+            if status_request_state.precreated_replay_reason == _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE:
+                _clear_websocket_precreated_replay_fallback(status_request_state)
         elif (
             retry_error_code is not None
             and retry_error_code != _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -1217,6 +1217,7 @@ class _StreamingRetryMixin:
                         yield format_sse_event(event)
                         return
                     except (RefreshError, aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                        selected_account_model_replacement = account.id == account_model_replacement_account_id
                         if isinstance(exc, RefreshError):
                             if exc.is_permanent:
                                 await proxy._load_balancer.mark_permanent_failure(account, exc.code)
@@ -1229,7 +1230,8 @@ class _StreamingRetryMixin:
                                 # duration of the replacement stream.
                                 await _release_tracked_stream_lease(current_account_lease)
                                 current_account_lease = None
-                                continue
+                                if not selected_account_model_replacement:
+                                    continue
                             if is_transient_refresh_contention(exc):
                                 # Transient CROSS-REPLICA refresh contention: benign
                                 # claim contention (the account's refresh claim is
@@ -1248,7 +1250,11 @@ class _StreamingRetryMixin:
                                         exc.code,
                                         account.id,
                                     )
-                                if not require_preferred_account and preferred_account_id is None:
+                                if (
+                                    not selected_account_model_replacement
+                                    and not require_preferred_account
+                                    and preferred_account_id is None
+                                ):
                                     # Movable request: release the stream lease and
                                     # fail over to a different account instead of
                                     # reselecting the same one until attempts are
@@ -1311,7 +1317,7 @@ class _StreamingRetryMixin:
                                 )
                                 yield format_sse_event(event)
                                 return
-                            if not exc.transport_error:
+                            if not exc.transport_error and not selected_account_model_replacement:
                                 # Non-transport, non-permanent RefreshError: release
                                 # the stream lease and reselect (its prior behavior).
                                 await _release_tracked_stream_lease(current_account_lease)
@@ -1334,7 +1340,8 @@ class _StreamingRetryMixin:
                         )
                         message = getattr(exc, "message", None) or str(exc) or "Request to upstream timed out"
                         if (
-                            _facade()._should_retry_transient_stream_error("upstream_unavailable", message)
+                            not selected_account_model_replacement
+                            and _facade()._should_retry_transient_stream_error("upstream_unavailable", message)
                             and attempt + 1 < max_attempts
                             and _move_verified_fresh_replay_from_owner(
                                 account_id=account.id,
@@ -1355,7 +1362,8 @@ class _StreamingRetryMixin:
                             )
                             continue
                         if (
-                            not require_preferred_account
+                            not selected_account_model_replacement
+                            and not require_preferred_account
                             and preferred_account_id is None
                             and _facade()._should_retry_transient_stream_error("upstream_unavailable", message)
                             and attempt + 1 < max_attempts

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -1825,6 +1825,7 @@ class _StreamingRetryMixin:
                     if _facade()._is_proxy_budget_exhausted_error(exc):
                         await _settle_process_network_budget_exhaustion(account, settlement)
                         yield format_sse_event(_facade()._proxy_request_timeout_event(request_id))
+                        return
                     account_model_retry = await _retry_account_model_rejection(
                         exc,
                         account,

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -34,6 +34,7 @@ from app.modules.proxy._service.observability import (
 )
 from app.modules.proxy._service.streaming.protocol import _StreamingServiceProtocol
 from app.modules.proxy._service.support import (
+    _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE,
     _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS,
     _LOCAL_ACCOUNT_CAP_ERROR_CODES,
     _account_capacity_wait_payload,
@@ -60,6 +61,7 @@ from app.modules.proxy.affinity import (
 from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
 from app.modules.proxy.helpers import (
     _apply_error_metadata,
+    _is_account_model_unsupported_error,
     _normalize_error_code,
     _parse_openai_error,
     _upstream_error_from_openai,
@@ -331,6 +333,9 @@ class _StreamingRetryMixin:
         network_recovery = ProcessNetworkRecovery(transport="stream", request_id=request_id)
         settlement = _StreamSettlement()
         last_transient_exc: ProxyResponseError | None = None
+        last_account_model_rejection: ProxyResponseError | None = None
+        last_account_model_rejection_account_id: str | None = None
+        current_account_lease: AccountLease | None = None
         last_security_work_retry_error: _RetryableStreamError | None = None
         excluded_account_ids: set[str] = set()
         deferred_capacity_account: Account | None = None
@@ -538,6 +543,103 @@ class _StreamingRetryMixin:
                 sticky=upstream_transport_sticky,
                 status=status,
             )
+
+        async def _render_account_model_rejection(
+            exc: ProxyResponseError,
+            *,
+            account_id: str | None,
+        ) -> str:
+            error = _parse_openai_error(exc.payload)
+            error_code = (
+                _normalize_error_code(
+                    error.code if error else None,
+                    error.type if error else None,
+                )
+                or "invalid_request_error"
+            )
+            error_message = error.message if error and error.message else "Upstream rejected the requested model"
+            event = response_failed_event(
+                error_code,
+                error_message,
+                error_type=(error.type if error else None) or "invalid_request_error",
+                response_id=request_id,
+                error_param=error.param if error else None,
+            )
+            _apply_error_metadata(event["response"]["error"], error)
+            if not any_attempt_logged:
+                await proxy._write_request_log(
+                    account_id=account_id,
+                    api_key=api_key,
+                    request_id=request_id,
+                    model=payload.model,
+                    latency_ms=int((time.monotonic() - start) * 1000),
+                    status="error",
+                    error_code=error_code,
+                    error_message=error_message,
+                    reasoning_effort=payload.reasoning.effort if payload.reasoning else None,
+                    transport=request_transport,
+                    upstream_transport=upstream_stream_transport,
+                    service_tier=payload.service_tier,
+                    requested_service_tier=payload.service_tier,
+                    useragent=useragent,
+                    useragent_group=useragent_group,
+                    client_ip=client_ip,
+                )
+            return format_sse_event(event)
+
+        async def _retry_account_model_rejection(
+            exc: ProxyResponseError,
+            account: Account,
+            *,
+            outcome: str,
+        ) -> bool | None:
+            nonlocal affinity, current_account_lease
+            nonlocal last_account_model_rejection, last_account_model_rejection_account_id
+            error = _parse_openai_error(exc.payload)
+            error_code = _normalize_error_code(
+                error.code if error else None,
+                error.type if error else None,
+            )
+            if not _is_account_model_unsupported_error(
+                code=error_code,
+                message=error.message if error else None,
+                model=payload.model,
+            ):
+                return None
+            can_move_verified_owner = bool(
+                require_preferred_account
+                and preferred_account_id == account.id
+                and verified_fresh_replay_payload is not None
+            )
+            can_try_other_account = bool(
+                last_account_model_rejection is None
+                and attempt < max_attempts - 1
+                and (
+                    can_move_verified_owner
+                    or (not require_preferred_account and account.id != file_preferred_account_id)
+                )
+            )
+            if not can_try_other_account:
+                return False
+            logger.info(
+                "Retrying stream after account/model rejection request_id=%s account_id=%s model=%s phase=%s reason=%s",
+                request_id,
+                account.id,
+                payload.model,
+                outcome,
+                _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE,
+            )
+            last_account_model_rejection = exc
+            last_account_model_rejection_account_id = account.id
+            await _release_tracked_stream_lease(current_account_lease)
+            current_account_lease = None
+            if not _move_verified_fresh_replay_from_owner(
+                account_id=account.id,
+                outcome=outcome,
+            ):
+                excluded_account_ids.add(account.id)
+                affinity = replace(affinity, reallocate_sticky=True)
+            return True
 
         try:
             if payload.previous_response_id is not None:
@@ -804,6 +906,14 @@ class _StreamingRetryMixin:
                             continue
                     break
                 if not account:
+                    if last_account_model_rejection is not None:
+                        if propagate_http_errors:
+                            raise last_account_model_rejection
+                        yield await _render_account_model_rejection(
+                            last_account_model_rejection,
+                            account_id=last_account_model_rejection_account_id,
+                        )
+                        return
                     if selection.error_code in _LOCAL_ACCOUNT_CAP_ERROR_CODES:
                         no_accounts_msg = selection.error_message or "Local account capacity is exhausted"
                         error_code = selection.error_code
@@ -1434,6 +1544,15 @@ class _StreamingRetryMixin:
                                     error.type if error else None,
                                 )
                                 error_message = error.message if error else None
+                                account_model_retry = await _retry_account_model_rejection(
+                                    tex,
+                                    account,
+                                    outcome="previsible",
+                                )
+                                if account_model_retry is not None:
+                                    if not account_model_retry:
+                                        raise
+                                    break
                                 if _facade()._is_security_work_authorization_required_error(code, error_message):
                                     if (
                                         account.security_work_authorized
@@ -1690,6 +1809,17 @@ class _StreamingRetryMixin:
                     if _facade()._is_proxy_budget_exhausted_error(exc):
                         await _settle_process_network_budget_exhaustion(account, settlement)
                         yield format_sse_event(_facade()._proxy_request_timeout_event(request_id))
+                    account_model_retry = await _retry_account_model_rejection(
+                        exc,
+                        account,
+                        outcome="outer_proxy_error",
+                    )
+                    if account_model_retry:
+                        continue
+                    if account_model_retry is False:
+                        if propagate_http_errors:
+                            raise
+                        yield await _render_account_model_rejection(exc, account_id=account.id)
                         return
                     if exc.status_code == 401:
                         remaining_budget = _facade()._remaining_budget_seconds(deadline)
@@ -1981,6 +2111,21 @@ class _StreamingRetryMixin:
                                 error.code if error else None,
                                 error.type if error else None,
                             )
+                            account_model_retry = await _retry_account_model_rejection(
+                                retry_exc,
+                                account,
+                                outcome="post_refresh",
+                            )
+                            if account_model_retry:
+                                continue
+                            if account_model_retry is False:
+                                if propagate_http_errors:
+                                    raise
+                                yield await _render_account_model_rejection(
+                                    retry_exc,
+                                    account_id=account.id,
+                                )
+                                return
                             if error_code == "account_response_create_cap":
                                 last_transient_exc = retry_exc
                                 if can_try_other_account:
@@ -2132,6 +2277,14 @@ class _StreamingRetryMixin:
                     return
             # When HTTP error propagation is enabled and the last failure was
             # a transient 500, re-raise to preserve the upstream status/payload.
+            if last_account_model_rejection is not None:
+                if propagate_http_errors:
+                    raise last_account_model_rejection
+                yield await _render_account_model_rejection(
+                    last_account_model_rejection,
+                    account_id=last_account_model_rejection_account_id,
+                )
+                return
             if propagate_http_errors and last_transient_exc is not None:
                 raise last_transient_exc
             if last_retryable_stream_error is not None:

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -335,6 +335,7 @@ class _StreamingRetryMixin:
         last_transient_exc: ProxyResponseError | None = None
         last_account_model_rejection: ProxyResponseError | None = None
         last_account_model_rejection_account_id: str | None = None
+        account_model_replacement_account_id: str | None = None
         account_model_replay_attempted = False
         current_account_lease: AccountLease | None = None
         last_security_work_retry_error: _RetryableStreamError | None = None
@@ -1106,6 +1107,7 @@ class _StreamingRetryMixin:
                     # that must reach the client. Keep the separate replay
                     # budget so another account/model rejection cannot trigger
                     # a second transparent replay.
+                    account_model_replacement_account_id = account.id
                     last_account_model_rejection = None
                     last_account_model_rejection_account_id = None
                 if (
@@ -1482,6 +1484,23 @@ class _StreamingRetryMixin:
                             ):
                                 yield line
                         except (_TransientStreamError, ProxyResponseError) as tex:
+                            if account.id == account_model_replacement_account_id:
+                                # Account/model routing gets exactly one selected
+                                # replacement.  Its own pre-visible 5xx/transport
+                                # failure is terminal; allowing the normal
+                                # transient path here would silently select a third
+                                # account.  Re-raise into the outer terminal
+                                # renderer to retain the replacement details.
+                                if isinstance(tex, ProxyResponseError):
+                                    raise
+                                raise ProxyResponseError(
+                                    502,
+                                    openai_error(
+                                        tex.code,
+                                        str(tex.error.get("message") or "Upstream error"),
+                                        error_type="server_error",
+                                    ),
+                                ) from tex
                             if settlement.downstream_visible:
                                 failed_response_id = settlement.response_id or request_id
                                 if isinstance(tex, ProxyResponseError):

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -335,6 +335,7 @@ class _StreamingRetryMixin:
         last_transient_exc: ProxyResponseError | None = None
         last_account_model_rejection: ProxyResponseError | None = None
         last_account_model_rejection_account_id: str | None = None
+        account_model_replay_attempted = False
         current_account_lease: AccountLease | None = None
         last_security_work_retry_error: _RetryableStreamError | None = None
         excluded_account_ids: set[str] = set()
@@ -594,6 +595,7 @@ class _StreamingRetryMixin:
             outcome: str,
         ) -> bool | None:
             nonlocal affinity, current_account_lease
+            nonlocal account_model_replay_attempted
             nonlocal last_account_model_rejection, last_account_model_rejection_account_id
             error = _parse_openai_error(exc.payload)
             error_code = _normalize_error_code(
@@ -612,7 +614,7 @@ class _StreamingRetryMixin:
                 and verified_fresh_replay_payload is not None
             )
             can_try_other_account = bool(
-                last_account_model_rejection is None
+                not account_model_replay_attempted
                 and attempt < max_attempts - 1
                 and (
                     can_move_verified_owner
@@ -629,6 +631,7 @@ class _StreamingRetryMixin:
                 outcome,
                 _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE,
             )
+            account_model_replay_attempted = True
             last_account_model_rejection = exc
             last_account_model_rejection_account_id = account.id
             await _release_tracked_stream_lease(current_account_lease)
@@ -1096,6 +1099,15 @@ class _StreamingRetryMixin:
                     return
 
                 account_id_value = account.id
+                if last_account_model_rejection is not None and account.id != last_account_model_rejection_account_id:
+                    # The original 400 is only the fallback when account
+                    # selection cannot produce a replacement. Once this
+                    # replacement attempt starts, its own failure is the one
+                    # that must reach the client. Keep the separate replay
+                    # budget so another account/model rejection cannot trigger
+                    # a second transparent replay.
+                    last_account_model_rejection = None
+                    last_account_model_rejection_account_id = None
                 if (
                     require_preferred_account
                     and preferred_account_id is not None
@@ -1552,6 +1564,10 @@ class _StreamingRetryMixin:
                                 if account_model_retry is not None:
                                     if not account_model_retry:
                                         raise
+                                    # Leaving the same-account loop reaches
+                                    # the outer account-selection ``continue``
+                                    # below, where the rejected account is
+                                    # already excluded by the helper.
                                     break
                                 if _facade()._is_security_work_authorization_required_error(code, error_message):
                                     if (

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -60,6 +60,7 @@ _ACCOUNT_SELECTION_RECOVERY_MAX_SLEEP_SECONDS = 300.0
 _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS = 10.0
 _ACCOUNT_SELECTION_RETRY_HINT_RE = re.compile(r"try again in\s+([0-9]+(?:\.[0-9]+)?)s", re.IGNORECASE)
 _LOCAL_ACCOUNT_CAP_ERROR_CODES = frozenset({"account_response_create_cap", "account_stream_cap"})
+_ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE = "account_model_unsupported"
 _PROPAGATED_CAPACITY_STARTUP_WAIT: ContextVar[asyncio.Event | None] = ContextVar(
     "propagated_capacity_startup_wait",
     default=None,
@@ -556,6 +557,12 @@ class _WebSocketRequestState:
     auth_replay_counts_by_account: dict[str, int] = field(default_factory=dict)
     force_refresh_account_id: str | None = None
     excluded_account_ids: set[str] = field(default_factory=set)
+    # A narrowly classified pre-acceptance account/model rejection may move
+    # once to another account. Keep the original upstream error until that
+    # replacement connection is established so an empty replacement pool does
+    # not turn the upstream 400 into a proxy-generated 5xx/no-accounts error.
+    precreated_replay_reason: str | None = None
+    precreated_replay_account_id: str | None = None
     skip_request_log: bool = False
     previous_response_id: str | None = None
     session_id: str | None = None

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -808,6 +808,14 @@ def _clear_websocket_request_error_overrides(request_state: _WebSocketRequestSta
     request_state.error_http_status_override = None
 
 
+def _clear_websocket_precreated_replay_fallback(request_state: _WebSocketRequestState) -> None:
+    if request_state.precreated_replay_reason != _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE:
+        return
+    request_state.precreated_replay_reason = None
+    request_state.precreated_replay_account_id = None
+    _clear_websocket_request_error_overrides(request_state)
+
+
 def _record_response_event(request_state: _WebSocketRequestState | None, event_type: str | None) -> None:
     if request_state is None or event_type is None or not event_type.startswith("response."):
         return

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -270,6 +270,7 @@ from app.modules.proxy._service.observability import (
     _truncate_identifier as _truncate_identifier,
 )
 from app.modules.proxy._service.support import (
+    _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE,
     _HARD_HTTP_BRIDGE_AFFINITY_KINDS,  # noqa: F401
     _WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS,
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
@@ -325,6 +326,7 @@ from app.modules.proxy.durable_bridge_coordinator import (
     DurableBridgeLookup as DurableBridgeLookup,
 )
 from app.modules.proxy.helpers import (
+    _is_account_model_unsupported_error,
     _normalize_error_code,
     _parse_openai_error,
 )
@@ -654,6 +656,8 @@ def _websocket_precreated_retry_error_code(
         return None
     if request_state.last_downstream_sequence_number is not None:
         return None
+    if request_state.downstream_visible:
+        return None
     if has_other_pending_requests:
         return None
     if request_state.response_id is not None:
@@ -687,9 +691,43 @@ def _websocket_precreated_retry_error_code(
         message=error_message,
     ):
         return None
+    if _is_account_model_unsupported_error(
+        code=error_code,
+        message=error_message,
+        model=request_state.model,
+    ):
+        return _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE
     if error_code not in _facade()._WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES:
         return None
     return error_code
+
+
+def _websocket_precreated_replay_fallback_error(
+    request_state: _WebSocketRequestState,
+) -> tuple[int, OpenAIErrorEnvelope, str, str, str | None] | None:
+    if request_state.precreated_replay_reason != _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE:
+        return None
+    error_code = request_state.error_code_override or "invalid_request_error"
+    error_message = request_state.error_message_override or "Upstream rejected the requested model for this account"
+    error_type = request_state.error_type_override or "invalid_request_error"
+    payload = openai_error(error_code, error_message, error_type=error_type)
+    if request_state.error_param_override is not None:
+        payload["error"]["param"] = request_state.error_param_override
+    return (
+        request_state.error_http_status_override or 400,
+        payload,
+        error_code,
+        error_message,
+        request_state.precreated_replay_account_id,
+    )
+
+
+def _clear_websocket_precreated_replay_fallback(request_state: _WebSocketRequestState) -> None:
+    if request_state.precreated_replay_reason != _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE:
+        return
+    request_state.precreated_replay_reason = None
+    request_state.precreated_replay_account_id = None
+    _clear_websocket_request_error_overrides(request_state)
 
 
 def _websocket_precreated_auth_error_code(

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -753,6 +753,8 @@ def _websocket_precreated_auth_error_code(
         return None
     if event_type not in {"error", "response.failed"}:
         return None
+    if event_type == "response.failed" and _websocket_response_id(None, payload) is not None:
+        return None
 
     error_code = _normalize_error_code(
         _websocket_event_error_code(event_type, payload),

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -696,6 +696,12 @@ def _websocket_precreated_retry_error_code(
         message=error_message,
         model=request_state.model,
     ):
+        # A response.failed that already names a response id is an accepted
+        # upstream response even when response.created was not observed on this
+        # socket.  It is therefore not safe to account-switch it as though the
+        # pre-created request were still unaccepted.
+        if event_type == "response.failed" and _websocket_response_id(None, payload) is not None:
+            return None
         return _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE
     if error_code not in _facade()._WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES:
         return None

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -722,14 +722,6 @@ def _websocket_precreated_replay_fallback_error(
     )
 
 
-def _clear_websocket_precreated_replay_fallback(request_state: _WebSocketRequestState) -> None:
-    if request_state.precreated_replay_reason != _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE:
-        return
-    request_state.precreated_replay_reason = None
-    request_state.precreated_replay_account_id = None
-    _clear_websocket_request_error_overrides(request_state)
-
-
 def _websocket_precreated_auth_error_code(
     request_state: _WebSocketRequestState | None,
     *,

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -696,11 +696,11 @@ def _websocket_precreated_retry_error_code(
         message=error_message,
         model=request_state.model,
     ):
-        # A response.failed that already names a response id is an accepted
-        # upstream response even when response.created was not observed on this
-        # socket.  It is therefore not safe to account-switch it as though the
-        # pre-created request were still unaccepted.
-        if event_type == "response.failed" and _websocket_response_id(None, payload) is not None:
+        # Any recognized response id means upstream has accepted this request,
+        # even when response.created was not observed on this socket.  Do not
+        # account-switch an error event that carries either response.id or a
+        # top-level response_id as though it were still pre-created.
+        if _websocket_response_id(None, payload) is not None:
             return None
         return _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE
     if error_code not in _facade()._WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES:
@@ -753,7 +753,7 @@ def _websocket_precreated_auth_error_code(
         return None
     if event_type not in {"error", "response.failed"}:
         return None
-    if event_type == "response.failed" and _websocket_response_id(None, payload) is not None:
+    if _websocket_response_id(None, payload) is not None:
         return None
 
     error_code = _normalize_error_code(

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -2008,7 +2008,6 @@ class _WebSocketMixin:
                 # exclude it, and reselect a healthy account.
                 await proxy._load_balancer.release_account_lease(selected_stream_lease)
                 selected_stream_lease = None
-                excluded_account_ids.add(failover.account_id)
                 # Record a capacity-style failure so that if every account
                 # attempt hits a transient refresh-claim failover, the loop
                 # still surfaces a proper terminal error after exhaustion
@@ -2016,7 +2015,7 @@ class _WebSocketMixin:
                 # credentials are fine (its refresh claim is just held by
                 # another replica), so this must be a 503/capacity-style
                 # upstream error, NOT a bogus 401 invalid_api_key.
-                last_failover_exc = ProxyResponseError(
+                refresh_failure = ProxyResponseError(
                     503,
                     openai_error(
                         "upstream_unavailable",
@@ -2024,6 +2023,23 @@ class _WebSocketMixin:
                         error_type="server_error",
                     ),
                 )
+                if selected_account_model_replacement:
+                    await proxy._emit_websocket_connect_failure(
+                        websocket,
+                        client_send_lock=client_send_lock,
+                        account_id=account.id,
+                        api_key=api_key,
+                        request_state=request_state,
+                        status_code=refresh_failure.status_code,
+                        payload=refresh_failure.payload,
+                        error_code="upstream_unavailable",
+                        error_message=(
+                            "Account refresh is temporarily unavailable; no healthy account could be reached."
+                        ),
+                    )
+                    return None, None
+                excluded_account_ids.add(failover.account_id)
+                last_failover_exc = refresh_failure
                 last_failover_account = account
                 continue
             except ProxyResponseError as exc:

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -307,6 +307,7 @@ from app.modules.proxy._service.observability import (
     _truncate_identifier as _truncate_identifier,
 )
 from app.modules.proxy._service.support import (
+    _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE,
     _FIRST_TOKEN_EVENT_TYPES,
     _HARD_HTTP_BRIDGE_AFFINITY_KINDS,  # noqa: F401
     _REQUEST_TRANSPORT_HTTP,
@@ -371,6 +372,7 @@ from app.modules.proxy._service.warmup import (
 from app.modules.proxy._service.websocket.helpers import (
     _app_error_to_websocket_event,
     _assign_websocket_response_id,
+    _clear_websocket_precreated_replay_fallback,
     _find_websocket_request_state_by_response_id,
     _is_websocket_response_create,
     _match_websocket_request_state_for_anonymous_event,
@@ -412,6 +414,7 @@ from app.modules.proxy._service.websocket.helpers import (
     _websocket_input_items_are_self_contained_fresh_replay,
     _websocket_owner_switch_has_other_pending_requests,
     _websocket_precreated_auth_error_code,
+    _websocket_precreated_replay_fallback_error,
     _websocket_precreated_retry_error_code,
     _websocket_receive_timeout_for_pending_requests,
     _websocket_response_id,
@@ -2053,6 +2056,7 @@ class _WebSocketMixin:
                 await proxy._load_balancer.release_account_lease(selected_stream_lease)
                 return None, None
             request_state.websocket_stream_lease = selected_stream_lease
+            _clear_websocket_precreated_replay_fallback(request_state)
             return connect_result
 
         if last_failover_exc is not None and last_failover_account is not None:
@@ -3736,6 +3740,50 @@ class _WebSocketMixin:
                     reallocate_sticky=True,
                 )
                 request_state.request_text = safe_request_text
+        if retry_error_code == _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE:
+            retry_text = None
+            if not request_state.file_required_preferred_account:
+                retry_text = _prepare_websocket_request_state_for_account_switch(request_state)
+            if retry_text is not None:
+                request_state.precreated_replay_reason = _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE
+                request_state.precreated_replay_account_id = account.id
+                request_state.error_code_override = (
+                    _normalize_error_code(
+                        _websocket_event_error_code(event_type, payload),
+                        _websocket_event_error_type(event_type, payload),
+                    )
+                    or "invalid_request_error"
+                )
+                request_state.error_message_override = (
+                    _websocket_event_error_message(event_type, payload) or "Upstream rejected the requested model"
+                )
+                request_state.error_type_override = (
+                    _websocket_event_error_type(event_type, payload) or "invalid_request_error"
+                )
+                request_state.error_param_override = _websocket_event_error_param(event_type, payload)
+                request_state.error_http_status_override = _facade()._http_error_status_from_payload(payload) or 400
+                await proxy._release_request_state_account_response_create_lease(request_state)
+                request_state.excluded_account_ids.add(account.id)
+                request_state.affinity_policy = replace(
+                    request_state.affinity_policy,
+                    reallocate_sticky=True,
+                )
+                request_state.request_text = retry_text
+                request_state.replay_count += 1
+                request_state.awaiting_response_created = True
+                request_state.response_id = None
+                request_state.response_event_count = 0
+                upstream_control.reconnect_requested = True
+                upstream_control.suppress_downstream_event = True
+                upstream_control.replay_request_state = request_state
+                _facade().logger.info(
+                    "Retrying pre-created request after account/model rejection request_id=%s account_id=%s model=%s",
+                    request_state.request_log_id or request_state.request_id,
+                    account.id,
+                    request_state.model,
+                )
+                return downstream_text
+            retry_error_code = None
         if retry_error_code is not None:
             if retry_is_previous_response_not_found:
                 if not (
@@ -4298,6 +4346,10 @@ class _WebSocketMixin:
     ) -> None:
         proxy = cast(_WebSocketServiceProtocol, self)
         _ = proxy
+        replay_fallback = _websocket_precreated_replay_fallback_error(request_state)
+        if replay_fallback is not None:
+            status_code, payload, error_code, error_message, rejected_account_id = replay_fallback
+            account_id = rejected_account_id
         status_code, payload, error_code, error_message = _sanitize_websocket_connect_failure(
             request_state=request_state,
             status_code=status_code,

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -1967,10 +1967,11 @@ class _WebSocketMixin:
                 if request_state.preferred_account_id == forced_refresh_account_id:
                     request_state.preferred_account_id = None
 
-            if (
+            selected_account_model_replacement = (
                 request_state.precreated_replay_reason == _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE
                 and account.id != request_state.precreated_replay_account_id
-            ):
+            )
+            if selected_account_model_replacement:
                 # Preserve the rejected account's 400 only when selection
                 # cannot find a replacement. Once this replacement attempt
                 # starts, a connection/open failure belongs to the replacement.
@@ -2026,14 +2027,20 @@ class _WebSocketMixin:
                 last_failover_account = account
                 continue
             except ProxyResponseError as exc:
-                action = await proxy._decide_websocket_failover_action(
-                    account=account,
-                    exc=exc,
-                    request_state=request_state,
-                    attempt=attempt + 1,
-                    max_attempts=max_attempts,
-                    deterministic_failover_enabled=getattr(base_settings, "deterministic_failover_enabled", True),
-                )
+                if selected_account_model_replacement:
+                    # The account/model retry budget selected this replacement;
+                    # its connection failure must be surfaced rather than
+                    # consuming another account through generic failover.
+                    action = "surface"
+                else:
+                    action = await proxy._decide_websocket_failover_action(
+                        account=account,
+                        exc=exc,
+                        request_state=request_state,
+                        attempt=attempt + 1,
+                        max_attempts=max_attempts,
+                        deterministic_failover_enabled=getattr(base_settings, "deterministic_failover_enabled", True),
+                    )
                 if action == "failover_next":
                     await proxy._load_balancer.release_account_lease(selected_stream_lease)
                     last_failover_exc = exc

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -1967,6 +1967,15 @@ class _WebSocketMixin:
                 if request_state.preferred_account_id == forced_refresh_account_id:
                     request_state.preferred_account_id = None
 
+            if (
+                request_state.precreated_replay_reason == _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE
+                and account.id != request_state.precreated_replay_account_id
+            ):
+                # Preserve the rejected account's 400 only when selection
+                # cannot find a replacement. Once this replacement attempt
+                # starts, a connection/open failure belongs to the replacement.
+                _clear_websocket_precreated_replay_fallback(request_state)
+
             try:
                 connect_result = await proxy._try_open_websocket_connect_attempt(
                     account,

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -3772,7 +3772,6 @@ class _WebSocketMixin:
                 request_state.error_param_override = _websocket_event_error_param(event_type, payload)
                 request_state.error_http_status_override = _facade()._http_error_status_from_payload(payload) or 400
                 await proxy._release_request_state_account_response_create_lease(request_state)
-                await _release_websocket_response_create_gate(request_state, response_create_gate)
                 request_state.excluded_account_ids.add(account.id)
                 request_state.affinity_policy = replace(
                     request_state.affinity_policy,

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -314,6 +314,7 @@ from app.modules.proxy._service.support import (
     _REQUEST_TRANSPORT_WEBSOCKET,
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
     _account_capacity_wait_payload,
+    _clear_websocket_precreated_replay_fallback,
     _clear_websocket_request_error_overrides,
     _DownstreamWebSocketActivity,
     _event_type_from_payload,
@@ -372,7 +373,6 @@ from app.modules.proxy._service.warmup import (
 from app.modules.proxy._service.websocket.helpers import (
     _app_error_to_websocket_event,
     _assign_websocket_response_id,
-    _clear_websocket_precreated_replay_fallback,
     _find_websocket_request_state_by_response_id,
     _is_websocket_response_create,
     _match_websocket_request_state_for_anonymous_event,
@@ -3772,6 +3772,7 @@ class _WebSocketMixin:
                 request_state.error_param_override = _websocket_event_error_param(event_type, payload)
                 request_state.error_http_status_override = _facade()._http_error_status_from_payload(payload) or 400
                 await proxy._release_request_state_account_response_create_lease(request_state)
+                await _release_websocket_response_create_gate(request_state, response_create_gate)
                 request_state.excluded_account_ids.add(account.id)
                 request_state.affinity_policy = replace(
                     request_state.affinity_policy,

--- a/app/modules/proxy/helpers.py
+++ b/app/modules/proxy/helpers.py
@@ -39,6 +39,20 @@ _QUOTA_CODES = frozenset({"insufficient_quota", "usage_not_included", "quota_exc
 _TRANSIENT_CODES = frozenset({"server_error", "upstream_error", "stream_incomplete", "overloaded_error"})
 
 
+def _is_account_model_unsupported_error(
+    *,
+    code: str | None,
+    message: str | None,
+    model: str | None,
+) -> bool:
+    """Match only the account-entitlement rejection for the requested model."""
+    if code != "invalid_request_error" or message is None or model is None:
+        return False
+    normalized_message = " ".join(message.split())
+    expected_message = f"The '{model}' model is not supported when using Codex with a ChatGPT account."
+    return normalized_message == expected_message
+
+
 def classify_upstream_failure(
     *,
     error_code: str,

--- a/openspec/changes/retry-stale-account-model-rejection/design.md
+++ b/openspec/changes/retry-stale-account-model-rejection/design.md
@@ -1,0 +1,39 @@
+# Design
+
+## Classification
+
+Recognize only an `invalid_request_error` whose normalized message exactly
+matches:
+
+```text
+The '<requested model>' model is not supported when using Codex with a ChatGPT account.
+```
+
+The quoted slug must equal the request's model. Internally classify this as
+`account_model_unsupported`; do not add the generic upstream code
+`invalid_request_error` to retry sets.
+
+## Replay boundary
+
+Replay at most once and only before upstream acceptance: no response id, no
+nonterminal `response.*` event, no downstream sequence/output, and no other
+pending request sharing the upstream socket. Initial turns may move accounts.
+A continuation may move only when the proxy already retained and verified a
+self-contained fresh body without the injected owner anchor. Account-scoped
+file references and other hard owner bindings never move.
+
+## Routing and health
+
+Exclude the rejecting account in request-local state, drop its per-account
+response-create lease, and select again with the same model and service tier.
+Existing model-catalog filtering therefore limits the replacement to an
+account currently advertising the requested model. The rejection is evidence
+of stale per-account routing metadata, not general account failure, so it must
+not update error health or deactivate the account.
+
+## Terminal behavior
+
+If replacement selection or connection cannot find a compatible account, emit
+the original upstream status and error envelope. Once a replacement connection
+has been established, later failures belong to that replacement attempt and
+follow the normal error path.

--- a/openspec/changes/retry-stale-account-model-rejection/proposal.md
+++ b/openspec/changes/retry-stale-account-model-rejection/proposal.md
@@ -1,0 +1,15 @@
+# Retry stale per-account model rejections
+
+The model registry can briefly be less current than the upstream account
+entitlement it represents. During that window, selection can route a model to
+an account whose last-known catalog advertised it, only for upstream to reject
+the request before `response.created` with the account/model unsupported
+envelope. The request is safe to move at that point, but the proxy currently
+surfaces the transient routing race (or rewrites it to a generic bridge
+failure).
+
+Add one narrowly classified, pre-acceptance failover attempt across native
+Responses WebSocket, the HTTP responses bridge, and raw HTTP/SSE. The rejected
+account is excluded only for that request and is not penalized globally. Hard
+account ownership and uploaded-file pins remain fail-closed, and the original
+upstream 400 is preserved when no compatible replacement account is available.

--- a/openspec/changes/retry-stale-account-model-rejection/proposal.md
+++ b/openspec/changes/retry-stale-account-model-rejection/proposal.md
@@ -1,5 +1,7 @@
 # Retry stale per-account model rejections
 
+## Why
+
 The model registry can briefly be less current than the upstream account
 entitlement it represents. During that window, selection can route a model to
 an account whose last-known catalog advertised it, only for upstream to reject
@@ -8,8 +10,28 @@ envelope. The request is safe to move at that point, but the proxy currently
 surfaces the transient routing race (or rewrites it to a generic bridge
 failure).
 
+## What Changes
+
 Add one narrowly classified, pre-acceptance failover attempt across native
 Responses WebSocket, the HTTP responses bridge, and raw HTTP/SSE. The rejected
 account is excluded only for that request and is not penalized globally. Hard
 account ownership and uploaded-file pins remain fail-closed, and the original
 upstream 400 is preserved when no compatible replacement account is available.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `responses-api-compat`: pre-acceptance account/model rejections MUST receive
+  at most one safe replacement-account attempt, while no-replacement and
+  replacement-failure paths preserve the correct upstream error.
+
+## Impact
+
+- Code: raw HTTP/SSE, HTTP-bridge, and native WebSocket retry state machines.
+- Tests: focused retry, no-replacement, and replacement-failure coverage.
+- API/schema: no public shape or database migration change.

--- a/openspec/changes/retry-stale-account-model-rejection/specs/responses-api-compat/spec.md
+++ b/openspec/changes/retry-stale-account-model-rejection/specs/responses-api-compat/spec.md
@@ -12,7 +12,8 @@ without violating continuation or uploaded-file ownership. The proxy MUST
 exclude the rejecting account only for that request and MUST NOT record an
 account-health penalty for this rejection.
 
-The proxy MUST NOT replay after a response id, a nonterminal `response.*`
+The proxy MUST NOT replay after a response id, including a `response.failed`
+payload that carries one even when `response.created` was not observed, a nonterminal `response.*`
 event, downstream sequence/output, another pending request on the shared
 socket, or an earlier replay. If no compatible replacement is available, or
 the request is account-bound, the proxy MUST preserve the original upstream
@@ -43,6 +44,18 @@ another proxy-generated failure.
 - **WHEN** that replacement attempt fails before acceptance
 - **THEN** the client receives the replacement attempt's failure
 - **AND** the skipped account's original HTTP 400 is not used as a fallback
+- **AND** the proxy does not select a third account after a retryable replacement
+  transport or server failure
+
+#### Scenario: failed bridge replacement retires without restoring rejected metadata
+
+- **GIVEN** an HTTP responses bridge reconnect has selected and installed a
+  replacement account after an account/model rejection
+- **WHEN** replacement response-create lease acquisition or request send fails
+- **THEN** the proxy forwards the replacement failure and retires that bridge
+  session after draining the rejected request
+- **AND** it does not restore the rejected account's turn state or headers onto
+  the replacement socket
 
 #### Scenario: accepted or visible request is never replayed
 

--- a/openspec/changes/retry-stale-account-model-rejection/specs/responses-api-compat/spec.md
+++ b/openspec/changes/retry-stale-account-model-rejection/specs/responses-api-compat/spec.md
@@ -1,0 +1,51 @@
+# responses-api-compat Delta Specification
+
+## ADDED Requirements
+
+### Requirement: Pre-acceptance account-model rejections fail over safely
+
+When upstream rejects a Responses request with `invalid_request_error` and the
+exact message `The '<model>' model is not supported when using Codex with a
+ChatGPT account.` before accepting the response, the proxy MUST classify the
+failure internally as `account_model_unsupported`. The quoted model MUST match
+the requested model. For native WebSocket, HTTP responses bridge, and raw
+HTTP/SSE transports, the proxy MUST make at most one transparent attempt on a
+different account that advertises the same model, provided the request can move
+without violating continuation or uploaded-file ownership. The proxy MUST
+exclude the rejecting account only for that request and MUST NOT record an
+account-health penalty for this rejection.
+
+The proxy MUST NOT replay after a response id, a nonterminal `response.*`
+event, downstream sequence/output, another pending request on the shared
+socket, or an earlier replay. If no compatible replacement is available, or
+the request is account-bound, the proxy MUST preserve the original upstream
+400 error instead of replacing it with `no_accounts`, `stream_incomplete`, or
+another proxy-generated failure.
+
+#### Scenario: stale model route retries another advertising account
+
+- **GIVEN** two accounts advertise the requested model in the current routing snapshot
+- **AND** upstream rejects the first account with the exact account/model unsupported envelope before `response.created`
+- **WHEN** the request has no hard account or uploaded-file binding
+- **THEN** the proxy excludes the first account for this request and retries once on the second account
+- **AND** it forwards only the replacement attempt's response events downstream
+- **AND** it does not penalize the first account's global health
+
+#### Scenario: no replacement preserves the upstream rejection
+
+- **GIVEN** upstream rejects a pre-acceptance request with the exact account/model unsupported envelope
+- **AND** no other compatible account is available
+- **WHEN** transparent failover cannot select a replacement
+- **THEN** the client receives the original HTTP 400 `invalid_request_error`
+- **AND** the error is not rewritten to `no_accounts`, `stream_incomplete`, or HTTP 502
+
+#### Scenario: accepted or visible request is never replayed
+
+- **WHEN** the account/model unsupported envelope arrives after a response id, a nonterminal response event, downstream sequence/output, or an earlier replay
+- **THEN** the proxy does not transparently replay the request on another account
+
+#### Scenario: account-bound request is never migrated
+
+- **WHEN** a rejected request depends on an account-scoped uploaded file or an owner-bound continuation without a verified self-contained fresh replay body
+- **THEN** the proxy does not move the request to another account
+- **AND** it preserves the original upstream rejection

--- a/openspec/changes/retry-stale-account-model-rejection/specs/responses-api-compat/spec.md
+++ b/openspec/changes/retry-stale-account-model-rejection/specs/responses-api-compat/spec.md
@@ -4,7 +4,7 @@
 
 ### Requirement: Pre-acceptance account-model rejections fail over safely
 
-When upstream rejects a Responses request with `invalid_request_error` and the
+The proxy MUST classify an upstream Responses request rejection with `invalid_request_error` and the
 exact message `The '<model>' model is not supported when using Codex with a
 ChatGPT account.` before accepting the response, the proxy MUST classify the
 failure internally as `account_model_unsupported`. The quoted model MUST match
@@ -38,6 +38,14 @@ another proxy-generated failure.
 - **WHEN** transparent failover cannot select a replacement
 - **THEN** the client receives the original HTTP 400 `invalid_request_error`
 - **AND** the error is not rewritten to `no_accounts`, `stream_incomplete`, or HTTP 502
+
+#### Scenario: selected replacement failure is surfaced
+
+- **GIVEN** upstream rejects a pre-acceptance request with the exact account/model unsupported envelope
+- **AND** the proxy selects a different compatible replacement account
+- **WHEN** that replacement attempt fails before acceptance
+- **THEN** the client receives the replacement attempt's failure
+- **AND** the skipped account's original HTTP 400 is not used as a fallback
 
 #### Scenario: accepted or visible request is never replayed
 

--- a/openspec/changes/retry-stale-account-model-rejection/specs/responses-api-compat/spec.md
+++ b/openspec/changes/retry-stale-account-model-rejection/specs/responses-api-compat/spec.md
@@ -12,8 +12,10 @@ without violating continuation or uploaded-file ownership. The proxy MUST
 exclude the rejecting account only for that request and MUST NOT record an
 account-health penalty for this rejection.
 
-The proxy MUST NOT replay after a response id, including a `response.failed`
-payload that carries one even when `response.created` was not observed, a nonterminal `response.*`
+The proxy MUST NOT replay after any response id recognized in an upstream payload,
+including a `response.failed` payload that carries `response.id` even when
+`response.created` was not observed or an `error` payload with top-level
+`response_id`, a nonterminal `response.*`
 event, downstream sequence/output, another pending request on the shared
 socket, or an earlier replay. If no compatible replacement is available, or
 the request is account-bound, the proxy MUST preserve the original upstream
@@ -45,7 +47,7 @@ another proxy-generated failure.
 - **THEN** the client receives the replacement attempt's failure
 - **AND** the skipped account's original HTTP 400 is not used as a fallback
 - **AND** the proxy does not select a third account after a retryable replacement
-  transport or server failure
+  refresh, transport, or server failure
 
 #### Scenario: failed bridge replacement retires without restoring rejected metadata
 

--- a/openspec/changes/retry-stale-account-model-rejection/specs/responses-api-compat/spec.md
+++ b/openspec/changes/retry-stale-account-model-rejection/specs/responses-api-compat/spec.md
@@ -4,10 +4,7 @@
 
 ### Requirement: Pre-acceptance account-model rejections fail over safely
 
-The proxy MUST classify an upstream Responses request rejection with `invalid_request_error` and the
-exact message `The '<model>' model is not supported when using Codex with a
-ChatGPT account.` before accepting the response, the proxy MUST classify the
-failure internally as `account_model_unsupported`. The quoted model MUST match
+When upstream rejects a Responses request with `invalid_request_error` and the exact message `The '<model>' model is not supported when using Codex with a ChatGPT account.` before accepting the response, the proxy MUST classify the failure internally as `account_model_unsupported`. The quoted model MUST match
 the requested model. For native WebSocket, HTTP responses bridge, and raw
 HTTP/SSE transports, the proxy MUST make at most one transparent attempt on a
 different account that advertises the same model, provided the request can move

--- a/openspec/changes/retry-stale-account-model-rejection/tasks.md
+++ b/openspec/changes/retry-stale-account-model-rejection/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+- [x] Add exact account/model unsupported classification.
+- [x] Add one request-local, pre-acceptance failover for native WebSocket.
+- [x] Add equivalent failover and original-error preservation to the HTTP bridge.
+- [x] Add equivalent failover and original-error preservation to raw HTTP/SSE.
+- [x] Add regressions for successful two-account failover and unsafe/no-replacement cases.
+- [x] Run focused tests, static checks, and strict OpenSpec validation.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -8693,6 +8693,81 @@ async def test_v1_responses_http_bridge_retries_stale_account_model_route_on_ano
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_http_bridge_surfaces_selected_replacement_failure(async_client, monkeypatch):
+    _install_bridge_settings(monkeypatch, enabled=True)
+    first_account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_selected_replacement_rejected",
+        "http-bridge-selected-replacement-rejected@example.com",
+    )
+    second_account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_selected_replacement_failed",
+        "http-bridge-selected-replacement-failed@example.com",
+    )
+    first_account = await _get_account(first_account_id)
+    second_account = await _get_account(second_account_id)
+    first_upstream = _ErrorOnlyUpstreamWebSocket()
+    connect_calls: list[str | None] = []
+
+    async def fake_select_account_with_budget(self, deadline, **kwargs):
+        del self, deadline
+        excluded = set(cast(set[str], kwargs.get("exclude_account_ids") or set()))
+        account = second_account if first_account.id in excluded else first_account
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, base_url, session
+        connect_calls.append(account_id_header)
+        if len(connect_calls) == 1:
+            return first_upstream
+        raise proxy_module.ProxyResponseError(
+            503,
+            proxy_module.openai_error(
+                "replacement_unavailable",
+                "Selected replacement connection failed",
+                error_type="server_error",
+            ),
+        )
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    response = await async_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-5.3-codex-spark",
+            "instructions": "Return exactly OK.",
+            "input": "hello",
+            "prompt_cache_key": "http-bridge-selected-replacement-failure-key",
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "error": {
+            "message": "Selected replacement connection failed",
+            "type": "server_error",
+            "code": "replacement_unavailable",
+        }
+    }
+    assert len(connect_calls) == 2
+
+
+@pytest.mark.asyncio
 async def test_v1_responses_http_bridge_preserves_rate_limit_metadata_in_429(async_client, monkeypatch):
     _install_bridge_settings(monkeypatch, enabled=True)
     account_id = await _import_account(

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -8614,6 +8614,85 @@ async def test_v1_responses_http_bridge_surfaces_upstream_error_event_as_http_40
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_http_bridge_retries_stale_account_model_route_on_another_account(
+    async_client,
+    monkeypatch,
+):
+    _install_bridge_settings(monkeypatch, enabled=True)
+    first_account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_model_rejected",
+        "http-bridge-model-rejected@example.com",
+    )
+    second_account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_model_supported",
+        "http-bridge-model-supported@example.com",
+    )
+    first_account = await _get_account(first_account_id)
+    second_account = await _get_account(second_account_id)
+    first_upstream = _ErrorOnlyUpstreamWebSocket()
+    second_upstream = _FakeBridgeUpstreamWebSocket()
+    connect_calls: list[str | None] = []
+    selection_exclusions: list[set[str]] = []
+    handle_stream_error = AsyncMock()
+
+    async def fake_select_account_with_budget(self, deadline, **kwargs):
+        del self, deadline
+        excluded = set(cast(set[str], kwargs.get("exclude_account_ids") or set()))
+        selection_exclusions.append(excluded)
+        account = second_account if first_account.id in excluded else first_account
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, base_url, session
+        connect_calls.append(account_id_header)
+        return first_upstream if len(connect_calls) == 1 else second_upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    events = await _collect_sse_events(
+        async_client,
+        "/v1/responses",
+        json_body={
+            "model": "gpt-5.3-codex-spark",
+            "instructions": "Return exactly OK.",
+            "input": "hello",
+            "prompt_cache_key": "http-bridge-account-model-retry-key",
+            "stream": True,
+        },
+    )
+
+    _assert_created_text_delta_completed(events)
+    assert len(connect_calls) == 2
+    assert selection_exclusions[0] == set()
+    assert first_account.id in selection_exclusions[-1]
+    assert first_upstream.closed is True
+    assert len(first_upstream.sent_text) == 1
+    assert len(second_upstream.sent_text) == 1
+    first_payload = json.loads(first_upstream.sent_text[0])
+    second_payload = json.loads(second_upstream.sent_text[0])
+    first_payload.get("client_metadata", {}).pop("x-codex-installation-id", None)
+    second_payload.get("client_metadata", {}).pop("x-codex-installation-id", None)
+    assert first_payload == second_payload
+    handle_stream_error.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_v1_responses_http_bridge_preserves_rate_limit_metadata_in_429(async_client, monkeypatch):
     _install_bridge_settings(monkeypatch, enabled=True)
     account_id = await _import_account(

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -178,15 +178,12 @@ def test_backend_responses_websocket_session_ended_auth_failure_fails_over_befor
                     "text",
                     text=json.dumps(
                         {
-                            "type": "response.failed",
-                            "response": {
-                                "id": "resp_ws_session_expired",
-                                "status": "failed",
-                                "error": {
-                                    "type": "authentication_error",
-                                    "code": "invalid_api_key",
-                                    "message": "Your session has ended. Please log in again.",
-                                },
+                            "type": "error",
+                            "status": 401,
+                            "error": {
+                                "type": "authentication_error",
+                                "code": "invalid_api_key",
+                                "message": "Your session has ended. Please log in again.",
                             },
                         },
                         separators=(",", ":"),
@@ -306,6 +303,97 @@ def test_backend_responses_websocket_session_ended_auth_failure_fails_over_befor
     assert permanent_failures == [("acct_ws_expired", "account_session_expired")]
 
 
+def test_backend_responses_websocket_id_bearing_auth_failure_is_forwarded_without_replay(
+    app_instance,
+    monkeypatch,
+):
+    failure = {
+        "type": "response.failed",
+        "response": {
+            "id": "resp_ws_id_bearing_auth_failure",
+            "status": "failed",
+            "error": {
+                "type": "authentication_error",
+                "code": "invalid_api_key",
+                "message": "Authentication token expired",
+            },
+        },
+    }
+    first_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[[_FakeUpstreamMessage("text", text=json.dumps(failure, separators=(",", ":")))]],
+    )
+    connect_accounts: list[str] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        prefer_earlier_reset_window,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            prefer_earlier_reset_window,
+            routing_strategy,
+            model,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        connect_accounts.append("acct_ws_id_bearing_auth_failure")
+        return SimpleNamespace(id="acct_ws_id_bearing_auth_failure"), first_upstream
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(
+                json.dumps(
+                    {
+                        "type": "response.create",
+                        "model": "gpt-5.4",
+                        "input": "do not replay",
+                        "stream": True,
+                    }
+                )
+            )
+            forwarded = json.loads(websocket.receive_text())
+
+    assert forwarded == failure
+    assert connect_accounts == ["acct_ws_id_bearing_auth_failure"]
+
+
 def test_backend_responses_websocket_generic_auth_failure_refreshes_once_then_fails_over(
     app_instance,
     monkeypatch,
@@ -315,15 +403,12 @@ def test_backend_responses_websocket_generic_auth_failure_refreshes_once_then_fa
             "text",
             text=json.dumps(
                 {
-                    "type": "response.failed",
-                    "response": {
-                        "id": "resp_ws_auth_failed",
-                        "status": "failed",
-                        "error": {
-                            "type": "authentication_error",
-                            "code": "invalid_api_key",
-                            "message": "token invalidated",
-                        },
+                    "type": "error",
+                    "status": 401,
+                    "error": {
+                        "type": "authentication_error",
+                        "code": "invalid_api_key",
+                        "message": "token invalidated",
                     },
                 },
                 separators=(",", ":"),
@@ -457,15 +542,12 @@ def test_backend_responses_websocket_generic_auth_refresh_budget_is_per_account(
             "text",
             text=json.dumps(
                 {
-                    "type": "response.failed",
-                    "response": {
-                        "id": "resp_ws_auth_failed",
-                        "status": "failed",
-                        "error": {
-                            "type": "authentication_error",
-                            "code": "invalid_api_key",
-                            "message": "token invalidated",
-                        },
+                    "type": "error",
+                    "status": 401,
+                    "error": {
+                        "type": "authentication_error",
+                        "code": "invalid_api_key",
+                        "message": "token invalidated",
                     },
                 },
                 separators=(",", ":"),

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -8446,6 +8446,152 @@ def test_backend_responses_websocket_transparently_retries_precreated_error_usag
     )
 
 
+def test_backend_responses_websocket_retries_stale_account_model_route_on_another_account(
+    app_instance,
+    monkeypatch,
+):
+    first_upstream = _FakeUpstreamWebSocket(
+        [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "error",
+                        "status": 400,
+                        "error": {
+                            "type": "invalid_request_error",
+                            "code": "invalid_request_error",
+                            "message": (
+                                "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."
+                            ),
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+            )
+        ]
+    )
+    second_upstream = _FakeUpstreamWebSocket(
+        [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.created",
+                        "response": {"id": "resp_ws_model_supported", "status": "in_progress"},
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_ws_model_supported",
+                            "status": "completed",
+                            "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+        ]
+    )
+    upstreams = [first_upstream, second_upstream]
+    account_ids = ["acct_ws_model_rejected", "acct_ws_model_supported"]
+    connect_models: list[str | None] = []
+    excluded_snapshots: list[set[str]] = []
+    handled_error_codes: list[str] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
+        return None
+
+    async def fake_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        prefer_earlier_reset_window,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            prefer_earlier_reset_window,
+            routing_strategy,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        index = len(connect_models)
+        connect_models.append(model)
+        excluded_snapshots.append(set(request_state.excluded_account_ids))
+        return SimpleNamespace(id=account_ids[index]), upstreams[index]
+
+    async def fake_handle_stream_error(self, account, error, code):
+        del self, account, error
+        handled_error_codes.append(code)
+
+    async def fake_write_request_log(self, **kwargs):
+        del self, kwargs
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(proxy_module.ProxyService, "_handle_stream_error", fake_handle_stream_error)
+    monkeypatch.setattr(proxy_module.ProxyService, "_write_request_log", fake_write_request_log)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "retry safely"}]}],
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            first_event = json.loads(websocket.receive_text())
+            second_event = json.loads(websocket.receive_text())
+
+    assert first_event["type"] == "response.created"
+    assert second_event["type"] == "response.completed"
+    assert connect_models == ["gpt-5.6-sol", "gpt-5.6-sol"]
+    assert excluded_snapshots == [set(), {account_ids[0]}]
+    assert handled_error_codes == []
+    assert first_upstream.closed is True
+    assert len(first_upstream.sent_text) == 1
+    assert len(second_upstream.sent_text) == 1
+    assert _without_installation_metadata(json.loads(first_upstream.sent_text[0])) == _without_installation_metadata(
+        json.loads(second_upstream.sent_text[0])
+    )
+
+
 def test_backend_responses_websocket_previous_response_usage_limit_returns_upstream_unavailable(
     app_instance,
     monkeypatch,

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9718,8 +9718,10 @@ async def test_http_bridge_model_rejection_releases_old_account_create_lease_bef
     forwarded = await request_state.event_queue.get()
     assert forwarded is not None
     forwarded_event = parse_sse_data_json(forwarded)
+    assert isinstance(forwarded_event, dict)
     assert forwarded_event["type"] == "response.failed"
-    assert forwarded_event["response"]["error"] == rejection["error"]
+    forwarded_response = cast(dict[str, JsonValue], forwarded_event["response"])
+    assert forwarded_response["error"] == rejection["error"]
     assert await request_state.event_queue.get() is None
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10263,6 +10263,69 @@ async def test_stream_with_retry_preserves_account_model_rejection_without_repla
 
 
 @pytest.mark.asyncio
+async def test_stream_with_retry_surfaces_selected_replacement_failure_after_account_model_rejection(monkeypatch):
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    rejected = _make_account("acc_stream_model_rejected")
+    replacement = _make_account("acc_stream_model_replacement")
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 2)
+    monkeypatch.setattr(proxy_service, "_MAX_TRANSIENT_SAME_ACCOUNT_RETRIES", 1)
+    monkeypatch.setattr(streaming_retry_module.ProcessNetworkRecovery, "wait", AsyncMock(return_value=None))
+
+    async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
+        excluded = cast(set[str], kwargs["exclude_account_ids"])
+        return AccountSelection(account=replacement if rejected.id in excluded else rejected, error_message=None)
+
+    async def fake_stream_once(account: Account, *_args: object, **_kwargs: object):
+        if account.id == rejected.id:
+            raise proxy_module.ProxyResponseError(
+                400,
+                proxy_module.openai_error(
+                    "invalid_request_error",
+                    "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+                    error_type="invalid_request_error",
+                ),
+            )
+        raise proxy_module.ProxyResponseError(
+            500,
+            proxy_module.openai_error("replacement_failed", "Replacement upstream failed", error_type="server_error"),
+        )
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=lambda account, **_kwargs: account))
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.6-sol", "instructions": "hi", "input": [], "stream": True}
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        async for _chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-account-model-replacement-failure"},
+            codex_session_affinity=False,
+            propagate_http_errors=True,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        ):
+            pass
+
+    assert exc_info.value.status_code == 500
+    error = proxy_service._parse_openai_error(exc_info.value.payload)
+    assert error is not None
+    assert error.code == "replacement_failed"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("propagate_http_errors", "budget_expires"),
     [(False, False), (True, False), (False, True)],
@@ -14465,6 +14528,71 @@ async def test_connect_proxy_websocket_preserves_account_model_rejection_without
     }
     assert request_logs.calls[0]["account_id"] == rejected_account.id
     assert request_logs.calls[0]["error_code"] == "invalid_request_error"
+
+
+@pytest.mark.asyncio
+async def test_connect_proxy_websocket_surfaces_selected_replacement_failure_after_account_model_rejection(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    rejected_account = _make_account("acc_ws_rejected_model")
+    replacement_account = _make_account("acc_ws_replacement_model")
+    select_account = AsyncMock(return_value=replacement_account)
+    replacement_failure = proxy_module.ProxyResponseError(
+        500,
+        proxy_module.openai_error("replacement_failed", "Replacement connection failed", error_type="server_error"),
+    )
+    monkeypatch.setattr(service, "_select_websocket_connect_account", select_account)
+    monkeypatch.setattr(service, "_try_open_websocket_connect_attempt", AsyncMock(side_effect=replacement_failure))
+    monkeypatch.setattr(service, "_decide_websocket_failover_action", AsyncMock(return_value="surface"))
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_rejected_model_replacement_failure",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        request_stage="reattach",
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
+        replay_count=1,
+        excluded_account_ids={rejected_account.id},
+        precreated_replay_reason="account_model_unsupported",
+        precreated_replay_account_id=rejected_account.id,
+        error_code_override="invalid_request_error",
+        error_message_override="The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+        error_type_override="invalid_request_error",
+        error_http_status_override=400,
+    )
+
+    websocket_send = AsyncMock()
+    selected_account, selected_upstream = await service._connect_proxy_websocket(
+        {},
+        sticky_key=None,
+        sticky_kind=None,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        model="gpt-5.6-sol",
+        request_state=request_state,
+        api_key=None,
+        client_send_lock=anyio.Lock(),
+        websocket=cast(WebSocket, SimpleNamespace(send_text=websocket_send)),
+    )
+
+    assert selected_account is None
+    assert selected_upstream is None
+    websocket_send_call = websocket_send.await_args
+    assert websocket_send_call is not None
+    sent = json.loads(websocket_send_call.args[0])
+    assert sent["status"] == 500
+    assert sent["error"] == {
+        "message": "Replacement connection failed",
+        "type": "server_error",
+        "code": "replacement_failed",
+    }
+    assert request_state.precreated_replay_reason is None
+    assert request_state.error_code_override is None
+    assert request_logs.calls[0]["account_id"] == replacement_account.id
+    assert request_logs.calls[0]["error_code"] == "replacement_failed"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9826,6 +9826,67 @@ async def test_http_bridge_does_not_replay_id_bearing_account_model_failure(monk
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_does_not_replay_id_bearing_auth_failure(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_bridge_id_bearing_auth_failure")
+    retry_precreated_auth = AsyncMock(return_value="retried")
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_auth_request", retry_precreated_auth)
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_id_bearing_auth_failure",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"do not replay"}',
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-id-bearing-auth-failure", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.6-sol",
+        account=account,
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    cast(Any, session.upstream).archive_received = MagicMock()
+    failure = {
+        "type": "response.failed",
+        "response": {
+            "id": "resp_bridge_id_bearing_auth_failure",
+            "status": "failed",
+            "error": {
+                "type": "authentication_error",
+                "code": "invalid_api_key",
+                "message": "Authentication token expired",
+            },
+        },
+    }
+
+    await service._process_http_bridge_upstream_text(session, json.dumps(failure, separators=(",", ":")))
+
+    retry_precreated_auth.assert_not_awaited()
+    assert session.upstream_control.reconnect_requested is False
+    assert request_state.replay_count == 0
+    assert list(session.pending_requests) == []
+    assert request_state.event_queue is not None
+    forwarded = await request_state.event_queue.get()
+    assert forwarded is not None
+    assert parse_sse_data_json(forwarded) == failure
+    assert await request_state.event_queue.get() is None
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_retires_replacement_session_after_replay_setup_failure(monkeypatch):
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     rejected_account = _make_account("acc_bridge_rejected_model_metadata")
@@ -13163,15 +13224,11 @@ async def test_http_bridge_token_invalidated_retries_then_fails_over(monkeypatch
     )
     token_invalidated_text = json.dumps(
         {
-            "type": "response.failed",
-            "response": {
-                "id": "resp_token_invalidated",
-                "status": "failed",
-                "error": {
-                    "code": "token_invalidated",
-                    "type": "invalid_request_error",
-                    "message": "Your authentication token has been invalidated. Please try signing in again.",
-                },
+            "type": "error",
+            "error": {
+                "code": "token_invalidated",
+                "type": "invalid_request_error",
+                "message": "Your authentication token has been invalidated. Please try signing in again.",
             },
         },
         separators=(",", ":"),
@@ -13250,15 +13307,11 @@ async def test_http_bridge_nonreplayable_auth_failure_marks_account_permanent(mo
     )
     token_invalidated_text = json.dumps(
         {
-            "type": "response.failed",
-            "response": {
-                "id": "resp_token_invalidated_pinned",
-                "status": "failed",
-                "error": {
-                    "code": "token_invalidated",
-                    "type": "invalid_request_error",
-                    "message": "Your authentication token has been invalidated. Please try signing in again.",
-                },
+            "type": "error",
+            "error": {
+                "code": "token_invalidated",
+                "type": "invalid_request_error",
+                "message": "Your authentication token has been invalidated. Please try signing in again.",
             },
         },
         separators=(",", ":"),
@@ -20000,6 +20053,62 @@ async def test_process_upstream_websocket_text_does_not_replay_id_bearing_accoun
     assert list(pending_requests) == []
     finalize_request_state.assert_awaited_once()
     handle_stream_error.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_does_not_replay_id_bearing_auth_failure(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    finalize_request_state = AsyncMock()
+    handle_precreated_auth_failure = AsyncMock(return_value=True)
+    account = _make_account("acc_ws_id_bearing_auth_failure")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_precreated_websocket_auth_failure", handle_precreated_auth_failure)
+
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_id_bearing_auth_failure",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"do not replay"}',
+    )
+    pending_requests = deque([pending_request])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    failure = {
+        "type": "response.failed",
+        "response": {
+            "id": "resp_ws_id_bearing_auth_failure",
+            "status": "failed",
+            "error": {
+                "type": "authentication_error",
+                "code": "invalid_api_key",
+                "message": "Authentication token expired",
+            },
+        },
+    }
+    upstream_text = json.dumps(failure, separators=(",", ":"))
+
+    downstream_text = await service._process_upstream_websocket_text(
+        upstream_text,
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert downstream_text == upstream_text
+    handle_precreated_auth_failure.assert_not_awaited()
+    assert upstream_control.reconnect_requested is False
+    assert upstream_control.replay_request_state is None
+    assert pending_request.replay_count == 0
+    assert list(pending_requests) == []
+    finalize_request_state.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6567,6 +6567,45 @@ def test_normalize_http_bridge_error_event_preserves_explicit_error_code_from_pa
     assert error["message"] == "explicit"
 
 
+def test_normalize_http_bridge_error_event_prefers_selected_replacement_failure_overrides():
+    original_error = {
+        "type": "invalid_request_error",
+        "code": "invalid_request_error",
+        "message": "The requested model is not supported by this account.",
+    }
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_selected_replacement_failed",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        error_code_override="replacement_unavailable",
+        error_message_override="Selected replacement connection failed",
+        error_type_override="server_error",
+        error_param_override="model",
+        error_http_status_override=503,
+    )
+
+    _line, payload, parsed_event, event_type = proxy_service._normalize_http_bridge_error_event(
+        event=None,
+        payload={"type": "error", "status": 400, "error": original_error},
+        request_state=request_state,
+    )
+
+    assert event_type == "response.failed"
+    assert parsed_event is not None
+    assert payload is not None
+    response = cast(dict[str, JsonValue], payload["response"])
+    error = cast(dict[str, JsonValue], response["error"])
+    assert error == {
+        "code": "replacement_unavailable",
+        "message": "Selected replacement connection failed",
+        "type": "server_error",
+        "param": "model",
+    }
+
+
 @pytest.mark.asyncio
 async def test_stream_responses_websocket_rejects_oversized_response_create_before_connect(monkeypatch):
     class Settings:
@@ -19722,10 +19761,16 @@ async def test_process_upstream_websocket_text_retries_account_model_rejection_w
     assert pending_request.precreated_replay_account_id == account.id
     assert pending_request.error_http_status_override == 400
     assert pending_request.error_code_override == "invalid_request_error"
+    assert pending_request.response_create_gate is response_create_gate
+    assert pending_request.response_create_gate_acquired is True
+    assert response_create_gate.locked() is True
+    assert list(pending_requests) == []
+
+    await proxy_service._release_websocket_response_create_gate(pending_request, response_create_gate)
+
     assert pending_request.response_create_gate is None
     assert pending_request.response_create_gate_acquired is False
     assert response_create_gate.locked() is False
-    assert list(pending_requests) == []
 
 
 @pytest.mark.asyncio
@@ -31235,6 +31280,75 @@ async def test_retry_http_bridge_precreated_request_migrates_only_safe_initial_t
     assert session.downstream_turn_state == expected_turn_state
     assert session.headers.get("x-codex-turn-state") == expected_turn_state
     upstream.send_text.assert_awaited_once_with(request_state.request_text)
+
+
+@pytest.mark.asyncio
+async def test_retry_http_bridge_precreated_request_reacquires_replacement_response_create_lease(monkeypatch):
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    rejected_account = _make_account("acc_bridge_retry_rejected")
+    replacement_account = _make_account("acc_bridge_retry_replacement")
+    replacement_upstream = AsyncMock()
+    replacement_lease = object()
+    release_lease = AsyncMock()
+    acquire_lease = AsyncMock(return_value=replacement_lease)
+    response_create_gate = asyncio.Semaphore(1)
+    await response_create_gate.acquire()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_retry_replacement_lease",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        response_create_gate=response_create_gate,
+        response_create_gate_acquired=True,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"retry"}',
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-retry-replacement-lease", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.6-sol",
+        account=rejected_account,
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=response_create_gate,
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+
+    async def reconnect(target_session, *, request_state):
+        del request_state
+        target_session.account = replacement_account
+        target_session.upstream = replacement_upstream
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
+    monkeypatch.setattr(service, "_acquire_account_response_create_lease_or_overload", acquire_lease)
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_lease)
+
+    assert await service._retry_http_bridge_precreated_request(session) is True
+
+    acquire_lease.assert_awaited_once_with(
+        account_id=replacement_account.id,
+        request_id=request_state.request_id,
+        surface="http_bridge",
+        concurrency_caps=proxy_service.effective_account_concurrency_caps(settings),
+    )
+    assert request_state.account_response_create_lease is replacement_lease
+    assert request_state.account_response_create_release is release_lease
+    replacement_upstream.send_text.assert_awaited_once_with(request_state.request_text)
+
+    await proxy_service._release_websocket_response_create_gate(request_state, response_create_gate)
+
+    release_lease.assert_awaited_once_with(replacement_lease)
+    assert request_state.account_response_create_lease is None
+    assert request_state.account_response_create_release is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9765,6 +9765,149 @@ async def test_http_bridge_model_rejection_releases_old_account_create_lease_bef
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_does_not_replay_id_bearing_account_model_failure(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_bridge_id_bearing_model_failure")
+    retry_precreated = AsyncMock(return_value=False)
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_id_bearing_model_failure",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"do not replay"}',
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-id-bearing-model-failure", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.6-sol",
+        account=account,
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    cast(Any, session.upstream).archive_received = MagicMock()
+    rejection = {
+        "type": "response.failed",
+        "response": {
+            "id": "resp_bridge_id_bearing_model_failure",
+            "status": "failed",
+            "error": {
+                "type": "invalid_request_error",
+                "code": "invalid_request_error",
+                "message": "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+            },
+        },
+    }
+
+    await service._process_http_bridge_upstream_text(session, json.dumps(rejection, separators=(",", ":")))
+
+    retry_precreated.assert_not_awaited()
+    assert session.upstream_control.reconnect_requested is False
+    assert request_state.replay_count == 0
+    assert list(session.pending_requests) == []
+    assert request_state.event_queue is not None
+    forwarded = await request_state.event_queue.get()
+    assert forwarded is not None
+    assert parse_sse_data_json(forwarded) == rejection
+    assert await request_state.event_queue.get() is None
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_retires_replacement_session_after_replay_setup_failure(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    rejected_account = _make_account("acc_bridge_rejected_model_metadata")
+    replacement_account = _make_account("acc_bridge_replacement_model_metadata")
+    replacement_upstream = AsyncMock()
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_replacement_metadata_failure",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"retry"}',
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-replacement-metadata-failure", None),
+        headers={"x-codex-turn-state": "turn_rejected"},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.6-sol",
+        account=rejected_account,
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+        upstream_turn_state="turn_rejected",
+        downstream_turn_state="turn_rejected",
+    )
+    cast(Any, session.upstream).archive_received = MagicMock()
+
+    async def replay_with_replacement_then_lease_failure(target_session):
+        target_session.account = replacement_account
+        target_session.upstream = replacement_upstream
+        target_session.headers = {"x-codex-turn-state": "turn_replacement"}
+        target_session.upstream_turn_state = "turn_replacement"
+        target_session.downstream_turn_state = "turn_replacement"
+        request_state.error_http_status_override = 503
+        request_state.error_code_override = "replacement_lease_failed"
+        request_state.error_message_override = "Replacement response-create lease failed"
+        request_state.error_type_override = "server_error"
+        return False
+
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", replay_with_replacement_then_lease_failure)
+    rejection = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "type": "invalid_request_error",
+            "code": "invalid_request_error",
+            "message": "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+        },
+    }
+
+    await service._process_http_bridge_upstream_text(session, json.dumps(rejection, separators=(",", ":")))
+
+    assert session.closed is True
+    assert session.account is replacement_account
+    assert session.headers == {"x-codex-turn-state": "turn_replacement"}
+    assert session.upstream_turn_state == "turn_replacement"
+    assert session.downstream_turn_state == "turn_replacement"
+    replacement_upstream.close.assert_awaited_once()
+    assert request_state.event_queue is not None
+    forwarded = await request_state.event_queue.get()
+    assert forwarded is not None
+    forwarded_event = parse_sse_data_json(forwarded)
+    assert isinstance(forwarded_event, dict)
+    assert forwarded_event["type"] == "response.failed"
+    forwarded_response = cast(dict[str, JsonValue], forwarded_event["response"])
+    forwarded_error = cast(dict[str, JsonValue], forwarded_response["error"])
+    assert forwarded_error["code"] == "replacement_lease_failed"
+    assert forwarded_error["message"] == "Replacement response-create lease failed"
+    assert await request_state.event_queue.get() is None
+
+
+@pytest.mark.asyncio
 async def test_service_stream_responses_does_not_infer_previous_response_id_from_session_scope(monkeypatch):
     settings = _make_proxy_settings()
     request_logs = _RequestLogsRecorder()
@@ -10424,21 +10567,39 @@ async def test_stream_with_retry_preserves_account_model_rejection_without_repla
 
 
 @pytest.mark.asyncio
-async def test_stream_with_retry_surfaces_selected_replacement_failure_after_account_model_rejection(monkeypatch):
+@pytest.mark.parametrize(
+    ("replacement_failure_kind", "expected_status", "expected_code"),
+    [("server", 500, "replacement_failed"), ("transport", 502, "upstream_unavailable")],
+)
+async def test_stream_with_retry_surfaces_selected_replacement_failure_after_account_model_rejection(
+    monkeypatch,
+    replacement_failure_kind,
+    expected_status,
+    expected_code,
+):
     settings = _make_proxy_settings()
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     rejected = _make_account("acc_stream_model_rejected")
     replacement = _make_account("acc_stream_model_replacement")
+    third_account = _make_account("acc_stream_model_third")
+    selected_account_ids: list[str] = []
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
-    monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 2)
+    monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 3)
     monkeypatch.setattr(proxy_service, "_MAX_TRANSIENT_SAME_ACCOUNT_RETRIES", 1)
     monkeypatch.setattr(streaming_retry_module.ProcessNetworkRecovery, "wait", AsyncMock(return_value=None))
 
     async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
         excluded = cast(set[str], kwargs["exclude_account_ids"])
-        return AccountSelection(account=replacement if rejected.id in excluded else rejected, error_message=None)
+        if rejected.id not in excluded:
+            selected = rejected
+        elif replacement.id not in excluded:
+            selected = replacement
+        else:
+            selected = third_account
+        selected_account_ids.append(selected.id)
+        return AccountSelection(account=selected, error_message=None)
 
     async def fake_stream_once(account: Account, *_args: object, **_kwargs: object):
         if account.id == rejected.id:
@@ -10449,6 +10610,11 @@ async def test_stream_with_retry_surfaces_selected_replacement_failure_after_acc
                     "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
                     error_type="invalid_request_error",
                 ),
+            )
+        if replacement_failure_kind == "transport":
+            raise streaming_retry_module._TransientStreamError(
+                "upstream_unavailable",
+                {"message": "Replacement transport failed"},
             )
         raise proxy_module.ProxyResponseError(
             500,
@@ -10480,10 +10646,11 @@ async def test_stream_with_retry_surfaces_selected_replacement_failure_after_acc
         ):
             pass
 
-    assert exc_info.value.status_code == 500
+    assert exc_info.value.status_code == expected_status
     error = proxy_service._parse_openai_error(exc_info.value.payload)
     assert error is not None
-    assert error.code == "replacement_failed"
+    assert error.code == expected_code
+    assert selected_account_ids == [rejected.id, replacement.id]
 
 
 @pytest.mark.asyncio
@@ -14697,14 +14864,17 @@ async def test_connect_proxy_websocket_surfaces_selected_replacement_failure_aft
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     rejected_account = _make_account("acc_ws_rejected_model")
     replacement_account = _make_account("acc_ws_replacement_model")
-    select_account = AsyncMock(return_value=replacement_account)
+    third_account = _make_account("acc_ws_third_model")
+    select_account = AsyncMock(side_effect=[replacement_account, third_account])
     replacement_failure = proxy_module.ProxyResponseError(
         500,
         proxy_module.openai_error("replacement_failed", "Replacement connection failed", error_type="server_error"),
     )
     monkeypatch.setattr(service, "_select_websocket_connect_account", select_account)
     monkeypatch.setattr(service, "_try_open_websocket_connect_attempt", AsyncMock(side_effect=replacement_failure))
-    monkeypatch.setattr(service, "_decide_websocket_failover_action", AsyncMock(return_value="surface"))
+    decide_failover = AsyncMock(return_value="failover_next")
+    monkeypatch.setattr(proxy_service, "_WEBSOCKET_MAX_ACCOUNT_ATTEMPTS", 3)
+    monkeypatch.setattr(service, "_decide_websocket_failover_action", decide_failover)
 
     request_state = proxy_service._WebSocketRequestState(
         request_id="ws_req_rejected_model_replacement_failure",
@@ -14754,6 +14924,8 @@ async def test_connect_proxy_websocket_surfaces_selected_replacement_failure_aft
     assert request_state.error_code_override is None
     assert request_logs.calls[0]["account_id"] == replacement_account.id
     assert request_logs.calls[0]["error_code"] == "replacement_failed"
+    assert select_account.await_count == 1
+    decide_failover.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -19771,6 +19943,63 @@ async def test_process_upstream_websocket_text_retries_account_model_rejection_w
     assert pending_request.response_create_gate is None
     assert pending_request.response_create_gate_acquired is False
     assert response_create_gate.locked() is False
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_does_not_replay_id_bearing_account_model_failure(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    handle_stream_error = AsyncMock()
+    account = _make_account("acc_ws_id_bearing_model_failure")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_id_bearing_model_failure",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"do not replay"}',
+    )
+    pending_requests = deque([pending_request])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    upstream_payload = {
+        "type": "response.failed",
+        "response": {
+            "id": "resp_ws_id_bearing_model_failure",
+            "status": "failed",
+            "error": {
+                "type": "invalid_request_error",
+                "code": "invalid_request_error",
+                "message": "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+            },
+        },
+    }
+    upstream_text = json.dumps(upstream_payload, separators=(",", ":"))
+
+    downstream_text = await service._process_upstream_websocket_text(
+        upstream_text,
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert downstream_text == upstream_text
+    assert upstream_control.reconnect_requested is False
+    assert upstream_control.replay_request_state is None
+    assert pending_request.replay_count == 0
+    assert list(pending_requests) == []
+    finalize_request_state.assert_awaited_once()
+    handle_stream_error.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14912,7 +14912,19 @@ async def test_connect_proxy_websocket_preserves_account_model_rejection_without
 
 
 @pytest.mark.asyncio
-async def test_connect_proxy_websocket_surfaces_selected_replacement_failure_after_account_model_rejection(monkeypatch):
+@pytest.mark.parametrize(
+    ("failure_status", "failure_code", "failure_message"),
+    [
+        (500, "replacement_failed", "Replacement connection failed"),
+        (502, "upstream_unavailable", "Replacement transport connection failed"),
+    ],
+)
+async def test_connect_proxy_websocket_surfaces_selected_replacement_failure_after_account_model_rejection(
+    monkeypatch,
+    failure_status,
+    failure_code,
+    failure_message,
+):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     rejected_account = _make_account("acc_ws_rejected_model")
@@ -14920,8 +14932,8 @@ async def test_connect_proxy_websocket_surfaces_selected_replacement_failure_aft
     third_account = _make_account("acc_ws_third_model")
     select_account = AsyncMock(side_effect=[replacement_account, third_account])
     replacement_failure = proxy_module.ProxyResponseError(
-        500,
-        proxy_module.openai_error("replacement_failed", "Replacement connection failed", error_type="server_error"),
+        failure_status,
+        proxy_module.openai_error(failure_code, failure_message, error_type="server_error"),
     )
     monkeypatch.setattr(service, "_select_websocket_connect_account", select_account)
     monkeypatch.setattr(service, "_try_open_websocket_connect_attempt", AsyncMock(side_effect=replacement_failure))
@@ -14967,16 +14979,16 @@ async def test_connect_proxy_websocket_surfaces_selected_replacement_failure_aft
     websocket_send_call = websocket_send.await_args
     assert websocket_send_call is not None
     sent = json.loads(websocket_send_call.args[0])
-    assert sent["status"] == 500
+    assert sent["status"] == failure_status
     assert sent["error"] == {
-        "message": "Replacement connection failed",
+        "message": failure_message,
         "type": "server_error",
-        "code": "replacement_failed",
+        "code": failure_code,
     }
     assert request_state.precreated_replay_reason is None
     assert request_state.error_code_override is None
     assert request_logs.calls[0]["account_id"] == replacement_account.id
-    assert request_logs.calls[0]["error_code"] == "replacement_failed"
+    assert request_logs.calls[0]["error_code"] == failure_code
     assert select_account.await_count == 1
     decide_failover.assert_not_awaited()
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -910,6 +910,48 @@ def test_websocket_precreated_retry_error_code_does_not_replay_after_response_ev
     )
 
 
+def test_websocket_precreated_retry_error_code_classifies_exact_account_model_rejection():
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_account_model_unsupported",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
+    )
+    payload: dict[str, JsonValue] = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "type": "invalid_request_error",
+            "message": ("The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."),
+        },
+    }
+
+    assert (
+        proxy_service._websocket_precreated_retry_error_code(
+            request_state,
+            event_type="error",
+            payload=payload,
+            has_other_pending_requests=False,
+        )
+        == "account_model_unsupported"
+    )
+
+    payload["error"]["message"] = "The 'gpt-5.6-terra' model is not supported when using Codex with a ChatGPT account."
+    assert (
+        proxy_service._websocket_precreated_retry_error_code(
+            request_state,
+            event_type="error",
+            payload=payload,
+            has_other_pending_requests=False,
+        )
+        is None
+    )
+
+
 def _assert_proxy_response_error(exc: BaseException) -> proxy_module.ProxyResponseError:
     assert isinstance(exc, proxy_module.ProxyResponseError)
     return exc
@@ -10086,6 +10128,141 @@ async def test_stream_with_retry_prefers_other_account_before_response_create_ca
 
 
 @pytest.mark.asyncio
+async def test_stream_with_retry_retries_account_model_rejection_on_another_account(monkeypatch):
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    rejected = _make_account("acc_stream_model_rejected")
+    supported = _make_account("acc_stream_model_supported")
+    selection_exclusions: list[set[str]] = []
+    stream_accounts: list[str] = []
+    handle_stream_error = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+
+    async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
+        excluded = set(cast(set[str], kwargs["exclude_account_ids"]))
+        selection_exclusions.append(excluded)
+        account = supported if rejected.id in excluded else rejected
+        return AccountSelection(account=account, error_message=None)
+
+    async def fake_stream_once(account: Account, *_args: object, **_kwargs: object):
+        stream_accounts.append(account.id)
+        if account.id == rejected.id:
+            raise proxy_module.ProxyResponseError(
+                400,
+                proxy_module.openai_error(
+                    "invalid_request_error",
+                    "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+                    error_type="invalid_request_error",
+                ),
+            )
+        yield 'data: {"type":"response.completed","response":{"id":"resp_model_supported"}}\n\n'
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh_with_budget",
+        AsyncMock(side_effect=lambda account, **_kwargs: account),
+    )
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.6-sol", "instructions": "hi", "input": [], "stream": True}
+    )
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-account-model-retry"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    assert json.loads(chunks[-1].split("data: ", 1)[1])["type"] == "response.completed"
+    assert stream_accounts == [rejected.id, supported.id]
+    assert selection_exclusions == [set(), {rejected.id}]
+    handle_stream_error.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_preserves_account_model_rejection_without_replacement(monkeypatch):
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    rejected = _make_account("acc_stream_model_rejected_only")
+    handle_stream_error = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+
+    async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
+        excluded = set(cast(set[str], kwargs["exclude_account_ids"]))
+        if rejected.id in excluded:
+            return AccountSelection(
+                account=None,
+                error_message="No alternate account advertises gpt-5.6-sol",
+                error_code="no_accounts",
+            )
+        return AccountSelection(account=rejected, error_message=None)
+
+    async def fake_stream_once(*_args: object, **_kwargs: object):
+        raise proxy_module.ProxyResponseError(
+            400,
+            proxy_module.openai_error(
+                "invalid_request_error",
+                "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+                error_type="invalid_request_error",
+            ),
+        )
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh_with_budget",
+        AsyncMock(side_effect=lambda account, **_kwargs: account),
+    )
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.6-sol", "instructions": "hi", "input": [], "stream": True}
+    )
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-account-model-no-replacement"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    failed = json.loads(chunks[-1].split("data: ", 1)[1])
+    assert failed["type"] == "response.failed"
+    assert failed["response"]["error"] == {
+        "message": "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+        "type": "invalid_request_error",
+        "code": "invalid_request_error",
+    }
+    handle_stream_error.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("propagate_http_errors", "budget_expires"),
     [(False, False), (True, False), (False, True)],
@@ -14219,6 +14396,75 @@ async def test_connect_proxy_websocket_surfaces_connect_timeout_when_no_failover
     assert sent_payload["error"]["code"] == "upstream_unavailable"
     assert request_logs.calls[0]["account_id"] == first_account.id
     assert request_logs.calls[0]["error_code"] == "upstream_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_connect_proxy_websocket_preserves_account_model_rejection_without_replacement(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    rejected_account = _make_account("acc_ws_rejected_model")
+    select_account = AsyncMock(
+        return_value=AccountSelection(
+            account=None,
+            error_message="No compatible replacement account",
+            error_code="no_accounts",
+        )
+    )
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+
+    message = "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_rejected_model_no_replacement",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        request_stage="reattach",
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
+        replay_count=1,
+        excluded_account_ids={rejected_account.id},
+        precreated_replay_reason="account_model_unsupported",
+        precreated_replay_account_id=rejected_account.id,
+        error_code_override="invalid_request_error",
+        error_message_override=message,
+        error_type_override="invalid_request_error",
+        error_http_status_override=400,
+    )
+
+    websocket_send = AsyncMock()
+    selected_account, selected_upstream = await service._connect_proxy_websocket(
+        {},
+        sticky_key=None,
+        sticky_kind=None,
+        prefer_earlier_reset=False,
+        routing_strategy="usage_weighted",
+        model="gpt-5.6-sol",
+        request_state=request_state,
+        api_key=None,
+        client_send_lock=anyio.Lock(),
+        websocket=cast(WebSocket, SimpleNamespace(send_text=websocket_send)),
+    )
+
+    assert selected_account is None
+    assert selected_upstream is None
+    call = select_account.await_args
+    assert call is not None
+    assert call.kwargs["exclude_account_ids"] == {rejected_account.id}
+    websocket_send_call = websocket_send.await_args
+    assert websocket_send_call is not None
+    sent = json.loads(websocket_send_call.args[0])
+    assert sent == {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "message": message,
+            "type": "invalid_request_error",
+            "code": "invalid_request_error",
+        },
+    }
+    assert request_logs.calls[0]["account_id"] == rejected_account.id
+    assert request_logs.calls[0]["error_code"] == "invalid_request_error"
 
 
 @pytest.mark.asyncio
@@ -19154,6 +19400,74 @@ async def test_process_upstream_websocket_text_transparently_retries_precreated_
     assert pending_request.error_code_override is None
     assert pending_request.error_message_override is None
     assert pending_request.error_http_status_override is None
+    assert list(pending_requests) == []
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_retries_account_model_rejection_without_health_penalty(
+    monkeypatch,
+):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    finalize_request_state = AsyncMock()
+    handle_stream_error = AsyncMock()
+    account = _make_account("acc_ws_stale_model_route")
+
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.6-sol",
+        "input": "retry on an account that actually supports Sol",
+    }
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_stale_model_route",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=json.dumps(request_payload, separators=(",", ":")),
+    )
+    pending_requests = deque([pending_request])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    upstream_payload = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "type": "invalid_request_error",
+            "code": "invalid_request_error",
+            "message": ("The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."),
+        },
+    }
+    upstream_text = json.dumps(upstream_payload, separators=(",", ":"))
+
+    downstream_text = await service._process_upstream_websocket_text(
+        upstream_text,
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert downstream_text == upstream_text
+    finalize_request_state.assert_not_awaited()
+    handle_stream_error.assert_not_awaited()
+    assert upstream_control.reconnect_requested is True
+    assert upstream_control.suppress_downstream_event is True
+    assert upstream_control.replay_request_state is pending_request
+    assert pending_request.replay_count == 1
+    assert pending_request.excluded_account_ids == {account.id}
+    assert pending_request.affinity_policy.reallocate_sticky is True
+    assert pending_request.precreated_replay_reason == "account_model_unsupported"
+    assert pending_request.precreated_replay_account_id == account.id
+    assert pending_request.error_http_status_override == 400
+    assert pending_request.error_code_override == "invalid_request_error"
     assert list(pending_requests) == []
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -952,6 +952,49 @@ def test_websocket_precreated_retry_error_code_classifies_exact_account_model_re
     )
 
 
+@pytest.mark.parametrize(
+    ("kind", "expected"),
+    [("account_model", "account_model_unsupported"), ("auth", "invalid_api_key")],
+)
+def test_websocket_precreated_error_classifiers_do_not_replay_top_level_response_id(
+    kind: str,
+    expected: str,
+) -> None:
+    request_state = proxy_service._WebSocketRequestState(
+        request_id=f"req_{kind}_top_level_response_id",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
+    )
+    error = (
+        {
+            "type": "invalid_request_error",
+            "message": "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+        }
+        if kind == "account_model"
+        else {
+            "type": "authentication_error",
+            "code": "invalid_api_key",
+            "message": "Authentication token expired",
+        }
+    )
+    payload: dict[str, JsonValue] = {"type": "error", "status": 401, "error": error}
+    classifier = (
+        proxy_service._websocket_precreated_retry_error_code
+        if kind == "account_model"
+        else proxy_service._websocket_precreated_auth_error_code
+    )
+
+    assert classifier(request_state, event_type="error", payload=payload, has_other_pending_requests=False) == expected
+
+    payload["response_id"] = "resp_already_accepted"
+    assert classifier(request_state, event_type="error", payload=payload, has_other_pending_requests=False) is None
+
+
 def _assert_proxy_response_error(exc: BaseException) -> proxy_module.ProxyResponseError:
     assert isinstance(exc, proxy_module.ProxyResponseError)
     return exc
@@ -10630,7 +10673,11 @@ async def test_stream_with_retry_preserves_account_model_rejection_without_repla
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("replacement_failure_kind", "expected_status", "expected_code"),
-    [("server", 500, "replacement_failed"), ("transport", 502, "upstream_unavailable")],
+    [
+        ("server", 500, "replacement_failed"),
+        ("transport", 502, "upstream_unavailable"),
+        ("refresh", 503, "upstream_unavailable"),
+    ],
 )
 async def test_stream_with_retry_surfaces_selected_replacement_failure_after_account_model_rejection(
     monkeypatch,
@@ -10683,14 +10730,45 @@ async def test_stream_with_retry_surfaces_selected_replacement_failure_after_acc
         )
         yield  # pragma: no cover
 
+    async def ensure_fresh(account: Account, **_kwargs: object) -> Account:
+        if account.id == replacement.id and replacement_failure_kind == "refresh":
+            raise proxy_service.RefreshError(
+                "refresh_claim_timeout",
+                "Replacement refresh is temporarily unavailable",
+                False,
+                transport_error=True,
+            )
+        return account
+
     monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
-    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=lambda account, **_kwargs: account))
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", ensure_fresh)
     monkeypatch.setattr(service, "_stream_once", fake_stream_once)
     monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
 
     payload = ResponsesRequest.model_validate(
         {"model": "gpt-5.6-sol", "instructions": "hi", "input": [], "stream": True}
     )
+
+    if replacement_failure_kind == "refresh":
+        chunks = [
+            chunk
+            async for chunk in service._stream_with_retry(
+                payload,
+                {"session_id": "sid-account-model-replacement-failure"},
+                codex_session_affinity=False,
+                propagate_http_errors=False,
+                openai_cache_affinity=False,
+                api_key=None,
+                api_key_reservation=None,
+                suppress_text_done_events=False,
+                request_transport="http",
+                upstream_stream_transport_override="http",
+            )
+        ]
+        event = json.loads(chunks[-1].split("data: ", 1)[1])
+        assert event["response"]["error"]["code"] == expected_code
+        assert selected_account_ids == [rejected.id, replacement.id]
+        return
 
     with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
         async for _chunk in service._stream_with_retry(
@@ -14913,14 +14991,21 @@ async def test_connect_proxy_websocket_preserves_account_model_rejection_without
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("failure_status", "failure_code", "failure_message"),
+    ("failure_kind", "failure_status", "failure_code", "failure_message"),
     [
-        (500, "replacement_failed", "Replacement connection failed"),
-        (502, "upstream_unavailable", "Replacement transport connection failed"),
+        ("server", 500, "replacement_failed", "Replacement connection failed"),
+        ("transport", 502, "upstream_unavailable", "Replacement transport connection failed"),
+        (
+            "refresh",
+            503,
+            "upstream_unavailable",
+            "Account refresh is temporarily unavailable; no healthy account could be reached.",
+        ),
     ],
 )
 async def test_connect_proxy_websocket_surfaces_selected_replacement_failure_after_account_model_rejection(
     monkeypatch,
+    failure_kind,
     failure_status,
     failure_code,
     failure_message,
@@ -14931,9 +15016,13 @@ async def test_connect_proxy_websocket_surfaces_selected_replacement_failure_aft
     replacement_account = _make_account("acc_ws_replacement_model")
     third_account = _make_account("acc_ws_third_model")
     select_account = AsyncMock(side_effect=[replacement_account, third_account])
-    replacement_failure = proxy_module.ProxyResponseError(
-        failure_status,
-        proxy_module.openai_error(failure_code, failure_message, error_type="server_error"),
+    replacement_failure: BaseException = (
+        proxy_support._WebSocketTransientRefreshFailover(replacement_account.id)
+        if failure_kind == "refresh"
+        else proxy_module.ProxyResponseError(
+            failure_status,
+            proxy_module.openai_error(failure_code, failure_message, error_type="server_error"),
+        )
     )
     monkeypatch.setattr(service, "_select_websocket_connect_account", select_account)
     monkeypatch.setattr(service, "_try_open_websocket_connect_attempt", AsyncMock(side_effect=replacement_failure))
@@ -28962,6 +29051,77 @@ async def test_reconnect_http_bridge_discards_model_fallback_before_selected_rep
     assert request_state.error_code_override is None
     assert request_state.error_message_override is None
     assert request_state.error_http_status_override is None
+
+
+@pytest.mark.asyncio
+async def test_reconnect_http_bridge_does_not_fail_over_after_selected_model_replacement_401(monkeypatch):
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    rejected_account = _make_account("acc_bridge_rejected_model_401")
+    replacement_account = _make_account("acc_bridge_replacement_model_401")
+    third_account = _make_account("acc_bridge_third_model_401")
+    first_401 = proxy_module.ProxyResponseError(401, openai_error("invalid_api_key", "expired"))
+    second_401 = proxy_module.ProxyResponseError(401, openai_error("invalid_api_key", "still expired"))
+    selected_account_ids: list[str] = []
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service.time, "monotonic", lambda: 10.0)
+
+    async def select_account(**_kwargs: object) -> AccountSelection:
+        selected = replacement_account if not selected_account_ids else third_account
+        selected_account_ids.append(selected.id)
+        return AccountSelection(account=selected, error_message=None)
+
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh_with_budget",
+        AsyncMock(side_effect=[replacement_account, replacement_account, third_account]),
+    )
+    monkeypatch.setattr(
+        service,
+        "_open_upstream_websocket_with_budget",
+        AsyncMock(side_effect=[first_401, second_401, SimpleNamespace(response_header=lambda _name: None)]),
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_selected_model_replacement_401",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=10.0,
+        excluded_account_ids={rejected_account.id},
+        precreated_replay_reason="account_model_unsupported",
+        precreated_replay_account_id=rejected_account.id,
+        error_code_override="invalid_request_error",
+        error_message_override="The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+        error_type_override="invalid_request_error",
+        error_http_status_override=400,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-model-replacement-401", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.6-sol",
+        account=rejected_account,
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service._reconnect_http_bridge_session(session, request_state=request_state)
+
+    assert exc_info.value is second_401
+    assert selected_account_ids == [replacement_account.id]
+    assert request_state.precreated_replay_reason is None
+    assert request_state.error_code_override is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9659,6 +9659,71 @@ async def test_http_bridge_preserves_raw_error_event_when_sdk_contract_disabled(
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_model_rejection_releases_old_account_create_lease_before_replay(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_bridge_stale_model_route")
+    old_lease = await service._load_balancer.acquire_account_lease(account.id, kind="response_create")
+    assert old_lease is not None
+    retry_precreated = AsyncMock(return_value=False)
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_stale_model_route",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"retry"}',
+        account_response_create_lease=old_lease,
+        account_response_create_release=service._load_balancer.release_account_lease,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-stale-model-route", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.6-sol",
+        account=account,
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    cast(Any, session.upstream).archive_received = MagicMock()
+    rejection = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "type": "invalid_request_error",
+            "code": "invalid_request_error",
+            "message": "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+        },
+    }
+
+    await service._process_http_bridge_upstream_text(session, json.dumps(rejection, separators=(",", ":")))
+
+    retry_precreated.assert_awaited_once_with(session)
+    assert request_state.account_response_create_lease is None
+    assert request_state.account_response_create_release is None
+    assert await service._load_balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
+    assert request_state.precreated_replay_reason is None
+    assert request_state.event_queue is not None
+    forwarded = await request_state.event_queue.get()
+    assert forwarded is not None
+    forwarded_event = parse_sse_data_json(forwarded)
+    assert forwarded_event["type"] == "response.failed"
+    assert forwarded_event["response"]["error"] == rejection["error"]
+    assert await request_state.event_queue.get() is None
+
+
+@pytest.mark.asyncio
 async def test_service_stream_responses_does_not_infer_previous_response_id_from_session_scope(monkeypatch):
     settings = _make_proxy_settings()
     request_logs = _RequestLogsRecorder()
@@ -10125,6 +10190,61 @@ async def test_stream_with_retry_prefers_other_account_before_response_create_ca
     assert completed["type"] == "response.completed"
     assert stream_accounts == [saturated.id, spare.id]
     assert selections[1]["exclude_account_ids"] == {saturated.id}
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_budget_exhaustion_emits_one_terminal_event(monkeypatch):
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_stream_budget_exhausted")
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(
+        service,
+        "_ensure_fresh_with_budget",
+        AsyncMock(side_effect=lambda selected, **_kwargs: selected),
+    )
+
+    async def fake_stream_once(*_args: object, **_kwargs: object):
+        raise proxy_module.ProxyResponseError(
+            502,
+            proxy_module.openai_error(
+                "upstream_request_timeout",
+                "Proxy request budget exhausted",
+                error_type="server_error",
+            ),
+        )
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-stream-budget-exhausted"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    assert len(chunks) == 1
+    failed = json.loads(chunks[0].split("data: ", 1)[1])
+    assert failed["type"] == "response.failed"
+    assert failed["response"]["error"]["code"] == "upstream_request_timeout"
 
 
 @pytest.mark.asyncio
@@ -19549,6 +19669,8 @@ async def test_process_upstream_websocket_text_retries_account_model_rejection_w
         "model": "gpt-5.6-sol",
         "input": "retry on an account that actually supports Sol",
     }
+    response_create_gate = asyncio.Semaphore(1)
+    await response_create_gate.acquire()
     pending_request = proxy_service._WebSocketRequestState(
         request_id="ws_req_stale_model_route",
         model="gpt-5.6-sol",
@@ -19557,6 +19679,8 @@ async def test_process_upstream_websocket_text_retries_account_model_rejection_w
         api_key_reservation=None,
         started_at=0.0,
         awaiting_response_created=True,
+        response_create_gate=response_create_gate,
+        response_create_gate_acquired=True,
         request_text=json.dumps(request_payload, separators=(",", ":")),
     )
     pending_requests = deque([pending_request])
@@ -19580,7 +19704,7 @@ async def test_process_upstream_websocket_text_retries_account_model_rejection_w
         pending_lock=anyio.Lock(),
         api_key=None,
         upstream_control=upstream_control,
-        response_create_gate=asyncio.Semaphore(1),
+        response_create_gate=response_create_gate,
     )
 
     assert downstream_text == upstream_text
@@ -19596,6 +19720,9 @@ async def test_process_upstream_websocket_text_retries_account_model_rejection_w
     assert pending_request.precreated_replay_account_id == account.id
     assert pending_request.error_http_status_override == 400
     assert pending_request.error_code_override == "invalid_request_error"
+    assert pending_request.response_create_gate is None
+    assert pending_request.response_create_gate_acquired is False
+    assert response_create_gate.locked() is False
     assert list(pending_requests) == []
 
 
@@ -28371,6 +28498,73 @@ async def test_reconnect_http_bridge_skips_extra_same_account_retry_after_keepal
     assert seen_account_ids == [None]
     assert session.account == account_b
     assert session.upstream is new_upstream
+
+
+@pytest.mark.asyncio
+async def test_reconnect_http_bridge_discards_model_fallback_before_selected_replacement_failure(monkeypatch):
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    rejected_account = _make_account("acc_bridge_rejected_model")
+    replacement_account = _make_account("acc_bridge_replacement_model")
+    original_message = "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."
+    replacement_failure = proxy_module.ProxyResponseError(
+        500,
+        proxy_module.openai_error("replacement_failed", "Replacement connection failed", error_type="server_error"),
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service.time, "monotonic", lambda: 10.0)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=replacement_account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=replacement_account))
+    monkeypatch.setattr(service, "_open_upstream_websocket_with_budget", AsyncMock(side_effect=replacement_failure))
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_rejected_model_replacement_failure",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=10.0,
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"retry"}',
+        excluded_account_ids={rejected_account.id},
+        precreated_replay_reason="account_model_unsupported",
+        precreated_replay_account_id=rejected_account.id,
+        error_code_override="invalid_request_error",
+        error_message_override=original_message,
+        error_type_override="invalid_request_error",
+        error_http_status_override=400,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-model-replacement", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.6-sol",
+        account=rejected_account,
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service._reconnect_http_bridge_session(session, request_state=request_state)
+
+    assert exc_info.value is replacement_failure
+    assert request_state.precreated_replay_reason is None
+    assert request_state.precreated_replay_account_id is None
+    assert request_state.error_code_override is None
+    assert request_state.error_message_override is None
+    assert request_state.error_http_status_override is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- classify only the exact ChatGPT account/model rejection for the requested model as `account_model_unsupported`
- retry once on another model-advertising account before upstream acceptance across native WebSocket, the HTTP responses bridge, and raw HTTP/SSE
- keep the rejection request-local: exclude only that account, do not penalize global account health, and preserve the original upstream 400 when no replacement exists
- retain fail-closed behavior for uploaded-file pins and owner continuations unless a proxy-verified self-contained fresh body can move safely

## Why

Local request logs exposed a short model-registry race: an account remained stored as `pro` while its authoritative usage payload reported `free`, so the last-known per-account catalog briefly routed Sol to it. Upstream rejected those turns before `response.created`; the next catalog refresh corrected the route. A pre-acceptance, request-local retry absorbs that race without globally hiding the model or mutating identity-sensitive account metadata.

Related to the multi-account rejection reported in #608. This is recurrence hardening for a transient stale snapshot, not a change to global catalog visibility.

## Replay safety

- exact `invalid_request_error` message and quoted model must match the requested model
- no retry after a response id, nonterminal `response.*` event, downstream sequence/output, another pending request, or an earlier replay
- rejected account is added only to the current request's exclusion set
- replacement selection still applies the model/service-tier catalog filters
- account response-create and stream leases are released before reselection
- file-pinned and unverified owner-bound requests never cross accounts
- no compatible replacement surfaces the original 400, not `no_accounts`, `stream_incomplete`, or 502

## Review size

The PR is one proxy-routing concern. Its **957 net lines** break down as:

- **305 net production-code lines** (306 additions, 1 deletion)
- **539 regression-test lines**
- **113 OpenSpec proposal/design/spec/task lines**

## Validation

- `uv run pytest -q tests/unit/test_proxy_utils.py` - 700 passed
- `uv run pytest -q tests/integration/test_proxy_websocket_responses.py` - 63 passed
- `uv run pytest -q tests/integration/test_http_responses_bridge.py` - 90 passed
- focused new/adjacent regression selection - 27 passed
- `uv run ruff format --check ...` - passed
- `uv run ruff check ...` - passed
- `uv run ty check` - passed
- `uv run python scripts/check_proxy_architecture.py` - passed
- `npx -y @fission-ai/openspec@latest validate retry-stale-account-model-rejection --strict` - passed
- `npx -y @fission-ai/openspec@latest validate --specs --strict` - 43 passed

## OpenSpec

- [x] Behavior change documented under `openspec/changes/retry-stale-account-model-rejection/`
- [x] Strict change and all-spec validation passed