### PR TITLE
fix(proxy): record early downstream cancellations

### DIFF
--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -1011,8 +1011,7 @@ class _StreamingMixin(_StreamingRetryMixin):
         except _TerminalStreamError:
             raise
         except (asyncio.CancelledError, GeneratorExit):
-            if settlement.downstream_visible:
-                status, error_code, error_message, failure_metadata = _mark_downstream_stream_cancelled(settlement)
+            status, error_code, error_message, failure_metadata = _mark_downstream_stream_cancelled(settlement)
             raise
         except Exception:
             if settlement.downstream_visible:

--- a/openspec/changes/record-early-downstream-cancellations/.openspec.yaml
+++ b/openspec/changes/record-early-downstream-cancellations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/record-early-downstream-cancellations/proposal.md
+++ b/openspec/changes/record-early-downstream-cancellations/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The raw Responses stream already records a downstream disconnect after visible
+output as `cancelled` with error code `client_disconnected`, but cancellation
+before the first upstream event bypasses that settlement helper. The canonical
+Responses API spec also still calls the existing `cancelled` outcome an
+`error`, so it disagrees with the runtime and its regression test.
+
+## What Changes
+
+- Record every downstream `CancelledError` or `GeneratorExit` as `cancelled`
+  with downstream `client_disconnected` metadata, including before visibility.
+- Keep the upstream account healthy because the client ended the request.
+- Correct the stale raw-stream contract to name the existing `cancelled`
+  request-log status.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: downstream cancellations use one client-side
+  settlement before and after the first visible stream event.
+
+## Impact
+
+- Code: `app/modules/proxy/_service/streaming/mixin.py`
+- Tests: `tests/unit/test_proxy_utils.py`
+- Specs: `openspec/specs/responses-api-compat/spec.md`

--- a/openspec/changes/record-early-downstream-cancellations/specs/responses-api-compat/spec.md
+++ b/openspec/changes/record-early-downstream-cancellations/specs/responses-api-compat/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Raw Responses streams require a terminal SSE event for success
+
+For raw HTTP streaming Responses attempts, the proxy MUST NOT record request-log
+status `success` or mark the selected account successful unless the stream
+observed a terminal SSE event: `response.completed`, `response.failed`,
+`response.incomplete`, or `error`. This requirement applies even when the
+upstream HTTP response status was 200 because the stream body remains part of
+the request outcome.
+
+If the upstream iterator ends before a terminal event, the proxy MUST surface a
+terminal `response.failed` SSE event with error code `stream_incomplete`, record
+the request-log row as an upstream `stream_incomplete` error, and apply the
+normal transient upstream account-health signal. If the downstream client
+cancels or disconnects before a terminal event, the proxy MUST record the
+request-log row with status `cancelled`, downstream error code
+`client_disconnected`, and downstream failure metadata, and MUST NOT penalize
+the upstream account.
+
+#### Scenario: Raw stream upstream EOF is not successful
+
+- **GIVEN** a raw HTTP streaming Responses request has emitted non-terminal SSE
+  data
+- **WHEN** the upstream stream ends before `response.completed`,
+  `response.failed`, `response.incomplete`, or `error`
+- **THEN** the downstream stream receives a terminal `response.failed` event
+  with error code `stream_incomplete`
+- **AND** the request log stores status `error`, error code
+  `stream_incomplete`, and upstream failure metadata
+- **AND** the selected account receives a transient upstream failure signal
+
+#### Scenario: Raw stream downstream cancellation is client-side
+
+- **GIVEN** a raw HTTP streaming Responses request has not observed a terminal
+  SSE event
+- **WHEN** the downstream client cancels or disconnects from the stream
+- **THEN** the request log stores status `cancelled`, error code
+  `client_disconnected`, and downstream failure metadata
+- **AND** the selected account is not penalized for the client-side close

--- a/openspec/changes/record-early-downstream-cancellations/tasks.md
+++ b/openspec/changes/record-early-downstream-cancellations/tasks.md
@@ -1,0 +1,11 @@
+## 1. Downstream cancellation settlement
+
+- [x] 1.1 Apply the existing downstream-cancel settlement before visibility.
+- [x] 1.2 Preserve cancellation propagation and avoid upstream health penalty.
+- [x] 1.3 Correct the stale request-log status in the raw-stream contract.
+
+## 2. Validation
+
+- [x] 2.1 Add a pre-visible cancellation regression.
+- [x] 2.2 Re-run the existing post-visible cancellation regression.
+- [x] 2.3 Run focused tests, lint, type checking, and strict OpenSpec validation.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9497,6 +9497,61 @@ async def test_stream_once_marks_downstream_cancel_after_visible_event(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_stream_once_marks_downstream_cancel_before_first_event(monkeypatch):
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_stream_previsible_cancel")
+    settlement = proxy_service._StreamSettlement()
+    started = asyncio.Event()
+
+    async def fake_stream(
+        payload,
+        headers,
+        access_token,
+        account_id,
+        base_url=None,
+        raise_for_status=False,
+        enforce_openai_sdk_contract=True,
+    ):
+        del payload, headers, access_token, account_id, base_url, raise_for_status, enforce_openai_sdk_contract
+        started.set()
+        await asyncio.Event().wait()
+        yield ""
+
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.4", "instructions": "hi", "input": [], "stream": True})
+    stream = service._stream_once(
+        account,
+        payload,
+        {"session_id": "sid-stream"},
+        "req_stream_previsible_cancel",
+        False,
+        request_started_at=time.monotonic(),
+        api_key=None,
+        api_key_reservation=None,
+        settlement=settlement,
+        suppress_text_done_events=False,
+        upstream_stream_transport="http",
+        request_transport="http",
+    )
+    next_event = asyncio.ensure_future(anext(stream))
+    await asyncio.wait_for(started.wait(), timeout=1)
+    next_event.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await next_event
+
+    assert settlement.status == "cancelled"
+    assert settlement.error == {"message": "Downstream client disconnected before response.completed"}
+    assert settlement.account_health_error is False
+    assert request_logs.calls[0]["status"] == "cancelled"
+    assert request_logs.calls[0]["error_code"] == "client_disconnected"
+    assert request_logs.calls[0]["failure_phase"] == "downstream"
+    assert request_logs.calls[0]["failure_detail"] == "client_disconnected_before_terminal_event"
+
+
+@pytest.mark.asyncio
 async def test_service_stream_responses_records_typeless_raw_codex_error_after_created(monkeypatch):
     settings = _make_proxy_settings()
     request_logs = _RequestLogsRecorder()


### PR DESCRIPTION
## Summary

Classify downstream cancellation consistently even when a raw Responses stream is
cancelled before its first visible SSE event. The cancellation still propagates,
while request-log metadata records a client-side close without penalizing the
upstream account.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Fixes Soju06/codex-lb#1323.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/record-early-downstream-cancellations/`

## Changes

- Apply the existing downstream-cancellation settlement before and after the first visible event.
- Preserve cancellation propagation and avoid upstream account-health penalties.
- Add a deterministic pre-visible cancellation regression alongside the existing post-visible case.
- Correct the Responses compatibility requirement to name the existing `cancelled` request-log status.

## Test plan

```text
uv run pytest -q tests/unit/test_proxy_utils.py -k 'test_stream_once_marks_downstream_cancel'
# 2 passed, 694 deselected

uv run ruff check app/modules/proxy/_service/streaming/mixin.py tests/unit/test_proxy_utils.py
# All checks passed!

uv run ruff format --check app/modules/proxy/_service/streaming/mixin.py tests/unit/test_proxy_utils.py
# 2 files already formatted

uv run ty check
# All checks passed!

npx --yes @fission-ai/openspec@1.6.0 validate record-early-downstream-cancellations --strict --no-interactive
# Change 'record-early-downstream-cancellations' is valid

npx --yes @fission-ai/openspec@1.6.0 validate --specs --no-interactive
# 43 passed, 0 failed
```

## Screenshots / output

The regression blocks the upstream async iterator before its first yield, cancels
the pending downstream read, and verifies `cancelled`, `client_disconnected`,
downstream failure metadata, propagation, and no account-health penalty.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local CI subsets.
- [x] OpenSpec validation passes and all change artifacts are complete.
- [x] CHANGELOG is not edited by hand.
