### PR TITLE
fix(proxy): reject unsupported multi-worker-per-instance for shared per-account caps

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -355,6 +355,16 @@ class Settings(BaseSettings):
     proxy_account_lease_ttl_seconds: float = Field(default=900.0, gt=0)
     proxy_account_caps_scope: Literal["partitioned", "replica"] = "partitioned"
     proxy_account_cap_partition_scale_down_seconds: int = Field(default=60, ge=30)
+    # Explicit operator declaration of how many worker processes
+    # (uvicorn/gunicorn) this instance runs behind a single bridge-ring instance
+    # id. Only ``1`` (the default) is supported: per-account concurrency caps are
+    # partitioned per REPLICA via the bridge ring, and intra-pod multi-worker
+    # cap partitioning cannot be made reliable (there is no portable per-worker
+    # index — standard multi-worker launches inherit the same environment into
+    # every child). A declared value greater than 1 is rejected at startup by
+    # ``_validate_workers_per_instance``; operators scale horizontally via
+    # replicas instead. Default 1 is a no-op requiring zero operator action.
+    workers_per_instance: int = Field(default=1, ge=1)
     proxy_refresh_failure_cooldown_seconds: float = Field(default=5.0, ge=0.0)
     usage_refresh_auth_failure_cooldown_seconds: float = Field(default=300.0, ge=0.0)
 
@@ -645,6 +655,28 @@ class Settings(BaseSettings):
             raise ValueError("dashboard_auth_mode=trusted_header requires firewall_trust_proxy_headers=true")
         if not self.firewall_trusted_proxy_cidrs:
             raise ValueError("dashboard_auth_mode=trusted_header requires non-empty firewall_trusted_proxy_cidrs")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_workers_per_instance(self) -> "Settings":
+        # Only one worker process per instance is supported. Per-account
+        # concurrency caps are partitioned per REPLICA via the bridge ring, which
+        # is correct only when a single process runs behind each ring instance
+        # id. Running multiple worker processes per instance cannot be made
+        # reliable for shared caps: there is no portable per-worker index, and a
+        # standard uvicorn/gunicorn multi-worker launch inherits the SAME
+        # environment into every child, so the workers cannot self-partition. Fail
+        # fast on the explicit declaration rather than silently over-admitting.
+        if self.workers_per_instance > 1:
+            raise ValueError(
+                "workers_per_instance (CODEX_LB_WORKERS_PER_INSTANCE="
+                f"{self.workers_per_instance}) is not supported: running more than one worker "
+                "process per instance would multiply per-account concurrency caps, because those "
+                "caps are partitioned per replica via the bridge ring and intra-pod worker "
+                "partitioning cannot be made reliable. Run ONE worker per pod/container and scale "
+                "horizontally via replicas (the bridge ring partitions caps per replica); set "
+                "CODEX_LB_WORKERS_PER_INSTANCE=1 (the default)."
+            )
         return self
 
 

--- a/openspec/changes/reject-multi-worker-per-instance/context.md
+++ b/openspec/changes/reject-multi-worker-per-instance/context.md
@@ -1,0 +1,60 @@
+# Context
+
+## Why multi-worker-per-instance is refused, not partitioned
+
+Per-account concurrency caps are cluster-wide targets partitioned **per replica**
+by the bridge ring: each replica derives its share of every cap from the sorted
+active `bridge_ring_members` list (`partition_cap(cap, R, rank)`), enforced
+against per-process in-memory lease counters. This is correct only when a single
+process runs behind each ring instance id.
+
+Running several worker processes behind one instance id breaks it: sibling
+workers share one ring rank but keep separate in-process counters, so each
+enforces the whole replica share and the effective cap is multiplied by the
+worker count. The obvious fix — an `R*W` slot partition with a distinct
+per-worker index — cannot be made reliable:
+
+- **No portable per-worker index.** Neither uvicorn `--workers` nor gunicorn
+  exposes a stable index in the child environment.
+- **Inherited environment.** A standard multi-worker launch copies the SAME
+  environment into every child, so an operator-declared `CODEX_LB_WORKER_INDEX`
+  is identical in all workers — every worker resolves to slot 0 and enforces slot
+  0's share independently. That is worse than no partitioning: it looks
+  configured but silently over-admits (e.g. `W=3`, stream cap 8: each worker
+  enforces slot 0's share of 3, aggregate 9 > 8) while slots 1..W-1 go uncovered.
+- **Auto-detection isn't portable either**, and shared-DB slot claims would add
+  per-request I/O on the admission hot path.
+
+The bridge ring already solves the real need — scaling per-account cap capacity —
+by partitioning per replica. So the supported model is **one worker per
+pod/container, scaled horizontally via replicas**, and an explicit declaration of
+more than one worker is refused rather than mis-served.
+
+## The tripwire and its accepted limitation
+
+`workers_per_instance` (`CODEX_LB_WORKERS_PER_INSTANCE`, default 1) is the only
+worker-related setting. A `model_validator(mode="after")` on `Settings` (the same
+pattern as the other cross-field validators, e.g.
+`_validate_token_refresh_claim_ttl`) rejects a declared value `> 1` at startup
+with a clear error naming the env var and directing the operator to run one
+worker per pod/container and scale via replicas. The default `1` is a complete
+no-op: zero operator action, behavior identical to `main` today.
+
+The tripwire catches only the **explicit declaration**. The worker count is not
+portably auto-detectable, so an operator who launches multiple workers without
+setting `CODEX_LB_WORKERS_PER_INSTANCE` is not caught at runtime — that case is
+covered by deployment documentation (one worker per pod). This is a deliberate,
+accepted trade-off: a loud refusal of the declared-unsupported config is worth
+more than an unreliable partition, and auto-detection would give false
+confidence it cannot back up.
+
+## What was removed from the earlier direction
+
+An earlier revision of this change added intra-pod worker cap partitioning: an
+`R*W` flattened `partition_cap_for_worker`, `worker_count`/`worker_index` on
+`CapPartition` and `AccountConcurrencyCaps`, a per-worker stream-reserve split,
+an ordinary-floor-at-zero rule for over-subscribed shares, and a
+`CODEX_LB_WORKER_INDEX` setting with per-worker-index validation. All of that is
+removed for the reasons above; the partitioning path is byte-for-byte `main`'s
+ring-only behavior, and the branch's only code change versus `main` is the
+`workers_per_instance > 1` tripwire.

--- a/openspec/changes/reject-multi-worker-per-instance/design.md
+++ b/openspec/changes/reject-multi-worker-per-instance/design.md
@@ -1,0 +1,83 @@
+# Design
+
+## Problem
+
+`share-account-concurrency-caps` made each configured per-account cap a
+cluster-wide target by dividing it across the `R` distinct bridge-ring instance
+ids (`partition_cap(cap, R, rank)`), enforced against per-process in-memory lease
+counters in `LoadBalancer`. That is correct only when one process runs per
+instance id. When an instance runs `W` uvicorn/gunicorn worker processes behind
+one bridge instance id:
+
+- All `W` workers register/heartbeat the same instance id, so they occupy a
+  single `rank` among `R` members — the ring cannot tell them apart.
+- Each worker is a separate OS process with its own `LoadBalancer` in-memory
+  lease counters, so each independently admits up to `partition_cap(cap, R,
+  rank)`, and the effective cap is multiplied by `W`.
+
+## Why intra-pod worker partitioning was rejected
+
+Making the cap correct under `W > 1` would require each worker to enforce a
+distinct slot of an `R*W` partition, which needs a reliable, distinct per-worker
+index in `[0, W)`. There is no portable way to obtain one:
+
+- Neither uvicorn `--workers` nor gunicorn exposes a stable per-worker index in
+  the child environment.
+- A standard multi-worker launch inherits the SAME environment into every child,
+  so an operator-declared `CODEX_LB_WORKER_INDEX` lands identically in all
+  workers — every worker resolves to slot 0 and enforces slot 0's share
+  independently, which over-admits while the other slots go uncovered.
+- Auto-deriving the index from PID/hostname hashing does not yield the contiguous
+  distinct set `{0..W-1}` a pod needs, so shares collide and the aggregate drifts.
+- Shared DB/atomic worker-slot claims add per-request DB round trips on the
+  admission hot path — the exact cost the replica change avoided.
+
+Because none of these is reliable, per-worker cap partitioning is not shipped.
+
+## Mechanism
+
+The supported deployment model is **one worker process per pod/container, scaled
+horizontally via replicas**. The bridge ring already partitions per-account caps
+per replica correctly (`partition_cap(cap, R, rank)`), so this needs no code
+change to the partitioning path — it is exactly `main`'s behavior.
+
+The only addition is a fail-fast tripwire. `workers_per_instance`
+(`CODEX_LB_WORKERS_PER_INSTANCE`, default 1) is an explicit operator declaration.
+A `model_validator(mode="after")` on `Settings` rejects a declared value `> 1` at
+startup with a clear error naming the variable and directing the operator to run
+one worker per pod/container and scale via replicas. The default `1` is a no-op:
+zero operator action, behavior identical to a deployment that never sets it.
+
+The tripwire deliberately catches only the explicit declaration — the worker
+count is not portably auto-detectable, so a misconfigured multi-worker launch
+that never sets the variable is covered by documentation (one worker per pod),
+not by runtime detection. That is the accepted trade-off: a loud, explicit
+refusal beats a silent, unreliable partition.
+
+## Rejected alternatives
+
+- **Register each worker as a distinct ring member id**: rejected — the bridge
+  instance id is deliberately pod-level for session routing/ownership; per-worker
+  ids would fragment bridge affinity and durable-session ownership.
+- **`R*W` flattened partition with a per-worker index**: rejected — no portable
+  distinct per-worker index (see above); the inherited-environment failure mode
+  makes it actively unsafe.
+- **Shared DB/atomic worker-slot claims**: rejected — per-request DB I/O on the
+  admission hot path.
+
+## SQLite vs PostgreSQL
+
+No schema or query change: the tripwire is process-local settings validation and
+the partitioning path is unchanged from `main`. There is no migration and no
+dialect-specific behavior on either backend.
+
+## Testing
+
+- Settings validation (`tests/unit/test_settings_multi_replica.py`):
+  `workers_per_instance > 1` raises the fail-fast `ValidationError` naming the
+  env var and the scale-via-replicas guidance; `workers_per_instance == 1`
+  (default and explicit) is accepted and unchanged.
+- The existing ring-only partition tests (`tests/unit/test_cap_partitioning.py`,
+  `tests/unit/test_load_balancer_concurrency.py`, `tests/integration/
+  test_multi_replica.py`) continue to pass unchanged, confirming the per-replica
+  partitioning path is untouched.

--- a/openspec/changes/reject-multi-worker-per-instance/proposal.md
+++ b/openspec/changes/reject-multi-worker-per-instance/proposal.md
@@ -1,0 +1,44 @@
+# Reject unsupported multi-worker-per-instance for shared per-account caps
+
+## Why
+
+Per-account concurrency caps are cluster-wide targets partitioned **per replica**
+via the bridge ring (`share-account-concurrency-caps`): each replica derives its
+share of every cap from the sorted active `bridge_ring_members` list. That is
+correct only when a single process runs behind each bridge-ring instance id.
+
+An instance that runs several uvicorn/gunicorn worker processes behind ONE bridge
+instance id breaks the invariant: sibling workers share one ring rank yet keep
+separate in-process lease counters, so each worker independently enforces the
+whole replica share and the effective per-account cap is multiplied by the worker
+count. Intra-pod worker cap partitioning cannot be made reliable to fix this:
+there is no portable per-worker index, and a standard multi-worker launch inherits
+the SAME environment (any declared `WORKER_INDEX`) into every child, so the
+workers cannot self-partition into distinct slots.
+
+Rather than ship an unworkable per-worker contract, the supported model is **one
+worker per pod/container, scaled horizontally via replicas** — the bridge ring
+already partitions per-account caps per replica correctly. An operator who
+explicitly declares more than one worker per instance must be told fast, at
+startup, instead of silently over-admitting against every account.
+
+## What Changes
+
+- Add a single fail-fast tripwire: `workers_per_instance`
+  (`CODEX_LB_WORKERS_PER_INSTANCE`, default 1). A value `> 1` raises a clear
+  settings `ValidationError` at startup explaining that multi-worker-per-instance
+  is unsupported for shared caps and that operators should run one worker per
+  pod/container and scale via replicas. Default `1` is a no-op requiring zero
+  operator action — behavior is identical to today.
+- Per-account cap partitioning stays exactly as it is on `main`: ring-based, per
+  replica (`partition_cap(cap, R, rank)`), with no worker dimension.
+
+## Non-goals
+
+- Intra-pod multi-worker cap partitioning (an `R*W` slot split, per-worker index,
+  per-worker reserve split): dropped as unworkable — no portable per-worker index
+  and inherited environment make it unreliable.
+- Auto-detecting the worker count: not portably detectable. The tripwire only
+  catches the explicit `CODEX_LB_WORKERS_PER_INSTANCE > 1` declaration;
+  documentation covers the one-worker-per-pod deployment guidance. This is the
+  accepted trade-off.

--- a/openspec/changes/reject-multi-worker-per-instance/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/reject-multi-worker-per-instance/specs/proxy-admission-control/spec.md
@@ -1,0 +1,41 @@
+# proxy-admission-control
+
+## ADDED Requirements
+
+### Requirement: Multiple worker processes per instance are rejected for shared per-account caps
+
+Per-account concurrency caps are partitioned per bridge-ring replica and are correct only when a single worker process runs behind each bridge-ring instance id. The system MUST expose `workers_per_instance` (env `CODEX_LB_WORKERS_PER_INSTANCE`, default 1, minimum 1) as an explicit operator declaration of how many worker processes an instance runs behind one instance id. When `workers_per_instance` is greater than 1 the process MUST fail fast at startup with a settings validation error that names `CODEX_LB_WORKERS_PER_INSTANCE` and states that running more than one worker per instance is not supported for shared per-account caps and that operators MUST run one worker per pod/container and scale horizontally via replicas. When `workers_per_instance` is 1 (the default) startup MUST proceed with no operator action required and behavior MUST be identical to a deployment that does not set the variable. The system MUST NOT attempt to auto-detect the worker count and MUST NOT partition per-account caps across intra-pod worker processes.
+
+#### Scenario: A single worker per instance is accepted
+
+- **GIVEN** `workers_per_instance` is 1 (the default, whether unset or explicitly set)
+- **WHEN** the process loads its settings at startup
+- **THEN** startup succeeds and per-account caps remain partitioned per replica via the bridge ring
+
+#### Scenario: More than one worker per instance fails fast
+
+- **GIVEN** `workers_per_instance` is configured as 2
+- **WHEN** the process loads its settings at startup
+- **THEN** startup fails with a settings validation error naming `CODEX_LB_WORKERS_PER_INSTANCE`
+- **AND** the error states multi-worker-per-instance is not supported and directs the operator to run one worker per pod/container and scale via replicas
+
+## MODIFIED Requirements
+
+### Requirement: Account-local Responses work is capped before upstream creation
+
+For `/v1/responses`, `/backend-api/codex/responses`, and compact Responses traffic, the proxy MUST enforce account-local response-create and streaming concurrency limits in addition to process-wide admission limits, and the configured limits MUST be cluster-wide per-account targets enforced across all replicas rather than per-replica allowances. Because per-account caps are partitioned per replica via the bridge ring and cannot be safely partitioned across intra-pod worker processes, each instance MUST run a single worker process; horizontal scaling is achieved by adding replicas. The default account response-create cap MUST be 4 and the default account stream cap MUST be 8 unless operators configure a different value. When an account is at either cap, new soft-affinity work MUST prefer another eligible account before returning local overload. Hard-continuity work MAY fail closed when the required owner account is saturated.
+
+#### Scenario: Soft work avoids saturated account
+
+- **GIVEN** account A is at its account response-create cap
+- **AND** account B is eligible and below cap
+- **WHEN** a soft-affinity `/v1/responses` request is routed
+- **THEN** the proxy selects account B instead of queueing on account A
+
+#### Scenario: Hard continuity owner saturation fails closed
+
+- **GIVEN** a follow-up request requires a specific previous-response owner account
+- **AND** that account is at its account stream or response-create cap
+- **WHEN** no safe continuity-preserving alternative exists
+- **THEN** the proxy returns a bounded local overload/continuity failure
+- **AND** the failure reason is stable and low-cardinality

--- a/openspec/changes/reject-multi-worker-per-instance/tasks.md
+++ b/openspec/changes/reject-multi-worker-per-instance/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+## 1. Settings tripwire
+- [x] 1.1 Keep `workers_per_instance` (`CODEX_LB_WORKERS_PER_INSTANCE`, default 1, `ge=1`) on `Settings` as an explicit operator declaration; document that only 1 is supported.
+- [x] 1.2 Add `_validate_workers_per_instance` (`model_validator(mode="after")`) that raises a clear `ValidationError` at startup when `workers_per_instance > 1`, naming `CODEX_LB_WORKERS_PER_INSTANCE` and directing operators to run one worker per pod/container and scale via replicas. `workers_per_instance == 1` (default or explicit) requires no operator action.
+- [x] 1.3 Remove `worker_index` / `CODEX_LB_WORKER_INDEX` entirely (no per-worker index anywhere).
+
+## 2. Revert intra-pod worker partitioning
+- [x] 2.1 Restore `app/modules/proxy/cap_partitioning.py` to `main` (ring-only `partition_cap(cap, R, rank)`; remove `partition_cap_for_worker`, `partition_stream_reserve`, `worker_count`/`worker_index` on `CapPartition`, `resolve_worker_partition` worker logic).
+- [x] 2.2 Restore `app/modules/proxy/load_balancer.py` to `main` (remove `rank`/`worker_index`/`worker_count` on `AccountConcurrencyCaps`, `_effective_stream_cap` worker logic, the per-worker reserve split, worker-spread overload phrasing).
+- [x] 2.3 Confirm the ring-based per-replica partitioning path (`bridge_ring_members` → `partition_cap` over `R`, `refresh_cap_partition` wiring in `app/main.py`) is untouched and unchanged from `main`.
+
+## 3. Tests
+- [x] 3.1 Restore `tests/unit/test_cap_partitioning.py` and `tests/unit/test_load_balancer_concurrency.py` to `main` (remove worker-partition unit tests: `partition_cap_for_worker`, reserve split, over-subscribed, worker_index matrix). Ring-only partition tests preserved.
+- [x] 3.2 `tests/unit/test_settings_multi_replica.py`: `workers_per_instance > 1` raises the fail-fast `ValidationError` (message names the env var and the scale-via-replicas guidance); `workers_per_instance == 1` (default and explicit) is accepted and unchanged.
+
+## 4. Spec + validation
+- [x] 4.1 Reframe the change delta: ADD the "multiple worker processes per instance are rejected" requirement (per-replica partitioning unchanged; `W>1` fails fast; scale via replicas); MODIFY "Account-local Responses work is capped before upstream creation" to state the one-worker-per-instance / replica-scaling contract. Remove the obsolete `R*W`, worker_index, reserve-per-worker, and over-subscribed requirements/scenarios. Rationale in `context.md`.
+- [x] 4.2 `openspec validate reject-multi-worker-per-instance --strict` and `openspec validate --specs` green.
+
+## 5. CI gates
+- [x] 5.1 `uv run ruff check`, `ruff format --check`, `scripts/check_proxy_architecture.py`, `uv run ty check`, target test files green.

--- a/tests/unit/test_settings_multi_replica.py
+++ b/tests/unit/test_settings_multi_replica.py
@@ -296,3 +296,36 @@ def test_settings_upstream_websocket_proxy_env_can_be_explicitly_disabled(monkey
     settings = Settings()
 
     assert settings.upstream_websocket_trust_env is False
+
+
+def test_settings_workers_per_instance_defaults_to_one(monkeypatch):
+    # The default (one worker per instance) requires no operator action and is
+    # accepted exactly as before: caps are partitioned per replica via the ring.
+    monkeypatch.delenv("CODEX_LB_WORKERS_PER_INSTANCE", raising=False)
+
+    settings = Settings()
+
+    assert settings.workers_per_instance == 1
+
+
+def test_settings_workers_per_instance_explicit_one_is_accepted(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_WORKERS_PER_INSTANCE", "1")
+
+    settings = Settings()
+
+    assert settings.workers_per_instance == 1
+
+
+def test_settings_rejects_multiple_workers_per_instance(monkeypatch):
+    # Multi-worker per instance is unsupported for shared per-account caps and
+    # MUST fail fast: intra-pod worker cap partitioning cannot be made reliable,
+    # so operators run one worker per pod/container and scale via replicas.
+    monkeypatch.setenv("CODEX_LB_WORKERS_PER_INSTANCE", "2")
+
+    with pytest.raises(ValidationError) as exc_info:
+        Settings()
+
+    message = str(exc_info.value)
+    assert "CODEX_LB_WORKERS_PER_INSTANCE" in message
+    assert "not supported" in message
+    assert "scale horizontally via replicas" in message


### PR DESCRIPTION
## Why

Per-account concurrency caps are cluster-wide targets partitioned **per replica** via the bridge ring (`partition_cap(cap, R, rank)`), enforced against per-process in-memory lease counters. That is correct only when a single process runs behind each bridge-ring instance id.

An instance running several uvicorn/gunicorn worker processes behind ONE instance id breaks it: sibling workers share one ring rank but keep separate in-process counters, so each enforces the whole replica share and the effective cap is multiplied by the worker count. **Intra-pod worker cap partitioning cannot be made reliable** — there is no portable per-worker index, and a standard multi-worker launch inherits the SAME environment (any declared `WORKER_INDEX`) into every child, so workers cannot self-partition into distinct slots.

The maintainer decision: do not support intra-pod multi-worker shared-cap partitioning. Narrow the feature to the honest contract — **one worker per pod/container, scale horizontally via replicas** (the bridge ring already partitions caps per replica correctly) — and fail fast if an operator declares more than one worker.

## What

- **Revert** all intra-pod worker cap-partitioning machinery: `cap_partitioning.py` and `load_balancer.py` return to `main`'s ring-only per-replica behavior (no `partition_cap_for_worker`, `partition_stream_reserve`, `worker_count`/`worker_index`, `R*W` flattening, per-worker reserve split, over-subscribed floor). `CODEX_LB_WORKER_INDEX` removed entirely.
- **Keep one fail-fast tripwire**: `workers_per_instance` (`CODEX_LB_WORKERS_PER_INSTANCE`, default 1). A value `> 1` raises a clear settings `ValidationError` at startup naming the env var and directing operators to run one worker per pod/container and scale via replicas. Default `1` is a no-op with zero operator action — behavior identical to today. The worker count is not portably auto-detectable, so the tripwire catches only the explicit declaration; one-worker-per-pod is covered by documentation (accepted trade-off — no false confidence from unreliable auto-detection).
- **OpenSpec** reframed to `reject-multi-worker-per-instance`: ADD requirement "multiple worker processes per instance are rejected"; MODIFY "Account-local Responses work is capped before upstream creation" to state the one-worker-per-instance / replica-scaling contract; rationale in `context.md`.

The final tree differs from `origin/main` only in `settings.py` (the tripwire), the OpenSpec change folder, and a settings test (`git diff origin/main...HEAD` = 315 insertions across 7 files; the proxy code shows no net change vs main).

## Testing

- `workers_per_instance > 1` raises the fail-fast `ValidationError` (message names the env var and the scale-via-replicas guidance); `workers_per_instance == 1` (default and explicit) is accepted and unchanged.
- The ring-only per-replica partition tests (`test_cap_partitioning.py`, `test_load_balancer_concurrency.py`, `test_multi_replica.py`) pass unchanged, confirming the partitioning path is untouched.
- Gates green: pytest (96 passed), ruff check + format, `scripts/check_proxy_architecture.py`, `ty check`, `openspec validate reject-multi-worker-per-instance --strict` + `openspec validate --specs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)