### PR TITLE
fix(oauth): persist dashboard OAuth flow state for multi-replica

### DIFF
--- a/app/db/alembic/versions/20260714_000000_add_oauth_flow_states.py
+++ b/app/db/alembic/versions/20260714_000000_add_oauth_flow_states.py
@@ -1,0 +1,63 @@
+"""add oauth flow states coordination table
+
+Revision ID: 20260714_000000_add_oauth_flow_states
+Revises: 20260713_040000_add_account_refresh_claims
+Create Date: 2026-07-14
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260714_000000_add_oauth_flow_states"
+down_revision = "20260713_040000_add_account_refresh_claims"
+branch_labels = None
+depends_on = None
+
+_TABLE_NAME = "oauth_flow_states"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table(_TABLE_NAME):
+        return
+    op.create_table(
+        _TABLE_NAME,
+        sa.Column("flow_id", sa.String(), nullable=False),
+        sa.Column("state_token", sa.String(), nullable=True),
+        sa.Column("method", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("intended_account_id", sa.String(), nullable=True),
+        sa.Column("code_verifier_encrypted", sa.LargeBinary(), nullable=True),
+        sa.Column("device_auth_id", sa.String(), nullable=True),
+        sa.Column("user_code", sa.String(), nullable=True),
+        sa.Column("interval_seconds", sa.Integer(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("flow_id"),
+    )
+    op.create_index(
+        "ix_oauth_flow_states_state_token",
+        _TABLE_NAME,
+        ["state_token"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_oauth_flow_states_created_at",
+        _TABLE_NAME,
+        ["created_at"],
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(_TABLE_NAME):
+        return
+    op.drop_index("ix_oauth_flow_states_created_at", table_name=_TABLE_NAME)
+    op.drop_index("ix_oauth_flow_states_state_token", table_name=_TABLE_NAME)
+    op.drop_table(_TABLE_NAME)

--- a/app/db/alembic/versions/20260714_000000_add_oauth_flow_states.py
+++ b/app/db/alembic/versions/20260714_000000_add_oauth_flow_states.py
@@ -1,7 +1,7 @@
 """add oauth flow states coordination table
 
 Revision ID: 20260714_000000_add_oauth_flow_states
-Revises: 20260713_040000_add_account_refresh_claims
+Revises: 20260715_000000_add_request_log_queue_latency
 Create Date: 2026-07-14
 """
 
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "20260714_000000_add_oauth_flow_states"
-down_revision = "20260713_040000_add_account_refresh_claims"
+down_revision = "20260715_000000_add_request_log_queue_latency"
 branch_labels = None
 depends_on = None
 

--- a/app/db/alembic/versions/20260716_000000_add_oauth_device_flow_slots.py
+++ b/app/db/alembic/versions/20260716_000000_add_oauth_device_flow_slots.py
@@ -1,0 +1,41 @@
+"""add oauth device-flow single-active-slot coordination table
+
+Revision ID: 20260716_000000_add_oauth_device_flow_slots
+Revises: 20260714_000000_add_oauth_flow_states
+Create Date: 2026-07-15
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260716_000000_add_oauth_device_flow_slots"
+down_revision = "20260714_000000_add_oauth_flow_states"
+branch_labels = None
+depends_on = None
+
+_TABLE_NAME = "oauth_device_flow_slots"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table(_TABLE_NAME):
+        return
+    op.create_table(
+        _TABLE_NAME,
+        sa.Column("slot_key", sa.String(), nullable=False),
+        sa.Column("flow_id", sa.String(), nullable=False),
+        sa.Column("generation", sa.Integer(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("slot_key"),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if not inspector.has_table(_TABLE_NAME):
+        return
+    op.drop_table(_TABLE_NAME)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -547,6 +547,29 @@ class OAuthFlowState(Base):
     finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
+class OAuthDeviceFlowSlot(Base):
+    """Single-active-device-flow coordination slot (cross-replica).
+
+    At most one dashboard device-code OAuth flow is "current" at a time. A
+    device ``start`` atomically REPLACES the slot via a single conditional
+    UPSERT on the fixed ``slot_key``, so two replicas starting device OAuth
+    simultaneously leave exactly one current ``flow_id`` instead of two orphaned
+    pending rows that both believe they are current. A poller atomically
+    CONSUMES the slot (delete-if-mine) as its point of no return immediately
+    before persisting tokens: a poller whose flow was superseded (the slot now
+    names a different ``flow_id``) loses the consume and MUST abort without
+    adding or re-authenticating an account. ``generation`` is a monotonic claim
+    token bumped on every replacement, retained for observability.
+    """
+
+    __tablename__ = "oauth_device_flow_slots"
+
+    slot_key: Mapped[str] = mapped_column(String, primary_key=True)
+    flow_id: Mapped[str] = mapped_column(String, nullable=False)
+    generation: Mapped[int] = mapped_column(Integer, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
 class StickySession(Base):
     __tablename__ = "sticky_sessions"
 

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -517,6 +517,36 @@ class ResetCreditRedeemClaim(Base):
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
 
+class OAuthFlowState(Base):
+    """Durable dashboard OAuth add-account / reauth flow state.
+
+    The dashboard OAuth flow (PKCE `code_verifier`, `state` token, device-code
+    poll metadata, and status) is persisted here keyed by `flow_id` so that any
+    replica behind a load balancer can complete a flow it did not start: the
+    browser callback, a manually pasted callback URL, or a device-code status
+    poll can land on a different replica than the one that ran `start`. The
+    `code_verifier` is stored encrypted with the same key material as account
+    tokens. Abandoned pending flows expire via `expires_at` and are purged
+    opportunistically on write.
+    """
+
+    __tablename__ = "oauth_flow_states"
+
+    flow_id: Mapped[str] = mapped_column(String, primary_key=True)
+    state_token: Mapped[str | None] = mapped_column(String, nullable=True, unique=True, index=True)
+    method: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    intended_account_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    code_verifier_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+    device_auth_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    user_code: Mapped[str | None] = mapped_column(String, nullable=True)
+    interval_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
 class StickySession(Base):
     __tablename__ = "sticky_sessions"
 

--- a/app/modules/oauth/repository.py
+++ b/app/modules/oauth/repository.py
@@ -5,13 +5,21 @@ from datetime import datetime, timezone
 from typing import Any, cast
 
 from sqlalchemy import CursorResult, delete, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import to_utc_naive, utcnow
-from app.db.models import OAuthFlowState
+from app.db.models import OAuthDeviceFlowSlot, OAuthFlowState
 
 _TERMINAL_OAUTH_STATUSES = {"error", "success"}
+
+# Fixed key for the single-active dashboard device-code OAuth flow slot. The
+# dashboard runs at most one device flow at a time (a new device ``start``
+# supersedes any prior one), so a single global slot models "which device flow
+# is current" across replicas.
+DEVICE_FLOW_SLOT_KEY = "dashboard"
 
 
 def epoch_to_naive_utc(value: float | None) -> datetime | None:
@@ -146,16 +154,6 @@ class OAuthFlowRepository:
         await self._session.commit()
         return int(result.rowcount or 0) > 0
 
-    async def delete_pending_device(self) -> list[str]:
-        result = await self._session.execute(
-            select(OAuthFlowState.flow_id).where(OAuthFlowState.method == "device", OAuthFlowState.status == "pending")
-        )
-        flow_ids = [row[0] for row in result.all()]
-        if flow_ids:
-            await self._session.execute(delete(OAuthFlowState).where(OAuthFlowState.flow_id.in_(flow_ids)))
-            await self._session.commit()
-        return flow_ids
-
     async def purge_expired(self, *, terminal_keep: int) -> None:
         now = utcnow()
         await self._session.execute(
@@ -175,3 +173,66 @@ class OAuthFlowRepository:
         if stale_terminal:
             await self._session.execute(delete(OAuthFlowState).where(OAuthFlowState.flow_id.in_(stale_terminal)))
         await self._session.commit()
+
+    # ------------------------------------------------------------------
+    # Single-active device-flow slot (atomic cross-replica coordination)
+    # ------------------------------------------------------------------
+
+    async def claim_device_slot(self, flow_id: str) -> None:
+        """Atomically make ``flow_id`` the single current device flow.
+
+        A single conditional UPSERT on the fixed slot key: two replicas starting
+        device OAuth simultaneously serialize on the slot row (PostgreSQL row
+        lock / SQLite single-writer lock), so the slot ends up naming exactly one
+        ``flow_id`` -- not two orphaned pending rows. ``generation`` is bumped on
+        every replacement so the slot is never silently left unchanged.
+        """
+
+        now = utcnow()
+        dialect = self._session.get_bind().dialect.name
+        if dialect == "postgresql":
+            insert_stmt = pg_insert(OAuthDeviceFlowSlot)
+        elif dialect == "sqlite":
+            insert_stmt = sqlite_insert(OAuthDeviceFlowSlot)
+        else:  # pragma: no cover - only sqlite/postgres are supported backends
+            raise RuntimeError(f"device-flow slot unsupported for dialect={dialect!r}")
+        statement = insert_stmt.values(
+            slot_key=DEVICE_FLOW_SLOT_KEY, flow_id=flow_id, generation=1, updated_at=now
+        ).on_conflict_do_update(
+            index_elements=[OAuthDeviceFlowSlot.slot_key],
+            set_={
+                "flow_id": flow_id,
+                "generation": OAuthDeviceFlowSlot.generation + 1,
+                "updated_at": now,
+            },
+        )
+        await self._session.execute(statement)
+        await self._session.commit()
+
+    async def consume_device_slot(self, flow_id: str) -> bool:
+        """Atomically consume the slot iff ``flow_id`` still holds it.
+
+        This is the poller's point of no return before persisting tokens: the
+        conditional delete removes the slot only when it still names this flow,
+        so a superseded poller (the slot was UPSERTed to a newer ``flow_id``)
+        matches zero rows and MUST abort without persisting an account. Atomic on
+        both backends (single conditional DELETE).
+        """
+
+        result = cast(
+            CursorResult[Any],
+            await self._session.execute(
+                delete(OAuthDeviceFlowSlot).where(
+                    OAuthDeviceFlowSlot.slot_key == DEVICE_FLOW_SLOT_KEY,
+                    OAuthDeviceFlowSlot.flow_id == flow_id,
+                )
+            ),
+        )
+        await self._session.commit()
+        return int(result.rowcount or 0) > 0
+
+    async def current_device_slot_flow_id(self) -> str | None:
+        result = await self._session.execute(
+            select(OAuthDeviceFlowSlot.flow_id).where(OAuthDeviceFlowSlot.slot_key == DEVICE_FLOW_SLOT_KEY)
+        )
+        return result.scalar_one_or_none()

--- a/app/modules/oauth/repository.py
+++ b/app/modules/oauth/repository.py
@@ -7,7 +7,7 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.crypto import TokenEncryptor
-from app.core.utils.time import utcnow
+from app.core.utils.time import to_utc_naive, utcnow
 from app.db.models import OAuthFlowState
 
 _TERMINAL_OAUTH_STATUSES = {"error", "success"}
@@ -72,7 +72,13 @@ class OAuthFlowRepository:
 
     @staticmethod
     def _is_expired_pending(row: OAuthFlowState, now: datetime) -> bool:
-        return row.status == "pending" and row.expires_at is not None and row.expires_at <= now
+        if row.status != "pending" or row.expires_at is None:
+            return False
+        # ``expires_at`` is ``DateTime(timezone=True)``: on PostgreSQL asyncpg
+        # returns an offset-AWARE datetime, while ``now`` (``utcnow``) is naive
+        # UTC. Normalize the row value to naive UTC before comparing so the
+        # comparison never raises ``TypeError`` for offset-naive vs -aware.
+        return to_utc_naive(row.expires_at) <= now
 
     async def create(self, record: OAuthFlowRecord) -> None:
         encrypted = None

--- a/app/modules/oauth/repository.py
+++ b/app/modules/oauth/repository.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from typing import Any, cast
 
-from sqlalchemy import delete, select
+from sqlalchemy import CursorResult, delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.crypto import TokenEncryptor
@@ -124,14 +125,26 @@ class OAuthFlowRepository:
         status: str,
         error_message: str | None,
     ) -> bool:
-        row = await self._session.get(OAuthFlowState, flow_id)
-        if row is None:
-            return False
-        row.status = status
-        row.error_message = error_message
-        row.finished_at = utcnow() if status in _TERMINAL_OAUTH_STATUSES else None
+        # Terminal writes are monotonic and enforced ATOMICALLY in SQL so the
+        # guard holds under real cross-session/cross-replica concurrency. A
+        # durable ``success`` is sticky: only a ``success`` write may land on an
+        # already-``success`` row (idempotent), and any non-success write is
+        # rejected by the ``WHERE`` predicate. This closes the read-then-write
+        # TOCTOU race where two pollers both load a still-``pending`` row and the
+        # later ``error`` writer would otherwise clobber a committed ``success``
+        # (e.g. a losing/duplicate device poller receiving an OAuth error for the
+        # now-consumed device code). ``pending -> terminal`` and
+        # ``error -> success`` remain allowed.
+        finished_at = utcnow() if status in _TERMINAL_OAUTH_STATUSES else None
+        statement = update(OAuthFlowState).where(OAuthFlowState.flow_id == flow_id)
+        if status != "success":
+            statement = statement.where(OAuthFlowState.status != "success")
+        statement = statement.values(
+            status=status, error_message=error_message, finished_at=finished_at
+        ).execution_options(synchronize_session=False)
+        result = cast(CursorResult[Any], await self._session.execute(statement))
         await self._session.commit()
-        return True
+        return int(result.rowcount or 0) > 0
 
     async def delete_pending_device(self) -> list[str]:
         result = await self._session.execute(

--- a/app/modules/oauth/repository.py
+++ b/app/modules/oauth/repository.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.crypto import TokenEncryptor
+from app.core.utils.time import utcnow
+from app.db.models import OAuthFlowState
+
+_TERMINAL_OAUTH_STATUSES = {"error", "success"}
+
+
+def epoch_to_naive_utc(value: float | None) -> datetime | None:
+    """Convert an epoch-seconds float (as used by the in-memory store) to the
+    naive-UTC datetime the rest of the schema stores."""
+
+    if value is None:
+        return None
+    return datetime.fromtimestamp(value, tz=timezone.utc).replace(tzinfo=None)
+
+
+@dataclass(slots=True)
+class OAuthFlowRecord:
+    """Durable representation of a dashboard OAuth flow.
+
+    ``code_verifier`` is held in plaintext in memory only; the repository
+    encrypts it at rest and decrypts it on read.
+    """
+
+    flow_id: str
+    method: str
+    status: str
+    state_token: str | None = None
+    error_message: str | None = None
+    intended_account_id: str | None = None
+    code_verifier: str | None = None
+    device_auth_id: str | None = None
+    user_code: str | None = None
+    interval_seconds: int | None = None
+    expires_at: datetime | None = None
+    finished_at: datetime | None = None
+
+
+class OAuthFlowRepository:
+    """DB access for the shared ``oauth_flow_states`` table."""
+
+    def __init__(self, session: AsyncSession, encryptor: TokenEncryptor) -> None:
+        self._session = session
+        self._encryptor = encryptor
+
+    def _to_record(self, row: OAuthFlowState) -> OAuthFlowRecord:
+        verifier: str | None = None
+        if row.code_verifier_encrypted is not None:
+            verifier = self._encryptor.decrypt(row.code_verifier_encrypted)
+        return OAuthFlowRecord(
+            flow_id=row.flow_id,
+            method=row.method,
+            status=row.status,
+            state_token=row.state_token,
+            error_message=row.error_message,
+            intended_account_id=row.intended_account_id,
+            code_verifier=verifier,
+            device_auth_id=row.device_auth_id,
+            user_code=row.user_code,
+            interval_seconds=row.interval_seconds,
+            expires_at=row.expires_at,
+            finished_at=row.finished_at,
+        )
+
+    @staticmethod
+    def _is_expired_pending(row: OAuthFlowState, now: datetime) -> bool:
+        return row.status == "pending" and row.expires_at is not None and row.expires_at <= now
+
+    async def create(self, record: OAuthFlowRecord) -> None:
+        encrypted = None
+        if record.code_verifier is not None:
+            encrypted = self._encryptor.encrypt(record.code_verifier)
+        row = OAuthFlowState(
+            flow_id=record.flow_id,
+            state_token=record.state_token,
+            method=record.method,
+            status=record.status,
+            error_message=record.error_message,
+            intended_account_id=record.intended_account_id,
+            code_verifier_encrypted=encrypted,
+            device_auth_id=record.device_auth_id,
+            user_code=record.user_code,
+            interval_seconds=record.interval_seconds,
+            expires_at=record.expires_at,
+            created_at=utcnow(),
+            finished_at=record.finished_at,
+        )
+        self._session.add(row)
+        await self._session.commit()
+
+    async def get_by_flow_id(self, flow_id: str) -> OAuthFlowRecord | None:
+        row = await self._session.get(OAuthFlowState, flow_id)
+        if row is None or self._is_expired_pending(row, utcnow()):
+            return None
+        return self._to_record(row)
+
+    async def get_by_state_token(self, state_token: str) -> OAuthFlowRecord | None:
+        result = await self._session.execute(
+            select(OAuthFlowState).where(OAuthFlowState.state_token == state_token).limit(1)
+        )
+        row = result.scalar_one_or_none()
+        if row is None or self._is_expired_pending(row, utcnow()):
+            return None
+        return self._to_record(row)
+
+    async def set_status(
+        self,
+        flow_id: str,
+        *,
+        status: str,
+        error_message: str | None,
+    ) -> bool:
+        row = await self._session.get(OAuthFlowState, flow_id)
+        if row is None:
+            return False
+        row.status = status
+        row.error_message = error_message
+        row.finished_at = utcnow() if status in _TERMINAL_OAUTH_STATUSES else None
+        await self._session.commit()
+        return True
+
+    async def delete_pending_device(self) -> list[str]:
+        result = await self._session.execute(
+            select(OAuthFlowState.flow_id).where(OAuthFlowState.method == "device", OAuthFlowState.status == "pending")
+        )
+        flow_ids = [row[0] for row in result.all()]
+        if flow_ids:
+            await self._session.execute(delete(OAuthFlowState).where(OAuthFlowState.flow_id.in_(flow_ids)))
+            await self._session.commit()
+        return flow_ids
+
+    async def purge_expired(self, *, terminal_keep: int) -> None:
+        now = utcnow()
+        await self._session.execute(
+            delete(OAuthFlowState).where(
+                OAuthFlowState.status == "pending",
+                OAuthFlowState.expires_at.is_not(None),
+                OAuthFlowState.expires_at <= now,
+            )
+        )
+        result = await self._session.execute(
+            select(OAuthFlowState.flow_id)
+            .where(OAuthFlowState.status.in_(tuple(_TERMINAL_OAUTH_STATUSES)))
+            .order_by(OAuthFlowState.finished_at.desc())
+            .offset(terminal_keep)
+        )
+        stale_terminal = [row[0] for row in result.all()]
+        if stale_terminal:
+            await self._session.execute(delete(OAuthFlowState).where(OAuthFlowState.flow_id.in_(stale_terminal)))
+        await self._session.commit()

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -493,14 +493,11 @@ class OauthService:
     async def complete_oauth(self, request: OauthCompleteRequest | None = None) -> OauthCompleteResponse:
         payload = request or OauthCompleteRequest()
         if payload.flow_id is not None:
-            # Durable status is authoritative. The gate reconciles local state
-            # and hydrates a still-pending flow this replica did not start (so a
-            # device poller can resume); a terminal flow is reported directly and
-            # never re-polled (single-use device code).
+            # Durable status is authoritative: reconcile local state and report a
+            # durable terminal directly (never re-polling a single-use code).
             record = await self._reconcile_flow_from_durable(flow_id=payload.flow_id)
             if record is not None and record.status in _TERMINAL_OAUTH_STATUSES:
                 return OauthCompleteResponse(status=record.status)
-        uninitialized_flow_id: str | None = None
         async with self._store.lock:
             flow = self._store.get_flow_locked(payload.flow_id)
             state = flow
@@ -513,43 +510,25 @@ class OauthService:
             if flow is not None:
                 self._store.set_latest_flow_locked(flow)
             if state.method == "device":
-                # ``/complete`` acknowledges a device flow and ensures its single
-                # in-process poller. A targeted query (explicit ``flow_id``, as the
-                # dashboard sends after a success status) reports the terminal
-                # status so the UI can invalidate; the fire-and-forget
-                # acknowledgement (no ``flow_id``) returns ``pending`` while the
-                # poll proceeds. A flow that already reached a terminal state is
-                # never re-polled — the device code is single-use.
-                if state.status in _TERMINAL_OAUTH_STATUSES:
-                    if payload.flow_id is not None:
-                        return OauthCompleteResponse(status=state.status)
-                    return OauthCompleteResponse(status="pending")
-                if self._ensure_device_poll_task_locked(state):
-                    return OauthCompleteResponse(status="pending")
-                if flow is not None:
-                    self._store.set_flow_status_locked(
-                        flow,
-                        status="error",
-                        error_message="Device code flow is not initialized.",
-                    )
-                    uninitialized_flow_id = flow.flow_id
-                else:
-                    state.status = "error"
-                    state.error_message = "Device code flow is not initialized."
-                if uninitialized_flow_id is None:
-                    return OauthCompleteResponse(status="error")
-            elif state.status == "success":
+                # ``/complete`` only REPORTS device status; it never starts a poll
+                # task. The originating replica is the sole device poller (started
+                # at ``start``), so a ``/complete`` served on a replica that did
+                # not originate the flow reports the durable status (via the gate
+                # above) without spawning a duplicate poller for the single-use
+                # device code. If the originating replica dies mid-poll the flow
+                # simply expires by TTL and the user retries. A targeted query
+                # (explicit ``flow_id``, sent by the dashboard after a success
+                # status) reports a terminal so the UI can invalidate; the
+                # fire-and-forget acknowledgement (no ``flow_id``) returns
+                # ``pending`` while the sole poller runs, even if this replica's
+                # own poller just raced to a terminal in-memory.
+                if state.status in _TERMINAL_OAUTH_STATUSES and payload.flow_id is not None:
+                    return OauthCompleteResponse(status=state.status)
+                return OauthCompleteResponse(status="pending")
+            if state.status == "success":
                 # Browser / manual-callback: report an observed success.
                 return OauthCompleteResponse(status="success")
-            else:
-                return OauthCompleteResponse(status="pending")
-        if uninitialized_flow_id is not None:
-            await self._persist_flow_status(
-                uninitialized_flow_id,
-                status="error",
-                error_message="Device code flow is not initialized.",
-            )
-        return OauthCompleteResponse(status="error")
+            return OauthCompleteResponse(status="pending")
 
     async def _start_browser_flow(self, *, intended_account_id: str | None = None) -> OauthStartResponse:
         await self._wait_for_callback_server_stop()
@@ -717,13 +696,9 @@ class OauthService:
             self._store.remove_pending_device_flows_locked()
             self._store.remember_flow_locked(flow)
 
-        # Persist the durable row and atomically claim the single-active device
-        # slot (superseding any prior device flow) BEFORE starting the in-process
-        # poll task. The poller consumes the slot before persisting an account
-        # (see ``_consume_device_slot``), so the slot must already name this flow
-        # when the poll task can first run; otherwise an instant token exchange
-        # could abort against a not-yet-claimed slot. The single-statement UPSERT
-        # makes two simultaneous starts leave exactly one current flow.
+        # Persist the durable row BEFORE claiming the single-active slot and
+        # starting the sole poll task, so the poller's slot consume never races a
+        # not-yet-written row.
         await self._persist_flow_record(
             OAuthFlowRecord(
                 flow_id=flow_id,
@@ -736,14 +711,20 @@ class OauthService:
                 expires_at=epoch_to_naive_utc(expires_at),
             )
         )
-        await self._claim_device_slot(flow_id)
 
         async with self._store.lock:
-            # The flow may have been superseded/cleared while the row was being
-            # written; only start the poller if it is still the registered flow.
-            current = self._store.get_flow_locked(flow_id)
-            if current is not None:
-                self._ensure_device_poll_task_locked(current)
+            # A later device start on THIS replica may have superseded this flow
+            # while its row was being persisted (the newer start removed it from
+            # the local store). Claim the single-active slot and start the sole
+            # poll task ONLY if this is still the current local device flow, and
+            # do so while holding the store lock: the claim then happens under the
+            # lock a competing start must also acquire, so claim order follows
+            # supersession order and a superseded start can neither install a
+            # stale slot pointer nor start a duplicate poller. A superseded start
+            # still returns its device code to its caller but does not poll.
+            if self._store.get_flow_locked(flow_id) is flow:
+                await self._claim_device_slot(flow_id)
+                self._ensure_device_poll_task_locked(flow)
 
         return OauthStartResponse(
             flow_id=flow_id,
@@ -813,6 +794,14 @@ class OauthService:
         return self._html_response(html)
 
     async def _poll_device_tokens(self, flow_id: str | None, context: "DevicePollContext") -> None:
+        # Slot ownership is the single authority for who may complete a device
+        # flow. Only the poller that atomically consumed the current device slot
+        # may persist an account OR write ANY terminal status (success or error).
+        # A poller that does not hold/win the slot writes NOTHING: this prevents a
+        # losing/duplicate poller that received ``invalid_grant`` for the consumed
+        # code from writing ``error`` during the winner's persist window (which
+        # would stop the dashboard polling before the winner's success lands).
+        consumed = False
         try:
             while time.time() < context.expires_at:
                 route = await _oauth_route()
@@ -823,27 +812,28 @@ class OauthService:
                     allow_direct_egress=route is None,
                 )
                 if tokens:
-                    # Point of no return: atomically consume the single-active
-                    # device-flow slot. Only the flow that still holds the slot
-                    # may persist; if a newer device start superseded this flow
-                    # (the slot now names a different flow_id), the consume
-                    # matches zero rows and we abort WITHOUT adding/reauthing an
-                    # account. This is a single conditional statement performed
-                    # immediately before the account write, so no replacement can
-                    # slip through a check->persist window.
-                    if not await self._consume_device_slot(flow_id):
+                    # Point of no return: consume the single-active slot. If a
+                    # newer start superseded this flow, the consume matches zero
+                    # rows and we abort WITHOUT persisting or writing anything.
+                    consumed = await self._consume_device_slot(flow_id)
+                    if not consumed:
                         return
                     await self._persist_tokens(tokens, intended_account_id=context.intended_account_id)
                     await self._set_success(flow_id)
                     return
                 await _async_sleep(context.interval_seconds)
-            await self._set_error("Device code expired.", flow_id=flow_id)
+            # Code expired: only the slot holder may record the terminal error.
+            if consumed or await self._consume_device_slot(flow_id):
+                await self._set_error("Device code expired.", flow_id=flow_id)
         except OAuthError as exc:
-            await self._set_error(exc.message, flow_id=flow_id)
+            if consumed or await self._consume_device_slot(flow_id):
+                await self._set_error(exc.message, flow_id=flow_id)
         except ReauthSeatMismatchError:
-            await self._set_error(_REAUTH_SEAT_MISMATCH_MESSAGE, flow_id=flow_id)
+            if consumed or await self._consume_device_slot(flow_id):
+                await self._set_error(_REAUTH_SEAT_MISMATCH_MESSAGE, flow_id=flow_id)
         except AccountIdentityConflictError:
-            await self._set_error(_ACCOUNT_IDENTITY_CONFLICT_MESSAGE, flow_id=flow_id)
+            if consumed or await self._consume_device_slot(flow_id):
+                await self._set_error(_ACCOUNT_IDENTITY_CONFLICT_MESSAGE, flow_id=flow_id)
         finally:
             async with self._store.lock:
                 flow = self._store.get_flow_locked(flow_id)

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -40,10 +40,15 @@ from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
 from app.core.plan_types import coerce_account_plan_type
 from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteError, resolve_upstream_route
-from app.core.utils.time import utcnow
+from app.core.utils.time import naive_utc_to_epoch, utcnow
 from app.db.models import Account, AccountProxyBinding, AccountStatus
 from app.db.session import get_background_session
 from app.modules.accounts.repository import AccountIdentityConflictError, AccountsRepository
+from app.modules.oauth.repository import (
+    OAuthFlowRecord,
+    OAuthFlowRepository,
+    epoch_to_naive_utc,
+)
 from app.modules.oauth.schemas import (
     ManualCallbackResponse,
     OauthCompleteRequest,
@@ -311,11 +316,89 @@ class OauthService:
         self,
         accounts_repo: AccountsRepository,
         repo_factory: Callable[[], AbstractAsyncContextManager[AccountsRepository]] | None = None,
+        store: OAuthStateStore | None = None,
     ) -> None:
         self._accounts_repo = accounts_repo
         self._encryptor = TokenEncryptor()
-        self._store = _OAUTH_STORE
+        # ``store`` is the process-local runtime registry (callback server +
+        # device poll tasks). It defaults to the module singleton; tests inject
+        # a distinct store to simulate a second replica over the shared DB.
+        self._store = store if store is not None else _OAUTH_STORE
         self._repo_factory = repo_factory
+
+    # ------------------------------------------------------------------
+    # Shared DB-backed flow persistence (cross-replica source of truth)
+    # ------------------------------------------------------------------
+
+    async def _persist_flow_record(self, record: OAuthFlowRecord, *, purge_pending_device: bool = False) -> None:
+        async with get_background_session() as session:
+            repo = OAuthFlowRepository(session, self._encryptor)
+            if purge_pending_device:
+                await repo.delete_pending_device()
+            await repo.purge_expired(terminal_keep=_MAX_RETAINED_TERMINAL_OAUTH_FLOWS)
+            await repo.create(record)
+
+    async def _persist_flow_status(self, flow_id: str, *, status: str, error_message: str | None) -> None:
+        async with get_background_session() as session:
+            repo = OAuthFlowRepository(session, self._encryptor)
+            await repo.set_status(flow_id, status=status, error_message=error_message)
+
+    async def _load_flow_record(
+        self,
+        *,
+        flow_id: str | None = None,
+        state_token: str | None = None,
+    ) -> OAuthFlowRecord | None:
+        async with get_background_session() as session:
+            repo = OAuthFlowRepository(session, self._encryptor)
+            if flow_id is not None:
+                return await repo.get_by_flow_id(flow_id)
+            if state_token is not None:
+                return await repo.get_by_state_token(state_token)
+        return None
+
+    @staticmethod
+    def _record_to_state(record: OAuthFlowRecord) -> OAuthState:
+        return OAuthState(
+            flow_id=record.flow_id,
+            status=record.status,
+            method=record.method,
+            error_message=record.error_message,
+            state_token=record.state_token,
+            intended_account_id=record.intended_account_id,
+            code_verifier=record.code_verifier,
+            device_auth_id=record.device_auth_id,
+            user_code=record.user_code,
+            interval_seconds=record.interval_seconds,
+            expires_at=naive_utc_to_epoch(record.expires_at) if record.expires_at is not None else None,
+            finished_at=naive_utc_to_epoch(record.finished_at) if record.finished_at is not None else None,
+        )
+
+    async def _hydrate_flow_locked_from_db(
+        self,
+        *,
+        flow_id: str | None = None,
+        state_token: str | None = None,
+    ) -> None:
+        """Load a flow the local store never saw (started on another replica)
+        from the shared DB and register it in the process-local store."""
+
+        async with self._store.lock:
+            if flow_id is not None and self._store.get_flow_locked(flow_id) is not None:
+                return
+            if state_token is not None and self._store.get_flow_by_state_token_locked(state_token) is not None:
+                return
+        record = await self._load_flow_record(flow_id=flow_id, state_token=state_token)
+        if record is None:
+            return
+        async with self._store.lock:
+            if self._store.get_flow_locked(record.flow_id) is not None:
+                return
+            if record.state_token is not None and (
+                self._store.get_flow_by_state_token_locked(record.state_token) is not None
+            ):
+                return
+            self._store.remember_flow_locked(self._record_to_state(record))
 
     async def start_oauth(self, request: OauthStartRequest) -> OauthStartResponse:
         force_method = (request.force_method or "").lower()
@@ -349,6 +432,14 @@ class OauthService:
             return await self._start_device_flow()
 
     async def oauth_status(self, flow_id: str | None = None) -> OauthStatusResponse:
+        if flow_id is not None:
+            # The shared DB is authoritative: another replica may have completed
+            # this flow, so a local ``pending`` on the originating replica must
+            # not shadow a durable success/error.
+            record = await self._load_flow_record(flow_id=flow_id)
+            if record is not None:
+                status = record.status if record.status != "idle" else "pending"
+                return OauthStatusResponse(status=status, error_message=record.error_message)
         async with self._store.lock:
             state = self._store.get_flow_locked(flow_id)
             if state is None:
@@ -358,6 +449,11 @@ class OauthService:
 
     async def complete_oauth(self, request: OauthCompleteRequest | None = None) -> OauthCompleteResponse:
         payload = request or OauthCompleteRequest()
+        if payload.flow_id is not None:
+            # The device poll runs in-process; if this replica did not start the
+            # flow, hydrate it from the shared DB so it can resume polling.
+            await self._hydrate_flow_locked_from_db(flow_id=payload.flow_id)
+        uninitialized_flow_id: str | None = None
         async with self._store.lock:
             flow = self._store.get_flow_locked(payload.flow_id)
             state = flow
@@ -380,11 +476,21 @@ class OauthService:
                         status="error",
                         error_message="Device code flow is not initialized.",
                     )
+                    uninitialized_flow_id = flow.flow_id
                 else:
                     state.status = "error"
                     state.error_message = "Device code flow is not initialized."
-                return OauthCompleteResponse(status="error")
-            return OauthCompleteResponse(status="pending")
+                if uninitialized_flow_id is None:
+                    return OauthCompleteResponse(status="error")
+            else:
+                return OauthCompleteResponse(status="pending")
+        if uninitialized_flow_id is not None:
+            await self._persist_flow_status(
+                uninitialized_flow_id,
+                status="error",
+                error_message="Device code flow is not initialized.",
+            )
+        return OauthCompleteResponse(status="error")
 
     async def _start_browser_flow(self, *, intended_account_id: str | None = None) -> OauthStartResponse:
         await self._wait_for_callback_server_stop()
@@ -396,6 +502,7 @@ class OauthService:
         settings = get_settings()
         callback_server: OAuthCallbackServer | None = None
 
+        expires_at = time.time() + _PENDING_BROWSER_OAUTH_FLOW_TTL_SECONDS
         async with self._store.lock:
             self._store.remember_flow_locked(
                 OAuthState(
@@ -405,7 +512,7 @@ class OauthService:
                     state_token=state_token,
                     code_verifier=code_verifier,
                     intended_account_id=intended_account_id,
-                    expires_at=time.time() + _PENDING_BROWSER_OAUTH_FLOW_TTL_SECONDS,
+                    expires_at=expires_at,
                 )
             )
             if self._store._callback_server is None:
@@ -415,6 +522,18 @@ class OauthService:
                     port=settings.oauth_callback_port,
                 )
                 self._store._callback_server = callback_server
+
+        await self._persist_flow_record(
+            OAuthFlowRecord(
+                flow_id=flow_id,
+                method="browser",
+                status="pending",
+                state_token=state_token,
+                code_verifier=code_verifier,
+                intended_account_id=intended_account_id,
+                expires_at=epoch_to_naive_utc(expires_at),
+            )
+        )
 
         if callback_server is not None:
             try:
@@ -446,6 +565,12 @@ class OauthService:
         error = params.get("error", [None])[0]
         code = params.get("code", [None])[0]
         state = params.get("state", [None])[0]
+
+        if state is not None:
+            # Any replica may receive the pasted callback; hydrate the flow (and
+            # its encrypted verifier) from the shared DB when this replica did
+            # not start it.
+            await self._hydrate_flow_locked_from_db(state_token=state)
 
         async with self._store.lock:
             flow = self._store.get_flow_by_state_token_locked(state)
@@ -508,6 +633,7 @@ class OauthService:
             await self._set_error(exc.message)
             raise
 
+        expires_at = time.time() + device.expires_in_seconds
         async with self._store.lock:
             flow = OAuthState(
                 flow_id=flow_id,
@@ -517,11 +643,25 @@ class OauthService:
                 user_code=device.user_code,
                 interval_seconds=device.interval_seconds,
                 intended_account_id=intended_account_id,
-                expires_at=time.time() + device.expires_in_seconds,
+                expires_at=expires_at,
             )
             self._store.remove_pending_device_flows_locked()
             self._store.remember_flow_locked(flow)
             self._ensure_device_poll_task_locked(flow)
+
+        await self._persist_flow_record(
+            OAuthFlowRecord(
+                flow_id=flow_id,
+                method="device",
+                status="pending",
+                device_auth_id=device.device_auth_id,
+                user_code=device.user_code,
+                interval_seconds=device.interval_seconds,
+                intended_account_id=intended_account_id,
+                expires_at=epoch_to_naive_utc(expires_at),
+            ),
+            purge_pending_device=True,
+        )
 
         return OauthStartResponse(
             flow_id=flow_id,
@@ -538,6 +678,9 @@ class OauthService:
         error = params.get("error")
         code = params.get("code")
         state = params.get("state")
+
+        if state is not None:
+            await self._hydrate_flow_locked_from_db(state_token=state)
 
         async with self._store.lock:
             flow = self._store.get_flow_by_state_token_locked(state)
@@ -753,26 +896,28 @@ class OauthService:
     async def _set_success(self, flow_id: str | None = None) -> None:
         async with self._store.lock:
             flow = self._store.get_flow_locked(flow_id)
-            if flow_id is not None and flow is None:
-                return
-            if flow is None:
+            if flow is not None:
+                self._store.set_flow_status_locked(flow, status="success", error_message=None)
+            elif flow_id is None:
                 self._store.state.status = "success"
                 self._store.state.error_message = None
-                return
-            self._store.set_flow_status_locked(flow, status="success", error_message=None)
+        if flow_id is not None:
+            # Durable, cross-replica status: the originating replica reads this
+            # on its next status poll instead of its stale in-memory pending.
+            await self._persist_flow_status(flow_id, status="success", error_message=None)
 
     async def _set_error(self, message: str, flow_id: str | None = None) -> None:
         async with self._store.lock:
-            if flow_id is None and self._store.state.flow_id is not None:
-                return
-            flow = self._store.get_flow_locked(flow_id)
-            if flow_id is not None and flow is None:
-                return
-            if flow is None:
-                self._store.state.status = "error"
-                self._store.state.error_message = message
-                return
-            self._store.set_flow_status_locked(flow, status="error", error_message=message)
+            if flow_id is None:
+                if self._store.state.flow_id is None:
+                    self._store.state.status = "error"
+                    self._store.state.error_message = message
+            else:
+                flow = self._store.get_flow_locked(flow_id)
+                if flow is not None:
+                    self._store.set_flow_status_locked(flow, status="error", error_message=message)
+        if flow_id is not None:
+            await self._persist_flow_status(flow_id, status="error", error_message=message)
 
     def _start_callback_server_stop_locked(self, server: OAuthCallbackServer) -> asyncio.Task[None]:
         stop_task = self._store._callback_server_stop_task

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -42,7 +42,7 @@ from app.core.plan_types import coerce_account_plan_type
 from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteError, resolve_upstream_route
 from app.core.utils.time import naive_utc_to_epoch, utcnow
 from app.db.models import Account, AccountProxyBinding, AccountStatus
-from app.db.session import get_background_session
+from app.db.session import get_background_session, sqlite_writer_section
 from app.modules.accounts.repository import AccountIdentityConflictError, AccountsRepository
 from app.modules.oauth.repository import (
     OAuthFlowRecord,
@@ -330,13 +330,34 @@ class OauthService:
     # Shared DB-backed flow persistence (cross-replica source of truth)
     # ------------------------------------------------------------------
 
-    async def _persist_flow_record(self, record: OAuthFlowRecord, *, purge_pending_device: bool = False) -> None:
+    async def _persist_flow_record(self, record: OAuthFlowRecord) -> None:
         async with get_background_session() as session:
             repo = OAuthFlowRepository(session, self._encryptor)
-            if purge_pending_device:
-                await repo.delete_pending_device()
             await repo.purge_expired(terminal_keep=_MAX_RETAINED_TERMINAL_OAUTH_FLOWS)
             await repo.create(record)
+
+    async def _claim_device_slot(self, flow_id: str) -> None:
+        """Atomically make ``flow_id`` the single current device flow, superseding
+        any prior one. Serialized in-process for SQLite; the single UPSERT is
+        atomic across replicas/processes on both backends."""
+
+        async with sqlite_writer_section():
+            async with get_background_session() as session:
+                await OAuthFlowRepository(session, self._encryptor).claim_device_slot(flow_id)
+
+    async def _consume_device_slot(self, flow_id: str | None) -> bool:
+        """Atomically consume the device slot iff ``flow_id`` still holds it.
+
+        The poller's point of no return before persisting tokens: returns False
+        (and the poller aborts without persisting) when the flow was superseded
+        by a newer device start, which atomically UPSERTed the slot to a
+        different ``flow_id``."""
+
+        if flow_id is None:
+            return False
+        async with sqlite_writer_section():
+            async with get_background_session() as session:
+                return await OAuthFlowRepository(session, self._encryptor).consume_device_slot(flow_id)
 
     async def _persist_flow_status(self, flow_id: str, *, status: str, error_message: str | None) -> None:
         async with get_background_session() as session:
@@ -356,26 +377,6 @@ class OauthService:
             if state_token is not None:
                 return await repo.get_by_state_token(state_token)
         return None
-
-    async def _device_flow_is_current(self, flow_id: str | None) -> bool:
-        """Return whether ``flow_id`` is still the active pending device flow in
-        the shared DB.
-
-        A second device ``start`` (possibly on another replica) deletes the
-        previous pending device row before inserting the replacement, so this
-        replica's still-running poll task cannot be cancelled cross-process. The
-        poller therefore re-reads the durable row before persisting: if the row
-        is gone (superseded/deleted) or no longer ``pending`` (already terminal,
-        or expired -> classified absent by ``get_by_flow_id``), the poller must
-        abort without adding/reauthing an account. Combined with the atomic
-        monotonic ``set_status``, an abandoned poller can neither persist an
-        account nor write a terminal status once its row was replaced.
-        """
-
-        if flow_id is None:
-            return False
-        record = await self._load_flow_record(flow_id=flow_id)
-        return record is not None and record.status == "pending"
 
     @staticmethod
     def _record_to_state(record: OAuthFlowRecord) -> OAuthState:
@@ -723,12 +724,13 @@ class OauthService:
             self._store.remove_pending_device_flows_locked()
             self._store.remember_flow_locked(flow)
 
-        # Persist the durable row (and supersede any prior pending device row)
-        # BEFORE starting the in-process poll task. The poller re-reads its
-        # durable row before persisting an account (see ``_device_flow_is_current``),
-        # so the row must already exist when the poll task can first run;
-        # otherwise an instant token exchange could abort against a not-yet
-        # -written row.
+        # Persist the durable row and atomically claim the single-active device
+        # slot (superseding any prior device flow) BEFORE starting the in-process
+        # poll task. The poller consumes the slot before persisting an account
+        # (see ``_consume_device_slot``), so the slot must already name this flow
+        # when the poll task can first run; otherwise an instant token exchange
+        # could abort against a not-yet-claimed slot. The single-statement UPSERT
+        # makes two simultaneous starts leave exactly one current flow.
         await self._persist_flow_record(
             OAuthFlowRecord(
                 flow_id=flow_id,
@@ -739,9 +741,9 @@ class OauthService:
                 interval_seconds=device.interval_seconds,
                 intended_account_id=intended_account_id,
                 expires_at=epoch_to_naive_utc(expires_at),
-            ),
-            purge_pending_device=True,
+            )
         )
+        await self._claim_device_slot(flow_id)
 
         async with self._store.lock:
             # The flow may have been superseded/cleared while the row was being
@@ -820,12 +822,15 @@ class OauthService:
                     allow_direct_egress=route is None,
                 )
                 if tokens:
-                    # A replacement device start may have superseded/deleted this
-                    # flow's durable row while the exchange was in flight. Confirm
-                    # this flow is still the active pending record before doing any
-                    # durable damage; otherwise abort so an abandoned poller cannot
-                    # add or reauth an account for a consumed code.
-                    if not await self._device_flow_is_current(flow_id):
+                    # Point of no return: atomically consume the single-active
+                    # device-flow slot. Only the flow that still holds the slot
+                    # may persist; if a newer device start superseded this flow
+                    # (the slot now names a different flow_id), the consume
+                    # matches zero rows and we abort WITHOUT adding/reauthing an
+                    # account. This is a single conditional statement performed
+                    # immediately before the account write, so no replacement can
+                    # slip through a check->persist window.
+                    if not await self._consume_device_slot(flow_id):
                         return
                     await self._persist_tokens(tokens, intended_account_id=context.intended_account_id)
                     await self._set_success(flow_id)

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -357,6 +357,26 @@ class OauthService:
                 return await repo.get_by_state_token(state_token)
         return None
 
+    async def _device_flow_is_current(self, flow_id: str | None) -> bool:
+        """Return whether ``flow_id`` is still the active pending device flow in
+        the shared DB.
+
+        A second device ``start`` (possibly on another replica) deletes the
+        previous pending device row before inserting the replacement, so this
+        replica's still-running poll task cannot be cancelled cross-process. The
+        poller therefore re-reads the durable row before persisting: if the row
+        is gone (superseded/deleted) or no longer ``pending`` (already terminal,
+        or expired -> classified absent by ``get_by_flow_id``), the poller must
+        abort without adding/reauthing an account. Combined with the atomic
+        monotonic ``set_status``, an abandoned poller can neither persist an
+        account nor write a terminal status once its row was replaced.
+        """
+
+        if flow_id is None:
+            return False
+        record = await self._load_flow_record(flow_id=flow_id)
+        return record is not None and record.status == "pending"
+
     @staticmethod
     def _record_to_state(record: OAuthFlowRecord) -> OAuthState:
         return OAuthState(
@@ -622,6 +642,12 @@ class OauthService:
             await self._hydrate_flow_locked_from_db(state_token=state)
 
         async with self._store.lock:
+            # Enforce the pending-flow TTL uniformly, including on the replica
+            # that started the flow: drop an expired local browser flow before
+            # trusting its cached verifier, so a callback arriving after the TTL
+            # is rejected here exactly as it is on a replica without local state
+            # (where the durable row is classified expired on read).
+            self._store.prune_expired_pending_browser_flows_locked()
             flow = self._store.get_flow_by_state_token_locked(state)
             verifier = flow.code_verifier if flow is not None else None
             target_flow_id = flow.flow_id if flow is not None else flow_id
@@ -683,21 +709,26 @@ class OauthService:
             raise
 
         expires_at = time.time() + device.expires_in_seconds
+        flow = OAuthState(
+            flow_id=flow_id,
+            status="pending",
+            method="device",
+            device_auth_id=device.device_auth_id,
+            user_code=device.user_code,
+            interval_seconds=device.interval_seconds,
+            intended_account_id=intended_account_id,
+            expires_at=expires_at,
+        )
         async with self._store.lock:
-            flow = OAuthState(
-                flow_id=flow_id,
-                status="pending",
-                method="device",
-                device_auth_id=device.device_auth_id,
-                user_code=device.user_code,
-                interval_seconds=device.interval_seconds,
-                intended_account_id=intended_account_id,
-                expires_at=expires_at,
-            )
             self._store.remove_pending_device_flows_locked()
             self._store.remember_flow_locked(flow)
-            self._ensure_device_poll_task_locked(flow)
 
+        # Persist the durable row (and supersede any prior pending device row)
+        # BEFORE starting the in-process poll task. The poller re-reads its
+        # durable row before persisting an account (see ``_device_flow_is_current``),
+        # so the row must already exist when the poll task can first run;
+        # otherwise an instant token exchange could abort against a not-yet
+        # -written row.
         await self._persist_flow_record(
             OAuthFlowRecord(
                 flow_id=flow_id,
@@ -711,6 +742,13 @@ class OauthService:
             ),
             purge_pending_device=True,
         )
+
+        async with self._store.lock:
+            # The flow may have been superseded/cleared while the row was being
+            # written; only start the poller if it is still the registered flow.
+            current = self._store.get_flow_locked(flow_id)
+            if current is not None:
+                self._ensure_device_poll_task_locked(current)
 
         return OauthStartResponse(
             flow_id=flow_id,
@@ -732,6 +770,10 @@ class OauthService:
             await self._hydrate_flow_locked_from_db(state_token=state)
 
         async with self._store.lock:
+            # Enforce the pending-flow TTL uniformly (see manual_callback): an
+            # expired local browser flow on the originating replica must not be
+            # completed via its stale cached verifier after the TTL.
+            self._store.prune_expired_pending_browser_flows_locked()
             flow = self._store.get_flow_by_state_token_locked(state)
             verifier = flow.code_verifier if flow is not None else None
 
@@ -778,6 +820,13 @@ class OauthService:
                     allow_direct_egress=route is None,
                 )
                 if tokens:
+                    # A replacement device start may have superseded/deleted this
+                    # flow's durable row while the exchange was in flight. Confirm
+                    # this flow is still the active pending record before doing any
+                    # durable damage; otherwise abort so an abandoned poller cannot
+                    # add or reauth an account for a consumed code.
+                    if not await self._device_flow_is_current(flow_id):
+                        return
                     await self._persist_tokens(tokens, intended_account_id=context.intended_account_id)
                     await self._set_success(flow_id)
                     return

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -431,6 +431,25 @@ class OauthService:
                 return await self._start_device_flow(intended_account_id=intended_account_id)
             return await self._start_device_flow()
 
+    async def _reconcile_local_flow_from_db_terminal(self, record: OAuthFlowRecord) -> None:
+        """Once a flow reaches a terminal status in the shared DB that status is
+        authoritative across replicas. Reconcile the origin replica's stale
+        in-memory ``OAuthState`` so a subsequent ``/complete`` (or later status
+        poll) on this replica converges on the durable terminal instead of
+        regressing to its local ``pending``.
+        """
+
+        if record.status not in _TERMINAL_OAUTH_STATUSES:
+            return
+        async with self._store.lock:
+            flow = self._store.get_flow_locked(record.flow_id)
+            if flow is not None and flow.status != record.status:
+                self._store.set_flow_status_locked(
+                    flow,
+                    status=record.status,
+                    error_message=record.error_message,
+                )
+
     async def oauth_status(self, flow_id: str | None = None) -> OauthStatusResponse:
         if flow_id is not None:
             # The shared DB is authoritative: another replica may have completed
@@ -438,6 +457,10 @@ class OauthService:
             # not shadow a durable success/error.
             record = await self._load_flow_record(flow_id=flow_id)
             if record is not None:
+                # Sync the origin replica's in-memory flow before returning the
+                # durable terminal, so the follow-up ``/complete`` call does not
+                # read a stale ``pending``.
+                await self._reconcile_local_flow_from_db_terminal(record)
                 status = record.status if record.status != "idle" else "pending"
                 return OauthStatusResponse(status=status, error_message=record.error_message)
         async with self._store.lock:
@@ -450,6 +473,15 @@ class OauthService:
     async def complete_oauth(self, request: OauthCompleteRequest | None = None) -> OauthCompleteResponse:
         payload = request or OauthCompleteRequest()
         if payload.flow_id is not None:
+            # The shared DB is authoritative once a flow is terminal. If another
+            # replica already completed this browser flow, honor that durable
+            # success/error here instead of the origin replica's stale local
+            # ``pending`` (which would flip the dashboard back to pending and
+            # skip account invalidation).
+            record = await self._load_flow_record(flow_id=payload.flow_id)
+            if record is not None and record.status in _TERMINAL_OAUTH_STATUSES:
+                await self._reconcile_local_flow_from_db_terminal(record)
+                return OauthCompleteResponse(status=record.status)
             # The device poll runs in-process; if this replica did not start the
             # flow, hydrate it from the shared DB so it can resume polling.
             await self._hydrate_flow_locked_from_db(flow_id=payload.flow_id)

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -473,17 +473,22 @@ class OauthService:
     async def complete_oauth(self, request: OauthCompleteRequest | None = None) -> OauthCompleteResponse:
         payload = request or OauthCompleteRequest()
         if payload.flow_id is not None:
-            # The shared DB is authoritative once a flow is terminal. If another
-            # replica already completed this browser flow, honor that durable
-            # success/error here instead of the origin replica's stale local
-            # ``pending`` (which would flip the dashboard back to pending and
-            # skip account invalidation).
             record = await self._load_flow_record(flow_id=payload.flow_id)
             if record is not None and record.status in _TERMINAL_OAUTH_STATUSES:
+                # A targeted ``/complete`` (explicit ``flow_id``, as the dashboard
+                # sends after observing a success status) reports the shared-DB
+                # authoritative terminal status. For a browser / manual-callback
+                # flow completed on another replica this overrides the origin
+                # replica's stale local ``pending`` (which would otherwise flip
+                # the dashboard back to pending and skip account invalidation).
+                # For a device flow it reflects the (possibly cross-replica)
+                # result WITHOUT re-polling the single-use device code.
                 await self._reconcile_local_flow_from_db_terminal(record)
                 return OauthCompleteResponse(status=record.status)
-            # The device poll runs in-process; if this replica did not start the
-            # flow, hydrate it from the shared DB so it can resume polling.
+            # Only (re)attach an in-process device poller for a still-pending
+            # flow this replica did not start; a terminal flow returned above and
+            # must never be re-polled (the device code is single-use, and a
+            # duplicate poller's later error must not clobber the success).
             await self._hydrate_flow_locked_from_db(flow_id=payload.flow_id)
         uninitialized_flow_id: str | None = None
         async with self._store.lock:
@@ -497,11 +502,20 @@ class OauthService:
                 flow.user_code = payload.user_code
             if flow is not None:
                 self._store.set_latest_flow_locked(flow)
-            if state.status == "success":
-                return OauthCompleteResponse(status="success")
-            if state.method != "device":
-                return OauthCompleteResponse(status="pending")
-            if not self._ensure_device_poll_task_locked(state):
+            if state.method == "device":
+                # ``/complete`` acknowledges a device flow and ensures its single
+                # in-process poller. A targeted query (explicit ``flow_id``, as the
+                # dashboard sends after a success status) reports the terminal
+                # status so the UI can invalidate; the fire-and-forget
+                # acknowledgement (no ``flow_id``) returns ``pending`` while the
+                # poll proceeds. A flow that already reached a terminal state is
+                # never re-polled — the device code is single-use.
+                if state.status in _TERMINAL_OAUTH_STATUSES:
+                    if payload.flow_id is not None:
+                        return OauthCompleteResponse(status=state.status)
+                    return OauthCompleteResponse(status="pending")
+                if self._ensure_device_poll_task_locked(state):
+                    return OauthCompleteResponse(status="pending")
                 if flow is not None:
                     self._store.set_flow_status_locked(
                         flow,
@@ -514,6 +528,9 @@ class OauthService:
                     state.error_message = "Device code flow is not initialized."
                 if uninitialized_flow_id is None:
                     return OauthCompleteResponse(status="error")
+            elif state.status == "success":
+                # Browser / manual-callback: report an observed success.
+                return OauthCompleteResponse(status="success")
             else:
                 return OauthCompleteResponse(status="pending")
         if uninitialized_flow_id is not None:

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -395,31 +395,53 @@ class OauthService:
             finished_at=naive_utc_to_epoch(record.finished_at) if record.finished_at is not None else None,
         )
 
-    async def _hydrate_flow_locked_from_db(
+    async def _reconcile_flow_from_durable(
         self,
         *,
         flow_id: str | None = None,
         state_token: str | None = None,
-    ) -> None:
-        """Load a flow the local store never saw (started on another replica)
-        from the shared DB and register it in the process-local store."""
+    ) -> OAuthFlowRecord | None:
+        """Single authoritative reconciliation gate: make the local in-memory
+        ``OAuthState`` agree with the shared DB BEFORE any local-state-based
+        decision, and return the durable record.
 
-        async with self._store.lock:
-            if flow_id is not None and self._store.get_flow_locked(flow_id) is not None:
-                return
-            if state_token is not None and self._store.get_flow_by_state_token_locked(state_token) is not None:
-                return
+        The shared DB always wins over a local ``pending``. This one gate closes
+        the whole class of "origin replica acts on stale local state" bugs by
+        unifying hydrate / terminal-reconcile / expiry-prune. Every entry point
+        that resolves a flow from local state MUST call this first:
+
+        - durable terminal (``success``/``error``) OVERRIDES a local ``pending``
+          (the flow was completed here or on another replica), so no consumed
+          authorization code is replayed and no stale pending is reported;
+        - durable ``pending`` present but missing locally -> HYDRATE it (encrypted
+          verifier + metadata) so this replica can resume/complete a flow it did
+          not start;
+        - durable row ABSENT or EXPIRED (``get_by_*`` returns ``None`` for an
+          expired pending row) -> DROP any local non-terminal flow so its cached
+          verifier / device code can never be reused past the TTL.
+        """
+
         record = await self._load_flow_record(flow_id=flow_id, state_token=state_token)
-        if record is None:
-            return
         async with self._store.lock:
-            if self._store.get_flow_locked(record.flow_id) is not None:
-                return
-            if record.state_token is not None and (
-                self._store.get_flow_by_state_token_locked(record.state_token) is not None
-            ):
-                return
-            self._store.remember_flow_locked(self._record_to_state(record))
+            local = self._store.get_flow_locked(flow_id) if flow_id is not None else None
+            if local is None and state_token is not None:
+                local = self._store.get_flow_by_state_token_locked(state_token)
+            if record is None:
+                # No live durable row (absent or expired-pending): a local
+                # non-terminal flow is stale and MUST NOT be acted on.
+                if local is not None and local.status not in _TERMINAL_OAUTH_STATUSES:
+                    self._store.remove_flow_locked(local)
+                return None
+            if record.status in _TERMINAL_OAUTH_STATUSES:
+                if local is None:
+                    self._store.remember_flow_locked(self._record_to_state(record))
+                elif local.status != record.status:
+                    self._store.set_flow_status_locked(local, status=record.status, error_message=record.error_message)
+                return record
+            # Durable pending: hydrate a flow this replica never saw.
+            if local is None:
+                self._store.remember_flow_locked(self._record_to_state(record))
+        return record
 
     async def start_oauth(self, request: OauthStartRequest) -> OauthStartResponse:
         force_method = (request.force_method or "").lower()
@@ -452,36 +474,13 @@ class OauthService:
                 return await self._start_device_flow(intended_account_id=intended_account_id)
             return await self._start_device_flow()
 
-    async def _reconcile_local_flow_from_db_terminal(self, record: OAuthFlowRecord) -> None:
-        """Once a flow reaches a terminal status in the shared DB that status is
-        authoritative across replicas. Reconcile the origin replica's stale
-        in-memory ``OAuthState`` so a subsequent ``/complete`` (or later status
-        poll) on this replica converges on the durable terminal instead of
-        regressing to its local ``pending``.
-        """
-
-        if record.status not in _TERMINAL_OAUTH_STATUSES:
-            return
-        async with self._store.lock:
-            flow = self._store.get_flow_locked(record.flow_id)
-            if flow is not None and flow.status != record.status:
-                self._store.set_flow_status_locked(
-                    flow,
-                    status=record.status,
-                    error_message=record.error_message,
-                )
-
     async def oauth_status(self, flow_id: str | None = None) -> OauthStatusResponse:
         if flow_id is not None:
-            # The shared DB is authoritative: another replica may have completed
-            # this flow, so a local ``pending`` on the originating replica must
-            # not shadow a durable success/error.
-            record = await self._load_flow_record(flow_id=flow_id)
+            # Durable status is authoritative: the reconciliation gate syncs the
+            # local in-memory flow (terminal overrides pending; expired/absent
+            # drops the stale local flow) and returns the durable record.
+            record = await self._reconcile_flow_from_durable(flow_id=flow_id)
             if record is not None:
-                # Sync the origin replica's in-memory flow before returning the
-                # durable terminal, so the follow-up ``/complete`` call does not
-                # read a stale ``pending``.
-                await self._reconcile_local_flow_from_db_terminal(record)
                 status = record.status if record.status != "idle" else "pending"
                 return OauthStatusResponse(status=status, error_message=record.error_message)
         async with self._store.lock:
@@ -494,23 +493,13 @@ class OauthService:
     async def complete_oauth(self, request: OauthCompleteRequest | None = None) -> OauthCompleteResponse:
         payload = request or OauthCompleteRequest()
         if payload.flow_id is not None:
-            record = await self._load_flow_record(flow_id=payload.flow_id)
+            # Durable status is authoritative. The gate reconciles local state
+            # and hydrates a still-pending flow this replica did not start (so a
+            # device poller can resume); a terminal flow is reported directly and
+            # never re-polled (single-use device code).
+            record = await self._reconcile_flow_from_durable(flow_id=payload.flow_id)
             if record is not None and record.status in _TERMINAL_OAUTH_STATUSES:
-                # A targeted ``/complete`` (explicit ``flow_id``, as the dashboard
-                # sends after observing a success status) reports the shared-DB
-                # authoritative terminal status. For a browser / manual-callback
-                # flow completed on another replica this overrides the origin
-                # replica's stale local ``pending`` (which would otherwise flip
-                # the dashboard back to pending and skip account invalidation).
-                # For a device flow it reflects the (possibly cross-replica)
-                # result WITHOUT re-polling the single-use device code.
-                await self._reconcile_local_flow_from_db_terminal(record)
                 return OauthCompleteResponse(status=record.status)
-            # Only (re)attach an in-process device poller for a still-pending
-            # flow this replica did not start; a terminal flow returned above and
-            # must never be re-polled (the device code is single-use, and a
-            # duplicate poller's later error must not clobber the success).
-            await self._hydrate_flow_locked_from_db(flow_id=payload.flow_id)
         uninitialized_flow_id: str | None = None
         async with self._store.lock:
             flow = self._store.get_flow_locked(payload.flow_id)
@@ -637,18 +626,15 @@ class OauthService:
         state = params.get("state", [None])[0]
 
         if state is not None:
-            # Any replica may receive the pasted callback; hydrate the flow (and
-            # its encrypted verifier) from the shared DB when this replica did
-            # not start it.
-            await self._hydrate_flow_locked_from_db(state_token=state)
+            # Durable status is authoritative: the reconciliation gate hydrates
+            # (verifier + metadata) when this replica never saw the flow, and --
+            # critically -- overrides a stale local ``pending`` with a durable
+            # terminal and drops an expired/absent flow. This closes the callback
+            # -replay class: a pasted callback for a flow already completed on
+            # another replica never re-exchanges the consumed authorization code.
+            await self._reconcile_flow_from_durable(state_token=state)
 
         async with self._store.lock:
-            # Enforce the pending-flow TTL uniformly, including on the replica
-            # that started the flow: drop an expired local browser flow before
-            # trusting its cached verifier, so a callback arriving after the TTL
-            # is rejected here exactly as it is on a replica without local state
-            # (where the durable row is classified expired on read).
-            self._store.prune_expired_pending_browser_flows_locked()
             flow = self._store.get_flow_by_state_token_locked(state)
             verifier = flow.code_verifier if flow is not None else None
             target_flow_id = flow.flow_id if flow is not None else flow_id
@@ -658,8 +644,15 @@ class OauthService:
                 verifier = None
                 target_flow_id = None
                 can_update_error = False
-            if flow is not None and flow.status == "success" and state == flow.state_token:
+            # Durable terminal wins: return the recorded outcome instead of
+            # replaying the (already-consumed) code.
+            terminal_status = flow.status if (flow is not None and flow.status in _TERMINAL_OAUTH_STATUSES) else None
+            terminal_error = flow.error_message if flow is not None else None
+
+        if terminal_status is not None:
+            if terminal_status == "success":
                 return ManualCallbackResponse(status="success")
+            return ManualCallbackResponse(status="error", error_message=terminal_error)
 
         if error:
             message = f"OAuth error: {error}"
@@ -769,15 +762,23 @@ class OauthService:
         state = params.get("state")
 
         if state is not None:
-            await self._hydrate_flow_locked_from_db(state_token=state)
+            # Durable status is authoritative (see manual_callback): reconcile
+            # local state before trusting the cached verifier so a browser
+            # redirect that lands back on the origin after the flow completed
+            # elsewhere -- or after the TTL -- is not replayed.
+            await self._reconcile_flow_from_durable(state_token=state)
 
         async with self._store.lock:
-            # Enforce the pending-flow TTL uniformly (see manual_callback): an
-            # expired local browser flow on the originating replica must not be
-            # completed via its stale cached verifier after the TTL.
-            self._store.prune_expired_pending_browser_flows_locked()
             flow = self._store.get_flow_by_state_token_locked(state)
             verifier = flow.code_verifier if flow is not None else None
+            terminal_status = flow.status if (flow is not None and flow.status in _TERMINAL_OAUTH_STATUSES) else None
+            terminal_error = flow.error_message if flow is not None else None
+
+        # Durable terminal wins: do not replay a consumed authorization code.
+        if terminal_status is not None:
+            if terminal_status == "success":
+                return self._html_response(_success_html())
+            return self._html_response(_error_html(terminal_error or "Authorization failed."))
 
         if error:
             await self._set_error(f"OAuth error: {error}", flow_id=flow.flow_id if flow is not None else None)

--- a/app/modules/oauth/service.py
+++ b/app/modules/oauth/service.py
@@ -359,10 +359,14 @@ class OauthService:
             async with get_background_session() as session:
                 return await OAuthFlowRepository(session, self._encryptor).consume_device_slot(flow_id)
 
-    async def _persist_flow_status(self, flow_id: str, *, status: str, error_message: str | None) -> None:
+    async def _persist_flow_status(self, flow_id: str, *, status: str, error_message: str | None) -> bool:
+        """Write a durable status transition. Returns whether it was applied; a
+        non-success write is rejected (``False``) by the monotonic guard when the
+        durable row is already ``success`` (a racing winner committed first)."""
+
         async with get_background_session() as session:
             repo = OAuthFlowRepository(session, self._encryptor)
-            await repo.set_status(flow_id, status=status, error_message=error_message)
+            return await repo.set_status(flow_id, status=status, error_message=error_message)
 
     async def _load_flow_record(
         self,
@@ -635,14 +639,14 @@ class OauthService:
 
         if error:
             message = f"OAuth error: {error}"
-            if can_update_error:
-                await self._set_error(message, flow_id=target_flow_id)
+            if can_update_error and await self._finalize_callback_error(message, flow_id=target_flow_id) == "success":
+                return ManualCallbackResponse(status="success")
             return ManualCallbackResponse(status="error", error_message=message)
 
         if not code or not state or flow is None or not verifier:
             message = "Invalid OAuth callback: state mismatch or missing code."
-            if can_update_error:
-                await self._set_error(message, flow_id=target_flow_id)
+            if can_update_error and await self._finalize_callback_error(message, flow_id=target_flow_id) == "success":
+                return ManualCallbackResponse(status="success")
             return ManualCallbackResponse(status="error", error_message=message)
 
         try:
@@ -658,18 +662,28 @@ class OauthService:
             asyncio.create_task(self._stop_callback_server_if_idle())
             return ManualCallbackResponse(status="success")
         except OAuthError as exc:
-            await self._set_error(exc.message, flow_id=flow.flow_id)
+            # Loser race: a concurrent callback may have committed success for the
+            # same single-use code, so honor the durable success on a rejected
+            # error write instead of surfacing this ``invalid_grant``.
+            if await self._finalize_callback_error(exc.message, flow_id=flow.flow_id) == "success":
+                return ManualCallbackResponse(status="success")
             return ManualCallbackResponse(status="error", error_message=exc.message)
         except ReauthSeatMismatchError:
-            await self._set_error(_REAUTH_SEAT_MISMATCH_MESSAGE, flow_id=flow.flow_id)
+            if await self._finalize_callback_error(_REAUTH_SEAT_MISMATCH_MESSAGE, flow_id=flow.flow_id) == "success":
+                return ManualCallbackResponse(status="success")
             return ManualCallbackResponse(status="error", error_message=_REAUTH_SEAT_MISMATCH_MESSAGE)
         except AccountIdentityConflictError:
-            await self._set_error(_ACCOUNT_IDENTITY_CONFLICT_MESSAGE, flow_id=flow.flow_id)
+            if (
+                await self._finalize_callback_error(_ACCOUNT_IDENTITY_CONFLICT_MESSAGE, flow_id=flow.flow_id)
+                == "success"
+            ):
+                return ManualCallbackResponse(status="success")
             return ManualCallbackResponse(status="error", error_message=_ACCOUNT_IDENTITY_CONFLICT_MESSAGE)
         except Exception as exc:
             logger.error("manual OAuth callback failed exception_type=%s", type(exc).__name__)
             message = "An internal error occurred."
-            await self._set_error(message, flow_id=flow.flow_id)
+            if await self._finalize_callback_error(message, flow_id=flow.flow_id) == "success":
+                return ManualCallbackResponse(status="success")
             return ManualCallbackResponse(status="error", error_message=message)
 
     async def _start_device_flow(self, *, intended_account_id: str | None = None) -> OauthStartResponse:
@@ -762,11 +776,19 @@ class OauthService:
             return self._html_response(_error_html(terminal_error or "Authorization failed."))
 
         if error:
-            await self._set_error(f"OAuth error: {error}", flow_id=flow.flow_id if flow is not None else None)
+            outcome = await self._finalize_callback_error(
+                f"OAuth error: {error}", flow_id=flow.flow_id if flow is not None else None
+            )
+            if outcome == "success":
+                return self._html_response(_success_html())
             return self._html_response(_error_html("Authorization failed."))
 
         if not code or not state or flow is None or not verifier:
-            await self._set_error("Invalid OAuth callback state.", flow_id=flow.flow_id if flow is not None else None)
+            outcome = await self._finalize_callback_error(
+                "Invalid OAuth callback state.", flow_id=flow.flow_id if flow is not None else None
+            )
+            if outcome == "success":
+                return self._html_response(_success_html())
             return self._html_response(_error_html("Invalid OAuth callback."))
 
         try:
@@ -781,14 +803,26 @@ class OauthService:
             await self._set_success(flow.flow_id)
             html = _success_html()
         except OAuthError as exc:
-            await self._set_error(exc.message, flow_id=flow.flow_id)
-            html = _error_html(exc.message)
+            # Loser race: honor a durable success committed by a concurrent
+            # callback for the same single-use code instead of showing an error.
+            html = (
+                _success_html()
+                if await self._finalize_callback_error(exc.message, flow_id=flow.flow_id) == "success"
+                else _error_html(exc.message)
+            )
         except ReauthSeatMismatchError:
-            await self._set_error(_REAUTH_SEAT_MISMATCH_MESSAGE, flow_id=flow.flow_id)
-            html = _error_html(_REAUTH_SEAT_MISMATCH_MESSAGE)
+            html = (
+                _success_html()
+                if await self._finalize_callback_error(_REAUTH_SEAT_MISMATCH_MESSAGE, flow_id=flow.flow_id) == "success"
+                else _error_html(_REAUTH_SEAT_MISMATCH_MESSAGE)
+            )
         except AccountIdentityConflictError:
-            await self._set_error(_ACCOUNT_IDENTITY_CONFLICT_MESSAGE, flow_id=flow.flow_id)
-            html = _error_html(_ACCOUNT_IDENTITY_CONFLICT_MESSAGE)
+            html = (
+                _success_html()
+                if await self._finalize_callback_error(_ACCOUNT_IDENTITY_CONFLICT_MESSAGE, flow_id=flow.flow_id)
+                == "success"
+                else _error_html(_ACCOUNT_IDENTITY_CONFLICT_MESSAGE)
+            )
 
         asyncio.create_task(self._stop_callback_server_if_idle())
         return self._html_response(html)
@@ -1000,18 +1034,45 @@ class OauthService:
             # on its next status poll instead of its stale in-memory pending.
             await self._persist_flow_status(flow_id, status="success", error_message=None)
 
-    async def _set_error(self, message: str, flow_id: str | None = None) -> None:
-        async with self._store.lock:
-            if flow_id is None:
+    async def _set_error(self, message: str, flow_id: str | None = None) -> bool:
+        """Record a terminal error. Returns whether the durable error was applied.
+
+        The durable write happens FIRST: if the monotonic guard rejects it
+        (``False``) because the durable row is already ``success`` — a racing
+        callback/poller committed success for the same single-use code — the
+        local in-memory flow is left untouched (never shadowed into ``error``),
+        and the caller must honor the durable success instead of surfacing the
+        error. ``flow_id`` of ``None`` updates only the local latest state.
+        """
+
+        if flow_id is None:
+            async with self._store.lock:
                 if self._store.state.flow_id is None:
                     self._store.state.status = "error"
                     self._store.state.error_message = message
-            else:
-                flow = self._store.get_flow_locked(flow_id)
-                if flow is not None:
-                    self._store.set_flow_status_locked(flow, status="error", error_message=message)
-        if flow_id is not None:
-            await self._persist_flow_status(flow_id, status="error", error_message=message)
+            return True
+        applied = await self._persist_flow_status(flow_id, status="error", error_message=message)
+        if not applied:
+            return False
+        async with self._store.lock:
+            flow = self._store.get_flow_locked(flow_id)
+            if flow is not None:
+                self._store.set_flow_status_locked(flow, status="error", error_message=message)
+        return True
+
+    async def _finalize_callback_error(self, message: str, *, flow_id: str | None) -> str:
+        """Record a terminal error for a browser/manual-callback flow and return
+        the status to report. If the durable error write is rejected because a
+        racing callback already committed ``success`` for the same single-use
+        code, reconcile the local flow and report the durable ``success`` instead
+        of misreporting an error (the loser must not surface an error)."""
+
+        if await self._set_error(message, flow_id=flow_id):
+            return "error"
+        record = await self._reconcile_flow_from_durable(flow_id=flow_id) if flow_id is not None else None
+        if record is not None and record.status == "success":
+            return "success"
+        return "error"
 
     def _start_callback_server_stop_locked(self, server: OAuthCallbackServer) -> asyncio.Task[None]:
         stop_task = self._store._callback_server_stop_task

--- a/openspec/changes/persist-oauth-flow-state/design.md
+++ b/openspec/changes/persist-oauth-flow-state/design.md
@@ -1,0 +1,79 @@
+# Design: persist dashboard OAuth flow state
+
+## Problem
+
+`OAuthStateStore` (`app/modules/oauth/service.py`) holds all OAuth flow state in
+a process-local dict `_flows` (plus a `state_token -> flow_id` index). Three
+externally reachable paths must find that state:
+
+1. **Browser callback** (`GET /auth/callback` on the localhost callback server)
+   — needs the PKCE `code_verifier` for the `state` token in the redirect.
+2. **Manual callback** (`POST /api/oauth/manual-callback`) — the documented
+   remote-access path where the operator pastes the callback URL into the
+   dashboard; it flows through the load balancer to any replica.
+3. **Status / complete polling** (`GET /api/oauth/status`,
+   `POST /api/oauth/complete`) — polled through the load balancer.
+
+Behind a load balancer any of these can hit a replica that never ran
+`start_oauth`, so the in-memory lookup misses and the flow fails.
+
+## Mechanism
+
+Introduce a durable `oauth_flow_states` table and an `OAuthFlowRepository`. The
+DB becomes the source of truth for the persistable flow record; the in-process
+`OAuthStateStore` is retained only for runtime handles that cannot be
+serialized — the localhost `OAuthCallbackServer` and the in-process device
+`poll_task` — and as a same-process fast path.
+
+- **Create**: `_start_browser_flow` / `_start_device_flow` persist the record
+  (verifier encrypted) after remembering it locally.
+- **Status writes**: `_set_success` / `_set_error` and the device
+  not-initialized error path write the terminal status + `finished_at` to the DB.
+- **Cross-replica reads**: `oauth_status(flow_id)` reads the authoritative
+  status from the DB when a row exists (fixing the stale-`pending` bug on the
+  originating replica); `manual_callback` / `_handle_callback` load the flow by
+  `state` token from the DB and hydrate the local store when it is missing;
+  device `complete_oauth` hydrates by `flow_id` and starts a local poll task.
+- **Encryption at rest**: the PKCE `code_verifier` is stored via
+  `TokenEncryptor` (same Fernet key already used for account tokens); no
+  plaintext verifier is written to the DB.
+
+The verifier existing transiently in the in-RAM `OAuthState` while also being
+persisted (encrypted) is a runtime handle over the single durable copy, not a
+second persistent representation.
+
+## TTL / cleanup
+
+Pending browser flows carry a 15-minute TTL (`expires_at`); device flows carry
+the upstream `expires_in_seconds`. On read, an expired pending flow is treated
+as absent. On write (flow creation) the repository opportunistically deletes
+pending rows past `expires_at` and bounds retained terminal rows to the newest
+`_MAX_RETAINED_TERMINAL_OAUTH_FLOWS`. This mirrors the previous in-memory prune
+semantics and needs no new scheduler; a leader-gated periodic purge can be added
+later if row volume ever warrants it.
+
+## SQLite vs PostgreSQL
+
+- The table uses portable column types (`String`, `Text`, `LargeBinary`,
+  `DateTime`, `Integer`) and no dialect-specific DDL, so the single migration
+  runs identically on both backends.
+- On **PostgreSQL** (the only supported multi-replica backend) the shared table
+  is what lets a callback/poll on replica B complete a flow started on replica
+  A.
+- On **SQLite** (single-process, per the replica-operations contract) the table
+  still works and simply persists flow state across the one process; it also
+  makes the flow survive a mid-flow worker restart. Timestamps are stored as
+  naive UTC via `utcnow()`, matching every other table.
+
+## Rejected alternatives
+
+- **Sticky sessions / IP hash at the LB**: fragile, operator-dependent, and does
+  not survive replica restarts mid-flow; the project already coordinates all
+  cross-replica state through the shared DB.
+- **Broadcast the verifier over the cache-invalidation bus**: the bus is a
+  best-effort cache signal, not durable storage; a callback arriving before the
+  signal propagates would still fail.
+- **Full rewrite removing the in-process store**: the callback server and device
+  poll task are inherently process-local (a socket and an asyncio task); they
+  cannot be persisted, so a hybrid (durable record + local runtime) is required
+  regardless.

--- a/openspec/changes/persist-oauth-flow-state/proposal.md
+++ b/openspec/changes/persist-oauth-flow-state/proposal.md
@@ -1,0 +1,30 @@
+# Persist dashboard OAuth flow state for multi-replica
+
+## Why
+
+The dashboard OAuth add-account / reauth flow keeps its per-flow state (PKCE
+`code_verifier`, `state` token, device-code poll metadata, status) in a
+process-local in-memory dict (`_OAUTH_STORE` in `app/modules/oauth/service.py`).
+With N replicas behind a load balancer, the browser callback, the manually
+pasted callback URL, or the device-code status poll can land on a different
+replica than the one that started the flow. That replica has no verifier or
+state, so the authorization-code exchange fails ("state mismatch") and status
+polls report `pending` forever even after another replica succeeded. Adding or
+re-authenticating an account is therefore intermittently broken on every
+multi-replica deployment.
+
+## What Changes
+
+- Add an `oauth_flow_states` table (Alembic migration on the current head)
+  keyed by `flow_id`, storing the encrypted PKCE verifier, `state` token,
+  method, status, device-code metadata, intended account id, and timestamps.
+- Persist every flow to the shared DB at creation and write status transitions
+  (success/error) durably, so any replica can complete a flow it did not start.
+- Read flow state (by `flow_id` and by `state` token) and the authoritative
+  status from the DB on the callback, manual-callback, device-complete, and
+  status paths, hydrating the process-local runtime as needed.
+- Encrypt the PKCE verifier at rest with the existing `TokenEncryptor`.
+- Expire abandoned flows via a short TTL: filter expired pending flows on read
+  and purge them (plus bound retained terminal rows) opportunistically on write.
+- Keep inherently process-local runtime (the localhost callback server and the
+  in-process device poll task) local, keyed by `flow_id`.

--- a/openspec/changes/persist-oauth-flow-state/specs/replica-operations/spec.md
+++ b/openspec/changes/persist-oauth-flow-state/specs/replica-operations/spec.md
@@ -34,6 +34,18 @@ MUST expire via a short TTL.
 - **THEN** replica A returns the authoritative `success` status from the shared
   database rather than its stale in-memory `pending`
 
+#### Scenario: Complete honors a durable terminal written by another replica
+
+- **GIVEN** replica A started a browser OAuth flow and still holds it in memory
+  as `pending`
+- **AND** replica B completed the same flow and wrote `success` (or `error`) to
+  the shared database
+- **WHEN** the dashboard calls `POST /api/oauth/complete` for that `flow_id` and
+  the request lands on replica A
+- **THEN** replica A returns the authoritative terminal status from the shared
+  database rather than its stale in-memory `pending`
+- **AND** replica A reconciles its in-memory flow state to that terminal status
+
 #### Scenario: Abandoned pending flow expires
 
 - **GIVEN** a persisted pending flow whose `expires_at` is in the past

--- a/openspec/changes/persist-oauth-flow-state/specs/replica-operations/spec.md
+++ b/openspec/changes/persist-oauth-flow-state/specs/replica-operations/spec.md
@@ -13,10 +13,7 @@ the flow. The PKCE `code_verifier` MUST be encrypted at rest with the same
 encryption key material used for account tokens, and abandoned pending flows
 MUST expire via a short TTL. The TTL MUST be enforced uniformly on every
 replica, including the originating replica that still holds the flow in local
-memory. A device-code poll task MUST re-verify that its flow is still the
-active pending record in the shared database before persisting an account, so a
-flow superseded by a newer device `start` (whose poll task cannot be cancelled
-cross-process) cannot add or re-authenticate an account for a consumed code.
+memory.
 
 #### Scenario: Callback completes on a replica that did not start the flow
 
@@ -88,13 +85,37 @@ cross-process) cannot add or re-authenticate an account for a consumed code.
 - **AND** the outcome matches a replica without local state (where the durable
   row is classified expired on read), so the TTL holds uniformly
 
-#### Scenario: Superseded device poller does not persist an account
+### Requirement: At most one device-code OAuth flow is active, enforced atomically
 
-- **GIVEN** replica A is running an in-process device-code poll task for a flow
-- **AND** a newer device `start` (on any replica) deletes that pending device row
-  before inserting its replacement
-- **WHEN** replica A's poll task later exchanges the now-superseded device code
-- **THEN** replica A re-reads the durable row, finds it absent or no longer
-  `pending`, and aborts WITHOUT adding or re-authenticating an account
-- **AND** no terminal status is written for the superseded flow (the atomic
-  status write also rejects a write to the deleted row)
+The dashboard device-code OAuth flow SHALL be coordinated as a single active
+"slot" in the shared database so that at most one device flow is current at a
+time, and replacement SHALL be atomic. A device `start` MUST claim the slot with
+a single conditional UPSERT (not a delete-then-insert), so two replicas starting
+device OAuth simultaneously leave exactly ONE current `flow_id` rather than two
+orphaned pending records that both believe they are current.
+
+Because a poll task running on another replica cannot be cancelled
+cross-process, a device poll task MUST atomically consume the slot as its point
+of no return immediately before persisting tokens, and MUST persist the account
+only if that consume succeeded. A poll task whose flow was superseded (the slot
+now names a different `flow_id`) MUST lose the consume and abort WITHOUT adding
+or re-authenticating an account, leaving no window between the liveness check
+and the account write through which a replacement can slip. This composes with
+the atomic monotonic status write (a durable `success` is never regressed).
+
+#### Scenario: Simultaneous device starts leave exactly one current flow
+
+- **GIVEN** two replicas sharing one database
+- **WHEN** both start a device-code OAuth flow at the same time
+- **THEN** the slot names exactly one of the two `flow_id`s as current
+- **AND** only the poll task holding the current slot can consume it and persist;
+  the other's consume matches zero rows and it cannot persist
+
+#### Scenario: Superseded device poll task cannot persist (liveness race)
+
+- **GIVEN** a device poll task has exchanged its code and is about to persist
+- **AND** a newer device `start` atomically re-claims the slot to a different
+  `flow_id` before the first task's account write commits
+- **THEN** the superseded task's slot consume matches zero rows
+- **AND** it aborts without adding or re-authenticating an account, and writes no
+  terminal status for the superseded flow

--- a/openspec/changes/persist-oauth-flow-state/specs/replica-operations/spec.md
+++ b/openspec/changes/persist-oauth-flow-state/specs/replica-operations/spec.md
@@ -11,7 +11,12 @@ so that a browser callback, a manually pasted callback URL, or a device-code
 status poll can be completed by any replica regardless of which replica started
 the flow. The PKCE `code_verifier` MUST be encrypted at rest with the same
 encryption key material used for account tokens, and abandoned pending flows
-MUST expire via a short TTL.
+MUST expire via a short TTL. The TTL MUST be enforced uniformly on every
+replica, including the originating replica that still holds the flow in local
+memory. A device-code poll task MUST re-verify that its flow is still the
+active pending record in the shared database before persisting an account, so a
+flow superseded by a newer device `start` (whose poll task cannot be cancelled
+cross-process) cannot add or re-authenticate an account for a consumed code.
 
 #### Scenario: Callback completes on a replica that did not start the flow
 
@@ -70,3 +75,26 @@ MUST expire via a short TTL.
 - **WHEN** a replica reads that flow by `flow_id` or `state` token
 - **THEN** the expired pending flow is treated as absent
 - **AND** it is purged opportunistically so it cannot complete after its TTL
+
+#### Scenario: Expired flow is rejected uniformly on the originating replica
+
+- **GIVEN** replica A started a browser OAuth flow and still holds its state
+  (including the cached PKCE verifier) in memory
+- **AND** the flow's TTL has elapsed
+- **WHEN** the browser callback or a manually pasted callback URL for that flow
+  lands on replica A
+- **THEN** replica A rejects it as expired / state-mismatch and MUST NOT complete
+  the authorization-code exchange from the stale cached verifier
+- **AND** the outcome matches a replica without local state (where the durable
+  row is classified expired on read), so the TTL holds uniformly
+
+#### Scenario: Superseded device poller does not persist an account
+
+- **GIVEN** replica A is running an in-process device-code poll task for a flow
+- **AND** a newer device `start` (on any replica) deletes that pending device row
+  before inserting its replacement
+- **WHEN** replica A's poll task later exchanges the now-superseded device code
+- **THEN** replica A re-reads the durable row, finds it absent or no longer
+  `pending`, and aborts WITHOUT adding or re-authenticating an account
+- **AND** no terminal status is written for the superseded flow (the atomic
+  status write also rejects a write to the deleted row)

--- a/openspec/changes/persist-oauth-flow-state/specs/replica-operations/spec.md
+++ b/openspec/changes/persist-oauth-flow-state/specs/replica-operations/spec.md
@@ -119,3 +119,35 @@ the atomic monotonic status write (a durable `success` is never regressed).
 - **THEN** the superseded task's slot consume matches zero rows
 - **AND** it aborts without adding or re-authenticating an account, and writes no
   terminal status for the superseded flow
+
+### Requirement: Durable status is authoritative over local state at every entry point
+
+Each dashboard OAuth entry point MUST consult the DB-authoritative durable status through one reconciliation gate before it branches on local in-memory flow state.
+This covers status polling, `/complete`, the device acknowledgement, the browser
+callback handler, and the manual pasted callback. The durable row SHALL always
+win over a local `pending`: a
+durable terminal (`success` or `error`) overrides local `pending`, and a durable
+row that is absent or expired drops the stale local flow. An entry point MUST
+NOT branch on a local `pending`, reuse a locally cached PKCE verifier, or replay
+a callback without first reconciling against the durable status.
+
+#### Scenario: Replayed callback observes the durable terminal instead of re-exchanging
+
+- **GIVEN** replica A started a browser OAuth flow and still holds it locally as
+  `pending`
+- **AND** the flow was completed on another replica, so the shared DB status is
+  `success` (the authorization code is consumed)
+- **WHEN** a second browser redirect or a pasted callback for the same `state`
+  lands back on replica A
+- **THEN** replica A returns the durable `success` and MUST NOT re-exchange the
+  already-consumed authorization code
+- **AND** replica A reconciles its in-memory flow to `success`
+
+#### Scenario: Every entry point honors a durable terminal over local pending
+
+- **GIVEN** a flow held locally as `pending` on the originating replica whose
+  shared-DB status is a terminal written by another replica
+- **WHEN** any of status polling, `/complete`, the device acknowledgement, the
+  browser callback handler, or the manual callback is invoked for that flow
+- **THEN** that entry point reports the durable terminal (never the stale local
+  `pending`) and reconciles the local in-memory flow to it

--- a/openspec/changes/persist-oauth-flow-state/specs/replica-operations/spec.md
+++ b/openspec/changes/persist-oauth-flow-state/specs/replica-operations/spec.md
@@ -156,6 +156,15 @@ row that is absent or expired drops the stale local flow. An entry point MUST
 NOT branch on a local `pending`, reuse a locally cached PKCE verifier, or replay
 a callback without first reconciling against the durable status.
 
+A caller that attempts a durable terminal ERROR write MUST honor a rejected
+result. When the monotonic guard rejects a non-success terminal write because
+the durable row is already `success` (a racing callback/poller committed success
+for the same single-use code), the caller MUST NOT surface an error or leave the
+local flow in `error`; it MUST reconcile against the durable row and report the
+durable `success`. This applies uniformly to every browser/manual-callback error
+branch (invalid callback, `invalid_grant`/`OAuthError` exchange failure, reauth
+seat mismatch, identity conflict, and unexpected errors).
+
 #### Scenario: Replayed callback observes the durable terminal instead of re-exchanging
 
 - **GIVEN** replica A started a browser OAuth flow and still holds it locally as
@@ -176,3 +185,12 @@ a callback without first reconciling against the durable status.
   browser callback handler, or the manual callback is invoked for that flow
 - **THEN** that entry point reports the durable terminal (never the stale local
   `pending`) and reconciles the local in-memory flow to it
+
+#### Scenario: Loser callback honors durable success on a rejected error write
+
+- **GIVEN** two browser callbacks race on the same single-use authorization code
+- **AND** the winner commits durable `success` while the loser is exchanging
+- **WHEN** the loser's exchange fails with `invalid_grant` and it attempts a
+  durable `error` write that the monotonic guard rejects
+- **THEN** the loser reports the durable `success` (not an error) and does not
+  leave the local flow in `error`

--- a/openspec/changes/persist-oauth-flow-state/specs/replica-operations/spec.md
+++ b/openspec/changes/persist-oauth-flow-state/specs/replica-operations/spec.md
@@ -1,0 +1,42 @@
+# replica-operations Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Dashboard OAuth flow state is persisted for cross-replica completion
+
+The dashboard OAuth add-account / reauth flow SHALL persist its per-flow state
+(PKCE `code_verifier`, `state` token, method, status, device-code metadata,
+intended account id, and timestamps) in the shared database keyed by `flow_id`,
+so that a browser callback, a manually pasted callback URL, or a device-code
+status poll can be completed by any replica regardless of which replica started
+the flow. The PKCE `code_verifier` MUST be encrypted at rest with the same
+encryption key material used for account tokens, and abandoned pending flows
+MUST expire via a short TTL.
+
+#### Scenario: Callback completes on a replica that did not start the flow
+
+- **GIVEN** two replicas sharing one PostgreSQL database
+- **AND** replica A starts a browser OAuth flow, persisting the flow record
+- **WHEN** the callback (or manually pasted callback URL) for that `state` token
+  lands on replica B, which never held the flow in memory
+- **THEN** replica B loads the encrypted verifier and metadata from the shared
+  database and completes the authorization-code exchange
+- **AND** the added or re-authenticated account is persisted
+
+#### Scenario: Status poll reflects a completion written by another replica
+
+- **GIVEN** replica A started an OAuth flow and still holds it in memory as
+  `pending`
+- **AND** replica B completed the same flow and wrote `success` to the shared
+  database
+- **WHEN** the dashboard polls `GET /api/oauth/status` for that `flow_id` and the
+  request lands on replica A
+- **THEN** replica A returns the authoritative `success` status from the shared
+  database rather than its stale in-memory `pending`
+
+#### Scenario: Abandoned pending flow expires
+
+- **GIVEN** a persisted pending flow whose `expires_at` is in the past
+- **WHEN** a replica reads that flow by `flow_id` or `state` token
+- **THEN** the expired pending flow is treated as absent
+- **AND** it is purged opportunistically so it cannot complete after its TTL

--- a/openspec/changes/persist-oauth-flow-state/specs/replica-operations/spec.md
+++ b/openspec/changes/persist-oauth-flow-state/specs/replica-operations/spec.md
@@ -46,6 +46,24 @@ MUST expire via a short TTL.
   database rather than its stale in-memory `pending`
 - **AND** replica A reconciles its in-memory flow state to that terminal status
 
+#### Scenario: A durable success is never regressed to error
+
+- **GIVEN** a persisted flow whose shared-database status is `success`
+- **WHEN** a later status write attempts to set the same `flow_id` to `error`
+  (e.g. a duplicate or losing device poller receiving an OAuth error for the
+  already-consumed device code)
+- **THEN** the persisted `success` status is retained and MUST NOT be overwritten
+- **AND** status polling continues to report `success`
+
+#### Scenario: Device-code acknowledgement does not re-poll a completed flow
+
+- **GIVEN** a device-code flow whose in-process poller has already reached a
+  terminal status
+- **WHEN** `POST /api/oauth/complete` is called for that flow
+- **THEN** no second poll of the single-use device code is started
+- **AND** the untargeted acknowledgement (no `flow_id`) reports `pending` while a
+  targeted call (explicit `flow_id`) reports the durable terminal status
+
 #### Scenario: Abandoned pending flow expires
 
 - **GIVEN** a persisted pending flow whose `expires_at` is in the past

--- a/openspec/changes/persist-oauth-flow-state/specs/replica-operations/spec.md
+++ b/openspec/changes/persist-oauth-flow-state/specs/replica-operations/spec.md
@@ -94,14 +94,24 @@ a single conditional UPSERT (not a delete-then-insert), so two replicas starting
 device OAuth simultaneously leave exactly ONE current `flow_id` rather than two
 orphaned pending records that both believe they are current.
 
-Because a poll task running on another replica cannot be cancelled
-cross-process, a device poll task MUST atomically consume the slot as its point
-of no return immediately before persisting tokens, and MUST persist the account
-only if that consume succeeded. A poll task whose flow was superseded (the slot
-now names a different `flow_id`) MUST lose the consume and abort WITHOUT adding
-or re-authenticating an account, leaving no window between the liveness check
-and the account write through which a replacement can slip. This composes with
-the atomic monotonic status write (a durable `success` is never regressed).
+Slot ownership SHALL be the single authority for who may complete a device flow.
+A device `start` claims the slot only while it is still the current local device
+flow, so a start superseded on the same replica (its local record already
+replaced by a later start) MUST NOT install a stale slot pointer or begin
+polling. Because a poll task on another replica cannot be cancelled
+cross-process, a poll task MUST atomically consume the slot as its point of no
+return, and only the poller that consumed/holds the slot MAY persist an account
+OR write ANY terminal status (success or error). A poller that did not win/hold
+the slot MUST write nothing, so a losing or duplicate poller that received
+`invalid_grant` for the already-consumed code cannot record an `error` during
+the winner's persist window. This composes with the atomic monotonic status
+write (a durable `success` is never regressed).
+
+The originating replica SHALL be the sole poller for a device flow. A device
+`/complete` served on a replica that did not originate the flow MUST report the
+durable status through the reconciliation gate and MUST NOT spawn a second poll
+task for the single-use device code. If the originating replica dies mid-poll,
+the flow expires by its TTL and the user retries.
 
 #### Scenario: Simultaneous device starts leave exactly one current flow
 
@@ -111,14 +121,29 @@ the atomic monotonic status write (a durable `success` is never regressed).
 - **AND** only the poll task holding the current slot can consume it and persist;
   the other's consume matches zero rows and it cannot persist
 
-#### Scenario: Superseded device poll task cannot persist (liveness race)
+#### Scenario: Overlapping same-replica starts — the later start wins
 
-- **GIVEN** a device poll task has exchanged its code and is about to persist
-- **AND** a newer device `start` atomically re-claims the slot to a different
-  `flow_id` before the first task's account write commits
-- **THEN** the superseded task's slot consume matches zero rows
-- **AND** it aborts without adding or re-authenticating an account, and writes no
-  terminal status for the superseded flow
+- **GIVEN** a device `start` is awaiting its durable persist on a replica
+- **WHEN** a later device `start` on the same replica supersedes it locally,
+  claims the slot, and begins polling
+- **THEN** the later start is the current slot holder and the sole poller
+- **AND** the superseded earlier start installs no stale slot pointer and starts
+  no poll task
+
+#### Scenario: Only the slot holder writes a terminal status
+
+- **GIVEN** the winning poller consumed the slot and is mid-persist (success not
+  yet written)
+- **WHEN** a losing/duplicate poller receives `invalid_grant` for the consumed
+  device code
+- **THEN** the loser writes NO terminal status (no `pending` -> `error`)
+- **AND** the winner's later `success` is the durable outcome
+
+#### Scenario: Non-originating /complete does not start a second poller
+
+- **GIVEN** a device flow started (and being polled) on its originating replica
+- **WHEN** `/complete` for that flow is served on a different replica
+- **THEN** that replica reports the durable status and starts no second poll task
 
 ### Requirement: Durable status is authoritative over local state at every entry point
 

--- a/openspec/changes/persist-oauth-flow-state/tasks.md
+++ b/openspec/changes/persist-oauth-flow-state/tasks.md
@@ -11,8 +11,22 @@
 
 - [x] 2.1 Add `OAuthFlowRepository` (`app/modules/oauth/repository.py`) with
       create / get-by-flow-id / get-by-state-token / latest / set-status /
-      delete-pending-device / purge-expired methods.
+      purge-expired methods.
 - [x] 2.2 Encrypt the PKCE verifier at rest; expose a typed record dataclass.
+
+## 6. Cross-replica hardening (review-driven)
+
+- [x] 6.1 Make terminal status writes atomically monotonic (durable `success`
+      is sticky) via a conditional SQL UPDATE, safe under two-session concurrency.
+- [x] 6.2 Enforce the pending-flow TTL uniformly, including on the originating
+      replica that still holds local state (prune expired local flows before
+      trusting the cached verifier on callback/manual-callback).
+- [x] 6.3 Coordinate device flows through a single atomic active slot
+      (`oauth_device_flow_slots`): device `start` claims the slot with one
+      conditional UPSERT (atomic replacement, exactly one current flow); the
+      poller atomically consumes the slot before persisting tokens and aborts
+      if superseded. Migration `20260716_000000_add_oauth_device_flow_slots`
+      parented on the current single head.
 
 ## 3. Service wiring
 

--- a/openspec/changes/persist-oauth-flow-state/tasks.md
+++ b/openspec/changes/persist-oauth-flow-state/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: persist dashboard OAuth flow state
+
+## 1. Schema
+
+- [x] 1.1 Add `OAuthFlowState` ORM model (`oauth_flow_states`) to `app/db/models.py`.
+- [x] 1.2 Add Alembic migration on the current head
+      (`20260713_040000_add_account_refresh_claims`) with upgrade + downgrade,
+      dialect-agnostic DDL.
+
+## 2. Repository
+
+- [x] 2.1 Add `OAuthFlowRepository` (`app/modules/oauth/repository.py`) with
+      create / get-by-flow-id / get-by-state-token / latest / set-status /
+      delete-pending-device / purge-expired methods.
+- [x] 2.2 Encrypt the PKCE verifier at rest; expose a typed record dataclass.
+
+## 3. Service wiring
+
+- [x] 3.1 Persist flow records at creation (browser + device).
+- [x] 3.2 Write terminal status transitions to the DB.
+- [x] 3.3 Make `oauth_status` DB-authoritative when a row exists.
+- [x] 3.4 Hydrate the local store from the DB on manual-callback, browser
+      callback, and device complete when the flow is missing locally.
+- [x] 3.5 Allow injecting a distinct store per `OauthService` (two-replica tests).
+
+## 4. Tests
+
+- [x] 4.1 Two-replica simulation: start on store/session A, complete on B.
+- [x] 4.2 Cross-replica status: originator sees success written by another replica.
+- [x] 4.3 Migration upgrade/downgrade round-trip on SQLite.
+- [x] 4.4 Existing oauth flow suite stays green.
+
+## 5. Spec + validation
+
+- [x] 5.1 Add delta requirement to `replica-operations`.
+- [x] 5.2 `openspec validate persist-oauth-flow-state --strict` passes.
+- [x] 5.3 `openspec validate --specs` stays green.

--- a/openspec/changes/persist-oauth-flow-state/tasks.md
+++ b/openspec/changes/persist-oauth-flow-state/tasks.md
@@ -37,6 +37,10 @@
       loser writes nothing); the originating replica is the sole poller and a
       non-originating `/complete` reports durable status without spawning a
       second poller.
+- [x] 6.6 Propagate rejected durable terminal-error writes: browser/manual
+      callback error branches honor a durable `success` (report success, do not
+      leave local `error`) when the monotonic guard rejects the error write for a
+      single-use code already completed by a racing callback.
 
 ## 3. Service wiring
 

--- a/openspec/changes/persist-oauth-flow-state/tasks.md
+++ b/openspec/changes/persist-oauth-flow-state/tasks.md
@@ -27,6 +27,16 @@
       poller atomically consumes the slot before persisting tokens and aborts
       if superseded. Migration `20260716_000000_add_oauth_device_flow_slots`
       parented on the current single head.
+- [x] 6.4 Route every entry point through the durable reconciliation gate so a
+      durable terminal/expired always wins over local pending (status, complete,
+      browser callback, manual callback, device).
+- [x] 6.5 Converge the device-flow class on slot ownership: claim only while
+      still the current local flow and under the store lock (a superseded
+      same-replica start installs no stale slot pointer / no poller); ALL
+      terminal writes (success and error) gated on holding the consumed slot (a
+      loser writes nothing); the originating replica is the sole poller and a
+      non-originating `/complete` reports durable status without spawning a
+      second poller.
 
 ## 3. Service wiring
 

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -1067,3 +1067,43 @@ async def test_account_refresh_claims_migration_upgrade_and_downgrade(tmp_path):
         assert await _has_claims_table(engine)
     finally:
         await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_oauth_flow_states_migration_upgrade_and_downgrade(tmp_path):
+    """Upgrade creates the OAuth flow-state coordination table; downgrade drops
+    it; a final walk to head proves the revision sits on a single-head graph."""
+    from alembic import command
+
+    from app.db.migrate import _build_alembic_config
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'oauth-flow-states.sqlite'}"
+    parent_revision = "20260713_040000_add_account_refresh_claims"
+    flow_revision = "20260714_000000_add_oauth_flow_states"
+
+    async def _has_flow_table(engine) -> bool:
+        async with engine.connect() as conn:
+            result = await conn.execute(
+                text("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'oauth_flow_states'")
+            )
+            return result.scalar_one_or_none() is not None
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, parent_revision, bootstrap_legacy=False))
+    engine = create_async_engine(db_url, future=True)
+    try:
+        assert not await _has_flow_table(engine)
+
+        await to_thread.run_sync(lambda: run_upgrade(db_url, flow_revision, bootstrap_legacy=False))
+        assert await _has_flow_table(engine)
+
+        config = _build_alembic_config(db_url)
+        await to_thread.run_sync(lambda: command.downgrade(config, parent_revision))
+        assert not await _has_flow_table(engine)
+
+        # Single-head sanity: upgrading to "head" from the parent must pass
+        # through the flow revision without a multi-head failure.
+        result = await to_thread.run_sync(lambda: run_upgrade(db_url, "head", bootstrap_legacy=False))
+        assert result.current_revision == _HEAD_REVISION
+        assert await _has_flow_table(engine)
+    finally:
+        await engine.dispose()

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -5,6 +5,7 @@ import base64
 import json
 import logging
 import time
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock
@@ -19,7 +20,7 @@ from app.core.clients.oauth import DeviceCode, OAuthError, OAuthTokens
 from app.core.crypto import TokenEncryptor
 from app.core.upstream_proxy import UpstreamProxyRouteError
 from app.core.utils.time import utcnow
-from app.db.models import Account, AccountStatus
+from app.db.models import Account, AccountStatus, OAuthFlowState
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.oauth import api as oauth_api_module
@@ -1817,3 +1818,114 @@ async def test_oauth_status_reads_completion_written_by_another_replica(monkeypa
 
     status = await replica_a.oauth_status(start.flow_id)
     assert status.status == "success"
+
+
+def test_is_expired_pending_normalizes_tz_aware_expiry():
+    """Finding 1 (dialect-agnostic): on PostgreSQL asyncpg returns an
+    offset-AWARE ``expires_at`` for the ``DateTime(timezone=True)`` column while
+    ``utcnow()`` is naive UTC. The expiry comparison must normalize before
+    comparing instead of raising ``TypeError: can't compare offset-naive and
+    offset-aware datetimes``.
+    """
+
+    from app.modules.oauth.repository import OAuthFlowRepository
+
+    now = utcnow()  # naive UTC, as returned by ``utcnow``
+    live_aware = cast(
+        OAuthFlowState,
+        SimpleNamespace(status="pending", expires_at=datetime.now(timezone.utc) + timedelta(hours=1)),
+    )
+    expired_aware = cast(
+        OAuthFlowState,
+        SimpleNamespace(status="pending", expires_at=datetime.now(timezone.utc) - timedelta(hours=1)),
+    )
+
+    # Must not raise, and must classify correctly.
+    assert OAuthFlowRepository._is_expired_pending(live_aware, now) is False
+    assert OAuthFlowRepository._is_expired_pending(expired_aware, now) is True
+
+
+@pytest.mark.asyncio
+async def test_get_by_flow_id_survives_tz_aware_expiry_from_asyncpg():
+    """Finding 1 (read path): ``get_by_flow_id`` / ``get_by_state_token`` must
+    not raise when the ORM row carries an offset-aware ``expires_at`` (asyncpg's
+    representation for ``DateTime(timezone=True)`` on PostgreSQL) and must still
+    correctly classify live vs expired pending flows.
+    """
+
+    encryptor = TokenEncryptor()
+    async with SessionLocal() as session:
+        repo = oauth_module.OAuthFlowRepository(session, encryptor)
+        await repo.create(
+            oauth_module.OAuthFlowRecord(
+                flow_id="tz-aware-flow",
+                method="browser",
+                status="pending",
+                state_token="tz-aware-state",
+                code_verifier="tz-aware-verifier",
+                expires_at=utcnow() + timedelta(hours=1),
+            )
+        )
+
+    async with SessionLocal() as session:
+        repo = oauth_module.OAuthFlowRepository(session, encryptor)
+        row = await session.get(OAuthFlowState, "tz-aware-flow")
+        assert row is not None
+
+        # Simulate asyncpg: replace the naive value with an offset-aware one.
+        row.expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+        live = await repo.get_by_flow_id("tz-aware-flow")
+        assert live is not None
+        live_by_state = await repo.get_by_state_token("tz-aware-state")
+        assert live_by_state is not None
+
+        # Aware + expired must be filtered out, still without raising.
+        row.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        assert await repo.get_by_flow_id("tz-aware-flow") is None
+        assert await repo.get_by_state_token("tz-aware-state") is None
+
+
+@pytest.mark.asyncio
+async def test_complete_on_origin_replica_honors_durable_success_from_other_replica(monkeypatch):
+    """Finding 2: replica A starts a browser flow; replica B completes it and
+    writes durable success to the shared DB. The dashboard on A polls status
+    (success) then immediately calls ``/complete`` with the same ``flowId``.
+
+    Before the fix, ``complete_oauth`` used A's stale local ``pending`` browser
+    flow (hydration skips existing flows) and returned ``pending``, so the UI
+    flipped back to pending and never invalidated accounts. Now the durable
+    terminal status is authoritative: ``/complete`` returns success and A's
+    in-memory flow is reconciled.
+    """
+
+    async def fake_callback_server_start(self) -> None:
+        return None
+
+    monkeypatch.setattr(oauth_module.OAuthCallbackServer, "start", fake_callback_server_start)
+
+    replica_a = _make_replica_service(oauth_module.OAuthStateStore())
+    start = await replica_a.start_oauth(oauth_module.OauthStartRequest(force_method="browser"))
+    assert start.flow_id is not None
+
+    # Replica A's in-memory flow is still pending.
+    async with replica_a._store.lock:
+        local = replica_a._store.get_flow_locked(start.flow_id)
+        assert local is not None and local.status == "pending"
+
+    # Another replica completes the flow and writes durable success.
+    async with SessionLocal() as session:
+        repo = oauth_module.OAuthFlowRepository(session, TokenEncryptor())
+        assert await repo.set_status(start.flow_id, status="success", error_message=None)
+
+    # poll(): status returns the durable success ...
+    status = await replica_a.oauth_status(start.flow_id)
+    assert status.status == "success"
+
+    # ... then the frontend immediately calls /complete with the same flowId.
+    complete = await replica_a.complete_oauth(oauth_module.OauthCompleteRequest(flow_id=start.flow_id))
+    assert complete.status == "success"
+
+    # The origin replica's in-memory flow converges on the durable terminal.
+    async with replica_a._store.lock:
+        local = replica_a._store.get_flow_locked(start.flow_id)
+        assert local is not None and local.status == "success"

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import json
 import logging
 import time
@@ -24,6 +25,7 @@ from app.db.models import Account, AccountStatus, OAuthFlowState
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.oauth import api as oauth_api_module
+from app.modules.oauth.repository import OAuthFlowRepository
 from app.modules.oauth.schemas import ManualCallbackRequest
 
 pytestmark = pytest.mark.integration
@@ -2075,10 +2077,11 @@ async def test_device_complete_ack_stays_pending_when_own_poller_already_succeed
 
 @pytest.mark.asyncio
 async def test_superseded_device_poller_does_not_persist_account(monkeypatch):
-    """A device flow's in-process poller whose durable row is superseded by a
-    newer device start (the old pending row is deleted, possibly on another
-    replica) must abort before doing durable damage: no account is added and no
-    terminal status is written for the abandoned attempt.
+    """Liveness race: a device flow's in-process poller is superseded by a newer
+    device start (which atomically re-claims the single-active slot) in the
+    window between the exchange and the account write. The abandoned poller must
+    lose the atomic slot consume and abort before doing durable damage: no
+    account is added and no terminal status is written for the abandoned attempt.
     """
 
     email = "superseded-device@example.com"
@@ -2123,15 +2126,15 @@ async def test_superseded_device_poller_does_not_persist_account(monkeypatch):
     assert start.flow_id is not None
 
     # The poller is now blocked mid-exchange, holding the (about-to-be-consumed)
-    # device code.
+    # device code, and it holds the single-active device slot.
     await asyncio.wait_for(exchange_started.wait(), timeout=2)
-
-    # A replacement device start supersedes the in-flight flow by deleting the
-    # previous pending device row (exactly what _start_device_flow does before
-    # inserting the replacement).
     async with SessionLocal() as session:
-        superseded = await oauth_module.OAuthFlowRepository(session, TokenEncryptor()).delete_pending_device()
-    assert start.flow_id in superseded
+        assert await OAuthFlowRepository(session, TokenEncryptor()).current_device_slot_flow_id() == start.flow_id
+
+    # A replacement device start (another replica) atomically re-claims the slot
+    # in the window between the exchange and the abandoned poller's account write.
+    async with SessionLocal() as session:
+        await OAuthFlowRepository(session, TokenEncryptor()).claim_device_slot("replacement-flow")
 
     async with replica._store.lock:
         flow = replica._store.get_flow_locked(start.flow_id)
@@ -2139,8 +2142,8 @@ async def test_superseded_device_poller_does_not_persist_account(monkeypatch):
         poll_task = flow.poll_task
         assert poll_task is not None
 
-    # Let the abandoned exchange complete; the poller must abort on its "still
-    # current?" re-read rather than persist the account.
+    # Let the abandoned exchange complete; the poller must lose the atomic slot
+    # consume and abort rather than persist the account.
     release_exchange.set()
     await asyncio.wait_for(poll_task, timeout=2)
 
@@ -2149,10 +2152,78 @@ async def test_superseded_device_poller_does_not_persist_account(monkeypatch):
         stored = await AccountsRepository(session).get_by_id(expected_account_id)
     assert stored is None
 
-    # No terminal status was written for the superseded (deleted) flow.
+    # No terminal status was written for the superseded flow; the replacement
+    # still holds the slot.
     async with SessionLocal() as session:
-        record = await oauth_module.OAuthFlowRepository(session, TokenEncryptor()).get_by_flow_id(start.flow_id)
-    assert record is None
+        repo = OAuthFlowRepository(session, TokenEncryptor())
+        record = await repo.get_by_flow_id(start.flow_id)
+        assert record is not None and record.status == "pending"
+        assert await repo.current_device_slot_flow_id() == "replacement-flow"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_device_starts_leave_exactly_one_current_flow(monkeypatch):
+    """Two replicas starting device OAuth "simultaneously" must leave exactly ONE
+    current device flow (the atomic slot UPSERT), and only the poller that still
+    holds the slot may persist -- the other's consume matches zero rows.
+    """
+
+    async def fake_device_code(**_):
+        return DeviceCode(
+            verification_url="https://auth.openai.com/codex/device",
+            user_code="RACE-CODE",
+            device_auth_id="dev-race",
+            interval_seconds=30,
+            expires_in_seconds=300,
+        )
+
+    # Never returns tokens: keep both pollers pending so we can assert the slot
+    # invariant deterministically without either completing.
+    async def fake_exchange_device_token(**_):
+        await asyncio.Event().wait()
+
+    async def fake_oauth_route():
+        return None
+
+    monkeypatch.setattr(oauth_module, "request_device_code", fake_device_code)
+    monkeypatch.setattr(oauth_module, "exchange_device_token", fake_exchange_device_token)
+    monkeypatch.setattr(oauth_module, "_oauth_route", fake_oauth_route)
+
+    replica_a = _make_replica_service(oauth_module.OAuthStateStore())
+    replica_b = _make_replica_service(oauth_module.OAuthStateStore())
+
+    start_a, start_b = await asyncio.gather(
+        replica_a.start_oauth(oauth_module.OauthStartRequest(force_method="device")),
+        replica_b.start_oauth(oauth_module.OauthStartRequest(force_method="device")),
+    )
+    assert start_a.flow_id is not None and start_b.flow_id is not None
+    assert start_a.flow_id != start_b.flow_id
+
+    # Exactly one flow holds the single-active slot.
+    async with SessionLocal() as session:
+        current = await OAuthFlowRepository(session, TokenEncryptor()).current_device_slot_flow_id()
+    assert current in {start_a.flow_id, start_b.flow_id}
+
+    # Only the current flow can consume the slot; the other loses.
+    async with SessionLocal() as session:
+        repo = OAuthFlowRepository(session, TokenEncryptor())
+        other = start_b.flow_id if current == start_a.flow_id else start_a.flow_id
+        assert await repo.consume_device_slot(other) is False
+    async with SessionLocal() as session:
+        repo = OAuthFlowRepository(session, TokenEncryptor())
+        assert await repo.consume_device_slot(current) is True
+        # Once consumed, neither can consume again (no double-persist).
+        assert await repo.consume_device_slot(current) is False
+
+    # Clean up the parked poll tasks.
+    for replica, start in ((replica_a, start_a), (replica_b, start_b)):
+        async with replica._store.lock:
+            flow = replica._store.get_flow_locked(start.flow_id)
+            task = flow.poll_task if flow is not None else None
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -106,6 +106,18 @@ async def test_manual_callback_api_preserves_oauth_error():
 async def test_manual_callback_service_sanitizes_unexpected_exception(monkeypatch, caplog):
     await oauth_module._OAUTH_STORE.reset()
     caplog.set_level(logging.ERROR, logger=oauth_module.logger.name)
+    # Persist the flow durably (real flows are written to the shared DB at start)
+    # so the reconciliation gate keeps it rather than dropping it as stale.
+    async with SessionLocal() as session:
+        await OAuthFlowRepository(session, TokenEncryptor()).create(
+            oauth_module.OAuthFlowRecord(
+                flow_id="flow-1",
+                method="browser",
+                status="pending",
+                state_token="state-1",
+                code_verifier="verifier-1",
+            )
+        )
     async with oauth_module._OAUTH_STORE.lock:
         oauth_module._OAUTH_STORE.remember_flow_locked(
             oauth_module.OAuthState(
@@ -2270,4 +2282,154 @@ async def test_expired_local_browser_flow_callback_is_rejected_on_origin_replica
     assert result.status == "error"
     assert result.error_message == "Invalid OAuth callback: state mismatch or missing code."
     # The stale verifier was never used to exchange the code.
+    assert exchange_calls == []
+
+
+@pytest.mark.parametrize("entry_point", ["status", "complete", "manual_callback", "handle_callback", "device_complete"])
+@pytest.mark.asyncio
+async def test_entry_points_honor_durable_terminal_over_local_pending(monkeypatch, entry_point):
+    """Root-consolidation regression: EVERY entry point that resolves a flow from
+    local state must consult the DB-authoritative status first, so a durable
+    terminal written by another replica wins over this replica's stale local
+    ``pending`` -- and a consumed authorization / device code is never replayed.
+    """
+
+    from aiohttp.test_utils import make_mocked_request
+
+    async def fake_callback_server_start(self) -> None:
+        return None
+
+    async def fake_oauth_route():
+        return None
+
+    exchange_calls: list[str | None] = []
+
+    async def fake_exchange_authorization_code(**kwargs):
+        exchange_calls.append(kwargs.get("code"))
+        raise AssertionError("a durable-terminal flow must never re-exchange the code")
+
+    async def fake_device_code(**_):
+        return DeviceCode(
+            verification_url="https://auth.openai.com/codex/device",
+            user_code="TERM-CODE",
+            device_auth_id="dev-term",
+            interval_seconds=30,
+            expires_in_seconds=300,
+        )
+
+    async def fake_exchange_device_token(**_):
+        # The device poll task legitimately calls this once at start; it is not a
+        # replay. Only authorization-code exchanges are tracked in exchange_calls.
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(oauth_module.OAuthCallbackServer, "start", fake_callback_server_start)
+    monkeypatch.setattr(oauth_module, "_oauth_route", fake_oauth_route)
+    monkeypatch.setattr(oauth_module, "exchange_authorization_code", fake_exchange_authorization_code)
+    monkeypatch.setattr(oauth_module, "request_device_code", fake_device_code)
+    monkeypatch.setattr(oauth_module, "exchange_device_token", fake_exchange_device_token)
+
+    replica = _make_replica_service(oauth_module.OAuthStateStore())
+    force_method = "device" if entry_point == "device_complete" else "browser"
+    start = await replica.start_oauth(oauth_module.OauthStartRequest(force_method=force_method))
+    assert start.flow_id is not None
+    state_token = _oauth_state_token(start.authorization_url or "") if force_method == "browser" else None
+
+    # Origin replica still holds the flow as pending in memory.
+    async with replica._store.lock:
+        local = replica._store.get_flow_locked(start.flow_id)
+        assert local is not None and local.status == "pending"
+
+    # Another replica writes the durable terminal success.
+    async with SessionLocal() as session:
+        assert await OAuthFlowRepository(session, TokenEncryptor()).set_status(
+            start.flow_id, status="success", error_message=None
+        )
+
+    if entry_point == "status":
+        resp = await replica.oauth_status(start.flow_id)
+        assert resp.status == "success"
+    elif entry_point in ("complete", "device_complete"):
+        resp = await replica.complete_oauth(oauth_module.OauthCompleteRequest(flow_id=start.flow_id))
+        assert resp.status == "success"
+    elif entry_point == "manual_callback":
+        resp = await replica.manual_callback(
+            f"http://localhost:1455/auth/callback?code=replay-code&state={state_token}",
+            flow_id=start.flow_id,
+        )
+        assert resp.status == "success"
+    elif entry_point == "handle_callback":
+        request = make_mocked_request("GET", f"/auth/callback?code=replay-code&state={state_token}")
+        response = await replica._handle_callback(request)
+        assert response.status == 200
+        assert response.text is not None and "Login failed" not in response.text
+
+    # The origin replica's in-memory flow is reconciled to the durable terminal.
+    async with replica._store.lock:
+        local = replica._store.get_flow_locked(start.flow_id)
+        assert local is not None and local.status == "success"
+
+    # The consumed authorization / device code was never re-exchanged.
+    assert exchange_calls == []
+
+    # Clean up any parked device poll task.
+    async with replica._store.lock:
+        flow = replica._store.get_flow_locked(start.flow_id)
+        task = flow.poll_task if flow is not None else None
+    if task is not None:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_browser_callback_replay_on_origin_does_not_reexchange_consumed_code(monkeypatch):
+    """The reported callback-replay class: replica A starts a browser flow (local
+    pending); another replica completes it (durable success). A second browser
+    redirect / pasted callback for the same state lands back on A. A must observe
+    the durable success instead of reusing the already-consumed authorization
+    code (which upstream would reject, surfacing a spurious error to the user).
+    """
+
+    from aiohttp.test_utils import make_mocked_request
+
+    async def fake_callback_server_start(self) -> None:
+        return None
+
+    async def fake_oauth_route():
+        return None
+
+    exchange_calls: list[str | None] = []
+
+    async def fake_exchange_authorization_code(**kwargs):
+        exchange_calls.append(kwargs.get("code"))
+        raise AssertionError("replayed callback must not re-exchange the consumed code")
+
+    monkeypatch.setattr(oauth_module.OAuthCallbackServer, "start", fake_callback_server_start)
+    monkeypatch.setattr(oauth_module, "_oauth_route", fake_oauth_route)
+    monkeypatch.setattr(oauth_module, "exchange_authorization_code", fake_exchange_authorization_code)
+
+    replica_a = _make_replica_service(oauth_module.OAuthStateStore())
+    start = await replica_a.start_oauth(oauth_module.OauthStartRequest(force_method="browser"))
+    assert start.flow_id is not None
+    state_token = _oauth_state_token(start.authorization_url or "")
+
+    # Another replica completed the flow: durable success in the shared DB.
+    async with SessionLocal() as session:
+        assert await OAuthFlowRepository(session, TokenEncryptor()).set_status(
+            start.flow_id, status="success", error_message=None
+        )
+
+    # Replayed pasted callback on the origin replica.
+    manual = await replica_a.manual_callback(
+        f"http://localhost:1455/auth/callback?code=consumed-code&state={state_token}",
+        flow_id=start.flow_id,
+    )
+    assert manual.status == "success"
+
+    # Replayed browser redirect on the origin replica.
+    request = make_mocked_request("GET", f"/auth/callback?code=consumed-code&state={state_token}")
+    response = await replica_a._handle_callback(request)
+    assert response.status == 200
+    assert response.text is not None and "Login failed" not in response.text
+
     assert exchange_calls == []

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -2071,3 +2071,132 @@ async def test_device_complete_ack_stays_pending_when_own_poller_already_succeed
             assert done is not None
             # No second poller was started for the already-consumed device code.
             assert done.poll_task is None
+
+
+@pytest.mark.asyncio
+async def test_superseded_device_poller_does_not_persist_account(monkeypatch):
+    """A device flow's in-process poller whose durable row is superseded by a
+    newer device start (the old pending row is deleted, possibly on another
+    replica) must abort before doing durable damage: no account is added and no
+    terminal status is written for the abandoned attempt.
+    """
+
+    email = "superseded-device@example.com"
+    raw_account_id = "acc_superseded_device"
+
+    exchange_started = asyncio.Event()
+    release_exchange = asyncio.Event()
+
+    async def fake_device_code(**_):
+        return DeviceCode(
+            verification_url="https://auth.openai.com/codex/device",
+            user_code="SUPER-CODE",
+            device_auth_id="dev-super",
+            interval_seconds=0,
+            expires_in_seconds=300,
+        )
+
+    async def fake_exchange_device_token(**_):
+        exchange_started.set()
+        await release_exchange.wait()
+        return OAuthTokens(
+            access_token="super-access",
+            refresh_token="super-refresh",
+            id_token=_encode_jwt(
+                {
+                    "email": email,
+                    "chatgpt_account_id": raw_account_id,
+                    "https://api.openai.com/auth": {"chatgpt_plan_type": "plus"},
+                }
+            ),
+        )
+
+    async def fake_oauth_route():
+        return None
+
+    monkeypatch.setattr(oauth_module, "request_device_code", fake_device_code)
+    monkeypatch.setattr(oauth_module, "exchange_device_token", fake_exchange_device_token)
+    monkeypatch.setattr(oauth_module, "_oauth_route", fake_oauth_route)
+
+    replica = _make_replica_service(oauth_module.OAuthStateStore())
+    start = await replica.start_oauth(oauth_module.OauthStartRequest(force_method="device"))
+    assert start.flow_id is not None
+
+    # The poller is now blocked mid-exchange, holding the (about-to-be-consumed)
+    # device code.
+    await asyncio.wait_for(exchange_started.wait(), timeout=2)
+
+    # A replacement device start supersedes the in-flight flow by deleting the
+    # previous pending device row (exactly what _start_device_flow does before
+    # inserting the replacement).
+    async with SessionLocal() as session:
+        superseded = await oauth_module.OAuthFlowRepository(session, TokenEncryptor()).delete_pending_device()
+    assert start.flow_id in superseded
+
+    async with replica._store.lock:
+        flow = replica._store.get_flow_locked(start.flow_id)
+        assert flow is not None
+        poll_task = flow.poll_task
+        assert poll_task is not None
+
+    # Let the abandoned exchange complete; the poller must abort on its "still
+    # current?" re-read rather than persist the account.
+    release_exchange.set()
+    await asyncio.wait_for(poll_task, timeout=2)
+
+    expected_account_id = generate_unique_account_id(raw_account_id, email)
+    async with SessionLocal() as session:
+        stored = await AccountsRepository(session).get_by_id(expected_account_id)
+    assert stored is None
+
+    # No terminal status was written for the superseded (deleted) flow.
+    async with SessionLocal() as session:
+        record = await oauth_module.OAuthFlowRepository(session, TokenEncryptor()).get_by_flow_id(start.flow_id)
+    assert record is None
+
+
+@pytest.mark.asyncio
+async def test_expired_local_browser_flow_callback_is_rejected_on_origin_replica(monkeypatch):
+    """The pending-flow TTL must hold uniformly, including on the replica that
+    started the flow and still holds its local state: a callback that arrives
+    after the TTL is rejected (state-mismatch / expired) instead of being
+    completed from the stale cached verifier.
+    """
+
+    async def fake_callback_server_start(self) -> None:
+        return None
+
+    exchange_calls: list[str | None] = []
+
+    async def fake_exchange_authorization_code(**kwargs):
+        exchange_calls.append(kwargs.get("code"))
+        raise AssertionError("an expired flow must never exchange the authorization code")
+
+    monkeypatch.setattr(oauth_module.OAuthCallbackServer, "start", fake_callback_server_start)
+    monkeypatch.setattr(oauth_module, "exchange_authorization_code", fake_exchange_authorization_code)
+
+    replica = _make_replica_service(oauth_module.OAuthStateStore())
+    start = await replica.start_oauth(oauth_module.OauthStartRequest(force_method="browser"))
+    assert start.flow_id is not None
+    state_token = _oauth_state_token(start.authorization_url or "")
+
+    # Force the flow past its TTL both in the local store and the shared DB.
+    async with replica._store.lock:
+        local = replica._store.get_flow_by_state_token_locked(state_token)
+        assert local is not None and local.status == "pending"
+        local.expires_at = time.time() - 1
+    async with SessionLocal() as session:
+        row = await session.get(OAuthFlowState, start.flow_id)
+        assert row is not None
+        row.expires_at = utcnow() - timedelta(seconds=1)
+        await session.commit()
+
+    result = await replica.manual_callback(
+        f"http://localhost:1455/auth/callback?code=expired-code&state={state_token}",
+        flow_id=start.flow_id,
+    )
+
+    assert result.status == "error"
+    assert result.error_message == "Invalid OAuth callback: state mismatch or missing code."
+    # The stale verifier was never used to exchange the code.
+    assert exchange_calls == []

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -2630,3 +2630,66 @@ async def test_non_originating_complete_reports_durable_status_without_second_po
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await task
+
+
+@pytest.mark.parametrize("path", ["manual_callback", "handle_callback"])
+@pytest.mark.asyncio
+async def test_loser_browser_callback_honors_durable_success_not_error(monkeypatch, path):
+    """Browser-callback analog of the loser-writes-error bug: two callbacks race
+    on the same single-use authorization code. The winner commits durable success
+    WHILE the loser is exchanging; the loser's exchange then fails with
+    ``invalid_grant``. The loser's terminal ERROR write is rejected by the
+    monotonic guard (durable row already ``success``), so the loser MUST report
+    the durable SUCCESS (not error) and MUST NOT leave the local flow in error.
+    """
+
+    from aiohttp.test_utils import make_mocked_request
+
+    holder: dict[str, str] = {}
+
+    async def fake_callback_server_start(self) -> None:
+        return None
+
+    async def fake_oauth_route():
+        return None
+
+    async def fake_exchange_authorization_code(**_kwargs):
+        # The winner commits durable success DURING the loser's exchange (so the
+        # top-of-callback reconciliation gate saw ``pending`` and the loser
+        # actually reaches this exchange), then the loser's exchange of the
+        # now-consumed code fails.
+        async with SessionLocal() as session:
+            await OAuthFlowRepository(session, TokenEncryptor()).set_status(
+                holder["flow_id"], status="success", error_message=None
+            )
+        raise OAuthError("invalid_grant", "Authorization code expired", status_code=400)
+
+    monkeypatch.setattr(oauth_module.OAuthCallbackServer, "start", fake_callback_server_start)
+    monkeypatch.setattr(oauth_module, "_oauth_route", fake_oauth_route)
+    monkeypatch.setattr(oauth_module, "exchange_authorization_code", fake_exchange_authorization_code)
+
+    replica = _make_replica_service(oauth_module.OAuthStateStore())
+    start = await replica.start_oauth(oauth_module.OauthStartRequest(force_method="browser"))
+    assert start.flow_id is not None
+    holder["flow_id"] = start.flow_id
+    state_token = _oauth_state_token(start.authorization_url or "")
+
+    if path == "manual_callback":
+        manual = await replica.manual_callback(
+            f"http://localhost:1455/auth/callback?code=consumed-code&state={state_token}",
+            flow_id=start.flow_id,
+        )
+        assert manual.status == "success"
+    else:
+        request = make_mocked_request("GET", f"/auth/callback?code=consumed-code&state={state_token}")
+        response = await replica._handle_callback(request)
+        assert response.status == 200
+        assert response.text is not None and "Login failed" not in response.text
+
+    # The loser must not leave the local flow in error; it honors durable success.
+    async with replica._store.lock:
+        local = replica._store.get_flow_locked(start.flow_id)
+        assert local is not None and local.status == "success"
+    async with SessionLocal() as session:
+        record = await OAuthFlowRepository(session, TokenEncryptor()).get_by_flow_id(start.flow_id)
+    assert record is not None and record.status == "success"

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -1929,3 +1929,145 @@ async def test_complete_on_origin_replica_honors_durable_success_from_other_repl
     async with replica_a._store.lock:
         local = replica_a._store.get_flow_locked(start.flow_id)
         assert local is not None and local.status == "success"
+
+
+@pytest.mark.asyncio
+async def test_set_status_success_is_not_overwritten_by_later_error():
+    """Monotonic terminal write (repository.py): when a device flow is completed
+    twice (duplicate/losing poller), the poller that exchanged the code persists
+    ``success`` while the other later receives an OAuth error for the consumed
+    code. That stale error MUST NOT turn the durable row back to ``error``.
+    """
+
+    encryptor = TokenEncryptor()
+    async with SessionLocal() as session:
+        repo = oauth_module.OAuthFlowRepository(session, encryptor)
+        await repo.create(
+            oauth_module.OAuthFlowRecord(
+                flow_id="mono-flow",
+                method="device",
+                status="pending",
+                device_auth_id="dev-mono",
+                user_code="MONO-CODE",
+                interval_seconds=1,
+                expires_at=utcnow() + timedelta(hours=1),
+            )
+        )
+
+    async with SessionLocal() as session:
+        repo = oauth_module.OAuthFlowRepository(session, encryptor)
+        # Winning poller persists success.
+        assert await repo.set_status("mono-flow", status="success", error_message=None) is True
+        # Losing/duplicate poller's later error for the consumed code is rejected.
+        assert await repo.set_status("mono-flow", status="error", error_message="invalid_grant") is False
+        record = await repo.get_by_flow_id("mono-flow")
+        assert record is not None
+        assert record.status == "success"
+        assert record.error_message is None
+        # success -> success remains idempotent.
+        assert await repo.set_status("mono-flow", status="success", error_message=None) is True
+        # error -> success is still allowed (success may win over an earlier error).
+        await repo.create(
+            oauth_module.OAuthFlowRecord(
+                flow_id="err-then-ok",
+                method="device",
+                status="error",
+                error_message="transient",
+                expires_at=utcnow() + timedelta(hours=1),
+            )
+        )
+        assert await repo.set_status("err-then-ok", status="success", error_message=None) is True
+        healed = await repo.get_by_flow_id("err-then-ok")
+        assert healed is not None and healed.status == "success"
+
+
+@pytest.mark.asyncio
+async def test_set_status_success_is_atomic_across_concurrent_sessions():
+    """The monotonic guard MUST hold under real cross-session concurrency, not
+    only single-session Python logic. Two pollers (separate DB sessions) both
+    read the row while it is ``pending`` (the TOCTOU window); the winning poller
+    commits ``success`` first, then the losing poller tries to write ``error``
+    for the now-consumed device code. A client-side read-then-write guard would
+    still see its stale ``pending`` snapshot and clobber the success; the SQL
+    conditional UPDATE rejects it atomically.
+    """
+
+    encryptor = TokenEncryptor()
+    async with SessionLocal() as seed_session:
+        await oauth_module.OAuthFlowRepository(seed_session, encryptor).create(
+            oauth_module.OAuthFlowRecord(
+                flow_id="race-flow",
+                method="device",
+                status="pending",
+                device_auth_id="dev-race",
+                user_code="RACE-CODE",
+                interval_seconds=1,
+                expires_at=utcnow() + timedelta(hours=1),
+            )
+        )
+
+    async with SessionLocal() as session_win, SessionLocal() as session_lose:
+        repo_win = oauth_module.OAuthFlowRepository(session_win, encryptor)
+        repo_lose = oauth_module.OAuthFlowRepository(session_lose, encryptor)
+
+        # Losing poller loads the still-``pending`` row into its own session and
+        # keeps that transaction/snapshot open — the TOCTOU window where both
+        # transactions have observed ``pending``. A client-side read-then-write
+        # guard would re-use this cached ``pending`` snapshot on its own status
+        # write and wrongly conclude the downgrade is allowed.
+        preloaded = await session_lose.get(OAuthFlowState, "race-flow")
+        assert preloaded is not None and preloaded.status == "pending"
+
+        # Winning poller exchanges the code and commits ``success`` first.
+        assert await repo_win.set_status("race-flow", status="success", error_message=None) is True
+
+        # Losing poller now gets an OAuth error for the consumed code while still
+        # holding its stale ``pending`` snapshot. The atomic conditional UPDATE
+        # re-checks the current row state in SQL and refuses to downgrade the
+        # committed ``success``; a client-side guard would clobber it.
+        applied = await repo_lose.set_status("race-flow", status="error", error_message="invalid_grant")
+        assert applied is False
+
+    async with SessionLocal() as verify_session:
+        record = await oauth_module.OAuthFlowRepository(verify_session, encryptor).get_by_flow_id("race-flow")
+        assert record is not None
+        assert record.status == "success"
+        assert record.error_message is None
+
+
+@pytest.mark.asyncio
+async def test_device_complete_ack_stays_pending_when_own_poller_already_succeeded():
+    """Device same-replica ``/complete`` contract: the fire-and-forget
+    acknowledgement (no ``flow_id``) must report ``pending`` even when this
+    flow's own in-process poller has already raced to ``success`` (the DB/store
+    already shows success). This deterministically reproduces the CI race where
+    the instant device-token exchange completed before ``/complete`` was read,
+    and must NOT spawn a second poll of the consumed device code.
+    """
+
+    await oauth_module._OAUTH_STORE.reset()
+    async with SessionLocal() as session:
+        service = oauth_module.OauthService(AccountsRepository(session))
+
+        async with oauth_module._OAUTH_STORE.lock:
+            flow = oauth_module.OAuthState(
+                flow_id="device-raced",
+                status="pending",
+                method="device",
+                device_auth_id="dev-raced",
+                user_code="RACED-CODE",
+                interval_seconds=1,
+                expires_at=time.time() + 30,
+            )
+            oauth_module._OAUTH_STORE.remember_flow_locked(flow)
+            # The flow's own poller has already written success.
+            oauth_module._OAUTH_STORE.set_flow_status_locked(flow, status="success", error_message=None)
+
+        response = await service.complete_oauth(oauth_module.OauthCompleteRequest())
+        assert response.status == "pending"
+
+        async with oauth_module._OAUTH_STORE.lock:
+            done = oauth_module._OAUTH_STORE.get_flow_locked("device-raced")
+            assert done is not None
+            # No second poller was started for the already-consumed device code.
+            assert done.poll_task is None

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -28,6 +28,18 @@ from app.modules.oauth.schemas import ManualCallbackRequest
 pytestmark = pytest.mark.integration
 
 
+@pytest.fixture(autouse=True)
+def _oauth_flow_schema(db_setup):
+    """Ensure the shared schema (incl. ``oauth_flow_states``) exists.
+
+    Every OAuth service path now persists flow state to the shared DB, so the
+    service-level tests that construct ``OauthService`` directly need the table
+    present, not only the ``async_client`` ones.
+    """
+
+    del db_setup
+
+
 def _encode_jwt(payload: dict) -> str:
     raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     body = base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
@@ -1694,3 +1706,114 @@ async def test_manual_callback_idempotent_success_requires_requested_flow(async_
     second_status = await async_client.get("/api/oauth/status", params={"flowId": second_payload["flowId"]})
     assert second_status.status_code == 200
     assert second_status.json() == {"status": "pending", "errorMessage": None}
+
+
+def _make_replica_service(store: "oauth_module.OAuthStateStore") -> oauth_module.OauthService:
+    """Build an OauthService bound to a distinct process-local store, standing in
+    for one replica behind a load balancer. All replicas share the one test DB."""
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _repo_factory():
+        async with SessionLocal() as session:
+            yield AccountsRepository(session)
+
+    return oauth_module.OauthService(
+        cast(AccountsRepository, SimpleNamespace(list_accounts=AsyncMock(return_value=[]))),
+        repo_factory=_repo_factory,
+        store=store,
+    )
+
+
+@pytest.mark.asyncio
+async def test_browser_oauth_flow_completes_on_replica_that_did_not_start_it(monkeypatch):
+    """Multi-replica regression: replica A starts a browser flow; the manually
+    pasted callback lands on replica B, whose in-memory store never saw the flow.
+
+    Before this change the flow record lived only in replica A's process-local
+    ``_OAUTH_STORE``, so replica B reported "state mismatch" and the account was
+    never added. Now B loads the encrypted verifier + metadata from the shared
+    DB and completes the exchange.
+    """
+
+    async def fake_callback_server_start(self) -> None:
+        return None
+
+    email = "cross-replica@example.com"
+    raw_account_id = "acc_cross_replica"
+
+    async def fake_exchange_authorization_code(**_):
+        payload = {
+            "email": email,
+            "chatgpt_account_id": raw_account_id,
+            "https://api.openai.com/auth": {"chatgpt_plan_type": "plus"},
+        }
+        return OAuthTokens(
+            access_token="cross-access",
+            refresh_token="cross-refresh",
+            id_token=_encode_jwt(payload),
+        )
+
+    async def fake_oauth_route():
+        return None
+
+    monkeypatch.setattr(oauth_module.OAuthCallbackServer, "start", fake_callback_server_start)
+    monkeypatch.setattr(oauth_module, "exchange_authorization_code", fake_exchange_authorization_code)
+    monkeypatch.setattr(oauth_module, "_oauth_route", fake_oauth_route)
+
+    replica_a = _make_replica_service(oauth_module.OAuthStateStore())
+    replica_b = _make_replica_service(oauth_module.OAuthStateStore())
+
+    start = await replica_a.start_oauth(oauth_module.OauthStartRequest(force_method="browser"))
+    assert start.method == "browser"
+    assert start.flow_id is not None
+    state_token = _oauth_state_token(start.authorization_url or "")
+
+    # Replica B never held this flow in memory.
+    async with replica_b._store.lock:
+        assert replica_b._store.get_flow_by_state_token_locked(state_token) is None
+
+    result = await replica_b.manual_callback(
+        f"http://localhost:1455/auth/callback?code=cross-code&state={state_token}",
+        flow_id=start.flow_id,
+    )
+    assert result.status == "success"
+
+    expected_account_id = generate_unique_account_id(raw_account_id, email)
+    async with SessionLocal() as session:
+        stored = await AccountsRepository(session).get_by_id(expected_account_id)
+    assert stored is not None
+
+    # Replica A, still holding a stale in-memory pending flow, must report the
+    # authoritative success written by replica B to the shared DB.
+    status_a = await replica_a.oauth_status(start.flow_id)
+    assert status_a.status == "success"
+
+
+@pytest.mark.asyncio
+async def test_oauth_status_reads_completion_written_by_another_replica(monkeypatch):
+    """A flow started on replica A and marked success in the shared DB by another
+    replica is reported as success by A's status poll, not its stale pending."""
+
+    async def fake_callback_server_start(self) -> None:
+        return None
+
+    monkeypatch.setattr(oauth_module.OAuthCallbackServer, "start", fake_callback_server_start)
+
+    replica_a = _make_replica_service(oauth_module.OAuthStateStore())
+    start = await replica_a.start_oauth(oauth_module.OauthStartRequest(force_method="browser"))
+    assert start.flow_id is not None
+
+    # Replica A's in-memory view is still pending.
+    async with replica_a._store.lock:
+        local = replica_a._store.get_flow_locked(start.flow_id)
+        assert local is not None and local.status == "pending"
+
+    # Another replica writes the terminal status directly to the shared DB.
+    async with SessionLocal() as session:
+        repo = oauth_module.OAuthFlowRepository(session, TokenEncryptor())
+        assert await repo.set_status(start.flow_id, status="success", error_message=None)
+
+    status = await replica_a.oauth_status(start.flow_id)
+    assert status.status == "success"

--- a/tests/integration/test_oauth_flow.py
+++ b/tests/integration/test_oauth_flow.py
@@ -2433,3 +2433,200 @@ async def test_browser_callback_replay_on_origin_does_not_reexchange_consumed_co
     assert response.text is not None and "Login failed" not in response.text
 
     assert exchange_calls == []
+
+
+@pytest.mark.asyncio
+async def test_overlapping_same_replica_device_starts_later_start_wins_slot_and_poller(monkeypatch):
+    """Finding 1: two device starts overlap on the SAME replica; the earlier
+    start is superseded in the local store while awaiting its durable persist. It
+    must NOT install a stale slot pointer or a poll task; the later start ends up
+    as the current slot holder and the sole poller.
+    """
+
+    async def fake_device_code(**_):
+        return DeviceCode(
+            verification_url="https://auth.openai.com/codex/device",
+            user_code="OVERLAP-CODE",
+            device_auth_id="dev-overlap",
+            interval_seconds=30,
+            expires_in_seconds=300,
+        )
+
+    async def fake_exchange_device_token(**_):
+        await asyncio.Event().wait()  # never completes; keep pollers pending
+
+    async def fake_oauth_route():
+        return None
+
+    monkeypatch.setattr(oauth_module, "request_device_code", fake_device_code)
+    monkeypatch.setattr(oauth_module, "exchange_device_token", fake_exchange_device_token)
+    monkeypatch.setattr(oauth_module, "_oauth_route", fake_oauth_route)
+
+    replica = _make_replica_service(oauth_module.OAuthStateStore())
+
+    # Gate the FIRST start's durable persist so a second start can supersede it
+    # while it is parked mid-persist (after it registered locally, before it
+    # claims the slot / starts its poller).
+    original_persist = replica._persist_flow_record
+    persist_first_reached = asyncio.Event()
+    release_first_persist = asyncio.Event()
+    calls = {"n": 0}
+
+    async def gated_persist(record):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            persist_first_reached.set()
+            await release_first_persist.wait()
+        await original_persist(record)
+
+    monkeypatch.setattr(replica, "_persist_flow_record", gated_persist)
+
+    first_task = asyncio.create_task(replica.start_oauth(oauth_module.OauthStartRequest(force_method="device")))
+    await asyncio.wait_for(persist_first_reached.wait(), timeout=2)
+
+    # Second start runs to completion: it supersedes the first locally, claims the
+    # slot, and starts its poller.
+    second = await replica.start_oauth(oauth_module.OauthStartRequest(force_method="device"))
+
+    # Release the first start; it resumes past its persist and must detect it was
+    # superseded (no stale claim, no poll task).
+    release_first_persist.set()
+    first = await asyncio.wait_for(first_task, timeout=2)
+
+    assert first.flow_id is not None and second.flow_id is not None and first.flow_id != second.flow_id
+
+    async with SessionLocal() as session:
+        current = await OAuthFlowRepository(session, TokenEncryptor()).current_device_slot_flow_id()
+    assert current == second.flow_id  # the later start holds the slot
+
+    async with replica._store.lock:
+        second_flow = replica._store.get_flow_locked(second.flow_id)
+        first_flow = replica._store.get_flow_locked(first.flow_id)
+        assert second_flow is not None and second_flow.poll_task is not None  # sole poller
+        # The superseded first start neither remains current nor holds a poller.
+        assert first_flow is None or first_flow.poll_task is None
+        second_task = second_flow.poll_task
+
+    if second_task is not None:
+        second_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await second_task
+
+
+@pytest.mark.asyncio
+async def test_loser_device_poller_writes_no_terminal_during_winner_persist(monkeypatch):
+    """Finding 2: only the slot holder may write a terminal status. A loser poller
+    that received ``invalid_grant`` for the consumed code (while the winner is
+    mid-persist, slot already consumed, success not yet written) MUST write NO
+    terminal (no pending->error), so the dashboard keeps polling and the winner's
+    later success is the durable outcome.
+    """
+
+    async def fake_oauth_route():
+        return None
+
+    monkeypatch.setattr(oauth_module, "_oauth_route", fake_oauth_route)
+
+    encryptor = TokenEncryptor()
+    async with SessionLocal() as session:
+        await OAuthFlowRepository(session, encryptor).create(
+            oauth_module.OAuthFlowRecord(
+                flow_id="race-terminal",
+                method="device",
+                status="pending",
+                device_auth_id="dev-rt",
+                user_code="RT-CODE",
+                interval_seconds=0,
+                expires_at=utcnow() + timedelta(hours=1),
+            )
+        )
+
+    service = _make_replica_service(oauth_module.OAuthStateStore())
+    await service._claim_device_slot("race-terminal")
+
+    # Winner consumes the slot (it is now mid-persist, success not yet written).
+    assert await service._consume_device_slot("race-terminal") is True
+
+    # Loser poll task: its exchange raises invalid_grant for the consumed code.
+    async def fake_exchange_device_token(**_):
+        raise OAuthError("invalid_grant", "Authorization code expired", status_code=400)
+
+    monkeypatch.setattr(oauth_module, "exchange_device_token", fake_exchange_device_token)
+    loser_context = oauth_module.DevicePollContext(
+        device_auth_id="dev-rt",
+        user_code="RT-CODE",
+        interval_seconds=0,
+        expires_at=time.time() + 300,
+    )
+    await service._poll_device_tokens("race-terminal", loser_context)
+
+    # The loser wrote NO terminal status; the flow is still pending.
+    async with SessionLocal() as session:
+        record = await OAuthFlowRepository(session, encryptor).get_by_flow_id("race-terminal")
+    assert record is not None and record.status == "pending"
+
+    # The winner's success (written after its persist) is the durable outcome.
+    await service._set_success("race-terminal")
+    async with SessionLocal() as session:
+        record = await OAuthFlowRepository(session, encryptor).get_by_flow_id("race-terminal")
+    assert record is not None and record.status == "success"
+
+
+@pytest.mark.asyncio
+async def test_non_originating_complete_reports_durable_status_without_second_poller(monkeypatch):
+    """Reduced duplicate-poller surface: a device ``/complete`` served on a
+    replica that did NOT originate the flow reports the durable status and does
+    NOT spawn a second poll task for the single-use device code.
+    """
+
+    async def fake_device_code(**_):
+        return DeviceCode(
+            verification_url="https://auth.openai.com/codex/device",
+            user_code="ORIG-CODE",
+            device_auth_id="dev-orig",
+            interval_seconds=30,
+            expires_in_seconds=300,
+        )
+
+    async def fake_exchange_device_token(**_):
+        await asyncio.Event().wait()
+
+    async def fake_oauth_route():
+        return None
+
+    monkeypatch.setattr(oauth_module, "request_device_code", fake_device_code)
+    monkeypatch.setattr(oauth_module, "exchange_device_token", fake_exchange_device_token)
+    monkeypatch.setattr(oauth_module, "_oauth_route", fake_oauth_route)
+
+    origin = _make_replica_service(oauth_module.OAuthStateStore())
+    other = _make_replica_service(oauth_module.OAuthStateStore())
+
+    start = await origin.start_oauth(oauth_module.OauthStartRequest(force_method="device"))
+    assert start.flow_id is not None
+
+    # The non-originating replica reports the durable pending status ...
+    resp = await other.complete_oauth(oauth_module.OauthCompleteRequest(flow_id=start.flow_id))
+    assert resp.status == "pending"
+
+    # ... and did NOT start a second poll task for the flow.
+    async with other._store.lock:
+        other_flow = other._store.get_flow_locked(start.flow_id)
+    assert other_flow is None or other_flow.poll_task is None
+
+    # Cross-replica durable terminal is still reported by /complete on the other
+    # replica once written.
+    async with SessionLocal() as session:
+        assert await OAuthFlowRepository(session, TokenEncryptor()).set_status(
+            start.flow_id, status="success", error_message=None
+        )
+    resp2 = await other.complete_oauth(oauth_module.OauthCompleteRequest(flow_id=start.flow_id))
+    assert resp2.status == "success"
+
+    # Clean up the origin's sole poll task.
+    async with origin._store.lock:
+        origin_flow = origin._store.get_flow_locked(start.flow_id)
+        task = origin_flow.poll_task if origin_flow is not None else None
+    if task is not None:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task


### PR DESCRIPTION
## Why

The dashboard OAuth add-account / reauth flow kept its per-flow state (PKCE `code_verifier`, `state` token, device-code poll metadata, status) in a **process-local in-memory dict** (`_OAUTH_STORE` in `app/modules/oauth/service.py`). With N replicas behind a load balancer, the browser callback, the manually pasted callback URL, or the device-code status poll can land on a different replica than the one that started the flow. That replica has no verifier/state, so the authorization-code exchange fails ("state mismatch") and status polls report `pending` forever even after another replica succeeded. Adding/re-authenticating an account was therefore intermittently broken on every multi-replica deployment.

## What Changes

- New `oauth_flow_states` table (Alembic migration on the current head `20260713_040000_add_account_refresh_claims`; upgrade + downgrade; dialect-agnostic DDL for SQLite & PostgreSQL) keyed by `flow_id`, storing the **encrypted** PKCE verifier, `state` token, method, status, device-code metadata, intended account id, and timestamps.
- Every flow is persisted to the shared DB at creation and status transitions (success/error) are written durably, so any replica can complete a flow it did not start.
- Flow lookups (by `flow_id` and by `state` token) and the authoritative status are read from the shared DB on the callback, manual-callback, device-complete, and status paths, hydrating the process-local runtime as needed. `oauth_status` is now DB-authoritative, fixing the stale-`pending` bug on the originating replica.
- PKCE verifier is encrypted at rest with the existing `TokenEncryptor` (same Fernet key as account tokens).
- Abandoned pending flows expire via a short TTL: expired pending flows are treated as absent on read and purged (plus retained terminal rows bounded) opportunistically on write.
- The inherently process-local runtime (localhost callback server, in-process device poll task) stays local, keyed by `flow_id`.

OpenSpec change: `openspec/changes/persist-oauth-flow-state` (adds a `replica-operations` requirement + `design.md` with the SQLite-vs-PostgreSQL behavior and rejected alternatives).

## Testing

All run in the worktree with `uv run`:

- `uv run ruff check app tests` — pass
- `uv run ruff format --check app tests` — pass (754 files)
- `uv run ty check` — pass
- `uv run openspec validate persist-oauth-flow-state --strict` — valid
- `uv run openspec validate --specs` — 43 passed, 0 failed
- `uv run pytest tests/integration/test_oauth_flow.py tests/integration/test_migrations.py tests/unit/test_oauth_client.py tests/unit/test_oauth_proxy_route.py tests/unit/test_db_migrate.py` — **107 passed, 3 skipped** (PostgreSQL-only migration tests)

New regression tests (in `tests/integration/`):
- `test_browser_oauth_flow_completes_on_replica_that_did_not_start_it` — replica A starts a browser flow; the pasted callback is completed on replica B (fresh in-memory store) over the shared DB; account is persisted and replica A's status reflects success.
- `test_oauth_status_reads_completion_written_by_another_replica` — a success written to the shared DB by another replica is reported by the originator's status poll.
- `test_oauth_flow_states_migration_upgrade_and_downgrade` — SQLite upgrade/downgrade round-trip + single-head walk to `head`.

Both cross-replica tests were confirmed to **fail against the pre-change behavior**: with DB hydration and DB-authoritative status neutralized (simulating the old process-local store), replica B returns `error` ("state mismatch") and the originator's status stays `pending`.

Deferred follow-up from the multi-replica reliability effort (post #1252–#1264).

🤖 Generated with [Claude Code](https://claude.com/claude-code)