### PR TITLE
chore: release v1.21.1-beta.1

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.21.0"  # x-release-please-version
+__version__ = "1.21.1-beta.1"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.21.0
-appVersion: 1.21.0
+version: 1.21.1-beta.1
+appVersion: 1.21.1-beta.1
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.21.0",
+  "version": "1.21.1-beta.1",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.21.0"
+version = "1.21.1-beta.1"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.21.0"
+version = "1.21.1-beta.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.21.1-beta.1 for the 1.21.1 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.21.1-beta.1 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1330; no manual beta workflow dispatch is required.

## Changes since v1.21.0
- fix(balancer): decorrelate round-robin tie-breaking across replicas (#1327) (fd529b2)
- fix(observability): anchor TTFT to the attempt, expose queue wait as a dashboard trend (#1333) (
f79f09)
- fix(proxy): settle API-key reservation before budget-exhausted compact preflight raises (#1332) (
fe625b)
- fix(proxy): reject unsupported multi-worker-per-instance for shared per-account caps (#1328) (
2e1040)
- feat(dashboard): group advanced navigation and settings behind progressive disclosure (#1339) (
0c2283)

## Release-candidate validation
Validated candidate: 5a11c6ab13c66d938741d07a4b924f8fbcc52d72

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [ ] Backend/unit/integration gates
- [ ] Frontend tests/build
- [ ] Wheel/package validation
- [ ] Docker/container smoke
- [ ] Live upstream/account smoke
- [ ] Live upstream/account smoke not required

## Install after publish
```bash
uvx --from "codex-lb==1.21.1b1" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.21.1-beta.1
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.21.1-beta.1 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.21.1.
