### PR TITLE
fix(proxy): settle compact reservations on budget timeout

### DIFF
--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -887,6 +887,15 @@ class _CompactMixin:
                 if remaining_budget <= 0:
                     logger.warning("Compact request budget exhausted before freshness check request_id=%s", request_id)
                     await proxy._load_balancer.release_account_lease(selected_account_response_create_lease)
+                    # Forwarded compact requests do not own their reservation at
+                    # the caller, and this terminal bypasses the retry-loop
+                    # settlement handlers. Release the held quota before raising.
+                    await proxy._settle_compact_api_key_usage(
+                        api_key=api_key,
+                        api_key_reservation=api_key_reservation,
+                        response=None,
+                        request_service_tier=request_service_tier,
+                    )
                     _raise_proxy_budget_exhausted()
                 freshness_budget = _compact_freshness_budget_seconds(remaining_budget)
                 if freshness_budget <= 0:
@@ -897,6 +906,12 @@ class _CompactMixin:
                         remaining_budget,
                     )
                     await proxy._load_balancer.release_account_lease(selected_account_response_create_lease)
+                    await proxy._settle_compact_api_key_usage(
+                        api_key=api_key,
+                        api_key_reservation=api_key_reservation,
+                        response=None,
+                        request_service_tier=request_service_tier,
+                    )
                     _raise_proxy_budget_exhausted()
                 try:
                     logger.info(
@@ -1042,6 +1057,12 @@ class _CompactMixin:
                         account.id,
                     )
                     await proxy._load_balancer.release_account_lease(selected_account_response_create_lease)
+                    await proxy._settle_compact_api_key_usage(
+                        api_key=api_key,
+                        api_key_reservation=api_key_reservation,
+                        response=None,
+                        request_service_tier=request_service_tier,
+                    )
                     _raise_proxy_budget_exhausted()
                 request_service_tier = _service_tier_from_compact_payload(payload)
 
@@ -1105,6 +1126,12 @@ class _CompactMixin:
                                         "account_id=%s",
                                         request_id,
                                         account.id,
+                                    )
+                                    await proxy._settle_compact_api_key_usage(
+                                        api_key=api_key,
+                                        api_key_reservation=api_key_reservation,
+                                        response=None,
+                                        request_service_tier=request_service_tier,
                                     )
                                     _raise_proxy_budget_exhausted()
                                 account = await proxy._ensure_fresh_with_budget(

--- a/openspec/changes/settle-budget-exhausted-compact-preflight/.openspec.yaml
+++ b/openspec/changes/settle-budget-exhausted-compact-preflight/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/settle-budget-exhausted-compact-preflight/context.md
+++ b/openspec/changes/settle-budget-exhausted-compact-preflight/context.md
@@ -1,0 +1,25 @@
+# Compact Preflight Reservation Context
+
+## Purpose and Scope
+
+This change closes one reservation-lifecycle gap in forwarded compact requests. It does not change compact retry policy, timeout budgets, API-key limit calculation, or stale-reservation cleanup.
+
+## Ownership Constraint
+
+The HTTP bridge reserves API-key quota before forwarding and passes the reservation into the stream path as an override. That caller reports `owns_reservation = false`; during compact handling, `compact_responses` is therefore the only component that can settle the reservation before returning control.
+
+## Failure Mode
+
+If the compact request budget expires before or immediately after account freshness work, `_raise_proxy_budget_exhausted()` raises `502 upstream_request_timeout`. The outer `ProxyResponseError` handler only records failure metadata, and the finalizer only writes the request log. Without an explicit settlement at the terminal exit, the reservation remains `reserved` and continues contributing to API-key limits.
+
+## Decision and Alternative
+
+The fix settles immediately before each leaking terminal raise. A broad outer `finally` cleanup was considered, but compact success, retry, and upstream-attempt paths already have distinct finalize/release behavior; unconditional cleanup there risks double settlement or releasing usage that should be finalized. The narrow terminal-site fix preserves those ownership boundaries.
+
+## Concrete Example
+
+An HTTP-bridge request reserves an 8,192-token input budget and a 2,048-token output budget, then exhausts its proxy budget during compact freshness preflight. The client still receives the normal 502 timeout. With this change, the unused reservation is released before that response, so a subsequent request is evaluated against actual usage rather than the abandoned 10,240-token hold.
+
+## Operational Note
+
+No migration or rollout sequencing is required. Existing stale-reservation cleanup remains a safety net, but it is no longer the normal recovery path for these exits.

--- a/openspec/changes/settle-budget-exhausted-compact-preflight/design.md
+++ b/openspec/changes/settle-budget-exhausted-compact-preflight/design.md
@@ -1,0 +1,51 @@
+## Context
+
+The HTTP bridge reserves API-key quota before forwarding a Responses request. When that request enters compact handling, the forwarded reservation is passed as an override and the caller does not own settlement; `compact_responses` must finalize successful usage or release the reservation on every terminal failure.
+
+Four compact budget checks currently escape before any existing settlement branch: before freshness, when no freshness reserve remains, after freshness, and before a post-401 forced refresh. Their `ProxyResponseError` reaches an outer handler that only records metadata and a `finally` that only writes the request log.
+
+Inner `_call_compact` budget checks are structurally different: the enclosing retry-loop error handler already settles `upstream_request_timeout` before re-raising.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Release the forwarded API-key reservation at every leaking compact preflight budget terminal.
+- Preserve the existing account-lease and external error contracts.
+- Prove settlement occurs exactly once on both newly fixed preflight exits and already-covered inner exits.
+
+**Non-Goals:**
+
+- Changing compact timeout values, retry eligibility, or account selection.
+- Changing API-key quota calculation or stale-reservation cleanup.
+- Broadly refactoring compact settlement ownership.
+
+## Decisions
+
+### Settle at each terminal ownership boundary
+
+Each leaking branch will call `_settle_compact_api_key_usage` with `response=None` immediately before `_raise_proxy_budget_exhausted()`. The existing account-lease release remains in its current order.
+
+An unconditional outer cleanup was rejected because success, retry, and upstream-attempt paths already settle with different outcomes; a broad finalizer would obscure ownership and could double-settle or release usage that must be finalized.
+
+### Do not modify inner upstream-call budget exits
+
+The inner `_call_compact` timeout is caught by the retry-loop `ProxyResponseError` handler, which already settles account-neutral `upstream_request_timeout` failures. Adding settlement at the inner raise would perform the lifecycle transition twice.
+
+### Keep the public response unchanged
+
+After settlement, each fixed branch still raises the same `502 upstream_request_timeout` error. The change affects only reservation state.
+
+## Risks / Trade-offs
+
+- **Risk: duplicate settlement** → Keep inner `_call_compact` terminals unchanged and add an exactly-once regression.
+- **Risk: one terminal remains uncovered** → Enumerate all four escaping checks in the delta spec and exercise representative outer and inner control-flow paths in tests.
+- **Risk: the database release fails** → Reuse `_settle_compact_api_key_usage`, which logs and contains settlement errors so the original timeout still surfaces; stale-reservation cleanup remains the fallback for the unreleased hold.
+
+## Migration Plan
+
+No migration is required. Deploy as a normal application patch. Rollback restores the previous behavior but may reintroduce abandoned reservations until the six-hour stale cleanup threshold is reached.
+
+## Open Questions
+
+None.

--- a/openspec/changes/settle-budget-exhausted-compact-preflight/proposal.md
+++ b/openspec/changes/settle-budget-exhausted-compact-preflight/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Forwarded compact requests can exhaust their request budget after reserving API-key quota but before calling upstream. Several compact preflight exits raise the existing timeout error without settling that reservation, so later requests can be rejected by phantom usage until stale-reservation cleanup runs.
+
+## What Changes
+
+- Settle any held API-key usage reservation before each compact preflight budget-exhaustion error that otherwise escapes without cleanup.
+- Preserve the existing account-lease release and `502 upstream_request_timeout` response contract.
+- Keep inner upstream-call budget exits unchanged because their enclosing handler already settles the reservation.
+- Add route-level regression coverage for cleanup and exactly-once settlement.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `api-keys`: Extend the compact reservation-cleanup invariant to forwarded preflight budget-exhaustion terminals.
+
+## Impact
+
+- Affected code: `app/modules/proxy/_service/compact.py`
+- Affected tests: `tests/integration/test_proxy_compact.py`
+- External API behavior: no status, error-code, or payload change
+- Persistence impact: abandoned API-key reservations are released immediately instead of remaining charged until stale cleanup

--- a/openspec/changes/settle-budget-exhausted-compact-preflight/specs/api-keys/spec.md
+++ b/openspec/changes/settle-budget-exhausted-compact-preflight/specs/api-keys/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Compact preflight budget exhaustion settles forwarded API-key reservations
+
+When a compact request holds a forwarded API-key usage reservation and a budget-exhaustion check will terminate `compact_responses` without reaching an existing settlement handler, the system MUST settle the reservation with no response usage before raising the budget-exhausted error. This requirement MUST cover exhaustion before freshness evaluation, when no freshness-check reserve remains, after freshness evaluation, and before a post-401 forced-refresh attempt. Existing account-lease release behavior and the external `502 upstream_request_timeout` response MUST remain unchanged.
+
+Budget-exhaustion errors raised inside `_call_compact` MUST continue to be settled only by their enclosing retry-loop error handler, so a reservation is settled exactly once.
+
+#### Scenario: Forwarded compact preflight exhausts its budget
+
+- **GIVEN** a forwarded compact request holds an unsettled API-key usage reservation
+- **WHEN** a compact preflight budget check terminates the request before an upstream compact call
+- **THEN** the system releases the held reservation before raising the error
+- **AND** the client receives the existing `502 upstream_request_timeout` response
+
+#### Scenario: Post-401 forced-refresh preflight exhausts its budget
+
+- **GIVEN** a forwarded compact request holds an unsettled API-key usage reservation
+- **AND** its upstream compact attempt returns `401`
+- **WHEN** the remaining request budget is exhausted before forced refresh
+- **THEN** the system releases the held reservation before raising the budget-exhausted error
+- **AND** the client receives the existing `502 upstream_request_timeout` response
+
+#### Scenario: Inner compact-call budget exhaustion is settled exactly once
+
+- **GIVEN** a compact request reaches an inner `_call_compact` budget check
+- **WHEN** that check raises `upstream_request_timeout`
+- **THEN** the enclosing retry-loop error handler settles the reservation exactly once
+- **AND** the inner budget terminal does not perform an additional settlement

--- a/openspec/changes/settle-budget-exhausted-compact-preflight/tasks.md
+++ b/openspec/changes/settle-budget-exhausted-compact-preflight/tasks.md
@@ -1,0 +1,21 @@
+## 1. OpenSpec Contract
+
+- [x] 1.1 Validate the proposal, design, context, and `api-keys` delta strictly.
+
+## 2. Compact Reservation Settlement
+
+- [x] 2.1 Settle the held API-key reservation before the pre-freshness and no-freshness-reserve budget terminals.
+- [x] 2.2 Settle the held API-key reservation before the post-freshness budget terminal.
+- [x] 2.3 Settle the held API-key reservation before the post-401 forced-refresh budget terminal.
+- [x] 2.4 Preserve the inner `_call_compact` settlement path without adding a second settlement.
+
+## 3. Regression Coverage
+
+- [x] 3.1 Add route-level coverage proving preflight budget exhaustion settles before returning the unchanged 502 error.
+- [x] 3.2 Add focused coverage proving inner compact-call budget exhaustion settles exactly once.
+
+## 4. Validation
+
+- [x] 4.1 Run focused compact and API-key reservation tests.
+- [x] 4.2 Run Ruff formatting/checks, type and architecture checks, strict change validation, and main-spec validation.
+- [x] 4.3 Verify implementation completeness, correctness, and coherence against the change artifacts.

--- a/openspec/changes/settle-budget-exhausted-compact-preflight/verify-report.md
+++ b/openspec/changes/settle-budget-exhausted-compact-preflight/verify-report.md
@@ -1,0 +1,44 @@
+# Verification Report: settle-budget-exhausted-compact-preflight
+
+## Summary
+
+| Dimension | Status |
+| --- | --- |
+| Completeness | 10/10 tasks; 1/1 requirement implemented |
+| Correctness | 3/3 scenarios covered |
+| Coherence | Design and existing compact settlement patterns followed |
+
+## Completeness
+
+- All four budget-exhaustion terminals that bypass existing settlement handlers now release the API-key reservation before raising.
+- Inner `_call_compact` budget terminals remain unchanged and are guarded by an exactly-once regression.
+- Route-level tests cover all four fixed branches.
+- A database-backed service test proves the reservation becomes `released`, quota returns to baseline, and an immediate next reservation succeeds.
+
+## Correctness
+
+- The fixed branches preserve the existing `502 upstream_request_timeout` error.
+- Existing account-lease releases remain before the terminal error.
+- Settlement uses `response=None`, selecting reservation release rather than usage finalization.
+- The post-401 case does not perform forced refresh after the budget has expired.
+
+## Coherence
+
+- The implementation uses the same explicit settle-before-raise pattern as neighboring compact terminal branches.
+- The delta is attached to the `api-keys` capability, which owns the reservation lifecycle contract.
+- No schema, migration, dependency, or public API changes were introduced.
+
+## Validation
+
+- Related pytest suite: 30 passed.
+- Focused post-type-fix regression recheck: 6 passed.
+- Ruff check: passed.
+- Ruff format check: passed for 752 files.
+- Ty type check: passed.
+- Proxy architecture check: passed.
+- Strict change validation: passed.
+- Main OpenSpec validation: 43 passed, 0 failed.
+
+## Issues
+
+No critical issues, warnings, or suggestions within this change's scope. Ready for archive after review.

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -16,11 +16,12 @@ from app.core.auth import generate_unique_account_id
 from app.core.clients.proxy import ProxyResponseError
 from app.core.errors import openai_error
 from app.core.openai.models import CompactResponsePayload, OpenAIResponsePayload
+from app.core.openai.requests import ResponsesCompactRequest
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus
 from app.db.session import SessionLocal
 from app.modules.api_keys.repository import ApiKeysRepository
-from app.modules.api_keys.service import ApiKeyCreateData, ApiKeysService
+from app.modules.api_keys.service import ApiKeyCreateData, ApiKeysService, LimitRuleInput
 from app.modules.proxy.rate_limit_cache import get_rate_limit_headers_cache
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
 
@@ -1048,6 +1049,146 @@ async def test_proxy_compact_preflight_permanent_refresh_settles_reservation(asy
         await async_client.post("/backend-api/codex/responses/compact", json=payload)
 
     settle_compact_usage.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("terminal", "remaining_budgets", "zero_freshness_budget", "expected_freshness_calls", "expected_upstream_calls"),
+    [
+        pytest.param("before_freshness", (0.0,), False, 0, 0, id="before-freshness"),
+        pytest.param("before_freshness_reserve", (10.0,), True, 0, 0, id="before-freshness-reserve"),
+        pytest.param("after_freshness", (10.0, 0.0), False, 1, 0, id="after-freshness"),
+        pytest.param("before_forced_refresh", (10.0, 10.0, 10.0, 10.0, 0.0), False, 1, 1, id="post-401"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_proxy_compact_budget_exhausted_preflight_settles_reservation(
+    async_client,
+    monkeypatch,
+    terminal,
+    remaining_budgets,
+    zero_freshness_budget,
+    expected_freshness_calls,
+    expected_upstream_calls,
+):
+    """Every budget terminal that bypasses the retry-loop handlers settles
+    before preserving the public ``502 upstream_request_timeout`` contract."""
+    import app.modules.proxy._service.compact as compact_module
+
+    email = f"compact-budget-{terminal}@example.com"
+    raw_account_id = f"acc_compact_budget_{terminal}"
+    auth_json = _make_auth_json(raw_account_id, email)
+    response = await async_client.post(
+        "/api/accounts/import",
+        files={"auth_json": ("auth.json", json.dumps(auth_json), "application/json")},
+    )
+    assert response.status_code == 200
+
+    budget_values = iter(remaining_budgets)
+    monkeypatch.setattr(compact_module, "_remaining_budget_seconds", lambda _deadline: next(budget_values))
+    if zero_freshness_budget:
+        monkeypatch.setattr(compact_module, "_compact_freshness_budget_seconds", lambda _remaining: 0.0)
+
+    freshness_calls: list[bool] = []
+
+    async def fake_ensure_fresh(self, account, *, force: bool = False, timeout_seconds=None):
+        del self, timeout_seconds
+        freshness_calls.append(force)
+        return account
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh)
+
+    upstream_compact = AsyncMock()
+    if terminal == "before_forced_refresh":
+        upstream_compact.side_effect = ProxyResponseError(
+            401,
+            openai_error("invalid_api_key", "token expired", error_type="authentication_error"),
+        )
+    monkeypatch.setattr(proxy_module, "core_compact_responses", upstream_compact)
+
+    settle_compact_usage = AsyncMock()
+    monkeypatch.setattr(proxy_module.ProxyService, "_settle_compact_api_key_usage", settle_compact_usage)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": []}
+    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
+
+    assert response.status_code == 502
+    assert response.json()["error"]["code"] == "upstream_request_timeout"
+    settle_compact_usage.assert_awaited_once()
+    settle_call = settle_compact_usage.await_args
+    assert settle_call is not None
+    assert settle_call.kwargs["response"] is None
+    assert freshness_calls == [False] * expected_freshness_calls
+    assert upstream_compact.await_count == expected_upstream_calls
+    assert list(budget_values) == []
+
+
+@pytest.mark.asyncio
+async def test_compact_service_budget_exhaustion_releases_forwarded_reservation(
+    async_client,
+    app_instance,
+    monkeypatch,
+):
+    """A service-owned forwarded reservation is released in the database, so
+    the same API key can reserve its quota again immediately instead of 429ing."""
+    import app.modules.proxy._service.compact as compact_module
+    from app.dependencies import get_proxy_service_for_app
+
+    auth_json = _make_auth_json(
+        "acc_compact_forwarded_reservation",
+        "compact-forwarded-reservation@example.com",
+    )
+    response = await async_client.post(
+        "/api/accounts/import",
+        files={"auth_json": ("auth.json", json.dumps(auth_json), "application/json")},
+    )
+    assert response.status_code == 200
+
+    async with SessionLocal() as session:
+        api_keys = ApiKeysService(ApiKeysRepository(session))
+        created = await api_keys.create_key(
+            ApiKeyCreateData(
+                name="compact-forwarded-reservation",
+                allowed_models=None,
+                limits=[
+                    LimitRuleInput(
+                        limit_type="total_tokens",
+                        limit_window="weekly",
+                        max_value=100,
+                    )
+                ],
+            )
+        )
+        api_key = await api_keys.get_key_by_id(created.id)
+        reservation = await api_keys.enforce_limits_for_request(created.id, request_model="gpt-5.1")
+
+    proxy_service = get_proxy_service_for_app(app_instance)
+    monkeypatch.setattr(compact_module, "_remaining_budget_seconds", lambda _deadline: 0.0)
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await proxy_service.compact_responses(
+            payload,
+            {"session_id": "sid-compact-forwarded-reservation"},
+            api_key=api_key,
+            api_key_reservation=reservation,
+        )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.payload["error"]["code"] == "upstream_request_timeout"
+
+    async with SessionLocal() as session:
+        api_keys_repo = ApiKeysRepository(session)
+        released = await api_keys_repo.get_usage_reservation(reservation.reservation_id)
+        limits = await api_keys_repo.get_limits_by_key(created.id)
+        assert released is not None
+        assert released.status == "released"
+        assert len(limits) == 1
+        assert limits[0].current_value == 0
+
+        api_keys = ApiKeysService(api_keys_repo)
+        next_reservation = await api_keys.enforce_limits_for_request(created.id, request_model="gpt-5.1")
+        assert next_reservation.reservation_id != reservation.reservation_id
+        await api_keys.release_usage_reservation(next_reservation.reservation_id)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -24300,6 +24300,48 @@ async def test_compact_responses_budget_exhaustion_returns_request_timeout(monke
 
 
 @pytest.mark.asyncio
+async def test_compact_responses_inner_budget_exhaustion_settles_once(monkeypatch):
+    """The inner upstream-call budget terminal is already settled by its
+    enclosing retry handler and must not gain a second terminal-site settle."""
+    settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_compact_inner_budget")
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+
+    remaining_budgets = iter((10.0, 10.0, 0.0))
+    monkeypatch.setattr(
+        proxy_compact_service,
+        "_remaining_budget_seconds",
+        lambda _deadline: next(remaining_budgets),
+    )
+    settle_compact_usage = AsyncMock()
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", settle_compact_usage)
+    upstream_compact = AsyncMock()
+    monkeypatch.setattr(proxy_service, "core_compact_responses", upstream_compact)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.compact_responses(payload, {"session_id": "sid-compact-inner-budget"})
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 502
+    assert _proxy_error_code(exc) == "upstream_request_timeout"
+    settle_compact_usage.assert_awaited_once()
+    upstream_compact.assert_not_awaited()
+    assert list(remaining_budgets) == []
+
+
+@pytest.mark.asyncio
 async def test_compact_responses_refresh_connection_reset_fails_over(monkeypatch):
     settings = _make_proxy_settings(log_proxy_service_tier_trace=False)
     request_logs = _RequestLogsRecorder()


### PR DESCRIPTION
## Summary

  Release API-key usage reservations before every compact preflight budget-exhaustion terminal that bypasses existing settlement handlers.

  This prevents abandoned quota holds from causing later local `429 rate_limit_exceeded` responses for otherwise valid requests.
  The existing `502 upstream_request_timeout` response remains unchanged.

  ## Type of change

  - [x] `fix:` — bug fix (no behavior change beyond the bug)
  - [ ] `feat:` — new user-facing feature or capability
  - [ ] `refactor:` — internal refactor (no behavior change, no API change)
  - [ ] `docs:` — documentation only
  - [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
  - [ ] `test:` — test-only change
  - [ ] **Breaking change**

  Linked issue: None. Related PR: #1332.

  ## OpenSpec

  - [x] This PR includes / updates an OpenSpec change
  - [ ] Not applicable — bug fix that matches the existing spec
  - [ ] Not applicable — docs / CI / chore only
  - [x] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

  Change directory: `openspec/changes/settle-budget-exhausted-compact-preflight/`

  ## Changes

  - Settle held API-key reservations before all four leaking compact budget terminals:
  - before freshness evaluation;
  - when no freshness-check reserve remains;
  - after freshness evaluation;
  - before post-401 forced refresh.
  - Preserve existing account-lease cleanup and the public `502 upstream_request_timeout` contract.
  - Leave inner `_call_compact` budget terminals unchanged because their enclosing retry handler already settles the reservation.
  - Add parameterized route coverage for all four terminal paths.
  - Add a database-backed regression proving:
  - the reservation becomes `released`;
  - reserved quota returns to baseline;
  - an immediate subsequent reservation succeeds instead of returning 429.
  - Add exactly-once coverage for inner compact-call settlement.
  - Record the behavior under the `api-keys` OpenSpec capability.

  ## Test plan

  ```bash
  uv run pytest \
    tests/integration/test_proxy_compact.py \
    tests/integration/test_api_keys_api.py::test_compact_unexpected_exception_releases_reservation \
    tests/unit/test_proxy_utils.py::test_compact_responses_budget_exhaustion_returns_request_timeout \
    tests/unit/test_proxy_utils.py::test_compact_responses_inner_budget_exhaustion_settles_once \
    -q
  # 30 passed

  uv run ruff check \
    app/modules/proxy/_service/compact.py \
    tests/integration/test_proxy_compact.py \
    tests/unit/test_proxy_utils.py

  uv run ruff format --check \
    app/modules/proxy/_service/compact.py \
    tests/integration/test_proxy_compact.py \
    tests/unit/test_proxy_utils.py

  uv run ty check
  .venv/bin/python scripts/check_proxy_architecture.py
  openspec validate settle-budget-exhausted-compact-preflight --strict
  openspec validate --specs
  # 43 specs passed
  ```

  ## Behavioral proof

  Before this fix:

  1. Compact preflight reserved API-key quota.
  2. Its request budget expired.
  3. The request returned `502 upstream_request_timeout`.
  4. The reservation remained charged.
  5. A later request could receive a local 429 until stale cleanup ran.

  After this fix, the same 502 is returned only after the unused reservation is released.

  ## Checklist

  - [x] Title is in Conventional Commits format.
  - [x] Related PR #1332 is linked above; no standalone issue was identified.
  - [x] Added tests covering all four fixed terminals and real reservation state.
  - [x] Ran the relevant local test, lint, format, type, and architecture checks.
  - [x] `openspec validate --specs` passes and verification is clean.
  - [x] CHANGELOG was not edited by hand.
