### PR TITLE
docs(contributing): codify simplicity principles and merge gates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -261,9 +261,11 @@ every PR (budget checks are enforced by CI as of the
    The PR body answers "why can't this be a hardcoded default?" for
    each new setting; internals-only knobs stay out of `.env.example`.
 3. **README, `.env.example`, and dashboard nav are budgeted.** The
-   caps live in `.github/simplicity-budgets.toml`; exceeding one
-   requires the maintainer-applied `simplicity-budget-approved` label
-   before merge.
+   caps live in `.github/simplicity-budgets.toml` (introduced by the
+   `ci-simplicity-budgets` change; until that manifest exists on
+   `main`, reviewers judge growth of these surfaces directionally
+   rather than against numeric caps). Exceeding a cap requires the
+   maintainer-applied `simplicity-budget-approved` label before merge.
 4. **Feature docs go to `docs/` + OpenSpec, never new README
    sections.** Each spec-governed docs page links back to its
    `openspec/specs/<capability>/` entry.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -240,6 +240,35 @@ Before a PR is squash-merged into `main`:
 5. **`Fixes #N` / `Closes #N` in the PR body** for anything that
    resolves an issue, so the issue close stays automatic and the merge
    stays traceable. Use `Refs #N` / `Related to #N` for partial cover.
+6. **Simplicity gates must pass** (see
+   [Simplicity gates](#simplicity-gates)): the five simplicity rules
+   (PRINCIPLES.md P1-P5). Budget exceptions need the
+   maintainer-applied `simplicity-budget-approved` label.
+
+### Simplicity gates
+
+These implement [PRINCIPLES.md](../PRINCIPLES.md); the normative spec is
+`openspec/specs/contribution-simplicity/spec.md` (created when the
+codify-simplicity-principles change is archived). Reviewers apply them to
+every PR (budget checks are enforced by CI as of the
+`ci-simplicity-budgets` change; reviewer-enforced before that):
+
+1. **New features default to off or zero-config.** No new required
+   setup step (env var, migration action, external account, manual
+   file edit) on the base install path without maintainer approval via
+   the `simplicity-budget-approved` label.
+2. **Every new `CODEX_LB_*` setting justifies not being a default.**
+   The PR body answers "why can't this be a hardcoded default?" for
+   each new setting; internals-only knobs stay out of `.env.example`.
+3. **README, `.env.example`, and dashboard nav are budgeted.** The
+   caps live in `.github/simplicity-budgets.toml`; exceeding one
+   requires the maintainer-applied `simplicity-budget-approved` label
+   before merge.
+4. **Feature docs go to `docs/` + OpenSpec, never new README
+   sections.** Each spec-governed docs page links back to its
+   `openspec/specs/<capability>/` entry.
+5. **Dashboard-visible PRs include before/after screenshots** (or a
+   short recording) in the PR body.
 
 ### Collaborator rules
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -49,6 +49,16 @@ Change directory: <!-- openspec/changes/<change>/ -->
 -
 -
 
+## Simplicity
+
+<!-- See PRINCIPLES.md. Delete this section if the PR adds no setting, no README
+     section, no dashboard nav item, and changes no default. -->
+
+- [ ] New feature defaults to **off** or works with **zero config**
+- [ ] No new required setup step (or maintainer approval via `simplicity-budget-approved` label)
+- New setting(s) and why each can't be a default: <!-- name → justification -->
+- [ ] README sections / `.env.example` / dashboard nav within budget (or `simplicity-budget-approved` label requested)
+
 ## Test plan
 
 <!--
@@ -61,9 +71,11 @@ Required: unit tests for new logic, integration tests for new endpoints.
 # uv run pytest tests/integration/test_<area>.py -q
 ```
 
-## Screenshots / output (optional)
+## Screenshots / output
 
-<!-- For dashboard / UI changes: before/after screenshots. For proxy behavior: example request + response, or a log excerpt. -->
+<!-- REQUIRED for dashboard-visible changes: before/after screenshots (or a short
+     recording). For proxy behavior: example request + response, or a log excerpt.
+     Delete only if this PR has no user-visible surface. -->
 
 ## Checklist
 
@@ -72,4 +84,5 @@ Required: unit tests for new logic, integration tests for new endpoints.
 - [ ] Added or updated tests covering the change.
 - [ ] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
 - [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
+- [ ] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
 - [ ] CHANGELOG is **not** edited by hand (release-please handles it).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ This repo uses **OpenSpec as the primary workflow and SSOT** for change-driven d
 
 ## Documentation & Release Notes
 
-- **Do not add/update feature or behavior documentation under `docs/`**. Use OpenSpec context docs under `openspec/specs/<capability>/context.md` (or change-level context under `openspec/changes/<change>/context.md`) as the SSOT.
+- **OpenSpec is the SSOT for feature/behavior documentation.** User-facing rendering lives under `docs/` (the published docs pages), and each spec-governed page MUST link back to the owning `openspec/specs/<capability>/` entry. Do not create `docs/` content that has no OpenSpec counterpart, and do not add feature docs as new README sections. Keep normative requirements in `openspec/specs/<capability>/spec.md` and free-form rationale in the capability's `context.md` (or change-level context under `openspec/changes/<change>/context.md`).
 - **Do not edit `CHANGELOG.md` directly.** Leave changelog updates to the release process; record change notes in OpenSpec artifacts instead.
 
 ### Documentation Model (Spec + Context)
@@ -69,7 +69,9 @@ an AI assistant most often needs are:
 - [Merge gates](.github/CONTRIBUTING.md#merge-gates) — CI green +
   `@codex review` clean (or findings addressed) + `mergeable=CLEAN` +
   OpenSpec change folder for behavior changes + `Fixes #N` /
-  `Closes #N` for issue cover.
+  `Closes #N` for issue cover + the five simplicity rules
+  (PRINCIPLES.md P1-P5; see
+  [Simplicity gates](.github/CONTRIBUTING.md#simplicity-gates)).
 - [Collaborator rules](.github/CONTRIBUTING.md#collaborator-rules) —
   no self-merge by default; large PRs get split (≈1-concern per PR,
   ~800 net lines / scoped capability ceiling).
@@ -128,3 +130,12 @@ These rules encode recurring review blockers observed across codex-lb PRs.
   behavior, external error envelopes, env-var semantics, and response-schema
   contracts. Update OpenSpec/context and tests together so docs cannot promise
   behavior the code does not implement.
+- Simplicity gates are a merge gate (`PRINCIPLES.md` +
+  [CONTRIBUTING.md Simplicity gates](.github/CONTRIBUTING.md#simplicity-gates)).
+  New features must default off or work zero-config; new `CODEX_LB_*` settings
+  need a why-not-a-default justification in the PR body; README top-level
+  sections, `.env.example`, and dashboard core-nav items are budgeted per
+  `.github/simplicity-budgets.toml` and exceptions need the maintainer-applied
+  `simplicity-budget-approved` label; feature documentation goes to `docs/` +
+  openspec (never new README sections); dashboard-visible PRs include
+  before/after screenshots.

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -1,0 +1,75 @@
+# codex-lb Founding Principles
+
+codex-lb exists to be a proxy you can run in one command, with a dashboard
+you can read in one glance. Every feature the project has gained since then
+is welcome — but none of them may tax the first five minutes of a new
+user's experience.
+
+These principles are normative. Reviewers apply them as merge gates (see
+[Simplicity gates](.github/CONTRIBUTING.md#simplicity-gates)); the
+machine-checkable spec is `openspec/specs/contribution-simplicity/spec.md`
+(created when the codify-simplicity-principles change is archived; until
+then the delta spec lives under
+`openspec/changes/codify-simplicity-principles/`) and this file is its
+human-readable rendering.
+
+## P1 — One-click setup is sacred
+
+- New features MUST default to **off**, or to a zero-config working default.
+- A PR MUST NOT add a new required setup step (env var, migration action,
+  external account, manual file edit) to the base install path. If a change
+  genuinely cannot avoid one, it needs explicit maintainer approval recorded
+  on the PR via the `simplicity-budget-approved` label.
+- `docker run` / `uvx codex-lb` with no env file MUST keep producing a
+  working proxy and dashboard.
+
+## P2 — Every new setting must justify not being a default
+
+- A PR that adds a `CODEX_LB_*` setting or an `.env.example` line MUST
+  answer "why can't this be a hardcoded default?" in the PR body (the PR
+  template has a slot for it).
+- Settings that only tune internals SHOULD stay out of `.env.example`.
+  The documented-by-default configuration surface is budgeted (see P3).
+
+## P3 — README and dashboard surface are budgeted
+
+- README top-level sections, the `.env.example` surface, and dashboard
+  core-nav items are capped. The concrete budget values live in
+  `.github/simplicity-budgets.toml` — that file, not this one, is where
+  numbers are set and changed.
+- Exceeding a budget requires the maintainer-applied
+  `simplicity-budget-approved` label on the PR before merge.
+- Raising a budget value itself is a change to this contract and gets the
+  same label plus an OpenSpec change.
+
+## P4 — Features are documented in the docs site + OpenSpec, not the README
+
+- New feature documentation goes to `docs/` (the user-facing rendering)
+  and MUST link back to the owning `openspec/specs/<capability>/` entry,
+  which stays the source of truth.
+- A new README section is a budget exception under P3, not a documentation
+  mechanism. The README exists to get a new user from zero to a running
+  proxy — everything else belongs in the docs site.
+
+## P5 — Dashboard-visible changes show their pixels
+
+- Any PR that changes what the dashboard renders MUST include before/after
+  screenshots (or a short screen recording) in the PR body.
+- "It's a small CSS tweak" is not an exemption; small tweaks make small
+  screenshots.
+
+## Applying these principles
+
+| Principle | What the reviewer checks | Where the gate lives |
+|-----------|--------------------------|----------------------|
+| P1 defaults-off | New feature works untouched with zero config; no new required setup step | CONTRIBUTING [Simplicity gates](.github/CONTRIBUTING.md#simplicity-gates); PR template "Simplicity" |
+| P2 settings justified | PR body names each new setting and why it can't be a default | PR template "Simplicity" |
+| P3 budgets | README sections, `.env.example`, dashboard core nav within `.github/simplicity-budgets.toml` | CI budget check (CI-enforced as of the `ci-simplicity-budgets` change; reviewer-enforced before that); `simplicity-budget-approved` label for exceptions |
+| P4 docs placement | Feature docs land in `docs/` + OpenSpec, not new README sections | CONTRIBUTING [Simplicity gates](.github/CONTRIBUTING.md#simplicity-gates) |
+| P5 screenshots | Before/after screenshots for dashboard-visible changes | PR template "Screenshots / output" |
+
+Rationale, the erosion metrics that motivated codifying these rules, and a
+worked example live in
+`openspec/specs/contribution-simplicity/context.md` (change-level context
+until the change is archived:
+`openspec/changes/codify-simplicity-principles/context.md`).

--- a/openspec/changes/codify-simplicity-principles/context.md
+++ b/openspec/changes/codify-simplicity-principles/context.md
@@ -1,0 +1,47 @@
+# Context: codify-simplicity-principles
+
+## Purpose
+
+codex-lb's original value proposition was "run one command, get a load-balancing proxy and a dashboard you can read in one glance." Nothing in the contribution process defended that proposition: every merge gate checked correctness (CI, codex review, OpenSpec coverage) and none checked whether the default experience got heavier. This change codifies five principles (P1–P5 in `PRINCIPLES.md`) as reviewable merge gates so simplicity regressions are blocked the same way broken tests are.
+
+## Erosion metrics (snapshot 2026-07-15, main @ fd529b21)
+
+| Surface | Measured | Note |
+|---------|----------|------|
+| `README.md` | 652 lines | Single-page docs for every feature; new-user path buried mid-file |
+| `Settings.model_fields` (`app/core/config/settings.py`) | 164 fields | Each individually reasonable; collectively an un-navigable config surface |
+| `.env.example` | 115 lines | Includes values that drift from code defaults |
+| Dashboard feature modules (`frontend/src/features/`) | 14 modules | All compete for primary navigation space |
+| Dashboard primary nav (`NAV_ITEMS`, `app-header.tsx`) | 6 items | No distinction between core and advanced destinations |
+
+None of these numbers were decided; they accreted. The principles do not roll them back by themselves — the follow-up changes do (`docs-site` diets the README and `.env.example`, `dashboard-progressive-disclosure` splits core from advanced nav) — but they stop the counters from silently climbing again.
+
+## Decisions
+
+- **One override label: `simplicity-budget-approved`.** A single, colon-free, space-free name is safe in `gh` CLI quoting and CI label JSON, and every document (PRINCIPLES, CONTRIBUTING, PR template, CLAUDE.md, the CI check) references the same string. Rejected: a namespaced variant containing a colon and space (quoting hazards, and a second name for the same gate).
+- **No budget numbers in PRINCIPLES.md.** Concrete caps live only in `.github/simplicity-budgets.toml` (added by `ci-simplicity-budgets`) so prose and enforcement cannot drift. PRINCIPLES.md references the file by path.
+- **New capability rather than extending an existing one.** `release-management`, `github-automation`, and `deployment-installation` each own adjacent machinery, but none owns the contribution/review contract. The CI enforcement delta (`ci-simplicity-budgets`) lands under `github-automation` and references this capability.
+- **Documentation rule amended, not inverted.** OpenSpec stays the normative SSOT. What changes: user-facing rendering now lives under `docs/`, and each spec-governed page must link back to its `openspec/specs/<capability>/` entry. README sections stop being a documentation target.
+- **Gate text stays truthful before CI enforcement exists.** The budgets requirement says "reviewer-enforced until `ci-simplicity-budgets` lands" so gate 6 is accurate in the window between this change and the CI change.
+
+## Constraints
+
+- The `simplicity-budget-approved` label must be created on GitHub by an operator (`gh label create simplicity-budget-approved ...`); repository labels are not versioned in-repo.
+- The PR template must not itself bloat: the Simplicity section is capped at four checkbox/prompt lines plus a delete-if-N/A comment.
+- `CLAUDE.md`'s amended documentation rule deliberately omits the docs-site URL — the site does not exist until the `docs-site` change deploys; that change adds the URL.
+
+## Failure modes
+
+- **Label drift**: if a second override label name ever appears, CI and reviewers enforce different gates. Mitigation: this context names the single label; a repo-wide grep for any other override-label spelling should return nothing.
+- **Budget drift**: numbers quoted in prose go stale. Mitigation: numbers exist only in `.github/simplicity-budgets.toml`.
+- **Gate fatigue**: contributors rubber-stamping the Simplicity checklist. Mitigation: the CI budget check makes the highest-traffic budgets (README/env/nav) machine-verified regardless of checkbox state.
+
+## Worked example (P2)
+
+A PR adds `CODEX_LB_FOO_TIMEOUT_SECONDS` to tune an upstream call. The PR body must answer "why can't this be a default?":
+
+> Acceptable: "Operators behind corporate proxies see 30–120s handshake times; no single default works for both LAN and proxied deployments. Default stays 8s; the setting is not added to `.env.example` because it only matters for proxied networks (documented in docs/troubleshooting.md, which links back to openspec/specs/upstream-proxying/)."
+>
+> Not acceptable: "Makes the timeout configurable." — that restates the diff. The reviewer blocks until the PR either justifies the knob or hardcodes a better default.
+
+If the same PR also added the setting to `.env.example`, it would count against the `env_example` budget in `.github/simplicity-budgets.toml`, and pushing that file over its cap would additionally require the `simplicity-budget-approved` label.

--- a/openspec/changes/codify-simplicity-principles/proposal.md
+++ b/openspec/changes/codify-simplicity-principles/proposal.md
@@ -1,0 +1,32 @@
+# Change: codify-simplicity-principles
+
+## Why
+
+codex-lb started as a one-command proxy with a glanceable dashboard, and the contribution process has no gate that protects that shape. The erosion is measurable: the README has grown to 652 lines, `Settings` exposes 164 fields, and the dashboard ships 14 feature modules competing for navigation space (snapshot 2026-07-15; see `context.md`). Each addition passed review individually because no principle said "the default experience is budgeted" — reviewers had nothing to point at.
+
+## What Changes
+
+- Add `PRINCIPLES.md` at the repo root: five normative, reviewer-checkable rules (P1 defaults-off/zero-config, P2 every new setting justifies not being a default, P3 budgeted README/config/dashboard surface, P4 feature docs go to docs/ + OpenSpec instead of new README sections, P5 screenshots for dashboard-visible PRs).
+- Add merge gate 6 ("Simplicity gates") and a `### Simplicity gates` subsection to `.github/CONTRIBUTING.md`.
+- Add a "Simplicity" section to `.github/PULL_REQUEST_TEMPLATE.md`, make the Screenshots section required for dashboard-visible changes, and add a simplicity line to the final checklist.
+- Amend `CLAUDE.md`: a simplicity-gates trapdoor bullet, an updated documentation rule (OpenSpec stays the SSOT; user-facing rendering lives under `docs/` and links back to the owning spec), and a merge-gates summary that includes the new gate.
+- Introduce the `simplicity-budget-approved` label as the single maintainer-applied override for budget exceptions (label creation on GitHub is an operator action; all documents reference this exact name).
+- Budget numbers are NOT set here: they live in `.github/simplicity-budgets.toml`, introduced by the CI enforcement change (`ci-simplicity-budgets`). Until that lands, the simplicity gates are reviewer-enforced.
+
+## Capabilities
+
+### New Capabilities
+
+- `contribution-simplicity`: the normative contract for keeping codex-lb's default experience simple — defaults-off features, justified settings, budgeted README/config/dashboard surface, docs-site documentation placement, and screenshot evidence for dashboard changes.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Code: none (documentation and process only).
+- Docs: `PRINCIPLES.md` (new), `.github/CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, `CLAUDE.md`.
+- Specs: new `openspec/specs/contribution-simplicity/spec.md` (via this change's delta).
+- Operator action: create the `simplicity-budget-approved` label on GitHub before the first budget exception is needed.
+- Follow-ups: `docs-site` (docs/ rendering + README diet), `ci-simplicity-budgets` (machine enforcement + `.github/simplicity-budgets.toml`), `dashboard-progressive-disclosure` (core vs advanced nav).

--- a/openspec/changes/codify-simplicity-principles/specs/contribution-simplicity/spec.md
+++ b/openspec/changes/codify-simplicity-principles/specs/contribution-simplicity/spec.md
@@ -1,0 +1,81 @@
+# contribution-simplicity
+
+## ADDED Requirements
+
+### Requirement: New features default to off or zero-config
+
+A PR that introduces a new feature MUST NOT add a required setup step (environment variable, migration action, external account, or manual file edit) to the base install path. The feature SHALL either default to off or work with a zero-config default, and `docker run` / `uvx codex-lb` without an env file SHALL continue to produce a working proxy and dashboard. A change that genuinely cannot avoid a new required setup step SHALL carry the maintainer-applied `simplicity-budget-approved` label before merge.
+
+#### Scenario: Feature ships with a working default
+
+- **WHEN** a PR introduces a new feature without any new required setup step
+- **THEN** the base install path (`docker run` / `uvx codex-lb` with no env file) still produces a working proxy and dashboard
+- **AND** the PR passes this gate without a label
+
+#### Scenario: Unavoidable setup step needs maintainer approval
+
+- **GIVEN** a PR whose feature cannot work without a new required setup step
+- **WHEN** the PR is evaluated for merge
+- **THEN** it is blocked until a maintainer applies the `simplicity-budget-approved` label
+
+### Requirement: New settings justify not being a default
+
+A PR that adds a `CODEX_LB_*` setting or an `.env.example` entry MUST include, in the PR body, a justification of why the value cannot be a hardcoded default. Settings that only tune internals SHOULD NOT be added to `.env.example`.
+
+#### Scenario: Setting added with justification
+
+- **WHEN** a PR adds a new `CODEX_LB_*` setting and its PR body names the setting with a why-not-a-default justification
+- **THEN** the PR passes this gate
+
+#### Scenario: Setting added without justification
+
+- **WHEN** a PR adds a new `CODEX_LB_*` setting or `.env.example` line and the PR body carries no justification for it
+- **THEN** the reviewer blocks the PR until the justification is added or the setting is replaced by a default
+
+### Requirement: README, configuration, and dashboard surface are budgeted
+
+README top-level sections, the `.env.example` surface, and dashboard core-navigation items SHALL be capped by the budget values defined in `.github/simplicity-budgets.toml` (introduced by the `ci-simplicity-budgets` change; reviewer-enforced until that lands). A PR that exceeds a budget SHALL be blocked from merge unless a maintainer applies the `simplicity-budget-approved` label. Raising a budget value SHALL itself require the label plus an OpenSpec change.
+
+#### Scenario: PR stays within budgets
+
+- **WHEN** a PR leaves README top-level sections, `.env.example`, and dashboard core-nav items within the budgets in `.github/simplicity-budgets.toml`
+- **THEN** the PR passes this gate with no label required
+
+#### Scenario: Budget exceeded without the override label
+
+- **WHEN** a PR pushes a budgeted surface over its cap and no `simplicity-budget-approved` label is present
+- **THEN** the PR is blocked from merge
+
+#### Scenario: Budget exceeded with maintainer approval
+
+- **GIVEN** a PR that exceeds a budget
+- **WHEN** a maintainer applies the `simplicity-budget-approved` label
+- **THEN** the PR may merge, and the exception is visible in the PR's label history
+
+### Requirement: Feature documentation lives in docs plus OpenSpec, not new README sections
+
+New feature or behavior documentation SHALL be added under `docs/` (the user-facing rendering) and MUST link back to the owning `openspec/specs/<capability>/` entry, which remains the source of truth. A PR SHALL NOT add a new README top-level section to document a feature; doing so is a budget exception under the budget requirement, not a documentation mechanism.
+
+#### Scenario: Feature documented in the docs site
+
+- **WHEN** a PR documents a new feature with a page under `docs/` that links back to the owning `openspec/specs/<capability>/` entry
+- **THEN** the PR passes this gate
+
+#### Scenario: Feature documented as a new README section
+
+- **WHEN** a PR adds a new README top-level section to document a feature
+- **THEN** the reviewer blocks the PR unless it carries the `simplicity-budget-approved` label, and the content is redirected to `docs/`
+
+### Requirement: Dashboard-visible changes include screenshots
+
+A PR that changes what the dashboard renders MUST include before/after screenshots (or a short screen recording) in the PR body before merge.
+
+#### Scenario: Dashboard change with screenshots
+
+- **WHEN** a PR alters dashboard rendering and its body contains before/after screenshots
+- **THEN** the PR passes this gate
+
+#### Scenario: Dashboard change without screenshots
+
+- **WHEN** a PR alters dashboard rendering and its body contains no screenshots or recording
+- **THEN** the reviewer blocks the PR until visual evidence is attached

--- a/openspec/changes/codify-simplicity-principles/tasks.md
+++ b/openspec/changes/codify-simplicity-principles/tasks.md
@@ -1,0 +1,8 @@
+# Tasks
+
+- [x] 1. Write `PRINCIPLES.md` at the repo root: preamble, P1–P5 as MUST-style reviewer-checkable rules, and an "Applying these principles" table; reference `.github/simplicity-budgets.toml` for budget values instead of hardcoding numbers.
+- [x] 2. Add merge gate 6 ("Simplicity gates must pass") to the numbered gate list in `.github/CONTRIBUTING.md` and insert a `### Simplicity gates` subsection between `### Merge gates` and `### Collaborator rules`, linking `../PRINCIPLES.md` and `openspec/specs/contribution-simplicity/spec.md`.
+- [x] 3. Update `.github/PULL_REQUEST_TEMPLATE.md`: add a `## Simplicity` section (checkboxes + delete-if-N/A comment), make `## Screenshots / output` explicitly REQUIRED for dashboard-visible changes, and add one simplicity item to the final checklist.
+- [x] 4. Update `CLAUDE.md`: append a simplicity-gates bullet to "PR Readiness / Review Trapdoors", amend the Documentation & Release Notes rule (OpenSpec SSOT + `docs/` rendering with spec backlinks, no feature docs as README sections), and extend the merge-gates summary bullet with the simplicity gate.
+- [x] 5. Author the `contribution-simplicity` spec delta (ADDED requirements mirroring P1–P5 with scenarios) and `context.md` (erosion metrics snapshot + worked example).
+- [x] 6. Validation: grep the diff for a single consistent label name (`simplicity-budget-approved`); `openspec validate codify-simplicity-principles --strict` and `openspec validate --specs`.


### PR DESCRIPTION
## Summary

Codifies the project's three founding principles (1-click setup, simple dashboard UX, short clean README) as five reviewer-checkable MUST rules in a new root-level `PRINCIPLES.md`, and wires them into the merge gates: CONTRIBUTING gains merge gate 6 + a "Simplicity gates" subsection, AGENTS.md gains a review trapdoor bullet and an amended docs-placement rule (user-facing rendering may live under `docs/`, OpenSpec stays the normative SSOT), and the PR template gains a compact Simplicity section with screenshots required for dashboard-visible changes.

Part 1/4 of the simplicity-effort stack (this PR → docs site #1337 → CI budgets #1338 → dashboard disclosure #1339). The `simplicity-budget-approved` label referenced by these documents has been created; concrete budget numbers deliberately live only in `.github/simplicity-budgets.toml` (introduced by the CI-budgets PR) so prose can never drift from enforcement.

## Type of change

- [x] `docs:` — documentation only

Linked issue: part of the simplicity effort (no single issue; see the tracking issue for the follow-up backlog).

## OpenSpec

`openspec/changes/codify-simplicity-principles/` — new capability `contribution-simplicity` (proposal, tasks, ADDED requirements with scenarios, context with the erosion-metrics snapshot: README 652 lines, 164 settings fields, 14 dashboard feature modules). `openspec validate codify-simplicity-principles --strict` and `openspec validate --specs` both pass.

## Notes for review

- `CLAUDE.md` is a symlink to `AGENTS.md`, so the edits land in `AGENTS.md`.
- The docs-rule amendment intentionally carries no site URL — the docs site lands in the next PR of the stack.
- Merge order: this PR is independent and can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
