### PR TITLE
ci(budgets): enforce simplicity budgets on README, env example, and core nav

### DIFF
--- a/.github/scripts/check_simplicity_budgets.py
+++ b/.github/scripts/check_simplicity_budgets.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Enforce simplicity budgets on README, .env.example, and the dashboard core nav.
+
+Budgets live in .github/simplicity-budgets.toml and are enforced by
+.github/workflows/simplicity-budgets.yml. Intentionally stdlib-only so it runs
+on the runner's python3 before project dependencies are installed.
+
+Override: the 'simplicity-budget-approved' PR label (passed in via the
+PR_LABELS env var as a JSON array of label names) downgrades violations to
+warning annotations and exits 0. push and merge_group events carry no PR
+labels, so main itself must always satisfy the budgets in-file.
+
+Exit codes: 0 = within budget (or overridden), 1 = over budget,
+2 = configuration error (the budget config is missing or malformed, a
+budgeted file or the nav array is missing, or an ALL-CONTRIBUTORS-LIST
+block is opened but never closed).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import tomllib
+from pathlib import Path
+from typing import NoReturn
+
+OVERRIDE_LABEL = "simplicity-budget-approved"
+CONFIG_PATH = Path(".github/simplicity-budgets.toml")
+CONTRIBUTORS_START = "<!-- ALL-CONTRIBUTORS-LIST:START"
+CONTRIBUTORS_END = "<!-- ALL-CONTRIBUTORS-LIST:END"
+# CommonMark code fences: ``` or ~~~ (3+ characters), indented up to 3 spaces.
+FENCE_RE = re.compile(r"^ {0,3}(?P<fence>```+|~~~+)")
+HEADING_RE = re.compile(r"^#{1,2}\s")
+
+CONFIG_ERROR_EXIT = 2
+
+OVERRIDE_HELP = (
+    f"To accept a temporary exceedance during review, a maintainer adds the '{OVERRIDE_LABEL}' "
+    "PR label — adding or removing the label starts a fresh check run that sees it. Do NOT "
+    "re-run this failed run after labeling: re-runs reuse the stale event payload and will not "
+    "see the new label. merge_group runs carry no PR labels, so any merge that leaves main over "
+    f"budget must raise the budget in {CONFIG_PATH} in the same diff."
+)
+
+
+def _config_error(message: str) -> NoReturn:
+    print(
+        f"::error::{message} — if the file was moved or the array renamed, update "
+        f"{CONFIG_PATH} in the same PR so the budget keeps applying; this check refuses "
+        "to pass silently when its target disappears."
+    )
+    sys.exit(CONFIG_ERROR_EXIT)
+
+
+def _read_lines(path: Path, section: str) -> list[str]:
+    if not path.is_file():
+        _config_error(f"[{section}] budgeted file '{path}' not found")
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+def strip_contributors_block(lines: list[str]) -> list[str]:
+    """Drop the generated all-contributors table (START..END marker lines inclusive)."""
+    kept: list[str] = []
+    in_block = False
+    for line in lines:
+        if not in_block and CONTRIBUTORS_START in line:
+            in_block = True
+            continue
+        if in_block:
+            if CONTRIBUTORS_END in line:
+                in_block = False
+            continue
+        kept.append(line)
+    if in_block:
+        _config_error(
+            f"[readme] '{CONTRIBUTORS_START}' marker has no matching '{CONTRIBUTORS_END}' marker; "
+            "an unclosed block would silently exclude the rest of the file from the budget"
+        )
+    return kept
+
+
+def count_top_level_headings(lines: list[str]) -> int:
+    """Count h1/h2 headings, ignoring lines inside fenced code blocks.
+
+    Fences may use ``` or ~~~ and be indented up to 3 spaces (CommonMark);
+    a fence is closed only by a fence line using the same character.
+    """
+    fence_char: str | None = None
+    count = 0
+    for line in lines:
+        fence = FENCE_RE.match(line)
+        if fence is not None:
+            char = fence.group("fence")[0]
+            if fence_char is None:
+                fence_char = char
+            elif char == fence_char:
+                fence_char = None
+            continue
+        if fence_char is None and HEADING_RE.match(line):
+            count += 1
+    return count
+
+
+def count_nav_items(path: Path, array: str) -> int:
+    """Count `to:` entries in the configured nav array; exit 2 loudly if it is missing."""
+    if not path.is_file():
+        _config_error(f"[core_nav] nav file '{path}' not found")
+    match = re.search(
+        rf"const\s+{re.escape(array)}[^=]*=\s*\[(?P<body>.*?)\]",
+        path.read_text(encoding="utf-8"),
+        re.DOTALL,
+    )
+    if match is None:
+        _config_error(f"[core_nav] array '{array}' not found in '{path}'")
+    return len(re.findall(r"\bto:\s*[\"']", match.group("body")))
+
+
+def _override_labels() -> list[str]:
+    raw = os.environ.get("PR_LABELS") or "[]"
+    try:
+        labels = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(labels, list):
+        return []
+    return [label for label in labels if isinstance(label, str)]
+
+
+def main() -> int:
+    try:
+        config = tomllib.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        _config_error(f"budget config '{CONFIG_PATH}' not found")
+    except tomllib.TOMLDecodeError as exc:
+        _config_error(f"budget config '{CONFIG_PATH}' is not valid TOML: {exc}")
+    overridden = OVERRIDE_LABEL in _override_labels()
+
+    readme_cfg = config["readme"]
+    readme_path = Path(readme_cfg["path"])
+    readme_lines = strip_contributors_block(_read_lines(readme_path, "readme"))
+
+    env_cfg = config["env_example"]
+    env_path = Path(env_cfg["path"])
+    env_lines = _read_lines(env_path, "env_example")
+
+    nav_cfg = config["core_nav"]
+    nav_path = Path(nav_cfg["path"])
+    nav_items = count_nav_items(nav_path, nav_cfg["array"])
+
+    metrics: list[tuple[str, Path, int, int]] = [
+        (
+            "README lines (all-contributors block excluded)",
+            readme_path,
+            len(readme_lines),
+            readme_cfg["max_lines"],
+        ),
+        (
+            "README top-level headings (h1+h2, fenced code excluded)",
+            readme_path,
+            count_top_level_headings(readme_lines),
+            readme_cfg["max_top_level_headings"],
+        ),
+        ("env example lines", env_path, len(env_lines), env_cfg["max_lines"]),
+        (f"core nav items ({nav_cfg['array']})", nav_path, nav_items, nav_cfg["max_items"]),
+    ]
+
+    violations: list[tuple[str, Path, int, int]] = []
+    for name, path, actual, budget in metrics:
+        status = "OK" if actual <= budget else "OVER"
+        print(f"{name}: {actual}/{budget} {status}")
+        if actual > budget:
+            violations.append((name, path, actual, budget))
+
+    if not violations:
+        return 0
+
+    annotation = "warning" if overridden else "error"
+    for name, path, actual, budget in violations:
+        print(f"::{annotation} file={path}::simplicity budget exceeded: {name}: {actual} > {budget}")
+
+    if overridden:
+        print(f"Budgets exceeded, but the '{OVERRIDE_LABEL}' label is applied; passing with warnings. {OVERRIDE_HELP}")
+        return 0
+
+    print(f"Simplicity budgets exceeded. {OVERRIDE_HELP}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_simplicity_budgets.py
+++ b/.github/scripts/check_simplicity_budgets.py
@@ -85,8 +85,9 @@ def count_top_level_headings(lines: list[str]) -> int:
     """Count h1/h2 headings, ignoring lines inside fenced code blocks.
 
     Fences may use ``` or ~~~ and be indented up to 3 spaces (CommonMark);
-    a fence is closed only by a fence line using the same character and at
-    least the same length (so a ``` line inside a ```` block is content).
+    a fence is closed only by a fence line using the same character, at
+    least the same length, and no info string (so a ``` line inside a
+    ```` block and a ```bash line inside a ``` block are both content).
     """
     fence_open: tuple[str, int] | None = None
     count = 0
@@ -95,9 +96,10 @@ def count_top_level_headings(lines: list[str]) -> int:
         if fence is not None:
             fence_str = fence.group("fence")
             char, length = fence_str[0], len(fence_str)
+            bare = line[fence.end() :].strip() == ""
             if fence_open is None:
                 fence_open = (char, length)
-            elif char == fence_open[0] and length >= fence_open[1]:
+            elif char == fence_open[0] and length >= fence_open[1] and bare:
                 fence_open = None
             continue
         if fence_open is None and HEADING_RE.match(line):

--- a/.github/scripts/check_simplicity_budgets.py
+++ b/.github/scripts/check_simplicity_budgets.py
@@ -112,8 +112,10 @@ def count_nav_items(path: Path, array: str) -> int:
     # Anchor on the closing `] as const` so nested arrays inside items
     # (e.g. a future `roles: ["admin"]`) cannot truncate the body early.
     # The nav source-of-truth array is required to stay `as const`.
+    # `(?!\w)` pins the exact identifier: a rename to e.g. NAV_ITEMS_V2
+    # must not satisfy a config that still says NAV_ITEMS.
     match = re.search(
-        rf"const\s+{re.escape(array)}[^=]*=\s*\[(?P<body>.*?)\]\s*as\s+const",
+        rf"const\s+{re.escape(array)}(?!\w)[^=]*=\s*\[(?P<body>.*?)\]\s*as\s+const",
         path.read_text(encoding="utf-8"),
         re.DOTALL,
     )
@@ -142,33 +144,40 @@ def main() -> int:
         _config_error(f"budget config '{CONFIG_PATH}' is not valid TOML: {exc}")
     overridden = OVERRIDE_LABEL in _override_labels()
 
-    readme_cfg = config["readme"]
-    readme_path = Path(readme_cfg["path"])
+    try:
+        readme_cfg = config["readme"]
+        readme_path = Path(readme_cfg["path"])
+        readme_max_lines = int(readme_cfg["max_lines"])
+        readme_max_headings = int(readme_cfg["max_top_level_headings"])
+        env_cfg = config["env_example"]
+        env_path = Path(env_cfg["path"])
+        env_max_lines = int(env_cfg["max_lines"])
+        nav_cfg = config["core_nav"]
+        nav_path = Path(nav_cfg["path"])
+        nav_array = str(nav_cfg["array"])
+        nav_max_items = int(nav_cfg["max_items"])
+    except (KeyError, TypeError, ValueError) as exc:
+        _config_error(f"budget config '{CONFIG_PATH}' is missing or has a malformed section/key: {exc!r}")
+
     readme_lines = strip_contributors_block(_read_lines(readme_path, "readme"))
-
-    env_cfg = config["env_example"]
-    env_path = Path(env_cfg["path"])
     env_lines = _read_lines(env_path, "env_example")
-
-    nav_cfg = config["core_nav"]
-    nav_path = Path(nav_cfg["path"])
-    nav_items = count_nav_items(nav_path, nav_cfg["array"])
+    nav_items = count_nav_items(nav_path, nav_array)
 
     metrics: list[tuple[str, Path, int, int]] = [
         (
             "README lines (all-contributors block excluded)",
             readme_path,
             len(readme_lines),
-            readme_cfg["max_lines"],
+            readme_max_lines,
         ),
         (
             "README top-level headings (h1+h2, fenced code excluded)",
             readme_path,
             count_top_level_headings(readme_lines),
-            readme_cfg["max_top_level_headings"],
+            readme_max_headings,
         ),
-        ("env example lines", env_path, len(env_lines), env_cfg["max_lines"]),
-        (f"core nav items ({nav_cfg['array']})", nav_path, nav_items, nav_cfg["max_items"]),
+        ("env example lines", env_path, len(env_lines), env_max_lines),
+        (f"core nav items ({nav_array})", nav_path, nav_items, nav_max_items),
     ]
 
     violations: list[tuple[str, Path, int, int]] = []

--- a/.github/scripts/check_simplicity_budgets.py
+++ b/.github/scripts/check_simplicity_budgets.py
@@ -85,20 +85,22 @@ def count_top_level_headings(lines: list[str]) -> int:
     """Count h1/h2 headings, ignoring lines inside fenced code blocks.
 
     Fences may use ``` or ~~~ and be indented up to 3 spaces (CommonMark);
-    a fence is closed only by a fence line using the same character.
+    a fence is closed only by a fence line using the same character and at
+    least the same length (so a ``` line inside a ```` block is content).
     """
-    fence_char: str | None = None
+    fence_open: tuple[str, int] | None = None
     count = 0
     for line in lines:
         fence = FENCE_RE.match(line)
         if fence is not None:
-            char = fence.group("fence")[0]
-            if fence_char is None:
-                fence_char = char
-            elif char == fence_char:
-                fence_char = None
+            fence_str = fence.group("fence")
+            char, length = fence_str[0], len(fence_str)
+            if fence_open is None:
+                fence_open = (char, length)
+            elif char == fence_open[0] and length >= fence_open[1]:
+                fence_open = None
             continue
-        if fence_char is None and HEADING_RE.match(line):
+        if fence_open is None and HEADING_RE.match(line):
             count += 1
     return count
 
@@ -107,8 +109,11 @@ def count_nav_items(path: Path, array: str) -> int:
     """Count `to:` entries in the configured nav array; exit 2 loudly if it is missing."""
     if not path.is_file():
         _config_error(f"[core_nav] nav file '{path}' not found")
+    # Anchor on the closing `] as const` so nested arrays inside items
+    # (e.g. a future `roles: ["admin"]`) cannot truncate the body early.
+    # The nav source-of-truth array is required to stay `as const`.
     match = re.search(
-        rf"const\s+{re.escape(array)}[^=]*=\s*\[(?P<body>.*?)\]",
+        rf"const\s+{re.escape(array)}[^=]*=\s*\[(?P<body>.*?)\]\s*as\s+const",
         path.read_text(encoding="utf-8"),
         re.DOTALL,
     )

--- a/.github/simplicity-budgets.toml
+++ b/.github/simplicity-budgets.toml
@@ -1,0 +1,28 @@
+# Simplicity budgets — enforced by .github/scripts/check_simplicity_budgets.py
+# (workflow: .github/workflows/simplicity-budgets.yml).
+#
+# Raising a number here is the intended escape hatch: a one-line, reviewable
+# diff. During review a maintainer can instead apply the
+# "simplicity-budget-approved" PR label to downgrade violations to warnings;
+# the label never applies to push/merge_group runs, so anything that leaves
+# main over budget must bump the number here in the same diff.
+
+[readme]
+path = "README.md"
+# Lines counted AFTER stripping the generated ALL-CONTRIBUTORS-LIST block
+# (bot-managed; not hand-written complexity).
+max_lines = 200
+# h1 + h2 only; lines inside fenced code blocks are excluded.
+max_top_level_headings = 10
+
+[env_example]
+path = ".env.example"
+max_lines = 60
+
+[core_nav]
+# Single source of truth for dashboard nav width. If the nav refactor moves or
+# renames this array, the checker exits 2 until path/array here are repointed —
+# that coupling is intentional.
+path = "frontend/src/components/layout/app-header.tsx"
+array = "NAV_ITEMS"
+max_items = 6

--- a/.github/workflows/simplicity-budgets.yml
+++ b/.github/workflows/simplicity-budgets.yml
@@ -1,0 +1,48 @@
+name: Simplicity budgets
+
+# Enforces .github/simplicity-budgets.toml via
+# .github/scripts/check_simplicity_budgets.py.
+#
+# This is deliberately a SEPARATE workflow from ci.yml, with different
+# pull_request trigger types: the simplicity-budget-approved override is read
+# from the event payload, and re-running a failed run reuses a stale payload —
+# only a fresh `labeled`/`unlabeled` event sees a just-applied label. Adding
+# those types to ci.yml instead would re-run the full CI matrix on every label
+# churn from codex-review-labels.yml (15-minute cron + workflow_run syncs of
+# the codex labels), which is why they live here on a seconds-long job.
+#
+# No `paths:` filter: the job is cheap, and a required check behind a paths
+# filter would leave non-matching PRs pending forever.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+  push:
+    branches: ["main"]
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  budgets:
+    name: Simplicity budgets
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      - name: Check simplicity budgets
+        env:
+          # Empty/null on push and merge_group; the override never applies
+          # there — main must always satisfy the budgets in-file.
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: python3 .github/scripts/check_simplicity_budgets.py

--- a/openspec/changes/ci-simplicity-budgets/context.md
+++ b/openspec/changes/ci-simplicity-budgets/context.md
@@ -1,0 +1,74 @@
+# Context: ci-simplicity-budgets
+
+## Purpose
+
+Make the simplicity effort self-enforcing. The `contribution-simplicity`
+principles (PR A) and the docs-site diet (PR B) shrink the entry-point
+documents; this change adds the mechanical gate that keeps them shrunk.
+Budgets live in data (`.github/simplicity-budgets.toml`) so every increase is
+a one-line, reviewable diff rather than an argument.
+
+## Decisions
+
+- **Separate workflow, never ci.yml.** The override label is read from the
+  event payload, so the workflow must trigger on `labeled`/`unlabeled` to see
+  a just-applied label. Adding those types to ci.yml would re-run the entire
+  sharded CI matrix on every `🤖 codex: ok` label sync from
+  `codex-review-labels.yml` (15-minute cron + `workflow_run`). The standalone
+  budget job costs seconds.
+- **No `paths:` filter.** The job is cheap, and a required check behind a
+  workflow-level paths filter would leave non-matching PRs pending forever
+  (ci.yml solves this with the dorny-filter placeholder pattern — overkill
+  here).
+- **Stdlib-only script, plain `python3`.** Matches the
+  `scripts/guard_beta_release.py` convention: runs before any dependency
+  install; `tomllib` is stdlib on the runner's Python 3.12.
+- **All-contributors block excluded from README counts.** The generated table
+  (~137 lines between the `ALL-CONTRIBUTORS-LIST:START/END` markers, which are
+  kept in README.md by design) is bot-managed, not hand-written complexity;
+  counting it would make the 200-line budget arithmetically impossible.
+- **Exit 2 on missing nav target.** The nav budget reads `NAV_ITEMS` from
+  `app-header.tsx` today. The planned progressive-disclosure refactor splits
+  core vs advanced nav; the checker refuses to pass silently when the
+  configured array vanishes, forcing that PR to repoint `[core_nav]` (array →
+  `CORE_NAV_ITEMS`) in its own diff. Intentional coupling, not an accident.
+  The same fail-loud exit 2 covers a missing or malformed
+  `.github/simplicity-budgets.toml` and an unclosed `ALL-CONTRIBUTORS-LIST`
+  block (whose tail would otherwise be silently excluded from the count).
+
+## Label caveats (operational)
+
+- **Stale payload on re-run.** The event payload is a snapshot from when the
+  event fired. Adding `simplicity-budget-approved` after a failed run and then
+  re-running that run does nothing — the re-run reuses the stale payload.
+  Applying or removing the label fires a fresh `labeled`/`unlabeled` event,
+  and that new run sees the current labels. The failure message says exactly
+  this.
+- **merge_group and push carry no labels.** The override is a review-time
+  acknowledgment only. If a PR would leave `main` over budget, the label
+  cannot save the merge queue or the post-merge push run: the budget number in
+  `.github/simplicity-budgets.toml` must be raised in the same diff.
+  Alternative considered and rejected: skipping the check on `merge_group`
+  would launder an over-budget `main` into green required checks.
+- **Label creation is out of band**: `gh label create simplicity-budget-approved`
+  once, by a maintainer. Applying it is a deliberate approval act; no
+  automation assigns it.
+
+## Rollout
+
+- Merge after the docs-site diet so the budgets pass on `main` from the first
+  run (verified: README 256 raw / ~119 counted vs 200; headings within 10;
+  `.env.example` 41 vs 60; nav 6 vs 6).
+- Add `Simplicity budgets` to the required-checks ruleset only after one green
+  run on `main` (GitHub cannot require a context that has never reported). It
+  does not join ci.yml's `ci-required` aggregate — cross-workflow `needs` is
+  impossible and the label triggers must stay out of ci.yml.
+
+## Non-goals / deferred
+
+- `README.zh-CN.md` is unbudgeted (banner-only treatment in the docs-site
+  change); a `[readme_zh]` section is a two-line follow-up if needed.
+- A settings-count budget for `app/core/config` would need the app import
+  graph (not stdlib-only) — deferred to the simplicity backlog.
+- Docs-site pages are intentionally unbudgeted: depth is supposed to move
+  there.

--- a/openspec/changes/ci-simplicity-budgets/proposal.md
+++ b/openspec/changes/ci-simplicity-budgets/proposal.md
@@ -1,0 +1,48 @@
+# Change: ci-simplicity-budgets
+
+## Why
+
+The simplicity effort (see the `contribution-simplicity` capability introduced
+by the `codify-simplicity-principles` change) restores the project's 1-click
+promise: a short README, a minimal `.env.example`, and a narrow dashboard core
+nav. Without a mechanical gate those documents regrow — the README had reached
+652 lines and `.env.example` 115 lines before the docs-site diet. A budget
+check in CI turns "keep it simple" from a review opinion into a cheap,
+deterministic merge gate whose escape hatch is itself a reviewable one-line
+diff.
+
+## What Changes
+
+- Add `.github/simplicity-budgets.toml`: budget numbers in data, not code —
+  README max lines (counted after stripping the generated all-contributors
+  block) and max top-level headings, `.env.example` max lines, and the
+  dashboard core-nav max item count with the nav file/array it is read from.
+- Add `.github/scripts/check_simplicity_budgets.py` (stdlib-only, runs on the
+  runner's `python3`): fence-aware heading counting, contributors-block
+  stripping, nav-array item counting that exits 2 loudly when the configured
+  file/array is missing (so nav refactors must repoint the TOML), and a
+  `simplicity-budget-approved` PR-label override that downgrades violations to
+  warning annotations.
+- Add `.github/workflows/simplicity-budgets.yml`: a separate seconds-long
+  workflow on `pull_request` (including `labeled`/`unlabeled` so applying the
+  override label starts a fresh run), `push` to `main`, and `merge_group`.
+  Kept out of `ci.yml` because label churn from the Codex label sync would
+  re-run the full CI matrix.
+- Add unit tests for the checker at `tests/unit/test_check_simplicity_budgets.py`.
+
+## Impact
+
+- Affected specs: `github-automation` (new simplicity-budget gate requirements)
+- Affected code: `.github/simplicity-budgets.toml`,
+  `.github/scripts/check_simplicity_budgets.py`,
+  `.github/workflows/simplicity-budgets.yml`,
+  `tests/unit/test_check_simplicity_budgets.py`
+- Operator actions (out of band): create the `simplicity-budget-approved`
+  label once; add the `Simplicity budgets` check to the required-checks
+  ruleset only after the workflow has produced at least one green run on
+  `main`. The check never joins ci.yml's `ci-required` aggregate
+  (cross-workflow `needs` is impossible; the label triggers must stay out of
+  ci.yml).
+- Ordering: merges after the docs-site diet (README/.env.example already
+  within budget); the later dashboard nav refactor must repoint `[core_nav]`
+  in its own diff — the checker's exit-2 behavior makes forgetting impossible.

--- a/openspec/changes/ci-simplicity-budgets/specs/github-automation/spec.md
+++ b/openspec/changes/ci-simplicity-budgets/specs/github-automation/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: Simplicity budgets are enforced mechanically in CI
+
+The repository SHALL define simplicity budgets in `.github/simplicity-budgets.toml`
+covering at least: `README.md` maximum line count (counted after removing the
+generated `ALL-CONTRIBUTORS-LIST` block, marker lines inclusive), `README.md`
+maximum top-level heading count (h1 and h2 only, with lines inside fenced code
+blocks excluded), `.env.example` maximum line count, and the dashboard
+core-navigation maximum item count together with the source file and array
+name it is read from. A dedicated `Simplicity budgets` workflow, separate from
+the main CI workflow, SHALL run `.github/scripts/check_simplicity_budgets.py`
+(stdlib-only) on pull requests (including `labeled`/`unlabeled` events),
+pushes to `main`, and `merge_group` events, and the check SHALL fail when any
+measured value exceeds its budget. Budget increases are made by editing
+`.github/simplicity-budgets.toml`, which keeps every exceedance a reviewable
+diff (see the `contribution-simplicity` capability for the governing
+principles).
+
+#### Scenario: README grows past its line budget
+
+- **GIVEN** a pull request whose `README.md`, after removing the
+  `ALL-CONTRIBUTORS-LIST` block, exceeds `readme.max_lines`
+- **WHEN** the Simplicity budgets workflow runs
+- **THEN** the check prints the measured and budgeted values, emits an error
+  annotation for `README.md`, and exits non-zero
+
+#### Scenario: Shell comments inside fenced code blocks are not headings
+
+- **GIVEN** a `README.md` containing `# comment` lines inside fenced code
+  blocks
+- **WHEN** the checker counts top-level headings
+- **THEN** lines inside fenced code blocks are not counted
+- **AND** fences using ` ``` ` or `~~~`, indented up to 3 spaces, are
+  recognized, and a fence is closed only by a fence line using the same
+  character
+- **AND** only h1 and h2 heading lines outside fences count against
+  `readme.max_top_level_headings`
+
+#### Scenario: All budgets within limits
+
+- **WHEN** every measured value is at or below its configured budget
+- **THEN** the check prints each metric as `actual/budget OK` and exits 0
+
+### Requirement: Nav budget refuses to pass when its target disappears
+
+The budget checker MUST exit with a distinct configuration-error status
+(exit code 2) and an explicit repoint instruction when the navigation source
+file or the configured navigation array named in
+`.github/simplicity-budgets.toml` `[core_nav]` cannot be found. A refactor
+that moves or renames the navigation array MUST update `[core_nav]` in the
+same change for the check to pass. The checker MUST use the same exit code 2
+when `.github/simplicity-budgets.toml` itself is missing or malformed, and
+when a `README.md` `ALL-CONTRIBUTORS-LIST:START` marker has no matching `END`
+marker (an unclosed block would otherwise silently exclude the rest of the
+file from the budget).
+
+#### Scenario: Nav array renamed without repointing the manifest
+
+- **GIVEN** the configured nav array no longer exists in the configured file
+- **WHEN** the checker runs
+- **THEN** it exits with code 2
+- **AND** the error message names the missing array and instructs updating
+  `.github/simplicity-budgets.toml` in the same pull request
+
+### Requirement: Simplicity budget override label
+
+The checker SHALL read PR label names from the `PR_LABELS` environment
+variable (a JSON array injected by the workflow from the pull-request event
+payload). When the `simplicity-budget-approved` label is present, budget
+violations SHALL be downgraded to warning annotations and the check SHALL
+exit 0 while still printing every measured metric. Because the event payload
+is a snapshot, the workflow MUST trigger on `labeled` and `unlabeled` so that
+applying the label starts a fresh run; the failure message MUST explain that
+re-running a failed run reuses the stale payload. Push and merge-group runs
+carry no pull-request labels, so the override MUST NOT apply there: a change
+that would leave `main` over budget MUST raise the budget in
+`.github/simplicity-budgets.toml` in the same diff.
+
+#### Scenario: Maintainer approves a temporary exceedance
+
+- **GIVEN** a pull request over budget
+- **WHEN** a maintainer applies the `simplicity-budget-approved` label
+- **THEN** the `labeled` event starts a fresh check run whose payload includes
+  the label
+- **AND** the run reports the violations as warning annotations and exits 0
+
+#### Scenario: Label override does not launder main
+
+- **GIVEN** a run triggered by a push to `main` or a `merge_group` event
+- **WHEN** a budget is exceeded
+- **THEN** no label payload is available and the check fails regardless of any
+  label on the originating pull request

--- a/openspec/changes/ci-simplicity-budgets/tasks.md
+++ b/openspec/changes/ci-simplicity-budgets/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: ci-simplicity-budgets
+
+## 1. Budget manifest and checker
+
+- [x] 1.1 Add `.github/simplicity-budgets.toml` with the `[readme]`
+      (max_lines counted after stripping the all-contributors block,
+      max_top_level_headings fence-aware), `[env_example]` (max_lines), and
+      `[core_nav]` (path/array/max_items) budgets
+- [x] 1.2 Add `.github/scripts/check_simplicity_budgets.py` (stdlib-only):
+      contributors-block stripping, fence-aware h1+h2 counting, nav `to:`
+      counting with exit 2 when the configured nav file/array is missing,
+      `PR_LABELS` JSON override via the `simplicity-budget-approved` label,
+      and a failure message covering the label path, the stale re-run caveat,
+      and the merge_group bump-the-TOML policy
+
+## 2. Workflow
+
+- [x] 2.1 Add `.github/workflows/simplicity-budgets.yml`: separate workflow
+      on `pull_request` `[opened, reopened, synchronize, labeled, unlabeled]`,
+      `push` to `main`, and `merge_group`; `contents: read`; SHA-pinned
+      checkout with `persist-credentials: false`; `PR_LABELS` passed as
+      `toJson(github.event.pull_request.labels.*.name)`; header comment
+      explaining why the triggers differ from ci.yml; no `paths:` filter
+
+## 3. Tests
+
+- [x] 3.1 Add `tests/unit/test_check_simplicity_budgets.py`: fence-aware
+      counting, contributors-block stripping, over/under budget exit codes,
+      label override, null-payload handling, and nav file/array-missing exit 2
+
+## 4. Validation
+
+- [x] 4.1 `uv run pytest tests/unit/test_check_simplicity_budgets.py -q`
+- [x] 4.2 Run the checker against the repository tree; all budgets pass
+- [x] 4.3 `uv run ruff check` / `ruff format --check` on the new script and test
+- [x] 4.4 `openspec validate ci-simplicity-budgets --strict` and
+      `openspec validate --specs`

--- a/tests/unit/test_check_simplicity_budgets.py
+++ b/tests/unit/test_check_simplicity_budgets.py
@@ -128,6 +128,20 @@ def test_heading_count_fence_close_must_match_opening_character():
     assert checker.count_top_level_headings(lines) == 1
 
 
+def test_heading_count_close_fence_must_have_no_info_string():
+    checker = _load_checker_module()
+
+    lines = [
+        "```",
+        "```bash",
+        "# still inside: a close fence may not carry an info string",
+        "```",
+        "# heading after the real close",
+    ]
+
+    assert checker.count_top_level_headings(lines) == 1
+
+
 def test_strip_contributors_block_removes_markers_and_body():
     checker = _load_checker_module()
 

--- a/tests/unit/test_check_simplicity_budgets.py
+++ b/tests/unit/test_check_simplicity_budgets.py
@@ -331,6 +331,39 @@ def test_nav_count_stops_at_target_array_when_file_has_multiple(tmp_path):
     assert checker.count_nav_items(nav_file, "ADVANCED_NAV_ITEMS") == 1
 
 
+def test_nav_count_rejects_suffixed_identifier(tmp_path, capsys):
+    checker = _load_checker_module()
+    nav_file = tmp_path / "nav.tsx"
+    nav_file.write_text(
+        'const NAV_ITEMS_V2 = [\n  { to: "/dashboard" },\n  { to: "/reports" },\n] as const;\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        checker.count_nav_items(nav_file, "NAV_ITEMS")
+
+    assert excinfo.value.code == 2
+    assert "NAV_ITEMS" in capsys.readouterr().out
+
+
+def test_main_config_missing_key_exits_2(tmp_path, monkeypatch, capsys):
+    checker = _load_checker_module()
+    _write_repo(tmp_path)
+    config_path = tmp_path / ".github" / "simplicity-budgets.toml"
+    config = config_path.read_text(encoding="utf-8").replace("max_top_level_headings", "typo_key")
+    config_path.write_text(config, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PR_LABELS", raising=False)
+
+    with pytest.raises(SystemExit) as excinfo:
+        checker.main()
+
+    assert excinfo.value.code == 2
+    out = capsys.readouterr().out
+    assert "::error::" in out
+    assert "section/key" in out
+
+
 def test_missing_nav_array_exits_2_with_repoint_instruction(tmp_path, monkeypatch, capsys):
     checker = _load_checker_module()
     _write_repo(tmp_path, nav_source="const OTHER_ITEMS = [] as const;\n")

--- a/tests/unit/test_check_simplicity_budgets.py
+++ b/tests/unit/test_check_simplicity_budgets.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import importlib.util
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_checker_module():
+    script_path = REPO_ROOT / ".github" / "scripts" / "check_simplicity_budgets.py"
+    spec = importlib.util.spec_from_file_location("check_simplicity_budgets", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+NAV_SOURCE = """
+const NAV_ITEMS = [
+  { to: "/dashboard", labelKey: "nav.dashboard" },
+  { to: "/reports", labelKey: "nav.reports" },
+  { to: "/settings", labelKey: "nav.settings" },
+] as const;
+"""
+
+
+def _write_repo(
+    tmp_path: Path,
+    *,
+    readme: str = "# Title\n\nbody\n",
+    env_example: str = "# A=1\n",
+    nav_source: str = NAV_SOURCE,
+    max_lines: int = 200,
+    max_headings: int = 10,
+    max_env_lines: int = 60,
+    max_nav_items: int = 6,
+) -> None:
+    (tmp_path / "README.md").write_text(readme, encoding="utf-8")
+    (tmp_path / ".env.example").write_text(env_example, encoding="utf-8")
+    (tmp_path / "nav.tsx").write_text(nav_source, encoding="utf-8")
+    config_dir = tmp_path / ".github"
+    config_dir.mkdir()
+    (config_dir / "simplicity-budgets.toml").write_text(
+        f"""
+[readme]
+path = "README.md"
+max_lines = {max_lines}
+max_top_level_headings = {max_headings}
+
+[env_example]
+path = ".env.example"
+max_lines = {max_env_lines}
+
+[core_nav]
+path = "nav.tsx"
+array = "NAV_ITEMS"
+max_items = {max_nav_items}
+""",
+        encoding="utf-8",
+    )
+
+
+def test_heading_count_ignores_fenced_code_blocks():
+    checker = _load_checker_module()
+
+    lines = [
+        "# Title",
+        "## Real section",
+        "```bash",
+        "# comment inside a fence, not a heading",
+        "## also not a heading",
+        "```",
+        "## Another real section",
+        "### h3 is not top-level",
+    ]
+
+    assert checker.count_top_level_headings(lines) == 3
+
+
+def test_heading_count_handles_fence_reopen():
+    checker = _load_checker_module()
+
+    lines = [
+        "```python",
+        "# fenced",
+        "```",
+        "# heading between fences",
+        "```",
+        "# fenced again",
+        "```",
+    ]
+
+    assert checker.count_top_level_headings(lines) == 1
+
+
+def test_heading_count_handles_tilde_and_indented_fences():
+    checker = _load_checker_module()
+
+    lines = [
+        "# Title",
+        "~~~text",
+        "# inside a tilde fence",
+        "~~~",
+        "   ```bash",
+        "# inside an indented backtick fence",
+        "   ```",
+        "## Real section",
+    ]
+
+    assert checker.count_top_level_headings(lines) == 2
+
+
+def test_heading_count_fence_close_must_match_opening_character():
+    checker = _load_checker_module()
+
+    lines = [
+        "```",
+        "~~~",
+        "# still inside the backtick fence",
+        "```",
+        "# heading after the fence",
+    ]
+
+    assert checker.count_top_level_headings(lines) == 1
+
+
+def test_strip_contributors_block_removes_markers_and_body():
+    checker = _load_checker_module()
+
+    lines = [
+        "# Title",
+        "<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->",
+        "<table>generated</table>",
+        "## Generated heading that must not count",
+        "<!-- ALL-CONTRIBUTORS-LIST:END -->",
+        "tail",
+    ]
+
+    stripped = checker.strip_contributors_block(lines)
+
+    assert stripped == ["# Title", "tail"]
+
+
+def test_strip_contributors_block_unclosed_exits_2(capsys):
+    checker = _load_checker_module()
+
+    lines = [
+        "# Title",
+        "<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->",
+        "<table>generated</table>",
+        "tail that would be silently swallowed",
+    ]
+
+    with pytest.raises(SystemExit) as excinfo:
+        checker.strip_contributors_block(lines)
+
+    assert excinfo.value.code == 2
+    out = capsys.readouterr().out
+    assert "::error::" in out
+    assert "ALL-CONTRIBUTORS-LIST:END" in out
+
+
+def test_main_missing_config_exits_2(tmp_path, monkeypatch, capsys):
+    checker = _load_checker_module()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PR_LABELS", raising=False)
+
+    with pytest.raises(SystemExit) as excinfo:
+        checker.main()
+
+    assert excinfo.value.code == 2
+    out = capsys.readouterr().out
+    assert "::error::" in out
+    assert "not found" in out
+
+
+def test_main_malformed_config_exits_2(tmp_path, monkeypatch, capsys):
+    checker = _load_checker_module()
+    config_dir = tmp_path / ".github"
+    config_dir.mkdir()
+    (config_dir / "simplicity-budgets.toml").write_text("[readme\nnot toml", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PR_LABELS", raising=False)
+
+    with pytest.raises(SystemExit) as excinfo:
+        checker.main()
+
+    assert excinfo.value.code == 2
+    out = capsys.readouterr().out
+    assert "::error::" in out
+    assert "not valid TOML" in out
+
+
+def test_main_passes_within_budgets(tmp_path, monkeypatch, capsys):
+    checker = _load_checker_module()
+    _write_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PR_LABELS", raising=False)
+
+    assert checker.main() == 0
+
+    out = capsys.readouterr().out
+    assert "OK" in out
+    assert "::error" not in out
+
+
+def test_main_counts_readme_lines_after_stripping_contributors_block(tmp_path, monkeypatch):
+    checker = _load_checker_module()
+    generated = (
+        ["<!-- ALL-CONTRIBUTORS-LIST:START -->"] + ["<td>row</td>"] * 50 + ["<!-- ALL-CONTRIBUTORS-LIST:END -->"]
+    )
+    readme = "\n".join(["# Title", "intro", *generated]) + "\n"
+    _write_repo(tmp_path, readme=readme, max_lines=5)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PR_LABELS", raising=False)
+
+    assert checker.main() == 0
+
+
+def test_main_fails_when_readme_over_line_budget(tmp_path, monkeypatch, capsys):
+    checker = _load_checker_module()
+    _write_repo(tmp_path, readme="# Title\n" + "line\n" * 50, max_lines=10)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PR_LABELS", raising=False)
+
+    assert checker.main() == 1
+
+    out = capsys.readouterr().out
+    assert "::error file=README.md::" in out
+    assert "simplicity-budget-approved" in out
+    assert "re-run" in out.lower()
+    assert "merge_group" in out
+
+
+def test_main_fails_when_env_example_over_budget(tmp_path, monkeypatch, capsys):
+    checker = _load_checker_module()
+    _write_repo(tmp_path, env_example="# A=1\n" * 61)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PR_LABELS", raising=False)
+
+    assert checker.main() == 1
+
+    assert "::error file=.env.example::" in capsys.readouterr().out
+
+
+def test_main_fails_when_nav_over_budget(tmp_path, monkeypatch, capsys):
+    checker = _load_checker_module()
+    _write_repo(tmp_path, max_nav_items=2)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PR_LABELS", raising=False)
+
+    assert checker.main() == 1
+
+    assert "core nav items (NAV_ITEMS): 3/2 OVER" in capsys.readouterr().out
+
+
+def test_override_label_downgrades_violations_to_warnings(tmp_path, monkeypatch, capsys):
+    checker = _load_checker_module()
+    _write_repo(tmp_path, readme="# Title\n" + "line\n" * 50, max_lines=10)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PR_LABELS", '["db migration", "simplicity-budget-approved"]')
+
+    assert checker.main() == 0
+
+    out = capsys.readouterr().out
+    assert "::warning file=README.md::" in out
+    assert "::error" not in out
+    assert "passing with warnings" in out
+
+
+def test_override_label_ignored_on_null_payload(tmp_path, monkeypatch):
+    checker = _load_checker_module()
+    _write_repo(tmp_path, readme="# Title\n" + "line\n" * 50, max_lines=10)
+    monkeypatch.chdir(tmp_path)
+    # push / merge_group events render the PR_LABELS expression to "null"
+    monkeypatch.setenv("PR_LABELS", "null")
+
+    assert checker.main() == 1
+
+
+def test_missing_nav_array_exits_2_with_repoint_instruction(tmp_path, monkeypatch, capsys):
+    checker = _load_checker_module()
+    _write_repo(tmp_path, nav_source="const OTHER_ITEMS = [] as const;\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PR_LABELS", raising=False)
+
+    with pytest.raises(SystemExit) as excinfo:
+        checker.main()
+
+    assert excinfo.value.code == 2
+    out = capsys.readouterr().out
+    assert "::error::" in out
+    assert "NAV_ITEMS" in out
+    assert "simplicity-budgets.toml" in out
+
+
+def test_missing_nav_file_exits_2(tmp_path, monkeypatch):
+    checker = _load_checker_module()
+    _write_repo(tmp_path)
+    (tmp_path / "nav.tsx").unlink()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PR_LABELS", raising=False)
+
+    with pytest.raises(SystemExit) as excinfo:
+        checker.main()
+
+    assert excinfo.value.code == 2
+
+
+def test_nav_count_in_live_tree_is_within_configured_budget():
+    """The live tree satisfies its own [core_nav] budget, wherever the TOML points.
+
+    Config-driven on purpose: a nav refactor repoints .github/simplicity-budgets.toml
+    (path/array/max_items) as its ONLY required edit, and this test follows it.
+    """
+    checker = _load_checker_module()
+
+    config = tomllib.loads((REPO_ROOT / ".github" / "simplicity-budgets.toml").read_text(encoding="utf-8"))
+    nav_cfg = config["core_nav"]
+
+    count = checker.count_nav_items(REPO_ROOT / nav_cfg["path"], nav_cfg["array"])
+
+    assert count > 0
+    assert count <= nav_cfg["max_items"]

--- a/tests/unit/test_check_simplicity_budgets.py
+++ b/tests/unit/test_check_simplicity_budgets.py
@@ -282,6 +282,55 @@ def test_override_label_ignored_on_null_payload(tmp_path, monkeypatch):
     assert checker.main() == 1
 
 
+def test_heading_count_respects_fence_length():
+    checker = _load_checker_module()
+
+    lines = [
+        "````markdown",
+        "```",
+        "# still inside the four-backtick fence",
+        "```",
+        "````",
+        "# heading after the outer fence",
+    ]
+
+    assert checker.count_top_level_headings(lines) == 1
+
+
+def test_nav_count_ignores_nested_arrays_inside_items(tmp_path):
+    checker = _load_checker_module()
+    nav_file = tmp_path / "nav.tsx"
+    nav_file.write_text(
+        "const NAV_ITEMS = [\n"
+        '  { to: "/dashboard", roles: ["admin"] },\n'
+        '  { to: "/reports", labelKey: "nav.reports" },\n'
+        '  { to: "/settings", labelKey: "nav.settings" },\n'
+        "] as const;\n",
+        encoding="utf-8",
+    )
+
+    assert checker.count_nav_items(nav_file, "NAV_ITEMS") == 3
+
+
+def test_nav_count_stops_at_target_array_when_file_has_multiple(tmp_path):
+    checker = _load_checker_module()
+    nav_file = tmp_path / "nav.tsx"
+    nav_file.write_text(
+        "const CORE_NAV_ITEMS = [\n"
+        '  { to: "/dashboard" },\n'
+        '  { to: "/settings" },\n'
+        "] as const;\n"
+        "\n"
+        "const ADVANCED_NAV_ITEMS = [\n"
+        '  { to: "/automations" },\n'
+        "] as const;\n",
+        encoding="utf-8",
+    )
+
+    assert checker.count_nav_items(nav_file, "CORE_NAV_ITEMS") == 2
+    assert checker.count_nav_items(nav_file, "ADVANCED_NAV_ITEMS") == 1
+
+
 def test_missing_nav_array_exits_2_with_repoint_instruction(tmp_path, monkeypatch, capsys):
     checker = _load_checker_module()
     _write_repo(tmp_path, nav_source="const OTHER_ITEMS = [] as const;\n")


### PR DESCRIPTION
## Summary

Adds mechanical enforcement for the simplicity budgets referenced by `PRINCIPLES.md`: a data-only manifest (`.github/simplicity-budgets.toml`: README ≤200 lines / ≤10 top-level headings, `.env.example` ≤60 lines, core dashboard nav ≤6 items), a stdlib-only checker script, and a separate `simplicity-budgets.yml` workflow. Counting is fence-aware and excludes the bot-generated ALL-CONTRIBUTORS block; the nav counter fails loudly (exit 2) if the configured array disappears, so nav refactors are forced to repoint the manifest in the same diff. The maintainer label `simplicity-budget-approved` downgrades violations to warnings on PR runs (never on `merge_group`/push — anything leaving main over budget must bump the manifest in the same diff).

Part 3/4 of the simplicity-effort stack. **Stacked on the docs-site PR #1337** (stack: #1336 → #1337 → this → #1339) (its budgets only pass against the dieted README/.env.example) — GitHub will retarget to `main` when that merges.

## Type of change

- [x] `ci:` — tooling/CI

Linked issue: part of the simplicity effort.

## OpenSpec

`openspec/changes/ci-simplicity-budgets/` — delta on the `github-automation` capability, referencing `contribution-simplicity`; context documents the label-override caveats (stale re-run payload; labeled-event refresh) and the merge-queue policy. Strict validation passes.

## Notes for review

- Separate workflow instead of a ci.yml job because `labeled`/`unlabeled` triggers on ci.yml would re-run the full CI matrix on every codex-review-labels sync (cron */15).
- 18 unit tests cover fence variants (``` and ~~~, indented), contributors-block stripping incl. unclosed-block exit 2, missing/malformed manifest exit 2, label override, and a config-driven live-tree check that reads the manifest itself (so the dashboard PR's nav repoint needs no test edit).
- The "Simplicity budgets" check should be added to the required-checks ruleset only after ≥1 green run on `main`, and never into `ci-required`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
