### PR TITLE
chore: release v1.22.0-beta.1

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.21.0"  # x-release-please-version
+__version__ = "1.22.0-beta.1"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.21.0
-appVersion: 1.21.0
+version: 1.22.0-beta.1
+appVersion: 1.22.0-beta.1
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.21.0",
+  "version": "1.22.0-beta.1",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.21.0"
+version = "1.22.0-beta.1"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.21.0"
+version = "1.22.0-beta.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.22.0-beta.1 for the 1.22.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.22.0-beta.1 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1330; no manual beta workflow dispatch is required.

## Changes since v1.21.0
- fix(balancer): decorrelate round-robin tie-breaking across replicas (#1327) (fd529b2)
- fix(observability): anchor TTFT to the attempt, expose queue wait as a dashboard trend (#1333) (
f79f09)
- fix(proxy): settle API-key reservation before budget-exhausted compact preflight raises (#1332) (
fe625b)
- fix(proxy): reject unsupported multi-worker-per-instance for shared per-account caps (#1328) (
2e1040)
- feat(dashboard): group advanced navigation and settings behind progressive disclosure (#1339) (
0c2283)
- fix(oauth): persist dashboard OAuth flow state for multi-replica (#1329) (
8e2ee2)
- fix(proxy): recover from host network changes (#1234) (
c2814b)
- fix(proxy): preserve HTTP bridge model-transition forks (#1356) (
153bbc)
- fix(proxy): record early downstream cancellations (#1324) (
1089ab)
- fix(models): complete required Codex catalog fields (#1299) (
a97bcc)
- fix(proxy): recover stale response-create gates (#1296) (
fb5a57)
- fix(proxy): forward Codex standalone web search (#1232) (
667cda)
- fix(proxy): retry server_is_overloaded responses (#1315) (
93383a)
- fix(usage): price gpt-5.6 personality models (#1275) (
bcdc38)
- fix(proxy): recover sequenced Codex prewarms (#1359) (
c9dac8)
- feat(model-sources): report upstream generation timings (#1319) (
1ebd19)
- fix(api-keys): reject duplicate limit rules on create (#1312) (
31f7aa)
- feat(settings): manage data retention from the dashboard (#1364) (
cacc6c)
- fix(proxy): retry stale per-account model rejections (#1321) (
edc486)
- fix(proxy): release pending websocket stream leases on disconnect (#1282) (
f06173)
- feat(ui): add Korean dashboard locale (#1375) (
ccaa4a)
- fix(proxy): retry upstream model capacity errors (#1385) (
63bfcd)
- fix(proxy): preserve encrypted compaction item ids (#1316) (
9b79db)
- feat(proxy): add stale-anchor diagnostics (#1225) (
4720e0)
- fix(balancer): reject implausible rate-limit resets (#1374) (
aea1e6)
- fix(proxy): route Spark using fresh per-account quota evidence (#1248) (
147147)
- fix(security): harden trusted Forwarded chain resolution (#1377) (
21313b)
- feat(accounts): add reset-credit controls and auto redeem (#1358) (
1c985d)
- fix(docker): preserve runtime readability for owner-only build files (#1373) (
cf5db0)
- fix(security): enforce trusted proxy locality (#1381) (
d9709c)
- fix(proxy): slim inline images nested in historical tool-call outputs (#1344) (
a8578d)
- perf(db): optimize dashboard hot-path indexes (#1386) (
1422be)
- fix(security): inspect repeated session proxy headers (#1378) (
dae97c)
- fix(config): reject empty trusted proxy CIDRs (#1379) (
e5b101)
- fix(reports): reject inverted date ranges (#1396) (
f3c6ff)
- fix(dashboard): keep overview visible when request logs fail (#1397) (
603d18)
- fix(usage): make weekly-primary remap tiebreak data-aware (#1391) (
71f31e)
- fix(proxy): spill bare session affinity under account caps (#1382) (
5d5519)
- fix(db): pin asyncpg sessions to UTC (#1352) (
977b99)
- fix(observability): improve TTFT and TPS accuracy (#1325) (
bc8d0f)
- fix(proxy): purge stale durable bridge rows on startup (#1310) (
9b40f7)
- fix(balancer): recover probing accounts (#1376) (
fe9377)
- perf(proxy): cache upstream-route resolution per account (#1283) (
a52c45)
- fix(cli): reject out-of-range server port before startup (#1400) (
ec7aad)
- fix(proxy): bound raw HTTP request ingress (#1440) (
453c1e)
- fix(proxy): serialize shared-session rate-limit reads (#1432) (
539c4a)
- fix(proxy-responses): normalize Lite reasoning context (#1431) (
c93e80)
- fix(db): reject empty migration database URL (#1399) (
f527de)
- fix(proxy): dedup and cap oversized response.create dumps (#1366) (
d0f5b0)
- fix(proxy): recover idle Codex Desktop bridge (#1439) (
b49f25)
- feat(ui): header brand back to /dashboard on click (#1452) (
dca802)
- fix(api): give thread-goal GET/POST distinct operationIds (#1398) (
3b9776)
- fix(shutdown): drain audit and fleet tasks (#1443) (
ec36ef)
- perf(automations): bound run-history query work (#1451) (
4fbe59)
- perf(usage): persist account snapshots transactionally (#1448) (
10f535)
- perf(usage): scope refresh work to selected account (#1446) (
eebb75)
- feat(helm): make ExternalSecret remote refs configurable (#1455) (
1c91cb)
- feat(conversation): implementation on conversation grouping on Opencode + Codex (#1453) (
be363d)
- fix(uploads): bound multipart request resources (#1447) (
6ff5af)
- fix(proxy): ignore API-key-enforced service tier a model never advertises (#1438) (
e04226)
- fix(auth): require trusted-proxy identity consensus (#1380) (
b3a5c2)
- fix(proxy): recover verified responses after owner loss (#1437) (
e6270f)
- fix(useragent): fixing the unexpected category on useragent group (#1458) (
69b397)
- feat(helm): support Gateway API rule filters (#1459) (
acd50d)
- fix(streaming): preserve terminal no-replay boundaries (#1389) (
a4a221)
- fix(proxy): harden compact continuity recovery (
c1c3f3)
- fix(compact): preserve historical side-effect anchors (
f76469)
- fix(ci): run ruff from the locked environment (#1465) (
d52521)

## Release-candidate validation
Validated candidate: d4cfcb8e4d94e2737385f7149aff66ad3d3a62d4

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [ ] Backend/unit/integration gates
- [ ] Frontend tests/build
- [ ] Wheel/package validation
- [ ] Docker/container smoke
- [ ] Live upstream/account smoke
- [ ] Live upstream/account smoke not required

## Install after publish
```bash
uvx --from "codex-lb==1.22.0b1" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.22.0-beta.1
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.22.0-beta.1 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.22.0.
