### PR TITLE
test(balancer): make sticky-selection test deterministic under decorrelated tie-breaking

### DIFF
--- a/tests/unit/test_select_with_stickiness.py
+++ b/tests/unit/test_select_with_stickiness.py
@@ -960,8 +960,18 @@ async def test_sticky_thread_below_threshold_does_not_reallocate():
 
 @pytest.mark.asyncio
 async def test_fresh_sticky_mapping_uses_normal_budget_gate():
+    # "a" is secondary-pressured (99% > secondary threshold 98%) but must stay
+    # eligible for a FRESH mapping: the secondary budget gate applies only to
+    # sticky reallocation, not to normal selection. Mark "b" as recently
+    # selected so round_robin's least-recently-selected primary key
+    # deterministically prefers "a" whenever "a" is eligible — the selection
+    # must not fall through to the final tie-break, which is decorrelated per
+    # replica (keyed on the host identity) and therefore host-dependent.
+    # If the secondary gate were wrongly applied here, "a" would be excluded
+    # and "b" selected, failing the assertion below.
     acc_a = _active("a", used_percent=10.0, secondary_used_percent=99.0)
     acc_b = _active("b", used_percent=20.0, secondary_used_percent=10.0)
+    acc_b.last_selected_at = time.time()
     repo = _make_sticky_repo(existing_account_id=None)
 
     result = await _invoke_stickiness(


### PR DESCRIPTION
## Summary

Fixes the flaky `test_fresh_sticky_mapping_uses_normal_budget_gate` (5 CI failures on 2026-07-15 alone, always green on re-run).

**Root cause:** with a fresh sticky mapping both candidate accounts tie on the round-robin primary keys (equal planner cost, `last_selected_at=None`), so selection falls to the #1327 decorrelated tie-break `sha256(replica_salt + account_id)` — and since tests never configure a salt, it defaults to `socket.gethostname()`. CI runners get random hostnames; for ~half of them the hash orders `'b'` before `'a'`, failing the assertion. Any given host is process-stable, which is why re-runs (fresh runner) pass and local loops never reproduced. Reproduced deterministically by pinning an Azure-runner-style salt (`fv-az123`).

**Fix (test-only):** give the competitor account a recent `last_selected_at` so the intended account wins on the round-robin *primary* key and selection never reaches the salted tie-break. This sharpens the test's original intent — the intended account is secondary-pressured, so if the secondary budget gate were wrongly applied to fresh mappings it would be excluded and the test would fail.

**Proof:** unpatched test fails under the pinned salt; patched test passes 100/100 separate pytest runs and 100/100 in-process runs under 100 random salts; related selection/balancer files all green (324 passed). Sibling audit found no other tests depending on tie-break randomness (details in the issue).

Fixes #1342

## Type of change

- [x] `test:` — test-only change

## OpenSpec

Test-only; no behavior/contract change, no OpenSpec folder required.

## Simplicity

- [x] No new settings, docs, or surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)