### PR TITLE
fix(db): pin asyncpg session time zone to UTC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ POSTGRES_PYTEST_TARGETS := \
 	tests/integration/test_sticky_sessions_api.py::test_durable_bridge_owned_alias_registration_is_epoch_fenced \
 	tests/integration/test_proxy_api_extended.py::test_proxy_stream_usage_limit_returns_http_error \
 	tests/integration/test_repositories.py::test_accounts_upsert_with_merge_disabled_uses_identity_lock_on_postgresql \
+	tests/integration/test_db_session_timezone.py \
 	tests/test_request_logs_options_api.py \
 	tests/integration/test_account_usage_rollup.py \
 	tests/integration/test_data_retention.py

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -45,12 +45,23 @@ def _is_sqlite_memory_url(url: str) -> bool:
     return _is_sqlite_url(url) and ":memory:" in url
 
 
-def _postgres_async_connect_args(url: str) -> dict[str, int] | None:
+def _postgres_async_connect_args(url: str) -> dict[str, object] | None:
     if not url.startswith("postgresql+asyncpg://"):
         return None
-    if not os.environ.get("CODEX_LB_TEST_DATABASE_URL"):
-        return None
-    return {"prepared_statement_cache_size": 0}
+    # Pin the asyncpg session time zone to UTC. The application persists naive
+    # UTC datetimes (see app.core.utils.time.utcnow) into timestamptz columns.
+    # asyncpg binds a naive datetime using the connection's session time zone,
+    # so if that time zone follows the container's TZ (e.g. Europe/Amsterdam)
+    # PostgreSQL shifts every written timestamp away from real UTC. That skew is
+    # silent but corrupts every wall-clock comparison the coordinator relies on:
+    # ring-membership heartbeats look perpetually stale, leader election and the
+    # bridge-session cleanup stop running, and account/stream lease expiry is
+    # mis-evaluated. Forcing UTC keeps stored timestamps correct regardless of
+    # the container time zone.
+    connect_args: dict[str, object] = {"server_settings": {"timezone": "UTC"}}
+    if os.environ.get("CODEX_LB_TEST_DATABASE_URL"):
+        connect_args["prepared_statement_cache_size"] = 0
+    return connect_args
 
 
 def _postgres_async_engine_kwargs(url: str) -> dict[str, object]:

--- a/openspec/changes/pin-asyncpg-session-timezone-utc/context.md
+++ b/openspec/changes/pin-asyncpg-session-timezone-utc/context.md
@@ -1,0 +1,18 @@
+# Context: pin-asyncpg-session-timezone-utc
+
+The application helper `app.core.utils.time.utcnow()` returns naive UTC
+datetimes. PostgreSQL `timestamptz` storage is still safe only if the client
+session interprets those naive values as UTC. With asyncpg, binding a naive
+Python `datetime` uses the connection's session time zone. If a deployment or
+database default is `Europe/Amsterdam`, for example, a naive UTC value is
+interpreted as Amsterdam local time and stored with a one- or two-hour offset.
+
+This is especially damaging for coordinator data because the corruption is
+silent: rows look valid, but comparisons against fresh `utcnow()` values are
+wrong. Bridge-ring membership can look stale too early or too late, leader
+election timing can drift, cleanup jobs can skip or purge the wrong rows, and
+account or stream leases can be evaluated against shifted timestamps.
+
+The fix belongs in engine construction instead of individual repository writes:
+all PostgreSQL sessions must share the same interpretation before any ORM or
+Core query binds a timestamp. SQLite behavior is unchanged.

--- a/openspec/changes/pin-asyncpg-session-timezone-utc/proposal.md
+++ b/openspec/changes/pin-asyncpg-session-timezone-utc/proposal.md
@@ -1,0 +1,27 @@
+# Pin Asyncpg Session Time Zone to UTC
+
+## Why
+
+`codex-lb` stores naive UTC `datetime` values in PostgreSQL `timestamptz`
+columns. `asyncpg` binds a naive datetime using the database session time zone,
+so a PostgreSQL session inheriting a non-UTC default silently shifts persisted
+timestamps away from real UTC. That corrupts wall-clock comparisons used by
+bridge-ring heartbeats, leader election, cleanup cutoffs, and account or stream
+lease expiry.
+
+## What Changes
+
+- Configure every `postgresql+asyncpg://` SQLAlchemy async engine with
+  `server_settings.timezone=UTC`.
+- Preserve the existing PostgreSQL test tuning for asyncpg prepared-statement
+  caching.
+- Add unit coverage for the engine kwargs and a PostgreSQL integration
+  regression that forces the database default time zone away from UTC before
+  opening a new app-configured asyncpg engine.
+
+## Impact
+
+- Affected spec: `database-backends`
+- Affected code: `app/db/session.py`
+- Affected tests: `tests/unit/test_db_session.py`,
+  `tests/integration/test_db_session_timezone.py`

--- a/openspec/changes/pin-asyncpg-session-timezone-utc/specs/database-backends/spec.md
+++ b/openspec/changes/pin-asyncpg-session-timezone-utc/specs/database-backends/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Asyncpg PostgreSQL sessions pin time zone to UTC
+
+When `database_url` resolves to a PostgreSQL backend through the asyncpg driver, the application MUST configure each SQLAlchemy async engine connection with a database session time zone of `UTC`.
+
+This requirement applies to the request-path `engine`, the optional background
+`_background_engine`, and any app-created PostgreSQL async engine that uses the
+shared PostgreSQL engine kwargs helper.
+
+#### Scenario: Asyncpg sessions ignore non-UTC database defaults
+
+- **GIVEN** `database_url` uses `postgresql+asyncpg://`
+- **AND** the PostgreSQL role, database, container, or server default time zone
+  is not UTC
+- **WHEN** the application opens a new asyncpg connection through its engine
+  configuration
+- **THEN** `SHOW TIME ZONE` on that connection reports `UTC`
+- **AND** naive UTC datetimes written by the application are interpreted as UTC
+  before PostgreSQL stores them in `timestamptz` columns
+
+#### Scenario: SQLite backends are not affected
+
+- **GIVEN** `database_url` resolves to a SQLite backend
+- **WHEN** the application creates its async engine
+- **THEN** PostgreSQL asyncpg `server_settings` are not configured
+- **AND** existing SQLite PRAGMAs, busy timeout, and pooling behavior remain
+  unchanged

--- a/openspec/changes/pin-asyncpg-session-timezone-utc/tasks.md
+++ b/openspec/changes/pin-asyncpg-session-timezone-utc/tasks.md
@@ -1,0 +1,12 @@
+# Tasks: pin-asyncpg-session-timezone-utc
+
+- [x] Add a `database-backends` requirement that PostgreSQL asyncpg sessions
+      MUST pin the database session time zone to UTC.
+- [x] Configure `postgresql+asyncpg://` engine connect args with
+      `server_settings.timezone=UTC`, preserving existing test-only prepared
+      statement cache tuning.
+- [x] Add unit coverage for the PostgreSQL connect args and engine kwargs.
+- [x] Add PostgreSQL integration coverage proving a new app-configured asyncpg
+      engine reports `SHOW TIME ZONE = UTC` even when the database default is
+      temporarily non-UTC.
+- [x] Run focused unit/integration tests and `openspec validate --specs`.

--- a/tests/integration/test_db_session_timezone.py
+++ b/tests/integration/test_db_session_timezone.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+import re
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.db import session as session_module
+
+pytestmark = pytest.mark.integration
+
+
+def _postgres_test_url() -> str:
+    url = os.environ.get("CODEX_LB_TEST_DATABASE_URL")
+    if not url or not url.startswith("postgresql+asyncpg://"):
+        pytest.skip("requires CODEX_LB_TEST_DATABASE_URL=postgresql+asyncpg://...")
+    return url
+
+
+async def _current_database_name(url: str) -> str:
+    engine = create_async_engine(url)
+    try:
+        async with engine.connect() as conn:
+            name = await conn.scalar(text("SELECT current_database()"))
+    finally:
+        await engine.dispose()
+    assert isinstance(name, str)
+    if not re.fullmatch(r"[A-Za-z0-9_]+", name):
+        pytest.skip(f"test database name is not safe to quote in ALTER DATABASE: {name!r}")
+    return name
+
+
+async def _set_database_timezone_default(url: str, database_name: str, timezone: str | None) -> None:
+    engine = create_async_engine(url)
+    try:
+        async with engine.connect() as conn:
+            conn = await conn.execution_options(isolation_level="AUTOCOMMIT")
+            if timezone is None:
+                await conn.execute(text(f'ALTER DATABASE "{database_name}" RESET timezone'))
+            else:
+                await conn.execute(text(f"ALTER DATABASE \"{database_name}\" SET timezone TO '{timezone}'"))
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_postgres_asyncpg_engine_pins_session_timezone_to_utc_despite_database_default() -> None:
+    """Regression: asyncpg interprets naive datetimes using the session time zone.
+
+    Force the test database default away from UTC, then create a brand-new engine
+    through the application's PostgreSQL engine kwargs. Without
+    ``server_settings.timezone=UTC`` this connection inherits the database
+    default and the assertion below fails on the PostgreSQL CI job.
+    """
+
+    url = _postgres_test_url()
+    database_name = await _current_database_name(url)
+
+    try:
+        await _set_database_timezone_default(url, database_name, "Europe/Amsterdam")
+        engine = create_async_engine(
+            url,
+            **session_module._postgres_async_engine_kwargs(url),
+        )
+        try:
+            async with engine.connect() as conn:
+                timezone = await conn.scalar(text("SHOW TIME ZONE"))
+        finally:
+            await engine.dispose()
+    finally:
+        await _set_database_timezone_default(url, database_name, None)
+
+    assert timezone == "UTC"

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -247,6 +247,48 @@ def test_postgres_engine_kwargs_keep_pool_controls(monkeypatch) -> None:
     assert kwargs["pool_timeout"] == 30.0
 
 
+def test_postgres_connect_args_pin_session_timezone_to_utc(monkeypatch) -> None:
+    """Regression: the application writes naive UTC datetimes into timestamptz
+    columns, so the asyncpg session time zone MUST be UTC. Otherwise a container
+    running e.g. TZ=Europe/Amsterdam makes PostgreSQL interpret those naive
+    values in local time and shift every stored timestamp, which silently breaks
+    ring-membership staleness, leader election and bridge-session lease expiry.
+    """
+    monkeypatch.delenv("CODEX_LB_TEST_DATABASE_URL", raising=False)
+
+    connect_args = session_module._postgres_async_connect_args("postgresql+asyncpg://u:p@h/db")
+
+    assert connect_args == {"server_settings": {"timezone": "UTC"}}
+
+
+def test_postgres_connect_args_pin_utc_and_keep_test_db_url_tuning(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_TEST_DATABASE_URL", "1")
+
+    connect_args = session_module._postgres_async_connect_args("postgresql+asyncpg://u:p@h/db")
+
+    assert connect_args == {
+        "server_settings": {"timezone": "UTC"},
+        "prepared_statement_cache_size": 0,
+    }
+
+
+def test_postgres_connect_args_none_for_non_postgres_url() -> None:
+    assert session_module._postgres_async_connect_args("sqlite+aiosqlite:///:memory:") is None
+
+
+def test_postgres_engine_kwargs_forward_utc_connect_args(monkeypatch) -> None:
+    monkeypatch.delenv("CODEX_LB_TEST_DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        session_module,
+        "_settings",
+        _FakeSettings(database_url="postgresql+asyncpg://u:p@h/db"),
+    )
+
+    kwargs = session_module._postgres_async_engine_kwargs("postgresql+asyncpg://u:p@h/db")
+
+    assert kwargs["connect_args"] == {"server_settings": {"timezone": "UTC"}}
+
+
 @pytest.mark.asyncio
 async def test_close_session_rolls_back_open_transaction_before_close() -> None:
     calls: list[str] = []


### PR DESCRIPTION
## Problem

The application persists **naive UTC** datetimes into `timestamptz` columns (`app/core/utils/time.py::utcnow` returns `datetime.now(timezone.utc).replace(tzinfo=None)`).

asyncpg binds a naive datetime using the **connection's session time zone**. In production `_postgres_async_connect_args` does not set a session time zone, so it follows the container's `TZ`. When the container runs e.g. `TZ=Europe/Amsterdam`, PostgreSQL interprets those naive-UTC values as local time and shifts **every** written `timestamptz` ~2h away from real UTC.

The skew is silent but corrupts every wall-clock comparison the coordinator relies on:

- `bridge_ring_members` heartbeats are written ~2h in the past, so replicas look perpetually **stale** → leader election / the sticky- and bridge-session cleanup scheduler stop doing their work.
- account/stream **lease expiry** is mis-evaluated.

The practical failure mode: abandoned HTTP bridge sessions (`http_bridge_sessions`, `state=ACTIVE` with an expired lease from an aborted client) are never reclaimed and accumulate until the per-account stream cap is exhausted. New streams then block in `account_stream_cap` retry loops and **never return response headers**, so OpenCode/Codex clients fail with `response headers timed out`. A container restart temporarily clears it, which matches the "works for a while after redeploy" symptom.

### Reproduction

Run the container with `TZ=Europe/Amsterdam` (any non-UTC zone) against PostgreSQL, then:

```sql
select instance_id, now() - last_heartbeat_at as age from bridge_ring_members;
```

`age` sits at a constant ~2h (the UTC↔local offset) even though the heartbeat loop is running.

## Fix

Force the asyncpg session time zone to UTC via `server_settings={"timezone": "UTC"}` so stored timestamps stay correct regardless of the container time zone. Verified locally: with the setting, `SHOW timezone` is `UTC` and heartbeat age drops to ~0.

## Tests

Added unit tests to `tests/unit/test_db_session.py` covering the UTC pin (prod + `CODEX_LB_TEST_DATABASE_URL` paths, non-postgres passthrough, and that the connect args reach the engine kwargs). Full file passes (32 tests).
