### PR TITLE
fix(proxy): preserve HTTP bridge model-transition forks

### DIFF
--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -503,6 +503,10 @@ class _HTTPBridgeMixin(
                 and key.affinity_key == durable_lookup.canonical_key
                 and key.affinity_kind != "turn_state_header"
             )
+            preserve_internal_fork_key = key.affinity_kind in {
+                "internal_unanchored_parallel",
+                "internal_model_parallel",
+            }
             require_preferred_account = (previous_response_id is not None and preferred_account_id is not None) or (
                 preferred_account_id is not None
                 and (key.strength == "hard" or not fallback_on_preferred_account_unavailable)
@@ -512,6 +516,7 @@ class _HTTPBridgeMixin(
                     incoming_turn_state is not None
                     and forwarded_affinity is None
                     and not preserve_durable_canonical_key
+                    and not preserve_internal_fork_key
                 ):
                     alias_index_key = _http_bridge_turn_state_alias_key(incoming_turn_state, api_key_id)
                     alias_key = self._http_bridge_turn_state_index.get(alias_index_key)

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -481,8 +481,8 @@ class _HTTPBridgeMixin(
             else None
         )
         old_account_id: str | None = None
-        force_durable_takeover_after_detach = False
-        own_fork_locally = False
+        force_durable_takeover_after_detach = own_fork_locally = used_session_header_fallback = False
+        model_transition_parent_key: _HTTPBridgeSessionKey | None = None
         while True:
             inflight_future: asyncio.Future[_HTTPBridgeSession] | None = None
             capacity_wait_future: asyncio.Future[_HTTPBridgeSession] | None = None
@@ -492,7 +492,6 @@ class _HTTPBridgeMixin(
             owner_forward: _HTTPBridgeOwnerForward | None = None
             force_durable_takeover = force_durable_takeover_after_detach
             missing_turn_state_alias = False
-            used_session_header_fallback = False
             sessions_to_close_before_create: list[_HTTPBridgeSession] = []
             session_to_return_after_close: _HTTPBridgeSession | None = None
             preserve_durable_canonical_key = (
@@ -649,6 +648,7 @@ class _HTTPBridgeMixin(
                     else None
                 )
                 if model_fork_key is not None:
+                    model_transition_parent_key = key
                     key = model_fork_key
                     durable_lookup = None
                     force_durable_takeover_after_detach = False
@@ -1182,6 +1182,8 @@ class _HTTPBridgeMixin(
                         ):
                             evictable_sessions: list[tuple[_HTTPBridgeSessionKey, _HTTPBridgeSession]] = []
                             for candidate_key, candidate_session in self._http_bridge_sessions.items():
+                                if candidate_key == model_transition_parent_key:
+                                    continue
                                 if getattr(candidate_session, "unanchored_reservation_id", None) is not None:
                                     continue
                                 pending_count = self._http_bridge_pending_count_nowait(
@@ -1243,7 +1245,6 @@ class _HTTPBridgeMixin(
                             )
                             self._http_bridge_inflight_sessions[key] = inflight_future
                             owns_creation = True
-
             try:
                 for session_to_close in sessions_to_close_before_create:
                     await self._close_http_bridge_session_bounded(session_to_close, reason="registry_detach")

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -1329,7 +1329,7 @@ class _HTTPBridgeMixin(
                     request_scope_id=request_scope_id,
                 )
                 if model_fork_key is not None:
-                    key = model_fork_key
+                    model_transition_parent_key, key = key, model_fork_key
                     durable_lookup = None
                     force_durable_takeover_after_detach = False
                     continue

--- a/openspec/changes/prevent-http-bridge-model-transition-loop/.openspec.yaml
+++ b/openspec/changes/prevent-http-bridge-model-transition-loop/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/prevent-http-bridge-model-transition-loop/proposal.md
+++ b/openspec/changes/prevent-http-bridge-model-transition-loop/proposal.md
@@ -6,7 +6,7 @@ When a request carries a fresh generated turn-state header plus a session header
 
 - Preserve an internal parallel bridge key and its session-header fallback state once lookup has selected it instead of resolving the original turn-state/session headers again on the next creation-loop iteration.
 - Protect the incompatible session-header parent from capacity eviction while the isolated child is created.
-- Cover follow-up requests without a previous-response/durable lookup and full-cache model transitions.
+- Cover follow-up requests without a previous-response/durable lookup and full-cache model transitions, including parent sessions that finish creation while the child waits.
 
 ## Capabilities
 

--- a/openspec/changes/prevent-http-bridge-model-transition-loop/proposal.md
+++ b/openspec/changes/prevent-http-bridge-model-transition-loop/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+When a request carries a fresh generated turn-state header plus a session header whose live bridge uses another model, the HTTP bridge lookup can repeatedly discard its internal model fork and reapply the session-header fallback. The request spins before account selection, emits an unbounded `model_transition_fork` log stream, and other clients stop making progress until the process restarts.
+
+## What Changes
+
+- Preserve an internal parallel bridge key once lookup has selected it instead of resolving the original turn-state/session headers again on the next creation-loop iteration.
+- Cover the unmatched turn-state plus incompatible session-header transition that previously repeated the same fork.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `responses-api-compat`: model-transition isolation MUST terminate after one fork and continue bridge creation without reusing the incompatible session.
+
+## Impact
+
+`app/modules/proxy/_service/http_bridge/mixin.py` and focused HTTP bridge unit coverage. No API, schema, configuration, or archive-format change.

--- a/openspec/changes/prevent-http-bridge-model-transition-loop/proposal.md
+++ b/openspec/changes/prevent-http-bridge-model-transition-loop/proposal.md
@@ -4,8 +4,9 @@ When a request carries a fresh generated turn-state header plus a session header
 
 ## What Changes
 
-- Preserve an internal parallel bridge key once lookup has selected it instead of resolving the original turn-state/session headers again on the next creation-loop iteration.
-- Cover the unmatched turn-state plus incompatible session-header transition that previously repeated the same fork.
+- Preserve an internal parallel bridge key and its session-header fallback state once lookup has selected it instead of resolving the original turn-state/session headers again on the next creation-loop iteration.
+- Protect the incompatible session-header parent from capacity eviction while the isolated child is created.
+- Cover follow-up requests without a previous-response/durable lookup and full-cache model transitions.
 
 ## Capabilities
 

--- a/openspec/changes/prevent-http-bridge-model-transition-loop/specs/responses-api-compat/spec.md
+++ b/openspec/changes/prevent-http-bridge-model-transition-loop/specs/responses-api-compat/spec.md
@@ -1,0 +1,20 @@
+# responses-api-compat Delta
+
+## ADDED Requirements
+
+### Requirement: HTTP bridge model-transition isolation is single-pass
+
+When an HTTP bridge request cannot reuse the session selected by its incoming affinity because that session uses an incompatible model, the service MUST preserve the resulting internal model-parallel key until bridge creation or reuse completes. It MUST NOT reapply the original session-header or turn-state fallback to the same request after selecting that fork.
+
+#### Scenario: Fresh turn state falls back to a session on another model
+
+- **GIVEN** a request carries a fresh generated turn-state header and a session header whose active bridge uses an incompatible model
+- **WHEN** lookup isolates the request with an internal model-parallel key
+- **THEN** lookup emits at most one model-transition fork for that request scope
+- **AND** bridge creation continues under the internal key without closing or reusing the incompatible session
+
+#### Scenario: Compatible session fallback remains reusable
+
+- **GIVEN** a request carries a fresh generated turn-state header and a session header whose active bridge uses a compatible model
+- **WHEN** lookup applies the session-header fallback
+- **THEN** the compatible bridge remains eligible for normal reuse

--- a/openspec/changes/prevent-http-bridge-model-transition-loop/specs/responses-api-compat/spec.md
+++ b/openspec/changes/prevent-http-bridge-model-transition-loop/specs/responses-api-compat/spec.md
@@ -27,6 +27,12 @@ When an HTTP bridge request cannot reuse the session selected by its incoming af
 - **THEN** the incompatible session-header parent MUST NOT be selected for that eviction
 - **AND** ordinary LRU eviction remains eligible for other idle sessions
 
+#### Scenario: In-flight parent completes before model isolation
+
+- **GIVEN** a request waits for an in-flight session-header parent whose completed bridge uses an incompatible model
+- **WHEN** the request isolates itself with an internal model-parallel key after that wait
+- **THEN** the completed parent MUST receive the same capacity-eviction protection as an immediately available parent
+
 #### Scenario: Compatible session fallback remains reusable
 
 - **GIVEN** a request carries a fresh generated turn-state header and a session header whose active bridge uses a compatible model

--- a/openspec/changes/prevent-http-bridge-model-transition-loop/specs/responses-api-compat/spec.md
+++ b/openspec/changes/prevent-http-bridge-model-transition-loop/specs/responses-api-compat/spec.md
@@ -13,6 +13,20 @@ When an HTTP bridge request cannot reuse the session selected by its incoming af
 - **THEN** lookup emits at most one model-transition fork for that request scope
 - **AND** bridge creation continues under the internal key without closing or reusing the incompatible session
 
+#### Scenario: Follow-up fallback has no previous-response lookup
+
+- **GIVEN** a request carries a fresh generated turn-state header, a `previous_response_id` without a local or durable lookup, and a session header whose active bridge uses an incompatible model
+- **WHEN** lookup isolates the request with an internal model-parallel key
+- **THEN** the session-header fallback remains an anchored continuation for the rest of that lookup/create operation
+- **AND** bridge creation continues under the internal key without a `continuity_lost` error
+
+#### Scenario: Full cache preserves the incompatible parent
+
+- **GIVEN** the HTTP bridge cache is at its session limit and a model transition isolates a session-header fallback into a child key
+- **WHEN** creation needs to evict an idle session
+- **THEN** the incompatible session-header parent MUST NOT be selected for that eviction
+- **AND** ordinary LRU eviction remains eligible for other idle sessions
+
 #### Scenario: Compatible session fallback remains reusable
 
 - **GIVEN** a request carries a fresh generated turn-state header and a session header whose active bridge uses a compatible model

--- a/openspec/changes/prevent-http-bridge-model-transition-loop/tasks.md
+++ b/openspec/changes/prevent-http-bridge-model-transition-loop/tasks.md
@@ -1,0 +1,8 @@
+## 1. Implementation
+
+- [x] 1.1 Preserve internal parallel fork keys across lookup-loop iterations.
+
+## 2. Validation
+
+- [x] 2.1 Add a regression test for an unmatched generated turn state with an incompatible session-header fallback.
+- [x] 2.2 Run focused and full repository validation, including strict OpenSpec validation.

--- a/openspec/changes/prevent-http-bridge-model-transition-loop/tasks.md
+++ b/openspec/changes/prevent-http-bridge-model-transition-loop/tasks.md
@@ -1,8 +1,9 @@
 ## 1. Implementation
 
-- [x] 1.1 Preserve internal parallel fork keys across lookup-loop iterations.
+- [x] 1.1 Preserve internal parallel fork keys and session-header fallback state across lookup-loop iterations.
+- [x] 1.2 Protect incompatible session-header parents from capacity eviction while creating an isolated model child.
 
 ## 2. Validation
 
-- [x] 2.1 Add a regression test for an unmatched generated turn state with an incompatible session-header fallback.
+- [x] 2.1 Add regressions for an unmatched generated turn state with an incompatible session-header fallback, missing previous-response lookup, and full-cache eviction.
 - [x] 2.2 Run focused and full repository validation, including strict OpenSpec validation.

--- a/openspec/changes/prevent-http-bridge-model-transition-loop/tasks.md
+++ b/openspec/changes/prevent-http-bridge-model-transition-loop/tasks.md
@@ -5,5 +5,5 @@
 
 ## 2. Validation
 
-- [x] 2.1 Add regressions for an unmatched generated turn state with an incompatible session-header fallback, missing previous-response lookup, and full-cache eviction.
+- [x] 2.1 Add regressions for an unmatched generated turn state with an incompatible session-header fallback, missing previous-response lookup, full-cache eviction, and an in-flight parent completing before isolation.
 - [x] 2.2 Run focused and full repository validation, including strict OpenSpec validation.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -9677,7 +9677,7 @@ async def test_get_or_create_http_bridge_session_isolates_model_transition_from_
 
 
 @pytest.mark.asyncio
-async def test_get_or_create_http_bridge_session_preserves_model_fork_after_session_header_fallback(
+async def test_get_or_create_http_bridge_session_preserves_session_header_fallback_for_model_fork_follow_up(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
@@ -9737,6 +9737,7 @@ async def test_get_or_create_http_bridge_session_preserves_model_fork_after_sess
         request_model="gpt-5.6-sol",
         idle_ttl_seconds=120.0,
         max_sessions=8,
+        previous_response_id="resp_missing_lookup",
         session_header_fallback_key=parent_key,
     )
 
@@ -9747,6 +9748,72 @@ async def test_get_or_create_http_bridge_session_preserves_model_fork_after_sess
     assert parent.request_model == "gpt-5.6-terra"
     assert parent.closed is False
     assert service._http_bridge_sessions[parent_key] is parent
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_preserves_model_transition_parent_during_capacity_eviction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    requested_key = proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_child", None)
+    parent_key = proxy_service._HTTPBridgeSessionKey("session_header", "shared-root", None)
+    parent = _make_bridge_session(key=parent_key)
+    parent.request_model = "gpt-5.6-terra"
+    parent.last_used_at = 1.0
+    evictable_key = proxy_service._HTTPBridgeSessionKey("session_header", "evictable", None)
+    evictable = _make_bridge_session(key=evictable_key)
+    evictable.last_used_at = 2.0
+    child = _make_bridge_session(key=requested_key)
+    child.request_model = "gpt-5.6-sol"
+    service._http_bridge_sessions[parent_key] = parent
+    service._http_bridge_sessions[evictable_key] = evictable
+    closed_sessions: list[proxy_service._HTTPBridgeSession] = []
+
+    async def fake_create_http_bridge_session(
+        create_key: proxy_service._HTTPBridgeSessionKey,
+        **_kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        child.key = create_key
+        return child
+
+    async def track_close(session: proxy_service._HTTPBridgeSession, *, reason: str) -> None:
+        assert reason == "registry_detach"
+        closed_sessions.append(session)
+
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_create_http_bridge_session", fake_create_http_bridge_session)
+    monkeypatch.setattr(service, "_close_http_bridge_session_bounded", track_close)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ["instance-a"])),
+    )
+
+    resolved = await service._get_or_create_http_bridge_session(
+        requested_key,
+        headers={
+            "x-codex-turn-state": "http_turn_child",
+            "x-codex-session-id": "shared-root",
+        },
+        affinity=proxy_service._AffinityPolicy(
+            key="shared-root",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        api_key=None,
+        request_model="gpt-5.6-sol",
+        idle_ttl_seconds=120.0,
+        max_sessions=2,
+        session_header_fallback_key=parent_key,
+    )
+
+    assert resolved is child
+    assert parent.closed is False
+    assert service._http_bridge_sessions[parent_key] is parent
+    assert evictable_key not in service._http_bridge_sessions
+    assert closed_sessions == [evictable]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -9677,6 +9677,79 @@ async def test_get_or_create_http_bridge_session_isolates_model_transition_from_
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_preserves_model_fork_after_session_header_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    requested_key = proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_child", None)
+    parent_key = proxy_service._HTTPBridgeSessionKey("session_header", "shared-root", None)
+    parent = _make_bridge_session(key=parent_key)
+    parent.request_model = "gpt-5.6-terra"
+    child = _make_bridge_session(key=requested_key)
+    child.request_model = "gpt-5.6-sol"
+    service._http_bridge_sessions[parent_key] = parent
+    captured: dict[str, object] = {}
+    model_fork_keys: list[proxy_service._HTTPBridgeSessionKey] = []
+    incompatible_model_fork_key = http_bridge_mixin_module._http_bridge_incompatible_model_fork_key
+
+    def track_incompatible_model_fork_key(**kwargs: Any) -> proxy_service._HTTPBridgeSessionKey | None:
+        fork_key = incompatible_model_fork_key(**kwargs)
+        if fork_key is not None:
+            model_fork_keys.append(fork_key)
+            assert len(model_fork_keys) == 1, "model transition repeated instead of preserving its internal fork"
+        return fork_key
+
+    async def fake_create_http_bridge_session(
+        create_key: proxy_service._HTTPBridgeSessionKey,
+        **_kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        captured["key"] = create_key
+        child.key = create_key
+        return child
+
+    monkeypatch.setattr(
+        http_bridge_mixin_module,
+        "_http_bridge_incompatible_model_fork_key",
+        track_incompatible_model_fork_key,
+    )
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_create_http_bridge_session", fake_create_http_bridge_session)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ["instance-a"])),
+    )
+
+    resolved = await service._get_or_create_http_bridge_session(
+        requested_key,
+        headers={
+            "x-codex-turn-state": "http_turn_child",
+            "x-codex-session-id": "shared-root",
+        },
+        affinity=proxy_service._AffinityPolicy(
+            key="shared-root",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        api_key=None,
+        request_model="gpt-5.6-sol",
+        idle_ttl_seconds=120.0,
+        max_sessions=8,
+        session_header_fallback_key=parent_key,
+    )
+
+    assert resolved is child
+    assert len(model_fork_keys) == 1
+    assert model_fork_keys[0].affinity_kind == "internal_model_parallel"
+    assert captured["key"] == model_fork_keys[0]
+    assert parent.request_model == "gpt-5.6-terra"
+    assert parent.closed is False
+    assert service._http_bridge_sessions[parent_key] is parent
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_closes_stale_session_before_previous_response_recovery(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -9817,6 +9817,83 @@ async def test_get_or_create_http_bridge_session_preserves_model_transition_pare
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_preserves_inflight_model_transition_parent_during_capacity_eviction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    requested_key = proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_child", None)
+    parent_key = proxy_service._HTTPBridgeSessionKey("session_header", "shared-root", None)
+    parent = _make_bridge_session(key=parent_key)
+    parent.request_model = "gpt-5.6-terra"
+    parent.last_used_at = 1.0
+    evictable_key = proxy_service._HTTPBridgeSessionKey("session_header", "evictable", None)
+    evictable = _make_bridge_session(key=evictable_key)
+    evictable.last_used_at = 2.0
+    child = _make_bridge_session(key=requested_key)
+    child.request_model = "gpt-5.6-sol"
+    parent_creation: asyncio.Future[proxy_service._HTTPBridgeSession] = asyncio.get_running_loop().create_future()
+    service._http_bridge_inflight_sessions[parent_key] = parent_creation
+    closed_sessions: list[proxy_service._HTTPBridgeSession] = []
+
+    async def fake_create_http_bridge_session(
+        create_key: proxy_service._HTTPBridgeSessionKey,
+        **_kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        child.key = create_key
+        return child
+
+    async def track_close(session: proxy_service._HTTPBridgeSession, *, reason: str) -> None:
+        assert reason == "registry_detach"
+        closed_sessions.append(session)
+
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_create_http_bridge_session", fake_create_http_bridge_session)
+    monkeypatch.setattr(service, "_close_http_bridge_session_bounded", track_close)
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", AsyncMock())
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-a"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ["instance-a"])),
+    )
+
+    request_task = asyncio.create_task(
+        service._get_or_create_http_bridge_session(
+            requested_key,
+            headers={
+                "x-codex-turn-state": "http_turn_child",
+                "x-codex-session-id": "shared-root",
+            },
+            affinity=proxy_service._AffinityPolicy(
+                key="shared-root",
+                kind=proxy_service.StickySessionKind.CODEX_SESSION,
+            ),
+            api_key=None,
+            request_model="gpt-5.6-sol",
+            idle_ttl_seconds=120.0,
+            max_sessions=2,
+            session_header_fallback_key=parent_key,
+        )
+    )
+    await asyncio.sleep(0)
+    assert request_task.done() is False
+
+    service._http_bridge_sessions[parent_key] = parent
+    service._http_bridge_sessions[evictable_key] = evictable
+    service._http_bridge_inflight_sessions.pop(parent_key)
+    parent_creation.set_result(parent)
+
+    resolved = await request_task
+
+    assert resolved is child
+    assert parent.closed is False
+    assert service._http_bridge_sessions[parent_key] is parent
+    assert evictable_key not in service._http_bridge_sessions
+    assert closed_sessions == [evictable]
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_closes_stale_session_before_previous_response_recovery(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Preserve an HTTP bridge's internal model-transition fork after sticky-affinity lookup has selected it. Without this guard, a fresh turn-state key can fall back to an incompatible session-header bridge, fork for the requested model, then be rewritten to the same parent on the next lookup iteration. That cycle repeats before account selection and can stall unrelated clients until the process is restarted.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issues: related to the sticky HTTP-bridge failure classes in [Soju06/codex-lb#471](https://github.com/Soju06/codex-lb/issues/471) and [Soju06/codex-lb#1167](https://github.com/Soju06/codex-lb/issues/1167). The exact model-transition loop is covered by the regression in this PR.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change.
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent behavior.

Change directory: `openspec/changes/prevent-http-bridge-model-transition-loop/`

## Changes

- Preserve `internal_model_parallel` and `internal_unanchored_parallel` keys across the HTTP bridge lookup/create loop.
- Keep the incompatible parent session open and unchanged while the child is created under its derived model-parallel key.
- Add a regression that fails if one request emits more than one model fork.
- Document the single-pass isolation invariant in OpenSpec.

## Validation

- `make ci-fast`
- Full local CI target set: frontend, architecture, Ruff, type checking, 3,864 unit tests, 1,343 core integration tests, 155 bridge integration tests, and 27 end-to-end tests
- PostgreSQL tests and migration/schema checks against an isolated `postgres:16` fixture: 44 tests, migration policy clean, no schema drift
- Package build, Docker image build, and critical-vulnerability gate
- Helm lint and schema validation
- Bundled-DB and external-DB kind smoke, including a two-member bridge ring
- Strict OpenSpec change validation and all 47 base specs
- Focused HTTP/Responses regression set: 441 tests

[Current-head GitHub CI](https://github.com/Soju06/codex-lb/actions/runs/29442473397) passed the required checks, and [the current-head Codex review](https://github.com/Soju06/codex-lb/pull/1356#issuecomment-4985130828) found no major issues.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Related failure-class issues are linked above.
- [x] Added regression coverage for the exact loop.
- [x] Ran the complete local CI target set.
- [x] Strict change and repository-wide OpenSpec validation pass.
- [x] CHANGELOG is not edited by hand.
