### PR TITLE
fix(proxy): recover sequenced Codex prewarms

### DIFF
--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -326,6 +326,7 @@ class _HTTPBridgeRequestSubmitMixin:
                 input_full_fingerprint = _fingerprint_input_items(payload_input_list)
 
         resolved_request_id = request_id or f"ws_{uuid4().hex}"
+        request_kind = _request_kind_from_headers(headers)
         request_state = _WebSocketRequestState(
             request_id=resolved_request_id,
             request_log_id=request_log_id,
@@ -346,7 +347,8 @@ class _HTTPBridgeRequestSubmitMixin:
             session_id=_normalize_session_id(session_id),
             input_item_count=input_item_count,
             input_full_fingerprint=input_full_fingerprint,
-            request_kind=_request_kind_from_headers(headers),
+            request_kind=request_kind,
+            generate_false_prewarm=request_kind == "prewarm" and upstream_payload.get("generate") is False,
         )
         if deduped_replayed_input_count is not None:
             request_state.input_item_count = deduped_replayed_input_count

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -548,6 +548,7 @@ class _WebSocketRequestState:
     upstream_transport: str | None = _REQUEST_TRANSPORT_WEBSOCKET
     enforce_openai_sdk_contract: bool = True
     request_kind: str = "normal"
+    generate_false_prewarm: bool = False
     api_key: ApiKeyData | None = None
     request_usage_budget: ApiKeyRequestUsageBudget | None = None
     request_text: str | None = None
@@ -814,7 +815,15 @@ def _websocket_request_can_replay_before_visible_output(request_state: _WebSocke
         return False
     if request_state.replay_count >= 1:
         return False
-    if request_state.last_downstream_sequence_number is not None:
+    sequenced_created_only_prewarm = (
+        request_state.generate_false_prewarm
+        and request_state.last_downstream_sequence_number == 0
+        and request_state.response_id is not None
+        and not request_state.awaiting_response_created
+        and request_state.response_event_count == 1
+        and not request_state.downstream_visible
+    )
+    if request_state.last_downstream_sequence_number is not None and not sequenced_created_only_prewarm:
         return False
     if request_state.downstream_visible:
         return False

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -469,6 +469,10 @@ logger = logging.getLogger(__name__)
 _WEBSOCKET_PINNED_REFRESH_UNAVAILABLE_MESSAGE = "Account refresh is temporarily unavailable; retry later."
 
 
+class _WebSocketReplaySequenceRegression(Exception):
+    pass
+
+
 def _log_websocket_persist_conflict(context: str, exc: RefreshError, account_id: str) -> None:
     """Surface a post-exchange persist/status CAS conflict distinctly in logs.
 
@@ -3333,6 +3337,34 @@ class _WebSocketMixin:
                 break
         except asyncio.CancelledError:
             raise
+        except _WebSocketReplaySequenceRegression as exc:
+            _facade().logger.warning(
+                "Refusing websocket replay after non-advancing sequence account_id=%s detail=%s",
+                account_id_value,
+                exc,
+            )
+            await proxy._fail_pending_websocket_requests(
+                account=account,
+                account_id_value=account_id_value,
+                pending_requests=pending_requests,
+                pending_lock=pending_lock,
+                error_code="stream_incomplete",
+                error_message="Replayed upstream websocket sequence did not advance",
+                api_key=api_key,
+                response_create_gate=response_create_gate,
+                suppress_sequenced_downstream_errors=True,
+            )
+            await _close_downstream_after_sequenced_replay_refusal(
+                websocket,
+                downstream_activity,
+            )
+            try:
+                await upstream.close()
+            except Exception:
+                _facade().logger.debug(
+                    "Failed to close upstream websocket after replay sequence refusal",
+                    exc_info=True,
+                )
         except Exception:
             _facade().logger.warning(
                 "Upstream websocket reader crashed account_id=%s",
@@ -3449,6 +3481,24 @@ class _WebSocketMixin:
             else:
                 release_create_gate = False
             if request_state is not None:
+                replay_created_will_be_suppressed = (
+                    event_type == "response.created" and request_state.suppress_next_created_downstream
+                )
+                sequence_number = payload.get("sequence_number") if payload is not None else None
+                if (
+                    request_state.replay_downstream_response_id is not None
+                    and request_state.last_downstream_sequence_number is not None
+                    and isinstance(sequence_number, int)
+                    and not isinstance(sequence_number, bool)
+                    and sequence_number <= request_state.last_downstream_sequence_number
+                    and not replay_created_will_be_suppressed
+                ):
+                    raise _WebSocketReplaySequenceRegression(
+                        f"request_id={request_state.request_log_id or request_state.request_id} "
+                        f"watermark={request_state.last_downstream_sequence_number} replay={sequence_number}"
+                    )
+                if event_type not in {"response.completed", "response.failed", "response.incomplete", "error"}:
+                    _record_response_event(request_state, event_type)
                 elapsed_ms = int((time.monotonic() - request_state.started_at) * 1000)
                 if request_state.latency_first_upstream_event_ms is None:
                     request_state.latency_first_upstream_event_ms = elapsed_ms

--- a/openspec/changes/recover-sequenced-codex-prewarm/design.md
+++ b/openspec/changes/recover-sequenced-codex-prewarm/design.md
@@ -1,0 +1,98 @@
+## Context
+
+The direct Responses WebSocket path supports a bounded one-shot replay before
+downstream-visible output. The sequence-safety contract added for #1222
+disables that replay after any numeric `sequence_number` has been sent because
+a fresh upstream generation normally restarts its sequence and can duplicate
+semantic events under the original downstream response id.
+
+Codex `generate = false` prewarms are a narrower protocol shape. They warm and
+establish request continuity but do not generate model output or tool calls. A
+normal successful prewarm emits `response.created` at sequence `0`, followed by
+an empty `response.completed`. If the upstream socket disappears between those
+events, the general sequence guard currently turns a recoverable no-output
+failure into a client-visible reconnect.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Recover an accepted, created-only Codex `generate = false` prewarm through
+  the existing one-shot reconnect and replay path.
+- Preserve a strictly advancing downstream numeric sequence.
+- Keep request ownership, response-create admission, reservations, logging,
+  and Lite continuity finalized exactly once.
+- Preserve the general fail-closed rule for every model-generating or
+  semantically progressed request.
+
+**Non-Goals:**
+
+- Renumber, offset, or synthesize sequence numbers.
+- Replay normal model turns after a numeric sequence is visible.
+- Retry more than once, replay multiplexed pending requests, or change HTTP
+  bridge behavior.
+- Treat the client metadata label alone as proof that a request is a prewarm.
+
+## Decisions
+
+### Verify the no-generation request shape
+
+Replay eligibility requires both trusted request observations:
+
+- Codex turn metadata classifies the request as `request_kind = "prewarm"`.
+- The normalized request body contains the literal boolean `generate = false`.
+
+The request state records this conjunction at preparation time. A caller that
+only spoofs the metadata label while sending a generating request receives no
+exception to the sequence guard.
+
+### Limit recovery to the initial created watermark
+
+The exception applies only when the request has:
+
+- exactly one recorded `response.*` progress event (`response.created`),
+- an assigned response id and no longer awaits `response.created`,
+- no text or tool output marked visible,
+- a downstream numeric watermark of exactly `0`, and
+- no previous replay attempt.
+
+Direct-WebSocket response progress is recorded when the event is matched,
+including non-terminal events. This prevents an intervening
+`response.in_progress` or other response event from being mistaken for a
+created-only state.
+
+Requiring watermark `0` matches the native prewarm start sequence and avoids
+sequence offsets. Any other exposed numeric watermark retains the existing
+1011 fail-closed behavior.
+
+### Preserve, rather than rewrite, sequence ordering
+
+The replayed `response.created` remains suppressed and its upstream response
+id remains rewritten to the original downstream-visible id, as in the existing
+created-only replay path. The original watermark remains `0`.
+
+Before a later replay event is finalized or forwarded, any numeric sequence
+that is less than or equal to the exposed watermark is treated as a replay
+sequence violation. The proxy settles the request as `stream_incomplete`, emits
+no synthetic terminal frame under the sequenced response id, and closes the
+downstream WebSocket with code 1011. No sequence is renumbered or invented.
+
+### Keep the retry and ownership bounds unchanged
+
+The existing `replay_count < 1`, single-pending-request, replay-safe anchor,
+file-owner, account-selection, admission, and reservation rules continue to
+apply. The exception only relaxes the numeric-watermark predicate for the
+verified prewarm state; it does not create a second retry mechanism.
+
+## Risks / Trade-offs
+
+- A prewarm may be accepted twice upstream. Because `generate = false` cannot
+  produce model output or external tool side effects, the cost is limited to
+  duplicate cache warming and is preferable to failing the client turn.
+- The exception intentionally does not recover non-zero initial watermarks or
+  prewarms with extra progress. Those cases remain client-visible reconnects
+  because preserving their semantics would require sequence rewriting or
+  broader event deduplication.
+- Incorrect response progress accounting could broaden replay eligibility, so
+  unit and endpoint regressions cover created-only, extra-progress, spoofed
+  metadata, ordinary-turn, and non-advancing-replay cases.

--- a/openspec/changes/recover-sequenced-codex-prewarm/proposal.md
+++ b/openspec/changes/recover-sequenced-codex-prewarm/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Codex sends `generate = false` prewarm requests before some GPT-5.6 turns. The
+upstream can accept the prewarm and emit a sequenced `response.created`, then
+lose the WebSocket before `response.completed`. The direct-WebSocket sequence
+guard correctly prevents general replay after a numeric sequence is visible,
+but it also rejects this no-generation prewarm and forces Codex to reconnect
+even though no model output or tool call can have been produced.
+
+## What Changes
+
+- Permit the existing bounded, created-only replay for a narrowly verified
+  Codex prewarm: `request_kind = "prewarm"`, `generate = false`, exactly one
+  `response.created` event, sequence watermark `0`, and no visible output.
+- Keep ordinary sequenced Responses requests, spoofed prewarm metadata, and
+  prewarms with additional response progress on the existing fail-closed 1011
+  path.
+- Refuse the replay if a forwarded replay sequence would not advance beyond
+  the sequence already exposed downstream.
+- Track direct-WebSocket response progress accurately and add endpoint-level
+  regressions for successful recovery and every fail-closed boundary.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: Define the safe `generate = false` prewarm exception
+  to the direct-WebSocket numeric-sequence replay guard.
+
+## Impact
+
+- Affected code: direct Responses WebSocket request classification, response
+  progress tracking, replay eligibility, and sequence validation.
+- Affected clients: Codex CLI GPT-5.6 prewarm requests can survive an abnormal
+  upstream close after `response.created` without a client reconnect.
+- Compatibility: normal turns retain the existing no-mixed-generation rule;
+  no setting, migration, dashboard change, or deployment action is added.

--- a/openspec/changes/recover-sequenced-codex-prewarm/specs/responses-api-compat/spec.md
+++ b/openspec/changes/recover-sequenced-codex-prewarm/specs/responses-api-compat/spec.md
@@ -1,0 +1,141 @@
+## MODIFIED Requirements
+
+### Requirement: Upstream websocket drops penalize affected accounts
+
+When an upstream websocket closes while one or more streamed response requests
+are pending and have not reached a terminal event, the proxy MUST record a
+transient upstream error for the account before signaling failure for those
+pending requests. The proxy MUST surface `stream_incomplete` to affected
+pending requests except when a direct Responses WebSocket request has already
+successfully emitted a finite integer `sequence_number`. For that sequenced
+direct-WebSocket case, the proxy MUST record the request outcome as
+`stream_incomplete` without emitting a synthetic terminal frame under the
+active response id, then MUST close the downstream WebSocket with code 1011,
+unless the request satisfies the verified no-generation prewarm recovery
+contract below and its one-shot replay succeeds.
+
+#### Scenario: websocket closes before pending responses complete
+
+- **GIVEN** a streamed response request is pending on an upstream websocket
+- **AND** the direct downstream response has not emitted a numeric sequence, or
+  the request uses another transport
+- **WHEN** the websocket closes before a terminal response event is observed
+- **THEN** the pending request fails with `stream_incomplete`
+- **AND** the account receives a transient upstream failure signal for routing
+
+#### Scenario: ordinary sequenced direct websocket closes before completion
+
+- **GIVEN** a direct Responses WebSocket request has successfully emitted a
+  finite integer `sequence_number`
+- **AND** the request does not satisfy the verified no-generation prewarm
+  recovery contract
+- **WHEN** the upstream websocket closes before a terminal response event is
+  observed
+- **THEN** the request is recorded as failed with `stream_incomplete`
+- **AND** no synthetic terminal frame is emitted under the active response id
+- **AND** the downstream WebSocket closes with code 1011
+- **AND** the account receives a transient upstream failure signal for routing
+
+#### Scenario: created-only generate-false Codex prewarm recovers
+
+- **GIVEN** a direct Responses WebSocket request is classified by Codex turn
+  metadata as `request_kind = "prewarm"`
+- **AND** its normalized request body contains `generate = false`
+- **AND** only `response.created` at numeric sequence `0` has been sent
+  downstream, with no other response progress or visible output
+- **WHEN** the upstream websocket closes before the terminal event
+- **THEN** the proxy MAY perform the existing bounded one-shot replay
+- **AND** it suppresses the replayed `response.created`
+- **AND** it forwards only replay numeric sequences that advance beyond `0`
+- **AND** the recovered request is finalized and logged exactly once
+
+### Requirement: Direct WebSocket replay never mixes numeric response sequences
+
+For direct Responses WebSocket requests, the proxy MUST NOT transparently
+replay a request on a fresh upstream generation after any finite integer
+`sequence_number` frame for that request has been successfully sent downstream,
+except for the verified no-generation prewarm case defined below. When an
+upstream close would otherwise trigger replay, the proxy MUST settle the failed
+pending request without emitting frames from a new upstream generation under
+the existing downstream response id, and MUST close the downstream WebSocket
+with code 1011 so the client can retry on a fresh transport. When an upstream
+terminal error would otherwise trigger quota, authentication, security-work,
+or equivalent replay, the proxy MUST finalize and surface that terminal error
+without reconnecting. Suppressed frames and non-integer sequence sentinels MUST
+NOT by themselves disable otherwise-safe replay.
+
+The sole numeric-sequence exception MUST require `request_kind = "prewarm"`, a
+literal normalized `generate = false`, exactly one recorded
+`response.created`, no visible output, sequence watermark `0`, a single pending
+request, and the existing one-shot replay eligibility. The proxy MUST suppress
+the replayed `response.created` and MUST NOT renumber or synthesize sequences.
+If a later replay event has a finite integer sequence that does not advance
+beyond the exposed watermark, the proxy MUST settle it as `stream_incomplete`,
+emit no synthetic terminal frame, and close downstream with code 1011.
+
+#### Scenario: Sequenced model-generating response is interrupted
+
+- **WHEN** a direct WebSocket model-generating request has emitted
+  `response.created` or another frame with a finite integer `sequence_number`
+- **AND** upstream closes before a terminal response event
+- **THEN** codex-lb does not transparently replay that request under the
+  existing downstream response id
+- **AND** no lower replay sequence is emitted downstream
+- **AND** the downstream WebSocket closes with code 1011
+
+#### Scenario: Prewarm metadata without generate-false body is not sufficient
+
+- **WHEN** a direct WebSocket request claims `request_kind = "prewarm"`
+- **BUT** its normalized body does not contain the literal `generate = false`
+- **AND** a numeric sequence has been sent downstream
+- **THEN** codex-lb does not transparently replay the request
+
+#### Scenario: Progressed prewarm is not replayed
+
+- **WHEN** a verified no-generation prewarm has emitted `response.created` and
+  any additional `response.*` progress event
+- **AND** upstream closes before completion
+- **THEN** codex-lb does not transparently replay the request
+- **AND** the downstream WebSocket closes with code 1011
+
+#### Scenario: Replayed prewarm sequence must advance
+
+- **GIVEN** a verified no-generation prewarm is replayed after exposing
+  `response.created` at sequence `0`
+- **WHEN** a non-suppressed replay frame has a finite integer
+  `sequence_number <= 0`
+- **THEN** codex-lb emits no frame from that replay generation downstream
+- **AND** it settles the request as `stream_incomplete`
+- **AND** it closes the downstream WebSocket with code 1011
+
+#### Scenario: Unsafe replay settles request ownership
+
+- **WHEN** sequenced replay is refused after upstream close or a replay
+  sequence fails to advance
+- **THEN** response-create admission, account-local leases, API-key
+  reservations, and request logging are finalized exactly once
+- **AND** the failed attempt does not become a successful continuity owner
+
+#### Scenario: Sequenced retryable terminal event is not replayed
+
+- **WHEN** a direct WebSocket request has successfully emitted a finite integer
+  `sequence_number`
+- **AND** upstream emits a terminal error that would ordinarily trigger
+  transparent quota, authentication, or security-work replay
+- **THEN** codex-lb does not reconnect or resend the request
+- **AND** the terminal error is finalized and remains client-visible under the
+  existing error contract
+
+#### Scenario: Sequence-free startup remains replayable
+
+- **WHEN** upstream closes before any numeric sequence-bearing frame has been
+  successfully sent downstream
+- **AND** the request otherwise satisfies the existing one-shot replay guard
+- **THEN** codex-lb MAY transparently replay the request on a fresh upstream
+  connection
+
+#### Scenario: Suppressed frame does not establish exposure
+
+- **WHEN** codex-lb suppresses an upstream frame before downstream emission
+- **AND** the suppressed frame contains a numeric `sequence_number`
+- **THEN** that frame does not establish the downstream sequence watermark

--- a/openspec/changes/recover-sequenced-codex-prewarm/tasks.md
+++ b/openspec/changes/recover-sequenced-codex-prewarm/tasks.md
@@ -1,0 +1,34 @@
+## 1. Contract and classification
+
+- [x] 1.1 Record whether a prepared request is both a Codex prewarm and
+  `generate = false`.
+- [x] 1.2 Count matched direct-WebSocket response progress events accurately.
+- [x] 1.3 Allow only the created-only sequence-zero prewarm through the existing
+  one-shot replay guard.
+
+## 2. Sequence and lifecycle safety
+
+- [x] 2.1 Reject a replay event whose numeric sequence does not advance beyond
+  the exposed watermark.
+- [x] 2.2 Preserve the existing 1011 close, single settlement, request logging,
+  and reservation/admission cleanup on replay refusal.
+- [x] 2.3 Preserve fail-closed behavior for ordinary turns, metadata-only
+  prewarm claims, progressed prewarms, non-zero watermarks, and multiple
+  pending requests.
+
+## 3. Regression coverage
+
+- [x] 3.1 Add a direct `/backend-api/codex/responses` product-path regression
+  for abnormal close after sequenced prewarm `response.created`.
+- [x] 3.2 Add focused regressions for request classification, progress
+  accounting, and every replay-refusal boundary.
+- [x] 3.3 Verify recovered prewarms emit one downstream `response.created`, one
+  advancing terminal event, and finalize/log exactly once.
+
+## 4. Validation
+
+- [x] 4.1 Run focused unit and direct-WebSocket integration tests.
+- [x] 4.2 Run changed-file lint/format, type checking, architecture checks, and
+  strict OpenSpec validation.
+- [x] 4.3 Review the final diff against the sequence, account ownership,
+  settlement, and simplicity invariants before opening the PR.

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -9110,3 +9110,157 @@ def test_backend_responses_websocket_closes_before_replaying_exposed_sequence(
     assert log_calls[0]["request_id"] == "resp_ws_sequenced_first"
     assert log_calls[0]["status"] == "error"
     assert log_calls[0]["error_code"] == "stream_incomplete"
+
+
+@pytest.mark.parametrize(("terminal_sequence", "expect_recovery"), [(1, True), (0, False)])
+def test_backend_responses_websocket_recovers_created_only_sequenced_prewarm(
+    app_instance,
+    monkeypatch,
+    terminal_sequence: int,
+    expect_recovery: bool,
+):
+    first_upstream = _FakeUpstreamWebSocket(
+        [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.created",
+                        "sequence_number": 0,
+                        "response": {"id": "resp_ws_prewarm_first", "status": "in_progress"},
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+            _FakeUpstreamMessage(
+                "error",
+                error="no close frame received or sent",
+            ),
+        ]
+    )
+    replay_upstream = _FakeUpstreamWebSocket(
+        [
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.created",
+                        "sequence_number": 0,
+                        "response": {"id": "resp_ws_prewarm_replay", "status": "in_progress"},
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.completed",
+                        "sequence_number": terminal_sequence,
+                        "response": {
+                            "id": "resp_ws_prewarm_replay",
+                            "status": "completed",
+                            "usage": {
+                                "input_tokens": 12,
+                                "output_tokens": 0,
+                                "total_tokens": 12,
+                            },
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+            ),
+        ]
+    )
+    upstreams = [first_upstream, replay_upstream]
+    connect_calls = 0
+    log_calls: list[dict[str, object]] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
+        return None
+
+    async def fake_connect_proxy_websocket(self, headers, **kwargs):
+        nonlocal connect_calls
+        del self, headers, kwargs
+        connect_calls += 1
+        return SimpleNamespace(id="acct_ws_prewarm_replay"), upstreams.pop(0)
+
+    async def fake_write_request_log(self, **kwargs):
+        del self
+        log_calls.append(kwargs)
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+    monkeypatch.setattr(proxy_module.ProxyService, "_write_request_log", fake_write_request_log)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "generate": False,
+        "input": [
+            {
+                "type": "additional_tools",
+                "role": "developer",
+                "tools": [{"type": "custom", "name": "shell"}],
+            }
+        ],
+        "stream": True,
+    }
+    headers = {
+        "x-codex-turn-metadata": json.dumps(
+            {"request_kind": "prewarm", "turn_id": "turn_sequenced_prewarm"},
+            separators=(",", ":"),
+        )
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses", headers=headers) as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            created_event = json.loads(websocket.receive_text())
+            if expect_recovery:
+                terminal_event = json.loads(websocket.receive_text())
+                disconnect = None
+            else:
+                terminal_event = None
+                with pytest.raises(WebSocketDisconnect) as disconnect_info:
+                    websocket.receive_text()
+                disconnect = disconnect_info.value
+
+    assert created_event["type"] == "response.created"
+    assert created_event["response"]["id"] == "resp_ws_prewarm_first"
+    assert created_event["sequence_number"] == 0
+    assert connect_calls == 2
+    assert upstreams == []
+    assert len(first_upstream.sent_text) == 1
+    assert len(replay_upstream.sent_text) == 1
+    assert json.loads(first_upstream.sent_text[0])["generate"] is False
+    assert json.loads(replay_upstream.sent_text[0])["generate"] is False
+    assert len(log_calls) == 1
+    assert log_calls[0]["request_kind"] == "prewarm"
+
+    if expect_recovery:
+        assert terminal_event is not None
+        assert terminal_event["type"] == "response.completed"
+        assert terminal_event["response"]["id"] == "resp_ws_prewarm_first"
+        assert terminal_event["sequence_number"] == 1
+        assert log_calls[0]["request_id"] == "resp_ws_prewarm_replay"
+        assert log_calls[0]["status"] == "success"
+        assert log_calls[0]["output_tokens"] == 0
+        assert disconnect is None
+    else:
+        assert terminal_event is None
+        assert disconnect is not None
+        assert disconnect.code == 1011
+        assert log_calls[0]["request_id"] == "resp_ws_prewarm_replay"
+        assert log_calls[0]["status"] == "error"
+        assert log_calls[0]["error_code"] == "stream_incomplete"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -15268,6 +15268,7 @@ async def test_prepare_websocket_response_create_request_normalizes_payload_and_
     assert prepared.request_state.service_tier == "priority"
     assert prepared.request_state.reasoning_effort == "high"
     assert prepared.request_state.request_kind == "prewarm"
+    assert prepared.request_state.generate_false_prewarm is False
     assert prepared.affinity_policy.key == "thread_123"
     assert prepared.affinity_policy.kind == proxy_service.StickySessionKind.PROMPT_CACHE
     normalized_payload = json.loads(prepared.text_data)
@@ -15476,6 +15477,7 @@ async def test_websocket_lite_prewarm_acceptance_preserves_incremental_marker(
     assert first_payload["generate"] is False
     assert first_payload["client_metadata"][marker] == "true"
     assert first.request_state.request_kind == "prewarm"
+    assert first.request_state.generate_false_prewarm is True
     assert continuity_state.responses_lite_model is None
     first.request_state.response_create_gate_acquired = True
     response_create_gate = asyncio.Semaphore(0)
@@ -15499,6 +15501,7 @@ async def test_websocket_lite_prewarm_acceptance_preserves_incremental_marker(
     )
     assert continuity_state.responses_lite_model == "gpt-5.6-sol"
     assert continuity_state.responses_lite_response_id == "resp_ws_lite_prewarm"
+    assert first.request_state.response_event_count == 1
     await asyncio.wait_for(response_create_gate.acquire(), timeout=1.0)
 
     incremental = await service._prepare_websocket_response_create_request(
@@ -22691,6 +22694,82 @@ async def test_pop_replayable_created_request_refuses_exposed_sequence():
         awaiting_response_created=False,
         response_event_count=1,
         last_downstream_sequence_number=5,
+    )
+    pending_requests = deque([pending_request])
+    replay_refusal_reasons: list[str] = []
+
+    replayed_request = await proxy_service._pop_replayable_precreated_websocket_request_state(
+        pending_requests,
+        pending_lock=anyio.Lock(),
+        replay_refusal_reasons=replay_refusal_reasons,
+    )
+
+    assert replayed_request is None
+    assert pending_requests == deque([pending_request])
+    assert replay_refusal_reasons == ["sequenced_downstream_frame"]
+
+
+@pytest.mark.asyncio
+async def test_pop_replayable_created_generate_false_prewarm_accepts_initial_sequence():
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_created_prewarm_sequence_replay",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        request_text=('{"type":"response.create","model":"gpt-5.6-sol","generate":false,"input":[]}'),
+        request_kind="prewarm",
+        generate_false_prewarm=True,
+        response_id="resp_created_prewarm_then_closed",
+        awaiting_response_created=False,
+        response_event_count=1,
+        last_downstream_sequence_number=0,
+    )
+    pending_requests = deque([pending_request])
+
+    replayed_request = await proxy_service._pop_replayable_precreated_websocket_request_state(
+        pending_requests,
+        pending_lock=anyio.Lock(),
+    )
+
+    assert replayed_request is pending_request
+    assert pending_requests == deque()
+    assert pending_request.replay_count == 1
+    assert pending_request.response_event_count == 0
+    assert pending_request.last_downstream_sequence_number == 0
+    assert pending_request.replay_downstream_response_id == "resp_created_prewarm_then_closed"
+    assert pending_request.suppress_next_created_downstream is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("generate_false_prewarm", "response_event_count", "sequence_number"),
+    [
+        (False, 1, 0),
+        (True, 2, 0),
+        (True, 1, 1),
+    ],
+)
+async def test_pop_replayable_created_sequenced_prewarm_keeps_unsafe_boundaries(
+    generate_false_prewarm: bool,
+    response_event_count: int,
+    sequence_number: int,
+):
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_created_unsafe_prewarm_sequence",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        request_text=('{"type":"response.create","model":"gpt-5.6-sol","generate":false,"input":[]}'),
+        request_kind="prewarm",
+        generate_false_prewarm=generate_false_prewarm,
+        response_id="resp_created_unsafe_prewarm",
+        awaiting_response_created=False,
+        response_event_count=response_event_count,
+        last_downstream_sequence_number=sequence_number,
     )
     pending_requests = deque([pending_request])
     replay_refusal_reasons: list[str] = []


### PR DESCRIPTION
## Summary

Recover a narrow direct Responses WebSocket failure seen with GPT-5.6 Codex prewarms: upstream can emit response.created at sequence 0 for a generate=false prewarm, then reset the socket without a close frame before response.completed.

The numeric-sequence guard added by #1223 correctly blocks general replay after a sequence is visible, but this no-generation prewarm cannot have emitted model output or tool side effects. This PR permits the existing one-shot replay only for that verified created-only shape, while keeping every model-generating or progressed request fail-closed.

Diff composition: 63 added production lines (61 net), 233 test lines, and 314 OpenSpec/design/task lines.

## Type of change

- [x] fix: bug fix (no behavior change beyond the bug)
- [ ] feat: new user-facing feature or capability
- [ ] refactor: internal refactor
- [ ] docs: documentation only
- [ ] chore / ci / build
- [ ] test: test-only change
- [ ] Breaking change

Related to #987.

This is intentionally partial coverage: #987 also tracks broader HTTP-bridge and model-generating stream failures. This PR fixes only the direct GPT-5.6 generate=false prewarm subset that can be replayed without duplicating output.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches a Codex-faithful response.create framing path and preserves upstream sequence values

Change directory: openspec/changes/recover-sequenced-codex-prewarm/

## Changes

- Classify a replay candidate only when Codex turn metadata says request_kind=prewarm and the normalized body literally has generate=false.
- Count matched non-terminal response progress on the direct WebSocket path, so anything after response.created disqualifies created-only replay.
- Relax the numeric watermark guard only for one pending request with exactly one response.created event, no visible output, sequence 0, and no prior replay.
- Suppress the replayed response.created and preserve the original downstream response id without renumbering or synthesizing sequences.
- Reject any non-suppressed replay sequence that does not advance beyond the exposed watermark; settle stream_incomplete once and close downstream with 1011 without emitting an invalid terminal frame.
- Add unit boundaries plus product-path recovery and fail-closed integration coverage.

## Ownership and settlement safety

- Existing one-shot, single-pending-request, replay-safe-anchor, account-selection, file ownership, admission, and reservation rules remain in force.
- Successful recovery finalizes and logs once.
- A non-advancing replay releases admission/account/API-key ownership, records stream_incomplete once, emits no synthetic sequenced error, and closes with 1011.
- Ordinary turns, metadata-only prewarm claims, progressed prewarms, non-zero watermarks, and multiplexed pending requests retain the existing fail-closed path.

## Simplicity

No setting, environment variable, required setup step, migration, README section, dashboard navigation item, dashboard rendering, or default changes. The zero-config behavior and all simplicity budgets remain unchanged.

## Test plan

    uv run pytest tests/unit/test_proxy_utils.py -q
    733 passed in 29.22s

    uv run pytest tests/integration/test_proxy_websocket_responses.py -q
    68 passed in 71.02s

    uv run pytest tests/integration/test_http_responses_bridge.py -q
    89 passed in 81.65s

    uv run ruff check <changed Python files>
    All checks passed!

    uv run ruff format --check <changed Python files>
    5 files already formatted

    uv run ty check <changed Python files>
    All checks passed!

    uv run python scripts/check_proxy_architecture.py
    proxy architecture checks passed

    npx --yes @fission-ai/openspec@latest validate recover-sequenced-codex-prewarm --strict
    Change 'recover-sequenced-codex-prewarm' is valid

    npx --yes @fission-ai/openspec@latest validate --specs --strict
    47 passed, 0 failed

    uv run python .github/scripts/check_simplicity_budgets.py
    all four budgets OK

    git diff --check
    clean

## Observable sequence

Before: downstream receives response.created(sequence_number=0), upstream resets without a close frame, and Codex must reconnect.

After: codex-lb keeps the first response.created, reconnects once, suppresses the replayed response.created(0), and forwards response.completed(1) under the original response id. If the replay terminal sequence is 0 or otherwise non-advancing, codex-lb emits no replay frame and closes downstream with 1011.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue and stated the partial scope.
- [x] Added unit and externally observable direct-WebSocket regression coverage.
- [x] Ran the relevant local CI subsets.
- [x] Strict change and repository-wide OpenSpec validation passes.
- [x] Reviewed sequence, ownership, settlement, account-health, and simplicity invariants.
- [x] CHANGELOG.md is unchanged.