### PR TITLE
refactor(config): remove phase-2 low-risk tunables from the settings surface

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -622,9 +622,13 @@ _SDK_FINGERPRINT_HEADER_KEYS: frozenset[str] = frozenset(
 _SDK_FINGERPRINT_HEADER_PREFIXES: tuple[str, ...] = ("x-stainless-",)
 _CODEX_CLI_ORIGINATOR = "codex_cli_rs"
 _CHATGPT_ACCOUNT_ID_HEADER = "ChatGPT-Account-Id"
-_DEFAULT_FINGERPRINT_OS = "Mac OS 26.5.0"
-_DEFAULT_FINGERPRINT_ARCH = "arm64"
-_DEFAULT_FINGERPRINT_TERMINAL = "iTerm.app/3.6.10"
+# Fixed Codex client fingerprint (issue #1340 / PRINCIPLES.md P2). These
+# values impersonate a plausible first-party Codex CLI install and are
+# maintained in lockstep with ``model_registry_client_version`` bumps; they
+# are not deployment tunables.
+_FINGERPRINT_OS = "Mac OS 26.5.0"
+_FINGERPRINT_ARCH = "arm64"
+_FINGERPRINT_TERMINAL = "iTerm.app/3.6.10"
 
 
 def build_codex_user_agent(version: str) -> str:
@@ -632,16 +636,10 @@ def build_codex_user_agent(version: str) -> str:
     ``openai/codex`` (``codex-rs/login/src/auth/default_client.rs``):
     ``codex_cli_rs/<version> (<os>; <arch>) <terminal>``.
 
-    OS/arch/terminal come from operator-configurable settings; the version is
-    the live Codex client version resolved by the caller. Settings access is
-    defensive (``getattr`` with built-in defaults) so header construction can
-    never raise and fail an otherwise-valid upstream request.
+    OS/arch/terminal are fixed fingerprint constants; the version is the live
+    Codex client version resolved by the caller.
     """
-    settings = get_settings()
-    os_name = getattr(settings, "codex_fingerprint_os", _DEFAULT_FINGERPRINT_OS)
-    arch = getattr(settings, "codex_fingerprint_arch", _DEFAULT_FINGERPRINT_ARCH)
-    terminal = getattr(settings, "codex_fingerprint_terminal", _DEFAULT_FINGERPRINT_TERMINAL)
-    return f"{_CODEX_CLI_ORIGINATOR}/{version} ({os_name}; {arch}) {terminal}"
+    return f"{_CODEX_CLI_ORIGINATOR}/{version} ({_FINGERPRINT_OS}; {_FINGERPRINT_ARCH}) {_FINGERPRINT_TERMINAL}"
 
 
 def _is_native_codex_user_agent(user_agent: str | None) -> bool:

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -38,6 +38,7 @@ OAUTH_CALLBACK_PORT = 1455  # Do not change the port. OpenAI dislikes changes.
 # PRINCIPLES.md P2). ``extra="ignore"`` already makes them harmless; startup
 # emits one WARN for one release as a courtesy to operators who still set them.
 _REMOVED_SETTINGS: tuple[str, ...] = (
+    # Phase 1 (reduce-settings-surface-phase-1)
     "CODEX_LB_AUTH_BASE_URL",
     "CODEX_LB_OAUTH_CLIENT_ID",
     "CODEX_LB_OAUTH_ORIGINATOR",
@@ -62,6 +63,22 @@ _REMOVED_SETTINGS: tuple[str, ...] = (
     "CODEX_LB_BULKHEAD_PROXY_COMPACT_LIMIT",
     "CODEX_LB_TOKEN_REFRESH_CLAIM_WAIT_SECONDS",
     "CODEX_LB_TOKEN_REFRESH_CLAIM_POLL_SECONDS",
+    # Phase 2 (reduce-settings-surface-phase-2)
+    "CODEX_LB_QUOTA_PLANNER_TICK_SECONDS",
+    "CODEX_LB_AUTOMATIONS_SCHEDULER_INTERVAL_SECONDS",
+    "CODEX_LB_MODEL_REGISTRY_REFRESH_INTERVAL_SECONDS",
+    "CODEX_LB_STICKY_SESSION_CLEANUP_INTERVAL_SECONDS",
+    "CODEX_LB_CODEX_FINGERPRINT_OS",
+    "CODEX_LB_CODEX_FINGERPRINT_ARCH",
+    "CODEX_LB_CODEX_FINGERPRINT_TERMINAL",
+    "CODEX_LB_LIVE_USAGE_WRITE_MIN_INTERVAL_SECONDS",
+    "CODEX_LB_LIVE_USAGE_QUEUE_SIZE",
+    "CODEX_LB_REQUEST_LOG_COUNT_CACHE_TTL_SECONDS",
+    "CODEX_LB_CIRCUIT_BREAKER_FAILURE_THRESHOLD",
+    "CODEX_LB_CIRCUIT_BREAKER_RECOVERY_TIMEOUT_SECONDS",
+    "CODEX_LB_MEMORY_WARNING_THRESHOLD_MB",
+    "CODEX_LB_IMAGES_HOST_MODEL",
+    "CODEX_LB_IMAGES_MAX_PARTIAL_IMAGES",
 )
 
 
@@ -256,8 +273,6 @@ class Settings(BaseSettings):
     usage_refresh_enabled: bool = True
     usage_refresh_interval_seconds: int = Field(default=60, gt=0)
     live_usage_ingestion_enabled: bool = True
-    live_usage_write_min_interval_seconds: float = Field(default=5.0, ge=0)
-    live_usage_queue_size: int = Field(default=512, gt=0)
     rate_limit_reset_credits_refresh_interval_seconds: int = Field(default=60, gt=0)
     openai_cache_affinity_max_age_seconds: int = Field(default=1800, gt=0)
     warmup_model: str = "gpt-5.4-mini"
@@ -286,17 +301,12 @@ class Settings(BaseSettings):
     http_responses_session_bridge_instance_ring: Annotated[list[str], NoDecode] = Field(default_factory=list)
     http_responses_session_bridge_advertise_base_url: str | None = None
     sticky_session_cleanup_enabled: bool = True
-    sticky_session_cleanup_interval_seconds: int = Field(default=300, gt=0)
     # Data retention (0 = disabled). Non-zero values have safety floors so
     # every in-product consumer window stays inside retained data.
-    # Display-only pagination total for the request-log listing; 0 disables.
-    request_log_count_cache_ttl_seconds: float = Field(default=30.0, ge=0)
     request_log_retention_days: int = Field(default=0, ge=0, le=3650)
     usage_history_retention_days: int = Field(default=0, ge=0, le=3650)
     quota_planner_scheduler_enabled: bool = True
-    quota_planner_tick_seconds: int = Field(default=300, gt=0)
     automations_scheduler_enabled: bool = True
-    automations_scheduler_interval_seconds: int = Field(default=30, gt=0)
     encryption_key_file: Path = DEFAULT_ENCRYPTION_KEY_FILE
     # Startup cross-replica encryption-key consistency check against the shared
     # database sentinel: "enforce" refuses startup on mismatch, "warn" logs an
@@ -319,20 +329,17 @@ class Settings(BaseSettings):
     image_inline_fetch_enabled: bool = True
     image_inline_allowed_hosts: Annotated[list[str], NoDecode] = Field(default_factory=list)
     # OpenAI Images API compatibility (POST /v1/images/{generations,edits})
-    # ``images_host_model`` is the internal Responses model used to invoke the
-    # built-in ``image_generation`` tool. It is never echoed to clients.
     # ``images_default_model`` is the public model returned to clients when
-    # they omit ``model``; it must remain in the ``gpt-image-*`` family.
-    images_host_model: str = "gpt-5.5"
+    # they omit ``model``; it must remain in the ``gpt-image-*`` family. The
+    # internal Responses host model used to invoke the ``image_generation``
+    # tool is a fixed constant in ``app/modules/proxy/api.py``.
     images_default_model: str = "gpt-image-2"
-    images_max_partial_images: int = Field(default=3, ge=0, le=3)
     # NOTE: there is intentionally no ``images_max_n`` setting. The
     # upstream ``image_generation`` tool path accepts only a single
     # image per call and codex-lb does not yet implement client-side
     # fan-out, so ``n > 1`` is hard-rejected at the API boundary. The
     # cap is lifted in the same change that introduces fan-out.
     model_registry_enabled: bool = True
-    model_registry_refresh_interval_seconds: int = Field(default=300, gt=0)
     # Fallback Codex client version used when the live release lookup fails.
     # Must stay >= the highest ``minimal_client_version`` in the bootstrap
     # catalog (GPT-5.6 requires 0.144.0) or a degraded-startup refresh would
@@ -341,9 +348,6 @@ class Settings(BaseSettings):
     # Persisted registry snapshots older than this are ignored at load time
     # (bootstrap catalog remains the floor until the next leader refresh).
     model_registry_snapshot_max_age_seconds: int = Field(default=86400, gt=0)
-    codex_fingerprint_os: str = "Mac OS 26.5.0"
-    codex_fingerprint_arch: str = "arm64"
-    codex_fingerprint_terminal: str = "iTerm.app/3.6.10"
     model_context_window_overrides: Annotated[dict[str, int], NoDecode] = Field(default_factory=dict)
     proxy_unauthenticated_client_cidrs: Annotated[list[str], NoDecode] = Field(default_factory=list)
     firewall_trust_proxy_headers: bool = False
@@ -371,10 +375,9 @@ class Settings(BaseSettings):
     leader_election_enabled: bool = True
     leader_election_ttl_seconds: int = Field(default=60, ge=5)
 
-    # Circuit breaker
+    # Circuit breaker (failure threshold and recovery timeout are fixed
+    # constants in ``app/core/resilience/circuit_breaker.py``)
     circuit_breaker_enabled: bool = False
-    circuit_breaker_failure_threshold: int = 5
-    circuit_breaker_recovery_timeout_seconds: int = 60
 
     # Soft drain & deterministic failover
     soft_drain_enabled: bool = True
@@ -420,7 +423,9 @@ class Settings(BaseSettings):
     proxy_refresh_failure_cooldown_seconds: float = Field(default=5.0, ge=0.0)
     usage_refresh_auth_failure_cooldown_seconds: float = Field(default=300.0, ge=0.0)
 
-    memory_warning_threshold_mb: int = 0
+    # Local memory-pressure guard (0 = disabled). Requests are rejected with
+    # 503 once RSS reaches the threshold; a warning is logged from 80% of it
+    # (``app/core/resilience/memory_monitor.py`` derives the warning level).
     memory_reject_threshold_mb: int = 0
 
     # OpenTelemetry

--- a/app/core/openai/images.py
+++ b/app/core/openai/images.py
@@ -64,6 +64,9 @@ _BACKGROUND_VALUES: Final[frozenset[str]] = frozenset({"transparent", "opaque", 
 _OUTPUT_FORMATS: Final[frozenset[str]] = frozenset({"png", "jpeg", "webp"})
 _MODERATION_VALUES: Final[frozenset[str]] = frozenset({"auto", "low"})
 _INPUT_FIDELITY_VALUES: Final[frozenset[str]] = frozenset({"low", "high"})
+# Upstream streams at most 3 partial image frames per generation; the cap is
+# an upstream contract, not a deployment tunable (issue #1340).
+_MAX_PARTIAL_IMAGES: Final[int] = 3
 
 # gpt-image-2 size limits (per the upstream image_generation tool contract).
 _GPT_IMAGE_2_MAX_EDGE: Final[int] = 3840
@@ -163,7 +166,6 @@ def validate_image_request_parameters(
     n: int,
     partial_images: int | None,
     output_compression: int,
-    images_max_partial_images: int,
 ) -> None:
     """Apply the cross-field per-model validation matrix.
 
@@ -218,9 +220,9 @@ def validate_image_request_parameters(
         )
 
     if partial_images is not None:
-        if partial_images < 0 or partial_images > images_max_partial_images:
+        if partial_images < 0 or partial_images > _MAX_PARTIAL_IMAGES:
             raise _images_invalid(
-                f"partial_images must be between 0 and {images_max_partial_images}",
+                f"partial_images must be between 0 and {_MAX_PARTIAL_IMAGES}",
                 param="partial_images",
             )
 

--- a/app/core/openai/model_refresh_scheduler.py
+++ b/app/core/openai/model_refresh_scheduler.py
@@ -34,6 +34,11 @@ from app.modules.proxy.account_cache import get_account_selection_cache
 
 logger = logging.getLogger(__name__)
 
+# Registry refresh cadence (fixed; issue #1340 / PRINCIPLES.md P2). The
+# scheduler keeps ``interval_seconds`` as a constructor field so tests can
+# exercise the loop with a short interval.
+_REFRESH_INTERVAL_SECONDS = 300
+
 
 _T = TypeVar("_T")
 
@@ -410,6 +415,6 @@ async def _refresh_http_client_after_transport_error(account: Account, transport
 def build_model_refresh_scheduler() -> ModelRefreshScheduler:
     settings = get_settings()
     return ModelRefreshScheduler(
-        interval_seconds=settings.model_registry_refresh_interval_seconds,
+        interval_seconds=_REFRESH_INTERVAL_SECONDS,
         enabled=settings.model_registry_enabled,
     )

--- a/app/core/resilience/circuit_breaker.py
+++ b/app/core/resilience/circuit_breaker.py
@@ -11,6 +11,12 @@ from app.core.config.settings import Settings
 
 T = TypeVar("T")
 
+# Breaker tuning (fixed; issue #1340 / PRINCIPLES.md P2). ``CircuitBreaker``
+# keeps both as constructor fields so tests can exercise state transitions
+# with small values. ``circuit_breaker_enabled`` remains the single switch.
+_FAILURE_THRESHOLD = 5
+_RECOVERY_TIMEOUT_SECONDS = 60
+
 
 class CircuitState(Enum):
     CLOSED = "closed"
@@ -131,8 +137,8 @@ def get_circuit_breaker(settings: Settings | None = None) -> CircuitBreaker | No
     enabled = getattr(settings, "circuit_breaker_enabled", False)
     if enabled and _circuit_breaker is None:
         _circuit_breaker = CircuitBreaker(
-            failure_threshold=getattr(settings, "circuit_breaker_failure_threshold", 5),
-            recovery_timeout_seconds=getattr(settings, "circuit_breaker_recovery_timeout_seconds", 60),
+            failure_threshold=_FAILURE_THRESHOLD,
+            recovery_timeout_seconds=_RECOVERY_TIMEOUT_SECONDS,
         )
 
     return _circuit_breaker if enabled else None
@@ -149,8 +155,8 @@ def get_circuit_breaker_for_account(
     breaker = _account_circuit_breakers.get(account_id)
     if breaker is None:
         breaker = CircuitBreaker(
-            failure_threshold=getattr(settings, "circuit_breaker_failure_threshold", 5),
-            recovery_timeout_seconds=getattr(settings, "circuit_breaker_recovery_timeout_seconds", 60),
+            failure_threshold=_FAILURE_THRESHOLD,
+            recovery_timeout_seconds=_RECOVERY_TIMEOUT_SECONDS,
         )
         _account_circuit_breakers[account_id] = breaker
     return breaker

--- a/app/core/resilience/memory_monitor.py
+++ b/app/core/resilience/memory_monitor.py
@@ -25,10 +25,16 @@ _memory_reject_threshold_bytes: int = 0
 _rss_provider_warning_logged = False
 
 
-def configure(warning_threshold_mb: int = 0, reject_threshold_mb: int = 0) -> None:
+# The warning level is derived, not configured: it exists only as an early
+# signal that the reject threshold is being approached, so it is fixed at 80%
+# of the reject threshold (issue #1340 / PRINCIPLES.md P2). 0 disables both.
+_WARNING_FRACTION = 0.8
+
+
+def configure(reject_threshold_mb: int = 0) -> None:
     global _memory_warning_threshold_bytes, _memory_reject_threshold_bytes
-    _memory_warning_threshold_bytes = warning_threshold_mb * 1024 * 1024
     _memory_reject_threshold_bytes = reject_threshold_mb * 1024 * 1024
+    _memory_warning_threshold_bytes = int(_memory_reject_threshold_bytes * _WARNING_FRACTION)
 
 
 def _get_windows_rss_bytes() -> int | None:

--- a/app/main.py
+++ b/app/main.py
@@ -551,10 +551,7 @@ async def lifespan(app: FastAPI):
 
 def create_app() -> FastAPI:
     settings = get_settings()
-    configure_memory_monitor(
-        warning_threshold_mb=settings.memory_warning_threshold_mb,
-        reject_threshold_mb=settings.memory_reject_threshold_mb,
-    )
+    configure_memory_monitor(reject_threshold_mb=settings.memory_reject_threshold_mb)
     app = FastAPI(
         title="codex-lb",
         version="0.1.0",

--- a/app/modules/automations/scheduler.py
+++ b/app/modules/automations/scheduler.py
@@ -17,6 +17,11 @@ from app.modules.request_logs.repository import RequestLogsRepository
 
 logger = logging.getLogger(__name__)
 
+# Scheduler poll cadence (fixed; issue #1340 / PRINCIPLES.md P2). The
+# scheduler keeps ``interval_seconds`` as a constructor field so tests can
+# exercise the loop with a short interval.
+_INTERVAL_SECONDS = 30
+
 
 _T = TypeVar("_T")
 
@@ -82,6 +87,6 @@ class AutomationsScheduler:
 def build_automations_scheduler() -> AutomationsScheduler:
     settings = get_settings()
     return AutomationsScheduler(
-        interval_seconds=settings.automations_scheduler_interval_seconds,
+        interval_seconds=_INTERVAL_SECONDS,
         enabled=settings.automations_scheduler_enabled,
     )

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -358,6 +358,14 @@ class _CapacityStartupReadyEvent(asyncio.Event):
 
 _OPPORTUNISTIC_RETRY_AFTER_SECONDS = 60
 
+# Internal Responses host model used to invoke the built-in
+# ``image_generation`` tool on the /v1/images/* routes. It is never echoed
+# to clients (only the requested ``gpt-image-*`` value appears in public
+# responses) and is fixed (issue #1340 / PRINCIPLES.md P2): it tracks the
+# registry bootstrap catalog's stable ``gpt-5.5`` slug and changes only in
+# lockstep with catalog maintenance.
+_IMAGES_HOST_MODEL = "gpt-5.5"
+
 # OpenAI error ``type`` -> HTTP status for the /v1/images/* non-streaming
 # error path. The /v1/responses path has its own ``_status_for_error``
 # helper that operates on a parsed ``OpenAIError`` model; the image
@@ -2166,7 +2174,7 @@ async def _proxy_images_generation_request(
 
     public_model = payload.model
     assert public_model is not None
-    host_model = settings.images_host_model
+    host_model = _IMAGES_HOST_MODEL
 
     try:
         validate_model_access(api_key, effective_model)
@@ -2468,7 +2476,7 @@ async def _proxy_images_edit_request(
 
     public_model = payload.model
     assert public_model is not None
-    host_model = settings.images_host_model
+    host_model = _IMAGES_HOST_MODEL
 
     try:
         validate_model_access(api_key, effective_model)

--- a/app/modules/proxy/images_service.py
+++ b/app/modules/proxy/images_service.py
@@ -306,7 +306,6 @@ def validate_generations_payload(payload: V1ImagesGenerationsRequest) -> V1Image
     """Apply the cross-field validation matrix and return the payload with
     ``model`` populated to the configured default when the client omitted it.
     """
-    settings = get_settings()
     resolved_model = resolve_public_image_model(payload.model)
     # Forward ``payload.input_fidelity`` so the validator rejects it on the
     # generations path (it is an edit-only parameter). Without this the
@@ -324,7 +323,6 @@ def validate_generations_payload(payload: V1ImagesGenerationsRequest) -> V1Image
         n=payload.n,
         partial_images=payload.partial_images,
         output_compression=payload.output_compression,
-        images_max_partial_images=settings.images_max_partial_images,
     )
     if payload.model != resolved_model:
         # Pydantic models are immutable by default; build a copy with the
@@ -338,7 +336,6 @@ def validate_edits_payload(payload: V1ImagesEditsForm) -> V1ImagesEditsForm:
     """Apply the cross-field validation matrix and return the payload with
     ``model`` populated to the configured default when the client omitted it.
     """
-    settings = get_settings()
     resolved_model = resolve_public_image_model(payload.model)
     validate_image_request_parameters(
         model=resolved_model,
@@ -352,7 +349,6 @@ def validate_edits_payload(payload: V1ImagesEditsForm) -> V1ImagesEditsForm:
         n=payload.n,
         partial_images=payload.partial_images,
         output_compression=payload.output_compression,
-        images_max_partial_images=settings.images_max_partial_images,
     )
     if payload.model != resolved_model:
         return payload.model_copy(update={"model": resolved_model})

--- a/app/modules/quota_planner/scheduler.py
+++ b/app/modules/quota_planner/scheduler.py
@@ -19,6 +19,11 @@ from app.modules.usage.repository import UsageRepository
 
 logger = logging.getLogger(__name__)
 
+# Planner tick cadence (fixed; issue #1340 / PRINCIPLES.md P2). The scheduler
+# keeps ``interval_seconds`` as a constructor field so tests can exercise the
+# loop with a short interval.
+_TICK_SECONDS = 300
+
 
 _T = TypeVar("_T")
 
@@ -166,6 +171,6 @@ class QuotaPlannerScheduler:
 def build_quota_planner_scheduler() -> QuotaPlannerScheduler:
     settings = get_settings()
     return QuotaPlannerScheduler(
-        interval_seconds=max(60, getattr(settings, "quota_planner_tick_seconds", 300)),
+        interval_seconds=_TICK_SECONDS,
         enabled=getattr(settings, "quota_planner_scheduler_enabled", True),
     )

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -12,7 +12,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.sql.elements import ColumnElement
 
-from app.core.config.settings import get_settings
 from app.core.usage.logs import RequestLogLike, calculated_cost_from_log
 from app.core.usage.types import BucketModelAggregate, RequestActivityAggregate, UsageSummaryLogsAggregate
 from app.core.utils.request_id import ensure_request_id
@@ -31,8 +30,9 @@ class _RequestLogFilters:
 # whole filtered set on PostgreSQL; the dashboard re-runs it on every 30s
 # poll and every pagination click even though the displayed total is
 # tolerant of short staleness. Cache it per filter signature for a small
-# TTL (configurable; 0 disables, which the test suite uses so totals stay
-# exact within a test).
+# fixed TTL (issue #1340 / PRINCIPLES.md P2; the test suite patches the
+# TTL to 0 so totals stay exact within a test).
+_COUNT_CACHE_TTL_SECONDS = 30.0
 _COUNT_CACHE_MAX_ENTRIES = 256
 _recent_count_cache: dict[tuple, tuple[int, float]] = {}
 
@@ -548,7 +548,7 @@ class RequestLogsRepository:
         result = await self._session.execute(stmt)
         logs = list(result.scalars().all())
 
-        ttl_seconds = get_settings().request_log_count_cache_ttl_seconds
+        ttl_seconds = _COUNT_CACHE_TTL_SECONDS
         if ttl_seconds <= 0:
             return logs, await self._count_recent(filters)
         cache_key = (

--- a/app/modules/sticky_sessions/cleanup_scheduler.py
+++ b/app/modules/sticky_sessions/cleanup_scheduler.py
@@ -21,6 +21,11 @@ from app.modules.settings.repository import SettingsRepository
 
 logger = logging.getLogger(__name__)
 
+# Cleanup poll cadence (fixed; issue #1340 / PRINCIPLES.md P2). The scheduler
+# keeps ``interval_seconds`` as a constructor field so tests can exercise the
+# loop with a short interval.
+_CLEANUP_INTERVAL_SECONDS = 300
+
 
 _T = TypeVar("_T")
 
@@ -127,6 +132,6 @@ class StickySessionCleanupScheduler:
 def build_sticky_session_cleanup_scheduler() -> StickySessionCleanupScheduler:
     settings = get_settings()
     return StickySessionCleanupScheduler(
-        interval_seconds=settings.sticky_session_cleanup_interval_seconds,
+        interval_seconds=_CLEANUP_INTERVAL_SECONDS,
         enabled=settings.sticky_session_cleanup_enabled,
     )

--- a/app/modules/usage/live_ingest.py
+++ b/app/modules/usage/live_ingest.py
@@ -20,6 +20,12 @@ from app.modules.usage.repository import UsageRepository
 logger = logging.getLogger(__name__)
 
 _RESOLUTION_TTL_SECONDS = 300.0
+
+# Write-coalescing tuning (fixed; issue #1340 / PRINCIPLES.md P2). The
+# ingestor keeps both as constructor fields so tests can exercise queue
+# overflow and coalescing with small values.
+_QUEUE_SIZE = 512
+_WRITE_MIN_INTERVAL_SECONDS = 5.0
 _CACHE_INVALIDATION_MIN_INTERVAL_SECONDS = 5.0
 
 
@@ -260,8 +266,8 @@ def start_live_usage_ingestor() -> LiveUsageIngestor | None:
         register_live_usage_publisher(None)
         return None
     ingestor = LiveUsageIngestor(
-        queue_size=getattr(settings, "live_usage_queue_size", 512),
-        write_min_interval_seconds=getattr(settings, "live_usage_write_min_interval_seconds", 5.0),
+        queue_size=_QUEUE_SIZE,
+        write_min_interval_seconds=_WRITE_MIN_INTERVAL_SECONDS,
     )
     ingestor.start()
     register_live_usage_publisher(ingestor.publish)

--- a/deploy/helm/codex-lb/README.md
+++ b/deploy/helm/codex-lb/README.md
@@ -267,8 +267,8 @@ Single-replica deployments can use SQLite, but **multi-replica requires PostgreS
   
 - **Circuit Breaker**: Enabled by default (`config.circuitBreakerEnabled=true`)
   - Protects upstream API endpoints from cascading failures
-  - Opens after `config.circuitBreakerFailureThreshold=5` consecutive failures
-  - Enters half-open state after `config.circuitBreakerRecoveryTimeoutSeconds=60` seconds
+  - Opens after 5 consecutive failures; enters half-open state after 60
+    seconds (fixed application constants)
   - Prevents thundering herd when upstream is degraded
 
 ### Session Bridge Ring

--- a/deploy/helm/codex-lb/templates/configmap.yaml
+++ b/deploy/helm/codex-lb/templates/configmap.yaml
@@ -28,10 +28,9 @@ data:
   # Leader election
   CODEX_LB_LEADER_ELECTION_ENABLED: {{ .Values.config.leaderElectionEnabled | toString | quote }}
   CODEX_LB_LEADER_ELECTION_TTL_SECONDS: {{ .Values.config.leaderElectionTtlSeconds | toString | quote }}
-  # Circuit breaker
+  # Circuit breaker (failure threshold and recovery timeout are fixed
+  # application constants)
   CODEX_LB_CIRCUIT_BREAKER_ENABLED: {{ .Values.config.circuitBreakerEnabled | toString | quote }}
-  CODEX_LB_CIRCUIT_BREAKER_FAILURE_THRESHOLD: {{ .Values.config.circuitBreakerFailureThreshold | toString | quote }}
-  CODEX_LB_CIRCUIT_BREAKER_RECOVERY_TIMEOUT_SECONDS: {{ .Values.config.circuitBreakerRecoveryTimeoutSeconds | toString | quote }}
   # Backpressure
   CODEX_LB_BACKPRESSURE_MAX_CONCURRENT_REQUESTS: {{ .Values.config.backpressureMaxConcurrentRequests | toString | quote }}
   # Shutdown
@@ -50,9 +49,8 @@ data:
   CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_MAX_SESSIONS: {{ .Values.config.sessionBridgeMaxSessions | toString | quote }}
   CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_QUEUE_LIMIT: {{ .Values.config.sessionBridgeQueueLimit | toString | quote }}
   CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_INSTANCE_RING: {{ .Values.config.sessionBridgeInstanceRing | quote }}
-  # Sticky session cleanup
+  # Sticky session cleanup (the interval is a fixed application constant)
   CODEX_LB_STICKY_SESSION_CLEANUP_ENABLED: {{ .Values.config.stickySessionCleanupEnabled | toString | quote }}
-  CODEX_LB_STICKY_SESSION_CLEANUP_INTERVAL_SECONDS: {{ .Values.config.stickySessionCleanupIntervalSeconds | toString | quote }}
   {{- if .Values.tracing.enabled }}
   CODEX_LB_OTEL_ENABLED: "true"
   CODEX_LB_OTEL_EXPORTER_ENDPOINT: {{ .Values.tracing.endpoint | quote }}

--- a/deploy/helm/codex-lb/values.yaml
+++ b/deploy/helm/codex-lb/values.yaml
@@ -143,11 +143,8 @@ config:
   # @param config.leaderElectionTtlSeconds Leader election TTL in seconds
   leaderElectionTtlSeconds: 30
   # @param config.circuitBreakerEnabled Enable circuit breaker for upstream requests
+  # (failure threshold and recovery timeout are fixed application constants)
   circuitBreakerEnabled: true
-  # @param config.circuitBreakerFailureThreshold Number of failures before opening circuit
-  circuitBreakerFailureThreshold: 5
-  # @param config.circuitBreakerRecoveryTimeoutSeconds Seconds before half-open state
-  circuitBreakerRecoveryTimeoutSeconds: 60
   # @param config.backpressureMaxConcurrentRequests Max concurrent in-flight requests
   backpressureMaxConcurrentRequests: 200
   # @param config.shutdownDrainTimeoutSeconds Graceful shutdown drain timeout
@@ -177,9 +174,8 @@ config:
   # @param config.sessionBridgeAdvertiseBaseUrl Optional explicit owner-handoff base URL. Empty = auto-advertise headless-service DNS for the current pod
   sessionBridgeAdvertiseBaseUrl: ""
   # @param config.stickySessionCleanupEnabled Enable periodic cleanup of stale sticky sessions
+  # (the cleanup interval is a fixed application constant)
   stickySessionCleanupEnabled: true
-  # @param config.stickySessionCleanupIntervalSeconds Interval between sticky session cleanup runs
-  stickySessionCleanupIntervalSeconds: 300
 
 # @section Authentication parameters
 auth:

--- a/openspec/changes/cache-request-log-count/proposal.md
+++ b/openspec/changes/cache-request-log-count/proposal.md
@@ -4,7 +4,7 @@ Every request-log page load and pagination click runs an exact `COUNT(*)` over t
 
 ## What Changes
 
-- Cache the listing total per filter signature (all filter params except limit/offset) with a configurable TTL: `CODEX_LB_REQUEST_LOG_COUNT_CACHE_TTL_SECONDS`, default 30 s, `0` disables (the test suite disables it so totals stay exact within a test). Bounded LRU-ish eviction at 256 entries; per-instance.
+- Cache the listing total per filter signature (all filter params except limit/offset) with a fixed 30 s TTL (application constant; made non-tunable by the `reduce-settings-surface-phase-2` change — the test suite patches the constant to 0 so totals stay exact within a test). Bounded LRU-ish eviction at 256 entries; per-instance.
 - API contract unchanged: `total` and `has_more` keep their exact semantics up to ≤TTL staleness of a monotonically-growing display figure; new rows always appear on page 1 (newest-first ordering) regardless.
 
 ## Capabilities
@@ -19,4 +19,4 @@ Every request-log page load and pagination click runs an exact `COUNT(*)` over t
 
 ## Impact
 
-`app/modules/request_logs/repository.py`, `app/core/config/settings.py`, `tests/conftest.py` (suite disables the TTL). No schema/API change.
+`app/modules/request_logs/repository.py`, `tests/conftest.py` (suite patches the TTL constant to 0). No schema/API change.

--- a/openspec/changes/cache-request-log-count/specs/query-caching/spec.md
+++ b/openspec/changes/cache-request-log-count/specs/query-caching/spec.md
@@ -4,7 +4,7 @@
 
 ### Requirement: Request-log listing totals are cached per filter signature
 
-The request-log listing MUST NOT execute an exact `COUNT(*)` over the filtered set on every page request; the total MUST be reused from a per-filter-signature cache within a configurable TTL (default 30 s), with `0` disabling the cache entirely. Cached totals are display-only: page contents themselves MUST remain exact and newest-first.
+The request-log listing MUST NOT execute an exact `COUNT(*)` over the filtered set on every page request; the total MUST be reused from a per-filter-signature cache within a fixed 30-second TTL (an application constant per the `reduce-settings-surface-phase-2` change — not an operator tunable). Cached totals are display-only: page contents themselves MUST remain exact and newest-first.
 
 #### Scenario: Repeated pages reuse the cached total
 
@@ -17,7 +17,8 @@ The request-log listing MUST NOT execute an exact `COUNT(*)` over the filtered s
 - **WHEN** a listing request arrives with different filters
 - **THEN** its total comes from its own count, not another signature's cache entry
 
-#### Scenario: TTL zero disables caching
+#### Scenario: Expired entries are recounted
 
-- **WHEN** the TTL setting is `0`
-- **THEN** every listing request executes an exact count
+- **GIVEN** a cached total whose 30-second TTL has elapsed
+- **WHEN** a listing request with the same filter signature arrives
+- **THEN** an exact count is executed and the cache entry is refreshed

--- a/openspec/changes/cache-request-log-count/tasks.md
+++ b/openspec/changes/cache-request-log-count/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Implementation
 
-- [x] 1.1 Per-filter-signature TTL cache around `_count_recent` (bounded entries; TTL from settings; 0 disables)
-- [x] 1.2 Suite disables the TTL via conftest env so in-test totals stay exact
+- [x] 1.1 Per-filter-signature TTL cache around `_count_recent` (bounded entries; fixed 30 s TTL application constant — made non-tunable by reduce-settings-surface-phase-2)
+- [x] 1.2 Suite neutralizes the cache by patching the TTL constant to 0 via an autouse conftest fixture so in-test totals stay exact
 
 ## 2. Validation
 

--- a/openspec/changes/reduce-settings-surface-phase-2/context.md
+++ b/openspec/changes/reduce-settings-surface-phase-2/context.md
@@ -112,3 +112,11 @@ removed setting(s) ignored: CODEX_LB_QUOTA_PLANNER_TICK_SECONDS — values are n
 ```
 
 and the planner ticks on the fixed five-minute cadence.
+
+## Cross-change coordination
+
+The active (unarchived) `cache-request-log-count` change originally specified
+the count-cache TTL as a configurable setting with `0` disabling the cache.
+Its delta spec and tasks were updated in this change to the fixed-constant
+reality so a later archive cannot reintroduce a requirement the code no
+longer satisfies.

--- a/openspec/changes/reduce-settings-surface-phase-2/context.md
+++ b/openspec/changes/reduce-settings-surface-phase-2/context.md
@@ -1,0 +1,114 @@
+# Context: reduce-settings-surface-phase-2
+
+## Rationale
+
+Phase 2 of issue #1340, following the same selection rule as phase 1: every
+removed field keeps its exact previous default as the new fixed value, and
+the only behavioral seam (the removed-settings warning) is additive. Unlike
+phase 1, three of this batch's env names were rendered by the Helm chart
+(`config.circuitBreakerFailureThreshold`,
+`config.circuitBreakerRecoveryTimeoutSeconds`,
+`config.stickySessionCleanupIntervalSeconds`); the chart values are removed
+in the same change so a default install does not trip its own removal
+warning. Chart users who overrode them fall back to the identical fixed
+constants.
+
+Capability choice mirrors phase 1: `deployment-installation` owns the
+operator env-var contract at settings-load time, so the phase-2 fixed-values
+requirement is added there alongside the phase-1 requirement.
+
+## Removed fields (env names)
+
+Scheduler cadences (now constants next to their builders):
+
+- `CODEX_LB_QUOTA_PLANNER_TICK_SECONDS` (fixed: 300; the previous
+  `max(60, ...)` floor is moot for a fixed 300 and was dropped)
+- `CODEX_LB_AUTOMATIONS_SCHEDULER_INTERVAL_SECONDS` (fixed: 30)
+- `CODEX_LB_MODEL_REGISTRY_REFRESH_INTERVAL_SECONDS` (fixed: 300)
+- `CODEX_LB_STICKY_SESSION_CLEANUP_INTERVAL_SECONDS` (fixed: 300)
+
+Codex client fingerprint (now constants in `app/core/clients/proxy.py`;
+maintained in lockstep with `model_registry_client_version` bumps):
+
+- `CODEX_LB_CODEX_FINGERPRINT_OS` (fixed: `Mac OS 26.5.0`)
+- `CODEX_LB_CODEX_FINGERPRINT_ARCH` (fixed: `arm64`)
+- `CODEX_LB_CODEX_FINGERPRINT_TERMINAL` (fixed: `iTerm.app/3.6.10`)
+
+Live-usage write coalescing (now constants in
+`app/modules/usage/live_ingest.py`):
+
+- `CODEX_LB_LIVE_USAGE_WRITE_MIN_INTERVAL_SECONDS` (fixed: 5.0)
+- `CODEX_LB_LIVE_USAGE_QUEUE_SIZE` (fixed: 512)
+
+Request-log count cache (now a constant in
+`app/modules/request_logs/repository.py`):
+
+- `CODEX_LB_REQUEST_LOG_COUNT_CACHE_TTL_SECONDS` (fixed: 30.0; the test
+  suite patches the constant to 0 so listing totals stay exact per test)
+
+Circuit-breaker tuning (now constants in
+`app/core/resilience/circuit_breaker.py`):
+
+- `CODEX_LB_CIRCUIT_BREAKER_FAILURE_THRESHOLD` (fixed: 5)
+- `CODEX_LB_CIRCUIT_BREAKER_RECOVERY_TIMEOUT_SECONDS` (fixed: 60)
+
+Memory thresholds (warning now derived in
+`app/core/resilience/memory_monitor.py`):
+
+- `CODEX_LB_MEMORY_WARNING_THRESHOLD_MB` (derived: 80% of
+  `memory_reject_threshold_mb`)
+
+Images internals:
+
+- `CODEX_LB_IMAGES_HOST_MODEL` (fixed: `gpt-5.5`, a constant in
+  `app/modules/proxy/api.py`)
+- `CODEX_LB_IMAGES_MAX_PARTIAL_IMAGES` (fixed: 3, a constant in
+  `app/core/openai/images.py`)
+
+Kept deliberately: `CODEX_LB_QUOTA_PLANNER_SCHEDULER_ENABLED`,
+`CODEX_LB_AUTOMATIONS_SCHEDULER_ENABLED`, `CODEX_LB_MODEL_REGISTRY_ENABLED`,
+`CODEX_LB_STICKY_SESSION_CLEANUP_ENABLED`,
+`CODEX_LB_LIVE_USAGE_INGESTION_ENABLED`, `CODEX_LB_CIRCUIT_BREAKER_ENABLED`
+(each subsystem keeps exactly one switch);
+`CODEX_LB_MODEL_REGISTRY_CLIENT_VERSION` (degraded-startup catalog floor
+with a documented minimum, not merely fingerprint cosmetics);
+`CODEX_LB_MEMORY_REJECT_THRESHOLD_MB` (the one genuine deployment decision
+in the memory guard — it depends on the host's memory size);
+`CODEX_LB_IMAGES_DEFAULT_MODEL` (public API contract for clients that omit
+`model`).
+
+## Memory-threshold decision
+
+`memory_warning_threshold_mb` and `memory_reject_threshold_mb` were two
+independent knobs for one mechanism: the bulkhead middleware logs a warning
+when RSS crosses the warning level and rejects with 503 when it crosses the
+reject level. The warning has no meaning on its own — it exists to announce
+that the reject threshold is being approached — so it is not an independent
+operator decision. Phase 2 keeps `memory_reject_threshold_mb` (0 = off, the
+default) and derives the warning level as a fixed 80% of it. With the
+default of 0 both thresholds remain disabled, so zero-config behavior is
+unchanged; deployments that set only the reject threshold now get an early
+warning for free. The only lost configuration is a warning-only setup with
+no reject threshold, which rejected nothing and merely logged — an
+observability half-measure the log stream covers anyway.
+
+## Images host model decision
+
+The audit suggested deriving the images host model from the model registry,
+but the registry has no "default Responses model" concept — `gpt-5.5` is
+one of several bootstrap catalog entries. Inventing registry plumbing for
+one internal default would add more surface than the setting it removes, so
+the host model is a documented module constant (`_IMAGES_HOST_MODEL` in
+`app/modules/proxy/api.py`) that tracks the catalog's stable `gpt-5.5` slug
+and changes only with catalog maintenance. It is never echoed to clients.
+
+## Example
+
+An operator running `CODEX_LB_QUOTA_PLANNER_TICK_SECONDS=60` upgrades:
+startup logs
+
+```
+removed setting(s) ignored: CODEX_LB_QUOTA_PLANNER_TICK_SECONDS — values are now fixed; see PRINCIPLES.md P2 / issue #1340
+```
+
+and the planner ticks on the fixed five-minute cadence.

--- a/openspec/changes/reduce-settings-surface-phase-2/proposal.md
+++ b/openspec/changes/reduce-settings-surface-phase-2/proposal.md
@@ -1,0 +1,87 @@
+# Change: reduce-settings-surface-phase-2
+
+## Why
+
+Phase 2 of issue #1340 (simplicity backlog: settings-surface reduction) and
+PRINCIPLES.md P2 ("a setting the operator never needs to touch is a default
+in disguise"). After phase 1 (`reduce-settings-surface-phase-1`) the
+`Settings` class still carried 142 env-settable fields, of which another
+batch are internals no supported deployment should change: background
+scheduler cadences, the Codex client fingerprint triplet, live-usage write
+coalescing, the request-log count-cache TTL, circuit-breaker tuning, the
+memory warning threshold, and images-route internals.
+
+## What Changes
+
+Phase 2 removes 15 more fields (142 -> 127), with no behavior change for
+default installs.
+
+- **Scheduler cadences (4 removed)**: `quota_planner_tick_seconds` (fixed
+  300, making the old `max(60, ...)` clamp moot),
+  `automations_scheduler_interval_seconds` (fixed 30),
+  `model_registry_refresh_interval_seconds` (fixed 300), and
+  `sticky_session_cleanup_interval_seconds` (fixed 300) become constants
+  next to their scheduler builders. Each scheduler's `*_enabled` switch
+  remains.
+- **Codex fingerprint (3 removed)**: `codex_fingerprint_os`,
+  `codex_fingerprint_arch`, `codex_fingerprint_terminal` become the fixed
+  `_FINGERPRINT_*` constants in `app/core/clients/proxy.py` (previous
+  defaults `Mac OS 26.5.0` / `arm64` / `iTerm.app/3.6.10`). They are
+  maintained in lockstep with `model_registry_client_version` bumps, which
+  stays a setting because it doubles as the degraded-startup catalog floor.
+- **Live-usage write coalescing (2 removed)**:
+  `live_usage_write_min_interval_seconds` (fixed 5.0) and
+  `live_usage_queue_size` (fixed 512) become constants in
+  `app/modules/usage/live_ingest.py`. `live_usage_ingestion_enabled`
+  remains the single switch.
+- **Request-log count cache (1 removed)**:
+  `request_log_count_cache_ttl_seconds` becomes a fixed 30.0-second TTL in
+  `app/modules/request_logs/repository.py`; the test suite patches the
+  constant to 0 where exact totals matter.
+- **Circuit breaker tuning (2 removed)**:
+  `circuit_breaker_failure_threshold` (fixed 5) and
+  `circuit_breaker_recovery_timeout_seconds` (fixed 60) become constants in
+  `app/core/resilience/circuit_breaker.py`. `circuit_breaker_enabled`
+  remains the single switch. The Helm chart values
+  `config.circuitBreakerFailureThreshold` and
+  `config.circuitBreakerRecoveryTimeoutSeconds` (and
+  `config.stickySessionCleanupIntervalSeconds`) are removed with it.
+- **Memory warning threshold (1 removed)**: `memory_warning_threshold_mb`
+  is now derived as 80% of `memory_reject_threshold_mb` in
+  `app/core/resilience/memory_monitor.py`; the warning exists only as an
+  early signal that the reject threshold is being approached, so it is not
+  an independent operator decision. Both default to off (0), so default
+  behavior is unchanged. `memory_reject_threshold_mb` stays.
+- **Images internals (2 removed)**: `images_host_model` becomes the fixed
+  internal host model constant in `app/modules/proxy/api.py` (`gpt-5.5`,
+  tracking the registry bootstrap catalog; never echoed to clients), and
+  `images_max_partial_images` becomes a fixed cap of 3 in
+  `app/core/openai/images.py` (an upstream streaming contract, previously
+  already clamped to 0..3). `images_default_model` stays: it is the public
+  model contract for clients that omit `model`.
+- **One-release removal warning**: the phase-2 env names join
+  `_REMOVED_SETTINGS`, so startup logs the existing single WARN when any
+  of them are still set (`extra="ignore"` already makes them inert).
+
+## Impact
+
+- Affected specs: `deployment-installation` (new requirement covering the
+  phase-2 fixed values and derived memory warning); non-normative wording
+  update in `openspec/specs/quota-phase-planner/context.md`.
+- Affected code: `app/core/config/settings.py`,
+  `app/modules/quota_planner/scheduler.py`,
+  `app/modules/automations/scheduler.py`,
+  `app/core/openai/model_refresh_scheduler.py`,
+  `app/modules/sticky_sessions/cleanup_scheduler.py`,
+  `app/core/clients/proxy.py`, `app/modules/usage/live_ingest.py`,
+  `app/modules/request_logs/repository.py`,
+  `app/core/resilience/circuit_breaker.py`,
+  `app/core/resilience/memory_monitor.py`, `app/main.py`,
+  `app/modules/proxy/api.py`, `app/modules/proxy/images_service.py`,
+  `app/core/openai/images.py`, `deploy/helm/codex-lb/**`
+- Operator impact: none for default installs. Deployments that set a
+  removed env var keep working on the fixed value and see one startup WARN.
+  Helm installs that overrode the three removed chart values fall back to
+  the identical fixed constants.
+- Not in scope: further settings-surface phases tracked in #1340 (the issue
+  stays open).

--- a/openspec/changes/reduce-settings-surface-phase-2/specs/deployment-installation/spec.md
+++ b/openspec/changes/reduce-settings-surface-phase-2/specs/deployment-installation/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Phase-2 removed tunables are fixed constants or derived values
+
+The phase-2 internals SHALL NOT be operator-configurable: background
+scheduler cadences (quota planner tick, automations poll, model registry
+refresh, sticky-session cleanup), the Codex client fingerprint (OS,
+architecture, terminal), live-usage write coalescing (minimum write
+interval and queue size), the request-log count-cache TTL, circuit-breaker
+tuning (failure threshold and recovery timeout), and the images-route
+internals (internal host model and partial-images cap) MUST each be fixed
+at its previously documented default. Each affected subsystem MUST retain at most one enable/disable
+setting. The memory-pressure warning threshold MUST be derived as 80% of
+the configurable reject threshold (`CODEX_LB_MEMORY_REJECT_THRESHOLD_MB`),
+with both disabled when the reject threshold is 0. The removed phase-2
+environment variable names MUST be covered by the existing removed-settings
+startup warning: they are ignored without failing startup and reported in
+the single warning log (names only, never values) for at least one release.
+The Helm chart MUST NOT render environment variables for removed settings.
+
+#### Scenario: Phase-2 removed env vars are ignored with one startup warning
+
+- **GIVEN** a deployment whose environment still sets removed settings such
+  as `CODEX_LB_QUOTA_PLANNER_TICK_SECONDS` and `CODEX_LB_IMAGES_HOST_MODEL`
+- **WHEN** the application starts
+- **THEN** startup succeeds and the fixed built-in values are used
+- **AND** exactly one warning log lists both removed names without their
+  values
+
+#### Scenario: Memory warning threshold derives from the reject threshold
+
+- **GIVEN** `CODEX_LB_MEMORY_REJECT_THRESHOLD_MB=100`
+- **WHEN** process RSS reaches 80 MiB
+- **THEN** a memory warning is logged while requests continue to be served
+- **AND** requests are rejected with 503 only once RSS reaches 100 MiB
+
+#### Scenario: Memory guard stays fully disabled by default
+
+- **GIVEN** a default install with `CODEX_LB_MEMORY_REJECT_THRESHOLD_MB`
+  unset (0)
+- **WHEN** the proxy serves requests under any memory usage
+- **THEN** no memory warning is logged and no request is rejected for
+  memory pressure
+
+#### Scenario: Helm chart renders no removed settings
+
+- **GIVEN** a Helm install using the chart's default values
+- **WHEN** the config map is rendered
+- **THEN** it contains no `CODEX_LB_CIRCUIT_BREAKER_FAILURE_THRESHOLD`,
+  `CODEX_LB_CIRCUIT_BREAKER_RECOVERY_TIMEOUT_SECONDS`, or
+  `CODEX_LB_STICKY_SESSION_CLEANUP_INTERVAL_SECONDS` entries
+- **AND** startup emits no removed-settings warning

--- a/openspec/changes/reduce-settings-surface-phase-2/tasks.md
+++ b/openspec/changes/reduce-settings-surface-phase-2/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: reduce-settings-surface-phase-2
+
+- [x] 1.1 Move the four scheduler cadences to constants next to their
+      builders (`app/modules/quota_planner/scheduler.py` — the `max(60, ...)`
+      clamp becomes moot and is dropped —,
+      `app/modules/automations/scheduler.py`,
+      `app/core/openai/model_refresh_scheduler.py`,
+      `app/modules/sticky_sessions/cleanup_scheduler.py`); keep every
+      `*_enabled` switch
+- [x] 1.2 Delete the three `codex_fingerprint_*` fields and build the Codex
+      `User-Agent` from the fixed `_FINGERPRINT_*` constants in
+      `app/core/clients/proxy.py`
+- [x] 1.3 Move `live_usage_write_min_interval_seconds` and
+      `live_usage_queue_size` to constants in
+      `app/modules/usage/live_ingest.py`; keep
+      `live_usage_ingestion_enabled`
+- [x] 1.4 Fix the request-log count-cache TTL at 30 s in
+      `app/modules/request_logs/repository.py`; the test suite patches the
+      constant to 0 via an autouse fixture
+- [x] 1.5 Move circuit-breaker failure threshold and recovery timeout to
+      constants in `app/core/resilience/circuit_breaker.py`; keep
+      `circuit_breaker_enabled`; drop the corresponding Helm chart values
+      (`configmap.yaml`, `values.yaml`, chart README)
+- [x] 1.6 Derive the memory warning threshold as 80% of
+      `memory_reject_threshold_mb` in
+      `app/core/resilience/memory_monitor.py`; delete
+      `memory_warning_threshold_mb` and simplify the `app/main.py` wiring
+- [x] 1.7 Fix the images host model (`gpt-5.5`) as a constant in
+      `app/modules/proxy/api.py` and the partial-images cap (3) in
+      `app/core/openai/images.py`; keep `images_default_model`
+- [x] 1.8 Add the fifteen phase-2 env names to `_REMOVED_SETTINGS`
+      (grouped and commented per phase) so the existing startup WARN covers
+      them; update the non-normative
+      `openspec/specs/quota-phase-planner/context.md` mention
+- [x] 2.1 Update tests that set removed fields; preserve what each test
+      proves (constants patched via `monkeypatch.setattr`, settings-plumbing
+      tests replaced with removed-field assertions, memory-warning
+      derivation covered in `tests/unit/test_memory_monitor.py`)
+- [x] 2.2 Extend `tests/unit/test_settings_trace_and_removed.py` with the
+      phase-2 names (tuple count, membership, ignored env vars)
+- [x] 3.1 `uv run pytest tests/unit -q`
+- [x] 3.2 `uv run ruff check .` and `uv run ruff format --check .`
+- [x] 3.3 `make typecheck` (ty)
+- [x] 3.4 `python3 .github/scripts/check_simplicity_budgets.py`
+- [x] 3.5 `openspec validate reduce-settings-surface-phase-2 --strict` and
+      `openspec validate --specs`

--- a/openspec/specs/quota-phase-planner/context.md
+++ b/openspec/specs/quota-phase-planner/context.md
@@ -45,7 +45,7 @@ selectors instead of being persisted on account state.
 ## Scheduler
 
 The scheduler gates every tick on the enabled-by-default scheduler leader lease (see the `scheduler-coordination`
-capability), ticking every `CODEX_LB_QUOTA_PLANNER_TICK_SECONDS` seconds and defaulting to five minutes. It can be
+capability), ticking every five minutes (a fixed application constant since issue #1340 phase 2). It can be
 disabled with `CODEX_LB_QUOTA_PLANNER_SCHEDULER_ENABLED=false`.
 
 Each tick:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,6 @@ os.environ["CODEX_LB_MODEL_REGISTRY_ENABLED"] = "false"
 os.environ["CODEX_LB_STICKY_SESSION_CLEANUP_ENABLED"] = "false"
 os.environ["CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_ENABLED"] = "false"
 os.environ["CODEX_LB_QUOTA_PLANNER_SCHEDULER_ENABLED"] = "false"
-os.environ["CODEX_LB_REQUEST_LOG_COUNT_CACHE_TTL_SECONDS"] = "0"
 # The app-level automations scheduler ticks on the real clock; with leader
 # election enabled its startup tick runs as a background task and can land
 # inside a test that stages its own due-now jobs, racing the test's
@@ -128,6 +127,16 @@ async def app_instance(_reset_db_state, monkeypatch):
     monkeypatch.setattr(main_module, "build_rate_limit_reset_credits_scheduler", lambda: _NoopScheduler())
     app = create_app()
     return app
+
+
+@pytest.fixture(autouse=True)
+def _disable_request_log_count_cache(monkeypatch):
+    """Zero the request-log COUNT cache TTL so listing totals stay exact
+    within a test. The TTL is a fixed constant in production (issue #1340
+    phase 2); the cache-behavior test patches it back to a positive value."""
+    import app.modules.request_logs.repository as logs_repository_module
+
+    monkeypatch.setattr(logs_repository_module, "_COUNT_CACHE_TTL_SECONDS", 0.0)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/e2e/test_openai_sdk_compat.py
+++ b/tests/e2e/test_openai_sdk_compat.py
@@ -693,8 +693,8 @@ class TestImages:
         assert result.data[0].b64_json == "GENERATED_B64"
         # ``revised_prompt`` survives the translation layer.
         assert result.data[0].revised_prompt == "a clean red circle"
-        # Image routes hide the host model behind ``images_host_model``;
-        # ensure the upstream call really used the configured host model.
+        # Image routes hide the fixed internal host model from clients;
+        # ensure the upstream call really used a host model.
         assert captured["model"] not in {None, ""}
         tools = captured["tools"]
         assert tools, "image_generation tool must be forwarded to upstream"

--- a/tests/integration/test_request_logs_api.py
+++ b/tests/integration/test_request_logs_api.py
@@ -301,12 +301,10 @@ async def test_request_log_total_count_is_cached_per_filter_signature(async_clie
     the same filter signature; distinct signatures count separately."""
     from sqlalchemy import event
 
-    from app.core.config.settings import get_settings
     from app.db.session import engine
     from app.modules.request_logs import repository as logs_repository_module
 
-    monkeypatch.setenv("CODEX_LB_REQUEST_LOG_COUNT_CACHE_TTL_SECONDS", "30")
-    get_settings.cache_clear()
+    monkeypatch.setattr(logs_repository_module, "_COUNT_CACHE_TTL_SECONDS", 30.0)
     logs_repository_module._clear_recent_count_cache()
 
     count_statements: list[str] = []
@@ -323,7 +321,6 @@ async def test_request_log_total_count_is_cached_per_filter_signature(async_clie
     finally:
         event.remove(engine.sync_engine, "before_cursor_execute", _capture)
         logs_repository_module._clear_recent_count_cache()
-        get_settings.cache_clear()
 
     assert first.status_code == 200
     assert second.status_code == 200

--- a/tests/unit/test_images_schemas.py
+++ b/tests/unit/test_images_schemas.py
@@ -179,7 +179,6 @@ def _validate_default(**overrides: object) -> None:
         "n": 1,
         "partial_images": None,
         "output_compression": 100,
-        "images_max_partial_images": 3,
     }
     kwargs.update(overrides)
     validate_image_request_parameters(**kwargs)  # type: ignore[arg-type]

--- a/tests/unit/test_memory_monitor.py
+++ b/tests/unit/test_memory_monitor.py
@@ -20,8 +20,28 @@ def test_get_rss_bytes_returns_positive_number():
 def test_is_memory_pressure_returns_false_when_threshold_disabled():
     from app.core.resilience import memory_monitor
 
-    memory_monitor.configure(warning_threshold_mb=0, reject_threshold_mb=0)
+    memory_monitor.configure(reject_threshold_mb=0)
     assert memory_monitor.is_memory_pressure() is False
+    assert memory_monitor.is_memory_warning() is False
+
+
+def test_memory_warning_threshold_is_derived_at_80_percent_of_reject(monkeypatch):
+    from app.core.resilience import memory_monitor
+
+    memory_monitor.configure(reject_threshold_mb=100)
+    try:
+        reject_bytes = 100 * 1024 * 1024
+        warning_bytes = int(reject_bytes * 0.8)
+        monkeypatch.setattr(memory_monitor, "get_rss_bytes", lambda: warning_bytes - 1)
+        assert memory_monitor.is_memory_warning() is False
+        assert memory_monitor.is_memory_pressure() is False
+        monkeypatch.setattr(memory_monitor, "get_rss_bytes", lambda: warning_bytes)
+        assert memory_monitor.is_memory_warning() is True
+        assert memory_monitor.is_memory_pressure() is False
+        monkeypatch.setattr(memory_monitor, "get_rss_bytes", lambda: reject_bytes)
+        assert memory_monitor.is_memory_pressure() is True
+    finally:
+        memory_monitor.configure(reject_threshold_mb=0)
 
 
 def test_memory_monitor_imports_on_windows_without_resource(monkeypatch: pytest.MonkeyPatch):

--- a/tests/unit/test_settings_multi_replica.py
+++ b/tests/unit/test_settings_multi_replica.py
@@ -18,8 +18,6 @@ def test_settings_multi_replica_defaults():
     assert settings.leader_election_ttl_seconds == 60
     assert settings.auth_guardian_enabled is False
     assert settings.circuit_breaker_enabled is False
-    assert settings.circuit_breaker_failure_threshold == 5
-    assert settings.circuit_breaker_recovery_timeout_seconds == 60
     assert settings.backpressure_max_concurrent_requests == 0
     assert settings.bulkhead_proxy_limit == 512
     assert settings.bulkhead_dashboard_limit == 50
@@ -113,16 +111,15 @@ def test_settings_circuit_breaker_enabled_from_env(monkeypatch):
     assert settings.circuit_breaker_enabled is True
 
 
-def test_settings_circuit_breaker_failure_threshold_from_env(monkeypatch):
+def test_settings_circuit_breaker_tuning_env_overrides_are_removed(monkeypatch):
+    # Failure threshold and recovery timeout became fixed constants in
+    # app/core/resilience/circuit_breaker.py (issue #1340 phase 2); the env
+    # vars are ignored and the fields no longer exist.
     monkeypatch.setenv("CODEX_LB_CIRCUIT_BREAKER_FAILURE_THRESHOLD", "10")
-    settings = Settings()
-    assert settings.circuit_breaker_failure_threshold == 10
-
-
-def test_settings_circuit_breaker_recovery_timeout_from_env(monkeypatch):
     monkeypatch.setenv("CODEX_LB_CIRCUIT_BREAKER_RECOVERY_TIMEOUT_SECONDS", "120")
     settings = Settings()
-    assert settings.circuit_breaker_recovery_timeout_seconds == 120
+    assert not hasattr(settings, "circuit_breaker_failure_threshold")
+    assert not hasattr(settings, "circuit_breaker_recovery_timeout_seconds")
 
 
 def test_settings_backpressure_max_concurrent_requests_from_env(monkeypatch):

--- a/tests/unit/test_settings_trace_and_removed.py
+++ b/tests/unit/test_settings_trace_and_removed.py
@@ -89,5 +89,44 @@ def test_warn_removed_settings_scans_env_files(tmp_path, monkeypatch, caplog):
 
 
 def test_removed_settings_tuple_covers_all_five_groups():
-    assert len(_REMOVED_SETTINGS) == 24
+    assert len(_REMOVED_SETTINGS) == 39
     assert all(name.startswith("CODEX_LB_") for name in _REMOVED_SETTINGS)
+    assert len(set(_REMOVED_SETTINGS)) == len(_REMOVED_SETTINGS)
+
+
+def test_phase_2_removed_settings_are_listed_and_ignored(monkeypatch):
+    phase_2_names = (
+        "CODEX_LB_QUOTA_PLANNER_TICK_SECONDS",
+        "CODEX_LB_AUTOMATIONS_SCHEDULER_INTERVAL_SECONDS",
+        "CODEX_LB_MODEL_REGISTRY_REFRESH_INTERVAL_SECONDS",
+        "CODEX_LB_STICKY_SESSION_CLEANUP_INTERVAL_SECONDS",
+        "CODEX_LB_CODEX_FINGERPRINT_OS",
+        "CODEX_LB_CODEX_FINGERPRINT_ARCH",
+        "CODEX_LB_CODEX_FINGERPRINT_TERMINAL",
+        "CODEX_LB_LIVE_USAGE_WRITE_MIN_INTERVAL_SECONDS",
+        "CODEX_LB_LIVE_USAGE_QUEUE_SIZE",
+        "CODEX_LB_REQUEST_LOG_COUNT_CACHE_TTL_SECONDS",
+        "CODEX_LB_CIRCUIT_BREAKER_FAILURE_THRESHOLD",
+        "CODEX_LB_CIRCUIT_BREAKER_RECOVERY_TIMEOUT_SECONDS",
+        "CODEX_LB_MEMORY_WARNING_THRESHOLD_MB",
+        "CODEX_LB_IMAGES_HOST_MODEL",
+        "CODEX_LB_IMAGES_MAX_PARTIAL_IMAGES",
+    )
+    for name in phase_2_names:
+        assert name in _REMOVED_SETTINGS
+
+    monkeypatch.setenv("CODEX_LB_QUOTA_PLANNER_TICK_SECONDS", "60")
+    monkeypatch.setenv("CODEX_LB_IMAGES_HOST_MODEL", "gpt-5.6")
+    settings = Settings()
+    assert not hasattr(settings, "quota_planner_tick_seconds")
+    assert not hasattr(settings, "images_host_model")
+    found = warn_removed_settings(
+        {
+            "CODEX_LB_QUOTA_PLANNER_TICK_SECONDS": "60",
+            "CODEX_LB_IMAGES_HOST_MODEL": "gpt-5.6",
+        }
+    )
+    assert found == [
+        "CODEX_LB_QUOTA_PLANNER_TICK_SECONDS",
+        "CODEX_LB_IMAGES_HOST_MODEL",
+    ]

--- a/tests/unit/test_sticky_session_cleanup_scheduler.py
+++ b/tests/unit/test_sticky_session_cleanup_scheduler.py
@@ -22,8 +22,9 @@ class _FakeLeader:
 
 
 def test_build_sticky_session_cleanup_scheduler_respects_enabled_setting(monkeypatch) -> None:
-    settings = SimpleNamespace(sticky_session_cleanup_interval_seconds=42, sticky_session_cleanup_enabled=False)
+    settings = SimpleNamespace(sticky_session_cleanup_enabled=False)
     monkeypatch.setattr(cleanup_scheduler, "get_settings", lambda: settings)
+    monkeypatch.setattr(cleanup_scheduler, "_CLEANUP_INTERVAL_SECONDS", 42)
 
     scheduler = cleanup_scheduler.build_sticky_session_cleanup_scheduler()
 


### PR DESCRIPTION
## Summary

Phase 2 of #1340: **142 → 127 env-settable fields** (15 removed, 0 added), continuing #1351's pattern — constants live next to their consumers, removed env names join the one-release startup warning (now 39 names, grouped by phase).

| Group | Fields | What happened |
|---|---|---|
| Scheduler cadences | −4 | quota-planner tick (300s), automations interval (30s), model-registry refresh (300s), sticky cleanup (300s) → constants; every `*_enabled` flag stays. |
| Codex fingerprint | −3 | os/arch/terminal change in lockstep with `model_registry_client_version` maintenance bumps — the existing `_FINGERPRINT_*` constants are now the single source. |
| live-usage + count cache | −3 | write-coalescing queue/interval and the request-log count-cache TTL → constants; `live_usage_ingestion_enabled` stays. |
| Circuit breaker + memory | −3 | threshold/recovery → constants (5/60); `memory_warning_threshold_mb` removed — warning derives as **80% of `memory_reject_threshold_mb`** (its only role was announcing approach to reject; both defaulted off, so zero default-behavior change). `circuit_breaker_enabled` and the reject threshold stay. |
| Images internals | −2 | host model → module constant (no registry-derived default exists; comment tracks the catalog), partial-image cap → constant 3. `images_default_model` stays (public contract). |

**Helm chart**: the chart rendered three of the removed names (circuit-breaker threshold/recovery, sticky-cleanup interval) — configmap/values/README updated so default installs don't trip their own removal warning. Helm artifact tests pass (19).

## Type of change

- [x] `refactor:` — internal refactor (operator-contract change covered by OpenSpec; no default-behavior change)

Refs #1340 (partial — phase 2; items 10, 11, 12, 14, 15 of the reduction table).

## OpenSpec

`openspec/changes/reduce-settings-surface-phase-2/` — ADDED requirement on `deployment-installation` (same shape as phase 1, distinct name so archives merge cleanly), scenarios incl. the 80% memory derivation and Helm rendering; non-normative `quota-phase-planner/context.md` line updated. `--strict` + `--specs` (47/47) pass.

## Checks

- `pytest tests/unit`: 3936 passed, 3 skipped; helm artifacts: 19 passed; affected integration (request-logs, live-usage): 13 passed
- `ruff check` / `format --check` / `ty check`: clean; simplicity budgets: green

## Simplicity

- [x] Removes 15 settings, adds none; no README/nav surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)