### PR TITLE
chore(contributors): add fozbek to all-contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1014,6 +1014,16 @@
         "test",
         "doc"
       ]
+    },
+    {
+      "login": "fozbek",
+      "name": "Fatih Özbek",
+      "avatar_url": "https://avatars.githubusercontent.com/u/17993880?v=4",
+      "profile": "https://github.com/fozbek",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -255,6 +255,9 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/e
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/jamesx0416"><img src="https://avatars.githubusercontent.com/u/105842516?v=4?s=100" width="100px;" alt="James"/><br /><sub><b>James</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=jamesx0416" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=jamesx0416" title="Tests">⚠️</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/mereyabdenbekuly-ctrl"><img src="https://avatars.githubusercontent.com/u/234955825?v=4?s=100" width="100px;" alt="SSY"/><br /><sub><b>SSY</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=mereyabdenbekuly-ctrl" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=mereyabdenbekuly-ctrl" title="Tests">⚠️</a> <a href="https://github.com/Soju06/codex-lb/commits?author=mereyabdenbekuly-ctrl" title="Documentation">📖</a></td>
     </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/fozbek"><img src="https://avatars.githubusercontent.com/u/17993880?v=4?s=100" width="100px;" alt="Fatih Özbek"/><br /><sub><b>Fatih Özbek</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=fozbek" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=fozbek" title="Tests">⚠️</a></td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
## Summary
Add @fozbek (author of #1275, gpt-5.6 personality model pricing) to `.all-contributorsrc` and the README contributors table.

The **Contributors attribution** gate on #1275 fails because the PR author is not yet listed, and the fork does not allow maintainer edits, so the entry lands via this repo-side change instead. Metadata-only — no behavior change, no OpenSpec impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)