### PR TITLE
refactor(config): remove phase-3 pool and drain tunables from the settings surface

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -79,6 +79,17 @@ _REMOVED_SETTINGS: tuple[str, ...] = (
     "CODEX_LB_MEMORY_WARNING_THRESHOLD_MB",
     "CODEX_LB_IMAGES_HOST_MODEL",
     "CODEX_LB_IMAGES_MAX_PARTIAL_IMAGES",
+    # Phase 3 (reduce-settings-surface-phase-3)
+    "CODEX_LB_DATABASE_BACKGROUND_POOL_SIZE",
+    "CODEX_LB_DATABASE_BACKGROUND_MAX_OVERFLOW",
+    "CODEX_LB_DATABASE_POOL_TIMEOUT_SECONDS",
+    "CODEX_LB_DATABASE_POOL_RECYCLE_SECONDS",
+    "CODEX_LB_DRAIN_PRIMARY_THRESHOLD_PCT",
+    "CODEX_LB_DRAIN_SECONDARY_THRESHOLD_PCT",
+    "CODEX_LB_DRAIN_ERROR_WINDOW_SECONDS",
+    "CODEX_LB_DRAIN_ERROR_COUNT_THRESHOLD",
+    "CODEX_LB_PROBE_QUIET_SECONDS",
+    "CODEX_LB_PROBE_SUCCESS_STREAK_REQUIRED",
 )
 
 
@@ -225,12 +236,11 @@ class Settings(BaseSettings):
 
     data_dir: Path = Field(default_factory=_default_home_dir)
     database_url: str = DEFAULT_DATABASE_URL
+    # Pool timeout and recycle are fixed constants in ``app/db/session.py``;
+    # the background-task engine always derives its pool sizing from the two
+    # settings below.
     database_pool_size: int = Field(default=15, gt=0)
     database_max_overflow: int = Field(default=10, ge=0)
-    database_background_pool_size: int | None = Field(default=None, gt=0)
-    database_background_max_overflow: int | None = Field(default=None, ge=0)
-    database_pool_timeout_seconds: float = Field(default=30.0, gt=0)
-    database_pool_recycle_seconds: int = Field(default=1800, gt=0)
     database_migrate_on_startup: bool = True
     database_sqlite_pre_migrate_backup_enabled: bool = True
     database_sqlite_pre_migrate_backup_max_files: int = Field(default=5, ge=1)
@@ -379,15 +389,10 @@ class Settings(BaseSettings):
     # constants in ``app/core/resilience/circuit_breaker.py``)
     circuit_breaker_enabled: bool = False
 
-    # Soft drain & deterministic failover
+    # Soft drain & deterministic failover (drain/probe thresholds are fixed
+    # constants in ``app/core/balancer/logic.py``)
     soft_drain_enabled: bool = True
     deterministic_failover_enabled: bool = True
-    drain_primary_threshold_pct: float = 85.0
-    drain_secondary_threshold_pct: float = 90.0
-    drain_error_window_seconds: float = 60.0
-    drain_error_count_threshold: int = 2
-    probe_quiet_seconds: float = 60.0
-    probe_success_streak_required: int = 3
 
     # Backpressure
     backpressure_max_concurrent_requests: int = 0  # 0 = unlimited

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -28,6 +28,14 @@ logger = logging.getLogger(__name__)
 _SQLITE_BUSY_TIMEOUT_MS = 30_000
 _SQLITE_BUSY_TIMEOUT_SECONDS = _SQLITE_BUSY_TIMEOUT_MS / 1000
 
+# PostgreSQL pool checkout timeout and connection recycle window. Fixed
+# application constants (issue #1340): recycle keeps pooled connections
+# younger than any reasonable server/proxy keep-alive boundary, and neither
+# value is an operator decision. Pool sizing stays configurable via
+# ``database_pool_size`` / ``database_max_overflow``.
+_POSTGRES_POOL_TIMEOUT_SECONDS = 30.0
+_POSTGRES_POOL_RECYCLE_SECONDS = 1800
+
 
 def _is_sqlite_url(url: str) -> bool:
     return url.startswith("sqlite+aiosqlite:///") or url.startswith("sqlite:///")
@@ -45,21 +53,27 @@ def _postgres_async_connect_args(url: str) -> dict[str, int] | None:
     return {"prepared_statement_cache_size": 0}
 
 
-def _postgres_async_engine_kwargs(url: str, *, background: bool) -> dict[str, object]:
+def _postgres_async_engine_kwargs(url: str) -> dict[str, object]:
+    """Engine kwargs shared by the main and background PostgreSQL engines.
+
+    The background engine always derives its pool sizing from the main pool
+    settings; it exists to isolate background-task checkouts, not to be sized
+    independently.
+    """
     connect_args = _postgres_async_connect_args(url)
     kwargs: dict[str, object] = {"connect_args": connect_args or {}}
     if os.environ.get("CODEX_LB_TEST_DATABASE_URL") and url.startswith("postgresql+asyncpg://"):
         kwargs["poolclass"] = NullPool
     else:
-        kwargs["pool_size"] = _database_pool_size(background=background)
-        kwargs["max_overflow"] = _database_max_overflow(background=background)
-        kwargs["pool_timeout"] = _settings.database_pool_timeout_seconds
+        kwargs["pool_size"] = _settings.database_pool_size
+        kwargs["max_overflow"] = _settings.database_max_overflow
+        kwargs["pool_timeout"] = _POSTGRES_POOL_TIMEOUT_SECONDS
         # Detect server-side connection drops (idle timeout, restart, network reset)
         # before the first real query, and cycle long-lived connections so they
         # never reach an upstream keep-alive boundary. SQLite paths do not need
         # either knob — aiosqlite has no analogous server-side disconnect.
         kwargs["pool_pre_ping"] = True
-        kwargs["pool_recycle"] = _settings.database_pool_recycle_seconds
+        kwargs["pool_recycle"] = _POSTGRES_POOL_RECYCLE_SECONDS
     return kwargs
 
 
@@ -68,20 +82,6 @@ def _sqlite_file_async_engine_kwargs() -> dict[str, object]:
         "poolclass": NullPool,
         "connect_args": {"timeout": _SQLITE_BUSY_TIMEOUT_SECONDS},
     }
-
-
-def _database_pool_size(*, background: bool) -> int:
-    if background:
-        return _settings.database_background_pool_size or _settings.database_pool_size
-    return _settings.database_pool_size
-
-
-def _database_max_overflow(*, background: bool) -> int:
-    if background:
-        if _settings.database_background_max_overflow is not None:
-            return _settings.database_background_max_overflow
-        return _settings.database_max_overflow
-    return _settings.database_max_overflow
 
 
 def _configure_sqlite_engine(engine: Engine, *, enable_wal: bool) -> None:
@@ -117,7 +117,7 @@ else:
     engine = create_async_engine(
         _settings.database_url,
         echo=False,
-        **_postgres_async_engine_kwargs(_settings.database_url, background=False),
+        **_postgres_async_engine_kwargs(_settings.database_url),
     )
 
 SessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
@@ -213,7 +213,11 @@ def _load_sqlite_backup_creator() -> _SqliteBackupCreator:
 
 
 def init_background_db(url: str | None = None) -> None:
-    """Initialize separate DB pool for background tasks (smaller pool).
+    """Initialize a separate DB engine for background tasks.
+
+    The background engine isolates background-task checkouts from the request
+    pool; its pool sizing always derives from ``database_pool_size`` /
+    ``database_max_overflow``.
 
     Args:
         url: Database URL. If None, uses settings.database_url.
@@ -240,7 +244,7 @@ def init_background_db(url: str | None = None) -> None:
         _background_engine = create_async_engine(
             db_url,
             echo=False,
-            **_postgres_async_engine_kwargs(db_url, background=True),
+            **_postgres_async_engine_kwargs(db_url),
         )
 
     _background_session_factory = async_sessionmaker(_background_engine, expire_on_commit=False, class_=AsyncSession)

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -2232,12 +2232,8 @@ def _state_from_account(
             now=time.time(),
             drain_entered_at=runtime.drain_entered_at,
             probe_success_streak=runtime.probe_success_streak,
-            drain_primary_threshold_pct=getattr(settings, "drain_primary_threshold_pct", 85.0),
-            drain_secondary_threshold_pct=getattr(settings, "drain_secondary_threshold_pct", 90.0),
-            drain_error_window_seconds=getattr(settings, "drain_error_window_seconds", 60.0),
-            drain_error_count_threshold=getattr(settings, "drain_error_count_threshold", 2),
-            probe_quiet_seconds=getattr(settings, "probe_quiet_seconds", 60.0),
-            probe_success_streak_required=getattr(settings, "probe_success_streak_required", 3),
+            # Drain/probe thresholds are the fixed constants in
+            # ``app/core/balancer/logic.py`` (evaluate_health_tier defaults).
         )
         if new_tier == HEALTH_TIER_DRAINING and runtime.health_tier != HEALTH_TIER_DRAINING:
             runtime.drain_entered_at = time.time()

--- a/openspec/changes/reduce-settings-surface-phase-3/context.md
+++ b/openspec/changes/reduce-settings-surface-phase-3/context.md
@@ -1,0 +1,89 @@
+# Context: reduce-settings-surface-phase-3
+
+## Rationale
+
+Phase 3 of issue #1340, following the same selection rule as phases 1 and
+2: every removed field keeps its exact previous default as the new fixed
+value, and the only behavioral seam (the removed-settings warning) is
+additive. None of this batch's env names were rendered by the Helm chart
+or listed in `.env.example`, so no deployment artifacts change.
+
+Capability choice mirrors the earlier phases: `deployment-installation`
+owns the operator env-var contract at settings-load time, so the phase-3
+fixed-values requirement is added there alongside the phase-1 and phase-2
+requirements. Unlike phase 2, this batch also touches normative main-spec
+text: three `database-backends` requirements named the removed settings,
+so the change carries MODIFIED deltas for them.
+
+## Removed fields (env names)
+
+Database pool tuning (`app/db/session.py`):
+
+- `CODEX_LB_DATABASE_BACKGROUND_POOL_SIZE` (derived: always
+  `database_pool_size`; the previous default was already "unset = derive")
+- `CODEX_LB_DATABASE_BACKGROUND_MAX_OVERFLOW` (derived: always
+  `database_max_overflow`)
+- `CODEX_LB_DATABASE_POOL_TIMEOUT_SECONDS` (fixed: 30.0,
+  `_POSTGRES_POOL_TIMEOUT_SECONDS`)
+- `CODEX_LB_DATABASE_POOL_RECYCLE_SECONDS` (fixed: 1800,
+  `_POSTGRES_POOL_RECYCLE_SECONDS`)
+
+Soft-drain/probe thresholds (already constants in
+`app/core/balancer/logic.py`; the settings plumbing is deleted):
+
+- `CODEX_LB_DRAIN_PRIMARY_THRESHOLD_PCT` (fixed: 85.0)
+- `CODEX_LB_DRAIN_SECONDARY_THRESHOLD_PCT` (fixed: 90.0)
+- `CODEX_LB_DRAIN_ERROR_WINDOW_SECONDS` (fixed: 60.0)
+- `CODEX_LB_DRAIN_ERROR_COUNT_THRESHOLD` (fixed: 2)
+- `CODEX_LB_PROBE_QUIET_SECONDS` (fixed: 60.0)
+- `CODEX_LB_PROBE_SUCCESS_STREAK_REQUIRED` (fixed: 3)
+
+Kept deliberately: `CODEX_LB_DATABASE_POOL_SIZE` and
+`CODEX_LB_DATABASE_MAX_OVERFLOW` — the one genuine PostgreSQL HA sizing
+decision. Operators must budget
+`(pool_size + max_overflow) x maxReplicas <= max_connections`, and the
+Helm chart pins both values (`config.databasePoolSize=5`,
+`config.databaseMaxOverflow`), so removing them would break real
+deployments' connection budgets. `CODEX_LB_SOFT_DRAIN_ENABLED` and
+`CODEX_LB_DETERMINISTIC_FAILOVER_ENABLED` stay as the failover
+subsystem's switches.
+
+## Background-pool decision
+
+`database_background_pool_size` / `database_background_max_overflow`
+defaulted to `None` = "use the main pool settings", and nothing in the
+repository, Helm chart, docs, or `.env.example` ever set them. The
+background engine's purpose is isolation of background-task checkouts
+from the request pool (see the detached-session requirements in
+`database-backends`), not independent sizing — a smaller auxiliary pool
+was a hypothetical tuning nobody exercised. The derivation is now
+unconditional, which also collapses the `background` branch out of the
+PostgreSQL engine-kwargs helper: both engines are built from one code
+path, so pre-ping/recycle regressions (#672) can no longer diverge
+between them.
+
+## Drain-threshold decision
+
+The drain/probe thresholds encode the deterministic-failover design
+(drain at 85%/90% used, back off after 2 errors in 60 s, probe after a
+60 s quiet window, recover after 3 successful probes). They interlock —
+raising one without the others degrades failover in non-obvious ways —
+and `app/core/balancer/logic.py` already declared the same values as
+constants used for `evaluate_health_tier` parameter defaults, so the
+settings were a second source of truth for numbers that must not drift.
+The function keeps its full parameter surface (tests and the replica-local
+health-tier machinery pass explicit values), but production call sites now
+rely on the constant defaults. Per-replica drain/probe state semantics
+(`account-routing` spec) are unchanged.
+
+## Example
+
+An operator running `CODEX_LB_PROBE_QUIET_SECONDS=30` upgrades: startup
+logs
+
+```
+removed setting(s) ignored: CODEX_LB_PROBE_QUIET_SECONDS — values are now fixed; see PRINCIPLES.md P2 / issue #1340
+```
+
+and drained accounts enter the probing tier after the fixed 60-second
+quiet window.

--- a/openspec/changes/reduce-settings-surface-phase-3/proposal.md
+++ b/openspec/changes/reduce-settings-surface-phase-3/proposal.md
@@ -1,0 +1,65 @@
+# Change: reduce-settings-surface-phase-3
+
+## Why
+
+Phase 3 of issue #1340 (simplicity backlog: settings-surface reduction) and
+PRINCIPLES.md P2 ("a setting the operator never needs to touch is a default
+in disguise"). After phase 2 (`reduce-settings-surface-phase-2`) the
+`Settings` class still carried 127 env-settable fields. This batch covers
+audit items 5 and 6: database pool tuning nobody sizes independently of the
+main pool, and the soft-drain/probe thresholds, which encode failover
+invariants rather than deployment decisions.
+
+## What Changes
+
+Phase 3 removes 10 more fields (127 -> 117), with no behavior change for
+default installs.
+
+- **DB pool tuning (4 removed)**: `database_background_pool_size` and
+  `database_background_max_overflow` are removed; the background-task
+  engine now always derives its pool sizing from `database_pool_size` and
+  `database_max_overflow` (the previous default when the overrides were
+  unset). `database_pool_timeout_seconds` (fixed 30.0) and
+  `database_pool_recycle_seconds` (fixed 1800) become the
+  `_POSTGRES_POOL_TIMEOUT_SECONDS` / `_POSTGRES_POOL_RECYCLE_SECONDS`
+  constants in `app/db/session.py`. `database_pool_size` (15) and
+  `database_max_overflow` (10) stay: PostgreSQL HA operators must be able
+  to budget `(pool_size + max_overflow) x replicas` against the server's
+  `max_connections`, and the Helm chart pins both
+  (`config.databasePoolSize`, `config.databaseMaxOverflow`).
+- **Soft-drain/probe thresholds (6 removed)**:
+  `drain_primary_threshold_pct` (85.0), `drain_secondary_threshold_pct`
+  (90.0), `drain_error_window_seconds` (60.0),
+  `drain_error_count_threshold` (2), `probe_quiet_seconds` (60.0), and
+  `probe_success_streak_required` (3) are removed. The identical constants
+  already existed in `app/core/balancer/logic.py`
+  (`DRAIN_PRIMARY_THRESHOLD_PCT` etc.) as `evaluate_health_tier` parameter
+  defaults; `app/modules/proxy/load_balancer.py` simply stops forwarding
+  settings values and relies on those defaults, making `logic.py` the
+  single source of truth. `soft_drain_enabled` and
+  `deterministic_failover_enabled` remain the only switches.
+- **One-release removal warning**: the phase-3 env names join
+  `_REMOVED_SETTINGS`, so startup logs the existing single WARN when any
+  of them are still set (`extra="ignore"` already makes them inert).
+
+## Impact
+
+- Affected specs: `deployment-installation` (new requirement covering the
+  phase-3 fixed values and the background-pool derivation);
+  `database-backends` (three requirements modified to drop the removed
+  setting names in favor of the fixed constants and the unconditional
+  background-pool derivation); non-normative wording update in
+  `openspec/specs/database-backends/context.md`.
+- Affected code: `app/core/config/settings.py`, `app/db/session.py`,
+  `app/modules/proxy/load_balancer.py`.
+- Operator impact: none for default installs. Deployments that set a
+  removed env var keep working on the fixed value and see one startup
+  WARN. The Helm chart never rendered any of the removed names, so no
+  chart changes are needed.
+- Proxy-failover invariants: every fixed drain/probe value equals the
+  previous settings default, `evaluate_health_tier` keeps its full
+  parameter surface for tests and future callers, and drain/probe/failover
+  behavior is byte-identical for installs that never overrode the
+  thresholds.
+- Not in scope: further settings-surface phases tracked in #1340 (the
+  issue stays open).

--- a/openspec/changes/reduce-settings-surface-phase-3/specs/database-backends/spec.md
+++ b/openspec/changes/reduce-settings-surface-phase-3/specs/database-backends/spec.md
@@ -1,0 +1,128 @@
+## MODIFIED Requirements
+
+### Requirement: PostgreSQL engines validate and recycle pooled connections
+
+When `database_url` resolves to a PostgreSQL backend, the application MUST configure each async engine — both the request-path `engine` and the optional background-task `_background_engine` — with `pool_pre_ping=True` and a finite `pool_recycle` window. This is required so the application detects connections that the PostgreSQL server has silently closed (idle timeout, restart, network reset) before the first real query is dispatched on them, and so connections are cycled before they reach any reasonable upstream keep-alive boundary. The recycle window is the fixed 1800-second application constant in `app/db/session.py`.
+
+#### Scenario: Stale connections are rejected before checkout
+
+- **WHEN** a pooled connection has been closed by the server while sitting idle
+- **AND** that connection is the next one a session tries to use
+- **THEN** SQLAlchemy issues a pre-ping (`SELECT 1`), detects the dead connection, and transparently replaces it
+- **AND** the application returns `200` (or the real business-level result), not `500 server_error` with `asyncpg.InterfaceError: connection is closed`
+
+#### Scenario: Pool recycle bounds connection age
+
+- **WHEN** a pooled connection has been open longer than the fixed 1800-second recycle window
+- **AND** that connection is the next one a session tries to use
+- **THEN** SQLAlchemy discards and replaces the connection before the next query
+
+#### Scenario: SQLite backends are not affected
+
+- **WHEN** `database_url` resolves to a SQLite backend (file or `:memory:`)
+- **THEN** neither `pool_pre_ping` nor `pool_recycle` is configured on the engine
+- **AND** existing SQLite-specific tuning (PRAGMAs, `busy_timeout`) is unchanged
+
+### Requirement: Database pool controls cover request-adjacent background sessions
+
+The service SHALL size both the main request pool and the
+background/request-adjacent session pool from `database_pool_size` and
+`database_max_overflow`. The background pool SHALL always derive from those
+two settings; it exists to isolate background-task checkouts from the
+request pool, not to be sized independently.
+
+#### Scenario: Background pool inherits main pool capacity
+
+- **WHEN** the application creates the background/request-adjacent DB engine for a pooled backend
+- **THEN** the background pool uses `database_pool_size` and `database_max_overflow`
+- **AND** no separate background pool sizing setting exists
+
+### Requirement: Detached background tasks own their database session lifetime
+
+Detached background tasks MUST own database session lifetime independently from cancellable callers.
+
+A background task that is intentionally decoupled from its caller's lifetime
+(for example a singleflight refresh kept alive with `asyncio.shield` so
+concurrent waiters share one in-flight operation) MUST NOT perform database work
+through a session whose lifetime is owned by the cancellable caller. Such a task
+MUST acquire its own session (via `get_background_session()` or an equivalent
+caller-independent factory), use it, and release it entirely within the task.
+
+Background refresh schedulers MUST also avoid holding an `AsyncSession` while
+performing upstream network I/O. Usage refresh, model-registry refresh, and
+reset-credits refresh MUST perform account/usage/settings reads in short
+sessions, close those sessions, perform upstream fetches, and reacquire short
+sessions only for required database writes.
+
+#### Scenario: Client disconnect during token refresh does not strand a connection
+
+- **GIVEN** a proxy request triggers an account token refresh through `AuthManager.ensure_fresh`
+- **AND** the refresh runs as a detached singleflight task held alive by `asyncio.shield`
+- **AND** the request that initiated it is bound to a request-scoped background session
+- **WHEN** the client disconnects mid-refresh and the request task is cancelled
+- **THEN** the refresh task MUST complete its token/status writes against its own session, acquired independently of the cancelled request
+- **AND** the request-scoped session MUST close without being used by the refresh task after close
+- **AND** no background-pool connection is left checked out after the refresh task finishes
+
+#### Scenario: Non-cancellable callers without network I/O retain the bound-session path
+
+- **GIVEN** a caller whose session is not tied to a client-cancellable request
+- **AND** the caller does not hold that session across external network I/O
+- **AND** that caller invokes `AuthManager.ensure_fresh` without supplying a refresh session factory
+- **WHEN** a token refresh runs
+- **THEN** the refresh MAY use the caller's bound session
+- **AND** behavior is unchanged from before this requirement
+
+#### Scenario: Accumulated leak no longer exhausts the background pool
+
+- **GIVEN** repeated client disconnects during token refreshes over an extended period
+- **WHEN** each disconnect-during-refresh occurs
+- **THEN** each refresh task releases its connection back to the background pool
+- **AND** the background engine pool (sized from `database_pool_size` + `database_max_overflow`) is not driven to exhaustion by stranded refresh connections
+- **AND** `/backend-api/codex/*` requests do not begin returning `500` from `QueuePool limit ... connection timed out` as a result of this path
+
+#### Scenario: Usage refresh fetch runs after the read session closes
+
+- **GIVEN** usage refresh selects an account from the database
+- **WHEN** it calls the upstream usage endpoint
+- **THEN** the session used to read latest usage, accounts, and settings has already closed
+- **AND** usage rows, account status changes, and warm-up attempt/log writes use separate short sessions
+
+#### Scenario: Model registry refresh fetch runs after the account read session closes
+
+- **GIVEN** model registry refresh reads active accounts from the database
+- **WHEN** it calls the upstream model discovery endpoint
+- **THEN** the account-list session has already closed
+- **AND** token refresh and route resolution use independent short sessions when database access is required
+
+#### Scenario: Reset-credits refresh fetch runs after the account read session closes
+
+- **GIVEN** reset-credits refresh reads accounts from the database
+- **WHEN** it calls the upstream reset-credits endpoint
+- **THEN** the account-list session has already closed
+- **AND** route resolution uses an independent short session when database access is required
+
+### Requirement: File-backed SQLite engines do not retain idle pooled descriptors
+
+File-backed SQLite main and background async engines MUST use non-pooled connection semantics.
+
+SQLite `:memory:` databases MUST preserve the existing shared-engine behavior
+for background sessions so schema state remains visible to background tasks.
+
+Pool sizing (`database_pool_size`, `database_max_overflow`) and the fixed
+pool checkout timeout SHALL constrain pooled backends only. They SHALL NOT
+be passed to file-backed SQLite engines.
+
+#### Scenario: File SQLite uses NullPool
+
+- **GIVEN** `database_url` resolves to a file-backed SQLite database
+- **WHEN** the application creates its main or background async engine
+- **THEN** the engine is configured with `NullPool`
+- **AND** `pool_size`, `max_overflow`, and `pool_timeout` are not passed
+- **AND** existing SQLite PRAGMAs and busy timeout behavior remain enabled
+
+#### Scenario: PostgreSQL pooling is unchanged
+
+- **GIVEN** `database_url` resolves to PostgreSQL
+- **WHEN** the application creates its main or background async engine
+- **THEN** PostgreSQL pool sizing, overflow, pre-ping, and recycle controls remain configured as before

--- a/openspec/changes/reduce-settings-surface-phase-3/specs/deployment-installation/spec.md
+++ b/openspec/changes/reduce-settings-surface-phase-3/specs/deployment-installation/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Phase-3 removed tunables are fixed constants or derived values
+
+The phase-3 internals SHALL NOT be operator-configurable: the PostgreSQL
+pool checkout timeout MUST be fixed at 30 seconds and the pooled-connection
+recycle window at 1800 seconds; the background-task database engine MUST
+always derive its pool size and max overflow from `database_pool_size` and
+`database_max_overflow`; and the soft-drain/probe thresholds (primary drain
+threshold 85%, secondary drain threshold 90%, error window 60 seconds,
+error count 2, probe quiet window 60 seconds, probe success streak 3) MUST
+each be fixed at its previously documented default in
+`app/core/balancer/logic.py`. `database_pool_size` and
+`database_max_overflow` MUST remain operator-configurable settings, and
+`soft_drain_enabled` and `deterministic_failover_enabled` MUST remain the
+failover subsystem's enable switches. The removed phase-3 environment
+variable names MUST be covered by the existing removed-settings startup
+warning: they are ignored without failing startup and reported in the
+single warning log (names only, never values) for at least one release.
+
+#### Scenario: Phase-3 removed env vars are ignored with one startup warning
+
+- **GIVEN** a deployment whose environment still sets removed settings such
+  as `CODEX_LB_DATABASE_POOL_RECYCLE_SECONDS` and
+  `CODEX_LB_DRAIN_PRIMARY_THRESHOLD_PCT`
+- **WHEN** the application starts
+- **THEN** startup succeeds and the fixed built-in values are used
+- **AND** exactly one warning log lists both removed names without their
+  values
+
+#### Scenario: Background pool sizing derives from the main pool settings
+
+- **GIVEN** `CODEX_LB_DATABASE_POOL_SIZE=12` and
+  `CODEX_LB_DATABASE_MAX_OVERFLOW=4` on a PostgreSQL deployment
+- **WHEN** the application creates the background-task database engine
+- **THEN** the background engine uses pool size 12 and max overflow 4
+- **AND** no separate background pool sizing can be configured
+
+#### Scenario: Drain and probe thresholds are fixed constants
+
+- **GIVEN** a deployment with `soft_drain_enabled` left at its default
+- **WHEN** an account's primary window usage reaches 85%
+- **THEN** the account enters the draining health tier
+- **AND** a drained account enters the probing tier only after the fixed
+  60-second quiet window, regardless of any `CODEX_LB_PROBE_QUIET_SECONDS`
+  value still present in the environment

--- a/openspec/changes/reduce-settings-surface-phase-3/tasks.md
+++ b/openspec/changes/reduce-settings-surface-phase-3/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: reduce-settings-surface-phase-3
+
+- [x] 1.1 Remove the two background-pool overrides and make the
+      background engine derive its pool sizing from
+      `database_pool_size` / `database_max_overflow` unconditionally
+      (`app/db/session.py`; the `background` branch of the engine-kwargs
+      helper collapses away)
+- [x] 1.2 Fix the PostgreSQL pool checkout timeout (30.0 s) and connection
+      recycle window (1800 s) as `_POSTGRES_POOL_TIMEOUT_SECONDS` /
+      `_POSTGRES_POOL_RECYCLE_SECONDS` constants in `app/db/session.py`;
+      keep `database_pool_size` and `database_max_overflow` as settings
+- [x] 1.3 Remove the six drain/probe threshold settings and stop passing
+      them from `app/modules/proxy/load_balancer.py`; the
+      `evaluate_health_tier` parameter defaults in
+      `app/core/balancer/logic.py` (identical values) become the single
+      source of truth; keep `soft_drain_enabled` and
+      `deterministic_failover_enabled`
+- [x] 1.4 Add the ten phase-3 env names to `_REMOVED_SETTINGS` (grouped
+      and commented per phase) so the existing startup WARN covers them;
+      update the non-normative pool wording in
+      `openspec/specs/database-backends/context.md`
+- [x] 2.1 Update tests that set removed fields; preserve what each test
+      proves (engine-kwargs tests assert the fixed constants and the
+      derived background sizing; `_state_from_account` drain tests
+      exercise the fixed thresholds imported from
+      `app.core.balancer.logic`)
+- [x] 2.2 Extend `tests/unit/test_settings_trace_and_removed.py` with the
+      phase-3 names (tuple count, membership, ignored env vars)
+- [x] 3.1 `uv run pytest tests/unit -q` (plus the drain/failover and DB
+      session test files explicitly)
+- [x] 3.2 `uv run ruff check .` and `uv run ruff format --check .`
+- [x] 3.3 `make typecheck` (ty)
+- [x] 3.4 `python3 .github/scripts/check_simplicity_budgets.py`
+- [x] 3.5 `openspec validate reduce-settings-surface-phase-3 --strict` and
+      `openspec validate --specs`

--- a/openspec/specs/database-backends/context.md
+++ b/openspec/specs/database-backends/context.md
@@ -16,8 +16,8 @@ For higher concurrency or infrastructure-managed deployments, PostgreSQL support
 - SQLite default URL: `sqlite+aiosqlite:///~/.codex-lb/store.db`
 - SQLite startup check mode: `CODEX_LB_DATABASE_SQLITE_STARTUP_CHECK_MODE=quick|full|off` (default `quick`)
 - PostgreSQL example URL: `postgresql+asyncpg://codex_lb:codex_lb@127.0.0.1:5432/codex_lb`
-- Pool controls (`database_pool_size`, `database_max_overflow`, `database_pool_timeout_seconds`) apply to non-memory SQLite and PostgreSQL engine creation.
-- Background/request-adjacent DB pool controls (`database_background_pool_size`, `database_background_max_overflow`) default to the main pool settings, and can be lowered explicitly for deployments that want a smaller auxiliary pool.
+- Pool sizing (`database_pool_size`, `database_max_overflow`) applies to PostgreSQL engine creation; the pool checkout timeout (30 s) and connection recycle window (1800 s) are fixed constants in `app/db/session.py` (issue #1340 phase 3).
+- The background/request-adjacent DB engine always derives its pool sizing from `database_pool_size` and `database_max_overflow`; it isolates background-task checkouts rather than being sized independently.
 
 ## Example
 

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -24,10 +24,6 @@ class _FakeSettings:
     database_url: str
     database_pool_size: int = 15
     database_max_overflow: int = 10
-    database_background_pool_size: int | None = None
-    database_background_max_overflow: int | None = None
-    database_pool_timeout_seconds: float = 30.0
-    database_pool_recycle_seconds: int = 1800
     database_migrate_on_startup: bool = True
     database_sqlite_pre_migrate_backup_enabled: bool = False
     database_sqlite_pre_migrate_backup_max_files: int = 5
@@ -149,46 +145,15 @@ async def test_sqlite_writer_section_does_not_serialize_memory_sqlite(monkeypatc
     await asyncio.wait_for(asyncio.gather(first_writer(), second_writer()), timeout=1)
 
 
-def test_background_pool_defaults_to_main_pool_settings(monkeypatch) -> None:
-    monkeypatch.setattr(
-        session_module,
-        "_settings",
-        _FakeSettings(
-            database_url="sqlite+aiosqlite:///:memory:",
-            database_pool_size=15,
-            database_max_overflow=10,
-        ),
-    )
-
-    assert session_module._database_pool_size(background=True) == 15
-    assert session_module._database_max_overflow(background=True) == 10
-
-
-def test_background_pool_settings_can_override_main_pool(monkeypatch) -> None:
-    monkeypatch.setattr(
-        session_module,
-        "_settings",
-        _FakeSettings(
-            database_url="sqlite+aiosqlite:///:memory:",
-            database_pool_size=15,
-            database_max_overflow=10,
-            database_background_pool_size=4,
-            database_background_max_overflow=1,
-        ),
-    )
-
-    assert session_module._database_pool_size(background=True) == 4
-    assert session_module._database_max_overflow(background=True) == 1
-    assert session_module._database_pool_size(background=False) == 15
-    assert session_module._database_max_overflow(background=False) == 10
-
-
 def test_postgres_engine_kwargs_enable_pre_ping_and_recycle(monkeypatch) -> None:
     """Regression for #672: PostgreSQL engines MUST validate pooled connections
-    on checkout (``pool_pre_ping``) and recycle them within the configured
-    window (``pool_recycle``). Without these the pool serves stale connections
+    on checkout (``pool_pre_ping``) and recycle them within a finite window
+    (``pool_recycle``). Without these the pool serves stale connections
     after the server idles them out, causing
     ``asyncpg.InterfaceError: connection is closed`` on the first real query.
+
+    Both the main and the background engine build their kwargs through this
+    single helper, so one assertion covers both engines.
     """
     monkeypatch.setenv("CODEX_LB_TEST_DATABASE_URL", "")
     monkeypatch.delenv("CODEX_LB_TEST_DATABASE_URL", raising=False)
@@ -199,36 +164,28 @@ def test_postgres_engine_kwargs_enable_pre_ping_and_recycle(monkeypatch) -> None
             database_url="postgresql+asyncpg://u:p@h/db",
             database_pool_size=15,
             database_max_overflow=10,
-            database_pool_timeout_seconds=30.0,
-            database_pool_recycle_seconds=1800,
         ),
     )
 
-    kwargs = session_module._postgres_async_engine_kwargs("postgresql+asyncpg://u:p@h/db", background=False)
+    kwargs = session_module._postgres_async_engine_kwargs("postgresql+asyncpg://u:p@h/db")
     assert kwargs["pool_pre_ping"] is True
     assert kwargs["pool_recycle"] == 1800
     assert kwargs["pool_size"] == 15
     assert kwargs["max_overflow"] == 10
     assert kwargs["pool_timeout"] == 30.0
 
-    background_kwargs = session_module._postgres_async_engine_kwargs("postgresql+asyncpg://u:p@h/db", background=True)
-    assert background_kwargs["pool_pre_ping"] is True
-    assert background_kwargs["pool_recycle"] == 1800
 
-
-def test_postgres_engine_kwargs_honor_custom_recycle(monkeypatch) -> None:
+def test_postgres_engine_kwargs_use_fixed_timeout_and_recycle_constants(monkeypatch) -> None:
     monkeypatch.delenv("CODEX_LB_TEST_DATABASE_URL", raising=False)
     monkeypatch.setattr(
         session_module,
         "_settings",
-        _FakeSettings(
-            database_url="postgresql+asyncpg://u:p@h/db",
-            database_pool_recycle_seconds=600,
-        ),
+        _FakeSettings(database_url="postgresql+asyncpg://u:p@h/db"),
     )
 
-    kwargs = session_module._postgres_async_engine_kwargs("postgresql+asyncpg://u:p@h/db", background=False)
-    assert kwargs["pool_recycle"] == 600
+    kwargs = session_module._postgres_async_engine_kwargs("postgresql+asyncpg://u:p@h/db")
+    assert kwargs["pool_timeout"] == session_module._POSTGRES_POOL_TIMEOUT_SECONDS == 30.0
+    assert kwargs["pool_recycle"] == session_module._POSTGRES_POOL_RECYCLE_SECONDS == 1800
 
 
 def test_postgres_engine_kwargs_use_nullpool_under_test_db_url(monkeypatch) -> None:
@@ -243,7 +200,7 @@ def test_postgres_engine_kwargs_use_nullpool_under_test_db_url(monkeypatch) -> N
         _FakeSettings(database_url="postgresql+asyncpg://u:p@h/db"),
     )
 
-    kwargs = session_module._postgres_async_engine_kwargs("postgresql+asyncpg://u:p@h/db", background=False)
+    kwargs = session_module._postgres_async_engine_kwargs("postgresql+asyncpg://u:p@h/db")
     assert kwargs["poolclass"] is NullPool
     assert "pool_pre_ping" not in kwargs
     assert "pool_recycle" not in kwargs
@@ -257,7 +214,6 @@ def test_sqlite_file_engine_kwargs_use_nullpool_without_pool_controls(monkeypatc
             database_url="sqlite+aiosqlite:///store.db",
             database_pool_size=15,
             database_max_overflow=10,
-            database_pool_timeout_seconds=30.0,
         ),
     )
 
@@ -279,18 +235,16 @@ def test_postgres_engine_kwargs_keep_pool_controls(monkeypatch) -> None:
             database_url="postgresql+asyncpg://u:p@h/db",
             database_pool_size=12,
             database_max_overflow=4,
-            database_pool_timeout_seconds=11.0,
-            database_pool_recycle_seconds=900,
         ),
     )
 
-    kwargs = session_module._postgres_async_engine_kwargs("postgresql+asyncpg://u:p@h/db", background=False)
+    kwargs = session_module._postgres_async_engine_kwargs("postgresql+asyncpg://u:p@h/db")
 
     assert kwargs["pool_pre_ping"] is True
-    assert kwargs["pool_recycle"] == 900
+    assert kwargs["pool_recycle"] == 1800
     assert kwargs["pool_size"] == 12
     assert kwargs["max_overflow"] == 4
-    assert kwargs["pool_timeout"] == 11.0
+    assert kwargs["pool_timeout"] == 30.0
 
 
 @pytest.mark.asyncio
@@ -664,7 +618,7 @@ async def test_init_background_db_creates_separate_engine() -> None:
 
 
 @pytest.mark.asyncio
-async def test_init_background_db_uses_main_pool_size_for_postgres_by_default() -> None:
+async def test_init_background_db_derives_postgres_pool_size_from_main_pool() -> None:
     session_module.init_background_db("postgresql+asyncpg://user:pass@localhost/db")
 
     assert session_module._background_engine is not None

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -20,6 +20,7 @@ from app.core.balancer import (
     handle_rate_limit,
     select_account,
 )
+from app.core.balancer.logic import DRAIN_PRIMARY_THRESHOLD_PCT, PROBE_QUIET_SECONDS
 from app.core.usage.quota import apply_usage_quota
 from app.db.models import Account, AccountStatus, UsageHistory
 from app.modules.proxy.load_balancer import (
@@ -3290,27 +3291,23 @@ def test_background_recovery_state_keeps_rate_limited_without_persisted_reset(mo
     assert state.blocked_at == pytest.approx(blocked)
 
 
-def test_state_from_account_uses_configured_drain_primary_threshold(monkeypatch):
+def test_state_from_account_drains_at_fixed_primary_threshold(monkeypatch):
+    """Drain thresholds are the fixed constants in ``app.core.balancer.logic``
+    (85% primary by default); ``_state_from_account`` applies them without any
+    settings plumbing.
+    """
     now = 1_700_000_000.0
     monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
     monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
     monkeypatch.setattr(
         "app.modules.proxy.load_balancer.get_settings",
-        lambda: SimpleNamespace(
-            soft_drain_enabled=True,
-            drain_primary_threshold_pct=75.0,
-            drain_secondary_threshold_pct=90.0,
-            drain_error_window_seconds=60.0,
-            drain_error_count_threshold=2,
-            probe_quiet_seconds=60.0,
-            probe_success_streak_required=3,
-        ),
+        lambda: SimpleNamespace(soft_drain_enabled=True),
     )
 
     account = _make_test_account(status=AccountStatus.ACTIVE)
     primary = _make_test_usage(
         window="primary",
-        used_percent=80.0,
+        used_percent=DRAIN_PRIMARY_THRESHOLD_PCT + 1.0,
         reset_at=int(now + 3600),
         recorded_at=_epoch_to_naive_utc(now - 10),
     )
@@ -3325,27 +3322,19 @@ def test_state_from_account_uses_configured_drain_primary_threshold(monkeypatch)
     assert state.health_tier == 1
 
 
-def test_state_from_account_uses_configured_probe_quiet_seconds(monkeypatch):
+def test_state_from_account_promotes_to_probing_after_fixed_quiet_window(monkeypatch):
     now = 1_700_000_000.0
     monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
     monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
     monkeypatch.setattr(
         "app.modules.proxy.load_balancer.get_settings",
-        lambda: SimpleNamespace(
-            soft_drain_enabled=True,
-            drain_primary_threshold_pct=85.0,
-            drain_secondary_threshold_pct=90.0,
-            drain_error_window_seconds=60.0,
-            drain_error_count_threshold=2,
-            probe_quiet_seconds=10.0,
-            probe_success_streak_required=3,
-        ),
+        lambda: SimpleNamespace(soft_drain_enabled=True),
     )
 
     account = _make_test_account(status=AccountStatus.ACTIVE)
     runtime = RuntimeState(
         health_tier=1,
-        drain_entered_at=now - 11.0,
+        drain_entered_at=now - (PROBE_QUIET_SECONDS + 1.0),
         probe_success_streak=0,
     )
     primary = _make_test_usage(

--- a/tests/unit/test_settings_trace_and_removed.py
+++ b/tests/unit/test_settings_trace_and_removed.py
@@ -89,7 +89,7 @@ def test_warn_removed_settings_scans_env_files(tmp_path, monkeypatch, caplog):
 
 
 def test_removed_settings_tuple_covers_all_five_groups():
-    assert len(_REMOVED_SETTINGS) == 39
+    assert len(_REMOVED_SETTINGS) == 49
     assert all(name.startswith("CODEX_LB_") for name in _REMOVED_SETTINGS)
     assert len(set(_REMOVED_SETTINGS)) == len(_REMOVED_SETTINGS)
 
@@ -129,4 +129,39 @@ def test_phase_2_removed_settings_are_listed_and_ignored(monkeypatch):
     assert found == [
         "CODEX_LB_QUOTA_PLANNER_TICK_SECONDS",
         "CODEX_LB_IMAGES_HOST_MODEL",
+    ]
+
+
+def test_phase_3_removed_settings_are_listed_and_ignored(monkeypatch):
+    phase_3_names = (
+        "CODEX_LB_DATABASE_BACKGROUND_POOL_SIZE",
+        "CODEX_LB_DATABASE_BACKGROUND_MAX_OVERFLOW",
+        "CODEX_LB_DATABASE_POOL_TIMEOUT_SECONDS",
+        "CODEX_LB_DATABASE_POOL_RECYCLE_SECONDS",
+        "CODEX_LB_DRAIN_PRIMARY_THRESHOLD_PCT",
+        "CODEX_LB_DRAIN_SECONDARY_THRESHOLD_PCT",
+        "CODEX_LB_DRAIN_ERROR_WINDOW_SECONDS",
+        "CODEX_LB_DRAIN_ERROR_COUNT_THRESHOLD",
+        "CODEX_LB_PROBE_QUIET_SECONDS",
+        "CODEX_LB_PROBE_SUCCESS_STREAK_REQUIRED",
+    )
+    for name in phase_3_names:
+        assert name in _REMOVED_SETTINGS
+
+    monkeypatch.setenv("CODEX_LB_DATABASE_POOL_RECYCLE_SECONDS", "600")
+    monkeypatch.setenv("CODEX_LB_DRAIN_PRIMARY_THRESHOLD_PCT", "75.0")
+    settings = Settings()
+    assert not hasattr(settings, "database_pool_recycle_seconds")
+    assert not hasattr(settings, "drain_primary_threshold_pct")
+    assert settings.database_pool_size == 15
+    assert settings.soft_drain_enabled is True
+    found = warn_removed_settings(
+        {
+            "CODEX_LB_DATABASE_POOL_RECYCLE_SECONDS": "600",
+            "CODEX_LB_DRAIN_PRIMARY_THRESHOLD_PCT": "75.0",
+        }
+    )
+    assert found == [
+        "CODEX_LB_DATABASE_POOL_RECYCLE_SECONDS",
+        "CODEX_LB_DRAIN_PRIMARY_THRESHOLD_PCT",
     ]


### PR DESCRIPTION
## Summary

Phase 3 of #1340: **127 → 117 env-settable fields** (−10). Items 5 and 6 of the reduction table.

| Group | Fields | What happened |
|---|---|---|
| DB pool 6 → 2 | −4 | `database_pool_size` and `database_max_overflow` stay (the knobs Postgres HA operators actually pin). Background pool size/overflow now derive unconditionally from the main pool; timeout (30 s) and recycle (1800 s) become engine-setup constants. Both engines build from one code path. |
| Soft-drain / probe thresholds | −6 | The six thresholds already existed as parameter defaults in `app/core/balancer/logic.py` (`DRAIN_PRIMARY_THRESHOLD_PCT` etc., identical values); the load-balancer call site stops passing settings-sourced overrides, making logic.py the single source of truth. `soft_drain_enabled` and `deterministic_failover_enabled` stay; `evaluate_health_tier`'s full parameter surface is preserved (tests keep passing explicit params). |

Removed env names join the one-release startup warning (list now 49 names across three phases).

Note: `openspec/specs/database-backends/spec.md` normatively referenced the removed pool names — this change carries MODIFIED deltas for those requirements (recycle window, background-pool derivation, SQLite pool-controls wording) alongside the usual phase ADDED requirement.

## Type of change

- [x] `refactor:` — internal refactor (operator-contract change covered by OpenSpec; no default-behavior change)

Refs #1340 (partial — phase 3; deviation: item 5 removed 4 pool fields, not 3, because keeping `database_background_max_overflow` while removing `database_background_pool_size` would be an incoherent half-contract).

## OpenSpec

`openspec/changes/reduce-settings-surface-phase-3/` — ADDED on `deployment-installation` + MODIFIED on `database-backends`; `--strict` and `--specs` (47/47) pass.

## Checks

- `pytest tests/unit`: 3981 passed, 3 skipped; drain/failover + db-session + load-balancer integration files explicitly green
- `ruff` / `ty`: clean; simplicity budgets: green; Helm chart renders only kept names (no de-reference needed)

## Simplicity

- [x] Removes 10 settings, adds none; no README/nav/docs surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)