### PR TITLE
chore(contributors): add ShiroKSH and aididhaiqal to all-contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1024,6 +1024,26 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "ShiroKSH",
+      "name": "Kushida",
+      "avatar_url": "https://avatars.githubusercontent.com/u/218489957?v=4",
+      "profile": "https://github.com/ShiroKSH",
+      "contributions": [
+        "code",
+        "test"
+      ]
+    },
+    {
+      "login": "aididhaiqal",
+      "name": "Aidid Haiqal",
+      "avatar_url": "https://avatars.githubusercontent.com/u/10329190?v=4",
+      "profile": "https://github.com/aididhaiqal",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -257,6 +257,8 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/e
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/fozbek"><img src="https://avatars.githubusercontent.com/u/17993880?v=4?s=100" width="100px;" alt="Fatih Özbek"/><br /><sub><b>Fatih Özbek</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=fozbek" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=fozbek" title="Tests">⚠️</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ShiroKSH"><img src="https://avatars.githubusercontent.com/u/218489957?v=4?s=100" width="100px;" alt="Kushida"/><br /><sub><b>Kushida</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=ShiroKSH" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=ShiroKSH" title="Tests">⚠️</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/aididhaiqal"><img src="https://avatars.githubusercontent.com/u/10329190?v=4?s=100" width="100px;" alt="Aidid Haiqal"/><br /><sub><b>Aidid Haiqal</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=aididhaiqal" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=aididhaiqal" title="Tests">⚠️</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Summary
Add @ShiroKSH (#1312) and @aididhaiqal (#1274) to `.all-contributorsrc` and the README contributors table, so the **Contributors attribution** gate passes on their PRs (both forks; the entries land repo-side like #1361).

Metadata-only — no behavior change, no OpenSpec impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)