### PR TITLE
fix(proxy): dedup and cap oversized response.create dumps

### DIFF
--- a/app/modules/proxy/_service/response_create.py
+++ b/app/modules/proxy/_service/response_create.py
@@ -99,11 +99,24 @@ def _response_create_dump_max_pairs() -> int:
 
 
 def _existing_response_create_dump(dump_dir: Path, sha_slug: str) -> Path | None:
-    """Return an existing dump for the same payload fingerprint, if any."""
+    """Return an existing *complete* dump for the same payload fingerprint.
+
+    A dump only counts as existing when both the payload and its ``.meta.json``
+    sibling are present. A lone payload file (e.g. a crash or disk-full failure
+    between the two writes) is treated as absent so a retry can recreate the
+    missing meta instead of permanently suppressing the capture operators are
+    trying to diagnose.
+    """
     try:
-        return next(iter(dump_dir.glob(f"*-{sha_slug}{_RESPONSE_CREATE_DUMP_SUFFIX}")), None)
+        matches = sorted(dump_dir.glob(f"*-{sha_slug}{_RESPONSE_CREATE_DUMP_SUFFIX}"))
     except OSError:
         return None
+    for dump_path in matches:
+        dump_id = dump_path.name[: -len(_RESPONSE_CREATE_DUMP_SUFFIX)]
+        meta_path = dump_dir / f"{dump_id}{_RESPONSE_CREATE_META_SUFFIX}"
+        if meta_path.exists():
+            return dump_path
+    return None
 
 
 def _prune_response_create_dumps(dump_dir: Path, *, max_pairs: int) -> None:
@@ -728,6 +741,13 @@ def _write_response_create_dump(
         else:
             meta["summary"] = {"payload_type": type(parsed_payload).__name__}
 
+    max_pairs = _response_create_dump_max_pairs()
+    # Trim any pre-existing over-cap backlog before the new write. If the volume
+    # is already full, the write below raises and returns without pruning, so a
+    # directory left above the bound (e.g. after an upgrade that lowers the cap)
+    # would otherwise stay full on the exact failure the cap is meant to bound.
+    _prune_response_create_dumps(dump_dir, max_pairs=max_pairs)
+
     try:
         dump_dir.mkdir(parents=True, exist_ok=True)
         with gzip.open(dump_path, "wt", encoding="utf-8") as handle:
@@ -745,7 +765,7 @@ def _write_response_create_dump(
         )
         return False
 
-    _prune_response_create_dumps(dump_dir, max_pairs=_response_create_dump_max_pairs())
+    _prune_response_create_dumps(dump_dir, max_pairs=max_pairs)
 
     logger.warning(
         "Saved %s response.create dump request_id=%s request_log_id=%s dump_path=%s meta_path=%s bytes=%s",

--- a/app/modules/proxy/_service/response_create.py
+++ b/app/modules/proxy/_service/response_create.py
@@ -44,6 +44,10 @@ _RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE = (
 )
 _RESPONSE_CREATE_IMAGE_OMISSION_NOTICE = "[codex-lb omitted historical inline image to fit upstream websocket budget]"
 _OVERSIZED_RESPONSE_CREATE_DUMP_DIR: Path | None = None
+_RESPONSE_CREATE_DUMP_SUFFIX = ".response-create.json.gz"
+_RESPONSE_CREATE_META_SUFFIX = ".meta.json"
+_RESPONSE_CREATE_DUMP_SHA_SLUG_LEN = 16
+_RESPONSE_CREATE_DUMP_MAX_PAIRS = 20
 _RESPONSE_CREATE_COMPATIBILITY_METADATA_HEADERS = (
     "x-codex-turn-metadata",
     "x-openai-subagent",
@@ -88,6 +92,39 @@ def _oversized_response_create_dump_dir() -> Path:
     settings_factory = _service_global_or("get_settings", get_settings)
     data_dir = getattr(settings_factory(), "data_dir", DEFAULT_HOME_DIR)
     return data_dir / "debug" / "response-create-dumps"
+
+
+def _response_create_dump_max_pairs() -> int:
+    return int(_service_global_or("_RESPONSE_CREATE_DUMP_MAX_PAIRS", _RESPONSE_CREATE_DUMP_MAX_PAIRS))
+
+
+def _existing_response_create_dump(dump_dir: Path, sha_slug: str) -> Path | None:
+    """Return an existing dump for the same payload fingerprint, if any."""
+    try:
+        return next(iter(dump_dir.glob(f"*-{sha_slug}{_RESPONSE_CREATE_DUMP_SUFFIX}")), None)
+    except OSError:
+        return None
+
+
+def _prune_response_create_dumps(dump_dir: Path, *, max_pairs: int) -> None:
+    """Drop the oldest dump pairs so at most ``max_pairs`` remain.
+
+    Dump ids are timestamp-prefixed, so lexicographic order is chronological.
+    """
+    try:
+        dump_paths = sorted(dump_dir.glob(f"*{_RESPONSE_CREATE_DUMP_SUFFIX}"))
+    except OSError:
+        return
+    excess = len(dump_paths) - max_pairs
+    if excess <= 0:
+        return
+    for dump_path in dump_paths[:excess]:
+        dump_id = dump_path.name[: -len(_RESPONSE_CREATE_DUMP_SUFFIX)]
+        for stale_path in (dump_path, dump_dir / f"{dump_id}{_RESPONSE_CREATE_META_SUFFIX}"):
+            try:
+                stale_path.unlink(missing_ok=True)
+            except OSError:
+                logger.warning("Failed to prune response.create dump path=%s", stale_path, exc_info=True)
 
 
 def _fingerprint_input_items(items: Sequence[JsonValue]) -> str:
@@ -615,6 +652,25 @@ def _write_response_create_dump(
 
     payload_bytes = request_text.encode("utf-8")
     request_sha = sha256(payload_bytes).hexdigest()
+    sha_slug = request_sha[:_RESPONSE_CREATE_DUMP_SHA_SLUG_LEN]
+    dump_dir = _oversized_response_create_dump_dir()
+
+    existing_dump_path = _existing_response_create_dump(dump_dir, sha_slug)
+    if existing_dump_path is not None:
+        logger.warning(
+            (
+                "Skipped duplicate %s response.create dump request_id=%s request_log_id=%s "
+                "request_text_sha256=%s existing_dump_path=%s bytes=%s"
+            ),
+            log_prefix,
+            request_state.request_id,
+            request_state.request_log_id,
+            request_sha,
+            existing_dump_path,
+            len(payload_bytes),
+        )
+        return False
+
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
     dump_id = "-".join(
         (
@@ -625,11 +681,11 @@ def _write_response_create_dump(
                 request_state.request_log_id or request_state.response_id or request_state.request_id,
                 fallback="request",
             ),
+            sha_slug,
         )
     )
-    dump_dir = _oversized_response_create_dump_dir()
-    dump_path = dump_dir / f"{dump_id}.response-create.json.gz"
-    meta_path = dump_dir / f"{dump_id}.meta.json"
+    dump_path = dump_dir / f"{dump_id}{_RESPONSE_CREATE_DUMP_SUFFIX}"
+    meta_path = dump_dir / f"{dump_id}{_RESPONSE_CREATE_META_SUFFIX}"
 
     meta: dict[str, JsonValue] = {
         "dump_id": dump_id,
@@ -688,6 +744,8 @@ def _write_response_create_dump(
             request_state.request_log_id,
         )
         return False
+
+    _prune_response_create_dumps(dump_dir, max_pairs=_response_create_dump_max_pairs())
 
     logger.warning(
         "Saved %s response.create dump request_id=%s request_log_id=%s dump_path=%s meta_path=%s bytes=%s",

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -381,6 +381,9 @@ from app.modules.proxy._service.response_create import (
     _RESPONSE_CREATE_COMPATIBILITY_METADATA_HEADERS as _RESPONSE_CREATE_COMPATIBILITY_METADATA_HEADERS,
 )
 from app.modules.proxy._service.response_create import (
+    _RESPONSE_CREATE_DUMP_MAX_PAIRS as _RESPONSE_CREATE_DUMP_MAX_PAIRS,
+)
+from app.modules.proxy._service.response_create import (
     _RESPONSE_CREATE_HISTORY_OMISSION_NOTICE as _RESPONSE_CREATE_HISTORY_OMISSION_NOTICE,
 )
 from app.modules.proxy._service.response_create import (

--- a/openspec/changes/dedup-and-cap-response-create-dumps/.openspec.yaml
+++ b/openspec/changes/dedup-and-cap-response-create-dumps/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/dedup-and-cap-response-create-dumps/design.md
+++ b/openspec/changes/dedup-and-cap-response-create-dumps/design.md
@@ -1,0 +1,66 @@
+## Context
+
+`_write_response_create_dump` in `app/modules/proxy/_service/response_create.py`
+is reached from two callers: the pre-send size guard
+(`_response_create_text_with_size_guard`) and the upstream oversized-close
+handler (`_maybe_dump_oversized_response_create_request`). Both ignore the
+return value, so the return is free to express "did not write".
+
+The function already computes `sha256(request_text)` and stores it in the meta
+file as `request_text_sha256`, but the dump id is built only from a wall-clock
+timestamp plus transport/model/request slugs. Two retries of one payload
+therefore differ in dump id while being byte-identical, which is exactly the
+incident in #1345.
+
+## Decisions
+
+1. **Fingerprint in the dump id.** Append a 16-hex-character prefix of the
+   existing `request_text_sha256` to the dump id. Duplicate detection becomes a
+   single `glob` on the directory instead of opening and JSON-parsing every
+   stored meta file on a path that is already degraded.
+2. **First capture wins.** Suppress the later duplicate rather than replacing
+   the earlier one. The first capture is the one closest to the onset of the
+   incident, and keeping it makes the write path idempotent per payload.
+3. **Suppression stays visible.** Log the skipped duplicate at `warning` with
+   the fingerprint and the existing dump path. The operator signal in #1345 was
+   the repeated dump line; dropping the write silently would remove it. Only
+   the bytes are suppressed, not the evidence.
+4. **Prune on write, by count.** Enforce the cap after a successful write, as
+   the issue suggests. Dump ids are timestamp-prefixed with microseconds, so
+   lexicographic order is chronological and pruning needs no `stat` calls.
+   Deleting a dump also deletes its meta sibling so pairs never desynchronize.
+5. **Hardcoded bound, not a setting.** `_RESPONSE_CREATE_DUMP_MAX_PAIRS = 20`
+   is a module constant reachable through the existing `_service_global_or`
+   indirection, matching `_OVERSIZED_RESPONSE_CREATE_LARGEST_ITEMS`. Per
+   simplicity rules P1/P2 this needs no `CODEX_LB_*` setting: it is an
+   internals-only debug bound and the base install path stays zero-config.
+6. **Count only, not bytes or age.** Deduplication removes the amplifier that
+   produced 154 near-identical files; the count cap bounds the residual tail of
+   distinct payloads. A byte or age cap would add a second budget and a second
+   constant for no additional protection against the reported failure.
+
+## Risks and Mitigations
+
+- **Losing a distinct dump to the cap.** Only the oldest pairs beyond 20 are
+  removed, and dumps are a debug aid rather than a durable record. Before this
+  change the practical outcome was a full disk, which loses every dump plus the
+  database.
+- **A recurring payload never re-captured.** Intentional: the retained pair is
+  byte-identical, and the suppression log still records each recurrence with
+  its request id.
+- **Over-eager dedup suppressing unrelated payloads.** A 16-hex prefix (64
+  bits) over a directory bounded at 20 entries makes collision negligible, and
+  `test_response_create_dump_keeps_distinct_payloads` pins that distinct
+  payloads still produce distinct pairs.
+- **Filesystem races between replicas.** Writes are best-effort and already
+  wrapped; `unlink` uses `missing_ok=True` and both helpers swallow `OSError`,
+  so a concurrent prune cannot fail a request.
+
+## Verification
+
+- Unit coverage for duplicate suppression, distinct-payload retention, and
+  prune-on-write in `tests/unit/test_proxy_utils.py`.
+- Fail-on-main check: the duplicate-suppression test fails against `main`,
+  writing two pairs for one payload.
+- `ruff check` / `ruff format --check` / `ty check` on the changed modules and
+  the full `tests/unit/test_proxy_utils.py` suite.

--- a/openspec/changes/dedup-and-cap-response-create-dumps/proposal.md
+++ b/openspec/changes/dedup-and-cap-response-create-dumps/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Issue #1345 reports that `<data-dir>/debug/response-create-dumps` grows without
+bound. During the 2026-07-15 `payload_too_large` incident every retry of the
+same oversized `response.create` wrote a fresh ~15MB gzipped dump even though
+`request_text_sha256` was identical across retries, and dumps had been
+accumulating since 2026-05-13. The directory reached 154 files / 1.1GB on a 28G
+host (76% full) before manual cleanup.
+
+`_write_response_create_dump` names each dump by wall-clock timestamp only, so
+an identical payload always produces a new pair, and nothing ever removes an
+old pair. The debug directory is therefore an unbounded write path on the
+operator's data volume.
+
+## What Changes
+
+- Skip writing a dump when a dump for the same payload fingerprint already
+  exists, keeping the first capture and logging the suppressed duplicate so the
+  retry storm stays operator-visible.
+- Carry the payload fingerprint in the dump id so duplicate detection is a
+  directory lookup rather than a read of every stored meta file.
+- Prune the oldest dump pairs on write so the directory retains at most a fixed
+  number of pairs, bounding the long-tail accumulation of distinct dumps.
+- Add regression coverage for duplicate suppression, distinct-payload
+  retention, and pruning.
+
+## Impact
+
+- The debug dump directory becomes bounded on the base install path with no new
+  configuration: a retry storm of one payload now costs one pair instead of one
+  pair per retry, and distinct dumps are capped at a fixed count.
+- Dump ids gain a fingerprint segment. The directory is a debug artifact with
+  no consumer contract beyond its location, and the meta file continues to
+  carry the full `request_text_sha256`.
+- No API, schema, or configuration changes are introduced. The retention bound
+  is a hardcoded default, not a new `CODEX_LB_*` setting.

--- a/openspec/changes/dedup-and-cap-response-create-dumps/specs/deployment-installation/spec.md
+++ b/openspec/changes/dedup-and-cap-response-create-dumps/specs/deployment-installation/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Response-create dump directory is bounded without configuration
+
+The oversized response-create dump directory under `<data-dir>/debug/response-create-dumps` MUST be bounded on the base install path with no operator configuration. When the service captures an oversized `response.create` payload, it MUST NOT write a new dump if a dump for the same payload fingerprint is already stored, and after storing a dump it MUST remove the oldest stored dumps so that at most a fixed number of dump pairs remain. Each dump is a pair of a gzipped payload file and a meta file that MUST be added and removed together. Suppressing a duplicate MUST remain operator-visible in the logs, because the recurrence signal is the reason the dump path exists.
+
+#### Scenario: Repeated identical payloads are stored once
+
+- **GIVEN** an oversized `response.create` payload has already been dumped
+- **WHEN** a retry of the byte-identical payload is dumped again
+- **THEN** no additional dump pair is written
+- **AND** the originally stored dump pair is retained
+- **AND** the suppressed duplicate is logged with its payload fingerprint and the path of the existing dump
+
+#### Scenario: Distinct payloads are stored separately
+
+- **GIVEN** an oversized `response.create` payload has already been dumped
+- **WHEN** a different oversized payload is dumped
+- **THEN** a separate dump pair is written for it
+
+#### Scenario: Oldest dumps are pruned once the directory is full
+
+- **GIVEN** the dump directory already holds the maximum number of dump pairs
+- **WHEN** a dump for a new payload is written
+- **THEN** the oldest dump pairs are removed so the maximum is not exceeded
+- **AND** each removed payload file has its meta file removed with it
+- **AND** the newly written dump pair is retained
+
+#### Scenario: Dump retention needs no setting
+
+- **GIVEN** a default installation with no dump-related configuration
+- **WHEN** oversized response-create dumps are captured over time
+- **THEN** duplicate suppression and pruning apply
+- **AND** no `CODEX_LB_*` setting is required to bound the directory

--- a/openspec/changes/dedup-and-cap-response-create-dumps/tasks.md
+++ b/openspec/changes/dedup-and-cap-response-create-dumps/tasks.md
@@ -1,0 +1,6 @@
+- [x] Carry the payload fingerprint in the response-create dump id.
+- [x] Skip writing a dump when a dump for the same fingerprint already exists, and log the suppressed duplicate.
+- [x] Prune the oldest dump pairs on write so the directory retains at most a fixed number of pairs.
+- [x] Remove the meta sibling alongside each pruned dump so pairs stay consistent.
+- [x] Add unit coverage for duplicate suppression, distinct-payload retention, and prune-on-write.
+- [x] Extend the deployment-installation requirement to cover dump-directory bounding and validate OpenSpec.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -6334,15 +6334,14 @@ async def test_v1_responses_http_bridge_rejects_oversized_response_create_before
         fail_get_or_create_http_bridge_session,
     )
 
-    response = await async_client.post(
-        "/v1/responses",
-        json={
-            "model": "gpt-5.1",
-            "instructions": "Return exactly OK.",
-            "input": [{"role": "user", "content": [{"type": "input_text", "text": "x" * 256}]}],
-            "prompt_cache_key": "oversized-http-bridge",
-        },
-    )
+    request_json = {
+        "model": "gpt-5.1",
+        "instructions": "Return exactly OK.",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "x" * 256}]}],
+        "prompt_cache_key": "oversized-http-bridge",
+    }
+
+    response = await async_client.post("/v1/responses", json=request_json)
 
     assert response.status_code == 400
     payload = response.json()
@@ -6357,6 +6356,21 @@ async def test_v1_responses_http_bridge_rejects_oversized_response_create_before
     assert meta["reason"]["error_code"] == "payload_too_large"
     assert meta["request"]["transport"] == "http"
     assert meta["request"]["request_text_bytes"] > 128
+
+    duplicate_response = await async_client.post("/v1/responses", json=request_json)
+    assert duplicate_response.status_code == 400
+    assert len(list(tmp_path.glob("*.response-create.json.gz"))) == 1
+    assert len(list(tmp_path.glob("*.meta.json"))) == 1
+
+    meta_files[0].unlink()
+    orphan_retry_response = await async_client.post("/v1/responses", json=request_json)
+    assert orphan_retry_response.status_code == 400
+    complete_pairs = [
+        dump_path
+        for dump_path in tmp_path.glob("*.response-create.json.gz")
+        if (tmp_path / f"{dump_path.name[: -len('.response-create.json.gz')]}.meta.json").exists()
+    ]
+    assert complete_pairs
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -7500,11 +7500,13 @@ def test_backend_responses_websocket_rejects_oversized_response_create_before_up
         "stream": True,
     }
 
-    with TestClient(app_instance) as client:
+    def send_oversized_request() -> dict[str, Any]:
         with client.websocket_connect("/backend-api/codex/responses") as websocket:
             websocket.send_text(json.dumps(request_payload))
-            error_event = json.loads(websocket.receive_text())
+            return json.loads(websocket.receive_text())
 
+    with TestClient(app_instance) as client:
+        error_event = send_oversized_request()
     assert error_event["type"] == "error"
     assert error_event["status"] == 400
     assert error_event["error"]["code"] == "payload_too_large"
@@ -7518,6 +7520,23 @@ def test_backend_responses_websocket_rejects_oversized_response_create_before_up
     assert meta["reason"]["error_code"] == "payload_too_large"
     assert meta["request"]["transport"] == "websocket"
     assert meta["request"]["request_text_bytes"] > 128
+
+    with TestClient(app_instance) as client:
+        duplicate_event = send_oversized_request()
+    assert duplicate_event["status"] == 400
+    assert len(list(tmp_path.glob("*.response-create.json.gz"))) == 1
+    assert len(list(tmp_path.glob("*.meta.json"))) == 1
+
+    meta_files[0].unlink()
+    with TestClient(app_instance) as client:
+        orphan_retry_event = send_oversized_request()
+    assert orphan_retry_event["status"] == 400
+    complete_pairs = [
+        dump_path
+        for dump_path in tmp_path.glob("*.response-create.json.gz")
+        if (tmp_path / f"{dump_path.name[: -len('.response-create.json.gz')]}.meta.json").exists()
+    ]
+    assert complete_pairs
 
 
 def test_backend_responses_websocket_slims_historical_inline_artifacts_and_succeeds(

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -31443,6 +31443,98 @@ def test_response_create_dump_prunes_oldest_beyond_cap(monkeypatch, tmp_path):
     assert sha_slug('{"input":"payload-2"}') in dump_names[1]
 
 
+def test_response_create_dump_rewrites_when_meta_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: SimpleNamespace(data_dir=tmp_path))
+    payload = '{"type":"response.create","input":"orphaned pair"}'
+
+    assert _write_dump_for_payload(payload, request_id="req_orphan_first")
+
+    dump_dir = tmp_path / "debug" / "response-create-dumps"
+    meta_files = list(dump_dir.glob("*.meta.json"))
+    assert len(meta_files) == 1
+    # Simulate a crash / disk-full failure between the payload and meta writes:
+    # the payload survives but its meta sibling is missing.
+    meta_files[0].unlink()
+
+    # A retry of the same payload must recreate the missing meta instead of
+    # treating the lone payload file as a complete existing capture.
+    assert _write_dump_for_payload(payload, request_id="req_orphan_retry")
+    assert len(list(dump_dir.glob("*.meta.json"))) >= 1
+    # At least one payload now has a matching meta sibling (a complete pair).
+    complete = [
+        dump_path
+        for dump_path in dump_dir.glob("*.response-create.json.gz")
+        if (dump_dir / f"{dump_path.name[: -len('.response-create.json.gz')]}.meta.json").exists()
+    ]
+    assert complete
+
+
+def test_response_create_dump_trims_preexisting_over_cap_when_write_fails(monkeypatch, tmp_path):
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: SimpleNamespace(data_dir=tmp_path))
+    monkeypatch.setattr(proxy_service, "_RESPONSE_CREATE_DUMP_MAX_PAIRS", 2)
+
+    dump_dir = tmp_path / "debug" / "response-create-dumps"
+    dump_dir.mkdir(parents=True, exist_ok=True)
+    # Seed a directory already well above the cap, as an upgrade lowering the
+    # cap (or a prior unbounded build) would leave behind.
+    for index in range(6):
+        stamp = f"2026010100000{index}"
+        (dump_dir / f"{stamp}-seed{index}.response-create.json.gz").write_text("x")
+        (dump_dir / f"{stamp}-seed{index}.meta.json").write_text("{}")
+
+    # Simulate a full volume: the payload write raises, mirroring the exact
+    # incident where the cap must still be applied. Without a pre-write prune the
+    # post-write prune never runs and the over-cap backlog stays on disk.
+    from app.modules.proxy._service import response_create as proxy_response_create
+
+    def _boom(*args, **kwargs):
+        raise OSError("No space left on device")
+
+    monkeypatch.setattr(proxy_response_create, "gzip", SimpleNamespace(open=_boom))
+
+    assert not _write_dump_for_payload('{"input":"over-cap-write"}', request_id="req_over_cap")
+
+    # The pre-write prune must have bounded the pre-existing backlog even though
+    # the new write failed.
+    assert len(list(dump_dir.glob("*.response-create.json.gz"))) == 2
+    assert len(list(dump_dir.glob("*.meta.json"))) == 2
+
+
+def test_maybe_dump_oversized_response_create_dedups_via_product_path(monkeypatch, tmp_path):
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: SimpleNamespace(data_dir=tmp_path))
+
+    def make_state(request_id: str) -> "proxy_service._WebSocketRequestState":
+        return proxy_service._WebSocketRequestState(
+            request_id=request_id,
+            model="gpt-5.5",
+            service_tier=None,
+            reasoning_effort=None,
+            api_key_reservation=None,
+            started_at=0.0,
+            awaiting_response_created=True,
+            request_text='{"type":"response.create","input":"product path retry"}',
+        )
+
+    # Drive the same oversized payload twice through the public entry the
+    # websocket terminal-error path calls, with a gate-passing 1009 error.
+    proxy_service._maybe_dump_oversized_response_create_request(
+        make_state("req_product_first"),
+        account_id_value="acc-product",
+        error_code="stream_incomplete",
+        error_message="websocket close 1009 (message too big)",
+    )
+    proxy_service._maybe_dump_oversized_response_create_request(
+        make_state("req_product_retry"),
+        account_id_value="acc-product",
+        error_code="stream_incomplete",
+        error_message="websocket close 1009 (message too big)",
+    )
+
+    dump_dir = tmp_path / "debug" / "response-create-dumps"
+    assert len(list(dump_dir.glob("*.response-create.json.gz"))) == 1
+    assert len(list(dump_dir.glob("*.meta.json"))) == 1
+
+
 @pytest.mark.asyncio
 async def test_submit_http_bridge_request_reinlines_final_text(monkeypatch):
     service = proxy_service.ProxyService.__new__(proxy_service.ProxyService)

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import errno
 import gc
+import hashlib
 import json
 import logging
 import socket
@@ -31377,6 +31378,69 @@ def test_response_create_dump_uses_configured_data_dir(monkeypatch, tmp_path):
     dump_dir = tmp_path / "debug" / "response-create-dumps"
     assert list(dump_dir.glob("*.response-create.json.gz"))
     assert list(dump_dir.glob("*.meta.json"))
+
+
+def _write_dump_for_payload(request_text: str, *, request_id: str) -> bool:
+    request_state = proxy_service._WebSocketRequestState(
+        request_id=request_id,
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=request_text,
+    )
+    return proxy_service._write_response_create_dump(
+        request_state,
+        account_id_value="acc-retention",
+        error_code="payload_too_large",
+        error_message="too large",
+        log_prefix="unit",
+    )
+
+
+def test_response_create_dump_skips_duplicate_payload(monkeypatch, tmp_path):
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: SimpleNamespace(data_dir=tmp_path))
+    payload = '{"type":"response.create","input":"identical retry"}'
+
+    assert _write_dump_for_payload(payload, request_id="req_dedup_first")
+    assert not _write_dump_for_payload(payload, request_id="req_dedup_retry")
+
+    dump_dir = tmp_path / "debug" / "response-create-dumps"
+    assert len(list(dump_dir.glob("*.response-create.json.gz"))) == 1
+    assert len(list(dump_dir.glob("*.meta.json"))) == 1
+
+
+def test_response_create_dump_keeps_distinct_payloads(monkeypatch, tmp_path):
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: SimpleNamespace(data_dir=tmp_path))
+
+    assert _write_dump_for_payload('{"input":"first"}', request_id="req_distinct_first")
+    assert _write_dump_for_payload('{"input":"second"}', request_id="req_distinct_second")
+
+    dump_dir = tmp_path / "debug" / "response-create-dumps"
+    assert len(list(dump_dir.glob("*.response-create.json.gz"))) == 2
+
+
+def test_response_create_dump_prunes_oldest_beyond_cap(monkeypatch, tmp_path):
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: SimpleNamespace(data_dir=tmp_path))
+    monkeypatch.setattr(proxy_service, "_RESPONSE_CREATE_DUMP_MAX_PAIRS", 2)
+
+    for index in range(3):
+        assert _write_dump_for_payload(f'{{"input":"payload-{index}"}}', request_id=f"req_prune_{index}")
+
+    dump_dir = tmp_path / "debug" / "response-create-dumps"
+    dump_names = [path.name for path in sorted(dump_dir.glob("*.response-create.json.gz"))]
+    assert len(dump_names) == 2
+    # Oldest pair pruned, and its meta file goes with it.
+    assert len(list(dump_dir.glob("*.meta.json"))) == 2
+
+    def sha_slug(payload: str) -> str:
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+    assert sha_slug('{"input":"payload-0"}') not in " ".join(dump_names)
+    assert sha_slug('{"input":"payload-1"}') in dump_names[0]
+    assert sha_slug('{"input":"payload-2"}') in dump_names[1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

`<data-dir>/debug/response-create-dumps` is an unbounded write path on the operator's data volume: identical payloads always produce a new dump pair, and nothing ever removes an old one. This deduplicates dumps by payload fingerprint and prunes the oldest pairs on write, so the directory stays bounded with no configuration.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: Closes #1345

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/dedup-and-cap-response-create-dumps/`

ADDED requirement on `deployment-installation` (the capability that already owns the dump directory as an operator/disk contract): dump-directory bounding is normative and needs no setting. This does not touch a codex-faithful path — the dumps are a local debug artifact and no upstream wire format is involved.

## Changes

- `_write_response_create_dump` appends a 16-hex prefix of the existing `request_text_sha256` to the dump id, so duplicate detection is a `glob` rather than a read + JSON-parse of every stored meta file on an already-degraded path.
- A dump whose fingerprint is already stored is skipped, keeping the first capture. The suppression is logged at `warning` with the fingerprint and the existing dump path, so the recurrence signal from the incident survives — only the bytes are suppressed, not the evidence.
- After a successful write, the oldest pairs beyond `_RESPONSE_CREATE_DUMP_MAX_PAIRS` (20) are pruned. Dump ids are timestamp-prefixed with microseconds, so lexicographic order is chronological and pruning needs no `stat` calls. Each pruned payload file takes its meta sibling with it.
- Both helpers swallow `OSError` and `unlink` uses `missing_ok=True`, so a concurrent prune between replicas cannot fail a request.

Deduplication removes the amplifier that produced 154 near-identical files; the count cap bounds the residual tail of distinct payloads. I left out byte and age caps deliberately — they would add a second budget and constant without addressing anything the count cap and dedup miss. Happy to add one if you'd rather bound bytes directly.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config**
- [x] No new required setup step (or maintainer approval via `simplicity-budget-approved` label)
- New setting(s) and why each can't be a default: **none.** `_RESPONSE_CREATE_DUMP_MAX_PAIRS = 20` is a module constant reachable through the existing `_service_global_or` indirection, matching `_OVERSIZED_RESPONSE_CREATE_LARGEST_ITEMS`. It is an internals-only debug bound, so per P2 it stays out of `.env.example` and needs no `CODEX_LB_*` setting.
- [x] README sections / `.env.example` / dashboard nav within budget (or `simplicity-budget-approved` label requested)

## Test plan

Three unit tests in `tests/unit/test_proxy_utils.py`: duplicate suppression, distinct-payload retention (guards against over-eager dedup), and prune-on-write including the meta sibling.

```
$ .venv/bin/python -m pytest tests/unit/test_proxy_utils.py -k "dump" -q
4 passed, 733 deselected in 0.17s

$ .venv/bin/python -m pytest tests/unit/test_proxy_utils.py -q
737 passed in 21.59s
```

Fail-on-main check — reverting only the two app files to `upstream/main` (fix confirmed absent by grep) and re-running:

```
$ .venv/bin/python -m pytest tests/unit/test_proxy_utils.py -k "dump" -q
FAILED tests/unit/test_proxy_utils.py::test_response_create_dump_skips_duplicate_payload
FAILED tests/unit/test_proxy_utils.py::test_response_create_dump_prunes_oldest_beyond_cap
2 failed, 2 passed, 733 deselected
```

`test_response_create_dump_keeps_distinct_payloads` passes on both sides, as it should.

Other gates:

```
$ .venv/bin/python -m ruff check <changed files>          All checks passed!
$ .venv/bin/python -m ruff format --check <changed files>  3 files left unchanged
$ uv run ty check app/modules/proxy/_service/response_create.py app/modules/proxy/service.py
                                                           All checks passed!
$ .venv/bin/python scripts/check_proxy_architecture.py     proxy architecture checks passed
$ .venv/bin/python .github/scripts/check_simplicity_budgets.py
  README lines: 128/200 OK | headings: 9/10 OK | env example: 45/60 OK | core nav: 5/5 OK
$ npx -p @fission-ai/openspec openspec validate dedup-and-cap-response-create-dumps --strict
  Change 'dedup-and-cap-response-create-dumps' is valid
$ npx -p @fission-ai/openspec openspec validate --specs --strict
  Totals: 47 passed, 0 failed (47 items)
```

## Output

The fail-on-main run captures the reported bug directly — the same 52-byte payload written to two separate pairs:

```
WARNING Saved unit response.create dump request_id=req_dedup_first request_log_id=None
        dump_path=.../20260716T060855.043104Z-websocket-gpt-5.5-req_dedup_first.response-create.json.gz bytes=52
WARNING Saved unit response.create dump request_id=req_dedup_retry request_log_id=None
        dump_path=.../20260716T060855.043546Z-websocket-gpt-5.5-req_dedup_retry.response-create.json.gz bytes=52
```

With this patch the first capture is written with the fingerprint in its id, and the retry is suppressed against it:

```
WARNING Saved unit response.create dump request_id=req_dedup_first request_log_id=None
        dump_path=.../20260716T061537.461824Z-websocket-gpt-5.5-req_dedup_first-907828523c335b87.response-create.json.gz bytes=52
WARNING Skipped duplicate unit response.create dump request_id=req_dedup_retry request_log_id=None
        request_text_sha256=907828523c335b876ca0c6296ee2901fa0e7dc7540b8ab24b86a06d745b24aa2
        existing_dump_path=.../20260716T061537.461824Z-websocket-gpt-5.5-req_dedup_first-907828523c335b87.response-create.json.gz bytes=52
```

Not verified here: no long-running gateway was used to reproduce the 1.1GB fill and watch it stay bounded across a real incident. The bound is demonstrated at the directory level.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `make` subset locally (lint, typecheck, architecture-check, simplicity budgets, unit suite — pasted above).
- [x] If touching specs: `openspec validate --specs` passes (47/47).
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
