### PR TITLE
docs(reference): add generated settings reference with drift guards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,4 +42,5 @@
 
 # Everything else (timeouts, pools, bulkheads, session bridge, observability) is an
 # advanced setting with tested defaults. Do not tune it unless the docs page for
-# your scenario says so: https://soju06.github.io/codex-lb/configuration/
+# your scenario says so. Full generated reference of every variable:
+# https://soju06.github.io/codex-lb/reference/settings/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,10 @@ jobs:
               - 'uv.lock'
               - 'Makefile'
               - '.github/workflows/ci.yml'
+              # Drift-guarded files (tests/unit/test_settings_reference.py):
+              # a docs-only or env-example-only edit must still run the guards.
+              - 'docs/reference/settings.md'
+              - '.env.example'
             helm:
               - 'deploy/helm/**'
               - 'Makefile'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,7 @@ Settings are environment variables with the `CODEX_LB_` prefix, or a `.env.local
 
 ## Everything else
 
-The remaining settings (timeouts, connection pools, bulkheads, session bridge, leader election, observability, circuit breakers, ...) are advanced operational tunables with tested defaults. Do not tune them unless the documentation for your specific scenario says so:
+The remaining settings (timeouts, connection pools, bulkheads, session bridge, leader election, observability, circuit breakers, ...) are advanced operational tunables with tested defaults. The full generated [settings reference](reference/settings.md) lists every variable with its type and default. Do not tune them unless the documentation for your specific scenario says so:
 
 - [Deployment on Kubernetes / multi-replica](deployment/kubernetes.md)
 - [Remote access and reverse proxies](deployment/remote.md)

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -306,4 +306,4 @@ issue [#1340](https://github.com/Soju06/codex-lb/issues/1340)):
 
 ---
 
-*Specs: [deployment-installation](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/deployment-installation)*
+*Specs: [user-documentation](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/user-documentation) · [deployment-installation](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/deployment-installation)*

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -1,0 +1,309 @@
+<!-- GENERATED — edit scripts/generate_settings_reference.py, not this file. -->
+
+# Settings Reference
+
+**GENERATED** — edit `scripts/generate_settings_reference.py`, not this file.
+Regenerate with `uv run python scripts/generate_settings_reference.py`;
+`tests/unit/test_settings_reference.py` fails when this page drifts from
+`app/core/config/settings.py`.
+
+codex-lb currently exposes 114 settings. Every setting is an environment
+variable with the `CODEX_LB_` prefix (process environment or `.env` /
+`.env.local` next to the process). All defaults work with zero configuration —
+start from [Configuration](../configuration.md) for the handful that matter,
+and treat everything else as advanced operational tunables.
+
+## `PORT` (special case, no prefix)
+
+The listen port (default `2455`) is read from the bare `PORT` process
+environment variable, not a `CODEX_LB_*` setting, and applies to host
+(uvx/local) runs only — env files map only prefixed variables. In Docker the
+container always listens on 2455 (the entrypoint pins `--port 2455`); change
+the host side of the compose `ports` mapping instead.
+
+## Core
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_DATA_DIR` | `Path` | `~/.codex-lb` (host) / `/var/lib/codex-lb` (container) |
+
+## Database
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_DATABASE_ALEMBIC_AUTO_REMAP_ENABLED` | `bool` | `True` |
+| `CODEX_LB_DATABASE_MAX_OVERFLOW` | `int` | `10` |
+| `CODEX_LB_DATABASE_MIGRATE_ON_STARTUP` | `bool` | `True` |
+| `CODEX_LB_DATABASE_MIGRATION_LOCK_TIMEOUT_SECONDS` | `float` | `300.0` |
+| `CODEX_LB_DATABASE_MIGRATIONS_FAIL_FAST` | `bool` | `True` |
+| `CODEX_LB_DATABASE_POOL_SIZE` | `int` | `15` |
+| `CODEX_LB_DATABASE_SQLITE_PRE_MIGRATE_BACKUP_ENABLED` | `bool` | `True` |
+| `CODEX_LB_DATABASE_SQLITE_PRE_MIGRATE_BACKUP_MAX_FILES` | `int` | `5` |
+| `CODEX_LB_DATABASE_SQLITE_STARTUP_CHECK_MODE` | `'quick' \| 'full' \| 'off'` | `'quick'` |
+| `CODEX_LB_DATABASE_URL` | `str` | `sqlite+aiosqlite:///<data_dir>/store.db` |
+
+## Encryption
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_ENCRYPTION_KEY_FILE` | `Path` | `<data_dir>/encryption.key` |
+| `CODEX_LB_ENCRYPTION_KEY_FINGERPRINT_MODE` | `'enforce' \| 'warn' \| 'off'` | `'enforce'` |
+
+## Upstream transport
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_UPSTREAM_BASE_URL` | `str` | `'https://chatgpt.com/backend-api'` |
+| `CODEX_LB_UPSTREAM_COMPACT_TIMEOUT_SECONDS` | `float \| None` | `None` |
+| `CODEX_LB_UPSTREAM_CONNECT_TIMEOUT_SECONDS` | `float` | `8.0` |
+| `CODEX_LB_UPSTREAM_RESPONSE_CREATE_MAX_BYTES` | `int` | `15728640` |
+| `CODEX_LB_UPSTREAM_STREAM_TRANSPORT` | `'http' \| 'websocket' \| 'auto'` | `'auto'` |
+| `CODEX_LB_UPSTREAM_WEBSOCKET_TRUST_ENV` | `bool` | auto-detected from outbound proxy env vars |
+
+## HTTP & streaming
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_COMPACT_REQUEST_BUDGET_SECONDS` | `float` | `180.0` |
+| `CODEX_LB_HTTP_CONNECTOR_LIMIT` | `int` | `100` |
+| `CODEX_LB_HTTP_CONNECTOR_LIMIT_PER_HOST` | `int` | `50` |
+| `CODEX_LB_HTTP_DOWNSTREAM_TRANSPORT_POLICY` | `'smart' \| 'always_http' \| 'always_websocket' \| 'pinned'` | `'smart'` |
+| `CODEX_LB_HTTP_RESPONSES_STREAM_REQUEST_BUDGET_SECONDS` | `float` | `7200.0` |
+| `CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES` | `int` | `33554432` |
+| `CODEX_LB_MAX_DECOMPRESSED_RESPONSES_BODY_BYTES` | `int` | `134217728` |
+| `CODEX_LB_MAX_SSE_EVENT_BYTES` | `int` | `16777216` |
+| `CODEX_LB_SSE_KEEPALIVE_INTERVAL_SECONDS` | `float` | `10.0` |
+| `CODEX_LB_STREAM_IDLE_TIMEOUT_SECONDS` | `float` | `7200.0` |
+| `CODEX_LB_TRANSCRIPTION_REQUEST_BUDGET_SECONDS` | `float` | `120.0` |
+
+## HTTP Responses session bridge
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_ADVERTISE_BASE_URL` | `str \| None` | `None` |
+| `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_CODEX_IDLE_TTL_SECONDS` | `float` | `900.0` |
+| `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_CODEX_PREWARM_ENABLED` | `bool` | `False` |
+| `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_ENABLED` | `bool` | `True` |
+| `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_GATEWAY_SAFE_MODE` | `bool` | `False` |
+| `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_IDLE_TTL_SECONDS` | `float` | `120.0` |
+| `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_INSTANCE_ID` | `str` | process hostname |
+| `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_INSTANCE_RING` | `list[str]` | `[]` |
+| `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_MAX_SESSIONS` | `int` | `256` |
+| `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_QUEUE_LIMIT` | `int` | `8` |
+| `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_REQUEST_BUDGET_SECONDS` | `float` | `7200.0` |
+| `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_STUCK_GATE_RETIRE_AFTER_SECONDS` | `float` | `300.0` |
+
+## Proxy admission & account caps
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_PROXY_ACCOUNT_CAP_PARTITION_SCALE_DOWN_SECONDS` | `int` | `60` |
+| `CODEX_LB_PROXY_ACCOUNT_CAPS_SCOPE` | `'partitioned' \| 'replica'` | `'partitioned'` |
+| `CODEX_LB_PROXY_ACCOUNT_INFLIGHT_PENALTY_PCT` | `float` | `2.5` |
+| `CODEX_LB_PROXY_ACCOUNT_LEASE_TOKEN_WEIGHT` | `float` | `1.0` |
+| `CODEX_LB_PROXY_ACCOUNT_LEASE_TTL_SECONDS` | `float` | `900.0` |
+| `CODEX_LB_PROXY_ACCOUNT_RESPONSE_CREATE_LIMIT` | `int` | `4` |
+| `CODEX_LB_PROXY_ACCOUNT_STREAM_LIMIT` | `int` | `8` |
+| `CODEX_LB_PROXY_ACCOUNT_STREAM_RECOVERY_RESERVE` | `int` | `1` |
+| `CODEX_LB_PROXY_ADMISSION_WAIT_TIMEOUT_SECONDS` | `float` | `10.0` |
+| `CODEX_LB_PROXY_COMPACT_RESPONSE_CREATE_LIMIT` | `int` | `64` |
+| `CODEX_LB_PROXY_DOWNSTREAM_WEBSOCKET_IDLE_TIMEOUT_SECONDS` | `float` | `120.0` |
+| `CODEX_LB_PROXY_REFRESH_FAILURE_COOLDOWN_SECONDS` | `float` | `5.0` |
+| `CODEX_LB_PROXY_REQUEST_BUDGET_SECONDS` | `float` | `600.0` |
+| `CODEX_LB_PROXY_RESPONSE_CREATE_LIMIT` | `int` | `256` |
+| `CODEX_LB_PROXY_TOKEN_REFRESH_LIMIT` | `int` | `64` |
+| `CODEX_LB_PROXY_UNAUTHENTICATED_CLIENT_CIDRS` | `list[str]` | `[]` |
+| `CODEX_LB_PROXY_UPSTREAM_WEBSOCKET_CONNECT_LIMIT` | `int` | `128` |
+
+## OAuth
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_OAUTH_CALLBACK_HOST` | `str` | `127.0.0.1` (host) / `0.0.0.0` (container) |
+| `CODEX_LB_OAUTH_TIMEOUT_SECONDS` | `float` | `30.0` |
+
+## Token refresh
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_AUTH_GUARDIAN_ENABLED` | `bool` | `False` |
+| `CODEX_LB_TOKEN_REFRESH_CLAIM_TTL_SECONDS` | `float` | `30.0` |
+| `CODEX_LB_TOKEN_REFRESH_INTERVAL_DAYS` | `int` | `8` |
+| `CODEX_LB_TOKEN_REFRESH_TIMEOUT_SECONDS` | `float` | `8.0` |
+
+## Usage & retention
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_LIVE_USAGE_INGESTION_ENABLED` | `bool` | `True` |
+| `CODEX_LB_RATE_LIMIT_RESET_CREDITS_REFRESH_INTERVAL_SECONDS` | `int` | `60` |
+| `CODEX_LB_REQUEST_LOG_RETENTION_DAYS` | `int` | `0` |
+| `CODEX_LB_USAGE_FETCH_MAX_RETRIES` | `int` | `2` |
+| `CODEX_LB_USAGE_FETCH_TIMEOUT_SECONDS` | `float` | `10.0` |
+| `CODEX_LB_USAGE_HISTORY_RETENTION_DAYS` | `int` | `0` |
+| `CODEX_LB_USAGE_REFRESH_AUTH_FAILURE_COOLDOWN_SECONDS` | `float` | `300.0` |
+| `CODEX_LB_USAGE_REFRESH_ENABLED` | `bool` | `True` |
+| `CODEX_LB_USAGE_REFRESH_INTERVAL_SECONDS` | `int` | `60` |
+
+## Prompt caching & affinity
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_OPENAI_CACHE_AFFINITY_MAX_AGE_SECONDS` | `int` | `1800` |
+| `CODEX_LB_OPENAI_PROMPT_CACHE_KEY_DERIVATION_ENABLED` | `bool` | `True` |
+
+## Images
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_IMAGE_INLINE_ALLOWED_HOSTS` | `list[str]` | `[]` |
+| `CODEX_LB_IMAGE_INLINE_FETCH_ENABLED` | `bool` | `True` |
+| `CODEX_LB_IMAGES_DEFAULT_MODEL` | `str` | `'gpt-image-2'` |
+
+## Model registry
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_MODEL_CONTEXT_WINDOW_OVERRIDES` | `dict[str, int]` | `{}` |
+| `CODEX_LB_MODEL_REGISTRY_CLIENT_VERSION` | `str` | `'0.144.0'` |
+| `CODEX_LB_MODEL_REGISTRY_ENABLED` | `bool` | `True` |
+| `CODEX_LB_MODEL_REGISTRY_SNAPSHOT_MAX_AGE_SECONDS` | `int` | `86400` |
+
+## Firewall
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_FIREWALL_IP_CACHE_TTL_SECONDS` | `int` | `30` |
+| `CODEX_LB_FIREWALL_TRUST_PROXY_HEADERS` | `bool` | `False` |
+| `CODEX_LB_FIREWALL_TRUSTED_PROXY_CIDRS` | `list[str]` | `['127.0.0.1/32', '::1/128']` |
+
+## Dashboard
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_DASHBOARD_AUTH_MODE` | `'standard' \| 'trusted_header' \| 'disabled'` | `'standard'` |
+| `CODEX_LB_DASHBOARD_AUTH_PROXY_HEADER` | `str` | `'Remote-User'` |
+| `CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN` | `str \| None` | `None` |
+| `CODEX_LB_DASHBOARD_TRUST_LOOPBACK_HOST_HEADER_FOR_LONG_SESSIONS` | `bool` | `False` |
+
+## Conversation archive
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_CONVERSATION_ARCHIVE_DIR` | `Path` | `<data_dir>/conversation-archive` |
+| `CODEX_LB_CONVERSATION_ARCHIVE_ENABLED` | `bool` | `False` |
+| `CODEX_LB_CONVERSATION_ARCHIVE_QUEUE_MAX_BYTES` | `int` | `268435456` |
+
+## Schedulers
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_AUTOMATIONS_SCHEDULER_ENABLED` | `bool` | `True` |
+| `CODEX_LB_QUOTA_PLANNER_SCHEDULER_ENABLED` | `bool` | `True` |
+| `CODEX_LB_STICKY_SESSION_CLEANUP_ENABLED` | `bool` | `True` |
+
+## Multi-replica
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_LEADER_ELECTION_ENABLED` | `bool` | `True` |
+| `CODEX_LB_LEADER_ELECTION_TTL_SECONDS` | `int` | `60` |
+| `CODEX_LB_WORKERS_PER_INSTANCE` | `int` | `1` |
+
+## Observability
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_LOG_FORMAT` | `str` | `'text'` |
+| `CODEX_LB_METRICS_ENABLED` | `bool` | `False` |
+| `CODEX_LB_METRICS_PORT` | `int` | `9090` |
+| `CODEX_LB_OTEL_ENABLED` | `bool` | `False` |
+| `CODEX_LB_OTEL_EXPORTER_ENDPOINT` | `str` | `''` |
+| `CODEX_LB_TRACE` | `str` | `''` |
+
+## Resilience & load shedding
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_BACKPRESSURE_MAX_CONCURRENT_REQUESTS` | `int` | `0` |
+| `CODEX_LB_BULKHEAD_DASHBOARD_LIMIT` | `int` | `50` |
+| `CODEX_LB_BULKHEAD_PROXY_LIMIT` | `int` | `512` |
+| `CODEX_LB_CIRCUIT_BREAKER_ENABLED` | `bool` | `False` |
+| `CODEX_LB_DETERMINISTIC_FAILOVER_ENABLED` | `bool` | `True` |
+| `CODEX_LB_MEMORY_REJECT_THRESHOLD_MB` | `int` | `0` |
+| `CODEX_LB_SHUTDOWN_DRAIN_TIMEOUT_SECONDS` | `int` | `30` |
+| `CODEX_LB_SOFT_DRAIN_ENABLED` | `bool` | `True` |
+
+## Other
+
+| Environment variable | Type | Default |
+| --- | --- | --- |
+| `CODEX_LB_WARMUP_MODEL` | `str` | `'gpt-5.4-mini'` |
+
+## Removed / deprecated
+
+Deprecated env aliases (still functional for one release; the dashboard
+runtime value wins when set):
+
+- `CODEX_LB_REQUEST_LOG_RETENTION_DAYS`
+- `CODEX_LB_USAGE_HISTORY_RETENTION_DAYS`
+
+Removed settings (ignored; values are now fixed — see PRINCIPLES.md P2 /
+issue [#1340](https://github.com/Soju06/codex-lb/issues/1340)):
+
+- `CODEX_LB_AUTH_BASE_URL`
+- `CODEX_LB_OAUTH_CLIENT_ID`
+- `CODEX_LB_OAUTH_ORIGINATOR`
+- `CODEX_LB_OAUTH_SCOPE`
+- `CODEX_LB_OAUTH_REDIRECT_URI`
+- `CODEX_LB_OAUTH_CALLBACK_PORT`
+- `CODEX_LB_AUTH_GUARDIAN_INTERVAL_SECONDS`
+- `CODEX_LB_AUTH_GUARDIAN_MAX_REFRESH_AGE_SECONDS`
+- `CODEX_LB_AUTH_GUARDIAN_BATCH_SIZE`
+- `CODEX_LB_AUTH_GUARDIAN_CONCURRENCY`
+- `CODEX_LB_AUTH_GUARDIAN_JITTER_SECONDS`
+- `CODEX_LB_AUTH_GUARDIAN_FAILURE_BACKOFF_BASE_SECONDS`
+- `CODEX_LB_AUTH_GUARDIAN_FAILURE_BACKOFF_MAX_SECONDS`
+- `CODEX_LB_LOG_PROXY_REQUEST_SHAPE`
+- `CODEX_LB_LOG_PROXY_REQUEST_SHAPE_RAW_CACHE_KEY`
+- `CODEX_LB_LOG_PROXY_REQUEST_PAYLOAD`
+- `CODEX_LB_LOG_PROXY_SERVICE_TIER_TRACE`
+- `CODEX_LB_LOG_UPSTREAM_REQUEST_SUMMARY`
+- `CODEX_LB_LOG_UPSTREAM_REQUEST_PAYLOAD`
+- `CODEX_LB_BULKHEAD_PROXY_HTTP_LIMIT`
+- `CODEX_LB_BULKHEAD_PROXY_WEBSOCKET_LIMIT`
+- `CODEX_LB_BULKHEAD_PROXY_COMPACT_LIMIT`
+- `CODEX_LB_TOKEN_REFRESH_CLAIM_WAIT_SECONDS`
+- `CODEX_LB_TOKEN_REFRESH_CLAIM_POLL_SECONDS`
+- `CODEX_LB_QUOTA_PLANNER_TICK_SECONDS`
+- `CODEX_LB_AUTOMATIONS_SCHEDULER_INTERVAL_SECONDS`
+- `CODEX_LB_MODEL_REGISTRY_REFRESH_INTERVAL_SECONDS`
+- `CODEX_LB_STICKY_SESSION_CLEANUP_INTERVAL_SECONDS`
+- `CODEX_LB_CODEX_FINGERPRINT_OS`
+- `CODEX_LB_CODEX_FINGERPRINT_ARCH`
+- `CODEX_LB_CODEX_FINGERPRINT_TERMINAL`
+- `CODEX_LB_LIVE_USAGE_WRITE_MIN_INTERVAL_SECONDS`
+- `CODEX_LB_LIVE_USAGE_QUEUE_SIZE`
+- `CODEX_LB_REQUEST_LOG_COUNT_CACHE_TTL_SECONDS`
+- `CODEX_LB_CIRCUIT_BREAKER_FAILURE_THRESHOLD`
+- `CODEX_LB_CIRCUIT_BREAKER_RECOVERY_TIMEOUT_SECONDS`
+- `CODEX_LB_MEMORY_WARNING_THRESHOLD_MB`
+- `CODEX_LB_IMAGES_HOST_MODEL`
+- `CODEX_LB_IMAGES_MAX_PARTIAL_IMAGES`
+- `CODEX_LB_DATABASE_BACKGROUND_POOL_SIZE`
+- `CODEX_LB_DATABASE_BACKGROUND_MAX_OVERFLOW`
+- `CODEX_LB_DATABASE_POOL_TIMEOUT_SECONDS`
+- `CODEX_LB_DATABASE_POOL_RECYCLE_SECONDS`
+- `CODEX_LB_DRAIN_PRIMARY_THRESHOLD_PCT`
+- `CODEX_LB_DRAIN_SECONDARY_THRESHOLD_PCT`
+- `CODEX_LB_DRAIN_ERROR_WINDOW_SECONDS`
+- `CODEX_LB_DRAIN_ERROR_COUNT_THRESHOLD`
+- `CODEX_LB_PROBE_QUIET_SECONDS`
+- `CODEX_LB_PROBE_SUCCESS_STREAK_REQUIRED`
+- `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_CODEX_PREWARM_CANARY_PERCENT`
+- `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_CODEX_PREWARM_ALLOW_API_KEY_IDS`
+- `CODEX_LB_HTTP_RESPONSES_SESSION_BRIDGE_CODEX_PREWARM_DENY_API_KEY_IDS`
+
+---
+
+*Specs: [deployment-installation](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/deployment-installation)*

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,4 +66,6 @@ nav:
       - Docker: deployment/docker.md
       - Kubernetes: deployment/kubernetes.md
       - Remote Access: deployment/remote.md
+  - Reference:
+      - Settings: reference/settings.md
   - Troubleshooting: troubleshooting.md

--- a/openspec/changes/settings-reference-page/context.md
+++ b/openspec/changes/settings-reference-page/context.md
@@ -1,0 +1,39 @@
+# Context: settings-reference-page
+
+## Decisions
+
+- **Generated page is checked in, not built on the fly.** The docs workflow
+  installs only the `docs` dependency group; importing `Settings` at docs
+  build time would drag the whole application dependency tree into the docs
+  build. Checking the page in keeps `mkdocs build --strict` hermetic, and the
+  regenerate-and-diff unit test (which runs with the full app environment)
+  is the freshness guarantee.
+- **Symbolic defaults for environment-derived values.** `data_dir`,
+  `database_url`, `encryption_key_file`, `conversation_archive_dir`,
+  `oauth_callback_host`, `upstream_websocket_trust_env`, and
+  `http_responses_session_bridge_instance_id` compute their defaults from the
+  runtime environment (home directory, container detection, hostname,
+  outbound proxy env). Rendering the live values would make the page differ
+  per machine and break the byte-identical drift test in CI, so these render
+  as symbolic descriptions (e.g. `<data_dir>/store.db`).
+- **No invented prose.** Most fields carry no `Field(description=...)`; the
+  source-comment convention in `settings.py` is left as-is. The table of
+  name/type/default is the deliverable; a Description column appears only for
+  fields that declare one.
+- **Ratchet at 115.** The surface is 114 fields today. The ratchet only goes
+  down when fields are removed; raising it requires a simplicity-budget
+  discussion (PRINCIPLES.md P2, CONTRIBUTING.md simplicity gates, issue
+  #1340).
+- **Prefix grouping is a heuristic, not a taxonomy.** Longest-matching
+  field-name prefix wins, a small exact-name override map handles outliers
+  (`data_dir`, `trace`, `workers_per_instance`), and anything unmatched lands
+  in "Other". Renaming a group is a one-line generator edit plus a
+  regeneration.
+
+## Example
+
+Adding a new setting without regenerating the page fails
+`tests/unit/test_settings_reference.py::test_generated_settings_reference_matches_code`;
+the fix is `uv run python scripts/generate_settings_reference.py` and
+committing the diff. Adding a 116th setting additionally fails the ratchet
+until the budget discussion lands.

--- a/openspec/changes/settings-reference-page/proposal.md
+++ b/openspec/changes/settings-reference-page/proposal.md
@@ -1,0 +1,38 @@
+# Change: settings-reference-page
+
+## Why
+
+Deferred follow-up from issue #1340 (settings-surface reduction): operators
+have no complete, trustworthy list of the `CODEX_LB_*` environment variables.
+`docs/configuration.md` deliberately lists only the handful that matter and
+hand-written full lists drift immediately — the settings surface still has
+100+ fields and changes across releases. A generated reference page keeps the
+docs honest at zero maintenance cost, and drift guards make CI fail whenever
+the page, the ratcheted settings count, or `.env.example` disagree with
+`app/core/config/settings.py`.
+
+## What Changes
+
+- New generator `scripts/generate_settings_reference.py` renders
+  `docs/reference/settings.md` from `Settings.model_fields`: env var name,
+  type, and default per field, grouped by functional-area prefix with an
+  "Other" bucket, plus the bare-`PORT` special case and a
+  "Removed / deprecated" section sourced from `_REMOVED_SETTINGS` and the
+  deprecated retention env aliases. Output is deterministic and
+  machine-independent (environment-derived defaults render symbolically).
+- The generated page is checked in (the strict mkdocs build stays hermetic),
+  added to the mkdocs nav under a "Reference" section, and linked from
+  `docs/configuration.md` and the `.env.example` trailer comment.
+- New drift guards in `tests/unit/test_settings_reference.py`:
+  regenerate-and-diff (byte-identical), a settings-surface ratchet
+  (`len(Settings.model_fields) <= 115`), and `.env.example` honesty
+  (any uncommented `KEY=value` must equal the code default).
+
+## Impact
+
+- Affected specs: `user-documentation`
+- Affected code: `scripts/generate_settings_reference.py` (new),
+  `docs/reference/settings.md` (generated, checked in), `mkdocs.yml`,
+  `docs/configuration.md`, `.env.example` (comment only),
+  `tests/unit/test_settings_reference.py` (new)
+- No runtime behavior change; documentation and CI guards only

--- a/openspec/changes/settings-reference-page/specs/user-documentation/spec.md
+++ b/openspec/changes/settings-reference-page/specs/user-documentation/spec.md
@@ -1,0 +1,38 @@
+# user-documentation Delta
+
+## ADDED Requirements
+
+### Requirement: Generated settings reference stays in sync with the code
+
+The documentation site SHALL include a settings reference page
+(`docs/reference/settings.md`) generated from `Settings.model_fields` by
+`scripts/generate_settings_reference.py`. The page SHALL list, for every
+setting, the `CODEX_LB_`-prefixed environment variable name, its type, and
+its default (environment-derived defaults rendered symbolically), grouped by
+functional area; it SHALL document the bare `PORT` special case and SHALL
+list the removed (`_REMOVED_SETTINGS`) and deprecated env names sourced from
+the code. The generated page SHALL be checked into the repository so the
+strict docs build stays hermetic, SHALL carry a header identifying it as
+generated, and SHALL link the owning OpenSpec capability. CI unit tests MUST
+fail when the checked-in page differs from regenerated output, when the
+settings surface exceeds its ratchet (115 fields; lower-only without a
+simplicity-budget decision), or when an uncommented `.env.example` assignment
+differs from the code default.
+
+#### Scenario: Settings change without regeneration fails CI
+
+- **GIVEN** a change to `Settings` fields in `app/core/config/settings.py`
+- **WHEN** the unit test suite runs without regenerating `docs/reference/settings.md`
+- **THEN** the regenerate-and-diff test fails until the page is regenerated and committed
+
+#### Scenario: Reference page is reachable and generated
+
+- **WHEN** a reader opens the published settings reference page
+- **THEN** it is in the site navigation and linked from the Configuration page
+- **AND** it identifies itself as generated from `scripts/generate_settings_reference.py`
+- **AND** it links the owning OpenSpec capability
+
+#### Scenario: Settings surface growth trips the ratchet
+
+- **WHEN** the number of `Settings` fields exceeds the ratchet value
+- **THEN** the ratchet unit test fails, forcing a simplicity-budget discussion before the surface grows

--- a/openspec/changes/settings-reference-page/tasks.md
+++ b/openspec/changes/settings-reference-page/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: settings-reference-page
+
+## 1. Generator
+
+- [x] 1.1 `scripts/generate_settings_reference.py`: render env var / type / default per `Settings` field, grouped by prefix heuristic with an "Other" bucket
+- [x] 1.2 Deterministic, machine-independent output (symbolic rendering for environment-derived defaults; sorted fields; trailing newline)
+- [x] 1.3 GENERATED header warning, `PORT` special-case note, "Removed / deprecated" section from `_REMOVED_SETTINGS` + retention aliases, `deployment-installation` spec footer link
+
+## 2. Docs wiring
+
+- [x] 2.1 Check in `docs/reference/settings.md` and add it to the mkdocs nav (Reference section)
+- [x] 2.2 Link the page from `docs/configuration.md`
+- [x] 2.3 Point the `.env.example` trailer comment at the published reference page
+- [x] 2.4 `uv sync --only-group docs --frozen && uv run --no-sync mkdocs build --strict` passes
+
+## 3. Drift guards
+
+- [x] 3.1 Regenerate-and-diff test: generator output byte-identical to the checked-in page
+- [x] 3.2 Ratchet test: `len(Settings.model_fields) <= 115` with a lower-only comment
+- [x] 3.3 `.env.example` honesty test: uncommented assignments must equal code defaults

--- a/scripts/generate_settings_reference.py
+++ b/scripts/generate_settings_reference.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Render ``docs/reference/settings.md`` from ``Settings.model_fields``.
+
+Usage::
+
+    uv run python scripts/generate_settings_reference.py
+
+The generated page is checked in so the docs build stays hermetic;
+``tests/unit/test_settings_reference.py`` regenerates it and fails when the
+page drifts from ``app/core/config/settings.py``.
+"""
+
+from __future__ import annotations
+
+import enum
+import types
+import typing
+from pathlib import Path
+from typing import cast
+
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
+
+from app.core.config.settings import _REMOVED_SETTINGS, Settings
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+OUTPUT_PATH = REPO_ROOT / "docs" / "reference" / "settings.md"
+
+ENV_PREFIX = "CODEX_LB_"
+
+# Defaults computed from the runtime environment (home directory, container
+# detection, hostname, outbound proxy env vars). Rendered symbolically so the
+# generated page is machine-independent and deterministic.
+_SYMBOLIC_DEFAULTS: dict[str, str] = {
+    "data_dir": "`~/.codex-lb` (host) / `/var/lib/codex-lb` (container)",
+    "database_url": "`sqlite+aiosqlite:///<data_dir>/store.db`",
+    "encryption_key_file": "`<data_dir>/encryption.key`",
+    "conversation_archive_dir": "`<data_dir>/conversation-archive`",
+    "oauth_callback_host": "`127.0.0.1` (host) / `0.0.0.0` (container)",
+    "upstream_websocket_trust_env": "auto-detected from outbound proxy env vars",
+    "http_responses_session_bridge_instance_id": "process hostname",
+}
+
+_SECTION_OTHER = "Other"
+
+# Functional-area grouping by field-name prefix; the longest matching prefix
+# wins and unmatched fields land in the "Other" bucket.
+_PREFIX_SECTIONS: tuple[tuple[str, str], ...] = (
+    ("database_", "Database"),
+    ("encryption_", "Encryption"),
+    ("upstream_", "Upstream transport"),
+    ("http_responses_session_bridge_", "HTTP Responses session bridge"),
+    ("http_responses_", "HTTP & streaming"),
+    ("http_downstream_", "HTTP & streaming"),
+    ("http_connector_", "HTTP & streaming"),
+    ("compact_", "HTTP & streaming"),
+    ("stream_", "HTTP & streaming"),
+    ("sse_", "HTTP & streaming"),
+    ("max_", "HTTP & streaming"),
+    ("transcription_", "HTTP & streaming"),
+    ("proxy_", "Proxy admission & account caps"),
+    ("oauth_", "OAuth"),
+    ("token_refresh_", "Token refresh"),
+    ("auth_guardian_", "Token refresh"),
+    ("usage_", "Usage & retention"),
+    ("live_usage_", "Usage & retention"),
+    ("rate_limit_", "Usage & retention"),
+    ("request_log_", "Usage & retention"),
+    ("openai_", "Prompt caching & affinity"),
+    ("image_", "Images"),
+    ("images_", "Images"),
+    ("model_", "Model registry"),
+    ("firewall_", "Firewall"),
+    ("dashboard_", "Dashboard"),
+    ("conversation_archive_", "Conversation archive"),
+    ("quota_planner_", "Schedulers"),
+    ("automations_", "Schedulers"),
+    ("sticky_session_", "Schedulers"),
+    ("leader_election_", "Multi-replica"),
+    ("metrics_", "Observability"),
+    ("otel_", "Observability"),
+    ("log_", "Observability"),
+    ("circuit_breaker_", "Resilience & load shedding"),
+    ("soft_drain_", "Resilience & load shedding"),
+    ("deterministic_failover_", "Resilience & load shedding"),
+    ("backpressure_", "Resilience & load shedding"),
+    ("bulkhead_", "Resilience & load shedding"),
+    ("memory_", "Resilience & load shedding"),
+    ("shutdown_", "Resilience & load shedding"),
+)
+
+# Exact-name overrides applied before prefix matching.
+_EXACT_SECTIONS: dict[str, str] = {
+    "data_dir": "Core",
+    "trace": "Observability",
+    "workers_per_instance": "Multi-replica",
+}
+
+_SECTION_ORDER: tuple[str, ...] = (
+    "Core",
+    "Database",
+    "Encryption",
+    "Upstream transport",
+    "HTTP & streaming",
+    "HTTP Responses session bridge",
+    "Proxy admission & account caps",
+    "OAuth",
+    "Token refresh",
+    "Usage & retention",
+    "Prompt caching & affinity",
+    "Images",
+    "Model registry",
+    "Firewall",
+    "Dashboard",
+    "Conversation archive",
+    "Schedulers",
+    "Multi-replica",
+    "Observability",
+    "Resilience & load shedding",
+    _SECTION_OTHER,
+)
+
+
+def _section_for(name: str) -> str:
+    exact = _EXACT_SECTIONS.get(name)
+    if exact is not None:
+        return exact
+    matches = [(len(prefix), section) for prefix, section in _PREFIX_SECTIONS if name.startswith(prefix)]
+    if not matches:
+        return _SECTION_OTHER
+    return max(matches)[1]
+
+
+def _escape_cell(text: str) -> str:
+    return text.replace("|", "\\|")
+
+
+def _render_type(annotation: object) -> str:
+    if annotation is type(None):
+        return "None"
+    origin = typing.get_origin(annotation)
+    if origin is typing.Literal:
+        return " | ".join(repr(arg) for arg in typing.get_args(annotation))
+    if origin is types.UnionType:
+        return " | ".join(_render_type(arg) for arg in typing.get_args(annotation))
+    if isinstance(annotation, type):
+        if issubclass(annotation, enum.Enum):
+            return " | ".join(repr(member.value) for member in annotation)
+        return annotation.__name__
+    return str(annotation)
+
+
+def _render_default(name: str, field: FieldInfo) -> str:
+    symbolic = _SYMBOLIC_DEFAULTS.get(name)
+    if symbolic is not None:
+        return symbolic
+    default: object = field.default
+    if default is PydanticUndefined:
+        factory = field.default_factory
+        if factory is None:
+            return "required"
+        default = cast("typing.Callable[[], object]", factory)()
+    if isinstance(default, enum.Enum):
+        default = default.value
+    return f"`{default!r}`"
+
+
+def _render_section_table(names: list[str], fields: dict[str, FieldInfo]) -> list[str]:
+    with_description = any(fields[name].description for name in names)
+    lines: list[str] = []
+    if with_description:
+        lines.append("| Environment variable | Type | Default | Description |")
+        lines.append("| --- | --- | --- | --- |")
+    else:
+        lines.append("| Environment variable | Type | Default |")
+        lines.append("| --- | --- | --- |")
+    for name in names:
+        field = fields[name]
+        env_var = f"`{ENV_PREFIX}{name.upper()}`"
+        type_cell = _escape_cell(f"`{_render_type(field.annotation)}`")
+        default_cell = _escape_cell(_render_default(name, field))
+        row = f"| {env_var} | {type_cell} | {default_cell} |"
+        if with_description:
+            row += f" {_escape_cell(field.description or '')} |"
+        lines.append(row)
+    return lines
+
+
+def render_settings_reference() -> str:
+    fields = dict(Settings.model_fields)
+    sections: dict[str, list[str]] = {}
+    for name in sorted(fields):
+        sections.setdefault(_section_for(name), []).append(name)
+    unknown = set(sections) - set(_SECTION_ORDER)
+    if unknown:
+        raise RuntimeError(f"sections missing from _SECTION_ORDER: {sorted(unknown)}")
+
+    deprecated_env_aliases = [
+        f"{ENV_PREFIX}{name.upper()}" for name in sorted(fields) if name.endswith("_retention_days")
+    ]
+
+    lines: list[str] = [
+        "<!-- GENERATED — edit scripts/generate_settings_reference.py, not this file. -->",
+        "",
+        "# Settings Reference",
+        "",
+        "**GENERATED** — edit `scripts/generate_settings_reference.py`, not this file.",
+        "Regenerate with `uv run python scripts/generate_settings_reference.py`;",
+        "`tests/unit/test_settings_reference.py` fails when this page drifts from",
+        "`app/core/config/settings.py`.",
+        "",
+        f"codex-lb currently exposes {len(fields)} settings. Every setting is an environment",
+        f"variable with the `{ENV_PREFIX}` prefix (process environment or `.env` /",
+        "`.env.local` next to the process). All defaults work with zero configuration —",
+        "start from [Configuration](../configuration.md) for the handful that matter,",
+        "and treat everything else as advanced operational tunables.",
+        "",
+        "## `PORT` (special case, no prefix)",
+        "",
+        "The listen port (default `2455`) is read from the bare `PORT` process",
+        f"environment variable, not a `{ENV_PREFIX}*` setting, and applies to host",
+        "(uvx/local) runs only — env files map only prefixed variables. In Docker the",
+        "container always listens on 2455 (the entrypoint pins `--port 2455`); change",
+        "the host side of the compose `ports` mapping instead.",
+    ]
+
+    for section in _SECTION_ORDER:
+        names = sections.get(section)
+        if not names:
+            continue
+        lines.append("")
+        lines.append(f"## {section}")
+        lines.append("")
+        lines.extend(_render_section_table(names, fields))
+
+    lines.extend(
+        [
+            "",
+            "## Removed / deprecated",
+            "",
+            "Deprecated env aliases (still functional for one release; the dashboard",
+            "runtime value wins when set):",
+            "",
+        ]
+    )
+    lines.extend(f"- `{alias}`" for alias in deprecated_env_aliases)
+    lines.extend(
+        [
+            "",
+            "Removed settings (ignored; values are now fixed — see PRINCIPLES.md P2 /",
+            "issue [#1340](https://github.com/Soju06/codex-lb/issues/1340)):",
+            "",
+        ]
+    )
+    lines.extend(f"- `{name}`" for name in _REMOVED_SETTINGS)
+    lines.extend(
+        [
+            "",
+            "---",
+            "",
+            "*Specs: [deployment-installation](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/deployment-installation)*",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(render_settings_reference(), encoding="utf-8")
+    print(f"wrote {OUTPUT_PATH.relative_to(REPO_ROOT)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_settings_reference.py
+++ b/scripts/generate_settings_reference.py
@@ -258,7 +258,10 @@ def render_settings_reference() -> str:
             "",
             "---",
             "",
-            "*Specs: [deployment-installation](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/deployment-installation)*",
+            "*Specs: [user-documentation]"
+            "(https://github.com/Soju06/codex-lb/tree/main/openspec/specs/user-documentation) · "
+            "[deployment-installation]"
+            "(https://github.com/Soju06/codex-lb/tree/main/openspec/specs/deployment-installation)*",
             "",
         ]
     )

--- a/tests/unit/test_settings_reference.py
+++ b/tests/unit/test_settings_reference.py
@@ -25,13 +25,16 @@ from scripts.generate_settings_reference import OUTPUT_PATH, render_settings_ref
 def _isolated_settings(**overrides: Any) -> Settings:
     """Build Settings from code defaults only.
 
-    Strips ``CODEX_LB_*`` from the process environment and disables env-file
-    loading, so a developer's local ``.env.local`` or exported variables can
-    never mask (or fake) a drift between ``.env.example`` and the code.
+    Strips ``CODEX_LB_*`` and the bare ``PORT`` variable from the process
+    environment and disables env-file loading, so a developer's local
+    ``.env.local`` or exported variables can never mask (or fake) a drift
+    between ``.env.example`` and the code.
     """
-    clean = {k: v for k, v in os.environ.items() if not k.startswith("CODEX_LB_")}
+    clean = {k: v for k, v in os.environ.items() if not k.startswith("CODEX_LB_") and k != "PORT"}
     with mock.patch.dict(os.environ, clean, clear=True):
-        return Settings(_env_file=None, **overrides)
+        # ``_env_file`` is a documented pydantic-settings init kwarg that its
+        # type stubs do not expose; ty flags it as unknown.
+        return Settings(_env_file=None, **overrides)  # ty: ignore[unknown-argument]
 
 
 pytestmark = pytest.mark.unit

--- a/tests/unit/test_settings_reference.py
+++ b/tests/unit/test_settings_reference.py
@@ -1,0 +1,87 @@
+"""Drift guards for the generated settings reference page (issue #1340).
+
+Guards three contracts:
+
+- ``docs/reference/settings.md`` is byte-identical to what the generator
+  renders from the current ``Settings`` surface,
+- the settings surface does not silently grow past its ratchet,
+- ``.env.example`` never states an active value that contradicts the code
+  default.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from app.core.config.settings import Settings
+from scripts.generate_settings_reference import OUTPUT_PATH, render_settings_reference
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENV_EXAMPLE_PATH = REPO_ROOT / ".env.example"
+
+# Ratchet on the settings surface (issue #1340, PRINCIPLES.md P2). Lower this
+# number when fields are removed; never raise it without a simplicity-budget
+# discussion — every new CODEX_LB_* setting needs a why-not-a-default
+# justification per CONTRIBUTING.md's simplicity gates.
+MAX_SETTINGS_FIELDS = 115
+
+
+def test_generated_settings_reference_matches_code() -> None:
+    """Regenerate-and-diff: the checked-in page must match the code exactly.
+
+    On failure run: uv run python scripts/generate_settings_reference.py
+    """
+    assert OUTPUT_PATH.read_text(encoding="utf-8") == render_settings_reference()
+
+
+def test_settings_reference_page_is_checked_in_under_docs() -> None:
+    assert OUTPUT_PATH == REPO_ROOT / "docs" / "reference" / "settings.md"
+    assert OUTPUT_PATH.is_file()
+
+
+def test_settings_surface_ratchet() -> None:
+    assert len(Settings.model_fields) <= MAX_SETTINGS_FIELDS, (
+        f"Settings grew to {len(Settings.model_fields)} fields (ratchet: {MAX_SETTINGS_FIELDS}). "
+        "New settings need a simplicity-budget discussion (PRINCIPLES.md P2, issue #1340); "
+        "lower MAX_SETTINGS_FIELDS when fields are removed."
+    )
+
+
+def _uncommented_assignments(text: str) -> list[tuple[str, str]]:
+    assignments: list[tuple[str, str]] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        key, sep, value = stripped.partition("=")
+        assert sep == "=", f".env.example contains a non-assignment line: {line!r}"
+        assignments.append((key.strip(), value.strip()))
+    return assignments
+
+
+def test_env_example_uncommented_values_match_code_defaults() -> None:
+    """Every active KEY=value in .env.example must equal the code default.
+
+    Commented lines are exempt; today the file is fully commented out and
+    copying it verbatim must change nothing (user-documentation spec).
+    """
+    defaults = Settings()
+    for key, value in _uncommented_assignments(ENV_EXAMPLE_PATH.read_text(encoding="utf-8")):
+        if key == "PORT":
+            assert value == "2455", f".env.example sets PORT={value}, but the code default is 2455"
+            continue
+        assert key.startswith("CODEX_LB_"), f".env.example sets unknown env var {key}"
+        field_name = key.removeprefix("CODEX_LB_").lower()
+        assert field_name in Settings.model_fields, f".env.example sets unknown setting {key}"
+        # The raw env-file string is validated through the field's own
+        # validators/coercion, exactly as pydantic-settings would apply it.
+        candidate = Settings(**cast("dict[str, Any]", {field_name: value}))
+        assert getattr(candidate, field_name) == getattr(defaults, field_name), (
+            f".env.example sets {key}={value}, which differs from the code default "
+            f"{getattr(defaults, field_name)!r}; keep the line commented or fix the value"
+        )

--- a/tests/unit/test_settings_reference.py
+++ b/tests/unit/test_settings_reference.py
@@ -11,13 +11,27 @@ Guards three contracts:
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any, cast
+from unittest import mock
 
 import pytest
 
 from app.core.config.settings import Settings
 from scripts.generate_settings_reference import OUTPUT_PATH, render_settings_reference
+
+
+def _isolated_settings(**overrides: Any) -> Settings:
+    """Build Settings from code defaults only.
+
+    Strips ``CODEX_LB_*`` from the process environment and disables env-file
+    loading, so a developer's local ``.env.local`` or exported variables can
+    never mask (or fake) a drift between ``.env.example`` and the code.
+    """
+    clean = {k: v for k, v in os.environ.items() if not k.startswith("CODEX_LB_")}
+    with mock.patch.dict(os.environ, clean, clear=True):
+        return Settings(_env_file=None, **overrides)
 
 pytestmark = pytest.mark.unit
 
@@ -70,7 +84,7 @@ def test_env_example_uncommented_values_match_code_defaults() -> None:
     Commented lines are exempt; today the file is fully commented out and
     copying it verbatim must change nothing (user-documentation spec).
     """
-    defaults = Settings()
+    defaults = _isolated_settings()
     for key, value in _uncommented_assignments(ENV_EXAMPLE_PATH.read_text(encoding="utf-8")):
         if key == "PORT":
             assert value == "2455", f".env.example sets PORT={value}, but the code default is 2455"
@@ -80,7 +94,7 @@ def test_env_example_uncommented_values_match_code_defaults() -> None:
         assert field_name in Settings.model_fields, f".env.example sets unknown setting {key}"
         # The raw env-file string is validated through the field's own
         # validators/coercion, exactly as pydantic-settings would apply it.
-        candidate = Settings(**cast("dict[str, Any]", {field_name: value}))
+        candidate = _isolated_settings(**cast("dict[str, Any]", {field_name: value}))
         assert getattr(candidate, field_name) == getattr(defaults, field_name), (
             f".env.example sets {key}={value}, which differs from the code default "
             f"{getattr(defaults, field_name)!r}; keep the line commented or fix the value"

--- a/tests/unit/test_settings_reference.py
+++ b/tests/unit/test_settings_reference.py
@@ -33,6 +33,7 @@ def _isolated_settings(**overrides: Any) -> Settings:
     with mock.patch.dict(os.environ, clean, clear=True):
         return Settings(_env_file=None, **overrides)
 
+
 pytestmark = pytest.mark.unit
 
 REPO_ROOT = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary

Closes out the deferred #1340 documentation items: a **generated settings reference** at `docs/reference/settings.md` (114 fields / 21 sections, env name + type + default, bare-`PORT` special case, removed/deprecated inventory sourced from `_REMOVED_SETTINGS`) rendered by `scripts/generate_settings_reference.py`, checked in so the docs build stays hermetic — plus three CI drift guards:

1. **Regenerate-and-diff** — the checked-in page must byte-match a fresh render of `Settings.model_fields` (environment-derived defaults render symbolically, verified machine-independent), so the reference can never drift the way `.env.example` once did.
2. **Field-count ratchet** — `len(Settings.model_fields) ≤ 115` (114 today), lower-only per PRINCIPLES.md P2.
3. **`.env.example` honesty** — any uncommented value must equal the code default (via each field's own pydantic coercion).

Docs nav gains Reference → Settings; `docs/configuration.md` and the `.env.example` trailer link to it.

## Type of change

- [x] `docs:` — documentation + drift-guard tests (no behavior change)

Refs #1340 (deferred follow-ups: generated reference + ratchet + env honesty check).

## OpenSpec

`openspec/changes/settings-reference-page/` — ADDED requirement on `user-documentation` (page exists, is generated, CI-guarded). `--strict` + `--specs` (47/47) pass, re-validated after rebasing over the #1368 archive sweep.

## Checks

- New guards 4/4; full `pytest tests/unit` 4002 passed / 3 skipped; ruff/ty clean; budgets green; `mkdocs build --strict` passes.

## Simplicity

- [x] No new settings or surfaces; adds one docs page (spec-linked) and lowers the effective settings ceiling via the ratchet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)