### PR TITLE
fix(docker): preserve runtime readability for owner-only build files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,10 +56,10 @@ RUN adduser --disabled-password --gecos "" app \
     && chown -R app:app /var/lib/codex-lb
 
 COPY --from=python-build /opt/venv /opt/venv
-COPY app app
-COPY config config
-COPY scripts scripts
-COPY --from=frontend-build /app/app/static app/static
+COPY --chown=app:app app app
+COPY --chown=app:app config config
+COPY --chown=app:app scripts scripts
+COPY --chown=app:app --from=frontend-build /app/app/static app/static
 
 # The runtime image copies source files instead of installing the project, so
 # recreate the console-script entry point that pyproject would normally install.
@@ -68,6 +68,7 @@ RUN chmod +x /app/scripts/docker-entrypoint.sh \
     && chmod +x /usr/local/bin/codex-lb
 
 USER app
+RUN test -z "$(find /app/app /app/config /app/scripts -type f ! -readable -print -quit)"
 EXPOSE 2455 1455
 
 CMD ["/app/scripts/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary

Makes runtime ownership independent of restrictive file modes in the Docker build context. This prevents the non-root `app` process from failing startup and causing reverse-proxy 502 responses.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Fixes #1372

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [x] Not applicable — bug fix that matches the existing deployment contract
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: N/A

## Changes

- Copy application, configuration, scripts, and frontend assets as the runtime `app` user.
- Fail the Docker build if any packaged runtime file is unreadable by `app`.

## Test plan

```sh
# Reproduce the reported restrictive build-context mode.
chmod 600 config/additional_quota_registry.json
docker build --no-cache -t codex-lb:pr-1372 .
docker run --rm --entrypoint sh codex-lb:pr-1372 -lc "test -r /app/config/additional_quota_registry.json && stat -c 'owner=%U mode=%a' /app/config/additional_quota_registry.json"
# owner=app mode=600
```

The Docker build executes the same unreadable-file guard under `USER app`.

## Screenshots / output

Not applicable — no dashboard-visible change.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [ ] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally. The Docker runtime regression command above was run; the full fleet gate requires the project Helm/Postgres/kind toolchain.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean. Not applicable — no spec-governed behavior changed.
- [x] Simplicity gates reviewed: no setting, README, dashboard, or default changed.
- [x] CHANGELOG is not edited by hand (release-please handles it).
