### PR TITLE
fix(balancer): reject implausible rate-limit resets

### DIFF
--- a/app/core/balancer/__init__.py
+++ b/app/core/balancer/__init__.py
@@ -4,6 +4,7 @@ from app.core.balancer.logic import (
     HEALTH_TIER_PROBING,
     PERMANENT_FAILURE_CODES,
     QUOTA_EXCEEDED_COOLDOWN_SECONDS,
+    RATE_LIMIT_RESET_MAX_HORIZON_SECONDS,
     RATE_LIMITED_MIN_COOLDOWN_SECONDS,
     REAUTH_REQUIRED_FAILURE_CODES,
     ROUTING_POLICY_BURN_FIRST,
@@ -26,6 +27,7 @@ from app.core.balancer.logic import (
     handle_permanent_failure,
     handle_quota_exceeded,
     handle_rate_limit,
+    plausible_rate_limit_reset_at,
     select_account,
 )
 
@@ -39,6 +41,7 @@ __all__ = [
     "RoutingCost",
     "RoutingCostsByAccount",
     "QUOTA_EXCEEDED_COOLDOWN_SECONDS",
+    "RATE_LIMIT_RESET_MAX_HORIZON_SECONDS",
     "RATE_LIMITED_MIN_COOLDOWN_SECONDS",
     "ROUTING_POLICY_BURN_FIRST",
     "ROUTING_POLICY_PRESERVE",
@@ -57,5 +60,6 @@ __all__ = [
     "handle_permanent_failure",
     "handle_quota_exceeded",
     "handle_rate_limit",
+    "plausible_rate_limit_reset_at",
     "select_account",
 ]

--- a/app/core/balancer/logic.py
+++ b/app/core/balancer/logic.py
@@ -51,6 +51,8 @@ REAUTH_REQUIRED_FAILURE_CODES = frozenset(
 SECONDS_PER_DAY = 60 * 60 * 24
 SECONDS_PER_HOUR = 60 * 60
 SECONDS_PER_WEEK = 7 * SECONDS_PER_DAY
+RATE_LIMIT_RESET_MAX_HORIZON_SECONDS = 366 * SECONDS_PER_DAY
+RATE_LIMIT_RESET_ROUNDING_TOLERANCE_SECONDS = 1.0
 UNKNOWN_RESET_BUCKET_DAYS = 10_000
 UNKNOWN_RESET_FALLBACK_SECONDS = 7 * SECONDS_PER_DAY
 RELATIVE_AVAILABILITY_MIN_DIVISOR_SECONDS = 5 * 60
@@ -1077,7 +1079,7 @@ def handle_rate_limit(state: AccountState, error: UpstreamError) -> None:
     state.last_error_at = now
     state.blocked_at = now
 
-    reset_at = _extract_reset_at(error)
+    reset_at = _extract_reset_at(error, now=now)
 
     message = error.get("message")
     delay = parse_retry_after(message) if message else None
@@ -1123,16 +1125,17 @@ def _format_retry_hint(wait_seconds: float) -> str:
 
 
 def handle_quota_exceeded(state: AccountState, error: UpstreamError) -> None:
+    now = time.time()
     state.status = AccountStatus.QUOTA_EXCEEDED
     state.used_percent = 100.0
-    state.blocked_at = time.time()
-    state.cooldown_until = time.time() + QUOTA_EXCEEDED_COOLDOWN_SECONDS
+    state.blocked_at = now
+    state.cooldown_until = now + QUOTA_EXCEEDED_COOLDOWN_SECONDS
 
-    reset_at = _extract_reset_at(error)
+    reset_at = _extract_reset_at(error, now=now)
     if reset_at is not None:
         state.reset_at = reset_at
     else:
-        state.reset_at = int(time.time() + 3600)
+        state.reset_at = int(now + 3600)
 
 
 def handle_permanent_failure(state: AccountState, error_code: str) -> None:
@@ -1168,13 +1171,53 @@ def failover_decision(
     return "surface"
 
 
-def _extract_reset_at(error: UpstreamError) -> int | None:
-    reset_at = error.get("resets_at")
+def plausible_rate_limit_reset_at(
+    reset_at: int | float | None,
+    *,
+    now: float | None = None,
+    allow_rounding_slack: bool = True,
+) -> float | None:
+    """Return a finite near-future reset deadline, or ``None`` when invalid."""
+
+    if reset_at is None or isinstance(reset_at, bool):
+        return None
+    current = time.time() if now is None else now
+    if isinstance(reset_at, float) and not math.isfinite(reset_at):
+        return None
+    horizon = RATE_LIMIT_RESET_MAX_HORIZON_SECONDS
+    if allow_rounding_slack:
+        # Persisted deadlines are whole seconds; ceil may move an otherwise
+        # valid raw deadline just beyond the metadata horizon.
+        horizon += RATE_LIMIT_RESET_ROUNDING_TOLERANCE_SECONDS
+    # Keep this comparison ahead of float conversion: Python integers can be
+    # arbitrarily large, while converting malformed metadata can overflow.
+    if reset_at <= current or reset_at > current + horizon:
+        return None
+    return float(reset_at)
+
+
+def _extract_reset_at(error: UpstreamError, *, now: float) -> int | None:
+    reset_at = plausible_rate_limit_reset_at(
+        error.get("resets_at"),
+        now=now,
+        allow_rounding_slack=False,
+    )
     if reset_at is not None:
-        return int(reset_at)
+        rounded_reset_at = int(math.ceil(reset_at))
+        if plausible_rate_limit_reset_at(rounded_reset_at, now=now) is not None:
+            return rounded_reset_at
+        return None
+
     reset_in = error.get("resets_in_seconds")
-    if reset_in is not None:
-        return int(time.time() + float(reset_in))
+    if reset_in is None or isinstance(reset_in, bool):
+        return None
+    if isinstance(reset_in, float) and not math.isfinite(reset_in):
+        return None
+    if reset_in <= 0 or reset_in > RATE_LIMIT_RESET_MAX_HORIZON_SECONDS:
+        return None
+    rounded_reset_at = int(math.ceil(now + float(reset_in)))
+    if plausible_rate_limit_reset_at(rounded_reset_at, now=now) is not None:
+        return rounded_reset_at
     return None
 
 

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -32,6 +32,7 @@ from app.core.balancer import (
     handle_permanent_failure,
     handle_quota_exceeded,
     handle_rate_limit,
+    plausible_rate_limit_reset_at,
     select_account,
 )
 from app.core.balancer.types import UpstreamError
@@ -2015,7 +2016,8 @@ def _state_from_account(
     # while waiting for the next usage refresh. Expired samples map to 0.0
     # rather than None because usage-derived status recovery only evaluates
     # non-None percentages.
-    now_epoch = int(time.time())
+    now = time.time()
+    now_epoch = int(now)
     if primary_used is not None and primary_reset is not None and primary_reset <= now_epoch:
         primary_used = 0.0
         primary_reset = None
@@ -2055,15 +2057,15 @@ def _state_from_account(
     # stale window data, not for an upstream 429 whose cooldown is running.
     rate_limited_cooldown_deadline: float | None = None
     if account.status == AccountStatus.RATE_LIMITED and effective_blocked_at is not None:
-        persisted_deadline = (
-            float(account.reset_at) if account.reset_at else effective_blocked_at + RATE_LIMITED_MIN_COOLDOWN_SECONDS
+        persisted_deadline = plausible_rate_limit_reset_at(account.reset_at, now=now) or (
+            effective_blocked_at + RATE_LIMITED_MIN_COOLDOWN_SECONDS
         )
-        if time.time() < persisted_deadline:
+        if now < persisted_deadline:
             rate_limited_cooldown_deadline = persisted_deadline
         if (
             rate_limited_cooldown_deadline is not None
             and runtime.cooldown_until is not None
-            and runtime.cooldown_until <= time.time()
+            and runtime.cooldown_until <= now
             and runtime.blocked_at is not None
             and runtime.blocked_at >= effective_blocked_at
         ):
@@ -2106,11 +2108,25 @@ def _state_from_account(
 
     # Use account.reset_at from DB as the authoritative source for runtime reset
     # and to survive process restarts.
-    db_reset_at = (
-        None if ignore_zero_capacity_primary_runtime_reset else (float(account.reset_at) if account.reset_at else None)
+    persisted_reset_at = float(account.reset_at) if account.reset_at is not None else None
+    runtime_reset_at = runtime.reset_at
+    # Validate only future RATE_LIMITED hints. Elapsed deadlines must still
+    # reach apply_usage_quota's ordinary expiry transition, and QUOTA_EXCEEDED
+    # deadlines have separate recovery semantics.
+    if account.status == AccountStatus.RATE_LIMITED:
+        if persisted_reset_at is not None and persisted_reset_at > now:
+            persisted_reset_at = plausible_rate_limit_reset_at(persisted_reset_at, now=now)
+        if runtime_reset_at is not None and runtime_reset_at > now:
+            runtime_reset_at = plausible_rate_limit_reset_at(runtime_reset_at, now=now)
+    rejected_persisted_rate_limit_reset = (
+        account.status == AccountStatus.RATE_LIMITED
+        and account.reset_at is not None
+        and persisted_reset_at is None
+        and account.reset_at > now
     )
+    db_reset_at = None if ignore_zero_capacity_primary_runtime_reset else persisted_reset_at
     if status_seed in (AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED) or runtime.blocked_at is not None:
-        effective_runtime_reset = db_reset_at or runtime.reset_at
+        effective_runtime_reset = db_reset_at or runtime_reset_at
     else:
         effective_runtime_reset = None
 
@@ -2126,7 +2142,7 @@ def _state_from_account(
         and effective_blocked_at is not None
     ):
         floor_deadline = effective_blocked_at + RATE_LIMITED_MIN_COOLDOWN_SECONDS
-        if time.time() < floor_deadline:
+        if now < floor_deadline:
             effective_runtime_reset = floor_deadline
 
     if (
@@ -2184,13 +2200,38 @@ def _state_from_account(
             if recorded_epoch > effective_blocked_at:
                 effective_runtime_reset = None
 
+    rejected_reset_recovery_evidence = False
+    if rejected_persisted_rate_limit_reset:
+        rejected_reset_freshness_entry = _rate_limited_freshness_entry(
+            account=account,
+            primary_entry=primary_entry,
+            long_window_entry=effective_secondary_entry,
+        )
+        # One healthy window must not conceal exhaustion in another applicable
+        # window; at least one window must also have supplied actual evidence.
+        all_quota_windows_available = (
+            (primary_used is None or float(primary_used) < 100.0)
+            and (secondary_used is None or float(secondary_used) < 100.0)
+            and (primary_used is not None or secondary_used is not None)
+        )
+        rejected_reset_recovery_evidence = all_quota_windows_available and _usage_entry_is_recent_available(
+            rejected_reset_freshness_entry
+        )
+        if effective_blocked_at is not None:
+            # A sample predating the 429 cannot disprove the persisted block.
+            rejected_reset_recovery_evidence = (
+                rejected_reset_recovery_evidence
+                and now >= effective_blocked_at + RATE_LIMITED_MIN_COOLDOWN_SECONDS
+                and _usage_entry_recorded_after_block(rejected_reset_freshness_entry, effective_blocked_at)
+            )
+
     # A resetless rate limit whose runtime cooldown was lost (e.g. a restart
     # after a 429 without reset metadata) has no deadline to expire and no
     # post-block evidence trail; a long-window sample alone must not clear
     # it. Evidence-gated clearing above always starts from a persisted or
     # runtime reset, so this only matches the truly resetless case.
     resetless_rate_limit_without_evidence = (
-        status_seed == AccountStatus.RATE_LIMITED and db_reset_at is None and runtime.reset_at is None
+        status_seed == AccountStatus.RATE_LIMITED and account.reset_at is None and runtime.reset_at is None
     )
 
     status, used_percent, reset_at = apply_usage_quota(
@@ -2208,6 +2249,9 @@ def _state_from_account(
     )
     if resetless_rate_limit_without_evidence and primary_used is None and status == AccountStatus.ACTIVE:
         status = AccountStatus.RATE_LIMITED
+    if rejected_persisted_rate_limit_reset and not rejected_reset_recovery_evidence:
+        status = AccountStatus.RATE_LIMITED
+        reset_at = float(account.reset_at)
 
     if status == AccountStatus.QUOTA_EXCEEDED:
         next_blocked_at = effective_blocked_at
@@ -2304,14 +2348,16 @@ def background_recovery_state_from_account(
 
     runtime = RuntimeState()
     blocked_at = float(account.blocked_at) if account.blocked_at is not None else None
+    now = time.time()
     reset_at = float(account.reset_at) if account.reset_at is not None else None
+    valid_reset_at = plausible_rate_limit_reset_at(reset_at, now=now)
 
     if blocked_at is not None:
         runtime.blocked_at = blocked_at
 
     if account.status == AccountStatus.RATE_LIMITED and blocked_at is not None:
-        if reset_at is not None:
-            runtime.cooldown_until = reset_at
+        if valid_reset_at is not None:
+            runtime.cooldown_until = valid_reset_at
     state = _state_from_account(
         account=account,
         primary_entry=primary_entry,
@@ -2324,16 +2370,21 @@ def background_recovery_state_from_account(
             primary_entry=primary_entry,
             long_window_entry=secondary_entry,
         )
-        if blocked_at is not None and reset_at is not None and reset_at <= time.time():
-            if not _usage_entry_recorded_after_block(freshness_entry, blocked_at):
+        # Keep elapsed resets intact until _state_from_account evaluates the
+        # selector's normal expiry path; only freshness gates the final repair.
+        if blocked_at is not None and reset_at is not None and reset_at <= now:
+            minimum_floor_deadline = blocked_at + RATE_LIMITED_MIN_COOLDOWN_SECONDS
+            # An early explicit reset does not let scheduler reconciliation
+            # bypass the persisted post-429 minimum floor.
+            if now < minimum_floor_deadline or not _usage_entry_recorded_after_block(freshness_entry, blocked_at):
                 return replace(
                     state,
                     status=AccountStatus.RATE_LIMITED,
                     reset_at=reset_at,
                     blocked_at=blocked_at,
-                    cooldown_until=reset_at,
+                    cooldown_until=max(reset_at, minimum_floor_deadline),
                 )
-        elif blocked_at is None and reset_at is not None and reset_at <= time.time():
+        elif blocked_at is None and reset_at is not None and reset_at <= now:
             if not _usage_entry_is_recent_available(freshness_entry):
                 return replace(
                     state,

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -17,6 +17,7 @@ from app.core.balancer import (
     QUOTA_EXCEEDED_COOLDOWN_SECONDS,
     RATE_LIMITED_MIN_COOLDOWN_SECONDS,
     account_status_for_permanent_failure,
+    plausible_rate_limit_reset_at,
 )
 from app.core.clients.usage import UsageFetchError, fetch_usage
 from app.core.config.settings import get_settings
@@ -818,12 +819,11 @@ class UsageUpdater:
                 # ended: throttles are not always quota-based. Rows without
                 # blocked_at are stale window-derived markings and keep the
                 # fresh-usage recovery below.
-                cooldown_deadline = (
-                    float(account.reset_at)
-                    if account.reset_at
-                    else float(account.blocked_at) + RATE_LIMITED_MIN_COOLDOWN_SECONDS
+                now = time.time()
+                cooldown_deadline = plausible_rate_limit_reset_at(account.reset_at, now=now) or (
+                    float(account.blocked_at) + RATE_LIMITED_MIN_COOLDOWN_SECONDS
                 )
-                if time.time() < cooldown_deadline:
+                if now < cooldown_deadline:
                     return
             long_window = monthly or secondary
             if primary is None and monthly is None:

--- a/openspec/changes/bound-rate-limit-reset-metadata/.openspec.yaml
+++ b/openspec/changes/bound-rate-limit-reset-metadata/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/bound-rate-limit-reset-metadata/context.md
+++ b/openspec/changes/bound-rate-limit-reset-metadata/context.md
@@ -1,0 +1,34 @@
+# Implausible Rate-Limit Reset Metadata
+
+## Purpose and scope
+
+This change hardens the existing durable rate-limit cooldown contract against malformed or wrong-unit metadata from the OpenAI service that codex-lb proxies. It does not change normal quota accounting or introduce a manual account-state override.
+
+## Incident shape
+
+A live account was persisted as `rate_limited` with `blocked_at=1784146959` and `reset_at=15023672358`. The latter maps to January 2446, while fresh usage snapshots repeatedly reported `used_percent=0.0`. Because the reset deadline remained in the future, the normal recovery path correctly—but indefinitely—preserved the block.
+
+The exact OpenAI service payload was not retained, so the malformed value may have originated in that service or during a runtime response-normalization layer. The codex-lb application boundary must be safe in either case.
+
+## Decision rationale
+
+Reset metadata is an untrusted hint, not an authorization or billing record. codex-lb should honor plausible explicit metadata for cross-replica correctness but should never let one numeric field disable an account for centuries. A fixed 366-day horizon is intentionally much larger than the currently supported monthly quota window while still rejecting obvious unit/domain errors.
+
+Invalid metadata is not converted heuristically. Treating `15023672358` as milliseconds or nanoseconds would guess at the OpenAI service's intent. Instead, codex-lb uses the already-defined Retry-After/message/backoff chain.
+
+## Constraints and failure modes
+
+- Legitimate weekly and monthly deadlines remain authoritative.
+- Missing or rejected metadata still produces a persisted minimum cooldown, so peer replicas do not hammer a throttled account.
+- Existing poisoned rows with a block marker recover only after the minimum floor and only from post-block evidence; legacy rows without a marker require recent evidence.
+- Recovery requires every applicable primary and long quota window to remain below `100%` usage.
+- Compare-and-set persistence prevents stale recovery from overwriting a concurrent new rate-limit event.
+- No setting is added: accepting century-scale cooldowns is not a useful operator-tunable behavior.
+
+## Concrete example
+
+At epoch `1784146959`, an error with `resets_at=15023672358` is rejected because it is more than 366 days ahead. If the error message has no parseable duration, the persisted deadline becomes at least 30 seconds after the block. A subsequent fresh usage snapshot showing available quota can then restore the account to `active` after that floor elapses.
+
+## Operational notes
+
+No migration or manual cleanup is required. After deployment, background usage refresh or the next selection evaluation repairs affected rows in place. The normative contracts are in the account-routing and usage-refresh-policy delta specs for this change.

--- a/openspec/changes/bound-rate-limit-reset-metadata/design.md
+++ b/openspec/changes/bound-rate-limit-reset-metadata/design.md
@@ -1,0 +1,61 @@
+## Context
+
+Rate-limit errors may carry an absolute `resets_at` value, a relative `resets_in_seconds` value, a duration in the message, or no reset hint. The balancer currently converts explicit numeric metadata directly into an integer deadline and persists it. Cross-replica cooldown enforcement and usage-refresh recovery then correctly trust that durable deadline, but they have no way to distinguish a real monthly reset from a malformed value centuries in the future.
+
+The fix crosses the pure balancer logic, selection-time reconstruction of persisted state, and background usage recovery. It must preserve the cooldown guarantees introduced for peer replicas while allowing existing poisoned rows to self-heal without a migration.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Accept legitimate finite reset metadata for all currently supported quota windows.
+- Prevent malformed, wrong-unit, elapsed, or non-finite metadata from creating an effectively permanent block.
+- Reuse the existing Retry-After/backoff fallback when explicit metadata is unusable.
+- Repair already-persisted implausible deadlines through ordinary CAS-guarded selection or usage-refresh recovery.
+
+**Non-Goals:**
+
+- Guess the unit or intended value of malformed OpenAI service metadata.
+- Add an operator setting, database migration, or bulk cleanup job.
+- Change the normal cooldown or recovery rules for plausible deadlines.
+
+## Decisions
+
+### Use one conservative hardcoded plausibility horizon
+
+Add a pure balancer helper that accepts a deadline only when it is finite, strictly later than the evaluation time, and no more than 366 days in the future. Relative durations must likewise be finite, positive, and no greater than 366 days before being converted to an absolute deadline.
+
+Persistence accepts less than one second of additional horizon only for the whole-second ceiling applied to an already-valid deadline. This keeps horizon-edge values stable across write/read reconstruction without widening acceptance of raw OpenAI service metadata.
+
+The supported usage windows currently top out at a month. A one-year horizon leaves substantial compatibility margin without allowing wrong-unit millisecond/nanosecond values to pin an account for decades or centuries. This is a safety invariant rather than an operator preference, so it remains a constant rather than a new setting.
+
+Alternatives considered:
+
+- Derive the limit from a usage-window field. Rejected because rate-limit error metadata does not reliably carry the affected window identity.
+- Convert suspicious values as milliseconds or nanoseconds. Rejected because guessing can shorten a legitimate cooldown or interpret unrelated numeric data as a timestamp.
+- Clamp suspicious values to the horizon. Rejected because it would still block an account for a year; invalid metadata should use the existing bounded fallback.
+
+### Prefer usable explicit metadata, then preserve the existing fallback chain
+
+Evaluate `resets_at` first. If it is invalid, evaluate `resets_in_seconds`; if neither is usable, behave exactly as if explicit reset metadata were absent and resolve the message duration or error-count backoff. Round an accepted fractional deadline up to the next integer second so persistence cannot shorten it.
+
+### Apply the same validation to persisted rate-limit rows
+
+Selection reconstruction and background usage recovery will validate `accounts.reset_at` before treating it as an unexpired 429 cooldown. An implausible value is treated as missing metadata, so a row with `blocked_at` still honors the existing 30-second minimum floor. After that floor, fresh recovery evidence can clear `status`, `reset_at`, and `blocked_at` through the existing compare-and-set write.
+
+This read-time interpretation repairs existing rows without a migration and remains safe under concurrent new 429 writes.
+
+## Risks / Trade-offs
+
+- **A future OpenAI product introduces a reset more than one year away** → The value falls back to the short Retry-After/backoff path. The one-year margin is far above current monthly windows and can be revised in code/spec if the OpenAI service contract changes.
+- **A malformed deadline is ignored while the account is genuinely throttled** → The existing Retry-After parser or minimum persisted backoff still prevents immediate peer re-selection.
+- **An existing poisoned row has no fresh usage evidence** → It remains rate-limited after the minimum floor until ordinary recovery evidence arrives; the fix does not manufacture quota availability.
+- **Concurrent recovery races with a new OpenAI service block** → Existing compare-and-set guards reject the stale recovery write.
+
+## Migration Plan
+
+Deploy normally with no schema change. New malformed metadata is rejected immediately. Existing implausible rows become recoverable on their next selection or usage-refresh evaluation. Rollback restores the old interpretation but does not alter stored rows.
+
+## Open Questions
+
+None.

--- a/openspec/changes/bound-rate-limit-reset-metadata/proposal.md
+++ b/openspec/changes/bound-rate-limit-reset-metadata/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+An OpenAI service rate-limit error can carry malformed or wrong-unit reset metadata, and codex-lb currently persists that value without validation. An implausible deadline can therefore keep an account `rate_limited` indefinitely even after fresh usage proves quota is available.
+
+## What Changes
+
+- Validate absolute and relative OpenAI service reset metadata against a conservative finite future horizon before using it as a cooldown deadline.
+- Fall back to the existing Retry-After or bounded backoff path when reset metadata is non-finite, elapsed, or implausibly far in the future.
+- Treat already-persisted implausible rate-limit deadlines as invalid so normal selection and background usage recovery can repair affected accounts.
+- Add regressions for malformed metadata and automatic recovery of an affected persisted account.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `account-routing`: Bound explicit OpenAI service reset metadata and define the fallback and persisted-row behavior for implausible deadlines.
+- `usage-refresh-policy`: Allow fresh post-block quota evidence to recover accounts whose persisted rate-limit deadline is implausible.
+
+## Impact
+
+- Affected code: balancer rate-limit handling, account selection state derivation, and usage-refresh recovery.
+- Affected data: existing `accounts.reset_at` values are interpreted defensively; no schema migration or bulk rewrite is required.
+- APIs and configuration: no API, environment variable, or dashboard changes.

--- a/openspec/changes/bound-rate-limit-reset-metadata/specs/account-routing/spec.md
+++ b/openspec/changes/bound-rate-limit-reset-metadata/specs/account-routing/spec.md
@@ -1,0 +1,144 @@
+## MODIFIED Requirements
+
+### Requirement: Upstream rate-limit cooldown honors the Retry-After hint duration
+
+The account cooldown SHALL last for the full duration expressed by a "try
+again in" hint on an upstream rate-limit error. The parser SHALL
+recognize hour, minute, second, and millisecond units, including their word
+forms, and SHALL sum compound hints such as `1h2m3s` into a single duration.
+A unit token SHALL be recognized only when it is not immediately followed by
+another letter, so an unsupported longer word whose prefix matches a unit (for
+example `month`, where `m` prefixes the word) is not mis-read as that shorter
+unit. When the hint contains no recognizable unit token, the system SHALL fall
+back to the error-count backoff schedule. A rate-limited account SHALL NOT be
+re-selected before its cooldown elapses.
+
+Explicit upstream reset metadata SHALL be accepted only when it resolves to a
+finite deadline strictly later than the current time and no more than
+`RATE_LIMIT_RESET_MAX_HORIZON_SECONDS` (366 days) in the future. `resets_at`
+SHALL be interpreted as an absolute Unix timestamp and `resets_in_seconds`
+SHALL be interpreted as a relative duration. When `resets_at` is invalid but
+`resets_in_seconds` is valid, the relative duration SHALL be used. An accepted
+fractional deadline SHALL be rounded up to the next whole second before
+persistence. A persisted integer deadline produced by that rounding MAY be
+less than one second beyond the raw 366-day horizon and MUST remain valid when
+selection reconstructs it. When neither field is valid, the error SHALL be
+treated as carrying no explicit reset metadata.
+
+When the upstream rate-limit error carries no valid explicit reset metadata,
+the resolved cooldown deadline SHALL be persisted on the account row
+(`reset_at`) so the cooldown survives process restarts and is visible to all
+replicas sharing the database: a parsed Retry-After hint deadline SHALL be
+persisted rounded up to the next whole second (persistence stores `reset_at`
+as an integer, so a short or fractional hint MUST NOT truncate down to an
+already-elapsed deadline), and when the cooldown comes from the error-count
+backoff fallback the persisted deadline SHALL be at least
+`RATE_LIMITED_MIN_COOLDOWN_SECONDS` (30 seconds) in the future. The marking
+replica's in-process cooldown MAY remain shorter than the persisted deadline
+so its existing fresh-usage recovery gate is unchanged.
+
+An already-persisted `rate_limited` reset deadline beyond the same plausibility
+horizon SHALL be treated as missing metadata rather than as an unexpired
+cooldown. A row carrying `blocked_at` SHALL still honor the existing 30-second
+minimum floor and SHALL require recent usage evidence recorded after that block
+before selection-time recovery may clear it. A row without `blocked_at` SHALL
+require recent available usage evidence. In both cases, every applicable
+derived quota window MUST report below `100%` usage before recovery.
+
+#### Scenario: Compound minute-and-second hint sets the full cooldown
+
+- **GIVEN** an upstream 429 whose message says "try again in 6m0s"
+- **WHEN** the balancer records the rate limit for the account
+- **THEN** the account cooldown lasts 360 seconds
+- **AND** the account is not re-selected until its cooldown elapses
+
+#### Scenario: Minutes-only hint is honored
+
+- **GIVEN** an upstream 429 whose message says "try again in 20m"
+- **WHEN** the balancer records the rate limit for the account
+- **THEN** the account cooldown lasts 1200 seconds
+
+#### Scenario: Unparseable hint falls back to backoff
+
+- **GIVEN** an upstream 429 whose message has no recognizable "try again in" duration
+- **WHEN** the balancer records the rate limit for the account
+- **THEN** the cooldown uses the error-count backoff schedule instead
+
+#### Scenario: Unsupported longer word is not mis-read as a shorter unit
+
+- **GIVEN** an upstream 429 whose message says "try again in 1 month"
+- **WHEN** the balancer records the rate limit for the account
+- **THEN** the `month` token is not read as a 1-minute hint
+- **AND** the cooldown uses the error-count backoff schedule instead
+
+#### Scenario: Cooldown without upstream reset metadata is persisted
+
+- **GIVEN** an upstream 429 that carries no `resets_at`/`resets_in_seconds` metadata and no parseable Retry-After hint
+- **WHEN** the balancer records the rate limit for the account
+- **THEN** the persisted account row holds status `RATE_LIMITED` with `blocked_at` set
+- **AND** the persisted `reset_at` is at least 30 seconds in the future
+
+#### Scenario: Retry-After hint deadline is persisted
+
+- **GIVEN** an upstream 429 whose message says "try again in 20m" and that carries no reset metadata
+- **WHEN** the balancer records the rate limit for the account
+- **THEN** the persisted `reset_at` is approximately 1200 seconds in the future
+
+#### Scenario: Short fractional Retry-After hint is not truncated away
+
+- **GIVEN** an upstream 429 whose message says "try again in 500ms" and that carries no reset metadata
+- **WHEN** the balancer records the rate limit for the account
+- **THEN** the persisted integer `reset_at` deadline is strictly in the future
+- **AND** peer replicas honor the hinted cooldown instead of reselecting the account immediately
+
+#### Scenario: Plausible explicit reset metadata remains authoritative
+
+- **GIVEN** an OpenAI service 429 carrying a finite `resets_at` deadline 30 days in the future
+- **WHEN** the balancer records the rate limit for the account
+- **THEN** the accepted explicit deadline is persisted
+- **AND** the Retry-After/backoff fallback does not replace it
+
+#### Scenario: Implausible explicit reset metadata uses the bounded fallback
+
+- **GIVEN** an OpenAI service 429 carrying `resets_at=15023672358` while the current Unix time is approximately `1784146959`
+- **AND** the error carries no valid `resets_in_seconds` or parseable duration
+- **WHEN** the balancer records the rate limit for the account
+- **THEN** the implausible absolute deadline is rejected
+- **AND** the persisted deadline uses the minimum bounded backoff instead
+
+#### Scenario: Valid relative metadata survives an invalid absolute value
+
+- **GIVEN** an OpenAI service 429 whose `resets_at` is implausibly far in the future
+- **AND** whose `resets_in_seconds` is a finite positive duration within 366 days
+- **WHEN** the balancer records the rate limit for the account
+- **THEN** the relative duration determines the persisted deadline
+
+#### Scenario: Horizon-edge rounding remains stable
+
+- **GIVEN** valid absolute or relative reset metadata resolves exactly 366 days after a fractional current timestamp
+- **WHEN** the balancer rounds and persists the deadline to a whole second
+- **THEN** persisted-state reconstruction continues to accept that deadline
+- **AND** does not clear the cooldown solely because rounding crossed the raw horizon by less than one second
+
+#### Scenario: Existing implausible deadline does not pin selection indefinitely
+
+- **GIVEN** a persisted `rate_limited` account whose `reset_at` is more than 366 days in the future
+- **AND** whose `blocked_at` minimum floor has elapsed
+- **WHEN** selection reconstructs the account from fresh available usage evidence
+- **THEN** the implausible deadline is treated as missing metadata
+- **AND** normal compare-and-set recovery may restore the account to `active`
+
+#### Scenario: Exhausted long-window quota prevents poisoned-row recovery
+
+- **GIVEN** a persisted `rate_limited` account whose reset deadline is implausible
+- **AND** a fresh primary window reports available quota
+- **AND** an applicable weekly or monthly window reports `100%` usage
+- **WHEN** selection reconstructs the account
+- **THEN** the account remains `rate_limited`
+
+#### Scenario: Implausible legacy deadline without a block marker recovers
+
+- **GIVEN** a persisted `rate_limited` account whose reset deadline is implausible
+- **AND** the row has no `blocked_at` marker
+- **WHEN** selection reconstructs the account from recent available usage in every applicable window
+- **THEN** normal compare-and-set recovery may restore the account to `active`

--- a/openspec/changes/bound-rate-limit-reset-metadata/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/bound-rate-limit-reset-metadata/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Implausible persisted rate-limit deadlines do not block recovery
+
+Background usage refresh MUST treat a persisted `rate_limited` reset deadline
+as invalid when it is non-finite, elapsed, or beyond
+`RATE_LIMIT_RESET_MAX_HORIZON_SECONDS` (366 days) plus the less-than-one-second
+whole-second persistence tolerance. An invalid deadline MUST NOT be treated as
+an unexpired explicit cooldown. When the account carries `blocked_at`, recovery
+MUST still honor the existing 30-second minimum floor and MUST still require
+the existing fresh available quota evidence recorded after the block. Without
+`blocked_at`, recent available evidence SHALL suffice. Every applicable quota
+window MUST report below `100%` usage before recovery.
+
+#### Scenario: Scheduler recovers an implausible persisted cooldown
+
+- **WHEN** an account is persisted as `rate_limited` with a reset deadline more than 366 days in the future
+- **AND** its persisted `blocked_at` minimum floor has elapsed
+- **AND** a later background usage refresh writes fresh available quota evidence
+- **THEN** the scheduler treats the reset deadline as invalid
+- **AND** marks the account `active`
+- **AND** clears persisted `reset_at` and `blocked_at`
+
+#### Scenario: Scheduler preserves a plausible unexpired cooldown
+
+- **GIVEN** an account is persisted as `rate_limited` with a finite reset deadline within 366 days
+- **AND** that deadline has not elapsed
+- **WHEN** a later background usage refresh writes fresh available quota evidence
+- **THEN** the scheduler leaves the account `rate_limited`
+
+#### Scenario: Scheduler recovers an implausible legacy deadline without a block marker
+
+- **GIVEN** an account is persisted as `rate_limited` with an implausible reset deadline and no `blocked_at`
+- **WHEN** a later background usage refresh writes recent available quota evidence for every applicable window
+- **THEN** the scheduler marks the account `active`
+- **AND** clears persisted `reset_at`

--- a/openspec/changes/bound-rate-limit-reset-metadata/tasks.md
+++ b/openspec/changes/bound-rate-limit-reset-metadata/tasks.md
@@ -1,0 +1,19 @@
+## 1. Reset metadata validation
+
+- [x] 1.1 Add a deterministic, finite 366-day plausibility validator for absolute and relative rate-limit reset metadata.
+- [x] 1.2 Make rate-limit and quota handlers prefer valid explicit metadata and otherwise retain the existing Retry-After/backoff fallback.
+
+## 2. Persisted-state recovery
+
+- [x] 2.1 Treat implausible persisted rate-limit deadlines as missing metadata during account-selection reconstruction while preserving the minimum block floor.
+- [x] 2.2 Let background usage refresh recover implausibly blocked rows from fresh available-quota evidence through the existing compare-and-set write.
+
+## 3. Regression coverage
+
+- [x] 3.1 Add unit coverage for plausible, wrong-unit, non-finite, expired, and valid-relative-fallback metadata.
+- [x] 3.2 Add selection and usage-refresh regressions proving a poisoned persisted row self-heals without weakening valid cooldowns.
+
+## 4. Validation
+
+- [x] 4.1 Run focused balancer and usage-refresh tests plus lint/format checks for touched Python files.
+- [x] 4.2 Run strict OpenSpec validation and verify implementation/spec/task coherence.

--- a/tests/integration/test_load_balancer_multi_replica.py
+++ b/tests/integration/test_load_balancer_multi_replica.py
@@ -334,3 +334,30 @@ async def test_legacy_rate_limited_row_recovers_after_floor_elapses(db_setup):
 
     row = await _fetch_account(limited.id)
     assert row.status == AccountStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_implausible_persisted_reset_does_not_pin_account_after_floor(db_setup):
+    """A wrong-unit reset timestamp must not keep an available account blocked."""
+    now_epoch = int(time.time())
+    limited = _make_account(
+        "implausible_reset",
+        status=AccountStatus.RATE_LIMITED,
+        blocked_at=now_epoch - 3600,
+        reset_at=15_023_672_358,
+    )
+    healthy = _make_account("implausible_reset_healthy")
+    # fill_first chooses the formerly-limited row once it recovers, proving
+    # the selection path did not merely hide the bad dashboard status.
+    await _seed_accounts_with_usage((limited, 50.0, 40.0), (healthy, 20.0, 10.0))
+
+    balancer = LoadBalancer(_repo_factory)
+    selection = await balancer.select_account(routing_strategy="fill_first")
+
+    assert selection.account is not None
+    assert selection.account.id == limited.id
+
+    row = await _fetch_account(limited.id)
+    assert row.status == AccountStatus.ACTIVE
+    assert row.reset_at is None
+    assert row.blocked_at is None

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -12,12 +12,14 @@ from app.core import usage as usage_core
 from app.core.balancer import (
     HEALTH_TIER_DRAINING,
     HEALTH_TIER_HEALTHY,
+    RATE_LIMIT_RESET_MAX_HORIZON_SECONDS,
     RATE_LIMITED_MIN_COOLDOWN_SECONDS,
     AccountState,
     RoutingCost,
     handle_permanent_failure,
     handle_quota_exceeded,
     handle_rate_limit,
+    plausible_rate_limit_reset_at,
     select_account,
 )
 from app.core.balancer.logic import DRAIN_PRIMARY_THRESHOLD_PCT, PROBE_QUIET_SECONDS
@@ -1002,6 +1004,97 @@ def test_handle_rate_limit_upstream_reset_metadata_still_wins(monkeypatch):
     assert state.reset_at == pytest.approx(now + 600.0)
 
 
+def test_handle_rate_limit_accepts_plausible_absolute_reset_metadata(monkeypatch):
+    now = 1_700_000_000.0
+    reset_at = now + 30 * 24 * 3600 + 0.25
+    monkeypatch.setattr("app.core.balancer.logic.time.time", lambda: now)
+    state = AccountState("a", AccountStatus.ACTIVE, used_percent=5.0)
+
+    handle_rate_limit(state, {"message": "Rate limit exceeded.", "resets_at": reset_at})
+
+    assert state.reset_at == 1_702_592_001
+
+
+def test_handle_rate_limit_rejects_implausible_absolute_reset_metadata(monkeypatch):
+    # Production incident shape: this value maps to January 2446 and must not
+    # pin the account until then. With no other usable hint, the durable reset
+    # falls back to the existing minimum peer-visible cooldown.
+    now = 1_784_146_959.0
+    monkeypatch.setattr("app.core.balancer.logic.time.time", lambda: now)
+    monkeypatch.setattr("app.core.balancer.logic.backoff_seconds", lambda _: 0.2)
+    state = AccountState("a", AccountStatus.ACTIVE, used_percent=5.0)
+
+    handle_rate_limit(state, {"message": "Rate limit exceeded.", "resets_at": 15_023_672_358})
+
+    assert state.reset_at == now + RATE_LIMITED_MIN_COOLDOWN_SECONDS
+    assert state.cooldown_until == pytest.approx(now + 0.2)
+
+
+def test_handle_rate_limit_uses_valid_relative_reset_after_invalid_absolute(monkeypatch):
+    now = 1_700_000_000.0
+    monkeypatch.setattr("app.core.balancer.logic.time.time", lambda: now)
+    state = AccountState("a", AccountStatus.ACTIVE, used_percent=5.0)
+
+    handle_rate_limit(
+        state,
+        {
+            "message": "Rate limit exceeded.",
+            "resets_at": 15_023_672_358,
+            "resets_in_seconds": 600.25,
+        },
+    )
+
+    assert state.reset_at == 1_700_000_601
+
+
+@pytest.mark.parametrize("reset_at", [float("nan"), float("inf"), -float("inf"), 1_699_999_999.0])
+def test_handle_rate_limit_rejects_nonfinite_and_elapsed_reset_metadata(monkeypatch, reset_at):
+    now = 1_700_000_000.0
+    monkeypatch.setattr("app.core.balancer.logic.time.time", lambda: now)
+    monkeypatch.setattr("app.core.balancer.logic.backoff_seconds", lambda _: 0.2)
+    state = AccountState("a", AccountStatus.ACTIVE, used_percent=5.0)
+
+    handle_rate_limit(state, {"message": "Rate limit exceeded.", "resets_at": reset_at})
+
+    assert state.reset_at == now + RATE_LIMITED_MIN_COOLDOWN_SECONDS
+
+
+def test_handle_rate_limit_rejects_oversized_integer_metadata_without_overflow(monkeypatch):
+    now = 1_700_000_000.0
+    monkeypatch.setattr("app.core.balancer.logic.time.time", lambda: now)
+    monkeypatch.setattr("app.core.balancer.logic.backoff_seconds", lambda _: 0.2)
+    state = AccountState("a", AccountStatus.ACTIVE, used_percent=5.0)
+
+    handle_rate_limit(
+        state,
+        {
+            "message": "Rate limit exceeded.",
+            "resets_at": 10**309,
+            "resets_in_seconds": 10**309,
+        },
+    )
+
+    assert state.reset_at == now + RATE_LIMITED_MIN_COOLDOWN_SECONDS
+
+
+@pytest.mark.parametrize("metadata_key", ["resets_at", "resets_in_seconds"])
+def test_handle_rate_limit_horizon_edge_remains_valid_after_rounding(monkeypatch, metadata_key):
+    now = 1_700_000_000.9
+    monkeypatch.setattr("app.core.balancer.logic.time.time", lambda: now)
+    state = AccountState("a", AccountStatus.ACTIVE, used_percent=5.0)
+    metadata_value = (
+        now + RATE_LIMIT_RESET_MAX_HORIZON_SECONDS
+        if metadata_key == "resets_at"
+        else RATE_LIMIT_RESET_MAX_HORIZON_SECONDS
+    )
+
+    handle_rate_limit(state, {metadata_key: metadata_value})
+
+    expected = int(now + RATE_LIMIT_RESET_MAX_HORIZON_SECONDS) + 1
+    assert state.reset_at == expected
+    assert plausible_rate_limit_reset_at(state.reset_at, now=now) == float(expected)
+
+
 def test_handle_rate_limit_cooldown_honors_word_unit_hint(monkeypatch):
     now = 1_700_000_000.0
     monkeypatch.setattr("app.core.balancer.logic.time.time", lambda: now)
@@ -1212,6 +1305,17 @@ def test_handle_quota_exceeded_sets_used_percent_and_cooldown():
     assert state.status == AccountStatus.QUOTA_EXCEEDED
     assert state.used_percent == 100.0
     assert state.cooldown_until is not None
+
+
+def test_handle_quota_exceeded_rejects_implausible_reset_metadata(monkeypatch):
+    now = 1_700_000_000.0
+    monkeypatch.setattr("app.core.balancer.logic.time.time", lambda: now)
+    state = AccountState("a", AccountStatus.ACTIVE, used_percent=5.0)
+
+    handle_quota_exceeded(state, {"resets_at": 15_023_672_358})
+
+    assert state.status == AccountStatus.QUOTA_EXCEEDED
+    assert state.reset_at == int(now + 3600)
 
 
 def test_handle_permanent_failure_sets_reason():
@@ -2893,6 +2997,160 @@ def test_background_recovery_state_preserves_rate_limit_cooldown_when_reset_is_i
 
     assert state.status == AccountStatus.RATE_LIMITED
     assert state.cooldown_until == pytest.approx(future_reset)
+
+
+def test_state_from_account_rejected_reset_requires_fresh_post_block_evidence(monkeypatch):
+    now = 1_700_000_000.0
+    blocked = now - 60.0
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_test_account(
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=15_023_672_358,
+        blocked_at=int(blocked),
+    )
+    stale_primary = _make_test_usage(
+        window="primary",
+        used_percent=10.0,
+        reset_at=int(now + 3600),
+        recorded_at=_epoch_to_naive_utc(blocked - 10),
+    )
+
+    state = _state_from_account(
+        account=account,
+        primary_entry=stale_primary,
+        secondary_entry=None,
+        runtime=RuntimeState(),
+    )
+
+    assert state.status == AccountStatus.RATE_LIMITED
+    assert state.reset_at == 15_023_672_358.0
+    assert state.blocked_at == blocked
+
+
+def test_state_from_account_rejected_reset_requires_all_quota_windows_available(monkeypatch):
+    now = 1_700_000_000.0
+    blocked = now - 60.0
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_test_account(
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=15_023_672_358,
+        blocked_at=int(blocked),
+    )
+    fresh_primary = _make_test_usage(
+        window="primary",
+        used_percent=10.0,
+        reset_at=int(now + 3600),
+        recorded_at=_epoch_to_naive_utc(now - 10),
+    )
+    exhausted_secondary = _make_test_usage(
+        window="secondary",
+        used_percent=100.0,
+        reset_at=int(now + 7 * 24 * 3600),
+        recorded_at=_epoch_to_naive_utc(now - 10),
+        window_minutes=10080,
+    )
+
+    state = _state_from_account(
+        account=account,
+        primary_entry=fresh_primary,
+        secondary_entry=exhausted_secondary,
+        runtime=RuntimeState(),
+    )
+
+    assert state.status == AccountStatus.RATE_LIMITED
+    assert state.reset_at == 15_023_672_358.0
+
+
+def test_state_from_account_rejected_reset_without_block_recovers_from_fresh_usage(monkeypatch):
+    now = 1_700_000_000.0
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_test_account(
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=15_023_672_358,
+        blocked_at=None,
+    )
+    fresh_primary = _make_test_usage(
+        window="primary",
+        used_percent=10.0,
+        reset_at=int(now + 3600),
+        recorded_at=_epoch_to_naive_utc(now - 10),
+    )
+
+    state = _state_from_account(
+        account=account,
+        primary_entry=fresh_primary,
+        secondary_entry=None,
+        runtime=RuntimeState(),
+    )
+
+    assert state.status == AccountStatus.ACTIVE
+    assert state.reset_at is None
+    assert state.blocked_at is None
+
+
+def test_state_from_account_preserves_elapsed_reset_for_selector_recovery(monkeypatch):
+    now = 1_700_000_000.0
+    elapsed_reset = now - 10.0
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    account = _make_test_account(
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=int(elapsed_reset),
+        blocked_at=int(now - 60),
+    )
+    state = _state_from_account(
+        account=account,
+        primary_entry=None,
+        secondary_entry=None,
+        runtime=RuntimeState(),
+    )
+
+    assert state.status == AccountStatus.RATE_LIMITED
+    assert state.reset_at == elapsed_reset
+    selection = select_account([state], now=now)
+    assert selection.account is state
+    assert state.status == AccountStatus.ACTIVE
+    assert state.reset_at is None
+
+
+def test_state_from_account_does_not_apply_rate_limit_repair_to_quota_exceeded(monkeypatch):
+    now = 1_700_000_000.0
+    implausible_reset = 15_023_672_358
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    account = _make_test_account(
+        status=AccountStatus.QUOTA_EXCEEDED,
+        reset_at=implausible_reset,
+        blocked_at=int(now - 5),
+    )
+    exhausted_secondary = _make_test_usage(
+        window="secondary",
+        used_percent=100.0,
+        reset_at=int(now + 7 * 24 * 3600),
+        recorded_at=_epoch_to_naive_utc(now - 10),
+        window_minutes=10080,
+    )
+    state = _state_from_account(
+        account=account,
+        primary_entry=None,
+        secondary_entry=exhausted_secondary,
+        runtime=RuntimeState(),
+    )
+
+    assert state.status == AccountStatus.QUOTA_EXCEEDED
+    assert state.reset_at == float(implausible_reset)
+    assert select_account([state], now=now).account is None
 
 
 def test_background_recovery_state_recovers_rate_limited_after_reset_elapses(monkeypatch):

--- a/tests/unit/test_usage_refresh_scheduler_recovery.py
+++ b/tests/unit/test_usage_refresh_scheduler_recovery.py
@@ -243,6 +243,50 @@ async def test_reconcile_recoverable_account_statuses_restores_rate_limited_afte
 
 
 @pytest.mark.asyncio
+async def test_reconcile_recoverable_account_statuses_keeps_elapsed_reset_until_block_floor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_700_000_000.0
+    past_reset = int(now - 1)
+    blocked_at = int(now - 10)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    account = _make_account(
+        "acc_rate_limited_floor",
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=past_reset,
+        blocked_at=blocked_at,
+    )
+    accounts_repo = StubAccountsRepository([account])
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: _make_usage(
+                account.id,
+                window="primary",
+                used_percent=10.0,
+                reset_at=past_reset,
+                recorded_at=_epoch_to_naive_utc(now - 5),
+                window_minutes=300,
+            )
+        }
+    )
+
+    recovered = await refresh_scheduler_module.reconcile_recoverable_account_statuses(
+        accounts_repo=accounts_repo,
+        usage_repo=usage_repo,
+        accounts=[account],
+    )
+
+    assert recovered == 0
+    assert account.status == AccountStatus.RATE_LIMITED
+    assert account.reset_at == past_reset
+    assert account.blocked_at == blocked_at
+    assert accounts_repo.status_updates == []
+
+
+@pytest.mark.asyncio
 async def test_reconcile_recoverable_account_statuses_keeps_legacy_rate_limited_when_primary_is_not_recent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -736,6 +736,38 @@ async def test_recover_keeps_rate_limited_account_during_persisted_retry_after_c
 
 
 @pytest.mark.asyncio
+async def test_recover_restores_rate_limited_account_with_implausible_deadline() -> None:
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(StubUsageRepository(), accounts_repo)
+    account = _make_account("acc_implausible_deadline", "workspace_implausible_deadline")
+    account.status = AccountStatus.RATE_LIMITED
+    account.deactivation_reason = None
+    now = int(time.time())
+    account.blocked_at = now - 60
+    account.reset_at = 15_023_672_358
+    accounts_repo.accounts_by_id[account.id] = account
+
+    await updater._recover_quota_status_from_usage(
+        account,
+        primary=usage_updater_module.UsageWindow(used_percent=0.0),
+        secondary=usage_updater_module.UsageWindow(used_percent=10.0),
+    )
+
+    assert accounts_repo.status_updates == [
+        {
+            "account_id": account.id,
+            "status": AccountStatus.ACTIVE,
+            "deactivation_reason": None,
+            "reset_at": None,
+            "blocked_at": None,
+        },
+    ]
+    assert account.status == AccountStatus.ACTIVE
+    assert account.reset_at is None
+    assert account.blocked_at is None
+
+
+@pytest.mark.asyncio
 async def test_recover_keeps_rate_limited_account_during_legacy_blocked_at_floor() -> None:
     accounts_repo = StubAccountsRepository()
     updater = UsageUpdater(StubUsageRepository(), accounts_repo)


### PR DESCRIPTION
## Summary

Reject malformed or wrong-unit OpenAI service reset metadata before it can persist an account as rate limited for an implausible duration. Existing poisoned rate-limited rows now recover through fresh quota evidence while preserving the 30-second post-block floor and normal quota-exceeded semantics.

## Type of change

- [x] fix: bug fix (no behavior change beyond the bug)
- [ ] Breaking change

Linked issue: Resolves no filed issue. A repository issue search found no active report for this malformed-reset persistence bug.

## OpenSpec

- [x] This PR includes an OpenSpec change
- [x] This PR preserves valid OpenAI service reset metadata behavior and rejects only invalid metadata

Change directory: openspec/changes/bound-rate-limit-reset-metadata/

## Changes

- Bound absolute and relative reset metadata to a finite 366-day horizon, with a one-second tolerance only for persisted whole-second rounding.
- Fall back from invalid absolute metadata to valid relative metadata, then to the existing Retry-After or backoff path.
- Repair implausible persisted rate-limited rows only from recent available evidence in every applicable quota window, with post-block evidence and the minimum floor where applicable.
- Add focused unit, scheduler, and multi-replica regressions plus production comments documenting the subtle invariants.

## Simplicity

- [x] No new setting, required setup step, migration, README section, environment surface, dashboard navigation, or default change.
- [x] Simplicity gates P1-P5 reviewed; no budget exception is required.

## Test plan

    uv run pytest tests/unit/test_load_balancer.py tests/unit/test_usage_updater.py tests/unit/test_usage_refresh_scheduler_recovery.py tests/integration/test_load_balancer_multi_replica.py
    # 354 passed
    uvx ruff check .
    uvx ruff format --check .
    uv run ty check
    npx --yes @fission-ai/openspec@1.6.0 validate --specs --strict
    # 47 specs passed
    git diff --check origin/main...HEAD

The pre-commit Codex review loop addressed all findings and terminated cleanly with no discrete actionable bugs.

## Screenshots / output

No dashboard surface changes. For the reproduced failure, an absolute reset timestamp resolving to year 2446 is now rejected and replaced by the bounded fallback; a previously poisoned row can return to active after fresh quota evidence and the post-block floor.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] No related filed issue exists after repository search.
- [x] Added tests covering the external scheduler and multi-replica recovery paths.
- [x] Ran the relevant local tests, lint, format, typing, and diff gates.
- [x] Strict OpenSpec validation and OpenSpec verification are clean.
- [x] Simplicity gates P1-P5 reviewed.
- [x] CHANGELOG was not edited.