### PR TITLE
fix(security): harden trusted Forwarded chain resolution

### DIFF
--- a/app/core/middleware/api_firewall.py
+++ b/app/core/middleware/api_firewall.py
@@ -10,7 +10,11 @@ from fastapi.responses import JSONResponse, Response
 from app.core.config.settings import get_settings
 from app.core.errors import openai_error
 from app.core.middleware.firewall_cache import get_firewall_ip_cache
-from app.core.request_locality import parse_trusted_proxy_networks, resolve_connection_client_ip
+from app.core.request_locality import (
+    FORWARDED_CHAIN_HEADER_NAMES,
+    parse_trusted_proxy_networks,
+    resolve_connection_client_ip,
+)
 from app.db.session import get_background_session
 from app.modules.firewall.repository import FirewallRepository
 from app.modules.firewall.service import FirewallRepositoryPort, FirewallService
@@ -35,6 +39,7 @@ def add_api_firewall_middleware(app: FastAPI) -> None:
             request.client.host if request.client else None,
             trust_proxy_headers=settings.firewall_trust_proxy_headers,
             trusted_proxy_networks=trusted_proxy_networks,
+            allowed_proxy_header_names=FORWARDED_CHAIN_HEADER_NAMES,
         )
         cached_decision = await firewall_cache.is_allowed(client_ip) if client_ip is not None else None
         if cached_decision is not None:
@@ -74,4 +79,5 @@ def _resolve_client_ip(
         request.client.host if request.client else None,
         trust_proxy_headers=trust_proxy_headers,
         trusted_proxy_networks=trusted_proxy_networks,
+        allowed_proxy_header_names=FORWARDED_CHAIN_HEADER_NAMES,
     )

--- a/app/core/middleware/api_firewall.py
+++ b/app/core/middleware/api_firewall.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Mapping
-from ipaddress import IPv4Network, IPv6Network, ip_address, ip_network
+from collections.abc import Awaitable, Callable
+from ipaddress import IPv4Network, IPv6Network
 from typing import cast
 
 from fastapi import FastAPI, Request
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse, Response
 from app.core.config.settings import get_settings
 from app.core.errors import openai_error
 from app.core.middleware.firewall_cache import get_firewall_ip_cache
+from app.core.request_locality import parse_trusted_proxy_networks, resolve_connection_client_ip
 from app.db.session import get_background_session
 from app.modules.firewall.repository import FirewallRepository
 from app.modules.firewall.service import FirewallRepositoryPort, FirewallService
@@ -17,7 +18,7 @@ from app.modules.firewall.service import FirewallRepositoryPort, FirewallService
 
 def add_api_firewall_middleware(app: FastAPI) -> None:
     settings = get_settings()
-    trusted_proxy_networks = _parse_trusted_proxy_networks(settings.firewall_trusted_proxy_cidrs)
+    trusted_proxy_networks = parse_trusted_proxy_networks(settings.firewall_trusted_proxy_cidrs)
     firewall_cache = get_firewall_ip_cache()
 
     @app.middleware("http")
@@ -74,71 +75,3 @@ def _resolve_client_ip(
         trust_proxy_headers=trust_proxy_headers,
         trusted_proxy_networks=trusted_proxy_networks,
     )
-
-
-def resolve_connection_client_ip(
-    headers: Mapping[str, str],
-    socket_ip: str | None,
-    *,
-    trust_proxy_headers: bool,
-    trusted_proxy_networks: tuple[IPv4Network | IPv6Network, ...] = (),
-) -> str | None:
-    if trust_proxy_headers and socket_ip and _is_trusted_proxy_source(socket_ip, trusted_proxy_networks):
-        forwarded_for = headers.get("x-forwarded-for")
-        if forwarded_for:
-            resolved_from_chain = _resolve_client_ip_from_xff_chain(
-                socket_ip,
-                forwarded_for,
-                trusted_proxy_networks,
-            )
-            if resolved_from_chain is not None:
-                return resolved_from_chain
-    return socket_ip
-
-
-def _parse_trusted_proxy_networks(cidrs: list[str]) -> tuple[IPv4Network | IPv6Network, ...]:
-    return tuple(ip_network(cidr, strict=False) for cidr in cidrs)
-
-
-def _resolve_client_ip_from_xff_chain(
-    socket_ip: str,
-    forwarded_for: str,
-    trusted_proxy_networks: tuple[IPv4Network | IPv6Network, ...],
-) -> str | None:
-    hops = [entry.strip() for entry in forwarded_for.split(",")]
-    if not hops:
-        return None
-    if any(not _is_valid_ip(entry) for entry in hops):
-        return None
-
-    chain = [*hops, socket_ip]
-    resolved = socket_ip
-    for index in range(len(chain) - 1, 0, -1):
-        current_proxy = chain[index]
-        previous_hop = chain[index - 1]
-        if not _is_trusted_proxy_source(current_proxy, trusted_proxy_networks):
-            resolved = current_proxy
-            break
-        resolved = previous_hop
-    return resolved
-
-
-def _is_trusted_proxy_source(
-    host: str,
-    trusted_proxy_networks: tuple[IPv4Network | IPv6Network, ...],
-) -> bool:
-    if not trusted_proxy_networks:
-        return False
-    try:
-        source_ip = ip_address(host)
-    except ValueError:
-        return False
-    return any(source_ip in network for network in trusted_proxy_networks)
-
-
-def _is_valid_ip(value: str) -> bool:
-    try:
-        ip_address(value)
-    except ValueError:
-        return False
-    return True

--- a/app/core/middleware/dashboard_auth_proxy.py
+++ b/app/core/middleware/dashboard_auth_proxy.py
@@ -7,7 +7,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from app.core.auth.dashboard_mode import DashboardAuthMode
 from app.core.config.settings import get_settings
-from app.core.middleware.api_firewall import _is_trusted_proxy_source, _parse_trusted_proxy_networks
+from app.core.request_locality import is_trusted_proxy_source, parse_trusted_proxy_networks
 
 
 class DashboardAuthProxyHeaderSanitizerMiddleware:
@@ -16,7 +16,7 @@ class DashboardAuthProxyHeaderSanitizerMiddleware:
         settings = get_settings()
         self._enabled = settings.dashboard_auth_mode == DashboardAuthMode.TRUSTED_HEADER
         self._trust_proxy_headers = settings.firewall_trust_proxy_headers
-        self._trusted_proxy_networks = _parse_trusted_proxy_networks(settings.firewall_trusted_proxy_cidrs)
+        self._trusted_proxy_networks = parse_trusted_proxy_networks(settings.firewall_trusted_proxy_cidrs)
         self._trusted_header_name = settings.dashboard_auth_proxy_header.lower().encode("latin-1")
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
@@ -29,7 +29,7 @@ class DashboardAuthProxyHeaderSanitizerMiddleware:
         if (
             self._trust_proxy_headers
             and client_host
-            and _is_trusted_proxy_source(client_host, self._trusted_proxy_networks)
+            and is_trusted_proxy_source(client_host, self._trusted_proxy_networks)
         ):
             await self.app(scope, receive, send)
             return

--- a/app/core/request_locality.py
+++ b/app/core/request_locality.py
@@ -267,9 +267,11 @@ def _parse_forwarded_node(value: str, *, is_quoted: bool) -> str:
 
 def _parse_forwarded_pair(parameter: str) -> tuple[str, str, bool]:
     name, separator, raw_value = parameter.partition("=")
-    normalized_name = name.strip().lower()
-    value = raw_value.strip()
-    if not separator or not _is_http_token(normalized_name) or not value:
+    if not separator or name != name.strip() or raw_value != raw_value.strip():
+        raise ValueError("Malformed Forwarded parameter")
+    normalized_name = name.lower()
+    value = raw_value
+    if not _is_http_token(normalized_name) or not value:
         raise ValueError("Malformed Forwarded parameter")
     if value.startswith('"'):
         return normalized_name, _unquote_forwarded_value(value), True

--- a/app/core/request_locality.py
+++ b/app/core/request_locality.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from ipaddress import IPv4Network, IPv6Network, ip_address, ip_network
 
+from starlette.datastructures import Headers
 from starlette.requests import HTTPConnection
 
 from app.core.config.settings import get_settings
@@ -31,6 +32,13 @@ def is_local_host(host: str | None) -> bool:
     return host.strip().lower() in _LOCAL_HOSTS
 
 
+def _combined_chain_header(headers: Mapping[str, str], header_name: str) -> str | None:
+    if isinstance(headers, Headers):
+        values = headers.getlist(header_name)
+        return ",".join(values) if values else None
+    return headers.get(header_name)
+
+
 def resolve_connection_client_ip(
     headers: Mapping[str, str],
     socket_ip: str | None,
@@ -38,8 +46,8 @@ def resolve_connection_client_ip(
     trust_proxy_headers: bool,
     trusted_proxy_networks: tuple[IPv4Network | IPv6Network, ...] = (),
 ) -> str | None:
-    if trust_proxy_headers and socket_ip and _is_trusted_proxy_source(socket_ip, trusted_proxy_networks):
-        forwarded_for = headers.get("x-forwarded-for")
+    if trust_proxy_headers and socket_ip and is_trusted_proxy_source(socket_ip, trusted_proxy_networks):
+        forwarded_for = _combined_chain_header(headers, "x-forwarded-for")
         if forwarded_for:
             try:
                 resolved_from_chain = _resolve_client_ip_from_xff_chain(
@@ -58,11 +66,16 @@ def resolve_connection_client_ip(
                 candidate = forwarded_ip.strip()
                 return candidate if _is_valid_ip(candidate) else None
 
-        forwarded = headers.get("forwarded")
+        forwarded = _combined_chain_header(headers, "forwarded")
         if forwarded:
-            resolved = _resolve_forwarded_header_ip(forwarded)
-            if resolved is not None:
-                return resolved
+            try:
+                return _resolve_client_ip_from_forwarded_chain(
+                    socket_ip,
+                    forwarded,
+                    trusted_proxy_networks,
+                )
+            except ValueError:
+                return None
 
         return None
     return socket_ip
@@ -76,26 +89,27 @@ def _resolve_client_ip_from_xff_chain(
     socket_ip: str,
     forwarded_for: str,
     trusted_proxy_networks: tuple[IPv4Network | IPv6Network, ...],
-) -> str | None:
+) -> str:
     hops = [entry.strip() for entry in forwarded_for.split(",")]
-    if not hops:
-        return None
     if any(not _is_valid_ip(entry) for entry in hops):
         raise ValueError("Invalid X-Forwarded-For chain")
+    return _resolve_client_ip_from_hops(socket_ip, hops, trusted_proxy_networks)
 
-    chain = [*hops, socket_ip]
+
+def _resolve_client_ip_from_hops(
+    socket_ip: str,
+    hops: list[str],
+    trusted_proxy_networks: tuple[IPv4Network | IPv6Network, ...],
+) -> str:
     resolved = socket_ip
-    for index in range(len(chain) - 1, 0, -1):
-        current_proxy = chain[index]
-        previous_hop = chain[index - 1]
-        if not _is_trusted_proxy_source(current_proxy, trusted_proxy_networks):
-            resolved = current_proxy
+    for previous_hop in reversed(hops):
+        if not is_trusted_proxy_source(resolved, trusted_proxy_networks):
             break
         resolved = previous_hop
     return resolved
 
 
-def _is_trusted_proxy_source(
+def is_trusted_proxy_source(
     host: str,
     trusted_proxy_networks: tuple[IPv4Network | IPv6Network, ...],
 ) -> bool:
@@ -116,19 +130,130 @@ def _is_valid_ip(value: str) -> bool:
     return True
 
 
-def _resolve_forwarded_header_ip(forwarded: str) -> str | None:
-    for segment in forwarded.split(","):
-        for part in segment.split(";"):
-            item = part.strip()
-            if not item.lower().startswith("for="):
+def _split_forwarded_value(value: str, delimiter: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    in_quotes = False
+    escaped = False
+
+    for index, character in enumerate(value):
+        if escaped:
+            escaped = False
+            continue
+        if in_quotes and character == "\\":
+            escaped = True
+            continue
+        if character == '"':
+            in_quotes = not in_quotes
+            continue
+        if character == delimiter and not in_quotes:
+            part = value[start:index].strip()
+            if not part:
+                raise ValueError("Empty Forwarded header part")
+            parts.append(part)
+            start = index + 1
+
+    if in_quotes or escaped:
+        raise ValueError("Malformed quoted Forwarded header value")
+
+    part = value[start:].strip()
+    if not part:
+        raise ValueError("Empty Forwarded header part")
+    parts.append(part)
+    return parts
+
+
+def _unquote_forwarded_value(raw_value: str) -> str:
+    value = raw_value.strip()
+    if not value:
+        raise ValueError("Empty Forwarded header value")
+    if '"' not in value:
+        return value
+    if len(value) < 2 or not (value.startswith('"') and value.endswith('"')):
+        raise ValueError("Malformed quoted Forwarded header value")
+
+    unescaped: list[str] = []
+    escaped = False
+    for character in value[1:-1]:
+        if escaped:
+            unescaped.append(character)
+            escaped = False
+        elif character == "\\":
+            escaped = True
+        elif character == '"':
+            raise ValueError("Malformed quoted Forwarded header value")
+        else:
+            unescaped.append(character)
+    if escaped:
+        raise ValueError("Malformed quoted Forwarded header value")
+    return "".join(unescaped)
+
+
+def _validate_forwarded_port(port: str) -> None:
+    if not port.isascii() or not port.isdigit() or not 0 <= int(port) <= 65535:
+        raise ValueError("Invalid Forwarded node port")
+
+
+def _parse_forwarded_node(raw_value: str) -> str:
+    value = _unquote_forwarded_value(raw_value)
+    if value.lower() == "unknown" or value.startswith("_"):
+        raise ValueError("Unsupported Forwarded node identifier")
+
+    candidate = value
+    if value.startswith("["):
+        closing_bracket = value.find("]")
+        if closing_bracket == -1:
+            raise ValueError("Invalid bracketed Forwarded node")
+        candidate = value[1:closing_bracket]
+        suffix = value[closing_bracket + 1 :]
+        if suffix:
+            if not suffix.startswith(":"):
+                raise ValueError("Invalid bracketed Forwarded node")
+            _validate_forwarded_port(suffix[1:])
+    else:
+        try:
+            return str(ip_address(value))
+        except ValueError:
+            candidate, separator, port = value.rpartition(":")
+            if not separator or ":" in candidate:
+                raise ValueError("Invalid Forwarded node") from None
+            _validate_forwarded_port(port)
+
+    try:
+        return str(ip_address(candidate))
+    except ValueError:
+        raise ValueError("Invalid Forwarded node") from None
+
+
+def _parse_forwarded_for_chain(forwarded: str) -> list[str]:
+    hops: list[str] = []
+    for element in _split_forwarded_value(forwarded, ","):
+        forwarded_for: str | None = None
+        for parameter in _split_forwarded_value(element, ";"):
+            name, separator, raw_value = parameter.partition("=")
+            if not separator or not name.strip() or not raw_value.strip():
+                raise ValueError("Malformed Forwarded parameter")
+            if name.strip().lower() != "for":
                 continue
-            candidate = item[4:].strip().strip('"')
-            if candidate.startswith("[") and candidate.endswith("]"):
-                candidate = candidate[1:-1]
-            if candidate.startswith("_"):
-                return None
-            return candidate if _is_valid_ip(candidate) else None
-    return None
+            if forwarded_for is not None:
+                raise ValueError("Duplicate Forwarded for parameter")
+            forwarded_for = _parse_forwarded_node(raw_value)
+        if forwarded_for is None:
+            raise ValueError("Missing Forwarded for parameter")
+        hops.append(forwarded_for)
+    return hops
+
+
+def _resolve_client_ip_from_forwarded_chain(
+    socket_ip: str,
+    forwarded: str,
+    trusted_proxy_networks: tuple[IPv4Network | IPv6Network, ...],
+) -> str:
+    return _resolve_client_ip_from_hops(
+        socket_ip,
+        _parse_forwarded_for_chain(forwarded),
+        trusted_proxy_networks,
+    )
 
 
 def _trusted_proxy_networks() -> tuple[IPv4Network | IPv6Network, ...]:

--- a/app/core/request_locality.py
+++ b/app/core/request_locality.py
@@ -17,13 +17,10 @@ _LOCAL_HOSTS = {
 }
 
 _TEST_SERVER_HOSTS = {"testserver", "testclient"}
-_FORWARDED_CLIENT_IP_HEADERS = {
-    "x-forwarded-for",
-    "forwarded",
-    "x-real-ip",
-    "true-client-ip",
-    "cf-connecting-ip",
-}
+FORWARDED_CHAIN_HEADER_NAMES = frozenset({"x-forwarded-for", "forwarded"})
+_SINGLETON_CLIENT_IP_HEADER_NAMES = ("x-real-ip", "true-client-ip", "cf-connecting-ip")
+_FORWARDED_CLIENT_IP_HEADERS = FORWARDED_CHAIN_HEADER_NAMES | frozenset(_SINGLETON_CLIENT_IP_HEADER_NAMES)
+_HTTP_TOKEN_CHARACTERS = frozenset("!#$%&'*+-.^_`|~0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
 
 
 def is_local_host(host: str | None) -> bool:
@@ -45,9 +42,20 @@ def resolve_connection_client_ip(
     *,
     trust_proxy_headers: bool,
     trusted_proxy_networks: tuple[IPv4Network | IPv6Network, ...] = (),
+    allowed_proxy_header_names: frozenset[str] | None = None,
 ) -> str | None:
     if trust_proxy_headers and socket_ip and is_trusted_proxy_source(socket_ip, trusted_proxy_networks):
-        forwarded_for = _combined_chain_header(headers, "x-forwarded-for")
+        allowed_header_names = (
+            _FORWARDED_CLIENT_IP_HEADERS if allowed_proxy_header_names is None else allowed_proxy_header_names
+        )
+        if isinstance(headers, Headers):
+            for header_name in _SINGLETON_CLIENT_IP_HEADER_NAMES:
+                if header_name in allowed_header_names and len(headers.getlist(header_name)) > 1:
+                    return None
+
+        forwarded_for = (
+            _combined_chain_header(headers, "x-forwarded-for") if "x-forwarded-for" in allowed_header_names else None
+        )
         if forwarded_for:
             try:
                 resolved_from_chain = _resolve_client_ip_from_xff_chain(
@@ -60,13 +68,15 @@ def resolve_connection_client_ip(
             if resolved_from_chain is not None:
                 return resolved_from_chain
 
-        for header_name in ("x-real-ip", "true-client-ip", "cf-connecting-ip"):
+        for header_name in _SINGLETON_CLIENT_IP_HEADER_NAMES:
+            if header_name not in allowed_header_names:
+                continue
             forwarded_ip = headers.get(header_name)
             if forwarded_ip:
                 candidate = forwarded_ip.strip()
                 return candidate if _is_valid_ip(candidate) else None
 
-        forwarded = _combined_chain_header(headers, "forwarded")
+        forwarded = _combined_chain_header(headers, "forwarded") if "forwarded" in allowed_header_names else None
         if forwarded:
             try:
                 return _resolve_client_ip_from_forwarded_chain(
@@ -163,12 +173,25 @@ def _split_forwarded_value(value: str, delimiter: str) -> list[str]:
     return parts
 
 
+def _is_http_token(value: str) -> bool:
+    return bool(value) and all(character in _HTTP_TOKEN_CHARACTERS for character in value)
+
+
+def _is_forwarded_quoted_character(character: str, *, escaped: bool) -> bool:
+    code_point = ord(character)
+    if escaped:
+        return code_point == 0x09 or code_point == 0x20 or 0x21 <= code_point <= 0x7E or 0x80 <= code_point <= 0xFF
+    return (
+        code_point == 0x09
+        or code_point in (0x20, 0x21)
+        or 0x23 <= code_point <= 0x5B
+        or 0x5D <= code_point <= 0x7E
+        or 0x80 <= code_point <= 0xFF
+    )
+
+
 def _unquote_forwarded_value(raw_value: str) -> str:
     value = raw_value.strip()
-    if not value:
-        raise ValueError("Empty Forwarded header value")
-    if '"' not in value:
-        return value
     if len(value) < 2 or not (value.startswith('"') and value.endswith('"')):
         raise ValueError("Malformed quoted Forwarded header value")
 
@@ -176,11 +199,13 @@ def _unquote_forwarded_value(raw_value: str) -> str:
     escaped = False
     for character in value[1:-1]:
         if escaped:
+            if not _is_forwarded_quoted_character(character, escaped=True):
+                raise ValueError("Malformed quoted Forwarded header value")
             unescaped.append(character)
             escaped = False
         elif character == "\\":
             escaped = True
-        elif character == '"':
+        elif character == '"' or not _is_forwarded_quoted_character(character, escaped=False):
             raise ValueError("Malformed quoted Forwarded header value")
         else:
             unescaped.append(character)
@@ -190,21 +215,27 @@ def _unquote_forwarded_value(raw_value: str) -> str:
 
 
 def _validate_forwarded_port(port: str) -> None:
-    if not port.isascii() or not port.isdigit() or not 0 <= int(port) <= 65535:
+    if not 1 <= len(port) <= 5 or not port.isascii() or not port.isdigit():
+        raise ValueError("Invalid Forwarded node port")
+    if not 0 <= int(port) <= 65535:
         raise ValueError("Invalid Forwarded node port")
 
 
-def _parse_forwarded_node(raw_value: str) -> str:
-    value = _unquote_forwarded_value(raw_value)
+def _parse_forwarded_node(value: str, *, is_quoted: bool) -> str:
     if value.lower() == "unknown" or value.startswith("_"):
         raise ValueError("Unsupported Forwarded node identifier")
 
     candidate = value
-    if value.startswith("["):
+    expects_ipv6 = value.startswith("[")
+    if expects_ipv6:
+        if not is_quoted:
+            raise ValueError("Bracketed Forwarded nodes must be quoted")
         closing_bracket = value.find("]")
         if closing_bracket == -1:
             raise ValueError("Invalid bracketed Forwarded node")
         candidate = value[1:closing_bracket]
+        if "%" in candidate:
+            raise ValueError("Scoped IPv6 Forwarded nodes are unsupported")
         suffix = value[closing_bracket + 1 :]
         if suffix:
             if not suffix.startswith(":"):
@@ -212,32 +243,53 @@ def _parse_forwarded_node(raw_value: str) -> str:
             _validate_forwarded_port(suffix[1:])
     else:
         try:
-            return str(ip_address(value))
+            parsed_ip = ip_address(value)
         except ValueError:
+            if not is_quoted:
+                raise ValueError("Forwarded nodes with ports must be quoted") from None
             candidate, separator, port = value.rpartition(":")
             if not separator or ":" in candidate:
                 raise ValueError("Invalid Forwarded node") from None
             _validate_forwarded_port(port)
+        else:
+            if parsed_ip.version != 4:
+                raise ValueError("IPv6 Forwarded nodes must be bracketed")
+            return str(parsed_ip)
 
     try:
-        return str(ip_address(candidate))
+        parsed_ip = ip_address(candidate)
     except ValueError:
         raise ValueError("Invalid Forwarded node") from None
+    if (parsed_ip.version == 6) != expects_ipv6:
+        raise ValueError("Invalid Forwarded node address family")
+    return str(parsed_ip)
+
+
+def _parse_forwarded_pair(parameter: str) -> tuple[str, str, bool]:
+    name, separator, raw_value = parameter.partition("=")
+    normalized_name = name.strip().lower()
+    value = raw_value.strip()
+    if not separator or not _is_http_token(normalized_name) or not value:
+        raise ValueError("Malformed Forwarded parameter")
+    if value.startswith('"'):
+        return normalized_name, _unquote_forwarded_value(value), True
+    if not _is_http_token(value):
+        raise ValueError("Malformed Forwarded parameter value")
+    return normalized_name, value, False
 
 
 def _parse_forwarded_for_chain(forwarded: str) -> list[str]:
     hops: list[str] = []
     for element in _split_forwarded_value(forwarded, ","):
         forwarded_for: str | None = None
+        seen_parameter_names: set[str] = set()
         for parameter in _split_forwarded_value(element, ";"):
-            name, separator, raw_value = parameter.partition("=")
-            if not separator or not name.strip() or not raw_value.strip():
-                raise ValueError("Malformed Forwarded parameter")
-            if name.strip().lower() != "for":
-                continue
-            if forwarded_for is not None:
-                raise ValueError("Duplicate Forwarded for parameter")
-            forwarded_for = _parse_forwarded_node(raw_value)
+            name, value, is_quoted = _parse_forwarded_pair(parameter)
+            if name in seen_parameter_names:
+                raise ValueError("Duplicate Forwarded parameter")
+            seen_parameter_names.add(name)
+            if name == "for":
+                forwarded_for = _parse_forwarded_node(value, is_quoted=is_quoted)
         if forwarded_for is None:
             raise ValueError("Missing Forwarded for parameter")
         hops.append(forwarded_for)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -73,7 +73,6 @@ from app.core.exceptions import (
     ProxyUpstreamError,
 )
 from app.core.metrics.prometheus import PROMETHEUS_AVAILABLE, bridge_public_contract_error_total
-from app.core.middleware.api_firewall import _parse_trusted_proxy_networks, resolve_connection_client_ip
 from app.core.openai.chat_requests import ChatCompletionsRequest
 from app.core.openai.chat_responses import (
     ChatCompletion,
@@ -103,7 +102,11 @@ from app.core.openai.requests import (
     normalize_tool_type,
 )
 from app.core.openai.v1_requests import V1ResponsesCompactRequest, V1ResponsesRequest
-from app.core.request_locality import resolve_request_client_host
+from app.core.request_locality import (
+    parse_trusted_proxy_networks,
+    resolve_connection_client_ip,
+    resolve_request_client_host,
+)
 from app.core.resilience.overload import is_local_overload_error_code, merge_retry_after_headers
 from app.core.runtime_logging import log_error_response
 from app.core.types import JsonValue
@@ -5689,7 +5692,7 @@ async def _websocket_firewall_denial_response(websocket: WebSocket) -> JSONRespo
         websocket.headers,
         websocket.client.host if websocket.client else None,
         trust_proxy_headers=settings.firewall_trust_proxy_headers,
-        trusted_proxy_networks=_parse_trusted_proxy_networks(settings.firewall_trusted_proxy_cidrs),
+        trusted_proxy_networks=parse_trusted_proxy_networks(settings.firewall_trusted_proxy_cidrs),
     )
     async with get_background_session() as session:
         repository = cast(FirewallRepositoryPort, FirewallRepository(session))

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -103,6 +103,7 @@ from app.core.openai.requests import (
 )
 from app.core.openai.v1_requests import V1ResponsesCompactRequest, V1ResponsesRequest
 from app.core.request_locality import (
+    FORWARDED_CHAIN_HEADER_NAMES,
     parse_trusted_proxy_networks,
     resolve_connection_client_ip,
     resolve_request_client_host,
@@ -5693,6 +5694,7 @@ async def _websocket_firewall_denial_response(websocket: WebSocket) -> JSONRespo
         websocket.client.host if websocket.client else None,
         trust_proxy_headers=settings.firewall_trust_proxy_headers,
         trusted_proxy_networks=parse_trusted_proxy_networks(settings.firewall_trusted_proxy_cidrs),
+        allowed_proxy_header_names=FORWARDED_CHAIN_HEADER_NAMES,
     )
     async with get_background_session() as session:
         repository = cast(FirewallRepositoryPort, FirewallRepository(session))

--- a/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/design.md
+++ b/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/design.md
@@ -1,0 +1,72 @@
+## Context
+
+`resolve_connection_client_ip()` is the shared trust boundary for firewall decisions, unauthenticated proxy access, dashboard bootstrap, session lifetime locality, and request metadata. Its `X-Forwarded-For` path already walks an appended chain from the trusted socket peer toward the client, but its RFC 7239 `Forwarded` fallback returns the first `for=` parameter. Because compliant proxies append elements, the first element remains attacker-controlled when a client supplies the initial header.
+
+`api_firewall.py` also defines a second `resolve_connection_client_ip()` and CIDR parser. That local function shadows the shared resolver for HTTP middleware and is imported by the WebSocket firewall path, so fixing only `request_locality.py` would leave the firewall trust boundary vulnerable and preserve semantic drift.
+
+The resolver must remain fail-closed: a partial or ambiguous chain cannot establish a trustworthy client identity. No external parser dependency is justified for the small IP-only subset consumed here.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Apply the same right-to-left trusted-hop algorithm to `Forwarded` and `X-Forwarded-For`.
+- Parse comma-separated elements and semicolon-separated parameters without treating delimiters inside quoted strings as structure.
+- Accept valid IP node identifiers used by deployed proxies: IPv4, bracketed IPv6, and optional numeric ports.
+- Reject incomplete, duplicate, obfuscated, unknown, malformed, or non-IP `for=` hops as one invalid chain.
+- Remove the firewall-local resolver and migrate firewall, WebSocket, and trusted-header sanitizer callers to the shared implementation.
+- Preserve existing header precedence and trusted-socket gating.
+
+**Non-Goals:**
+
+- Trust `by=`, `host=`, or `proto=` parameters.
+- Resolve obfuscated node identifiers or hostnames.
+- Change trusted-proxy configuration, firewall policy, or header precedence.
+- Add a general-purpose RFC 7239 library.
+
+## Decisions
+
+### Parse the complete `Forwarded` chain before resolving it
+
+Each comma-delimited forwarded element must contain exactly one valid `for=` parameter. A quote-aware splitter rejects unmatched quotes and dangling escapes; the node parser then extracts an IP and discards an optional valid port. Any invalid element invalidates the entire header.
+
+Alternative: skip malformed elements and use the remaining IPs. Rejected because deleting an attacker-controlled or intermediary hop changes chain ownership and can move a spoofed value into the trusted position.
+
+### Resolve from the socket inward
+
+Starting with the socket peer, consume parsed hops right to left. Advance past a hop only while the current peer belongs to a configured trusted CIDR; return the first hop reached from an untrusted peer. This matches append semantics and the existing `X-Forwarded-For` trust model.
+
+Alternative: select the leftmost or rightmost header value unconditionally. Rejected because neither distinguishes attacker-supplied values from values appended by trusted intermediaries.
+
+### Preserve every repeated chain-header field
+
+When the runtime header object exposes `getlist()`, join all values in arrival order with commas before parsing. Retain `Mapping[str, str]` support by treating its single value as the complete chain. Apply this to both `Forwarded` and `X-Forwarded-For` so the shared trust model cannot diverge at the field-normalization boundary.
+
+Alternative: use `headers.get()` and assume intermediaries combine repeated fields. Rejected because RFC 7239 explicitly permits multiple `Forwarded` fields and Starlette returns only the first duplicate from `get()`.
+
+### Share only the chain trust algorithm
+
+Keep format-specific parsing separate, then pass both IP lists to a small common right-to-left resolver. This removes the semantic drift without introducing a general header abstraction.
+
+Alternative: translate `Forwarded` into an `X-Forwarded-For` string. Rejected because serializing parsed data back into another wire format adds ambiguity and avoidable work.
+
+### Consolidate every firewall caller on the shared resolver
+
+Delete the firewall-local client-chain, CIDR, and trusted-source implementations. HTTP firewall middleware and the WebSocket firewall path import the shared resolver and CIDR parser; trusted-header sanitization imports the shared trusted-source predicate.
+
+Alternative: patch both implementations in parallel. Rejected because duplicated security logic already drifted in header formats, malformed-chain behavior, and repeated-field handling.
+
+## Risks / Trade-offs
+
+- [Previously accepted malformed or partial `Forwarded` values stop resolving] → This is intentional fail-closed behavior at an authentication boundary; valid single-hop values remain supported.
+- [Some proxies emit nonstandard hostnames or obfuscated identifiers] → Continue rejecting them because configured trust is IP/CIDR-based and cannot authenticate those identifiers.
+- [Parser edge cases around quoting] → Cover escaped quoted strings, unmatched quotes, duplicate/missing `for=`, IPv4 ports, and bracketed IPv6 ports with focused tests.
+- [Shared resolver behavior affects several callers] → Preserve socket trust gating and header precedence, then exercise dashboard bootstrap and firewall-facing ASGI headers plus the existing firewall resolver suite.
+
+## Migration Plan
+
+Deploy as a code-only security correction; no data or configuration migration is required. Operators with valid proxy-generated `Forwarded` chains retain behavior. Rollback is the branch commit reversal.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/design.md
+++ b/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/design.md
@@ -44,6 +44,14 @@ When the runtime header object exposes `getlist()`, join all values in arrival o
 
 Alternative: use `headers.get()` and assume intermediaries combine repeated fields. Rejected because RFC 7239 explicitly permits multiple `Forwarded` fields and Starlette returns only the first duplicate from `get()`.
 
+### Reject repeated singleton identity fields
+
+Unlike `Forwarded` and `X-Forwarded-For`, `X-Real-IP`, `True-Client-IP`, and `CF-Connecting-IP` each assert one client identity rather than an ordered chain. When the runtime exposes repeated fields, the shared resolver rejects more than one value instead of accepting Starlette's first-value `get()` result.
+
+Singleton repetition is validated before header precedence is applied. A valid higher-priority `X-Forwarded-For` chain therefore cannot hide an ambiguous repeated singleton field from general trusted-proxy resolution; firewall callers remain unaffected because their explicit header policy excludes singleton fields.
+
+Alternative: accept the first or last singleton field. Rejected because a client and proxy can each supply one field, and field order alone does not prove which party owns either value.
+
 ### Share only the chain trust algorithm
 
 Keep format-specific parsing separate, then pass both IP lists to a small common right-to-left resolver. This removes the semantic drift without introducing a general header abstraction.
@@ -54,13 +62,15 @@ Alternative: translate `Forwarded` into an `X-Forwarded-For` string. Rejected be
 
 Delete the firewall-local client-chain, CIDR, and trusted-source implementations. HTTP firewall middleware and the WebSocket firewall path import the shared resolver and CIDR parser; trusted-header sanitization imports the shared trusted-source predicate.
 
+The shared resolver accepts an explicit allowed-header policy. Firewall callers pass only `X-Forwarded-For` and `Forwarded`; general request-locality callers retain their existing singleton `X-Real-IP`, `True-Client-IP`, and `CF-Connecting-IP` fallbacks. This keeps consolidation from silently broadening the firewall trust contract.
+
 Alternative: patch both implementations in parallel. Rejected because duplicated security logic already drifted in header formats, malformed-chain behavior, and repeated-field handling.
 
 ## Risks / Trade-offs
 
 - [Previously accepted malformed or partial `Forwarded` values stop resolving] → This is intentional fail-closed behavior at an authentication boundary; valid single-hop values remain supported.
 - [Some proxies emit nonstandard hostnames or obfuscated identifiers] → Continue rejecting them because configured trust is IP/CIDR-based and cannot authenticate those identifiers.
-- [Parser edge cases around quoting] → Cover escaped quoted strings, unmatched quotes, duplicate/missing `for=`, IPv4 ports, and bracketed IPv6 ports with focused tests.
+- [Parser edge cases around quoting] → Cover escaped quoted strings, unmatched quotes, duplicate parameters, token and quoted-string character syntax, mandatory quoting for IPv6 and port-bearing nodes, numeric port bounds, and bracketed address-family validation with focused tests.
 - [Shared resolver behavior affects several callers] → Preserve socket trust gating and header precedence, then exercise dashboard bootstrap and firewall-facing ASGI headers plus the existing firewall resolver suite.
 
 ## Migration Plan

--- a/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/proposal.md
+++ b/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Trusted-proxy client resolution validates `X-Forwarded-For` from right to left, but accepts the first `for=` value in an RFC 7239 `Forwarded` header. A client can therefore pre-seed an appended `Forwarded` chain with a loopback address and be misclassified as local, bypassing remote-only dashboard bootstrap and proxy-auth protections.
+
+## What Changes
+
+- Parse every RFC 7239 `Forwarded` hop and resolve the effective client from right to left using the configured trusted-proxy CIDRs.
+- Join every repeated `Forwarded` or `X-Forwarded-For` field value in arrival order before parsing the effective chain.
+- Fail closed when any hop is missing, obfuscated, malformed, or otherwise cannot establish a complete IP chain.
+- Preserve support for valid IPv4 and bracketed IPv6 `for=` values, including optional ports.
+- Add regression coverage for attacker-preseeded chains, trusted multi-proxy chains, malformed chains, and IPv6 values.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `admin-auth`: Require trusted-proxy client identity and local-request classification to resist spoofed or malformed appended `Forwarded` chains.
+- `api-firewall`: Require firewall client resolution to use the same complete, duplicate-field-safe trusted-proxy chain rules.
+
+## Impact
+
+- Affected code: shared request-locality resolution, API firewall middleware, trusted-header sanitization, WebSocket firewall resolution, and focused tests.
+- Affected behavior: firewall allowlist identity, dashboard bootstrap, unauthenticated proxy access checks, session lifetime locality, and request metadata that rely on trusted client IP resolution.
+- Dependencies and persistent schema: unchanged.

--- a/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/proposal.md
+++ b/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/proposal.md
@@ -7,6 +7,7 @@ Trusted-proxy client resolution validates `X-Forwarded-For` from right to left, 
 - Parse every RFC 7239 `Forwarded` hop and resolve the effective client from right to left using the configured trusted-proxy CIDRs.
 - Join every repeated `Forwarded` or `X-Forwarded-For` field value in arrival order before parsing the effective chain.
 - Fail closed when any hop is missing, obfuscated, malformed, or otherwise cannot establish a complete IP chain.
+- Reject repeated singleton client-IP fields instead of trusting whichever value the HTTP runtime exposes first.
 - Preserve support for valid IPv4 and bracketed IPv6 `for=` values, including optional ports.
 - Add regression coverage for attacker-preseeded chains, trusted multi-proxy chains, malformed chains, and IPv6 values.
 

--- a/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/specs/admin-auth/spec.md
+++ b/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/specs/admin-auth/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Trusted proxy client identity resists appended Forwarded chain spoofing
+
+When proxy-header trust is enabled and the socket peer belongs to a configured trusted proxy CIDR, the system MUST resolve an RFC 7239 `Forwarded` client chain from right to left. It MUST advance toward an earlier `for=` hop only while the immediately downstream peer is trusted. Every forwarded element MUST contain exactly one valid IP `for=` node, optionally with a valid port; otherwise the entire `Forwarded` value MUST fail closed and MUST NOT classify the request as local.
+
+#### Scenario: Client-preseeded loopback value cannot bypass remote bootstrap protection
+
+- **WHEN** a trusted socket proxy appends `for=203.0.113.24` to a client-supplied `Forwarded: for=127.0.0.1` value
+- **THEN** the resolved client is `203.0.113.24`
+- **AND** the request is not classified as local
+
+#### Scenario: Proxy appends a separate Forwarded field
+
+- **WHEN** a client supplies `Forwarded: for=127.0.0.1`
+- **AND** a trusted socket proxy appends a second `Forwarded: for=203.0.113.24` field
+- **THEN** the system combines both field values in arrival order
+- **AND** resolves the client as `203.0.113.24`
+- **AND** does not classify the request as local
+
+#### Scenario: Complete trusted multi-proxy chain resolves the originating client
+
+- **WHEN** the socket peer and each downstream proxy hop belong to configured trusted proxy CIDRs
+- **AND** the `Forwarded` elements contain one valid IP `for=` node per hop
+- **THEN** the system resolves the originating client IP from the earliest reachable element
+
+#### Scenario: Malformed or incomplete Forwarded chain fails closed
+
+- **WHEN** any `Forwarded` element has a missing, duplicate, obfuscated, unknown, or malformed `for=` node
+- **THEN** trusted proxy client resolution returns no client IP from that header
+- **AND** the request is not classified as local
+
+#### Scenario: Bracketed IPv6 node with port is resolved
+
+- **WHEN** a trusted socket proxy supplies a valid quoted bracketed IPv6 `for=` node with a numeric port
+- **THEN** the system resolves the IPv6 address without the brackets or port

--- a/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/specs/admin-auth/spec.md
+++ b/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/specs/admin-auth/spec.md
@@ -2,7 +2,9 @@
 
 ### Requirement: Trusted proxy client identity resists appended Forwarded chain spoofing
 
-When proxy-header trust is enabled and the socket peer belongs to a configured trusted proxy CIDR, the system MUST resolve an RFC 7239 `Forwarded` client chain from right to left. It MUST advance toward an earlier `for=` hop only while the immediately downstream peer is trusted. Every forwarded element MUST contain exactly one valid IP `for=` node, optionally with a valid port; otherwise the entire `Forwarded` value MUST fail closed and MUST NOT classify the request as local.
+When proxy-header trust is enabled and the socket peer belongs to a configured trusted proxy CIDR, the system MUST resolve an RFC 7239 `Forwarded` client chain from right to left. It MUST advance toward an earlier `for=` hop only while the immediately downstream peer is trusted. Every forwarded element MUST contain exactly one valid IP `for=` node, optionally with a valid port. Every parameter name and value MUST follow RFC 7239 token or quoted-string syntax, and no parameter name may repeat within an element. IPv6 nodes MUST be bracketed and quoted, and every node carrying a port MUST be quoted; numeric ports MUST contain one to five ASCII digits and fall within `0..65535`. Otherwise the entire `Forwarded` value MUST fail closed and MUST NOT classify the request as local.
+
+`X-Real-IP`, `True-Client-IP`, and `CF-Connecting-IP` MUST each occur at most once. Repetition of any such singleton client-IP header MUST return no resolved client IP and MUST NOT classify the request as local.
 
 #### Scenario: Client-preseeded loopback value cannot bypass remote bootstrap protection
 
@@ -30,7 +32,19 @@ When proxy-header trust is enabled and the socket peer belongs to a configured t
 - **THEN** trusted proxy client resolution returns no client IP from that header
 - **AND** the request is not classified as local
 
+#### Scenario: Unquoted IPv6 or port-bearing node fails closed
+
+- **WHEN** a `Forwarded` element contains an unquoted bracketed IPv6 node or an unquoted node with a port
+- **THEN** trusted proxy client resolution returns no client IP from that header
+- **AND** the request is not classified as local
+
 #### Scenario: Bracketed IPv6 node with port is resolved
 
 - **WHEN** a trusted socket proxy supplies a valid quoted bracketed IPv6 `for=` node with a numeric port
 - **THEN** the system resolves the IPv6 address without the brackets or port
+
+#### Scenario: Repeated singleton client-IP header fails closed
+
+- **WHEN** a trusted socket request contains more than one field for `X-Real-IP`, `True-Client-IP`, or `CF-Connecting-IP`
+- **THEN** trusted proxy client resolution returns no client IP
+- **AND** the request is not classified as local

--- a/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/specs/api-firewall/spec.md
+++ b/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/specs/api-firewall/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Trusted proxy header handling
 
-Firewall IP resolution MUST use forwarded client headers only when proxy-header trust is enabled and the socket source IP belongs to the configured trusted proxy CIDR list. `X-Forwarded-For` and RFC 7239 `Forwarded` values MUST be resolved from right to left through one shared trusted-hop algorithm. Every repeated field value MUST be combined in arrival order before resolution. A missing, malformed, ambiguous, obfuscated, unknown, or non-IP trusted-proxy chain MUST return no resolved client IP so an active firewall allowlist fails closed.
+Firewall IP resolution MUST use forwarded client headers only when proxy-header trust is enabled and the socket source IP belongs to the configured trusted proxy CIDR list. `X-Forwarded-For` and RFC 7239 `Forwarded` values MUST be resolved from right to left through one shared trusted-hop algorithm. Other client-IP headers, including `X-Real-IP`, `True-Client-IP`, and `CF-Connecting-IP`, MUST NOT affect firewall identity. Every repeated field value MUST be combined in arrival order before resolution. A missing, malformed, ambiguous, obfuscated, unknown, or non-IP trusted-proxy chain MUST return no resolved client IP so an active firewall allowlist fails closed.
 
 #### Scenario: Trusted proxy chain
 
@@ -17,6 +17,12 @@ Firewall IP resolution MUST use forwarded client headers only when proxy-header 
 - **AND** a trusted socket proxy appends the actual remote client in a second field
 - **THEN** the firewall combines both fields in arrival order
 - **AND** resolves the actual remote client rather than the spoofed loopback value
+
+#### Scenario: Singleton proxy headers do not authorize firewall access
+
+- **WHEN** a trusted socket proxy supplies only `X-Real-IP`, `True-Client-IP`, or `CF-Connecting-IP`
+- **THEN** firewall client resolution returns no client IP
+- **AND** an active firewall allowlist denies the request
 
 #### Scenario: Untrusted proxy source
 

--- a/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/specs/api-firewall/spec.md
+++ b/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/specs/api-firewall/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: Trusted proxy header handling
+
+Firewall IP resolution MUST use forwarded client headers only when proxy-header trust is enabled and the socket source IP belongs to the configured trusted proxy CIDR list. `X-Forwarded-For` and RFC 7239 `Forwarded` values MUST be resolved from right to left through one shared trusted-hop algorithm. Every repeated field value MUST be combined in arrival order before resolution. A missing, malformed, ambiguous, obfuscated, unknown, or non-IP trusted-proxy chain MUST return no resolved client IP so an active firewall allowlist fails closed.
+
+#### Scenario: Trusted proxy chain
+
+- **WHEN** `firewall_trust_proxy_headers=true`
+- **AND** the source socket IP and downstream proxy hops match configured trusted CIDRs
+- **AND** a valid `X-Forwarded-For` or `Forwarded` chain is present
+- **THEN** the firewall resolves the originating client by traversing the chain from right to left
+
+#### Scenario: Trusted proxy appends a separate field
+
+- **WHEN** a client supplies a spoofed loopback value in the first `X-Forwarded-For` or `Forwarded` field
+- **AND** a trusted socket proxy appends the actual remote client in a second field
+- **THEN** the firewall combines both fields in arrival order
+- **AND** resolves the actual remote client rather than the spoofed loopback value
+
+#### Scenario: Untrusted proxy source
+
+- **WHEN** the source socket IP is outside the configured trusted CIDR list
+- **THEN** the firewall ignores forwarded client headers
+- **AND** uses the socket client IP
+
+#### Scenario: Trusted source supplies no complete valid chain
+
+- **WHEN** proxy-header trust is enabled and the source socket IP is trusted
+- **AND** the forwarded client chain is missing or contains an invalid hop
+- **THEN** firewall client resolution returns no client IP
+- **AND** an active firewall allowlist denies the request

--- a/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/tasks.md
+++ b/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/tasks.md
@@ -4,6 +4,9 @@
 - [x] 1.2 Resolve parsed `Forwarded` and `X-Forwarded-For` hops through one right-to-left trusted-proxy algorithm
 - [x] 1.3 Consume every repeated `Forwarded` and `X-Forwarded-For` field as one ordered chain while retaining plain mapping support
 - [x] 1.4 Remove the firewall-local resolver and migrate HTTP firewall, WebSocket firewall, and trusted-header sanitizer callers to shared locality helpers
+- [x] 1.5 Preserve the firewall's narrower `X-Forwarded-For` and `Forwarded` trust contract through an explicit shared-resolver header policy
+- [x] 1.6 Enforce RFC 7239 quoting and address-family syntax for IPv6 and port-bearing nodes with bounded numeric ports
+- [x] 1.7 Validate every Forwarded parameter's token or quoted-string syntax and reject repeated parameter names
 
 ## 2. Regression Evidence
 
@@ -11,4 +14,8 @@
 - [x] 2.2 Add an integration regression proving a preseeded loopback `Forwarded` value cannot authorize remote dashboard bootstrap
 - [x] 2.3 Add an ASGI-level regression for a proxy-appended second `Forwarded` field and duplicate `X-Forwarded-For` coverage
 - [x] 2.4 Update firewall resolver regressions for duplicate fields and fail-closed missing or malformed trusted-proxy chains
-- [x] 2.5 Run the original exploit reproduction, focused tests, diagnostics, and strict OpenSpec validation
+- [x] 2.5 Add regressions proving firewall callers reject singleton client-IP headers while general locality callers retain them
+- [x] 2.6 Add fail-closed regressions for unquoted ports, unquoted or bare IPv6, scoped IPv6, bracketed IPv4, and overlong ports
+- [x] 2.7 Add fail-closed regressions for duplicate non-`for` parameters, invalid tokens, and control characters
+- [x] 2.8 Run the original exploit reproduction, focused tests, diagnostics, and strict OpenSpec validation
+- [x] 2.9 Add unit and dashboard-bootstrap regressions proving repeated singleton client-IP fields fail closed even alongside a valid higher-priority chain

--- a/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/tasks.md
+++ b/openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/tasks.md
@@ -1,0 +1,14 @@
+## 1. Trusted Forwarded Resolution
+
+- [x] 1.1 Parse complete RFC 7239 `Forwarded` chains into validated IP hops and reject ambiguous or malformed elements
+- [x] 1.2 Resolve parsed `Forwarded` and `X-Forwarded-For` hops through one right-to-left trusted-proxy algorithm
+- [x] 1.3 Consume every repeated `Forwarded` and `X-Forwarded-For` field as one ordered chain while retaining plain mapping support
+- [x] 1.4 Remove the firewall-local resolver and migrate HTTP firewall, WebSocket firewall, and trusted-header sanitizer callers to shared locality helpers
+
+## 2. Regression Evidence
+
+- [x] 2.1 Add focused resolver tests for preseeded chains, trusted chains, malformed elements, quoted delimiters, and IP nodes with ports
+- [x] 2.2 Add an integration regression proving a preseeded loopback `Forwarded` value cannot authorize remote dashboard bootstrap
+- [x] 2.3 Add an ASGI-level regression for a proxy-appended second `Forwarded` field and duplicate `X-Forwarded-For` coverage
+- [x] 2.4 Update firewall resolver regressions for duplicate fields and fail-closed missing or malformed trusted-proxy chains
+- [x] 2.5 Run the original exploit reproduction, focused tests, diagnostics, and strict OpenSpec validation

--- a/openspec/specs/admin-auth/context.md
+++ b/openspec/specs/admin-auth/context.md
@@ -39,6 +39,8 @@ Set `CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN=<value>` as an environment variable befo
 
 Requests from localhost (127.0.0.1, ::1) bypass bootstrap entirely — no token or password needed for initial setup. This is handled by `is_local_request()` in `app/core/request_locality.py` and checked in both the session endpoint and the auth guard.
 
+Behind a trusted proxy, locality comes from the resolved client identity rather than from header presence alone. Chain headers preserve repeated fields because they form one ordered route; singleton identity headers (`X-Real-IP`, `True-Client-IP`, and `CF-Connecting-IP`) must appear once. Repetition is ambiguous and fails closed so a client-preseeded loopback field cannot win a first-value lookup.
+
 ### Threat Model
 
 - **Token in logs**: Acceptable risk (same pattern as Grafana/GitLab/Portainer). `docker logs` requires container access. Token is one-time — useless after password is set.

--- a/openspec/specs/admin-auth/spec.md
+++ b/openspec/specs/admin-auth/spec.md
@@ -189,7 +189,9 @@ Mutations to security-bearing dashboard settings (dashboard password hash, guest
 
 ### Requirement: Trusted proxy client identity resists appended Forwarded chain spoofing
 
-When proxy-header trust is enabled and the socket peer belongs to a configured trusted proxy CIDR, the system MUST resolve an RFC 7239 `Forwarded` client chain from right to left. It MUST advance toward an earlier `for=` hop only while the immediately downstream peer is trusted. Every forwarded element MUST contain exactly one valid IP `for=` node, optionally with a valid port; otherwise the entire `Forwarded` value MUST fail closed and MUST NOT classify the request as local.
+When proxy-header trust is enabled and the socket peer belongs to a configured trusted proxy CIDR, the system MUST resolve an RFC 7239 `Forwarded` client chain from right to left. It MUST advance toward an earlier `for=` hop only while the immediately downstream peer is trusted. Every forwarded element MUST contain exactly one valid IP `for=` node, optionally with a valid port. Every parameter name and value MUST follow RFC 7239 token or quoted-string syntax, and no parameter name may repeat within an element. IPv6 nodes MUST be bracketed and quoted, and every node carrying a port MUST be quoted; numeric ports MUST contain one to five ASCII digits and fall within `0..65535`. Otherwise the entire `Forwarded` value MUST fail closed and MUST NOT classify the request as local.
+
+`X-Real-IP`, `True-Client-IP`, and `CF-Connecting-IP` MUST each occur at most once. Repetition of any such singleton client-IP header MUST return no resolved client IP and MUST NOT classify the request as local.
 
 #### Scenario: Client-preseeded loopback value cannot bypass remote bootstrap protection
 
@@ -217,7 +219,19 @@ When proxy-header trust is enabled and the socket peer belongs to a configured t
 - **THEN** trusted proxy client resolution returns no client IP from that header
 - **AND** the request is not classified as local
 
+#### Scenario: Unquoted IPv6 or port-bearing node fails closed
+
+- **WHEN** a `Forwarded` element contains an unquoted bracketed IPv6 node or an unquoted node with a port
+- **THEN** trusted proxy client resolution returns no client IP from that header
+- **AND** the request is not classified as local
+
 #### Scenario: Bracketed IPv6 node with port is resolved
 
 - **WHEN** a trusted socket proxy supplies a valid quoted bracketed IPv6 `for=` node with a numeric port
 - **THEN** the system resolves the IPv6 address without the brackets or port
+
+#### Scenario: Repeated singleton client-IP header fails closed
+
+- **WHEN** a trusted socket request contains more than one field for `X-Real-IP`, `True-Client-IP`, or `CF-Connecting-IP`
+- **THEN** trusted proxy client resolution returns no client IP
+- **AND** the request is not classified as local

--- a/openspec/specs/admin-auth/spec.md
+++ b/openspec/specs/admin-auth/spec.md
@@ -187,3 +187,37 @@ Mutations to security-bearing dashboard settings (dashboard password hash, guest
 - **THEN** after replica B's next poll cycle, replica B's settings cache reflects the new password hash and API-key auth toggle
 - **AND** replica B rejects keyless proxy requests and unauthenticated dashboard requests without waiting for the settings TTL to expire
 
+### Requirement: Trusted proxy client identity resists appended Forwarded chain spoofing
+
+When proxy-header trust is enabled and the socket peer belongs to a configured trusted proxy CIDR, the system MUST resolve an RFC 7239 `Forwarded` client chain from right to left. It MUST advance toward an earlier `for=` hop only while the immediately downstream peer is trusted. Every forwarded element MUST contain exactly one valid IP `for=` node, optionally with a valid port; otherwise the entire `Forwarded` value MUST fail closed and MUST NOT classify the request as local.
+
+#### Scenario: Client-preseeded loopback value cannot bypass remote bootstrap protection
+
+- **WHEN** a trusted socket proxy appends `for=203.0.113.24` to a client-supplied `Forwarded: for=127.0.0.1` value
+- **THEN** the resolved client is `203.0.113.24`
+- **AND** the request is not classified as local
+
+#### Scenario: Proxy appends a separate Forwarded field
+
+- **WHEN** a client supplies `Forwarded: for=127.0.0.1`
+- **AND** a trusted socket proxy appends a second `Forwarded: for=203.0.113.24` field
+- **THEN** the system combines both field values in arrival order
+- **AND** resolves the client as `203.0.113.24`
+- **AND** does not classify the request as local
+
+#### Scenario: Complete trusted multi-proxy chain resolves the originating client
+
+- **WHEN** the socket peer and each downstream proxy hop belong to configured trusted proxy CIDRs
+- **AND** the `Forwarded` elements contain one valid IP `for=` node per hop
+- **THEN** the system resolves the originating client IP from the earliest reachable element
+
+#### Scenario: Malformed or incomplete Forwarded chain fails closed
+
+- **WHEN** any `Forwarded` element has a missing, duplicate, obfuscated, unknown, or malformed `for=` node
+- **THEN** trusted proxy client resolution returns no client IP from that header
+- **AND** the request is not classified as local
+
+#### Scenario: Bracketed IPv6 node with port is resolved
+
+- **WHEN** a trusted socket proxy supplies a valid quoted bracketed IPv6 `for=` node with a numeric port
+- **THEN** the system resolves the IPv6 address without the brackets or port

--- a/openspec/specs/api-firewall/spec.md
+++ b/openspec/specs/api-firewall/spec.md
@@ -43,7 +43,7 @@ The application MUST enforce firewall allowlist for proxy-facing paths `/backend
 
 ### Requirement: Trusted proxy header handling
 
-Firewall IP resolution MUST use forwarded client headers only when proxy-header trust is enabled and the socket source IP belongs to the configured trusted proxy CIDR list. `X-Forwarded-For` and RFC 7239 `Forwarded` values MUST be resolved from right to left through one shared trusted-hop algorithm. Every repeated field value MUST be combined in arrival order before resolution. A missing, malformed, ambiguous, obfuscated, unknown, or non-IP trusted-proxy chain MUST return no resolved client IP so an active firewall allowlist fails closed.
+Firewall IP resolution MUST use forwarded client headers only when proxy-header trust is enabled and the socket source IP belongs to the configured trusted proxy CIDR list. `X-Forwarded-For` and RFC 7239 `Forwarded` values MUST be resolved from right to left through one shared trusted-hop algorithm. Other client-IP headers, including `X-Real-IP`, `True-Client-IP`, and `CF-Connecting-IP`, MUST NOT affect firewall identity. Every repeated field value MUST be combined in arrival order before resolution. A missing, malformed, ambiguous, obfuscated, unknown, or non-IP trusted-proxy chain MUST return no resolved client IP so an active firewall allowlist fails closed.
 
 #### Scenario: Trusted proxy chain
 
@@ -58,6 +58,12 @@ Firewall IP resolution MUST use forwarded client headers only when proxy-header 
 - **AND** a trusted socket proxy appends the actual remote client in a second field
 - **THEN** the firewall combines both fields in arrival order
 - **AND** resolves the actual remote client rather than the spoofed loopback value
+
+#### Scenario: Singleton proxy headers do not authorize firewall access
+
+- **WHEN** a trusted socket proxy supplies only `X-Real-IP`, `True-Client-IP`, or `CF-Connecting-IP`
+- **THEN** firewall client resolution returns no client IP
+- **AND** an active firewall allowlist denies the request
 
 #### Scenario: Untrusted proxy source
 

--- a/openspec/specs/api-firewall/spec.md
+++ b/openspec/specs/api-firewall/spec.md
@@ -42,15 +42,35 @@ The application MUST enforce firewall allowlist for proxy-facing paths `/backend
 - **THEN** dashboard endpoints under `/api/*` remain accessible (subject to dashboard auth only)
 
 ### Requirement: Trusted proxy header handling
-Firewall IP resolution MUST optionally use `X-Forwarded-For` only when proxy header trust is enabled and the socket source IP belongs to configured trusted proxy CIDR list.
 
-#### Scenario: Trusted proxy source
-- **WHEN** `firewall_trust_proxy_headers=true`, source socket IP matches trusted CIDR, and `X-Forwarded-For` is present
-- **THEN** firewall uses first valid IP from `X-Forwarded-For`
+Firewall IP resolution MUST use forwarded client headers only when proxy-header trust is enabled and the socket source IP belongs to the configured trusted proxy CIDR list. `X-Forwarded-For` and RFC 7239 `Forwarded` values MUST be resolved from right to left through one shared trusted-hop algorithm. Every repeated field value MUST be combined in arrival order before resolution. A missing, malformed, ambiguous, obfuscated, unknown, or non-IP trusted-proxy chain MUST return no resolved client IP so an active firewall allowlist fails closed.
+
+#### Scenario: Trusted proxy chain
+
+- **WHEN** `firewall_trust_proxy_headers=true`
+- **AND** the source socket IP and downstream proxy hops match configured trusted CIDRs
+- **AND** a valid `X-Forwarded-For` or `Forwarded` chain is present
+- **THEN** the firewall resolves the originating client by traversing the chain from right to left
+
+#### Scenario: Trusted proxy appends a separate field
+
+- **WHEN** a client supplies a spoofed loopback value in the first `X-Forwarded-For` or `Forwarded` field
+- **AND** a trusted socket proxy appends the actual remote client in a second field
+- **THEN** the firewall combines both fields in arrival order
+- **AND** resolves the actual remote client rather than the spoofed loopback value
 
 #### Scenario: Untrusted proxy source
-- **WHEN** source socket IP is outside trusted CIDR list
-- **THEN** firewall ignores `X-Forwarded-For` and uses socket client IP
+
+- **WHEN** the source socket IP is outside the configured trusted CIDR list
+- **THEN** the firewall ignores forwarded client headers
+- **AND** uses the socket client IP
+
+#### Scenario: Trusted source supplies no complete valid chain
+
+- **WHEN** proxy-header trust is enabled and the source socket IP is trusted
+- **AND** the forwarded client chain is missing or contains an invalid hop
+- **THEN** firewall client resolution returns no client IP
+- **AND** an active firewall allowlist denies the request
 
 ### Requirement: Firewall IP cache TTL is operator-configurable with a safe default
 

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -348,6 +348,33 @@ async def test_separate_forwarded_field_cannot_spoof_local_first_run(app_instanc
 
 
 @pytest.mark.asyncio
+async def test_repeated_singleton_proxy_header_cannot_spoof_local_first_run(app_instance, monkeypatch):
+    monkeypatch.setenv("CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN", "bootstrap-secret")
+    _set_dashboard_auth_env(
+        monkeypatch,
+        mode=DashboardAuthMode.STANDARD,
+        trust_proxy_headers=True,
+    )
+    await get_settings_cache().invalidate()
+
+    async with app_instance.router.lifespan_context(app_instance):
+        transport = ASGITransport(app=app_instance, client=("127.0.0.1", 50000))
+        async with AsyncClient(transport=transport, base_url="http://localhost") as proxied_client:
+            blocked = await proxied_client.post(
+                "/api/dashboard-auth/password/setup",
+                headers=[
+                    ("X-Forwarded-For", "127.0.0.1"),
+                    ("X-Real-IP", "127.0.0.1"),
+                    ("X-Real-IP", "203.0.113.24"),
+                ],
+                json={"password": "password123"},
+            )
+
+    assert blocked.status_code == 401
+    assert blocked.json()["error"]["code"] == "invalid_bootstrap_token"
+
+
+@pytest.mark.asyncio
 async def test_passwordless_guest_access_allows_remote_reads_and_blocks_writes(app_instance):
     async with app_instance.router.lifespan_context(app_instance):
         local_transport = ASGITransport(app=app_instance, client=("127.0.0.1", 50000))

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -322,6 +322,32 @@ async def test_remote_first_run_requires_bootstrap_token(app_instance, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_separate_forwarded_field_cannot_spoof_local_first_run(app_instance, monkeypatch):
+    monkeypatch.setenv("CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN", "bootstrap-secret")
+    _set_dashboard_auth_env(
+        monkeypatch,
+        mode=DashboardAuthMode.STANDARD,
+        trust_proxy_headers=True,
+    )
+    await get_settings_cache().invalidate()
+
+    async with app_instance.router.lifespan_context(app_instance):
+        transport = ASGITransport(app=app_instance, client=("127.0.0.1", 50000))
+        async with AsyncClient(transport=transport, base_url="http://localhost") as proxied_client:
+            blocked = await proxied_client.post(
+                "/api/dashboard-auth/password/setup",
+                headers=[
+                    ("Forwarded", "for=127.0.0.1"),
+                    ("Forwarded", "for=203.0.113.24"),
+                ],
+                json={"password": "password123"},
+            )
+
+    assert blocked.status_code == 401
+    assert blocked.json()["error"]["code"] == "invalid_bootstrap_token"
+
+
+@pytest.mark.asyncio
 async def test_passwordless_guest_access_allows_remote_reads_and_blocks_writes(app_instance):
     async with app_instance.router.lifespan_context(app_instance):
         local_transport = ASGITransport(app=app_instance, client=("127.0.0.1", 50000))

--- a/tests/unit/test_firewall_ip_resolution.py
+++ b/tests/unit/test_firewall_ip_resolution.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import pytest
 from starlette.requests import Request
 
-from app.core.middleware.api_firewall import _parse_trusted_proxy_networks, _resolve_client_ip
+from app.core.middleware.api_firewall import _resolve_client_ip
+from app.core.request_locality import parse_trusted_proxy_networks
 
 pytestmark = pytest.mark.unit
 
@@ -36,7 +37,7 @@ def test_resolve_client_ip_uses_socket_ip_when_proxy_headers_not_trusted():
 
 
 def test_resolve_client_ip_uses_first_forwarded_ip_when_trusted():
-    trusted = _parse_trusted_proxy_networks(["127.0.0.1/32"])
+    trusted = parse_trusted_proxy_networks(["127.0.0.1/32"])
     request = _make_request(
         headers=[(b"x-forwarded-for", b"198.51.100.10")],
         client=("127.0.0.1", 12345),
@@ -45,7 +46,7 @@ def test_resolve_client_ip_uses_first_forwarded_ip_when_trusted():
 
 
 def test_resolve_client_ip_uses_rightmost_untrusted_from_forwarded_chain():
-    trusted = _parse_trusted_proxy_networks(["127.0.0.1/32"])
+    trusted = parse_trusted_proxy_networks(["127.0.0.1/32"])
     request = _make_request(
         headers=[(b"x-forwarded-for", b"10.10.10.10, 198.51.100.10")],
         client=("127.0.0.1", 12345),
@@ -54,7 +55,7 @@ def test_resolve_client_ip_uses_rightmost_untrusted_from_forwarded_chain():
 
 
 def test_resolve_client_ip_traverses_trusted_proxy_chain_right_to_left():
-    trusted = _parse_trusted_proxy_networks(["10.0.0.0/8"])
+    trusted = parse_trusted_proxy_networks(["10.0.0.0/8"])
     request = _make_request(
         headers=[(b"x-forwarded-for", b"198.51.100.10, 10.0.0.1")],
         client=("10.0.0.2", 12345),
@@ -63,7 +64,7 @@ def test_resolve_client_ip_traverses_trusted_proxy_chain_right_to_left():
 
 
 def test_resolve_client_ip_ignores_forwarded_ip_from_untrusted_source():
-    trusted = _parse_trusted_proxy_networks(["127.0.0.1/32"])
+    trusted = parse_trusted_proxy_networks(["127.0.0.1/32"])
     request = _make_request(
         headers=[(b"x-forwarded-for", b"198.51.100.10, 203.0.113.20")],
         client=("198.51.100.25", 12345),
@@ -71,21 +72,43 @@ def test_resolve_client_ip_ignores_forwarded_ip_from_untrusted_source():
     assert _resolve_client_ip(request, trust_proxy_headers=True, trusted_proxy_networks=trusted) == "198.51.100.25"
 
 
-def test_resolve_client_ip_falls_back_to_socket_ip_when_forwarded_missing():
-    trusted = _parse_trusted_proxy_networks(["127.0.0.1/32"])
+def test_resolve_client_ip_returns_none_when_forwarded_missing_from_trusted_proxy():
+    trusted = parse_trusted_proxy_networks(["127.0.0.1/32"])
     request = _make_request(client=("127.0.0.1", 12345))
-    assert _resolve_client_ip(request, trust_proxy_headers=True, trusted_proxy_networks=trusted) == "127.0.0.1"
+    assert _resolve_client_ip(request, trust_proxy_headers=True, trusted_proxy_networks=trusted) is None
 
 
-def test_resolve_client_ip_falls_back_to_socket_ip_on_invalid_forwarded_chain():
-    trusted = _parse_trusted_proxy_networks(["127.0.0.1/32"])
+def test_resolve_client_ip_returns_none_on_invalid_trusted_proxy_chain():
+    trusted = parse_trusted_proxy_networks(["127.0.0.1/32"])
     request = _make_request(
         headers=[(b"x-forwarded-for", b"198.51.100.10, not-an-ip")],
         client=("127.0.0.1", 12345),
     )
-    assert _resolve_client_ip(request, trust_proxy_headers=True, trusted_proxy_networks=trusted) == "127.0.0.1"
+    assert _resolve_client_ip(request, trust_proxy_headers=True, trusted_proxy_networks=trusted) is None
 
 
 def test_resolve_client_ip_returns_none_when_client_missing():
     request = _make_request(client=None)
     assert _resolve_client_ip(request, trust_proxy_headers=True) is None
+
+
+@pytest.mark.parametrize("header_name", [b"x-forwarded-for", b"forwarded"])
+def test_resolve_client_ip_combines_duplicate_chain_header_fields(header_name: bytes):
+    trusted = parse_trusted_proxy_networks(["127.0.0.1/32"])
+    prefix = b"for=" if header_name == b"forwarded" else b""
+    request = _make_request(
+        headers=[
+            (header_name, prefix + b"127.0.0.1"),
+            (header_name, prefix + b"203.0.113.24"),
+        ],
+        client=("127.0.0.1", 12345),
+    )
+
+    assert (
+        _resolve_client_ip(
+            request,
+            trust_proxy_headers=True,
+            trusted_proxy_networks=trusted,
+        )
+        == "203.0.113.24"
+    )

--- a/tests/unit/test_firewall_ip_resolution.py
+++ b/tests/unit/test_firewall_ip_resolution.py
@@ -112,3 +112,21 @@ def test_resolve_client_ip_combines_duplicate_chain_header_fields(header_name: b
         )
         == "203.0.113.24"
     )
+
+
+@pytest.mark.parametrize("header_name", [b"x-real-ip", b"true-client-ip", b"cf-connecting-ip"])
+def test_resolve_client_ip_rejects_non_firewall_proxy_headers(header_name: bytes):
+    trusted = parse_trusted_proxy_networks(["127.0.0.1/32"])
+    request = _make_request(
+        headers=[(header_name, b"127.0.0.1")],
+        client=("127.0.0.1", 12345),
+    )
+
+    assert (
+        _resolve_client_ip(
+            request,
+            trust_proxy_headers=True,
+            trusted_proxy_networks=trusted,
+        )
+        is None
+    )

--- a/tests/unit/test_firewall_service.py
+++ b/tests/unit/test_firewall_service.py
@@ -89,3 +89,4 @@ async def test_is_ip_allowed_follows_allowlist_mode():
     assert await service.is_ip_allowed("127.0.0.1") is True
     assert await service.is_ip_allowed("192.168.0.1") is False
     assert await service.is_ip_allowed("invalid-ip") is False
+    assert await service.is_ip_allowed(None) is False

--- a/tests/unit/test_request_locality.py
+++ b/tests/unit/test_request_locality.py
@@ -138,6 +138,8 @@ def test_forwarded_chain_traverses_only_complete_trusted_proxy_path() -> None:
         'for=203.0.113.24;proto=abc"def"',
         'for=203.0.113.24;proto="bad\x01value"',
         'for="[fe80::1%eth0]"',
+        "for =127.0.0.1",
+        "for= 127.0.0.1",
         "for=203.0.113.24; proto",
     ],
 )

--- a/tests/unit/test_request_locality.py
+++ b/tests/unit/test_request_locality.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+from starlette.datastructures import Headers
 from starlette.requests import Request
 
 import app.core.request_locality as request_locality
@@ -30,6 +31,20 @@ def _request(*, client_host: str, host: str) -> Request:
         "query_string": b"",
     }
     return Request(scope)
+
+
+def _resolve_forwarded(
+    forwarded: str,
+    *,
+    socket_ip: str = "127.0.0.1",
+    trusted_cidrs: list[str] | None = None,
+) -> str | None:
+    return request_locality.resolve_connection_client_ip(
+        {"forwarded": forwarded},
+        socket_ip,
+        trust_proxy_headers=True,
+        trusted_proxy_networks=request_locality.parse_trusted_proxy_networks(trusted_cidrs or ["127.0.0.1/32"]),
+    )
 
 
 def test_loopback_with_local_host_is_local() -> None:
@@ -80,3 +95,79 @@ def test_trusted_proxy_mode_accepts_loopback_with_forwarded_hint(monkeypatch: py
     }
     request = Request(scope)
     assert is_local_request(request) is True
+
+
+def test_forwarded_chain_stops_at_proxy_appended_remote_client() -> None:
+    resolved = _resolve_forwarded("for=127.0.0.1, for=203.0.113.24")
+
+    assert resolved == "203.0.113.24"
+
+
+def test_forwarded_chain_traverses_only_complete_trusted_proxy_path() -> None:
+    resolved = _resolve_forwarded(
+        'for=198.51.100.7;proto=https, for=10.0.0.1;host="proxy,internal", for=10.0.0.2',
+        socket_ip="10.0.0.3",
+        trusted_cidrs=["10.0.0.0/8"],
+    )
+
+    assert resolved == "198.51.100.7"
+
+
+@pytest.mark.parametrize(
+    "forwarded",
+    [
+        "for=127.0.0.1, by=203.0.113.24",
+        "for=127.0.0.1; for=203.0.113.24",
+        "for=_hidden",
+        "for=unknown",
+        "for=not-an-ip",
+        'for="127.0.0.1',
+        "for=127.0.0.1,, for=203.0.113.24",
+        'for="127.0.0.1;proto=https"',
+        'for="[2001:db8::1]:65536"',
+        "for=203.0.113.24; proto",
+    ],
+)
+def test_forwarded_chain_fails_closed_on_malformed_element(forwarded: str) -> None:
+    assert _resolve_forwarded(forwarded) is None
+
+
+@pytest.mark.parametrize(
+    ("forwarded", "expected"),
+    [
+        ('for="198.51.100.7:4711"', "198.51.100.7"),
+        ('for="[2001:db8::1]:4711"', "2001:db8::1"),
+        ('for="[2001:0db8::1]"', "2001:db8::1"),
+    ],
+)
+def test_forwarded_chain_accepts_ip_nodes_with_optional_port(forwarded: str, expected: str) -> None:
+    assert _resolve_forwarded(forwarded) == expected
+
+
+def test_xff_chain_keeps_right_to_left_trusted_proxy_resolution() -> None:
+    resolved = request_locality.resolve_connection_client_ip(
+        {"x-forwarded-for": "198.51.100.7, 10.0.0.1, 10.0.0.2"},
+        "10.0.0.3",
+        trust_proxy_headers=True,
+        trusted_proxy_networks=request_locality.parse_trusted_proxy_networks(["10.0.0.0/8"]),
+    )
+
+    assert resolved == "198.51.100.7"
+
+
+def test_xff_chain_combines_duplicate_header_fields() -> None:
+    headers = Headers(
+        raw=[
+            (b"x-forwarded-for", b"127.0.0.1"),
+            (b"x-forwarded-for", b"203.0.113.24"),
+        ]
+    )
+
+    resolved = request_locality.resolve_connection_client_ip(
+        headers,
+        "127.0.0.1",
+        trust_proxy_headers=True,
+        trusted_proxy_networks=request_locality.parse_trusted_proxy_networks(["127.0.0.1/32"]),
+    )
+
+    assert resolved == "203.0.113.24"

--- a/tests/unit/test_request_locality.py
+++ b/tests/unit/test_request_locality.py
@@ -125,6 +125,19 @@ def test_forwarded_chain_traverses_only_complete_trusted_proxy_path() -> None:
         "for=127.0.0.1,, for=203.0.113.24",
         'for="127.0.0.1;proto=https"',
         'for="[2001:db8::1]:65536"',
+        "for=198.51.100.7:4711",
+        "for=[2001:db8::1]",
+        "for=[2001:db8::1]:4711",
+        "for=2001:db8::1",
+        'for="2001:db8::1"',
+        'for="[198.51.100.7]"',
+        'for="198.51.100.7:000080"',
+        "for=203.0.113.24;proto=https;PROTO=http",
+        "for=203.0.113.24;bad name=value",
+        "for=203.0.113.24;proto=bad value",
+        'for=203.0.113.24;proto=abc"def"',
+        'for=203.0.113.24;proto="bad\x01value"',
+        'for="[fe80::1%eth0]"',
         "for=203.0.113.24; proto",
     ],
 )
@@ -171,3 +184,54 @@ def test_xff_chain_combines_duplicate_header_fields() -> None:
     )
 
     assert resolved == "203.0.113.24"
+
+
+@pytest.mark.parametrize("header_name", ["x-real-ip", "true-client-ip", "cf-connecting-ip"])
+def test_connection_resolver_preserves_default_singleton_proxy_headers(header_name: str) -> None:
+    resolved = request_locality.resolve_connection_client_ip(
+        {header_name: "203.0.113.24"},
+        "127.0.0.1",
+        trust_proxy_headers=True,
+        trusted_proxy_networks=request_locality.parse_trusted_proxy_networks(["127.0.0.1/32"]),
+    )
+
+    assert resolved == "203.0.113.24"
+
+
+@pytest.mark.parametrize("header_name", ["x-real-ip", "true-client-ip", "cf-connecting-ip"])
+def test_connection_resolver_rejects_repeated_singleton_proxy_headers(header_name: str) -> None:
+    encoded_name = header_name.encode()
+    headers = Headers(
+        raw=[
+            (encoded_name, b"127.0.0.1"),
+            (encoded_name, b"203.0.113.24"),
+        ]
+    )
+
+    resolved = request_locality.resolve_connection_client_ip(
+        headers,
+        "127.0.0.1",
+        trust_proxy_headers=True,
+        trusted_proxy_networks=request_locality.parse_trusted_proxy_networks(["127.0.0.1/32"]),
+    )
+
+    assert resolved is None
+
+
+def test_connection_resolver_rejects_repeated_singleton_before_valid_xff() -> None:
+    headers = Headers(
+        raw=[
+            (b"x-forwarded-for", b"127.0.0.1"),
+            (b"x-real-ip", b"127.0.0.1"),
+            (b"x-real-ip", b"203.0.113.24"),
+        ]
+    )
+
+    resolved = request_locality.resolve_connection_client_ip(
+        headers,
+        "127.0.0.1",
+        trust_proxy_headers=True,
+        trusted_proxy_networks=request_locality.parse_trusted_proxy_networks(["127.0.0.1/32"]),
+    )
+
+    assert resolved is None


### PR DESCRIPTION
## Summary

Harden trusted-proxy client identity resolution so an attacker-controlled first `Forwarded` element cannot override the remote identity appended by a trusted proxy. This also consolidates HTTP and WebSocket firewall callers on the shared resolver and makes malformed or ambiguous chains fail closed.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: None — this security defect was confirmed during a repository audit and no existing issue or discussion covers it.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/archive/2026-07-16-fix-trusted-forwarded-chain/`

## Changes

- Parse every RFC 7239 `Forwarded` element and resolve the effective client from the trusted socket inward, matching the existing `X-Forwarded-For` trust model.
- Preserve repeated `Forwarded` and `X-Forwarded-For` fields in arrival order; reject malformed chains and repeated singleton identity fields.
- Remove the firewall-local resolver and migrate HTTP middleware, WebSocket firewall, and trusted-header sanitization to the shared implementation with caller-specific header allowlists.
- Add resolver, dashboard-bootstrap, firewall, malformed-chain, repeated-field, and IPv6/port regressions.

## Test plan

```text
make ci-fast
# 4029 passed, 55 skipped, 6 warnings; Ruff, format, ty, frontend coverage, import, build, and wheel asset verification passed

pytest -q tests/unit/test_request_locality.py tests/unit/test_firewall_ip_resolution.py tests/unit/test_firewall_service.py tests/integration/test_auth_middleware.py tests/integration/test_api_firewall_middleware.py
# 93 passed

openspec validate --specs --strict
# 47 passed, 0 failed
```

## Screenshots / output

No dashboard-visible change. Proxy-resolution example:

```text
Trusted socket: 127.0.0.1
Forwarded: for=127.0.0.1, for=203.0.113.24

Before: 127.0.0.1 (attacker-preseeded first element)
After:  203.0.113.24 (proxy-appended remote client)
```

## Checklist

- [x] Title is in Conventional Commits format.
- [x] No pre-existing issue or discussion covers this audit finding.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local CI gate and focused integration tests.
- [x] `openspec validate --specs --strict` passes and the change was verified before archive.
- [x] Simplicity gates reviewed: no setting, default, README section, `.env.example` entry, dashboard nav item, or required setup step is added.
- [x] `CHANGELOG.md` is not edited by hand.
- [x] No new dependency is introduced.
