### PR TITLE
fix(security): inspect repeated session proxy headers

### DIFF
--- a/app/core/auth/dashboard_session_ttl.py
+++ b/app/core/auth/dashboard_session_ttl.py
@@ -37,7 +37,7 @@ def _allows_long_local_dashboard_session(request: HTTPConnection) -> bool:
         return True
     if not settings.dashboard_trust_loopback_host_header_for_long_sessions:
         return False
-    if any(request.headers.get(header) for header in _FORWARDED_CLIENT_IP_HEADERS):
+    if any(value for header in _FORWARDED_CLIENT_IP_HEADERS for value in request.headers.getlist(header)):
         return False
     return _uses_loopback_dashboard_url(request)
 

--- a/app/core/auth/dashboard_session_ttl.py
+++ b/app/core/auth/dashboard_session_ttl.py
@@ -33,11 +33,11 @@ def _allows_long_local_dashboard_session(request: HTTPConnection) -> bool:
         return False
     if settings.firewall_trust_proxy_headers:
         return False
+    if any(value for header in _FORWARDED_CLIENT_IP_HEADERS for value in request.headers.getlist(header)):
+        return False
     if _is_local_request(request):
         return True
     if not settings.dashboard_trust_loopback_host_header_for_long_sessions:
-        return False
-    if any(value for header in _FORWARDED_CLIENT_IP_HEADERS for value in request.headers.getlist(header)):
         return False
     return _uses_loopback_dashboard_url(request)
 

--- a/openspec/changes/archive/2026-07-16-fix-duplicate-forwarded-session-ttl/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-16-fix-duplicate-forwarded-session-ttl/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/archive/2026-07-16-fix-duplicate-forwarded-session-ttl/design.md
+++ b/openspec/changes/archive/2026-07-16-fix-duplicate-forwarded-session-ttl/design.md
@@ -1,0 +1,43 @@
+## Context
+
+`HTTPConnection.headers` is a Starlette `Headers` object that preserves repeated raw fields. `Headers.get(name)` returns one field value, while `Headers.getlist(name)` exposes every occurrence. The long-session loopback-host-header override currently calls `get()` for each forwarded client-IP header, so an empty first field hides a later non-empty value and bypasses the 12-hour cap.
+
+The original hardening in PR #1137 intentionally allows long sessions only for direct local requests or an explicitly enabled localhost-published bridge path without a forwarded client identity. This fix preserves that trust boundary and the existing treatment of absent or entirely empty fields.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Treat any non-empty value among all occurrences of all supported forwarded client-IP headers as evidence that disables the long-session override.
+- Preserve the configured long lifetime when those headers are absent or every occurrence is empty.
+- Prove the duplicate-field ordering case with the same raw ASGI header representation used at runtime.
+
+**Non-Goals:**
+
+- Change the 30-day threshold, 12-hour cap, dashboard auth modes, or persisted settings.
+- Reinterpret trusted proxy chains or alter general request-locality resolution.
+- Add a generic header abstraction or dependency for one security predicate.
+
+## Decisions
+
+### Inspect every value through `Headers.getlist()`
+
+Iterate the existing forwarded client-IP header names and every value returned by `request.headers.getlist(name)`. This matches Starlette's runtime representation and closes ordering-dependent behavior without copying or reparsing headers.
+
+Alternative: reject every repeated field. Rejected because repeated `Forwarded` and `X-Forwarded-For` fields are legal and the TTL predicate only needs to know whether any client-identity hint is non-empty.
+
+Alternative: add a shared public helper to `request_locality`. Rejected for this independent fix because the TTL predicate is small, the current upstream module has no suitable public helper, and a new cross-module API would widen the patch.
+
+### Preserve all-empty compatibility
+
+An absent header and one or more empty values continue to mean that no forwarded client identity was supplied. This matches the original `any(value)` intent and avoids broadening the compatibility change beyond the proven bypass.
+
+### Test the raw duplicate ordering
+
+Construct the `Request` with two `X-Forwarded-For` fields: an empty first occurrence and a non-empty remote second occurrence. Assert that the effective lifetime is 43,200 seconds.
+
+## Risks / Trade-offs
+
+- A deployment that intentionally sends a non-empty forwarded client-IP field while relying on the loopback-host-header override will now receive the documented 12-hour cap. This is the security boundary, not a regression.
+- The fix depends on Starlette's `Headers.getlist()` API, already used elsewhere in the project and available on every `HTTPConnection.headers` object.
+- Whitespace-only values remain truthy, as before for a first field. Treating them as a client-identity hint is fail-closed.

--- a/openspec/changes/archive/2026-07-16-fix-duplicate-forwarded-session-ttl/proposal.md
+++ b/openspec/changes/archive/2026-07-16-fix-duplicate-forwarded-session-ttl/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+When the loopback-host-header override is enabled, dashboard session TTL enforcement inspects only the first value of each forwarded client-IP header. A remote request can therefore place an empty field first and a non-empty duplicate second, receiving the configured long session lifetime instead of the required 12-hour cap.
+
+## What Changes
+
+- Inspect every field value for each forwarded client-IP header before granting a long dashboard session through the loopback-host-header override.
+- Add a regression proving that a later non-empty duplicate forces the 12-hour remote-session cap.
+- Clarify the admin-auth contract for repeated forwarded client-IP fields.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `admin-auth`: Require the long-session loopback-host-header override to reject a request when any value of any forwarded client-IP field is non-empty, including repeated fields.
+
+## Impact
+
+- Affected code: `app/core/auth/dashboard_session_ttl.py`.
+- Affected tests: `tests/unit/test_dashboard_session_ttl.py`.
+- Compatibility: Requests without forwarded client-IP fields and requests whose every such field value is empty retain existing behavior. Requests that relied on a later non-empty duplicate being ignored are intentionally capped at 12 hours.
+- Dependencies and persisted data: None.

--- a/openspec/changes/archive/2026-07-16-fix-duplicate-forwarded-session-ttl/specs/admin-auth/spec.md
+++ b/openspec/changes/archive/2026-07-16-fix-duplicate-forwarded-session-ttl/specs/admin-auth/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Dashboard password sessions use a configurable absolute lifetime
+
+The system SHALL issue dashboard password-authenticated sessions with an absolute lifetime controlled by persisted dashboard settings. The default persisted lifetime SHALL be 1 year. Configured lifetimes at or below 30 days SHALL apply to newly issued dashboard password sessions by setting both the encrypted session expiry payload and the cookie `Max-Age` to the same value. Configured lifetimes above 30 days SHALL apply only in standard dashboard auth mode when the request is socket-level local, or when an explicit loopback-host-header override is enabled, the request uses a loopback dashboard URL, and every field value of every forwarded client-IP header is empty. Non-loopback, proxy-aware, trusted-header, or bridge-without-override requests MUST receive a 12-hour effective lifetime without rewriting the persisted setting.
+
+#### Scenario: Newly issued dashboard password session honors configured lifetime
+
+- **WHEN** an admin configures a dashboard session lifetime and successfully completes password authentication from a socket-level local request
+- **THEN** the newly issued dashboard session expires after the configured absolute lifetime
+- **AND** the cookie `Max-Age` matches the same configured lifetime
+
+#### Scenario: Long localhost-published bridge session requires explicit override
+
+- **WHEN** an admin configures a dashboard session lifetime greater than 30 days and successfully completes password authentication through a loopback dashboard URL whose socket peer is not loopback
+- **AND** the explicit loopback-host-header override is disabled
+- **THEN** the newly issued dashboard session expires after 12 hours
+
+#### Scenario: Long localhost-published bridge session can opt in
+
+- **WHEN** an admin configures a dashboard session lifetime greater than 30 days and successfully completes password authentication through a loopback dashboard URL whose socket peer is not loopback
+- **AND** the explicit loopback-host-header override is enabled
+- **AND** every field value of every forwarded client-IP header is empty
+- **THEN** the newly issued dashboard session expires after the configured absolute lifetime
+
+#### Scenario: Later duplicate forwarded client identity disables the long session override
+
+- **WHEN** a non-loopback socket peer authenticates through a loopback dashboard URL with the explicit loopback-host-header override enabled
+- **AND** a forwarded client-IP header contains an empty first field followed by a non-empty field
+- **THEN** the newly issued dashboard session expires after 12 hours
+- **AND** the cookie `Max-Age` is `43200`
+
+#### Scenario: Long dashboard password session falls back for non-loopback access
+
+- **WHEN** an admin configures a dashboard session lifetime greater than 30 days and successfully completes password authentication from a non-loopback, proxy-aware, or trusted-header request
+- **THEN** the newly issued dashboard session expires after 12 hours
+- **AND** the cookie `Max-Age` is `43200`
+
+#### Scenario: Existing dashboard sessions keep their original expiry
+
+- **WHEN** an admin changes the configured dashboard session lifetime after a session cookie has already been issued
+- **THEN** previously issued cookies continue to expire according to the expiry embedded in their encrypted payload
+- **AND** only newly issued dashboard password sessions use the updated lifetime

--- a/openspec/changes/archive/2026-07-16-fix-duplicate-forwarded-session-ttl/tasks.md
+++ b/openspec/changes/archive/2026-07-16-fix-duplicate-forwarded-session-ttl/tasks.md
@@ -1,0 +1,18 @@
+## 1. Regression Evidence
+
+- [x] 1.1 Add a raw repeated-header regression proving that a later non-empty forwarded client identity receives the 12-hour cap.
+
+## 2. Implementation
+
+- [x] 2.1 Inspect every occurrence of every supported forwarded client-IP header before granting the long-session loopback-host-header override.
+- [x] 2.2 Preserve existing behavior for absent headers and fields whose every value is empty.
+
+## 3. Specification Sync
+
+- [x] 3.1 Sync the repeated-field requirement and security context into the main `admin-auth` capability.
+
+## 4. Verification
+
+- [x] 4.1 Run the original exploit reproduction and focused dashboard session TTL tests.
+- [x] 4.2 Run diagnostics, strict OpenSpec validation, diff checks, and the full fast CI gate.
+- [x] 4.3 Archive the verified OpenSpec change and revalidate the main specifications.

--- a/openspec/specs/admin-auth/context.md
+++ b/openspec/specs/admin-auth/context.md
@@ -47,7 +47,7 @@ Requests from localhost (127.0.0.1, ::1) bypass bootstrap entirely — no token 
 
 ## Session Management
 
-Stateless encrypted cookies using Fernet. Session payload: `{exp, pw, tv}`. Default persisted TTL: 1 year for local dashboard use. Long configured lifetimes above 30 days fall back to 12 hours for non-loopback, proxy-aware, trusted-header, or bridge-without-override requests. Localhost-published bridge deployments can opt in with `CODEX_LB_DASHBOARD_TRUST_LOOPBACK_HOST_HEADER_FOR_LONG_SESSIONS=true`, which still requires a loopback dashboard URL and no forwarded-client headers. No server-side session storage.
+Stateless encrypted cookies using Fernet. Session payload: `{exp, pw, tv}`. Default persisted TTL: 1 year for local dashboard use. Long configured lifetimes above 30 days fall back to 12 hours for non-loopback, proxy-aware, trusted-header, or bridge-without-override requests. Localhost-published bridge deployments can opt in with `CODEX_LB_DASHBOARD_TRUST_LOOPBACK_HOST_HEADER_FOR_LONG_SESSIONS=true`, which still requires a loopback dashboard URL and no non-empty forwarded-client field value. Every occurrence is inspected: an empty first `X-Forwarded-For` field cannot hide a later non-empty duplicate. No server-side session storage.
 
 ## Rate Limiting
 

--- a/openspec/specs/admin-auth/spec.md
+++ b/openspec/specs/admin-auth/spec.md
@@ -51,7 +51,7 @@ The system SHALL enforce both a minimum and a maximum length on dashboard passwo
 
 ### Requirement: Dashboard password sessions use a configurable absolute lifetime
 
-The system SHALL issue dashboard password-authenticated sessions with an absolute lifetime controlled by persisted dashboard settings. The default persisted lifetime SHALL be 1 year. Configured lifetimes at or below 30 days SHALL apply to newly issued dashboard password sessions by setting both the encrypted session expiry payload and the cookie `Max-Age` to the same value. Configured lifetimes above 30 days SHALL apply only in standard dashboard auth mode when the request is socket-level local, or when an explicit loopback-host-header override is enabled and the request uses a loopback dashboard URL with no forwarded-client headers. Non-loopback, proxy-aware, trusted-header, or bridge-without-override requests MUST receive a 12-hour effective lifetime without rewriting the persisted setting.
+The system SHALL issue dashboard password-authenticated sessions with an absolute lifetime controlled by persisted dashboard settings. The default persisted lifetime SHALL be 1 year. Configured lifetimes at or below 30 days SHALL apply to newly issued dashboard password sessions by setting both the encrypted session expiry payload and the cookie `Max-Age` to the same value. Configured lifetimes above 30 days SHALL apply only in standard dashboard auth mode when the request is socket-level local, or when an explicit loopback-host-header override is enabled, the request uses a loopback dashboard URL, and every field value of every forwarded client-IP header is empty. Non-loopback, proxy-aware, trusted-header, or bridge-without-override requests MUST receive a 12-hour effective lifetime without rewriting the persisted setting.
 
 #### Scenario: Newly issued dashboard password session honors configured lifetime
 
@@ -69,8 +69,15 @@ The system SHALL issue dashboard password-authenticated sessions with an absolut
 
 - **WHEN** an admin configures a dashboard session lifetime greater than 30 days and successfully completes password authentication through a loopback dashboard URL whose socket peer is not loopback
 - **AND** the explicit loopback-host-header override is enabled
-- **AND** no forwarded-client headers are present
+- **AND** every field value of every forwarded client-IP header is empty
 - **THEN** the newly issued dashboard session expires after the configured absolute lifetime
+
+#### Scenario: Later duplicate forwarded client identity disables the long session override
+
+- **WHEN** a non-loopback socket peer authenticates through a loopback dashboard URL with the explicit loopback-host-header override enabled
+- **AND** a forwarded client-IP header contains an empty first field followed by a non-empty field
+- **THEN** the newly issued dashboard session expires after 12 hours
+- **AND** the cookie `Max-Age` is `43200`
 
 #### Scenario: Long dashboard password session falls back for non-loopback access
 

--- a/tests/unit/test_dashboard_auth_api.py
+++ b/tests/unit/test_dashboard_auth_api.py
@@ -319,7 +319,7 @@ async def test_login_password_caps_non_loopback_dashboard_session_ttl():
 
 
 @pytest.mark.asyncio
-async def test_login_password_caps_later_duplicate_forwarded_identity():
+async def test_login_password_caps_later_duplicate_forwarded_identity_from_loopback_socket():
     limiter = SimpleNamespace(
         check_and_increment=AsyncMock(),
         clear_for_key=AsyncMock(),
@@ -365,7 +365,7 @@ async def test_login_password_caps_later_duplicate_forwarded_identity():
         response = await login_password(
             _build_login_request(
                 "/api/dashboard-auth/password/login",
-                client_host="172.17.0.1",
+                client_host="127.0.0.1",
                 host="127.0.0.1:2455",
                 headers=[
                     (b"x-forwarded-for", b""),

--- a/tests/unit/test_dashboard_auth_api.py
+++ b/tests/unit/test_dashboard_auth_api.py
@@ -39,7 +39,13 @@ def _build_request(path: str) -> Request:
     )
 
 
-def _build_login_request(path: str, *, client_host: str = "203.0.113.10", host: str = "lb.example") -> Request:
+def _build_login_request(
+    path: str,
+    *,
+    client_host: str = "203.0.113.10",
+    host: str = "lb.example",
+    headers: list[tuple[bytes, bytes]] | None = None,
+) -> Request:
     return Request(
         {
             "type": "http",
@@ -49,7 +55,7 @@ def _build_login_request(path: str, *, client_host: str = "203.0.113.10", host: 
             "path": path,
             "raw_path": path.encode(),
             "query_string": b"",
-            "headers": [(b"host", host.encode())],
+            "headers": [(b"host", host.encode()), *(headers or [])],
             "client": (client_host, 12345),
             "server": (host.split(":", 1)[0], 80),
         }
@@ -295,6 +301,77 @@ async def test_login_password_caps_non_loopback_dashboard_session_ttl():
     ):
         response = await login_password(
             _build_login_request("/api/dashboard-auth/password/login"),
+            PasswordLoginRequest(password="password123"),
+            context,
+        )
+
+    assert isinstance(response, JSONResponse)
+    assert f"Max-Age={REMOTE_DASHBOARD_SESSION_TTL_SECONDS}" in response.headers["set-cookie"]
+    session_store.create.assert_called_once_with(
+        password_verified=True,
+        totp_verified=False,
+        ttl_seconds=REMOTE_DASHBOARD_SESSION_TTL_SECONDS,
+        role=DashboardRole.ADMIN,
+        guest_verified=False,
+    )
+    limiter.check_and_increment.assert_awaited_once()
+    limiter.clear_for_key.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_login_password_caps_later_duplicate_forwarded_identity():
+    limiter = SimpleNamespace(
+        check_and_increment=AsyncMock(),
+        clear_for_key=AsyncMock(),
+    )
+    session_store = SimpleNamespace(
+        create=Mock(return_value="session-1"),
+        get=lambda _sid: SimpleNamespace(
+            password_verified=True,
+            totp_verified=False,
+            role=DashboardRole.ADMIN,
+            guest_verified=False,
+        ),
+    )
+    context = cast(
+        DashboardAuthContext,
+        SimpleNamespace(
+            service=SimpleNamespace(
+                verify_password=AsyncMock(),
+                get_session_state=AsyncMock(
+                    return_value=DashboardAuthSessionResponse(
+                        authenticated=True,
+                        password_required=True,
+                        totp_required_on_login=False,
+                        totp_configured=False,
+                    )
+                ),
+            ),
+            session=object(),
+        ),
+    )
+    settings = SimpleNamespace(password_hash="hash", dashboard_session_ttl_seconds=90 * 24 * 60 * 60)
+    settings_cache = SimpleNamespace(get=AsyncMock(return_value=settings))
+    runtime_settings = _runtime_settings()
+    runtime_settings.dashboard_trust_loopback_host_header_for_long_sessions = True
+
+    with (
+        patch("app.core.auth.dashboard_session_ttl._get_settings", return_value=runtime_settings),
+        patch("app.core.request_locality.get_settings", return_value=runtime_settings),
+        patch("app.modules.dashboard_auth.api.get_password_rate_limiter", return_value=limiter),
+        patch("app.modules.dashboard_auth.api.get_dashboard_session_store", return_value=session_store),
+        patch("app.modules.dashboard_auth.api.get_settings_cache", return_value=settings_cache),
+    ):
+        response = await login_password(
+            _build_login_request(
+                "/api/dashboard-auth/password/login",
+                client_host="172.17.0.1",
+                host="127.0.0.1:2455",
+                headers=[
+                    (b"x-forwarded-for", b""),
+                    (b"x-forwarded-for", b"203.0.113.24"),
+                ],
+            ),
             PasswordLoginRequest(password="password123"),
             context,
         )

--- a/tests/unit/test_dashboard_session_ttl.py
+++ b/tests/unit/test_dashboard_session_ttl.py
@@ -122,14 +122,14 @@ def test_long_dashboard_session_ttl_accepts_only_empty_repeated_forwarded_fields
     assert ttl_seconds == DEFAULT_DASHBOARD_SESSION_TTL_SECONDS
 
 
-def test_long_dashboard_session_ttl_clamps_for_later_duplicate_forwarded_identity(
+def test_long_dashboard_session_ttl_clamps_for_later_duplicate_forwarded_identity_from_loopback_socket(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _patch_settings(monkeypatch, _settings(trust_loopback_host_header=True))
 
     ttl_seconds = resolve_dashboard_session_ttl_seconds(
         _request(
-            client_host="172.17.0.1",
+            client_host="127.0.0.1",
             host="127.0.0.1:2455",
             headers=[(b"x-forwarded-for", b""), (b"x-forwarded-for", b"203.0.113.24")],
         ),

--- a/tests/unit/test_dashboard_session_ttl.py
+++ b/tests/unit/test_dashboard_session_ttl.py
@@ -105,6 +105,40 @@ def test_long_dashboard_session_ttl_accepts_loopback_host_header_with_explicit_o
     assert ttl_seconds == DEFAULT_DASHBOARD_SESSION_TTL_SECONDS
 
 
+def test_long_dashboard_session_ttl_accepts_only_empty_repeated_forwarded_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_settings(monkeypatch, _settings(trust_loopback_host_header=True))
+
+    ttl_seconds = resolve_dashboard_session_ttl_seconds(
+        _request(
+            client_host="172.17.0.1",
+            host="127.0.0.1:2455",
+            headers=[(b"x-forwarded-for", b""), (b"x-forwarded-for", b"")],
+        ),
+        DEFAULT_DASHBOARD_SESSION_TTL_SECONDS,
+    )
+
+    assert ttl_seconds == DEFAULT_DASHBOARD_SESSION_TTL_SECONDS
+
+
+def test_long_dashboard_session_ttl_clamps_for_later_duplicate_forwarded_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_settings(monkeypatch, _settings(trust_loopback_host_header=True))
+
+    ttl_seconds = resolve_dashboard_session_ttl_seconds(
+        _request(
+            client_host="172.17.0.1",
+            host="127.0.0.1:2455",
+            headers=[(b"x-forwarded-for", b""), (b"x-forwarded-for", b"203.0.113.24")],
+        ),
+        DEFAULT_DASHBOARD_SESSION_TTL_SECONDS,
+    )
+
+    assert ttl_seconds == REMOTE_DASHBOARD_SESSION_TTL_SECONDS
+
+
 def test_long_dashboard_session_ttl_clamps_when_proxy_headers_are_trusted(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_settings(monkeypatch, _settings(trust_proxy_headers=True))
 


### PR DESCRIPTION
## Summary

Dashboard session TTL resolution now inspects **raw repeated** proxy identity headers instead of relying only on already-normalized values. Later non-empty duplicates that were previously ignored can no longer keep a long (1y) loopback TTL; those requests are capped at the remote 12h TTL. This is independent of #1377.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: none (no matching open issue or Discussion). Context only from historical related PRs #1137 and #465 — no `Fixes` / `Closes`. Explicitly independent of #1377.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/archive/2026-07-16-fix-duplicate-forwarded-session-ttl/`

Also updates main specs: `openspec/specs/admin-auth/spec.md` and `openspec/specs/admin-auth/context.md`.

## Changes

- Inspect raw repeated session proxy headers when resolving dashboard session TTL so later non-empty duplicate identity values cannot preserve the long loopback TTL.
- Archive OpenSpec change for the duplicate-forwarded session TTL behavior under `openspec/changes/archive/2026-07-16-fix-duplicate-forwarded-session-ttl/`.
- Add unit coverage for duplicate/raw-header TTL resolution and login cookie TTL under later duplicate forwarded identity.

### Compatibility

Only requests that previously relied on a **later non-empty duplicate being ignored** are newly capped at the remote **12h** TTL. Direct loopback / non-duplicate paths keep existing long-TTL behavior.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config**
- [x] No new required setup step (or maintainer approval via `simplicity-budget-approved` label)
- New setting(s) and why each can't be a default: none
- [x] README sections / `.env.example` / dashboard nav within budget (or `simplicity-budget-approved` label requested)

No new settings, README sections, `.env.example` keys, or dashboard nav items.

## Test plan

```bash
# Focused dashboard TTL / auth API coverage (includes duplicate raw headers)
uv run pytest -q -ra --timeout=180 \
  tests/unit/test_dashboard_session_ttl.py \
  tests/unit/test_dashboard_auth_api.py \
  -k 'session_ttl or duplicate or login_password'
# -> 12 passed, 2 deselected

openspec validate --specs --strict
# -> 47 passed, 0 failed

# Full local gate (venv python on PATH for Makefile architecture-check)
PATH="$(pwd)/.venv/bin:$PATH" make ci-fast
# -> architecture-check pass
# -> ruff check/format pass
# -> ty check pass
# -> frontend: 124 files / 864 tests passed
# -> unit: 3990 passed, 55 skipped
# -> package build + wheel asset verify pass
```

## Screenshots / output

Not applicable — no dashboard UI surface; security/TTL behavior only.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above. (none matching; historical context #1137 / #465 only; independent of #1377)
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally. (`make ci-fast`)
- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean. (strict `openspec validate --specs --strict` passed 47/47; `/opsx:verify` was not run)
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
