### PR TITLE
fix(config): reject empty trusted proxy CIDRs

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -680,13 +680,20 @@ class Settings(BaseSettings):
         return self
 
     @model_validator(mode="after")
+    def _validate_firewall_proxy_trust(self) -> "Settings":
+        if self.firewall_trust_proxy_headers and not self.firewall_trusted_proxy_cidrs:
+            raise ValueError(
+                "firewall_trust_proxy_headers=true requires at least one entry in "
+                "firewall_trusted_proxy_cidrs; configure a trusted proxy CIDR or disable proxy header trust"
+            )
+        return self
+
+    @model_validator(mode="after")
     def _validate_dashboard_auth_mode(self) -> "Settings":
         if self.dashboard_auth_mode != DashboardAuthMode.TRUSTED_HEADER:
             return self
         if not self.firewall_trust_proxy_headers:
             raise ValueError("dashboard_auth_mode=trusted_header requires firewall_trust_proxy_headers=true")
-        if not self.firewall_trusted_proxy_cidrs:
-            raise ValueError("dashboard_auth_mode=trusted_header requires non-empty firewall_trusted_proxy_cidrs")
         return self
 
     @model_validator(mode="after")

--- a/openspec/changes/archive/2026-07-16-reject-empty-trusted-proxy-cidrs/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-16-reject-empty-trusted-proxy-cidrs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/archive/2026-07-16-reject-empty-trusted-proxy-cidrs/design.md
+++ b/openspec/changes/archive/2026-07-16-reject-empty-trusted-proxy-cidrs/design.md
@@ -1,0 +1,48 @@
+## Context
+
+The trusted-proxy CIDR field is normalized before validation: empty strings, whitespace-only entries, comma-only input, and an empty list all become `[]`. Individual CIDRs are validated, but the relationship between `firewall_trust_proxy_headers` and the normalized list is enforced only when `dashboard_auth_mode=trusted_header`. Standard and disabled dashboard modes therefore accept enabled header trust with no authorized proxy source.
+
+The remote-deployment documentation always configures the trust flag and CIDR list together. PR #84 introduced source-CIDR-gated forwarded identity, and the later dashboard proxy-auth work added the same non-empty invariant only for `trusted_header` mode. The invariant belongs to proxy trust itself, not to one dashboard mode.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reject enabled proxy-header trust when normalization yields no trusted source CIDRs.
+- Apply the invariant across dashboard authentication modes.
+- Preserve empty CIDR input as valid when proxy-header trust is disabled.
+- Emit an actionable validation error at startup.
+
+**Non-Goals:**
+
+- Change CIDR parsing, canonicalization, or default values.
+- Infer a CIDR from the runtime socket or container network.
+- Change forwarded-header resolution or firewall allowlist behavior.
+
+## Decisions
+
+### Validate the normalized cross-field state
+
+Add a model-level settings validator after field normalization. It will reject `firewall_trust_proxy_headers=true` when `firewall_trusted_proxy_cidrs` is empty. This catches every textual representation that normalizes to an empty list and keeps individual CIDR syntax validation in the existing field validator.
+
+Alternative: reject an empty raw environment string in the field validator. Rejected because field validation cannot distinguish whether header trust is enabled and would also forbid an intentionally empty list while trust is disabled.
+
+### Fail startup instead of changing operator intent
+
+Do not silently disable header trust and do not repopulate default loopback CIDRs. Both alternatives would run with a configuration different from the explicit input. Startup rejection exposes the contradiction and tells the operator to configure a CIDR or turn trust off.
+
+Alternative: keep accepting the configuration as a fail-closed staging state. Rejected because enabled trust has no authorized source, silently alters local/proxied classification, and contradicts the documented two-setting contract.
+
+### Remove the dashboard-mode duplicate
+
+The existing `trusted_header` validator will continue to require proxy-header trust. Its narrower non-empty-CIDR check becomes redundant under the shared invariant and will be removed so one validator owns the relationship.
+
+## Risks / Trade-offs
+
+- [A deployment intentionally stages the trust flag before its CIDRs] → Startup now fails; stage both settings atomically or leave trust disabled.
+- [Empty CIDRs with trust disabled regress] → Cover this valid boundary explicitly.
+- [Dashboard trusted-header error text changes for empty CIDRs] → The replacement error names the underlying proxy-trust settings and gives both valid corrections.
+
+## Migration Plan
+
+Before upgrading, any deployment with `CODEX_LB_FIREWALL_TRUST_PROXY_HEADERS=true` and an empty `CODEX_LB_FIREWALL_TRUSTED_PROXY_CIDRS` must either configure the actual proxy CIDR or set header trust to false. No data migration is required. Rollback restores acceptance of the contradictory configuration.

--- a/openspec/changes/archive/2026-07-16-reject-empty-trusted-proxy-cidrs/proposal.md
+++ b/openspec/changes/archive/2026-07-16-reject-empty-trusted-proxy-cidrs/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`firewall_trust_proxy_headers=true` is currently accepted after `firewall_trusted_proxy_cidrs` normalizes to an empty list, although no socket source can then be authorized to supply forwarded identity. The contradictory configuration silently changes locality behavior while failing to provide the documented proxy trust, so startup must reject it instead of running with operator intent unmet.
+
+## What Changes
+
+- Require at least one normalized trusted-proxy CIDR whenever proxy-header trust is enabled, independent of dashboard authentication mode.
+- Preserve an empty trusted-proxy list when proxy-header trust is disabled.
+- Move the existing trusted-header dashboard check under the shared proxy-trust invariant rather than maintaining a narrower duplicate.
+- Add settings regressions for empty and whitespace-only CIDR input.
+- **BREAKING (invalid configuration only):** deployments that explicitly enable proxy-header trust with no usable trusted CIDR will fail startup until they configure a CIDR or disable header trust.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `api-firewall`: Define the startup invariant that enabled proxy-header trust requires a non-empty normalized trusted-proxy CIDR list.
+
+## Impact
+
+- Affected code: `app/core/config/settings.py` cross-field validation.
+- Affected tests: firewall settings validation.
+- Existing documented reverse-proxy examples already configure both settings, so no user-documentation correction or new setting is required.

--- a/openspec/changes/archive/2026-07-16-reject-empty-trusted-proxy-cidrs/specs/api-firewall/spec.md
+++ b/openspec/changes/archive/2026-07-16-reject-empty-trusted-proxy-cidrs/specs/api-firewall/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Enabled proxy-header trust requires source configuration
+
+The application MUST fail settings validation when `firewall_trust_proxy_headers` is enabled and the normalized `firewall_trusted_proxy_cidrs` list is empty. The validation MUST apply independently of dashboard authentication mode and MUST identify the conflicting settings. An empty trusted-proxy CIDR list MUST remain valid while proxy-header trust is disabled.
+
+#### Scenario: Enabled trust with empty CIDRs fails startup
+
+- **WHEN** `firewall_trust_proxy_headers=true`
+- **AND** `firewall_trusted_proxy_cidrs` is empty or contains only whitespace and delimiters
+- **THEN** settings validation fails before the application starts
+- **AND** the error identifies that enabled proxy-header trust requires at least one trusted-proxy CIDR
+
+#### Scenario: Disabled trust permits an empty CIDR list
+
+- **WHEN** `firewall_trust_proxy_headers=false`
+- **AND** `firewall_trusted_proxy_cidrs` normalizes to an empty list
+- **THEN** settings validation succeeds
+- **AND** forwarded client-IP headers remain untrusted

--- a/openspec/changes/archive/2026-07-16-reject-empty-trusted-proxy-cidrs/tasks.md
+++ b/openspec/changes/archive/2026-07-16-reject-empty-trusted-proxy-cidrs/tasks.md
@@ -1,0 +1,10 @@
+## 1. Settings invariant
+
+- [x] 1.1 Add failing settings regressions for enabled trust with empty normalized CIDRs and the disabled-trust boundary
+- [x] 1.2 Add cross-field validation requiring at least one trusted-proxy CIDR whenever proxy-header trust is enabled
+- [x] 1.3 Remove the narrower dashboard-mode duplicate while preserving trusted-header validation
+
+## 2. Specification and verification
+
+- [x] 2.1 Sync the proxy-trust configuration requirement to the main api-firewall specification
+- [x] 2.2 Run focused reproduction, tests, diagnostics, formatting, and strict OpenSpec validation

--- a/openspec/specs/api-firewall/spec.md
+++ b/openspec/specs/api-firewall/spec.md
@@ -74,3 +74,21 @@ The application MUST cache firewall allow/deny decisions per source IP for a con
 - **THEN** the firewall cache is invalidated for all IPs before the API response is returned
 - **AND** the next request from any IP re-checks the database
 
+### Requirement: Enabled proxy-header trust requires source configuration
+
+The application MUST fail settings validation when `firewall_trust_proxy_headers` is enabled and the normalized `firewall_trusted_proxy_cidrs` list is empty. The validation MUST apply independently of dashboard authentication mode and MUST identify the conflicting settings. An empty trusted-proxy CIDR list MUST remain valid while proxy-header trust is disabled.
+
+#### Scenario: Enabled trust with empty CIDRs fails startup
+
+- **WHEN** `firewall_trust_proxy_headers=true`
+- **AND** `firewall_trusted_proxy_cidrs` is empty or contains only whitespace and delimiters
+- **THEN** settings validation fails before the application starts
+- **AND** the error identifies that enabled proxy-header trust requires at least one trusted-proxy CIDR
+
+#### Scenario: Disabled trust permits an empty CIDR list
+
+- **WHEN** `firewall_trust_proxy_headers=false`
+- **AND** `firewall_trusted_proxy_cidrs` normalizes to an empty list
+- **THEN** settings validation succeeds
+- **AND** forwarded client-IP headers remain untrusted
+

--- a/tests/unit/test_settings_firewall.py
+++ b/tests/unit/test_settings_firewall.py
@@ -21,6 +21,43 @@ def test_settings_rejects_invalid_firewall_trusted_proxy_cidr(monkeypatch):
         Settings()
 
 
+@pytest.mark.parametrize("cidrs", ["", " ", ",", " , "])
+def test_settings_rejects_proxy_header_trust_without_trusted_cidrs(monkeypatch, cidrs):
+    monkeypatch.setenv("CODEX_LB_FIREWALL_TRUST_PROXY_HEADERS", "true")
+    monkeypatch.setenv("CODEX_LB_FIREWALL_TRUSTED_PROXY_CIDRS", cidrs)
+
+    with pytest.raises(
+        ValidationError,
+        match="firewall_trust_proxy_headers=true requires at least one entry in firewall_trusted_proxy_cidrs",
+    ):
+        Settings()
+
+
+@pytest.mark.parametrize("dashboard_auth_mode", list(DashboardAuthMode))
+def test_settings_rejects_empty_trusted_proxy_cidr_list_in_every_dashboard_mode(
+    dashboard_auth_mode: DashboardAuthMode,
+):
+    with pytest.raises(
+        ValidationError,
+        match="firewall_trust_proxy_headers=true requires at least one entry in firewall_trusted_proxy_cidrs",
+    ):
+        Settings(
+            dashboard_auth_mode=dashboard_auth_mode,
+            firewall_trust_proxy_headers=True,
+            firewall_trusted_proxy_cidrs=[],
+        )
+
+
+def test_settings_allows_empty_trusted_proxy_cidrs_when_header_trust_is_disabled(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_FIREWALL_TRUST_PROXY_HEADERS", "false")
+    monkeypatch.setenv("CODEX_LB_FIREWALL_TRUSTED_PROXY_CIDRS", " , ")
+
+    settings = Settings()
+
+    assert settings.firewall_trust_proxy_headers is False
+    assert settings.firewall_trusted_proxy_cidrs == []
+
+
 def test_settings_parses_proxy_unauthenticated_client_cidrs_from_csv(monkeypatch):
     monkeypatch.setenv("CODEX_LB_PROXY_UNAUTHENTICATED_CLIENT_CIDRS", "192.168.65.1/32, 172.17.0.0/16")
 


### PR DESCRIPTION
## Summary

Reject startup when `firewall_trust_proxy_headers=true` but the normalized `firewall_trusted_proxy_cidrs` list is empty (including empty/whitespace/comma-only input). This closes a config hole where proxy-header trust was enabled without any authorized proxy source.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [x] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: none matching (no open issue/Discussion found for this invariant). Historical context only: #84, #366. Independent of #1377.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/archive/2026-07-16-reject-empty-trusted-proxy-cidrs/`

## Changes

- Add cross-field settings validation: enabled proxy-header trust requires at least one normalized trusted-proxy CIDR.
- Keep empty trusted-proxy CIDRs valid when proxy-header trust is disabled.
- Archive + sync OpenSpec `api-firewall` requirement for the startup invariant.
- Add settings regressions for empty/whitespace CIDR input and the trust-disabled boundary.

## Migration / compatibility

**BREAKING (invalid configuration only):** deployments that previously started with `firewall_trust_proxy_headers=true` and no usable trusted CIDR will now fail settings validation at startup.

To migrate:
1. configure at least one entry in `CODEX_LB_FIREWALL_TRUSTED_PROXY_CIDRS` / `firewall_trusted_proxy_cidrs`, **or**
2. disable proxy-header trust (`CODEX_LB_FIREWALL_TRUST_PROXY_HEADERS=false` / `firewall_trust_proxy_headers=false`).

Documented reverse-proxy setups already configure both settings together, so no new setting and no docs correction are required. Trust-disabled empty CIDRs remain allowed.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config**
- [x] No new required setup step (or maintainer approval via `simplicity-budget-approved` label)
- New setting(s) and why each can't be a default: none — this only rejects previously accepted invalid configuration
- [x] README sections / `.env.example` / dashboard nav within budget (or `simplicity-budget-approved` label requested)

## Test plan

```
uv run pytest tests/unit/test_settings_firewall.py -q --tb=short
# 29 passed

openspec validate --specs --strict
# 47 passed, 0 failed (47 items)

PATH=.venv/bin:$PATH make ci-fast
# architecture ok; ruff ok; ty ok
# frontend: 124 files / 864 tests passed
# unit: 3995 passed, 55 skipped
# package built; wheel assets verified
```

## Screenshots / output

Not applicable — settings validation only; no dashboard-visible surface.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [ ] If touching specs: `openspec validate --specs --strict` passed 47/47; `/opsx:verify` was not run.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).