### PR TITLE
fix(security): enforce trusted proxy locality

### DIFF
--- a/app/core/request_locality.py
+++ b/app/core/request_locality.py
@@ -337,7 +337,9 @@ def _is_test_server_request(request: HTTPConnection) -> bool:
 
 
 def _has_forwarded_client_ip_hint(headers: Mapping[str, str]) -> bool:
-    return any(headers.get(header) for header in _FORWARDED_CLIENT_IP_HEADERS)
+    if isinstance(headers, Headers):
+        return any(value for header_name in _FORWARDED_CLIENT_IP_HEADERS for value in headers.getlist(header_name))
+    return any(headers.get(header_name) for header_name in _FORWARDED_CLIENT_IP_HEADERS)
 
 
 def _parse_host_header_hostname(host_header: str | None) -> str | None:
@@ -361,7 +363,14 @@ def is_local_request(request: HTTPConnection) -> bool:
         return True
 
     settings = get_settings()
-    client_host = resolve_request_client_host(request)
+    trusted_proxy_networks = parse_trusted_proxy_networks(settings.firewall_trusted_proxy_cidrs)
+    socket_ip = request.client.host if request.client else None
+    client_host = resolve_connection_client_ip(
+        request.headers,
+        socket_ip,
+        trust_proxy_headers=settings.firewall_trust_proxy_headers,
+        trusted_proxy_networks=trusted_proxy_networks,
+    )
     if not client_host:
         return False
     try:
@@ -371,6 +380,10 @@ def is_local_request(request: HTTPConnection) -> bool:
     if address.is_loopback:
         host_name = _parse_host_header_hostname(request.headers.get("host"))
         if settings.firewall_trust_proxy_headers:
-            return is_local_host(host_name) and _has_forwarded_client_ip_hint(request.headers)
+            return (
+                is_local_host(host_name)
+                and socket_ip is not None
+                and is_trusted_proxy_source(socket_ip, trusted_proxy_networks)
+            )
         return is_local_host(host_name) and not _has_forwarded_client_ip_hint(request.headers)
     return address.is_loopback

--- a/openspec/changes/archive/2026-07-16-fix-untrusted-proxy-locality/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-16-fix-untrusted-proxy-locality/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/archive/2026-07-16-fix-untrusted-proxy-locality/design.md
+++ b/openspec/changes/archive/2026-07-16-fix-untrusted-proxy-locality/design.md
@@ -1,0 +1,50 @@
+## Context
+
+`is_local_request()` gates first-run dashboard setup and unauthenticated protected proxy access. In trusted-proxy mode it currently resolves the client through configured proxy CIDRs, but its final loopback decision separately treats any forwarded client-IP header as provenance. If the socket peer is loopback but outside the configured trusted CIDRs, resolution correctly ignores the header and returns the socket address; the raw header-presence check then incorrectly turns that loopback address into a local identity.
+
+PR #339 introduced the provenance requirement to keep remote traffic behind loopback proxies from becoming local. PR #399 deliberately kept the later unauthenticated-proxy escape hatch bound to the raw socket peer and left dashboard/bootstrap auth protected. The correction must preserve both decisions.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Require a configured trusted socket peer and a successfully resolved forwarded client identity before trusted-proxy mode can classify loopback identity as local.
+- Preserve direct-local behavior when proxy-header trust is disabled.
+- Preserve explicit raw-socket `proxy_unauthenticated_client_cidrs` behavior.
+- Cover the externally failing dashboard bootstrap path as well as the shared locality predicate.
+
+**Non-Goals:**
+
+- Change forwarded-chain parsing or header precedence.
+- Add configuration validation or new settings.
+- Broaden local access for Docker or other non-loopback bridge peers.
+
+## Decisions
+
+### Bind trusted-proxy locality to both socket trust and resolved identity
+
+`is_local_request()` will compute the configured proxy networks once, resolve the client through the existing shared resolver, and retain the raw socket peer for provenance. In trusted-proxy mode, a resolved loopback address is local only when the raw socket peer belongs to those networks and the Host header is local. A trusted peer without a usable forwarded identity already resolves to no client and remains remote.
+
+Alternative: keep the raw header-presence check and additionally test the socket CIDR. Rejected because successful resolution is the stronger evidence: it also excludes missing and malformed values without duplicating resolver policy.
+
+### Inspect every direct-mode forwarded hint field
+
+When proxy-header trust is disabled, the resolver intentionally returns the socket peer and the locality predicate separately rejects requests carrying a non-empty forwarded client-IP hint. For Starlette `Headers`, that scan must use all field values because `get()` exposes only the first repeated field. Plain `Mapping[str, str]` inputs retain their single-value behavior.
+
+Alternative: reject any forwarded header name regardless of value. Rejected to preserve established direct-local behavior for empty header fields while still failing closed if any repeated value is non-empty.
+
+### Keep the explicit proxy escape hatch independent
+
+No change is made to `proxy_unauthenticated_client_cidrs`. Its existing raw-socket match remains the only way an otherwise non-local protected proxy request may proceed without API-key auth.
+
+Alternative: treat the escape-hatch CIDRs as locality. Rejected because PR #399 intentionally scoped them to proxy traffic and excluded dashboard/bootstrap authorization.
+
+## Risks / Trade-offs
+
+- [A proxy's actual socket address is absent from trusted CIDRs] → Requests remain remote, matching documented configuration and fail-closed behavior; operators must configure the observed proxy CIDR.
+- [Legitimate forwarded loopback identity regresses] → Preserve and test the case where the socket peer is configured as trusted and the resolved forwarded client is loopback.
+- [Shared locality affects dashboard and proxy auth] → Exercise both the unit predicate and an end-to-end password-bootstrap denial; retain the raw-socket proxy allowlist tests.
+
+## Migration Plan
+
+No data or configuration migration. Deploy as a fail-closed security correction. Roll back by reverting the implementation commit if a documented trusted-proxy setup regresses.

--- a/openspec/changes/archive/2026-07-16-fix-untrusted-proxy-locality/proposal.md
+++ b/openspec/changes/archive/2026-07-16-fix-untrusted-proxy-locality/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Trusted-proxy mode currently treats the mere presence of a forwarded client-IP header as provenance for loopback locality, even when the socket peer is outside every configured trusted-proxy CIDR. A remote request relayed over an untrusted loopback proxy can therefore be classified as local and bypass dashboard bootstrap or disabled-API-key remote protections.
+
+## What Changes
+
+- Require the loopback socket peer to match a configured trusted-proxy CIDR before a forwarded client-IP header can establish local request identity.
+- Keep direct-local behavior unchanged when proxy-header trust is disabled and no non-empty forwarded client-IP hint is present.
+- Inspect every repeated forwarded client-IP field in direct mode so a later non-empty value cannot be hidden behind an empty first field.
+- Keep valid forwarded loopback identity from a configured trusted proxy classified as local.
+- Add request-locality and dashboard-bootstrap regressions for untrusted loopback proxy sources.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `admin-auth`: Make dashboard locality depend on forwarded identity accepted from a configured trusted proxy, not raw header presence.
+- `api-keys`: Keep unauthenticated protected proxy access fail-closed when forwarded headers arrive from an untrusted socket peer.
+
+## Impact
+
+- Affected code: `app/core/request_locality.py` and its dashboard/proxy-auth callers through the shared locality predicate.
+- Affected tests: request-locality unit coverage and dashboard authentication integration coverage.
+- Configuration and wire formats remain unchanged; deployments whose actual proxy socket address is missing from `firewall_trusted_proxy_cidrs` remain remote until configured correctly.

--- a/openspec/changes/archive/2026-07-16-fix-untrusted-proxy-locality/specs/admin-auth/spec.md
+++ b/openspec/changes/archive/2026-07-16-fix-untrusted-proxy-locality/specs/admin-auth/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Trusted-proxy locality requires trusted socket provenance
+
+When proxy-header trust is enabled, the system MUST classify a forwarded loopback client as local only when the raw socket peer belongs to a configured trusted-proxy CIDR and forwarded client resolution succeeds. The mere presence of a forwarded client-IP header from an untrusted socket peer MUST NOT establish locality or bypass remote dashboard bootstrap requirements.
+
+#### Scenario: Untrusted loopback proxy cannot bypass remote bootstrap
+
+- **WHEN** proxy-header trust is enabled
+- **AND** the raw loopback socket peer is outside every configured trusted-proxy CIDR
+- **AND** the request supplies a local Host header and a forwarded client-IP header
+- **THEN** the request is classified as remote
+- **AND** first-run password setup requires the configured bootstrap token
+
+#### Scenario: Trusted proxy may forward a loopback client
+
+- **WHEN** proxy-header trust is enabled
+- **AND** the raw socket peer belongs to a configured trusted-proxy CIDR
+- **AND** valid forwarded client resolution yields a loopback address
+- **AND** the Host header is local
+- **THEN** the request is classified as local
+
+### Requirement: Direct locality inspects every forwarded client hint field
+
+When proxy-header trust is disabled, the system MUST classify a loopback socket peer with a local Host as local only when no non-empty forwarded client-IP field value is present. When such a header occurs more than once, the system MUST inspect every field value rather than only the first.
+
+#### Scenario: Later duplicate forwarded hint prevents local bootstrap
+
+- **WHEN** proxy-header trust is disabled
+- **AND** a loopback request with a local Host contains an empty `X-Forwarded-For` field followed by a non-empty `X-Forwarded-For` field
+- **THEN** the request is classified as remote
+- **AND** first-run password setup requires the configured bootstrap token

--- a/openspec/changes/archive/2026-07-16-fix-untrusted-proxy-locality/specs/api-keys/spec.md
+++ b/openspec/changes/archive/2026-07-16-fix-untrusted-proxy-locality/specs/api-keys/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Untrusted forwarded headers do not grant unauthenticated proxy locality
+
+When API-key authentication is disabled and proxy-header trust is enabled, forwarded client-IP headers from a socket peer outside every configured trusted-proxy CIDR MUST NOT cause a protected proxy request to be classified as local. Such a request MUST remain blocked unless its raw socket peer independently matches `proxy_unauthenticated_client_cidrs`.
+
+#### Scenario: Untrusted loopback proxy remains blocked
+
+- **WHEN** API-key authentication is disabled
+- **AND** proxy-header trust is enabled
+- **AND** the raw loopback socket peer is outside every configured trusted-proxy CIDR
+- **AND** a forwarded client-IP header is present
+- **AND** the raw socket peer is outside `proxy_unauthenticated_client_cidrs`
+- **THEN** the protected proxy request is rejected with HTTP 401
+
+#### Scenario: Explicit raw-socket allowlist remains authoritative
+
+- **WHEN** the raw socket peer belongs to `proxy_unauthenticated_client_cidrs`
+- **THEN** the protected proxy request may proceed without API-key authentication
+- **AND** forwarded header contents do not determine that allowlist match
+
+### Requirement: Direct-local proxy access inspects every forwarded client hint field
+
+When API-key authentication and proxy-header trust are disabled, a loopback socket peer MUST qualify for direct-local protected proxy access only when no non-empty forwarded client-IP field value is present. The system MUST inspect every repeated field value; a later non-empty value MUST keep the request blocked unless the raw socket peer independently matches `proxy_unauthenticated_client_cidrs`.
+
+#### Scenario: Later duplicate forwarded hint remains unauthorized
+
+- **WHEN** API-key authentication and proxy-header trust are disabled
+- **AND** a loopback request contains an empty `X-Forwarded-For` field followed by a non-empty `X-Forwarded-For` field
+- **AND** the raw socket peer is outside `proxy_unauthenticated_client_cidrs`
+- **THEN** the protected proxy request is rejected with HTTP 401

--- a/openspec/changes/archive/2026-07-16-fix-untrusted-proxy-locality/tasks.md
+++ b/openspec/changes/archive/2026-07-16-fix-untrusted-proxy-locality/tasks.md
@@ -1,0 +1,12 @@
+## 1. Provenance-aware locality
+
+- [x] 1.1 Add failing unit and integration reproductions for forwarded hints from an untrusted loopback socket peer
+- [x] 1.2 Require both configured socket trust and successful forwarded resolution for trusted-proxy loopback locality
+- [x] 1.3 Preserve direct-local behavior, configured trusted-proxy loopback behavior, and the explicit raw-socket proxy allowlist
+
+## 2. Verification and specification
+
+- [x] 2.1 Add behavior-level dashboard bootstrap and unauthenticated proxy regressions
+- [x] 2.2 Sync the admin-auth and api-keys requirements to their main specifications
+- [x] 2.3 Run focused reproductions, tests, diagnostics, formatting, and strict OpenSpec validation
+- [x] 2.4 Add unit, protected-proxy, and dashboard-bootstrap regressions for a non-empty forwarded hint hidden behind an empty duplicate field

--- a/openspec/specs/admin-auth/context.md
+++ b/openspec/specs/admin-auth/context.md
@@ -41,6 +41,8 @@ Requests from localhost (127.0.0.1, ::1) bypass bootstrap entirely — no token 
 
 Behind a trusted proxy, locality comes from the resolved client identity rather than from header presence alone. Chain headers preserve repeated fields because they form one ordered route; singleton identity headers (`X-Real-IP`, `True-Client-IP`, and `CF-Connecting-IP`) must appear once. Repetition is ambiguous and fails closed so a client-preseeded loopback field cannot win a first-value lookup.
 
+Direct loopback requests remain local when proxy-header trust is disabled only if every forwarded client-IP field value is empty. Repeated fields are all inspected: for example, an empty first `X-Forwarded-For` field followed by `203.0.113.24` is treated as proxied and remote. The same shared locality decision protects first-run dashboard setup and unauthenticated protected proxy access.
+
 ### Threat Model
 
 - **Token in logs**: Acceptable risk (same pattern as Grafana/GitLab/Portainer). `docker logs` requires container access. Token is one-time — useless after password is set.

--- a/openspec/specs/admin-auth/spec.md
+++ b/openspec/specs/admin-auth/spec.md
@@ -235,3 +235,34 @@ When proxy-header trust is enabled and the socket peer belongs to a configured t
 - **WHEN** a trusted socket request contains more than one field for `X-Real-IP`, `True-Client-IP`, or `CF-Connecting-IP`
 - **THEN** trusted proxy client resolution returns no client IP
 - **AND** the request is not classified as local
+
+### Requirement: Trusted-proxy locality requires trusted socket provenance
+
+When proxy-header trust is enabled, the system MUST classify a forwarded loopback client as local only when the raw socket peer belongs to a configured trusted-proxy CIDR and forwarded client resolution succeeds. The mere presence of a forwarded client-IP header from an untrusted socket peer MUST NOT establish locality or bypass remote dashboard bootstrap requirements.
+
+#### Scenario: Untrusted loopback proxy cannot bypass remote bootstrap
+
+- **WHEN** proxy-header trust is enabled
+- **AND** the raw loopback socket peer is outside every configured trusted-proxy CIDR
+- **AND** the request supplies a local Host header and a forwarded client-IP header
+- **THEN** the request is classified as remote
+- **AND** first-run password setup requires the configured bootstrap token
+
+#### Scenario: Trusted proxy may forward a loopback client
+
+- **WHEN** proxy-header trust is enabled
+- **AND** the raw socket peer belongs to a configured trusted-proxy CIDR
+- **AND** valid forwarded client resolution yields a loopback address
+- **AND** the Host header is local
+- **THEN** the request is classified as local
+
+### Requirement: Direct locality inspects every forwarded client hint field
+
+When proxy-header trust is disabled, the system MUST classify a loopback socket peer with a local Host as local only when no non-empty forwarded client-IP field value is present. When such a header occurs more than once, the system MUST inspect every field value rather than only the first.
+
+#### Scenario: Later duplicate forwarded hint prevents local bootstrap
+
+- **WHEN** proxy-header trust is disabled
+- **AND** a loopback request with a local Host contains an empty `X-Forwarded-For` field followed by a non-empty `X-Forwarded-For` field
+- **THEN** the request is classified as remote
+- **AND** first-run password setup requires the configured bootstrap token

--- a/openspec/specs/api-keys/spec.md
+++ b/openspec/specs/api-keys/spec.md
@@ -1112,3 +1112,32 @@ Settling a stream API-key reservation MUST NOT block the response/stream close, 
 - **WHEN** the service shuts down gracefully with settlements in flight
 - **THEN** shutdown waits for them up to the configured drain timeout
 
+### Requirement: Untrusted forwarded headers do not grant unauthenticated proxy locality
+
+When API-key authentication is disabled and proxy-header trust is enabled, forwarded client-IP headers from a socket peer outside every configured trusted-proxy CIDR MUST NOT cause a protected proxy request to be classified as local. Such a request MUST remain blocked unless its raw socket peer independently matches `proxy_unauthenticated_client_cidrs`.
+
+#### Scenario: Untrusted loopback proxy remains blocked
+
+- **WHEN** API-key authentication is disabled
+- **AND** proxy-header trust is enabled
+- **AND** the raw loopback socket peer is outside every configured trusted-proxy CIDR
+- **AND** a forwarded client-IP header is present
+- **AND** the raw socket peer is outside `proxy_unauthenticated_client_cidrs`
+- **THEN** the protected proxy request is rejected with HTTP 401
+
+#### Scenario: Explicit raw-socket allowlist remains authoritative
+
+- **WHEN** the raw socket peer belongs to `proxy_unauthenticated_client_cidrs`
+- **THEN** the protected proxy request may proceed without API-key authentication
+- **AND** forwarded header contents do not determine that allowlist match
+
+### Requirement: Direct-local proxy access inspects every forwarded client hint field
+
+When API-key authentication and proxy-header trust are disabled, a loopback socket peer MUST qualify for direct-local protected proxy access only when no non-empty forwarded client-IP field value is present. The system MUST inspect every repeated field value; a later non-empty value MUST keep the request blocked unless the raw socket peer independently matches `proxy_unauthenticated_client_cidrs`.
+
+#### Scenario: Later duplicate forwarded hint remains unauthorized
+
+- **WHEN** API-key authentication and proxy-header trust are disabled
+- **AND** a loopback request contains an empty `X-Forwarded-For` field followed by a non-empty `X-Forwarded-For` field
+- **AND** the raw socket peer is outside `proxy_unauthenticated_client_cidrs`
+- **THEN** the protected proxy request is rejected with HTTP 401

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -224,6 +224,27 @@ async def test_remote_proxy_denied_before_auth_is_configured(app_instance):
 
 
 @pytest.mark.asyncio
+async def test_untrusted_loopback_proxy_hint_does_not_bypass_proxy_auth(app_instance, monkeypatch):
+    _set_dashboard_auth_env(
+        monkeypatch,
+        mode=DashboardAuthMode.STANDARD,
+        trust_proxy_headers=True,
+        trusted_proxy_cidrs="10.0.0.0/8",
+    )
+
+    async with app_instance.router.lifespan_context(app_instance):
+        transport = ASGITransport(app=app_instance, client=("127.0.0.1", 50001))
+        async with AsyncClient(transport=transport, base_url="http://localhost") as proxied_client:
+            response = await proxied_client.get(
+                "/v1/models",
+                headers={"X-Forwarded-For": "203.0.113.24"},
+            )
+
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_api_key"
+
+
+@pytest.mark.asyncio
 async def test_proxy_unauthenticated_client_cidr_allows_explicit_remote_proxy_peer(app_instance, monkeypatch):
     _set_proxy_unauthenticated_client_cidrs_env(
         monkeypatch,
@@ -258,6 +279,60 @@ async def test_proxy_unauthenticated_client_cidr_does_not_allow_other_remote_pee
             spoofed = await remote_client.get("/v1/models", headers={"Host": "localhost"})
             assert spoofed.status_code == 401
             assert spoofed.json()["error"]["code"] == "invalid_api_key"
+
+
+@pytest.mark.asyncio
+async def test_untrusted_loopback_proxy_hint_does_not_bypass_dashboard_bootstrap(app_instance, monkeypatch):
+    monkeypatch.setenv("CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN", "bootstrap-secret")
+    _set_dashboard_auth_env(
+        monkeypatch,
+        mode=DashboardAuthMode.STANDARD,
+        trust_proxy_headers=True,
+        trusted_proxy_cidrs="10.0.0.0/8",
+    )
+    await get_settings_cache().invalidate()
+
+    async with app_instance.router.lifespan_context(app_instance):
+        transport = ASGITransport(app=app_instance, client=("127.0.0.1", 50000))
+        async with AsyncClient(transport=transport, base_url="http://localhost") as proxied_client:
+            response = await proxied_client.post(
+                "/api/dashboard-auth/password/setup",
+                headers={"X-Forwarded-For": "203.0.113.24"},
+                json={"password": "password123"},
+            )
+
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_bootstrap_token"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_forwarded_hint_does_not_bypass_direct_local_auth(app_instance, monkeypatch):
+    monkeypatch.setenv("CODEX_LB_DASHBOARD_BOOTSTRAP_TOKEN", "bootstrap-secret")
+    _set_dashboard_auth_env(
+        monkeypatch,
+        mode=DashboardAuthMode.STANDARD,
+        trust_proxy_headers=False,
+    )
+    await get_settings_cache().invalidate()
+    forwarded_headers = [
+        ("X-Forwarded-For", ""),
+        ("X-Forwarded-For", "203.0.113.24"),
+    ]
+
+    async with app_instance.router.lifespan_context(app_instance):
+        transport = ASGITransport(app=app_instance, client=("127.0.0.1", 50000))
+        async with AsyncClient(transport=transport, base_url="http://localhost") as proxied_client:
+            proxy_response = await proxied_client.get("/v1/models", headers=forwarded_headers)
+            bootstrap_response = await proxied_client.post(
+                "/api/dashboard-auth/password/setup",
+                headers=forwarded_headers,
+                json={"password": "password123"},
+            )
+
+    assert proxy_response.status_code == 401
+    assert proxy_response.json()["error"]["code"] == "invalid_api_key"
+    assert bootstrap_response.status_code == 401
+    assert bootstrap_response.json()["error"]["code"] == "invalid_bootstrap_token"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_request_locality.py
+++ b/tests/unit/test_request_locality.py
@@ -241,6 +241,7 @@ def test_connection_resolver_rejects_repeated_singleton_before_valid_xff() -> No
 
     assert resolved is None
 
+
 @pytest.mark.parametrize("trusted_cidrs", [[], ["10.0.0.0/8"]], ids=["empty", "nonmatching"])
 def test_trusted_proxy_mode_rejects_forwarded_hint_from_untrusted_loopback_peer(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_request_locality.py
+++ b/tests/unit/test_request_locality.py
@@ -81,7 +81,10 @@ def test_trusted_proxy_mode_accepts_loopback_with_forwarded_hint(monkeypatch: py
     monkeypatch.setattr(
         request_locality,
         "get_settings",
-        lambda: SimpleNamespace(firewall_trust_proxy_headers=True, firewall_trusted_proxy_cidrs=[]),
+        lambda: SimpleNamespace(
+            firewall_trust_proxy_headers=True,
+            firewall_trusted_proxy_cidrs=["127.0.0.1/32"],
+        ),
     )
     scope = {
         "type": "http",
@@ -237,3 +240,58 @@ def test_connection_resolver_rejects_repeated_singleton_before_valid_xff() -> No
     )
 
     assert resolved is None
+
+@pytest.mark.parametrize("trusted_cidrs", [[], ["10.0.0.0/8"]], ids=["empty", "nonmatching"])
+def test_trusted_proxy_mode_rejects_forwarded_hint_from_untrusted_loopback_peer(
+    monkeypatch: pytest.MonkeyPatch,
+    trusted_cidrs: list[str],
+) -> None:
+    monkeypatch.setattr(
+        request_locality,
+        "get_settings",
+        lambda: SimpleNamespace(
+            firewall_trust_proxy_headers=True,
+            firewall_trusted_proxy_cidrs=trusted_cidrs,
+        ),
+    )
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [(b"host", b"localhost"), (b"x-forwarded-for", b"203.0.113.24")],
+        "client": ("127.0.0.1", 50000),
+        "server": ("localhost", 80),
+        "scheme": "http",
+        "query_string": b"",
+    }
+
+    assert is_local_request(Request(scope)) is False
+
+
+def test_direct_locality_checks_every_duplicate_forwarded_header_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        request_locality,
+        "get_settings",
+        lambda: SimpleNamespace(
+            firewall_trust_proxy_headers=False,
+            firewall_trusted_proxy_cidrs=[],
+        ),
+    )
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": [
+            (b"host", b"localhost"),
+            (b"x-forwarded-for", b""),
+            (b"x-forwarded-for", b"203.0.113.24"),
+        ],
+        "client": ("127.0.0.1", 50000),
+        "server": ("localhost", 80),
+        "scheme": "http",
+        "query_string": b"",
+    }
+
+    assert is_local_request(Request(scope)) is False


### PR DESCRIPTION
## Summary

Make trusted-proxy locality require both a configured trusted raw socket peer and successful forwarded-client resolution. This is a standalone 12-file, one-commit change based directly on `main`; it is independent of #1377 and contains no commits or inherited changes from that PR.

Compatibility note: a proxy socket outside configured trusted CIDRs is now treated as remote, even when it sends a local Host and forwarded client-IP hint.

Historical context: PR #339 and PR #399.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: None — no matching issue or Discussion.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/archive/2026-07-16-fix-untrusted-proxy-locality/`

## Changes

- Parse configured trusted-proxy networks once in `is_local_request()`, retain the raw socket IP, resolve the forwarded client through the existing main-branch resolver, and require the raw peer itself to be trusted before trusted-mode loopback locality.
- Inspect every raw forwarded client-IP field value through Starlette `Headers.getlist()` for every supported header family, while preserving the plain `Mapping[str, str]` fallback.
- Preserve direct-local behavior when proxy-header trust is disabled and preserve the independent raw-peer semantics of `proxy_unauthenticated_client_cidrs`.
- Add unit and integration regressions for protected proxy auth, dashboard bootstrap, trusted proxy locality, explicit raw-peer allowlisting, and duplicate forwarded hints; sync the admin-auth and API-key specifications.
- Add no settings, runtime dependencies, database/schema changes, migrations, README sections, `.env.example` entries, or dashboard navigation changes.

## Simplicity

- [x] Zero-config behavior is preserved; this security fix adds no feature flag or setting.
- [x] No new required setup step.
- New setting(s) and why each can't be a default: None.
- [x] README sections / `.env.example` / dashboard nav remain within budget because none changes.

## Test plan

```text
uv run pytest -q tests/unit/test_request_locality.py tests/unit/test_firewall_ip_resolution.py tests/unit/test_firewall_service.py tests/unit/test_settings_firewall.py tests/unit/test_firewall_cache_ttl.py tests/integration/test_auth_middleware.py tests/integration/test_api_firewall_middleware.py tests/integration/test_firewall_api.py
# 82 passed in 12.41s

openspec validate --specs --strict
# 47/47 specs passed

PATH="$PWD/.venv/bin:$PATH" make ci-fast
# proxy architecture checks passed
# Ruff check passed; Ruff format check passed (790 files)
# ty check passed
# frontend Vitest: 124 files / 864 tests passed; frontend build passed
# unit pytest: 3990 passed, 55 skipped, 6 warnings
# package build and wheel asset verification passed
```

The focused security acceptance subset also passed 6/6 after reproducing the original untrusted-loopback bypass as 4/4 failures on the pre-fix main behavior.

## Screenshots / output

Not applicable — this changes authorization/locality behavior but no dashboard-visible rendering. No screenshots.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Issue/Discussion status is stated above (none matches); historical context PRs are linked without closing keywords.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `make ci-fast` gate locally.
- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
  - Strict `openspec validate --specs --strict` passed 47/47; `/opsx:verify` was not run because this change package is already archived.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is not edited by hand (release-please handles it).