### PR TITLE
fix(proxy): allow codex search browser preflight

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -796,6 +796,7 @@ def create_app() -> FastAPI:
     add_trusted_proxy_headers_middleware(app)
 
     app.include_router(proxy_api.realtime_call_router)
+    app.include_router(proxy_api.codex_preflight_router)
     app.include_router(proxy_api.router)
     app.include_router(proxy_api.internal_router)
     app.include_router(proxy_api.ws_router)

--- a/app/main.py
+++ b/app/main.py
@@ -793,7 +793,6 @@ def create_app() -> FastAPI:
     add_backend_api_codex_v1_alias_middleware(app)
     add_app_version_middleware(app)
     add_exception_handlers(app)
-    add_trusted_proxy_headers_middleware(app)
 
     @app.middleware("http")
     async def codex_alpha_search_cors_middleware(request: Request, call_next: Any) -> Response:
@@ -801,6 +800,8 @@ def create_app() -> FastAPI:
         if request.url.path == "/backend-api/codex/alpha/search":
             response.headers.update(proxy_api._codex_alpha_search_cors_headers(request))
         return response
+
+    add_trusted_proxy_headers_middleware(app)
 
     app.include_router(proxy_api.realtime_call_router)
     app.include_router(proxy_api.codex_preflight_router)

--- a/app/main.py
+++ b/app/main.py
@@ -796,8 +796,17 @@ def create_app() -> FastAPI:
 
     @app.middleware("http")
     async def codex_alpha_search_cors_middleware(request: Request, call_next: Any) -> Response:
-        response = await call_next(request)
-        if request.url.path == "/backend-api/codex/alpha/search":
+        route_path = proxy_api.codex_alpha_search_route_path(request.url.path)
+        try:
+            response = await call_next(request)
+        except Exception as exc:
+            if route_path is None:
+                raise
+            exception_handler = app.exception_handlers.get(Exception)
+            if exception_handler is None:
+                raise
+            response = await exception_handler(request, exc)
+        if route_path is not None:
             response.headers.update(proxy_api._codex_alpha_search_cors_headers(request))
         return response
 

--- a/app/main.py
+++ b/app/main.py
@@ -18,7 +18,7 @@ from typing import Any, Protocol, cast
 from urllib.parse import urlparse
 
 import aiohttp
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import FileResponse
 from starlette.staticfiles import StaticFiles
 
@@ -794,6 +794,13 @@ def create_app() -> FastAPI:
     add_app_version_middleware(app)
     add_exception_handlers(app)
     add_trusted_proxy_headers_middleware(app)
+
+    @app.middleware("http")
+    async def codex_alpha_search_cors_middleware(request: Request, call_next: Any) -> Response:
+        response = await call_next(request)
+        if request.url.path == "/backend-api/codex/alpha/search":
+            response.headers.update(proxy_api._codex_alpha_search_cors_headers(request))
+        return response
 
     app.include_router(proxy_api.realtime_call_router)
     app.include_router(proxy_api.codex_preflight_router)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -894,7 +894,7 @@ async def _codex_control_proxy(
         response = await context.service.codex_control_request(
             path,
             method=request.method,
-            payload=await request.body() if request.method.upper() not in {"GET", "HEAD"} else None,
+            payload=await _codex_control_payload(request),
             query_params=list(request.query_params.multi_items()),
             headers=request.headers,
             codex_session_affinity=True,
@@ -989,6 +989,25 @@ async def codex_safety_arc(
 
 _CODEX_ALPHA_SEARCH_ALLOWED_METHODS = "GET, POST, OPTIONS"
 _CODEX_ALPHA_SEARCH_ALLOWED_ORIGINS = frozenset({"https://chatgpt.com"})
+_CODEX_ALPHA_SEARCH_ROUTE_PATHS = frozenset(
+    {
+        "/backend-api/codex/alpha/search",
+        "/backend-api/codex/v1/alpha/search",
+    }
+)
+
+
+def codex_alpha_search_route_path(path: str | None) -> str | None:
+    if path in _CODEX_ALPHA_SEARCH_ROUTE_PATHS:
+        return path
+    return None
+
+
+async def _codex_control_payload(request: Request) -> bytes | None:
+    if request.method.upper() == "HEAD":
+        return None
+    payload = await request.body()
+    return payload or None
 
 
 def _codex_alpha_search_cors_headers(request: Request) -> dict[str, str]:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -982,7 +982,7 @@ async def codex_safety_arc(
     return await _codex_control_proxy(request, "safety/arc", context, api_key)
 
 
-@router.post("/alpha/search")
+@router.api_route("/alpha/search", methods=["GET", "POST"])
 async def codex_alpha_search(
     request: Request,
     context: ProxyContext = Depends(get_proxy_context),

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -982,7 +982,25 @@ async def codex_safety_arc(
     return await _codex_control_proxy(request, "safety/arc", context, api_key)
 
 
-@router.api_route("/alpha/search", methods=["GET", "POST"])
+_CODEX_ALPHA_SEARCH_ALLOWED_METHODS = "GET, POST, HEAD, OPTIONS"
+
+
+@router.options("/alpha/search")
+async def codex_alpha_search_options(request: Request) -> Response:
+    requested_headers = request.headers.get("access-control-request-headers")
+    allow_headers = requested_headers or "authorization, content-type, session_id"
+    return Response(
+        status_code=204,
+        headers={
+            "allow": _CODEX_ALPHA_SEARCH_ALLOWED_METHODS,
+            "access-control-allow-methods": _CODEX_ALPHA_SEARCH_ALLOWED_METHODS,
+            "access-control-allow-headers": allow_headers,
+            "access-control-max-age": "600",
+        },
+    )
+
+
+@router.api_route("/alpha/search", methods=["GET", "POST", "HEAD"])
 async def codex_alpha_search(
     request: Request,
     context: ProxyContext = Depends(get_proxy_context),

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -987,7 +987,7 @@ async def codex_safety_arc(
     return await _codex_control_proxy(request, "safety/arc", context, api_key)
 
 
-_CODEX_ALPHA_SEARCH_ALLOWED_METHODS = "GET, POST, HEAD, OPTIONS"
+_CODEX_ALPHA_SEARCH_ALLOWED_METHODS = "GET, POST, OPTIONS"
 
 
 @codex_preflight_router.options("/alpha/search")
@@ -1005,7 +1005,7 @@ async def codex_alpha_search_options(request: Request) -> Response:
     )
 
 
-@router.api_route("/alpha/search", methods=["GET", "POST", "HEAD"])
+@router.api_route("/alpha/search", methods=["GET", "POST"])
 async def codex_alpha_search(
     request: Request,
     context: ProxyContext = Depends(get_proxy_context),

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -345,6 +345,11 @@ class _RealtimeLiveCallIdConvertor(Convertor[str]):
 
 register_url_convertor("realtime_live_call_id", _RealtimeLiveCallIdConvertor())
 
+codex_preflight_router = APIRouter(
+    prefix="/backend-api/codex",
+    tags=["proxy"],
+    dependencies=[Depends(set_openai_error_format)],
+)
 router = APIRouter(
     prefix="/backend-api/codex",
     tags=["proxy"],
@@ -985,7 +990,7 @@ async def codex_safety_arc(
 _CODEX_ALPHA_SEARCH_ALLOWED_METHODS = "GET, POST, HEAD, OPTIONS"
 
 
-@router.options("/alpha/search")
+@codex_preflight_router.options("/alpha/search")
 async def codex_alpha_search_options(request: Request) -> Response:
     requested_headers = request.headers.get("access-control-request-headers")
     allow_headers = requested_headers or "authorization, content-type, session_id"

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -988,30 +988,76 @@ async def codex_safety_arc(
 
 
 _CODEX_ALPHA_SEARCH_ALLOWED_METHODS = "GET, POST, OPTIONS"
+_CODEX_ALPHA_SEARCH_ALLOWED_ORIGINS = frozenset({"https://chatgpt.com"})
+
+
+def _codex_alpha_search_cors_headers(request: Request) -> dict[str, str]:
+    origin = request.headers.get("origin")
+    if origin not in _CODEX_ALPHA_SEARCH_ALLOWED_ORIGINS:
+        return {}
+    return {
+        "access-control-allow-origin": origin,
+        "vary": "Origin",
+    }
 
 
 @codex_preflight_router.options("/alpha/search")
 async def codex_alpha_search_options(request: Request) -> Response:
     requested_headers = request.headers.get("access-control-request-headers")
     allow_headers = requested_headers or "authorization, content-type, session_id"
+    cors_headers = _codex_alpha_search_cors_headers(request)
+    headers = {
+        "allow": _CODEX_ALPHA_SEARCH_ALLOWED_METHODS,
+        "access-control-allow-methods": _CODEX_ALPHA_SEARCH_ALLOWED_METHODS,
+        "access-control-allow-headers": allow_headers,
+        "access-control-max-age": "600",
+    }
+    if cors_headers and request.headers.get("access-control-request-private-network", "").lower() == "true":
+        headers["access-control-allow-private-network"] = "true"
+    headers.update(cors_headers)
     return Response(
         status_code=204,
+        headers=headers,
+    )
+
+
+@codex_preflight_router.api_route(
+    "/alpha/search",
+    methods=["DELETE", "HEAD", "PATCH", "PUT", "TRACE"],
+    include_in_schema=False,
+)
+async def codex_alpha_search_method_not_allowed(request: Request) -> Response:
+    return Response(
+        status_code=405,
         headers={
             "allow": _CODEX_ALPHA_SEARCH_ALLOWED_METHODS,
-            "access-control-allow-methods": _CODEX_ALPHA_SEARCH_ALLOWED_METHODS,
-            "access-control-allow-headers": allow_headers,
-            "access-control-max-age": "600",
+            **_codex_alpha_search_cors_headers(request),
         },
     )
 
 
-@router.api_route("/alpha/search", methods=["GET", "POST"])
+async def _codex_alpha_search(request: Request, context: ProxyContext, api_key: ApiKeyData | None) -> Response:
+    response = await _codex_control_proxy(request, "alpha/search", context, api_key)
+    response.headers.update(_codex_alpha_search_cors_headers(request))
+    return response
+
+
+@router.get("/alpha/search", operation_id="codex_alpha_search_get")
 async def codex_alpha_search(
     request: Request,
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> Response:
-    return await _codex_control_proxy(request, "alpha/search", context, api_key)
+    return await _codex_alpha_search(request, context, api_key)
+
+
+@router.post("/alpha/search", operation_id="codex_alpha_search_post")
+async def codex_alpha_search_post(
+    request: Request,
+    context: ProxyContext = Depends(get_proxy_context),
+    api_key: ApiKeyData | None = Security(validate_proxy_api_key),
+) -> Response:
+    return await _codex_alpha_search(request, context, api_key)
 
 
 @router.get("/agent-identities/jwks")

--- a/openspec/changes/archive/2026-08-13-forward-codex-alpha-search/proposal.md
+++ b/openspec/changes/archive/2026-08-13-forward-codex-alpha-search/proposal.md
@@ -3,14 +3,17 @@
 ## Why
 
 Codex runtime 0.144.1 sends standalone web searches to
-`POST /backend-api/codex/alpha/search`. codex-lb does not register that route,
-so the request reaches the application fallback and returns HTTP 405 before an
-upstream account can be selected. Model-driven `web_search` calls inside the
-Responses API use a different path and do not cover this client contract.
+`POST /backend-api/codex/alpha/search`, and browser-backed search clients may
+use `GET` plus a cross-origin `OPTIONS` preflight. codex-lb did not register
+that route, so the request reached the application fallback and returned HTTP
+405 before an upstream account could be selected. Model-driven `web_search`
+calls inside the Responses API use a different path and do not cover this
+client contract.
 
 ## What Changes
 
-- Register `POST /backend-api/codex/alpha/search` on the Codex proxy router.
+- Register `GET` and `POST /backend-api/codex/alpha/search` on the Codex proxy
+  router, plus a local unauthenticated `OPTIONS` preflight.
 - Forward the request through the existing Codex control-request path so proxy
   authentication, account selection, refresh, affinity, failover, upstream
   routing, and response-header filtering remain consistent with other Codex
@@ -19,6 +22,9 @@ Responses API use a different path and do not cover this client contract.
   the upstream status, body, and allowlisted headers; failures retain the
   existing Codex control error normalization, refresh, health, and failover
   behavior.
+- Return CORS preflight metadata for the allowed ChatGPT browser origin without
+  forwarding the preflight upstream or bypassing authentication for actual
+  search requests.
 - Add unit and integration regressions for the public route contract.
 
 ## Issue Trace
@@ -28,6 +34,6 @@ Responses API use a different path and do not cover this client contract.
 ## Impact
 
 - **Spec**: `responses-api-compat`
-- **Behavior**: standalone Codex web search works through codex-lb instead of
-  returning HTTP 405.
+- **Behavior**: standalone Codex web search and its browser preflight work
+  through codex-lb instead of returning HTTP 405.
 - **Persistence/UI**: no database, migration, configuration, or dashboard changes.

--- a/openspec/changes/archive/2026-08-13-forward-codex-alpha-search/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-08-13-forward-codex-alpha-search/specs/responses-api-compat/spec.md
@@ -2,17 +2,18 @@
 
 ### Requirement: Standalone Codex web search is forwarded faithfully
 
-The proxy SHALL expose `POST /backend-api/codex/alpha/search` through the same
-proxy-authenticated Codex control-request path used by other unary Codex control
-endpoints. The proxy MUST preserve the inbound request body and query parameters,
-MUST apply the existing API-key scope, account selection, token refresh, session
-affinity, failover, and upstream-route policies, and MUST forward the request to
-the upstream `POST /codex/alpha/search` path. Successful downstream responses
-MUST preserve the upstream status and body and MUST include only response
-headers allowed by the existing Codex control-response policy. Final non-2xx
-responses MUST preserve their status while using the existing Codex control
-OpenAI error-envelope normalization. The proxy MUST NOT parse, normalize, or
-invent a local schema for successful search requests or responses.
+The proxy SHALL expose `GET` and `POST /backend-api/codex/alpha/search` through
+the same proxy-authenticated Codex control-request path used by other unary
+Codex control endpoints. The proxy MUST preserve the inbound request body and
+query parameters, MUST apply the existing API-key scope, account selection,
+token refresh, session affinity, failover, and upstream-route policies, and MUST
+forward the request to the upstream `/codex/alpha/search` path using the same
+HTTP method. Successful downstream responses MUST preserve the upstream status
+and body and MUST include only response headers allowed by the existing Codex
+control-response policy. Final non-2xx responses MUST preserve their status
+while using the existing Codex control OpenAI error-envelope normalization. The
+proxy MUST NOT parse, normalize, or invent a local schema for successful search
+requests or responses.
 
 #### Scenario: authenticated standalone search reaches the upstream Codex path
 
@@ -22,6 +23,27 @@ invent a local schema for successful search requests or responses.
 - **THEN** the proxy forwards the unchanged body and query parameters to
   `POST /codex/alpha/search` using the selected account credentials
 - **AND** the downstream client receives the upstream status and body
+
+#### Scenario: authenticated standalone search forwards GET query requests
+
+- **GIVEN** a valid proxy API key and at least one eligible ChatGPT account
+- **WHEN** Codex sends `GET /backend-api/codex/alpha/search` with query
+  parameters
+- **THEN** the proxy forwards the unchanged query parameters to
+  `GET /codex/alpha/search` using the selected account credentials
+- **AND** the downstream client receives the upstream status and body
+
+#### Scenario: browser preflight succeeds locally for the allowed origin
+
+- **WHEN** a browser sends `OPTIONS /backend-api/codex/alpha/search` with
+  `Origin: https://chatgpt.com` and an access-control request method of `GET` or
+  `POST`
+- **THEN** the proxy returns HTTP 204 locally
+- **AND** the response includes `Access-Control-Allow-Origin:
+  https://chatgpt.com`, `Vary: Origin`, `Access-Control-Allow-Methods: GET,
+  POST, OPTIONS`, and the requested access-control headers
+- **AND** the proxy does not forward the preflight upstream or require proxy API
+  key authentication for the preflight
 
 #### Scenario: unsafe upstream response headers are not exposed
 
@@ -39,6 +61,6 @@ invent a local schema for successful search requests or responses.
 
 #### Scenario: unsupported methods do not enter search forwarding
 
-- **WHEN** a client sends a non-POST request to
+- **WHEN** a client sends a non-GET, non-POST, non-OPTIONS request to
   `/backend-api/codex/alpha/search`
 - **THEN** the request does not enter the upstream search forwarding path

--- a/openspec/changes/archive/2026-08-13-forward-codex-alpha-search/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-08-13-forward-codex-alpha-search/specs/responses-api-compat/spec.md
@@ -9,11 +9,13 @@ query parameters, MUST apply the existing API-key scope, account selection,
 token refresh, session affinity, failover, and upstream-route policies, and MUST
 forward the request to the upstream `/codex/alpha/search` path using the same
 HTTP method. Successful downstream responses MUST preserve the upstream status
-and body and MUST include only response headers allowed by the existing Codex
-control-response policy. Final non-2xx responses MUST preserve their status
-while using the existing Codex control OpenAI error-envelope normalization. The
-proxy MUST NOT parse, normalize, or invent a local schema for successful search
-requests or responses.
+and body. The proxy MUST include only response headers allowed by the existing
+Codex control-response policy, except for the route-scoped browser CORS headers
+required on this surface for the allowed origin. Final non-2xx responses MUST
+preserve their status while using the existing Codex control OpenAI
+error-envelope normalization and MUST keep that same route-scoped CORS contract
+on proxy-produced failures. The proxy MUST NOT parse, normalize, or invent a
+local schema for successful search requests or responses.
 
 #### Scenario: authenticated standalone search reaches the upstream Codex path
 
@@ -33,6 +35,15 @@ requests or responses.
   `GET /codex/alpha/search` using the selected account credentials
 - **AND** the downstream client receives the upstream status and body
 
+#### Scenario: authenticated standalone search preserves GET request bodies
+
+- **GIVEN** a valid proxy API key and at least one eligible ChatGPT account
+- **WHEN** Codex sends `GET /backend-api/codex/alpha/search` with a request body
+  and query parameters
+- **THEN** the proxy forwards the unchanged request body and query parameters to
+  `GET /codex/alpha/search` using the selected account credentials
+- **AND** the downstream client receives the upstream status and body
+
 #### Scenario: browser preflight succeeds locally for the allowed origin
 
 - **WHEN** a browser sends `OPTIONS /backend-api/codex/alpha/search` with
@@ -42,8 +53,19 @@ requests or responses.
 - **AND** the response includes `Access-Control-Allow-Origin:
   https://chatgpt.com`, `Vary: Origin`, `Access-Control-Allow-Methods: GET,
   POST, OPTIONS`, and the requested access-control headers
+- **AND** the response includes `Access-Control-Allow-Private-Network: true`
+  whenever the request asks for private-network access
 - **AND** the proxy does not forward the preflight upstream or require proxy API
   key authentication for the preflight
+
+#### Scenario: allowed-origin search responses keep route-scoped CORS headers
+
+- **WHEN** an allowed-origin browser request reaches either
+  `/backend-api/codex/alpha/search` or the equivalent
+  `/backend-api/codex/v1/alpha/search` path
+- **THEN** successful upstream search responses include
+  `Access-Control-Allow-Origin: https://chatgpt.com` and `Vary: Origin`
+- **AND** proxy-produced early failures on the same routes keep those headers
 
 #### Scenario: unsafe upstream response headers are not exposed
 

--- a/openspec/changes/archive/2026-08-13-forward-codex-alpha-search/tasks.md
+++ b/openspec/changes/archive/2026-08-13-forward-codex-alpha-search/tasks.md
@@ -2,13 +2,13 @@
 
 - [x] 1.1 Define the standalone Codex search forwarding requirement under
   `responses-api-compat`.
-- [x] 1.2 Record authentication, account-routing, wire-fidelity, and response
-  header constraints.
+- [x] 1.2 Record authentication, account-routing, wire-fidelity, preflight, and
+  response header constraints.
 
 ## 2. Implementation
 
-- [x] 2.1 Register the POST-only Codex search route through the existing control
-  proxy.
+- [x] 2.1 Register the GET/POST Codex search routes through the existing control
+  proxy and keep browser OPTIONS preflight local.
 - [x] 2.2 Add unit route-contract and integration forwarding regressions.
 
 ## 3. Verification

--- a/tests/integration/test_daybreak_capability_routes.py
+++ b/tests/integration/test_daybreak_capability_routes.py
@@ -44,6 +44,7 @@ _FAIL_CLOSED_HTTP_ROUTES: frozenset[_RouteKey] = frozenset(
         ("HTTP", "POST", "/backend-api/codex/memories/trace_summarize"),
         ("HTTP", "POST", "/backend-api/codex/safety/arc"),
         ("HTTP", "POST", "/backend-api/codex/alpha/search"),
+        ("HTTP", "GET", "/backend-api/codex/alpha/search"),
         ("HTTP", "GET", "/backend-api/codex/agent-identities/jwks"),
         ("HTTP", "POST", "/backend-api/codex/responses"),
         ("HTTP", "POST", "/backend-api/codex/responses/"),
@@ -80,6 +81,16 @@ _LOCAL_AUTHENTICATED_ROUTES: frozenset[_RouteKey] = frozenset(
         ("HTTP", "GET", "/api/codex/usage"),
     }
 )
+_LOCAL_UNAUTHENTICATED_ROUTES: frozenset[_RouteKey] = frozenset(
+    {
+        ("HTTP", "OPTIONS", "/backend-api/codex/alpha/search"),
+        ("HTTP", "DELETE", "/backend-api/codex/alpha/search"),
+        ("HTTP", "HEAD", "/backend-api/codex/alpha/search"),
+        ("HTTP", "PATCH", "/backend-api/codex/alpha/search"),
+        ("HTTP", "PUT", "/backend-api/codex/alpha/search"),
+        ("HTTP", "TRACE", "/backend-api/codex/alpha/search"),
+    }
+)
 _RESPONSES_WEBSOCKET_ROUTES: frozenset[_RouteKey] = frozenset(
     {
         ("WS", "WEBSOCKET", "/backend-api/codex/responses"),
@@ -114,6 +125,7 @@ def test_registered_proxy_route_inventory_has_one_explicit_capability_policy(app
     policy_groups = (
         _FAIL_CLOSED_HTTP_ROUTES,
         _LOCAL_AUTHENTICATED_ROUTES,
+        _LOCAL_UNAUTHENTICATED_ROUTES,
         _RESPONSES_WEBSOCKET_ROUTES,
         _FAIL_CLOSED_WEBSOCKET_ROUTES,
         _SEPARATE_NAMESPACE_ROUTES,

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -797,11 +797,17 @@ async def test_codex_alpha_search_forwards_request_and_response(async_client, mo
     response = await async_client.post(
         "/backend-api/codex/alpha/search?result_count=10",
         content=payload,
-        headers={"content-type": "application/json", "session_id": "search-session"},
+        headers={
+            "content-type": "application/json",
+            "origin": "https://chatgpt.com",
+            "session_id": "search-session",
+        },
     )
 
     assert response.status_code == 200
     assert response.content == upstream_body
+    assert response.headers["access-control-allow-origin"] == "https://chatgpt.com"
+    assert response.headers["vary"] == "Origin"
     assert response.headers["x-request-id"] == "search-request"
     assert "set-cookie" not in response.headers
     assert calls == [
@@ -903,6 +909,45 @@ async def test_codex_alpha_search_options_returns_local_preflight(async_client, 
     assert response.headers["allow"] == "GET, POST, OPTIONS"
     assert response.headers["access-control-allow-methods"] == "GET, POST, OPTIONS"
     assert response.headers["access-control-allow-headers"] == "authorization, session_id"
+    assert response.headers["access-control-allow-origin"] == "https://chatgpt.com"
+    assert response.headers["vary"] == "Origin"
+    codex_control_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_codex_alpha_search_options_allows_private_network_preflight(async_client, monkeypatch):
+    codex_control_request = AsyncMock()
+    monkeypatch.setattr(proxy_module.ProxyService, "codex_control_request", codex_control_request)
+
+    response = await async_client.options(
+        "/backend-api/codex/alpha/search?query=OpenAI&result_count=10",
+        headers={
+            "origin": "https://chatgpt.com",
+            "access-control-request-method": "POST",
+            "access-control-request-headers": "authorization, content-type, session_id",
+            "access-control-request-private-network": "true",
+        },
+    )
+
+    assert response.status_code == 204
+    assert response.headers["access-control-allow-private-network"] == "true"
+    assert response.headers["access-control-allow-origin"] == "https://chatgpt.com"
+    codex_control_request.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_codex_alpha_search_unsupported_method_returns_full_allow_set(async_client, monkeypatch):
+    codex_control_request = AsyncMock()
+    monkeypatch.setattr(proxy_module.ProxyService, "codex_control_request", codex_control_request)
+
+    response = await async_client.put(
+        "/backend-api/codex/alpha/search?query=OpenAI&result_count=10",
+        headers={"origin": "https://chatgpt.com"},
+    )
+
+    assert response.status_code == 405
+    assert response.headers["allow"] == "GET, POST, OPTIONS"
+    assert response.headers["access-control-allow-origin"] == "https://chatgpt.com"
     codex_control_request.assert_not_called()
 
 

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -900,8 +900,8 @@ async def test_codex_alpha_search_options_returns_local_preflight(async_client, 
     )
 
     assert response.status_code == 204
-    assert response.headers["allow"] == "GET, POST, HEAD, OPTIONS"
-    assert response.headers["access-control-allow-methods"] == "GET, POST, HEAD, OPTIONS"
+    assert response.headers["allow"] == "GET, POST, OPTIONS"
+    assert response.headers["access-control-allow-methods"] == "GET, POST, OPTIONS"
     assert response.headers["access-control-allow-headers"] == "authorization, session_id"
     codex_control_request.assert_not_called()
 

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -821,6 +821,71 @@ async def test_codex_alpha_search_forwards_request_and_response(async_client, mo
 
 
 @pytest.mark.asyncio
+async def test_codex_alpha_search_get_forwards_query_without_body(async_client, monkeypatch):
+    await _import_account(async_client, "acc_codex_search_get", "codex-search-get@example.com")
+    calls = []
+    upstream_body = b'{"results":[{"title":"OpenAI","url":"https://openai.com/"}]}'
+
+    async def fake_codex_control_request(
+        path,
+        *,
+        method,
+        payload: bytes | None,
+        query_params,
+        headers,
+        access_token,
+        account_id,
+        timeout_seconds=None,
+        **_kwargs,
+    ):
+        calls.append(
+            {
+                "path": path,
+                "method": method,
+                "payload": payload,
+                "query_params": list(query_params),
+                "session_id": headers.get("session_id"),
+                "access_token": access_token,
+                "account_id": account_id,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        return core_proxy.CodexControlResponse(
+            status_code=200,
+            body=upstream_body,
+            headers={
+                "content-type": "application/json",
+                "x-request-id": "search-get-request",
+            },
+        )
+
+    monkeypatch.setattr(proxy_module, "core_codex_control_request", fake_codex_control_request)
+
+    response = await async_client.get(
+        "/backend-api/codex/alpha/search?query=OpenAI&result_count=10",
+        headers={"session_id": "search-get-session"},
+    )
+
+    assert response.status_code == 200
+    assert response.content == upstream_body
+    assert response.headers["x-request-id"] == "search-get-request"
+    assert calls == [
+        {
+            "path": "alpha/search",
+            "method": "GET",
+            "payload": None,
+            "query_params": [("query", "OpenAI"), ("result_count", "10")],
+            "session_id": "search-get-session",
+            "access_token": "access-token",
+            "account_id": "acc_codex_search_get",
+            "timeout_seconds": calls[0]["timeout_seconds"],
+        }
+    ]
+    assert isinstance(calls[0]["timeout_seconds"], float)
+    assert calls[0]["timeout_seconds"] > 0
+
+
+@pytest.mark.asyncio
 async def test_codex_alpha_search_preserves_normalized_control_error_contract(async_client, monkeypatch):
     async def fake_codex_control_request(*_args, **_kwargs):
         raise ProxyResponseError(

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -886,6 +886,27 @@ async def test_codex_alpha_search_get_forwards_query_without_body(async_client, 
 
 
 @pytest.mark.asyncio
+async def test_codex_alpha_search_options_returns_local_preflight(async_client, monkeypatch):
+    codex_control_request = AsyncMock()
+    monkeypatch.setattr(proxy_module.ProxyService, "codex_control_request", codex_control_request)
+
+    response = await async_client.options(
+        "/backend-api/codex/alpha/search?query=OpenAI&result_count=10",
+        headers={
+            "origin": "https://chatgpt.com",
+            "access-control-request-method": "GET",
+            "access-control-request-headers": "authorization, session_id",
+        },
+    )
+
+    assert response.status_code == 204
+    assert response.headers["allow"] == "GET, POST, HEAD, OPTIONS"
+    assert response.headers["access-control-allow-methods"] == "GET, POST, HEAD, OPTIONS"
+    assert response.headers["access-control-allow-headers"] == "authorization, session_id"
+    codex_control_request.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_codex_alpha_search_preserves_normalized_control_error_contract(async_client, monkeypatch):
     async def fake_codex_control_request(*_args, **_kwargs):
         raise ProxyResponseError(

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -983,6 +983,22 @@ async def test_codex_alpha_search_preserves_normalized_control_error_contract(as
 
 
 @pytest.mark.asyncio
+async def test_codex_alpha_search_cors_survives_auth_rejection(async_client):
+    response = await async_client.post(
+        "/backend-api/codex/alpha/search",
+        json={"query": "OpenAI official website"},
+        headers={
+            "origin": "https://chatgpt.com",
+            "authorization": "Bearer definitely-invalid-for-this-request",
+        },
+    )
+
+    assert response.status_code in {401, 403, 503}
+    assert response.headers["access-control-allow-origin"] == "https://chatgpt.com"
+    assert response.headers["vary"] == "Origin"
+
+
+@pytest.mark.asyncio
 async def test_codex_realtime_call_normalizes_upstream_control_error(
     async_client,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -892,6 +892,77 @@ async def test_codex_alpha_search_get_forwards_query_without_body(async_client, 
 
 
 @pytest.mark.asyncio
+async def test_codex_alpha_search_get_preserves_body_when_present(async_client, monkeypatch):
+    await _import_account(async_client, "acc_codex_search_get_body", "codex-search-get-body@example.com")
+    calls = []
+    upstream_body = b'{"results":[{"title":"OpenAI","url":"https://openai.com/"}]}'
+
+    async def fake_codex_control_request(
+        path,
+        *,
+        method,
+        payload: bytes | None,
+        query_params,
+        headers,
+        access_token,
+        account_id,
+        timeout_seconds=None,
+        **_kwargs,
+    ):
+        calls.append(
+            {
+                "path": path,
+                "method": method,
+                "payload": payload,
+                "query_params": list(query_params),
+                "session_id": headers.get("session_id"),
+                "access_token": access_token,
+                "account_id": account_id,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        return core_proxy.CodexControlResponse(
+            status_code=200,
+            body=upstream_body,
+            headers={
+                "content-type": "application/json",
+                "x-request-id": "search-get-body-request",
+            },
+        )
+
+    monkeypatch.setattr(proxy_module, "core_codex_control_request", fake_codex_control_request)
+    payload = b'{ "query": "OpenAI official website" }'
+
+    response = await async_client.request(
+        "GET",
+        "/backend-api/codex/alpha/search?query=OpenAI&result_count=10",
+        content=payload,
+        headers={
+            "content-type": "application/json",
+            "session_id": "search-get-body-session",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.content == upstream_body
+    assert response.headers["x-request-id"] == "search-get-body-request"
+    assert calls == [
+        {
+            "path": "alpha/search",
+            "method": "GET",
+            "payload": payload,
+            "query_params": [("query", "OpenAI"), ("result_count", "10")],
+            "session_id": "search-get-body-session",
+            "access_token": "access-token",
+            "account_id": "acc_codex_search_get_body",
+            "timeout_seconds": calls[0]["timeout_seconds"],
+        }
+    ]
+    assert isinstance(calls[0]["timeout_seconds"], float)
+    assert calls[0]["timeout_seconds"] > 0
+
+
+@pytest.mark.asyncio
 async def test_codex_alpha_search_options_returns_local_preflight(async_client, monkeypatch):
     codex_control_request = AsyncMock()
     monkeypatch.setattr(proxy_module.ProxyService, "codex_control_request", codex_control_request)
@@ -994,6 +1065,49 @@ async def test_codex_alpha_search_cors_survives_auth_rejection(async_client):
     )
 
     assert response.status_code in {401, 403, 503}
+    assert response.headers["access-control-allow-origin"] == "https://chatgpt.com"
+    assert response.headers["vary"] == "Origin"
+
+
+@pytest.mark.asyncio
+async def test_codex_alpha_search_alias_cors_survives_auth_rejection(async_client):
+    response = await async_client.post(
+        "/backend-api/codex/v1/alpha/search",
+        json={"query": "OpenAI official website"},
+        headers={
+            "origin": "https://chatgpt.com",
+            "authorization": "Bearer definitely-invalid-for-this-request",
+        },
+    )
+
+    assert response.status_code in {401, 403, 503}
+    assert response.headers["access-control-allow-origin"] == "https://chatgpt.com"
+    assert response.headers["vary"] == "Origin"
+
+
+@pytest.mark.asyncio
+async def test_codex_alpha_search_cors_survives_unhandled_exception(async_client, monkeypatch):
+    await _import_account(async_client, "acc_codex_search_exception", "codex-search-exception@example.com")
+
+    async def explode_codex_control_request(*_args, **_kwargs):
+        raise RuntimeError("search exploded")
+
+    monkeypatch.setattr(proxy_module.ProxyService, "codex_control_request", explode_codex_control_request)
+
+    response = await async_client.post(
+        "/backend-api/codex/alpha/search",
+        json={"query": "OpenAI official website"},
+        headers={"origin": "https://chatgpt.com"},
+    )
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "error": {
+            "code": "server_error",
+            "message": "Internal server error",
+            "type": "server_error",
+        }
+    }
     assert response.headers["access-control-allow-origin"] == "https://chatgpt.com"
     assert response.headers["vary"] == "Origin"
 

--- a/tests/unit/test_codex_alpha_search_route.py
+++ b/tests/unit/test_codex_alpha_search_route.py
@@ -1,14 +1,19 @@
 from fastapi.routing import APIRoute
 
-from app.modules.proxy.api import router
+from app.modules.proxy.api import codex_preflight_router, router
 
 
 def test_codex_alpha_search_route_allows_browser_search_methods() -> None:
-    routes = [
+    protected_routes = [
         route
         for route in router.routes
         if isinstance(route, APIRoute) and route.path == "/backend-api/codex/alpha/search"
     ]
+    preflight_routes = [
+        route
+        for route in codex_preflight_router.routes
+        if isinstance(route, APIRoute) and route.path == "/backend-api/codex/alpha/search"
+    ]
 
-    methods = set().union(*(route.methods for route in routes))
+    methods = set().union(*(route.methods for route in protected_routes + preflight_routes))
     assert methods == {"GET", "POST", "HEAD", "OPTIONS"}

--- a/tests/unit/test_codex_alpha_search_route.py
+++ b/tests/unit/test_codex_alpha_search_route.py
@@ -15,5 +15,26 @@ def test_codex_alpha_search_route_allows_browser_search_methods() -> None:
         if isinstance(route, APIRoute) and route.path == "/backend-api/codex/alpha/search"
     ]
 
-    methods = set().union(*(route.methods for route in protected_routes + preflight_routes))
-    assert methods == {"GET", "POST", "OPTIONS"}
+    protected_methods = set().union(*(route.methods for route in protected_routes))
+    preflight_methods = set().union(*(route.methods for route in preflight_routes))
+
+    assert protected_methods == {"GET", "POST"}
+    assert "OPTIONS" in preflight_methods
+    assert {"DELETE", "HEAD", "PATCH", "PUT", "TRACE"}.issubset(preflight_methods)
+
+    unsupported_route = next(route for route in preflight_routes if "PUT" in route.methods)
+    assert unsupported_route.include_in_schema is False
+
+
+def test_codex_alpha_search_openapi_operations_are_unique() -> None:
+    operations = {
+        (method, route.operation_id)
+        for route in router.routes
+        if isinstance(route, APIRoute) and route.path == "/backend-api/codex/alpha/search"
+        for method in route.methods
+    }
+
+    assert operations == {
+        ("GET", "codex_alpha_search_get"),
+        ("POST", "codex_alpha_search_post"),
+    }

--- a/tests/unit/test_codex_alpha_search_route.py
+++ b/tests/unit/test_codex_alpha_search_route.py
@@ -3,12 +3,12 @@ from fastapi.routing import APIRoute
 from app.modules.proxy.api import router
 
 
-def test_codex_alpha_search_route_is_post_only() -> None:
+def test_codex_alpha_search_route_allows_browser_search_methods() -> None:
     routes = [
         route
         for route in router.routes
         if isinstance(route, APIRoute) and route.path == "/backend-api/codex/alpha/search"
     ]
 
-    assert len(routes) == 1
-    assert routes[0].methods == {"POST"}
+    methods = set().union(*(route.methods for route in routes))
+    assert methods == {"GET", "POST", "HEAD", "OPTIONS"}

--- a/tests/unit/test_codex_alpha_search_route.py
+++ b/tests/unit/test_codex_alpha_search_route.py
@@ -16,4 +16,4 @@ def test_codex_alpha_search_route_allows_browser_search_methods() -> None:
     ]
 
     methods = set().union(*(route.methods for route in protected_routes + preflight_routes))
-    assert methods == {"GET", "POST", "HEAD", "OPTIONS"}
+    assert methods == {"GET", "POST", "OPTIONS"}


### PR DESCRIPTION
## Summary

Standalone Codex search could reach the protected generic proxy route before
browser preflight completed, producing method- or authorization-shaped failures
instead of forwarding the search request. This change gives
`/backend-api/codex/alpha/search` an explicit browser-safe contract while
keeping the forwarded route narrow.

The branch also hardens the shared GitHub Actions API client after review found
that GitHub may report primary or secondary rate limits as HTTP 403 as well as
429. Required contributor and change-detection checks now retry only proven
rate-limit responses while preserving permanent 403 failures.

## Changes

- Serve unauthenticated local `OPTIONS` preflight for the standalone search
  endpoint.
- Advertise only `GET, POST, OPTIONS`, including the required private-network
  preflight headers.
- Forward real `GET` and `POST` search requests through the existing authenticated
  Codex control path.
- Keep unsupported methods out of OpenAPI and give the supported methods unique
  operation IDs.
- Detect and retry GitHub 403 rate-limit responses from headers/body without
  treating unrelated authorization failures as transient.
- Add route, OpenAPI, preflight, auth, and CI-helper regressions.

## OpenSpec

Change directory: `openspec/changes/forward-codex-alpha-search/`

The delta specifies the exact method set, preflight/auth boundary, forwarding
behavior, and private-network response headers.

## Validation

- Current head: `29936d34d17ddd108e48dc98140029a902a4aa9f`
- [Current-head CI passed](https://github.com/Soju06/codex-lb/actions/runs/29564321328).
- [Current-head Codex review is clean](https://github.com/Soju06/codex-lb/pull/1383#issuecomment-5000459339).
- Strict OpenSpec, focused route/CI-helper tests, Ruff, type checking, and
  `git diff --check` passed while preparing the branch.

## Checklist

- [x] The public method and authentication contract is covered at the route.
- [x] OpenAPI exposes no unsupported search operations.
- [x] GitHub 403 retry behavior distinguishes rate limits from permanent denial.
- [x] The active OpenSpec change matches the implementation.
- [x] Current-head CI and Codex review are green.
