### PR TITLE
fix(proxy): retry upstream model capacity errors

### DIFF
--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -385,6 +385,7 @@ from app.modules.proxy.durable_bridge_coordinator import (
 from app.modules.proxy.helpers import (
     _normalize_error_code,
     classify_upstream_failure,
+    is_upstream_model_capacity_error,
 )
 from app.modules.proxy.http_bridge_forwarding import (
     HTTPBridgeForwardContext as HTTPBridgeForwardContext,
@@ -431,6 +432,8 @@ def _should_retry_transient_stream_error(code: str | None, message: str | None) 
         # replaying the POST is safe.
         return False
     if code in _facade()._TRANSIENT_RETRY_CODES:
+        return True
+    if is_upstream_model_capacity_error(message):
         return True
     if code != "upstream_unavailable" or not message:
         return False

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -423,7 +423,21 @@ def _should_penalize_stream_error(code: str | None) -> bool:
     return code in _facade()._ACCOUNT_RECOVERY_RETRY_CODES or code in _facade()._TRANSIENT_RETRY_CODES
 
 
-def _should_retry_transient_stream_error(code: str | None, message: str | None) -> bool:
+_MODEL_CAPACITY_LIMIT_CODES = {
+    "rate_limit_exceeded",
+    "usage_limit_reached",
+    "insufficient_quota",
+    "usage_not_included",
+    "quota_exceeded",
+}
+
+
+def _should_retry_transient_stream_error(
+    code: str | None,
+    message: str | None,
+    *,
+    response_id: str | None = None,
+) -> bool:
     if code is None or code == "stream_idle_timeout":
         return False
     if code == PROCESS_NETWORK_UNAVAILABLE_CODE:
@@ -434,6 +448,8 @@ def _should_retry_transient_stream_error(code: str | None, message: str | None) 
     if code in _facade()._TRANSIENT_RETRY_CODES:
         return True
     if is_upstream_model_capacity_error(message):
+        if code in _MODEL_CAPACITY_LIMIT_CODES or response_id is not None:
+            return False
         return True
     if code != "upstream_unavailable" or not message:
         return False

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -717,7 +717,11 @@ class _StreamingMixin(_StreamingRetryMixin):
                         )
                     if allow_retry and _facade()._should_retry_stream_error(code):
                         raise _RetryableStreamError(code, upstream_error, exclude_account=True)
-                    if allow_transient_retry and _facade()._should_retry_transient_stream_error(code, error_message):
+                    if allow_transient_retry and _facade()._should_retry_transient_stream_error(
+                        code,
+                        error_message,
+                        response_id=response_id if event.type == "response.failed" else None,
+                    ):
                         raise _TransientStreamError(code, upstream_error)
                 terminal_stream_error = _TerminalStreamError(
                     error_code or code,

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -329,6 +329,7 @@ from app.modules.proxy.helpers import (
     _is_account_model_unsupported_error,
     _normalize_error_code,
     _parse_openai_error,
+    is_upstream_model_capacity_error,
 )
 from app.modules.proxy.http_bridge_forwarding import (
     HTTPBridgeForwardContext as HTTPBridgeForwardContext,
@@ -703,6 +704,8 @@ def _websocket_precreated_retry_error_code(
         if _websocket_response_id(None, payload) is not None:
             return None
         return _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE
+    if is_upstream_model_capacity_error(error_message):
+        return "server_is_overloaded"
     if error_code not in _facade()._WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES:
         return None
     return error_code

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -705,6 +705,16 @@ def _websocket_precreated_retry_error_code(
             return None
         return _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE
     if is_upstream_model_capacity_error(error_message):
+        if error_code in {
+            "rate_limit_exceeded",
+            "usage_limit_reached",
+            "insufficient_quota",
+            "usage_not_included",
+            "quota_exceeded",
+        }:
+            return error_code
+        if _websocket_response_id(None, payload) is not None:
+            return None
         return "server_is_overloaded"
     if error_code not in _facade()._WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES:
         return None
@@ -861,6 +871,18 @@ def _websocket_owner_pinned_quota_error_code(
         _websocket_event_error_code(event_type, payload),
         _websocket_event_error_type(event_type, payload),
     )
+    if is_upstream_model_capacity_error(_websocket_event_error_message(event_type, payload)):
+        if error_code in {
+            "rate_limit_exceeded",
+            "usage_limit_reached",
+            "insufficient_quota",
+            "usage_not_included",
+            "quota_exceeded",
+        }:
+            return error_code
+        if _websocket_response_id(None, payload) is not None:
+            return None
+        return "server_is_overloaded"
     if error_code not in _facade()._WEBSOCKET_TRANSPARENT_REPLAY_ERROR_CODES:
         return None
     return error_code

--- a/app/modules/proxy/helpers.py
+++ b/app/modules/proxy/helpers.py
@@ -39,11 +39,7 @@ _QUOTA_CODES = frozenset({"insufficient_quota", "usage_not_included", "quota_exc
 _TRANSIENT_CODES = frozenset(
     {"server_error", "upstream_error", "stream_incomplete", "overloaded_error", "server_is_overloaded"}
 )
-_MODEL_CAPACITY_MESSAGE_MARKERS = (
-    "selected model is at capacity",
-    "model is at capacity",
-    "try a different model",
-)
+_MODEL_CAPACITY_MESSAGE_MARKERS = ("selected model is at capacity",)
 
 
 def _is_account_model_unsupported_error(
@@ -64,9 +60,7 @@ def is_upstream_model_capacity_error(message: str | None) -> bool:
     if message is None:
         return False
     normalized_message = " ".join(message.lower().split())
-    return all(marker in normalized_message for marker in ("model", "capacity")) or any(
-        marker in normalized_message for marker in _MODEL_CAPACITY_MESSAGE_MARKERS
-    )
+    return any(marker in normalized_message for marker in _MODEL_CAPACITY_MESSAGE_MARKERS)
 
 
 def classify_upstream_failure(

--- a/app/modules/proxy/helpers.py
+++ b/app/modules/proxy/helpers.py
@@ -39,6 +39,11 @@ _QUOTA_CODES = frozenset({"insufficient_quota", "usage_not_included", "quota_exc
 _TRANSIENT_CODES = frozenset(
     {"server_error", "upstream_error", "stream_incomplete", "overloaded_error", "server_is_overloaded"}
 )
+_MODEL_CAPACITY_MESSAGE_MARKERS = (
+    "selected model is at capacity",
+    "model is at capacity",
+    "try a different model",
+)
 
 
 def _is_account_model_unsupported_error(
@@ -55,6 +60,15 @@ def _is_account_model_unsupported_error(
     return normalized_message == expected_message
 
 
+def is_upstream_model_capacity_error(message: str | None) -> bool:
+    if message is None:
+        return False
+    normalized_message = " ".join(message.lower().split())
+    return all(marker in normalized_message for marker in ("model", "capacity")) or any(
+        marker in normalized_message for marker in _MODEL_CAPACITY_MESSAGE_MARKERS
+    )
+
+
 def classify_upstream_failure(
     *,
     error_code: str,
@@ -67,7 +81,11 @@ def classify_upstream_failure(
         failure_class = "rate_limit"
     elif error_code in _QUOTA_CODES:
         failure_class = "quota"
-    elif error_code in _TRANSIENT_CODES or (http_status is not None and http_status >= 500):
+    elif (
+        error_code in _TRANSIENT_CODES
+        or is_upstream_model_capacity_error(error.get("message"))
+        or (http_status is not None and http_status >= 500)
+    ):
         failure_class = "retryable_transient"
     else:
         failure_class = "non_retryable"

--- a/openspec/changes/retry-model-capacity-errors/proposal.md
+++ b/openspec/changes/retry-model-capacity-errors/proposal.md
@@ -1,0 +1,16 @@
+# Change: Retry upstream model-capacity errors
+
+## Why
+
+Codex can receive upstream failures whose user-facing message is exactly `Selected model is at capacity. Please try a different model.` These failures are temporary provider capacity, not a bad request from the user. When they are classified as non-retryable, Codex CLI surfaces the terminal error and then wastes a reconnect cycle on each affected thread.
+
+## What changes
+
+- Treat upstream model-capacity messages as retryable transient failures even when the upstream code/status looks like `invalid_request_error` / HTTP 400.
+- Apply the same classification to streaming first events, pre-visible HTTP errors, and websocket pre-created replay decisions.
+- Keep quota/rate-limit codes classified as quota/rate-limit before message-based transient detection.
+
+## Impact
+
+- Reduces user-visible thread stalls caused by temporary model capacity.
+- Preserves existing account quota and rate-limit handling.

--- a/openspec/changes/retry-model-capacity-errors/specs/responses-api-compat/spec.md
+++ b/openspec/changes/retry-model-capacity-errors/specs/responses-api-compat/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Model-capacity messages are retryable transient failures
+
+When upstream returns a temporary model-capacity failure whose message says that the selected model is at capacity, the proxy MUST treat the failure as retryable transient even if the upstream error code or HTTP status would otherwise look non-retryable.
+
+#### Scenario: Selected model capacity with invalid request code is retryable
+
+- **WHEN** upstream returns an error envelope with `error.message = "Selected model is at capacity. Please try a different model."`
+- **AND** the normalized error code is `invalid_request_error`
+- **AND** the HTTP status is `400`
+- **THEN** `classify_upstream_failure` returns `failure_class = "retryable_transient"`
+- **AND** pre-visible streaming/websocket paths are eligible to retry or fail over instead of surfacing a terminal client error.
+
+#### Scenario: Quota and rate-limit codes retain their stronger classification
+
+- **WHEN** upstream returns a quota or rate-limit error code
+- **THEN** the proxy MUST keep classifying it as quota or rate-limit before applying message-based model-capacity detection.

--- a/openspec/changes/retry-model-capacity-errors/tasks.md
+++ b/openspec/changes/retry-model-capacity-errors/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] Add OpenSpec requirement for model-capacity message retry classification.
+- [x] Add shared capacity-message predicate and wire it into failover/retry paths.
+- [x] Add regressions for the literal Codex capacity message.
+- [x] Run targeted tests and strict OpenSpec validation.

--- a/tests/unit/test_failover_foundation.py
+++ b/tests/unit/test_failover_foundation.py
@@ -126,6 +126,17 @@ class TestClassifyUpstreamFailure:
         )
         assert result["failure_class"] == "retryable_transient"
 
+    def test_generic_capacity_message_is_not_model_capacity_retry(self) -> None:
+        result = classify_upstream_failure(
+            error_code="invalid_request_error",
+            error=UpstreamError(
+                message=("This model has a fixed context capacity; reduce input size or try a different model."),
+            ),
+            http_status=400,
+            phase="first_event",
+        )
+        assert result["failure_class"] == "non_retryable"
+
     def test_rate_limit_code_takes_precedence_over_capacity_message(self) -> None:
         result = classify_upstream_failure(
             error_code="rate_limit_exceeded",

--- a/tests/unit/test_failover_foundation.py
+++ b/tests/unit/test_failover_foundation.py
@@ -117,6 +117,24 @@ class TestClassifyUpstreamFailure:
         )
         assert result["failure_class"] == "retryable_transient"
 
+    def test_selected_model_capacity_message(self) -> None:
+        result = classify_upstream_failure(
+            error_code="invalid_request_error",
+            error=UpstreamError(message="Selected model is at capacity. Please try a different model."),
+            http_status=400,
+            phase="first_event",
+        )
+        assert result["failure_class"] == "retryable_transient"
+
+    def test_rate_limit_code_takes_precedence_over_capacity_message(self) -> None:
+        result = classify_upstream_failure(
+            error_code="rate_limit_exceeded",
+            error=UpstreamError(message="Selected model is at capacity. Please try a different model."),
+            http_status=429,
+            phase="first_event",
+        )
+        assert result["failure_class"] == "rate_limit"
+
     def test_non_retryable_bad_request(self) -> None:
         result = classify_upstream_failure(
             error_code="invalid_request",

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -952,6 +952,38 @@ def test_websocket_precreated_retry_error_code_classifies_exact_account_model_re
     )
 
 
+def test_websocket_precreated_retry_error_code_classifies_model_capacity_message():
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_model_capacity",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
+    )
+    payload: dict[str, JsonValue] = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "type": "invalid_request_error",
+            "code": "invalid_request_error",
+            "message": "Selected model is at capacity. Please try a different model.",
+        },
+    }
+
+    assert (
+        proxy_service._websocket_precreated_retry_error_code(
+            request_state,
+            event_type="error",
+            payload=payload,
+            has_other_pending_requests=False,
+        )
+        == "server_is_overloaded"
+    )
+
+
 @pytest.mark.parametrize(
     ("kind", "expected"),
     [("account_model", "account_model_unsupported"), ("auth", "invalid_api_key")],
@@ -1193,6 +1225,16 @@ def test_upstream_unavailable_certificate_connect_error_is_not_transient_retry()
             message,
         )
         is False
+    )
+
+
+def test_selected_model_capacity_message_is_transient_retry() -> None:
+    assert (
+        proxy_service._should_retry_transient_stream_error(
+            "invalid_request_error",
+            "Selected model is at capacity. Please try a different model.",
+        )
+        is True
     )
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -984,6 +984,72 @@ def test_websocket_precreated_retry_error_code_classifies_model_capacity_message
     )
 
 
+def test_websocket_precreated_retry_error_code_preserves_capacity_quota_code():
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_model_capacity_quota",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
+    )
+    payload: dict[str, JsonValue] = {
+        "type": "error",
+        "status": 429,
+        "error": {
+            "type": "rate_limit_error",
+            "code": "rate_limit_exceeded",
+            "message": "Selected model is at capacity. Please try a different model.",
+        },
+    }
+
+    assert (
+        proxy_service._websocket_precreated_retry_error_code(
+            request_state,
+            event_type="error",
+            payload=payload,
+            has_other_pending_requests=False,
+        )
+        == "rate_limit_exceeded"
+    )
+
+
+def test_websocket_precreated_retry_error_code_does_not_replay_accepted_model_capacity():
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_model_capacity_accepted",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
+    )
+    payload: dict[str, JsonValue] = {
+        "type": "response.failed",
+        "response": {
+            "id": "resp_model_capacity_accepted",
+            "error": {
+                "type": "invalid_request_error",
+                "code": "invalid_request_error",
+                "message": "Selected model is at capacity. Please try a different model.",
+            },
+        },
+    }
+
+    assert (
+        proxy_service._websocket_precreated_retry_error_code(
+            request_state,
+            event_type="response.failed",
+            payload=payload,
+            has_other_pending_requests=False,
+        )
+        is None
+    )
+
+
 @pytest.mark.parametrize(
     ("kind", "expected"),
     [("account_model", "account_model_unsupported"), ("auth", "invalid_api_key")],
@@ -1235,6 +1301,27 @@ def test_selected_model_capacity_message_is_transient_retry() -> None:
             "Selected model is at capacity. Please try a different model.",
         )
         is True
+    )
+
+
+def test_selected_model_capacity_stream_preserves_limit_code() -> None:
+    assert (
+        proxy_service._should_retry_transient_stream_error(
+            "rate_limit_exceeded",
+            "Selected model is at capacity. Please try a different model.",
+        )
+        is False
+    )
+
+
+def test_selected_model_capacity_stream_does_not_retry_accepted_response() -> None:
+    assert (
+        proxy_service._should_retry_transient_stream_error(
+            "invalid_request_error",
+            "Selected model is at capacity. Please try a different model.",
+            response_id="resp_model_capacity_accepted",
+        )
+        is False
     )
 
 
@@ -20862,6 +20949,81 @@ async def test_process_upstream_websocket_text_replays_proxy_verified_anchor_aft
     )
 
     handle_stream_error.assert_awaited_once()
+    finalize_request_state.assert_not_awaited()
+    assert upstream_control.reconnect_requested is True
+    assert upstream_control.suppress_downstream_event is True
+    assert upstream_control.replay_request_state is pending_request
+    assert pending_request.request_text == fresh_text
+    assert pending_request.previous_response_id is None
+    assert pending_request.preferred_account_id is None
+    assert list(pending_requests) == []
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_replays_proxy_verified_anchor_after_model_capacity(
+    monkeypatch,
+):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    finalize_request_state = AsyncMock()
+    handle_stream_error = AsyncMock()
+    account = _make_account("acc_ws_proxy_anchor_model_capacity")
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    anchored_payload = {
+        "type": "response.create",
+        "model": "gpt-5.6-sol",
+        "previous_response_id": "resp_proxy_anchor_capacity",
+        "input": [{"role": "user", "content": "next"}],
+    }
+    fresh_payload = {
+        "type": "response.create",
+        "model": "gpt-5.6-sol",
+        "input": [{"role": "user", "content": "full history"}],
+    }
+    fresh_text = json.dumps(fresh_payload, separators=(",", ":"))
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="ws_req_proxy_anchor_model_capacity",
+        model="gpt-5.6-sol",
+        service_tier="priority",
+        reasoning_effort="high",
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text=json.dumps(anchored_payload, separators=(",", ":")),
+        previous_response_id="resp_proxy_anchor_capacity",
+        preferred_account_id=account.id,
+        proxy_injected_previous_response_id=True,
+        fresh_upstream_request_text=fresh_text,
+        fresh_upstream_request_is_retry_safe=True,
+    )
+    pending_requests = deque([pending_request])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    upstream_payload = {
+        "type": "error",
+        "status": 400,
+        "error": {
+            "type": "invalid_request_error",
+            "code": "invalid_request_error",
+            "message": "Selected model is at capacity. Please try a different model.",
+        },
+    }
+
+    await service._process_upstream_websocket_text(
+        json.dumps(upstream_payload, separators=(",", ":")),
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    handle_stream_error.assert_awaited_once()
+    handle_call = handle_stream_error.await_args
+    assert handle_call is not None
+    assert handle_call.args[2] == "server_is_overloaded"
     finalize_request_state.assert_not_awaited()
     assert upstream_control.reconnect_requested is True
     assert upstream_control.suppress_downstream_event is True


### PR DESCRIPTION
## Summary

- Treat upstream `Selected model is at capacity. Please try a different model.` failures as retryable transient model-capacity errors, even when upstream wraps them as `invalid_request_error` / HTTP 400.
- Wire the same capacity-message predicate through deterministic failover classification, stream retry decisions, and websocket pre-created replay classification.
- Add OpenSpec coverage plus regressions for the literal Codex capacity message and for keeping rate-limit codes classified as rate limits.

## Tests

- `uv run pytest tests/unit/test_failover_foundation.py tests/unit/test_proxy_utils.py -q -k 'selected_model_capacity or rate_limit_code_takes_precedence or model_capacity_message or overloaded_error or server_is_overloaded or certificate_connect_error'`
- `openspec validate retry-model-capacity-errors --strict`
- `openspec validate --specs`
