### PR TITLE
fix(proxy): retry websocket EOF before visible output

### DIFF
--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -106,6 +106,13 @@ class ApiKeysRepository:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
 
+    async def update_last_used(self, key_id: str, *, commit: bool = True) -> None:
+        await self._session.execute(
+            update(ApiKey).where(ApiKey.id == key_id).values(last_used_at=utcnow())
+        )
+        if commit:
+            await self._session.commit()
+
     @staticmethod
     def _build_account_costs(rows: Sequence[object]) -> list[ApiKeyAccountCost]:
         account_costs: list[ApiKeyAccountCost] = []

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -107,9 +107,7 @@ class ApiKeysRepository:
         self._session = session
 
     async def update_last_used(self, key_id: str, *, commit: bool = True) -> None:
-        await self._session.execute(
-            update(ApiKey).where(ApiKey.id == key_id).values(last_used_at=utcnow())
-        )
+        await self._session.execute(update(ApiKey).where(ApiKey.id == key_id).values(last_used_at=utcnow()))
         if commit:
             await self._session.commit()
 

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -1677,6 +1677,9 @@ class _WebSocketMixin:
                     and upstream_control.reconnect_requested
                     and upstream_reader is not None
                     and (
+                        # Keep receiving downstream controls while a live
+                        # reader still owns pending work; only replay or a
+                        # completed/empty drain needs immediate settlement.
                         upstream_reader.done()
                         or upstream_control.replay_request_state is not None
                         or not pending_requests

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -1676,8 +1676,18 @@ class _WebSocketMixin:
                     and upstream_control is not None
                     and upstream_control.reconnect_requested
                     and upstream_reader is not None
+                    and (
+                        upstream_reader.done()
+                        or upstream_control.replay_request_state is not None
+                        or not pending_requests
+                    )
                 ):
-                    await upstream_reader
+                    try:
+                        await upstream_reader
+                    except asyncio.CancelledError:
+                        current_task = asyncio.current_task()
+                        if current_task is not None and current_task.cancelling():
+                            raise
                     if replay_request_state is None:
                         replay_request_state = upstream_control.replay_request_state
                     upstream_reader = None

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -1727,6 +1727,7 @@ class _WebSocketMixin:
                             ("previous response", previous_response_owner_account_id),
                         )
                     except ProxyResponseError as exc:
+                        response_create_request_state = request_state
                         error = _parse_openai_error(exc.payload)
                         error_code = _normalize_error_code(
                             error.code if error else None,
@@ -1735,7 +1736,7 @@ class _WebSocketMixin:
                         error_message = error.message if error and error.message else "Upstream error"
                         error_type = error.type if error and error.type else "server_error"
                         error_param = error.param if error else None
-                        await proxy._release_websocket_request_state_reservation(request_state)
+                        await proxy._release_websocket_request_state_reservation(response_create_request_state)
                         await proxy._write_websocket_connect_failure(
                             account_id=None,
                             api_key=api_key,


### PR DESCRIPTION
## Summary

Adds bounded transparent retry for Codex websocket upstream EOFs that happen after `response.created` but before any downstream-visible text/tool output. This keeps transient `no close frame received or sent` upstream disconnects inside codex-lb instead of making Codex CLI spend a long reconnect loop on every affected thread.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: n/a

## OpenSpec

- [x] Not applicable — bug fix that matches the existing spec
- [x] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: n/a

## Changes

- Allow up to three transparent websocket close replays before visible output instead of only one.
- Add jittered backoff before reconnecting the upstream websocket.
- Preserve the original downstream response id across repeated transparent replays.
- Cover repeated created-only upstream EOFs and retry-budget exhaustion in websocket integration tests.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config**
- [x] No new required setup step (or maintainer approval via `simplicity-budget-approved` label)
- New setting(s) and why each can't be a default: none
- [x] README sections / `.env.example` / dashboard nav within budget (or `simplicity-budget-approved` label requested)

## Test plan

```
uv run pytest -q tests/integration/test_proxy_websocket_responses.py -k 'retries_repeated_created_only_upstream_eof or emits_response_failed_before_close_on_upstream_eof or closes_before_replaying_exposed_sequence' --tb=short
# 3 passed, 71 deselected, 1 warning in 5.55s

uvx ruff check app/modules/proxy/_service/support.py app/modules/proxy/_service/websocket/helpers.py app/modules/proxy/_service/websocket/mixin.py tests/integration/test_proxy_websocket_responses.py
# All checks passed!

uvx ruff format --check app/modules/proxy/_service/support.py app/modules/proxy/_service/websocket/helpers.py app/modules/proxy/_service/websocket/mixin.py tests/integration/test_proxy_websocket_responses.py
# 4 files already formatted
```

## Screenshots / output

Proxy behavior: repeated upstream websocket EOFs before visible output are retried internally; the downstream sees the original `response.created` followed by the final terminal event using the original response id.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
