### PR TITLE
fix(streaming): preserve terminal no-replay boundaries

### DIFF
--- a/app/core/clients/codex.py
+++ b/app/core/clients/codex.py
@@ -274,10 +274,7 @@ class CodexClient:
                         failure_phase="connect",
                         # No response.create frame can be delivered before the
                         # websocket open returns to its caller.
-                        retryable_same_contract=is_process_network_failure(
-                            exc,
-                            include_permanent_dns=False,
-                        ),
+                        retryable_same_contract=is_pre_dispatch_connection_failure(exc),
                     ) from None
         raise RuntimeError("unreachable Codex client websocket fallback state")
 

--- a/app/core/clients/codex.py
+++ b/app/core/clients/codex.py
@@ -34,12 +34,14 @@ class CodexTransportError(RuntimeError):
         error_code: str | None = None,
         retryable_same_contract: bool = False,
         failure_phase: str | None = None,
+        is_tls_verification_failure: bool = False,
     ) -> None:
         super().__init__(message)
         self.status_code = status_code
         self.error_code = error_code
         self.retryable_same_contract = retryable_same_contract
         self.failure_phase = failure_phase
+        self.is_tls_verification_failure = is_tls_verification_failure
 
 
 def require_route_or_direct_egress_opt_in(
@@ -474,6 +476,7 @@ def _transport_error(
         error_code=PROCESS_NETWORK_UNAVAILABLE_CODE if process_network_failure else None,
         retryable_same_contract=retryable_same_contract,
         failure_phase=failure_phase,
+        is_tls_verification_failure=isinstance(exc, aiohttp.ClientSSLError),
     )
 
 

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -3165,8 +3165,8 @@ async def _stream_responses_with_session(
         failure_phase = exc.failure_phase or "upstream"
         failure_detail = "transport_error"
         failure_exception_type = type(exc).__name__
-        retryable_same_contract = exc.retryable_same_contract
-        if routed_error_code == PROCESS_NETWORK_UNAVAILABLE_CODE and exc.retryable_same_contract:
+        retryable_same_contract = exc.retryable_same_contract and not exc.is_tls_verification_failure
+        if routed_error_code == PROCESS_NETWORK_UNAVAILABLE_CODE and retryable_same_contract:
             # Routed Codex sessions are private to this attempt, so recovery
             # legitimately has no shared HTTP generation for compare-and-swap.
             raise _process_network_failure_error(
@@ -3175,7 +3175,7 @@ async def _stream_responses_with_session(
                 retryable_same_contract=True,
                 failed_session=None,
             ) from exc
-        if raise_for_status and exc.retryable_same_contract:
+        if raise_for_status and retryable_same_contract:
             raise ProxyResponseError(
                 exc.status_code or 502,
                 openai_error(routed_error_code, response_error_message),

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -3175,6 +3175,17 @@ async def _stream_responses_with_session(
                 retryable_same_contract=True,
                 failed_session=None,
             ) from exc
+        if raise_for_status and exc.retryable_same_contract:
+            raise ProxyResponseError(
+                exc.status_code or 502,
+                openai_error(routed_error_code, response_error_message),
+                failure_phase="connect",
+                retryable_same_contract=True,
+                failure_detail=failure_detail,
+                failure_exception_type=failure_exception_type,
+                upstream_status_code=exc.status_code,
+                upstream_error_code=routed_error_code,
+            ) from exc
         yield format_sse_event(
             response_failed_event(routed_error_code, response_error_message, response_id=get_request_id()),
         )
@@ -3204,6 +3215,16 @@ async def _stream_responses_with_session(
                 response_error_message,
                 exc,
                 retryable_same_contract=retryable_same_contract,
+                failed_session=client_session,
+            ) from exc
+        if raise_for_status and retryable_same_contract:
+            raise ProxyResponseError(
+                502,
+                openai_error(error_code or "upstream_unavailable", response_error_message),
+                failure_phase="connect",
+                retryable_same_contract=True,
+                failure_detail=failure_detail,
+                failure_exception_type=failure_exception_type,
                 failed_session=client_session,
             ) from exc
         yield format_sse_event(

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -3203,8 +3203,13 @@ async def _stream_responses_with_session(
             exc=exc,
         )
         response_error_message = cast(str, error_message)
-        retryable_same_contract = transport == "http" and is_pre_dispatch_connection_failure(exc)
-        failure_phase = "connect" if retryable_same_contract else "upstream"
+        pre_dispatch_connection_failure = is_pre_dispatch_connection_failure(exc)
+        # Typed connector failures prove that neither the HTTP request nor the
+        # websocket response.create frame was dispatched. TLS verification is
+        # also pre-dispatch, but it is a stable configuration failure rather
+        # than a transient condition worth retrying on another account.
+        retryable_same_contract = pre_dispatch_connection_failure and not isinstance(exc, aiohttp.ClientSSLError)
+        failure_phase = "connect" if pre_dispatch_connection_failure else "upstream"
         failure_detail = "transport_error"
         failure_exception_type = type(exc).__name__
         # Direct HTTP streams and direct upstream WebSockets both use this

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -452,6 +452,8 @@ def _should_retry_transient_stream_error(
         if code in _MODEL_CAPACITY_LIMIT_CODES or response_id is not None:
             return False
         return True
+    if response_id is not None:
+        return False
     if code != "upstream_unavailable" or not message:
         return False
     normalized_message = message.lower()

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -446,14 +446,14 @@ def _should_retry_transient_stream_error(
         # stable code keeps settlement account-neutral, but cannot prove that
         # replaying the POST is safe.
         return False
+    if response_id is not None:
+        return False
     if code in _facade()._TRANSIENT_RETRY_CODES:
         return True
     if is_upstream_model_capacity_error(message):
-        if code in _MODEL_CAPACITY_LIMIT_CODES or response_id is not None:
+        if code in _MODEL_CAPACITY_LIMIT_CODES:
             return False
         return True
-    if response_id is not None:
-        return False
     if code != "upstream_unavailable" or not message:
         return False
     normalized_message = message.lower()

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -598,10 +598,6 @@ class _StreamingMixin(_StreamingRetryMixin):
                 settlement.record_success = False
                 settlement.account_health_error = True
                 settlement.error = {"message": error_message}
-                if allow_transient_retry and _facade()._should_retry_transient_stream_error(error_code, error_message):
-                    raise _TransientStreamError(error_code, settlement.error, preserve_on_selection_exhausted=True)
-                if allow_retry:
-                    raise _RetryableStreamError(error_code, settlement.error, exclude_account=True)
                 yield format_sse_event(
                     response_failed_event(
                         error_code,

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -599,7 +599,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                 settlement.account_health_error = True
                 settlement.error = {"message": error_message}
                 if allow_transient_retry and _facade()._should_retry_transient_stream_error(error_code, error_message):
-                    raise _TransientStreamError(error_code, settlement.error)
+                    raise _TransientStreamError(error_code, settlement.error, preserve_on_selection_exhausted=True)
                 if allow_retry:
                     raise _RetryableStreamError(error_code, settlement.error, exclude_account=True)
                 yield format_sse_event(

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -578,8 +578,6 @@ class _StreamingMixin(_StreamingRetryMixin):
                 settlement.record_success = False
                 settlement.account_health_error = True
                 settlement.error = {"message": error_message}
-                if allow_transient_retry:
-                    raise _TransientStreamError(error_code, settlement.error, preserve_on_selection_exhausted=True)
                 yield format_sse_event(
                     response_failed_event(
                         error_code,
@@ -713,6 +711,11 @@ class _StreamingMixin(_StreamingRetryMixin):
                     if allow_retry and _facade()._should_retry_stream_error(code):
                         raise _RetryableStreamError(code, upstream_error, exclude_account=True)
                     transient_response_id = tool_call_response_id_from_payload(first_payload)
+                    if transient_response_id == request_id:
+                        # Normalized raw upstream `error` events use the
+                        # proxy request id as the synthetic response id. That
+                        # is not proof that upstream accepted the request.
+                        transient_response_id = None
                     if allow_transient_retry and _facade()._should_retry_transient_stream_error(
                         code, error_message, response_id=transient_response_id
                     ):

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -298,7 +298,6 @@ from app.modules.proxy._service.support import (
     _RetryableStreamError,
     _StreamSettlement,
     _TerminalStreamError,
-    _TransientStreamError,
     _ttft_event_latency_ms,
     _WebSocketUpstreamControl,
 )
@@ -710,18 +709,6 @@ class _StreamingMixin(_StreamingRetryMixin):
                         )
                     if allow_retry and _facade()._should_retry_stream_error(code):
                         raise _RetryableStreamError(code, upstream_error, exclude_account=True)
-                    transient_response_id = tool_call_response_id_from_payload(first_payload)
-                    if event_type == "error" and transient_response_id == request_id:
-                        # Normalized raw upstream `error` events use the
-                        # proxy request id as the synthetic response id. That
-                        # is not proof that upstream accepted the request.
-                        transient_response_id = None
-                    if allow_transient_retry and _facade()._should_retry_transient_stream_error(
-                        code, error_message, response_id=transient_response_id
-                    ):
-                        raise _TransientStreamError(
-                            code, upstream_error, preserve_on_selection_exhausted=transient_response_id is None
-                        )
                 terminal_stream_error = _TerminalStreamError(
                     error_code or code,
                     upstream_error,

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -711,7 +711,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                     if allow_retry and _facade()._should_retry_stream_error(code):
                         raise _RetryableStreamError(code, upstream_error, exclude_account=True)
                     transient_response_id = tool_call_response_id_from_payload(first_payload)
-                    if transient_response_id == request_id:
+                    if event_type == "error" and transient_response_id == request_id:
                         # Normalized raw upstream `error` events use the
                         # proxy request id as the synthetic response id. That
                         # is not proof that upstream accepted the request.

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -712,7 +712,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                         )
                     if allow_retry and _facade()._should_retry_stream_error(code):
                         raise _RetryableStreamError(code, upstream_error, exclude_account=True)
-                    transient_response_id = event.response.id if event.response and event.response.id else None
+                    transient_response_id = tool_call_response_id_from_payload(first_payload)
                     if allow_transient_retry and _facade()._should_retry_transient_stream_error(
                         code, error_message, response_id=transient_response_id
                     ):

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -578,6 +578,8 @@ class _StreamingMixin(_StreamingRetryMixin):
                 settlement.record_success = False
                 settlement.account_health_error = True
                 settlement.error = {"message": error_message}
+                if allow_transient_retry:
+                    raise _TransientStreamError(error_code, settlement.error, preserve_on_selection_exhausted=True)
                 yield format_sse_event(
                     response_failed_event(
                         error_code,
@@ -596,6 +598,8 @@ class _StreamingMixin(_StreamingRetryMixin):
                 settlement.record_success = False
                 settlement.account_health_error = True
                 settlement.error = {"message": error_message}
+                if allow_transient_retry and _facade()._should_retry_transient_stream_error(error_code, error_message):
+                    raise _TransientStreamError(error_code, settlement.error)
                 if allow_retry:
                     raise _RetryableStreamError(error_code, settlement.error, exclude_account=True)
                 yield format_sse_event(
@@ -712,12 +716,13 @@ class _StreamingMixin(_StreamingRetryMixin):
                         )
                     if allow_retry and _facade()._should_retry_stream_error(code):
                         raise _RetryableStreamError(code, upstream_error, exclude_account=True)
+                    transient_response_id = event.response.id if event.response and event.response.id else None
                     if allow_transient_retry and _facade()._should_retry_transient_stream_error(
-                        code,
-                        error_message,
-                        response_id=response_id if event.type == "response.failed" else None,
+                        code, error_message, response_id=transient_response_id
                     ):
-                        raise _TransientStreamError(code, upstream_error)
+                        raise _TransientStreamError(
+                            code, upstream_error, preserve_on_selection_exhausted=transient_response_id is None
+                        )
                 terminal_stream_error = _TerminalStreamError(
                     error_code or code,
                     upstream_error,

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -1859,8 +1859,14 @@ class _StreamingRetryMixin:
                             # Preserve last ProxyResponseError for propagate_http_errors path.
                             if isinstance(tex, ProxyResponseError):
                                 last_transient_exc = tex
-                            if not isinstance(tex, _TransientStreamError) or tex.preserve_on_selection_exhausted:
-                                last_retryable_stream_error = _RetryableStreamError(error_code, error_payload)
+                            if isinstance(tex, _TransientStreamError) and (
+                                tex.preserve_on_selection_exhausted or error_code == "stream_incomplete"
+                            ):
+                                last_retryable_stream_error = _RetryableStreamError(
+                                    error_code,
+                                    error_payload,
+                                    exclude_account=True,
+                                )
                             await _release_tracked_stream_lease(current_account_lease)
                             current_account_lease = None
                             excluded_account_ids.add(account.id)

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -1800,6 +1800,8 @@ class _StreamingRetryMixin:
                             # Preserve last ProxyResponseError for propagate_http_errors path.
                             if isinstance(tex, ProxyResponseError):
                                 last_transient_exc = tex
+                            if not isinstance(tex, _TransientStreamError) or tex.preserve_on_selection_exhausted:
+                                last_retryable_stream_error = _RetryableStreamError(error_code, error_payload)
                             await _release_tracked_stream_lease(current_account_lease)
                             current_account_lease = None
                             excluded_account_ids.add(account.id)

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -365,6 +365,7 @@ class _StreamingRetryMixin:
         require_preferred_account = False
         last_retryable_stream_error: _RetryableStreamError | None = None
         pending_post_refresh_transient_penalty: tuple[Account, UpstreamError, str, int, int] | None = None
+        post_refresh_transient_replacement_selected = False
         require_security_work_authorized = False
         account_leases: list[AccountLease] = []
         estimated_lease_tokens = _facade()._estimated_lease_tokens_from_request_usage_budget(
@@ -385,6 +386,47 @@ class _StreamingRetryMixin:
             except ValueError:
                 pass
             await proxy._load_balancer.release_account_lease(lease)
+
+        async def _settle_stream_usage_before_pending_penalty(
+            current_settlement: _StreamSettlement,
+        ) -> bool:
+            nonlocal pending_post_refresh_transient_penalty
+            apply_pending_penalty = (
+                post_refresh_transient_replacement_selected and pending_post_refresh_transient_penalty is not None
+            )
+            if apply_pending_penalty:
+                settled_result = await proxy._settle_stream_api_key_usage(
+                    api_key,
+                    api_key_reservation,
+                    current_settlement,
+                    request_id,
+                    wait_for_settlement=True,
+                )
+                pending_penalty = pending_post_refresh_transient_penalty
+                pending_post_refresh_transient_penalty = None
+                assert pending_penalty is not None
+                (
+                    failed_account,
+                    transient_error_payload,
+                    transient_error_code,
+                    transient_http_status,
+                    transient_retry_count,
+                ) = pending_penalty
+                await proxy._handle_stream_error(
+                    failed_account,
+                    transient_error_payload,
+                    transient_error_code,
+                    http_status=transient_http_status,
+                )
+                if transient_retry_count > 1:
+                    await proxy._load_balancer.record_errors(failed_account, transient_retry_count - 1)
+                return settled_result
+            return await proxy._settle_stream_api_key_usage(
+                api_key,
+                api_key_reservation,
+                current_settlement,
+                request_id,
+            )
 
         async def _wait_for_process_network_recovery(
             account: Account,
@@ -430,12 +472,7 @@ class _StreamingRetryMixin:
                 conversation_id=conversation_id,
                 client_ip=client_ip,
             )
-            settled = await proxy._settle_stream_api_key_usage(
-                api_key,
-                api_key_reservation,
-                settlement,
-                request_id,
-            )
+            settled = await _settle_stream_usage_before_pending_penalty(settlement)
 
         def _move_verified_fresh_replay_from_owner(*, account_id: str, outcome: str) -> bool:
             # Only a proxy-injected owner anchor with locally verified full
@@ -516,6 +553,7 @@ class _StreamingRetryMixin:
                         raise _TransientStreamError(
                             error_code or "upstream_error",
                             _upstream_error_from_openai(error),
+                            account_health_error=retryable_connect_failure,
                         ) from exc
                     raise
 
@@ -572,9 +610,11 @@ class _StreamingRetryMixin:
                     settlement.error_code = exc.code
                     settlement.error_message = error_message
                     settlement.error = exc.error
-                    settlement.account_health_error = _facade()._should_penalize_stream_error(
-                        exc.code
-                    ) or is_upstream_model_capacity_error(error_message)
+                    settlement.account_health_error = (
+                        _facade()._should_penalize_stream_error(exc.code)
+                        or is_upstream_model_capacity_error(error_message)
+                        or exc.account_health_error
+                    )
                     if can_try_other_account:
                         retry_exc = ProxyResponseError(502, openai_error(exc.code, error_message))
                         setattr(retry_exc, _POST_REFRESH_TRANSIENT_EXHAUSTED_ATTR, True)
@@ -1211,22 +1251,7 @@ class _StreamingRetryMixin:
                     return
 
                 if pending_post_refresh_transient_penalty is not None:
-                    (
-                        failed_account,
-                        transient_error_payload,
-                        transient_error_code,
-                        transient_http_status,
-                        transient_retry_count,
-                    ) = pending_post_refresh_transient_penalty
-                    pending_post_refresh_transient_penalty = None
-                    await proxy._handle_stream_error(
-                        failed_account,
-                        transient_error_payload,
-                        transient_error_code,
-                        http_status=transient_http_status,
-                    )
-                    if transient_retry_count > 1:
-                        await proxy._load_balancer.record_errors(failed_account, transient_retry_count - 1)
+                    post_refresh_transient_replacement_selected = True
 
                 account_id_value = account.id
                 if last_account_model_rejection is not None and account.id != last_account_model_rejection_account_id:
@@ -1705,12 +1730,7 @@ class _StreamingRetryMixin:
                                         _stream_settlement_error_payload(settlement),
                                         settlement.error_code or "upstream_error",
                                     )
-                                settled = await proxy._settle_stream_api_key_usage(
-                                    api_key,
-                                    api_key_reservation,
-                                    settlement,
-                                    request_id,
-                                )
+                                settled = await _settle_stream_usage_before_pending_penalty(settlement)
                                 return
                             if isinstance(tex, ProxyResponseError) and tex.status_code != 500:
                                 error = _parse_openai_error(tex.payload)
@@ -1932,12 +1952,7 @@ class _StreamingRetryMixin:
                         elif settlement.record_success:
                             await proxy._load_balancer.record_success(account)
                         network_recovery.log_recovered()
-                        settled = await proxy._settle_stream_api_key_usage(
-                            api_key,
-                            api_key_reservation,
-                            settlement,
-                            request_id,
-                        )
+                        settled = await _settle_stream_usage_before_pending_penalty(settlement)
                         upstream_transport_metric_status = settlement.status
                         _record_upstream_transport_metric_once(settlement.status)
                         return
@@ -2291,12 +2306,7 @@ class _StreamingRetryMixin:
                                         settlement.error_code or "upstream_error",
                                         http_status=retry_exc.status_code,
                                     )
-                                settled = await proxy._settle_stream_api_key_usage(
-                                    api_key,
-                                    api_key_reservation,
-                                    settlement,
-                                    request_id,
-                                )
+                                settled = await _settle_stream_usage_before_pending_penalty(settlement)
                                 return
                             error = _parse_openai_error(retry_exc.payload)
                             error_code = _normalize_error_code(
@@ -2410,12 +2420,7 @@ class _StreamingRetryMixin:
                             )
                         elif settlement.record_success:
                             await proxy._load_balancer.record_success(account)
-                        settled = await proxy._settle_stream_api_key_usage(
-                            api_key,
-                            api_key_reservation,
-                            settlement,
-                            request_id,
-                        )
+                        settled = await _settle_stream_usage_before_pending_penalty(settlement)
                         upstream_transport_metric_status = settlement.status
                         _record_upstream_transport_metric_once(settlement.status)
                         return

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -464,6 +464,7 @@ class _StreamingRetryMixin:
             tool_call_dedupe: _WebSocketUpstreamControl,
         ) -> AsyncIterator[str]:
             nonlocal last_transient_exc
+            transient_retries = 0
             while True:
                 settlement.reset()
                 stream_timeout_tokens = _facade()._push_stream_attempt_timeout_overrides(
@@ -477,6 +478,7 @@ class _StreamingRetryMixin:
                         request_id,
                         False,
                         request_started_at=start,
+                        allow_transient_retry=True,
                         api_key=api_key,
                         api_key_reservation=api_key_reservation,
                         settlement=settlement,
@@ -498,6 +500,56 @@ class _StreamingRetryMixin:
                     # `_stream_once()` has already yielded the terminal event.
                     # Returning preserves fail-closed delivery: replaying here
                     # could duplicate a request that reached the upstream.
+                    return
+                except _TransientStreamError as exc:
+                    recovery_decision = await _wait_for_process_network_recovery(
+                        account,
+                        error_code=exc.code,
+                        retryable_same_contract=False,
+                        failed_session=None,
+                    )
+                    if recovery_decision == "retry":
+                        continue
+                    if recovery_decision == "exhausted":
+                        raise ProxyResponseError(
+                            502,
+                            openai_error("upstream_request_timeout", "Proxy request budget exhausted"),
+                        ) from exc
+                    transient_retries += 1
+                    if (
+                        transient_retries < _facade()._MAX_TRANSIENT_SAME_ACCOUNT_RETRIES
+                        and _facade()._remaining_budget_seconds(deadline) > 0
+                        and not settlement.downstream_visible
+                    ):
+                        delay = backoff_seconds(transient_retries)
+                        _facade().logger.info(
+                            "Transient post-refresh stream error, retrying same account "
+                            "request_id=%s account_id=%s retry=%s/%s delay=%.2fs code=%s",
+                            request_id,
+                            account.id,
+                            transient_retries,
+                            _facade()._MAX_TRANSIENT_SAME_ACCOUNT_RETRIES,
+                            delay,
+                            exc.code,
+                        )
+                        await asyncio.sleep(delay)
+                        continue
+                    await proxy._handle_stream_error(account, exc.error, exc.code)
+                    if transient_retries > 1:
+                        await proxy._load_balancer.record_errors(account, transient_retries - 1)
+                    error_message = str(exc.error.get("message") or "Upstream error")
+                    yield format_sse_event(
+                        response_failed_event(
+                            exc.code,
+                            error_message,
+                            response_id=settlement.response_id or request_id,
+                        )
+                    )
+                    settlement.record_success = False
+                    settlement.error_code = exc.code
+                    settlement.error_message = error_message
+                    settlement.error = exc.error
+                    settlement.account_health_error = _facade()._should_penalize_stream_error(exc.code)
                     return
                 except ProxyResponseError as exc:
                     error = _parse_openai_error(exc.payload)

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -428,6 +428,13 @@ class _StreamingRetryMixin:
                 request_id,
             )
 
+        async def _drain_pending_post_refresh_penalty_on_terminal(
+            current_settlement: _StreamSettlement,
+        ) -> None:
+            nonlocal settled
+            if post_refresh_transient_replacement_selected and pending_post_refresh_transient_penalty is not None:
+                settled = await _settle_stream_usage_before_pending_penalty(current_settlement)
+
         async def _wait_for_process_network_recovery(
             account: Account,
             *,
@@ -2340,6 +2347,7 @@ class _StreamingRetryMixin:
                             if account_model_retry:
                                 continue
                             if account_model_retry is False:
+                                await _drain_pending_post_refresh_penalty_on_terminal(settlement)
                                 if propagate_http_errors:
                                     raise
                                 yield await _render_account_model_rejection(
@@ -2360,8 +2368,10 @@ class _StreamingRetryMixin:
                                 # loop so the preserved cap is propagated or
                                 # rendered below, instead of replacing it with
                                 # a next-attempt timeout.
+                                await _drain_pending_post_refresh_penalty_on_terminal(settlement)
                                 break
                             if _facade()._is_account_neutral_error_code(error_code):
+                                await _drain_pending_post_refresh_penalty_on_terminal(settlement)
                                 raise
                             classified = await proxy._handle_stream_error(
                                 account,
@@ -2399,6 +2409,7 @@ class _StreamingRetryMixin:
                                 )
                                 excluded_account_ids.add(account.id)
                                 continue
+                            await _drain_pending_post_refresh_penalty_on_terminal(settlement)
                             if propagate_http_errors:
                                 raise
                             error_message = error.message if error else None

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -431,8 +431,12 @@ class _StreamingRetryMixin:
         async def _drain_pending_post_refresh_penalty_on_terminal(
             current_settlement: _StreamSettlement,
         ) -> None:
-            nonlocal settled
-            if post_refresh_transient_replacement_selected and pending_post_refresh_transient_penalty is not None:
+            nonlocal post_refresh_transient_replacement_selected, settled
+            if pending_post_refresh_transient_penalty is not None:
+                # A failed replacement selection still ends the request. Mark
+                # it as terminal so the deferred failure is settled and
+                # recorded before this path returns or re-raises.
+                post_refresh_transient_replacement_selected = True
                 settled = await _settle_stream_usage_before_pending_penalty(current_settlement)
 
         async def _wait_for_process_network_recovery(
@@ -1062,6 +1066,7 @@ class _StreamingRetryMixin:
                     break
                 if not account:
                     if last_account_model_rejection is not None:
+                        await _drain_pending_post_refresh_penalty_on_terminal(settlement)
                         if propagate_http_errors:
                             raise last_account_model_rejection
                         yield await _render_account_model_rejection(
@@ -1070,6 +1075,7 @@ class _StreamingRetryMixin:
                         )
                         return
                     if selection.error_code in _LOCAL_ACCOUNT_CAP_ERROR_CODES:
+                        await _drain_pending_post_refresh_penalty_on_terminal(settlement)
                         no_accounts_msg = selection.error_message or "Local account capacity is exhausted"
                         error_code = selection.error_code
                         event = response_failed_event(
@@ -1124,6 +1130,7 @@ class _StreamingRetryMixin:
                             request_id,
                         )
                         continue
+                    await _drain_pending_post_refresh_penalty_on_terminal(settlement)
                     if propagate_http_errors and last_transient_exc is not None:
                         raise last_transient_exc
                     if last_retryable_stream_error is not None:

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -988,6 +988,35 @@ class _StreamingRetryMixin:
                             request_id,
                         )
                         continue
+                    if propagate_http_errors and last_transient_exc is not None:
+                        raise last_transient_exc
+                    if last_retryable_stream_error is not None:
+                        error_message = str(last_retryable_stream_error.error.get("message") or "Upstream error")
+                        event = response_failed_event(
+                            last_retryable_stream_error.code,
+                            error_message,
+                            response_id=request_id,
+                        )
+                        yield format_sse_event(event)
+                        await proxy._write_request_log(
+                            account_id=None,
+                            api_key=api_key,
+                            request_id=request_id,
+                            model=payload.model,
+                            latency_ms=int((time.monotonic() - start) * 1000),
+                            status="error",
+                            error_code=last_retryable_stream_error.code,
+                            error_message=error_message,
+                            reasoning_effort=payload.reasoning.effort if payload.reasoning else None,
+                            transport=request_transport,
+                            upstream_transport=upstream_stream_transport,
+                            service_tier=payload.service_tier,
+                            requested_service_tier=payload.service_tier,
+                            useragent=useragent,
+                            useragent_group=useragent_group,
+                            client_ip=client_ip,
+                        )
+                        return
                     if require_preferred_account and preferred_account_id is not None:
                         message = "Previous response owner account is unavailable; retry later."
                         _record_continuity_fail_closed(
@@ -1028,34 +1057,6 @@ class _StreamingRetryMixin:
                     # instead of returning a generic no_accounts event.
                     if propagate_http_errors and last_transient_exc is not None:
                         raise last_transient_exc
-                    if last_retryable_stream_error is not None:
-                        error_message = str(last_retryable_stream_error.error.get("message") or "Upstream error")
-                        event = response_failed_event(
-                            last_retryable_stream_error.code,
-                            error_message,
-                            response_id=request_id,
-                        )
-                        yield format_sse_event(event)
-                        await proxy._write_request_log(
-                            account_id=None,
-                            api_key=api_key,
-                            request_id=request_id,
-                            model=payload.model,
-                            latency_ms=int((time.monotonic() - start) * 1000),
-                            status="error",
-                            error_code=last_retryable_stream_error.code,
-                            error_message=error_message,
-                            reasoning_effort=payload.reasoning.effort if payload.reasoning else None,
-                            transport=request_transport,
-                            upstream_transport=upstream_stream_transport,
-                            service_tier=payload.service_tier,
-                            requested_service_tier=payload.service_tier,
-                            useragent=useragent,
-                            useragent_group=useragent_group,
-                            conversation_id=conversation_id,
-                            client_ip=client_ip,
-                        )
-                        return
                     if last_security_work_retry_error is not None:
                         message = (
                             last_security_work_retry_error.error.get("message")

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -93,7 +93,6 @@ def _http_downstream_request_is_sticky(payload: ResponsesRequest, headers: Mappi
 
 
 _POST_REFRESH_TRANSIENT_EXHAUSTED_ATTR = "_codex_lb_post_refresh_transient_exhausted"
-_POST_REFRESH_TRANSIENT_RETRY_COUNT_ATTR = "_codex_lb_post_refresh_transient_retry_count"
 
 
 def _resolve_http_downstream_transport(policy: str, *, payload: ResponsesRequest, headers: Mapping[str, str]) -> str:
@@ -364,7 +363,7 @@ class _StreamingRetryMixin:
         file_preferred_account_id: str | None = rewritten_file_account_id
         require_preferred_account = False
         last_retryable_stream_error: _RetryableStreamError | None = None
-        pending_post_refresh_transient_penalty: tuple[Account, UpstreamError, str, int, int] | None = None
+        pending_post_refresh_transient_penalties: list[tuple[Account, UpstreamError, str, int, int]] = []
         post_refresh_transient_replacement_selected = False
         require_security_work_authorized = False
         account_leases: list[AccountLease] = []
@@ -390,9 +389,8 @@ class _StreamingRetryMixin:
         async def _settle_stream_usage_before_pending_penalty(
             current_settlement: _StreamSettlement,
         ) -> bool:
-            nonlocal pending_post_refresh_transient_penalty
-            apply_pending_penalty = (
-                post_refresh_transient_replacement_selected and pending_post_refresh_transient_penalty is not None
+            apply_pending_penalty = post_refresh_transient_replacement_selected and bool(
+                pending_post_refresh_transient_penalties
             )
             if apply_pending_penalty:
                 settled_result = await proxy._settle_stream_api_key_usage(
@@ -402,24 +400,24 @@ class _StreamingRetryMixin:
                     request_id,
                     wait_for_settlement=True,
                 )
-                pending_penalty = pending_post_refresh_transient_penalty
-                pending_post_refresh_transient_penalty = None
-                assert pending_penalty is not None
-                (
-                    failed_account,
-                    transient_error_payload,
-                    transient_error_code,
-                    transient_http_status,
-                    transient_retry_count,
-                ) = pending_penalty
-                await proxy._handle_stream_error(
-                    failed_account,
-                    transient_error_payload,
-                    transient_error_code,
-                    http_status=transient_http_status,
-                )
-                if transient_retry_count > 1:
-                    await proxy._load_balancer.record_errors(failed_account, transient_retry_count - 1)
+                pending_penalties = list(pending_post_refresh_transient_penalties)
+                pending_post_refresh_transient_penalties.clear()
+                for pending_penalty in pending_penalties:
+                    (
+                        failed_account,
+                        transient_error_payload,
+                        transient_error_code,
+                        transient_http_status,
+                        transient_retry_count,
+                    ) = pending_penalty
+                    await proxy._handle_stream_error(
+                        failed_account,
+                        transient_error_payload,
+                        transient_error_code,
+                        http_status=transient_http_status,
+                    )
+                    if transient_retry_count > 1:
+                        await proxy._load_balancer.record_errors(failed_account, transient_retry_count - 1)
                 return settled_result
             return await proxy._settle_stream_api_key_usage(
                 api_key,
@@ -432,7 +430,7 @@ class _StreamingRetryMixin:
             current_settlement: _StreamSettlement,
         ) -> None:
             nonlocal post_refresh_transient_replacement_selected, settled
-            if pending_post_refresh_transient_penalty is not None:
+            if pending_post_refresh_transient_penalties:
                 # A failed replacement selection still ends the request. Mark
                 # it as terminal so the deferred failure is settled and
                 # recorded before this path returns or re-raises.
@@ -626,10 +624,19 @@ class _StreamingRetryMixin:
                         or is_upstream_model_capacity_error(error_message)
                         or exc.account_health_error
                     )
+                    if settlement.account_health_error:
+                        pending_post_refresh_transient_penalties.append(
+                            (
+                                account,
+                                _stream_settlement_error_payload(settlement),
+                                settlement.error_code or "upstream_error",
+                                502,
+                                transient_retries,
+                            )
+                        )
                     if can_try_other_account:
                         retry_exc = ProxyResponseError(502, openai_error(exc.code, error_message))
                         setattr(retry_exc, _POST_REFRESH_TRANSIENT_EXHAUSTED_ATTR, True)
-                        setattr(retry_exc, _POST_REFRESH_TRANSIENT_RETRY_COUNT_ATTR, transient_retries)
                         raise retry_exc from exc
                     yield format_sse_event(
                         response_failed_event(
@@ -1264,7 +1271,7 @@ class _StreamingRetryMixin:
                     )
                     return
 
-                if pending_post_refresh_transient_penalty is not None:
+                if pending_post_refresh_transient_penalties:
                     post_refresh_transient_replacement_selected = True
 
                 account_id_value = account.id
@@ -2329,14 +2336,6 @@ class _StreamingRetryMixin:
                             )
                             if getattr(retry_exc, _POST_REFRESH_TRANSIENT_EXHAUSTED_ATTR, False):
                                 transient_error_payload = _stream_settlement_error_payload(settlement)
-                                if settlement.account_health_error:
-                                    pending_post_refresh_transient_penalty = (
-                                        account,
-                                        transient_error_payload,
-                                        settlement.error_code or "upstream_error",
-                                        retry_exc.status_code,
-                                        int(getattr(retry_exc, _POST_REFRESH_TRANSIENT_RETRY_COUNT_ATTR, 1)),
-                                    )
                                 last_transient_exc = retry_exc
                                 last_retryable_stream_error = _RetryableStreamError(
                                     settlement.error_code or error_code or "upstream_error",
@@ -2430,7 +2429,13 @@ class _StreamingRetryMixin:
                             _apply_error_metadata(event["response"]["error"], error)
                             yield format_sse_event(event)
                             return
-                        if settlement.account_health_error:
+                        current_account_penalty_queued = any(
+                            failed_account is account
+                            for failed_account, *_rest in pending_post_refresh_transient_penalties
+                        )
+                        if pending_post_refresh_transient_penalties:
+                            await _drain_pending_post_refresh_penalty_on_terminal(settlement)
+                        if settlement.account_health_error and not current_account_penalty_queued:
                             await proxy._handle_stream_error(
                                 account,
                                 _stream_settlement_error_payload(settlement),
@@ -2438,7 +2443,8 @@ class _StreamingRetryMixin:
                             )
                         elif settlement.record_success:
                             await proxy._load_balancer.record_success(account)
-                        settled = await _settle_stream_usage_before_pending_penalty(settlement)
+                        if not settled:
+                            settled = await _settle_stream_usage_before_pending_penalty(settlement)
                         upstream_transport_metric_status = settlement.status
                         _record_upstream_transport_metric_once(settlement.status)
                         return

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -364,6 +364,7 @@ class _StreamingRetryMixin:
         file_preferred_account_id: str | None = rewritten_file_account_id
         require_preferred_account = False
         last_retryable_stream_error: _RetryableStreamError | None = None
+        pending_post_refresh_transient_penalty: tuple[Account, UpstreamError, str, int, int] | None = None
         require_security_work_authorized = False
         account_leases: list[AccountLease] = []
         estimated_lease_tokens = _facade()._estimated_lease_tokens_from_request_usage_budget(
@@ -1208,6 +1209,24 @@ class _StreamingRetryMixin:
                         client_ip=client_ip,
                     )
                     return
+
+                if pending_post_refresh_transient_penalty is not None:
+                    (
+                        failed_account,
+                        transient_error_payload,
+                        transient_error_code,
+                        transient_http_status,
+                        transient_retry_count,
+                    ) = pending_post_refresh_transient_penalty
+                    pending_post_refresh_transient_penalty = None
+                    await proxy._handle_stream_error(
+                        failed_account,
+                        transient_error_payload,
+                        transient_error_code,
+                        http_status=transient_http_status,
+                    )
+                    if transient_retry_count > 1:
+                        await proxy._load_balancer.record_errors(failed_account, transient_retry_count - 1)
 
                 account_id_value = account.id
                 if last_account_model_rejection is not None and account.id != last_account_model_rejection_account_id:
@@ -2286,24 +2305,14 @@ class _StreamingRetryMixin:
                             )
                             if getattr(retry_exc, _POST_REFRESH_TRANSIENT_EXHAUSTED_ATTR, False):
                                 transient_error_payload = _stream_settlement_error_payload(settlement)
-                                settled = await proxy._settle_stream_api_key_usage(
-                                    api_key,
-                                    api_key_reservation,
-                                    settlement,
-                                    request_id,
-                                )
                                 if settlement.account_health_error:
-                                    await proxy._handle_stream_error(
+                                    pending_post_refresh_transient_penalty = (
                                         account,
                                         transient_error_payload,
                                         settlement.error_code or "upstream_error",
-                                        http_status=retry_exc.status_code,
+                                        retry_exc.status_code,
+                                        int(getattr(retry_exc, _POST_REFRESH_TRANSIENT_RETRY_COUNT_ATTR, 1)),
                                     )
-                                    transient_retry_count = int(
-                                        getattr(retry_exc, _POST_REFRESH_TRANSIENT_RETRY_COUNT_ATTR, 1)
-                                    )
-                                    if transient_retry_count > 1:
-                                        await proxy._load_balancer.record_errors(account, transient_retry_count - 1)
                                 last_transient_exc = retry_exc
                                 last_retryable_stream_error = _RetryableStreamError(
                                     settlement.error_code or error_code or "upstream_error",

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -91,6 +91,9 @@ def _http_downstream_request_is_sticky(payload: ResponsesRequest, headers: Mappi
     )
 
 
+_POST_REFRESH_TRANSIENT_EXHAUSTED_ATTR = "_codex_lb_post_refresh_transient_exhausted"
+
+
 def _resolve_http_downstream_transport(policy: str, *, payload: ResponsesRequest, headers: Mapping[str, str]) -> str:
     normalized_policy = policy.strip().lower()
     if normalized_policy not in _HTTP_DOWNSTREAM_TRANSPORT_POLICIES:
@@ -534,10 +537,16 @@ class _StreamingRetryMixin:
                         )
                         await asyncio.sleep(delay)
                         continue
-                    await proxy._handle_stream_error(account, exc.error, exc.code)
-                    if transient_retries > 1:
-                        await proxy._load_balancer.record_errors(account, transient_retries - 1)
                     error_message = str(exc.error.get("message") or "Upstream error")
+                    settlement.record_success = False
+                    settlement.error_code = exc.code
+                    settlement.error_message = error_message
+                    settlement.error = exc.error
+                    settlement.account_health_error = _facade()._should_penalize_stream_error(exc.code)
+                    if can_try_other_account:
+                        retry_exc = ProxyResponseError(502, openai_error(exc.code, error_message))
+                        setattr(retry_exc, _POST_REFRESH_TRANSIENT_EXHAUSTED_ATTR, True)
+                        raise retry_exc from exc
                     yield format_sse_event(
                         response_failed_event(
                             exc.code,
@@ -545,11 +554,6 @@ class _StreamingRetryMixin:
                             response_id=settlement.response_id or request_id,
                         )
                     )
-                    settlement.record_success = False
-                    settlement.error_code = exc.code
-                    settlement.error_message = error_message
-                    settlement.error = exc.error
-                    settlement.account_health_error = _facade()._should_penalize_stream_error(exc.code)
                     return
                 except ProxyResponseError as exc:
                     error = _parse_openai_error(exc.payload)
@@ -2241,6 +2245,24 @@ class _StreamingRetryMixin:
                                 error.code if error else None,
                                 error.type if error else None,
                             )
+                            if getattr(retry_exc, _POST_REFRESH_TRANSIENT_EXHAUSTED_ATTR, False):
+                                transient_error_payload = _stream_settlement_error_payload(settlement)
+                                if settlement.account_health_error:
+                                    await proxy._handle_stream_error(
+                                        account,
+                                        transient_error_payload,
+                                        settlement.error_code or "upstream_error",
+                                        http_status=retry_exc.status_code,
+                                    )
+                                last_transient_exc = retry_exc
+                                last_retryable_stream_error = _RetryableStreamError(
+                                    settlement.error_code or error_code or "upstream_error",
+                                    transient_error_payload,
+                                )
+                                await _release_tracked_stream_lease(current_account_lease)
+                                current_account_lease = None
+                                excluded_account_ids.add(account.id)
+                                continue
                             account_model_retry = await _retry_account_model_rejection(
                                 retry_exc,
                                 account,

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -571,7 +571,9 @@ class _StreamingRetryMixin:
                     settlement.error_code = exc.code
                     settlement.error_message = error_message
                     settlement.error = exc.error
-                    settlement.account_health_error = _facade()._should_penalize_stream_error(exc.code)
+                    settlement.account_health_error = _facade()._should_penalize_stream_error(
+                        exc.code
+                    ) or is_upstream_model_capacity_error(error_message)
                     if can_try_other_account:
                         retry_exc = ProxyResponseError(502, openai_error(exc.code, error_message))
                         setattr(retry_exc, _POST_REFRESH_TRANSIENT_EXHAUSTED_ATTR, True)
@@ -1100,6 +1102,7 @@ class _StreamingRetryMixin:
                             requested_service_tier=payload.service_tier,
                             useragent=useragent,
                             useragent_group=useragent_group,
+                            conversation_id=conversation_id,
                             client_ip=client_ip,
                         )
                         return
@@ -2283,6 +2286,12 @@ class _StreamingRetryMixin:
                             )
                             if getattr(retry_exc, _POST_REFRESH_TRANSIENT_EXHAUSTED_ATTR, False):
                                 transient_error_payload = _stream_settlement_error_payload(settlement)
+                                settled = await proxy._settle_stream_api_key_usage(
+                                    api_key,
+                                    api_key_reservation,
+                                    settlement,
+                                    request_id,
+                                )
                                 if settlement.account_health_error:
                                     await proxy._handle_stream_error(
                                         account,

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -67,6 +67,7 @@ from app.modules.proxy.helpers import (
     _normalize_error_code,
     _parse_openai_error,
     _upstream_error_from_openai,
+    is_upstream_model_capacity_error,
 )
 from app.modules.proxy.load_balancer import AccountLease, AccountSelection
 
@@ -469,11 +470,8 @@ class _StreamingRetryMixin:
         ) -> AsyncIterator[str]:
             nonlocal last_transient_exc
             transient_retries = 0
-            while True:
-                settlement.reset()
-                stream_timeout_tokens = _facade()._push_stream_attempt_timeout_overrides(
-                    _facade()._remaining_budget_seconds(deadline)
-                )
+
+            async def _iter_stream_once() -> AsyncIterator[str]:
                 try:
                     async for line in proxy._stream_once(
                         account,
@@ -497,6 +495,36 @@ class _StreamingRetryMixin:
                         tool_call_dedupe=tool_call_dedupe,
                         enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                     ):
+                        yield line
+                except ProxyResponseError as exc:
+                    error = _parse_openai_error(exc.payload)
+                    error_code = _normalize_error_code(
+                        error.code if error else None,
+                        error.type if error else None,
+                    )
+                    error_message = error.message if error else None
+                    retryable_connect_failure = bool(
+                        exc.failure_phase == "connect"
+                        and _facade()._should_retry_transient_stream_error(error_code, error_message)
+                    )
+                    retryable_capacity_rejection = bool(
+                        is_upstream_model_capacity_error(error_message)
+                        and _facade()._should_retry_transient_stream_error(error_code, error_message)
+                    )
+                    if retryable_connect_failure or retryable_capacity_rejection:
+                        raise _TransientStreamError(
+                            error_code or "upstream_error",
+                            _upstream_error_from_openai(error),
+                        ) from exc
+                    raise
+
+            while True:
+                settlement.reset()
+                stream_timeout_tokens = _facade()._push_stream_attempt_timeout_overrides(
+                    _facade()._remaining_budget_seconds(deadline)
+                )
+                try:
+                    async for line in _iter_stream_once():
                         yield line
                     network_recovery.log_recovered()
                     return

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -92,6 +92,7 @@ def _http_downstream_request_is_sticky(payload: ResponsesRequest, headers: Mappi
 
 
 _POST_REFRESH_TRANSIENT_EXHAUSTED_ATTR = "_codex_lb_post_refresh_transient_exhausted"
+_POST_REFRESH_TRANSIENT_RETRY_COUNT_ATTR = "_codex_lb_post_refresh_transient_retry_count"
 
 
 def _resolve_http_downstream_transport(policy: str, *, payload: ResponsesRequest, headers: Mapping[str, str]) -> str:
@@ -546,6 +547,7 @@ class _StreamingRetryMixin:
                     if can_try_other_account:
                         retry_exc = ProxyResponseError(502, openai_error(exc.code, error_message))
                         setattr(retry_exc, _POST_REFRESH_TRANSIENT_EXHAUSTED_ATTR, True)
+                        setattr(retry_exc, _POST_REFRESH_TRANSIENT_RETRY_COUNT_ATTR, transient_retries)
                         raise retry_exc from exc
                     yield format_sse_event(
                         response_failed_event(
@@ -2254,6 +2256,11 @@ class _StreamingRetryMixin:
                                         settlement.error_code or "upstream_error",
                                         http_status=retry_exc.status_code,
                                     )
+                                    transient_retry_count = int(
+                                        getattr(retry_exc, _POST_REFRESH_TRANSIENT_RETRY_COUNT_ATTR, 1)
+                                    )
+                                    if transient_retry_count > 1:
+                                        await proxy._load_balancer.record_errors(account, transient_retry_count - 1)
                                 last_transient_exc = retry_exc
                                 last_retryable_stream_error = _RetryableStreamError(
                                     settlement.error_code or error_code or "upstream_error",

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -67,6 +67,7 @@ from app.modules.proxy.helpers import (
     _normalize_error_code,
     _parse_openai_error,
     _upstream_error_from_openai,
+    classify_upstream_failure,
     is_upstream_model_capacity_error,
 )
 from app.modules.proxy.load_balancer import AccountLease, AccountSelection
@@ -877,6 +878,7 @@ class _StreamingRetryMixin:
             for attempt in range(max_attempts):
                 remaining_budget = _facade()._remaining_budget_seconds(deadline)
                 if remaining_budget <= 0:
+                    await _drain_pending_post_refresh_penalty_on_terminal(settlement)
                     _facade().logger.warning(
                         "Proxy request budget exhausted before retry request_id=%s attempt=%s",
                         request_id,
@@ -927,6 +929,7 @@ class _StreamingRetryMixin:
                             ),
                         )
                     except ProxyResponseError as exc:
+                        await _drain_pending_post_refresh_penalty_on_terminal(settlement)
                         error = _parse_openai_error(exc.payload)
                         error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
                         error_message = error.message if error else None
@@ -1745,13 +1748,13 @@ class _StreamingRetryMixin:
                                 else:
                                     settlement.error = tex.error
                                 settlement.account_health_error = _facade()._should_penalize_stream_error(error_code)
+                                settled = await _settle_stream_usage_before_pending_penalty(settlement)
                                 if settlement.account_health_error:
                                     await proxy._handle_stream_error(
                                         account,
                                         _stream_settlement_error_payload(settlement),
                                         settlement.error_code or "upstream_error",
                                     )
-                                settled = await _settle_stream_usage_before_pending_penalty(settlement)
                                 return
                             if isinstance(tex, ProxyResponseError) and tex.status_code != 500:
                                 error = _parse_openai_error(tex.payload)
@@ -1964,6 +1967,7 @@ class _StreamingRetryMixin:
                             break  # outer loop: select different account
                         finally:
                             pop_stream_timeout_overrides(stream_timeout_tokens)
+                        settled = await _settle_stream_usage_before_pending_penalty(settlement)
                         if settlement.account_health_error:
                             await proxy._handle_stream_error(
                                 account,
@@ -1973,7 +1977,6 @@ class _StreamingRetryMixin:
                         elif settlement.record_success:
                             await proxy._load_balancer.record_success(account)
                         network_recovery.log_recovered()
-                        settled = await _settle_stream_usage_before_pending_penalty(settlement)
                         upstream_transport_metric_status = settlement.status
                         _record_upstream_transport_metric_once(settlement.status)
                         return
@@ -2025,6 +2028,7 @@ class _StreamingRetryMixin:
                     )
                     continue
                 except _TerminalStreamError as exc:
+                    await _drain_pending_post_refresh_penalty_on_terminal(settlement)
                     if _facade()._should_penalize_stream_error(exc.code):
                         await proxy._handle_stream_error(account, exc.error, exc.code)
                     return
@@ -2041,6 +2045,7 @@ class _StreamingRetryMixin:
                     if account_model_retry:
                         continue
                     if account_model_retry is False:
+                        await _drain_pending_post_refresh_penalty_on_terminal(settlement)
                         if propagate_http_errors:
                             raise
                         yield await _render_account_model_rejection(exc, account_id=account.id)
@@ -2320,6 +2325,7 @@ class _StreamingRetryMixin:
                                 settlement.error_message = error_message
                                 settlement.error = _upstream_error_from_openai(error)
                                 settlement.account_health_error = _facade()._should_penalize_stream_error(error_code)
+                                settled = await _settle_stream_usage_before_pending_penalty(settlement)
                                 if settlement.account_health_error:
                                     await proxy._handle_stream_error(
                                         account,
@@ -2327,7 +2333,6 @@ class _StreamingRetryMixin:
                                         settlement.error_code or "upstream_error",
                                         http_status=retry_exc.status_code,
                                     )
-                                settled = await _settle_stream_usage_before_pending_penalty(settlement)
                                 return
                             error = _parse_openai_error(retry_exc.payload)
                             error_code = _normalize_error_code(
@@ -2379,11 +2384,13 @@ class _StreamingRetryMixin:
                             if _facade()._is_account_neutral_error_code(error_code):
                                 await _drain_pending_post_refresh_penalty_on_terminal(settlement)
                                 raise
-                            classified = await proxy._handle_stream_error(
-                                account,
-                                _upstream_error_from_openai(error),
-                                error_code,
+                            current_error_payload = _upstream_error_from_openai(error)
+                            current_error_code = error_code or "upstream_error"
+                            classified = classify_upstream_failure(
+                                error_code=current_error_code,
+                                error=current_error_payload,
                                 http_status=retry_exc.status_code,
+                                phase="first_event",
                             )
                             candidates_remaining = max_attempts - attempt - 1
                             if retry_exc.status_code == 401 and candidates_remaining > 0:
@@ -2406,6 +2413,12 @@ class _StreamingRetryMixin:
                                 action,
                             )
                             if action == "failover_next":
+                                await proxy._handle_stream_error(
+                                    account,
+                                    current_error_payload,
+                                    current_error_code,
+                                    http_status=retry_exc.status_code,
+                                )
                                 last_transient_exc = retry_exc
                                 await _release_tracked_stream_lease(current_account_lease)
                                 current_account_lease = None
@@ -2416,6 +2429,12 @@ class _StreamingRetryMixin:
                                 excluded_account_ids.add(account.id)
                                 continue
                             await _drain_pending_post_refresh_penalty_on_terminal(settlement)
+                            await proxy._handle_stream_error(
+                                account,
+                                current_error_payload,
+                                current_error_code,
+                                http_status=retry_exc.status_code,
+                            )
                             if propagate_http_errors:
                                 raise
                             error_message = error.message if error else None
@@ -2479,6 +2498,7 @@ class _StreamingRetryMixin:
                             excluded_account_ids.add(account.id)
                             require_security_work_authorized = True
                             continue
+                    await _drain_pending_post_refresh_penalty_on_terminal(settlement)
                     if _facade()._should_penalize_stream_error(error_code):
                         await proxy._handle_stream_error(
                             account,
@@ -2502,6 +2522,7 @@ class _StreamingRetryMixin:
                         await proxy._load_balancer.mark_permanent_failure(account, exc.code)
                     continue
                 except Exception:
+                    await _drain_pending_post_refresh_penalty_on_terminal(settlement)
                     _facade().logger.warning(
                         "Proxy streaming failed without retry account_id=%s request_id=%s",
                         account_id_value,
@@ -2515,6 +2536,7 @@ class _StreamingRetryMixin:
                     )
                     yield format_sse_event(event)
                     return
+            await _drain_pending_post_refresh_penalty_on_terminal(settlement)
             # When HTTP error propagation is enabled and the last failure was
             # a transient 500, re-raise to preserve the upstream status/payload.
             if last_account_model_rejection is not None:

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -640,11 +640,13 @@ class _TransientStreamError(Exception):
         error: UpstreamError,
         *,
         preserve_on_selection_exhausted: bool = False,
+        account_health_error: bool = False,
     ) -> None:
         super().__init__(code)
         self.code = code
         self.error = error
         self.preserve_on_selection_exhausted = preserve_on_selection_exhausted
+        self.account_health_error = account_health_error
 
 
 class _TerminalStreamError(Exception):

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -634,10 +634,17 @@ async def failover_after_previsible_refresh_error(
 class _TransientStreamError(Exception):
     """Transient upstream error (e.g. 500 server_error) - retry on same account first."""
 
-    def __init__(self, code: str, error: UpstreamError) -> None:
+    def __init__(
+        self,
+        code: str,
+        error: UpstreamError,
+        *,
+        preserve_on_selection_exhausted: bool = False,
+    ) -> None:
         super().__init__(code)
         self.code = code
         self.error = error
+        self.preserve_on_selection_exhausted = preserve_on_selection_exhausted
 
 
 class _TerminalStreamError(Exception):

--- a/openspec/changes/retry-model-capacity-errors/proposal.md
+++ b/openspec/changes/retry-model-capacity-errors/proposal.md
@@ -7,7 +7,8 @@ Codex can receive upstream failures whose user-facing message is exactly `Select
 ## What changes
 
 - Treat upstream model-capacity messages as retryable transient failures even when the upstream code/status looks like `invalid_request_error` / HTTP 400.
-- Apply the same classification to serialized pre-visible streaming first events, pre-visible HTTP errors, and websocket pre-created replay decisions.
+- Apply the same classification to pre-dispatch HTTP errors and websocket pre-created replay decisions.
+- Surface serialized streaming terminal events without replay because receiving an event does not prove the POST was not accepted.
 - Keep post-connect transport/body-read disconnects non-replayed unless typed transport provenance proves the request was not dispatched.
 - Keep quota/rate-limit codes classified as quota/rate-limit before message-based transient detection.
 

--- a/openspec/changes/retry-model-capacity-errors/proposal.md
+++ b/openspec/changes/retry-model-capacity-errors/proposal.md
@@ -7,10 +7,12 @@ Codex can receive upstream failures whose user-facing message is exactly `Select
 ## What changes
 
 - Treat upstream model-capacity messages as retryable transient failures even when the upstream code/status looks like `invalid_request_error` / HTTP 400.
-- Apply the same classification to streaming first events, pre-visible HTTP errors, and websocket pre-created replay decisions.
+- Apply the same classification to serialized pre-visible streaming first events, pre-visible HTTP errors, and websocket pre-created replay decisions.
+- Keep post-connect transport/body-read disconnects non-replayed unless typed transport provenance proves the request was not dispatched.
 - Keep quota/rate-limit codes classified as quota/rate-limit before message-based transient detection.
 
 ## Impact
 
 - Reduces user-visible thread stalls caused by temporary model capacity.
+- Preserves the Responses compatibility no-replay boundary for uncertain post-dispatch failures.
 - Preserves existing account quota and rate-limit handling.

--- a/openspec/changes/retry-model-capacity-errors/specs/responses-api-compat/spec.md
+++ b/openspec/changes/retry-model-capacity-errors/specs/responses-api-compat/spec.md
@@ -26,6 +26,18 @@ When upstream returns a temporary model-capacity failure whose message says that
 - **THEN** the proxy MUST surface the stream failure to the downstream client
 - **AND** the proxy MUST NOT transparently re-POST the request as a model-capacity retry.
 
+#### Scenario: Websocket connect failure retries before request dispatch
+
+- **WHEN** an upstream websocket handshake raises a typed connector failure or connect timeout before the `response.create` frame is sent
+- **THEN** the proxy MUST preserve typed pre-dispatch provenance and MAY retry or fail over before any downstream-visible output
+- **AND** a websocket transport selection MUST NOT turn that failure into a terminal serialized SSE event.
+
+#### Scenario: Direct HTTP TLS verification failure is not retried
+
+- **WHEN** a direct HTTP stream raises a certificate or TLS connector failure before request dispatch
+- **THEN** the proxy MUST surface the TLS failure without transparently retrying or failing over
+- **AND** pre-dispatch provenance MUST NOT classify the non-transient TLS failure as retryable.
+
 #### Scenario: Quota and rate-limit codes retain their stronger classification
 
 - **WHEN** upstream returns a quota or rate-limit error code

--- a/openspec/changes/retry-model-capacity-errors/specs/responses-api-compat/spec.md
+++ b/openspec/changes/retry-model-capacity-errors/specs/responses-api-compat/spec.md
@@ -12,13 +12,12 @@ When upstream returns a temporary model-capacity failure whose message says that
 - **THEN** `classify_upstream_failure` returns `failure_class = "retryable_transient"`
 - **AND** pre-visible streaming/websocket paths are eligible to retry or fail over instead of surfacing a terminal client error.
 
-#### Scenario: Serialized selected-model capacity event can retry before visibility
+#### Scenario: Serialized selected-model capacity event surfaces without replay
 
 - **WHEN** a streaming Responses request receives a first upstream `response.failed` or `error` event whose message says the selected model is at capacity
-- **AND** the event does not include an upstream response id
 - **AND** no downstream-visible output has been emitted
-- **THEN** the stream retry layer MUST treat the event as a retryable transient failure inside the existing bounded same-account retry budget
-- **AND** the retry layer MUST preserve the existing no-replay behavior once downstream-visible output exists.
+- **THEN** the proxy MUST surface that terminal event without transparently re-POSTing the request
+- **AND** the absence of an upstream response id MUST NOT by itself prove the POST was safe to replay.
 
 #### Scenario: Post-connect body-read disconnect is not replayed as capacity retry
 

--- a/openspec/changes/retry-model-capacity-errors/specs/responses-api-compat/spec.md
+++ b/openspec/changes/retry-model-capacity-errors/specs/responses-api-compat/spec.md
@@ -42,3 +42,10 @@ When upstream returns a temporary model-capacity failure whose message says that
 
 - **WHEN** upstream returns a quota or rate-limit error code
 - **THEN** the proxy MUST keep classifying it as quota or rate-limit before applying message-based model-capacity detection.
+
+#### Scenario: Post-refresh transient exhaustion preserves every health signal
+
+- **WHEN** one or more accounts each exhaust multiple same-account post-refresh transient retries before the request succeeds or terminates
+- **THEN** the proxy MUST settle API-key usage before recording any deferred account-health failure
+- **AND** each exhausted account MUST receive exactly one classified health failure plus one additional failure for every remaining exhausted retry
+- **AND** selecting or exhausting a later account MUST NOT replace, lose, or duplicate an earlier account's deferred failures.

--- a/openspec/changes/retry-model-capacity-errors/specs/responses-api-compat/spec.md
+++ b/openspec/changes/retry-model-capacity-errors/specs/responses-api-compat/spec.md
@@ -12,6 +12,21 @@ When upstream returns a temporary model-capacity failure whose message says that
 - **THEN** `classify_upstream_failure` returns `failure_class = "retryable_transient"`
 - **AND** pre-visible streaming/websocket paths are eligible to retry or fail over instead of surfacing a terminal client error.
 
+#### Scenario: Serialized selected-model capacity event can retry before visibility
+
+- **WHEN** a streaming Responses request receives a first upstream `response.failed` or `error` event whose message says the selected model is at capacity
+- **AND** the event does not include an upstream response id
+- **AND** no downstream-visible output has been emitted
+- **THEN** the stream retry layer MUST treat the event as a retryable transient failure inside the existing bounded same-account retry budget
+- **AND** the retry layer MUST preserve the existing no-replay behavior once downstream-visible output exists.
+
+#### Scenario: Post-connect body-read disconnect is not replayed as capacity retry
+
+- **WHEN** a streaming Responses request fails while reading the upstream stream body after the upstream request has been dispatched
+- **AND** the failure is an `aiohttp` client error, timeout, EOF, or other transport/body-read close without typed pre-dispatch provenance
+- **THEN** the proxy MUST surface the stream failure to the downstream client
+- **AND** the proxy MUST NOT transparently re-POST the request as a model-capacity retry.
+
 #### Scenario: Quota and rate-limit codes retain their stronger classification
 
 - **WHEN** upstream returns a quota or rate-limit error code

--- a/openspec/changes/retry-model-capacity-errors/tasks.md
+++ b/openspec/changes/retry-model-capacity-errors/tasks.md
@@ -5,4 +5,5 @@
 - [x] Document the serialized-event and post-connect no-replay boundaries.
 - [x] Add regressions for the literal Codex capacity message.
 - [x] Cover websocket pre-dispatch connector retry and direct HTTP TLS no-retry boundaries.
+- [x] Preserve per-account post-refresh retry health accounting after usage settlement.
 - [x] Run targeted tests and strict OpenSpec validation.

--- a/openspec/changes/retry-model-capacity-errors/tasks.md
+++ b/openspec/changes/retry-model-capacity-errors/tasks.md
@@ -2,6 +2,6 @@
 
 - [x] Add OpenSpec requirement for model-capacity message retry classification.
 - [x] Add shared capacity-message predicate and wire it into failover/retry paths.
-- [x] Document the serialized-event retry boundary and the post-connect no-replay boundary.
+- [x] Document the serialized-event and post-connect no-replay boundaries.
 - [x] Add regressions for the literal Codex capacity message.
 - [x] Run targeted tests and strict OpenSpec validation.

--- a/openspec/changes/retry-model-capacity-errors/tasks.md
+++ b/openspec/changes/retry-model-capacity-errors/tasks.md
@@ -2,5 +2,6 @@
 
 - [x] Add OpenSpec requirement for model-capacity message retry classification.
 - [x] Add shared capacity-message predicate and wire it into failover/retry paths.
+- [x] Document the serialized-event retry boundary and the post-connect no-replay boundary.
 - [x] Add regressions for the literal Codex capacity message.
 - [x] Run targeted tests and strict OpenSpec validation.

--- a/openspec/changes/retry-model-capacity-errors/tasks.md
+++ b/openspec/changes/retry-model-capacity-errors/tasks.md
@@ -4,4 +4,5 @@
 - [x] Add shared capacity-message predicate and wire it into failover/retry paths.
 - [x] Document the serialized-event and post-connect no-replay boundaries.
 - [x] Add regressions for the literal Codex capacity message.
+- [x] Cover websocket pre-dispatch connector retry and direct HTTP TLS no-retry boundaries.
 - [x] Run targeted tests and strict OpenSpec validation.

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -1129,7 +1129,7 @@ async def test_proxy_stream_classifies_core_generated_eof_failure(async_client, 
         assert log.failure_detail == "upstream_eof_before_terminal_event"
 
 
-async def test_proxy_stream_retries_first_core_generated_eof_before_no_accounts(async_client, monkeypatch):
+async def test_proxy_stream_surfaces_first_core_generated_eof_before_no_accounts(async_client, monkeypatch):
     expected_account_id = await _import_account(
         async_client,
         "acc_stream_first_core_eof",
@@ -1166,7 +1166,7 @@ async def test_proxy_stream_retries_first_core_generated_eof_before_no_accounts(
         json.loads(line[6:]) for line in lines if line.startswith("data: ") and not line.startswith("data: [DONE]")
     ][-1]
     assert event["type"] == "response.failed"
-    assert event["response"]["error"]["code"] == "no_accounts"
+    assert event["response"]["error"]["code"] == "stream_incomplete"
 
     async with SessionLocal() as session:
         result = await session.execute(

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -298,6 +298,50 @@ async def test_stream_model_capacity_without_response_id_sleeps_and_retries_same
 
 
 @pytest.mark.asyncio
+async def test_stream_raw_capacity_error_with_proxy_request_id_retries_same_account(async_client, monkeypatch):
+    """A normalized raw error may get the proxy request id; that is not an upstream response id."""
+    await _import_account(async_client, "acc_raw_model_capacity_retry", "raw-model-capacity@example.com")
+
+    call_count = 0
+    seen_account_ids: list[str | None] = []
+    sleeps: list[float] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        nonlocal call_count
+        call_count += 1
+        seen_account_ids.append(account_id)
+        if call_count == 1:
+            yield _sse_event(
+                {
+                    "type": "error",
+                    "code": "invalid_request_error",
+                    "message": "Selected model is at capacity. Please try a different model.",
+                }
+            )
+            return
+        yield _success_sse_event("resp_raw_model_capacity_retry_ok")
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module.asyncio, "sleep", fake_sleep)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    events = _extract_events(lines)
+    assert [event["response"]["id"] for event in events if event.get("type") == "response.completed"] == [
+        "resp_raw_model_capacity_retry_ok"
+    ]
+    assert [event for event in events if event.get("type") == "response.failed"] == []
+    assert seen_account_ids == ["acc_raw_model_capacity_retry", "acc_raw_model_capacity_retry"]
+    assert sleeps
+
+
+@pytest.mark.asyncio
 async def test_stream_model_capacity_top_level_response_id_surfaces_without_replay(async_client, monkeypatch):
     """A top-level upstream response_id proves dispatch, so capacity errors must not be replayed."""
     await _import_account(async_client, "acc_model_capacity_accepted", "model-capacity-accepted@example.com")
@@ -334,13 +378,12 @@ async def test_stream_model_capacity_top_level_response_id_surfaces_without_repl
 
 
 @pytest.mark.asyncio
-async def test_stream_previsible_upstream_close_sleeps_and_retries_same_account(async_client, monkeypatch):
-    """A websocket EOF before the first upstream event is retried instead of surfacing to the client."""
-    await _import_account(async_client, "acc_previsible_close_retry", "previsible-close@example.com")
+async def test_stream_empty_upstream_body_surfaces_without_replay(async_client, monkeypatch):
+    """An untyped empty upstream stream may be post-dispatch, so it is not replayed."""
+    await _import_account(async_client, "acc_empty_body_no_replay", "empty-body-no-replay@example.com")
 
     call_count = 0
     seen_account_ids: list[str | None] = []
-    sleeps: list[float] = []
 
     async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
         nonlocal call_count
@@ -350,13 +393,8 @@ async def test_stream_previsible_upstream_close_sleeps_and_retries_same_account(
             if False:
                 yield ""
             return
-        yield _success_sse_event("resp_previsible_close_retry_ok")
-
-    async def fake_sleep(delay: float) -> None:
-        sleeps.append(delay)
 
     monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
-    monkeypatch.setattr(proxy_module.asyncio, "sleep", fake_sleep)
 
     payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
     async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
@@ -364,12 +402,9 @@ async def test_stream_previsible_upstream_close_sleeps_and_retries_same_account(
         lines = [line async for line in resp.aiter_lines() if line]
 
     events = _extract_events(lines)
-    assert [event["response"]["id"] for event in events if event.get("type") == "response.completed"] == [
-        "resp_previsible_close_retry_ok"
-    ]
-    assert [event for event in events if event.get("type") == "response.failed"] == []
-    assert seen_account_ids == ["acc_previsible_close_retry", "acc_previsible_close_retry"]
-    assert sleeps
+    error_codes = [event["response"]["error"]["code"] for event in events if event.get("type") == "response.failed"]
+    assert error_codes[-1] == "stream_incomplete"
+    assert seen_account_ids == ["acc_empty_body_no_replay"]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -162,8 +162,8 @@ def _extract_events(lines: list[str]) -> list[dict]:
 
 
 @pytest.mark.asyncio
-async def test_stream_server_error_succeeds_on_second_try_same_account(async_client, monkeypatch):
-    """server_error on 1st SSE event → inner retry on same account → success on 2nd try."""
+async def test_stream_server_error_surfaces_without_replay(async_client, monkeypatch):
+    """An upstream terminal server error cannot prove that retrying the POST is safe."""
     await _import_account(async_client, "acc_trans_1", "trans1@example.com")
 
     call_count = 0
@@ -186,17 +186,15 @@ async def test_stream_server_error_succeeds_on_second_try_same_account(async_cli
         lines = [line async for line in resp.aiter_lines() if line]
 
     events = _extract_events(lines)
-    completed = [e for e in events if e.get("type") == "response.completed"]
-    assert len(completed) == 1
-
-    # Both calls should be to the same account
-    assert len(seen_account_ids) == 2
-    assert seen_account_ids[0] == seen_account_ids[1]
+    failed = [event for event in events if event.get("type") == "response.failed"]
+    assert len(failed) == 1
+    assert failed[0]["response"]["error"]["code"] == "server_error"
+    assert seen_account_ids == ["acc_trans_1"]
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("error_code", ["overloaded_error", "server_is_overloaded"])
-async def test_stream_overload_alias_succeeds_on_second_try_same_account(async_client, monkeypatch, error_code):
+async def test_stream_overload_alias_surfaces_without_replay(async_client, monkeypatch, error_code):
     await _import_account(async_client, f"acc_{error_code}", f"{error_code}@example.com")
 
     call_count = 0
@@ -219,17 +217,15 @@ async def test_stream_overload_alias_succeeds_on_second_try_same_account(async_c
         lines = [line async for line in resp.aiter_lines() if line]
 
     events = _extract_events(lines)
-    assert [event["response"]["id"] for event in events if event.get("type") == "response.completed"] == [
-        "resp_server_overloaded_ok"
-    ]
-    assert [event for event in events if event.get("type") == "response.failed"] == []
-    assert len(seen_account_ids) == 2
-    assert seen_account_ids[0] == seen_account_ids[1]
+    failed = [event for event in events if event.get("type") == "response.failed"]
+    assert len(failed) == 1
+    assert failed[0]["response"]["error"]["code"] == error_code
+    assert seen_account_ids == [f"acc_{error_code}"]
 
 
 @pytest.mark.asyncio
-async def test_stream_timeout_succeeds_on_second_try_same_account(async_client, monkeypatch):
-    """Timeout as the first SSE event is a reconnectable transient failure."""
+async def test_stream_timeout_surfaces_without_replay(async_client, monkeypatch):
+    """An upstream terminal timeout is not proven pre-dispatch work."""
     await _import_account(async_client, "acc_trans_timeout", "timeout@example.com")
 
     call_count = 0
@@ -252,22 +248,19 @@ async def test_stream_timeout_succeeds_on_second_try_same_account(async_client, 
         lines = [line async for line in resp.aiter_lines() if line]
 
     events = _extract_events(lines)
-    completed = [e for e in events if e.get("type") == "response.completed"]
     failed = [e for e in events if e.get("type") == "response.failed"]
-    assert len(completed) == 1
-    assert failed == []
-    assert len(seen_account_ids) == 2
-    assert seen_account_ids[0] == seen_account_ids[1]
+    assert len(failed) == 1
+    assert failed[0]["response"]["error"]["code"] == "upstream_request_timeout"
+    assert seen_account_ids == ["acc_trans_timeout"]
 
 
 @pytest.mark.asyncio
-async def test_stream_model_capacity_without_response_id_sleeps_and_retries_same_account(async_client, monkeypatch):
-    """Model capacity errors without a real upstream response id are safe pre-visible retries."""
+async def test_stream_model_capacity_without_response_id_surfaces_without_replay(async_client, monkeypatch):
+    """An upstream terminal event is accepted work even when it omits a response id."""
     await _import_account(async_client, "acc_model_capacity_retry", "model-capacity@example.com")
 
     call_count = 0
     seen_account_ids: list[str | None] = []
-    sleeps: list[float] = []
 
     async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
         nonlocal call_count
@@ -276,13 +269,8 @@ async def test_stream_model_capacity_without_response_id_sleeps_and_retries_same
         if call_count == 1:
             yield _model_capacity_sse_event()
             return
-        yield _success_sse_event("resp_model_capacity_retry_ok")
-
-    async def fake_sleep(delay: float) -> None:
-        sleeps.append(delay)
 
     monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
-    monkeypatch.setattr(proxy_module.asyncio, "sleep", fake_sleep)
 
     payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
     async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
@@ -290,22 +278,19 @@ async def test_stream_model_capacity_without_response_id_sleeps_and_retries_same
         lines = [line async for line in resp.aiter_lines() if line]
 
     events = _extract_events(lines)
-    assert [event["response"]["id"] for event in events if event.get("type") == "response.completed"] == [
-        "resp_model_capacity_retry_ok"
-    ]
-    assert [event for event in events if event.get("type") == "response.failed"] == []
-    assert seen_account_ids == ["acc_model_capacity_retry", "acc_model_capacity_retry"]
-    assert sleeps
+    failed = [event for event in events if event.get("type") == "response.failed"]
+    assert len(failed) == 1
+    assert failed[0]["response"]["error"]["code"] == "invalid_request_error"
+    assert seen_account_ids == ["acc_model_capacity_retry"]
 
 
 @pytest.mark.asyncio
-async def test_stream_raw_capacity_error_with_proxy_request_id_retries_same_account(async_client, monkeypatch):
-    """A normalized raw error may get the proxy request id; that is not an upstream response id."""
+async def test_stream_raw_capacity_error_with_proxy_request_id_surfaces_without_replay(async_client, monkeypatch):
+    """A terminal upstream error remains terminal even with a proxy-generated id."""
     await _import_account(async_client, "acc_raw_model_capacity_retry", "raw-model-capacity@example.com")
 
     call_count = 0
     seen_account_ids: list[str | None] = []
-    sleeps: list[float] = []
 
     async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
         nonlocal call_count
@@ -320,13 +305,8 @@ async def test_stream_raw_capacity_error_with_proxy_request_id_retries_same_acco
                 }
             )
             return
-        yield _success_sse_event("resp_raw_model_capacity_retry_ok")
-
-    async def fake_sleep(delay: float) -> None:
-        sleeps.append(delay)
 
     monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
-    monkeypatch.setattr(proxy_module.asyncio, "sleep", fake_sleep)
 
     payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
     async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
@@ -334,12 +314,10 @@ async def test_stream_raw_capacity_error_with_proxy_request_id_retries_same_acco
         lines = [line async for line in resp.aiter_lines() if line]
 
     events = _extract_events(lines)
-    assert [event["response"]["id"] for event in events if event.get("type") == "response.completed"] == [
-        "resp_raw_model_capacity_retry_ok"
-    ]
-    assert [event for event in events if event.get("type") == "response.failed"] == []
-    assert seen_account_ids == ["acc_raw_model_capacity_retry", "acc_raw_model_capacity_retry"]
-    assert sleeps
+    errors = [event for event in events if event.get("type") == "error"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == "invalid_request_error"
+    assert seen_account_ids == ["acc_raw_model_capacity_retry"]
 
 
 @pytest.mark.asyncio
@@ -569,8 +547,8 @@ async def test_stream_pinned_previsible_close_exhaustion_surfaces_stream_incompl
 
 
 @pytest.mark.asyncio
-async def test_stream_server_error_exhausts_inner_retries_then_failover(async_client, monkeypatch):
-    """server_error x3 on account A → penalize A → failover to account B → success."""
+async def test_stream_server_error_does_not_fail_over_after_accepted_terminal_event(async_client, monkeypatch):
+    """A terminal event stays on its first account even when another account is eligible."""
     await _import_account(async_client, "acc_trans_fo_a", "fo_a@example.com")
     await _import_account(async_client, "acc_trans_fo_b", "fo_b@example.com")
 
@@ -591,14 +569,10 @@ async def test_stream_server_error_exhausts_inner_retries_then_failover(async_cl
         lines = [line async for line in resp.aiter_lines() if line]
 
     events = _extract_events(lines)
-    completed = [e for e in events if e.get("type") == "response.completed"]
-    assert len(completed) == 1
-
-    # 3 retries on account A + 1 success on account B
-    a_calls = [aid for aid in seen_account_ids if aid == "acc_trans_fo_a"]
-    b_calls = [aid for aid in seen_account_ids if aid == "acc_trans_fo_b"]
-    assert len(a_calls) == 3
-    assert len(b_calls) >= 1
+    failed = [event for event in events if event.get("type") == "response.failed"]
+    assert len(failed) == 1
+    assert failed[0]["response"]["error"]["code"] == "server_error"
+    assert seen_account_ids == ["acc_trans_fo_a"]
 
 
 @pytest.mark.asyncio
@@ -623,8 +597,8 @@ async def test_stream_server_error_all_accounts_exhausted(async_client, monkeypa
 
 
 @pytest.mark.asyncio
-async def test_stream_server_error_succeeds_on_third_try(async_client, monkeypatch):
-    """server_error on tries 1 and 2, success on try 3 — all same account."""
+async def test_stream_server_error_does_not_make_a_third_post(async_client, monkeypatch):
+    """An accepted terminal event prevents follow-up same-account POSTs."""
     await _import_account(async_client, "acc_trans_3rd", "trans3@example.com")
 
     call_count = 0
@@ -647,12 +621,10 @@ async def test_stream_server_error_succeeds_on_third_try(async_client, monkeypat
         lines = [line async for line in resp.aiter_lines() if line]
 
     events = _extract_events(lines)
-    completed = [e for e in events if e.get("type") == "response.completed"]
-    assert len(completed) == 1
-
-    # All 3 calls to the same account
-    assert len(seen_account_ids) == 3
-    assert len(set(seen_account_ids)) == 1
+    failed = [event for event in events if event.get("type") == "response.failed"]
+    assert len(failed) == 1
+    assert failed[0]["response"]["error"]["code"] == "server_error"
+    assert seen_account_ids == ["acc_trans_3rd"]
 
 
 # ===========================================================================

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -21,6 +21,7 @@ from app.core.auth import generate_unique_account_id
 from app.core.clients.proxy import ProxyResponseError
 from app.core.errors import openai_error
 from app.core.openai.models import CompactResponsePayload
+from app.core.utils.request_id import get_request_id
 from app.db.models import Account, AccountStatus
 from app.db.session import SessionLocal
 
@@ -476,6 +477,48 @@ async def test_stream_serialized_body_read_disconnect_with_response_id_surfaces_
     assert len(failed) == 1
     assert failed[0]["response"]["error"]["code"] == "upstream_unavailable"
     assert seen_account_ids == ["acc_serialized_disconnect_a"]
+
+
+@pytest.mark.asyncio
+async def test_stream_serialized_body_read_disconnect_with_request_id_surfaces_without_replay(
+    async_client, monkeypatch
+):
+    """A response.failed using the proxy request id still represents an unsafe post-dispatch failure."""
+    await _import_account(async_client, "acc_serialized_request_id_disconnect_a", "serialized-request-a@example.com")
+    await _import_account(async_client, "acc_serialized_request_id_disconnect_b", "serialized-request-b@example.com")
+
+    seen_account_ids: list[str | None] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        del payload, headers, access_token, base_url, raise_for_status
+        seen_account_ids.append(account_id)
+        request_id = get_request_id()
+        assert request_id is not None
+        yield _sse_event(
+            {
+                "type": "response.failed",
+                "response": {
+                    "id": request_id,
+                    "error": {
+                        "code": "upstream_unavailable",
+                        "message": "Server disconnected",
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    events = _extract_events(lines)
+    failed = [event for event in events if event.get("type") == "response.failed"]
+    assert len(failed) == 1
+    assert failed[0]["response"]["error"]["code"] == "upstream_unavailable"
+    assert seen_account_ids == ["acc_serialized_request_id_disconnect_a"]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -337,8 +337,8 @@ async def test_stream_previsible_upstream_close_sleeps_and_retries_same_account(
 
 
 @pytest.mark.asyncio
-async def test_stream_previsible_client_error_exhaustion_surfaces_upstream_unavailable(async_client, monkeypatch):
-    """If every account disconnects before first output, surface the upstream failure, not no_accounts."""
+async def test_stream_body_read_client_error_surfaces_without_replay(async_client, monkeypatch):
+    """Post-connect body-read errors are not replayed because upstream delivery is uncertain."""
     await _import_account(async_client, "acc_previsible_disconnect_a", "previsible-disconnect-a@example.com")
     await _import_account(async_client, "acc_previsible_disconnect_b", "previsible-disconnect-b@example.com")
 
@@ -365,7 +365,7 @@ async def test_stream_previsible_client_error_exhaustion_surfaces_upstream_unava
     error_codes = [event["response"]["error"]["code"] for event in events if event.get("type") == "response.failed"]
     assert error_codes[-1] == "upstream_unavailable"
     assert "no_accounts" not in error_codes
-    assert len(set(seen_account_ids)) == 2
+    assert seen_account_ids == ["acc_previsible_disconnect_a"]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -117,6 +117,20 @@ def _stream_timeout_sse_event() -> str:
     )
 
 
+def _model_capacity_sse_event() -> str:
+    return _sse_event(
+        {
+            "type": "response.failed",
+            "response": {
+                "error": {
+                    "code": "server_error",
+                    "message": "Selected model is at capacity. Please try a different model.",
+                },
+            },
+        }
+    )
+
+
 def _success_sse_event(response_id: str = "resp_ok") -> str:
     return _sse_event(
         {
@@ -242,6 +256,83 @@ async def test_stream_timeout_succeeds_on_second_try_same_account(async_client, 
     assert failed == []
     assert len(seen_account_ids) == 2
     assert seen_account_ids[0] == seen_account_ids[1]
+
+
+@pytest.mark.asyncio
+async def test_stream_model_capacity_without_response_id_sleeps_and_retries_same_account(async_client, monkeypatch):
+    """Model capacity errors without a real upstream response id are safe pre-visible retries."""
+    await _import_account(async_client, "acc_model_capacity_retry", "model-capacity@example.com")
+
+    call_count = 0
+    seen_account_ids: list[str | None] = []
+    sleeps: list[float] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        nonlocal call_count
+        call_count += 1
+        seen_account_ids.append(account_id)
+        if call_count == 1:
+            yield _model_capacity_sse_event()
+            return
+        yield _success_sse_event("resp_model_capacity_retry_ok")
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module.asyncio, "sleep", fake_sleep)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    events = _extract_events(lines)
+    assert [event["response"]["id"] for event in events if event.get("type") == "response.completed"] == [
+        "resp_model_capacity_retry_ok"
+    ]
+    assert [event for event in events if event.get("type") == "response.failed"] == []
+    assert seen_account_ids == ["acc_model_capacity_retry", "acc_model_capacity_retry"]
+    assert sleeps
+
+
+@pytest.mark.asyncio
+async def test_stream_previsible_upstream_close_sleeps_and_retries_same_account(async_client, monkeypatch):
+    """A websocket EOF before the first upstream event is retried instead of surfacing to the client."""
+    await _import_account(async_client, "acc_previsible_close_retry", "previsible-close@example.com")
+
+    call_count = 0
+    seen_account_ids: list[str | None] = []
+    sleeps: list[float] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        nonlocal call_count
+        call_count += 1
+        seen_account_ids.append(account_id)
+        if call_count == 1:
+            if False:
+                yield ""
+            return
+        yield _success_sse_event("resp_previsible_close_retry_ok")
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module.asyncio, "sleep", fake_sleep)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    events = _extract_events(lines)
+    assert [event["response"]["id"] for event in events if event.get("type") == "response.completed"] == [
+        "resp_previsible_close_retry_ok"
+    ]
+    assert [event for event in events if event.get("type") == "response.failed"] == []
+    assert seen_account_ids == ["acc_previsible_close_retry", "acc_previsible_close_retry"]
+    assert sleeps
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import base64
 import json
 
+import aiohttp
 import pytest
 
 import app.modules.proxy.service as proxy_module
@@ -123,7 +124,7 @@ def _model_capacity_sse_event() -> str:
             "type": "response.failed",
             "response": {
                 "error": {
-                    "code": "server_error",
+                    "code": "invalid_request_error",
                     "message": "Selected model is at capacity. Please try a different model.",
                 },
             },
@@ -333,6 +334,85 @@ async def test_stream_previsible_upstream_close_sleeps_and_retries_same_account(
     assert [event for event in events if event.get("type") == "response.failed"] == []
     assert seen_account_ids == ["acc_previsible_close_retry", "acc_previsible_close_retry"]
     assert sleeps
+
+
+@pytest.mark.asyncio
+async def test_stream_previsible_client_error_exhaustion_surfaces_upstream_unavailable(async_client, monkeypatch):
+    """If every account disconnects before first output, surface the upstream failure, not no_accounts."""
+    await _import_account(async_client, "acc_previsible_disconnect_a", "previsible-disconnect-a@example.com")
+    await _import_account(async_client, "acc_previsible_disconnect_b", "previsible-disconnect-b@example.com")
+
+    seen_account_ids: list[str | None] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        seen_account_ids.append(account_id)
+        if False:
+            yield ""
+        raise aiohttp.ServerDisconnectedError("Server disconnected")
+
+    async def fake_sleep(delay: float) -> None:
+        pass
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module.asyncio, "sleep", fake_sleep)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    events = _extract_events(lines)
+    error_codes = [event["response"]["error"]["code"] for event in events if event.get("type") == "response.failed"]
+    assert error_codes[-1] == "upstream_unavailable"
+    assert "no_accounts" not in error_codes
+    assert len(set(seen_account_ids)) == 2
+
+
+@pytest.mark.asyncio
+async def test_stream_pinned_previsible_close_exhaustion_surfaces_stream_incomplete(async_client, monkeypatch):
+    """Pinned previous-response EOF cannot fail over, so preserve the stream failure for the client."""
+    upstream_account_id = "acc_pinned_previsible_close"
+    owner_account_id = await _import_account(
+        async_client,
+        upstream_account_id,
+        "pinned-previsible-close@example.com",
+    )
+
+    seen_account_ids: list[str | None] = []
+
+    async def fake_owner(self, *, previous_response_id, api_key, session_id=None, surface):
+        del self, previous_response_id, api_key, session_id, surface
+        return owner_account_id
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        seen_account_ids.append(account_id)
+        if False:
+            yield ""
+        return
+
+    async def fake_sleep(delay: float) -> None:
+        pass
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_resolve_websocket_previous_response_owner", fake_owner)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module.asyncio, "sleep", fake_sleep)
+
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": [],
+        "stream": True,
+        "previous_response_id": "resp_pinned_previsible_close",
+    }
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    events = _extract_events(lines)
+    error_codes = [event["response"]["error"]["code"] for event in events if event.get("type") == "response.failed"]
+    assert error_codes[-1] == "stream_incomplete"
+    assert "previous_response_owner_unavailable" not in error_codes
+    assert set(seen_account_ids) == {upstream_account_id}
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_transient_retry.py
+++ b/tests/integration/test_proxy_transient_retry.py
@@ -298,6 +298,42 @@ async def test_stream_model_capacity_without_response_id_sleeps_and_retries_same
 
 
 @pytest.mark.asyncio
+async def test_stream_model_capacity_top_level_response_id_surfaces_without_replay(async_client, monkeypatch):
+    """A top-level upstream response_id proves dispatch, so capacity errors must not be replayed."""
+    await _import_account(async_client, "acc_model_capacity_accepted", "model-capacity-accepted@example.com")
+
+    seen_account_ids: list[str | None] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        seen_account_ids.append(account_id)
+        yield _sse_event(
+            {
+                "type": "response.failed",
+                "response_id": "resp_model_capacity_accepted",
+                "response": {
+                    "error": {
+                        "code": "invalid_request_error",
+                        "message": "Selected model is at capacity. Please try a different model.",
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    events = _extract_events(lines)
+    failed = [event for event in events if event.get("type") == "response.failed"]
+    assert len(failed) == 1
+    assert failed[0]["response"]["error"]["code"] == "invalid_request_error"
+    assert seen_account_ids == ["acc_model_capacity_accepted"]
+
+
+@pytest.mark.asyncio
 async def test_stream_previsible_upstream_close_sleeps_and_retries_same_account(async_client, monkeypatch):
     """A websocket EOF before the first upstream event is retried instead of surfacing to the client."""
     await _import_account(async_client, "acc_previsible_close_retry", "previsible-close@example.com")
@@ -366,6 +402,45 @@ async def test_stream_body_read_client_error_surfaces_without_replay(async_clien
     assert error_codes[-1] == "upstream_unavailable"
     assert "no_accounts" not in error_codes
     assert seen_account_ids == ["acc_previsible_disconnect_a"]
+
+
+@pytest.mark.asyncio
+async def test_stream_serialized_body_read_disconnect_with_response_id_surfaces_without_replay(
+    async_client, monkeypatch
+):
+    """Serialized post-dispatch body-read failures with response_id are not safe to replay."""
+    await _import_account(async_client, "acc_serialized_disconnect_a", "serialized-disconnect-a@example.com")
+    await _import_account(async_client, "acc_serialized_disconnect_b", "serialized-disconnect-b@example.com")
+
+    seen_account_ids: list[str | None] = []
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        seen_account_ids.append(account_id)
+        yield _sse_event(
+            {
+                "type": "response.failed",
+                "response_id": "resp_serialized_disconnect",
+                "response": {
+                    "error": {
+                        "code": "upstream_unavailable",
+                        "message": "Server disconnected",
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    async with async_client.stream("POST", "/backend-api/codex/responses", json=payload) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    events = _extract_events(lines)
+    failed = [event for event in events if event.get("type") == "response.failed"]
+    assert len(failed) == 1
+    assert failed[0]["response"]["error"]["code"] == "upstream_unavailable"
+    assert seen_account_ids == ["acc_serialized_disconnect_a"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_codex_client.py
+++ b/tests/unit/test_codex_client.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 
 import aiohttp
 import pytest
+from aiohttp.client_reqrep import ConnectionKey
 from python_socks import ProxyType
 
 from app.core.clients.codex import CodexClient, require_route_or_direct_egress_opt_in
@@ -233,6 +234,25 @@ async def test_websocket_transport_error_preserves_handshake_status(route: Resol
         await client.open_ws_with_route_metadata("wss://upstream.test", route=route)
 
     assert getattr(exc_info.value, "status_code") == 426
+
+
+@pytest.mark.asyncio
+async def test_websocket_connector_error_preserves_pre_dispatch_retry_provenance(
+    route: ResolvedUpstreamRoute,
+) -> None:
+    connection_key = ConnectionKey("upstream.test", 443, True, True, None, None, None)
+
+    class _ConnectorFailSession:
+        def ws_connect(self, *_args: object, **_kwargs: object) -> object:
+            raise aiohttp.ClientConnectorError(connection_key, ConnectionRefusedError("connection refused"))
+
+    client = CodexClient(_ConnectorFailSession())
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await client.open_ws_with_route_metadata("wss://upstream.test", route=route)
+
+    assert getattr(exc_info.value, "failure_phase") == "connect"
+    assert getattr(exc_info.value, "retryable_same_contract") is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1541,6 +1541,18 @@ def test_upstream_unavailable_stream_does_not_retry_accepted_response() -> None:
     )
 
 
+@pytest.mark.parametrize("code", ["server_error", "stream_incomplete", "overloaded_error"])
+def test_generic_transient_stream_does_not_retry_accepted_response(code: str) -> None:
+    assert (
+        proxy_service._should_retry_transient_stream_error(
+            code,
+            "temporary upstream failure",
+            response_id="resp_generic_transient_accepted",
+        )
+        is False
+    )
+
+
 def test_apply_api_key_enforcement_overrides_service_tier_aliases_to_priority():
     payload = ResponsesRequest.model_validate(
         {
@@ -12242,6 +12254,236 @@ async def test_stream_with_retry_post_refresh_model_capacity_retries_same_accoun
 
 
 @pytest.mark.asyncio
+async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(monkeypatch):
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account_a = _make_account("acc_post_refresh_transient_a")
+    account_b = _make_account("acc_post_refresh_transient_b")
+    stream_account_ids: list[str] = []
+    excluded_snapshots: list[set[str]] = []
+    handle_stream_error = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 2)
+    monkeypatch.setattr(proxy_service, "_MAX_TRANSIENT_SAME_ACCOUNT_RETRIES", 1)
+    monkeypatch.setattr(streaming_retry_module.ProcessNetworkRecovery, "wait", AsyncMock(return_value=None))
+    monkeypatch.setattr(streaming_retry_module.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=lambda account, **_k: account))
+    monkeypatch.setattr(service._load_balancer, "record_errors", AsyncMock())
+
+    async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
+        excluded = set(cast(set[str], kwargs["exclude_account_ids"]))
+        excluded_snapshots.append(excluded)
+        account = account_b if account_a.id in excluded else account_a
+        return AccountSelection(account=account, error_message=None)
+
+    async def fake_stream_once(account: Account, *_args: object, **_kwargs: object):
+        stream_account_ids.append(account.id)
+        if stream_account_ids == [account_a.id]:
+            raise proxy_module.ProxyResponseError(
+                401,
+                proxy_module.openai_error("invalid_api_key", "expired", error_type="invalid_request_error"),
+            )
+        if stream_account_ids == [account_a.id, account_a.id]:
+            raise proxy_service._TransientStreamError(
+                "server_error",
+                cast(
+                    UpstreamError,
+                    {
+                        "message": "Selected model is at capacity. Please try a different model.",
+                        "code": "server_error",
+                    },
+                ),
+            )
+        yield 'data: {"type":"response.completed","response":{"id":"resp_post_refresh_transient_b_ok"}}\n\n'
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-post-refresh-transient-failover"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    completed = json.loads(chunks[-1].split("data: ", 1)[1])
+    assert completed["response"]["id"] == "resp_post_refresh_transient_b_ok"
+    assert stream_account_ids == [account_a.id, account_a.id, account_b.id]
+    assert excluded_snapshots == [set(), {account_a.id}]
+    transient_penalties = [call for call in handle_stream_error.await_args_list if call.args[2] == "server_error"]
+    assert len(transient_penalties) == 1
+    assert transient_penalties[0].args[0] is account_a
+    service._load_balancer.record_errors.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_post_refresh_transient_exhaustion_terminal_penalizes_once(monkeypatch):
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_post_refresh_transient_terminal")
+    stream_once_calls = 0
+    handle_stream_error = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 1)
+    monkeypatch.setattr(proxy_service, "_MAX_TRANSIENT_SAME_ACCOUNT_RETRIES", 1)
+    monkeypatch.setattr(streaming_retry_module.ProcessNetworkRecovery, "wait", AsyncMock(return_value=None))
+    monkeypatch.setattr(streaming_retry_module.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account, account]))
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service._load_balancer, "record_errors", AsyncMock())
+
+    async def fake_stream_once(*_args: object, **_kwargs: object):
+        nonlocal stream_once_calls
+        stream_once_calls += 1
+        if stream_once_calls == 1:
+            raise proxy_module.ProxyResponseError(
+                401,
+                proxy_module.openai_error("invalid_api_key", "expired", error_type="invalid_request_error"),
+            )
+        raise proxy_service._TransientStreamError(
+            "server_error",
+            cast(
+                UpstreamError,
+                {
+                    "message": "Selected model is at capacity. Please try a different model.",
+                    "code": "server_error",
+                },
+            ),
+        )
+        yield ""  # pragma: no cover
+
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-post-refresh-transient-terminal"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    failed = json.loads(chunks[-1].split("data: ", 1)[1])
+    assert failed["type"] == "response.failed"
+    assert failed["response"]["error"]["message"] == "Selected model is at capacity. Please try a different model."
+    assert stream_once_calls == 2
+    transient_penalties = [call for call in handle_stream_error.await_args_list if call.args[2] == "server_error"]
+    assert len(transient_penalties) == 1
+    assert transient_penalties[0].args[0] is account
+    service._load_balancer.record_errors.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_post_refresh_transient_exhaustion_preserves_error_without_replacement(monkeypatch):
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_post_refresh_transient_no_replacement")
+    stream_once_calls = 0
+    selections = 0
+    handle_stream_error = AsyncMock()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 2)
+    monkeypatch.setattr(proxy_service, "_MAX_TRANSIENT_SAME_ACCOUNT_RETRIES", 1)
+    monkeypatch.setattr(streaming_retry_module.ProcessNetworkRecovery, "wait", AsyncMock(return_value=None))
+    monkeypatch.setattr(streaming_retry_module.asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=lambda account, **_k: account))
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service._load_balancer, "record_errors", AsyncMock())
+
+    async def select_account(_deadline: float, **_kwargs: object) -> AccountSelection:
+        nonlocal selections
+        selections += 1
+        if selections == 1:
+            return AccountSelection(account=account, error_message=None)
+        return AccountSelection(account=None, error_message="No active accounts available", error_code="no_accounts")
+
+    async def fake_stream_once(*_args: object, **_kwargs: object):
+        nonlocal stream_once_calls
+        stream_once_calls += 1
+        if stream_once_calls == 1:
+            raise proxy_module.ProxyResponseError(
+                401,
+                proxy_module.openai_error("invalid_api_key", "expired", error_type="invalid_request_error"),
+            )
+        raise proxy_service._TransientStreamError(
+            "invalid_request_error",
+            cast(
+                UpstreamError,
+                {
+                    "message": "Selected model is at capacity. Please try a different model.",
+                    "code": "invalid_request_error",
+                },
+            ),
+        )
+        yield ""  # pragma: no cover
+
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-post-refresh-transient-no-replacement"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    failed = json.loads(chunks[-1].split("data: ", 1)[1])
+    assert failed["type"] == "response.failed"
+    assert failed["response"]["error"] == {
+        "message": "Selected model is at capacity. Please try a different model.",
+        "type": "server_error",
+        "code": "invalid_request_error",
+    }
+    assert stream_once_calls == 2
+    assert selections == 2
+    assert all(call.args[2] != "invalid_request_error" for call in handle_stream_error.await_args_list)
+    service._load_balancer.record_errors.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_stream_with_retry_post_refresh_process_network_failure_recovers_same_owner(monkeypatch):
     settings = _make_proxy_settings()
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
@@ -13419,7 +13661,7 @@ async def test_stream_responses_visible_upstream_unavailable_with_response_id_do
 
 
 @pytest.mark.asyncio
-async def test_stream_responses_first_event_raw_eof_fails_over_before_downstream_visible(monkeypatch):
+async def test_stream_responses_first_event_raw_eof_with_response_id_surfaces_without_replay(monkeypatch):
     settings = _make_proxy_settings()
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -13436,9 +13678,7 @@ async def test_stream_responses_first_event_raw_eof_fails_over_before_downstream
     async def select_account(**kwargs: object) -> AccountSelection:
         excluded_account_ids = kwargs.get("exclude_account_ids")
         seen_excluded_account_ids.append(set(cast(set[str], excluded_account_ids)))
-        if len(seen_excluded_account_ids) == 1:
-            return AccountSelection(account=account_a, error_message=None)
-        return AccountSelection(account=account_b, error_message=None)
+        return AccountSelection(account=account_a, error_message=None)
 
     monkeypatch.setattr(service._load_balancer, "select_account", select_account)
     monkeypatch.setattr(service._load_balancer, "record_error", record_error)
@@ -13468,17 +13708,18 @@ async def test_stream_responses_first_event_raw_eof_fails_over_before_downstream
     chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream"})]
 
     event = json.loads(chunks[0].split("data: ", 1)[1])
-    assert event["type"] == "response.completed"
-    assert event["response"]["id"] == "resp_raw_eof_ok"
-    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    assert event["type"] == "response.failed"
+    assert event["response"]["id"] == "resp_raw_eof_event"
+    assert event["response"]["error"]["code"] == "stream_incomplete"
+    assert seen_excluded_account_ids == [set()]
     assert await service.drain_persistence_tasks(timeout_seconds=1)
     assert request_logs.calls[0]["error_code"] == "stream_incomplete"
     assert request_logs.calls[0]["failure_detail"] == "upstream_eof_before_terminal_event"
-    assert request_logs.calls[-1]["status"] == "success"
-    assert request_logs.calls[-1]["account_id"] == account_b.id
+    assert request_logs.calls[-1]["status"] == "error"
+    assert request_logs.calls[-1]["account_id"] == account_a.id
     record_error.assert_awaited_once_with(account_a)
-    record_errors.assert_awaited_once_with(account_a, 2)
-    record_success.assert_awaited_once_with(account_b)
+    record_errors.assert_not_awaited()
+    record_success.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12450,8 +12450,24 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
     handle_stream_error = AsyncMock()
     record_errors = AsyncMock()
     settlement_order: list[str] = []
+    stream_reservations: list[proxy_service.ApiKeyUsageReservationData | None] = []
+    api_key = _make_api_key_data("key_post_refresh_transient_failover")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_post_refresh_transient_failover",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+    release_unsettled = AsyncMock()
 
-    async def settle_usage(*_args: object, **_kwargs: object) -> bool:
+    async def settle_usage(
+        settled_api_key: ApiKeyData | None,
+        settled_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        *_args: object,
+        **_kwargs: object,
+    ) -> bool:
+        assert settled_api_key is api_key
+        assert settled_reservation is reservation
+        assert stream_account_ids[-1] == account_b.id
         settlement_order.append("settle")
         return True
 
@@ -12473,6 +12489,7 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
     handle_stream_error.side_effect = record_health
     monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
     monkeypatch.setattr(service, "_settle_stream_api_key_usage", settle_usage)
+    monkeypatch.setattr(service, "_release_unsettled_stream_api_key_usage", release_unsettled)
     monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=lambda account, **_k: account))
     monkeypatch.setattr(service._load_balancer, "record_errors", record_errors)
 
@@ -12483,6 +12500,9 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
         return AccountSelection(account=account, error_message=None)
 
     async def fake_stream_once(account: Account, *_args: object, **_kwargs: object):
+        stream_reservations.append(
+            cast(proxy_service.ApiKeyUsageReservationData | None, _kwargs["api_key_reservation"])
+        )
         stream_account_ids.append(account.id)
         if stream_account_ids == [account_a.id]:
             raise proxy_module.ProxyResponseError(
@@ -12517,8 +12537,8 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
             codex_session_affinity=False,
             propagate_http_errors=False,
             openai_cache_affinity=False,
-            api_key=None,
-            api_key_reservation=None,
+            api_key=api_key,
+            api_key_reservation=reservation,
             suppress_text_done_events=False,
             request_transport="http",
             upstream_stream_transport_override="http",
@@ -12534,7 +12554,12 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
     ]
     assert len(transient_penalties) == 1
     assert transient_penalties[0].args[0] is account_a
-    assert settlement_order.index("settle") < settlement_order.index("health:invalid_request_error")
+    assert [entry for entry in settlement_order if entry != "health:invalid_api_key"] == [
+        "health:invalid_request_error",
+        "settle",
+    ]
+    assert stream_reservations == [reservation] * 5
+    release_unsettled.assert_not_awaited()
     record_errors.assert_any_await(account_a, 2)
 
 
@@ -12687,7 +12712,7 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_preserves_err
     }
     assert stream_once_calls == 2
     assert selections == 2
-    assert any(call.args[2] == "invalid_request_error" for call in handle_stream_error.await_args_list)
+    assert all(call.args[2] != "invalid_request_error" for call in handle_stream_error.await_args_list)
     service._load_balancer.record_errors.assert_not_awaited()
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12677,13 +12677,29 @@ async def test_stream_with_retry_post_refresh_connect_exhaustion_terminal_penali
 
 
 @pytest.mark.asyncio
-async def test_stream_with_retry_post_refresh_transient_exhaustion_preserves_error_without_replacement(monkeypatch):
+@pytest.mark.parametrize("propagate_http_errors", [False, True])
+async def test_stream_with_retry_post_refresh_transient_exhaustion_penalizes_without_replacement(
+    monkeypatch,
+    propagate_http_errors: bool,
+):
     settings = _make_proxy_settings()
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_post_refresh_transient_no_replacement")
     stream_once_calls = 0
     selections = 0
-    handle_stream_error = AsyncMock()
+    settlement_order: list[str] = []
+
+    async def settle_usage(*_args: object, **_kwargs: object) -> bool:
+        assert _kwargs["wait_for_settlement"] is True
+        settlement_order.append("settle")
+        return True
+
+    async def handle_stream_error(*args: object, **kwargs: object) -> object:
+        del kwargs
+        if args[2] == "invalid_request_error":
+            assert args[0] is account
+            settlement_order.append("health")
+        return {"failure_class": "non_retryable"}
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
@@ -12693,6 +12709,7 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_preserves_err
     monkeypatch.setattr(streaming_retry_module.asyncio, "sleep", AsyncMock())
     monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=lambda account, **_k: account))
     monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", settle_usage)
     monkeypatch.setattr(service._load_balancer, "record_errors", AsyncMock())
 
     async def select_account(_deadline: float, **_kwargs: object) -> AccountSelection:
@@ -12727,32 +12744,50 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_preserves_err
 
     payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
 
-    chunks = [
-        chunk
-        async for chunk in service._stream_with_retry(
-            payload,
-            {"session_id": "sid-post-refresh-transient-no-replacement"},
-            codex_session_affinity=False,
-            propagate_http_errors=False,
-            openai_cache_affinity=False,
-            api_key=None,
-            api_key_reservation=None,
-            suppress_text_done_events=False,
-            request_transport="http",
-            upstream_stream_transport_override="http",
-        )
-    ]
+    if propagate_http_errors:
+        with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+            async for _chunk in service._stream_with_retry(
+                payload,
+                {"session_id": "sid-post-refresh-transient-no-replacement"},
+                codex_session_affinity=False,
+                propagate_http_errors=True,
+                openai_cache_affinity=False,
+                api_key=None,
+                api_key_reservation=None,
+                suppress_text_done_events=False,
+                request_transport="http",
+                upstream_stream_transport_override="http",
+            ):
+                pass
+        assert exc_info.value.status_code == 502
+    else:
+        chunks = [
+            chunk
+            async for chunk in service._stream_with_retry(
+                payload,
+                {"session_id": "sid-post-refresh-transient-no-replacement"},
+                codex_session_affinity=False,
+                propagate_http_errors=False,
+                openai_cache_affinity=False,
+                api_key=None,
+                api_key_reservation=None,
+                suppress_text_done_events=False,
+                request_transport="http",
+                upstream_stream_transport_override="http",
+            )
+        ]
 
-    failed = json.loads(chunks[-1].split("data: ", 1)[1])
-    assert failed["type"] == "response.failed"
-    assert failed["response"]["error"] == {
-        "message": "Selected model is at capacity. Please try a different model.",
-        "type": "server_error",
-        "code": "invalid_request_error",
-    }
+        failed = json.loads(chunks[-1].split("data: ", 1)[1])
+        assert failed["type"] == "response.failed"
+        assert failed["response"]["error"] == {
+            "message": "Selected model is at capacity. Please try a different model.",
+            "type": "server_error",
+            "code": "invalid_request_error",
+        }
+
     assert stream_once_calls == 2
     assert selections == 2
-    assert all(call.args[2] != "invalid_request_error" for call in handle_stream_error.await_args_list)
+    assert settlement_order == ["settle", "health"]
     service._load_balancer.record_errors.assert_not_awaited()
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12439,7 +12439,10 @@ async def test_stream_with_retry_post_refresh_transport_failure_retries_same_acc
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("replacement_outcome", ["success", "model_rejection", "surface"])
+@pytest.mark.parametrize(
+    "replacement_outcome",
+    ["success", "model_rejection", "surface", "second_transient_exhaustion"],
+)
 async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
     monkeypatch,
     replacement_outcome: str,
@@ -12449,6 +12452,7 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
     original_handle_stream_error = service._handle_stream_error
     account_a = _make_account("acc_post_refresh_transient_a")
     account_b = _make_account("acc_post_refresh_transient_b")
+    account_c = _make_account("acc_post_refresh_transient_c")
     stream_account_ids: list[str] = []
     excluded_snapshots: list[set[str]] = []
     handle_stream_error = AsyncMock()
@@ -12472,7 +12476,8 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
     ) -> bool:
         assert settled_api_key is api_key
         assert settled_reservation is reservation
-        assert stream_account_ids[-1] == account_b.id
+        expected_settlement_account = account_c if replacement_outcome == "second_transient_exhaustion" else account_b
+        assert stream_account_ids[-1] == expected_settlement_account.id
         settlement_wait_flags.append(bool(_kwargs.get("wait_for_settlement")))
         settlement_order.append("settle")
         return True
@@ -12488,7 +12493,11 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
-    monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 2)
+    monkeypatch.setattr(
+        proxy_service,
+        "_STREAM_MAX_ACCOUNT_ATTEMPTS",
+        3 if replacement_outcome == "second_transient_exhaustion" else 2,
+    )
     monkeypatch.setattr(proxy_service, "_MAX_TRANSIENT_SAME_ACCOUNT_RETRIES", 3)
     monkeypatch.setattr(streaming_retry_module.ProcessNetworkRecovery, "wait", AsyncMock(return_value=None))
     monkeypatch.setattr(streaming_retry_module.asyncio, "sleep", AsyncMock())
@@ -12502,7 +12511,12 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
     async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
         excluded = set(cast(set[str], kwargs["exclude_account_ids"]))
         excluded_snapshots.append(excluded)
-        account = account_b if account_a.id in excluded else account_a
+        if account_b.id in excluded:
+            account = account_c
+        elif account_a.id in excluded:
+            account = account_b
+        else:
+            account = account_a
         return AccountSelection(account=account, error_message=None)
 
     async def fake_stream_once(account: Account, *_args: object, **_kwargs: object):
@@ -12536,6 +12550,17 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
             raise proxy_module.ProxyResponseError(
                 401,
                 proxy_module.openai_error("invalid_api_key", "replacement token expired"),
+            )
+        if account.id == account_b.id and replacement_outcome == "second_transient_exhaustion":
+            raise proxy_service._TransientStreamError(
+                "invalid_request_error",
+                cast(
+                    UpstreamError,
+                    {
+                        "message": "Selected model is at capacity. Please try a different model.",
+                        "code": "invalid_request_error",
+                    },
+                ),
             )
         if replacement_outcome == "model_rejection":
             raise proxy_module.ProxyResponseError(
@@ -12581,42 +12606,68 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
     ]
 
     terminal = json.loads(chunks[-1].split("data: ", 1)[1])
-    if replacement_outcome == "success":
+    if replacement_outcome in ("success", "second_transient_exhaustion"):
         assert terminal["response"]["id"] == "resp_post_refresh_transient_b_ok"
     elif replacement_outcome == "model_rejection":
         assert terminal["response"]["error"]["message"].startswith("The 'gpt-5.6-sol' model is not supported")
     else:
         assert terminal["response"]["error"]["code"] == "replacement_failed"
     expected_account_ids = [account_a.id, account_a.id, account_a.id, account_a.id, account_b.id]
-    if replacement_outcome != "success":
+    if replacement_outcome == "second_transient_exhaustion":
+        expected_account_ids.extend([account_b.id, account_b.id, account_b.id, account_c.id])
+    elif replacement_outcome != "success":
         expected_account_ids.append(account_b.id)
     assert stream_account_ids == expected_account_ids
-    assert excluded_snapshots == [set(), {account_a.id}]
+    expected_exclusions = [set(), {account_a.id}]
+    if replacement_outcome == "second_transient_exhaustion":
+        expected_exclusions.append({account_a.id, account_b.id})
+    assert excluded_snapshots == expected_exclusions
     transient_penalties = [
         call for call in handle_stream_error.await_args_list if call.args[2] == "invalid_request_error"
     ]
-    assert len(transient_penalties) == 1
-    assert transient_penalties[0].args[0] is account_a
-    ordered_effects = [entry for entry in settlement_order if entry != "health:invalid_api_key"]
-    assert ordered_effects.index("settle") < ordered_effects.index("health:invalid_request_error")
+    expected_penalty_accounts = [account_a]
+    if replacement_outcome == "second_transient_exhaustion":
+        expected_penalty_accounts.append(account_b)
+    assert [call.args[0] for call in transient_penalties] == expected_penalty_accounts
+    ordered_effects = [entry for entry in settlement_order if entry in ("settle", "health:invalid_request_error")]
+    assert ordered_effects == ["settle"] + ["health:invalid_request_error"] * len(expected_penalty_accounts)
     assert settlement_wait_flags == [True]
     assert stream_reservations == [reservation] * len(expected_account_ids)
     release_unsettled.assert_not_awaited()
-    record_errors.assert_any_await(account_a, 2)
+    expected_record_error_calls = [mock_call(account_a, 2)]
+    if replacement_outcome == "second_transient_exhaustion":
+        expected_record_error_calls.append(mock_call(account_b, 2))
+    extra_retry_calls = [call for call in record_errors.await_args_list if call.args[1] == 2]
+    assert extra_retry_calls == expected_record_error_calls
 
 
 @pytest.mark.asyncio
-async def test_stream_with_retry_post_refresh_connect_exhaustion_terminal_penalizes_once(monkeypatch):
+async def test_stream_with_retry_post_refresh_connect_exhaustion_terminal_counts_every_retry(monkeypatch):
     settings = _make_proxy_settings()
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_post_refresh_transient_terminal")
     stream_once_calls = 0
-    handle_stream_error = AsyncMock()
+    settlement_order: list[str] = []
+
+    async def settle_usage(*_args: object, **kwargs: object) -> bool:
+        assert kwargs["wait_for_settlement"] is True
+        settlement_order.append("settle")
+        return True
+
+    async def handle_stream_error(*args: object, **_kwargs: object) -> object:
+        if args[2] == "upstream_unavailable":
+            assert args[0] is account
+            settlement_order.append("health")
+        return {"failure_class": "non_retryable"}
+
+    async def record_errors(failed_account: Account, count: int) -> None:
+        assert failed_account is account
+        settlement_order.append(f"extra:{count}")
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
     monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 1)
-    monkeypatch.setattr(proxy_service, "_MAX_TRANSIENT_SAME_ACCOUNT_RETRIES", 1)
+    monkeypatch.setattr(proxy_service, "_MAX_TRANSIENT_SAME_ACCOUNT_RETRIES", 3)
     monkeypatch.setattr(streaming_retry_module.ProcessNetworkRecovery, "wait", AsyncMock(return_value=None))
     monkeypatch.setattr(streaming_retry_module.asyncio, "sleep", AsyncMock())
     monkeypatch.setattr(
@@ -12626,7 +12677,8 @@ async def test_stream_with_retry_post_refresh_connect_exhaustion_terminal_penali
     )
     monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account, account]))
     monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
-    monkeypatch.setattr(service._load_balancer, "record_errors", AsyncMock())
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", settle_usage)
+    monkeypatch.setattr(service._load_balancer, "record_errors", record_errors)
 
     async def fake_stream_once(*_args: object, **_kwargs: object):
         nonlocal stream_once_calls
@@ -12667,13 +12719,8 @@ async def test_stream_with_retry_post_refresh_connect_exhaustion_terminal_penali
     failed = json.loads(chunks[-1].split("data: ", 1)[1])
     assert failed["type"] == "response.failed"
     assert failed["response"]["error"]["message"] == "proxy cannot connect"
-    assert stream_once_calls == 2
-    transient_penalties = [
-        call for call in handle_stream_error.await_args_list if call.args[2] == "upstream_unavailable"
-    ]
-    assert len(transient_penalties) == 1
-    assert transient_penalties[0].args[0] is account
-    service._load_balancer.record_errors.assert_not_awaited()
+    assert stream_once_calls == 4
+    assert settlement_order == ["settle", "health", "extra:2"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -33,6 +33,7 @@ from websockets.frames import Close
 import app.core.clients.proxy as proxy_module
 import app.core.resilience.network_recovery as network_recovery_module
 import app.modules.proxy.load_balancer as load_balancer_module
+from app.core.balancer.types import UpstreamError
 from app.core.clients.proxy import _build_upstream_headers, filter_inbound_headers
 from app.core.clients.proxy_websocket import (
     CodexResponsesWebSocket,
@@ -1524,6 +1525,17 @@ def test_selected_model_capacity_stream_does_not_retry_accepted_response() -> No
             "invalid_request_error",
             "Selected model is at capacity. Please try a different model.",
             response_id="resp_model_capacity_accepted",
+        )
+        is False
+    )
+
+
+def test_upstream_unavailable_stream_does_not_retry_accepted_response() -> None:
+    assert (
+        proxy_service._should_retry_transient_stream_error(
+            "upstream_unavailable",
+            "Server disconnected",
+            response_id="resp_body_read_accepted",
         )
         is False
     )
@@ -12108,6 +12120,7 @@ async def test_stream_with_retry_post_refresh_response_create_cap_waits_with_str
                 proxy_module.openai_error("invalid_api_key", "expired", error_type="invalid_request_error"),
             )
         if stream_once_calls == 2:
+            assert _kwargs["allow_transient_retry"] is True
             settlement.record_success = False
             raise proxy_module.ProxyResponseError(
                 429,
@@ -12157,6 +12170,75 @@ async def test_stream_with_retry_post_refresh_response_create_cap_waits_with_str
     assert ensure_fresh.await_count == 2
     assert ensure_fresh.await_args_list[1].kwargs["force"] is True
     release_account_lease.assert_awaited_once_with(stream_lease)
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_post_refresh_model_capacity_retries_same_account(monkeypatch):
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_post_refresh_model_capacity")
+    stream_once_calls = 0
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account, account]))
+    monkeypatch.setattr(streaming_retry_module.asyncio, "sleep", fake_sleep)
+
+    async def fake_stream_once(*_args: object, **kwargs: object):
+        nonlocal stream_once_calls
+        stream_once_calls += 1
+        if stream_once_calls == 1:
+            raise proxy_module.ProxyResponseError(
+                401,
+                proxy_module.openai_error("invalid_api_key", "expired", error_type="invalid_request_error"),
+            )
+        if stream_once_calls == 2:
+            assert kwargs["allow_transient_retry"] is True
+            raise proxy_service._TransientStreamError(
+                "invalid_request_error",
+                cast(
+                    UpstreamError,
+                    {
+                        "message": "Selected model is at capacity. Please try a different model.",
+                        "code": "invalid_request_error",
+                    },
+                ),
+            )
+        yield 'data: {"type":"response.completed","response":{"id":"resp_post_refresh_model_capacity_ok"}}\n\n'
+
+    monkeypatch.setattr(service, "_stream_once", fake_stream_once)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-post-refresh-model-capacity"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    completed = json.loads(chunks[-1].split("data: ", 1)[1])
+    assert completed["response"]["id"] == "resp_post_refresh_model_capacity_ok"
+    assert stream_once_calls == 3
+    assert sleeps
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6562,7 +6562,8 @@ async def test_stream_responses_keeps_budget_timeout_when_budget_precedes_idle(m
 
 
 @pytest.mark.asyncio
-async def test_stream_responses_maps_connect_timeout_to_upstream_unavailable(monkeypatch):
+@pytest.mark.parametrize("raise_for_status", [False, True])
+async def test_stream_responses_preserves_connect_timeout_retry_provenance(monkeypatch, raise_for_status: bool):
     class Settings:
         upstream_base_url = "https://chatgpt.com/backend-api"
         upstream_connect_timeout_seconds = 8.0
@@ -6592,17 +6593,23 @@ async def test_stream_responses_maps_connect_timeout_to_upstream_unavailable(mon
         {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
     )
 
-    events = [
-        event
-        async for event in proxy_module.stream_responses(
-            payload,
-            headers={},
-            access_token="token",
-            account_id="acc_1",
-            session=cast(proxy_module.aiohttp.ClientSession, _ConnectTimeoutSseSession()),
-        )
-    ]
+    stream = proxy_module.stream_responses(
+        payload,
+        headers={},
+        access_token="token",
+        account_id="acc_1",
+        session=cast(proxy_module.aiohttp.ClientSession, _ConnectTimeoutSseSession()),
+        raise_for_status=raise_for_status,
+    )
+    if raise_for_status:
+        with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+            _ = [event async for event in stream]
+        assert _proxy_error_code(exc_info.value) == "upstream_unavailable"
+        assert exc_info.value.failure_phase == "connect"
+        assert exc_info.value.retryable_same_contract is True
+        return
 
+    events = [event async for event in stream]
     event = json.loads(events[0].split("data: ", 1)[1])
     assert event["response"]["error"]["code"] == "upstream_unavailable"
 
@@ -12185,7 +12192,8 @@ async def test_stream_with_retry_post_refresh_response_create_cap_waits_with_str
 
 
 @pytest.mark.asyncio
-async def test_stream_with_retry_post_refresh_model_capacity_retries_same_account(monkeypatch):
+@pytest.mark.parametrize("post_refresh_failure", ["model_capacity", "connect"])
+async def test_stream_with_retry_post_refresh_http_failure_retries_same_account(monkeypatch, post_refresh_failure: str):
     settings = _make_proxy_settings()
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_post_refresh_model_capacity")
@@ -12215,14 +12223,18 @@ async def test_stream_with_retry_post_refresh_model_capacity_retries_same_accoun
             )
         if stream_once_calls == 2:
             assert kwargs["allow_transient_retry"] is True
-            raise proxy_service._TransientStreamError(
-                "invalid_request_error",
-                cast(
-                    UpstreamError,
-                    {
-                        "message": "Selected model is at capacity. Please try a different model.",
-                        "code": "invalid_request_error",
-                    },
+            if post_refresh_failure == "connect":
+                raise proxy_module.ProxyResponseError(
+                    502,
+                    proxy_module.openai_error("upstream_unavailable", "Server disconnected"),
+                    failure_phase="connect",
+                    retryable_same_contract=True,
+                )
+            raise proxy_module.ProxyResponseError(
+                400,
+                proxy_module.openai_error(
+                    "invalid_request_error",
+                    "Selected model is at capacity. Please try a different model.",
                 ),
             )
         yield 'data: {"type":"response.completed","response":{"id":"resp_post_refresh_model_capacity_ok"}}\n\n'

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12262,16 +12262,17 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
     stream_account_ids: list[str] = []
     excluded_snapshots: list[set[str]] = []
     handle_stream_error = AsyncMock()
+    record_errors = AsyncMock()
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
     monkeypatch.setattr(proxy_service, "_STREAM_MAX_ACCOUNT_ATTEMPTS", 2)
-    monkeypatch.setattr(proxy_service, "_MAX_TRANSIENT_SAME_ACCOUNT_RETRIES", 1)
+    monkeypatch.setattr(proxy_service, "_MAX_TRANSIENT_SAME_ACCOUNT_RETRIES", 3)
     monkeypatch.setattr(streaming_retry_module.ProcessNetworkRecovery, "wait", AsyncMock(return_value=None))
     monkeypatch.setattr(streaming_retry_module.asyncio, "sleep", AsyncMock())
     monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
     monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=lambda account, **_k: account))
-    monkeypatch.setattr(service._load_balancer, "record_errors", AsyncMock())
+    monkeypatch.setattr(service._load_balancer, "record_errors", record_errors)
 
     async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
         excluded = set(cast(set[str], kwargs["exclude_account_ids"]))
@@ -12286,7 +12287,9 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
                 401,
                 proxy_module.openai_error("invalid_api_key", "expired", error_type="invalid_request_error"),
             )
-        if stream_account_ids == [account_a.id, account_a.id]:
+        if stream_account_ids[:1] == [account_a.id] and all(
+            account_id == account_a.id for account_id in stream_account_ids[1:]
+        ):
             raise proxy_service._TransientStreamError(
                 "server_error",
                 cast(
@@ -12322,12 +12325,12 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
 
     completed = json.loads(chunks[-1].split("data: ", 1)[1])
     assert completed["response"]["id"] == "resp_post_refresh_transient_b_ok"
-    assert stream_account_ids == [account_a.id, account_a.id, account_b.id]
+    assert stream_account_ids == [account_a.id, account_a.id, account_a.id, account_a.id, account_b.id]
     assert excluded_snapshots == [set(), {account_a.id}]
     transient_penalties = [call for call in handle_stream_error.await_args_list if call.args[2] == "server_error"]
     assert len(transient_penalties) == 1
     assert transient_penalties[0].args[0] is account_a
-    service._load_balancer.record_errors.assert_not_awaited()
+    record_errors.assert_awaited_once_with(account_a, 2)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12441,7 +12441,7 @@ async def test_stream_with_retry_post_refresh_transport_failure_retries_same_acc
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "replacement_outcome",
-    ["success", "model_rejection", "surface", "second_transient_exhaustion"],
+    ["success", "model_rejection", "surface", "visible_surface", "second_transient_exhaustion"],
 )
 async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
     monkeypatch,
@@ -12562,6 +12562,16 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
                     },
                 ),
             )
+        if account.id == account_b.id and replacement_outcome == "visible_surface":
+            yield 'data: {"type":"response.created","response":{"id":"resp_replacement_visible"}}\n\n'
+            raise proxy_module.ProxyResponseError(
+                500,
+                proxy_module.openai_error(
+                    "replacement_failed",
+                    "Visible replacement upstream failed",
+                    error_type="server_error",
+                ),
+            )
         if replacement_outcome == "model_rejection":
             raise proxy_module.ProxyResponseError(
                 400,
@@ -12629,8 +12639,11 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
     if replacement_outcome == "second_transient_exhaustion":
         expected_penalty_accounts.append(account_b)
     assert [call.args[0] for call in transient_penalties] == expected_penalty_accounts
-    ordered_effects = [entry for entry in settlement_order if entry in ("settle", "health:invalid_request_error")]
-    assert ordered_effects == ["settle"] + ["health:invalid_request_error"] * len(expected_penalty_accounts)
+    expected_health_codes = ["invalid_request_error"] * len(expected_penalty_accounts)
+    if replacement_outcome in ("surface", "visible_surface"):
+        expected_health_codes.append("replacement_failed")
+    ordered_terminal_effects = [entry for entry in settlement_order if entry != "health:invalid_api_key"]
+    assert ordered_terminal_effects == ["settle"] + [f"health:{code}" for code in expected_health_codes]
     assert settlement_wait_flags == [True]
     assert stream_reservations == [reservation] * len(expected_account_ids)
     release_unsettled.assert_not_awaited()
@@ -12724,10 +12737,19 @@ async def test_stream_with_retry_post_refresh_connect_exhaustion_terminal_counts
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("propagate_http_errors", [False, True])
+@pytest.mark.parametrize(
+    ("propagate_http_errors", "terminal_outcome"),
+    [
+        (False, "no_accounts"),
+        (True, "no_accounts"),
+        (False, "budget_before_selection"),
+        (False, "budget_during_selection"),
+    ],
+)
 async def test_stream_with_retry_post_refresh_transient_exhaustion_penalizes_without_replacement(
     monkeypatch,
     propagate_http_errors: bool,
+    terminal_outcome: str,
 ):
     settings = _make_proxy_settings()
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
@@ -12758,12 +12780,22 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_penalizes_wit
     monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
     monkeypatch.setattr(service, "_settle_stream_api_key_usage", settle_usage)
     monkeypatch.setattr(service._load_balancer, "record_errors", AsyncMock())
+    monkeypatch.setattr(
+        proxy_service,
+        "_remaining_budget_seconds",
+        lambda _deadline: 0.0 if terminal_outcome == "budget_before_selection" and stream_once_calls >= 2 else 10.0,
+    )
 
     async def select_account(_deadline: float, **_kwargs: object) -> AccountSelection:
         nonlocal selections
         selections += 1
         if selections == 1:
             return AccountSelection(account=account, error_message=None)
+        if terminal_outcome == "budget_during_selection":
+            raise proxy_module.ProxyResponseError(
+                504,
+                proxy_module.openai_error("upstream_request_timeout", "Proxy request budget exhausted"),
+            )
         return AccountSelection(account=None, error_message="No active accounts available", error_code="no_accounts")
 
     async def fake_stream_once(*_args: object, **_kwargs: object):
@@ -12826,14 +12858,17 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_penalizes_wit
 
         failed = json.loads(chunks[-1].split("data: ", 1)[1])
         assert failed["type"] == "response.failed"
-        assert failed["response"]["error"] == {
-            "message": "Selected model is at capacity. Please try a different model.",
-            "type": "server_error",
-            "code": "invalid_request_error",
-        }
+        if terminal_outcome.startswith("budget_"):
+            assert failed["response"]["error"]["code"] == "upstream_request_timeout"
+        else:
+            assert failed["response"]["error"] == {
+                "message": "Selected model is at capacity. Please try a different model.",
+                "type": "server_error",
+                "code": "invalid_request_error",
+            }
 
     assert stream_once_calls == 2
-    assert selections == 2
+    assert selections == (1 if terminal_outcome == "budget_before_selection" else 2)
     assert settlement_order == ["settle", "health"]
     service._load_balancer.record_errors.assert_not_awaited()
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -13025,12 +13025,11 @@ async def test_stream_responses_post_yield_upstream_error_emits_terminal_failure
 
 
 @pytest.mark.asyncio
-async def test_stream_responses_first_event_connection_reset_fails_over(monkeypatch):
+async def test_stream_responses_first_event_connection_reset_surfaces_without_replay(monkeypatch):
     settings = _make_proxy_settings()
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     account_a = _make_account("acc_reset_stream_a")
-    account_b = _make_account("acc_reset_stream_b")
     record_error = AsyncMock()
     record_success = AsyncMock()
     seen_excluded_account_ids: list[set[str]] = []
@@ -13041,14 +13040,12 @@ async def test_stream_responses_first_event_connection_reset_fails_over(monkeypa
     async def select_account(**kwargs: object) -> AccountSelection:
         excluded_account_ids = kwargs.get("exclude_account_ids")
         seen_excluded_account_ids.append(set(cast(set[str], excluded_account_ids)))
-        if len(seen_excluded_account_ids) == 1:
-            return AccountSelection(account=account_a, error_message=None)
-        return AccountSelection(account=account_b, error_message=None)
+        return AccountSelection(account=account_a, error_message=None)
 
     monkeypatch.setattr(service._load_balancer, "select_account", select_account)
     monkeypatch.setattr(service._load_balancer, "record_error", record_error)
     monkeypatch.setattr(service._load_balancer, "record_success", record_success)
-    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(side_effect=[account_a, account_b]))
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account_a))
 
     async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
         if account_id == account_a.chatgpt_account_id:
@@ -13066,12 +13063,13 @@ async def test_stream_responses_first_event_connection_reset_fails_over(monkeypa
     chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream"})]
 
     event = json.loads(chunks[0].split("data: ", 1)[1])
-    assert event["type"] == "response.completed"
-    assert event["response"]["id"] == "resp_reset_ok"
-    assert seen_excluded_account_ids == [set(), {account_a.id}]
+    assert event["type"] == "response.failed"
+    assert event["response"]["error"]["code"] == "upstream_unavailable"
+    assert seen_excluded_account_ids == [set()]
+    assert await service.drain_persistence_tasks(timeout_seconds=1)
     assert request_logs.calls[0]["error_code"] == "upstream_unavailable"
     record_error.assert_awaited_once_with(account_a)
-    record_success.assert_awaited_once_with(account_b)
+    record_success.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12442,12 +12442,22 @@ async def test_stream_with_retry_post_refresh_transport_failure_retries_same_acc
 async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(monkeypatch):
     settings = _make_proxy_settings()
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    original_handle_stream_error = service._handle_stream_error
     account_a = _make_account("acc_post_refresh_transient_a")
     account_b = _make_account("acc_post_refresh_transient_b")
     stream_account_ids: list[str] = []
     excluded_snapshots: list[set[str]] = []
     handle_stream_error = AsyncMock()
     record_errors = AsyncMock()
+    settlement_order: list[str] = []
+
+    async def settle_usage(*_args: object, **_kwargs: object) -> bool:
+        settlement_order.append("settle")
+        return True
+
+    async def record_health(*args: object, **kwargs: object) -> object:
+        settlement_order.append(f"health:{args[2]}")
+        return await original_handle_stream_error(*args, **kwargs)
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
@@ -12455,7 +12465,9 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
     monkeypatch.setattr(proxy_service, "_MAX_TRANSIENT_SAME_ACCOUNT_RETRIES", 3)
     monkeypatch.setattr(streaming_retry_module.ProcessNetworkRecovery, "wait", AsyncMock(return_value=None))
     monkeypatch.setattr(streaming_retry_module.asyncio, "sleep", AsyncMock())
+    handle_stream_error.side_effect = record_health
     monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", settle_usage)
     monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=lambda account, **_k: account))
     monkeypatch.setattr(service._load_balancer, "record_errors", record_errors)
 
@@ -12476,12 +12488,12 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
             account_id == account_a.id for account_id in stream_account_ids[1:]
         ):
             raise proxy_service._TransientStreamError(
-                "server_error",
+                "invalid_request_error",
                 cast(
                     UpstreamError,
                     {
                         "message": "Selected model is at capacity. Please try a different model.",
-                        "code": "server_error",
+                        "code": "invalid_request_error",
                     },
                 ),
             )
@@ -12512,10 +12524,13 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
     assert completed["response"]["id"] == "resp_post_refresh_transient_b_ok"
     assert stream_account_ids == [account_a.id, account_a.id, account_a.id, account_a.id, account_b.id]
     assert excluded_snapshots == [set(), {account_a.id}]
-    transient_penalties = [call for call in handle_stream_error.await_args_list if call.args[2] == "server_error"]
+    transient_penalties = [
+        call for call in handle_stream_error.await_args_list if call.args[2] == "invalid_request_error"
+    ]
     assert len(transient_penalties) == 1
     assert transient_penalties[0].args[0] is account_a
-    record_errors.assert_awaited_once_with(account_a, 2)
+    assert settlement_order.index("settle") < settlement_order.index("health:invalid_request_error")
+    record_errors.assert_any_await(account_a, 2)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6722,6 +6722,66 @@ async def test_stream_responses_direct_http_tls_connect_failure_is_not_retryable
 
 
 @pytest.mark.asyncio
+async def test_stream_responses_routed_http_tls_connect_failure_is_not_retryable(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 8.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        trace_channels = frozenset()
+        proxy_request_budget_seconds = 5.0
+        upstream_stream_transport = "http"
+
+    certificate_error = _client_connector_certificate_error()
+
+    class _TlsFailureCodexSession:
+        async def request(self, *_args: object, **_kwargs: object):
+            raise certificate_error
+
+    completions: list[dict[str, object]] = []
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(
+        proxy_module,
+        "_maybe_log_upstream_request_complete",
+        lambda **kwargs: completions.append(dict(kwargs)),
+    )
+    route = ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="pool_tls",
+        endpoint=ResolvedProxyEndpoint("ep_tls", "http", "proxy.test", 8080),
+    )
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_routed_tls_failure",
+            session=cast(proxy_module.aiohttp.ClientSession, object()),
+            route=route,
+            codex_client=proxy_module.CodexClient(_TlsFailureCodexSession()),
+            allow_direct_egress=False,
+            raise_for_status=True,
+        )
+    ]
+
+    assert len(events) == 1
+    failed = cast(dict[str, object], parse_sse_data_json(events[0]))
+    response = cast(dict[str, object], failed["response"])
+    error = cast(dict[str, object], response["error"])
+    assert error["code"] == "upstream_unavailable"
+    assert completions[-1]["failure_phase"] == "connect"
+    assert completions[-1]["failure_exception_type"] == "CodexTransportError"
+    assert completions[-1]["retryable_same_contract"] is False
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_maps_typed_dns_failure_with_failed_session_provenance(monkeypatch):
     class Settings:
         upstream_base_url = "https://chatgpt.com/backend-api"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -6615,6 +6615,113 @@ async def test_stream_responses_preserves_connect_timeout_retry_provenance(monke
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("failure_kind", ["connector", "timeout"])
+async def test_stream_responses_websocket_pre_dispatch_connect_failure_is_retryable(
+    monkeypatch,
+    failure_kind: str,
+):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 8.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        trace_channels = frozenset()
+        proxy_request_budget_seconds = 5.0
+        upstream_stream_transport = "websocket"
+
+    connection_key = ConnectionKey("chatgpt.com", 443, True, True, None, None, None)
+    connect_error: aiohttp.ClientError = (
+        aiohttp.ClientConnectorError(connection_key, ConnectionRefusedError("connection refused"))
+        if failure_kind == "connector"
+        else aiohttp.ConnectionTimeoutError("connect timed out")
+    )
+
+    class _WebsocketConnectFailureSession:
+        def ws_connect(self, *_args: object, **_kwargs: object):
+            raise connect_error
+
+    session = _WebsocketConnectFailureSession()
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        _ = [
+            event
+            async for event in proxy_module.stream_responses(
+                payload,
+                headers={},
+                access_token="token",
+                account_id="acc_ws_connect_failure",
+                session=cast(proxy_module.aiohttp.ClientSession, session),
+                raise_for_status=True,
+            )
+        ]
+
+    assert _proxy_error_code(exc_info.value) == "upstream_unavailable"
+    assert exc_info.value.failure_phase == "connect"
+    assert exc_info.value.retryable_same_contract is True
+    assert exc_info.value.failed_session is session
+
+
+@pytest.mark.asyncio
+async def test_stream_responses_direct_http_tls_connect_failure_is_not_retryable(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 8.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        trace_channels = frozenset()
+        proxy_request_budget_seconds = 5.0
+        upstream_stream_transport = "http"
+
+    certificate_error = _client_connector_certificate_error()
+
+    class _TlsFailureSseSession:
+        def post(self, *_args: object, **_kwargs: object):
+            raise certificate_error
+
+    completions: list[dict[str, object]] = []
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(
+        proxy_module,
+        "_maybe_log_upstream_request_complete",
+        lambda **kwargs: completions.append(dict(kwargs)),
+    )
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_http_tls_failure",
+            session=cast(proxy_module.aiohttp.ClientSession, _TlsFailureSseSession()),
+            raise_for_status=True,
+        )
+    ]
+
+    assert len(events) == 1
+    failed = cast(dict[str, object], parse_sse_data_json(events[0]))
+    response = cast(dict[str, object], failed["response"])
+    error = cast(dict[str, object], response["error"])
+    assert error["code"] == "upstream_unavailable"
+    assert error["message"] == str(certificate_error)
+    assert completions[-1]["failure_phase"] == "connect"
+    assert completions[-1]["failure_exception_type"] == "ClientConnectorCertificateError"
+    assert completions[-1]["retryable_same_contract"] is False
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_maps_typed_dns_failure_with_failed_session_provenance(monkeypatch):
     class Settings:
         upstream_base_url = "https://chatgpt.com/backend-api"
@@ -12193,7 +12300,12 @@ async def test_stream_with_retry_post_refresh_response_create_cap_waits_with_str
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("post_refresh_failure", ["model_capacity", "connect"])
-async def test_stream_with_retry_post_refresh_http_failure_retries_same_account(monkeypatch, post_refresh_failure: str):
+@pytest.mark.parametrize("upstream_transport", ["http", "websocket"])
+async def test_stream_with_retry_post_refresh_transport_failure_retries_same_account(
+    monkeypatch,
+    post_refresh_failure: str,
+    upstream_transport: str,
+):
     settings = _make_proxy_settings()
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_post_refresh_model_capacity")
@@ -12216,6 +12328,7 @@ async def test_stream_with_retry_post_refresh_http_failure_retries_same_account(
     async def fake_stream_once(*_args: object, **kwargs: object):
         nonlocal stream_once_calls
         stream_once_calls += 1
+        assert kwargs["upstream_stream_transport"] == upstream_transport
         if stream_once_calls == 1:
             raise proxy_module.ProxyResponseError(
                 401,
@@ -12255,7 +12368,7 @@ async def test_stream_with_retry_post_refresh_http_failure_retries_same_account(
             api_key_reservation=None,
             suppress_text_done_events=False,
             request_transport="http",
-            upstream_stream_transport_override="http",
+            upstream_stream_transport_override=upstream_transport,
         )
     ]
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12455,9 +12455,14 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
         settlement_order.append("settle")
         return True
 
-    async def record_health(*args: object, **kwargs: object) -> object:
-        settlement_order.append(f"health:{args[2]}")
-        return await original_handle_stream_error(*args, **kwargs)
+    async def record_health(
+        account: Account,
+        error: UpstreamError,
+        code: str,
+        http_status: int | None = None,
+    ) -> object:
+        settlement_order.append(f"health:{code}")
+        return await original_handle_stream_error(account, error, code, http_status=http_status)
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
@@ -12682,7 +12687,7 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_preserves_err
     }
     assert stream_once_calls == 2
     assert selections == 2
-    assert all(call.args[2] != "invalid_request_error" for call in handle_stream_error.await_args_list)
+    assert any(call.args[2] == "invalid_request_error" for call in handle_stream_error.await_args_list)
     service._load_balancer.record_errors.assert_not_awaited()
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12439,7 +12439,11 @@ async def test_stream_with_retry_post_refresh_transport_failure_retries_same_acc
 
 
 @pytest.mark.asyncio
-async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(monkeypatch):
+@pytest.mark.parametrize("replacement_outcome", ["success", "model_rejection", "surface"])
+async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
+    monkeypatch,
+    replacement_outcome: str,
+):
     settings = _make_proxy_settings()
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     original_handle_stream_error = service._handle_stream_error
@@ -12524,12 +12528,41 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
                     },
                 ),
             )
+        if (
+            account.id == account_b.id
+            and replacement_outcome != "success"
+            and stream_account_ids.count(account_b.id) == 1
+        ):
+            raise proxy_module.ProxyResponseError(
+                401,
+                proxy_module.openai_error("invalid_api_key", "replacement token expired"),
+            )
+        if replacement_outcome == "model_rejection":
+            raise proxy_module.ProxyResponseError(
+                400,
+                proxy_module.openai_error(
+                    "invalid_request_error",
+                    "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+                    error_type="invalid_request_error",
+                ),
+            )
+        if replacement_outcome == "surface":
+            raise proxy_module.ProxyResponseError(
+                500,
+                proxy_module.openai_error(
+                    "replacement_failed",
+                    "Replacement upstream failed",
+                    error_type="server_error",
+                ),
+            )
         yield 'data: {"type":"response.completed","response":{"id":"resp_post_refresh_transient_b_ok"}}\n\n'
 
     monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
     monkeypatch.setattr(service, "_stream_once", fake_stream_once)
 
-    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.6-sol", "instructions": "hi", "input": [], "stream": True}
+    )
 
     chunks = [
         chunk
@@ -12547,21 +12580,27 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
         )
     ]
 
-    completed = json.loads(chunks[-1].split("data: ", 1)[1])
-    assert completed["response"]["id"] == "resp_post_refresh_transient_b_ok"
-    assert stream_account_ids == [account_a.id, account_a.id, account_a.id, account_a.id, account_b.id]
+    terminal = json.loads(chunks[-1].split("data: ", 1)[1])
+    if replacement_outcome == "success":
+        assert terminal["response"]["id"] == "resp_post_refresh_transient_b_ok"
+    elif replacement_outcome == "model_rejection":
+        assert terminal["response"]["error"]["message"].startswith("The 'gpt-5.6-sol' model is not supported")
+    else:
+        assert terminal["response"]["error"]["code"] == "replacement_failed"
+    expected_account_ids = [account_a.id, account_a.id, account_a.id, account_a.id, account_b.id]
+    if replacement_outcome != "success":
+        expected_account_ids.append(account_b.id)
+    assert stream_account_ids == expected_account_ids
     assert excluded_snapshots == [set(), {account_a.id}]
     transient_penalties = [
         call for call in handle_stream_error.await_args_list if call.args[2] == "invalid_request_error"
     ]
     assert len(transient_penalties) == 1
     assert transient_penalties[0].args[0] is account_a
-    assert [entry for entry in settlement_order if entry != "health:invalid_api_key"] == [
-        "settle",
-        "health:invalid_request_error",
-    ]
+    ordered_effects = [entry for entry in settlement_order if entry != "health:invalid_api_key"]
+    assert ordered_effects.index("settle") < ordered_effects.index("health:invalid_request_error")
     assert settlement_wait_flags == [True]
-    assert stream_reservations == [reservation] * 5
+    assert stream_reservations == [reservation] * len(expected_account_ids)
     release_unsettled.assert_not_awaited()
     record_errors.assert_any_await(account_a, 2)
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12450,6 +12450,7 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
     handle_stream_error = AsyncMock()
     record_errors = AsyncMock()
     settlement_order: list[str] = []
+    settlement_wait_flags: list[bool] = []
     stream_reservations: list[proxy_service.ApiKeyUsageReservationData | None] = []
     api_key = _make_api_key_data("key_post_refresh_transient_failover")
     reservation = proxy_service.ApiKeyUsageReservationData(
@@ -12468,6 +12469,7 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
         assert settled_api_key is api_key
         assert settled_reservation is reservation
         assert stream_account_ids[-1] == account_b.id
+        settlement_wait_flags.append(bool(_kwargs.get("wait_for_settlement")))
         settlement_order.append("settle")
         return True
 
@@ -12555,16 +12557,17 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(mo
     assert len(transient_penalties) == 1
     assert transient_penalties[0].args[0] is account_a
     assert [entry for entry in settlement_order if entry != "health:invalid_api_key"] == [
-        "health:invalid_request_error",
         "settle",
+        "health:invalid_request_error",
     ]
+    assert settlement_wait_flags == [True]
     assert stream_reservations == [reservation] * 5
     release_unsettled.assert_not_awaited()
     record_errors.assert_any_await(account_a, 2)
 
 
 @pytest.mark.asyncio
-async def test_stream_with_retry_post_refresh_transient_exhaustion_terminal_penalizes_once(monkeypatch):
+async def test_stream_with_retry_post_refresh_connect_exhaustion_terminal_penalizes_once(monkeypatch):
     settings = _make_proxy_settings()
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_post_refresh_transient_terminal")
@@ -12594,15 +12597,11 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_terminal_pena
                 401,
                 proxy_module.openai_error("invalid_api_key", "expired", error_type="invalid_request_error"),
             )
-        raise proxy_service._TransientStreamError(
-            "server_error",
-            cast(
-                UpstreamError,
-                {
-                    "message": "Selected model is at capacity. Please try a different model.",
-                    "code": "server_error",
-                },
-            ),
+        raise proxy_module.ProxyResponseError(
+            502,
+            proxy_module.openai_error("upstream_unavailable", "proxy cannot connect"),
+            failure_phase="connect",
+            retryable_same_contract=True,
         )
         yield ""  # pragma: no cover
 
@@ -12628,9 +12627,11 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_terminal_pena
 
     failed = json.loads(chunks[-1].split("data: ", 1)[1])
     assert failed["type"] == "response.failed"
-    assert failed["response"]["error"]["message"] == "Selected model is at capacity. Please try a different model."
+    assert failed["response"]["error"]["message"] == "proxy cannot connect"
     assert stream_once_calls == 2
-    transient_penalties = [call for call in handle_stream_error.await_args_list if call.args[2] == "server_error"]
+    transient_penalties = [
+        call for call in handle_stream_error.await_args_list if call.args[2] == "upstream_unavailable"
+    ]
     assert len(transient_penalties) == 1
     assert transient_penalties[0].args[0] is account
     service._load_balancer.record_errors.assert_not_awaited()

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -13361,7 +13361,7 @@ async def test_stream_websocket_network_drop_rotates_generation_for_next_request
 
 
 @pytest.mark.asyncio
-async def test_stream_responses_first_event_upstream_unavailable_fails_over(monkeypatch):
+async def test_stream_responses_visible_upstream_unavailable_with_response_id_does_not_replay(monkeypatch):
     settings = _make_proxy_settings()
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -13408,13 +13408,14 @@ async def test_stream_responses_first_event_upstream_unavailable_fails_over(monk
     chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-stream"})]
 
     event = json.loads(chunks[0].split("data: ", 1)[1])
-    assert event["type"] == "response.completed"
-    assert event["response"]["id"] == "resp_reset_event_ok"
-    assert seen_excluded_account_ids == [set(), {account_a.id}]
-    assert request_logs.calls[0]["error_code"] == "upstream_unavailable"
-    record_error.assert_awaited_once_with(account_a)
-    record_errors.assert_awaited_once_with(account_a, 2)
-    record_success.assert_awaited_once_with(account_b)
+    assert event["type"] == "response.failed"
+    assert event["response"]["id"] == "resp_reset_event"
+    assert event["response"]["error"]["code"] == "upstream_unavailable"
+    assert seen_excluded_account_ids == [set()]
+    assert request_logs.calls == []
+    record_error.assert_not_awaited()
+    record_errors.assert_not_awaited()
+    record_success.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Retry only pre-dispatch or otherwise provably replay-safe stream failures. Once an upstream request may have been accepted, terminal SSE errors and an empty upstream EOF are surfaced exactly once instead of resubmitting the POST.

Current head: `cc16c0facfb72e455aa6d986883c1d1c64e290e3`.

## Type of change

- [x] `fix:` — bug fix
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: none.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful SSE path and preserves upstream-equivalent replay safety

Change directory: `openspec/changes/retry-model-capacity-errors`.

## Root cause

A missing upstream `response_id` was treated as proof that a failed or closed stream was safe to replay. That is not sufficient after dispatch: upstream may have accepted the POST before returning a terminal error or closing without an event. Retrying in that state can duplicate work and cost.

## Changes

- Keep bounded sleep-and-retry behavior for pre-dispatch and otherwise proven replay-safe failures.
- Surface any received terminal SSE error once, even when it has no `response_id`.
- Surface an empty upstream iterator as one `stream_incomplete` result without replay.
- Preserve the final `stream_incomplete` error when an explicitly safe retry path exhausts account selection.
- Keep visible-output, pinned-owner, post-dispatch, and selection-exhaustion boundaries covered by regression tests.
- Update OpenSpec to describe the terminal no-replay contract.

## Simplicity

- [x] Works with zero configuration.
- [x] Adds no setting or setup step.
- New settings: none.
- [x] Adds no README, `.env.example`, or dashboard navigation surface.

## Test plan

```bash
openspec validate retry-model-capacity-errors --strict
uv run pytest tests/integration/test_proxy_transient_retry.py tests/integration/test_proxy_api_extended.py::test_proxy_stream_retries_first_core_generated_eof_before_no_accounts -q
uv run ruff check app/modules/proxy/_service/streaming/mixin.py app/modules/proxy/_service/streaming/retry.py tests/integration/test_proxy_transient_retry.py
uv run ruff format --check app/modules/proxy/_service/streaming/mixin.py app/modules/proxy/_service/streaming/retry.py tests/integration/test_proxy_transient_retry.py
uv run ty check app/modules/proxy/_service/streaming/mixin.py app/modules/proxy/_service/streaming/retry.py tests/integration/test_proxy_transient_retry.py
git diff --check
```

Local result: 34 focused tests passed; strict OpenSpec validation, Ruff, Ty, formatting, and `git diff --check` passed.

## Screenshots / output

Not dashboard-visible. Replay and terminal-error behavior is covered by integration tests.

## Checklist

- [x] Title uses Conventional Commits format.
- [x] The absence of a linked issue is explicit.
- [x] Tests cover safe retries and terminal no-replay boundaries.
- [x] OpenSpec describes the final contract.
- [x] Simplicity gates were reviewed.
- [x] `CHANGELOG.md` is unchanged.
