### PR TITLE
fix(server): preserve raw socket peer before proxy projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ docker compose watch
 
 # Local
 uv sync && cd frontend && bun install && cd ..
-uv run fastapi run app/main.py --reload        # backend :2455
+uv run fastapi run app/main.py --reload --no-proxy-headers  # backend :2455
 cd frontend && bun run dev                     # frontend :5173
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -446,7 +446,7 @@ docker compose watch
 
 # 本地
 uv sync && cd frontend && bun install && cd ..
-uv run fastapi run app/main.py --reload        # 后端 :2455
+uv run fastapi run app/main.py --reload --no-proxy-headers  # 后端 :2455
 cd frontend && bun run dev                     # 前端 :5173
 ```
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -108,6 +108,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         ssl_keyfile=args.ssl_keyfile,
         timeout_keep_alive=timeout_keep_alive,
         ws_max_size=ws_max_size,
+        proxy_headers=False,
         log_config=_build_log_config(),
     )
 

--- a/app/core/auth/dependencies.py
+++ b/app/core/auth/dependencies.py
@@ -25,6 +25,7 @@ from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.exceptions import DashboardAuthError, DashboardPermissionError, ProxyAuthError, ProxyUpstreamError
 from app.core.request_locality import is_local_request
+from app.core.socket_peer import raw_socket_peer_host
 from app.core.upstream_proxy import UpstreamProxyRouteError, resolve_upstream_route
 from app.core.utils.time import utcnow
 from app.db.models import AccountStatus
@@ -242,7 +243,7 @@ def get_dashboard_request_auth_mode() -> DashboardAuthMode:
 
 
 def _is_proxy_unauthenticated_socket_peer_allowed(request: HTTPConnection) -> bool:
-    socket_host = request.client.host if request.client else None
+    socket_host = raw_socket_peer_host(request)
     if socket_host is None:
         return False
 

--- a/app/core/middleware/__init__.py
+++ b/app/core/middleware/__init__.py
@@ -4,6 +4,7 @@ from app.core.middleware.dashboard_auth_proxy import add_dashboard_auth_proxy_mi
 from app.core.middleware.path_rewrite import add_backend_api_codex_v1_alias_middleware
 from app.core.middleware.request_decompression import add_request_decompression_middleware
 from app.core.middleware.request_id import add_request_id_middleware
+from app.core.middleware.trusted_proxy_headers import add_trusted_proxy_headers_middleware
 
 __all__ = [
     "add_app_version_middleware",
@@ -12,4 +13,5 @@ __all__ = [
     "add_dashboard_auth_proxy_middleware",
     "add_request_decompression_middleware",
     "add_request_id_middleware",
+    "add_trusted_proxy_headers_middleware",
 ]

--- a/app/core/middleware/trusted_proxy_headers.py
+++ b/app/core/middleware/trusted_proxy_headers.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+from typing import cast
+
+from fastapi import FastAPI
+from starlette.types import ASGIApp, Receive, Scope, Send
+from uvicorn._types import ASGI3Application
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+
+from app.core.socket_peer import _capture_raw_socket_peer
+
+
+class TrustedProxyHeadersMiddleware:
+    """Preserve the raw socket peer, then apply Uvicorn's proxy projection."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self._proxy_headers = cast(
+            ASGIApp,
+            ProxyHeadersMiddleware(
+                cast(ASGI3Application, app),
+                trusted_hosts=os.getenv("FORWARDED_ALLOW_IPS", "127.0.0.1"),
+            ),
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] in {"http", "websocket"}:
+            _capture_raw_socket_peer(scope)
+        await self._proxy_headers(scope, receive, send)
+
+
+def add_trusted_proxy_headers_middleware(app: FastAPI) -> None:
+    app.add_middleware(TrustedProxyHeadersMiddleware)

--- a/app/core/socket_peer.py
+++ b/app/core/socket_peer.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Final, TypeAlias, cast
+
+from starlette.requests import HTTPConnection
+from starlette.types import Scope
+
+_RawSocketPeer: TypeAlias = tuple[str, int] | None
+_RAW_SOCKET_PEER_SCOPE_KEY: Final = "_codex_lb_raw_socket_peer"
+
+
+def _capture_raw_socket_peer(scope: Scope) -> None:
+    """Store the server-observed peer before proxy headers mutate the scope."""
+    scope[_RAW_SOCKET_PEER_SCOPE_KEY] = cast(_RawSocketPeer, scope.get("client"))
+
+
+def raw_socket_peer_host(connection: HTTPConnection) -> str | None:
+    """Return the server-observed socket peer, failing closed if uncaptured."""
+    if _RAW_SOCKET_PEER_SCOPE_KEY not in connection.scope:
+        return None
+    peer = cast(_RawSocketPeer, connection.scope[_RAW_SOCKET_PEER_SCOPE_KEY])
+    return peer[0] if peer is not None else None

--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,7 @@ from app.core.middleware import (
     add_dashboard_auth_proxy_middleware,
     add_request_decompression_middleware,
     add_request_id_middleware,
+    add_trusted_proxy_headers_middleware,
 )
 from app.core.middleware.dashboard_gzip import add_dashboard_gzip_middleware
 from app.core.middleware.inflight import InFlightMiddleware
@@ -585,6 +586,7 @@ def create_app() -> FastAPI:
     add_backend_api_codex_v1_alias_middleware(app)
     add_app_version_middleware(app)
     add_exception_handlers(app)
+    add_trusted_proxy_headers_middleware(app)
 
     app.include_router(proxy_api.router)
     app.include_router(proxy_api.internal_router)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       # websocket ingress budget that app.cli applies in production.
       - uvicorn
       - app.main:app
+      - --no-proxy-headers
       - --host
       - 0.0.0.0
       - --port

--- a/openspec/changes/preserve-raw-socket-peer/.openspec.yaml
+++ b/openspec/changes/preserve-raw-socket-peer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/preserve-raw-socket-peer/context.md
+++ b/openspec/changes/preserve-raw-socket-peer/context.md
@@ -1,0 +1,24 @@
+# Raw socket peer preservation context
+
+## Purpose and scope
+
+This change closes the transport boundary beneath the existing [`api-keys` requirements](../../specs/api-keys/spec.md): an address projected from trusted proxy headers must never be mistaken for the socket peer when evaluating `proxy_unauthenticated_client_cidrs`. The matching launcher contract is defined in [`deployment-installation`](specs/deployment-installation/spec.md).
+
+It intentionally does not decide which forwarded identity is authoritative, how conflicting header families are handled, or how locality, firewall, logging, bridge, drain, audit, and dashboard policies use projected identities.
+
+## Decision and constraints
+
+codex-lb captures the incoming ASGI client once, then delegates projection to Uvicorn's own middleware. This preserves a narrow raw identity for the unauthenticated allowlist while leaving `request.client` and the request/WebSocket scheme compatible for every existing consumer.
+
+`FORWARDED_ALLOW_IPS` remains the only trust input because introducing another setting would split one transport policy across two sources of truth. Owned server paths must turn off the outer Uvicorn projection; otherwise the application receives an already rewritten client and no middleware can reconstruct the transport peer.
+
+## Failure modes
+
+- An external Uvicorn or FastAPI command that omits `--no-proxy-headers` captures a projected value instead of the raw peer. Shipped direct commands document and test the required flag.
+- Missing raw-peer scope state fails closed for `proxy_unauthenticated_client_cidrs`; it never falls back to `request.client`.
+- Middleware reordering could capture too late. Registration and end-to-end middleware tests lock the outermost ordering.
+- Future Uvicorn parsing changes flow through the reused middleware rather than a codex-lb parser fork.
+
+## Concrete example
+
+Suppose the TCP peer is `10.0.0.8`, `proxy_unauthenticated_client_cidrs` contains only `192.168.65.1/32`, and a trusted proxy request supplies `X-Forwarded-For: 192.168.65.1` plus `X-Forwarded-Proto: https`. Downstream handlers still observe client `192.168.65.1` and scheme `https`, but the unauthenticated allowlist compares `10.0.0.8` and rejects the request. The same separation applies to a WebSocket upgrade, with `wss` projection preserved.

--- a/openspec/changes/preserve-raw-socket-peer/design.md
+++ b/openspec/changes/preserve-raw-socket-peer/design.md
@@ -1,0 +1,61 @@
+## Context
+
+Uvicorn enables proxy-header handling by default. On a trusted socket peer it mutates the ASGI `client` and `scheme` before invoking the application, so code inside FastAPI cannot recover the transport peer from `request.client`. codex-lb already promises that `proxy_unauthenticated_client_cidrs` is evaluated against the raw socket peer, while other request consumers rely on Uvicorn's projected `request.client` and scheme.
+
+The change must therefore preserve two identities without changing either policy: a private raw transport peer used only by the unauthenticated proxy-client allowlist, and Uvicorn's existing projected client/scheme used by current application behavior. It must cover both HTTP and WebSocket scopes and all owned server launch paths.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Capture the transport peer before any proxy-header projection and make it available for HTTP and WebSocket authentication.
+- Preserve Uvicorn 0.47's current `X-Forwarded-For` and `X-Forwarded-Proto` behavior.
+- Preserve the exact `FORWARDED_ALLOW_IPS` trust contract: unset defaults to `127.0.0.1`, an empty value trusts no peer, `*` trusts every peer, and other values retain Uvicorn's host/network parsing.
+- Ensure every owned launcher performs proxy projection exactly once and after raw-peer capture.
+- Fail closed for the unauthenticated allowlist when no preserved raw peer is available.
+
+**Non-Goals:**
+
+- Changing forwarded-header precedence, conflict/consensus rules, locality classification, or trusted-proxy configuration.
+- Changing API firewall, request-log, bridge, drain, audit, dashboard-throttle, or other generic `request.client` consumers.
+- Adding a new setting or replacing `FORWARDED_ALLOW_IPS` with a `CODEX_LB_*` setting.
+- Supporting an external server command that performs proxy projection before loading the codex-lb application; such commands must disable server-level proxy headers as documented.
+
+## Decisions
+
+### Capture and projection share one outer application middleware
+
+Add a focused ASGI middleware that records the incoming `scope["client"]` under a private codex-lb scope key for `http` and `websocket`, then delegates the same scope to Uvicorn's `ProxyHeadersMiddleware`. Register it last in `create_app()` so Starlette makes it the outermost user middleware.
+
+Keeping capture and delegation in one middleware makes their ordering structural rather than relying on two independently registered middleware entries. Copying Uvicorn's parsing was rejected because it would create a second compatibility implementation for trusted hops, client ports, IPv6, and HTTP/WebSocket scheme conversion.
+
+### Keep raw-peer access narrow and fail closed
+
+Expose a small typed helper that reads the preserved peer from an `HTTPConnection`, which covers both `Request` and `WebSocket`. Only `_is_proxy_unauthenticated_socket_peer_allowed()` will use it. If the scope key is missing, the helper returns no peer and the allowlist does not match; it does not fall back to the possibly projected `request.client`.
+
+Storing a second application-wide client identity or replacing `request.client` was rejected because other consumers intentionally depend on the projected value and are outside this change.
+
+### Disable server-level projection in owned launch paths
+
+Set `proxy_headers=False` in `app.cli` and add `--no-proxy-headers` to the direct Docker Compose command and direct FastAPI/Uvicorn documentation. Docker, distroless, production Compose, and Helm paths already delegate to `app.cli` and inherit the setting.
+
+Leaving Uvicorn's outer middleware enabled was rejected because the application would capture an already projected identity. Removing proxy projection entirely was rejected because it would change existing `request.client`, URL, and WebSocket scheme behavior.
+
+### Read the existing trust environment without reinterpretation
+
+Construct Uvicorn's application middleware with `os.getenv("FORWARDED_ALLOW_IPS", "127.0.0.1")`. Passing the raw string preserves Uvicorn's handling of empty strings, wildcards, comma-separated hosts, literals, addresses, and networks. No validation or normalization layer is added.
+
+## Risks / Trade-offs
+
+- **An external launch command omits `--no-proxy-headers` and projects too early** → Document the required flag on direct commands and add launcher contract tests; the allowlist still fails closed when capture is absent, but it cannot distinguish an already rewritten peer.
+- **Middleware registration order changes later** → Add a create-app/middleware regression that proves raw capture precedes projection and projected client/scheme remain visible downstream.
+- **Uvicorn changes proxy-header semantics in a future upgrade** → Delegate to Uvicorn's middleware and test codex-lb's required compatibility cases instead of maintaining a fork.
+- **A non-owned ASGI integration calls auth outside the configured app** → Missing raw-peer state never satisfies `proxy_unauthenticated_client_cidrs`.
+
+## Migration Plan
+
+No data migration is required. Ship the application middleware and owned launcher changes together so projection moves atomically from the server wrapper into the application. Rollback is the reverse code deployment; no persisted state or configuration conversion is involved.
+
+## Open Questions
+
+None.

--- a/openspec/changes/preserve-raw-socket-peer/proposal.md
+++ b/openspec/changes/preserve-raw-socket-peer/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Owned Uvicorn launch paths currently allow server-level proxy-header handling to rewrite the ASGI client before codex-lb can distinguish the transport peer from a forwarded identity. As a result, a forwarded address can incorrectly satisfy the unauthenticated proxy-client allowlist even though the existing API-key contract requires the raw socket peer to be authoritative.
+
+## What Changes
+
+- Preserve the raw HTTP or WebSocket socket peer before any trusted proxy-header projection occurs.
+- Move the owned launch paths' proxy-header projection into the application so raw-peer capture runs first while retaining Uvicorn's existing projected client and scheme behavior.
+- Make `proxy_unauthenticated_client_cidrs` evaluate only the preserved raw peer for both HTTP and WebSocket authentication.
+- Keep `FORWARDED_ALLOW_IPS` as the single source of truth for Uvicorn-compatible proxy trust, including its unset, empty, wildcard, and explicit-host semantics.
+- Update direct Uvicorn launch examples and add regression coverage for middleware ordering, launchers, HTTP, and WebSocket behavior.
+- Do not change proxy-identity conflict policy, locality resolution, API firewall behavior, request logging, bridge/drain/audit behavior, or dashboard throttling.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `deployment-installation`: Require owned server launch paths to preserve the raw transport peer before applying the existing trusted proxy-header projection.
+
+## Impact
+
+The change affects application middleware registration, conformance with the existing `api-keys` raw-peer allowlist contract, owned Uvicorn launch commands, direct-launch documentation, and focused tests. It introduces no new setting, dependency, API schema, database migration, dashboard surface, or general proxy-resolution policy.

--- a/openspec/changes/preserve-raw-socket-peer/specs/deployment-installation/spec.md
+++ b/openspec/changes/preserve-raw-socket-peer/specs/deployment-installation/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Owned server launch paths preserve the raw peer before proxy projection
+
+Every server launch path shipped by the project MUST disable server-level proxy-header projection before loading the main application. The main application MUST preserve the incoming HTTP or WebSocket `scope["client"]` before delegating to Uvicorn's proxy-header middleware, and downstream consumers MUST continue to observe Uvicorn's projected client and scheme.
+
+The application-level projection MUST use `FORWARDED_ALLOW_IPS` without reinterpretation. An unset value MUST use Uvicorn's `127.0.0.1` default, an empty value MUST trust no peer, `*` MUST trust every peer, and explicit hosts or networks MUST retain Uvicorn's parsing and trusted-chain behavior. No new operator setting SHALL be introduced for this projection.
+
+#### Scenario: Project CLI disables server-level proxy projection
+
+- **WHEN** the project CLI starts the main application with Uvicorn
+- **THEN** it explicitly disables Uvicorn's server-level proxy-header middleware
+- **AND** the application-level capture and projection middleware runs exactly once
+
+#### Scenario: Direct shipped launch commands disable server-level proxy projection
+
+- **WHEN** an operator uses a shipped direct FastAPI or Uvicorn launch command for the main application
+- **THEN** the command includes the server's no-proxy-headers option
+
+#### Scenario: Trusted HTTP peer retains projected behavior
+
+- **WHEN** a trusted HTTP socket peer sends valid `X-Forwarded-For` and `X-Forwarded-Proto` headers
+- **THEN** the application preserves the original socket peer before projection
+- **AND** downstream request handling observes the client and scheme projected by Uvicorn
+
+#### Scenario: Trusted WebSocket peer retains projected behavior
+
+- **WHEN** a trusted WebSocket socket peer sends valid `X-Forwarded-For` and `X-Forwarded-Proto` headers
+- **THEN** the application preserves the original socket peer before projection
+- **AND** downstream WebSocket handling observes Uvicorn's projected client and `ws` or `wss` scheme
+
+#### Scenario: Untrusted peer is not projected
+
+- **WHEN** an HTTP or WebSocket socket peer is not trusted by `FORWARDED_ALLOW_IPS`
+- **THEN** the preserved and downstream-visible clients both identify that socket peer
+- **AND** forwarded headers do not change the downstream scheme
+
+#### Scenario: Empty forwarded allowlist trusts no peer
+
+- **WHEN** `FORWARDED_ALLOW_IPS` is explicitly empty
+- **THEN** proxy headers from every socket peer leave the downstream client and scheme unchanged
+
+#### Scenario: Wildcard forwarded allowlist retains Uvicorn semantics
+
+- **WHEN** `FORWARDED_ALLOW_IPS` is `*`
+- **THEN** every socket peer is eligible for Uvicorn's existing proxy-header projection

--- a/openspec/changes/preserve-raw-socket-peer/tasks.md
+++ b/openspec/changes/preserve-raw-socket-peer/tasks.md
@@ -1,0 +1,26 @@
+## 1. Raw peer boundary
+
+- [x] 1.1 Add a typed raw-socket-peer scope helper and an outer ASGI middleware that captures HTTP/WebSocket peers before delegating to Uvicorn's proxy-header middleware with the unchanged `FORWARDED_ALLOW_IPS` contract
+- [x] 1.2 Register the capture/projection middleware as the outermost application middleware without changing other middleware or generic `request.client` consumers
+- [x] 1.3 Make `proxy_unauthenticated_client_cidrs` use only the preserved raw peer and fail closed when it is unavailable
+
+## 2. Owned launch paths
+
+- [x] 2.1 Disable server-level proxy-header projection in `app.cli` and the direct Docker Compose Uvicorn command
+- [x] 2.2 Add the no-proxy-headers option to every shipped direct FastAPI/Uvicorn command for the main application while leaving `app.cli`-based entrypoints unchanged
+
+## 3. Regression coverage
+
+- [x] 3.1 Cover HTTP and WebSocket capture/projection, middleware ordering, trusted and untrusted peers, and the unset/empty/wildcard/explicit `FORWARDED_ALLOW_IPS` cases
+- [x] 3.2 Cover HTTP and WebSocket authentication where a forwarded allowlisted identity differs from the non-allowlisted raw peer, plus the valid raw-allowlisted path
+- [x] 3.3 Lock the CLI, Compose, documentation, Docker, distroless, production Compose, and Helm launcher contracts
+
+## 4. OpenSpec synchronization
+
+- [x] 4.1 Sync the verified launcher requirement and stable operational context into `deployment-installation`, and confirm the implementation satisfies the existing `api-keys` raw-peer contract without duplicating it
+
+## 5. Verification
+
+- [x] 5.1 Run focused tests, Ruff format/check, full `ty check`, strict change and main-spec validation, and `git diff --check`
+- [x] 5.2 Run the repository fast CI gate and confirm its top-level exit result
+- [x] 5.3 Run the adversarial Codex review loop against current `main` and address all in-scope findings

--- a/openspec/specs/deployment-installation/context.md
+++ b/openspec/specs/deployment-installation/context.md
@@ -10,6 +10,26 @@ fixed, and how removed settings are retired.
 See `openspec/specs/deployment-installation/spec.md` for normative
 requirements.
 
+## Raw socket peer preservation and proxy projection
+
+codex-lb owns proxy-header projection inside the application so it can retain
+both identities needed by existing contracts: the incoming ASGI client for
+raw transport-peer policy, and Uvicorn's projected client and scheme for
+downstream request handling. Shipped launchers therefore disable Uvicorn's
+outer proxy-header middleware. A direct external FastAPI or Uvicorn command
+must do the same; otherwise the application receives an already projected
+client and cannot reconstruct the transport peer.
+
+`FORWARDED_ALLOW_IPS` remains the single proxy-trust input and is passed to
+Uvicorn without reinterpretation. Unset, empty, wildcard, host, and network
+values consequently keep Uvicorn's own semantics rather than acquiring a
+second codex-lb-specific policy.
+
+For example, when the TCP peer is `10.0.0.8` and a trusted proxy header
+projects `192.168.65.1` with scheme `https`, downstream handlers continue to
+observe `192.168.65.1` and `https`, while raw-peer authorization can still
+evaluate `10.0.0.8`.
+
 ## NEXT-RELEASE QUEUE (do not lose)
 
 Work queued for the release after the one that shipped the

--- a/openspec/specs/deployment-installation/spec.md
+++ b/openspec/specs/deployment-installation/spec.md
@@ -218,6 +218,51 @@ The shipped docker-compose files MUST document that they define a single-replica
 - **WHEN** `docker-compose.yml` and `docker-compose.prod.yml` are inspected
 - **THEN** each carries the single-replica guardrail statement referencing the Helm chart path
 
+### Requirement: Owned server launch paths preserve the raw peer before proxy projection
+
+Every server launch path shipped by the project MUST disable server-level proxy-header projection before loading the main application. The main application MUST preserve the incoming HTTP or WebSocket `scope["client"]` before delegating to Uvicorn's proxy-header middleware, and downstream consumers MUST continue to observe Uvicorn's projected client and scheme.
+
+The application-level projection MUST use `FORWARDED_ALLOW_IPS` without reinterpretation. An unset value MUST use Uvicorn's `127.0.0.1` default, an empty value MUST trust no peer, `*` MUST trust every peer, and explicit hosts or networks MUST retain Uvicorn's parsing and trusted-chain behavior. No new operator setting SHALL be introduced for this projection.
+
+#### Scenario: Project CLI disables server-level proxy projection
+
+- **WHEN** the project CLI starts the main application with Uvicorn
+- **THEN** it explicitly disables Uvicorn's server-level proxy-header middleware
+- **AND** the application-level capture and projection middleware runs exactly once
+
+#### Scenario: Direct shipped launch commands disable server-level proxy projection
+
+- **WHEN** an operator uses a shipped direct FastAPI or Uvicorn launch command for the main application
+- **THEN** the command includes the server's no-proxy-headers option
+
+#### Scenario: Trusted HTTP peer retains projected behavior
+
+- **WHEN** a trusted HTTP socket peer sends valid `X-Forwarded-For` and `X-Forwarded-Proto` headers
+- **THEN** the application preserves the original socket peer before projection
+- **AND** downstream request handling observes the client and scheme projected by Uvicorn
+
+#### Scenario: Trusted WebSocket peer retains projected behavior
+
+- **WHEN** a trusted WebSocket socket peer sends valid `X-Forwarded-For` and `X-Forwarded-Proto` headers
+- **THEN** the application preserves the original socket peer before projection
+- **AND** downstream WebSocket handling observes Uvicorn's projected client and `ws` or `wss` scheme
+
+#### Scenario: Untrusted peer is not projected
+
+- **WHEN** an HTTP or WebSocket socket peer is not trusted by `FORWARDED_ALLOW_IPS`
+- **THEN** the preserved and downstream-visible clients both identify that socket peer
+- **AND** forwarded headers do not change the downstream scheme
+
+#### Scenario: Empty forwarded allowlist trusts no peer
+
+- **WHEN** `FORWARDED_ALLOW_IPS` is explicitly empty
+- **THEN** proxy headers from every socket peer leave the downstream client and scheme unchanged
+
+#### Scenario: Wildcard forwarded allowlist retains Uvicorn semantics
+
+- **WHEN** `FORWARDED_ALLOW_IPS` is `*`
+- **THEN** every socket peer is eligible for Uvicorn's existing proxy-header projection
+
 ### Requirement: Removed tunables are fixed constants or derived values
 
 Values that are protocol constants or internal tuning details SHALL NOT be

--- a/openspec/specs/responses-api-compat/ops.md
+++ b/openspec/specs/responses-api-compat/ops.md
@@ -142,7 +142,7 @@ Interpretation:
 Start a local proxy instance on a spare port:
 
 ```bash
-cd /home/egor/services/codex-lb-defin85 && env CODEX_LB_USAGE_REFRESH_ENABLED=false CODEX_LB_MODEL_REGISTRY_ENABLED=false .venv/bin/fastapi run app/main.py --host 127.0.0.1 --port 2460
+cd /home/egor/services/codex-lb-defin85 && env CODEX_LB_USAGE_REFRESH_ENABLED=false CODEX_LB_MODEL_REGISTRY_ENABLED=false .venv/bin/fastapi run app/main.py --host 127.0.0.1 --port 2460 --no-proxy-headers
 ```
 
 Prepare an isolated `HOME` for the CLI:

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -62,6 +62,21 @@ async def _set_migration_inconsistent_totp_only_mode() -> None:
     await get_settings_cache().invalidate()
 
 
+async def _set_api_key_auth_enabled(enabled: bool) -> None:
+    settings_cache = get_settings_cache()
+    await settings_cache.get()
+
+    async with SessionLocal() as session:
+        settings = await session.get(DashboardSettings, 1)
+        assert settings is not None
+        settings.api_key_auth_enabled = enabled
+        await session.commit()
+
+    await settings_cache.invalidate()
+    refreshed_settings = await settings_cache.get()
+    assert refreshed_settings.api_key_auth_enabled is enabled
+
+
 def _set_dashboard_auth_env(
     monkeypatch: pytest.MonkeyPatch,
     *,
@@ -279,6 +294,55 @@ async def test_proxy_unauthenticated_client_cidr_does_not_allow_other_remote_pee
             spoofed = await remote_client.get("/v1/models", headers={"Host": "localhost"})
             assert spoofed.status_code == 401
             assert spoofed.json()["error"]["code"] == "invalid_api_key"
+
+
+@pytest.mark.asyncio
+async def test_proxy_unauthenticated_client_cidr_rejects_projected_client_when_raw_peer_is_not_allowlisted(
+    app_instance,
+    monkeypatch,
+):
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "127.0.0.1")
+    _set_proxy_unauthenticated_client_cidrs_env(
+        monkeypatch,
+        cidrs="192.168.65.1/32",
+    )
+
+    async with app_instance.router.lifespan_context(app_instance):
+        await _set_api_key_auth_enabled(False)
+        transport = ASGITransport(app=app_instance, client=("127.0.0.1", 50001))
+        async with AsyncClient(transport=transport, base_url="http://lb.example") as proxied_client:
+            response = await proxied_client.get(
+                "/v1/models",
+                headers={"X-Forwarded-For": "192.168.65.1"},
+            )
+
+    assert response.status_code == 401
+    payload = response.json()
+    assert payload["error"]["code"] == "invalid_api_key"
+    assert payload["error"]["message"] == "Proxy authentication must be configured before remote access is allowed"
+
+
+@pytest.mark.asyncio
+async def test_proxy_unauthenticated_client_cidr_allows_raw_peer_when_projected_client_differs(
+    app_instance,
+    monkeypatch,
+):
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "127.0.0.1")
+    _set_proxy_unauthenticated_client_cidrs_env(
+        monkeypatch,
+        cidrs="127.0.0.1/32",
+    )
+
+    async with app_instance.router.lifespan_context(app_instance):
+        await _set_api_key_auth_enabled(False)
+        transport = ASGITransport(app=app_instance, client=("127.0.0.1", 50001))
+        async with AsyncClient(transport=transport, base_url="http://lb.example") as proxied_client:
+            response = await proxied_client.get(
+                "/v1/models",
+                headers={"X-Forwarded-For": "203.0.113.24"},
+            )
+
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -36,6 +36,7 @@ def test_main_passes_timestamped_log_config(monkeypatch):
     assert formatters["access"]["fmt"].startswith("%(asctime)s ")
     assert kwargs["timeout_keep_alive"] == 7200
     assert kwargs["ws_max_size"] == 128 * 1024 * 1024
+    assert kwargs["proxy_headers"] is False
 
 
 def test_main_passes_custom_keep_alive_timeout(monkeypatch):

--- a/tests/unit/test_proxy_api_websocket_auth.py
+++ b/tests/unit/test_proxy_api_websocket_auth.py
@@ -9,18 +9,68 @@ from unittest.mock import AsyncMock
 import pytest
 from fastapi import WebSocket
 from fastapi.responses import JSONResponse
-from starlette.requests import Request
+from starlette.requests import HTTPConnection, Request
+from starlette.types import Message, Receive, Scope, Send
 
 import app.core.auth.dependencies as auth_dependencies
 import app.modules.proxy.api as proxy_api_module
 from app.core.clients.proxy import ProxyResponseError
 from app.core.errors import openai_error
 from app.core.exceptions import ProxyAuthError
+from app.core.middleware.trusted_proxy_headers import TrustedProxyHeadersMiddleware
 from app.core.openai.requests import ResponsesRequest
 from app.core.types import JsonValue
 from app.modules.api_keys.service import ApiKeyData, ApiKeyUsageReservationData
 
 pytestmark = pytest.mark.unit
+
+
+async def _validate_projected_proxy_websocket_request(
+    *,
+    raw_host: str,
+    projected_host: str,
+    capture_raw_peer: bool = True,
+) -> tuple[ApiKeyData | None, JSONResponse | None]:
+    result: tuple[ApiKeyData | None, JSONResponse | None] | None = None
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        nonlocal result
+        result = await proxy_api_module._validate_proxy_websocket_request(WebSocket(scope, receive, send))
+
+    async def fail_receive() -> Message:
+        raise AssertionError("proxy authorization must finish before the WebSocket upgrade")
+
+    async def fail_send(_message: Message) -> None:
+        raise AssertionError("proxy authorization must finish before the WebSocket upgrade")
+
+    middleware = TrustedProxyHeadersMiddleware(app)
+    scope = cast(
+        Scope,
+        {
+            "type": "websocket",
+            "asgi": {"version": "3.0", "spec_version": "2.4"},
+            "http_version": "1.1",
+            "scheme": "ws",
+            "server": ("lb.example", 80),
+            "client": (raw_host, 50001),
+            "root_path": "",
+            "path": "/v1/responses",
+            "raw_path": b"/v1/responses",
+            "query_string": b"",
+            "headers": [(b"x-forwarded-for", projected_host.encode("ascii"))],
+            "subprotocols": [],
+            "state": {},
+            "extensions": {},
+        },
+    )
+
+    if capture_raw_peer:
+        await middleware(scope, fail_receive, fail_send)
+    else:
+        await app(scope, fail_receive, fail_send)
+
+    assert result is not None
+    return result
 
 
 @pytest.mark.asyncio
@@ -165,27 +215,31 @@ async def test_validate_proxy_websocket_request_reraises_unrelated_type_error(mo
 
 
 @pytest.mark.asyncio
-async def test_validate_proxy_websocket_request_allows_explicit_socket_peer_when_auth_disabled(monkeypatch):
+async def test_validate_proxy_websocket_request_allows_raw_peer_when_projected_client_differs(monkeypatch):
     async def fake_denial(_websocket):
         return None
 
     async def fake_dashboard_settings() -> SimpleNamespace:
         return SimpleNamespace(api_key_auth_enabled=False)
 
+    def fake_is_local_request(request: HTTPConnection) -> bool:
+        assert request.client is not None
+        assert request.client.host == "192.168.65.2"
+        return False
+
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "127.0.0.1")
     monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", fake_denial)
     monkeypatch.setattr(auth_dependencies, "get_settings_cache", lambda: SimpleNamespace(get=fake_dashboard_settings))
     monkeypatch.setattr(
         auth_dependencies,
         "get_settings",
-        lambda: SimpleNamespace(proxy_unauthenticated_client_cidrs=["192.168.65.1/32"]),
+        lambda: SimpleNamespace(proxy_unauthenticated_client_cidrs=["127.0.0.1/32"]),
     )
-    monkeypatch.setattr(auth_dependencies, "is_local_request", lambda _request: False)
+    monkeypatch.setattr(auth_dependencies, "is_local_request", fake_is_local_request)
 
-    resolved_api_key, response = await proxy_api_module._validate_proxy_websocket_request(
-        cast(
-            WebSocket,
-            SimpleNamespace(headers={}, client=SimpleNamespace(host="192.168.65.1")),
-        )
+    resolved_api_key, response = await _validate_projected_proxy_websocket_request(
+        raw_host="127.0.0.1",
+        projected_host="192.168.65.2",
     )
 
     assert response is None
@@ -193,7 +247,45 @@ async def test_validate_proxy_websocket_request_allows_explicit_socket_peer_when
 
 
 @pytest.mark.asyncio
-async def test_validate_proxy_websocket_request_rejects_remote_socket_peer_outside_allowlist(monkeypatch):
+async def test_validate_proxy_websocket_request_rejects_projected_client_when_raw_peer_is_not_allowlisted(
+    monkeypatch,
+):
+    async def fake_denial(_websocket):
+        return None
+
+    async def fake_dashboard_settings() -> SimpleNamespace:
+        return SimpleNamespace(api_key_auth_enabled=False)
+
+    def fake_is_local_request(request: HTTPConnection) -> bool:
+        assert request.client is not None
+        assert request.client.host == "192.168.65.1"
+        return False
+
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "127.0.0.1")
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", fake_denial)
+    monkeypatch.setattr(auth_dependencies, "get_settings_cache", lambda: SimpleNamespace(get=fake_dashboard_settings))
+    monkeypatch.setattr(
+        auth_dependencies,
+        "get_settings",
+        lambda: SimpleNamespace(proxy_unauthenticated_client_cidrs=["192.168.65.1/32"]),
+    )
+    monkeypatch.setattr(auth_dependencies, "is_local_request", fake_is_local_request)
+
+    resolved_api_key, response = await _validate_projected_proxy_websocket_request(
+        raw_host="127.0.0.1",
+        projected_host="192.168.65.1",
+    )
+
+    assert resolved_api_key is None
+    assert response is not None
+    assert response.status_code == 401
+    payload = json.loads(cast(bytes, response.body).decode("utf-8"))
+    assert payload["error"]["code"] == "invalid_api_key"
+    assert payload["error"]["message"] == "Proxy authentication must be configured before remote access is allowed"
+
+
+@pytest.mark.asyncio
+async def test_validate_proxy_websocket_request_fails_closed_without_raw_peer_capture(monkeypatch):
     async def fake_denial(_websocket):
         return None
 
@@ -209,11 +301,10 @@ async def test_validate_proxy_websocket_request_rejects_remote_socket_peer_outsi
     )
     monkeypatch.setattr(auth_dependencies, "is_local_request", lambda _request: False)
 
-    resolved_api_key, response = await proxy_api_module._validate_proxy_websocket_request(
-        cast(
-            WebSocket,
-            SimpleNamespace(headers={}, client=SimpleNamespace(host="192.168.65.2")),
-        )
+    resolved_api_key, response = await _validate_projected_proxy_websocket_request(
+        raw_host="192.168.65.1",
+        projected_host="192.168.65.1",
+        capture_raw_peer=False,
     )
 
     assert resolved_api_key is None

--- a/tests/unit/test_proxy_header_launcher_contract.py
+++ b/tests/unit/test_proxy_header_launcher_contract.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_repo_file(relative_path: str) -> str:
+    return (_REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def _read_compose(relative_path: str) -> dict[str, Any]:
+    return yaml.safe_load(_read_repo_file(relative_path))
+
+
+def test_development_compose_disables_uvicorn_proxy_header_processing():
+    compose = _read_compose("docker-compose.yml")
+    command = compose["services"]["server"]["command"]
+
+    assert command[:2] == ["uvicorn", "app.main:app"]
+    assert command.count("--no-proxy-headers") == 1
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "command"),
+    [
+        ("README.md", "uv run fastapi run app/main.py --reload --no-proxy-headers"),
+        ("README.zh-CN.md", "uv run fastapi run app/main.py --reload --no-proxy-headers"),
+        (
+            "openspec/specs/responses-api-compat/ops.md",
+            ".venv/bin/fastapi run app/main.py --host 127.0.0.1 --port 2460 --no-proxy-headers",
+        ),
+    ],
+)
+def test_documented_direct_starters_disable_uvicorn_proxy_header_processing(relative_path: str, command: str):
+    assert command in _read_repo_file(relative_path)
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "contract"),
+    [
+        ("Dockerfile", 'CMD ["/app/scripts/docker-entrypoint.sh"]'),
+        ("scripts/docker-entrypoint.sh", "exec python -m app.cli"),
+        ("Dockerfile.distroless", 'CMD ["python", "/app/scripts/distroless-entrypoint.py"]'),
+        ("scripts/distroless-entrypoint.py", '[sys.executable, "-m", "app.cli"'),
+        ("deploy/helm/codex-lb/templates/deployment.yaml", "            - app.cli\n"),
+    ],
+)
+def test_owned_production_launchers_delegate_to_app_cli(relative_path: str, contract: str):
+    assert contract in _read_repo_file(relative_path)
+
+
+def test_production_compose_inherits_the_dockerfile_launcher():
+    server = _read_compose("docker-compose.prod.yml")["services"]["server"]
+
+    assert server["build"]["dockerfile"] == "Dockerfile"
+    assert "command" not in server

--- a/tests/unit/test_trusted_proxy_headers_middleware.py
+++ b/tests/unit/test_trusted_proxy_headers_middleware.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import pytest
+from starlette.requests import HTTPConnection
+from starlette.types import Message, Receive, Scope, Send
+
+import app.main as main
+from app.core.middleware.trusted_proxy_headers import TrustedProxyHeadersMiddleware
+from app.core.socket_peer import raw_socket_peer_host
+
+pytestmark = pytest.mark.unit
+
+_ScopeType = Literal["http", "websocket"]
+_ClientAddress = tuple[str, int]
+
+
+@dataclass(frozen=True)
+class _ObservedConnection:
+    scope: Scope
+    client: _ClientAddress | None
+    scheme: str
+    raw_socket_peer_host: str | None
+
+
+class _RecordingApp:
+    def __init__(self) -> None:
+        self.connections: list[_ObservedConnection] = []
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        connection = HTTPConnection(scope)
+        self.connections.append(
+            _ObservedConnection(
+                scope=scope,
+                client=connection.client,
+                scheme=scope["scheme"],
+                raw_socket_peer_host=raw_socket_peer_host(connection),
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_http_projects_forwarded_client_and_scheme_while_preserving_raw_peer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("FORWARDED_ALLOW_IPS", raising=False)
+    downstream = _RecordingApp()
+    middleware = TrustedProxyHeadersMiddleware(downstream)
+    scope = _connection_scope(
+        "http",
+        client=("127.0.0.1", 43120),
+        headers=[
+            (b"x-forwarded-for", b"203.0.113.41"),
+            (b"x-forwarded-proto", b"https"),
+        ],
+    )
+
+    await middleware(scope, _receive, _send)
+
+    observed = downstream.connections[0]
+    assert observed.scope is scope
+    assert observed.client == ("203.0.113.41", 0)
+    assert observed.scheme == "https"
+    assert observed.raw_socket_peer_host == "127.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_websocket_projects_forwarded_client_and_wss_while_preserving_raw_peer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("FORWARDED_ALLOW_IPS", raising=False)
+    downstream = _RecordingApp()
+    middleware = TrustedProxyHeadersMiddleware(downstream)
+    scope = _connection_scope(
+        "websocket",
+        client=("127.0.0.1", 43121),
+        headers=[
+            (b"x-forwarded-for", b"198.51.100.12"),
+            (b"x-forwarded-proto", b"https"),
+        ],
+    )
+
+    await middleware(scope, _receive, _send)
+
+    observed = downstream.connections[0]
+    assert observed.scope is scope
+    assert observed.client == ("198.51.100.12", 0)
+    assert observed.scheme == "wss"
+    assert observed.raw_socket_peer_host == "127.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_untrusted_peer_ignores_forwarded_headers_but_is_still_captured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("FORWARDED_ALLOW_IPS", raising=False)
+    downstream = _RecordingApp()
+    middleware = TrustedProxyHeadersMiddleware(downstream)
+    scope = _connection_scope(
+        "http",
+        client=("192.0.2.15", 43122),
+        headers=[
+            (b"x-forwarded-for", b"203.0.113.42"),
+            (b"x-forwarded-proto", b"https"),
+        ],
+    )
+
+    await middleware(scope, _receive, _send)
+
+    observed = downstream.connections[0]
+    assert observed.client == ("192.0.2.15", 43122)
+    assert observed.scheme == "http"
+    assert observed.raw_socket_peer_host == "192.0.2.15"
+
+
+@pytest.mark.parametrize(
+    ("trusted_hosts", "raw_peer", "expected_client"),
+    [
+        ("", "127.0.0.1", ("127.0.0.1", 43123)),
+        ("127.0.0.1", "127.0.0.1", ("203.0.113.43", 0)),
+        ("10.0.0.0/8", "10.12.0.4", ("203.0.113.43", 0)),
+        ("192.0.2.1, 127.0.0.1", "127.0.0.1", ("203.0.113.43", 0)),
+        ("*", "192.0.2.16", ("203.0.113.43", 0)),
+    ],
+)
+@pytest.mark.asyncio
+async def test_forwarded_allow_ips_preserves_uvicorn_trust_semantics(
+    monkeypatch: pytest.MonkeyPatch,
+    trusted_hosts: str,
+    raw_peer: str,
+    expected_client: _ClientAddress,
+) -> None:
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", trusted_hosts)
+    downstream = _RecordingApp()
+    middleware = TrustedProxyHeadersMiddleware(downstream)
+    scope = _connection_scope(
+        "http",
+        client=(raw_peer, 43123),
+        headers=[(b"x-forwarded-for", b"203.0.113.43")],
+    )
+
+    await middleware(scope, _receive, _send)
+
+    observed = downstream.connections[0]
+    assert observed.client == expected_client
+    assert observed.raw_socket_peer_host == raw_peer
+
+
+@pytest.mark.asyncio
+async def test_captured_missing_client_remains_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FORWARDED_ALLOW_IPS", "*")
+    downstream = _RecordingApp()
+    middleware = TrustedProxyHeadersMiddleware(downstream)
+    scope = _connection_scope(
+        "http",
+        client=None,
+        headers=[(b"x-forwarded-for", b"203.0.113.44")],
+    )
+
+    await middleware(scope, _receive, _send)
+
+    observed = downstream.connections[0]
+    assert observed.client == ("203.0.113.44", 0)
+    assert observed.raw_socket_peer_host is None
+
+
+def test_raw_socket_peer_host_fails_closed_without_capture() -> None:
+    connection = HTTPConnection(
+        _connection_scope(
+            "http",
+            client=("203.0.113.45", 0),
+            headers=[],
+        )
+    )
+
+    assert raw_socket_peer_host(connection) is None
+
+
+def test_create_app_registers_trusted_proxy_headers_as_outermost_user_middleware() -> None:
+    assert main.app.user_middleware[0].cls is TrustedProxyHeadersMiddleware
+
+
+def _connection_scope(
+    scope_type: _ScopeType,
+    *,
+    client: _ClientAddress | None,
+    headers: list[tuple[bytes, bytes]],
+) -> Scope:
+    return {
+        "type": scope_type,
+        "asgi": {"version": "3.0", "spec_version": "2.4"},
+        "http_version": "1.1",
+        "scheme": "ws" if scope_type == "websocket" else "http",
+        "method": "GET",
+        "path": "/backend-api/codex",
+        "raw_path": b"/backend-api/codex",
+        "query_string": b"",
+        "root_path": "",
+        "headers": headers,
+        "client": client,
+        "server": ("testserver", 80),
+        "state": {},
+    }
+
+
+async def _receive() -> Message:
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+
+async def _send(_: Message) -> None:
+    return None


### PR DESCRIPTION
## Summary

Owned Uvicorn launch paths currently project trusted proxy headers before codex-lb receives the ASGI scope. That can replace the server-observed socket peer with a forwarded identity before `proxy_unauthenticated_client_cidrs` evaluates it, violating the existing raw-peer authentication contract.

This is a separate prerequisite for #1380: preserve the raw HTTP/WebSocket peer first, then apply Uvicorn's existing proxy projection so downstream client and scheme behavior remains unchanged.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] Breaking change

Linked issue: Related to #1380 — separate prerequisite; this PR does not resolve #1380.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/preserve-raw-socket-peer/`

The verified requirement is synchronized into `deployment-installation`. The existing `api-keys` raw-peer requirement remains unchanged.

## Changes

- Capture the raw HTTP/WebSocket socket peer in the outermost application middleware before delegating to Uvicorn's proxy-header middleware.
- Disable server-level projection in project-owned launch paths to avoid projection before capture or double projection.
- Preserve `FORWARDED_ALLOW_IPS` semantics unchanged, including unset, empty, wildcard, host, CIDR, and list values.
- Make the unauthenticated proxy-client allowlist use only the captured raw peer and fail closed when capture is unavailable.
- Update direct-launch documentation and add HTTP, WebSocket, middleware-ordering, trust-matrix, authentication, and launcher regression coverage.

## Non-goals

This PR does not change `request_locality`, proxy-identity consensus or conflict policy, firewall behavior, request logging, bridge/drain/audit behavior, dashboard throttling, or general proxy-projection policy.

## Simplicity

No setting, dependency, API/schema, migration, dashboard surface, README section, or required setup step is added. The change stays within one transport-boundary concern.

## Test plan

- Focused regression suite: `93 passed`
- Ruff check: passed
- Ruff format: `802 files already formatted`
- Full `ty check`: passed
- Strict OpenSpec change validation: passed
- Strict main-spec validation: `47/47`
- `make ci-fast`: exit `0`
  - Frontend: `876 passed`
  - Backend: `4153 passed, 55 skipped`
- Adversarial Codex review: no actionable findings
- `git diff --check`: passed

## Verified behavior

```text
raw socket peer:                         127.0.0.1
X-Forwarded-For:                         192.168.65.1
downstream request.client:               192.168.65.1
proxy_unauthenticated_client_cidrs peer: 127.0.0.1
```

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related discussion without claiming resolution.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant fast CI gate locally.
- [x] OpenSpec validation and verification are clean.
- [x] Simplicity gates reviewed.
- [x] `CHANGELOG.md` was not edited by hand.
