### PR TITLE
test(proxy): characterize load-balancer contract before decomposition

### DIFF
--- a/scripts/check_proxy_architecture.py
+++ b/scripts/check_proxy_architecture.py
@@ -15,15 +15,18 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 PROXY_DIR = ROOT / "app" / "modules" / "proxy"
 SERVICE_PATH = PROXY_DIR / "service.py"
+LOAD_BALANCER_PATH = PROXY_DIR / "load_balancer.py"
 _SERVICE_DIR = PROXY_DIR / "_service"
 SERVICE_PACKAGE_DIR = PROXY_DIR / "_service"
 HTTP_BRIDGE_MIXIN_PATH = PROXY_DIR / "_service" / "http_bridge" / "mixin.py"
 STREAMING_MIXIN_PATH = PROXY_DIR / "_service" / "streaming" / "mixin.py"
 
 MAX_SERVICE_LINES = 2_600
+MAX_LOAD_BALANCER_LINES = 3_021
 MAX_HTTP_BRIDGE_MIXIN_LINES = 2_400
 MAX_STREAMING_MIXIN_LINES = 1_100
 MAX_PROXY_SERVICE_METHOD_LINES = 1_200
+MAX_LOAD_BALANCER_SELECT_ACCOUNT_LINES = 527
 
 REQUIRED_SERVICE_PACKAGES = {
     "http_bridge",
@@ -134,6 +137,17 @@ def _proxy_service_methods(module: ast.Module) -> list[ast.FunctionDef | ast.Asy
     raise AssertionError("ProxyService class not found in service.py")
 
 
+def _load_balancer_select_account(module: ast.Module) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    for node in module.body:
+        if not isinstance(node, ast.ClassDef) or node.name != "LoadBalancer":
+            continue
+        for child in node.body:
+            if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef) and child.name == "select_account":
+                return child
+        raise AssertionError("LoadBalancer.select_account method not found in load_balancer.py")
+    raise AssertionError("LoadBalancer class not found in load_balancer.py")
+
+
 def _assert_shim_only(path: Path) -> None:
     module = _parse(path)
     allowed = (ast.Expr, ast.ImportFrom)
@@ -156,6 +170,12 @@ def _check_service_line_count() -> None:
         raise AssertionError(f"service.py has {count} lines; limit is {MAX_SERVICE_LINES}")
 
 
+def _check_load_balancer_line_count() -> None:
+    count = _line_count(LOAD_BALANCER_PATH)
+    if count > MAX_LOAD_BALANCER_LINES:
+        raise AssertionError(f"load_balancer.py has {count} lines; limit is {MAX_LOAD_BALANCER_LINES}")
+
+
 def _check_http_bridge_mixin_line_count() -> None:
     count = _line_count(HTTP_BRIDGE_MIXIN_PATH)
     if count > MAX_HTTP_BRIDGE_MIXIN_LINES:
@@ -174,6 +194,15 @@ def _check_proxy_service_method_size(module: ast.Module) -> None:
     if largest > MAX_PROXY_SERVICE_METHOD_LINES:
         raise AssertionError(
             f"largest ProxyService method spans {largest} lines; limit is {MAX_PROXY_SERVICE_METHOD_LINES}"
+        )
+
+
+def _check_load_balancer_select_account_size(module: ast.Module) -> None:
+    method = _load_balancer_select_account(module)
+    span = (method.end_lineno or method.lineno) - method.lineno + 1
+    if span > MAX_LOAD_BALANCER_SELECT_ACCOUNT_LINES:
+        raise AssertionError(
+            f"LoadBalancer.select_account spans {span} lines; limit is {MAX_LOAD_BALANCER_SELECT_ACCOUNT_LINES}"
         )
 
 
@@ -244,10 +273,13 @@ def _check_no_cross_domain_service_imports() -> None:
 def main() -> int:
     try:
         service_module = _parse(SERVICE_PATH)
+        load_balancer_module = _parse(LOAD_BALANCER_PATH)
         _check_service_line_count()
+        _check_load_balancer_line_count()
         _check_http_bridge_mixin_line_count()
         _check_streaming_mixin_line_count()
         _check_proxy_service_method_size(service_module)
+        _check_load_balancer_select_account_size(load_balancer_module)
         _check_service_facade_surface(service_module)
         _check_service_does_not_import_shims(service_module)
         _check_required_service_packages()

--- a/tests/unit/test_load_balancer_contract.py
+++ b/tests/unit/test_load_balancer_contract.py
@@ -1,0 +1,489 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Collection
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+import app.modules.proxy.load_balancer as load_balancer_module
+from app.db.models import Account, AccountStatus, StickySession, StickySessionKind, UsageHistory
+from app.modules.accounts.repository import AccountsRepository
+from app.modules.api_keys.repository import ApiKeysRepository
+from app.modules.proxy.account_cache import AccountSelectionCache
+from app.modules.proxy.load_balancer import AccountConcurrencyCaps, AccountSelection, LoadBalancer
+from app.modules.proxy.repo_bundle import ProxyRepositories
+from app.modules.proxy.sticky_repository import StickySessionsRepository
+from app.modules.request_logs.repository import RequestLogsRepository
+from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
+
+pytestmark = pytest.mark.unit
+
+_CONCURRENCY_CAPS = AccountConcurrencyCaps(response_create_limit=1, stream_limit=1)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_runtime_globals(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(load_balancer_module, "get_settings", lambda: SimpleNamespace(circuit_breaker_enabled=False))
+    monkeypatch.setattr(load_balancer_module, "set_normal", lambda: None)
+    monkeypatch.setattr(load_balancer_module, "set_degraded", lambda _reason: None)
+
+
+@pytest.fixture
+def selection_cache() -> AccountSelectionCache:
+    return AccountSelectionCache(ttl_seconds=60)
+
+
+def _account(account_id: str, *, security_work_authorized: bool = False) -> Account:
+    return Account(
+        id=account_id,
+        chatgpt_account_id=f"workspace-{account_id}",
+        email=f"{account_id}@example.com",
+        plan_type="plus",
+        access_token_encrypted=b"access",
+        refresh_token_encrypted=b"refresh",
+        id_token_encrypted=b"id",
+        last_refresh=datetime.now(UTC),
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+        security_work_authorized=security_work_authorized,
+    )
+
+
+def _usage_row(
+    row_id: int,
+    account_id: str,
+    *,
+    window: str,
+    used_percent: float,
+) -> UsageHistory:
+    now = datetime.now(UTC)
+    window_minutes = {"primary": 300, "secondary": 10_080, "monthly": 43_200}[window]
+    return UsageHistory(
+        id=row_id,
+        account_id=account_id,
+        recorded_at=now,
+        window=window,
+        used_percent=used_percent,
+        reset_at=int(now.timestamp()) + window_minutes * 60,
+        window_minutes=window_minutes,
+    )
+
+
+class _AccountsRepository:
+    def __init__(self, accounts: list[Account]) -> None:
+        self.accounts = accounts
+        self.list_calls = 0
+
+    async def list_accounts(self) -> list[Account]:
+        self.list_calls += 1
+        return list(self.accounts)
+
+    async def update_status_if_current(
+        self,
+        account_id: str,
+        status: AccountStatus,
+        deactivation_reason: str | None = None,
+        reset_at: int | None = None,
+        blocked_at: int | None = None,
+        **_expected: Any,
+    ) -> bool:
+        account = next((candidate for candidate in self.accounts if candidate.id == account_id), None)
+        if account is None:
+            return False
+        account.status = status
+        account.deactivation_reason = deactivation_reason
+        account.reset_at = reset_at
+        account.blocked_at = blocked_at
+        return True
+
+
+class _UsageRepository:
+    def __init__(
+        self,
+        *,
+        primary: dict[str, UsageHistory] | None = None,
+        secondary: dict[str, UsageHistory] | None = None,
+        monthly: dict[str, UsageHistory] | None = None,
+    ) -> None:
+        self.rows = {
+            "primary": primary or {},
+            "secondary": secondary or {},
+            "monthly": monthly or {},
+        }
+        self.calls = {"primary": 0, "secondary": 0, "monthly": 0}
+
+    async def latest_by_account(
+        self,
+        window: str | None = None,
+        *,
+        account_ids: Collection[str] | None = None,
+    ) -> dict[str, UsageHistory]:
+        del account_ids
+        key = window or "primary"
+        self.calls[key] += 1
+        return dict(self.rows[key])
+
+
+class _StickySessionsRepository:
+    def __init__(self) -> None:
+        self.account_id: str | None = None
+        self.get_calls = 0
+        self.upserts: list[StickySession] = []
+
+    async def get_account_id(self, *args: Any, **kwargs: Any) -> str | None:
+        del args, kwargs
+        self.get_calls += 1
+        return self.account_id
+
+    async def upsert(
+        self,
+        key: str,
+        account_id: str,
+        *,
+        kind: StickySessionKind,
+    ) -> StickySession:
+        self.account_id = account_id
+        row = StickySession(key=key, account_id=account_id, kind=kind)
+        self.upserts.append(row)
+        return row
+
+    async def delete(self, *args: Any, **kwargs: Any) -> bool:
+        del args, kwargs
+        self.account_id = None
+        return True
+
+
+@asynccontextmanager
+async def _repositories(
+    accounts: _AccountsRepository,
+    usage: _UsageRepository,
+    sticky_sessions: _StickySessionsRepository,
+) -> AsyncIterator[ProxyRepositories]:
+    yield ProxyRepositories(
+        accounts=cast(AccountsRepository, accounts),
+        usage=cast(UsageRepository, usage),
+        request_logs=cast(RequestLogsRepository, object()),
+        sticky_sessions=cast(StickySessionsRepository, sticky_sessions),
+        api_keys=cast(ApiKeysRepository, object()),
+        additional_usage=cast(AdditionalUsageRepository, object()),
+    )
+
+
+def _balancer(
+    accounts: list[Account],
+    cache: AccountSelectionCache,
+    *,
+    primary: dict[str, UsageHistory] | None = None,
+    secondary: dict[str, UsageHistory] | None = None,
+    monthly: dict[str, UsageHistory] | None = None,
+) -> tuple[LoadBalancer, _AccountsRepository, _UsageRepository, _StickySessionsRepository]:
+    accounts_repo = _AccountsRepository(accounts)
+    usage_repo = _UsageRepository(primary=primary, secondary=secondary, monthly=monthly)
+    sticky_repo = _StickySessionsRepository()
+    balancer = LoadBalancer(lambda: _repositories(accounts_repo, usage_repo, sticky_repo))
+    balancer._selection_inputs_cache = cache
+    return balancer, accounts_repo, usage_repo, sticky_repo
+
+
+async def _select_with_lease(balancer: LoadBalancer, *, sticky: bool) -> AccountSelection:
+    return await balancer.select_account(
+        "contract-session" if sticky else None,
+        sticky_kind=StickySessionKind.PROMPT_CACHE if sticky else None,
+        sticky_max_age_seconds=600 if sticky else None,
+        routing_strategy="usage_weighted",
+        lease_kind="stream",
+        estimated_lease_tokens=42.0,
+        concurrency_caps=_CONCURRENCY_CAPS,
+    )
+
+
+@pytest.mark.asyncio
+async def test_public_selection_returns_a_detached_success(selection_cache: AccountSelectionCache) -> None:
+    persisted = _account("contract-success")
+    balancer, _, _, _ = _balancer([persisted], selection_cache)
+
+    selection = await balancer.select_account(routing_strategy="usage_weighted")
+
+    assert selection.account is not None
+    assert selection.account.id == persisted.id
+    assert selection.account is not persisted
+    assert selection.error_message is None
+    assert selection.error_code is None
+    assert selection.lease is None
+
+    selection.account.email = "mutated@example.com"
+    assert persisted.email == "contract-success@example.com"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("gate", ["scope", "exclusion", "security"])
+async def test_public_selection_applies_candidate_gates(
+    selection_cache: AccountSelectionCache,
+    gate: str,
+) -> None:
+    ordinary = _account("contract-ordinary")
+    authorized = _account("contract-authorized", security_work_authorized=True)
+    primary = {
+        ordinary.id: _usage_row(10, ordinary.id, window="primary", used_percent=5.0),
+        authorized.id: _usage_row(11, authorized.id, window="primary", used_percent=60.0),
+    }
+    secondary = {
+        ordinary.id: _usage_row(12, ordinary.id, window="secondary", used_percent=10.0),
+        authorized.id: _usage_row(13, authorized.id, window="secondary", used_percent=10.0),
+    }
+    balancer, _, _, _ = _balancer(
+        [ordinary, authorized],
+        selection_cache,
+        primary=primary,
+        secondary=secondary,
+    )
+
+    unfiltered = await balancer.select_account(routing_strategy="usage_weighted")
+    assert unfiltered.account is not None and unfiltered.account.id == ordinary.id
+
+    if gate == "scope":
+        filtered = await balancer.select_account(
+            account_ids={authorized.id},
+            routing_strategy="usage_weighted",
+        )
+    elif gate == "exclusion":
+        filtered = await balancer.select_account(
+            exclude_account_ids={ordinary.id},
+            routing_strategy="usage_weighted",
+        )
+    else:
+        filtered = await balancer.select_account(
+            require_security_work_authorized=True,
+            routing_strategy="usage_weighted",
+        )
+
+    assert filtered.account is not None and filtered.account.id == authorized.id
+
+
+@pytest.mark.asyncio
+async def test_public_selection_reports_an_empty_security_pool(selection_cache: AccountSelectionCache) -> None:
+    balancer, _, _, _ = _balancer([_account("contract-unauthorized")], selection_cache)
+
+    selection = await balancer.select_account(require_security_work_authorized=True)
+
+    assert selection.account is None
+    assert selection.error_code == "no_security_work_authorized_accounts"
+    assert selection.error_message == "No accounts marked as authorized for security work"
+
+
+@pytest.mark.asyncio
+async def test_public_selection_prefers_the_primary_budget_safe_account(
+    selection_cache: AccountSelectionCache,
+) -> None:
+    budget_safe = _account("contract-budget-safe")
+    primary_pressured = _account("contract-primary-pressured")
+    primary = {
+        budget_safe.id: _usage_row(20, budget_safe.id, window="primary", used_percent=10.0),
+        primary_pressured.id: _usage_row(21, primary_pressured.id, window="primary", used_percent=60.0),
+    }
+    secondary = {
+        budget_safe.id: _usage_row(22, budget_safe.id, window="secondary", used_percent=80.0),
+        primary_pressured.id: _usage_row(23, primary_pressured.id, window="secondary", used_percent=5.0),
+    }
+    balancer, _, _, _ = _balancer(
+        [budget_safe, primary_pressured],
+        selection_cache,
+        primary=primary,
+        secondary=secondary,
+    )
+
+    selection = await balancer.select_account(
+        routing_strategy="usage_weighted",
+        budget_threshold_pct=50.0,
+    )
+
+    assert selection.account is not None
+    assert selection.account.id == budget_safe.id
+
+
+@pytest.mark.asyncio
+async def test_selection_cache_is_scoped_by_account_ids_and_service_tier(
+    selection_cache: AccountSelectionCache,
+) -> None:
+    account_a = _account("contract-cache-a")
+    account_b = _account("contract-cache-b")
+    balancer, accounts_repo, _, _ = _balancer([account_a, account_b], selection_cache)
+
+    first_a = await balancer._load_selection_inputs(model=None, account_ids={account_a.id})
+    second_a = await balancer._load_selection_inputs(model=None, account_ids={account_a.id})
+    only_b = await balancer._load_selection_inputs(model=None, account_ids={account_b.id})
+    flex_b = await balancer._load_selection_inputs(
+        model=None,
+        service_tier="flex",
+        account_ids={account_b.id},
+    )
+    cached_flex_b = await balancer._load_selection_inputs(
+        model=None,
+        service_tier="flex",
+        account_ids={account_b.id},
+    )
+    priority_b = await balancer._load_selection_inputs(
+        model=None,
+        service_tier="priority",
+        account_ids={account_b.id},
+    )
+    cached_priority_b = await balancer._load_selection_inputs(
+        model=None,
+        service_tier="priority",
+        account_ids={account_b.id},
+    )
+
+    assert [account.id for account in first_a.accounts] == [account_a.id]
+    assert [account.id for account in second_a.accounts] == [account_a.id]
+    assert [account.id for account in only_b.accounts] == [account_b.id]
+    assert [account.id for account in flex_b.accounts] == [account_b.id]
+    assert [account.id for account in cached_flex_b.accounts] == [account_b.id]
+    assert [account.id for account in priority_b.accounts] == [account_b.id]
+    assert [account.id for account in cached_priority_b.accounts] == [account_b.id]
+    assert accounts_repo.list_calls == 4
+
+
+@pytest.mark.asyncio
+async def test_cached_selection_inputs_are_mutation_isolated(selection_cache: AccountSelectionCache) -> None:
+    account = _account("contract-clone")
+    primary = _usage_row(1, account.id, window="primary", used_percent=10.0)
+    secondary = _usage_row(2, account.id, window="secondary", used_percent=20.0)
+    monthly = _usage_row(3, account.id, window="monthly", used_percent=30.0)
+    balancer, _, usage_repo, _ = _balancer(
+        [account],
+        selection_cache,
+        primary={account.id: primary},
+        secondary={account.id: secondary},
+        monthly={account.id: monthly},
+    )
+
+    first = await balancer._load_selection_inputs(model=None)
+    first.accounts[0].status = AccountStatus.PAUSED
+    first.latest_primary[account.id].used_percent = 91.0
+    assert first.runtime_accounts is not None
+    first.runtime_accounts[0].status = AccountStatus.DEACTIVATED
+
+    second = await balancer._load_selection_inputs(model=None)
+    assert second.accounts[0].status == AccountStatus.ACTIVE
+    assert second.latest_primary[account.id].used_percent == 10.0
+    assert second.runtime_accounts is not None
+    assert second.runtime_accounts[0].status == AccountStatus.ACTIVE
+
+    second.accounts[0].status = AccountStatus.PAUSED
+    second.latest_secondary[account.id].used_percent = 92.0
+    second.latest_monthly[account.id].used_percent = 93.0
+
+    third = await balancer._load_selection_inputs(model=None)
+    assert third.accounts[0].status == AccountStatus.ACTIVE
+    assert third.latest_primary[account.id].used_percent == 10.0
+    assert third.latest_secondary[account.id].used_percent == 20.0
+    assert third.latest_monthly[account.id].used_percent == 30.0
+    assert usage_repo.calls == {"primary": 1, "secondary": 1, "monthly": 1}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sticky", [False, True], ids=["non-sticky", "sticky"])
+async def test_selection_releases_lease_when_persistence_fails(
+    selection_cache: AccountSelectionCache,
+    monkeypatch: pytest.MonkeyPatch,
+    sticky: bool,
+) -> None:
+    account = _account(f"contract-failure-{sticky}")
+    balancer, _, _, sticky_repo = _balancer([account], selection_cache)
+    persist_calls = 0
+
+    async def fail_persist(*_args: Any, **_kwargs: Any) -> set[str]:
+        nonlocal persist_calls
+        persist_calls += 1
+        assert await balancer.account_pressure_snapshot(account.id) == (0, 1, 42.0)
+        raise RuntimeError("persistence failed")
+
+    monkeypatch.setattr(balancer, "_persist_selection_state", fail_persist)
+
+    with pytest.raises(RuntimeError, match="persistence failed"):
+        await _select_with_lease(balancer, sticky=sticky)
+
+    assert persist_calls == 1
+    assert sticky_repo.get_calls == (1 if sticky else 0)
+    assert len(sticky_repo.upserts) == (1 if sticky else 0)
+    assert await balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sticky", [False, True], ids=["non-sticky", "sticky"])
+async def test_selection_releases_lease_when_persistence_is_cancelled(
+    selection_cache: AccountSelectionCache,
+    monkeypatch: pytest.MonkeyPatch,
+    sticky: bool,
+) -> None:
+    account = _account(f"contract-cancel-{sticky}")
+    balancer, _, _, sticky_repo = _balancer([account], selection_cache)
+    persist_started = asyncio.Event()
+    persist_blocker = asyncio.Event()
+
+    async def block_persist(*_args: Any, **_kwargs: Any) -> set[str]:
+        assert await balancer.account_pressure_snapshot(account.id) == (0, 1, 42.0)
+        persist_started.set()
+        await persist_blocker.wait()
+        return set()
+
+    monkeypatch.setattr(balancer, "_persist_selection_state", block_persist)
+
+    selection_task = asyncio.create_task(_select_with_lease(balancer, sticky=sticky))
+    await asyncio.wait_for(persist_started.wait(), timeout=2.0)
+    assert selection_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await selection_task
+
+    assert selection_task.cancelled()
+    assert sticky_repo.get_calls == (1 if sticky else 0)
+    assert len(sticky_repo.upserts) == (1 if sticky else 0)
+    assert await balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sticky", [False, True], ids=["non-sticky", "sticky"])
+async def test_stale_selection_retries_do_not_leak_leases(
+    selection_cache: AccountSelectionCache,
+    monkeypatch: pytest.MonkeyPatch,
+    sticky: bool,
+) -> None:
+    account = _account(f"contract-stale-{sticky}")
+    balancer, _, _, sticky_repo = _balancer([account], selection_cache)
+    original_load = balancer._load_selection_inputs
+    load_spy = AsyncMock(side_effect=original_load)
+    monkeypatch.setattr(balancer, "_load_selection_inputs", load_spy)
+    persist_calls = 0
+
+    async def always_stale(*_args: Any, **_kwargs: Any) -> set[str]:
+        nonlocal persist_calls
+        persist_calls += 1
+        assert await balancer.account_pressure_snapshot(account.id) == (0, 1, 42.0)
+        return {account.id}
+
+    monkeypatch.setattr(balancer, "_persist_selection_state", always_stale)
+
+    selection = await _select_with_lease(balancer, sticky=sticky)
+
+    assert persist_calls == 4
+    assert load_spy.await_count == 4
+    assert selection.account is None
+    assert selection.lease is None
+    assert sticky_repo.get_calls == (4 if sticky else 0)
+    assert len(sticky_repo.upserts) == (4 if sticky else 0)
+    assert await balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
+
+    replacement = await balancer.acquire_account_lease(
+        account.id,
+        kind="stream",
+        concurrency_caps=_CONCURRENCY_CAPS,
+    )
+    assert replacement is not None
+    await balancer.release_account_lease(replacement)
+    assert await balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)

--- a/tests/unit/test_load_balancer_contract.py
+++ b/tests/unit/test_load_balancer_contract.py
@@ -133,7 +133,6 @@ class _StickySessionsRepository:
     def __init__(self) -> None:
         self.account_id: str | None = None
         self.get_calls = 0
-        self.upserts: list[StickySession] = []
 
     async def get_account_id(self, *args: Any, **kwargs: Any) -> str | None:
         del args, kwargs
@@ -148,9 +147,7 @@ class _StickySessionsRepository:
         kind: StickySessionKind,
     ) -> StickySession:
         self.account_id = account_id
-        row = StickySession(key=key, account_id=account_id, kind=kind)
-        self.upserts.append(row)
-        return row
+        return StickySession(key=key, account_id=account_id, kind=kind)
 
     async def delete(self, *args: Any, **kwargs: Any) -> bool:
         del args, kwargs
@@ -410,7 +407,6 @@ async def test_selection_releases_lease_when_persistence_fails(
 
     assert persist_calls == 1
     assert sticky_repo.get_calls == (1 if sticky else 0)
-    assert len(sticky_repo.upserts) == (1 if sticky else 0)
     assert await balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
 
 
@@ -443,7 +439,6 @@ async def test_selection_releases_lease_when_persistence_is_cancelled(
 
     assert selection_task.cancelled()
     assert sticky_repo.get_calls == (1 if sticky else 0)
-    assert len(sticky_repo.upserts) == (1 if sticky else 0)
     assert await balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
 
 
@@ -476,7 +471,6 @@ async def test_stale_selection_retries_do_not_leak_leases(
     assert selection.account is None
     assert selection.lease is None
     assert sticky_repo.get_calls == (4 if sticky else 0)
-    assert len(sticky_repo.upserts) == (4 if sticky else 0)
     assert await balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
 
     replacement = await balancer.acquire_account_lease(


### PR DESCRIPTION
## Summary

Add hermetic characterization coverage for the current `LoadBalancer` boundary before decomposing it, and add AST-based architecture ratchets that prevent `load_balancer.py` and `LoadBalancer.select_account` from growing beyond the current baselines.

This PR changes no production behavior, public API, schema, configuration, or upstream wire contract.

## Type of change

- [ ] `fix:` — bug fix
- [ ] `feat:` — user-facing capability
- [ ] `refactor:` — internal production refactor
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling or packaging
- [x] `test:` — characterization and architecture-fitness coverage
- [ ] Breaking change

Linked issue: N/A — preparatory coverage for ADR-0001 in `DECISIONS.md`.

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [x] Not applicable — test stabilization and development-tool checks only
- [ ] This PR touches a codex-faithful wire path

Change directory: N/A

Pure test stabilization and development-tool changes are exempt under `.github/CONTRIBUTING.md`. No observable requirement, contract, schema, or behavior changes.

## Changes

- Add 14 hermetic characterization cases covering:
  - detached successful selection and the stable `AccountSelection` result shape;
  - deterministic account-scope, exclusion, and security-work authorization gates;
  - the typed empty-security-pool error contract;
  - public primary-budget-safe policy wiring;
  - selection-cache partitioning by assigned account IDs and by distinct non-null service tiers;
  - mutation isolation for cached accounts and primary, secondary, monthly, and runtime snapshots;
  - stream-lease cleanup after persistence failure on sticky and non-sticky paths;
  - real `Task.cancel()` propagation while persistence is suspended, with lease cleanup on both paths;
  - bounded stale-selection retries without lease leakage, including proof that the sticky repository path ran.
- Add AST-based architecture ratchets for the current base:
  - `app/modules/proxy/load_balancer.py`: 3,021 lines;
  - `LoadBalancer.select_account`: 527 lines.
- Fail closed if the expected class or method cannot be located by the architecture check.
- Leave every production module unchanged.

## Ready for Review verification

- [x] Branch is based on the current `main` (`ahead 1`, `behind 0`).
- [x] Architecture baselines were verified on the current base: `3021` / `527`.
- [x] Focused tests and all static/architecture checks passed on the final head.
- [x] GitHub CI, Simplicity budgets, and current-head Codex review passed.

The ratchet values describe this PR's current base only and do not establish merge ordering for unrelated work.

## Test plan

Focused load-balancer matrix:

```bash
uv run pytest -q \
  tests/unit/test_load_balancer_contract.py \
  tests/unit/test_load_balancer.py \
  tests/unit/test_proxy_load_balancer_refresh.py \
  tests/unit/test_load_balancer_concurrency.py \
  tests/unit/test_select_with_stickiness.py \
  tests/unit/test_hot_path_caches.py \
  tests/unit/test_graceful_degradation.py
```

Result:

```text
406 passed, 3 skipped
```

The three skips predate this branch and document retired T21 race scenarios.

Static and architecture validation:

```bash
uv run ruff check .
uv run ruff format --check .
uv run ty check
uv run python scripts/check_proxy_architecture.py
uv run python .github/scripts/check_simplicity_budgets.py
git diff --check
```

All commands above passed on CPython 3.13.13.

A broader DB-backed unit/integration run was also attempted locally. It timed out in the existing `_reset_db_state` / `aiosqlite` fixture before the first test body; the thread dump showed the fixture awaiting database setup while the aiosqlite worker was idle. This branch changes no database or production code. GitHub CI subsequently passed the complete unit, integration-core, integration-bridge, PostgreSQL, and e2e matrix.

## Screenshots / output

Not applicable — no dashboard or user-visible changes.

## Checklist

- [x] Conventional Commit title
- [x] Readiness checks and rebase policy documented
- [x] Characterization coverage added
- [x] Relevant focused tests and static gates passed
- [ ] Full local CI (DB-backed fixture did not complete locally; GitHub CI is required)
- [x] OpenSpec exemption documented
- [x] Simplicity gates reviewed; no settings, defaults, README, `.env.example`, or dashboard navigation changes
- [x] CHANGELOG not edited