### PR TITLE
fix(http-bridge): wait before retrying model capacity

### DIFF
--- a/app/modules/proxy/_service/http_bridge/owner_forwarding.py
+++ b/app/modules/proxy/_service/http_bridge/owner_forwarding.py
@@ -99,6 +99,7 @@ from app.modules.proxy._service.support import (
     _HTTPBridgeSession,
     _HTTPBridgeSessionKey,
     _signal_propagated_capacity_startup_ready,
+    _signal_propagated_capacity_startup_wait,
 )
 from app.modules.proxy._service.support import (
     _websocket_route_log_kwargs as _websocket_route_log_kwargs,
@@ -402,6 +403,7 @@ class _HTTPBridgeOwnerForwardingMixin:
                 headers=forward_headers,
                 context=forward_context,
                 request_started_at=request_started_at,
+                on_response_wait=_signal_propagated_capacity_startup_wait,
                 on_response_ready=_signal_propagated_capacity_startup_ready,
             ):
                 forwarded_any = True

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -1560,6 +1560,17 @@ class _HTTPBridgeRequestSubmitMixin:
                     request_state.response_create_admission = None
                     await self._release_request_state_account_response_create_lease(request_state)
                     return False
+                async with session.pending_lock:
+                    retry_consumer_attached = (
+                        request_state in session.pending_requests
+                        and request_state.event_queue is not None
+                        and not request_state.draining_until_terminal
+                    )
+                if not retry_consumer_attached:
+                    request_state.response_create_admission.release()
+                    request_state.response_create_admission = None
+                    await self._release_request_state_account_response_create_lease(request_state)
+                    return False
             request_text = self._http_bridge_text_with_account_installation_id(session, request_state, request_text)
             await _send_http_bridge_request_text_with_archive_id(session, request_state, request_text)
             session.last_used_at = _service_time().monotonic()

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -72,6 +72,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_key_strength,
     _http_bridge_precreated_retry_failure_error,
     _http_bridge_prewarm_enabled,
+    _http_bridge_request_budget_seconds,
     _http_bridge_request_counts_against_queue,
     _log_http_bridge_event,
     _record_continuity_fail_closed,
@@ -1395,22 +1396,37 @@ class _HTTPBridgeRequestSubmitMixin:
             logger.warning("HTTP bridge retry on fresh upstream failed", exc_info=True)
             return False
 
-    async def _retry_http_bridge_precreated_request(self: Any, session: "_HTTPBridgeSession") -> bool:
+    async def _retry_http_bridge_precreated_request(
+        self: Any,
+        session: "_HTTPBridgeSession",
+        *,
+        request_state: _WebSocketRequestState | None = None,
+    ) -> bool:
         account_neutral_recovery = is_http_bridge_account_neutral_replay(
             kind=session.key.affinity_kind,
             key=session.key.affinity_key,
         )
         hard_owner_bound = _http_bridge_key_strength(session.key) == "hard"
         async with session.pending_lock:
-            retryable_requests = [
-                request_state
-                for request_state in session.pending_requests
-                if not request_state.draining_until_terminal
-                and _websocket_request_can_replay_before_visible_output(request_state)
-            ]
-            if len(retryable_requests) != 1:
-                return False
-            request_state = retryable_requests[0]
+            if request_state is not None:
+                if (
+                    request_state not in session.pending_requests
+                    or any(pending_request is not request_state for pending_request in session.pending_requests)
+                    or request_state.draining_until_terminal
+                    or not _http_bridge_request_counts_against_queue(request_state)
+                    or not _websocket_request_can_replay_before_visible_output(request_state)
+                ):
+                    return False
+            else:
+                retryable_requests = [
+                    request_state
+                    for request_state in session.pending_requests
+                    if not request_state.draining_until_terminal
+                    and _websocket_request_can_replay_before_visible_output(request_state)
+                ]
+                if len(retryable_requests) != 1:
+                    return False
+                request_state = retryable_requests[0]
             if request_state.previous_response_id is not None and not (
                 request_state.proxy_injected_previous_response_id
                 and request_state.fresh_upstream_request_is_retry_safe
@@ -1517,6 +1533,33 @@ class _HTTPBridgeRequestSubmitMixin:
                     )
                 )
                 request_state.account_response_create_release = self._load_balancer.release_account_lease
+            enforce_capacity_retry_deadline = request_state.response_create_admission_reacquire_required
+            if enforce_capacity_retry_deadline:
+                retry_deadline = request_state.bridge_request_deadline
+                if retry_deadline is None:
+                    retry_deadline = request_state.started_at + _http_bridge_request_budget_seconds(
+                        _service_get_settings()
+                    )
+                remaining_retry_budget_seconds = retry_deadline - _service_time().monotonic()
+                if remaining_retry_budget_seconds <= 0:
+                    request_state.response_create_admission_reacquire_required = False
+                    await self._release_request_state_account_response_create_lease(request_state)
+                    return False
+                try:
+                    request_state.response_create_admission = await asyncio.wait_for(
+                        self._get_work_admission().acquire_response_create(),
+                        timeout=remaining_retry_budget_seconds,
+                    )
+                except TimeoutError:
+                    request_state.response_create_admission_reacquire_required = False
+                    await self._release_request_state_account_response_create_lease(request_state)
+                    return False
+                request_state.response_create_admission_reacquire_required = False
+                if _service_time().monotonic() >= retry_deadline:
+                    request_state.response_create_admission.release()
+                    request_state.response_create_admission = None
+                    await self._release_request_state_account_response_create_lease(request_state)
+                    return False
             request_text = self._http_bridge_text_with_account_installation_id(session, request_state, request_text)
             await _send_http_bridge_request_text_with_archive_id(session, request_state, request_text)
             session.last_used_at = _service_time().monotonic()

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -310,8 +310,13 @@ async def _iter_account_capacity_wait_sse(
     reason: str | None,
     sleep_seconds: float,
     emit_keepalives: bool,
+    request_state: _WebSocketRequestState | None = None,
 ) -> AsyncIterator[str]:
     if not emit_keepalives:
+        if request_state is not None and request_state.capacity_startup_ready_event is not None:
+            request_state.capacity_startup_ready_event.clear()
+        if request_state is not None and request_state.capacity_startup_wait_event is not None:
+            request_state.capacity_startup_wait_event.set()
         _signal_propagated_capacity_startup_wait()
     wait_started_at = _service_time().monotonic()
     remaining_sleep_seconds = sleep_seconds
@@ -519,6 +524,8 @@ class _HTTPBridgeStreamingMixin:
         forwarded_file_owner_account_id: str | None = None,
         client_ip: str | None = None,
         enforce_openai_sdk_contract: bool = True,
+        capacity_startup_wait_event: asyncio.Event | None = None,
+        capacity_startup_ready_event: asyncio.Event | None = None,
     ) -> AsyncIterator[str]:
         _maybe_log_proxy_request_payload("stream_http", payload, headers)
         proxy_api_authorization = _header_value_case_insensitive(headers, "authorization")
@@ -542,6 +549,8 @@ class _HTTPBridgeStreamingMixin:
             forwarded_file_owner_account_id=forwarded_file_owner_account_id,
             client_ip=client_ip,
             enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+            capacity_startup_wait_event=capacity_startup_wait_event,
+            capacity_startup_ready_event=capacity_startup_ready_event,
         )
 
     async def _stream_http_bridge_or_retry(
@@ -565,6 +574,8 @@ class _HTTPBridgeStreamingMixin:
         forwarded_file_owner_account_id: str | None = None,
         client_ip: str | None = None,
         enforce_openai_sdk_contract: bool = True,
+        capacity_startup_wait_event: asyncio.Event | None = None,
+        capacity_startup_ready_event: asyncio.Event | None = None,
     ) -> AsyncIterator[str]:
         dashboard_settings = await _service_get_settings_cache().get()
         runtime_config = _http_bridge_runtime_config(dashboard_settings, _service_get_settings())
@@ -652,6 +663,8 @@ class _HTTPBridgeStreamingMixin:
                 rewritten_file_account_id=rewritten_file_account_id,
                 client_ip=client_ip,
                 enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+                capacity_startup_wait_event=capacity_startup_wait_event,
+                capacity_startup_ready_event=capacity_startup_ready_event,
             ):
                 yield line
         finally:
@@ -687,6 +700,8 @@ class _HTTPBridgeStreamingMixin:
         rewritten_file_account_id: str | None = None,
         client_ip: str | None = None,
         enforce_openai_sdk_contract: bool = True,
+        capacity_startup_wait_event: asyncio.Event | None = None,
+        capacity_startup_ready_event: asyncio.Event | None = None,
     ) -> AsyncIterator[str]:
         del suppress_text_done_events
         request_id = ensure_request_id()
@@ -710,7 +725,7 @@ class _HTTPBridgeStreamingMixin:
             reservation: ApiKeyUsageReservationData | None = api_key_reservation,
         ) -> tuple[_WebSocketRequestState, str]:
             if bridge_uses_responses_lite:
-                return self._prepare_http_bridge_request(
+                request_state, text_data = self._prepare_http_bridge_request(
                     request_payload,
                     headers,
                     api_key=api_key,
@@ -719,14 +734,18 @@ class _HTTPBridgeStreamingMixin:
                     client_ip=client_ip,
                     preserve_responses_lite_client_metadata=True,
                 )
-            return self._prepare_http_bridge_request(
-                request_payload,
-                headers,
-                api_key=api_key,
-                api_key_reservation=reservation,
-                request_id=request_id,
-                client_ip=client_ip,
-            )
+            else:
+                request_state, text_data = self._prepare_http_bridge_request(
+                    request_payload,
+                    headers,
+                    api_key=api_key,
+                    api_key_reservation=reservation,
+                    request_id=request_id,
+                    client_ip=client_ip,
+                )
+            request_state.capacity_startup_wait_event = capacity_startup_wait_event
+            request_state.capacity_startup_ready_event = capacity_startup_ready_event
+            return request_state, text_data
 
         incoming_turn_state_header = _sticky_key_from_turn_state_header(headers) if not forwarded_request else None
         incoming_session_header = _sticky_key_from_session_header(headers) if not forwarded_request else None
@@ -1324,6 +1343,7 @@ class _HTTPBridgeStreamingMixin:
                             reason=message,
                             sleep_seconds=bounded_wait_seconds,
                             emit_keepalives=not propagate_http_errors,
+                            request_state=request_state,
                         ):
                             yield line
                         if _service_time().monotonic() >= request_deadline:
@@ -1572,6 +1592,7 @@ class _HTTPBridgeStreamingMixin:
                             reason=message,
                             sleep_seconds=bounded_wait_seconds,
                             emit_keepalives=not propagate_http_errors,
+                            request_state=request_state,
                         ):
                             yield line
                         if _service_time().monotonic() >= request_deadline:
@@ -1997,6 +2018,7 @@ class _HTTPBridgeStreamingMixin:
                             reason=message,
                             sleep_seconds=bounded_wait_seconds,
                             emit_keepalives=not propagate_http_errors,
+                            request_state=request_state,
                         ):
                             yield line
                         if _service_time().monotonic() >= request_deadline:
@@ -2100,6 +2122,7 @@ class _HTTPBridgeStreamingMixin:
                             reason=message,
                             sleep_seconds=bounded_wait_seconds,
                             emit_keepalives=not propagate_http_errors,
+                            request_state=request_state,
                         ):
                             yield line
                         if _service_time().monotonic() >= request_deadline:
@@ -2289,6 +2312,7 @@ class _HTTPBridgeStreamingMixin:
                         reason=message,
                         sleep_seconds=bounded_wait_seconds,
                         emit_keepalives=not propagate_http_errors,
+                        request_state=request_state,
                     ):
                         yield line
                     if _service_time().monotonic() >= request_deadline:
@@ -2409,6 +2433,7 @@ class _HTTPBridgeStreamingMixin:
             kind=session.key.affinity_kind,
             key=session.key.affinity_key,
         )
+        request_state.propagate_http_errors = propagate_http_errors
         while True:
             try:
                 if account_neutral_recovery:
@@ -2472,6 +2497,7 @@ class _HTTPBridgeStreamingMixin:
                         reason=message,
                         sleep_seconds=bounded_wait_seconds,
                         emit_keepalives=not propagate_http_errors,
+                        request_state=request_state,
                     ):
                         yield line
                 finally:
@@ -2488,6 +2514,10 @@ class _HTTPBridgeStreamingMixin:
             if downstream_turn_state is not None and not account_neutral_recovery:
                 await self._register_http_bridge_turn_state(session, downstream_turn_state)
             _signal_propagated_capacity_startup_ready()
+            if request_state.capacity_startup_wait_event is not None:
+                request_state.capacity_startup_wait_event.clear()
+            if request_state.capacity_startup_ready_event is not None:
+                request_state.capacity_startup_ready_event.set()
             event_queue = request_state.event_queue
             assert event_queue is not None
             yielded_any = False
@@ -2515,6 +2545,8 @@ class _HTTPBridgeStreamingMixin:
                     except asyncio.TimeoutError:
                         if request_state.account_capacity_waiting:
                             keepalive_count = 0
+                            if request_state.account_capacity_wait_suppress_keepalive:
+                                continue
                             keepalive_sent = True
                             yielded_any = True
                             downstream_response_id = _websocket_downstream_response_id(request_state)

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -883,7 +883,9 @@ class _HTTPBridgeUpstreamEventsMixin:
                     matched_request_state,
                     event_type=event_type,
                     payload=payload,
-                    has_other_pending_requests=False,
+                    has_other_pending_requests=any(
+                        pending_request is not matched_request_state for pending_request in session.pending_requests
+                    ),
                 )
                 reserve_terminal_for_model_capacity_retry = bool(
                     matched_request_state is not None
@@ -1165,6 +1167,8 @@ class _HTTPBridgeUpstreamEventsMixin:
                         session.queued_request_count += 1
                     status_request_state.awaiting_response_created = True
                     status_request_state.response_id = None
+            if status_request_state.propagate_http_errors:
+                _signal_http_bridge_capacity_startup_wait(status_request_state)
             await self._handle_stream_error(
                 session.account,
                 {"message": retry_error_message or "Upstream error"},

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -879,24 +879,35 @@ class _HTTPBridgeUpstreamEventsMixin:
 
             terminal_request_state = None
             if event_type in {"response.completed", "response.failed", "response.incomplete", "error"}:
-                terminal_request_state = _pop_terminal_websocket_request_state(
-                    session.pending_requests,
-                    response_id=response_id,
-                    fallback_request_state=matched_request_state,
-                    prefer_previous_response_not_found=is_previous_response_not_found_event
-                    or is_missing_tool_output_event,
-                    previous_response_id_hint=previous_response_id_hint,
-                    error_message=error_message,
-                    allow_unanchored_previous_response_error=is_previous_response_not_found_event,
-                    allow_precreated_terminal_fallback=event_type
-                    in {
-                        "response.completed",
-                        "response.failed",
-                        "response.incomplete",
-                        "error",
-                    },
-                    prefer_draining_requests=anonymous_event_prefers_draining,
+                early_retry_error_code = _websocket_precreated_retry_error_code(
+                    matched_request_state,
+                    event_type=event_type,
+                    payload=payload,
+                    has_other_pending_requests=False,
                 )
+                reserve_terminal_for_model_capacity_retry = bool(
+                    matched_request_state is not None
+                    and early_retry_error_code is not None
+                    and early_retry_error_code != _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE
+                    and not is_previous_response_not_found_event
+                    and is_upstream_model_capacity_error(error_message)
+                    and _websocket_request_can_replay_before_visible_output(matched_request_state)
+                )
+                if reserve_terminal_for_model_capacity_retry:
+                    terminal_request_state = matched_request_state
+                else:
+                    terminal_request_state = _pop_terminal_websocket_request_state(
+                        session.pending_requests,
+                        response_id=response_id,
+                        fallback_request_state=matched_request_state,
+                        prefer_previous_response_not_found=is_previous_response_not_found_event
+                        or is_missing_tool_output_event,
+                        previous_response_id_hint=previous_response_id_hint,
+                        error_message=error_message,
+                        allow_unanchored_previous_response_error=is_previous_response_not_found_event,
+                        allow_precreated_terminal_fallback=True,
+                        prefer_draining_requests=anonymous_event_prefers_draining,
+                    )
                 if (
                     matched_request_state is None
                     and terminal_request_state is not None
@@ -913,8 +924,10 @@ class _HTTPBridgeUpstreamEventsMixin:
                     and terminal_request_state.response_id == response_id
                 ):
                     matched_request_state = terminal_request_state
-                if terminal_request_state is not None and _http_bridge_request_counts_against_queue(
-                    terminal_request_state
+                if (
+                    terminal_request_state is not None
+                    and not reserve_terminal_for_model_capacity_retry
+                    and _http_bridge_request_counts_against_queue(terminal_request_state)
                 ):
                     session.queued_request_count = max(0, session.queued_request_count - 1)
                 elif is_previous_response_not_found_event or is_missing_tool_output_event:
@@ -962,7 +975,9 @@ class _HTTPBridgeUpstreamEventsMixin:
                             0,
                             session.queued_request_count - grouped_counted_requests,
                         )
-                has_other_pending_requests = bool(session.pending_requests)
+                has_other_pending_requests = any(
+                    pending_request is not terminal_request_state for pending_request in session.pending_requests
+                )
 
         if len(grouped_previous_response_request_states) > 1:
             session.upstream_control.reconnect_requested = True
@@ -1171,9 +1186,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                     status_request_state.awaiting_response_created = True
                 retry_after_wait = await _wait_before_http_bridge_model_capacity_retry(
                     status_request_state,
-                    emit_keepalives=not (
-                        status_request_state.propagate_http_errors and status_request_state.enforce_openai_sdk_contract
-                    ),
+                    emit_keepalives=not status_request_state.propagate_http_errors,
                     error_message=retry_error_message,
                     cancel_when_detached=True,
                 )

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -109,9 +109,12 @@ from app.modules.proxy._service.observability import (
 )
 from app.modules.proxy._service.support import (
     _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE,
+    _ACCOUNT_SELECTION_RECOVERY_DEFAULT_SLEEP_SECONDS,
+    _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS,
     _HARD_HTTP_BRIDGE_AFFINITY_KINDS,  # noqa: F401
     _PENDING_TOOL_CALL_ITEM_TYPES,
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
+    _account_capacity_wait_payload,
     _clear_websocket_deferred_reasoning_downstream_texts,
     _clear_websocket_precreated_replay_fallback,
     _clear_websocket_request_error_overrides,
@@ -119,6 +122,8 @@ from app.modules.proxy._service.support import (
     _HTTPBridgeSession,
     _pop_websocket_deferred_reasoning_downstream_texts,
     _record_response_event,
+    _signal_propagated_capacity_startup_ready,
+    _signal_propagated_capacity_startup_wait,
     _websocket_request_can_replay_before_visible_output,
     _websocket_should_defer_reasoning_prelude,
     _WebSocketReceiveTimeout,
@@ -163,6 +168,7 @@ from app.modules.proxy.affinity import (
 from app.modules.proxy.continuity import is_http_bridge_account_neutral_replay
 from app.modules.proxy.helpers import (
     _normalize_error_code,
+    is_upstream_model_capacity_error,
 )
 from app.modules.proxy.tool_call_dedupe import (
     mark_duplicate_tool_call_downstream_event,
@@ -282,6 +288,111 @@ _SECURITY_WORK_RETRY_MESSAGE = (
     "Upstream flagged this request as possible cybersecurity work. "
     "codex-lb is retrying on an account marked as authorized for security work."
 )
+
+
+async def _wait_before_http_bridge_model_capacity_retry(
+    request_state: _WebSocketRequestState | None,
+    *,
+    emit_keepalives: bool,
+    error_message: str | None,
+    cancel_when_detached: bool = False,
+) -> bool:
+    if request_state is None or not is_upstream_model_capacity_error(error_message):
+        return True
+
+    deadline = request_state.bridge_request_deadline
+    if deadline is None:
+        deadline = request_state.started_at + _http_bridge_request_budget_seconds(_service_get_settings())
+    remaining_budget_seconds = max(0.0, deadline - _service_time().monotonic())
+    if remaining_budget_seconds <= 0:
+        return False
+
+    sleep_seconds = min(_ACCOUNT_SELECTION_RECOVERY_DEFAULT_SLEEP_SECONDS, remaining_budget_seconds)
+    request_state.account_capacity_waiting = True
+    request_state.account_capacity_wait_reason = error_message
+    request_state.account_capacity_wait_started_at = (
+        request_state.account_capacity_wait_started_at or _service_time().monotonic()
+    )
+    request_state.account_capacity_wait_retry_after_seconds = sleep_seconds
+    request_state.account_capacity_wait_suppress_keepalive = not emit_keepalives
+    if not emit_keepalives:
+        _signal_http_bridge_capacity_startup_wait(request_state)
+    try:
+        remaining_sleep_seconds = sleep_seconds
+        keepalive_countdown_seconds = 0.0
+        while remaining_sleep_seconds > 0:
+            if cancel_when_detached and request_state.event_queue is None:
+                return False
+            if emit_keepalives and keepalive_countdown_seconds <= 0 and request_state.event_queue is not None:
+                await request_state.event_queue.put(
+                    format_sse_event(
+                        _account_capacity_wait_payload(
+                            request_state,
+                            request_id=request_state.request_log_id or request_state.request_id,
+                            reason=error_message,
+                            retry_after_seconds=remaining_sleep_seconds,
+                        )
+                    )
+                )
+                keepalive_countdown_seconds = _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS
+            chunk_seconds = min(
+                remaining_sleep_seconds,
+                (
+                    _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS
+                    if cancel_when_detached
+                    else _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS
+                ),
+            )
+            await asyncio.sleep(chunk_seconds)
+            remaining_sleep_seconds -= chunk_seconds
+            keepalive_countdown_seconds -= chunk_seconds
+        return (
+            not cancel_when_detached or request_state.event_queue is not None
+        ) and _service_time().monotonic() < deadline
+    finally:
+        request_state.account_capacity_waiting = False
+        if emit_keepalives:
+            request_state.account_capacity_wait_suppress_keepalive = False
+        request_state.account_capacity_wait_reason = None
+        request_state.account_capacity_wait_retry_after_seconds = None
+
+
+async def _release_http_bridge_model_capacity_retry_admission(
+    request_state: _WebSocketRequestState,
+) -> None:
+    """Release shared capacity while retaining the session create gate."""
+    if request_state.response_create_admission is not None:
+        request_state.response_create_admission.release()
+        request_state.response_create_admission = None
+        request_state.response_create_admission_reacquire_required = True
+    account_response_create_lease = request_state.account_response_create_lease
+    account_response_create_release = request_state.account_response_create_release
+    request_state.account_response_create_lease = None
+    request_state.account_response_create_release = None
+    if account_response_create_lease is not None and account_response_create_release is not None:
+        await account_response_create_release(account_response_create_lease)
+
+
+def _signal_http_bridge_model_capacity_retry_ready(
+    request_state: _WebSocketRequestState,
+    *,
+    waited_for_model_capacity_retry: bool,
+    retried: bool,
+) -> None:
+    if waited_for_model_capacity_retry and retried and request_state.propagate_http_errors:
+        if request_state.capacity_startup_wait_event is not None:
+            request_state.capacity_startup_wait_event.clear()
+        if request_state.capacity_startup_ready_event is not None:
+            request_state.capacity_startup_ready_event.set()
+        _signal_propagated_capacity_startup_ready()
+
+
+def _signal_http_bridge_capacity_startup_wait(request_state: _WebSocketRequestState) -> None:
+    if request_state.capacity_startup_ready_event is not None:
+        request_state.capacity_startup_ready_event.clear()
+    if request_state.capacity_startup_wait_event is not None:
+        request_state.capacity_startup_wait_event.set()
+    _signal_propagated_capacity_startup_wait()
 
 
 def _archive_http_bridge_upstream_text(
@@ -986,6 +1097,15 @@ class _HTTPBridgeUpstreamEventsMixin:
             event_type=event_type,
             payload=payload,
         )
+        retry_error_message = _websocket_event_error_message(event_type, payload)
+        wait_for_model_capacity_retry = bool(
+            retry_error_code is not None
+            and retry_error_code != _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE
+            and not is_previous_response_not_found_event
+            and status_request_state is not None
+            and is_upstream_model_capacity_error(retry_error_message)
+            and _websocket_request_can_replay_before_visible_output(status_request_state)
+        )
         if (
             auth_error_code is not None
             and not is_previous_response_not_found_event
@@ -1017,10 +1137,90 @@ class _HTTPBridgeUpstreamEventsMixin:
                         payload,
                         event_type,
                     ) = _build_stream_incomplete_terminal_event_for_request(status_request_state)
+        elif wait_for_model_capacity_retry and status_request_state is not None and retry_error_code is not None:
+            # Reserve the terminal request again before any await so a younger
+            # submit cannot claim its queue slot while account health is being
+            # updated. A concurrent detach will mark this state as draining.
+            retry_consumer_attached = False
+            async with session.pending_lock:
+                if status_request_state.event_queue is not None:
+                    retry_consumer_attached = True
+                    if status_request_state not in session.pending_requests:
+                        session.pending_requests.appendleft(status_request_state)
+                        session.queued_request_count += 1
+                    status_request_state.awaiting_response_created = True
+                    status_request_state.response_id = None
+            await self._handle_stream_error(
+                session.account,
+                {"message": retry_error_message or "Upstream error"},
+                retry_error_code,
+            )
+            setattr(status_request_state, "account_health_error_handled", True)
+            retry_consumer_attached = (
+                retry_consumer_attached
+                and status_request_state.event_queue is not None
+                and not status_request_state.draining_until_terminal
+            )
+            if retry_consumer_attached:
+                wait_request_had_event_queue = True
+                if (
+                    status_request_state.response_create_admission is not None
+                    or status_request_state.account_response_create_lease is not None
+                ):
+                    await _release_http_bridge_model_capacity_retry_admission(status_request_state)
+                    status_request_state.awaiting_response_created = True
+                retry_after_wait = await _wait_before_http_bridge_model_capacity_retry(
+                    status_request_state,
+                    emit_keepalives=not (
+                        status_request_state.propagate_http_errors and status_request_state.enforce_openai_sdk_contract
+                    ),
+                    error_message=retry_error_message,
+                    cancel_when_detached=True,
+                )
+                if wait_request_had_event_queue and status_request_state.event_queue is None:
+                    retry_after_wait = False
+                suppress_capacity_keepalives_until_retry_finishes = (
+                    status_request_state.account_capacity_wait_suppress_keepalive
+                )
+                try:
+                    retried = retry_after_wait and await self._retry_http_bridge_precreated_request(
+                        session,
+                        request_state=status_request_state,
+                    )
+                    if retried:
+                        _signal_http_bridge_model_capacity_retry_ready(
+                            status_request_state,
+                            waited_for_model_capacity_retry=True,
+                            retried=True,
+                        )
+                        return
+                finally:
+                    if suppress_capacity_keepalives_until_retry_finishes:
+                        status_request_state.account_capacity_wait_suppress_keepalive = False
+                async with session.pending_lock:
+                    if status_request_state in session.pending_requests:
+                        session.pending_requests.remove(status_request_state)
+                        if _http_bridge_request_counts_against_queue(status_request_state):
+                            session.queued_request_count = max(0, session.queued_request_count - 1)
+                if retry_after_wait or not status_request_state.propagate_http_errors:
+                    status_request_state.error_http_status_override = 502
+                    (
+                        _downstream_text,
+                        event_block,
+                        event,
+                        payload,
+                        event_type,
+                    ) = _build_stream_incomplete_terminal_event_for_request(status_request_state)
+            else:
+                async with session.pending_lock:
+                    if status_request_state in session.pending_requests:
+                        session.pending_requests.remove(status_request_state)
+                        if _http_bridge_request_counts_against_queue(status_request_state):
+                            session.queued_request_count = max(0, session.queued_request_count - 1)
         elif owner_pinned_quota_error is not None and not is_previous_response_not_found_event:
             await self._handle_stream_error(
                 session.account,
-                {"message": _websocket_event_error_message(event_type, payload) or "Upstream error"},
+                {"message": retry_error_message or "Upstream error"},
                 owner_pinned_quota_error,
             )
             if status_request_state is not None:
@@ -1146,7 +1346,7 @@ class _HTTPBridgeUpstreamEventsMixin:
         ):
             await self._handle_stream_error(
                 session.account,
-                {"message": _websocket_event_error_message(event_type, payload) or "Upstream error"},
+                {"message": retry_error_message or "Upstream error"},
                 retry_error_code,
             )
             if status_request_state is not None:

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -779,6 +779,7 @@ class _WebSocketRequestState:
     transport: str = _REQUEST_TRANSPORT_WEBSOCKET
     upstream_transport: str | None = _REQUEST_TRANSPORT_WEBSOCKET
     enforce_openai_sdk_contract: bool = True
+    propagate_http_errors: bool = False
     request_kind: str = "normal"
     generate_false_prewarm: bool = False
     api_key: ApiKeyData | None = None
@@ -839,6 +840,7 @@ class _WebSocketRequestState:
     response_create_gate_acquired: bool = False
     response_create_gate: asyncio.Semaphore | None = None
     response_create_admission: AdmissionLease | None = None
+    response_create_admission_reacquire_required: bool = False
     account_response_create_lease: AccountLease | None = None
     account_response_create_release: Callable[[AccountLease | None], Coroutine[Any, Any, None]] | None = None
     websocket_stream_lease: AccountLease | None = None
@@ -871,9 +873,12 @@ class _WebSocketRequestState:
     replay_downstream_response_id: str | None = None
     draining_until_terminal: bool = False
     account_capacity_waiting: bool = False
+    account_capacity_wait_suppress_keepalive: bool = False
     account_capacity_wait_reason: str | None = None
     account_capacity_wait_started_at: float | None = None
     account_capacity_wait_retry_after_seconds: float | None = None
+    capacity_startup_wait_event: asyncio.Event | None = None
+    capacity_startup_ready_event: asyncio.Event | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -4950,6 +4950,8 @@ async def _stream_responses(
         finally:
             if owns_reservation:
                 await _release_reservation(reservation)
+    capacity_wait_event = asyncio.Event()
+    capacity_ready_event = _CapacityStartupReadyEvent()
     payload.stream = True
     if prefer_http_bridge:
         stream = context.service.stream_http_responses(
@@ -4970,6 +4972,8 @@ async def _stream_responses(
             forwarded_file_owner_account_id=forwarded_file_owner_account_id,
             client_ip=client_ip,
             enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+            capacity_startup_wait_event=capacity_wait_event,
+            capacity_startup_ready_event=capacity_ready_event,
         )
     else:
         stream = context.service.stream_responses(
@@ -4984,8 +4988,6 @@ async def _stream_responses(
             client_ip=client_ip,
             enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         )
-    capacity_wait_event = asyncio.Event()
-    capacity_ready_event = _CapacityStartupReadyEvent()
     capacity_wait_token = _bind_propagated_capacity_startup_wait(capacity_wait_event)
     capacity_ready_token = _bind_propagated_capacity_startup_ready(capacity_ready_event)
     try:

--- a/app/modules/proxy/http_bridge_forwarding.py
+++ b/app/modules/proxy/http_bridge_forwarding.py
@@ -123,6 +123,7 @@ class HTTPBridgeOwnerClient:
         headers: Mapping[str, str],
         context: HTTPBridgeForwardContext,
         request_started_at: float,
+        on_response_wait: Callable[[], None] | None = None,
         on_response_ready: Callable[[], None] | None = None,
     ) -> AsyncIterator[str]:
         settings = get_settings()
@@ -130,6 +131,8 @@ class HTTPBridgeOwnerClient:
             connect_timeout_seconds=settings.upstream_connect_timeout_seconds,
             idle_timeout_seconds=settings.stream_idle_timeout_seconds,
         )
+        if on_response_wait is not None:
+            on_response_wait()
         async with aiohttp.ClientSession(timeout=timeout, trust_env=False) as session:
             async with session.post(
                 f"{owner_endpoint}{HTTP_BRIDGE_INTERNAL_FORWARD_PATH}",

--- a/openspec/changes/retry-model-capacity-errors/specs/responses-api-compat/spec.md
+++ b/openspec/changes/retry-model-capacity-errors/specs/responses-api-compat/spec.md
@@ -49,3 +49,59 @@ When upstream returns a temporary model-capacity failure whose message says that
 - **THEN** the proxy MUST settle API-key usage before recording any deferred account-health failure
 - **AND** each exhausted account MUST receive exactly one classified health failure plus one additional failure for every remaining exhausted retry
 - **AND** selecting or exhausting a later account MUST NOT replace, lose, or duplicate an earlier account's deferred failures.
+
+#### Scenario: Classified quota failures still use the model-capacity replay wait
+
+- **WHEN** a replayable pre-created HTTP bridge request receives the selected-model capacity message with a quota or
+  rate-limit error code
+- **THEN** the proxy MUST preserve that quota or rate-limit classification for account health handling
+- **AND** the proxy MUST still apply the model-capacity wait before replaying the request.
+
+### Requirement: HTTP bridge model-capacity retry waits preserve stream contracts
+
+The proxy MUST wait before replaying a pre-created HTTP bridge request with a selected-model capacity failure only
+when the failure happened before any downstream-visible response event and the request is still replayable as a fresh
+request.
+
+#### Scenario: Public propagated-error streams do not receive pre-retry keepalives
+
+- **WHEN** a `/v1/responses`-compatible HTTP bridge stream is configured to propagate startup HTTP errors
+- **AND** upstream returns a selected-model capacity error before `response.created`
+- **THEN** the proxy MUST NOT emit `codex.keepalive` or account-capacity wait events before the retry completes.
+
+#### Scenario: Replay waits remain bounded by the original bridge deadline
+
+- **WHEN** the selected-model capacity error arrives near or after the original bridge request deadline
+- **THEN** the proxy MUST NOT start a fresh upstream replay after that deadline is exhausted.
+
+#### Scenario: Only fresh replayable bridge requests wait
+
+- **WHEN** the selected-model capacity error belongs to an anchored request that cannot be replayed without
+  `previous_response_id`
+- **THEN** the proxy MUST forward the terminal error promptly without sleeping for the model-capacity retry delay.
+
+#### Scenario: Retry-safe injected anchors still wait
+
+- **WHEN** the proxy injected `previous_response_id` and retained a fresh request body that is safe to replay without
+  that anchor
+- **AND** upstream returns a selected-model capacity error before visible output
+- **THEN** the proxy MUST apply the model-capacity wait before stripping the injected anchor and replaying the fresh
+  request.
+
+#### Scenario: Remote-owner relay preserves the hidden startup wait
+
+- **WHEN** an origin replica forwards a bridge request to its remote owner
+- **THEN** the origin MUST keep its startup probe pending until the owner relay returns response headers or a terminal
+  startup error
+- **AND** a selected-model capacity wait on the owner MUST NOT cause the origin to commit HTTP 200 before that wait
+  completes.
+
+#### Scenario: Waiting keeps the retry tied to the pending request
+
+- **WHEN** the proxy waits before replaying a selected-model capacity failure
+- **THEN** the request MUST remain reserved in the bridge pending queue while it waits
+- **AND** the proxy MUST retain the session response-create gate so a younger request cannot enter while the sole
+  upstream reader is sleeping
+- **AND** the proxy MUST release account-level and shared response-create capacity during the wait
+- **AND** the proxy MUST reacquire both capacity leases before sending the replay
+- **AND** the proxy MUST skip the replay if that queued request detaches before the wait completes.

--- a/openspec/changes/retry-model-capacity-errors/tasks.md
+++ b/openspec/changes/retry-model-capacity-errors/tasks.md
@@ -1,9 +1,11 @@
 # Tasks
 
 - [x] Add OpenSpec requirement for model-capacity message retry classification.
+- [x] Add OpenSpec requirement for HTTP bridge model-capacity retry wait contracts.
 - [x] Add shared capacity-message predicate and wire it into failover/retry paths.
 - [x] Document the serialized-event and post-connect no-replay boundaries.
 - [x] Add regressions for the literal Codex capacity message.
 - [x] Cover websocket pre-dispatch connector retry and direct HTTP TLS no-retry boundaries.
 - [x] Preserve per-account post-refresh retry health accounting after usage settlement.
+- [x] Add regressions for the literal Codex capacity message, preserved retry codes, propagated-error streams, deadlines, and anchored requests.
 - [x] Run targeted tests and strict OpenSpec validation.

--- a/tests/unit/test_http_bridge_forwarding.py
+++ b/tests/unit/test_http_bridge_forwarding.py
@@ -1116,7 +1116,7 @@ async def test_owner_forward_uses_direct_session_without_env_proxy(monkeypatch: 
     get_settings.cache_clear()
 
     client = HTTPBridgeOwnerClient()
-    ready_calls: list[bool] = []
+    response_state_calls: list[str] = []
     payload = _payload()
     context = HTTPBridgeForwardContext(
         origin_instance="instance-a",
@@ -1133,14 +1133,15 @@ async def test_owner_forward_uses_direct_session_without_env_proxy(monkeypatch: 
             headers={"Authorization": "Bearer proxy-key"},
             context=context,
             request_started_at=10.0,
-            on_response_ready=lambda: ready_calls.append(True),
+            on_response_wait=lambda: response_state_calls.append("wait"),
+            on_response_ready=lambda: response_state_calls.append("ready"),
         )
     ]
 
     assert len(events) == 1
     assert '"type":"response.failed"' in events[0]
     assert '"code":"stream_incomplete"' in events[0]
-    assert ready_calls == [True]
+    assert response_state_calls == ["wait", "ready"]
     assert captured["trust_env"] is False
     skip_auto_headers = captured["skip_auto_headers"]
     assert isinstance(skip_auto_headers, frozenset)

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -2789,6 +2789,78 @@ async def test_http_bridge_model_capacity_waits_before_retrying_safe_injected_an
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_model_capacity_with_younger_request_releases_failed_queue_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    failed_request = proxy_service._WebSocketRequestState(
+        request_id="req-model-capacity-failed",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        bridge_request_deadline=time.monotonic() + 60.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"first"}',
+    )
+    younger_request = proxy_service._WebSocketRequestState(
+        request_id="req-model-capacity-younger",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        bridge_request_deadline=time.monotonic() + 60.0,
+        awaiting_response_created=False,
+        response_id="resp-model-capacity-younger",
+        event_queue=asyncio.Queue(),
+        transport="http",
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"second"}',
+    )
+    session = _make_bridge_session(
+        key_value="bridge-model-capacity-with-younger-request",
+        pending_requests=deque([younger_request, failed_request]),
+        queued_request_count=2,
+    )
+    wait_before_retry = AsyncMock(return_value=True)
+    retry_precreated = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+    monkeypatch.setattr(
+        http_bridge_upstream_events_module,
+        "_wait_before_http_bridge_model_capacity_retry",
+        wait_before_retry,
+    )
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 400,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "invalid_request_error",
+                    "message": "Selected model is at capacity. Please try a different model.",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    wait_before_retry.assert_not_awaited()
+    retry_precreated.assert_not_awaited()
+    assert list(session.pending_requests) == [younger_request]
+    assert session.queued_request_count == 1
+    assert failed_request.event_queue is not None
+    assert await failed_request.event_queue.get() is not None
+    assert await failed_request.event_queue.get() is None
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_model_capacity_does_not_requeue_after_detach_during_health_update(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2805,6 +2877,8 @@ async def test_http_bridge_model_capacity_does_not_requeue_after_detach_during_h
         event_queue=asyncio.Queue(),
         transport="http",
         propagate_http_errors=True,
+        capacity_startup_wait_event=asyncio.Event(),
+        capacity_startup_ready_event=asyncio.Event(),
         request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
     )
     session = _make_bridge_session(
@@ -2815,6 +2889,10 @@ async def test_http_bridge_model_capacity_does_not_requeue_after_detach_during_h
 
     async def detach_during_health_update(*args: object, **kwargs: object) -> None:
         del args, kwargs
+        assert request_state.capacity_startup_wait_event is not None
+        assert request_state.capacity_startup_wait_event.is_set() is True
+        assert request_state.capacity_startup_ready_event is not None
+        assert request_state.capacity_startup_ready_event.is_set() is False
         assert request_state in session.pending_requests
         assert await service._detach_http_bridge_request(session, request_state=request_state) is True
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -2911,7 +2911,7 @@ async def test_http_bridge_model_capacity_wait_suppresses_keepalive_when_errors_
 
 
 @pytest.mark.asyncio
-async def test_http_bridge_model_capacity_wait_keeps_keepalive_for_non_sdk_propagated_streams(
+async def test_http_bridge_model_capacity_wait_hides_keepalive_for_non_sdk_propagated_streams(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
@@ -2967,12 +2967,7 @@ async def test_http_bridge_model_capacity_wait_keeps_keepalive_for_non_sdk_propa
     )
 
     assert request_state.event_queue is not None
-    keepalive_block = await asyncio.wait_for(request_state.event_queue.get(), timeout=1.0)
-    assert keepalive_block is not None
-    keepalive = proxy_service.parse_sse_data_json(keepalive_block)
-    assert isinstance(keepalive, dict)
-    assert keepalive["status"] == "waiting_for_account_capacity"
-    assert keepalive["request_id"] == "req-model-capacity-propagate-non-sdk"
+    assert request_state.event_queue.empty()
     retry_precreated.assert_awaited_once_with(session, request_state=request_state)
 
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -2617,6 +2617,537 @@ async def test_http_bridge_malformed_tool_lifecycle_persists_unknown_manifest(
     assert registration.kwargs["pending_tool_calls"] is None
 
 
+@pytest.mark.parametrize(
+    ("upstream_code", "expected_retry_error_code"),
+    [
+        ("invalid_request_error", "server_is_overloaded"),
+        ("rate_limit_exceeded", "rate_limit_exceeded"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_http_bridge_model_capacity_waits_before_precreated_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    upstream_code: str,
+    expected_retry_error_code: str,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    handle_stream_error = AsyncMock()
+    retry_precreated = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+    monkeypatch.setattr(
+        http_bridge_upstream_events_module,
+        "_ACCOUNT_SELECTION_RECOVERY_DEFAULT_SLEEP_SECONDS",
+        0.001,
+    )
+    monkeypatch.setattr(
+        http_bridge_upstream_events_module,
+        "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS",
+        0.001,
+    )
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-model-capacity-wait",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        bridge_request_deadline=time.monotonic() + 60.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
+    )
+    session = _make_bridge_session(
+        key_value="bridge-model-capacity-wait",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 400,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": upstream_code,
+                    "message": "Selected model is at capacity. Please try a different model.",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    assert request_state.event_queue is not None
+    keepalive_block = await asyncio.wait_for(request_state.event_queue.get(), timeout=1.0)
+    assert keepalive_block is not None
+    keepalive = proxy_service.parse_sse_data_json(keepalive_block)
+    assert isinstance(keepalive, dict)
+    assert keepalive["status"] == "waiting_for_account_capacity"
+    assert keepalive["request_id"] == "req-model-capacity-wait"
+    assert keepalive["retry_after_seconds"] == 0
+    reason = keepalive["reason"]
+    assert isinstance(reason, str)
+    assert "Selected model is at capacity" in reason
+    handle_stream_error.assert_awaited_once()
+    handle_call = handle_stream_error.await_args
+    assert handle_call is not None
+    assert handle_call.args[2] == expected_retry_error_code
+    retry_precreated.assert_awaited_once_with(session, request_state=request_state)
+    assert request_state in session.pending_requests
+    assert session.queued_request_count == 1
+    assert request_state.account_capacity_waiting is False
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_model_capacity_waits_before_retrying_safe_injected_anchor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    capacity_message = "Selected model is at capacity. Please try a different model."
+    fresh_request_text = '{"type":"response.create","model":"gpt-5.6-sol","input":"full resend"}'
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-model-capacity-injected-anchor",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        bridge_request_deadline=time.monotonic() + 60.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        previous_response_id="resp-proxy-injected",
+        preferred_account_id="acc-owner",
+        proxy_injected_previous_response_id=True,
+        fresh_upstream_request_text=fresh_request_text,
+        fresh_upstream_request_is_retry_safe=True,
+        request_text=(
+            '{"type":"response.create","model":"gpt-5.6-sol",'
+            '"previous_response_id":"resp-proxy-injected","input":"trimmed"}'
+        ),
+    )
+    session = _make_bridge_session(
+        key_value="bridge-model-capacity-injected-anchor",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+    call_order: list[str] = []
+
+    async def wait_before_retry(*args: object, **kwargs: object) -> bool:
+        assert args == (request_state,)
+        assert kwargs == {
+            "emit_keepalives": True,
+            "error_message": capacity_message,
+            "cancel_when_detached": True,
+        }
+        assert request_state.previous_response_id == "resp-proxy-injected"
+        call_order.append("wait")
+        return True
+
+    async def retry_precreated(
+        retry_session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState | None = None,
+    ) -> bool:
+        assert retry_session is session
+        assert request_state is not None
+        assert call_order == ["wait"]
+        call_order.append("retry")
+        return True
+
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+    monkeypatch.setattr(
+        http_bridge_upstream_events_module,
+        "_wait_before_http_bridge_model_capacity_retry",
+        wait_before_retry,
+    )
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 429,
+                "error": {
+                    "type": "rate_limit_error",
+                    "code": "rate_limit_exceeded",
+                    "message": capacity_message,
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    assert call_order == ["wait", "retry"]
+    assert list(session.pending_requests) == [request_state]
+    assert session.queued_request_count == 1
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_model_capacity_does_not_requeue_after_detach_during_health_update(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-model-capacity-detached-during-health",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        bridge_request_deadline=time.monotonic() + 60.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        propagate_http_errors=True,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
+    )
+    session = _make_bridge_session(
+        key_value="bridge-model-capacity-detached-during-health",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+
+    async def detach_during_health_update(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        assert request_state in session.pending_requests
+        assert await service._detach_http_bridge_request(session, request_state=request_state) is True
+
+    wait_before_retry = AsyncMock(return_value=True)
+    retry_precreated = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_handle_stream_error", detach_during_health_update)
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+    monkeypatch.setattr(
+        http_bridge_upstream_events_module,
+        "_wait_before_http_bridge_model_capacity_retry",
+        wait_before_retry,
+    )
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 400,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "invalid_request_error",
+                    "message": "Selected model is at capacity. Please try a different model.",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    wait_before_retry.assert_not_awaited()
+    retry_precreated.assert_not_awaited()
+    assert request_state not in session.pending_requests
+    assert session.queued_request_count == 0
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_model_capacity_wait_suppresses_keepalive_when_errors_propagate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    retry_precreated = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+    monkeypatch.setattr(
+        http_bridge_upstream_events_module,
+        "_ACCOUNT_SELECTION_RECOVERY_DEFAULT_SLEEP_SECONDS",
+        0.001,
+    )
+    monkeypatch.setattr(
+        http_bridge_upstream_events_module,
+        "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS",
+        0.001,
+    )
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-model-capacity-propagate",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        bridge_request_deadline=time.monotonic() + 60.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        propagate_http_errors=True,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
+    )
+    session = _make_bridge_session(
+        key_value="bridge-model-capacity-propagate",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 400,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "invalid_request_error",
+                    "message": "Selected model is at capacity. Please try a different model.",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    assert request_state.event_queue is not None
+    assert request_state.event_queue.empty()
+    retry_precreated.assert_awaited_once_with(session, request_state=request_state)
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_model_capacity_wait_keeps_keepalive_for_non_sdk_propagated_streams(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    retry_precreated = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+    monkeypatch.setattr(
+        http_bridge_upstream_events_module,
+        "_ACCOUNT_SELECTION_RECOVERY_DEFAULT_SLEEP_SECONDS",
+        0.001,
+    )
+    monkeypatch.setattr(
+        http_bridge_upstream_events_module,
+        "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS",
+        0.001,
+    )
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-model-capacity-propagate-non-sdk",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        bridge_request_deadline=time.monotonic() + 60.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        propagate_http_errors=True,
+        enforce_openai_sdk_contract=False,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
+    )
+    session = _make_bridge_session(
+        key_value="bridge-model-capacity-propagate-non-sdk",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 400,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "invalid_request_error",
+                    "message": "Selected model is at capacity. Please try a different model.",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    assert request_state.event_queue is not None
+    keepalive_block = await asyncio.wait_for(request_state.event_queue.get(), timeout=1.0)
+    assert keepalive_block is not None
+    keepalive = proxy_service.parse_sse_data_json(keepalive_block)
+    assert isinstance(keepalive, dict)
+    assert keepalive["status"] == "waiting_for_account_capacity"
+    assert keepalive["request_id"] == "req-model-capacity-propagate-non-sdk"
+    retry_precreated.assert_awaited_once_with(session, request_state=request_state)
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_model_capacity_wait_does_not_retry_after_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    retry_precreated = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-model-capacity-deadline",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        bridge_request_deadline=time.monotonic() - 0.001,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
+    )
+    session = _make_bridge_session(
+        key_value="bridge-model-capacity-deadline",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 400,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "invalid_request_error",
+                    "message": "Selected model is at capacity. Please try a different model.",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    retry_precreated.assert_not_awaited()
+    assert request_state not in session.pending_requests
+    assert session.queued_request_count == 0
+    assert request_state.event_queue is not None
+    terminal_block = await asyncio.wait_for(request_state.event_queue.get(), timeout=1.0)
+    assert terminal_block is not None
+    terminal = proxy_service.parse_sse_data_json(terminal_block)
+    assert isinstance(terminal, dict)
+    assert terminal["type"] == "response.failed"
+    assert await asyncio.wait_for(request_state.event_queue.get(), timeout=1.0) is None
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_model_capacity_wait_skips_sleep_for_non_replayable_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    wait_before_retry = AsyncMock(return_value=True)
+    retry_precreated = AsyncMock(return_value=False)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+    monkeypatch.setattr(
+        http_bridge_upstream_events_module,
+        "_wait_before_http_bridge_model_capacity_retry",
+        wait_before_retry,
+    )
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-model-capacity-not-replayable",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        bridge_request_deadline=time.monotonic() + 60.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
+        replay_count=1,
+    )
+    session = _make_bridge_session(
+        key_value="bridge-model-capacity-not-replayable",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 400,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "invalid_request_error",
+                    "message": "Selected model is at capacity. Please try a different model.",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    wait_before_retry.assert_not_awaited()
+    retry_precreated.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_model_capacity_wait_does_not_delay_anchored_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    retry_precreated = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+    monkeypatch.setattr(
+        http_bridge_upstream_events_module,
+        "_ACCOUNT_SELECTION_RECOVERY_DEFAULT_SLEEP_SECONDS",
+        60.0,
+    )
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-model-capacity-anchored",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        bridge_request_deadline=time.monotonic() + 60.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        previous_response_id="resp_anchor",
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","previous_response_id":"resp_anchor"}',
+    )
+    session = _make_bridge_session(
+        key_value="bridge-model-capacity-anchored",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+
+    started = time.monotonic()
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 400,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "invalid_request_error",
+                    "message": "Selected model is at capacity. Please try a different model.",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    assert time.monotonic() - started < 1.0
+    retry_precreated.assert_not_awaited()
+    assert request_state.event_queue is not None
+    terminal_block = await asyncio.wait_for(request_state.event_queue.get(), timeout=1.0)
+    assert terminal_block is not None
+    terminal = proxy_service.parse_sse_data_json(terminal_block)
+    assert isinstance(terminal, dict)
+    assert terminal["type"] == "response.failed"
+
+
 @pytest.mark.asyncio
 async def test_http_bridge_precreated_completed_terminal_falls_back_to_unresolved_request(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -67,6 +67,7 @@ from app.modules.proxy._service import support as proxy_support
 from app.modules.proxy._service import warmup as proxy_warmup_service
 from app.modules.proxy._service.http_bridge import request_submit as proxy_http_bridge_request_submit
 from app.modules.proxy._service.http_bridge import service_stubs as proxy_http_bridge_service_stubs
+from app.modules.proxy._service.http_bridge import upstream_events as proxy_http_bridge_upstream_events
 from app.modules.proxy._service.streaming import helpers as streaming_helpers_module
 from app.modules.proxy._service.streaming import retry as streaming_retry_module
 from app.modules.proxy._service.support import (
@@ -89,6 +90,7 @@ from app.modules.proxy.load_balancer import (
 )
 from app.modules.proxy.repo_bundle import ProxyRepositories
 from app.modules.proxy.sticky_repository import StickySessionsRepository
+from app.modules.proxy.work_admission import AdmissionLease
 from app.modules.request_logs.repository import PreviousResponseOwnerRecord, RequestLogsRepository
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
 from tests.unit._proxy_test_helpers import runtime_basic_auth_url
@@ -23590,6 +23592,534 @@ async def test_process_upstream_websocket_text_replays_proxy_verified_anchor_aft
 
 
 @pytest.mark.asyncio
+async def test_hidden_http_bridge_model_capacity_wait_signals_startup_probe(monkeypatch):
+    ready_event = asyncio.Event()
+    ready_event.set()
+    wait_event = asyncio.Event()
+    request_ready_event = asyncio.Event()
+    request_ready_event.set()
+    request_wait_event = asyncio.Event()
+    wait_token = proxy_support._bind_propagated_capacity_startup_wait(wait_event)
+    ready_token = proxy_support._bind_propagated_capacity_startup_ready(ready_event)
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_hidden_model_capacity_wait",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        request_text='{"type":"response.create"}',
+        bridge_request_deadline=time.monotonic() + 0.01,
+        capacity_startup_wait_event=request_wait_event,
+        capacity_startup_ready_event=request_ready_event,
+    )
+    monkeypatch.setattr(proxy_http_bridge_upstream_events, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.01)
+
+    try:
+        await proxy_http_bridge_upstream_events._wait_before_http_bridge_model_capacity_retry(
+            request_state,
+            emit_keepalives=False,
+            error_message="Selected model is at capacity. Please try a different model.",
+        )
+    finally:
+        proxy_support._reset_propagated_capacity_startup_ready(ready_token)
+        proxy_support._reset_propagated_capacity_startup_wait(wait_token)
+
+    assert wait_event.is_set() is True
+    assert ready_event.is_set() is False
+    assert request_wait_event.is_set() is True
+    assert request_ready_event.is_set() is False
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_model_capacity_wait_stops_when_request_detaches(monkeypatch):
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_model_capacity_detach_wait",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        request_text='{"type":"response.create"}',
+        bridge_request_deadline=time.monotonic() + 60.0,
+        event_queue=asyncio.Queue(),
+    )
+    monkeypatch.setattr(proxy_http_bridge_upstream_events, "_ACCOUNT_SELECTION_RECOVERY_DEFAULT_SLEEP_SECONDS", 60.0)
+
+    wait_task = asyncio.create_task(
+        proxy_http_bridge_upstream_events._wait_before_http_bridge_model_capacity_retry(
+            request_state,
+            emit_keepalives=False,
+            error_message="Selected model is at capacity. Please try a different model.",
+            cancel_when_detached=True,
+        )
+    )
+    await asyncio.sleep(0)
+    request_state.event_queue = None
+
+    assert await asyncio.wait_for(wait_task, timeout=1.0) is False
+    assert request_state.account_capacity_waiting is False
+
+
+def test_http_bridge_model_capacity_retry_success_signals_startup_ready():
+    ready_event = asyncio.Event()
+    ready_event.set()
+    wait_event = asyncio.Event()
+    request_ready_event = asyncio.Event()
+    request_wait_event = asyncio.Event()
+    wait_token = proxy_support._bind_propagated_capacity_startup_wait(wait_event)
+    ready_token = proxy_support._bind_propagated_capacity_startup_ready(ready_event)
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_model_capacity_ready_after_retry",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        propagate_http_errors=True,
+        bridge_request_deadline=time.monotonic() + 1.0,
+        capacity_startup_wait_event=request_wait_event,
+        capacity_startup_ready_event=request_ready_event,
+    )
+    try:
+        request_wait_event.set()
+        proxy_support._signal_propagated_capacity_startup_wait()
+        assert wait_event.is_set() is True
+        assert ready_event.is_set() is False
+        proxy_http_bridge_upstream_events._signal_http_bridge_model_capacity_retry_ready(
+            request_state,
+            waited_for_model_capacity_retry=True,
+            retried=True,
+        )
+        assert wait_event.is_set() is False
+        assert ready_event.is_set() is True
+        assert request_wait_event.is_set() is False
+        assert request_ready_event.is_set() is True
+    finally:
+        proxy_support._reset_propagated_capacity_startup_ready(ready_token)
+        proxy_support._reset_propagated_capacity_startup_wait(wait_token)
+
+
+@pytest.mark.asyncio
+async def test_hidden_http_bridge_model_capacity_retry_suppresses_reconnect_wait_keepalives(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_bridge_model_capacity_hidden_reconnect")
+    response_create_gate = asyncio.Semaphore(1)
+    await response_create_gate.acquire()
+    response_create_admission_gate = asyncio.Semaphore(0)
+    response_create_admission = AdmissionLease(
+        response_create_admission_gate,
+        stage="response_create",
+        request_id="req_bridge_model_capacity_hidden_reconnect",
+    )
+    account_response_create_lease = AccountLease(
+        lease_id="lease_bridge_model_capacity_hidden_reconnect",
+        account_id=account.id,
+        kind="response_create",
+        acquired_at=time.monotonic(),
+    )
+    account_response_create_release = AsyncMock()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_model_capacity_hidden_reconnect",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        propagate_http_errors=True,
+        bridge_request_deadline=time.monotonic() + 1.0,
+        response_create_gate=response_create_gate,
+        response_create_gate_acquired=True,
+        response_create_admission=response_create_admission,
+        account_response_create_lease=account_response_create_lease,
+        account_response_create_release=account_response_create_release,
+    )
+    upstream = AsyncMock()
+    upstream.archive_received = lambda _message: None
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.6-sol",
+        account=account,
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=response_create_gate,
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    suppress_seen_during_retry: list[bool] = []
+    suppress_seen_during_reconnect_wait: list[bool] = []
+    younger_gate_waiter = asyncio.create_task(response_create_gate.acquire())
+
+    async def retry_precreated(
+        _session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState | None = None,
+    ) -> bool:
+        assert request_state is not None
+        assert request_state.response_create_gate is response_create_gate
+        assert request_state.response_create_gate_acquired is True
+        assert request_state.response_create_admission is None
+        assert request_state.awaiting_response_created is True
+        assert response_create_gate.locked() is True
+        assert younger_gate_waiter.done() is False
+        assert response_create_admission._released is True
+        assert response_create_admission_gate._value == 1
+        account_response_create_release.assert_awaited_once_with(account_response_create_lease)
+        suppress_seen_during_retry.append(request_state.account_capacity_wait_suppress_keepalive)
+        request_state.account_capacity_waiting = True
+        request_state.account_capacity_wait_reason = "alternate account is locally capped"
+        suppress_seen_during_reconnect_wait.append(request_state.account_capacity_wait_suppress_keepalive)
+        await asyncio.sleep(0)
+        request_state.account_capacity_waiting = False
+        request_state.account_capacity_wait_reason = None
+        return True
+
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", AsyncMock())
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+    monkeypatch.setattr(proxy_http_bridge_upstream_events, "_ACCOUNT_SELECTION_RECOVERY_DEFAULT_SLEEP_SECONDS", 0.001)
+    monkeypatch.setattr(proxy_http_bridge_upstream_events, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.001)
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 429,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "server_is_overloaded",
+                    "message": "Selected model is at capacity. Please try a different model.",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    assert suppress_seen_during_retry == [True]
+    assert suppress_seen_during_reconnect_wait == [True]
+    assert request_state.account_capacity_wait_suppress_keepalive is False
+    assert request_state.event_queue is not None
+    assert request_state.event_queue.empty()
+    assert response_create_admission._released is True
+    assert response_create_admission_gate._value == 1
+    account_response_create_release.assert_awaited_once_with(account_response_create_lease)
+    assert request_state.response_create_gate is response_create_gate
+    assert request_state.response_create_gate_acquired is True
+    assert response_create_gate.locked() is True
+    assert younger_gate_waiter.done() is False
+    await proxy_service._release_websocket_response_create_gate(request_state, response_create_gate)
+    await asyncio.wait_for(younger_gate_waiter, timeout=1.0)
+    response_create_gate.release()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_model_capacity_deadline_preserves_propagated_error(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_bridge_model_capacity_deadline")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_model_capacity_deadline",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        propagate_http_errors=True,
+    )
+    upstream = AsyncMock()
+    upstream.archive_received = lambda _message: None
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.6-sol",
+        account=account,
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", AsyncMock())
+    monkeypatch.setattr(
+        proxy_http_bridge_upstream_events,
+        "_wait_before_http_bridge_model_capacity_retry",
+        AsyncMock(return_value=False),
+    )
+    retry_precreated = AsyncMock(side_effect=AssertionError("deadline-exhausted wait must not retry"))
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 429,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "server_is_overloaded",
+                    "message": "Selected model is at capacity. Please try a different model.",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    event_queue = request_state.event_queue
+    assert event_queue is not None
+    forwarded = await asyncio.wait_for(event_queue.get(), timeout=1.0)
+    assert isinstance(forwarded, str)
+    assert "Selected model is at capacity" in forwarded
+    assert "server_is_overloaded" in forwarded
+    assert "stream_incomplete" not in forwarded
+    assert await asyncio.wait_for(event_queue.get(), timeout=1.0) is None
+    assert list(session.pending_requests) == []
+    assert session.queued_request_count == 0
+    retry_precreated.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_model_capacity_detached_waiter_cleanup_keeps_other_queue_slots(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_bridge_model_capacity_detached")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_model_capacity_detached",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        propagate_http_errors=True,
+    )
+    next_request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_model_capacity_next",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","input":"next"}',
+    )
+    upstream = AsyncMock()
+    upstream.archive_received = lambda _message: None
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.6-sol",
+        account=account,
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+
+    async def detach_during_wait(*_args: object, **_kwargs: object) -> bool:
+        request_state.draining_until_terminal = True
+        request_state.event_queue = None
+        session.pending_requests.append(next_request_state)
+        session.queued_request_count = 1
+        return False
+
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", AsyncMock())
+    monkeypatch.setattr(
+        proxy_http_bridge_upstream_events,
+        "_wait_before_http_bridge_model_capacity_retry",
+        detach_during_wait,
+    )
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", AsyncMock())
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 429,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "server_is_overloaded",
+                    "message": "Selected model is at capacity. Please try a different model.",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    assert list(session.pending_requests) == [next_request_state]
+    assert session.queued_request_count == 1
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_model_capacity_wait_retries_only_original_pending_request(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_bridge_model_capacity_original_only")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_model_capacity_original_only",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        propagate_http_errors=True,
+    )
+    next_request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_model_capacity_later",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","input":"later"}',
+    )
+    upstream = AsyncMock()
+    upstream.archive_received = lambda _message: None
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.6-sol",
+        account=account,
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    original_retry = service._retry_http_bridge_precreated_request
+    retry_calls: list[proxy_service._WebSocketRequestState | None] = []
+
+    async def retry_precreated(
+        _session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState | None = None,
+    ) -> bool:
+        retry_calls.append(request_state)
+        return await original_retry(_session, request_state=request_state)
+
+    async def replace_original_during_wait(*_args: object, **_kwargs: object) -> bool:
+        async with session.pending_lock:
+            session.pending_requests.remove(request_state)
+            session.pending_requests.append(next_request_state)
+            session.queued_request_count = 1
+        return True
+
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", AsyncMock())
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+    monkeypatch.setattr(
+        proxy_http_bridge_upstream_events,
+        "_wait_before_http_bridge_model_capacity_retry",
+        replace_original_during_wait,
+    )
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 429,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "server_is_overloaded",
+                    "message": "Selected model is at capacity. Please try a different model.",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    assert retry_calls == [request_state]
+    assert list(session.pending_requests) == [next_request_state]
+    assert session.queued_request_count == 1
+    upstream.send_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_retry_http_bridge_precreated_request_refuses_explicit_retry_with_other_pending_request(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_model_capacity_explicit_retry",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text='{"type":"response.create"}',
+    )
+    younger_request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_model_capacity_younger",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","input":"younger"}',
+    )
+    upstream = AsyncMock()
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-key", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.6-sol",
+        account=_make_account("acc_bridge_model_capacity_explicit_retry"),
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state, younger_request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=2,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    reconnect = AsyncMock(return_value=None)
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
+
+    assert await service._retry_http_bridge_precreated_request(session, request_state=request_state) is False
+
+    reconnect.assert_not_awaited()
+    upstream.send_text.assert_not_awaited()
+    assert list(session.pending_requests) == [request_state, younger_request_state]
+
+
+@pytest.mark.asyncio
 async def test_process_upstream_websocket_text_keeps_file_backed_verified_anchor_owner_bound(
     monkeypatch,
 ):
@@ -36150,6 +36680,13 @@ async def test_retry_http_bridge_precreated_request_reacquires_replacement_respo
     replacement_lease = object()
     release_lease = AsyncMock()
     acquire_lease = AsyncMock(return_value=replacement_lease)
+    replacement_admission_gate = asyncio.Semaphore(0)
+    replacement_admission = AdmissionLease(
+        replacement_admission_gate,
+        stage="response_create",
+        request_id="req_bridge_retry_replacement_lease",
+    )
+    acquire_admission = AsyncMock(return_value=replacement_admission)
     response_create_gate = asyncio.Semaphore(1)
     await response_create_gate.acquire()
     request_state = proxy_service._WebSocketRequestState(
@@ -36159,9 +36696,11 @@ async def test_retry_http_bridge_precreated_request_reacquires_replacement_respo
         reasoning_effort=None,
         api_key_reservation=None,
         started_at=0.0,
+        bridge_request_deadline=time.monotonic() + 60.0,
         awaiting_response_created=True,
         response_create_gate=response_create_gate,
         response_create_gate_acquired=True,
+        response_create_admission_reacquire_required=True,
         request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"retry"}',
     )
     session = proxy_service._HTTPBridgeSession(
@@ -36195,6 +36734,11 @@ async def test_retry_http_bridge_precreated_request_reacquires_replacement_respo
     monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
     monkeypatch.setattr(service, "_acquire_account_response_create_lease_or_overload", acquire_lease)
     monkeypatch.setattr(service._load_balancer, "release_account_lease", release_lease)
+    monkeypatch.setattr(
+        service,
+        "_get_work_admission",
+        lambda: SimpleNamespace(acquire_response_create=acquire_admission),
+    )
 
     assert await service._retry_http_bridge_precreated_request(session) is True
 
@@ -36206,6 +36750,9 @@ async def test_retry_http_bridge_precreated_request_reacquires_replacement_respo
     )
     assert request_state.account_response_create_lease is replacement_lease
     assert request_state.account_response_create_release is release_lease
+    acquire_admission.assert_awaited_once_with()
+    assert request_state.response_create_admission is replacement_admission
+    assert request_state.response_create_admission_reacquire_required is False
     replacement_upstream.send_text.assert_awaited_once_with(request_state.request_text)
 
     await proxy_service._release_websocket_response_create_gate(request_state, response_create_gate)
@@ -36213,6 +36760,150 @@ async def test_retry_http_bridge_precreated_request_reacquires_replacement_respo
     release_lease.assert_awaited_once_with(replacement_lease)
     assert request_state.account_response_create_lease is None
     assert request_state.account_response_create_release is None
+    assert replacement_admission_gate._value == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_http_bridge_precreated_request_does_not_send_after_admission_exhausts_deadline(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_bridge_retry_deadline")
+    upstream = AsyncMock()
+    response_create_gate = asyncio.Semaphore(1)
+    await response_create_gate.acquire()
+    replacement_lease = object()
+    release_lease = AsyncMock()
+    replacement_admission_gate = asyncio.Semaphore(0)
+    replacement_admission = AdmissionLease(
+        replacement_admission_gate,
+        stage="response_create",
+        request_id="req_bridge_retry_deadline",
+    )
+    acquire_admission = AsyncMock(return_value=replacement_admission)
+    retry_times = iter((9.0, 11.0))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_retry_deadline",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        bridge_request_deadline=10.0,
+        awaiting_response_created=True,
+        response_create_gate=response_create_gate,
+        response_create_gate_acquired=True,
+        response_create_admission_reacquire_required=True,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"retry"}',
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-retry-deadline", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.6-sol",
+        account=account,
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=response_create_gate,
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        service,
+        "_acquire_account_response_create_lease_or_overload",
+        AsyncMock(return_value=replacement_lease),
+    )
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_lease)
+    monkeypatch.setattr(
+        service,
+        "_get_work_admission",
+        lambda: SimpleNamespace(acquire_response_create=acquire_admission),
+    )
+    monkeypatch.setattr(
+        proxy_http_bridge_request_submit,
+        "_service_time",
+        lambda: SimpleNamespace(monotonic=lambda: next(retry_times)),
+    )
+
+    assert await service._retry_http_bridge_precreated_request(session) is False
+
+    acquire_admission.assert_awaited_once_with()
+    upstream.send_text.assert_not_awaited()
+    await proxy_service._release_websocket_response_create_gate(request_state, response_create_gate)
+    release_lease.assert_awaited_once_with(replacement_lease)
+    assert replacement_admission_gate._value == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_http_bridge_precreated_request_bounds_admission_wait_by_deadline(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_bridge_retry_admission_deadline")
+    upstream = AsyncMock()
+    response_create_gate = asyncio.Semaphore(1)
+    await response_create_gate.acquire()
+    replacement_lease = object()
+    release_lease = AsyncMock()
+    admission_started = asyncio.Event()
+
+    async def acquire_admission() -> AdmissionLease:
+        admission_started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_retry_admission_deadline",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        bridge_request_deadline=time.monotonic() + 0.05,
+        awaiting_response_created=True,
+        response_create_gate=response_create_gate,
+        response_create_gate_acquired=True,
+        response_create_admission_reacquire_required=True,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"retry"}',
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-retry-admission-deadline", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.6-sol",
+        account=account,
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=response_create_gate,
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        service,
+        "_acquire_account_response_create_lease_or_overload",
+        AsyncMock(return_value=replacement_lease),
+    )
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_lease)
+    monkeypatch.setattr(
+        service,
+        "_get_work_admission",
+        lambda: SimpleNamespace(acquire_response_create=acquire_admission),
+    )
+
+    assert await asyncio.wait_for(service._retry_http_bridge_precreated_request(session), timeout=1.0) is False
+
+    assert admission_started.is_set() is True
+    upstream.send_text.assert_not_awaited()
+    release_lease.assert_awaited_once_with(replacement_lease)
+    assert request_state.account_response_create_lease is None
+    assert request_state.response_create_admission is None
+    await proxy_service._release_websocket_response_create_gate(request_state, response_create_gate)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -36701,6 +36701,7 @@ async def test_retry_http_bridge_precreated_request_reacquires_replacement_respo
         response_create_gate=response_create_gate,
         response_create_gate_acquired=True,
         response_create_admission_reacquire_required=True,
+        event_queue=asyncio.Queue(),
         request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"retry"}',
     )
     session = proxy_service._HTTPBridgeSession(

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -36764,6 +36764,87 @@ async def test_retry_http_bridge_precreated_request_reacquires_replacement_respo
 
 
 @pytest.mark.asyncio
+async def test_retry_http_bridge_precreated_request_does_not_send_after_detach_during_admission_wait(monkeypatch):
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    rejected_account = _make_account("acc_bridge_retry_detached")
+    replacement_account = _make_account("acc_bridge_retry_detached_replacement")
+    replacement_upstream = AsyncMock()
+    replacement_lease = object()
+    release_lease = AsyncMock()
+    response_create_gate = asyncio.Semaphore(1)
+    await response_create_gate.acquire()
+    replacement_admission_gate = asyncio.Semaphore(0)
+    replacement_admission = AdmissionLease(
+        replacement_admission_gate,
+        stage="response_create",
+        request_id="req_bridge_retry_detached_admission",
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_retry_detached_admission",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        bridge_request_deadline=time.monotonic() + 60.0,
+        awaiting_response_created=True,
+        response_create_gate=response_create_gate,
+        response_create_gate_acquired=True,
+        response_create_admission_reacquire_required=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"retry"}',
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-retry-detached-admission", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.6-sol",
+        account=rejected_account,
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=response_create_gate,
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+
+    async def reconnect(target_session, **kwargs):
+        del kwargs
+        target_session.account = replacement_account
+        target_session.upstream = replacement_upstream
+
+    async def acquire_admission() -> AdmissionLease:
+        assert await service._detach_http_bridge_request(session, request_state=request_state) is True
+        return replacement_admission
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
+    monkeypatch.setattr(
+        service,
+        "_acquire_account_response_create_lease_or_overload",
+        AsyncMock(return_value=replacement_lease),
+    )
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_lease)
+    monkeypatch.setattr(
+        service,
+        "_get_work_admission",
+        lambda: SimpleNamespace(acquire_response_create=acquire_admission),
+    )
+
+    assert await service._retry_http_bridge_precreated_request(session) is False
+
+    replacement_upstream.send_text.assert_not_awaited()
+    assert request_state not in session.pending_requests
+    assert request_state.draining_until_terminal is True
+    assert request_state.response_create_admission is None
+    assert replacement_admission_gate._value == 1
+    assert sum(call.args == (replacement_lease,) for call in release_lease.await_args_list) == 1
+
+
+@pytest.mark.asyncio
 async def test_retry_http_bridge_precreated_request_does_not_send_after_admission_exhausts_deadline(monkeypatch):
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_bridge_retry_deadline")


### PR DESCRIPTION
## Summary

- wait briefly before retrying HTTP bridge pre-created requests when upstream reports `Selected model is at capacity`
- emit the existing `waiting_for_account_capacity` keepalive while the retry waits, bounded by the original bridge request deadline
- cover the model-capacity retry path with a unit regression test

## Validation

- `uv run ty check`
- `pytest -q tests/unit/test_proxy_http_bridge.py::test_http_bridge_model_capacity_waits_before_precreated_retry tests/unit/test_proxy_http_bridge.py::test_http_bridge_submit_waits_for_local_account_capacity tests/unit/test_proxy_http_bridge.py::test_http_bridge_submit_waits_for_response_create_gate_contention`
- `pytest -q tests/unit/test_proxy_http_bridge.py::test_http_bridge_account_capacity_wait_treats_workspace_spend_cap_as_recoverable tests/unit/test_proxy_http_bridge.py::test_http_bridge_account_capacity_wait_honors_upstream_rate_limit_retry_hint tests/unit/test_proxy_http_bridge.py::test_http_bridge_account_capacity_wait_ignores_local_no_accounts_retry_hint tests/unit/test_proxy_http_bridge.py::test_http_bridge_account_capacity_wait_treats_local_account_caps_as_recoverable tests/unit/test_proxy_http_bridge.py::test_http_bridge_account_capacity_wait_treats_gate_timeout_as_recoverable tests/unit/test_proxy_http_bridge.py::test_http_bridge_submit_waits_for_local_account_capacity tests/unit/test_proxy_http_bridge.py::test_http_bridge_submit_waits_for_response_create_gate_contention tests/unit/test_proxy_http_bridge.py::test_http_bridge_model_capacity_waits_before_precreated_retry`
- `ruff check app/modules/proxy/_service/http_bridge/upstream_events.py tests/unit/test_proxy_http_bridge.py`
