### PR TITLE
fix(reports): reject inverted date ranges

### DIFF
--- a/app/modules/reports/api.py
+++ b/app/modules/reports/api.py
@@ -5,10 +5,15 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
-from app.core.auth.dependencies import set_dashboard_error_format, validate_dashboard_session
+from app.core.auth.dependencies import (
+    set_dashboard_error_format,
+    validate_dashboard_session,
+)
+from app.core.exceptions import DashboardBadRequestError
 from app.dependencies import ReportsContext, get_reports_context
 from app.modules.reports.repository import DailyReportRangeTooLargeError
 from app.modules.reports.schemas import ReportsResponse
+from app.modules.reports.service import InvalidReportDateRangeError
 
 router = APIRouter(
     prefix="/api/reports",
@@ -36,5 +41,7 @@ async def get_reports(
             model=model,
             useragent_group=useragent_group,
         )
+    except InvalidReportDateRangeError as exc:
+        raise DashboardBadRequestError(str(exc), code="invalid_report_date_range") from exc
     except DailyReportRangeTooLargeError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc

--- a/app/modules/reports/service.py
+++ b/app/modules/reports/service.py
@@ -17,6 +17,10 @@ from app.modules.reports.schemas import (
 )
 
 
+class InvalidReportDateRangeError(ValueError):
+    """Raised when a report starts after it ends."""
+
+
 class ReportsService:
     def __init__(self, repository: ReportsRepository) -> None:
         self._repository = repository
@@ -36,13 +40,14 @@ class ReportsService:
             end_date = now.date()
         if start_date is None:
             start_date = end_date - timedelta(days=6)
+        if start_date > end_date:
+            raise InvalidReportDateRangeError("start_date must be on or before end_date")
         window_days = (end_date - start_date).days + 1
         if window_days > MAX_DAILY_REPORT_DAYS:
             raise DailyReportRangeTooLargeError(f"report date range must be {MAX_DAILY_REPORT_DAYS} days or less")
 
         start_at = _local_midnight_to_utc_naive(start_date, timezone_info)
         end_at = _local_midnight_to_utc_naive(end_date + timedelta(days=1), timezone_info)
-        window_days = max(window_days, 1)
         previous_end_date = start_date - timedelta(days=1)
         previous_start_date = previous_end_date - timedelta(days=window_days - 1)
         previous_start_at = _local_midnight_to_utc_naive(previous_start_date, timezone_info)

--- a/frontend/src/__integration__/reports-date-range-flow.test.tsx
+++ b/frontend/src/__integration__/reports-date-range-flow.test.tsx
@@ -1,0 +1,238 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+
+import App from "@/App";
+import { daysAgoLocalISO } from "@/features/reports/date";
+import type { ReportsResponse } from "@/features/reports/schemas";
+import { server } from "@/test/mocks/server";
+import { renderWithProviders } from "@/test/utils";
+
+const EMPTY_REPORT: ReportsResponse = {
+  summary: {
+    totalCostUsd: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCachedTokens: 0,
+    totalRequests: 0,
+    totalErrors: 0,
+    activeAccounts: 0,
+    avgCostPerDay: 0,
+    avgRequestsPerDay: 0,
+  },
+  comparison: {
+    canCompare: false,
+    previous: {
+      totalCostUsd: 0,
+      totalTokens: 0,
+      totalRequests: 0,
+    },
+  },
+  daily: [],
+  byModel: [],
+  byUseragent: [],
+  byAccount: [],
+};
+
+const REPORT_WITH_MODEL: ReportsResponse = {
+  ...EMPTY_REPORT,
+  byModel: [
+    {
+      model: "gpt-5.1",
+      costUsd: 0,
+      requests: 0,
+      percentage: 100,
+    },
+  ],
+};
+
+const CORRECTIONS = [
+  {
+    name: "start date",
+    label: "Start date",
+    correctedDaysAgo: 9,
+    expectedStartDaysAgo: 9,
+    expectedEndDaysAgo: 8,
+  },
+  {
+    name: "end date",
+    label: "End date",
+    correctedDaysAgo: 6,
+    expectedStartDaysAgo: 7,
+    expectedEndDaysAgo: 6,
+  },
+] as const;
+
+describe("reports date-range flow integration", () => {
+  it.each(CORRECTIONS)(
+    "drives the App reports route, suppresses inverted requests, and recovers through the $name",
+    async ({ label, correctedDaysAgo, expectedStartDaysAgo, expectedEndDaysAgo }) => {
+      const user = userEvent.setup({ delay: null });
+      const referenceDate = new Date();
+      const invertedStart = daysAgoLocalISO(7, referenceDate);
+      const invertedEnd = daysAgoLocalISO(8, referenceDate);
+      const expectedStart = daysAgoLocalISO(expectedStartDaysAgo, referenceDate);
+      const expectedEnd = daysAgoLocalISO(expectedEndDaysAgo, referenceDate);
+      const reportsRequests: URLSearchParams[] = [];
+      let accountRequests = 0;
+
+      server.use(
+        http.get("/api/accounts", () => {
+          accountRequests += 1;
+          return HttpResponse.json({ accounts: [] });
+        }),
+        http.get("/api/reports", ({ request }) => {
+          reportsRequests.push(new URL(request.url).searchParams);
+          return HttpResponse.json(REPORT_WITH_MODEL);
+        }),
+      );
+
+      window.history.pushState({}, "", "/reports");
+      renderWithProviders(<App />);
+
+      expect(window.location.pathname).toBe("/reports");
+      await waitFor(() => {
+        expect(accountRequests).toBeGreaterThan(0);
+        expect(reportsRequests.length).toBeGreaterThan(0);
+      });
+      expect(await screen.findByRole("heading", { name: "Cost Report" })).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Model", expanded: false }));
+      await user.click(
+        await screen.findByRole("menuitemcheckbox", { name: "gpt-5.1" }),
+      );
+      await user.keyboard("{Escape}");
+      await waitFor(() => {
+        expect(
+          reportsRequests.some((params) => params.get("model") === "gpt-5.1"),
+        ).toBe(true);
+      });
+
+      const startInput = screen.getByLabelText("Start date");
+      const endInput = screen.getByLabelText("End date");
+      fireEvent.change(endInput, { target: { value: invertedEnd } });
+      fireEvent.change(startInput, { target: { value: invertedStart } });
+
+      await waitFor(() => {
+        expect(startInput).toHaveAttribute("aria-invalid", "true");
+        expect(endInput).toHaveAttribute("aria-invalid", "true");
+      });
+      expect(
+        screen.getByText("Start date must be on or before end date."),
+      ).toBeInTheDocument();
+      expect(
+        reportsRequests.filter((params) => {
+          const startDate = params.get("start_date");
+          const endDate = params.get("end_date");
+          return startDate !== null && endDate !== null && startDate > endDate;
+        }),
+      ).toHaveLength(0);
+
+      fireEvent.change(screen.getByLabelText(label), {
+        target: { value: daysAgoLocalISO(correctedDaysAgo, referenceDate) },
+      });
+
+      await waitFor(() => {
+        const correctedRequests = reportsRequests.filter(
+          (params) =>
+            params.get("start_date") === expectedStart &&
+            params.get("end_date") === expectedEnd,
+        );
+        expect(correctedRequests).toHaveLength(2);
+      });
+      const correctedRequests = reportsRequests.filter(
+        (params) =>
+          params.get("start_date") === expectedStart &&
+          params.get("end_date") === expectedEnd,
+      );
+      expect(
+        correctedRequests
+          .map((params) => params.get("model") ?? "")
+          .sort(),
+      ).toEqual(["", "gpt-5.1"]);
+      expect(
+        screen.queryByText("Start date must be on or before end date."),
+      ).not.toBeInTheDocument();
+      expect(startInput).not.toHaveAttribute("aria-invalid");
+      expect(endInput).not.toHaveAttribute("aria-invalid");
+      expect(startInput).not.toHaveAttribute("aria-describedby");
+      expect(endInput).not.toHaveAttribute("aria-describedby");
+    },
+  );
+
+  it("retries Accounts without refetching either Reports query while the range is inverted", async () => {
+    const user = userEvent.setup({ delay: null });
+    const referenceDate = new Date();
+    const reportsRequests: URLSearchParams[] = [];
+    let accountRequests = 0;
+
+    server.use(
+      http.get("/api/accounts", () => {
+        accountRequests += 1;
+        return HttpResponse.json(
+          {
+            error: {
+              code: "accounts_unavailable",
+              message: "Accounts unavailable",
+            },
+          },
+          { status: 503 },
+        );
+      }),
+      http.get("/api/reports", ({ request }) => {
+        reportsRequests.push(new URL(request.url).searchParams);
+        return HttpResponse.json(REPORT_WITH_MODEL);
+      }),
+    );
+
+    window.history.pushState({}, "", "/reports");
+    renderWithProviders(<App />);
+
+    expect(window.location.pathname).toBe("/reports");
+    await waitFor(() => {
+      expect(accountRequests).toBeGreaterThan(0);
+      expect(reportsRequests.length).toBeGreaterThan(0);
+    });
+    expect(await screen.findByRole("heading", { name: "Cost Report" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Model", expanded: false }));
+    await user.click(
+      await screen.findByRole("menuitemcheckbox", { name: "gpt-5.1" }),
+    );
+    await user.keyboard("{Escape}");
+    await waitFor(() => {
+      expect(
+        reportsRequests.some((params) => params.get("model") === "gpt-5.1"),
+      ).toBe(true);
+    });
+
+    fireEvent.change(screen.getByLabelText("End date"), {
+      target: { value: daysAgoLocalISO(8, referenceDate) },
+    });
+    fireEvent.change(screen.getByLabelText("Start date"), {
+      target: { value: daysAgoLocalISO(7, referenceDate) },
+    });
+
+    expect(
+      await screen.findByText("Start date must be on or before end date."),
+    ).toBeInTheDocument();
+    const retryButton = await screen.findByRole("button", { name: "Retry" });
+    const accountRequestsBeforeRetry = accountRequests;
+    const reportsRequestsBeforeRetry = reportsRequests.length;
+
+    await user.click(retryButton);
+
+    await waitFor(() => {
+      expect(accountRequests).toBe(accountRequestsBeforeRetry + 1);
+    });
+    expect(reportsRequests).toHaveLength(reportsRequestsBeforeRetry);
+    expect(
+      reportsRequests.filter((params) => {
+        const startDate = params.get("start_date");
+        const endDate = params.get("end_date");
+        return startDate !== null && endDate !== null && startDate > endDate;
+      }),
+    ).toHaveLength(0);
+  });
+});

--- a/frontend/src/features/reports/components/reports-filters.test.tsx
+++ b/frontend/src/features/reports/components/reports-filters.test.tsx
@@ -121,7 +121,7 @@ describe("ReportsFilters", () => {
     expect(onPresetSelect).toHaveBeenCalledWith(90);
   });
 
-  it("limits both date inputs to the current browser-local day", () => {
+  it("applies reciprocal bounds while keeping today as the end-date ceiling", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-12T12:00:00"));
 
@@ -139,7 +139,53 @@ describe("ReportsFilters", () => {
 
     const dateInputs = container.querySelectorAll<HTMLInputElement>('input[type="date"]');
     expect(dateInputs).toHaveLength(2);
-    expect(dateInputs[0]).toHaveAttribute("max", "2026-06-12");
+    expect(dateInputs[0]).toHaveAttribute("max", FILTERS.endDate);
+    expect(dateInputs[1]).toHaveAttribute("min", FILTERS.startDate);
     expect(dateInputs[1]).toHaveAttribute("max", "2026-06-12");
+  });
+
+  it("keeps today as the start-date ceiling when the end date is later", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-12T12:00:00"));
+
+    const { container } = render(
+      <ReportsFilters
+        filters={{ ...FILTERS, endDate: "2026-06-13" }}
+        selectedPresetDays={null}
+        accountOptions={[]}
+        modelOptions={[]}
+        useragentOptions={[]}
+        onPresetSelect={vi.fn()}
+        onFiltersChange={vi.fn()}
+      />,
+    );
+
+    const dateInputs = container.querySelectorAll<HTMLInputElement>('input[type="date"]');
+    expect(dateInputs[0]).toHaveAttribute("max", "2026-06-12");
+  });
+
+  it("links both invalid date inputs to one corrective message", () => {
+    const { container } = render(
+      <ReportsFilters
+        filters={{ ...FILTERS, startDate: "2026-06-08" }}
+        selectedPresetDays={null}
+        accountOptions={[]}
+        modelOptions={[]}
+        useragentOptions={[]}
+        onPresetSelect={vi.fn()}
+        onFiltersChange={vi.fn()}
+      />,
+    );
+
+    const dateInputs = container.querySelectorAll<HTMLInputElement>('input[type="date"]');
+    const message = screen.getByText("Start date must be on or before end date.");
+    const descriptionId = message.getAttribute("id");
+
+    expect(descriptionId).toBeTruthy();
+    expect(dateInputs[0]).toHaveAttribute("aria-invalid", "true");
+    expect(dateInputs[1]).toHaveAttribute("aria-invalid", "true");
+    expect(dateInputs[0]).toHaveAttribute("aria-describedby", descriptionId);
+    expect(dateInputs[1]).toHaveAttribute("aria-describedby", descriptionId);
+    expect(message).toHaveAttribute("aria-live", "polite");
   });
 });

--- a/frontend/src/features/reports/components/reports-filters.tsx
+++ b/frontend/src/features/reports/components/reports-filters.tsx
@@ -1,10 +1,11 @@
+import { useId } from "react";
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "react-i18next";
 import {
   MultiSelectFilter,
   type MultiSelectOption,
 } from "@/features/dashboard/components/filters/multi-select-filter";
-import { localDateISO } from "../date";
+import { isReportDateRangeValid, localDateISO } from "../date";
 
 export type ReportsFiltersState = {
   startDate: string;
@@ -41,6 +42,13 @@ export function ReportsFilters({
 }: ReportsFiltersProps) {
   const { t } = useTranslation();
   const maxDate = localDateISO();
+  const dateRangeErrorId = useId();
+  const isDateRangeInvalid = !isReportDateRangeValid(
+    filters.startDate,
+    filters.endDate,
+  );
+  const startDateMax =
+    filters.endDate && filters.endDate < maxDate ? filters.endDate : maxDate;
 
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-xl border bg-card p-3">
@@ -83,24 +91,50 @@ export function ReportsFilters({
         }
       />
 
-      <div className="ml-auto flex items-center gap-2">
-        <input
-          type="date"
-          aria-label={t("reports.filters.startDate")}
-          max={maxDate}
-          value={filters.startDate}
-          onChange={(e) => onFiltersChange({ ...filters, startDate: e.target.value })}
-          className="h-8 rounded-md border bg-transparent px-2 text-xs text-foreground"
-        />
-        <span className="text-xs text-muted-foreground">—</span>
-        <input
-          type="date"
-          aria-label={t("reports.filters.endDate")}
-          max={maxDate}
-          value={filters.endDate}
-          onChange={(e) => onFiltersChange({ ...filters, endDate: e.target.value })}
-          className="h-8 rounded-md border bg-transparent px-2 text-xs text-foreground"
-        />
+      <div className="ml-auto flex flex-col items-end gap-1">
+        <div className="flex items-center gap-2">
+          <input
+            type="date"
+            name="report-start-date"
+            autoComplete="off"
+            aria-label={t("reports.filters.startDate")}
+            aria-invalid={isDateRangeInvalid || undefined}
+            aria-describedby={isDateRangeInvalid ? dateRangeErrorId : undefined}
+            max={startDateMax}
+            value={filters.startDate}
+            onChange={(e) =>
+              onFiltersChange({ ...filters, startDate: e.target.value })
+            }
+            className="h-8 rounded-md border bg-transparent px-2 text-xs text-foreground aria-invalid:border-destructive aria-invalid:ring-destructive/20"
+          />
+          <span aria-hidden="true" className="text-xs text-muted-foreground">
+            —
+          </span>
+          <input
+            type="date"
+            name="report-end-date"
+            autoComplete="off"
+            aria-label={t("reports.filters.endDate")}
+            aria-invalid={isDateRangeInvalid || undefined}
+            aria-describedby={isDateRangeInvalid ? dateRangeErrorId : undefined}
+            min={filters.startDate || undefined}
+            max={maxDate}
+            value={filters.endDate}
+            onChange={(e) =>
+              onFiltersChange({ ...filters, endDate: e.target.value })
+            }
+            className="h-8 rounded-md border bg-transparent px-2 text-xs text-foreground aria-invalid:border-destructive aria-invalid:ring-destructive/20"
+          />
+        </div>
+        {isDateRangeInvalid ? (
+          <p
+            id={dateRangeErrorId}
+            aria-live="polite"
+            className="text-xs text-destructive"
+          >
+            {t("reports.filters.invalidDateRange")}
+          </p>
+        ) : null}
       </div>
     </div>
   );

--- a/frontend/src/features/reports/components/reports-page.tsx
+++ b/frontend/src/features/reports/components/reports-page.tsx
@@ -17,7 +17,12 @@ import type { QueueWaitChartProps } from "./queue-wait-chart";
 import type { ModelDistributionDonutProps } from "./model-distribution-donut";
 import type { UseragentDistributionDonutProps } from "./useragent-distribution-donut";
 import { DailyDetailTable } from "./daily-detail-table";
-import { daysAgoLocalISO, getBrowserReportsTimeZone, localDateISO } from "../date";
+import {
+  daysAgoLocalISO,
+  getBrowserReportsTimeZone,
+  isReportDateRangeValid,
+  localDateISO,
+} from "../date";
 
 const CostPerDayChart = lazy(() =>
   import("./cost-per-day-chart").then((module) => ({
@@ -164,6 +169,11 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
   );
 
   const handleRetry = async () => {
+    if (!isReportDateRangeValid(filters.startDate, filters.endDate)) {
+      await refetchAccounts();
+      return;
+    }
+
     await Promise.allSettled([
       reportsQuery.refetch(),
       filterCatalogQuery.refetch(),

--- a/frontend/src/features/reports/date.ts
+++ b/frontend/src/features/reports/date.ts
@@ -51,6 +51,13 @@ export function daysAgoLocalISO(days: number, date: Date = new Date()): string {
   return localDateISO(shifted);
 }
 
+export function isReportDateRangeValid(
+  startDate: string | undefined,
+  endDate: string | undefined,
+): boolean {
+  return !startDate || !endDate || startDate <= endDate;
+}
+
 export function formatReportBucketDate(date: string): string {
   const [year, month, day] = date.split("-");
   if (!year || !month || !day) {

--- a/frontend/src/features/reports/hooks/use-reports.ts
+++ b/frontend/src/features/reports/hooks/use-reports.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { getReports } from "../api";
+import { isReportDateRangeValid } from "../date";
 
 type ReportsFilterState = {
   startDate: string | undefined;
@@ -14,6 +15,7 @@ export function useReports(
   timeZone: string | undefined,
 ) {
   return useQuery({
+    enabled: isReportDateRangeValid(filters.startDate, filters.endDate),
     queryKey: ["reports", filters, timeZone],
     queryFn: () =>
       getReports({

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -905,6 +905,7 @@
   "reports.errors.options": "Failed to load model and user-agent options: {{error}}",
   "reports.errors.partial": "Some report data could not be loaded. Try reloading.",
   "reports.filters.endDate": "End date",
+  "reports.filters.invalidDateRange": "Start date must be on or before end date.",
   "reports.filters.startDate": "Start date",
   "reports.filters.userAgent": "UserAgent",
   "reports.page.subtitle": "Usage history by date range",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -905,6 +905,7 @@
   "reports.errors.options": "Model 및 User Agent 옵션을 불러오지 못했습니다: {{error}}",
   "reports.errors.partial": "일부 report data를 불러오지 못했습니다. 다시 불러오세요.",
   "reports.filters.endDate": "종료일",
+  "reports.filters.invalidDateRange": "시작일은 종료일보다 빠르거나 같아야 합니다.",
   "reports.filters.startDate": "시작일",
   "reports.filters.userAgent": "User Agent",
   "reports.page.subtitle": "기간별 사용 기록",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -905,6 +905,7 @@
   "reports.errors.options": "加载 Model 和 User Agent 选项失败：{{error}}",
   "reports.errors.partial": "部分报表数据无法加载。请重试。",
   "reports.filters.endDate": "结束日期",
+  "reports.filters.invalidDateRange": "开始日期必须早于或等于结束日期。",
   "reports.filters.startDate": "开始日期",
   "reports.filters.userAgent": "User Agent",
   "reports.page.subtitle": "按日期范围查看使用历史",

--- a/openspec/changes/reject-inverted-report-date-ranges/.openspec.yaml
+++ b/openspec/changes/reject-inverted-report-date-ranges/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/reject-inverted-report-date-ranges/design.md
+++ b/openspec/changes/reject-inverted-report-date-ranges/design.md
@@ -1,0 +1,51 @@
+## Context
+
+The Reports service applies date defaults, computes an inclusive window, and then performs several aggregate repository calls. A negative window is currently clamped to one day after the existing 730-day guard, so inverted bounds proceed through the repository and serialize as a plausible empty report. The dashboard keeps both date fields in page state, gives each only a `max` of the browser-local current day, and starts both the filtered and relaxed-catalog Reports queries for every state.
+
+The correction crosses the Reports service/API boundary and the Reports filter/query UI. It must preserve the existing inclusive 730-day guard, timezone conversion, presets, aggregates, and repository implementation. PR #1325 currently owns `app/modules/reports/repository.py`, so this change does not modify that file.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make date ordering an authoritative Reports domain invariant applied after defaults and before repository I/O.
+- Return the exact dashboard 400 envelope with stable code `invalid_report_date_range`.
+- Prevent routine inverted selections with reciprocal native date bounds.
+- Keep bypassed invalid state understandable to sighted and assistive-technology users.
+- Disable both Reports queries while invalid and resume them when either bound is corrected.
+- Preserve valid one-day and inclusive 730-day ranges.
+
+**Non-Goals:**
+
+- Changing the 730-day maximum, date presets, timezone semantics, aggregation or query behavior, repository code, charts, schemas, migrations, settings, navigation, or authentication.
+- Adding a new dashboard setting or API field.
+
+## Decisions
+
+### Validate in the Reports service with a typed domain error
+
+After applying omitted-bound defaults, `ReportsService.get_reports` compares the resulting dates. It raises a dedicated `InvalidReportDateRangeError` before date conversion or any repository await. The Reports route catches that domain error and raises `DashboardBadRequestError` with code `invalid_report_date_range`, reusing the registered dashboard envelope handler.
+
+This keeps the invariant authoritative for both HTTP and direct service callers. Route-only FastAPI validation was rejected because direct callers would remain unsafe and because cross-field ordering does not belong to either individual query parameter. Repository validation was rejected because it is too late, would mix domain policy with persistence, and would overlap PR #1325.
+
+### Share one frontend date-order predicate
+
+A small Reports date utility treats a range as inverted only when both bounds are present and `startDate > endDate`. The filters use it for accessible feedback and the Reports data hook uses it as the TanStack Query `enabled` condition. Empty bounds retain existing backend-default behavior; this change does not add unrelated required-field validation.
+
+Passing an `enabled` flag from every caller was rejected because it would allow callers to forget the invariant. Central query gating makes both automatic query flows safe by default. Because TanStack Query manual refetch bypasses `enabled`, the page-level Retry action applies the same predicate before invoking either Reports refetch and still retries Accounts while the range is invalid.
+
+### Use native prevention plus explicit accessible recovery
+
+The start input keeps the browser-local current day as its upper ceiling but narrows to the selected end date when that date is earlier. The end input keeps its current-day maximum and receives the selected start date as its minimum. If typed, restored, test-injected, or otherwise bypassed values remain inverted, both controls expose `aria-invalid` and reference one localized inline corrective message via `aria-describedby`. The message is textual and announced, so the state does not rely on color.
+
+Silently swapping dates was rejected because it would conceal operator input and could query an unintended period. Clearing a bound was rejected because it would discard user input and invoke backend defaults.
+
+### Let TanStack Query provide recovery
+
+While the range is inverted, both Reports queries remain mounted with `enabled: false`, preserving their previous cache state without network traffic. The page-level Retry action refetches Accounts only and does not invoke either Reports refetch in that state. Correcting either bound flips the same queries to enabled, causing one fetch for each distinct query key. Presets remain valid and require no special recovery path.
+
+## Risks / Trade-offs
+
+- Native date constraints can be bypassed by typing, browser restoration, or programmatic state; the explicit error and query gate are therefore required rather than relying on `min`/`max` alone.
+- Two controls share one description. This intentionally avoids duplicate announcements while still linking the corrective action from either invalid field.
+- A cached prior report may remain in TanStack Query memory while disabled, but the page does not issue an invalid request; the visible inline validation prevents the stale data from being mistaken for a response to the inverted range.

--- a/openspec/changes/reject-inverted-report-date-ranges/proposal.md
+++ b/openspec/changes/reject-inverted-report-date-ranges/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`GET /api/reports` currently accepts a `start_date` after `end_date`, performs report repository work, and returns a plausible empty report. The Reports UI can also submit that invalid state, which can mislead operators into treating an input error as a real zero-usage period.
+
+## What Changes
+
+- Reject inverted report date bounds in the Reports service before any repository operation and map the domain failure to a stable dashboard HTTP 400 error.
+- Constrain the Reports date inputs reciprocally for routine picker use.
+- Expose a linked accessible invalid state when typed or bypassed input still produces an inverted range.
+- Suppress report data and report-filter-option queries while the range is invalid, then refresh cleanly after either bound is corrected.
+- Add backend and frontend regression coverage while preserving valid one-day and 730-day ranges.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `frontend-architecture`: Define authoritative Reports date-order validation and accessible Reports UI prevention, query suppression, and recovery behavior.
+
+## Impact
+
+- Affected backend: `app/modules/reports/service.py`, `app/modules/reports/api.py`, and Reports API/service tests.
+- Affected frontend: Reports filters, page query gating, localized validation copy, and Reports component/MSW tests.
+- No changes to the 730-day limit, presets, timezone semantics, report aggregation or repository queries, charts, schema, migrations, settings, or navigation.

--- a/openspec/changes/reject-inverted-report-date-ranges/specs/frontend-architecture/spec.md
+++ b/openspec/changes/reject-inverted-report-date-ranges/specs/frontend-architecture/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Reports endpoint rejects inverted date ranges before repository work
+
+After applying defaults for any omitted date bound, the Reports service MUST reject a `start_date` later than `end_date` before converting report boundaries or awaiting any repository operation. `GET /api/reports` MUST map that domain failure to HTTP 400 with the exact dashboard envelope `{"error":{"code":"invalid_report_date_range","message":"start_date must be on or before end_date"}}`. Valid one-day ranges and valid inclusive ranges of 730 calendar days MUST remain accepted.
+
+#### Scenario: Explicit inverted Reports range is rejected
+
+- **WHEN** an authenticated operator requests `GET /api/reports` with `start_date` later than `end_date`
+- **THEN** the endpoint returns HTTP 400
+- **AND** the response body is exactly `{"error":{"code":"invalid_report_date_range","message":"start_date must be on or before end_date"}}`
+- **AND** the Reports repository receives no call
+
+#### Scenario: Defaulted end date makes the range inverted
+
+- **WHEN** an authenticated operator requests `GET /api/reports` with an explicit `start_date` later than the defaulted current `end_date`
+- **THEN** the endpoint returns the same `invalid_report_date_range` HTTP 400 before repository work
+
+#### Scenario: Boundary-valid Reports ranges remain accepted
+
+- **WHEN** an authenticated operator requests a one-day range whose `start_date` equals `end_date`
+- **THEN** the endpoint accepts the request and reports data for that day
+- **WHEN** an authenticated operator requests an inclusive range of exactly 730 calendar days
+- **THEN** the endpoint accepts the request under the existing range limit
+
+### Requirement: Reports date controls prevent, explain, and recover from inverted ranges
+
+The `/reports` start-date input MUST use the earlier of the browser-local current day and a present end date as its native `max`, and the end-date input MUST use a present start date as its native `min` while retaining the browser-local current day as its `max`. If both values are present and the start date is later than the end date, both controls MUST expose `aria-invalid`, both MUST reference the same localized inline corrective message through an accessible description, and neither the filtered Reports query nor the relaxed Reports filter-catalog query MAY send a request. Correcting either bound so the range is ordered MUST clear the invalid state and resume each distinct Reports query with the corrected bounds.
+
+#### Scenario: Reciprocal native bounds prevent routine inverted selection
+
+- **GIVEN** `/reports` has a selected start date and end date
+- **THEN** the start-date control's `max` is the earlier of the end date and the browser-local current day
+- **AND** the end-date control's `min` is the start date
+- **AND** the end-date control's `max` remains the browser-local current day
+
+#### Scenario: Bypassed inverted input is accessible and sends no Reports request
+
+- **WHEN** typed, restored, or programmatically supplied Reports dates have a start date later than the end date
+- **THEN** both date controls expose `aria-invalid`
+- **AND** both controls reference one visible localized message that tells the operator to place the start date on or before the end date
+- **AND** no `GET /api/reports` request is sent for either Reports query
+
+#### Scenario: Retry while inverted only retries Accounts
+
+- **GIVEN** `/reports` has an inverted date range and loading account options failed
+- **WHEN** the operator activates the page-level Retry action
+- **THEN** the Accounts query sends a retry request
+- **AND** neither Reports query sends a request
+
+#### Scenario: Correcting either invalid bound resumes Reports queries
+
+- **GIVEN** `/reports` has an inverted date range and both Reports queries are disabled
+- **WHEN** the operator corrects either date bound so the start date is on or before the end date
+- **THEN** both controls clear the invalid state and accessible description
+- **AND** the corrective message is removed
+- **AND** each distinct Reports query sends one request using the corrected ordered bounds

--- a/openspec/changes/reject-inverted-report-date-ranges/tasks.md
+++ b/openspec/changes/reject-inverted-report-date-ranges/tasks.md
@@ -1,0 +1,18 @@
+## 1. Backend Contract
+
+- [x] 1.1 Add failing Reports API and service regressions for the exact inverted-range error, pre-repository rejection, and valid one-day and 730-day controls.
+- [x] 1.2 Add the typed Reports date-order domain error and reject defaulted inverted bounds before date conversion or repository work.
+- [x] 1.3 Map the domain error to the exact `invalid_report_date_range` dashboard HTTP 400 envelope.
+
+## 2. Reports UI
+
+- [x] 2.1 Add failing frontend regressions at the real `<App />` `/reports` route for reciprocal date bounds, linked accessible invalid state, distinct-query suppression, Accounts-only Retry, and recovery through either corrected bound.
+- [x] 2.2 Add shared Reports date-order validation, reciprocal native input bounds, and localized corrective copy for every supported locale.
+- [x] 2.3 Disable both automatic and manual Reports query paths while date order is invalid, keep Accounts retryable, and resume Reports with corrected bounds.
+
+## 3. Verification
+
+- [x] 3.1 Run focused backend and frontend regressions, including the strict dual-mode HTTP reproduction.
+- [x] 3.2 Run relevant full Python and frontend lint, typecheck, test, build, architecture, and OpenSpec validation gates.
+- [x] 3.3 Complete browser smoke for inverted input and correction, saving before/after evidence outside the repository.
+- [x] 3.4 Verify OpenSpec completeness/coherence, LSP diagnostics, isolated worktree diff, and untouched canonical checkout.

--- a/tests/integration/test_reports_api.py
+++ b/tests/integration/test_reports_api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
@@ -124,6 +124,64 @@ async def test_reports_api_rejects_oversized_date_ranges_with_default_end_date(a
     )
     assert response.status_code == 400
     assert response.json()["error"]["message"] == "report date range must be 730 days or less"
+
+
+async def test_reports_api_rejects_inverted_range_and_preserves_valid_one_day(
+    async_client,
+    db_setup,
+):
+    report_day = date(2026, 6, 3)
+    async with SessionLocal() as session:
+        session.add(_make_account("acc_reports_range", "reports-range@example.com"))
+        session.add(
+            RequestLog(
+                account_id="acc_reports_range",
+                request_id="report-range-request",
+                requested_at=datetime(2026, 6, 3, 12, 0, 0),
+                model="gpt-5.1",
+                status="success",
+                input_tokens=12,
+                output_tokens=4,
+                cached_input_tokens=2,
+                cost_usd=0.35,
+            )
+        )
+        await session.commit()
+
+    inverted_response = await async_client.get(
+        "/api/reports",
+        params={"start_date": "2026-06-07", "end_date": "2026-06-01"},
+    )
+    valid_response = await async_client.get(
+        "/api/reports",
+        params={"start_date": report_day.isoformat(), "end_date": report_day.isoformat()},
+    )
+
+    assert valid_response.status_code == 200
+    valid_payload = valid_response.json()
+    assert valid_payload["summary"]["totalRequests"] == 1
+    assert valid_payload["summary"]["totalCostUsd"] == 0.35
+    assert [row["date"] for row in valid_payload["daily"]] == [report_day.isoformat()]
+
+    assert inverted_response.status_code == 400
+    assert inverted_response.json() == {
+        "error": {
+            "code": "invalid_report_date_range",
+            "message": "start_date must be on or before end_date",
+        }
+    }
+
+
+async def test_reports_api_accepts_inclusive_730_day_range(async_client, db_setup):
+    end_date = date(2026, 1, 1)
+    start_date = end_date - timedelta(days=729)
+
+    response = await async_client.get(
+        "/api/reports",
+        params={"start_date": start_date.isoformat(), "end_date": end_date.isoformat()},
+    )
+
+    assert response.status_code == 200
 
 
 async def test_reports_api_includes_preserved_deleted_account_history(async_client, db_setup):

--- a/tests/unit/test_reports_service.py
+++ b/tests/unit/test_reports_service.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from app.modules.reports.repository import DailyReportRangeTooLargeError, ReportsRepository
-from app.modules.reports.service import ReportsService
+from app.modules.reports.service import InvalidReportDateRangeError, ReportsService
 
 pytestmark = pytest.mark.unit
 
@@ -35,6 +35,36 @@ async def test_get_reports_rejects_oversized_range_after_applying_default_end_da
     repo.aggregate_daily_rows.assert_not_awaited()
     repo.aggregate_by_model.assert_not_awaited()
     repo.aggregate_by_account.assert_not_awaited()
+    repo.earliest_report_activity_at.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_reports_rejects_inverted_defaulted_range_before_repository_work(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = SimpleNamespace(
+        aggregate_summary=AsyncMock(),
+        aggregate_daily_rows=AsyncMock(),
+        aggregate_by_model=AsyncMock(),
+        aggregate_by_account=AsyncMock(),
+        aggregate_by_useragent=AsyncMock(),
+        earliest_report_activity_at=AsyncMock(),
+    )
+    service = ReportsService(cast(ReportsRepository, repo))
+    fixed_now = datetime(2026, 6, 12, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("app.modules.reports.service.utcnow", lambda: fixed_now)
+
+    with pytest.raises(
+        InvalidReportDateRangeError,
+        match="start_date must be on or before end_date",
+    ):
+        await service.get_reports(start_date=date(2026, 6, 13))
+
+    repo.aggregate_summary.assert_not_awaited()
+    repo.aggregate_daily_rows.assert_not_awaited()
+    repo.aggregate_by_model.assert_not_awaited()
+    repo.aggregate_by_account.assert_not_awaited()
+    repo.aggregate_by_useragent.assert_not_awaited()
     repo.earliest_report_activity_at.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary

Reject inverted Reports date ranges before repository I/O, return a stable dashboard HTTP 400 error, and prevent, explain, suppress, and recover invalid date ordering in the Reports UI. The bug was independently reproduced; repository searches found no matching issue.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: None — independently reproduced; searches of the upstream issues found no match.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

This PR is not codex-faithful: it changes dashboard Reports validation and query behavior only, not an upstream-mimicking request or response path.

Change directory: `openspec/changes/reject-inverted-report-date-ranges/`

## Changes

### Backend

- Apply omitted-bound defaults, then reject `start_date > end_date` with a typed Reports domain error before date conversion or any repository await.
- Map that failure to HTTP 400 with the exact dashboard envelope `{"error":{"code":"invalid_report_date_range","message":"start_date must be on or before end_date"}}`.
- Preserve valid one-day ranges and valid inclusive 730-day ranges.

### Dashboard

- Add reciprocal native date bounds: start is capped by the earlier of end/current day, while end uses start as its minimum and retains current day as its maximum.
- Expose a shared localized corrective message through linked `aria-invalid` and `aria-describedby` state when invalid ordering bypasses native constraints.
- Suppress both automatic Reports queries while inverted, keep Accounts retryable, suppress manual Reports retry, and resume both distinct Reports queries when either bound is corrected.

### Scope and isolation

- `app/modules/reports/repository.py` remains untouched. Open PR #1325 is the only adjacent work found and owns a separate Reports repository metric change.
- No schema, migration, setting, navigation, README, `.env.example`, aggregation, timezone, preset, or 730-day-limit change is included.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config**
- [x] No new required setup step (or maintainer approval via `simplicity-budget-approved` label)
- New setting(s) and why each can't be a default: None.
- [x] README sections / `.env.example` / dashboard nav remain within budget; none changed

## Test plan

```text
Backend unit suite: 4,132 passed
Backend integration-core suite: 1,386 passed
Frontend suite: 881 passed
Backend coverage gate: passed
Backend lint gate: passed
Backend typecheck gate: passed
Python architecture gate: passed
Frontend coverage gate: passed
Frontend lint gate: passed
Frontend typecheck gate: passed
Frontend build gate: passed
OpenSpec change strict validation: passed
OpenSpec strict specs: 47 passed, 0 failed
Browser smoke with textual network inspection: passed
```

## Screenshots / output

Text-only evidence is provided. At the user's explicit request, state screenshots and recordings are omitted because captures may contain private data. Under PRINCIPLES.md P5, that omission is transparently acknowledged as a potential merge blocker unless a maintainer accepts the text-only evidence.

- Invalid inverted range: emitted no Reports request.
- Accounts-only Retry while inverted: `+1` Accounts request and `+0` Reports requests.
- Corrected bounds: cleared the linked ARIA invalid state and emitted two distinct valid Reports queries using the corrected ordered bounds.
- Backend reproduction: HTTP 400 with the exact envelope `{"error":{"code":"invalid_report_date_range","message":"start_date must be on or before end_date"}}` before repository work.

No screenshot, image, recording, user attachment, or raw-media link is included.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Related issue / discussion search completed; no matching issue exists to link.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local CI gates, including unit, integration-core, frontend, coverage, lint, typecheck, architecture, and build.
- [x] If touching specs: strict change validation and `openspec validate --specs --strict` pass (47/47), and verification is clean.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
- [x] Commit and PR evidence are text only; no image media is committed, attached, or linked.