### PR TITLE
fix(dashboard): keep overview visible when request logs fail

### DIFF
--- a/frontend/src/__integration__/dashboard-flow.test.tsx
+++ b/frontend/src/__integration__/dashboard-flow.test.tsx
@@ -1,15 +1,21 @@
-import { act, screen, waitFor } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { HttpResponse, http } from "msw";
-import { describe, expect, it } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vitest";
 
 import App from "@/App";
 import {
+  createAccountSummary,
   createDashboardOverview,
+  createDashboardProjections,
   createDefaultRequestLogs,
+  createRequestLogEntry,
   createRequestLogFilterOptions,
   createRequestLogsResponse,
 } from "@/test/mocks/factories";
+import { queryClient } from "@/lib/query-client";
 import { server } from "@/test/mocks/server";
 import { renderWithProviders } from "@/test/utils";
 
@@ -19,6 +25,12 @@ if (!HTMLElement.prototype.scrollIntoView) {
     value: () => {},
   });
 }
+
+const REQUEST_LOG_OUTAGE_MESSAGE = "forced request-log outage";
+
+afterEach(() => {
+  queryClient.clear();
+});
 
 describe("dashboard flow integration", () => {
   it("loads dashboard, refetches overview on overview-timeframe changes, and keeps request-log refetches isolated", async () => {
@@ -101,5 +113,172 @@ describe("dashboard flow integration", () => {
       expect(requestLogCalls).toBeGreaterThan(logsAfterFilter);
     });
     expect(overviewCalls).toBe(overviewAfterTimeframe);
+  });
+
+  it("preserves healthy overview through initial request-log failure and Retry recovery", async () => {
+    const user = userEvent.setup({ delay: null });
+    let overviewCalls = 0;
+    let projectionsCalls = 0;
+    let requestLogCalls = 0;
+    let optionsCalls = 0;
+    let requestLogsAvailable = false;
+    let releaseRecoveredResponse = () => {};
+    const recoveredResponseGate = new Promise<void>((resolve) => {
+      releaseRecoveredResponse = resolve;
+    });
+    const recoveredLog = createRequestLogEntry({
+      requestId: "req_recovered",
+      accountId: "acc_healthy_overview",
+      apiKeyName: "Recovered API Key",
+    });
+
+    const healthyAccount = createAccountSummary({
+      accountId: "acc_healthy_overview",
+      chatgptAccountId: "chatgpt_acc_healthy_overview",
+      email: "healthy-overview@example.com",
+      displayName: "Healthy Overview Account",
+      usage: {
+        primaryRemainingPercent: 61.3,
+        secondaryRemainingPercent: 88.3,
+        monthlyRemainingPercent: null,
+      },
+      capacityCreditsPrimary: 9_876,
+      remainingCreditsPrimary: 6_055,
+      remainingCreditsSecondary: 6_675.48,
+    });
+    const baseOverview = createDashboardOverview({ accounts: [healthyAccount] });
+    const overview = createDashboardOverview({
+      accounts: [healthyAccount],
+      summary: {
+        ...baseOverview.summary,
+        primaryWindow: {
+          ...baseOverview.summary.primaryWindow,
+          remainingPercent: 61.3,
+          capacityCredits: 9_876,
+          remainingCredits: 6_055,
+        },
+        metrics: {
+          ...baseOverview.summary.metrics!,
+          requests: 424_242,
+        },
+      },
+      windows: {
+        ...baseOverview.windows,
+        primary: {
+          ...baseOverview.windows.primary,
+          accounts: [
+            {
+              accountId: healthyAccount.accountId,
+              remainingPercentAvg: 61.3,
+              capacityCredits: 9_876,
+              remainingCredits: 6_055,
+            },
+          ],
+        },
+      },
+    });
+
+    server.use(
+      http.get("/api/dashboard/overview", () => {
+        overviewCalls += 1;
+        return HttpResponse.json(overview);
+      }),
+      http.get("/api/dashboard/projections", () => {
+        projectionsCalls += 1;
+        return HttpResponse.json(createDashboardProjections());
+      }),
+      http.get("/api/request-logs/options", () => {
+        optionsCalls += 1;
+        return HttpResponse.json(createRequestLogFilterOptions());
+      }),
+      http.get("/api/request-logs", async () => {
+        requestLogCalls += 1;
+        if (!requestLogsAvailable) {
+          return HttpResponse.json(
+            {
+              error: {
+                code: "forced_request_log_outage",
+                message: REQUEST_LOG_OUTAGE_MESSAGE,
+              },
+            },
+            { status: 500 },
+          );
+        }
+
+        await recoveredResponseGate;
+        return HttpResponse.json(createRequestLogsResponse([recoveredLog], 1, false));
+      }),
+    );
+
+    window.history.pushState({}, "", "/dashboard");
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Dashboard" })).toBeInTheDocument();
+    const requestLogsHeading = await screen.findByRole("heading", { name: "Request Logs" });
+    const requestLogsSection = requestLogsHeading.closest("section");
+
+    expect(requestLogsSection).not.toBeNull();
+    const requestLogs = within(requestLogsSection as HTMLElement);
+    const errorAlert = await requestLogs.findByRole("alert");
+
+    await waitFor(() => {
+      expect(overviewCalls).toBeGreaterThan(0);
+      expect(projectionsCalls).toBeGreaterThan(0);
+      expect(requestLogCalls).toBeGreaterThan(1);
+      expect(optionsCalls).toBeGreaterThan(0);
+    });
+
+    const expectHealthySurfaces = () => {
+      expect(screen.getByText("Requests (7d)")).toBeInTheDocument();
+      expect(screen.getByText("424.24K")).toBeInTheDocument();
+      expect(screen.getByText("Account burn projection (5h/7d)")).toBeInTheDocument();
+      expect(screen.getByText("0.4 / 0.1")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "5-Hour Credits" })).toBeInTheDocument();
+      expect(screen.getByText("6,055")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Enable limit warm-up for Healthy Overview Account" }),
+      ).toBeInTheDocument();
+    };
+
+    await waitFor(expectHealthySurfaces);
+    expect(screen.getByRole("heading", { name: "Accounts" })).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(0);
+    expect(errorAlert).toHaveTextContent(REQUEST_LOG_OUTAGE_MESSAGE);
+    expect(requestLogs.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+
+    const overviewCallsBeforeRetry = overviewCalls;
+    const projectionsCallsBeforeRetry = projectionsCalls;
+    const requestLogCallsBeforeRetry = requestLogCalls;
+    const optionsCallsBeforeRetry = optionsCalls;
+    const retryButton = requestLogs.getByRole("button", { name: "Retry" });
+    requestLogsAvailable = true;
+
+    retryButton.focus();
+    expect(retryButton).toHaveFocus();
+    await user.keyboard("{Enter}");
+    await waitFor(() => {
+      expect(requestLogCalls).toBe(requestLogCallsBeforeRetry + 1);
+    });
+
+    expectHealthySurfaces();
+    expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(0);
+    expect(overviewCalls).toBe(overviewCallsBeforeRetry);
+    expect(projectionsCalls).toBe(projectionsCallsBeforeRetry);
+    expect(optionsCalls).toBe(optionsCallsBeforeRetry);
+
+    releaseRecoveredResponse();
+    expect(await screen.findByText("Recovered API Key")).toBeInTheDocument();
+    expect(screen.queryByText(REQUEST_LOG_OUTAGE_MESSAGE)).not.toBeInTheDocument();
+    expectHealthySurfaces();
+    expect(container.querySelectorAll('[data-slot="skeleton"]')).toHaveLength(0);
+    expect(overviewCalls).toBe(overviewCallsBeforeRetry);
+    expect(projectionsCalls).toBe(projectionsCallsBeforeRetry);
+    expect(optionsCalls).toBe(optionsCallsBeforeRetry);
   });
 });

--- a/frontend/src/features/dashboard/components/dashboard-page.test.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-page.test.tsx
@@ -106,6 +106,15 @@ const useDashboardProjectionsMock = vi.mocked(useDashboardProjections);
 const useRequestLogsMock = vi.mocked(useRequestLogs);
 const buildDashboardViewMock = vi.mocked(buildDashboardView);
 
+type RequestLogsQueryOverrides = {
+  data?: undefined;
+  error?: Error | null;
+  isFetching?: boolean;
+  isLoading?: boolean;
+  isPending?: boolean;
+  isSuccess?: boolean;
+};
+
 describe("DashboardPage", () => {
   beforeEach(() => {
     accountCardsSpy.mockReset();
@@ -124,7 +133,7 @@ describe("DashboardPage", () => {
     });
   });
 
-  function mockReadyDashboard() {
+  function mockReadyDashboard(logsQueryOverrides: RequestLogsQueryOverrides = {}) {
     const overview = createDashboardOverview();
 
     useAccountMutationsMock.mockReturnValue({
@@ -172,6 +181,11 @@ describe("DashboardPage", () => {
         data: { requests: [], total: 0, hasMore: false },
         isFetching: false,
         error: null,
+        isLoading: false,
+        isPending: false,
+        isSuccess: true,
+        refetch: vi.fn(),
+        ...logsQueryOverrides,
       },
       optionsQuery: {
         data: { accountIds: [], apiKeys: [], modelOptions: [], statuses: [] },
@@ -193,6 +207,44 @@ describe("DashboardPage", () => {
 
     return overview;
   }
+
+  it("keeps the page-wide skeleton while overview data is unavailable", () => {
+    mockReadyDashboard();
+    useDashboardMock.mockReturnValue({
+      data: undefined,
+      isFetching: true,
+      error: null,
+    } as ReturnType<typeof useDashboard>);
+
+    renderWithProviders(<DashboardPage />);
+
+    expect(screen.getByTestId("dashboard-skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("stats-grid")).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Accounts" })).not.toBeInTheDocument();
+  });
+
+  it("renders request-log loading inside its section without hiding overview content", () => {
+    mockReadyDashboard({
+      data: undefined,
+      error: null,
+      isFetching: true,
+      isLoading: true,
+      isPending: true,
+      isSuccess: false,
+    });
+
+    renderWithProviders(<DashboardPage />);
+
+    expect(screen.queryByTestId("dashboard-skeleton")).not.toBeInTheDocument();
+    expect(screen.getByTestId("stats-grid")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Accounts" })).toBeInTheDocument();
+    const requestLogsSection = screen.getByRole("heading", { name: "Request Logs" }).closest("section");
+
+    expect(requestLogsSection).not.toBeNull();
+    expect(within(requestLogsSection as HTMLElement).getByText("Loading...")).toBeInTheDocument();
+    expect(screen.queryByTestId("request-filters")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("recent-requests-table")).not.toBeInTheDocument();
+  });
 
   it("renders the account summary line in the Accounts header using overview accounts", () => {
     const overview = mockReadyDashboard();

--- a/frontend/src/features/dashboard/components/dashboard-page.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-page.tsx
@@ -5,6 +5,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import { RefreshCw } from "lucide-react";
 
 import { AlertMessage } from "@/components/alert-message";
+import { Button } from "@/components/ui/button";
+import { SpinnerBlock } from "@/components/ui/spinner";
 import { useDialogState } from "@/hooks/use-dialog-state";
 import { useAccountMutations } from "@/features/accounts/hooks/use-accounts";
 import { ResetCreditConfirmDialog } from "@/features/accounts/components/reset-credit-confirm-dialog";
@@ -117,12 +119,12 @@ export function DashboardPage() {
 
   const view = useMemo(() => {
     void resolvedLanguage;
-    if (!overview || !logPage) {
+    if (!overview) {
       return null;
     }
     return buildDashboardView(
       overview,
-      logPage.requests,
+      logPage?.requests ?? [],
       {
         isDark,
         showAccountBurnrate,
@@ -177,7 +179,6 @@ export function DashboardPage() {
 
   const errorMessage =
     (dashboardQuery.error instanceof Error && dashboardQuery.error.message) ||
-    (logsQuery.error instanceof Error && logsQuery.error.message) ||
     (optionsQuery.error instanceof Error && optionsQuery.error.message) ||
     null;
 
@@ -270,6 +271,29 @@ export function DashboardPage() {
               <h2 className="text-[13px] font-medium uppercase tracking-wider text-muted-foreground">{t("dashboard.requests.title")}</h2>
               <div className="h-px flex-1 bg-border" />
             </div>
+            {logsQuery.isPending && !logPage ? (
+              <div className="rounded-xl border bg-card py-8">
+                <SpinnerBlock />
+              </div>
+            ) : logsQuery.error ? (
+              <div className="space-y-3 rounded-xl border bg-card p-4">
+                <div role="alert">
+                  <AlertMessage variant="error">{logsQuery.error.message}</AlertMessage>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    void logsQuery.refetch();
+                  }}
+                  disabled={logsQuery.isFetching}
+                >
+                  {t("common.actions.retry")}
+                </Button>
+              </div>
+            ) : logPage ? (
+              <>
             <RequestFilters
               filters={filters}
               accountOptions={accountOptions}
@@ -308,6 +332,8 @@ export function DashboardPage() {
                 onOffsetChange={(offset) => updateFilters({ offset })}
               />
             </div>
+              </>
+            ) : null}
           </section>
         </>
       )}

--- a/openspec/changes/preserve-dashboard-overview-on-log-failure/.openspec.yaml
+++ b/openspec/changes/preserve-dashboard-overview-on-log-failure/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/preserve-dashboard-overview-on-log-failure/design.md
+++ b/openspec/changes/preserve-dashboard-overview-on-log-failure/design.md
@@ -1,0 +1,34 @@
+## Context
+
+`DashboardPage` starts overview, projections, request-log options, and request-log listing queries independently, but its composed `view` currently requires both overview and request-log data. A terminal listing error therefore leaves the full `DashboardSkeleton` mounted even after the healthy overview path has completed. The request-log query already exposes a local `refetch` operation, and existing shared loading, alert, and button components cover the required states without a new API or dependency.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep successful overview, quota, projection, and account content usable when the initial request-log listing fails.
+- Keep loading and terminal failure for the initial listing inside the Request Logs section.
+- Recover through the existing request-log query's `refetch` operation without invalidating or hiding healthy overview data.
+- Prove failure and recovery through the real `/dashboard` App route and production query retry policy.
+
+**Non-Goals:**
+
+- Preserve stale request-log rows after a later refetch failure.
+- Change request-log APIs, retry policy, polling, caching, indexes, or backend reliability.
+- Split routes, redesign layout, add global state/live-region semantics, or add settings, navigation, or dependencies.
+
+## Decisions
+
+1. **Compose overview-backed view data as soon as overview exists.** Pass an empty request array to the existing view builder until listing data is available, then render the Request Logs section according to the listing query state. This deepens the current page composition without creating a second view model. The rejected alternative—splitting the view builder or adding a new cross-query abstraction—would add surface area without changing the independent query contract.
+
+2. **Keep the failure boundary at the Request Logs section.** Initial pending state renders the shared scoped loading treatment; terminal listing error renders the shared error alert inside a section-local alert semantic plus the existing localized Retry button; ready state renders filters and table. The rejected alternative—continuing to aggregate the listing error at page level—would preserve the outage coupling this change removes.
+
+3. **Retry through `logsQuery.refetch` only.** The local control does not call broad Dashboard invalidation, so overview/projection requests and healthy content remain untouched. The header refresh action retains its existing broad behavior.
+
+4. **Cover the real route with MSW.** The regression uses `<App />`, the production `queryClient` (`retry: 1`), real hooks/API schemas, and call counters. It seeds unique values for a statistic, quota surface, projection metric, and account control; switches the listing handler from 500 to a deliberately pending 200 response; keyboard-activates the native Retry control; and asserts overview request count and visible healthy content remain stable throughout recovery.
+
+## Risks / Trade-offs
+
+- Passing an empty request array while the listing is unavailable means the shared view model briefly contains no request rows, but the table is not rendered until the listing is ready; this avoids exposing a false empty state.
+- Request-log option failures remain governed by their existing error path; this change isolates only the listing failure proven by the regression.
+- Later refetch failures with existing rows are intentionally not specified as stale-row preservation and can be addressed separately.

--- a/openspec/changes/preserve-dashboard-overview-on-log-failure/proposal.md
+++ b/openspec/changes/preserve-dashboard-overview-on-log-failure/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+A terminal request-log listing failure currently keeps an otherwise healthy Dashboard behind its page-wide loading skeleton. Operators lose usable overview, quota, and account controls during a request-log outage, when those healthy surfaces are especially valuable.
+
+## What Changes
+
+- Gate overview-backed Dashboard content only on the overview query instead of requiring request logs too.
+- Give the Request Logs section independent initial-loading, terminal-error, and ready states.
+- Expose a Request Logs-scoped Retry action that refetches only request logs and preserves healthy overview content throughout recovery.
+- Add App-route regression coverage for initial partial failure and logs-only recovery.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `frontend-architecture`: Require independent Dashboard overview and Request Logs loading/failure boundaries.
+
+## Impact
+
+- Dashboard composition in `frontend/src/features/dashboard/components/dashboard-page.tsx`.
+- MSW-backed route coverage in `frontend/src/__integration__/dashboard-flow.test.tsx`.
+- No backend API, query key, setting, navigation, dependency, or migration changes.

--- a/openspec/changes/preserve-dashboard-overview-on-log-failure/specs/frontend-architecture/spec.md
+++ b/openspec/changes/preserve-dashboard-overview-on-log-failure/specs/frontend-architecture/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Dashboard overview and request-log listing fail independently
+
+The Dashboard SHALL gate overview-backed statistics, quota, projections, and account controls only on dashboard overview availability. The Request Logs section SHALL own the initial loading, terminal error, and ready states of its listing query without hiding healthy overview-backed content.
+
+When the initial request-log listing reaches a terminal error, the Request Logs section MUST remain visible, MUST render the listing error inside that section, MUST announce that error through an alert semantic local to the section, and MUST expose a keyboard-operable, accessibly named Retry action. Activating Retry MUST refetch only the request-log listing query and MUST NOT refetch or hide healthy overview-backed content.
+
+#### Scenario: Initial request-log failure preserves healthy overview
+
+- **GIVEN** dashboard overview, projections, and request-log filter options load successfully
+- **WHEN** the initial request-log listing reaches a terminal error
+- **THEN** overview statistics, quota, and account content remain rendered
+- **AND** the page-wide Dashboard loading skeleton is not rendered
+- **AND** the Request Logs section contains and announces the listing error and exposes a Retry action
+
+#### Scenario: Request-log retry recovers independently
+
+- **GIVEN** healthy overview-backed content is rendered and the initial request-log listing has failed
+- **WHEN** the listing endpoint recovers and the operator activates Retry
+- **THEN** only the request-log listing query is refetched
+- **AND** healthy overview-backed content remains visible throughout recovery
+- **AND** the recovered request-log rows render in the Request Logs section
+
+#### Scenario: Request logs load inside their section
+
+- **GIVEN** dashboard overview data is available
+- **WHEN** the initial request-log listing is still pending
+- **THEN** overview-backed content is rendered
+- **AND** the Request Logs section renders its own loading state
+- **AND** the page-wide Dashboard loading skeleton is not rendered
+
+#### Scenario: Initial overview loading keeps the existing page skeleton
+
+- **WHEN** the dashboard overview is not yet available
+- **THEN** the Dashboard renders its existing page-wide loading skeleton
+- **AND** it does not render overview-backed content prematurely

--- a/openspec/changes/preserve-dashboard-overview-on-log-failure/tasks.md
+++ b/openspec/changes/preserve-dashboard-overview-on-log-failure/tasks.md
@@ -1,0 +1,15 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Port the strict MSW-backed `/dashboard` partial-failure reproduction into the permanent integration suite and record its pre-fix failure.
+- [x] 1.2 Extend the regression through 500-to-200 Retry recovery, asserting only request logs refetch and healthy overview content never disappears.
+
+## 2. Dashboard Isolation
+
+- [x] 2.1 Gate overview-backed composition only on overview data and render Request Logs initial-loading, terminal-error, and ready states inside its section.
+- [x] 2.2 Wire the scoped Retry action to the existing request-log query refetch operation while preserving all-success and overview-loading behavior.
+
+## 3. Verification
+
+- [x] 3.1 Run focused regression tests, relevant frontend unit/integration coverage, typecheck, lint, build, and the prescribed frontend suite.
+- [x] 3.2 Complete desktop browser smoke verification with identical request-log interception and capture before/after evidence outside the repository.
+- [x] 3.3 Promote stable frontend-architecture context, run strict OpenSpec validation, and verify the completed change against its artifacts.

--- a/openspec/specs/frontend-architecture/context.md
+++ b/openspec/specs/frontend-architecture/context.md
@@ -53,3 +53,25 @@ sections with their controls disabled by the existing `canWrite` gating.
   asserting through the same one-interaction path an operator uses.
 - The accounts reset-credits badge stays on the core Accounts item in both
   desktop and mobile navs.
+
+## Dashboard partial-failure isolation
+
+### Purpose and scope
+
+The dashboard overview and request-log listing are independent operator surfaces. A request-log storage or listing outage should not remove healthy fleet quota and account controls. Normative behavior lives in [`spec.md`](./spec.md); while the change is active, its added requirement lives in [`../../changes/preserve-dashboard-overview-on-log-failure/specs/frontend-architecture/spec.md`](../../changes/preserve-dashboard-overview-on-log-failure/specs/frontend-architecture/spec.md).
+
+### Decision rationale
+
+The page composes overview-backed view data as soon as overview data exists and treats request logs as a section-local state machine: initial loading, terminal error announced through a local alert semantic, or ready. Recovery calls the existing request-log query's local refetch operation. A broader dashboard invalidation was rejected because it would refetch healthy data and could make usable incident context disappear.
+
+### Constraints and non-goals
+
+This boundary does not change API shapes, query keys, retry policy, polling, or backend reliability. It does not preserve stale rows after later refetch failures, introduce route splitting or global state, or define global live-region behavior. The header refresh action intentionally keeps its existing broad refresh semantics; only the Request Logs Retry action is local.
+
+### Failure mode and example
+
+If overview, projections, and request-log options return successfully while the initial listing reaches terminal HTTP 500, operators continue to see statistics, quota charts, and account controls. The Request Logs heading remains visible with a locally announced endpoint error and native Retry control. After the endpoint recovers, keyboard-activating Retry replaces that error with the returned rows without issuing another overview request.
+
+### Testing notes
+
+The product-boundary regression renders the real `/dashboard` App route with the production query retry policy and MSW handlers. It counts each request family, seeds unique values for a statistic, quota surface, projection metric, and account control, focuses and keyboard-activates native Retry, holds the recovered listing response pending long enough to assert all healthy surfaces remain mounted, and then verifies the recovered row.


### PR DESCRIPTION
## Summary

Keep the Dashboard overview, quota, projections, and account controls visible when the initial request-log listing fails. Move request-log loading, terminal error, and Retry recovery into the Request Logs section so recovery refetches only that listing.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: None — independently reproduced defect; no matching issue/discussion

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/preserve-dashboard-overview-on-log-failure/`

Codex-faithful path: No — this change is limited to Dashboard query composition and request-log UI state; it does not touch an upstream-mimicking wire path.

## Changes

- Compose healthy overview-backed Dashboard content as soon as overview data is available instead of waiting for request-log data.
- Keep request-log initial loading and terminal failure inside the Request Logs section, with a section-local alert and keyboard-operable Retry that calls only the listing query's `refetch`.
- Add component and real `/dashboard` App-route regression coverage for partial failure and 500-to-200 recovery, plus the governing OpenSpec change and stable frontend-architecture context.

## Simplicity

- [x] This bug fix works with zero config and adds no required setup step.
- [x] No new settings, environment variables, dependencies, migrations, or navigation items.
- New setting(s) and why each can't be a default: None.
- [x] README sections, `.env.example`, and dashboard core navigation are unchanged and remain within budget.
- Defaults: unchanged; the existing overview, request-log API, retry policy, polling, caching, and header refresh defaults are preserved.
- Documentation: no README or user-facing docs changes; behavior is recorded only in the required OpenSpec artifacts and capability context.

## Test plan

```text
cd frontend && bun run test -- src/features/dashboard/components/dashboard-page.test.tsx src/__integration__/dashboard-flow.test.tsx
# 2 test files passed; 8 tests passed

cd frontend && bun run test
# 879 frontend tests passed

cd frontend && bun run test:coverage
# 879 frontend tests passed with the coverage run completed successfully

cd frontend && bun run lint
# passed

cd frontend && bun run typecheck
# passed

cd frontend && bun run build
# passed

openspec validate preserve-dashboard-overview-on-log-failure --strict
# change is valid

openspec validate --specs --strict
# 47 passed, 0 failed
```

The real `/dashboard` browser path was also exercised with the request-log listing intercepted through failure and recovery; sanitized textual results are below.

## Screenshots / output

- Baseline: healthy content was hidden behind 168 skeletons when the request-log listing failed.
- Fixed: a distinct statistic, quota surface, projection metric, and account control remained visible with 0 skeletons.
- Retry via Enter changed request-log calls from 2 to 3 while overview, projections, and options each stayed at 1.
- The request-log failure was announced by an alert local to the Request Logs section, and Retry remained outside that alert.
- Screenshots and recordings are omitted at user request because captures may contain private data. This follows the user's explicit privacy policy; the repository's P5 screenshot gate may therefore remain a merge blocker.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked issue / discussion is addressed above; none matched this independently reproduced defect.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant frontend local-CI subset: tests, coverage, lint, typecheck, and build.
- [x] Strict OpenSpec change and spec validation pass; all 7 OpenSpec tasks are checked.
- [x] Simplicity gates reviewed: P1-P4 are unchanged/satisfied; P5 is disclosed below.
- [ ] P5 media evidence attached — intentionally omitted under the user's privacy policy and transparently retained as a potential merge blocker.
- [x] CHANGELOG is not edited by hand (release-please handles it).
