### PR TITLE
fix(api): give thread-goal GET/POST distinct operationIds

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -519,7 +519,8 @@ async def _codex_control_proxy(
     )
 
 
-@router.api_route("/thread/goal/get", methods=["GET", "POST"])
+@router.get("/thread/goal/get")
+@router.post("/thread/goal/get")
 async def thread_goal_get(
     request: Request,
     context: ProxyContext = Depends(get_proxy_context),

--- a/openspec/changes/thread-goal-openapi-operation-ids/.openspec.yaml
+++ b/openspec/changes/thread-goal-openapi-operation-ids/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/thread-goal-openapi-operation-ids/design.md
+++ b/openspec/changes/thread-goal-openapi-operation-ids/design.md
@@ -1,0 +1,41 @@
+## Context
+
+FastAPI generates one route-level `unique_id` for an `APIRoute`. The thread-goal compatibility handler is currently registered once with `methods=["GET", "POST"]`, so OpenAPI generation reuses that single identifier for both operations. The generated suffix also depends on which method FastAPI reads first from an unordered method set, making the duplicate identifier process-dependent.
+
+The route must retain both methods, its exact path, the same handler body, router dependencies, request forwarding, and response behavior. The externally affected seam is the unauthenticated OpenAPI document; the existing method-parameterized integration test covers runtime parity.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make every generated OpenAPI `operationId` unique.
+- Make the thread-goal GET and POST identifiers deterministic without departing from FastAPI's default naming convention.
+- Preserve GET and POST runtime forwarding through one handler.
+- Lock both the global schema invariant and the exact target identifiers with a real `/openapi.json` regression.
+
+**Non-Goals:**
+
+- No split into separate handler functions.
+- No explicit `operation_id=` override or repository-wide operation naming convention.
+- No route alias, path, dependency, authentication, request, response, or upstream behavior change.
+- No global route refactor, frontend change, or unrelated OpenAPI cleanup.
+
+## Decisions
+
+- Register the existing handler with adjacent `@router.get(...)` and `@router.post(...)` decorators. Each decorator creates a single-method `APIRoute`, so FastAPI's normal generator produces deterministic `_get` and `_post` suffixes while both routes retain the same handler identity. The rejected alternative is an explicit `operation_id=` override, which would establish a one-off naming convention and mask the route-registration cause.
+- Test the public schema by requesting unauthenticated `GET /openapi.json`, enumerating documented HTTP operations, and asserting global `operationId` uniqueness plus the two exact thread-goal identifiers. The rejected alternative is inspecting router internals, which would not verify the emitted client contract.
+- Keep the existing parameterized GET/POST forwarding test unchanged. This separates the new schema contract from existing runtime compatibility evidence.
+
+## Risks / Trade-offs
+
+- **Risk: decorator order could make route registration hard to read.** → Keep both decorators adjacent on the existing function and use the same path literal.
+- **Risk: another route may later introduce a duplicate identifier.** → The full-schema uniqueness assertion fails at the public OpenAPI seam, not only for the current pair.
+- **Trade-off: exact generated identifiers couple the regression to FastAPI's established default naming convention.** → This is intentional because same-source deterministic identifiers are the compatibility contract being fixed, and no explicit repository naming convention exists.
+
+## Migration Plan
+
+No data or operator migration is required. Deployment changes only generated OpenAPI metadata; rollback restores the prior route registration and duplicate schema behavior.
+
+## Open Questions
+
+None.

--- a/openspec/changes/thread-goal-openapi-operation-ids/proposal.md
+++ b/openspec/changes/thread-goal-openapi-operation-ids/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The GET and POST variants of `/backend-api/codex/thread/goal/get` currently publish the same process-dependent OpenAPI `operationId`. This violates the OpenAPI uniqueness contract and can make generated clients or schema snapshots collapse or rename operations between otherwise identical processes.
+
+## What Changes
+
+- Require globally unique `operationId` values across the generated OpenAPI document.
+- Give the thread-goal GET and POST operations distinct, deterministic FastAPI-generated identifiers.
+- Preserve the existing path, methods, handler, dependencies, and runtime forwarding behavior.
+- Add schema-level regression coverage while retaining the existing GET/POST runtime parity coverage.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: Defines the stable OpenAPI metadata contract for the Codex-compatible thread-goal GET and POST operations while preserving their runtime compatibility.
+
+## Impact
+
+- Affected API metadata: unauthenticated `GET /openapi.json`.
+- Affected route registration: `app/modules/proxy/api.py` for `/backend-api/codex/thread/goal/get`.
+- Affected verification: focused integration coverage for schema uniqueness, exact target identifiers, and unchanged GET/POST forwarding parity.
+- No new dependencies, settings, route aliases, frontend behavior, or upstream wire behavior.

--- a/openspec/changes/thread-goal-openapi-operation-ids/specs/responses-api-compat/spec.md
+++ b/openspec/changes/thread-goal-openapi-operation-ids/specs/responses-api-compat/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Thread-goal OpenAPI operations have unique stable identifiers
+The generated OpenAPI document MUST assign a unique `operationId` to every documented HTTP operation. The GET and POST operations at `/backend-api/codex/thread/goal/get` MUST remain available through the same runtime behavior and MUST expose the deterministic identifiers `thread_goal_get_backend_api_codex_thread_goal_get_get` and `thread_goal_get_backend_api_codex_thread_goal_get_post`, respectively. Correcting this schema metadata MUST NOT change either method's authentication, dependency, request forwarding, upstream operation, response status, or response payload behavior.
+
+#### Scenario: Full OpenAPI schema has unique operation identifiers
+- **WHEN** an unauthenticated client requests `GET /openapi.json`
+- **THEN** every documented HTTP operation has an `operationId`
+- **AND** no two documented HTTP operations share an `operationId`
+
+#### Scenario: Thread-goal methods publish deterministic identifiers
+- **WHEN** an unauthenticated client inspects `/openapi.json`
+- **THEN** `GET /backend-api/codex/thread/goal/get` has `operationId` `thread_goal_get_backend_api_codex_thread_goal_get_get`
+- **AND** `POST /backend-api/codex/thread/goal/get` has `operationId` `thread_goal_get_backend_api_codex_thread_goal_get_post`
+
+#### Scenario: Thread-goal runtime forwarding remains compatible
+- **WHEN** a client invokes either GET or POST `/backend-api/codex/thread/goal/get` with valid existing dependencies
+- **THEN** the request is forwarded through the existing thread-goal handler using the original request method
+- **AND** the upstream operation, response status, and response payload remain unchanged

--- a/openspec/changes/thread-goal-openapi-operation-ids/tasks.md
+++ b/openspec/changes/thread-goal-openapi-operation-ids/tasks.md
@@ -1,0 +1,20 @@
+## 1. Schema Regression
+
+- [x] 1.1 Add a real unauthenticated `/openapi.json` regression that asserts every documented HTTP operation has a globally unique `operationId` and pins the exact thread-goal GET and POST identifiers.
+  - Evidence: `test_openapi_operation_ids_are_unique_and_thread_goal_methods_stable` requests `/openapi.json`, enumerates all documented HTTP methods, reports duplicate counts, and pins both target IDs.
+- [x] 1.2 Run the focused schema regression before the production fix and record the expected duplicate-identifier failure.
+  - Evidence: pre-fix `uv run pytest tests/integration/test_proxy_api_extended.py::test_openapi_operation_ids_are_unique_and_thread_goal_methods_stable -q` failed with one duplicate group, `thread_goal_get_backend_api_codex_thread_goal_get_get: 2`.
+
+## 2. Route Registration
+
+- [x] 2.1 Replace the thread-goal multi-method `api_route` decorator with adjacent GET and POST decorators on the same handler, without an explicit `operation_id`.
+  - Evidence: `app/modules/proxy/api.py` now stacks `@router.get("/thread/goal/get")` and `@router.post("/thread/goal/get")` directly on the unchanged `thread_goal_get` handler.
+- [x] 2.2 Confirm the schema regression passes and the existing parameterized GET/POST runtime forwarding parity test remains unchanged and green.
+  - Evidence: focused pytest for the schema regression, the hermetic route-registration unit regression, and `test_thread_goal_get_forwards_upstream_goal` completed `4 passed`; the existing parameterized parity test body is unchanged.
+
+## 3. Verification
+
+- [x] 3.1 Run focused Ruff and type checks for the touched Python scope.
+  - Evidence: `uv run ruff check app/modules/proxy/api.py tests/integration/test_proxy_api_extended.py tests/unit/test_thread_goal_route.py` returned `OK`; `uv run ty check` on the same files returned `All checks passed!`.
+- [x] 3.2 Validate the change and main OpenSpec specifications strictly, then verify implementation, scenarios, design, and task coherence.
+  - Evidence: `openspec validate thread-goal-openapi-operation-ids --strict` passed; `openspec validate --specs --strict` reported `47 passed, 0 failed`; `/opsx:verify` mapped all three scenarios to the schema regression or unchanged runtime parity test with no design divergence.

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+from collections import Counter
 from types import SimpleNamespace
 from typing import cast
 
@@ -88,6 +89,30 @@ async def _import_account(async_client, account_id: str, email: str) -> str:
     response = await async_client.post("/api/accounts/import", files=files)
     assert response.status_code == 200
     return generate_unique_account_id(account_id, email)
+
+
+@pytest.mark.asyncio
+async def test_openapi_operation_ids_are_unique_and_thread_goal_methods_stable(async_client):
+    response = await async_client.get("/openapi.json")
+
+    assert response.status_code == 200
+    schema = response.json()
+    operation_ids: list[str] = []
+    http_methods = {"get", "put", "post", "delete", "options", "head", "patch", "trace"}
+    for path, path_item in schema["paths"].items():
+        for method, operation in path_item.items():
+            if method not in http_methods:
+                continue
+            operation_id = operation.get("operationId")
+            assert isinstance(operation_id, str), f"{method.upper()} {path} has no operationId"
+            operation_ids.append(operation_id)
+
+    duplicate_ids = {operation_id: count for operation_id, count in Counter(operation_ids).items() if count > 1}
+    assert duplicate_ids == {}
+
+    thread_goal = schema["paths"]["/backend-api/codex/thread/goal/get"]
+    assert thread_goal["get"]["operationId"] == "thread_goal_get_backend_api_codex_thread_goal_get_get"
+    assert thread_goal["post"]["operationId"] == "thread_goal_get_backend_api_codex_thread_goal_get_post"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_thread_goal_route.py
+++ b/tests/unit/test_thread_goal_route.py
@@ -1,0 +1,18 @@
+from fastapi.routing import APIRoute
+
+from app.modules.proxy.api import router
+
+
+def test_thread_goal_get_and_post_routes_share_handler_with_distinct_ids() -> None:
+    routes = [
+        route
+        for route in router.routes
+        if isinstance(route, APIRoute) and route.path == "/backend-api/codex/thread/goal/get"
+    ]
+
+    assert len(routes) == 2
+    routes_by_method = {method: route for route in routes for method in route.methods}
+    assert set(routes_by_method) == {"GET", "POST"}
+    assert routes_by_method["GET"].endpoint is routes_by_method["POST"].endpoint
+    assert routes_by_method["GET"].unique_id == "thread_goal_get_backend_api_codex_thread_goal_get_get"
+    assert routes_by_method["POST"].unique_id == "thread_goal_get_backend_api_codex_thread_goal_get_post"


### PR DESCRIPTION
## Summary

Give the thread-goal GET and POST operations distinct, deterministic OpenAPI `operationId` values by registering separate single-method routes on the same handler. Runtime request forwarding remains unchanged.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: None — independently reproduced; no matching issue or discussion; searches recorded

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful proxy path and preserves upstream-equivalent request forwarding

Change directory: `openspec/changes/thread-goal-openapi-operation-ids/`

## Changes

- Replace the combined `api_route(..., methods=["GET", "POST"])` registration with adjacent `router.get` and `router.post` decorators on the unchanged handler.
- Add a hermetic route-registration unit regression and an unauthenticated `/openapi.json` integration regression for global uniqueness and exact target IDs.
- Preserve the existing parameterized GET/POST upstream-forwarding parity coverage.
- Keep the OpenSpec change active through merge under `responses-api-compat`.

## Simplicity

- [ ] New feature defaults to **off** or works with **zero config** — not applicable; this is a bug fix.
- [x] No new required setup step.
- New setting(s) and why each can't be a default: None.
- [x] README sections / `.env.example` / dashboard nav remain unchanged and within budget.

P1–P2: not applicable; no feature toggle, required setup, or setting. P3–P4: pass; no README, environment, navigation, or docs expansion, and the observable contract is in OpenSpec. P5: not applicable; this does not change dashboard rendering.

## Test plan

```text
uv run pytest -q \
  tests/integration/test_proxy_api_extended.py::test_openapi_operation_ids_are_unique_and_thread_goal_methods_stable \
  tests/integration/test_proxy_api_extended.py::test_thread_goal_get_forwards_upstream_goal \
  tests/unit/test_thread_goal_route.py
# 4 passed in 1.25s

uv run ruff check app/modules/proxy/api.py tests/integration/test_proxy_api_extended.py tests/unit/test_thread_goal_route.py
uv run ruff format --check app/modules/proxy/api.py tests/integration/test_proxy_api_extended.py tests/unit/test_thread_goal_route.py
uv run ty check app/modules/proxy/api.py tests/integration/test_proxy_api_extended.py tests/unit/test_thread_goal_route.py
# Ruff, format, and type checks passed

openspec validate thread-goal-openapi-operation-ids --strict
# valid
openspec validate --specs --strict
# 47 passed, 0 failed
/opsx:verify thread-goal-openapi-operation-ids
# 6/6 tasks, 1/1 requirement, 3/3 scenarios; no issues

```

Current-head validation after merging `upstream/main` `ed017d52876a32eb06fd101f47a224cf0b750b8e` into head `6dae47ea79b8c08598e03d8f990289a2b66e3e73`:

```text
pytest tests/unit/test_thread_goal_route.py tests/integration/test_proxy_api_extended.py
# 42 passed in 10.32s

ruff check .
# All checks passed
ruff format --check .
# 807 files already formatted
python scripts/check_proxy_architecture.py
# proxy architecture checks passed

openspec validate thread-goal-openapi-operation-ids --strict
# valid
openspec validate --specs --strict
# 47 passed, 0 failed
```

The inherited `service.py` architecture-ratchet failure no longer reproduces on current `main`; no unrelated code change was needed in this PR.

Independent binding reviews on the exact committed diff both passed with zero findings: Standards PASS and Spec PASS. The whole `api.py` AST matches the reviewed base except for the target decorator list, preserving the upstream non-target behavior already present in the base.

## Screenshots / output

Text-only `/openapi.json` evidence:

```text
Before
GET  /backend-api/codex/thread/goal/get -> thread_goal_get_backend_api_codex_thread_goal_get_get
POST /backend-api/codex/thread/goal/get -> thread_goal_get_backend_api_codex_thread_goal_get_get
duplicate operationId count for that identifier: 2

After
GET  /backend-api/codex/thread/goal/get -> thread_goal_get_backend_api_codex_thread_goal_get_get
POST /backend-api/codex/thread/goal/get -> thread_goal_get_backend_api_codex_thread_goal_get_post
global duplicate operationIds: none
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above — not applicable; independently reproduced and no match was found.
- [x] Added or updated tests covering the change.
- [x] Re-ran focused pytest, repo-wide Ruff/format, proxy architecture, and strict OpenSpec validation on the current merged head; all pass.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
