### PR TITLE
fix(db): reject empty migration database URL

### DIFF
--- a/app/db/migrate.py
+++ b/app/db/migrate.py
@@ -823,10 +823,17 @@ def wait_for_head(
         time.sleep(min(interval_seconds, timeout_seconds - elapsed))
 
 
+def _non_empty_database_url(value: str) -> str:
+    if value == "":
+        raise argparse.ArgumentTypeError("database URL must not be empty")
+    return value
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Database migration utility for codex-lb.")
     parser.add_argument(
         "--db-url",
+        type=_non_empty_database_url,
         default=None,
         help="Database URL to migrate. Defaults to CODEX_LB_DATABASE_URL from settings.",
     )
@@ -892,7 +899,7 @@ def _parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = _parse_args()
-    database_url = args.db_url or get_settings().database_url
+    database_url = get_settings().database_url if args.db_url is None else args.db_url
 
     if args.command == "upgrade":
         result = run_upgrade(

--- a/openspec/changes/reject-empty-migration-db-url/.openspec.yaml
+++ b/openspec/changes/reject-empty-migration-db-url/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/reject-empty-migration-db-url/context.md
+++ b/openspec/changes/reject-empty-migration-db-url/context.md
@@ -1,0 +1,36 @@
+## Purpose and Scope
+
+This change closes an operator-safety gap in the standalone migration CLI. Its normative behavior is defined in `specs/database-migrations/spec.md`; this context explains why the parser boundary and subprocess coverage were chosen.
+
+The affected surface is CLI target selection for all six supported migration subcommands. Migration mechanics and the settings model remain outside the change.
+
+## Decision Rationale
+
+An empty argv element is real input: scripts commonly invoke `--db-url "$DATABASE_URL"`, and an unset shell variable preserves an exact empty value when quoted. Treating that value as omission can redirect a destructive command to the configured or default database.
+
+Validation belongs in `argparse` because parsing completes before settings are constructed. A narrow supplied-value converter separates exact empty from the `None` omission sentinel. An explicit identity check at target resolution documents and preserves that distinction.
+
+Validating later, trimming values, or changing global settings validation were considered and rejected. Those options either allow fallback resolution first or expand the contract beyond the reproduced defect.
+
+## Constraints and Non-Goals
+
+- Existing deployment jobs omit `--db-url` and provide `CODEX_LB_DATABASE_URL`; that flow must continue unchanged.
+- Non-empty values pass through without normalization or new syntax checks.
+- Whitespace-only input and an empty global database setting retain existing behavior.
+- The change introduces no Alembic revision, settings field, deployment edit, or dashboard-visible output.
+
+## Failure Modes and Edge Cases
+
+- `upgrade` and `stamp` can durably change a wrongly selected database, so rejection must happen before command dispatch.
+- `current`, `check`, and both wait commands can open or create SQLite files even when their final exit status is nonzero; tests must inspect the filesystem rather than infer safety from exit status alone.
+- Shell calls that omit the value token entirely are handled by normal `argparse` missing-value errors and are not the reproduced exact-empty case.
+
+## Concrete Operator Flow
+
+A quoted empty variable such as `python -m app.db.migrate --db-url "$DATABASE_URL" upgrade head` must fail as an argument error when `DATABASE_URL` is empty. The same command without the `--db-url` option continues to resolve the configured settings target and migrate it.
+
+## Operational and Verification Notes
+
+The regression runs each supported subcommand in a fresh child process with a fresh configured fallback path. The explicit-empty matrix proves no fallback file is created or mutated; a separate omitted-option control proves the configured target reaches the current migration head.
+
+Related contracts: the main `database-migrations` capability owns migration CLI and deployment behavior, while database setting provision remains owned by existing configuration/backend contracts.

--- a/openspec/changes/reject-empty-migration-db-url/design.md
+++ b/openspec/changes/reject-empty-migration-db-url/design.md
@@ -1,0 +1,37 @@
+## Context
+
+The migration CLI parses `--db-url` with a `None` default, but resolves the target with a truthiness expression. An explicit empty argv value is therefore indistinguishable from omission at target resolution and selects `get_settings().database_url` before any subcommand dispatch. All six subcommands share this path; `upgrade` and `stamp` can durably mutate the unintended database, while the inspection and wait commands can still open or create it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reject an explicitly supplied exact empty `--db-url` during argument parsing, before settings construction and database I/O.
+- Keep omitted `--db-url` behavior unchanged for deployment jobs that rely on settings fallback.
+- Cover all six supported subcommands at the real subprocess/CLI seam and prove the fallback target remains untouched on rejection.
+
+**Non-Goals:**
+
+- No whitespace trimming or whitespace-only rejection.
+- No validation or normalization of non-empty URL syntax.
+- No validation of an empty global database setting.
+- No Alembic, Helm, Makefile, settings-model, or dashboard changes.
+
+## Decisions
+
+- Add a narrow `argparse` value converter for the global `--db-url` option that raises `ArgumentTypeError` only when the supplied value is exactly `""`. `argparse` does not call the converter for the `None` default, so omission remains distinguishable and rejection occurs before `get_settings()`.
+- Resolve the database target with an explicit `args.db_url is None` branch. A non-empty supplied value remains authoritative and passes through unchanged. This makes the omission contract visible in the code instead of relying on truthiness.
+- Add one parameterized real-subprocess regression covering `upgrade`, `current`, `check`, `wait-for-head`, `wait-for-connection`, and `stamp`. Each case uses a fresh configured fallback target, asserts argument-error exit, and asserts no fallback file creation or mutation.
+- Add an omitted-option control that upgrades the configured settings target to head. This protects the deployment contract rather than only testing the rejection path.
+
+Alternatives considered:
+
+- Validating after settings resolution was rejected because constructing settings would violate the fail-before-fallback contract and leave side-effect ordering ambiguous.
+- Treating whitespace-only values as empty was rejected as scope expansion; whitespace is a supplied non-empty value and retains existing URL parsing behavior.
+- Adding global database-setting validation was rejected because it is a separate configuration contract and does not fix the CLI omission collapse at its source.
+
+## Risks / Trade-offs
+
+- The parser error text becomes part of operator-facing CLI output; tests assert argument-error semantics and a stable explanatory fragment without coupling to the entire usage banner.
+- Running all six commands as subprocesses costs more than a helper unit test, but it is required to prove the real argv and database-side-effect boundary.
+- The explicit `is None` branch is intentionally redundant with parser validation. It preserves the target-resolution invariant if validation changes later.

--- a/openspec/changes/reject-empty-migration-db-url/proposal.md
+++ b/openspec/changes/reject-empty-migration-db-url/proposal.md
@@ -1,0 +1,37 @@
+# Reject Empty Migration Database URL
+
+## Summary
+
+Make the migration CLI distinguish an omitted database target from an explicitly supplied empty target so operator scripts cannot silently act on the settings-derived database.
+
+## Why
+
+`python -m app.db.migrate --db-url "" …` currently treats the empty argument as if `--db-url` were omitted. Every supported subcommand then resolves the settings-derived database; commands such as `upgrade` and `stamp` can mutate that unintended target.
+
+## What Changes
+
+- Reject an explicitly supplied exact empty `--db-url` as an argument error before settings resolution or database access.
+- Preserve the settings-derived database fallback only when `--db-url` is omitted.
+- Apply the rejection to all six migration subcommands and add real subprocess regression coverage for their database side effects.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `database-migrations`: Defines omission-versus-explicit-empty target handling for every migration CLI subcommand.
+
+## Impact
+
+- Affected code: `app/db/migrate.py`
+- Affected tests: migration CLI subprocess integration coverage
+- No Alembic revision or deployment configuration change is required.
+
+## Non-Goals
+
+- Whitespace-only URL handling, URL normalization, or URL syntax validation.
+- Validation of an empty global database setting.
+- Changes to Helm, Makefile, settings models, migration mechanics, or dashboard behavior.

--- a/openspec/changes/reject-empty-migration-db-url/specs/database-migrations/spec.md
+++ b/openspec/changes/reject-empty-migration-db-url/specs/database-migrations/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Migration CLI distinguishes omitted and empty targets
+
+The `app.db.migrate` / `codex-lb-db` CLI SHALL use the settings-derived database URL only when `--db-url` is omitted. If `--db-url` is explicitly supplied as an exact empty string, the CLI MUST terminate with an argument error before resolving or opening a settings-derived database target. This validation MUST apply to every supported migration subcommand: `upgrade`, `current`, `check`, `wait-for-head`, `wait-for-connection`, and `stamp`.
+
+#### Scenario: Explicit empty target is rejected before side effects
+
+- **GIVEN** settings would resolve a valid database target
+- **WHEN** any supported migration subcommand is invoked with `--db-url ""`
+- **THEN** the CLI exits nonzero with an argument-validation error
+- **AND** it does not select, connect to, create, inspect, migrate, or stamp the settings-derived target
+
+#### Scenario: Omitted target retains the settings fallback
+
+- **GIVEN** settings resolve a valid database target
+- **WHEN** a supported migration subcommand is invoked without `--db-url`
+- **THEN** the CLI uses the settings-derived database target

--- a/openspec/changes/reject-empty-migration-db-url/tasks.md
+++ b/openspec/changes/reject-empty-migration-db-url/tasks.md
@@ -1,0 +1,16 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add a real subprocess matrix for explicit-empty `--db-url` across all six migration subcommands and assert the configured fallback database is neither created nor mutated.
+- [x] 1.2 Add an omitted-option subprocess control that upgrades the configured settings target to the current migration head.
+- [x] 1.3 Run the new regression against the pre-fix implementation and record the expected explicit-empty failures while the omitted fallback control passes.
+
+## 2. CLI Target Validation
+
+- [x] 2.1 Reject an explicitly supplied exact empty `--db-url` during argument parsing without changing non-empty or whitespace-only values.
+- [x] 2.2 Resolve the settings fallback only when the parsed `--db-url` value is `None`.
+
+## 3. Focused Verification
+
+- [x] 3.1 Run the migration subprocess regression green and confirm all six explicit-empty cases produce argument errors without fallback side effects while omission still migrates the configured target.
+- [x] 3.2 Run focused migration tests plus lint and type checks for the touched Python scope.
+- [x] 3.3 Validate the active OpenSpec change strictly and verify implementation, requirements, design, and completed tasks are coherent without archiving the change.

--- a/tests/integration/test_migration_serialization.py
+++ b/tests/integration/test_migration_serialization.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import sqlite3
 import subprocess
 import sys
@@ -27,6 +28,21 @@ _FUTURE_REVISION = "20991231_000000_revision_from_a_newer_build"
 _REPO_ROOT = Path(migrate_module.__file__).resolve().parents[2]
 _LOCK_HOLD_TIMEOUT_SECONDS = 60.0
 
+_EMPTY_DB_URL_COMMANDS = (
+    pytest.param(("upgrade", "head"), id="upgrade"),
+    pytest.param(("stamp", "head"), id="stamp"),
+    pytest.param(("current",), id="current"),
+    pytest.param(
+        ("wait-for-connection", "--timeout-seconds", "0.2", "--interval-seconds", "0.05"),
+        id="wait-for-connection",
+    ),
+    pytest.param(("check",), id="check"),
+    pytest.param(
+        ("wait-for-head", "--timeout-seconds", "0.1", "--interval-seconds", "0.05"),
+        id="wait-for-head",
+    ),
+)
+
 
 def _is_postgresql_database_url(url: str) -> bool:
     return url.startswith("postgresql+")
@@ -36,6 +52,28 @@ def _sqlite_alembic_revisions(db_path: Path) -> list[str]:
     with sqlite3.connect(str(db_path)) as connection:
         rows = connection.execute("SELECT version_num FROM alembic_version").fetchall()
     return sorted(str(row[0]) for row in rows)
+
+
+def _sqlite_table_count(db_path: Path) -> int:
+    with sqlite3.connect(str(db_path)) as connection:
+        rows = connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'").fetchall()
+    return len(rows)
+
+
+def _run_migration_cli(
+    *arguments: str,
+    database_url: str,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["CODEX_LB_DATABASE_URL"] = database_url
+    return subprocess.run(
+        [sys.executable, "-m", "app.db.migrate", *arguments],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=_REPO_ROOT,
+        env=env,
+    )
 
 
 def test_concurrent_upgrades_on_fresh_sqlite_database_apply_head_exactly_once(tmp_path: Path) -> None:
@@ -170,6 +208,43 @@ def test_concurrent_cli_upgrades_share_one_sqlite_database(tmp_path: Path) -> No
         assert process.returncode == 0, f"stdout={process.stdout}\nstderr={process.stderr}"
         assert f"current_revision={_HEAD_REVISION}" in process.stdout
     assert _sqlite_alembic_revisions(db_path) == [_HEAD_REVISION]
+
+
+@pytest.mark.parametrize("command_arguments", _EMPTY_DB_URL_COMMANDS)
+def test_migration_cli_rejects_explicit_empty_db_url_before_settings_fallback(
+    tmp_path: Path,
+    command_arguments: tuple[str, ...],
+) -> None:
+    fallback_path = tmp_path / "settings-fallback.sqlite"
+    fallback_url = f"sqlite+aiosqlite:///{fallback_path}"
+
+    process = _run_migration_cli(
+        "--db-url",
+        "",
+        *command_arguments,
+        database_url=fallback_url,
+    )
+
+    created_paths = sorted(path.name for path in tmp_path.iterdir())
+    table_count = _sqlite_table_count(fallback_path) if fallback_path.exists() else 0
+    assert (
+        process.returncode,
+        created_paths,
+        table_count,
+        "argument --db-url: database URL must not be empty" in process.stderr,
+    ) == (2, [], 0, True), f"stdout={process.stdout}\nstderr={process.stderr}"
+
+
+def test_migration_cli_uses_settings_database_when_db_url_is_omitted(tmp_path: Path) -> None:
+    database_path = tmp_path / "configured.sqlite"
+    database_url = f"sqlite+aiosqlite:///{database_path}"
+
+    process = _run_migration_cli("upgrade", "head", database_url=database_url)
+
+    assert process.returncode == 0, f"stdout={process.stdout}\nstderr={process.stderr}"
+    assert f"current_revision={_HEAD_REVISION}" in process.stdout
+    assert _sqlite_alembic_revisions(database_path) == [_HEAD_REVISION]
+    assert _sqlite_table_count(database_path) > 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import json
 import sqlite3
+import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -40,6 +41,27 @@ from app.modules.usage.additional_quota_keys import clear_additional_quota_regis
 
 def _db_url(path: Path) -> str:
     return f"sqlite+aiosqlite:///{path}"
+
+
+def test_parse_args_rejects_explicit_empty_database_url(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["codex-lb-db", "--db-url", "", "current"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        migrate_module._parse_args()
+
+    assert exc_info.value.code == 2
+    assert "argument --db-url: database URL must not be empty" in capsys.readouterr().err
+
+
+def test_parse_args_preserves_omitted_database_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["codex-lb-db", "current"])
+
+    args = migrate_module._parse_args()
+
+    assert args.db_url is None
 
 
 def test_check_schema_drift_disposes_sync_engine(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- Reject an explicitly supplied exact-empty `--db-url` during migration CLI argument parsing, before any settings-derived database is resolved or opened.
- Preserve the existing settings fallback when `--db-url` is omitted across `upgrade`, `stamp`, `current`, `check`, `wait-for-connection`, and `wait-for-head`.
- Add parser and real-subprocess regression coverage for the six-command rejection matrix and the omitted-option control.

## Type of change

- [x] `fix`: bug fix (no behavior change beyond the bug)
- [ ] `feat`: new user-facing feature or capability
- [ ] `refactor`: internal refactor (no behavior change, no API change)
- [ ] `docs`: documentation only
- [ ] `chore` / `ci` / `build`: tooling, CI, packaging
- [ ] `test`: test-only change

**Breaking change:** No.

**Linked issue:** None - independently reproduced; no matching issue or discussion; searches recorded.

## OpenSpec

- [x] This behavior change has an active OpenSpec change under `openspec/changes/reject-empty-migration-db-url/`.
- [x] The `database-migrations` delta specifies exact-empty rejection and omitted-option fallback behavior.
- [x] The active change validates strictly and remains unarchived through merge.

## Rationale

The migration entry point previously used truthiness when choosing between the CLI value and the settings fallback. Passing `--db-url ""` therefore selected and could mutate the configured fallback database instead of rejecting the malformed explicit target. The parser now rejects only the exact empty string, while target resolution falls back only when the option is `None`. Whitespace-only and global URL normalization behavior are intentionally unchanged.

## Validation

- Parser regression: 2 passed.
- Migration CLI focused regression: 7 passed, including all six explicit-empty subcommands plus the omitted fallback control.
- Migration integration suite: 13 passed, 2 PostgreSQL-only tests skipped in the SQLite run.
- Migration unit suite: 49 passed.
- Focused PostgreSQL gate: 48 passed; `upgrade head` reached `20260717_000000_optimize_dashboard_hot_path_indexes`; `check` reported `migration_policy=ok` and `schema_drift=none`.
- Ruff format/lint, `ty`, LSP diagnostics, strict active-change validation, and main-spec validation passed for the touched scope.
- Binding review of the exact base-to-head diff: Standards PASS (0 findings) and Spec PASS (0 findings).

The branch was synced with current `upstream/main` (`ed017d52876a32eb06fd101f47a224cf0b750b8e`) by merge commit `ef7eb0e0d00557c82f9accdea5fc7e61032ac6c4`. Current-head local validation passed:

- Migration unit suite: 49 passed (with 2 SQLAlchemy reflection warnings).
- Migration serialization integration suite: 13 passed, with 2 PostgreSQL-only tests skipped.
- Repository-wide Ruff check and format check passed.
- The proxy architecture gate passed.
- Strict OpenSpec validation passed for `reject-empty-migration-db-url` and all 47 main specs.

The previous inherited architecture failure (`service.py has 2604 lines; limit is 2600`) is resolved by the upstream sync. Fresh GitHub CI and Codex review are being requested for commit `ef7eb0e0d00557c82f9accdea5fc7e61032ac6c4`.

P5 is not applicable: this is CLI/database behavior and does not change dashboard rendering. No screenshots, recordings, or other media are included.

## Checklist

- [x] Title follows Conventional Commits format (`fix(db): ...`).
- [x] One concern only; no unrelated refactor or dependency change.
- [x] Active OpenSpec change is present and validates.
- [x] Relevant migration tests and focused PostgreSQL checks pass.
- [x] Exact inherited local parity failure is disclosed above.
- [x] Simplicity gates reviewed; the change adds no required setup or configuration.
- [x] `CHANGELOG.md` was not edited by hand.
