### PR TITLE
fix(cli): reject out-of-range server port before startup

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -126,9 +126,12 @@ def _build_log_config() -> "LogConfig":
 
 def _parse_server_port(raw_port: str) -> int:
     try:
-        return int(raw_port)
+        port = int(raw_port)
     except ValueError as exc:
-        raise SystemExit(f"--port/PORT must be an integer, got {raw_port!r}.") from exc
+        raise SystemExit(f"--port/PORT must be an integer between 0 and 65535 inclusive, got {raw_port!r}.") from exc
+    if not 0 <= port <= 65535:
+        raise SystemExit(f"--port/PORT must be between 0 and 65535 inclusive, got {raw_port!r}.")
+    return port
 
 
 def _parse_server_timeout_keep_alive(raw_timeout: str) -> int:

--- a/openspec/changes/reject-out-of-range-server-port/.openspec.yaml
+++ b/openspec/changes/reject-out-of-range-server-port/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/reject-out-of-range-server-port/context.md
+++ b/openspec/changes/reject-out-of-range-server-port/context.md
@@ -1,0 +1,31 @@
+# Context: reject-out-of-range-server-port
+
+## Purpose and scope
+
+This change closes a server-startup foot-gun at the public CLI boundary. Its normative contract lives in the `runtime-portability` delta spec in this change. The implementation is intentionally limited to listener-port parsing plus CLI-entrypoint regressions; settings, launchers, deployment manifests, the dashboard, and upstream-proxy endpoint fields are separate surfaces.
+
+## Decision rationale
+
+Uvicorn starts the ASGI lifespan before it binds the listener socket. Letting the socket layer reject an impossible port is therefore too late: migrations and runtime-state creation can already have occurred, and the final platform-specific bind error does not identify the bad `--port` or `PORT` input. Validating in the existing `_parse_server_port` helper is the earliest server-only seam and avoids a second configuration path.
+
+The accepted range is `0..65535` inclusive. The upper bound is the operating-system port limit. The lower bound remains `0`, rather than `1`, because Uvicorn deliberately supports port zero as a request for an ephemeral listener and codex-lb already forwards it.
+
+## Constraints and non-goals
+
+- Preserve argparse's existing explicit-flag precedence over the environment.
+- Preserve the current integer syntax accepted by Python's `int(...)`; this change adds a range bound rather than normalization rules.
+- Fail before Uvicorn import, ASGI lifespan, migrations, secret generation, or data-directory writes.
+- Do not add a setting, fallback name, launcher change, UI control, retry, or telemetry.
+
+## Failure modes and boundaries
+
+Values such as `-1`, `65536`, and `70000` are syntactically integers but can never be valid listener ports; they should produce the same deterministic range error on every platform. Non-integer values retain an integer-specific error that also identifies the supported range. Ports can still fail later because they are occupied or require permissions; those are real runtime conditions and are not masked by this preflight check.
+
+## Example
+
+With `PORT=70000`, the command exits before Uvicorn is loaded and reports that `--port/PORT` supports `0..65535`. With `--port 0` or `PORT=65535`, the selected integer is forwarded unchanged to Uvicorn.
+
+## Related contracts
+
+- Main capability: `openspec/specs/runtime-portability/spec.md`
+- Change delta: `openspec/changes/reject-out-of-range-server-port/specs/runtime-portability/spec.md`

--- a/openspec/changes/reject-out-of-range-server-port/design.md
+++ b/openspec/changes/reject-out-of-range-server-port/design.md
@@ -1,0 +1,42 @@
+## Context
+
+`app.cli._parse_server_port` currently converts the selected `--port` or `PORT` value with `int(...)` and returns every integer. `main()` then stores the value in `PORT` and calls `_load_uvicorn().run(...)`. Uvicorn starts the ASGI lifespan before binding the listener socket, so an out-of-range integer can trigger migrations and runtime-state creation before the operating system rejects the bind.
+
+The supported socket range is `0..65535` inclusive. Port `0` is intentionally valid because Uvicorn uses it to request an ephemeral listener. The CLI flag already takes precedence over the environment through argparse and that behavior must remain unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reject out-of-range integer listener ports at the existing CLI parser boundary.
+- Preserve the current non-integer failure, valid boundary behavior, and flag-over-environment precedence.
+- Prove through `main()` that invalid values never load Uvicorn and valid boundaries are forwarded unchanged.
+
+**Non-Goals:**
+
+- Refactor settings or argument parsing.
+- Change Uvicorn startup or lifespan ordering.
+- Change deployment launchers, manifests, dashboard settings, or upstream-proxy endpoint validation.
+- Normalize whitespace/sign syntax or add retries, telemetry, or new configuration.
+
+## Decisions
+
+### Validate the converted integer in `_parse_server_port`
+
+After the existing `int(...)` conversion, `_parse_server_port` checks `0 <= port <= 65535` and raises `SystemExit` otherwise. The error names the shared `--port/PORT` input surface, includes the invalid value, and states the inclusive supported range.
+
+This keeps validation before `os.environ["PORT"]`, `_load_uvicorn`, ASGI imports, lifespan work, and socket binding. Moving validation into settings or relying on Uvicorn/the operating system was rejected because both occur too late and allow startup side effects. Adding an argparse `type=` callback was rejected because the existing helper already owns server-only validation after non-server subcommands return.
+
+### Preserve port zero and existing precedence
+
+Port `0` remains valid and is forwarded unchanged for Uvicorn's ephemeral-listener behavior; `65535` is the upper inclusive boundary. `_parse_args` remains unchanged, so an explicit `--port` continues to override `PORT`.
+
+### Test through the CLI `main()` seam
+
+Parameterized unit tests invoke `cli.main(argv)` for both flag and environment forms. Invalid values replace `_load_uvicorn` with a fail-if-called stub and assert the actionable error. Boundary values replace it with a capturing fake and assert the exact forwarded `port`. This exercises the externally affected CLI path rather than testing the helper alone.
+
+## Risks / Trade-offs
+
+- Port `0` may surprise operators who expect only numbered listeners, but rejecting it would break existing Uvicorn-compatible behavior and is outside this bug fix.
+- The combined `--port/PORT` label does not distinguish which source won; keeping it preserves the established integer-error source label and avoids threading source metadata through argparse for one validation branch.
+- Socket availability and permissions remain runtime concerns; this check only rejects values that are never valid TCP/UDP port numbers.

--- a/openspec/changes/reject-out-of-range-server-port/proposal.md
+++ b/openspec/changes/reject-out-of-range-server-port/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The server CLI currently accepts any integer listener port, so values outside the operating-system range can reach Uvicorn, start the ASGI lifespan, run migrations, and create runtime state before socket binding fails with an indirect platform error. The CLI should reject those values at its public input boundary before startup has side effects.
+
+## What Changes
+
+- Accept main listener ports only in the inclusive range `0..65535` from both `--port` and `PORT`.
+- Reject non-integer or out-of-range values before Uvicorn is imported or the ASGI application starts, with an error that identifies `--port/PORT` and the supported range.
+- Add CLI-entrypoint regression coverage for both input sources and the inclusive boundaries while preserving flag-over-environment precedence.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `runtime-portability`: defines the portable main-listener port range and fail-fast validation contract for `--port` and `PORT`.
+
+## Impact
+
+- Code: `app/cli.py` listener-port parsing only.
+- Tests: `tests/unit/test_cli.py` exercises the real CLI `main()` seam for flag and environment forms.
+- Operators: invalid listener-port configuration fails immediately with an actionable range error instead of after application startup; valid ports and precedence are unchanged.
+- No settings-model, launcher, deployment-manifest, dashboard, upstream-proxy, migration, or data-layout changes.

--- a/openspec/changes/reject-out-of-range-server-port/specs/runtime-portability/spec.md
+++ b/openspec/changes/reject-out-of-range-server-port/specs/runtime-portability/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Server CLI validates the main listener port before startup
+
+The `codex-lb` server CLI SHALL accept integer main-listener ports in the inclusive range `0..65535` when supplied through `--port` or `PORT`, and an explicit `--port` SHALL continue to take precedence over `PORT`. The CLI SHALL reject non-integer values and integers outside that range before loading Uvicorn, importing or starting the ASGI application, running its lifespan or migrations, or creating runtime data. A rejection MUST identify `--port/PORT`, state the supported range, and include the invalid value.
+
+#### Scenario: Out-of-range command-line port is rejected before startup
+
+- **WHEN** an operator supplies `--port` with an integer below `0` or above `65535`
+- **THEN** the CLI exits with an error that identifies `--port/PORT`, the invalid value, and the supported range `0..65535`
+- **AND** Uvicorn is not loaded
+- **AND** the ASGI lifespan, migrations, and runtime data creation do not run
+
+#### Scenario: Out-of-range environment port is rejected before startup
+
+- **WHEN** `PORT` contains an integer below `0` or above `65535`
+- **AND** no `--port` flag is supplied
+- **THEN** the CLI exits with an error that identifies `--port/PORT`, the invalid value, and the supported range `0..65535`
+- **AND** Uvicorn is not loaded
+- **AND** the ASGI lifespan, migrations, and runtime data creation do not run
+
+#### Scenario: Non-integer listener port is rejected before startup
+
+- **WHEN** the selected `--port` or `PORT` value is not an integer
+- **THEN** the CLI exits with an error that identifies `--port/PORT` and the invalid value
+- **AND** Uvicorn is not loaded
+
+#### Scenario: Inclusive listener-port boundaries are forwarded
+
+- **WHEN** the selected `--port` or `PORT` value is `0` or `65535`
+- **THEN** the CLI forwards the same integer to Uvicorn
+- **AND** port `0` retains Uvicorn's ephemeral-listener behavior
+
+#### Scenario: Command-line port retains precedence over the environment
+
+- **WHEN** `PORT` contains any value
+- **AND** the operator supplies an in-range `--port` value
+- **THEN** the CLI validates and forwards the flag value
+- **AND** the environment value does not replace it

--- a/openspec/changes/reject-out-of-range-server-port/tasks.md
+++ b/openspec/changes/reject-out-of-range-server-port/tasks.md
@@ -1,0 +1,16 @@
+## 1. CLI regression coverage
+
+- [x] 1.1 Add real `cli.main()` regressions for both `--port` and `PORT` that reject `-1`, `65536`, and `70000` with the supported range before `_load_uvicorn` is called.
+- [x] 1.2 Add real `cli.main()` boundary coverage for both input forms that accepts and forwards `0` and `65535`, while retaining explicit-flag precedence.
+- [x] 1.3 Run the focused new regressions before the production fix and record the expected out-of-range failures as red evidence.
+
+## 2. Listener-port validation
+
+- [x] 2.1 Update only `_parse_server_port` to reject converted integers outside the inclusive range `0..65535` with an actionable `--port/PORT` error.
+- [x] 2.2 Run the CLI regression group and focused CLI unit suite to confirm invalid inputs fail before startup and valid behavior remains green.
+- [x] 2.3 Run focused lint and type checks for the changed Python files.
+
+## 3. OpenSpec verification
+
+- [x] 3.1 Strictly validate the active change and main specifications on the focused worktree content.
+- [x] 3.2 Verify implementation, tests, tasks, delta spec, design, and context are coherent; retain the change with lifecycle `active_through_merge` and do not archive it.

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -115,12 +115,62 @@ def test_main_reports_non_positive_ws_max_size(monkeypatch):
         cli.main()
 
 
-def test_main_reports_invalid_server_port_env(monkeypatch):
-    monkeypatch.setattr(sys, "argv", ["codex-lb"])
-    monkeypatch.setenv("PORT", "not-a-port")
+@pytest.mark.parametrize("source", ["flag", "env"])
+def test_main_reports_invalid_server_port_before_loading_uvicorn(monkeypatch, source):
+    def fail_load_uvicorn():
+        pytest.fail("Uvicorn must not load for a non-integer server port")
 
-    with pytest.raises(SystemExit, match="--port/PORT must be an integer"):
-        cli.main()
+    if source == "flag":
+        monkeypatch.setenv("PORT", "2455")
+        argv = ["--port", "not-a-port"]
+    else:
+        monkeypatch.setenv("PORT", "not-a-port")
+        argv = []
+    monkeypatch.setattr(cli, "_load_uvicorn", fail_load_uvicorn)
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(argv)
+
+    assert str(exc_info.value) == ("--port/PORT must be an integer between 0 and 65535 inclusive, got 'not-a-port'.")
+
+
+@pytest.mark.parametrize("source", ["flag", "env"])
+@pytest.mark.parametrize("raw_port", ["-1", "65536", "70000"])
+def test_main_rejects_out_of_range_server_port_before_loading_uvicorn(monkeypatch, source, raw_port):
+    def fail_load_uvicorn():
+        pytest.fail("Uvicorn must not load for an out-of-range server port")
+
+    if source == "flag":
+        monkeypatch.setenv("PORT", "2455")
+        argv = ["--port", raw_port]
+    else:
+        monkeypatch.setenv("PORT", raw_port)
+        argv = []
+    monkeypatch.setattr(cli, "_load_uvicorn", fail_load_uvicorn)
+
+    with pytest.raises(SystemExit, match=r"--port/PORT must be between 0 and 65535 inclusive"):
+        cli.main(argv)
+
+
+@pytest.mark.parametrize("source", ["flag", "env"])
+@pytest.mark.parametrize("raw_port", ["0", "65535"])
+def test_main_forwards_server_port_boundaries(monkeypatch, source, raw_port):
+    captured: dict[str, Any] = {}
+
+    def fake_run(*args, **kwargs):
+        captured["kwargs"] = kwargs
+
+    if source == "flag":
+        monkeypatch.setenv("PORT", "70000")
+        argv = ["--port", raw_port]
+    else:
+        monkeypatch.setenv("PORT", raw_port)
+        argv = []
+    monkeypatch.setattr(cli, "_load_uvicorn", lambda: SimpleNamespace(run=fake_run))
+
+    cli.main(argv)
+
+    assert captured["kwargs"]["port"] == int(raw_port)
 
 
 def test_main_reports_invalid_keep_alive_timeout_env(monkeypatch):


### PR DESCRIPTION
## Summary

Reject invalid main-listener ports at the CLI boundary before Uvicorn or the ASGI application can start. Preserve explicit `--port` precedence, all in-range behavior, and Uvicorn's port-`0` ephemeral-listener behavior.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: None — independently reproduced; no matching issue or discussion; searches recorded

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/reject-out-of-range-server-port/`

Lifecycle: retained active through merge; not archived.

## Changes

- Validate the selected `--port` / `PORT` integer in `_parse_server_port` against the inclusive range `0..65535` before `_load_uvicorn`.
- Report the shared input surface, invalid value, and supported range for invalid values.
- Cover flag and environment inputs through the real `cli.main()` seam, including `-1`, `65536`, `70000`, non-integers, `0`, `65535`, and flag-over-environment precedence.

## Simplicity

- P1: no setting, setup step, migration, or default was added.
- P2: no new configuration surface was added.
- P3: no README, environment example, or dashboard navigation changed.
- P4: the behavior contract lives in OpenSpec; no feature documentation was added to the README.
- P5: not applicable because the dashboard rendering is unchanged.

## Test plan

```text
uv run pytest tests/unit/test_cli.py -q -k 'invalid_server_port or out_of_range_server_port or server_port_boundaries'
# 13 passed, 13 deselected

uv run pytest tests/unit/test_cli.py -q
# 26 passed

uv run ruff check app/cli.py tests/unit/test_cli.py
# All checks passed

uv run ruff format --check app/cli.py tests/unit/test_cli.py
# 2 files already formatted

uv run ty check app/cli.py tests/unit/test_cli.py
# All checks passed

openspec validate reject-out-of-range-server-port --strict
# valid

openspec validate --specs --strict
# 47 passed, 0 failed

/opsx:verify reject-out-of-range-server-port
# 8/8 tasks, 1/1 requirement, and 5/5 scenarios; correctness and coherence passed

After merging `upstream/main` at `ed017d52` into head `818b37e1`:

python scripts/check_proxy_architecture.py
# proxy architecture checks passed

uvx ruff check .
# All checks passed!

uvx ruff format --check .
# 806 files already formatted
```

The inherited architecture failure is resolved on the current base: `app/modules/proxy/service.py` is now 2542 lines, and the architecture gate passes on head `818b37e1`. Cloud CI is rerunning against this head.

## Output

No dashboard-visible surface changed, so visual media is not applicable. Sanitized CLI behavior:

```text
--port/PORT must be between 0 and 65535 inclusive, got '70000'.
```

Invalid values exit before Uvicorn loads; `0` and `65535` are forwarded unchanged.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above — N/A; independently reproduced with no match found.
- [x] Added or updated tests covering the change.
- [x] Revalidated the merged head with the CLI unit suite, Ruff check/format, ty, the proxy architecture gate, and strict OpenSpec validation.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] Simplicity gates reviewed: the five simplicity rules (P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
