### PR TITLE
fix(proxy): quarantine silent HTTP bridge sessions

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -293,6 +293,8 @@ class Settings(BaseSettings):
     openai_prompt_cache_key_derivation_enabled: bool = True
     http_responses_session_bridge_enabled: bool = True
     http_responses_session_bridge_request_budget_seconds: float = Field(default=7200.0, gt=0)
+    http_responses_session_bridge_response_created_timeout_seconds: float = Field(default=5.0, gt=0)
+    http_responses_session_bridge_quarantine_seconds: float = Field(default=60.0, ge=0)
     http_responses_session_bridge_idle_ttl_seconds: float = Field(default=120.0, gt=0)
     http_responses_session_bridge_codex_idle_ttl_seconds: float = Field(default=900.0, gt=0)
     http_responses_session_bridge_codex_prewarm_enabled: bool = False

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -1479,6 +1479,7 @@ class _HTTPBridgeMixin(
             self._http_bridge_sessions.clear()
             self._http_bridge_inflight_sessions.clear()
             self._http_bridge_previous_response_index.clear()
+            self._http_bridge_quarantine_until.clear()
         shutdown_error = ProxyResponseError(
             503,
             openai_error(

--- a/app/modules/proxy/_service/http_bridge/protocol.py
+++ b/app/modules/proxy/_service/http_bridge/protocol.py
@@ -23,6 +23,7 @@ class _HTTPBridgeServiceProtocol(Protocol):
     _http_bridge_inflight_sessions: Any
     _http_bridge_turn_state_index: Any
     _http_bridge_previous_response_index: Any
+    _http_bridge_quarantine_until: Any
     _sessions: Any
     _session_lock: Any
     _pending_lock: Any

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -202,6 +202,7 @@ async def _send_http_bridge_request_text_with_archive_id(
     token = set_request_id(request_state.archive_request_id)
     try:
         await session.upstream.send_text(text_data)
+        request_state.response_create_sent_at = _service_time().monotonic()
     finally:
         reset_request_id(token)
 

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -221,6 +221,81 @@ _HTTP_BRIDGE_BACKGROUND_CLEANUP_WARN_THRESHOLD = 100
 _RESPONSE_CREATE_GATE_RETRY_SLEEP_SECONDS = 10.0
 
 
+def _http_bridge_quarantine_remaining_seconds(
+    service: Any,
+    key: _HTTPBridgeSessionKey,
+) -> float:
+    now = _service_time().monotonic()
+    quarantine_by_key = service._http_bridge_quarantine_until
+    expired_keys = [candidate for candidate, deadline in quarantine_by_key.items() if deadline <= now]
+    for expired_key in expired_keys:
+        quarantine_by_key.pop(expired_key, None)
+    quarantine_until = quarantine_by_key.get(key)
+    if quarantine_until is None:
+        return 0.0
+    return quarantine_until - now
+
+
+async def _quarantine_silent_http_bridge_session(
+    service: Any,
+    session: _HTTPBridgeSession,
+    *,
+    request_state: _WebSocketRequestState,
+) -> None:
+    if session.closed:
+        return
+    session.closed = True
+    settings = _service_get_settings()
+    quarantine_seconds = max(
+        0.0,
+        float(
+            getattr(
+                settings,
+                "http_responses_session_bridge_quarantine_seconds",
+                60.0,
+            )
+        ),
+    )
+    if quarantine_seconds > 0:
+        quarantine_by_key = service._http_bridge_quarantine_until
+        quarantine_by_key[session.key] = _service_time().monotonic() + quarantine_seconds
+        max_entries = max(
+            1,
+            int(getattr(settings, "http_responses_session_bridge_max_sessions", 256)),
+        )
+        overflow = len(quarantine_by_key) - max_entries
+        if overflow > 0:
+            earliest_keys = sorted(
+                quarantine_by_key,
+                key=quarantine_by_key.__getitem__,
+            )[:overflow]
+            for earliest_key in earliest_keys:
+                quarantine_by_key.pop(earliest_key, None)
+    error_message = (
+        "HTTP bridge did not receive response.created in time; the next retry for this session will use HTTP"
+    )
+    async with session.pending_lock:
+        pending_states = list(session.pending_requests)
+    for pending_state in pending_states:
+        pending_state.error_code_override = "upstream_unavailable"
+        pending_state.error_message_override = error_message
+    _log_http_bridge_event(
+        "response_created_timeout",
+        session.key,
+        account_id=session.account.id,
+        model=session.request_model,
+        pending_count=len(pending_states),
+        detail=(f"request_id={request_state.request_id}, quarantine_seconds={quarantine_seconds:.3f}"),
+        cache_key_family=session.key.affinity_kind,
+        model_class=_extract_model_class(session.request_model) if session.request_model else None,
+    )
+    await service._retire_stale_pending_http_bridge_session(
+        session,
+        detail="response_created_timeout",
+    )
+    await service._close_http_bridge_session(session)
+
+
 def _proxy_error_code_message(exc: ProxyResponseError) -> tuple[str | None, str | None]:
     error = exc.payload.get("error") if isinstance(exc.payload, dict) else None
     if not isinstance(error, dict):
@@ -626,35 +701,37 @@ class _HTTPBridgeStreamingMixin:
             return
 
         request_scope_id = ensure_request_scope_id()
+        bridge_events = self._stream_via_http_bridge(
+            payload,
+            headers,
+            codex_session_affinity=codex_session_affinity,
+            propagate_http_errors=propagate_http_errors,
+            openai_cache_affinity=openai_cache_affinity,
+            api_key=api_key,
+            api_key_reservation=api_key_reservation,
+            suppress_text_done_events=suppress_text_done_events,
+            idle_ttl_seconds=runtime_config.idle_ttl_seconds,
+            codex_idle_ttl_seconds=runtime_config.codex_idle_ttl_seconds,
+            max_sessions=runtime_config.max_sessions,
+            queue_limit=runtime_config.queue_limit,
+            prompt_cache_idle_ttl_seconds=runtime_config.prompt_cache_idle_ttl_seconds,
+            downstream_turn_state=downstream_turn_state,
+            forwarded_request=forwarded_request,
+            forwarded_original_request_unanchored=forwarded_original_request_unanchored,
+            forwarded_legacy_signature=forwarded_legacy_signature,
+            proxy_api_authorization=proxy_api_authorization,
+            forwarded_affinity_kind=forwarded_affinity_kind,
+            forwarded_affinity_key=forwarded_affinity_key,
+            rewritten_file_account_id=rewritten_file_account_id,
+            client_ip=client_ip,
+            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+        )
         try:
-            async for line in self._stream_via_http_bridge(
-                payload,
-                headers,
-                codex_session_affinity=codex_session_affinity,
-                propagate_http_errors=propagate_http_errors,
-                openai_cache_affinity=openai_cache_affinity,
-                api_key=api_key,
-                api_key_reservation=api_key_reservation,
-                suppress_text_done_events=suppress_text_done_events,
-                idle_ttl_seconds=runtime_config.idle_ttl_seconds,
-                codex_idle_ttl_seconds=runtime_config.codex_idle_ttl_seconds,
-                max_sessions=runtime_config.max_sessions,
-                queue_limit=runtime_config.queue_limit,
-                prompt_cache_idle_ttl_seconds=runtime_config.prompt_cache_idle_ttl_seconds,
-                downstream_turn_state=downstream_turn_state,
-                forwarded_request=forwarded_request,
-                forwarded_original_request_unanchored=forwarded_original_request_unanchored,
-                forwarded_legacy_signature=forwarded_legacy_signature,
-                proxy_api_authorization=proxy_api_authorization,
-                forwarded_affinity_kind=forwarded_affinity_kind,
-                forwarded_affinity_key=forwarded_affinity_key,
-                rewritten_file_account_id=rewritten_file_account_id,
-                client_ip=client_ip,
-                enforce_openai_sdk_contract=enforce_openai_sdk_contract,
-            ):
+            async for line in bridge_events:
                 yield line
         finally:
             with anyio.CancelScope(shield=True):
+                await bridge_events.aclose()
                 await _release_http_bridge_unanchored_handoffs_for_request(
                     self,
                     request_scope_id=request_scope_id,
@@ -687,7 +764,6 @@ class _HTTPBridgeStreamingMixin:
         client_ip: str | None = None,
         enforce_openai_sdk_contract: bool = True,
     ) -> AsyncIterator[str]:
-        del suppress_text_done_events
         request_id = ensure_request_id()
         dashboard_settings = await _service_get_settings_cache().get()
         runtime_config = _http_bridge_runtime_config(dashboard_settings, _service_get_settings())
@@ -767,6 +843,38 @@ class _HTTPBridgeStreamingMixin:
             forwarded_affinity_kind=forwarded_affinity_kind,
             forwarded_affinity_key=forwarded_affinity_key,
         )
+        quarantine_remaining_seconds = _http_bridge_quarantine_remaining_seconds(
+            self,
+            bridge_session_key,
+        )
+        if quarantine_remaining_seconds > 0:
+            _log_http_bridge_event(
+                "quarantine_http_fallback",
+                bridge_session_key,
+                account_id=None,
+                model=payload.model,
+                detail=f"remaining_seconds={quarantine_remaining_seconds:.3f}",
+                cache_key_family=bridge_session_key.affinity_kind,
+                model_class=_extract_model_class(payload.model) if payload.model else None,
+            )
+            stream_with_retry = cast(Callable[..., AsyncIterator[str]], self._stream_with_retry)
+            async for line in stream_with_retry(
+                payload,
+                headers,
+                codex_session_affinity=codex_session_affinity,
+                propagate_http_errors=propagate_http_errors,
+                openai_cache_affinity=openai_cache_affinity,
+                api_key=api_key,
+                api_key_reservation=api_key_reservation,
+                suppress_text_done_events=suppress_text_done_events,
+                request_transport=_REQUEST_TRANSPORT_HTTP,
+                rewritten_file_account_id=rewritten_file_account_id,
+                upstream_stream_transport_override="http",
+                client_ip=client_ip,
+                enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+            ):
+                yield line
+            return
         session_header_fallback_key = (
             _make_http_bridge_session_header_fallback_key(
                 headers=headers,
@@ -852,6 +960,39 @@ class _HTTPBridgeStreamingMixin:
                 durable_lookup.canonical_key,
                 bridge_session_key.api_key_id,
             )
+            quarantine_remaining_seconds = _http_bridge_quarantine_remaining_seconds(
+                self,
+                bridge_session_key,
+            )
+            if quarantine_remaining_seconds > 0:
+                _log_http_bridge_event(
+                    "quarantine_http_fallback",
+                    bridge_session_key,
+                    account_id=durable_lookup.account_id,
+                    model=payload.model,
+                    detail=f"remaining_seconds={quarantine_remaining_seconds:.3f}",
+                    cache_key_family=bridge_session_key.affinity_kind,
+                    model_class=_extract_model_class(payload.model) if payload.model else None,
+                    owner_check_applied=True,
+                )
+                stream_with_retry = cast(Callable[..., AsyncIterator[str]], self._stream_with_retry)
+                async for line in stream_with_retry(
+                    payload,
+                    headers,
+                    codex_session_affinity=codex_session_affinity,
+                    propagate_http_errors=propagate_http_errors,
+                    openai_cache_affinity=openai_cache_affinity,
+                    api_key=api_key,
+                    api_key_reservation=api_key_reservation,
+                    suppress_text_done_events=suppress_text_done_events,
+                    request_transport=_REQUEST_TRANSPORT_HTTP,
+                    rewritten_file_account_id=rewritten_file_account_id,
+                    upstream_stream_transport_override="http",
+                    client_ip=client_ip,
+                    enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+                ):
+                    yield line
+                return
             live_local_session_exists = await self._http_bridge_has_live_local_session(
                 key=bridge_session_key,
                 incoming_turn_state=incoming_turn_state_header,
@@ -2118,9 +2259,34 @@ class _HTTPBridgeStreamingMixin:
             keepalive_sent = False
             keepalive_count = 0
             while True:
-                keepalive_interval = getattr(_service_get_settings(), "sse_keepalive_interval_seconds", 10.0)
+                settings = _service_get_settings()
+                keepalive_interval = getattr(settings, "sse_keepalive_interval_seconds", 10.0)
+                response_created_wait_timeout: float | None = None
+                response_create_sent_at = request_state.response_create_sent_at
+                if (
+                    request_state.awaiting_response_created
+                    and request_state.response_event_count == 0
+                    and response_create_sent_at is not None
+                ):
+                    response_created_timeout_seconds = float(
+                        getattr(
+                            settings,
+                            "http_responses_session_bridge_response_created_timeout_seconds",
+                            5.0,
+                        )
+                    )
+                    response_created_wait_timeout = max(
+                        0.0,
+                        response_create_sent_at + response_created_timeout_seconds - _service_time().monotonic(),
+                    )
+                if response_created_wait_timeout == 0:
+                    await _quarantine_silent_http_bridge_session(
+                        self,
+                        session,
+                        request_state=request_state,
+                    )
+                    event_block = await event_queue.get()
                 if keepalive_interval > 0:
-                    settings = _service_get_settings()
                     stream_keepalive_max_count = _stream_keepalive_max_count()
                     stream_idle_timeout_seconds = getattr(
                         settings,
@@ -2134,10 +2300,34 @@ class _HTTPBridgeStreamingMixin:
                     wait_timeout = keepalive_interval
                     if not yielded_any and not keepalive_sent:
                         wait_timeout = max(wait_timeout, _http_bridge_startup_keepalive_grace_seconds())
+                    if response_created_wait_timeout is not None:
+                        wait_timeout = min(wait_timeout, response_created_wait_timeout)
                     try:
-                        event_block = await asyncio.wait_for(event_queue.get(), timeout=wait_timeout)
+                        if response_created_wait_timeout != 0:
+                            event_block = await asyncio.wait_for(event_queue.get(), timeout=wait_timeout)
                     except asyncio.TimeoutError:
-                        if request_state.account_capacity_waiting:
+                        response_created_deadline_elapsed = (
+                            request_state.awaiting_response_created
+                            and request_state.response_event_count == 0
+                            and request_state.response_create_sent_at is not None
+                            and _service_time().monotonic()
+                            >= request_state.response_create_sent_at
+                            + float(
+                                getattr(
+                                    settings,
+                                    "http_responses_session_bridge_response_created_timeout_seconds",
+                                    5.0,
+                                )
+                            )
+                        )
+                        if response_created_deadline_elapsed:
+                            await _quarantine_silent_http_bridge_session(
+                                self,
+                                session,
+                                request_state=request_state,
+                            )
+                            event_block = await event_queue.get()
+                        elif request_state.account_capacity_waiting:
                             keepalive_count = 0
                             keepalive_sent = True
                             yielded_any = True
@@ -2167,9 +2357,10 @@ class _HTTPBridgeStreamingMixin:
                                     )
                                 )
                             continue
-                        keepalive_count += 1
-                        downstream_response_id = _websocket_downstream_response_id(request_state)
-                        if keepalive_count > max_keepalive_count:
+                        else:
+                            keepalive_count += 1
+                            downstream_response_id = _websocket_downstream_response_id(request_state)
+                        if not response_created_deadline_elapsed and keepalive_count > max_keepalive_count:
                             logger.info(
                                 "HTTP bridge stream idle timeout request_id=%s keepalive_count=%s "
                                 "max_keepalive_count=%s",
@@ -2188,11 +2379,18 @@ class _HTTPBridgeStreamingMixin:
                                 )
                             )
                             break
-                        if propagate_http_errors and request_state.response_id is None:
+                        if (
+                            not response_created_deadline_elapsed
+                            and propagate_http_errors
+                            and request_state.response_id is None
+                        ):
                             continue
-                        keepalive_sent = True
-                        yielded_any = True
-                        if request_state.response_id or request_state.replay_downstream_response_id:
+                        if not response_created_deadline_elapsed:
+                            keepalive_sent = True
+                            yielded_any = True
+                        if not response_created_deadline_elapsed and (
+                            request_state.response_id or request_state.replay_downstream_response_id
+                        ):
                             yield format_sse_event(
                                 cast(
                                     Mapping[str, JsonValue],
@@ -2205,11 +2403,27 @@ class _HTTPBridgeStreamingMixin:
                                     },
                                 )
                             )
-                        else:
+                        elif not response_created_deadline_elapsed:
                             yield _codex_keepalive_frame()
-                        continue
+                        if not response_created_deadline_elapsed:
+                            continue
                 else:
-                    event_block = await event_queue.get()
+                    if response_created_wait_timeout is None or response_created_wait_timeout == 0:
+                        if response_created_wait_timeout is None:
+                            event_block = await event_queue.get()
+                    else:
+                        try:
+                            event_block = await asyncio.wait_for(
+                                event_queue.get(),
+                                timeout=response_created_wait_timeout,
+                            )
+                        except asyncio.TimeoutError:
+                            await _quarantine_silent_http_bridge_session(
+                                self,
+                                session,
+                                request_state=request_state,
+                            )
+                            event_block = await event_queue.get()
                 if event_block is None:
                     break
                 keepalive_count = 0

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -707,6 +707,7 @@ class _WebSocketRequestState:
     latency_response_create_gate_wait_ms: int | None = None
     latency_bridge_queue_wait_ms: int | None = None
     response_create_gate_wait_started_at: float | None = None
+    response_create_sent_at: float | None = None
     bridge_queue_wait_started_at: float | None = None
     # Monotonic deadline of the original bridge request budget. Retry and
     # recovery paths re-prepare request states with a fresh started_at, so

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -4444,6 +4444,7 @@ async def _stream_responses(
             startup_error,
             headers=rate_limit_headers,
         )
+    lifecycle_stream = stream
     stream = _normalize_public_responses_stream(
         _stream_response_error_events(
             stream,
@@ -4460,11 +4461,15 @@ async def _stream_responses(
             request_id=get_request_id(),
             route_family="responses",
         )
+    response_stream = inject_sse_keepalives(
+        stream,
+        get_settings().sse_keepalive_interval_seconds,
+        keepalive_frame=keepalive_frame,
+    )
     return StreamingResponse(
-        inject_sse_keepalives(
-            stream,
-            get_settings().sse_keepalive_interval_seconds,
-            keepalive_frame=keepalive_frame,
+        _close_response_stream_on_exit(
+            response_stream,
+            lifecycle_stream=lifecycle_stream,
         ),
         media_type="text/event-stream",
         headers={
@@ -4474,6 +4479,113 @@ async def _stream_responses(
             **rate_limit_headers,
         },
     )
+
+
+async def _close_async_iterator(stream: AsyncIterator[str]) -> None:
+    aclose = getattr(stream, "aclose", None)
+    if not callable(aclose):
+        return
+    try:
+        await aclose()
+    except Exception:
+        logger.warning("Failed to close responses stream iterator", exc_info=True)
+
+
+async def _close_response_stream_on_exit(
+    stream: AsyncIterator[str],
+    *,
+    lifecycle_stream: AsyncIterator[str],
+) -> AsyncIterator[str]:
+    try:
+        async for chunk in stream:
+            yield chunk
+    finally:
+        await _close_async_iterator(stream)
+        if lifecycle_stream is not stream:
+            await _close_async_iterator(lifecycle_stream)
+
+
+class _BufferedStreamIterator:
+    def __init__(self, items: Iterable[str], stream: AsyncIterator[str]) -> None:
+        self._items = tuple(items)
+        self._index = 0
+        self._stream = stream
+        self._closed = False
+
+    def __aiter__(self) -> _BufferedStreamIterator:
+        return self
+
+    async def __anext__(self) -> str:
+        if self._closed:
+            raise StopAsyncIteration
+        if self._index < len(self._items):
+            item = self._items[self._index]
+            self._index += 1
+            return item
+        try:
+            return await self._stream.__anext__()
+        except StopAsyncIteration:
+            self._closed = True
+            raise
+
+    async def aclose(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await _close_async_iterator(self._stream)
+
+
+class _FirstTaskStreamIterator:
+    def __init__(self, first_task: asyncio.Task[str], stream: AsyncIterator[str]) -> None:
+        self._first_task = first_task
+        self._stream = stream
+        self._first_pending = True
+        self._closed = False
+
+    def __aiter__(self) -> _FirstTaskStreamIterator:
+        return self
+
+    async def __anext__(self) -> str:
+        if self._closed:
+            raise StopAsyncIteration
+        if self._first_pending:
+            self._first_pending = False
+            try:
+                return await self._first_task
+            except StopAsyncIteration:
+                self._closed = True
+                raise
+            except BaseException:
+                if not self._first_task.done():
+                    self._first_task.cancel()
+                await asyncio.gather(self._first_task, return_exceptions=True)
+                raise
+        try:
+            return await self._stream.__anext__()
+        except StopAsyncIteration:
+            self._closed = True
+            raise
+
+    async def aclose(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if not self._first_task.done():
+            self._first_task.cancel()
+        await asyncio.gather(self._first_task, return_exceptions=True)
+        await _close_async_iterator(self._stream)
+
+
+def _prepend_first(first: str | None, stream: AsyncIterator[str]) -> AsyncIterator[str]:
+    return _BufferedStreamIterator(() if first is None else (first,), stream)
+
+
+def _prepend_items(items: list[str], stream: AsyncIterator[str]) -> AsyncIterator[str]:
+    return _BufferedStreamIterator(items, stream)
+
+
+def _prepend_first_task(first_task: asyncio.Task[str], stream: AsyncIterator[str]) -> AsyncIterator[str]:
+    return _FirstTaskStreamIterator(first_task, stream)
 
 
 def _strip_internal_bridge_headers(headers: Mapping[str, str]) -> dict[str, str]:
@@ -4951,13 +5063,6 @@ def _request_state_str(request: Request, name: str) -> str | None:
         return None
     stripped = value.strip()
     return stripped or None
-
-
-async def _prepend_first(first: str | None, stream: AsyncIterator[str]) -> AsyncIterator[str]:
-    if first is not None:
-        yield first
-    async for line in stream:
-        yield line
 
 
 async def _read_first_stream_item(stream: AsyncIterator[str]) -> str:
@@ -5462,29 +5567,6 @@ async def _probe_chat_stream_startup_error(
             continue
         return _prepend_items(buffered, stream), None
     return _prepend_items(buffered, stream), None
-
-
-async def _prepend_items(items: list[str], stream: AsyncIterator[str]) -> AsyncIterator[str]:
-    for item in items:
-        yield item
-    async for line in stream:
-        yield line
-
-
-async def _prepend_first_task(first_task: asyncio.Task[str], stream: AsyncIterator[str]) -> AsyncIterator[str]:
-    try:
-        first = await first_task
-    except StopAsyncIteration:
-        return
-    finally:
-        # If the wrapping stream is closed before the first item is consumed
-        # (client disconnect, request teardown), cancel the still-running probe
-        # task so it does not hold the upstream connection open.
-        if not first_task.done():
-            first_task.cancel()
-    yield first
-    async for line in stream:
-        yield line
 
 
 async def _prepend_initial_sse_heartbeat(

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -947,16 +947,12 @@ class ProxyService(
         self._http_bridge_inflight_sessions: dict[_HTTPBridgeSessionKey, asyncio.Future[_HTTPBridgeSession]] = {}
         self._http_bridge_turn_state_index: dict[tuple[str, str | None], _HTTPBridgeSessionKey] = {}
         self._http_bridge_previous_response_index: dict[tuple[str, str | None], _HTTPBridgeSessionKey] = {}
+        self._http_bridge_quarantine_until: dict[_HTTPBridgeSessionKey, float] = {}
         self._websocket_previous_response_account_index: dict[tuple[str, str | None, str | None], str] = {}
         self._websocket_continuity_index: dict[tuple[str, str | None], _WebSocketContinuityState] = {}
         self._background_cleanup_tasks: set[asyncio.Task[None]] = set()
-        # In-memory pin from upstream-issued file_id -> codex-lb account_id.
-        # Used so ``finalize_file`` for a given ``file_id`` is routed to
-        # the same account that handled ``create_file``. Cross-instance
-        # routing is best-effort: if the finalize request lands on a
-        # different replica with no pin, we fall back to a fresh load-
-        # balancer selection. The TTL is short enough (5 min) that we
-        # never hold stale pins after the upstream upload window closes.
+        # Best-effort in-memory pin keeps finalize_file on create_file's account.
+        # Its five-minute TTL bounds stale pins across replicas.
         self._file_account_pins: dict[str, _FilePinEntry] = {}
         self._file_account_pin_lock = asyncio.Lock()
         self._http_bridge_lock = anyio.Lock()

--- a/openspec/changes/quarantine-silent-http-bridge-sessions/.openspec.yaml
+++ b/openspec/changes/quarantine-silent-http-bridge-sessions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-20

--- a/openspec/changes/quarantine-silent-http-bridge-sessions/proposal.md
+++ b/openspec/changes/quarantine-silent-http-bridge-sessions/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+An upstream Responses websocket can accept `response.create` without ever
+emitting `response.created` or a terminal event. The HTTP bridge then keeps the
+request pending and holds the session response-create gate, so later requests
+can appear idle or fail admission even when other accounts have capacity.
+
+Replaying the same request automatically is unsafe because the proxy cannot
+know whether upstream accepted it. Recovery must retire the silent bridge
+without duplicating work, then let a new client retry use a transport that does
+not depend on that bridge.
+
+## What Changes
+
+- Bound the wait from sending `response.create` to receiving
+  `response.created`.
+- Retire and temporarily quarantine a bridge session that exceeds that
+  deadline, failing its current request without internally replaying it.
+- Route the next independent client retry for the quarantined affinity key over
+  direct HTTP while preserving any `previous_response_id` account owner.
+- Ensure closing a downstream streaming response also closes the bridge
+  lifecycle iterator and its upstream websocket, including when only the
+  initial heartbeat was consumed.
+- Keep the timeout and quarantine duration as internal, zero-config settings
+  with conservative defaults.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: defines safe recovery from an accepted-but-silent
+  bridge submission and downstream stream cancellation.
+
+## Impact
+
+- HTTP Responses session bridge lifecycle and transport selection.
+- Codex-native and OpenAI-compatible Responses streaming routes.
+- No database migration, dashboard change, required setup step, or public API
+  schema change.

--- a/openspec/changes/quarantine-silent-http-bridge-sessions/specs/responses-api-compat/spec.md
+++ b/openspec/changes/quarantine-silent-http-bridge-sessions/specs/responses-api-compat/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Silent HTTP bridge submissions fail closed without replay
+
+After an HTTP bridge session sends `response.create`, the service MUST bound
+the wait for upstream to emit `response.created`. If the deadline expires, the
+service MUST fail the current request terminally, retire and close the affected
+bridge session, release its pending request and response-create admission
+state, and temporarily quarantine that bridge affinity key.
+
+The service MUST NOT automatically replay the same submitted request within
+the current client call because upstream acceptance is ambiguous. During the
+quarantine window, the next independent client retry for that affinity key MUST
+bypass the HTTP bridge and use direct HTTP. If that retry carries
+`previous_response_id`, it MUST remain pinned to the response owner's account.
+A quarantined key MUST NOT prevent unrelated affinity keys or accounts from
+making progress.
+
+#### Scenario: Silent submission is retired without internal replay
+
+- **WHEN** an HTTP bridge sends `response.create`
+- **AND** upstream emits neither `response.created` nor a terminal event before the configured deadline
+- **THEN** the current request fails with a retryable terminal error
+- **AND** the bridge session is retired, removed from reuse, and closed
+- **AND** its pending queue entry and response-create gate are released
+- **AND** the service does not resend the request during the same client call
+
+#### Scenario: Client retry bypasses a quarantined bridge
+
+- **GIVEN** an affinity key was quarantined after a silent bridge submission
+- **WHEN** the client independently retries before the quarantine expires
+- **THEN** the service sends the retry over direct HTTP instead of creating or reusing an upstream websocket bridge
+- **AND** the direct HTTP response is streamed through the existing Responses contract
+
+#### Scenario: Previous-response fallback preserves account ownership
+
+- **GIVEN** a quarantined retry carries `previous_response_id`
+- **AND** the service can resolve the account that owns that response
+- **WHEN** the retry is sent over direct HTTP
+- **THEN** the retry uses the owning account
+- **AND** the service does not move the response chain to another available account
+
+#### Scenario: Silent bridge does not block unrelated accounts
+
+- **GIVEN** one affinity key has an accepted-but-silent bridge submission on account A
+- **WHEN** independent requests target eligible sessions on other accounts
+- **THEN** those requests can complete without waiting for the silent bridge deadline
+
+### Requirement: Downstream stream cancellation closes bridge lifecycle
+
+When a downstream Responses streaming body is closed, the service MUST close
+the bridge lifecycle iterator and release the associated pending request,
+response-create gate, and upstream websocket resources. This requirement
+applies even when the downstream consumed only the initial SSE heartbeat and
+no upstream `response.created` event.
+
+#### Scenario: Client closes after initial heartbeat
+
+- **GIVEN** a Codex-native HTTP Responses stream has emitted its initial heartbeat
+- **AND** upstream has not emitted `response.created`
+- **WHEN** the downstream client closes the stream
+- **THEN** the pending bridge request and queue admission are released
+- **AND** the bridge session and upstream websocket are closed

--- a/openspec/changes/quarantine-silent-http-bridge-sessions/tasks.md
+++ b/openspec/changes/quarantine-silent-http-bridge-sessions/tasks.md
@@ -1,0 +1,21 @@
+## 1. Specification
+
+- [x] Define the bounded `response.created` wait and no-replay safety rule.
+- [x] Define temporary direct-HTTP fallback with continuity account ownership.
+- [x] Define cleanup when the downstream closes after the initial heartbeat.
+
+## 2. Implementation
+
+- [x] Track and bound the post-submit wait for `response.created`.
+- [x] Retire, close, and quarantine silent bridge sessions.
+- [x] Bypass quarantined bridge keys on the next independent client retry.
+- [x] Close the bridge lifecycle iterator when the public stream closes.
+
+## 3. Verification
+
+- [x] Cover silent-session quarantine and direct-HTTP retry.
+- [x] Cover `previous_response_id` account ownership during fallback.
+- [x] Cover unrelated-account concurrency while one bridge is silent.
+- [x] Cover downstream cancellation after the initial heartbeat.
+- [x] Run focused and full bridge/API integration tests, lint, type checks, and
+  OpenSpec validation.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -16,9 +16,12 @@ from unittest.mock import AsyncMock
 import anyio
 import pytest
 import pytest_asyncio
+from fastapi.responses import StreamingResponse
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
+from starlette.requests import Request
 
+import app.modules.proxy.api as proxy_api_module
 import app.modules.proxy.service as proxy_module
 from app.core.config.settings import Settings
 from app.core.openai.model_registry import ModelRegistry
@@ -28,10 +31,11 @@ from app.core.utils.request_id import (
     set_request_id,
     set_request_scope_id,
 )
+from app.core.utils.sse import CODEX_KEEPALIVE_FRAME, format_sse_event
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, DashboardSettings
 from app.db.session import SessionLocal
-from app.dependencies import get_proxy_service_for_app
+from app.dependencies import ProxyContext, get_proxy_service_for_app
 from app.modules.proxy._service import support as proxy_support
 from app.modules.proxy._service.http_bridge import streaming as http_bridge_streaming_module
 from app.modules.proxy._service.http_bridge.helpers import (
@@ -57,6 +61,7 @@ async def _cleanup_http_bridge_sessions(app_instance):
         service._http_bridge_inflight_sessions.clear()
         service._http_bridge_turn_state_index.clear()
         service._http_bridge_previous_response_index.clear()
+        service._http_bridge_quarantine_until.clear()
     for session in sessions:
         await service._close_http_bridge_session(session)
     for inflight_future in inflight_sessions:
@@ -489,6 +494,14 @@ class _CreatedOnlyUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
 class _SilentUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
     async def send_text(self, text: str) -> None:
         self.sent_text.append(text)
+
+
+class _SecondRequestSilentUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
+    async def send_text(self, text: str) -> None:
+        if self.sent_text:
+            self.sent_text.append(text)
+            return
+        await super().send_text(text)
 
 
 class _RecordingUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
@@ -7071,6 +7084,533 @@ async def test_v1_responses_http_bridge_retries_once_when_upstream_closes_before
 
 
 @pytest.mark.asyncio
+async def test_backend_http_bridge_quarantines_silent_session_then_uses_http_without_internal_replay(
+    async_client,
+    monkeypatch,
+):
+    app_settings = _make_app_settings(enabled=True)
+    object.__setattr__(
+        app_settings,
+        "http_responses_session_bridge_response_created_timeout_seconds",
+        0.03,
+    )
+    object.__setattr__(
+        app_settings,
+        "http_responses_session_bridge_quarantine_seconds",
+        0.1,
+    )
+    object.__setattr__(app_settings, "sse_keepalive_interval_seconds", 0.0)
+    _install_proxy_settings(
+        monkeypatch,
+        app_settings=app_settings,
+        dashboard_settings=_make_dashboard_settings(),
+    )
+    account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_silent_quarantine",
+        "http-bridge-silent-quarantine@example.com",
+    )
+    account = await _get_account(account_id)
+    silent_upstream = _SilentUpstreamWebSocket()
+    recovered_upstream = _FakeBridgeUpstreamWebSocket()
+    upstreams = [silent_upstream, recovered_upstream]
+    websocket_connect_count = 0
+    http_request_count = 0
+
+    async def fake_select_account_with_budget(
+        self,
+        deadline,
+        *,
+        request_id,
+        kind,
+        request_stage="first_turn",
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset_accounts,
+        routing_strategy,
+        model,
+        exclude_account_ids=None,
+        additional_limit_name=None,
+        api_key=None,
+        preferred_account_id=None,
+    ):
+        del (
+            self,
+            deadline,
+            request_id,
+            kind,
+            request_stage,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset_accounts,
+            routing_strategy,
+            model,
+            exclude_account_ids,
+            additional_limit_name,
+            api_key,
+            preferred_account_id,
+        )
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        nonlocal websocket_connect_count
+        upstream = upstreams[websocket_connect_count]
+        websocket_connect_count += 1
+        return upstream
+
+    async def fake_core_stream(
+        payload,
+        headers,
+        access_token,
+        account_id_header,
+        **kwargs,
+    ):
+        del payload, headers, access_token, account_id_header
+        nonlocal http_request_count
+        http_request_count += 1
+        assert kwargs["upstream_stream_transport_override"] == "http"
+        yield format_sse_event(
+            {
+                "type": "response.created",
+                "response": {"id": "resp_http_after_quarantine", "status": "in_progress"},
+            }
+        )
+        yield format_sse_event(
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_http_after_quarantine",
+                    "status": "completed",
+                    "usage": {
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_core_stream)
+
+    request_body = {
+        "model": "gpt-5.1",
+        "instructions": "Return exactly OK.",
+        "input": "silent-then-http",
+        "prompt_cache_key": "silent-then-http-key",
+        "stream": True,
+    }
+    first_events = await asyncio.wait_for(
+        _collect_sse_events(
+            async_client,
+            "/backend-api/codex/responses",
+            json_body=request_body,
+        ),
+        timeout=1.0,
+    )
+
+    assert first_events[-1]["type"] == "response.failed"
+    assert first_events[-1]["response"]["error"]["code"] == "upstream_unavailable"
+    assert websocket_connect_count == 1
+    assert http_request_count == 0
+
+    second_events = await asyncio.wait_for(
+        _collect_sse_events(
+            async_client,
+            "/backend-api/codex/responses",
+            json_body=request_body,
+        ),
+        timeout=1.0,
+    )
+
+    assert [event["type"] for event in second_events] == [
+        "response.created",
+        "response.completed",
+    ]
+    assert websocket_connect_count == 1
+    assert http_request_count == 1
+
+    await asyncio.sleep(0.11)
+    third_events = await asyncio.wait_for(
+        _collect_sse_events(
+            async_client,
+            "/backend-api/codex/responses",
+            json_body=request_body,
+        ),
+        timeout=1.0,
+    )
+
+    assert third_events[0]["type"] == "response.created"
+    assert third_events[-1]["type"] == "response.completed"
+    assert websocket_connect_count == 2
+    assert http_request_count == 1
+
+
+@pytest.mark.asyncio
+async def test_backend_http_bridge_quarantine_preserves_previous_response_account_on_http_retry(
+    async_client,
+    monkeypatch,
+):
+    app_settings = _make_app_settings(enabled=True)
+    object.__setattr__(
+        app_settings,
+        "http_responses_session_bridge_response_created_timeout_seconds",
+        0.03,
+    )
+    object.__setattr__(
+        app_settings,
+        "http_responses_session_bridge_quarantine_seconds",
+        10.0,
+    )
+    object.__setattr__(app_settings, "sse_keepalive_interval_seconds", 0.01)
+    _install_proxy_settings(
+        monkeypatch,
+        app_settings=app_settings,
+        dashboard_settings=_make_dashboard_settings(),
+    )
+    account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_quarantine_previous_owner",
+        "http-bridge-quarantine-previous-owner@example.com",
+    )
+    account = await _get_account(account_id)
+    upstream = _SecondRequestSilentUpstreamWebSocket()
+    websocket_connect_count = 0
+    http_request_count = 0
+    preferred_account_ids: list[str | None] = []
+    stream_error_mock = AsyncMock()
+
+    async def fake_select_account_with_budget(
+        self,
+        deadline,
+        *,
+        request_id,
+        kind,
+        request_stage="first_turn",
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset_accounts,
+        routing_strategy,
+        model,
+        exclude_account_ids=None,
+        additional_limit_name=None,
+        api_key=None,
+        preferred_account_id=None,
+    ):
+        del (
+            self,
+            deadline,
+            request_id,
+            kind,
+            request_stage,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset_accounts,
+            routing_strategy,
+            model,
+            exclude_account_ids,
+            additional_limit_name,
+            api_key,
+        )
+        preferred_account_ids.append(preferred_account_id)
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        nonlocal websocket_connect_count
+        websocket_connect_count += 1
+        return upstream
+
+    async def fake_core_stream(
+        payload,
+        headers,
+        access_token,
+        account_id_header,
+        **kwargs,
+    ):
+        del headers, access_token
+        nonlocal http_request_count
+        http_request_count += 1
+        assert payload.previous_response_id == "resp_bridge_1"
+        assert account_id_header == account.chatgpt_account_id
+        assert kwargs["upstream_stream_transport_override"] == "http"
+        yield format_sse_event(
+            {
+                "type": "response.created",
+                "response": {"id": "resp_http_continuation", "status": "in_progress"},
+            }
+        )
+        yield format_sse_event(
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_http_continuation",
+                    "status": "completed",
+                    "usage": {
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_handle_stream_error", stream_error_mock)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_core_stream)
+
+    first_request = {
+        "model": "gpt-5.1",
+        "instructions": "Return exactly OK.",
+        "input": "establish-owner",
+        "prompt_cache_key": "quarantine-previous-owner-key",
+        "stream": True,
+    }
+    first_events = await _collect_sse_events(
+        async_client,
+        "/backend-api/codex/responses",
+        json_body=first_request,
+    )
+    assert first_events[-1]["type"] == "response.completed"
+    assert first_events[-1]["response"]["id"] == "resp_bridge_1"
+
+    continuation_request = {
+        **first_request,
+        "input": "continue-on-owner",
+        "previous_response_id": "resp_bridge_1",
+    }
+    failed_events = await asyncio.wait_for(
+        _collect_sse_events(
+            async_client,
+            "/backend-api/codex/responses",
+            json_body=continuation_request,
+        ),
+        timeout=1.0,
+    )
+
+    assert failed_events[-1]["type"] == "response.failed"
+    assert failed_events[-1]["response"]["error"]["code"] == "upstream_unavailable"
+    assert websocket_connect_count == 1
+    assert len(upstream.sent_text) == 2
+    assert http_request_count == 0
+
+    retried_events = await asyncio.wait_for(
+        _collect_sse_events(
+            async_client,
+            "/backend-api/codex/responses",
+            json_body=continuation_request,
+        ),
+        timeout=1.0,
+    )
+
+    assert retried_events[0]["type"] == "response.created"
+    assert retried_events[-1]["type"] == "response.completed"
+    assert retried_events[-1]["response"]["id"] == "resp_http_continuation"
+    assert websocket_connect_count == 1
+    assert len(upstream.sent_text) == 2
+    assert http_request_count == 1
+    assert preferred_account_ids[-1] == account_id
+    stream_error_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_backend_http_bridge_silent_session_does_not_block_other_accounts(
+    async_client,
+    monkeypatch,
+):
+    app_settings = _make_app_settings(enabled=True)
+    object.__setattr__(
+        app_settings,
+        "http_responses_session_bridge_response_created_timeout_seconds",
+        0.03,
+    )
+    object.__setattr__(
+        app_settings,
+        "http_responses_session_bridge_quarantine_seconds",
+        10.0,
+    )
+    object.__setattr__(app_settings, "sse_keepalive_interval_seconds", 0.01)
+    _install_proxy_settings(
+        monkeypatch,
+        app_settings=app_settings,
+        dashboard_settings=_make_dashboard_settings(),
+    )
+
+    account_by_key: dict[str, Account] = {}
+    account_by_chatgpt_id: dict[str, Account] = {}
+    for suffix in ("bad", "good-a", "good-b"):
+        account_id = await _import_account(
+            async_client,
+            f"acc_http_bridge_concurrent_{suffix}",
+            f"http-bridge-concurrent-{suffix}@example.com",
+        )
+        account = await _get_account(account_id)
+        account_by_key[f"concurrent-{suffix}"] = account
+        assert account.chatgpt_account_id is not None
+        account_by_chatgpt_id[account.chatgpt_account_id] = account
+
+    websocket_connect_count = 0
+    http_request_count = 0
+    selection_keys: list[str] = []
+
+    async def fake_select_account_with_budget(self, deadline, **kwargs):
+        del self, deadline
+        sticky_key = str(kwargs["sticky_key"])
+        selection_keys.append(sticky_key)
+        account = next(candidate for key, candidate in account_by_key.items() if key in sticky_key)
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, base_url, session
+        nonlocal websocket_connect_count
+        websocket_connect_count += 1
+        account = account_by_chatgpt_id[account_id_header]
+        if account is account_by_key["concurrent-bad"]:
+            return _SilentUpstreamWebSocket()
+        return _FakeBridgeUpstreamWebSocket()
+
+    async def fake_core_stream(
+        payload,
+        headers,
+        access_token,
+        account_id_header,
+        **kwargs,
+    ):
+        del payload, headers, access_token
+        nonlocal http_request_count
+        http_request_count += 1
+        assert account_id_header == account_by_key["concurrent-bad"].chatgpt_account_id
+        assert kwargs["upstream_stream_transport_override"] == "http"
+        yield format_sse_event(
+            {
+                "type": "response.created",
+                "response": {"id": "resp_concurrent_http", "status": "in_progress"},
+            }
+        )
+        yield format_sse_event(
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_concurrent_http",
+                    "status": "completed",
+                    "usage": {
+                        "input_tokens": 1,
+                        "output_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_core_stream)
+
+    def request_body(suffix: str) -> dict[str, Any]:
+        return {
+            "model": "gpt-5.1",
+            "instructions": "Return exactly OK.",
+            "input": f"concurrent-{suffix}",
+            "prompt_cache_key": f"concurrent-{suffix}",
+            "stream": True,
+        }
+
+    bad_events, good_a_events, good_b_events = await asyncio.wait_for(
+        asyncio.gather(
+            _collect_sse_events(
+                async_client,
+                "/backend-api/codex/responses",
+                json_body=request_body("bad"),
+            ),
+            _collect_sse_events(
+                async_client,
+                "/backend-api/codex/responses",
+                json_body=request_body("good-a"),
+            ),
+            _collect_sse_events(
+                async_client,
+                "/backend-api/codex/responses",
+                json_body=request_body("good-b"),
+            ),
+        ),
+        timeout=1.0,
+    )
+
+    assert bad_events[-1]["type"] == "response.failed"
+    assert bad_events[-1]["response"]["error"]["code"] == "upstream_unavailable"
+    assert good_a_events[-1]["type"] == "response.completed"
+    assert good_b_events[-1]["type"] == "response.completed"
+    assert websocket_connect_count == 3
+    assert http_request_count == 0
+
+    retry_events = await asyncio.wait_for(
+        _collect_sse_events(
+            async_client,
+            "/backend-api/codex/responses",
+            json_body=request_body("bad"),
+        ),
+        timeout=1.0,
+    )
+
+    assert retry_events[0]["type"] == "response.created", (
+        retry_events,
+        selection_keys,
+        websocket_connect_count,
+        http_request_count,
+    )
+    assert retry_events[-1]["type"] == "response.completed"
+    assert websocket_connect_count == 3
+    assert http_request_count == 1
+
+
+@pytest.mark.asyncio
 async def test_backend_responses_http_bridge_retries_precreated_server_overload(async_client, monkeypatch):
     _install_bridge_settings(monkeypatch, enabled=True)
     account_id = await _import_account(
@@ -12066,6 +12606,127 @@ async def test_v1_responses_http_bridge_stream_cancel_retires_session(
     async with session.pending_lock:
         assert not session.pending_requests
         assert session.queued_request_count == 0
+    assert session.closed is True
+    assert session.upstream_control.retire_after_drain is True
+    assert fake_upstream.closed is True
+
+
+@pytest.mark.asyncio
+async def test_codex_http_response_close_after_initial_heartbeat_retires_bridge_session(
+    async_client,
+    app_instance,
+    monkeypatch,
+):
+    _install_bridge_settings(monkeypatch, enabled=True)
+    account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_public_stream_cancel",
+        "http-bridge-public-stream-cancel@example.com",
+    )
+    service = get_proxy_service_for_app(app_instance)
+    account = await _get_account(account_id)
+    fake_upstream = _CreatedOnlyUpstreamWebSocket()
+
+    async def fake_select_account_with_budget(
+        self,
+        deadline,
+        *,
+        request_id,
+        kind,
+        request_stage="first_turn",
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset_accounts,
+        routing_strategy,
+        model,
+        exclude_account_ids=None,
+        additional_limit_name=None,
+        api_key=None,
+        preferred_account_id=None,
+    ):
+        del (
+            self,
+            deadline,
+            request_id,
+            kind,
+            request_stage,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset_accounts,
+            routing_strategy,
+            model,
+            exclude_account_ids,
+            additional_limit_name,
+            api_key,
+            preferred_account_id,
+        )
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        return fake_upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    payload = proxy_module.ResponsesRequest(
+        model="gpt-5.1",
+        instructions="Return exactly OK.",
+        input="cancel-after-heartbeat",
+        prompt_cache_key="cancel-after-heartbeat-key",
+    )
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/backend-api/codex/responses",
+            "headers": [],
+            "client": ("127.0.0.1", 12345),
+        }
+    )
+    response = await proxy_api_module._stream_responses(
+        request,
+        payload,
+        ProxyContext(service=service),
+        api_key=None,
+        openai_cache_affinity=True,
+        prefer_http_bridge=True,
+        enforce_openai_sdk_contract=False,
+    )
+    response = cast(StreamingResponse, response)
+
+    iterator = response.body_iterator.__aiter__()
+    first_event = await asyncio.wait_for(iterator.__anext__(), timeout=0.2)
+    assert first_event == CODEX_KEEPALIVE_FRAME
+    await cast(Any, iterator).aclose()
+
+    session_key = proxy_module._HTTPBridgeSessionKey(
+        affinity_kind="prompt_cache",
+        affinity_key="cancel-after-heartbeat-key",
+        api_key_id=None,
+    )
+    async with service._http_bridge_lock:
+        session = service._http_bridge_sessions[session_key]
+    async with session.pending_lock:
+        assert not session.pending_requests
+        assert session.queued_request_count == 0
+    assert session.response_create_gate.locked() is False
     assert session.closed is True
     assert session.upstream_control.retire_after_drain is True
     assert fake_upstream.closed is True

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -4,7 +4,7 @@ import asyncio
 import base64
 import json
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 
 import pytest
 from fastapi.responses import StreamingResponse
@@ -1302,6 +1302,68 @@ async def test_codex_route_stream_responses_starts_event_keepalive_before_first_
     release_upstream.set()
     chunks = [cast(str, await asyncio.wait_for(iterator.__anext__(), timeout=0.2)) for _ in range(2)]
     assert any("response.completed" in chunk for chunk in chunks)
+
+
+@pytest.mark.asyncio
+async def test_codex_route_stream_close_after_initial_heartbeat_closes_upstream(monkeypatch):
+    upstream_started = asyncio.Event()
+    upstream_closed = asyncio.Event()
+    release_upstream = asyncio.Event()
+
+    class _FakeService:
+        async def rate_limit_headers(self):
+            return {}
+
+        async def stream_responses(self, *args, **kwargs):
+            del args, kwargs
+            upstream_started.set()
+            _signal_propagated_capacity_startup_ready()
+            try:
+                await release_upstream.wait()
+                event = {"type": "response.completed", "response": {"id": "resp_delayed"}}
+                yield _sse_event(event)
+            finally:
+                upstream_closed.set()
+
+    settings = SimpleNamespace(
+        http_responses_session_bridge_enabled=False,
+        sse_keepalive_interval_seconds=0.01,
+        proxy_account_stream_recovery_reserve=1,
+    )
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_api_module.proxy_service_module, "get_settings", lambda: settings)
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/backend-api/codex/responses",
+            "headers": [],
+        }
+    )
+    payload = proxy_api_module.ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True}
+    )
+
+    response = await proxy_api_module._stream_responses(
+        request,
+        payload,
+        ProxyContext(service=cast(proxy_module.ProxyService, _FakeService())),
+        api_key=None,
+        enforce_openai_sdk_contract=False,
+    )
+
+    assert isinstance(response, StreamingResponse)
+    assert upstream_started.is_set() is True
+    iterator = response.body_iterator.__aiter__()
+    first_chunk = await asyncio.wait_for(iterator.__anext__(), timeout=0.2)
+    assert first_chunk == CODEX_KEEPALIVE_FRAME
+    try:
+        await cast(Any, iterator).aclose()
+        await asyncio.wait_for(upstream_closed.wait(), timeout=0.1)
+    finally:
+        release_upstream.set()
+        await asyncio.wait_for(upstream_closed.wait(), timeout=0.2)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Bound accepted-but-silent HTTP bridge submissions so one stuck upstream
websocket cannot hold a session gate and stall later Codex requests. The
ambiguous current call fails without an internal replay; the next independent
retry temporarily bypasses that bridge over direct HTTP while preserving
`previous_response_id` account ownership.

Fixes #1404

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] Breaking change

Linked issue: Fixes #1404

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful Responses path and preserves
  upstream-equivalent request/SSE behavior

Change directory:
`openspec/changes/quarantine-silent-http-bridge-sessions/`

## Changes

- Record when bridge `response.create` is sent and bound the wait for
  `response.created` (default 5 seconds).
- Fail the ambiguous current request without replay, retire/close the silent
  bridge, and quarantine its affinity key for a bounded interval (default 60
  seconds).
- Send only the next independent retry through direct HTTP; existing owner
  resolution keeps `previous_response_id` chains on the account that created
  them.
- Close the underlying bridge lifecycle iterator and upstream websocket when a
  downstream stream closes, including after only the initial SSE heartbeat.
- Add regression coverage for quarantine/retry, continuity ownership,
  unrelated-account concurrency, and disconnect cleanup.

## Safety invariant

Once `response.create` has been sent, upstream acceptance is ambiguous. This PR
deliberately does **not** replay the same request inside that client call;
automatic replay could duplicate work or fork a response chain.

## Simplicity

- [x] Works with zero configuration and preserves existing bridge defaults
- [x] No new required setup step
- [x] No README section, `.env.example` entry, dashboard nav item, or UI change
- New internal settings and rationale:
  - `http_responses_session_bridge_response_created_timeout_seconds=5`:
    conservative working default; override remains available only for incident
    tuning on unusually slow upstreams.
  - `http_responses_session_bridge_quarantine_seconds=60`: conservative
    recovery window; override remains available only for incident tuning and
    can be set to zero to disable quarantine.

## Test plan

```text
pytest tests/integration/test_http_responses_bridge.py tests/integration/test_proxy_api_extended.py -q
146 passed in 184.42s

ruff check .
All checks passed!

ruff format --check .
802 files already formatted

ty check --python-platform linux
All checks passed!

openspec validate quarantine-silent-http-bridge-sessions --strict --no-interactive
Change 'quarantine-silent-http-bridge-sessions' is valid

openspec validate --specs --strict --no-interactive
47 passed, 0 failed
```

The full `make ci` parity target was not run on this Windows host because GNU
make, Docker/Helm, and local PostgreSQL gates are unavailable; GitHub CI
remains required. The standalone architecture script reaches a pre-existing
`origin/main` ratchet failure (`load_balancer.py`: 3260 lines vs 3021) in an
untouched file. Touched ratcheted files remain within limits (`service.py`:
2600, HTTP bridge mixin: 2393, streaming mixin: 1100).

## Screenshots / output

No dashboard-visible change. Expected recovery sequence is observable as
low-cardinality bridge events:

```text
response_created_timeout -> bridge retired/closed
next independent retry -> quarantine_http_fallback -> direct HTTP
```

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue.
- [x] Added integration tests at the externally failing HTTP/Codex streaming
  path.
- [ ] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files`
  (unavailable on this host; relevant local gates are listed above).
- [x] Strict OpenSpec validation passes.
- [x] Simplicity gates reviewed.
- [x] `CHANGELOG.md` was not edited.
