### PR TITLE
refactor(proxy): trim service.py under the architecture line-count gate

### DIFF
--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -18,10 +18,12 @@ from app.core.auth.refresh import RefreshError, is_transient_refresh_contention,
 from app.core.balancer.types import UpstreamError
 from app.core.clients.proxy import ProxyResponseError
 from app.core.clients.proxy_websocket import UpstreamResponsesWebSocket
-from app.core.errors import openai_error
+from app.core.errors import OpenAIErrorEnvelope, openai_error
 from app.core.openai.model_registry import get_model_registry
 from app.core.openai.models import OpenAIEvent
 from app.core.plan_types import account_plan_matches_allowed
+from app.core.resilience.network_recovery import PROCESS_NETWORK_UNAVAILABLE_CODE
+from app.core.resilience.overload import is_local_overload_error_code
 from app.core.types import JsonValue
 from app.core.upstream_proxy import ResolvedUpstreamRoute
 from app.db.models import Account
@@ -1184,3 +1186,67 @@ async def _websocket_full_replay_should_wait_for_continuity(
         return False
     async with pending_lock:
         return bool(pending_requests)
+
+
+def _is_account_neutral_error_code(code: str | None) -> bool:
+    return is_local_overload_error_code(code) or code in {
+        PROCESS_NETWORK_UNAVAILABLE_CODE,
+        "proxy_unavailable",
+        "responses_compact_input_too_large",
+    }
+
+
+def _is_local_account_cap_code(code: str | None) -> bool:
+    return code in {"account_response_create_cap", "account_stream_cap"}
+
+
+def _http_error_status_from_payload(payload: dict[str, JsonValue] | None) -> int | None:
+    if not isinstance(payload, dict):
+        return None
+    for status_field in ("status", "status_code"):
+        status = payload.get(status_field)
+        if isinstance(status, int) and not isinstance(status, bool):
+            return status
+    return None
+
+
+def _openai_error_envelope_from_response_failed_payload(
+    payload: dict[str, JsonValue] | None,
+) -> OpenAIErrorEnvelope:
+    default_envelope = openai_error("upstream_error", "Upstream error")
+    if not isinstance(payload, dict):
+        return default_envelope
+    response_payload = payload.get("response")
+    if not isinstance(response_payload, dict):
+        return default_envelope
+    error_payload = response_payload.get("error")
+    if not isinstance(error_payload, dict):
+        return default_envelope
+
+    message_value = error_payload.get("message")
+    if isinstance(message_value, str) and message_value.strip():
+        message = message_value.strip()
+    else:
+        message = "Upstream error"
+
+    code_value = error_payload.get("code")
+    code = code_value.strip() if isinstance(code_value, str) and code_value.strip() else "upstream_error"
+
+    type_value = error_payload.get("type")
+    error_type = type_value.strip() if isinstance(type_value, str) and type_value.strip() else "server_error"
+
+    envelope = openai_error(code, message, error_type)
+    param_value = error_payload.get("param")
+    if isinstance(param_value, str) and param_value.strip():
+        envelope["error"]["param"] = param_value.strip()
+    error_detail = envelope["error"]
+    plan_type = error_payload.get("plan_type")
+    if plan_type is not None:
+        error_detail["plan_type"] = str(plan_type)
+    resets_at = error_payload.get("resets_at")
+    if isinstance(resets_at, int | float):
+        error_detail["resets_at"] = resets_at
+    resets_in = error_payload.get("resets_in_seconds")
+    if isinstance(resets_in, int | float):
+        error_detail["resets_in_seconds"] = resets_in
+    return envelope

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -84,11 +84,9 @@ from app.core.openai.requests import (
     ResponsesCompactRequest,
     ResponsesRequest,
 )
-from app.core.resilience.network_recovery import PROCESS_NETWORK_UNAVAILABLE_CODE
 from app.core.resilience.network_recovery import (
     ProcessNetworkRecovery as ProcessNetworkRecovery,
 )
-from app.core.resilience.overload import is_local_overload_error_code
 from app.core.types import JsonValue
 from app.core.upstream_proxy import UpstreamProxyRouteError
 from app.core.upstream_proxy.resolver import (
@@ -565,9 +563,13 @@ from app.modules.proxy._service.support import (
     _event_type_from_payload,  # noqa: F401
     _FilePinEntry,
     _finalize_ttft_reasoning_deltas,  # noqa: F401
+    _http_error_status_from_payload,  # noqa: F401
     _HTTPBridgeSession,
     _HTTPBridgeSessionKey,
+    _is_account_neutral_error_code,
+    _is_local_account_cap_code,  # noqa: F401
     _is_ttft_event,  # noqa: F401
+    _openai_error_envelope_from_response_failed_payload,  # noqa: F401
     _PreparedWebSocketRequest,  # noqa: F401
     _record_response_event,  # noqa: F401
     _record_websocket_route_metadata,  # noqa: F401
@@ -2038,70 +2040,6 @@ class ProxyService(
             code,
             http_status=exc.status_code,
         )
-
-
-def _is_account_neutral_error_code(code: str | None) -> bool:
-    return is_local_overload_error_code(code) or code in {
-        PROCESS_NETWORK_UNAVAILABLE_CODE,
-        "proxy_unavailable",
-        "responses_compact_input_too_large",
-    }
-
-
-def _is_local_account_cap_code(code: str | None) -> bool:
-    return code in {"account_response_create_cap", "account_stream_cap"}
-
-
-def _http_error_status_from_payload(payload: dict[str, JsonValue] | None) -> int | None:
-    if not isinstance(payload, dict):
-        return None
-    for status_field in ("status", "status_code"):
-        status = payload.get(status_field)
-        if isinstance(status, int) and not isinstance(status, bool):
-            return status
-    return None
-
-
-def _openai_error_envelope_from_response_failed_payload(
-    payload: dict[str, JsonValue] | None,
-) -> OpenAIErrorEnvelope:
-    default_envelope = openai_error("upstream_error", "Upstream error")
-    if not isinstance(payload, dict):
-        return default_envelope
-    response_payload = payload.get("response")
-    if not isinstance(response_payload, dict):
-        return default_envelope
-    error_payload = response_payload.get("error")
-    if not isinstance(error_payload, dict):
-        return default_envelope
-
-    message_value = error_payload.get("message")
-    if isinstance(message_value, str) and message_value.strip():
-        message = message_value.strip()
-    else:
-        message = "Upstream error"
-
-    code_value = error_payload.get("code")
-    code = code_value.strip() if isinstance(code_value, str) and code_value.strip() else "upstream_error"
-
-    type_value = error_payload.get("type")
-    error_type = type_value.strip() if isinstance(type_value, str) and type_value.strip() else "server_error"
-
-    envelope = openai_error(code, message, error_type)
-    param_value = error_payload.get("param")
-    if isinstance(param_value, str) and param_value.strip():
-        envelope["error"]["param"] = param_value.strip()
-    error_detail = envelope["error"]
-    plan_type = error_payload.get("plan_type")
-    if plan_type is not None:
-        error_detail["plan_type"] = str(plan_type)
-    resets_at = error_payload.get("resets_at")
-    if isinstance(resets_at, int | float):
-        error_detail["resets_at"] = resets_at
-    resets_in = error_payload.get("resets_in_seconds")
-    if isinstance(resets_in, int | float):
-        error_detail["resets_in_seconds"] = resets_in
-    return envelope
 
 
 def _is_previous_response_not_found_message(message: str | None) -> bool:


### PR DESCRIPTION
## Summary

`service.py` currently sits at 2604 lines, 4 over the
`check_proxy_architecture.py` line-count gate (2600). Since that check
runs as part of `Lint (ruff)` in CI, this fails **every** PR that touches
this repo right now, regardless of what the PR actually changes (confirmed
on current `origin/main` directly, and on two unrelated open PRs of mine —
#1408, #1401 — both fail this same check with no diff to `service.py` at
all).

This is a small, purely mechanical fix: move four self-contained,
dependency-light helper functions out of `service.py` into
`_service/support.py` (a module `service.py` is already allowed to import
from per the architecture rules) and re-export them so every existing
`_facade()`-based caller elsewhere in the codebase is unaffected:

- `_is_account_neutral_error_code`
- `_is_local_account_cap_code`
- `_http_error_status_from_payload`
- `_openai_error_envelope_from_response_failed_payload`

No behavior change. `service.py` is now 2542 lines.

Note: `load_balancer.py` is *also* over its own architecture line-count
limit on current `main` (3260 vs. 3021) — a much larger gap that needs a
real method-level refactor, not a small move. Left out of this PR
intentionally to keep it single-concern; happy to open a follow-up if
useful.

## Test plan

- [x] `uv run python scripts/check_proxy_architecture.py` — service.py
      check now passes (the only remaining failure is the pre-existing,
      out-of-scope `load_balancer.py` line count, also present on
      unmodified `main`)
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run ty check` — clean
- [x] `uv run pytest` — full suite green except one pre-existing,
      unrelated flaky integration test
      (`test_quota_planner_warm_now_keeps_bootstrap_for_metadata_less_primary_rows`,
      confirmed to fail identically on unmodified `origin/main`)