### PR TITLE
fix(proxy): purge stale hard codex_session mappings pinned to a durably unavailable owner

### DIFF
--- a/app/db/alembic/versions/20260727_000000_add_sticky_session_continuity_abandoned_at.py
+++ b/app/db/alembic/versions/20260727_000000_add_sticky_session_continuity_abandoned_at.py
@@ -1,0 +1,45 @@
+"""add sticky session continuity_abandoned_at
+
+Revision ID: 20260727_000000_add_sticky_session_continuity_abandoned_at
+Revises: 20260725_000000_add_http_bridge_pending_tool_calls
+Create Date: 2026-07-27 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+revision = "20260727_000000_add_sticky_session_continuity_abandoned_at"
+down_revision = "20260725_000000_add_http_bridge_pending_tool_calls"
+branch_labels = None
+depends_on = None
+
+_STICKY_SESSIONS_TABLE = "sticky_sessions"
+_COLUMN_NAME = "continuity_abandoned_at"
+
+
+def _columns(connection: Connection, table_name: str) -> set[str]:
+    inspector = sa.inspect(connection)
+    if not inspector.has_table(table_name):
+        return set()
+    return {str(column["name"]) for column in inspector.get_columns(table_name) if column.get("name") is not None}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if not sa.inspect(bind).has_table(_STICKY_SESSIONS_TABLE):
+        return
+    if _COLUMN_NAME not in _columns(bind, _STICKY_SESSIONS_TABLE):
+        with op.batch_alter_table(_STICKY_SESSIONS_TABLE) as batch_op:
+            batch_op.add_column(sa.Column(_COLUMN_NAME, sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if not sa.inspect(bind).has_table(_STICKY_SESSIONS_TABLE):
+        return
+    if _COLUMN_NAME in _columns(bind, _STICKY_SESSIONS_TABLE):
+        with op.batch_alter_table(_STICKY_SESSIONS_TABLE) as batch_op:
+            batch_op.drop_column(_COLUMN_NAME)

--- a/app/db/alembic/versions/20260727_000000_add_sticky_session_continuity_abandoned_at.py
+++ b/app/db/alembic/versions/20260727_000000_add_sticky_session_continuity_abandoned_at.py
@@ -12,7 +12,7 @@ from alembic import op
 from sqlalchemy.engine import Connection
 
 revision = "20260727_000000_add_sticky_session_continuity_abandoned_at"
-down_revision = "20260803_000000_merge_http_bridge_recovery_and_capability_lineage_heads"
+down_revision = "20260726_000000_add_account_plan_downgrade_observations"
 branch_labels = None
 depends_on = None
 

--- a/app/db/alembic/versions/20260727_000000_add_sticky_session_continuity_abandoned_at.py
+++ b/app/db/alembic/versions/20260727_000000_add_sticky_session_continuity_abandoned_at.py
@@ -1,7 +1,7 @@
 """add sticky session continuity_abandoned_at
 
 Revision ID: 20260727_000000_add_sticky_session_continuity_abandoned_at
-Revises: 20260725_000000_add_http_bridge_pending_tool_calls
+Revises: 20260803_000000_merge_http_bridge_recovery_and_capability_lineage_heads
 Create Date: 2026-07-27 00:00:00.000000
 """
 
@@ -12,7 +12,7 @@ from alembic import op
 from sqlalchemy.engine import Connection
 
 revision = "20260727_000000_add_sticky_session_continuity_abandoned_at"
-down_revision = "20260725_000000_add_http_bridge_pending_tool_calls"
+down_revision = "20260803_000000_merge_http_bridge_recovery_and_capability_lineage_heads"
 branch_labels = None
 depends_on = None
 

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -717,6 +717,17 @@ class StickySession(Base):
         onupdate=func.now(),
         nullable=False,
     )
+    # Set only by purge_stale_hard_codex_session_mappings's first pass. A hard
+    # codex_session row normally proves ownership for `conversation`-continuity
+    # requests (see affinity.py's require_unambiguous_account), which have no
+    # other owner index. Once the durably-unavailable owner's proof is this
+    # stale, we stop treating the row as a live pin (so a fresh account can be
+    # selected) but keep it around with this marker set instead of deleting it
+    # outright, so selection can tell "this key was deliberately abandoned,
+    # picking a new owner is authorized" apart from "this key was never seen,
+    # ambiguity must fail closed." The row is only ever hard-deleted once it
+    # has sat abandoned past a further grace window with nobody claiming it.
+    continuity_abandoned_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, default=None)
 
 
 class CapabilityLineageMarker(Base):

--- a/app/main.py
+++ b/app/main.py
@@ -61,6 +61,7 @@ from app.core.usage.reset_credits_refresh_scheduler import build_rate_limit_rese
 from app.core.utils.time import utcnow
 from app.db.session import SessionLocal, close_db, close_session, init_background_db, init_db
 from app.modules.accounts import api as accounts_api
+from app.modules.accounts.repository import AccountsRepository
 from app.modules.accounts.usage_rollup_scheduler import build_account_usage_rollup_scheduler
 from app.modules.api_keys import api as api_keys_api
 from app.modules.api_keys.reset_scheduler import build_api_key_limit_reset_scheduler
@@ -381,6 +382,14 @@ async def lifespan(app: FastAPI):
         await reconcile_model_registry_from_store()
 
     await cache_poller.start()
+
+    async with SessionLocal() as session:
+        seeded_count = await AccountsRepository(session).seed_hard_sticky_outage_grace_on_startup()
+    if seeded_count > 0:
+        logger.info(
+            "Seeded hard codex_session purge grace for already-unavailable accounts seeded_count=%s",
+            seeded_count,
+        )
 
     usage_scheduler = build_usage_refresh_scheduler()
     api_key_limit_reset_scheduler = build_api_key_limit_reset_scheduler()

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from typing import Any
 
 from sqlalchemy import delete, or_, select, text, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -25,7 +27,9 @@ from app.db.models import (
     HttpBridgeSessionRecord,
     HttpBridgeSessionState,
     RequestLog,
+    RuntimeSentinel,
     StickySession,
+    StickySessionKind,
     UsageHistory,
 )
 from app.db.session import sqlite_writer_section
@@ -47,6 +51,10 @@ from app.modules.usage.repository import _clear_bulk_history_since_sqlite_cache
 _SETTINGS_ROW_ID = 1
 _DUPLICATE_ACCOUNT_SUFFIX = "__copy"
 _UNSET = object()
+_HARD_STICKY_UNAVAILABLE_STATUSES = frozenset(
+    (AccountStatus.PAUSED, AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED)
+)
+_HARD_STICKY_OUTAGE_GRACE_SEEDED_SENTINEL = "hard_sticky_outage_grace_seeded"
 
 
 @dataclass(frozen=True, slots=True)
@@ -549,6 +557,9 @@ class AccountsRepository:
         blocked_at: int | None | object = _UNSET,
     ) -> bool:
         async with sqlite_writer_section():
+            previous_status = await self._session.scalar(
+                select(Account.status).where(Account.id == account_id).with_for_update()
+            )
             values: dict[str, object | None] = {
                 "status": status,
                 "deactivation_reason": deactivation_reason,
@@ -559,11 +570,14 @@ class AccountsRepository:
             result = await self._session.execute(
                 update(Account).where(Account.id == account_id).values(**values).returning(Account.id)
             )
-            if status in (AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
+            updated_id = result.scalar_one_or_none()
+            if updated_id is not None and self._hard_sticky_outage_started(previous_status, status):
+                await self._refresh_hard_sticky_outage_grace(account_id)
+            if updated_id is not None and status in (AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
                 await self._session.execute(delete(StickySession).where(StickySession.account_id == account_id))
                 await self._close_http_bridge_sessions_for_account(account_id)
             await self._session.commit()
-            return result.scalar_one_or_none() is not None
+            return updated_id is not None
 
     async def update_security_work_authorized(self, account_id: str, enabled: bool) -> bool:
         async with sqlite_writer_section():
@@ -625,11 +639,91 @@ class AccountsRepository:
                 stmt = stmt.where(Account.refresh_token_encrypted == expected_refresh_token_encrypted)
             result = await self._session.execute(stmt)
             updated_id = result.scalar_one_or_none()
+            if updated_id is not None and self._hard_sticky_outage_started(expected_status, status):
+                await self._refresh_hard_sticky_outage_grace(account_id)
             if updated_id is not None and status in (AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
                 await self._session.execute(delete(StickySession).where(StickySession.account_id == account_id))
                 await self._close_http_bridge_sessions_for_account(account_id)
             await self._session.commit()
             return updated_id is not None
+
+    @staticmethod
+    def _hard_sticky_outage_started(
+        previous_status: AccountStatus | None,
+        status: AccountStatus,
+    ) -> bool:
+        return (
+            previous_status is not None
+            and previous_status not in _HARD_STICKY_UNAVAILABLE_STATUSES
+            and status in _HARD_STICKY_UNAVAILABLE_STATUSES
+        )
+
+    async def _refresh_hard_sticky_outage_grace(self, account_id: str) -> None:
+        """Start a fresh purge grace period when a hard owner goes unavailable."""
+
+        await self._session.execute(
+            update(StickySession)
+            .where(
+                StickySession.account_id == account_id,
+                StickySession.kind == StickySessionKind.CODEX_SESSION,
+            )
+            .values(updated_at=utcnow())
+        )
+
+    async def seed_hard_sticky_outage_grace_on_startup(self) -> int:
+        """Backfill, exactly once ever, a grace window for already-unavailable owners.
+
+        ``_refresh_hard_sticky_outage_grace`` only fires on a live status
+        transition into PAUSED/RATE_LIMITED/QUOTA_EXCEEDED, so it never runs
+        for an account that was already sitting in one of those statuses
+        before this process started (e.g. an outage that began minutes
+        before a deploy). Without this, the purge scheduler's very first
+        cleanup cycle after this feature ships could treat that mapping's
+        stale ``updated_at`` as proof of a long-dead owner and purge it, even
+        though the outage is brand new — violating the "merely transient
+        outage is never purged" invariant for the upgrade window.
+
+        That backfill only needs to happen once per database, not once per
+        process start. All replicas share one database, and reseeding on
+        every boot resets the grace clock for accounts that are still
+        (correctly) unavailable; if deploys or autoscaling cycle faster than
+        the purge cutoff, a durably-dead mapping's grace clock would never
+        run out and it would never be purged. ``runtime_sentinels`` gives
+        every replica a shared, durable "has this ever run" marker: the
+        first replica to atomically stamp
+        ``_HARD_STICKY_OUTAGE_GRACE_SEEDED_SENTINEL`` performs the backfill;
+        every later boot, on this or any other replica, finds the sentinel
+        already stamped and skips it, leaving the live per-transition hook
+        as the sole grace-clock source from then on.
+        """
+        dialect = self._session.get_bind().dialect.name
+        if dialect == "postgresql":
+            insert_fn = pg_insert
+        elif dialect == "sqlite":
+            insert_fn = sqlite_insert
+        else:
+            raise RuntimeError(f"Hard-sticky outage grace seeding sentinel unsupported for dialect={dialect!r}")
+        stamp_stmt = (
+            insert_fn(RuntimeSentinel)
+            .values(name=_HARD_STICKY_OUTAGE_GRACE_SEEDED_SENTINEL, value=utcnow().isoformat())
+            .on_conflict_do_nothing(index_elements=[RuntimeSentinel.name])
+            .returning(RuntimeSentinel.name)
+        )
+        async with sqlite_writer_section():
+            stamp_result = await self._session.execute(stamp_stmt)
+            stamped_by_this_boot = stamp_result.scalar_one_or_none() is not None
+            if not stamped_by_this_boot:
+                await self._session.commit()
+                return 0
+            account_ids = (
+                await self._session.scalars(
+                    select(Account.id).where(Account.status.in_(_HARD_STICKY_UNAVAILABLE_STATUSES))
+                )
+            ).all()
+            for account_id in account_ids:
+                await self._refresh_hard_sticky_outage_grace(account_id)
+            await self._session.commit()
+        return len(account_ids)
 
     async def _close_http_bridge_sessions_for_account(self, account_id: str) -> None:
         session_ids = select(HttpBridgeSessionRecord.id).where(HttpBridgeSessionRecord.account_id == account_id)

--- a/app/modules/proxy/_load_balancer/sticky_selection.py
+++ b/app/modules/proxy/_load_balancer/sticky_selection.py
@@ -284,6 +284,7 @@ async def run_sticky_selection_path(
         )
 
     sticky_existing_account_id: str | None | object = _STICKY_EXISTING_UNSET
+    sticky_continuity_abandoned = False
     attempt = 0
     suppress_recovery_probe_candidates = False
     while True:
@@ -293,17 +294,26 @@ async def run_sticky_selection_path(
             async with owner._runtime_lock:
                 pass
             async with owner._repo_factory() as repos:
-                sticky_existing_account_id = await repos.sticky_sessions.get_account_id(
+                sticky_owner_lookup = await repos.sticky_sessions.get_account_id_and_abandonment(
                     sticky_key,
                     kind=sticky_kind,
                     max_age_seconds=sticky_max_age_seconds,
                 )
+                sticky_existing_account_id = sticky_owner_lookup.account_id
+                # `is True` (not a truthy check): an un-configured test double
+                # for sticky_sessions may return an object whose attribute
+                # access auto-vivifies to a mock rather than a real bool, and
+                # that must fail safe as "not abandoned", the same as it
+                # always has, rather than silently bypassing the ambiguous
+                # owner check below.
+                sticky_continuity_abandoned = sticky_owner_lookup.continuity_abandoned is True
             if sticky_kind == StickySessionKind.CODEX_SESSION and sticky_existing_is_legacy:
                 # Mixed-version replicas can create both rows on
                 # different accounts. The raw row was loaded before
                 # branch selection and always wins as possible hard
                 # turn-state ownership.
                 sticky_existing_account_id = legacy_existing_account_id
+                sticky_continuity_abandoned = False
         async with owner._runtime_lock:
             states, account_map = owner._prepare_sticky_selection_states(
                 selection_inputs,
@@ -343,9 +353,19 @@ async def run_sticky_selection_path(
                 )
             # A resolved hard row proves ownership. Without one, use the
             # same pre-health/pre-cap pool as the no-sticky path above.
+            #
+            # A tombstoned row (sticky_continuity_abandoned — see
+            # purge_stale_hard_codex_session_mappings) is exempted from this
+            # fail-closed check even though it's just as pool-ambiguous as a
+            # never-seen key: unlike a never-seen key, we know this session's
+            # owner was durably unavailable and continuity was deliberately
+            # abandoned, so picking a fresh owner here is what lets the
+            # request recover instead of failing closed forever with no path
+            # back to a resolved hard row.
             if (
                 require_unambiguous_account
                 and not hard_sticky
+                and not sticky_continuity_abandoned
                 and len(selection_inputs.effective_continuity_owner_candidates) != 1
             ):
                 return _direct_error(

--- a/app/modules/proxy/sticky_repository.py
+++ b/app/modules/proxy/sticky_repository.py
@@ -10,8 +10,8 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import Insert
 
-from app.core.utils.time import to_utc_naive, utcnow
-from app.db.models import Account, StickySession, StickySessionKind
+from app.core.utils.time import naive_utc_to_epoch, to_utc_naive, utcnow
+from app.db.models import Account, AccountStatus, StickySession, StickySessionKind
 from app.db.session import sqlite_writer_section
 from app.modules.sticky_sessions.schemas import StickySessionSortBy, StickySessionSortDir
 
@@ -40,6 +40,23 @@ class StickySessionListEntryRecord:
     display_name: str
 
 
+@dataclass(frozen=True, slots=True)
+class StickyOwnerLookup:
+    """Result of resolving a mapping's owner, accessed by attribute (never
+    unpacked) so an un-configured test double for ``sticky_sessions`` degrades
+    to its existing safe defaults (no owner, not abandoned) instead of a hard
+    crash on tuple destructuring."""
+
+    account_id: str | None
+    continuity_abandoned: bool
+
+
+def _owner_lookup_from_row(row: StickySession) -> StickyOwnerLookup:
+    if row.continuity_abandoned_at is not None:
+        return StickyOwnerLookup(account_id=None, continuity_abandoned=True)
+    return StickyOwnerLookup(account_id=row.account_id, continuity_abandoned=False)
+
+
 class StickySessionsRepository:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
@@ -51,17 +68,38 @@ class StickySessionsRepository:
         kind: StickySessionKind,
         max_age_seconds: int | None = None,
     ) -> str | None:
+        lookup = await self.get_account_id_and_abandonment(key, kind=kind, max_age_seconds=max_age_seconds)
+        return lookup.account_id
+
+    async def get_account_id_and_abandonment(
+        self,
+        key: str,
+        *,
+        kind: StickySessionKind,
+        max_age_seconds: int | None = None,
+    ) -> StickyOwnerLookup:
+        """Resolve a mapping's owner, and whether it's a purge tombstone.
+
+        A tombstoned row (``continuity_abandoned_at`` set — see
+        ``purge_stale_hard_codex_session_mappings``) is deliberately reported
+        as ownerless here, same as a missing row, so every existing caller of
+        ``get_account_id`` keeps treating it as "no live pin" without change.
+        The extra flag lets ``run_sticky_selection_path`` additionally
+        distinguish "this key was purged" from "this key was never seen",
+        which matters only for the `conversation`-continuity ambiguous-owner
+        check that has no other index to fall back on.
+        """
         if not key:
-            return None
+            return StickyOwnerLookup(account_id=None, continuity_abandoned=False)
         row = await self.get_entry(key, kind=kind)
         if row is None:
-            return None
+            return StickyOwnerLookup(account_id=None, continuity_abandoned=False)
         if max_age_seconds is None:
-            return row.account_id
+            return _owner_lookup_from_row(row)
         cutoff = utcnow() - timedelta(seconds=max_age_seconds)
         observed_updated_at = to_utc_naive(row.updated_at)
         if observed_updated_at >= cutoff:
-            return row.account_id
+            return _owner_lookup_from_row(row)
 
         # Release the read snapshot before attempting a SQLite write upgrade.
         # The DELETE remains safe because every value observed above participates
@@ -78,14 +116,18 @@ class StickySessionsRepository:
             )
             .returning(StickySession.key)
         )
-        current: tuple[str, datetime] | None = None
+        current: tuple[str, datetime, datetime | None] | None = None
         async with sqlite_writer_section():
             deleted_key = (await self._session.execute(statement)).scalar_one_or_none()
             if deleted_key is None:
                 current = (
                     (
                         await self._session.execute(
-                            select(StickySession.account_id, StickySession.updated_at).where(
+                            select(
+                                StickySession.account_id,
+                                StickySession.updated_at,
+                                StickySession.continuity_abandoned_at,
+                            ).where(
                                 StickySession.key == key,
                                 StickySession.kind == kind,
                             )
@@ -97,11 +139,13 @@ class StickySessionsRepository:
             await self._session.commit()
 
         if deleted_key is not None or current is None:
-            return None
-        current_account_id, current_updated_at = current
+            return StickyOwnerLookup(account_id=None, continuity_abandoned=False)
+        current_account_id, current_updated_at, current_continuity_abandoned_at = current
         if to_utc_naive(current_updated_at) < cutoff:
-            return None
-        return current_account_id
+            return StickyOwnerLookup(account_id=None, continuity_abandoned=False)
+        if current_continuity_abandoned_at is not None:
+            return StickyOwnerLookup(account_id=None, continuity_abandoned=True)
+        return StickyOwnerLookup(account_id=current_account_id, continuity_abandoned=False)
 
     async def get_entry(self, key: str, *, kind: StickySessionKind) -> StickySession | None:
         if not key:
@@ -195,7 +239,7 @@ class StickySessionsRepository:
                     StickySession.kind == kind,
                     StickySession.account_id == expected_account_id,
                 )
-                .values(account_id=restore_account_id, updated_at=func.now())
+                .values(account_id=restore_account_id, updated_at=func.now(), continuity_abandoned_at=None)
                 .returning(StickySession.key)
             )
 
@@ -348,6 +392,85 @@ class StickySessionsRepository:
             await self._session.commit()
         return deleted
 
+    async def purge_stale_hard_codex_session_mappings(self, cutoff: datetime, *, now: datetime) -> int:
+        """Retire CODEX_SESSION mappings pinned to a durably unusable owner.
+
+        A hard `codex_session` mapping is never rebound by ordinary selection
+        (see load_balancer.py's hard_sticky branch) even once its owner is
+        rate-limited/quota-exceeded/paused, because that pin can represent
+        live, unverifiable session state that isn't safe to move mid-flight.
+        That correctly protects a transient blip, but leaves the mapping
+        stuck forever if the owner never recovers.
+
+        ``Account.reset_at`` is frequently absent, while ``blocked_at`` is
+        cleared when an account is paused, so neither field provides one
+        durable outage clock for every unavailable status. Instead,
+        ``AccountsRepository`` refreshes the mapping timestamp exactly when
+        its owner transitions from an available status into one of the
+        unavailable statuses below. ``StickySession.updated_at`` therefore
+        records the later of the mapping's last use and the outage start.
+        Only once BOTH the owner is still non-active AND that conservative
+        timestamp is before ``cutoff`` do we give up on the mapping.
+
+        When ``Account.reset_at`` is known and still in the future (e.g. a
+        multi-day quota window), the owner's own stated recovery point takes
+        priority over the flat cutoff: the mapping survives until after
+        ``reset_at`` even if it has long since gone stale by the cutoff
+        alone, since purging before an account's own known recovery time
+        would contradict "well past its own recovery point". ``reset_at``
+        only ever narrows eligibility (delays a purge); it never widens it
+        when unset, which is why the fixed cutoff remains the fallback.
+
+        Giving up is done in two phases, never by an outright delete on the
+        first pass:
+
+        1. Tombstone: set ``continuity_abandoned_at`` instead of deleting.
+           A `conversation`-continuity request has no owner index besides
+           this row (see affinity.py's ``require_unambiguous_account``), so
+           an outright delete would be indistinguishable from "this key was
+           never seen" — and with more than one account in the pool, that
+           makes ``run_sticky_selection_path`` fail closed forever, even
+           after the original owner recovers, because nothing on that path
+           can ever re-create the very row it needs to stop failing closed.
+           A tombstone instead lets selection recognize "this key's
+           continuity was deliberately abandoned, picking a fresh owner is
+           authorized", so a subsequent request can escape the stuck state.
+        2. Delete: once a tombstone has sat for a further ``cutoff`` window
+           with nobody claiming it (i.e. it's still a tombstone, so no
+           request re-pinned it), it's dropped outright. A fresh request for
+           that key then falls back to the same conservative fail-closed
+           default as a key that was never seen, which is fine this long
+           after the fact.
+        """
+        now_epoch = naive_utc_to_epoch(to_utc_naive(now))
+        unavailable_account_ids = select(Account.id).where(
+            Account.status.in_((AccountStatus.PAUSED, AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED)),
+            or_(Account.reset_at.is_(None), Account.reset_at < now_epoch),
+        )
+        cutoff_naive = to_utc_naive(cutoff)
+        tombstone_stmt = (
+            update(StickySession)
+            .where(
+                StickySession.kind == StickySessionKind.CODEX_SESSION,
+                StickySession.continuity_abandoned_at.is_(None),
+                StickySession.updated_at < cutoff_naive,
+                StickySession.account_id.in_(unavailable_account_ids),
+            )
+            .values(continuity_abandoned_at=to_utc_naive(now))
+        )
+        delete_stmt = delete(StickySession).where(
+            StickySession.kind == StickySessionKind.CODEX_SESSION,
+            StickySession.continuity_abandoned_at.is_not(None),
+            StickySession.continuity_abandoned_at < cutoff_naive,
+        )
+        async with sqlite_writer_section():
+            tombstoned_result = await self._session.execute(tombstone_stmt.returning(StickySession.key))
+            tombstoned = len(tombstoned_result.scalars().all())
+            deleted_result = await self._session.execute(delete_stmt.returning(StickySession.key))
+            deleted = len(deleted_result.scalars().all())
+            await self._session.commit()
+        return tombstoned + deleted
+
     def _build_upsert_statement(self, key: str, account_id: str, kind: StickySessionKind) -> Insert:
         dialect = self._session.get_bind().dialect.name
         if dialect == "postgresql":
@@ -362,6 +485,11 @@ class StickySessionsRepository:
             set_={
                 "account_id": account_id,
                 "updated_at": func.now(),
+                # A fresh pin fully re-establishes ownership, so any earlier
+                # purge tombstone (see purge_stale_hard_codex_session_mappings)
+                # no longer applies — otherwise this row would keep reporting
+                # itself as abandoned even though it now has a live owner.
+                "continuity_abandoned_at": None,
             },
         )
 

--- a/app/modules/sticky_sessions/cleanup_scheduler.py
+++ b/app/modules/sticky_sessions/cleanup_scheduler.py
@@ -31,6 +31,15 @@ logger = logging.getLogger(__name__)
 # loop with a short interval.
 _CLEANUP_INTERVAL_SECONDS = 300
 
+# A hard codex_session mapping is never rebound while its owner is merely
+# rate-limited/quota-exceeded/paused (see load_balancer.py's hard_sticky
+# branch and openspec/specs/sticky-session-operations/spec.md). This is
+# deliberately far longer than any ordinary quota-reset window (typically
+# minutes to a few hours) so a transient blip never loses its mapping; only
+# an owner stuck unavailable well past when it should have recovered gets
+# its mapping dropped (never rebound) so the next request re-resolves fresh.
+_STALE_HARD_CODEX_SESSION_UNAVAILABLE_SECONDS = 6 * 3600
+
 
 _T = TypeVar("_T")
 
@@ -114,6 +123,19 @@ class StickySessionCleanupScheduler:
                     deleted_count = await sticky_repo.purge_prompt_cache_before(cutoff)
                     if deleted_count > 0:
                         logger.info("Purged stale prompt-cache sticky sessions deleted_count=%s", deleted_count)
+                    cleanup_now = utcnow()
+                    stale_hard_codex_session_cutoff = cleanup_now - timedelta(
+                        seconds=_STALE_HARD_CODEX_SESSION_UNAVAILABLE_SECONDS
+                    )
+                    stale_hard_codex_session_deleted_count = await sticky_repo.purge_stale_hard_codex_session_mappings(
+                        stale_hard_codex_session_cutoff, now=cleanup_now
+                    )
+                    if stale_hard_codex_session_deleted_count > 0:
+                        logger.info(
+                            "Purged stale hard codex_session sticky mappings pinned to a durably unavailable "
+                            "owner deleted_count=%s",
+                            stale_hard_codex_session_deleted_count,
+                        )
                     if startup_module._bridge_durable_schema_ready or not await missing_durable_bridge_tables(session):
                         bridge_deleted_count = await bridge_repo.purge_closed_before(cutoff)
                         if bridge_deleted_count > 0:

--- a/openspec/changes/purge-stale-hard-codex-session-mappings/design.md
+++ b/openspec/changes/purge-stale-hard-codex-session-mappings/design.md
@@ -1,0 +1,181 @@
+# Design
+
+## Why the hot path is untouched
+
+`load_balancer.py`'s `hard_sticky` branch never enters the soft-reallocation
+code (recovery-sleep waits, budget-pressure reallocation, TTL rebinding) by
+design: a `codex_session` pin can represent live, unverifiable state (an
+in-flight tool call, account-scoped uploaded files, opaque CLI turn state)
+that another account cannot safely take over mid-session. Unlike the
+`previous_response_id` fixes in the same problem space, there is no
+stored-object replay to verify here — nothing proves the client's next
+message is a safe fresh start rather than a continuation of something only
+the original owner can resolve. So request-time selection must keep failing
+closed for an unavailable hard owner, exactly as today.
+
+## Why a periodic purge instead of a threshold inside selection
+
+Threading a "give up after N hours" check into the hot-path `hard_sticky`
+branch would make every selection call pay for a purge decision it usually
+doesn't need, and would tangle a background-cleanup concern into
+correctness-critical selection code that's already carefully scoped (see the
+comment at `load_balancer.py:866-869` about never entering sticky fallback
+code from the hard branch). The existing `StickySessionCleanupScheduler`
+already runs leader-elected, every 300 seconds, purging prompt-cache and
+bridge-session rows the same way. Adding one more purge query to that same
+cycle keeps the correctness-sensitive selection path completely unchanged
+and reuses infrastructure that's already tested for leader-election
+correctness and background-session handling.
+
+## What clock to gate the cutoff on
+
+The first draft gated on `Account.reset_at`/`blocked_at` — plausible in
+theory (they look like "when will/did this become unavailable" fields), but
+wrong against real data: `reset_at` is frequently `None` (upstream simply
+hasn't reported fresh quota data recently), and `blocked_at` is explicitly
+reset to `None` whenever an account is paused (`accounts/service.py`'s
+`pause_account` and the auto-pause-on-import path both pass
+`blocked_at=None`). Neither field reliably answers "how long has this
+specific account been broken" across all three unavailable statuses.
+
+`StickySession.updated_at` becomes the shared durable clock by recording the
+later of two events: the mapping's last use and the owner's transition from an
+available status into `PAUSED`, `RATE_LIMITED`, or `QUOTA_EXCEEDED`.
+`AccountsRepository` refreshes hard mapping timestamps only for that boundary;
+repeated writes while the owner remains unavailable do not extend the grace
+period. Gating on `Account.status` (still unavailable) AND
+`StickySession.updated_at < cutoff` therefore preserves the full threshold
+after a fresh outage even for a long-lived session, without adding another
+account status timestamp or relying on incomplete quota metadata.
+
+## Letting a known future reset_at override the flat cutoff
+
+`reset_at` is unreliable as the *only* clock (see above — it's frequently
+absent), but when it *is* populated and still in the future, ignoring it
+would be wrong in the other direction: a multi-day quota window (e.g. a
+weekly cap) can easily leave a mapping unused past the 6-hour cutoff while
+its owner's own stated recovery time is still days away. Purging in that
+window would contradict the spec's "well past its own recovery point" —
+recovery hasn't even arrived yet, let alone been passed. So the purge query
+excludes any account whose `reset_at` is set and still ahead of "now",
+regardless of how stale its mapping looks by the cutoff alone. This can only
+ever *delay* a purge relative to the plain cutoff, never accelerate one: an
+absent `reset_at` falls straight back to the cutoff-only behavior above.
+
+## Closing the rollout gap: seeding the clock for pre-existing outages
+
+The status-transition hook only fires on a live transition into an
+unavailable status — it has nothing to hook for an account that was already
+sitting in `PAUSED`/`RATE_LIMITED`/`QUOTA_EXCEEDED` before this process
+started. That's exactly true the moment this change is first deployed: any
+account already unavailable at that instant keeps whatever `updated_at` its
+mapping had *before* the outage, which could easily already be older than
+the 6-hour cutoff even though the outage itself might be minutes old. Left
+alone, the very first cleanup cycle after deploy would purge that mapping —
+a merely-transient (possibly brand-new) outage, purged as if it were ancient,
+which is precisely the invariant this whole feature exists to prevent.
+
+The fix is a startup-time seeding pass: for every account that is currently
+unavailable, refresh its hard mappings' timestamps to now, before the
+cleanup scheduler's first cycle can run. This reuses the exact same
+`_refresh_hard_sticky_outage_grace` write the transition hook already makes,
+just triggered by "found already unavailable at boot" instead of "just
+transitioned".
+
+The first version of this seeding ran unconditionally on every process
+start, reasoning that re-seeding an already-unavailable account's mapping
+only ever pushes its eligibility further out, so a frequently restarting
+deployment would merely delay cleanup, never cause a premature one. That
+reasoning is true for a single replica restarting occasionally, but wrong for
+a shared-database, multi-replica deployment: every boot on every replica
+re-seeds *all* currently-unavailable owners, not just ones that just started
+this process. If deploys or autoscaling cycle faster than the 6-hour cutoff,
+a durably-dead mapping's grace clock is perpetually pushed forward and it can
+never age out — the exact "stuck forever" failure mode this whole feature
+exists to fix, just moved from "no expiry mechanism" to "expiry mechanism
+that never actually elapses".
+
+The backfill only ever needs to run once per database, not once per process
+start — after that first pass, the live per-transition hook is the sole
+source of truth for every account's grace clock, so nothing subsequent needs
+seeding. `runtime_sentinels` already exists for exactly this shape of
+problem (see `key_fingerprint.py`'s `verify_encryption_key_fingerprint`,
+which stamps an insert-if-absent sentinel the first replica to boot writes
+and every other replica reads): the seeding method atomically inserts a
+`hard_sticky_outage_grace_seeded` sentinel with `ON CONFLICT DO NOTHING`,
+and only performs the backfill loop if that insert actually happened (i.e.
+this is the first replica, ever, against this database, to see the
+sentinel absent). Every later boot — same replica or a different one —
+finds the sentinel already stamped, skips the backfill, and returns 0.
+
+## Choosing the threshold
+
+Six hours is deliberately far longer than any ordinary quota-reset window
+(Codex quota windows are typically minutes to a few hours) so a transient
+blip — the exact case the "does not lose its mapping" scenario protects —
+never has its mapping purged mid-window. It only fires once an account has
+been stuck well past when it should have recovered on its own — and, when a
+`reset_at` is known, past that too — which is a strong signal something is
+actually wrong (manual pause left in place, etc.) rather than ordinary quota
+cycling. This is a
+fixed constant, not a new setting, matching this scheduler's existing
+"poll cadence is fixed; issue #1340 / PRINCIPLES.md P2" convention and the
+simplicity-gate norm of defaulting new behavior on without adding
+configuration surface.
+
+## Why tombstone before delete, not just delete
+
+A request carrying a non-empty `conversation` field sets
+`require_unambiguous_account=True` (see `affinity.py`'s
+`_affinity_with_payload_continuity`) precisely because `conversation` has no
+dedicated owner index of its own — the hard `codex_session` mapping (or a
+one-account pool) is the *only* thing that can prove who owns it. In
+`run_sticky_selection_path`, once `hard_sticky` is false (no resolved
+mapping) and the account pool has more than one candidate, that ambiguity
+check fails the request closed. Under normal operation this branch is nearly
+unreachable: by the time a request carries a non-empty `conversation`, an
+earlier turn already established the hard mapping, so `hard_sticky` is true.
+
+A straight delete breaks that invariant. The moment the mapping is gone,
+`hard_sticky` becomes false on the very next request for that turn state —
+and if that request also carries `conversation` (which it will, since it's a
+continuation), it hits the exact ambiguity check above. Worse, it can never
+recover: the only write path that could re-establish `hard_sticky` is the
+normal selection flow *past* that same check, so the request is stuck
+failing closed permanently, even once the original owner comes back — not
+merely for the transient-blip window this whole feature is designed to
+respect, but forever.
+
+The fix is to make the purge distinguishable from "this key was never seen".
+A tombstoned row (`continuity_abandoned_at` set) still causes
+`get_account_id_and_abandonment` to report no owner (so `hard_sticky` is
+still false, exactly as a straight delete would produce), but it also
+reports `sticky_continuity_abandoned=True`. `run_sticky_selection_path` uses
+that to exempt the row from the ambiguity check specifically — not because
+the pool has stopped being ambiguous (it hasn't), but because we *know* this
+key's owner was durably unavailable and continuity was deliberately
+abandoned, which is exactly the authorization the ambiguity check exists to
+require. Selection then proceeds through the normal (non-hard) path, picks a
+healthy account, and the resulting `upsert` clears `continuity_abandoned_at`
+as part of establishing the fresh owner — fully restoring `hard_sticky` for
+that key from then on.
+
+A tombstone that nobody ever claims is still eventually removed — after a
+further grace window past its own `continuity_abandoned_at`, not the
+mapping's original `updated_at` — so the row doesn't accumulate forever. At
+that point a fresh request for the key falls back to the ordinary
+never-seen-key fail-closed default, which is fine that long after the fact.
+
+## Why delete, never rebind
+
+Rebinding would require deciding *which* account to rebind to and asserting
+that account can safely inherit whatever live state the mapping represents —
+exactly the thing this whole subsystem says isn't verifiable for a hard
+`codex_session` pin. Tombstoning-then-deleting sidesteps that entirely: the
+mapping simply stops being a live pin (whether it's still present as a
+tombstone or fully gone), and the next request that would have resolved it
+instead goes through ordinary fresh selection, identical to a session no one
+has ever pinned. This is the same effect the existing reauth/deactivated
+cascade delete already produces for those two statuses — this change only
+extends it to the two recoverable-but-stuck statuses, gated on elapsed time
+instead of firing immediately.

--- a/openspec/changes/purge-stale-hard-codex-session-mappings/proposal.md
+++ b/openspec/changes/purge-stale-hard-codex-session-mappings/proposal.md
@@ -1,0 +1,122 @@
+# Purge hard codex_session mappings pinned to a durably unavailable owner
+
+## Why
+
+A `codex_session`-kind sticky mapping is deliberately hard: per
+`sticky-session-operations`, when its owner account becomes unavailable
+(rate-limited, quota-exceeded, paused), selection fails closed instead of
+reallocating to a healthy account, and the mapping is neither deleted nor
+rebound. This is correct — the mapping can represent live, unverifiable
+session state (mid-flight tool calls, account-scoped state) that isn't safe
+to move to a different account mid-session.
+
+But today that protection has no expiry. If the owner never recovers (stuck
+rate-limited well past its own `reset_at`, or paused and never resumed), the
+mapping is stuck forever and every future request against that session/turn
+state fails closed with `previous_response_owner_unavailable`
+("Hard affinity owner account is unavailable") indefinitely, with no
+automatic recovery path. We hit this in production and had to manually
+delete ~250 stale mappings directly in the database to unblock it.
+
+A request carrying a non-empty `conversation` field has no owner index
+besides this same mapping (see `sticky-session-operations`'s
+`require_unambiguous_account` behavior) — it has no other way to prove who
+owns the conversation. If the mapping were simply deleted outright and the
+account pool has more than one account, such a request would fail closed
+permanently on the very next attempt, with no way to ever recover even after
+the original owner comes back, because nothing on that path can re-create
+the row it needs in order to stop failing closed. The purge below is
+designed around that constraint from the start (see "tombstone, then
+delete" below), not merely a straight delete.
+
+## What Changes
+
+Add a bounded exception, enforced only by a periodic background purge —
+never by the hot-path selection logic, and never by rebinding:
+
+- Account status transitions refresh a hard `codex_session` mapping's
+  `updated_at` exactly when its owner first enters `PAUSED`, `RATE_LIMITED`,
+  or `QUOTA_EXCEEDED`. Repeated writes while already unavailable do not extend
+  the grace period.
+- A new repository method,
+  `StickySessionsRepository.purge_stale_hard_codex_session_mappings`, retires
+  mappings whose owner is still unavailable and whose timestamp — the later
+  of last use and outage start — is before a conservative cutoff. This is a
+  two-phase, never a one-shot delete:
+  1. **Tombstone**: the row's new `continuity_abandoned_at` column is set
+     instead of deleting the row. Selection treats a tombstoned mapping as
+     having no owner (same as if the row were gone), but — critically —
+     recognizes it as *deliberately abandoned* rather than *never seen*, so a
+     `conversation`-continuity request against that key is allowed to pick a
+     fresh account instead of failing closed forever (see "Why tombstone
+     before delete" in `design.md`).
+  2. **Delete**: once a tombstone has sat unclaimed for a further cutoff
+     window, it's dropped outright. By then a fresh request for that key is
+     fine falling back to the same conservative fail-closed default as a key
+     that was never seen.
+- The existing leader-elected `StickySessionCleanupScheduler` (already
+  running every 300s) calls this once per cycle, using a fixed threshold
+  (`_STALE_HARD_CODEX_SESSION_UNAVAILABLE_SECONDS`, 6 hours) deliberately far
+  longer than any ordinary quota-reset window, so a transient blip never
+  loses its mapping.
+- Never rebinding, at either phase. Once a mapping is tombstoned or deleted,
+  the next request against that session/turn state simply re-resolves fresh
+  (and, if it establishes a new owner, that write clears the tombstone),
+  exactly as it already does today for a request that has no mapping at all.
+- A known, future `Account.reset_at` overrides the flat cutoff: the mapping
+  survives until after the owner's own stated recovery point, even if it has
+  long since gone stale by the cutoff alone. `reset_at` only ever narrows
+  eligibility (delays a purge) — it never widens it when unset, so the fixed
+  cutoff remains the fallback for the common case where `reset_at` isn't
+  populated.
+- At process startup, every account that is already `PAUSED`,
+  `RATE_LIMITED`, or `QUOTA_EXCEEDED` gets its hard mappings' grace clock
+  seeded to now — but only *once ever per database*, not once per process
+  start. The status-transition hook above only fires on a live transition,
+  so it never runs for an outage that predates this process (e.g. one that
+  began minutes before a deploy) — without seeding, that mapping's stale
+  pre-existing `updated_at` could make the very first cleanup cycle after
+  upgrade treat a brand-new outage as ancient history. All replicas share one
+  database, so a durable marker in the existing `runtime_sentinels` table
+  (the same insert-if-absent mechanism the encryption-key fingerprint check
+  already uses) records that this backfill has run; every later boot, on any
+  replica, sees the marker and skips it. Without that marker, a deployment or
+  autoscaling cadence shorter than the purge cutoff would re-seed on every
+  boot and a durably-dead mapping could never age out.
+
+`load_balancer.py`'s `hard_sticky` selection branch is untouched. The
+correctness invariant it protects (never reallocate mid-flight to an
+unverified account) is preserved; this only changes what happens to an
+already-abandoned mapping between requests.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `sticky-session-operations`: a hard `codex_session` mapping whose owner has
+  been durably unavailable (not merely transiently rate-limited) for well
+  past its own recovery point MUST eventually be purged by the periodic
+  cleanup job, never reallocated by request-time selection.
+
+## Impact
+
+- Code: `app/modules/proxy/sticky_repository.py` (new repository method,
+  tombstone-then-delete purge, abandonment-aware reads), `app/db/models.py`
+  (new `StickySession.continuity_abandoned_at` column),
+  `app/modules/proxy/_load_balancer/sticky_selection.py` (ambiguous-owner
+  check bypass for a tombstoned mapping), `app/modules/sticky_sessions/cleanup_scheduler.py`
+  (wires the purge into the existing periodic job), `app/modules/accounts/repository.py`
+  (outage-start refresh on status transitions plus the one-time startup
+  seeding method), `app/main.py` (calls the startup seeding once during app
+  boot).
+- Tests: repository-level purge behavior (transient vs. durably-unavailable
+  owners, future `reset_at`, tombstone-then-delete phases, one-time startup
+  seeding), selection-level coverage that a tombstoned mapping unblocks a
+  `conversation`-continuity request instead of failing closed, scheduler
+  wiring.
+- API/schema: one new nullable column, `StickySession.continuity_abandoned_at`
+  (migration `20260727_000000_add_sticky_session_continuity_abandoned_at`).
+  No new settings — the outage clock still reuses `StickySession.updated_at`;
+  the threshold is still a fixed constant, matching this scheduler's existing
+  "poll cadence is fixed" convention; the one-time startup-seeding marker
+  reuses the existing `runtime_sentinels` table rather than adding a setting.

--- a/openspec/changes/purge-stale-hard-codex-session-mappings/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/purge-stale-hard-codex-session-mappings/specs/sticky-session-operations/spec.md
@@ -1,0 +1,108 @@
+# sticky-session-operations Delta Specification
+
+## MODIFIED Requirements
+
+### Requirement: Sticky sessions are explicitly typed
+
+The system SHALL persist each sticky-session mapping with an explicit kind so durable Codex backend affinity, durable dashboard sticky-thread routing, and bounded prompt-cache affinity can be managed independently. Budget-pressure reallocation MUST apply only to mappings whose kind/source is soft. A raw or legacy `codex_session` mapping MUST remain owner-bound because it may represent explicit turn-state continuity; budget pressure MUST NOT delete or rebind it. Request-time selection MUST NOT reallocate a hard `codex_session` mapping to a different account under any circumstance, including when its owner is unavailable. Independently of request-time selection, a periodic background job MAY retire (never rebind) a hard `codex_session` mapping once its owner has been durably unavailable — not merely transiently rate-limited or paused — for well past its own recovery point, so a future request against that session simply re-resolves fresh instead of failing closed forever. Retiring MUST happen in two phases, never a single delete: the mapping is first tombstoned (marked deliberately abandoned, not deleted), and only dropped outright after it has sat unclaimed for a further grace window. A tombstoned mapping MUST be exempt from the ambiguous-conversation-owner check, so a `conversation`-continuity request against it can select a fresh owner instead of failing closed forever with no way to recover. When the owner's own `reset_at` is known and still in the future, that recovery point MUST take priority over any flat cutoff. An account that is already unavailable when the process starts MUST still receive the full grace window from that point forward, so a merely-transient outage that predates a deploy is never purged on the first cleanup cycle after it; that seeding MUST happen at most once per database, not once per process start, so a fast-redeploying multi-replica deployment cannot perpetually reset the grace clock for a durably-dead mapping.
+
+#### Scenario: Soft sticky reallocation uses split primary and secondary pressure thresholds
+- **WHEN** a request resolves an existing prompt-cache, sticky-thread, or other explicitly soft mapping
+- **AND** the pinned account is otherwise eligible to serve traffic
+- **AND** the pinned account is strictly above either the configured primary sticky reallocation threshold or the configured secondary sticky reallocation threshold
+- **AND** another eligible account remains at or below both configured sticky reallocation thresholds
+- **THEN** selection rebinds the sticky-session mapping to the healthier account before sending the request upstream
+
+#### Scenario: Sticky reallocation preserves a pinned account when every candidate is split-threshold pressured
+- **WHEN** a request resolves an existing soft sticky-session mapping
+- **AND** the pinned account is otherwise eligible to serve traffic
+- **AND** the pinned account is strictly above either configured sticky reallocation threshold
+- **AND** every other eligible account is also strictly above at least one configured sticky reallocation threshold
+- **THEN** selection retains the existing pinned account to avoid sticky-pin thrashing
+
+#### Scenario: Fresh selection does not apply sticky secondary pressure threshold
+- **WHEN** a request has no sticky-session mapping
+- **AND** one eligible account is above the configured secondary sticky reallocation threshold but below the normal primary budget threshold
+- **THEN** the account remains eligible for ordinary non-sticky routing according to the selected routing strategy
+
+#### Scenario: Hard Codex mapping ignores budget-pressure reallocation
+
+- **GIVEN** a raw `codex_session` mapping points to account A
+- **AND** account A is above a sticky budget-pressure threshold
+- **AND** account B has more remaining budget
+- **WHEN** the request is selected
+- **THEN** selection remains constrained to account A
+- **AND** the raw mapping is neither deleted nor rebound to account B
+
+#### Scenario: Unavailable hard Codex owner does not lose its mapping at request time
+
+- **GIVEN** a raw `codex_session` mapping points to account A
+- **AND** account A is temporarily quota-exceeded or otherwise unusable
+- **AND** account B is healthy
+- **WHEN** hard-owner selection fails
+- **THEN** the request fails closed instead of selecting account B
+- **AND** the raw mapping is neither deleted nor rebound by that request
+
+#### Scenario: A durably unavailable hard Codex owner's mapping is eventually tombstoned
+
+- **GIVEN** a raw `codex_session` mapping points to account A
+- **AND** account A is still `PAUSED`, `RATE_LIMITED`, or `QUOTA_EXCEEDED`
+- **AND** the later of the mapping's last use and account A's transition into
+  an unavailable status is before a conservative cutoff
+- **AND** the mapping has not already been tombstoned
+- **WHEN** the periodic sticky-session cleanup job runs
+- **THEN** the mapping is tombstoned (marked deliberately abandoned) rather than deleted
+- **AND** it is not rebound to any other account
+- **AND** the next request against that session resolves a fresh mapping instead of failing closed
+
+#### Scenario: A tombstoned hard Codex mapping unblocks a conversation-continuity request
+
+- **GIVEN** a hard `codex_session` mapping for a turn state has been tombstoned by the periodic cleanup job
+- **AND** the request's `conversation` field is non-empty, requiring an unambiguous owner
+- **AND** the account pool has more than one eligible account
+- **WHEN** the request is selected
+- **THEN** selection does not fail closed with the ambiguous-conversation-owner error solely because of the tombstoned mapping
+- **AND** selection proceeds to choose a fresh eligible account
+- **AND** the resulting mapping write clears the tombstone, restoring a normal hard mapping for that turn state
+
+#### Scenario: An unclaimed tombstone is eventually deleted outright
+
+- **GIVEN** a hard `codex_session` mapping was tombstoned by the periodic cleanup job
+- **AND** no request has re-established an owner for it since
+- **AND** the tombstone's own abandonment timestamp is before a further conservative cutoff
+- **WHEN** the periodic sticky-session cleanup job runs
+- **THEN** the mapping is deleted outright
+- **AND** a subsequent request against that session falls back to the same fail-closed default as a session that was never seen
+
+#### Scenario: A merely transient hard Codex owner outage is never purged
+
+- **GIVEN** a raw `codex_session` mapping points to account A
+- **AND** account A became rate-limited or paused more recently than the
+  conservative cutoff, even if the mapping itself is older
+- **WHEN** the periodic sticky-session cleanup job runs
+- **THEN** the mapping is left untouched
+
+#### Scenario: A known future reset_at overrides the flat cutoff
+
+- **GIVEN** a raw `codex_session` mapping points to account A
+- **AND** account A is `RATE_LIMITED` or `QUOTA_EXCEEDED` with a known `reset_at` still in the future
+- **AND** the mapping's timestamp is already before the conservative cutoff
+- **WHEN** the periodic sticky-session cleanup job runs
+- **THEN** the mapping is left untouched
+- **AND** it remains eligible for purging only once `reset_at` has passed and the mapping is still stale by the cutoff
+
+#### Scenario: An outage that predates process startup still gets its grace window
+
+- **GIVEN** account A is already `PAUSED`, `RATE_LIMITED`, or `QUOTA_EXCEEDED` when this process starts
+- **AND** its hard `codex_session` mapping's timestamp already predates the conservative cutoff, unrelated to when the outage actually began
+- **AND** this is the first process, ever, to boot against this database since this behavior shipped
+- **WHEN** the process completes startup
+- **THEN** the mapping's timestamp is refreshed to the startup time
+- **AND** the first periodic cleanup cycle after startup does not purge that mapping solely because of its pre-startup timestamp
+
+#### Scenario: Startup seeding runs at most once per database
+
+- **GIVEN** the one-time startup-seeding backfill has already run, on this or any other replica sharing the same database
+- **WHEN** a process (the same replica restarting, or a different replica) completes startup
+- **THEN** no hard `codex_session` mapping's timestamp is refreshed by this seeding pass
+- **AND** an account that has remained unavailable since the original backfill is not given a fresh grace window merely by this process starting

--- a/openspec/changes/purge-stale-hard-codex-session-mappings/tasks.md
+++ b/openspec/changes/purge-stale-hard-codex-session-mappings/tasks.md
@@ -1,0 +1,50 @@
+# Tasks
+
+- [x] Add `StickySessionsRepository.purge_stale_hard_codex_session_mappings`,
+      gated on an unavailable account status and the conservative hard-mapping
+      clock (later of last use and transition into unavailability).
+- [x] Refresh that clock when an owner first becomes unavailable without
+      extending it on repeated unavailable-status writes.
+- [x] Wire it into `StickySessionCleanupScheduler`'s existing periodic
+      leader-elected cycle with a fixed, deliberately conservative threshold.
+- [x] Add regression coverage: a fresh (recently rate-limited/paused) owner's
+      mapping survives; a durably-unavailable owner's mapping is purged; a
+      healthy owner's mapping is never touched.
+- [x] Add scheduler-level coverage that the new purge call happens once per
+      cycle with the expected threshold.
+- [x] Update the pre-existing scheduler test whose docstring asserted
+      `codex_session` mappings are "never purged" by this job.
+- [x] Let a known, future `Account.reset_at` override the flat cutoff so a
+      mapping survives until after its owner's own stated recovery point.
+- [x] Add `AccountsRepository.seed_hard_sticky_outage_grace_on_startup`,
+      called once during app boot, so an account already unavailable before
+      this process started doesn't get its mapping treated as ancient by the
+      first cleanup cycle after deploy.
+- [x] Add regression coverage for the `reset_at` override and the startup
+      seeding method.
+- [x] Run focused and full test suites, ruff check/format, `ty check`.
+- [x] Add `StickySession.continuity_abandoned_at` (migration
+      `20260727_000000_add_sticky_session_continuity_abandoned_at`) and make
+      the purge tombstone (set the column) before ever deleting a mapping
+      outright, so a `conversation`-continuity request against a purged key
+      isn't stranded permanently once the pool has more than one account.
+- [x] Add `StickySessionsRepository.get_account_id_and_abandonment` and use
+      it in `run_sticky_selection_path` to exempt a tombstoned mapping from
+      the ambiguous-owner fail-closed check.
+- [x] Clear `continuity_abandoned_at` in `StickySessionsRepository.upsert`
+      and `restore_if_current` so re-establishing a hard owner fully
+      restores normal (non-abandoned) behavior for that key.
+- [x] Extend `purge_stale_hard_codex_session_mappings` to hard-delete a
+      tombstone once it's sat unclaimed past a further grace window.
+- [x] Replace the every-boot reseed in
+      `AccountsRepository.seed_hard_sticky_outage_grace_on_startup` with a
+      one-time backfill gated on a durable `runtime_sentinels` marker, so a
+      shared-database multi-replica deployment only ever seeds once, not on
+      every restart.
+- [x] Add regression coverage: a tombstoned mapping unblocks a
+      `conversation`-continuity request instead of failing closed; the
+      tombstone-then-delete phases (survive while claimed/within grace,
+      deleted once unclaimed past it); the startup seeding method is a no-op
+      on a second boot.
+- [x] Re-run focused and full test suites, ruff check/format, `ty check`,
+      and the architecture-check script after these fixes.

--- a/tests/integration/test_proxy_sticky_sessions.py
+++ b/tests/integration/test_proxy_sticky_sessions.py
@@ -1725,6 +1725,91 @@ async def test_stale_expiry_cleanup_cannot_delete_fresh_rebound_owner(async_clie
     assert persisted_owner == new_owner
 
 
+@pytest.mark.asyncio
+async def test_stale_expiry_race_reread_reports_concurrent_tombstone() -> None:
+    """The race-safe max-age expiry path (see get_account_id_and_abandonment)
+    re-reads the row when its delete-on-expiry predicate misses a concurrent
+    write, and must apply the abandonment check to that re-read row, not just
+    the initial snapshot — otherwise a mapping tombstoned by the purge job in
+    the gap between the stale read and the delete attempt would be reported
+    as a plain miss (never-seen key) instead of authorized-to-reselect."""
+    from sqlalchemy import update
+
+    from app.db.models import StickySession
+    from app.modules.proxy.sticky_repository import StickySessionsRepository
+
+    encryptor = TokenEncryptor()
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(
+            Account(
+                id="acc_race_tombstone_owner",
+                email="race-tombstone@example.com",
+                plan_type="plus",
+                access_token_encrypted=encryptor.encrypt("access"),
+                refresh_token_encrypted=encryptor.encrypt("refresh"),
+                id_token_encrypted=encryptor.encrypt("id"),
+                last_refresh=utcnow(),
+                status=AccountStatus.ACTIVE,
+                deactivation_reason=None,
+            )
+        )
+
+    key = "\ncodex_live_call:tombstone-race"
+    stale_read = asyncio.Event()
+    tombstoned = asyncio.Event()
+
+    async with SessionLocal() as setup_session:
+        repo = StickySessionsRepository(setup_session)
+        await repo.upsert(key, "acc_race_tombstone_owner", kind=StickySessionKind.CODEX_SESSION)
+        await setup_session.execute(
+            update(StickySession)
+            .where(StickySession.key == key, StickySession.kind == StickySessionKind.CODEX_SESSION)
+            .values(updated_at=utcnow() - timedelta(hours=3))
+        )
+        await setup_session.commit()
+
+    class PausedAfterStaleReadRepository(StickySessionsRepository):
+        async def get_entry(self, key: str, *, kind: StickySessionKind) -> StickySession | None:
+            row = await super().get_entry(key, kind=kind)
+            await self._session.commit()
+            stale_read.set()
+            await tombstoned.wait()
+            return row
+
+    async with SessionLocal() as stale_session, SessionLocal() as tombstone_session:
+        stale_repo = PausedAfterStaleReadRepository(stale_session)
+        resolution = asyncio.create_task(
+            stale_repo.get_account_id_and_abandonment(
+                key,
+                kind=StickySessionKind.CODEX_SESSION,
+                max_age_seconds=60,
+            )
+        )
+        await asyncio.wait_for(stale_read.wait(), timeout=1)
+        # Same account_id, but updated_at moves — this is exactly what the
+        # purge job's tombstone step does, and it's enough to miss the
+        # delete-on-expiry predicate (which pins on the originally observed
+        # updated_at), forcing the race-safe re-read.
+        await tombstone_session.execute(
+            update(StickySession)
+            .where(StickySession.key == key, StickySession.kind == StickySessionKind.CODEX_SESSION)
+            .values(updated_at=utcnow(), continuity_abandoned_at=utcnow())
+        )
+        await tombstone_session.commit()
+        tombstoned.set()
+        resolved = await asyncio.wait_for(resolution, timeout=1)
+
+    async with SessionLocal() as verification_session:
+        persisted_row = await StickySessionsRepository(verification_session).get_entry(
+            key, kind=StickySessionKind.CODEX_SESSION
+        )
+
+    assert resolved.account_id is None
+    assert resolved.continuity_abandoned is True
+    assert persisted_row is not None
+    assert persisted_row.continuity_abandoned_at is not None
+
+
 def test_realtime_call_affinity_key_is_scoped_and_opaque() -> None:
     api_key_a = cast(ApiKeyData, SimpleNamespace(id="api-key-a"))
     api_key_b = cast(ApiKeyData, SimpleNamespace(id="api-key-b"))

--- a/tests/integration/test_proxy_sticky_sessions.py
+++ b/tests/integration/test_proxy_sticky_sessions.py
@@ -8,12 +8,12 @@ from types import SimpleNamespace
 from typing import cast
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import text, update
 
 import app.modules.proxy.service as proxy_module
 from app.core.crypto import TokenEncryptor
 from app.core.openai.models import OpenAIResponsePayload
-from app.core.utils.time import utcnow
+from app.core.utils.time import naive_utc_to_epoch, utcnow
 from app.db.models import Account, AccountStatus, StickySessionKind
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
@@ -1815,3 +1815,292 @@ async def test_resolve_missing_realtime_call_does_not_purge_other_bindings(async
 
     assert resolved_owner is None
     assert retained_row.account_id == account_id
+
+
+@pytest.mark.asyncio
+async def test_purge_stale_hard_codex_session_mappings_only_drops_durably_unavailable_owners(db_setup):
+    """A hard codex_session mapping must survive a merely-transient owner
+    blip (rate-limited/paused, but recently used) and only be dropped once
+    BOTH the owner is non-active AND the mapping itself hasn't been used
+    since well before the cutoff. Mappings on a healthy owner, and mappings
+    still recently used despite an unavailable owner, must never be touched.
+    A known future reset_at overrides the flat cutoff entirely: the owner's
+    own stated recovery point must pass before its mapping is eligible."""
+    from app.db.models import StickySession
+    from app.modules.proxy.sticky_repository import StickySessionsRepository
+
+    encryptor = TokenEncryptor()
+    now = utcnow()
+    cutoff = now - timedelta(hours=6)
+    future_reset_at = naive_utc_to_epoch(now + timedelta(days=3))
+    accounts = [
+        ("acc_purge_active", AccountStatus.ACTIVE, None),
+        ("acc_purge_recent_transition_rate_limited", AccountStatus.ACTIVE, None),
+        ("acc_purge_recent_transition_paused", AccountStatus.ACTIVE, None),
+        ("acc_purge_fresh_rate_limited", AccountStatus.RATE_LIMITED, None),
+        ("acc_purge_stale_rate_limited", AccountStatus.RATE_LIMITED, None),
+        ("acc_purge_fresh_paused", AccountStatus.PAUSED, None),
+        ("acc_purge_stale_paused", AccountStatus.PAUSED, None),
+        ("acc_purge_stale_future_reset", AccountStatus.RATE_LIMITED, future_reset_at),
+    ]
+    # Only the "stale_*" mappings are backdated to before the cutoff; the
+    # rest keep their real upsert-time timestamp (well after the cutoff).
+    stale_account_ids = {"acc_purge_stale_rate_limited", "acc_purge_stale_paused", "acc_purge_stale_future_reset"}
+
+    async with SessionLocal() as session:
+        repo_accounts = AccountsRepository(session)
+        for account_id, status, reset_at in accounts:
+            await repo_accounts.upsert(
+                Account(
+                    id=account_id,
+                    email=f"{account_id}@example.com",
+                    plan_type="plus",
+                    access_token_encrypted=encryptor.encrypt("access"),
+                    refresh_token_encrypted=encryptor.encrypt("refresh"),
+                    id_token_encrypted=encryptor.encrypt("id"),
+                    last_refresh=utcnow(),
+                    status=status,
+                    deactivation_reason=None,
+                    reset_at=reset_at,
+                )
+            )
+
+    async with SessionLocal() as session:
+        repo = StickySessionsRepository(session)
+        for account_id, _status, _reset_at in accounts:
+            await repo.upsert(f"turn_{account_id}", account_id, kind=StickySessionKind.CODEX_SESSION)
+
+    async with SessionLocal() as session:
+        for account_id in stale_account_ids:
+            await session.execute(
+                update(StickySession)
+                .where(StickySession.key == f"turn_{account_id}", StickySession.kind == StickySessionKind.CODEX_SESSION)
+                .values(updated_at=cutoff - timedelta(hours=1))
+            )
+        for account_id in ("acc_purge_recent_transition_rate_limited", "acc_purge_recent_transition_paused"):
+            await session.execute(
+                update(StickySession)
+                .where(StickySession.key == f"turn_{account_id}", StickySession.kind == StickySessionKind.CODEX_SESSION)
+                .values(updated_at=cutoff - timedelta(hours=1))
+            )
+        await session.commit()
+
+    async with SessionLocal() as session:
+        repo_accounts = AccountsRepository(session)
+        assert await repo_accounts.update_status(
+            "acc_purge_recent_transition_rate_limited",
+            AccountStatus.RATE_LIMITED,
+        )
+        assert await repo_accounts.update_status_if_current(
+            "acc_purge_recent_transition_paused",
+            AccountStatus.PAUSED,
+            expected_status=AccountStatus.ACTIVE,
+        )
+        # Rewriting an already-unavailable state must not extend the grace
+        # period, and a failed compare-and-set must not touch it either.
+        assert await repo_accounts.update_status(
+            "acc_purge_stale_rate_limited",
+            AccountStatus.RATE_LIMITED,
+        )
+        assert not await repo_accounts.update_status_if_current(
+            "acc_purge_stale_paused",
+            AccountStatus.PAUSED,
+            expected_status=AccountStatus.ACTIVE,
+        )
+
+    async with SessionLocal() as session:
+        repo = StickySessionsRepository(session)
+        purged_count = await repo.purge_stale_hard_codex_session_mappings(cutoff, now=now)
+
+    # First pass only tombstones (continuity_abandoned_at set); nothing is
+    # actually deleted yet, so a `conversation`-continuity request against
+    # one of these keys can still recognize "abandoned, pick a fresh owner"
+    # instead of being told the key was never seen.
+    assert purged_count == 2
+    async with SessionLocal() as session:
+        repo = StickySessionsRepository(session)
+        entries = {
+            account_id: await repo.get_entry(f"turn_{account_id}", kind=StickySessionKind.CODEX_SESSION)
+            for account_id, _status, _reset_at in accounts
+        }
+    present = {account_id for account_id, entry in entries.items() if entry is not None}
+    tombstoned = {
+        account_id
+        for account_id, entry in entries.items()
+        if entry is not None and entry.continuity_abandoned_at is not None
+    }
+    assert present == {account_id for account_id, _status, _reset_at in accounts}
+    assert tombstoned == {"acc_purge_stale_rate_limited", "acc_purge_stale_paused"}
+
+
+@pytest.mark.asyncio
+async def test_purge_stale_hard_codex_session_mappings_deletes_unclaimed_tombstones(db_setup):
+    """Once a tombstone (continuity_abandoned_at set — see the first purge
+    pass) has sat unclaimed past a further grace window, it's dropped
+    outright: by then a fresh request for that key is fine falling back to
+    the same conservative fail-closed default as a key that was never seen.
+    A tombstone still inside its grace window, and a live (never-purged)
+    mapping, must both be left alone."""
+    from app.db.models import StickySession
+    from app.modules.proxy.sticky_repository import StickySessionsRepository
+
+    encryptor = TokenEncryptor()
+    now = utcnow()
+    cutoff = now - timedelta(hours=6)
+    accounts = [
+        ("acc_tombstone_old", AccountStatus.RATE_LIMITED, None),
+        ("acc_tombstone_recent", AccountStatus.RATE_LIMITED, None),
+        ("acc_tombstone_live", AccountStatus.RATE_LIMITED, None),
+    ]
+
+    async with SessionLocal() as session:
+        repo_accounts = AccountsRepository(session)
+        for account_id, status, reset_at in accounts:
+            await repo_accounts.upsert(
+                Account(
+                    id=account_id,
+                    email=f"{account_id}@example.com",
+                    plan_type="plus",
+                    access_token_encrypted=encryptor.encrypt("access"),
+                    refresh_token_encrypted=encryptor.encrypt("refresh"),
+                    id_token_encrypted=encryptor.encrypt("id"),
+                    last_refresh=utcnow(),
+                    status=status,
+                    deactivation_reason=None,
+                    reset_at=reset_at,
+                )
+            )
+
+    async with SessionLocal() as session:
+        repo = StickySessionsRepository(session)
+        for account_id, _status, _reset_at in accounts:
+            await repo.upsert(f"turn_{account_id}", account_id, kind=StickySessionKind.CODEX_SESSION)
+
+    async with SessionLocal() as session:
+        # Already a tombstone, past its own grace window: must be deleted.
+        await session.execute(
+            update(StickySession)
+            .where(StickySession.key == "turn_acc_tombstone_old", StickySession.kind == StickySessionKind.CODEX_SESSION)
+            .values(continuity_abandoned_at=cutoff - timedelta(hours=1))
+        )
+        # Already a tombstone, but still inside its grace window: must survive.
+        await session.execute(
+            update(StickySession)
+            .where(
+                StickySession.key == "turn_acc_tombstone_recent", StickySession.kind == StickySessionKind.CODEX_SESSION
+            )
+            .values(continuity_abandoned_at=cutoff + timedelta(hours=1))
+        )
+        # Never tombstoned at all, and its updated_at is recent: must survive
+        # untouched by either phase.
+        await session.commit()
+
+    async with SessionLocal() as session:
+        repo = StickySessionsRepository(session)
+        purged_count = await repo.purge_stale_hard_codex_session_mappings(cutoff, now=now)
+
+    assert purged_count == 1
+    async with SessionLocal() as session:
+        repo = StickySessionsRepository(session)
+        entries = {
+            account_id: await repo.get_entry(f"turn_{account_id}", kind=StickySessionKind.CODEX_SESSION)
+            for account_id, _status, _reset_at in accounts
+        }
+    assert entries["acc_tombstone_old"] is None
+    assert entries["acc_tombstone_recent"] is not None
+    assert entries["acc_tombstone_recent"].continuity_abandoned_at is not None
+    assert entries["acc_tombstone_live"] is not None
+    assert entries["acc_tombstone_live"].continuity_abandoned_at is None
+
+
+@pytest.mark.asyncio
+async def test_seed_hard_sticky_outage_grace_on_startup_refreshes_only_unavailable_accounts(db_setup):
+    """A hard codex_session mapping whose owner was already unavailable
+    before this process started (no live status transition to hook) must
+    still get a fresh grace window once, at startup — otherwise the very
+    first cleanup cycle could purge an outage that began moments before
+    deploy. A healthy owner's mapping must be left untouched."""
+    from app.db.models import StickySession
+    from app.modules.proxy.sticky_repository import StickySessionsRepository
+
+    encryptor = TokenEncryptor()
+    long_ago = utcnow() - timedelta(days=30)
+    accounts = [
+        ("acc_seed_active", AccountStatus.ACTIVE),
+        ("acc_seed_rate_limited", AccountStatus.RATE_LIMITED),
+        ("acc_seed_paused", AccountStatus.PAUSED),
+        ("acc_seed_quota_exceeded", AccountStatus.QUOTA_EXCEEDED),
+    ]
+
+    async with SessionLocal() as session:
+        repo_accounts = AccountsRepository(session)
+        for account_id, status in accounts:
+            await repo_accounts.upsert(
+                Account(
+                    id=account_id,
+                    email=f"{account_id}@example.com",
+                    plan_type="plus",
+                    access_token_encrypted=encryptor.encrypt("access"),
+                    refresh_token_encrypted=encryptor.encrypt("refresh"),
+                    id_token_encrypted=encryptor.encrypt("id"),
+                    last_refresh=utcnow(),
+                    status=status,
+                    deactivation_reason=None,
+                )
+            )
+
+    async with SessionLocal() as session:
+        repo = StickySessionsRepository(session)
+        for account_id, _status in accounts:
+            await repo.upsert(f"turn_{account_id}", account_id, kind=StickySessionKind.CODEX_SESSION)
+
+    # Backdate every mapping's updated_at, simulating rows that predate this
+    # process's startup entirely (no status transition ever touched them).
+    async with SessionLocal() as session:
+        for account_id, _status in accounts:
+            await session.execute(
+                update(StickySession)
+                .where(StickySession.key == f"turn_{account_id}", StickySession.kind == StickySessionKind.CODEX_SESSION)
+                .values(updated_at=long_ago)
+            )
+        await session.commit()
+
+    async with SessionLocal() as session:
+        seeded_count = await AccountsRepository(session).seed_hard_sticky_outage_grace_on_startup()
+
+    assert seeded_count == 3
+    async with SessionLocal() as session:
+        repo = StickySessionsRepository(session)
+        refreshed_at = {}
+        for account_id, _status in accounts:
+            entry = await repo.get_entry(f"turn_{account_id}", kind=StickySessionKind.CODEX_SESSION)
+            assert entry is not None
+            refreshed_at[account_id] = entry.updated_at
+
+    assert refreshed_at["acc_seed_active"] == long_ago
+    for account_id in ("acc_seed_rate_limited", "acc_seed_paused", "acc_seed_quota_exceeded"):
+        assert refreshed_at[account_id] > long_ago + timedelta(days=1)
+
+    # A later boot — same or a different replica, same shared database —
+    # must not reseed: the durable runtime_sentinels marker means this only
+    # ever runs once per database, so a fast redeploy/autoscaling cadence
+    # can't keep resetting the grace clock for a durably-dead mapping.
+    async with SessionLocal() as session:
+        for account_id, _status in accounts:
+            await session.execute(
+                update(StickySession)
+                .where(StickySession.key == f"turn_{account_id}", StickySession.kind == StickySessionKind.CODEX_SESSION)
+                .values(updated_at=long_ago)
+            )
+        await session.commit()
+
+    async with SessionLocal() as session:
+        second_boot_seeded_count = await AccountsRepository(session).seed_hard_sticky_outage_grace_on_startup()
+    assert second_boot_seeded_count == 0
+
+    async with SessionLocal() as session:
+        repo = StickySessionsRepository(session)
+        for account_id, _status in accounts:
+            entry = await repo.get_entry(f"turn_{account_id}", kind=StickySessionKind.CODEX_SESSION)
+            assert entry is not None
+            assert entry.updated_at == long_ago

--- a/tests/unit/test_accounts_repository_locks.py
+++ b/tests/unit/test_accounts_repository_locks.py
@@ -94,6 +94,7 @@ def _make_result(value: str | None = "acc") -> MagicMock:
 async def test_account_update_status_uses_sqlite_writer_section(monkeypatch):
     session = MagicMock()
     session.execute = AsyncMock(return_value=_make_result("acc"))
+    session.scalar = AsyncMock(return_value=AccountStatus.ACTIVE)
     session.commit = AsyncMock()
     repo = AccountsRepository(session)
     order: list[str] = []
@@ -109,16 +110,22 @@ async def test_account_update_status_uses_sqlite_writer_section(monkeypatch):
         order.append("execute")
         return _make_result("acc")
 
+    async def scalar_with_order(*args, **kwargs):
+        del args, kwargs
+        order.append("scalar")
+        return AccountStatus.ACTIVE
+
     async def commit_with_order():
         order.append("commit")
 
     monkeypatch.setattr(repository_module, "sqlite_writer_section", fake_writer_section)
     session.execute.side_effect = execute_with_order
+    session.scalar.side_effect = scalar_with_order
     session.commit.side_effect = commit_with_order
 
     assert await repo.update_status("acc", AccountStatus.RATE_LIMITED) is True
 
-    assert order == ["lock-enter", "execute", "commit", "lock-exit"]
+    assert order == ["lock-enter", "scalar", "execute", "execute", "commit", "lock-exit"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_graceful_degradation.py
+++ b/tests/unit/test_graceful_degradation.py
@@ -14,7 +14,7 @@ from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.proxy import load_balancer as load_balancer_module
 from app.modules.proxy.load_balancer import LoadBalancer
 from app.modules.proxy.repo_bundle import ProxyRepositories
-from app.modules.proxy.sticky_repository import StickySessionsRepository
+from app.modules.proxy.sticky_repository import StickyOwnerLookup, StickySessionsRepository
 from app.modules.request_logs.repository import RequestLogsRepository
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
 
@@ -72,6 +72,9 @@ class _StubUsageRepository:
 class _StubStickyRepository:
     async def get_account_id(self, *args, **kwargs) -> str | None:
         return None
+
+    async def get_account_id_and_abandonment(self, *args, **kwargs) -> StickyOwnerLookup:
+        return StickyOwnerLookup(account_id=None, continuity_abandoned=False)
 
     async def upsert(self, *args, **kwargs):
         return None

--- a/tests/unit/test_load_balancer_concurrency.py
+++ b/tests/unit/test_load_balancer_concurrency.py
@@ -32,6 +32,7 @@ from app.modules.proxy.affinity import _codex_session_selection_key
 from app.modules.proxy.cap_partitioning import CapPartition
 from app.modules.proxy.load_balancer import LoadBalancer, RuntimeState, effective_account_concurrency_caps
 from app.modules.proxy.repo_bundle import ProxyRepositories
+from app.modules.proxy.sticky_repository import StickyOwnerLookup
 from app.modules.request_logs.repository import RequestLogsRepository
 from app.modules.usage.repository import AdditionalUsageRepository
 
@@ -192,14 +193,27 @@ class _StubStickySessionsRepository:
     def __init__(self) -> None:
         self.account_id: str | None = None
         self.account_ids_by_key: dict[str, str] | None = None
+        # Keys reported as purge tombstones (see
+        # purge_stale_hard_codex_session_mappings): get_account_id_and_abandonment
+        # reports these as ownerless, same as a missing row, but flags them as
+        # abandoned so run_sticky_selection_path can bypass the
+        # ambiguous-owner check for them.
+        self.abandoned_keys: set[str] = set()
         self.deleted: list[tuple[str, StickySessionKind | None]] = []
         self.upserts: list[tuple[str, str, StickySessionKind | None]] = []
 
     async def get_account_id(self, *args: Any, **kwargs: Any) -> str | None:
+        lookup = await self.get_account_id_and_abandonment(*args, **kwargs)
+        return lookup.account_id
+
+    async def get_account_id_and_abandonment(self, *args: Any, **kwargs: Any) -> StickyOwnerLookup:
+        key = cast(str, args[0])
+        if key in self.abandoned_keys:
+            return StickyOwnerLookup(account_id=None, continuity_abandoned=True)
         if self.account_ids_by_key is not None:
-            return self.account_ids_by_key.get(cast(str, args[0]))
-        del args, kwargs
-        return self.account_id
+            return StickyOwnerLookup(account_id=self.account_ids_by_key.get(key), continuity_abandoned=False)
+        del kwargs
+        return StickyOwnerLookup(account_id=self.account_id, continuity_abandoned=False)
 
     async def upsert(self, *args: Any, **kwargs: Any) -> Any:
         sticky_key = cast(str, args[0])
@@ -240,13 +254,13 @@ class _ConcurrentUnboundStickySessionsRepository(_StubStickySessionsRepository):
         self._lookup_count = 0
         self._all_lookups_started = asyncio.Event()
 
-    async def get_account_id(self, *args: Any, **kwargs: Any) -> None:
+    async def get_account_id_and_abandonment(self, *args: Any, **kwargs: Any) -> StickyOwnerLookup:
         del args, kwargs
         self._lookup_count += 1
         if self._lookup_count >= self._expected_lookups:
             self._all_lookups_started.set()
         await self._all_lookups_started.wait()
-        return None
+        return StickyOwnerLookup(account_id=None, continuity_abandoned=False)
 
 
 class _ConcurrentBoundStickySessionsRepository(_StubStickySessionsRepository):
@@ -258,13 +272,13 @@ class _ConcurrentBoundStickySessionsRepository(_StubStickySessionsRepository):
         self._lookup_count = 0
         self._all_lookups_started = asyncio.Event()
 
-    async def get_account_id(self, *args: Any, **kwargs: Any) -> str:
+    async def get_account_id_and_abandonment(self, *args: Any, **kwargs: Any) -> StickyOwnerLookup:
         del args, kwargs
         self._lookup_count += 1
         if self._lookup_count >= self._expected_lookups:
             self._all_lookups_started.set()
         await self._all_lookups_started.wait()
-        return self._initial_account_id
+        return StickyOwnerLookup(account_id=self._initial_account_id, continuity_abandoned=False)
 
 
 class _FailingUpsertStickySessionsRepository(_StubStickySessionsRepository):
@@ -2697,6 +2711,37 @@ async def test_bare_session_mapping_does_not_prove_ambiguous_conversation_owner(
 
     assert selected.account is None
     assert selected.error_code == "conversation_owner_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_tombstoned_hard_owner_lets_conversation_continuity_reselect() -> None:
+    """A purge-tombstoned mapping (see purge_stale_hard_codex_session_mappings)
+    must not permanently strand a `conversation`-continuity request just
+    because the pool has more than one account. Unlike a key that was never
+    seen, we know this key's owner was durably unavailable and continuity was
+    deliberately abandoned, so a fresh account may be selected and a new hard
+    mapping re-established — otherwise the request could never recover even
+    after the original owner comes back, since nothing on this path would
+    ever re-create the very row needed to stop failing closed."""
+    balancer, owner, alternate, sticky_repo = _make_cap_spillover_balancer("conversation-tombstoned")
+    assert alternate is not None
+    turn_state_key = "conversation-tombstoned-turn-state"
+    sticky_repo.abandoned_keys = {turn_state_key}
+
+    selected = await balancer.select_account(
+        sticky_key=turn_state_key,
+        sticky_kind=StickySessionKind.CODEX_SESSION,
+        sticky_source="turn_state",
+        require_unambiguous_account=True,
+        lease_kind="response_create",
+    )
+
+    assert selected.account is not None
+    assert selected.account.id in {owner.id, alternate.id}
+    assert selected.error_code is None
+    assert sticky_repo.upserts
+    assert sticky_repo.upserts[-1][0] == turn_state_key
+    assert sticky_repo.upserts[-1][1] == selected.account.id
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_load_balancer_contract.py
+++ b/tests/unit/test_load_balancer_contract.py
@@ -17,7 +17,7 @@ from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.proxy.account_cache import AccountSelectionCache
 from app.modules.proxy.load_balancer import AccountConcurrencyCaps, AccountSelection, LoadBalancer
 from app.modules.proxy.repo_bundle import ProxyRepositories
-from app.modules.proxy.sticky_repository import StickySessionsRepository
+from app.modules.proxy.sticky_repository import StickyOwnerLookup, StickySessionsRepository
 from app.modules.request_logs.repository import RequestLogsRepository
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
 
@@ -138,6 +138,11 @@ class _StickySessionsRepository:
         del args, kwargs
         self.get_calls += 1
         return self.account_id
+
+    async def get_account_id_and_abandonment(self, *args: Any, **kwargs: Any) -> StickyOwnerLookup:
+        del args, kwargs
+        self.get_calls += 1
+        return StickyOwnerLookup(account_id=self.account_id, continuity_abandoned=False)
 
     async def upsert(
         self,

--- a/tests/unit/test_proxy_load_balancer_refresh.py
+++ b/tests/unit/test_proxy_load_balancer_refresh.py
@@ -50,7 +50,7 @@ from app.modules.proxy.request_policy import (
     apply_api_key_enforcement,
     apply_enforced_service_tier_model_fallback,
 )
-from app.modules.proxy.sticky_repository import StickySessionsRepository
+from app.modules.proxy.sticky_repository import StickyOwnerLookup, StickySessionsRepository
 from app.modules.request_logs.repository import RequestLogsRepository
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
 
@@ -204,6 +204,19 @@ class StubStickySessionsRepository(StickySessionsRepository):
         max_age_seconds: int | None = None,
     ) -> str | None:
         return None
+
+    async def get_account_id_and_abandonment(
+        self,
+        key: str,
+        *,
+        kind: StickySessionKind,
+        max_age_seconds: int | None = None,
+    ) -> StickyOwnerLookup:
+        # Delegates to get_account_id (rather than duplicating its logic) so
+        # a test that only overrides get_account_id — the common pattern in
+        # this file — is still observed here.
+        account_id = await self.get_account_id(key, kind=kind, max_age_seconds=max_age_seconds)
+        return StickyOwnerLookup(account_id=account_id, continuity_abandoned=False)
 
     async def upsert(self, key: str, account_id: str, *, kind: StickySessionKind) -> StickySession:
         row = self._build_row(key, account_id, kind)

--- a/tests/unit/test_sticky_session_cleanup_scheduler.py
+++ b/tests/unit/test_sticky_session_cleanup_scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from datetime import timedelta
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, patch
@@ -9,6 +10,7 @@ import pytest
 
 import app.modules.sticky_sessions.cleanup_scheduler as cleanup_scheduler
 from app.core.config.settings import Settings
+from app.core.utils.time import utcnow
 from app.db.models import DashboardSettings
 
 pytestmark = pytest.mark.unit
@@ -35,7 +37,9 @@ def test_build_sticky_session_cleanup_scheduler_respects_enabled_setting(monkeyp
 @pytest.mark.asyncio
 async def test_cleanup_once_purges_prompt_cache_only(monkeypatch) -> None:
     """_cleanup_once should purge prompt-cache entries by affinity TTL.
-    Durable kinds (STICKY_THREAD, CODEX_SESSION) must NOT be purged."""
+    STICKY_THREAD is never purged here. CODEX_SESSION is only ever purged
+    via the separate, account-status-gated purge_stale_hard_codex_session_mappings
+    call (see test_sticky_repository.py), never by this TTL-based path."""
     dashboard_settings = SimpleNamespace(
         openai_cache_affinity_max_age_seconds=600,
         http_responses_session_bridge_prompt_cache_idle_ttl_seconds=600,
@@ -53,6 +57,7 @@ async def test_cleanup_once_purges_prompt_cache_only(monkeypatch) -> None:
     )
 
     sticky_repo = AsyncMock()
+    sticky_repo.purge_stale_hard_codex_session_mappings = AsyncMock(return_value=0)
     sticky_repo.purge_prompt_cache_before = AsyncMock(return_value=5)
     sticky_repo.purge_before = AsyncMock(return_value=0)
     bridge_repo = AsyncMock()
@@ -91,6 +96,10 @@ async def test_cleanup_once_purges_prompt_cache_only(monkeypatch) -> None:
     bridge_repo.purge_abandoned_before.assert_called_once()
     bridge_repo.purge_retry_circuits_before.assert_called_once()
     ring_service.purge_stale_before.assert_called_once()
+    sticky_repo.purge_stale_hard_codex_session_mappings.assert_called_once()
+    passed_cutoff = sticky_repo.purge_stale_hard_codex_session_mappings.call_args.args[0]
+    expected_cutoff = utcnow() - timedelta(seconds=cleanup_scheduler._STALE_HARD_CODEX_SESSION_UNAVAILABLE_SECONDS)
+    assert abs((passed_cutoff - expected_cutoff).total_seconds()) < 5
 
 
 @pytest.mark.asyncio
@@ -112,6 +121,7 @@ async def test_cleanup_once_skips_bridge_purge_when_schema_is_not_ready(monkeypa
     )
 
     sticky_repo = AsyncMock()
+    sticky_repo.purge_stale_hard_codex_session_mappings = AsyncMock(return_value=0)
     sticky_repo.purge_prompt_cache_before = AsyncMock(return_value=0)
     bridge_repo = AsyncMock()
     bridge_repo.purge_closed_before = AsyncMock(return_value=0)
@@ -174,6 +184,7 @@ async def test_cleanup_once_purges_bridge_when_schema_exists_after_startup_flag_
     )
 
     sticky_repo = AsyncMock()
+    sticky_repo.purge_stale_hard_codex_session_mappings = AsyncMock(return_value=0)
     sticky_repo.purge_prompt_cache_before = AsyncMock(return_value=0)
     bridge_repo = AsyncMock()
     bridge_repo.purge_closed_before = AsyncMock(return_value=1)
@@ -261,6 +272,7 @@ async def test_cleanup_once_gates_abandoned_purge_on_prompt_cache_reuse_ttl(monk
     )
 
     sticky_repo = AsyncMock()
+    sticky_repo.purge_stale_hard_codex_session_mappings = AsyncMock(return_value=0)
     sticky_repo.purge_prompt_cache_before = AsyncMock(return_value=0)
     bridge_repo = AsyncMock()
     bridge_repo.purge_closed_before = AsyncMock(return_value=0)


### PR DESCRIPTION
## Summary

A `codex_session`-kind sticky mapping is hard-bound and never rebound at
request time, even once its owner account becomes unavailable
(rate-limited/quota-exceeded/paused) — correctly, per
`sticky-session-operations`, since the mapping can represent live,
unverifiable session state (mid-flight tool calls, account-scoped state)
that isn't safe to move to a different account mid-session.

But that protection has no expiry. If the owner never recovers, every
future request against that session fails closed with
`previous_response_owner_unavailable` ("Hard affinity owner account is
unavailable") indefinitely. We hit this in production and had to delete
~250 stale mappings by hand directly in the database to unblock it.

This adds a bounded exception, enforced only by a periodic background purge
— never by the hot-path selection logic, and never by rebinding:

- A new repository method,
  `StickySessionsRepository.purge_stale_hard_codex_session_mappings`, deletes
  `codex_session` mappings whose account is non-active (`PAUSED`,
  `RATE_LIMITED`, or `QUOTA_EXCEEDED`) **and** whose mapping hasn't actually
  been reused since well before a cutoff.
- The existing leader-elected `StickySessionCleanupScheduler` (already
  running every 300s) calls this once per cycle with a fixed 6-hour
  threshold — deliberately far longer than any ordinary quota-reset window,
  so a transient blip never loses its mapping.
- Deletion only, never rebinding: once a stale mapping is gone, the next
  request against that session simply re-resolves fresh, exactly as it
  already does today for a session with no mapping at all.

`load_balancer.py`'s `hard_sticky` selection branch is untouched — the
correctness invariant it protects (never reallocate mid-flight to an
unverified account) is preserved; this only changes what eventually happens
to an already-abandoned mapping between requests.

An earlier version of this gated on `Account.reset_at`/`blocked_at`, which
looked right on paper but doesn't hold up against real account data:
`reset_at` is frequently unset (upstream hasn't reported fresh quota data),
and `blocked_at` is explicitly cleared to `None` on pause. Gating on
`StickySession.updated_at` instead — "how long since this mapping was
actually last used" — is both simpler and correct across all three
statuses. See `design.md` in the linked OpenSpec change for the full
rationale.

Full proposal, design rationale, and spec delta:
`openspec/changes/purge-stale-hard-codex-session-mappings/`.

## Test plan

- [x] New repository-level regression: a fresh (recently-used-despite-owner-
      being-down) mapping survives; a durably stale one (owner non-active
      and unused past the cutoff) is purged; a healthy owner's mapping is
      never touched
      (`tests/integration/test_proxy_sticky_sessions.py::test_purge_stale_hard_codex_session_mappings_only_drops_durably_unavailable_owners`)
- [x] Scheduler-level regression that the new purge call happens once per
      cleanup cycle with the expected cutoff
- [x] Updated the pre-existing scheduler test whose docstring asserted
      `codex_session` mappings are "never purged" by this job
- [x] `uv run pytest` — full suite green except one pre-existing, unrelated
      flaky integration test
      (`test_quota_planner_warm_now_keeps_bootstrap_for_metadata_less_primary_rows`,
      confirmed to fail identically on unmodified `origin/main`)
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run ty check` — clean

Note: like my other recent PRs, CI's `Lint (ruff)` check will likely still
show red here due to the pre-existing, unrelated `service.py`/
`load_balancer.py` architecture line-count gate failures on current `main`
(see #1416 and my comments on #1408/#1401) — unrelated to this diff.