### PR TITLE
refactor(proxy): restore architecture ratchets

### DIFF
--- a/app/modules/proxy/_load_balancer/__init__.py
+++ b/app/modules/proxy/_load_balancer/__init__.py
@@ -1,0 +1,1 @@
+"""Private implementation units for proxy account selection."""

--- a/app/modules/proxy/_load_balancer/sticky_selection.py
+++ b/app/modules/proxy/_load_balancer/sticky_selection.py
@@ -1,0 +1,896 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Generic, Literal, Protocol, TypeVar
+
+from app.core.balancer import (
+    HEALTH_TIER_DRAINING,
+    HEALTH_TIER_HEALTHY,
+    HEALTH_TIER_PROBING,
+    ROUTING_POLICY_BURN_FIRST,
+    ROUTING_POLICY_PRESERVE,
+    TRAFFIC_CLASS_FOREGROUND,
+    AccountState,
+    ResetPreferenceWindow,
+    RoutingCostsByAccount,
+    RoutingStrategy,
+    SelectionResult,
+    TrafficClass,
+    select_account,
+)
+from app.db.models import Account, AccountStatus, AdditionalUsageHistory, StickySessionKind, UsageHistory
+from app.modules.accounts.repository import AccountsRepository
+from app.modules.proxy._load_balancer.types import (
+    MAX_SELECTION_ATTEMPTS,
+    AccountConcurrencyCaps,
+    AccountLease,
+    AccountLeaseKind,
+)
+from app.modules.proxy.affinity import _CodexSessionSource
+from app.modules.proxy.repo_bundle import ProxyRepoFactory
+from app.modules.proxy.sticky_repository import StickySessionsRepository
+from app.modules.quota_planner.logic import PlannerSettings, build_routing_costs
+
+# Preserve the established observability surface while implementation moves to
+# a private module; operators and tests filter this logger by its public owner.
+logger = logging.getLogger("app.modules.proxy.load_balancer")
+
+_STICKY_GRACE_PERIOD_SECONDS = 10.0
+_STICKY_EXISTING_UNSET = object()
+_RECOVERABLE_STATUSES = frozenset(
+    {
+        AccountStatus.ACTIVE,
+        AccountStatus.RATE_LIMITED,
+        AccountStatus.QUOTA_EXCEEDED,
+    }
+)
+
+StickySelectionDisposition = Literal["shared_result", "direct_error"]
+AccountCapRejectionCallback = Callable[[AccountLeaseKind | None], None]
+
+
+class SelectionInputsProtocol(Protocol):
+    accounts: list[Account]
+    latest_primary: dict[str, UsageHistory | AdditionalUsageHistory]
+    latest_secondary: dict[str, UsageHistory | AdditionalUsageHistory]
+    latest_monthly: dict[str, UsageHistory]
+    quota_planner_settings: PlannerSettings
+    runtime_accounts: list[Account] | None
+    error_message: str | None
+    error_code: str | None
+    ignore_standard_quota_account_ids: frozenset[str]
+    routing_policy_override: str | None
+
+    @property
+    def effective_continuity_owner_candidates(self) -> list[Account]: ...
+
+
+SelectionInputsT = TypeVar("SelectionInputsT", bound=SelectionInputsProtocol)
+
+
+class StickySelectionOwner(Protocol):
+    _runtime_lock: asyncio.Lock
+    _repo_factory: ProxyRepoFactory
+
+    def _prepare_sticky_selection_states(
+        self,
+        selection_inputs: SelectionInputsProtocol,
+        *,
+        required_account_id: str | None,
+    ) -> tuple[list[AccountState], dict[str, Account]]: ...
+
+    def _sync_runtime_state(
+        self,
+        account: Account,
+        state: AccountState,
+        *,
+        selected: bool = False,
+        expected_version: int | None = None,
+    ) -> bool: ...
+
+    def _account_lease_allowed_locked(
+        self,
+        account_id: str,
+        *,
+        kind: AccountLeaseKind,
+        caps: AccountConcurrencyCaps,
+        stream_reserve_slots: int = 0,
+    ) -> bool: ...
+
+    def _acquire_account_lease_locked(
+        self,
+        account_id: str,
+        *,
+        kind: AccountLeaseKind,
+        estimated_tokens: float,
+    ) -> AccountLease: ...
+
+    async def _persist_selection_state(
+        self,
+        accounts_repo: AccountsRepository,
+        account_map: dict[str, Account],
+        states: list[AccountState],
+    ) -> set[str]: ...
+
+    async def release_account_lease(self, lease: AccountLease | None) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class StickySelectionRequest(Generic[SelectionInputsT]):
+    sticky_key: str
+    sticky_kind: StickySessionKind | None
+    reallocate_sticky: bool
+    sticky_source: _CodexSessionSource | None
+    legacy_sticky_key: str | None
+    legacy_existing_account_id: str | None
+    spill_bare_session_on_account_cap: bool
+    require_unambiguous_account: bool
+    sticky_max_age_seconds: int | None
+    prefer_earlier_reset_accounts: bool
+    prefer_earlier_reset_window: ResetPreferenceWindow
+    routing_strategy: RoutingStrategy
+    relative_availability_power: float
+    relative_availability_top_k: int
+    required_account_id: str | None
+    budget_threshold_pct: float
+    secondary_budget_threshold_pct: float
+    routing_costs_by_account_id: RoutingCostsByAccount | None
+    lease_kind: AccountLeaseKind | None
+    estimated_lease_tokens: float
+    stream_reserve_slots: int
+    traffic_class: TrafficClass
+    concurrency_caps: AccountConcurrencyCaps
+    selection_inputs: SelectionInputsT
+    reload_inputs: Callable[[], Awaitable[SelectionInputsT]]
+    record_account_cap_rejection: AccountCapRejectionCallback
+
+
+@dataclass(frozen=True, slots=True)
+class StickySelectionOutcome(Generic[SelectionInputsT]):
+    selection_inputs: SelectionInputsT
+    selected_snapshot: Account | None
+    selected_lease: AccountLease | None
+    error_message: str | None
+    error_code: str | None
+    disposition: StickySelectionDisposition = "shared_result"
+
+
+async def run_sticky_selection_path(
+    owner: StickySelectionOwner,
+    *,
+    request: StickySelectionRequest[SelectionInputsT],
+) -> StickySelectionOutcome[SelectionInputsT]:
+    selection_inputs = request.selection_inputs
+    sticky_existing_account_id: str | None | object = _STICKY_EXISTING_UNSET
+    selected_snapshot: Account | None = None
+    selected_lease: AccountLease | None = None
+    error_message: str | None = None
+    selection_error_code: str | None = None
+    attempt = 0
+
+    while True:
+        attempt += 1
+        async with owner._runtime_lock:
+            states, account_map = owner._prepare_sticky_selection_states(
+                selection_inputs,
+                required_account_id=request.required_account_id,
+            )
+            effective_routing_costs = (
+                request.routing_costs_by_account_id
+                if request.routing_costs_by_account_id is not None
+                else build_routing_costs(
+                    settings=selection_inputs.quota_planner_settings,
+                    states=states,
+                    now=datetime.now(timezone.utc),
+                )
+            )
+
+        sticky_existing_is_legacy = isinstance(request.legacy_existing_account_id, str)
+        if request.sticky_key and request.sticky_kind == StickySessionKind.CODEX_SESSION:
+            async with owner._repo_factory() as repos:
+                sticky_existing_account_id = await repos.sticky_sessions.get_account_id(
+                    request.sticky_key,
+                    kind=request.sticky_kind,
+                    max_age_seconds=request.sticky_max_age_seconds,
+                )
+            if isinstance(request.legacy_existing_account_id, str):
+                # Mixed-version replicas can create both rows on different
+                # accounts. The raw row always wins as possible hard turn-state
+                # ownership.
+                sticky_existing_account_id = request.legacy_existing_account_id
+
+        # Key shape is deliberately irrelevant here. Only typed source
+        # provenance created by the affinity parser can grant mobility.
+        bare_session_key = (
+            request.sticky_kind == StickySessionKind.CODEX_SESSION
+            and request.sticky_source == "session_header"
+            and request.legacy_sticky_key is not None
+            and not sticky_existing_is_legacy
+        )
+        cap_spillover_allowed = (
+            request.spill_bare_session_on_account_cap and request.lease_kind is not None and bare_session_key
+        )
+        hard_sticky = (
+            request.sticky_kind == StickySessionKind.CODEX_SESSION
+            and isinstance(sticky_existing_account_id, str)
+            and not bare_session_key
+        )
+        if (
+            hard_sticky
+            and request.required_account_id is not None
+            and sticky_existing_account_id != request.required_account_id
+        ):
+            return StickySelectionOutcome(
+                selection_inputs=selection_inputs,
+                selected_snapshot=None,
+                selected_lease=None,
+                error_message="Account-owned continuity sources conflict; retry the logical turn",
+                error_code="continuity_owner_conflict",
+                disposition="direct_error",
+            )
+
+        if (
+            request.require_unambiguous_account
+            and not hard_sticky
+            and len(selection_inputs.effective_continuity_owner_candidates) != 1
+        ):
+            return StickySelectionOutcome(
+                selection_inputs=selection_inputs,
+                selected_snapshot=None,
+                selected_lease=None,
+                error_message="Conversation owner cannot be determined from the eligible account pool",
+                error_code="conversation_owner_unavailable",
+                disposition="direct_error",
+            )
+
+        if hard_sticky:
+            # A resolved hard Codex mapping is an ownership constraint, not a
+            # preference. Never delete or rebind it under transient pressure.
+            selection_states = [state for state in states if state.account_id == sticky_existing_account_id]
+        elif bare_session_key and isinstance(sticky_existing_account_id, str) and not cap_spillover_allowed:
+            selection_states = states
+        else:
+            selection_states = _filter_states_for_account_caps(
+                states,
+                lease_kind=request.lease_kind,
+                caps=request.concurrency_caps,
+                stream_reserve_slots=request.stream_reserve_slots,
+            )
+
+        if cap_spillover_allowed and request.lease_kind == "stream":
+            response_create_states = _filter_states_for_account_caps(
+                selection_states,
+                lease_kind="response_create",
+                caps=request.concurrency_caps,
+                stream_reserve_slots=0,
+            )
+            selection_states = response_create_states or selection_states
+
+        preserve_existing_mapping = (
+            bare_session_key
+            and isinstance(sticky_existing_account_id, str)
+            and (
+                (
+                    cap_spillover_allowed
+                    and any(state.account_id == sticky_existing_account_id for state in states)
+                    and not any(state.account_id == sticky_existing_account_id for state in selection_states)
+                )
+                or request.require_unambiguous_account
+            )
+        )
+
+        if hard_sticky and not selection_states:
+            selection_error_code = "hard_affinity_saturated"
+            result = SelectionResult(None, "Hard affinity owner account is unavailable")
+        elif not selection_states and states:
+            selection_error_code = _account_cap_error_code(request.lease_kind)
+            result = SelectionResult(
+                None,
+                _account_cap_error_message(request.lease_kind, request.concurrency_caps),
+            )
+            logger.warning(
+                "Account cap exhausted during sticky selection lease_kind=%s reason=%s candidates=%s",
+                request.lease_kind,
+                selection_error_code,
+                len(states),
+            )
+            request.record_account_cap_rejection(request.lease_kind)
+        elif hard_sticky:
+            result = _select_account_preferring_budget_safe(
+                selection_states,
+                prefer_earlier_reset=request.prefer_earlier_reset_accounts,
+                prefer_earlier_reset_window=request.prefer_earlier_reset_window,
+                routing_strategy=request.routing_strategy,
+                relative_availability_power=request.relative_availability_power,
+                relative_availability_top_k=request.relative_availability_top_k,
+                budget_threshold_pct=request.budget_threshold_pct,
+                secondary_budget_threshold_pct=request.secondary_budget_threshold_pct,
+                traffic_class=request.traffic_class,
+                ignore_standard_quota=False,
+                routing_costs_by_account_id=effective_routing_costs,
+            )
+            if result.account is None:
+                selection_error_code = "hard_affinity_saturated"
+                result = SelectionResult(
+                    None,
+                    result.error_message or "Hard affinity owner account is unavailable",
+                )
+            else:
+                selection_error_code = None
+        else:
+            selection_error_code = None
+            async with owner._repo_factory() as repos:
+                result = await _select_with_stickiness(
+                    states=selection_states,
+                    account_map=account_map,
+                    sticky_key=request.sticky_key,
+                    sticky_kind=request.sticky_kind,
+                    reallocate_sticky=request.reallocate_sticky,
+                    sticky_max_age_seconds=request.sticky_max_age_seconds,
+                    budget_threshold_pct=request.budget_threshold_pct,
+                    secondary_budget_threshold_pct=request.secondary_budget_threshold_pct,
+                    prefer_earlier_reset_accounts=request.prefer_earlier_reset_accounts,
+                    prefer_earlier_reset_window=request.prefer_earlier_reset_window,
+                    routing_strategy=request.routing_strategy,
+                    relative_availability_power=request.relative_availability_power,
+                    relative_availability_top_k=request.relative_availability_top_k,
+                    sticky_repo=repos.sticky_sessions,
+                    sticky_existing_account_id=sticky_existing_account_id,
+                    preserve_existing_mapping_on_fallback=preserve_existing_mapping,
+                    traffic_class=request.traffic_class,
+                    ignore_standard_quota=False,
+                    routing_costs_by_account_id=effective_routing_costs,
+                )
+
+        selected_states: list[AccountState] = []
+        async with owner._runtime_lock:
+            for state in states:
+                account = account_map.get(state.account_id)
+                if account is None:
+                    continue
+                owner._sync_runtime_state(
+                    account,
+                    state,
+                    selected=result.account is not None and state.account_id == result.account.account_id,
+                )
+                selected_states.append(state)
+
+            if result.account is not None:
+                selected = account_map.get(result.account.account_id)
+                if selected is None:
+                    error_message = result.error_message
+                else:
+                    selected_reset_at = selected.reset_at
+                    for state in selected_states:
+                        if state.account_id == result.account.account_id:
+                            state.status = result.account.status
+                            state.deactivation_reason = result.account.deactivation_reason
+                            selected_reset_at = int(state.reset_at) if state.reset_at else None
+                            break
+                    selected_snapshot = _clone_account(selected)
+                    selected_snapshot.status = result.account.status
+                    selected_snapshot.deactivation_reason = result.account.deactivation_reason
+                    selected_snapshot.reset_at = selected_reset_at
+                    if request.lease_kind is not None:
+                        if not owner._account_lease_allowed_locked(
+                            selected.id,
+                            kind=request.lease_kind,
+                            caps=request.concurrency_caps,
+                            stream_reserve_slots=request.stream_reserve_slots,
+                        ):
+                            selected_snapshot = None
+                            selection_error_code = _account_cap_error_code(request.lease_kind)
+                            error_message = _account_cap_error_message(
+                                request.lease_kind,
+                                request.concurrency_caps,
+                            )
+                        else:
+                            selected_lease = owner._acquire_account_lease_locked(
+                                selected.id,
+                                kind=request.lease_kind,
+                                estimated_tokens=request.estimated_lease_tokens,
+                            )
+            else:
+                error_message = result.error_message
+
+        try:
+            async with owner._repo_factory() as repos:
+                stale_account_ids = await owner._persist_selection_state(
+                    repos.accounts,
+                    account_map,
+                    selected_states,
+                )
+        except BaseException:
+            await owner.release_account_lease(selected_lease)
+            selected_lease = None
+            raise
+
+        stale_account_ids = stale_account_ids or set()
+        if selected_snapshot is not None and selected_snapshot.id in stale_account_ids:
+            await owner.release_account_lease(selected_lease)
+            selected_lease = None
+            selected_snapshot = None
+            error_message = None
+            if attempt >= MAX_SELECTION_ATTEMPTS:
+                break
+            selection_inputs = await request.reload_inputs()
+            if selection_inputs.error_code is not None and not selection_inputs.accounts:
+                return StickySelectionOutcome(
+                    selection_inputs=selection_inputs,
+                    selected_snapshot=None,
+                    selected_lease=None,
+                    error_message=selection_inputs.error_message,
+                    error_code=selection_inputs.error_code,
+                    disposition="direct_error",
+                )
+            await asyncio.sleep(0)
+            continue
+
+        if (
+            selected_snapshot is None
+            and selection_error_code is not None
+            and not hard_sticky
+            and attempt < MAX_SELECTION_ATTEMPTS
+        ):
+            selection_inputs = await request.reload_inputs()
+            if selection_inputs.error_code is not None and not selection_inputs.accounts:
+                return StickySelectionOutcome(
+                    selection_inputs=selection_inputs,
+                    selected_snapshot=None,
+                    selected_lease=None,
+                    error_message=selection_inputs.error_message,
+                    error_code=selection_inputs.error_code,
+                    disposition="direct_error",
+                )
+            error_message = None
+            await asyncio.sleep(0)
+            continue
+        break
+
+    return StickySelectionOutcome(
+        selection_inputs=selection_inputs,
+        selected_snapshot=selected_snapshot,
+        selected_lease=selected_lease,
+        error_message=error_message,
+        error_code=selection_error_code,
+    )
+
+
+async def _select_with_stickiness(
+    *,
+    states: list[AccountState],
+    account_map: dict[str, Account],
+    sticky_key: str | None,
+    sticky_kind: StickySessionKind | None,
+    reallocate_sticky: bool,
+    sticky_max_age_seconds: int | None,
+    budget_threshold_pct: float = 95.0,
+    secondary_budget_threshold_pct: float = 100.0,
+    prefer_earlier_reset_accounts: bool,
+    prefer_earlier_reset_window: ResetPreferenceWindow,
+    routing_strategy: RoutingStrategy,
+    relative_availability_power: float = 2.0,
+    relative_availability_top_k: int = 5,
+    sticky_repo: StickySessionsRepository | None,
+    routing_costs_by_account_id: RoutingCostsByAccount | None = None,
+    sticky_existing_account_id: str | None | object = _STICKY_EXISTING_UNSET,
+    preserve_existing_mapping_on_fallback: bool = False,
+    traffic_class: TrafficClass = TRAFFIC_CLASS_FOREGROUND,
+    ignore_standard_quota: bool = False,
+) -> SelectionResult:
+    if not sticky_key or not sticky_repo:
+        return _select_account_preferring_budget_safe(
+            states,
+            prefer_earlier_reset=prefer_earlier_reset_accounts,
+            prefer_earlier_reset_window=prefer_earlier_reset_window,
+            routing_strategy=routing_strategy,
+            relative_availability_power=relative_availability_power,
+            relative_availability_top_k=relative_availability_top_k,
+            budget_threshold_pct=budget_threshold_pct,
+            traffic_class=traffic_class,
+            ignore_standard_quota=ignore_standard_quota,
+            routing_costs_by_account_id=routing_costs_by_account_id,
+        )
+    if sticky_kind is None:
+        raise ValueError("sticky_kind is required when sticky_key is provided")
+
+    if sticky_existing_account_id is _STICKY_EXISTING_UNSET:
+        existing = await sticky_repo.get_account_id(
+            sticky_key,
+            kind=sticky_kind,
+            max_age_seconds=sticky_max_age_seconds,
+        )
+    else:
+        existing = sticky_existing_account_id if isinstance(sticky_existing_account_id, str) else None
+    # When the pinned account is temporarily unavailable but still in the pool,
+    # pick a fallback without overwriting the mapping unless explicitly asked.
+    persist_fallback = not preserve_existing_mapping_on_fallback
+    apply_sticky_secondary_budget_threshold = False
+
+    if existing:
+        pinned = next((state for state in states if state.account_id == existing), None)
+        if pinned is not None:
+            now = time.time()
+            budget_pressured = (
+                sticky_kind
+                in (
+                    StickySessionKind.PROMPT_CACHE,
+                    StickySessionKind.STICKY_THREAD,
+                    StickySessionKind.CODEX_SESSION,
+                )
+                and routing_strategy not in ("sequential_drain", "reset_drain", "single_account")
+                and pinned.status != AccountStatus.RATE_LIMITED
+                and _state_above_sticky_budget_threshold(
+                    pinned,
+                    budget_threshold_pct,
+                    secondary_budget_threshold_pct,
+                )
+            )
+            rate_limit_far_away = (
+                sticky_kind == StickySessionKind.PROMPT_CACHE
+                and pinned.status == AccountStatus.RATE_LIMITED
+                and pinned.reset_at is not None
+                and pinned.reset_at - now >= 600
+            )
+
+            burn_first_reallocate = pinned.routing_policy != ROUTING_POLICY_BURN_FIRST
+            if burn_first_reallocate:
+                burn_first_candidates = [state for state in states if state.routing_policy == ROUTING_POLICY_BURN_FIRST]
+                if burn_first_candidates:
+                    burn_first = select_account(
+                        burn_first_candidates,
+                        prefer_earlier_reset=prefer_earlier_reset_accounts,
+                        routing_strategy=routing_strategy,
+                        allow_backoff_fallback=False,
+                        deterministic_probe=True,
+                        relative_availability_power=relative_availability_power,
+                        relative_availability_top_k=relative_availability_top_k,
+                        traffic_class=traffic_class,
+                        ignore_standard_quota=ignore_standard_quota,
+                    )
+                    burn_first_reallocate = burn_first.account is not None
+
+            if not ((budget_pressured or rate_limit_far_away) and burn_first_reallocate):
+                pinned_result = select_account(
+                    [pinned],
+                    prefer_earlier_reset=prefer_earlier_reset_accounts,
+                    prefer_earlier_reset_window=prefer_earlier_reset_window,
+                    routing_strategy=routing_strategy,
+                    allow_backoff_fallback=False,
+                    relative_availability_power=relative_availability_power,
+                    relative_availability_top_k=relative_availability_top_k,
+                    traffic_class=traffic_class,
+                    ignore_standard_quota=ignore_standard_quota,
+                    routing_costs=routing_costs_by_account_id,
+                )
+                if pinned_result.account is not None:
+                    if sticky_max_age_seconds is not None:
+                        await sticky_repo.upsert(sticky_key, pinned.account_id, kind=sticky_kind)
+                    return pinned_result
+            else:
+                if budget_pressured:
+                    apply_sticky_secondary_budget_threshold = True
+                    pool_best = _select_account_preferring_budget_safe(
+                        states,
+                        prefer_earlier_reset=prefer_earlier_reset_accounts,
+                        prefer_earlier_reset_window=prefer_earlier_reset_window,
+                        routing_strategy=routing_strategy,
+                        relative_availability_power=relative_availability_power,
+                        relative_availability_top_k=relative_availability_top_k,
+                        deterministic_probe=True,
+                        budget_threshold_pct=budget_threshold_pct,
+                        secondary_budget_threshold_pct=secondary_budget_threshold_pct,
+                        apply_secondary_budget_threshold=True,
+                        traffic_class=traffic_class,
+                        ignore_standard_quota=ignore_standard_quota,
+                        routing_costs_by_account_id=routing_costs_by_account_id,
+                    )
+                    pool_also_exhausted = pool_best.account is not None and (
+                        pool_best.account.account_id == pinned.account_id
+                        or _state_above_sticky_budget_threshold(
+                            pool_best.account,
+                            budget_threshold_pct,
+                            secondary_budget_threshold_pct,
+                        )
+                    )
+                    if pool_also_exhausted:
+                        pinned_result = select_account(
+                            [pinned],
+                            prefer_earlier_reset=prefer_earlier_reset_accounts,
+                            prefer_earlier_reset_window=prefer_earlier_reset_window,
+                            routing_strategy=routing_strategy,
+                            allow_backoff_fallback=False,
+                            relative_availability_power=relative_availability_power,
+                            relative_availability_top_k=relative_availability_top_k,
+                            traffic_class=traffic_class,
+                            ignore_standard_quota=ignore_standard_quota,
+                            routing_costs=routing_costs_by_account_id,
+                        )
+                        if pinned_result.account is not None:
+                            if sticky_max_age_seconds is not None:
+                                await sticky_repo.upsert(
+                                    sticky_key,
+                                    pinned.account_id,
+                                    kind=sticky_kind,
+                                )
+                            return pinned_result
+                reallocate_sticky = True
+
+            if not reallocate_sticky and pinned.status == AccountStatus.RATE_LIMITED:
+                grace_copy = replace(pinned)
+                grace_result = select_account(
+                    [grace_copy],
+                    now=time.time() + _STICKY_GRACE_PERIOD_SECONDS,
+                    prefer_earlier_reset=prefer_earlier_reset_accounts,
+                    prefer_earlier_reset_window=prefer_earlier_reset_window,
+                    routing_strategy=routing_strategy,
+                    allow_backoff_fallback=False,
+                    relative_availability_power=relative_availability_power,
+                    relative_availability_top_k=relative_availability_top_k,
+                    traffic_class=traffic_class,
+                    ignore_standard_quota=ignore_standard_quota,
+                    routing_costs=routing_costs_by_account_id,
+                )
+                if grace_result.account is not None:
+                    if sticky_max_age_seconds is not None:
+                        await sticky_repo.upsert(sticky_key, pinned.account_id, kind=sticky_kind)
+                    return grace_result
+            if reallocate_sticky:
+                await sticky_repo.delete(sticky_key, kind=sticky_kind)
+            elif pinned.status not in _RECOVERABLE_STATUSES:
+                pass
+            elif sticky_max_age_seconds is not None:
+                persist_fallback = False
+        elif not preserve_existing_mapping_on_fallback:
+            await sticky_repo.delete(sticky_key, kind=sticky_kind)
+
+    chosen = _select_account_preferring_budget_safe(
+        states,
+        prefer_earlier_reset=prefer_earlier_reset_accounts,
+        prefer_earlier_reset_window=prefer_earlier_reset_window,
+        routing_strategy=routing_strategy,
+        relative_availability_power=relative_availability_power,
+        relative_availability_top_k=relative_availability_top_k,
+        budget_threshold_pct=budget_threshold_pct,
+        secondary_budget_threshold_pct=secondary_budget_threshold_pct,
+        apply_secondary_budget_threshold=apply_sticky_secondary_budget_threshold,
+        traffic_class=traffic_class,
+        ignore_standard_quota=ignore_standard_quota,
+        routing_costs_by_account_id=routing_costs_by_account_id,
+    )
+    if persist_fallback and chosen.account is not None and chosen.account.account_id in account_map:
+        await sticky_repo.upsert(sticky_key, chosen.account.account_id, kind=sticky_kind)
+    elif preserve_existing_mapping_on_fallback and chosen.account is not None and existing is not None:
+        logger.info(
+            "internal_soft_affinity_spillover old_account_id=%s new_account_id=%s sticky_kind=%s",
+            existing,
+            chosen.account.account_id,
+            sticky_kind.value,
+        )
+    return chosen
+
+
+def _filter_states_for_account_caps(
+    states: Iterable[AccountState],
+    *,
+    lease_kind: AccountLeaseKind | None,
+    caps: AccountConcurrencyCaps,
+    stream_reserve_slots: int = 0,
+) -> list[AccountState]:
+    if lease_kind is None:
+        return list(states)
+    filtered: list[AccountState] = []
+    for state in states:
+        if lease_kind == "response_create":
+            cap = caps.response_create_limit
+            if cap > 0 and state.inflight_response_creates >= cap:
+                continue
+        else:
+            cap = caps.stream_limit
+            effective_cap = max(1, cap - max(0, stream_reserve_slots))
+            if cap > 0 and state.inflight_streams >= effective_cap:
+                continue
+        filtered.append(state)
+    return filtered
+
+
+def _account_cap_error_code(lease_kind: AccountLeaseKind | None) -> str | None:
+    if lease_kind == "response_create":
+        return "account_response_create_cap"
+    if lease_kind == "stream":
+        return "account_stream_cap"
+    return None
+
+
+def _account_cap_error_message(lease_kind: AccountLeaseKind | None, caps: AccountConcurrencyCaps) -> str:
+    if lease_kind == "response_create":
+        cap = caps.response_create_limit
+        if caps.replica_count > 1 and caps.configured_response_create_limit is not None:
+            return (
+                f"Account response-create capacity is exhausted; this replica's share is {cap} "
+                f"of the per-account limit {caps.configured_response_create_limit} "
+                f"across {caps.replica_count} replicas"
+            )
+        return f"Account response-create capacity is exhausted; per-account limit is {cap}"
+    if lease_kind == "stream":
+        cap = caps.stream_limit
+        if caps.replica_count > 1 and caps.configured_stream_limit is not None:
+            return (
+                f"Account stream capacity is exhausted; this replica's share is {cap} "
+                f"of the per-account limit {caps.configured_stream_limit} "
+                f"across {caps.replica_count} replicas. "
+                "Increase the dashboard stream limit or wait for active streams to finish."
+            )
+        return (
+            f"Account stream capacity is exhausted; per-account limit is {cap}. "
+            "Increase the dashboard stream limit or wait for active streams to finish."
+        )
+    return "Account capacity is exhausted"
+
+
+def _state_above_budget_threshold(state: AccountState, budget_threshold_pct: float) -> bool:
+    used_percent = state.priority_used_percent if state.priority_used_percent is not None else state.used_percent
+    return used_percent is not None and used_percent > budget_threshold_pct
+
+
+def _state_above_sticky_budget_threshold(
+    state: AccountState,
+    budget_threshold_pct: float,
+    secondary_budget_threshold_pct: float | None = None,
+) -> bool:
+    secondary_threshold = (
+        budget_threshold_pct if secondary_budget_threshold_pct is None else secondary_budget_threshold_pct
+    )
+    used_percent = state.priority_used_percent if state.priority_used_percent is not None else state.used_percent
+    if state.limit_scoped_usage and state.priority_secondary_used_percent is None:
+        secondary_used_percent = used_percent
+    else:
+        secondary_used_percent = (
+            state.priority_secondary_used_percent
+            if state.priority_secondary_used_percent is not None
+            else state.secondary_used_percent
+        )
+    return (used_percent is not None and used_percent > budget_threshold_pct) or (
+        secondary_used_percent is not None and secondary_used_percent > secondary_threshold
+    )
+
+
+def _select_account_preferring_budget_safe(
+    states: Iterable[AccountState],
+    *,
+    prefer_earlier_reset: bool,
+    prefer_earlier_reset_window: ResetPreferenceWindow = "secondary",
+    routing_strategy: RoutingStrategy,
+    relative_availability_power: float = 2.0,
+    relative_availability_top_k: int = 5,
+    budget_threshold_pct: float,
+    secondary_budget_threshold_pct: float = 100.0,
+    apply_secondary_budget_threshold: bool = False,
+    allow_backoff_fallback: bool = True,
+    deterministic_probe: bool = False,
+    traffic_class: TrafficClass = TRAFFIC_CLASS_FOREGROUND,
+    ignore_standard_quota: bool = False,
+    routing_costs_by_account_id: RoutingCostsByAccount | None = None,
+) -> SelectionResult:
+    state_list = list(states)
+    state_budget_threshold = (
+        (
+            lambda state: _state_above_sticky_budget_threshold(
+                state,
+                budget_threshold_pct,
+                secondary_budget_threshold_pct,
+            )
+        )
+        if apply_secondary_budget_threshold
+        else (lambda state: _state_above_budget_threshold(state, budget_threshold_pct))
+    )
+    if routing_strategy in ("sequential_drain", "reset_drain", "single_account"):
+        budget_safe_states = [
+            state
+            for state in state_list
+            if state.routing_policy != ROUTING_POLICY_PRESERVE and not state_budget_threshold(state)
+        ]
+        return select_account(
+            budget_safe_states or state_list,
+            prefer_earlier_reset=prefer_earlier_reset,
+            prefer_earlier_reset_window=prefer_earlier_reset_window,
+            routing_strategy=routing_strategy,
+            allow_backoff_fallback=allow_backoff_fallback,
+            deterministic_probe=deterministic_probe,
+            relative_availability_power=relative_availability_power,
+            relative_availability_top_k=relative_availability_top_k,
+            traffic_class=traffic_class,
+            ignore_standard_quota=ignore_standard_quota,
+            routing_costs=routing_costs_by_account_id,
+        )
+
+    best_health_states = _best_health_tier_states(state_list)
+    burn_first_states = [state for state in best_health_states if state.routing_policy == ROUTING_POLICY_BURN_FIRST]
+    if burn_first_states:
+        burn_first = select_account(
+            burn_first_states,
+            prefer_earlier_reset=prefer_earlier_reset,
+            prefer_earlier_reset_window=prefer_earlier_reset_window,
+            routing_strategy=routing_strategy,
+            allow_backoff_fallback=False,
+            deterministic_probe=deterministic_probe,
+            relative_availability_power=relative_availability_power,
+            relative_availability_top_k=relative_availability_top_k,
+            traffic_class=traffic_class,
+            ignore_standard_quota=ignore_standard_quota,
+            routing_costs=routing_costs_by_account_id,
+        )
+        if burn_first.account is not None:
+            return burn_first
+
+    preferred_states = [
+        state
+        for state in state_list
+        if state.routing_policy != ROUTING_POLICY_PRESERVE and not state_budget_threshold(state)
+    ]
+    if preferred_states:
+        selection_pool = preferred_states if len(preferred_states) != len(state_list) else state_list
+        preferred = select_account(
+            selection_pool,
+            prefer_earlier_reset=prefer_earlier_reset,
+            prefer_earlier_reset_window=prefer_earlier_reset_window,
+            routing_strategy=routing_strategy,
+            allow_backoff_fallback=allow_backoff_fallback,
+            deterministic_probe=deterministic_probe,
+            relative_availability_power=relative_availability_power,
+            relative_availability_top_k=relative_availability_top_k,
+            traffic_class=traffic_class,
+            ignore_standard_quota=ignore_standard_quota,
+            routing_costs=routing_costs_by_account_id,
+        )
+        if preferred.account is not None:
+            return preferred
+        if len(preferred_states) == len(state_list):
+            return preferred
+    if routing_strategy == "usage_weighted" and state_list:
+        return select_account(
+            state_list,
+            prefer_earlier_reset=prefer_earlier_reset,
+            prefer_earlier_reset_window=prefer_earlier_reset_window,
+            routing_strategy=routing_strategy,
+            allow_backoff_fallback=allow_backoff_fallback,
+            deterministic_probe=deterministic_probe,
+            usage_weighted_order="primary_first",
+            traffic_class=traffic_class,
+            ignore_standard_quota=ignore_standard_quota,
+            routing_costs=routing_costs_by_account_id,
+        )
+    return select_account(
+        state_list,
+        prefer_earlier_reset=prefer_earlier_reset,
+        prefer_earlier_reset_window=prefer_earlier_reset_window,
+        routing_strategy=routing_strategy,
+        allow_backoff_fallback=allow_backoff_fallback,
+        deterministic_probe=deterministic_probe,
+        relative_availability_power=relative_availability_power,
+        relative_availability_top_k=relative_availability_top_k,
+        traffic_class=traffic_class,
+        ignore_standard_quota=ignore_standard_quota,
+        routing_costs=routing_costs_by_account_id,
+    )
+
+
+def _best_health_tier_states(states: list[AccountState]) -> list[AccountState]:
+    healthy = [state for state in states if state.health_tier == HEALTH_TIER_HEALTHY]
+    if healthy:
+        return healthy
+    probing = [state for state in states if state.health_tier == HEALTH_TIER_PROBING]
+    if probing:
+        return probing
+    draining = [state for state in states if state.health_tier == HEALTH_TIER_DRAINING]
+    return draining or states
+
+
+def _clone_account(account: Account) -> Account:
+    data = {column.name: getattr(account, column.name) for column in Account.__table__.columns}
+    return Account(**data)

--- a/app/modules/proxy/_load_balancer/types.py
+++ b/app/modules/proxy/_load_balancer/types.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+AccountLeaseKind = Literal["response_create", "stream"]
+
+MAX_SELECTION_ATTEMPTS = 4
+
+
+@dataclass
+class RuntimeState:
+    reset_at: float | None = None
+    cooldown_until: float | None = None
+    last_error_at: float | None = None
+    last_selected_at: float | None = None
+    error_count: int = 0
+    version: int = 0
+    blocked_at: float | None = None
+    health_tier: int = 0
+    drain_entered_at: float | None = None
+    probe_success_streak: int = 0
+    inflight_response_creates: int = 0
+    inflight_streams: int = 0
+    leased_tokens: float = 0.0
+    leases: dict[str, AccountLease] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AccountLease:
+    lease_id: str
+    account_id: str
+    kind: AccountLeaseKind
+    acquired_at: float
+    estimated_tokens: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class AccountConcurrencyCaps:
+    response_create_limit: int
+    stream_limit: int
+    configured_response_create_limit: int | None = None
+    configured_stream_limit: int | None = None
+    replica_count: int = 1

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -18,10 +18,12 @@ from app.core.auth.refresh import RefreshError, is_transient_refresh_contention,
 from app.core.balancer.types import UpstreamError
 from app.core.clients.proxy import ProxyResponseError
 from app.core.clients.proxy_websocket import UpstreamResponsesWebSocket
-from app.core.errors import openai_error
+from app.core.errors import OpenAIErrorEnvelope, openai_error
 from app.core.openai.model_registry import get_model_registry
 from app.core.openai.models import OpenAIEvent
 from app.core.plan_types import account_plan_matches_allowed
+from app.core.resilience.network_recovery import PROCESS_NETWORK_UNAVAILABLE_CODE
+from app.core.resilience.overload import is_local_overload_error_code
 from app.core.types import JsonValue
 from app.core.upstream_proxy import ResolvedUpstreamRoute
 from app.db.models import Account
@@ -1184,3 +1186,67 @@ async def _websocket_full_replay_should_wait_for_continuity(
         return False
     async with pending_lock:
         return bool(pending_requests)
+
+
+def _is_account_neutral_error_code(code: str | None) -> bool:
+    return is_local_overload_error_code(code) or code in {
+        PROCESS_NETWORK_UNAVAILABLE_CODE,
+        "proxy_unavailable",
+        "responses_compact_input_too_large",
+    }
+
+
+def _is_local_account_cap_code(code: str | None) -> bool:
+    return code in {"account_response_create_cap", "account_stream_cap"}
+
+
+def _http_error_status_from_payload(payload: dict[str, JsonValue] | None) -> int | None:
+    if not isinstance(payload, dict):
+        return None
+    for status_field in ("status", "status_code"):
+        status = payload.get(status_field)
+        if isinstance(status, int) and not isinstance(status, bool):
+            return status
+    return None
+
+
+def _openai_error_envelope_from_response_failed_payload(
+    payload: dict[str, JsonValue] | None,
+) -> OpenAIErrorEnvelope:
+    default_envelope = openai_error("upstream_error", "Upstream error")
+    if not isinstance(payload, dict):
+        return default_envelope
+    response_payload = payload.get("response")
+    if not isinstance(response_payload, dict):
+        return default_envelope
+    error_payload = response_payload.get("error")
+    if not isinstance(error_payload, dict):
+        return default_envelope
+
+    message_value = error_payload.get("message")
+    if isinstance(message_value, str) and message_value.strip():
+        message = message_value.strip()
+    else:
+        message = "Upstream error"
+
+    code_value = error_payload.get("code")
+    code = code_value.strip() if isinstance(code_value, str) and code_value.strip() else "upstream_error"
+
+    type_value = error_payload.get("type")
+    error_type = type_value.strip() if isinstance(type_value, str) and type_value.strip() else "server_error"
+
+    envelope = openai_error(code, message, error_type)
+    param_value = error_payload.get("param")
+    if isinstance(param_value, str) and param_value.strip():
+        envelope["error"]["param"] = param_value.strip()
+    error_detail = envelope["error"]
+    plan_type = error_payload.get("plan_type")
+    if plan_type is not None:
+        error_detail["plan_type"] = str(plan_type)
+    resets_at = error_payload.get("resets_at")
+    if isinstance(resets_at, int | float):
+        error_detail["resets_at"] = resets_at
+    resets_in = error_payload.get("resets_in_seconds")
+    if isinstance(resets_in, int | float):
+        error_detail["resets_in_seconds"] = resets_in
+    return envelope

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -8,7 +8,7 @@ import time
 from collections.abc import Collection, Mapping
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Iterable, Literal
+from typing import TYPE_CHECKING, Iterable
 from uuid import uuid4
 
 from app.core import usage as usage_core
@@ -33,7 +33,9 @@ from app.core.balancer import (
     handle_quota_exceeded,
     handle_rate_limit,
     plausible_rate_limit_reset_at,
-    select_account,
+)
+from app.core.balancer import (
+    select_account as select_account,
 )
 from app.core.balancer.types import UpstreamError
 from app.core.config import settings as config_settings
@@ -55,6 +57,38 @@ from app.core.resilience.degradation import set_degraded, set_normal
 from app.core.usage.quota import apply_usage_quota
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, AdditionalUsageHistory, StickySessionKind, UsageHistory
+from app.modules.proxy._load_balancer.sticky_selection import (
+    _STICKY_EXISTING_UNSET,
+    SelectionInputsProtocol,
+    StickySelectionRequest,
+    _account_cap_error_code,
+    _account_cap_error_message,
+    _clone_account,
+    _filter_states_for_account_caps,
+    _select_account_preferring_budget_safe,
+    run_sticky_selection_path,
+)
+from app.modules.proxy._load_balancer.sticky_selection import (
+    _best_health_tier_states as _best_health_tier_states,
+)
+from app.modules.proxy._load_balancer.sticky_selection import (
+    _select_with_stickiness as _run_select_with_stickiness,
+)
+from app.modules.proxy._load_balancer.sticky_selection import (
+    _state_above_budget_threshold as _state_above_budget_threshold,
+)
+from app.modules.proxy._load_balancer.sticky_selection import (
+    _state_above_sticky_budget_threshold as _state_above_sticky_budget_threshold,
+)
+from app.modules.proxy._load_balancer.types import (
+    MAX_SELECTION_ATTEMPTS as _MAX_SELECTION_ATTEMPTS,
+)
+from app.modules.proxy._load_balancer.types import (
+    AccountConcurrencyCaps,
+    AccountLease,
+    AccountLeaseKind,
+    RuntimeState,
+)
 from app.modules.proxy.account_cache import get_account_selection_cache, mark_account_routing_unavailable
 from app.modules.proxy.additional_model_limits import get_additional_quota_key_for_model_id
 from app.modules.proxy.affinity import _CodexSessionSource
@@ -85,18 +119,7 @@ _SIBLING_FETCH_MARGIN_SECONDS = 5.0
 
 _UsageWindowEntry = UsageHistory | AdditionalUsageHistory
 
-_MAX_SELECTION_ATTEMPTS = 4
-
 _ACCOUNT_STREAM_LEASE_STALE_GRACE_SECONDS = 60.0
-_STICKY_GRACE_PERIOD_SECONDS = 10.0
-_STICKY_EXISTING_UNSET = object()
-_RECOVERABLE_STATUSES = frozenset(
-    {
-        AccountStatus.ACTIVE,
-        AccountStatus.RATE_LIMITED,
-        AccountStatus.QUOTA_EXCEEDED,
-    }
-)
 
 _DEFAULT_USAGE_REFRESH_INTERVAL_SECONDS = 60
 
@@ -111,35 +134,6 @@ _ADDITIONAL_QUOTA_ROUTING_POLICIES = _ACCOUNT_ROUTING_POLICIES | frozenset({"inh
 OPPORTUNISTIC_BURN_WINDOW_CLOSED = "opportunistic_burn_window_closed"
 _AMBIGUOUS_CONVERSATION_OWNER_CODE = "conversation_owner_unavailable"
 _AMBIGUOUS_CONVERSATION_OWNER_MESSAGE = "Conversation owner cannot be determined from the eligible account pool"
-
-AccountLeaseKind = Literal["response_create", "stream"]
-
-
-@dataclass
-class RuntimeState:
-    reset_at: float | None = None
-    cooldown_until: float | None = None
-    last_error_at: float | None = None
-    last_selected_at: float | None = None
-    error_count: int = 0
-    version: int = 0
-    blocked_at: float | None = None
-    health_tier: int = 0
-    drain_entered_at: float | None = None
-    probe_success_streak: int = 0
-    inflight_response_creates: int = 0
-    inflight_streams: int = 0
-    leased_tokens: float = 0.0
-    leases: dict[str, "AccountLease"] | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class AccountLease:
-    lease_id: str
-    account_id: str
-    kind: AccountLeaseKind
-    acquired_at: float
-    estimated_tokens: float = 0.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -166,15 +160,6 @@ class AccountSelection:
 
 
 @dataclass(frozen=True, slots=True)
-class AccountConcurrencyCaps:
-    response_create_limit: int
-    stream_limit: int
-    configured_response_create_limit: int | None = None
-    configured_stream_limit: int | None = None
-    replica_count: int = 1
-
-
-@dataclass(frozen=True, slots=True)
 class _ModelAccountFilterResult:
     accounts: list[Account]
     general_model_account_ids: frozenset[str] | None
@@ -190,7 +175,7 @@ class _AdditionalLimitFilterResult:
 
 
 @dataclass(frozen=True, slots=True)
-class _SelectionInputs:
+class _SelectionInputs(SelectionInputsProtocol):
     accounts: list[Account]
     latest_primary: dict[str, UsageHistory | AdditionalUsageHistory]
     latest_secondary: dict[str, UsageHistory | AdditionalUsageHistory]
@@ -725,290 +710,48 @@ class LoadBalancer:
                 break
 
         else:
-            sticky_existing_account_id: str | None | object = _STICKY_EXISTING_UNSET
-            attempt = 0
-            while True:
-                attempt += 1
-                async with self._runtime_lock:
-                    self._reclaim_stale_account_leases_locked()
-                    self._prune_runtime(selection_inputs.runtime_accounts or selection_inputs.accounts)
-                    states, account_map = _build_states(
-                        accounts=selection_inputs.accounts,
-                        latest_primary=selection_inputs.latest_primary,
-                        latest_secondary=selection_inputs.latest_secondary,
-                        latest_monthly=selection_inputs.latest_monthly,
-                        runtime=self._runtime,
-                        routing_policy_override=selection_inputs.routing_policy_override,
-                        ignore_standard_quota_account_ids=selection_inputs.ignore_standard_quota_account_ids,
-                    )
-                    if required_account_id is not None:
-                        states = [state for state in states if state.account_id == required_account_id]
-                        account_map = {
-                            account_id: account
-                            for account_id, account in account_map.items()
-                            if account_id == required_account_id
-                        }
-                    effective_routing_costs = (
-                        routing_costs_by_account_id
-                        if routing_costs_by_account_id is not None
-                        else build_routing_costs(
-                            settings=selection_inputs.quota_planner_settings,
-                            states=states,
-                            now=datetime.now(timezone.utc),
-                        )
-                    )
-                sticky_existing_is_legacy = isinstance(legacy_existing_account_id, str)
-                if sticky_key and sticky_kind == StickySessionKind.CODEX_SESSION:
-                    async with self._repo_factory() as repos:
-                        sticky_existing_account_id = await repos.sticky_sessions.get_account_id(
-                            sticky_key,
-                            kind=sticky_kind,
-                            max_age_seconds=sticky_max_age_seconds,
-                        )
-                    if isinstance(legacy_existing_account_id, str):
-                        # Mixed-version replicas can create both rows on
-                        # different accounts. The raw row was loaded before
-                        # branch selection and always wins as possible hard
-                        # turn-state ownership.
-                        sticky_existing_account_id = legacy_existing_account_id
-                # Key shape is deliberately irrelevant here. Only typed source
-                # provenance created by the affinity parser can grant mobility;
-                # otherwise a crafted hard turn-state key could become spillable.
-                bare_session_key = (
-                    sticky_kind == StickySessionKind.CODEX_SESSION
-                    and sticky_source == "session_header"
-                    and legacy_sticky_key is not None
-                    and not sticky_existing_is_legacy
+            sticky_outcome = await run_sticky_selection_path(
+                self,
+                request=StickySelectionRequest(
+                    sticky_key=sticky_key,
+                    sticky_kind=sticky_kind,
+                    reallocate_sticky=reallocate_sticky,
+                    sticky_source=sticky_source,
+                    legacy_sticky_key=legacy_sticky_key,
+                    legacy_existing_account_id=legacy_existing_account_id,
+                    spill_bare_session_on_account_cap=spill_bare_session_on_account_cap,
+                    require_unambiguous_account=require_unambiguous_account,
+                    sticky_max_age_seconds=sticky_max_age_seconds,
+                    prefer_earlier_reset_accounts=prefer_earlier_reset_accounts,
+                    prefer_earlier_reset_window=prefer_earlier_reset_window,
+                    routing_strategy=routing_strategy,
+                    relative_availability_power=relative_availability_power,
+                    relative_availability_top_k=relative_availability_top_k,
+                    required_account_id=required_account_id,
+                    budget_threshold_pct=budget_threshold_pct,
+                    secondary_budget_threshold_pct=secondary_budget_threshold_pct,
+                    routing_costs_by_account_id=routing_costs_by_account_id,
+                    lease_kind=lease_kind,
+                    estimated_lease_tokens=estimated_lease_tokens,
+                    stream_reserve_slots=stream_reserve_slots,
+                    traffic_class=traffic_class,
+                    concurrency_caps=caps,
+                    selection_inputs=selection_inputs,
+                    reload_inputs=load_selection_inputs,
+                    record_account_cap_rejection=_record_account_cap_rejection,
+                ),
+            )
+            selection_inputs = sticky_outcome.selection_inputs
+            selected_snapshot = sticky_outcome.selected_snapshot
+            selected_lease = sticky_outcome.selected_lease
+            error_message = sticky_outcome.error_message
+            selection_error_code = sticky_outcome.error_code
+            if sticky_outcome.disposition == "direct_error":
+                return AccountSelection(
+                    account=None,
+                    error_message=error_message,
+                    error_code=selection_error_code,
                 )
-                cap_spillover_allowed = (
-                    spill_bare_session_on_account_cap and lease_kind is not None and bare_session_key
-                )
-                hard_sticky = (
-                    sticky_kind == StickySessionKind.CODEX_SESSION
-                    and isinstance(sticky_existing_account_id, str)
-                    and not bare_session_key
-                )
-                if (
-                    hard_sticky
-                    and required_account_id is not None
-                    and sticky_existing_account_id != required_account_id
-                ):
-                    return AccountSelection(
-                        account=None,
-                        error_message="Account-owned continuity sources conflict; retry the logical turn",
-                        error_code="continuity_owner_conflict",
-                    )
-                # A resolved hard row proves ownership. Without one, use the
-                # same pre-health/pre-cap pool as the no-sticky path above.
-                if (
-                    require_unambiguous_account
-                    and not hard_sticky
-                    and len(selection_inputs.effective_continuity_owner_candidates) != 1
-                ):
-                    return AccountSelection(
-                        account=None,
-                        error_message=_AMBIGUOUS_CONVERSATION_OWNER_MESSAGE,
-                        error_code=_AMBIGUOUS_CONVERSATION_OWNER_CODE,
-                    )
-                if hard_sticky:
-                    # A resolved hard Codex mapping is an ownership constraint,
-                    # not a preference. Scope, exclusions, health, and caps may
-                    # make it unavailable, but must never delete or rebind it.
-                    selection_states = [state for state in states if state.account_id == sticky_existing_account_id]
-                elif bare_session_key and isinstance(sticky_existing_account_id, str) and not cap_spillover_allowed:
-                    # Mobility was revoked by owner-bearing payload or recovery
-                    # stage. Keep the old cap exception for this soft hint; the
-                    # authoritative preferred-owner path normally bypasses it.
-                    selection_states = states
-                else:
-                    selection_states = _filter_states_for_account_caps(
-                        states,
-                        lease_kind=lease_kind,
-                        caps=caps,
-                        stream_reserve_slots=stream_reserve_slots,
-                    )
-                if cap_spillover_allowed and lease_kind == "stream":
-                    # Stream selection immediately precedes response-create
-                    # admission. Prefer an account that can satisfy both, while
-                    # preserving the later create-cap error when all are full.
-                    response_create_states = _filter_states_for_account_caps(
-                        selection_states,
-                        lease_kind="response_create",
-                        caps=caps,
-                        stream_reserve_slots=0,
-                    )
-                    selection_states = response_create_states or selection_states
-                preserve_existing_mapping = (
-                    bare_session_key
-                    and isinstance(sticky_existing_account_id, str)
-                    and (
-                        (
-                            cap_spillover_allowed
-                            and any(state.account_id == sticky_existing_account_id for state in states)
-                            and not any(state.account_id == sticky_existing_account_id for state in selection_states)
-                        )
-                        or require_unambiguous_account
-                    )
-                )
-                if hard_sticky and not selection_states:
-                    selection_error_code = "hard_affinity_saturated"
-                    result = SelectionResult(None, "Hard affinity owner account is unavailable")
-                elif not selection_states and states:
-                    selection_error_code = _account_cap_error_code(lease_kind)
-                    result = SelectionResult(None, _account_cap_error_message(lease_kind, caps))
-                    logger.warning(
-                        "Account cap exhausted during sticky selection lease_kind=%s reason=%s candidates=%s",
-                        lease_kind,
-                        selection_error_code,
-                        len(states),
-                    )
-                    _record_account_cap_rejection(lease_kind)
-                elif hard_sticky:
-                    # Hard rows are ownership evidence. Select only from the
-                    # resolved owner state and never enter sticky fallback code,
-                    # which may delete or rebind soft mappings under pressure.
-                    result = _select_account_preferring_budget_safe(
-                        selection_states,
-                        prefer_earlier_reset=prefer_earlier_reset_accounts,
-                        prefer_earlier_reset_window=prefer_earlier_reset_window,
-                        routing_strategy=routing_strategy,
-                        relative_availability_power=relative_availability_power,
-                        relative_availability_top_k=relative_availability_top_k,
-                        budget_threshold_pct=budget_threshold_pct,
-                        secondary_budget_threshold_pct=secondary_budget_threshold_pct,
-                        traffic_class=traffic_class,
-                        ignore_standard_quota=False,
-                        routing_costs_by_account_id=effective_routing_costs,
-                    )
-                    if result.account is None:
-                        selection_error_code = "hard_affinity_saturated"
-                        result = SelectionResult(
-                            None,
-                            result.error_message or "Hard affinity owner account is unavailable",
-                        )
-                    else:
-                        selection_error_code = None
-                else:
-                    selection_error_code = None
-                    async with self._repo_factory() as repos:
-                        result = await self._select_with_stickiness(
-                            states=selection_states,
-                            account_map=account_map,
-                            sticky_key=sticky_key,
-                            sticky_kind=sticky_kind,
-                            reallocate_sticky=reallocate_sticky,
-                            sticky_max_age_seconds=sticky_max_age_seconds,
-                            budget_threshold_pct=budget_threshold_pct,
-                            secondary_budget_threshold_pct=secondary_budget_threshold_pct,
-                            prefer_earlier_reset_accounts=prefer_earlier_reset_accounts,
-                            prefer_earlier_reset_window=prefer_earlier_reset_window,
-                            routing_strategy=routing_strategy,
-                            relative_availability_power=relative_availability_power,
-                            relative_availability_top_k=relative_availability_top_k,
-                            sticky_repo=repos.sticky_sessions,
-                            sticky_existing_account_id=sticky_existing_account_id,
-                            preserve_existing_mapping_on_fallback=preserve_existing_mapping,
-                            traffic_class=traffic_class,
-                            ignore_standard_quota=False,
-                            routing_costs_by_account_id=effective_routing_costs,
-                        )
-                selected_account_map = account_map
-                selected_states = []
-                async with self._runtime_lock:
-                    for state in states:
-                        account = account_map.get(state.account_id)
-                        if account is None:
-                            continue
-                        self._sync_runtime_state(
-                            account,
-                            state,
-                            selected=result.account is not None and state.account_id == result.account.account_id,
-                        )
-                        selected_states.append(state)
-                    if result.account is not None:
-                        selected = account_map.get(result.account.account_id)
-                        if selected is None:
-                            error_message = result.error_message
-                        else:
-                            selected_reset_at = selected.reset_at
-                            for state in selected_states:
-                                if state.account_id == result.account.account_id:
-                                    state.status = result.account.status
-                                    state.deactivation_reason = result.account.deactivation_reason
-                                    selected_reset_at = int(state.reset_at) if state.reset_at else None
-                                    break
-                            selected_snapshot = _clone_account(selected)
-                            selected_snapshot.status = result.account.status
-                            selected_snapshot.deactivation_reason = result.account.deactivation_reason
-                            selected_snapshot.reset_at = selected_reset_at
-                            if lease_kind is not None:
-                                if not self._account_lease_allowed_locked(
-                                    selected.id,
-                                    kind=lease_kind,
-                                    caps=caps,
-                                    stream_reserve_slots=stream_reserve_slots,
-                                ):
-                                    selected_snapshot = None
-                                    selection_error_code = _account_cap_error_code(lease_kind)
-                                    error_message = _account_cap_error_message(lease_kind, caps)
-                                else:
-                                    selected_lease = self._acquire_account_lease_locked(
-                                        selected.id,
-                                        kind=lease_kind,
-                                        estimated_tokens=estimated_lease_tokens,
-                                    )
-                    else:
-                        error_message = result.error_message
-
-                try:
-                    async with self._repo_factory() as repos:
-                        stale_account_ids = await self._persist_selection_state(
-                            repos.accounts,
-                            selected_account_map,
-                            selected_states,
-                        )
-                except BaseException:
-                    await self.release_account_lease(selected_lease)
-                    selected_lease = None
-                    raise
-                stale_account_ids = stale_account_ids or set()
-                if selected_snapshot is not None and selected_snapshot.id in stale_account_ids:
-                    await self.release_account_lease(selected_lease)
-                    selected_lease = None
-                    selected_snapshot = None
-                    error_message = None
-                    selected_states = []
-                    selected_account_map = {}
-                    if attempt >= _MAX_SELECTION_ATTEMPTS:
-                        break
-                    selection_inputs = await load_selection_inputs()
-                    if selection_inputs.error_code is not None and not selection_inputs.accounts:
-                        return AccountSelection(
-                            account=None,
-                            error_message=selection_inputs.error_message,
-                            error_code=selection_inputs.error_code,
-                        )
-                    await asyncio.sleep(0)
-                    continue
-                if (
-                    selected_snapshot is None
-                    and selection_error_code is not None
-                    and not hard_sticky
-                    and attempt < _MAX_SELECTION_ATTEMPTS
-                ):
-                    selection_inputs = await load_selection_inputs()
-                    if selection_inputs.error_code is not None and not selection_inputs.accounts:
-                        return AccountSelection(
-                            account=None,
-                            error_message=selection_inputs.error_message,
-                            error_code=selection_inputs.error_code,
-                        )
-                    error_message = None
-                    selected_states = []
-                    selected_account_map = {}
-                    await asyncio.sleep(0)
-                    continue
-                break
 
         if selected_snapshot is None:
             logger.warning(
@@ -1522,6 +1265,30 @@ class LoadBalancer:
         for account_id in stale_ids:
             self._runtime.pop(account_id, None)
 
+    def _prepare_sticky_selection_states(
+        self,
+        selection_inputs: SelectionInputsProtocol,
+        *,
+        required_account_id: str | None,
+    ) -> tuple[list[AccountState], dict[str, Account]]:
+        self._reclaim_stale_account_leases_locked()
+        self._prune_runtime(selection_inputs.runtime_accounts or selection_inputs.accounts)
+        states, account_map = _build_states(
+            accounts=selection_inputs.accounts,
+            latest_primary=selection_inputs.latest_primary,
+            latest_secondary=selection_inputs.latest_secondary,
+            latest_monthly=selection_inputs.latest_monthly,
+            runtime=self._runtime,
+            routing_policy_override=selection_inputs.routing_policy_override,
+            ignore_standard_quota_account_ids=selection_inputs.ignore_standard_quota_account_ids,
+        )
+        if required_account_id is None:
+            return states, account_map
+        return (
+            [state for state in states if state.account_id == required_account_id],
+            {account_id: account for account_id, account in account_map.items() if account_id == required_account_id},
+        )
+
     async def _get_account_lock(self, account_id: str) -> asyncio.Lock:
         lock = self._account_locks.get(account_id)
         if lock is not None:
@@ -1573,233 +1340,27 @@ class LoadBalancer:
         traffic_class: TrafficClass = TRAFFIC_CLASS_FOREGROUND,
         ignore_standard_quota: bool = False,
     ) -> SelectionResult:
-        if not sticky_key or not sticky_repo:
-            return _select_account_preferring_budget_safe(
-                states,
-                prefer_earlier_reset=prefer_earlier_reset_accounts,
-                prefer_earlier_reset_window=prefer_earlier_reset_window,
-                routing_strategy=routing_strategy,
-                relative_availability_power=relative_availability_power,
-                relative_availability_top_k=relative_availability_top_k,
-                budget_threshold_pct=budget_threshold_pct,
-                traffic_class=traffic_class,
-                ignore_standard_quota=ignore_standard_quota,
-                routing_costs_by_account_id=routing_costs_by_account_id,
-            )
-        if sticky_kind is None:
-            raise ValueError("sticky_kind is required when sticky_key is provided")
-
-        if sticky_existing_account_id is _STICKY_EXISTING_UNSET:
-            existing = await sticky_repo.get_account_id(
-                sticky_key,
-                kind=sticky_kind,
-                max_age_seconds=sticky_max_age_seconds,
-            )
-        else:
-            existing = sticky_existing_account_id if isinstance(sticky_existing_account_id, str) else None
-        # When the pinned account is temporarily unavailable (rate-limited,
-        # error backoff) but still in the pool, pick a fallback WITHOUT
-        # overwriting the sticky mapping so the next request returns to the
-        # original account — and its warm OpenAI prompt cache — once it
-        # recovers.  Only reallocate_sticky=True opts in to permanent
-        # reassignment.
-        persist_fallback = not preserve_existing_mapping_on_fallback
-        apply_sticky_secondary_budget_threshold = False
-
-        if existing:
-            pinned = next((state for state in states if state.account_id == existing), None)
-            if pinned is not None:
-                # Proactively rebind session affinity for any sticky kind
-                # once the pinned account is already above the configured
-                # budget threshold. That preserves continuity below the
-                # threshold while avoiding obvious short-window failures once
-                # the session is skating on the edge of exhaustion.
-                now = time.time()
-                budget_pressured = (
-                    sticky_kind
-                    in (
-                        StickySessionKind.PROMPT_CACHE,
-                        StickySessionKind.STICKY_THREAD,
-                        StickySessionKind.CODEX_SESSION,
-                    )
-                    and routing_strategy not in ("sequential_drain", "reset_drain", "single_account")
-                    and pinned.status != AccountStatus.RATE_LIMITED
-                    and _state_above_sticky_budget_threshold(
-                        pinned,
-                        budget_threshold_pct,
-                        secondary_budget_threshold_pct,
-                    )
-                )
-                rate_limit_far_away = (
-                    sticky_kind == StickySessionKind.PROMPT_CACHE
-                    and pinned.status == AccountStatus.RATE_LIMITED
-                    and pinned.reset_at is not None
-                    and pinned.reset_at - now >= 600  # 10 minutes
-                )
-
-                burn_first_reallocate = pinned.routing_policy != ROUTING_POLICY_BURN_FIRST
-                if burn_first_reallocate:
-                    burn_first_candidates = [
-                        state for state in states if state.routing_policy == ROUTING_POLICY_BURN_FIRST
-                    ]
-                    if burn_first_candidates:
-                        burn_first = select_account(
-                            burn_first_candidates,
-                            prefer_earlier_reset=prefer_earlier_reset_accounts,
-                            routing_strategy=routing_strategy,
-                            allow_backoff_fallback=False,
-                            deterministic_probe=True,
-                            relative_availability_power=relative_availability_power,
-                            relative_availability_top_k=relative_availability_top_k,
-                            traffic_class=traffic_class,
-                            ignore_standard_quota=ignore_standard_quota,
-                        )
-                        burn_first_reallocate = burn_first.account is not None
-
-                if not ((budget_pressured or rate_limit_far_away) and burn_first_reallocate):
-                    pinned_result = select_account(
-                        [pinned],
-                        prefer_earlier_reset=prefer_earlier_reset_accounts,
-                        prefer_earlier_reset_window=prefer_earlier_reset_window,
-                        routing_strategy=routing_strategy,
-                        allow_backoff_fallback=False,
-                        relative_availability_power=relative_availability_power,
-                        relative_availability_top_k=relative_availability_top_k,
-                        traffic_class=traffic_class,
-                        ignore_standard_quota=ignore_standard_quota,
-                        routing_costs=routing_costs_by_account_id,
-                    )
-                    if pinned_result.account is not None:
-                        if sticky_max_age_seconds is not None:
-                            await sticky_repo.upsert(sticky_key, pinned.account_id, kind=sticky_kind)
-                        return pinned_result
-                else:
-                    # Reallocate only when a burn-first target exists and can
-                    # currently be selected, avoiding sticky churn to
-                    # ineligible targets.
-                    # Before reallocating, check whether the pool has a
-                    # meaningfully better candidate.  When every account
-                    # is above the budget threshold, reallocating just
-                    # wastes DB writes and destroys prompt-cache locality
-                    # (thrashing).
-                    if budget_pressured:
-                        apply_sticky_secondary_budget_threshold = True
-                        pool_best = _select_account_preferring_budget_safe(
-                            states,
-                            prefer_earlier_reset=prefer_earlier_reset_accounts,
-                            prefer_earlier_reset_window=prefer_earlier_reset_window,
-                            routing_strategy=routing_strategy,
-                            relative_availability_power=relative_availability_power,
-                            relative_availability_top_k=relative_availability_top_k,
-                            deterministic_probe=True,
-                            budget_threshold_pct=budget_threshold_pct,
-                            secondary_budget_threshold_pct=secondary_budget_threshold_pct,
-                            apply_secondary_budget_threshold=True,
-                            traffic_class=traffic_class,
-                            ignore_standard_quota=ignore_standard_quota,
-                            routing_costs_by_account_id=routing_costs_by_account_id,
-                        )
-                        pool_also_exhausted = pool_best.account is not None and (
-                            pool_best.account.account_id == pinned.account_id
-                            or _state_above_sticky_budget_threshold(
-                                pool_best.account,
-                                budget_threshold_pct,
-                                secondary_budget_threshold_pct,
-                            )
-                        )
-                        if pool_also_exhausted:
-                            pinned_result = select_account(
-                                [pinned],
-                                prefer_earlier_reset=prefer_earlier_reset_accounts,
-                                prefer_earlier_reset_window=prefer_earlier_reset_window,
-                                routing_strategy=routing_strategy,
-                                allow_backoff_fallback=False,
-                                relative_availability_power=relative_availability_power,
-                                relative_availability_top_k=relative_availability_top_k,
-                                traffic_class=traffic_class,
-                                ignore_standard_quota=ignore_standard_quota,
-                                routing_costs=routing_costs_by_account_id,
-                            )
-                            if pinned_result.account is not None:
-                                if sticky_max_age_seconds is not None:
-                                    await sticky_repo.upsert(
-                                        sticky_key,
-                                        pinned.account_id,
-                                        kind=sticky_kind,
-                                    )
-                                return pinned_result
-                    reallocate_sticky = True
-                # Grace period: if the pinned account is rate-limited with a
-                # known reset time within a short window, retry selection
-                # with a small time advance to preserve prompt cache.
-                # A shallow copy is used so the time-advanced selection does
-                # not mutate the original state (which is later synced to DB
-                # by _sync_state for all accounts).
-                if not reallocate_sticky and pinned.status == AccountStatus.RATE_LIMITED:
-                    grace_copy = replace(pinned)
-                    grace_result = select_account(
-                        [grace_copy],
-                        now=time.time() + _STICKY_GRACE_PERIOD_SECONDS,
-                        prefer_earlier_reset=prefer_earlier_reset_accounts,
-                        prefer_earlier_reset_window=prefer_earlier_reset_window,
-                        routing_strategy=routing_strategy,
-                        allow_backoff_fallback=False,
-                        relative_availability_power=relative_availability_power,
-                        relative_availability_top_k=relative_availability_top_k,
-                        traffic_class=traffic_class,
-                        ignore_standard_quota=ignore_standard_quota,
-                        routing_costs=routing_costs_by_account_id,
-                    )
-                    if grace_result.account is not None:
-                        if sticky_max_age_seconds is not None:
-                            await sticky_repo.upsert(sticky_key, pinned.account_id, kind=sticky_kind)
-                        return grace_result
-                if reallocate_sticky:
-                    await sticky_repo.delete(sticky_key, kind=sticky_kind)
-                elif pinned.status not in _RECOVERABLE_STATUSES:
-                    # Permanently down (PAUSED/DEACTIVATED) — let the
-                    # fallback be persisted to rebind the mapping.
-                    pass
-                elif sticky_max_age_seconds is not None:
-                    # TTL-based kind (PROMPT_CACHE): preserve the original
-                    # mapping so the next request returns to the warm-cache
-                    # account once it recovers.  The TTL will naturally
-                    # expire the mapping if recovery takes too long.
-                    persist_fallback = False
-                # else: durable kind without TTL (CODEX_SESSION) — persist
-                # fallback so the session sticks to one account during
-                # the outage instead of bouncing across random fallbacks.
-            else:
-                if not preserve_existing_mapping_on_fallback:
-                    await sticky_repo.delete(sticky_key, kind=sticky_kind)
-
-        chosen = _select_account_preferring_budget_safe(
-            states,
-            prefer_earlier_reset=prefer_earlier_reset_accounts,
+        return await _run_select_with_stickiness(
+            states=states,
+            account_map=account_map,
+            sticky_key=sticky_key,
+            sticky_kind=sticky_kind,
+            reallocate_sticky=reallocate_sticky,
+            sticky_max_age_seconds=sticky_max_age_seconds,
+            budget_threshold_pct=budget_threshold_pct,
+            secondary_budget_threshold_pct=secondary_budget_threshold_pct,
+            prefer_earlier_reset_accounts=prefer_earlier_reset_accounts,
             prefer_earlier_reset_window=prefer_earlier_reset_window,
             routing_strategy=routing_strategy,
             relative_availability_power=relative_availability_power,
             relative_availability_top_k=relative_availability_top_k,
-            budget_threshold_pct=budget_threshold_pct,
-            secondary_budget_threshold_pct=secondary_budget_threshold_pct,
-            apply_secondary_budget_threshold=apply_sticky_secondary_budget_threshold,
+            sticky_repo=sticky_repo,
+            routing_costs_by_account_id=routing_costs_by_account_id,
+            sticky_existing_account_id=sticky_existing_account_id,
+            preserve_existing_mapping_on_fallback=preserve_existing_mapping_on_fallback,
             traffic_class=traffic_class,
             ignore_standard_quota=ignore_standard_quota,
-            routing_costs_by_account_id=routing_costs_by_account_id,
         )
-        if persist_fallback and chosen.account is not None and chosen.account.account_id in account_map:
-            await sticky_repo.upsert(sticky_key, chosen.account.account_id, kind=sticky_kind)
-        elif preserve_existing_mapping_on_fallback and chosen.account is not None and existing is not None:
-            # Spillover is deliberately request-local. The alternate may create
-            # its own hard response/file/bridge owner, but local cap pressure
-            # alone never turns this soft mapping into a distributed commit.
-            logger.info(
-                "internal_soft_affinity_spillover old_account_id=%s new_account_id=%s sticky_kind=%s",
-                existing,
-                chosen.account.account_id,
-                sticky_kind.value,
-            )
-        return chosen
 
     async def mark_rate_limit(self, account: Account, error: UpstreamError) -> None:
         lock = await self._get_account_lock(account.id)
@@ -2105,64 +1666,6 @@ def _account_lease_stale_ttl_seconds(kind: AccountLeaseKind, settings: object) -
         float(getattr(settings, "http_responses_session_bridge_request_budget_seconds", ttl_seconds)),
     )
     return max(ttl_seconds, valid_stream_budget_seconds + _ACCOUNT_STREAM_LEASE_STALE_GRACE_SECONDS)
-
-
-def _filter_states_for_account_caps(
-    states: Iterable[AccountState],
-    *,
-    lease_kind: AccountLeaseKind | None,
-    caps: AccountConcurrencyCaps,
-    stream_reserve_slots: int = 0,
-) -> list[AccountState]:
-    if lease_kind is None:
-        return list(states)
-    filtered: list[AccountState] = []
-    for state in states:
-        if lease_kind == "response_create":
-            cap = caps.response_create_limit
-            if cap > 0 and state.inflight_response_creates >= cap:
-                continue
-        else:
-            cap = caps.stream_limit
-            effective_cap = max(1, cap - max(0, stream_reserve_slots))
-            if cap > 0 and state.inflight_streams >= effective_cap:
-                continue
-        filtered.append(state)
-    return filtered
-
-
-def _account_cap_error_code(lease_kind: AccountLeaseKind | None) -> str | None:
-    if lease_kind == "response_create":
-        return "account_response_create_cap"
-    if lease_kind == "stream":
-        return "account_stream_cap"
-    return None
-
-
-def _account_cap_error_message(lease_kind: AccountLeaseKind | None, caps: AccountConcurrencyCaps) -> str:
-    if lease_kind == "response_create":
-        cap = caps.response_create_limit
-        if caps.replica_count > 1 and caps.configured_response_create_limit is not None:
-            return (
-                f"Account response-create capacity is exhausted; this replica's share is {cap} "
-                f"of the per-account limit {caps.configured_response_create_limit} "
-                f"across {caps.replica_count} replicas"
-            )
-        return f"Account response-create capacity is exhausted; per-account limit is {cap}"
-    if lease_kind == "stream":
-        cap = caps.stream_limit
-        if caps.replica_count > 1 and caps.configured_stream_limit is not None:
-            return (
-                f"Account stream capacity is exhausted; this replica's share is {cap} "
-                f"of the per-account limit {caps.configured_stream_limit} "
-                f"across {caps.replica_count} replicas. "
-                "Increase the dashboard stream limit or wait for active streams to finish."
-            )
-        return (
-            f"Account stream capacity is exhausted; per-account limit is {cap}. "
-            "Increase the dashboard stream limit or wait for active streams to finish."
-        )
-    return "Account capacity is exhausted"
 
 
 def effective_account_concurrency_caps(dashboard_settings: object | None = None) -> AccountConcurrencyCaps:
@@ -2934,11 +2437,6 @@ def _mapped_model_has_registry_entry(model: str | None) -> bool:
     return callable(is_suppressed_model) and is_suppressed_model(model)
 
 
-def _clone_account(account: Account) -> Account:
-    data = {column.name: getattr(account, column.name) for column in Account.__table__.columns}
-    return Account(**data)
-
-
 def _first_not_none(
     primary_entry: UsageHistory | AdditionalUsageHistory | None,
     secondary_entry: UsageHistory | AdditionalUsageHistory | None,
@@ -3086,164 +2584,6 @@ def _additional_usage_is_exhausted(entry: AdditionalUsageHistory) -> bool:
     if entry.reset_at is not None and int(entry.reset_at) <= int(time.time()):
         return False
     return float(entry.used_percent) >= 100.0
-
-
-def _state_above_budget_threshold(state: AccountState, budget_threshold_pct: float) -> bool:
-    used_percent = state.priority_used_percent if state.priority_used_percent is not None else state.used_percent
-    return used_percent is not None and used_percent > budget_threshold_pct
-
-
-def _state_above_sticky_budget_threshold(
-    state: AccountState,
-    budget_threshold_pct: float,
-    secondary_budget_threshold_pct: float | None = None,
-) -> bool:
-    secondary_threshold = (
-        budget_threshold_pct if secondary_budget_threshold_pct is None else secondary_budget_threshold_pct
-    )
-    used_percent = state.priority_used_percent if state.priority_used_percent is not None else state.used_percent
-    if state.limit_scoped_usage and state.priority_secondary_used_percent is None:
-        secondary_used_percent = used_percent
-    else:
-        secondary_used_percent = (
-            state.priority_secondary_used_percent
-            if state.priority_secondary_used_percent is not None
-            else state.secondary_used_percent
-        )
-    return (used_percent is not None and used_percent > budget_threshold_pct) or (
-        secondary_used_percent is not None and secondary_used_percent > secondary_threshold
-    )
-
-
-def _select_account_preferring_budget_safe(
-    states: Iterable[AccountState],
-    *,
-    prefer_earlier_reset: bool,
-    prefer_earlier_reset_window: ResetPreferenceWindow = "secondary",
-    routing_strategy: RoutingStrategy,
-    relative_availability_power: float = 2.0,
-    relative_availability_top_k: int = 5,
-    budget_threshold_pct: float,
-    secondary_budget_threshold_pct: float = 100.0,
-    apply_secondary_budget_threshold: bool = False,
-    allow_backoff_fallback: bool = True,
-    deterministic_probe: bool = False,
-    traffic_class: TrafficClass = TRAFFIC_CLASS_FOREGROUND,
-    ignore_standard_quota: bool = False,
-    routing_costs_by_account_id: RoutingCostsByAccount | None = None,
-) -> SelectionResult:
-    state_list = list(states)
-    state_budget_threshold = (
-        (
-            lambda state: _state_above_sticky_budget_threshold(
-                state,
-                budget_threshold_pct,
-                secondary_budget_threshold_pct,
-            )
-        )
-        if apply_secondary_budget_threshold
-        else (lambda state: _state_above_budget_threshold(state, budget_threshold_pct))
-    )
-    if routing_strategy in ("sequential_drain", "reset_drain", "single_account"):
-        budget_safe_states = [
-            state
-            for state in state_list
-            if state.routing_policy != ROUTING_POLICY_PRESERVE and not state_budget_threshold(state)
-        ]
-        return select_account(
-            budget_safe_states or state_list,
-            prefer_earlier_reset=prefer_earlier_reset,
-            prefer_earlier_reset_window=prefer_earlier_reset_window,
-            routing_strategy=routing_strategy,
-            allow_backoff_fallback=allow_backoff_fallback,
-            deterministic_probe=deterministic_probe,
-            relative_availability_power=relative_availability_power,
-            relative_availability_top_k=relative_availability_top_k,
-            traffic_class=traffic_class,
-            ignore_standard_quota=ignore_standard_quota,
-            routing_costs=routing_costs_by_account_id,
-        )
-
-    best_health_states = _best_health_tier_states(state_list)
-    burn_first_states = [state for state in best_health_states if state.routing_policy == ROUTING_POLICY_BURN_FIRST]
-    if burn_first_states:
-        burn_first = select_account(
-            burn_first_states,
-            prefer_earlier_reset=prefer_earlier_reset,
-            prefer_earlier_reset_window=prefer_earlier_reset_window,
-            routing_strategy=routing_strategy,
-            allow_backoff_fallback=False,
-            deterministic_probe=deterministic_probe,
-            relative_availability_power=relative_availability_power,
-            relative_availability_top_k=relative_availability_top_k,
-            traffic_class=traffic_class,
-            ignore_standard_quota=ignore_standard_quota,
-            routing_costs=routing_costs_by_account_id,
-        )
-        if burn_first.account is not None:
-            return burn_first
-
-    preferred_states = [
-        state
-        for state in state_list
-        if state.routing_policy != ROUTING_POLICY_PRESERVE and not state_budget_threshold(state)
-    ]
-    if preferred_states:
-        selection_pool = preferred_states if len(preferred_states) != len(state_list) else state_list
-        preferred = select_account(
-            selection_pool,
-            prefer_earlier_reset=prefer_earlier_reset,
-            prefer_earlier_reset_window=prefer_earlier_reset_window,
-            routing_strategy=routing_strategy,
-            allow_backoff_fallback=allow_backoff_fallback,
-            deterministic_probe=deterministic_probe,
-            relative_availability_power=relative_availability_power,
-            relative_availability_top_k=relative_availability_top_k,
-            traffic_class=traffic_class,
-            ignore_standard_quota=ignore_standard_quota,
-            routing_costs=routing_costs_by_account_id,
-        )
-        if preferred.account is not None:
-            return preferred
-        if len(preferred_states) == len(state_list):
-            return preferred
-    if routing_strategy == "usage_weighted" and state_list:
-        return select_account(
-            state_list,
-            prefer_earlier_reset=prefer_earlier_reset,
-            prefer_earlier_reset_window=prefer_earlier_reset_window,
-            routing_strategy=routing_strategy,
-            allow_backoff_fallback=allow_backoff_fallback,
-            deterministic_probe=deterministic_probe,
-            usage_weighted_order="primary_first",
-            traffic_class=traffic_class,
-            ignore_standard_quota=ignore_standard_quota,
-            routing_costs=routing_costs_by_account_id,
-        )
-    return select_account(
-        state_list,
-        prefer_earlier_reset=prefer_earlier_reset,
-        prefer_earlier_reset_window=prefer_earlier_reset_window,
-        routing_strategy=routing_strategy,
-        allow_backoff_fallback=allow_backoff_fallback,
-        deterministic_probe=deterministic_probe,
-        relative_availability_power=relative_availability_power,
-        relative_availability_top_k=relative_availability_top_k,
-        traffic_class=traffic_class,
-        ignore_standard_quota=ignore_standard_quota,
-        routing_costs=routing_costs_by_account_id,
-    )
-
-
-def _best_health_tier_states(states: list[AccountState]) -> list[AccountState]:
-    healthy = [state for state in states if state.health_tier == HEALTH_TIER_HEALTHY]
-    if healthy:
-        return healthy
-    probing = [state for state in states if state.health_tier == HEALTH_TIER_PROBING]
-    if probing:
-        return probing
-    draining = [state for state in states if state.health_tier == HEALTH_TIER_DRAINING]
-    return draining or states
 
 
 def _is_upstream_circuit_breaker_open() -> bool:

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -84,11 +84,9 @@ from app.core.openai.requests import (
     ResponsesCompactRequest,
     ResponsesRequest,
 )
-from app.core.resilience.network_recovery import PROCESS_NETWORK_UNAVAILABLE_CODE
 from app.core.resilience.network_recovery import (
     ProcessNetworkRecovery as ProcessNetworkRecovery,
 )
-from app.core.resilience.overload import is_local_overload_error_code
 from app.core.types import JsonValue
 from app.core.upstream_proxy import UpstreamProxyRouteError
 from app.core.upstream_proxy.resolver import (
@@ -565,9 +563,13 @@ from app.modules.proxy._service.support import (
     _event_type_from_payload,  # noqa: F401
     _FilePinEntry,
     _finalize_ttft_reasoning_deltas,  # noqa: F401
+    _http_error_status_from_payload,  # noqa: F401
     _HTTPBridgeSession,
     _HTTPBridgeSessionKey,
+    _is_account_neutral_error_code,
+    _is_local_account_cap_code,  # noqa: F401
     _is_ttft_event,  # noqa: F401
+    _openai_error_envelope_from_response_failed_payload,  # noqa: F401
     _PreparedWebSocketRequest,  # noqa: F401
     _record_response_event,  # noqa: F401
     _record_websocket_route_metadata,  # noqa: F401
@@ -2038,70 +2040,6 @@ class ProxyService(
             code,
             http_status=exc.status_code,
         )
-
-
-def _is_account_neutral_error_code(code: str | None) -> bool:
-    return is_local_overload_error_code(code) or code in {
-        PROCESS_NETWORK_UNAVAILABLE_CODE,
-        "proxy_unavailable",
-        "responses_compact_input_too_large",
-    }
-
-
-def _is_local_account_cap_code(code: str | None) -> bool:
-    return code in {"account_response_create_cap", "account_stream_cap"}
-
-
-def _http_error_status_from_payload(payload: dict[str, JsonValue] | None) -> int | None:
-    if not isinstance(payload, dict):
-        return None
-    for status_field in ("status", "status_code"):
-        status = payload.get(status_field)
-        if isinstance(status, int) and not isinstance(status, bool):
-            return status
-    return None
-
-
-def _openai_error_envelope_from_response_failed_payload(
-    payload: dict[str, JsonValue] | None,
-) -> OpenAIErrorEnvelope:
-    default_envelope = openai_error("upstream_error", "Upstream error")
-    if not isinstance(payload, dict):
-        return default_envelope
-    response_payload = payload.get("response")
-    if not isinstance(response_payload, dict):
-        return default_envelope
-    error_payload = response_payload.get("error")
-    if not isinstance(error_payload, dict):
-        return default_envelope
-
-    message_value = error_payload.get("message")
-    if isinstance(message_value, str) and message_value.strip():
-        message = message_value.strip()
-    else:
-        message = "Upstream error"
-
-    code_value = error_payload.get("code")
-    code = code_value.strip() if isinstance(code_value, str) and code_value.strip() else "upstream_error"
-
-    type_value = error_payload.get("type")
-    error_type = type_value.strip() if isinstance(type_value, str) and type_value.strip() else "server_error"
-
-    envelope = openai_error(code, message, error_type)
-    param_value = error_payload.get("param")
-    if isinstance(param_value, str) and param_value.strip():
-        envelope["error"]["param"] = param_value.strip()
-    error_detail = envelope["error"]
-    plan_type = error_payload.get("plan_type")
-    if plan_type is not None:
-        error_detail["plan_type"] = str(plan_type)
-    resets_at = error_payload.get("resets_at")
-    if isinstance(resets_at, int | float):
-        error_detail["resets_at"] = resets_at
-    resets_in = error_payload.get("resets_in_seconds")
-    if isinstance(resets_in, int | float):
-        error_detail["resets_in_seconds"] = resets_in
-    return envelope
 
 
 def _is_previous_response_not_found_message(message: str | None) -> bool:

--- a/openspec/changes/restore-proxy-architecture-ratchets/.openspec.yaml
+++ b/openspec/changes/restore-proxy-architecture-ratchets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-20

--- a/openspec/changes/restore-proxy-architecture-ratchets/context.md
+++ b/openspec/changes/restore-proxy-architecture-ratchets/context.md
@@ -1,0 +1,52 @@
+# Context: restoring proxy architecture ratchets
+
+## Purpose and scope
+
+This change restores the architecture boundaries accepted in ADR-0001 and
+makes their CI signal complete. It is an internal, behavior-preserving repair;
+the normative contract is in
+[`specs/proxy-architecture/spec.md`](./specs/proxy-architecture/spec.md).
+
+## Decisions and constraints
+
+- Existing thresholds are lower-only ratchets. Passing by increasing a number
+  is outside the change.
+- `ProxyService` remains the compatibility façade.
+- `LoadBalancer.select_account()` remains the public selection entry point, but
+  delegates the cohesive sticky retry path and its policy helper to private
+  load-balancer code. The no-sticky path stays in `load_balancer.py` for now.
+- Account ownership, security scope, affinity, budget, health, cap, lease,
+  persistence, and catalog-omission semantics are preserved exactly.
+- PR #1416 is input to a replacement branch for this combined repair; its
+  focused façade diff is preserved and the eventual PR records that it
+  supersedes #1416, while closure remains a maintainer action.
+
+## Failure modes
+
+The highest-risk failure is a structurally clean extraction that changes which
+account owns a turn or fails to release a lease after cancellation. Stale-row
+retries in both paths and the non-sticky cache-generation retry are also easy to
+lose if only happy-path tests are retained. Public-boundary characterization
+therefore precedes movement.
+
+The checker has a different failure mode: fail-fast output makes a repair look
+complete while later assertions remain red. Aggregating messages fixes the
+diagnostic without changing the pass/fail contract.
+
+## Concrete example
+
+At the planning baseline, one run reports only:
+
+```text
+proxy architecture check failed: service.py has 2604 lines; limit is 2600
+```
+
+The same run must instead expose the façade, load-balancer file, and
+`select_account()` violations together. After the extraction, it exits zero and
+prints `proxy architecture checks passed`.
+
+## Operational notes
+
+There is no runtime rollout or data migration. Review should treat changes to
+selection outcomes, error codes, or lease settlement as regressions rather than
+acceptable refactor differences.

--- a/openspec/changes/restore-proxy-architecture-ratchets/design.md
+++ b/openspec/changes/restore-proxy-architecture-ratchets/design.md
@@ -1,0 +1,159 @@
+## Context
+
+ADR-0001 establishes `app/modules/proxy/service.py` as a stable façade and
+requires CI ratchets to keep proxy implementation in focused private domains.
+At commit `9b40f746`, `service.py` is 2,604 lines against a 2,600-line limit,
+`load_balancer.py` is 3,260 lines against a 3,021-line limit, and
+`LoadBalancer.select_account()` spans 699 lines against a 527-line limit.
+
+The checker currently raises on the first failed assertion. PR #1416 moves one
+support block out of `service.py`, but it does not touch either load-balancer
+violation and therefore cannot restore a green architecture gate on its own.
+
+`select_account()` contains three distinguishable phases: shared input loading
+and continuity preflight, separate retry loops for requests with and without a
+sticky key, and shared result/error construction. The sticky retry loop spans
+about 285 lines, and its existing `_select_with_stickiness()` policy helper
+spans about 250 lines without using `self`; together they form a cohesive
+private implementation boundary. Extracting that boundary alone restores both
+load-balancer ratchets with margin.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Restore every current architecture threshold without relaxing the ratchets.
+- Keep `ProxyService` and `LoadBalancer.select_account()` public behavior and
+  import surfaces unchanged.
+- Give sticky account-selection orchestration focused private ownership with
+  explicit inputs and outcomes while leaving the smaller non-sticky path in the
+  public implementation module.
+- Preserve lease cleanup, stale-row retries, continuity ownership, and
+  settlement state across the extraction, plus the existing cache-generation
+  retry on the non-sticky path.
+- Report every independent architecture violation in a single checker run.
+
+**Non-Goals:**
+
+- Change account ranking, quota policy, routing weights, affinity semantics,
+  retry counts, error codes, or operator settings.
+- Raise, reset, or remove any existing line-count threshold.
+- Redesign `LoadBalancer`, replace its runtime lock, or combine this work with
+  unrelated proxy behavior fixes.
+- Move the no-sticky retry loop when the sticky-only boundary is sufficient to
+  restore both current ratchets.
+- Discard PR #1416's focused façade move while replacing its branch.
+
+## Decisions
+
+### Use one gate-restoration change
+
+The façade and load-balancer violations must be repaired together because every
+PR runs the repository-wide architecture gate. Landing a façade-only repair
+would still leave the PR red on the next fail-fast assertion. Implementation
+will use a replacement branch from current `main`, port PR #1416's focused
+façade-support diff, and identify the new PR as superseding #1416. Closing the
+older external PR remains a maintainer action rather than an implementation
+task.
+
+Alternative considered: merge several stacked threshold fixes. Rejected because
+no partial stack member can satisfy the current required check on its own.
+
+### Extract the sticky selection path behind the public method
+
+Create `app/modules/proxy/_load_balancer/sticky_selection.py` and move the
+sticky-key retry orchestration together with the existing self-free
+`_select_with_stickiness()` policy helper. `LoadBalancer.select_account()`
+remains the public entry point and retains shared input loading, ownership
+preflight, the no-sticky retry path, and final `AccountSelection` construction.
+This private package is a load-balancer implementation boundary; it is not the
+ADR-0001 `_service/account_selection/` slot, which is reserved for the
+higher-level `ProxyService` budget/failover/admission layer.
+
+The private implementation will expose a functional entry point such as
+`run_sticky_selection_path(owner, *, request, selection_inputs, reload_inputs)`
+against a narrow owner protocol instead of importing `LoadBalancer` back into
+the module. Typed request and outcome data carriers keep the call boundary
+explicit. The smallest cycle-free pure policy closure moves with the sticky
+path: `_select_account_preferring_budget_safe`, both budget-threshold
+predicates, `_best_health_tier_states`, `_filter_states_for_account_caps`, and
+the account-cap error code/message helpers. Side effects shared with the
+non-sticky path, including `_record_account_cap_rejection`, remain outside that
+pure closure and reach the extracted path through an explicit typed callback.
+Existing test/import surfaces are preserved through explicit re-exports from
+`load_balancer.py` where required.
+
+The extracted path must return enough state for the public method to construct
+the same success or error result: selected account snapshot, acquired lease,
+selection error code/message, and the current selection inputs needed for
+catalog-omission metadata. It also needs an explicit terminal/direct-error
+disposition because some retry-time input errors currently return before shared
+opportunistic/degraded remapping. Cleanup remains owned by the path that
+acquires the lease so cancellation and persistence failures cannot leak it.
+
+Alternative considered: move the unchanged 699-line method into a mixin. This
+would hide, rather than repair, the method-size violation and is rejected.
+
+Alternative considered: extract both sticky and no-sticky retry loops. Rejected
+because the sticky boundary plus its policy helper already restores both
+ratchets, while moving both loops doubles the behavior-sensitive surface.
+
+Alternative considered: split many small pure helpers while leaving the sticky
+retry loop in `select_account()`. This would not create a durable ownership
+boundary and would amount to shallow line shaving.
+
+### Preserve characterization at the public boundary
+
+Tests will continue to call `LoadBalancer.select_account()` rather than testing
+private extraction helpers as the primary contract. Focused helper tests are
+allowed for failure cleanup, but externally observable selection, continuity,
+lease, retry, and error behavior must be characterized at the public method.
+
+### Aggregate architecture failures deterministically
+
+`scripts/check_proxy_architecture.py` will run independent checks in a stable
+order, collect their assertion messages, print every violation, and return one
+non-zero exit status. Parse failures that prevent dependent AST checks may skip
+only those dependent checks; unrelated file and package checks still run.
+
+Alternative considered: keep fail-fast behavior. Rejected because it hid two
+known violations on `main` and made the repair scope emerge one CI run at a
+time.
+
+## Risks / Trade-offs
+
+- **Selection behavior drifts during extraction** → Add public-boundary
+  characterization for sticky and non-sticky success, ambiguity, hard affinity,
+  cap exhaustion, stale persistence, non-sticky cache invalidation, and
+  cancellation.
+- **A lease survives an exception or retry** → Keep acquisition and release in
+  the same private selection path and assert cleanup in failure tests.
+- **Private-module imports form a cycle** → Define protocols and small data
+  carriers in the private package; do not import `LoadBalancer` from it.
+- **PR #1416 work is duplicated or lost** → Reconcile its two-file diff before
+  implementation and record whether it was incorporated or superseded.
+- **New ratchet output breaks callers that match one exact line** → Preserve the
+  existing message text for each violation and the existing exit-code contract;
+  only multiple messages are new.
+
+## Migration Plan
+
+1. Create a replacement branch from current `main`, port PR #1416's focused
+   façade-support move, and record the supersession relationship without making
+   closure of the older PR an implementation prerequisite.
+2. Add/confirm public `select_account()` characterization tests before moving
+   branch orchestration.
+3. Introduce the private load-balancer package and cut over the sticky retry
+   loop plus `_select_with_stickiness()` as one cohesive boundary, while keeping
+   compatibility imports where current callers rely on them.
+4. Change the checker to aggregate failures and add a regression fixture with
+   more than one simultaneous violation.
+5. Run architecture, lint, type, unit, integration, and strict OpenSpec gates.
+
+Rollback is a code-only revert. There is no schema, configuration, or persisted
+state migration.
+
+## Open Questions
+
+None. The replacement-branch strategy and extraction boundary are fixed for
+implementation.

--- a/openspec/changes/restore-proxy-architecture-ratchets/proposal.md
+++ b/openspec/changes/restore-proxy-architecture-ratchets/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+The current `main` branch violates the proxy architecture ratchets that protect
+the accepted `ProxyService` decomposition: the façade, load-balancer module, and
+`LoadBalancer.select_account()` have all grown past their limits. CI stops at
+the first violation, leaving the remaining debt hidden until each preceding
+failure is fixed.
+
+## What Changes
+
+- Restore every current proxy architecture ratchet without increasing or
+  bypassing any threshold.
+- Port the façade extraction already started in PR #1416 into a replacement
+  branch, and move sticky selection orchestration plus its policy helper out of
+  `LoadBalancer.select_account()` into a focused private load-balancer package.
+- Preserve account selection, affinity, failover, settlement, and external
+  import behavior through characterization and regression coverage.
+- Make the architecture checker report all independent violations in one run so
+  a red baseline exposes its complete repair scope.
+- Codify the proxy decomposition and ratchet contract in a main OpenSpec
+  capability instead of leaving it only in an archived change and ADR.
+
+## Capabilities
+
+### New Capabilities
+
+- `proxy-architecture`: Defines the stable proxy façade, private domain
+  boundaries, account-selection decomposition, and CI-enforced architecture
+  ratchets.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected code: `app/modules/proxy/service.py`,
+  `app/modules/proxy/_service/support.py`,
+  `app/modules/proxy/load_balancer.py`, a focused private account-selection
+  module/package, and `scripts/check_proxy_architecture.py`.
+- Affected tests: proxy façade/import compatibility, load-balancer selection
+  characterization, architecture-check regressions, and the existing proxy
+  integration suites.
+- Public APIs, request/response schemas, routing policy, and database schemas do
+  not change.
+- The eventual combined PR supersedes #1416 after preserving its focused diff;
+  closing the older PR remains a maintainer action.

--- a/openspec/changes/restore-proxy-architecture-ratchets/specs/proxy-architecture/spec.md
+++ b/openspec/changes/restore-proxy-architecture-ratchets/specs/proxy-architecture/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Proxy architecture fitness gates are enforced
+
+The repository SHALL enforce the accepted proxy architecture thresholds during
+the required lint gate. `app/modules/proxy/service.py` SHALL contain no more
+than 2,600 lines, `app/modules/proxy/load_balancer.py` SHALL contain no more
+than 3,021 lines, and `LoadBalancer.select_account()` SHALL span no more than
+527 lines. Implementations SHALL restore or lower these ratchets rather than
+increase, bypass, or remove them to make CI pass.
+
+#### Scenario: Multiple ratchets are violated
+
+- **WHEN** more than one independent proxy architecture threshold or boundary is violated
+- **THEN** one architecture-check run reports every independently evaluable violation in deterministic order
+- **AND** the check exits non-zero
+
+#### Scenario: All architecture gates pass
+
+- **WHEN** every proxy architecture threshold and boundary is satisfied
+- **THEN** the architecture check exits zero
+- **AND** it reports that the proxy architecture checks passed
+
+### Requirement: ProxyService remains a stable façade
+
+`app.modules.proxy.service.ProxyService` and the required compatibility exports
+SHALL remain available to existing consumers. Behavior extracted from
+`ProxyService` or `service.py` SHALL be owned by focused private modules under
+`app/modules/proxy/_service/`.
+Compatibility shims SHALL remain re-export-only and private service domains
+SHALL comply with the repository's explicit cross-domain dependency policy.
+
+#### Scenario: Existing consumers import the proxy façade
+
+- **WHEN** an existing caller imports `ProxyService` or a required compatibility export from `app.modules.proxy.service`
+- **THEN** the import resolves to behavior compatible with the pre-change façade
+- **AND** no caller migration is required
+
+### Requirement: Account selection orchestration is decomposed without behavior drift
+
+`LoadBalancer.select_account()` SHALL remain the public account-selection entry
+point and SHALL delegate cohesive sticky-key retry orchestration and policy to a
+private, protocol-typed load-balancer implementation unit. The decomposition
+MUST preserve account scope, continuity ownership, security authorization,
+exclusions, routing policy, quota and health filtering, concurrency caps,
+affinity, stale-state retries, lease cleanup, persistence, result metadata, and
+error-code behavior.
+
+#### Scenario: Selection succeeds with or without stickiness
+
+- **WHEN** a request is eligible for account selection with either a sticky key or no sticky key
+- **THEN** the selected account, lease, persisted runtime state, and result metadata match the pre-change behavior for the same inputs
+
+#### Scenario: Ownership or capacity prevents selection
+
+- **WHEN** continuity ownership is ambiguous or conflicting, a hard-affinity owner is unavailable, or account caps are exhausted
+- **THEN** selection returns the same fail-closed outcome, error code, and mapping-preservation behavior as before the decomposition
+
+#### Scenario: Persistence or cancellation interrupts selection
+
+- **WHEN** persistence fails, a selected row becomes stale, or the selection task is cancelled
+- **THEN** acquired leases are released exactly once
+- **AND** retries and final errors follow the existing bounded behavior
+
+#### Scenario: Non-sticky selection observes a cache-generation change
+
+- **WHEN** non-sticky selection acquires a lease and the selection-input cache generation changes during persistence
+- **THEN** the acquired lease is released exactly once
+- **AND** non-sticky selection reloads its inputs and retries within the existing bound

--- a/openspec/changes/restore-proxy-architecture-ratchets/tasks.md
+++ b/openspec/changes/restore-proxy-architecture-ratchets/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Baseline and characterization
 
-- [ ] 1.1 Create a replacement implementation branch from current `main`, port PR #1416's focused `service.py` / `_service/support.py` diff, and record in the eventual PR that it supersedes #1416; leave closure of the older PR to a maintainer.
-  - The PR #1416 code move is ported exactly. Branch creation and eventual PR supersession text remain deferred until explicit user approval for those git actions.
+- [x] 1.1 Create a replacement implementation branch from current `main`, port PR #1416's focused `service.py` / `_service/support.py` diff, and record in the eventual PR that it supersedes #1416; leave closure of the older PR to a maintainer.
+  - Draft PR #1430 uses the replacement branch, ports PR #1416's code move exactly, records the supersession relationship, and leaves closure of #1416 to a maintainer.
 - [x] 1.2 Add or identify public-boundary `LoadBalancer.select_account()` characterization cases for non-sticky and sticky success, required-owner conflict, ambiguous ownership, hard-affinity saturation, account-cap exhaustion, stale persistence retry, and cancellation/exception lease cleanup; additionally assert cache-generation reselection on the non-sticky path and exactly-once lease release wherever either path has acquired a lease.
 - [x] 1.3 Run the focused characterization set before code movement and record the passing baseline and current architecture-check failures.
   - Before movement, the focused contract/concurrency baseline passed 57/57; the checker reported `service.py` 2,604/2,600, `load_balancer.py` 3,260/3,021, and `select_account()` 699/527.

--- a/openspec/changes/restore-proxy-architecture-ratchets/tasks.md
+++ b/openspec/changes/restore-proxy-architecture-ratchets/tasks.md
@@ -1,0 +1,29 @@
+## 1. Baseline and characterization
+
+- [ ] 1.1 Create a replacement implementation branch from current `main`, port PR #1416's focused `service.py` / `_service/support.py` diff, and record in the eventual PR that it supersedes #1416; leave closure of the older PR to a maintainer.
+  - The PR #1416 code move is ported exactly. Branch creation and eventual PR supersession text remain deferred until explicit user approval for those git actions.
+- [x] 1.2 Add or identify public-boundary `LoadBalancer.select_account()` characterization cases for non-sticky and sticky success, required-owner conflict, ambiguous ownership, hard-affinity saturation, account-cap exhaustion, stale persistence retry, and cancellation/exception lease cleanup; additionally assert cache-generation reselection on the non-sticky path and exactly-once lease release wherever either path has acquired a lease.
+- [x] 1.3 Run the focused characterization set before code movement and record the passing baseline and current architecture-check failures.
+  - Before movement, the focused contract/concurrency baseline passed 57/57; the checker reported `service.py` 2,604/2,600, `load_balancer.py` 3,260/3,021, and `select_account()` 699/527.
+
+## 2. Restore the proxy boundaries
+
+- [x] 2.1 Complete the focused support extraction from `service.py` while preserving every required façade export and compatibility import covered by the architecture checker.
+- [x] 2.2 Add `app/modules/proxy/_load_balancer/sticky_selection.py` with a narrow owner protocol plus typed request/outcome carriers, including updated selection inputs, an explicit terminal/direct-error disposition, and a typed callback for shared metrics side effects such as `_record_account_cap_rejection`; do not import `LoadBalancer` back into the private module.
+- [x] 2.3 Move the sticky-key retry loop, the existing self-free `_select_with_stickiness()` helper, and its smallest cycle-free pure policy closure (`_select_account_preferring_budget_safe`, both budget-threshold predicates, `_best_health_tier_states`, `_filter_states_for_account_caps`, and account-cap error code/message helpers) behind that boundary; keep shared metrics recording outside the pure closure, preserve explicit re-exports used by current tests/importers plus legacy-row precedence, mobility provenance, hard-affinity fail-closed behavior, mapping preservation, cap spillover, stale-row retries, and lease cleanup, then rerun its characterization cases.
+- [x] 2.4 Keep shared preflight, the no-sticky retry path, and final result construction in `LoadBalancer.select_account()`, then confirm `service.py`, `load_balancer.py`, and the public method all satisfy their existing thresholds without raising a ratchet.
+
+## 3. Improve architecture diagnostics
+
+- [x] 3.1 Refactor `scripts/check_proxy_architecture.py` to collect independent assertion failures in stable order, retain each existing message, and return one non-zero status after printing every violation.
+- [x] 3.2 Add checker regression coverage proving that two simultaneous fixture violations are both reported, dependent AST checks degrade safely after a parse failure, a clean fixture exits zero, and the repository's real files pass.
+
+## 4. Verification and handoff
+
+- [x] 4.1 Run `uv run pytest tests/unit/test_load_balancer.py tests/unit/test_load_balancer_contract.py tests/unit/test_load_balancer_concurrency.py tests/unit/test_proxy_load_balancer_refresh.py` and confirm all public selection contracts pass.
+  - Result: 374 passed, 3 pre-existing skips.
+- [x] 4.2 Run `uv run pytest tests/integration/test_load_balancer_integration.py tests/integration/test_load_balancer_multi_replica.py tests/integration/test_proxy_sticky_sessions.py` and confirm persistence, replica, and sticky-session paths pass.
+  - Result: 39 passed.
+- [x] 4.3 Run `python3 scripts/check_proxy_architecture.py`, changed-file Ruff format/lint, and `uv run ty check`; confirm all existing thresholds pass and no private-package import cycle is introduced.
+  - The architecture checker, Ruff, format, and scoped ty all pass. The global ty run reports only four unresolved `_analytics` imports in pre-existing untracked `.codex/hooks/` files outside this change.
+- [x] 4.4 Run `openspec validate restore-proxy-architecture-ratchets --strict` and `openspec validate --specs`, then verify the implementation against this change before requesting current-head CI and Codex review.

--- a/scripts/check_proxy_architecture.py
+++ b/scripts/check_proxy_architecture.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import ast
 import sys
+from collections.abc import Callable
+from functools import partial
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -67,6 +69,10 @@ REQUIRED_SERVICE_FACADE_NAMES = {
     "_REQUEST_TRANSPORT_WEBSOCKET",
     "_WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS",
     "_WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS",
+    "_http_error_status_from_payload",
+    "_is_account_neutral_error_code",
+    "_is_local_account_cap_code",
+    "_openai_error_envelope_from_response_failed_payload",
 }
 
 ALLOWED_SERVICE_INTERNAL_IMPORTS = {
@@ -100,8 +106,22 @@ ALLOWED_SERVICE_IMPORT_DOMAINS_BY_DOMAIN = {
 }
 
 
+ArchitectureCheck = Callable[[], None]
+
+
+def _relative_path(path: Path) -> Path:
+    try:
+        return path.relative_to(ROOT)
+    except ValueError:
+        return path
+
+
 def _parse(path: Path) -> ast.Module:
-    return ast.parse(path.read_text(), filename=str(path))
+    try:
+        return ast.parse(path.read_text(), filename=str(path))
+    except SyntaxError as exc:
+        location = f" at line {exc.lineno}" if exc.lineno is not None else ""
+        raise AssertionError(f"{_relative_path(path)} could not be parsed: {exc.msg}{location}") from None
 
 
 def _line_count(path: Path) -> int:
@@ -249,7 +269,7 @@ def _imported_service_domain(imported_module: str) -> str | None:
 
 
 def _check_no_cross_domain_service_imports() -> None:
-    for path in SERVICE_PACKAGE_DIR.rglob("*.py"):
+    for path in sorted(SERVICE_PACKAGE_DIR.rglob("*.py")):
         if path.name == "__init__.py" or path == SERVICE_PACKAGE_DIR / "support.py":
             continue
         current_domain = _service_domain(path)
@@ -270,25 +290,71 @@ def _check_no_cross_domain_service_imports() -> None:
             )
 
 
-def main() -> int:
+def _parse_for_checks(path: Path) -> tuple[ast.Module | None, str | None]:
     try:
-        service_module = _parse(SERVICE_PATH)
-        load_balancer_module = _parse(LOAD_BALANCER_PATH)
-        _check_service_line_count()
-        _check_load_balancer_line_count()
-        _check_http_bridge_mixin_line_count()
-        _check_streaming_mixin_line_count()
-        _check_proxy_service_method_size(service_module)
-        _check_load_balancer_select_account_size(load_balancer_module)
-        _check_service_facade_surface(service_module)
-        _check_service_does_not_import_shims(service_module)
-        _check_required_service_packages()
-        _check_required_service_modules()
-        _assert_shim_only(PROXY_DIR / "_support.py")
-        _assert_shim_only(PROXY_DIR / "_warmup.py")
-        _check_no_cross_domain_service_imports()
+        return _parse(path), None
     except AssertionError as exc:
-        print(f"proxy architecture check failed: {exc}", file=sys.stderr)
+        return None, str(exc)
+
+
+def _raise_assertion(message: str) -> None:
+    raise AssertionError(message)
+
+
+def _architecture_checks() -> list[ArchitectureCheck]:
+    service_module, service_parse_failure = _parse_for_checks(SERVICE_PATH)
+    load_balancer_module, load_balancer_parse_failure = _parse_for_checks(LOAD_BALANCER_PATH)
+
+    checks: list[ArchitectureCheck] = [
+        _check_service_line_count,
+        _check_load_balancer_line_count,
+        _check_http_bridge_mixin_line_count,
+        _check_streaming_mixin_line_count,
+    ]
+    if service_module is None:
+        assert service_parse_failure is not None
+        checks.append(partial(_raise_assertion, service_parse_failure))
+    else:
+        checks.append(partial(_check_proxy_service_method_size, service_module))
+    if load_balancer_module is None:
+        assert load_balancer_parse_failure is not None
+        checks.append(partial(_raise_assertion, load_balancer_parse_failure))
+    else:
+        checks.append(partial(_check_load_balancer_select_account_size, load_balancer_module))
+    if service_module is not None:
+        checks.extend(
+            (
+                partial(_check_service_facade_surface, service_module),
+                partial(_check_service_does_not_import_shims, service_module),
+            )
+        )
+    checks.extend(
+        (
+            _check_required_service_packages,
+            _check_required_service_modules,
+            partial(_assert_shim_only, PROXY_DIR / "_support.py"),
+            partial(_assert_shim_only, PROXY_DIR / "_warmup.py"),
+            _check_no_cross_domain_service_imports,
+        )
+    )
+    return checks
+
+
+def _collect_failures(checks: list[ArchitectureCheck]) -> list[str]:
+    failures: list[str] = []
+    for check in checks:
+        try:
+            check()
+        except AssertionError as exc:
+            failures.append(str(exc))
+    return failures
+
+
+def main() -> int:
+    failures = _collect_failures(_architecture_checks())
+    if failures:
+        for failure in failures:
+            print(f"proxy architecture check failed: {failure}", file=sys.stderr)
         return 1
 
     print("proxy architecture checks passed")

--- a/tests/unit/test_check_proxy_architecture.py
+++ b/tests/unit/test_check_proxy_architecture.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_checker_module() -> ModuleType:
+    script_path = REPO_ROOT / "scripts" / "check_proxy_architecture.py"
+    spec = importlib.util.spec_from_file_location("check_proxy_architecture", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_proxy_fixture(root: Path) -> Path:
+    proxy_dir = root / "app" / "modules" / "proxy"
+    service_dir = proxy_dir / "_service"
+    (service_dir / "http_bridge").mkdir(parents=True)
+    (service_dir / "streaming").mkdir()
+    (service_dir / "websocket").mkdir()
+
+    (proxy_dir / "service.py").write_text(
+        "class ProxyService:\n    def handle(self) -> None:\n        pass\n",
+        encoding="utf-8",
+    )
+    (proxy_dir / "load_balancer.py").write_text(
+        "class LoadBalancer:\n    async def select_account(self) -> None:\n        return None\n",
+        encoding="utf-8",
+    )
+    (service_dir / "__init__.py").write_text("", encoding="utf-8")
+    (service_dir / "support.py").write_text("VALUE = 1\n", encoding="utf-8")
+    (service_dir / "http_bridge" / "mixin.py").write_text("# HTTP bridge\n", encoding="utf-8")
+    (service_dir / "streaming" / "mixin.py").write_text("# Streaming\n", encoding="utf-8")
+    (service_dir / "websocket" / "__init__.py").write_text("", encoding="utf-8")
+    shim = "from app.modules.proxy._service.support import VALUE\n"
+    (proxy_dir / "_support.py").write_text(shim, encoding="utf-8")
+    (proxy_dir / "_warmup.py").write_text(shim, encoding="utf-8")
+    return proxy_dir
+
+
+def _configure_fixture(checker: ModuleType, root: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    proxy_dir = _write_proxy_fixture(root)
+    service_dir = proxy_dir / "_service"
+    monkeypatch.setattr(checker, "ROOT", root)
+    monkeypatch.setattr(checker, "PROXY_DIR", proxy_dir)
+    monkeypatch.setattr(checker, "SERVICE_PATH", proxy_dir / "service.py")
+    monkeypatch.setattr(checker, "LOAD_BALANCER_PATH", proxy_dir / "load_balancer.py")
+    monkeypatch.setattr(checker, "_SERVICE_DIR", service_dir)
+    monkeypatch.setattr(checker, "SERVICE_PACKAGE_DIR", service_dir)
+    monkeypatch.setattr(checker, "HTTP_BRIDGE_MIXIN_PATH", service_dir / "http_bridge" / "mixin.py")
+    monkeypatch.setattr(checker, "STREAMING_MIXIN_PATH", service_dir / "streaming" / "mixin.py")
+    monkeypatch.setattr(checker, "MAX_SERVICE_LINES", 20)
+    monkeypatch.setattr(checker, "MAX_LOAD_BALANCER_LINES", 20)
+    monkeypatch.setattr(checker, "MAX_HTTP_BRIDGE_MIXIN_LINES", 20)
+    monkeypatch.setattr(checker, "MAX_STREAMING_MIXIN_LINES", 20)
+    monkeypatch.setattr(checker, "MAX_PROXY_SERVICE_METHOD_LINES", 10)
+    monkeypatch.setattr(checker, "MAX_LOAD_BALANCER_SELECT_ACCOUNT_LINES", 10)
+    monkeypatch.setattr(checker, "REQUIRED_SERVICE_PACKAGES", {"http_bridge", "streaming", "websocket"})
+    monkeypatch.setattr(checker, "REQUIRED_SERVICE_MODULES", {"__init__.py", "support.py"})
+    monkeypatch.setattr(checker, "REQUIRED_SERVICE_FACADE_NAMES", {"ProxyService"})
+    return proxy_dir
+
+
+def test_main_reports_simultaneous_violations_in_stable_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    checker = _load_checker_module()
+    _configure_fixture(checker, tmp_path, monkeypatch)
+    monkeypatch.setattr(checker, "MAX_SERVICE_LINES", 1)
+    monkeypatch.setattr(checker, "MAX_LOAD_BALANCER_LINES", 1)
+
+    assert checker.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.splitlines() == [
+        "proxy architecture check failed: service.py has 3 lines; limit is 1",
+        "proxy architecture check failed: load_balancer.py has 3 lines; limit is 1",
+    ]
+
+
+def test_main_skips_only_dependent_ast_checks_after_parse_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    checker = _load_checker_module()
+    proxy_dir = _configure_fixture(checker, tmp_path, monkeypatch)
+    (proxy_dir / "service.py").write_text("class ProxyService(:\n", encoding="utf-8")
+    monkeypatch.setattr(checker, "MAX_LOAD_BALANCER_SELECT_ACCOUNT_LINES", 1)
+    monkeypatch.setattr(
+        checker,
+        "REQUIRED_SERVICE_PACKAGES",
+        {*checker.REQUIRED_SERVICE_PACKAGES, "missing_domain"},
+    )
+
+    assert checker.main() == 1
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    failures = captured.err.splitlines()
+    assert len(failures) == 3
+    assert failures[0].startswith("proxy architecture check failed: app/modules/proxy/service.py could not be parsed:")
+    assert failures[1] == ("proxy architecture check failed: LoadBalancer.select_account spans 2 lines; limit is 1")
+    assert failures[2] == ("proxy architecture check failed: missing required proxy _service packages: missing_domain")
+
+
+def test_main_clean_fixture_exits_zero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    checker = _load_checker_module()
+    _configure_fixture(checker, tmp_path, monkeypatch)
+
+    assert checker.main() == 0
+
+    captured = capsys.readouterr()
+    assert captured.out == "proxy architecture checks passed\n"
+    assert captured.err == ""
+
+
+def test_repository_proxy_architecture_passes(capsys: pytest.CaptureFixture[str]) -> None:
+    checker = _load_checker_module()
+
+    assert checker.main() == 0
+
+    captured = capsys.readouterr()
+    assert captured.out == "proxy architecture checks passed\n"
+    assert captured.err == ""

--- a/tests/unit/test_load_balancer_contract.py
+++ b/tests/unit/test_load_balancer_contract.py
@@ -400,12 +400,18 @@ async def test_selection_releases_lease_when_persistence_fails(
         assert await balancer.account_pressure_snapshot(account.id) == (0, 1, 42.0)
         raise RuntimeError("persistence failed")
 
+    release_spy = AsyncMock(wraps=balancer.release_account_lease)
     monkeypatch.setattr(balancer, "_persist_selection_state", fail_persist)
+    monkeypatch.setattr(balancer, "release_account_lease", release_spy)
 
     with pytest.raises(RuntimeError, match="persistence failed"):
         await _select_with_lease(balancer, sticky=sticky)
 
     assert persist_calls == 1
+    release_spy.assert_awaited_once()
+    release_call = release_spy.await_args
+    assert release_call is not None
+    assert release_call.args[0] is not None
     assert sticky_repo.get_calls == (1 if sticky else 0)
     assert await balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
 
@@ -428,7 +434,9 @@ async def test_selection_releases_lease_when_persistence_is_cancelled(
         await persist_blocker.wait()
         return set()
 
+    release_spy = AsyncMock(wraps=balancer.release_account_lease)
     monkeypatch.setattr(balancer, "_persist_selection_state", block_persist)
+    monkeypatch.setattr(balancer, "release_account_lease", release_spy)
 
     selection_task = asyncio.create_task(_select_with_lease(balancer, sticky=sticky))
     await asyncio.wait_for(persist_started.wait(), timeout=2.0)
@@ -438,6 +446,10 @@ async def test_selection_releases_lease_when_persistence_is_cancelled(
         await selection_task
 
     assert selection_task.cancelled()
+    release_spy.assert_awaited_once()
+    release_call = release_spy.await_args
+    assert release_call is not None
+    assert release_call.args[0] is not None
     assert sticky_repo.get_calls == (1 if sticky else 0)
     assert await balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
 
@@ -462,7 +474,9 @@ async def test_stale_selection_retries_do_not_leak_leases(
         assert await balancer.account_pressure_snapshot(account.id) == (0, 1, 42.0)
         return {account.id}
 
+    release_spy = AsyncMock(wraps=balancer.release_account_lease)
     monkeypatch.setattr(balancer, "_persist_selection_state", always_stale)
+    monkeypatch.setattr(balancer, "release_account_lease", release_spy)
 
     selection = await _select_with_lease(balancer, sticky=sticky)
 
@@ -470,6 +484,10 @@ async def test_stale_selection_retries_do_not_leak_leases(
     assert load_spy.await_count == 4
     assert selection.account is None
     assert selection.lease is None
+    assert release_spy.await_count == persist_calls
+    released_leases = [release_call.args[0] for release_call in release_spy.await_args_list]
+    assert all(lease is not None for lease in released_leases)
+    assert len({lease.lease_id for lease in released_leases if lease is not None}) == persist_calls
     assert sticky_repo.get_calls == (4 if sticky else 0)
     assert await balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
 
@@ -480,4 +498,47 @@ async def test_stale_selection_retries_do_not_leak_leases(
     )
     assert replacement is not None
     await balancer.release_account_lease(replacement)
+    assert await balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)
+
+
+@pytest.mark.asyncio
+async def test_non_sticky_cache_generation_change_reselects_and_releases_once(
+    selection_cache: AccountSelectionCache,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    account = _account("contract-cache-generation")
+    balancer, _, _, _ = _balancer([account], selection_cache)
+    original_load = balancer._load_selection_inputs
+    load_spy = AsyncMock(side_effect=original_load)
+    release_spy = AsyncMock(wraps=balancer.release_account_lease)
+    persist_calls = 0
+
+    async def invalidate_during_first_persist(*_args: Any, **_kwargs: Any) -> set[str]:
+        nonlocal persist_calls
+        persist_calls += 1
+        assert await balancer.account_pressure_snapshot(account.id) == (0, 1, 42.0)
+        if persist_calls == 1:
+            selection_cache.invalidate()
+        return set()
+
+    monkeypatch.setattr(balancer, "_load_selection_inputs", load_spy)
+    monkeypatch.setattr(balancer, "_persist_selection_state", invalidate_during_first_persist)
+    monkeypatch.setattr(balancer, "release_account_lease", release_spy)
+
+    selection = await _select_with_lease(balancer, sticky=False)
+
+    assert selection.account is not None
+    assert selection.account.id == account.id
+    assert selection.lease is not None
+    assert persist_calls == 2
+    assert load_spy.await_count == 2
+    release_spy.assert_awaited_once()
+    release_call = release_spy.await_args
+    assert release_call is not None
+    released_lease = release_call.args[0]
+    assert released_lease is not None
+    assert released_lease.lease_id != selection.lease.lease_id
+    assert await balancer.account_pressure_snapshot(account.id) == (0, 1, 42.0)
+
+    await balancer.release_account_lease(selection.lease)
     assert await balancer.account_pressure_snapshot(account.id) == (0, 0, 0.0)


### PR DESCRIPTION
## Summary

Restore the accepted proxy façade and load-balancer architecture ratchets without raising any threshold, while preserving account-selection behavior and making the architecture checker report all independent failures.

This supersedes #1416. It incorporates #1416's complete `service.py` / `_service/support.py` extraction and extends it to restore the load-balancer file and method ratchets and aggregate checker failures. Closure of #1416 is left to a maintainer.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [x] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: None. Related prior work: #947, #1392, and superseded PR #1416.

## Root cause

At the planning baseline, `service.py` had grown to 2,604 lines against a 2,600-line limit, `load_balancer.py` to 3,260 against 3,021, and `LoadBalancer.select_account()` to 699 against 527. The checker stopped at the first assertion, hiding the remaining violations until earlier ones were repaired.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/restore-proxy-architecture-ratchets/`

## Changes

- Move focused support helpers from `service.py` into `_service/support.py` while preserving compatibility exports.
- Extract sticky selection orchestration and its pure policy closure into a protocol-typed private `_load_balancer` package.
- Keep `LoadBalancer.select_account()` as the public entry point and retain shared preflight, non-sticky selection, and final result construction.
- Strengthen public-boundary coverage for ownership, affinity, account caps, stale persistence, cache invalidation, cancellation, and exactly-once lease release.
- Make the architecture checker collect failures deterministically and continue unrelated checks after a parse failure.

## Impact

All existing architecture thresholds now pass without being increased or bypassed. Public imports, account ownership, routing policy, affinity, failover, lease settlement, error codes, request/response schemas, and database behavior remain unchanged.

## Simplicity

- [x] Internal refactor with no setup or operator-facing default change
- [x] No new required setup step
- New setting(s) and why each can't be a default: None.
- [x] No README, `.env.example`, dashboard-nav, or documentation-surface growth

## Test plan

```text
.venv/bin/pytest tests/unit/test_load_balancer.py tests/unit/test_load_balancer_contract.py tests/unit/test_load_balancer_concurrency.py tests/unit/test_proxy_load_balancer_refresh.py -q
# 374 passed, 3 pre-existing skips

.venv/bin/pytest tests/integration/test_load_balancer_integration.py tests/integration/test_load_balancer_multi_replica.py tests/integration/test_proxy_sticky_sessions.py -q
# 39 passed

.venv/bin/pytest tests/unit/test_check_proxy_architecture.py -q
# 4 passed

.venv/bin/python scripts/check_proxy_architecture.py
# proxy architecture checks passed
```

Ruff lint/format, repository-scoped `ty`, `git diff --check`, strict change validation, all 47 main OpenSpec specs, and local `/opsx:verify` also pass. The only repo-wide local `ty` diagnostics came from pre-existing untracked `.codex/hooks` files, which are not part of this PR.

## Screenshots / output

No user-visible or dashboard changes. The architecture checker prints `proxy architecture checks passed`.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Related prior work is linked above; no matching issue exists.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local lint and test subsets.
- [x] `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is not edited by hand.

Cloud CI, current-head Codex review, and GitHub mergeability remain to be verified on this draft PR.