### PR TITLE
fix(proxy-responses): normalize Lite reasoning context

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1483,6 +1483,21 @@ def _payload_has_responses_lite_websocket_marker(payload: Mapping[str, JsonValue
     return is_json_mapping(raw_metadata) and _client_metadata_uses_responses_lite(raw_metadata)
 
 
+def _finalize_responses_lite_reasoning_context(
+    payload: dict[str, JsonValue],
+    *,
+    responses_lite: bool,
+) -> None:
+    if not responses_lite:
+        return
+    raw_reasoning = payload.get("reasoning")
+    if raw_reasoning is not None and not is_json_mapping(raw_reasoning):
+        return
+    reasoning = dict(raw_reasoning) if is_json_mapping(raw_reasoning) else {}
+    reasoning["context"] = "all_turns"
+    payload["reasoning"] = reasoning
+
+
 def _normalize_responses_lite_websocket_client_metadata(
     payload: Mapping[str, JsonValue],
     client_metadata: Mapping[str, JsonValue],
@@ -2697,8 +2712,16 @@ async def _stream_responses_with_session(
         )
     http_payload_dict = dict(payload_dict)
     _strip_responses_lite_websocket_client_metadata(http_payload_dict)
+    _finalize_responses_lite_reasoning_context(
+        http_payload_dict,
+        responses_lite=_payload_uses_responses_lite(http_payload_dict),
+    )
     websocket_payload_dict = dict(payload_dict)
     _set_responses_lite_websocket_client_metadata(websocket_payload_dict)
+    _finalize_responses_lite_reasoning_context(
+        websocket_payload_dict,
+        responses_lite=_payload_has_responses_lite_websocket_marker(websocket_payload_dict),
+    )
     payload_json = json.dumps(websocket_payload_dict, ensure_ascii=True, separators=(",", ":"))
     payload_size_estimate_bytes = len(payload_json.encode("utf-8"))
     transport_mode = _configured_stream_transport(
@@ -3504,13 +3527,17 @@ class _CompactCommandTransport:
         pre_request_started_at = time.monotonic()
         compact_timeout_seconds = _effective_compact_total_timeout(settings.upstream_compact_timeout_seconds)
         effective_connect_timeout = _effective_compact_connect_timeout(settings.upstream_connect_timeout_seconds)
-        payload_dict = self.payload.to_payload()
+        payload_dict = dict(self.payload.to_payload())
         if settings.image_inline_fetch_enabled:
             payload_dict = await _inline_input_image_urls(
                 payload_dict,
                 _as_image_fetch_session(self.session),
                 effective_connect_timeout,
             )
+        _finalize_responses_lite_reasoning_context(
+            payload_dict,
+            responses_lite=_payload_uses_responses_lite(payload_dict),
+        )
         _apply_responses_lite_http_header(upstream_headers, payload_dict)
         try:
             validate_compact_input_wire_budget(payload_dict)

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -18,8 +18,11 @@ from app.core.clients.proxy import (  # noqa: F401  # noqa: F401
     ProxyResponseError,
     UpstreamProxyRouteTrace,
     _as_image_fetch_session,
+    _finalize_responses_lite_reasoning_context,
     _inline_content_images,
     _inline_input_image_urls,
+    _payload_has_responses_lite_websocket_marker,
+    _payload_uses_responses_lite,
     _ws_transport_payload_budget_bytes,
     apply_codex_installation_metadata,
     filter_inbound_headers,
@@ -317,6 +320,13 @@ class _HTTPBridgeRequestSubmitMixin:
             upstream_payload["type"] = "response.create"
         if client_metadata:
             upstream_payload["client_metadata"] = client_metadata
+        _finalize_responses_lite_reasoning_context(
+            upstream_payload,
+            responses_lite=(
+                _payload_uses_responses_lite(upstream_payload)
+                or _payload_has_responses_lite_websocket_marker(upstream_payload)
+            ),
+        )
         forwarded_service_tier = _normalize_service_tier_value(upstream_payload.get("service_tier"))
         input_item_count = 0
         input_full_fingerprint: str | None = None

--- a/app/modules/proxy/_service/response_create.py
+++ b/app/modules/proxy/_service/response_create.py
@@ -17,8 +17,11 @@ from app.core.clients.proxy import (
     CODEX_INSTALLATION_ID_HEADER,
     ImageFetchSession,
     ProxyResponseError,
+    _finalize_responses_lite_reasoning_context,
     _inline_content_images,
     _normalize_responses_lite_websocket_client_metadata,
+    _payload_has_responses_lite_websocket_marker,
+    _payload_uses_responses_lite,
     apply_codex_installation_metadata,
 )
 from app.core.config.settings import DEFAULT_HOME_DIR, get_settings
@@ -141,6 +144,13 @@ def _response_create_text(
         upstream_payload["type"] = "response.create"
     if client_metadata:
         upstream_payload["client_metadata"] = client_metadata
+    _finalize_responses_lite_reasoning_context(
+        upstream_payload,
+        responses_lite=(
+            _payload_uses_responses_lite(upstream_payload)
+            or _payload_has_responses_lite_websocket_marker(upstream_payload)
+        ),
+    )
     return json.dumps(upstream_payload, ensure_ascii=True, separators=(",", ":"))
 
 
@@ -159,6 +169,13 @@ def _response_create_text_with_size_guard(
         upstream_payload["type"] = "response.create"
     if client_metadata:
         upstream_payload["client_metadata"] = client_metadata
+    _finalize_responses_lite_reasoning_context(
+        upstream_payload,
+        responses_lite=(
+            _payload_uses_responses_lite(upstream_payload)
+            or _payload_has_responses_lite_websocket_marker(upstream_payload)
+        ),
+    )
     text_data = json.dumps(upstream_payload, ensure_ascii=True, separators=(",", ":"))
     payload_size = len(text_data.encode("utf-8"))
     max_bytes = _upstream_response_create_max_bytes()

--- a/openspec/changes/normalize-responses-lite-reasoning-context/.openspec.yaml
+++ b/openspec/changes/normalize-responses-lite-reasoning-context/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-20

--- a/openspec/changes/normalize-responses-lite-reasoning-context/context.md
+++ b/openspec/changes/normalize-responses-lite-reasoning-context/context.md
@@ -1,0 +1,61 @@
+# Context: canonical reasoning state for Responses Lite
+
+## Purpose and scope
+
+Responses Lite is a coupled wire contract: its `additional_tools` request shape,
+canonical transport signal, and reasoning state must agree. This change repairs
+the missing reasoning half at the final upstream boundary. The normative
+contract is in
+[`specs/responses-api-compat/spec.md`](./specs/responses-api-compat/spec.md).
+
+## Decision rationale and alternatives
+
+The proxy repairs older or inconsistent client payloads because it already owns
+the derived Lite signal. Rejecting the request would continue the production
+failure, and suppressing the signal would forward a body whose Lite tool bundle
+no longer has the semantics the client requested.
+
+Normalization is conditional on the final canonical signal. It is not a general
+reasoning-schema restriction and does not make an inbound header or marker
+trusted. This keeps non-Lite clients and future reasoning extensions compatible.
+
+## Constraints and failure modes
+
+- The exact wire value is the JSON string `"all_turns"`; case variants and
+  non-string values are not equivalent.
+- Reasoning effort, summary, and extension fields must survive the repair.
+- Bridge trimming and marker-only incremental frames may no longer contain the
+  original `additional_tools` prefix, so the already-established trusted Lite
+  disposition must reach final serialization.
+- Fresh replays can deliberately sever Lite linkage. Mutating only final wire
+  dictionaries prevents an earlier send from contaminating that rebuilt body.
+- The added field must be present before whole-payload websocket sizing and
+  final compact serialization. Compact's existing input-only budget remains
+  unchanged because reasoning is outside the measured input array.
+
+## Concrete examples
+
+A Lite request from an older client can arrive as:
+
+```json
+{"reasoning":{"effort":"max","summary":"auto","vendor_hint":7}}
+```
+
+When the proxy emits the canonical Lite header or marker, the final upstream
+body becomes:
+
+```json
+{"reasoning":{"effort":"max","summary":"auto","vendor_hint":7,"context":"all_turns"}}
+```
+
+The same body on a non-Lite request is not changed by this feature. A stale
+inbound Lite header or untrusted websocket marker is stripped according to the
+existing contract and does not activate normalization.
+
+## Operational notes
+
+No rollout setting or data migration is needed. Verification should pair the
+serialized body assertion with the canonical header/marker assertion so future
+transport changes cannot reintroduce an inconsistent signal. The implementation
+PR should close issue #1411 and monitor upstream invalid-request counts after
+deployment.

--- a/openspec/changes/normalize-responses-lite-reasoning-context/design.md
+++ b/openspec/changes/normalize-responses-lite-reasoning-context/design.md
@@ -1,0 +1,139 @@
+## Context
+
+codex-lb already derives Responses Lite signaling from a normalized
+`additional_tools` input prefix and preserves that signal through HTTP,
+compact, direct websocket, HTTP bridge, fallback, prewarm, and trusted
+incremental continuity. It does not currently couple that signal to the
+upstream body invariant introduced for Lite clients.
+
+Issue #1411 records 273 production rejections from 2026-07-14 through
+2026-07-20 (217 on `gpt-5.6-sol`, 47 on `gpt-5.6-terra`, and 9 on
+`gpt-5.6-luna`) with the upstream error
+`X-OpenAI-Internal-Codex-Responses-Lite requires reasoning.context to be all_turns`.
+The observed path was raw HTTP with the bridge disabled, but the same
+inconsistent signal/body pair can be produced by every supported Lite
+transport.
+
+`ResponsesReasoning` deliberately allows extra fields, so globally narrowing
+its schema to one context literal would reject non-Lite or future-compatible
+payloads. Existing Lite classification and websocket continuity rules are also
+security-sensitive: an inbound header or stale client-metadata marker is not
+trusted by itself.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Guarantee exact `reasoning.context = "all_turns"` in every final upstream
+  payload that codex-lb canonically advertises as Responses Lite.
+- Preserve `effort`, `summary`, and unknown reasoning members while repairing
+  missing or incompatible context values.
+- Cover body-derived, bridge-preserved, and continuity-trusted signaling on
+  HTTP, compact, websocket, fallback, and replay serialization paths.
+- Keep the normalizer idempotent, apply it before whole-payload byte
+  calculations, and preserve the existing input-only compact budget semantics.
+
+**Non-Goals:**
+
+- Broaden Lite detection, trust an inbound Lite header or marker, or establish
+  websocket continuity before upstream acceptance.
+- Reject otherwise-valid Lite requests because an older client omitted or sent
+  a conflicting context value.
+- Remove the Lite signal or reinterpret the `additional_tools` contract.
+- Constrain or rewrite reasoning context on non-Lite requests.
+- Add settings, database state, frontend behavior, or user-facing docs.
+
+## Decisions
+
+### Normalize the body instead of rejecting or disabling Lite
+
+Once the canonical Lite header or websocket marker is emitted, upstream
+requires the all-turns reasoning context. The proxy will repair that invariant
+rather than return a client error. Rejection would preserve the observed
+client-version failure, while stripping the Lite signal would silently break
+the `additional_tools` request shape.
+
+The repair creates a reasoning object when it is absent or null. For an existing
+object, it shallow-copies the object, sets `context` to the exact string
+`"all_turns"`, and preserves every sibling. Missing, null, blank,
+differently-cased, other-string, and non-string context values all converge on
+the same canonical output.
+
+Alternative considered: make `ResponsesReasoning.context` a required
+`Literal["all_turns"]`. Rejected because the constraint is conditional on the
+final Lite disposition and non-Lite payloads remain pass-through compatible.
+
+### Finalize a wire dictionary adjacent to canonical signaling
+
+Add one idempotent dictionary-level finalizer beside the existing Responses
+Lite body/header/marker helpers. Callers pass the already-decided final Lite
+disposition; the helper does not inspect an untrusted inbound header and does
+not decide continuity trust.
+
+Apply it at all signal-bearing serialization boundaries:
+
+- Raw Responses transport preparation in `app/core/clients/proxy.py`, before
+  the HTTP/websocket split and payload-size calculation, so websocket handshake
+  fallback to HTTP keeps the same invariant while swapping marker for header.
+- Compact preparation before the final input-budget validation and POST,
+  without changing what that input-only budget measures.
+- Direct websocket response-create serialization in both the ordinary and
+  size-guarded/replay builders.
+- HTTP bridge response-create serialization after marker preservation and input
+  prefix trimming have produced the final request dictionary.
+
+This placement keeps the validated request model unchanged. A fresh replay that
+severs Lite linkage rebuilds from the unmodified model and is not accidentally
+normalized unless its final body or trusted marker independently qualifies.
+
+Alternative considered: normalize once during initial Pydantic validation.
+Rejected because final transport selection, bridge trimming, and trusted
+marker-only continuity are determined later, while some replays deliberately
+drop Lite linkage.
+
+### Test disposition and body as one transport contract
+
+Focused helper tests will parameterize absent, null, incorrect-string,
+wrong-type, and already-canonical context values, assert sibling preservation,
+and prove a non-Lite no-op. Transport and product-path tests will assert the
+final serialized body together with its header or marker for raw HTTP, compact,
+direct websocket, websocket-to-HTTP fallback, and HTTP
+bridge/trusted-continuation paths. Tests that monkeypatch above core egress and
+inspect `ResponsesRequest.to_payload()` remain model-preservation tests; they do
+not assert a wire-only mutation that has not run yet.
+
+The existing marker-linkage tests remain the authority for classification and
+trust. New assertions extend them without replacing or weakening their stale,
+wrong-model, and wrong-previous-response negative cases.
+
+## Risks / Trade-offs
+
+- **An untrusted marker triggers normalization** → Key the finalizer only from
+  the canonical disposition produced by existing body/trust logic and retain
+  stale-marker negative tests.
+- **One retry or bridge serializer misses the invariant** → Use one helper and
+  exercise every final serialization family, including size-guarded replay.
+- **Normalization changes websocket size after measurement** → Run it before
+  whole-payload size calculation and trimming; keep compact's existing
+  input-only budget validation in its current order before POST.
+- **Reasoning extensions are lost** → Shallow-copy the existing mapping and
+  parameterize custom sibling fields in tests.
+- **A marker-stripped fresh replay retains a mutation** → Mutate only final wire
+  dictionaries, never the reusable request model.
+
+## Migration Plan
+
+1. Add focused finalizer tests, including non-Lite and untrusted-marker no-ops.
+2. Apply the finalizer to raw Responses and compact transport preparation.
+3. Apply it to direct websocket, bridge, fallback, and replay serializers.
+4. Extend product-path regressions and run the relevant proxy, architecture,
+   lint, type, and strict OpenSpec gates.
+5. Open one focused PR with `Fixes #1411` after current-head CI and Codex review.
+
+Rollback is a code-only revert. There is no schema, configuration, or persisted
+state migration.
+
+## Open Questions
+
+None. The normalization value, qualifying signal dispositions, and transport
+coverage are fixed by the upstream error and existing Lite trust contract.

--- a/openspec/changes/normalize-responses-lite-reasoning-context/proposal.md
+++ b/openspec/changes/normalize-responses-lite-reasoning-context/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+Production telemetry in issue #1411 records 273 Responses Lite requests rejected
+by upstream because the proxy emitted the canonical Lite signal without the
+required `reasoning.context = "all_turns"` body contract. The proxy already owns
+Lite signaling across HTTP, compact, websocket, bridge, and replay paths, so it
+must make the signaled payload internally consistent before egress.
+
+## What Changes
+
+- Normalize every final request that carries the proxy-derived Responses Lite
+  HTTP header or trusted websocket metadata marker so its reasoning object has
+  `context = "all_turns"`.
+- Preserve reasoning effort, summary, and unknown sibling fields; create the
+  reasoning object when absent or null, and replace any incompatible context
+  value only for a request that is actually forwarded as Lite.
+- Apply the same contract to Responses, compact, direct websocket, HTTP bridge,
+  websocket-to-HTTP fallback, and trusted Lite continuity/replay preparation.
+- Leave non-Lite reasoning payloads and the existing Lite classification and
+  continuity trust rules unchanged.
+- Add transport- and product-path regression coverage for omitted, conflicting,
+  and already-canonical reasoning context.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: Extend the existing body-derived Responses Lite
+  signaling contract with the required canonical reasoning context on every
+  signaled upstream payload.
+
+## Impact
+
+- Affected code: Responses/compact request serialization and the shared
+  Responses Lite HTTP/websocket egress helpers in `app/core/clients/proxy.py`
+  and `app/modules/proxy/_service/`.
+- Affected tests: proxy Responses and compact integration tests, direct
+  websocket tests, HTTP bridge tests, and focused Lite helper/transport tests.
+- No public endpoint, response schema, database schema, setting, or dependency
+  changes. Non-Lite requests retain their current wire representation.

--- a/openspec/changes/normalize-responses-lite-reasoning-context/specs/responses-api-compat/spec.md
+++ b/openspec/changes/normalize-responses-lite-reasoning-context/specs/responses-api-compat/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Responses Lite signaling enforces all-turns reasoning context
+
+Every final upstream Responses payload that codex-lb advertises as Responses
+Lite—by the canonical HTTP header or the canonical per-request websocket
+client-metadata marker, whether body-derived, bridge-preserved, or
+continuity-trusted—MUST contain the exact JSON string
+`reasoning.context = "all_turns"`. Before upstream serialization, the service
+MUST create a reasoning object when it is omitted or null and MUST replace an
+absent, null, blank, differently-cased, otherwise different-string, or
+non-string context value with `"all_turns"`. It MUST preserve
+`reasoning.effort`, `reasoning.summary`, and every unrelated reasoning member.
+
+This normalization MUST be idempotent, MUST NOT establish Lite classification
+or continuity trust, MUST NOT reject an otherwise-valid Lite request solely for
+a context mismatch, and MUST NOT remove the Lite signal. For requests not
+advertised as Lite, this normalization MUST leave the client-supplied reasoning
+shape unchanged. An invalid non-object reasoning container remains subject to
+the existing client-payload validation contract.
+
+#### Scenario: Body-derived Lite HTTP request omits reasoning
+
+- **WHEN** a normalized HTTP Responses body contains an `additional_tools` input item and omits or nulls `reasoning`
+- **THEN** the final upstream HTTP body contains `reasoning.context = "all_turns"`
+- **AND** the request carries the canonical Responses Lite HTTP header
+
+#### Scenario: Existing Lite reasoning members survive normalization
+
+- **WHEN** a Responses Lite body includes reasoning effort, summary, or extension members and its context is absent, null, blank, differently cased, another string, or a non-string value
+- **THEN** the final upstream body contains the exact string `reasoning.context = "all_turns"`
+- **AND** every unrelated reasoning member retains its client-supplied value
+
+#### Scenario: Compact Lite request uses the same invariant
+
+- **WHEN** a compact request is advertised upstream as Responses Lite
+- **THEN** its final upstream POST body contains `reasoning.context = "all_turns"`
+- **AND** it carries the canonical Responses Lite HTTP header
+
+#### Scenario: Websocket and HTTP fallback agree on Lite reasoning
+
+- **WHEN** a body-derived Lite request is prepared for upstream websocket transport
+- **THEN** its `response.create` body contains both the canonical Lite client-metadata marker and `reasoning.context = "all_turns"`
+- **BUT WHEN** the websocket handshake falls back to upstream HTTP
+- **THEN** the HTTP body retains `reasoning.context = "all_turns"`, the marker is absent, and the canonical Lite HTTP header is present
+
+#### Scenario: HTTP bridge transformations preserve the invariant
+
+- **GIVEN** an HTTP bridge request established Lite mode from an `additional_tools` prefix
+- **WHEN** bridge trimming or retry builds a final `response.create` body whose input delta no longer contains that prefix
+- **THEN** the body retains the internally derived canonical Lite marker
+- **AND** it contains `reasoning.context = "all_turns"`
+
+#### Scenario: Trusted marker-only continuation is normalized
+
+- **GIVEN** a same-model websocket continuation has trusted Lite continuity to its referenced previous response
+- **WHEN** its incremental body carries the canonical marker but omits the original `additional_tools` prefix
+- **THEN** the final upstream body contains `reasoning.context = "all_turns"`
+- **AND** the canonical marker remains present
+
+#### Scenario: Untrusted and non-Lite requests are not normalized
+
+- **WHEN** a non-Lite request supplies arbitrary reasoning context, an inbound Lite header, or a stale or otherwise untrusted websocket marker
+- **THEN** the existing signal rules omit or strip the untrusted Lite signal
+- **AND** this normalization does not alter the request's client-supplied reasoning shape

--- a/openspec/changes/normalize-responses-lite-reasoning-context/tasks.md
+++ b/openspec/changes/normalize-responses-lite-reasoning-context/tasks.md
@@ -1,0 +1,26 @@
+## 1. Characterize the invariant
+
+- [x] 1.1 Add parameterized focused tests for the Lite reasoning finalizer covering omitted and null reasoning, absent/null/blank/differently-cased/other-string/non-string context, already-canonical idempotence, preservation of effort/summary/custom members, and a non-Lite no-op.
+- [x] 1.2 Extend the existing raw HTTP Responses and trusted-versus-untrusted websocket marker tests to reproduce the missing `all_turns` invariant before implementation, while retaining the existing invalid non-object reasoning 400 behavior.
+
+## 2. Normalize final Lite wire payloads
+
+- [x] 2.1 Add one idempotent dictionary-level Responses Lite reasoning finalizer beside the existing body/header/marker helpers; require an already-derived canonical Lite disposition, set the exact `"all_turns"` value, preserve every sibling member, and never mutate the reusable request model.
+- [x] 2.2 Apply the finalizer to raw Responses transport preparation before HTTP/websocket payload sizing and splitting, and to compact preparation before POST while preserving the existing input-only wire-budget validation, so normal websocket sends and automatic HTTP fallback share the invariant.
+- [x] 2.3 Apply the finalizer to ordinary and size-guarded direct websocket `response.create` serializers plus HTTP bridge request/retry serializers, keying marker-only normalization only from already-canonical body-derived, bridge-preserved, or continuity-trusted metadata.
+- [x] 2.4 Confirm fresh replay paths that sever `previous_response_id` linkage rebuild from an unmodified request model: marker-stripped non-Lite replays stay unnormalized, while replays whose own input retains `additional_tools` remain canonically signaled and normalized.
+
+## 3. Prove every transport path
+
+- [x] 3.1 Extend `tests/unit/test_proxy_utils.py` coverage for `test_stream_responses_derives_lite_http_header_from_additional_tools`, `test_stream_responses_uses_websocket_transport_and_marks_lite_payload`, the automatic websocket-upgrade HTTP fallback, and `test_compact_responses_derives_lite_http_header_from_additional_tools` to assert both the final signal and `reasoning.context`.
+- [x] 3.2 Keep `tests/integration/test_proxy_responses.py::test_backend_responses_preserves_responses_lite_tools_and_outputs` as a pre-egress model/input-preservation test rather than asserting a wire-only mutation from its monkeypatched `core_stream_responses`; assert the raw final HTTP body in the core transport tests, and extend `tests/integration/test_http_responses_bridge.py::test_backend_responses_http_bridge_lite_request_omits_synthesized_tools` to assert canonical context on its actually serialized upstream body without losing tools, input order, or reasoning siblings.
+- [x] 3.3 Extend the direct websocket base-Lite coverage and `tests/integration/test_proxy_websocket_responses.py::test_backend_responses_websocket_lite_marker_requires_previous_response_linkage` to prove trusted marker-only normalization and untrusted/stale marker no-op behavior.
+- [x] 3.4 Retain and extend fresh-replay regression coverage for both marker-stripped trusted incremental replay and body-derived Lite replay, including ordinary and size-guarded serialization paths.
+
+## 4. Verification and handoff
+
+- [x] 4.1 Run the focused unit and integration nodes changed above, then run the relevant full proxy transport suites if the focused set passes.
+- [x] 4.2 Run changed-file `uv run ruff check`, `uv run ruff format --check`, `uv run ty check`, `python3 scripts/check_proxy_architecture.py`, and `git diff --check`.
+  - Changed sources and tests pass Ruff, format, scoped ty, the architecture checker, and `git diff --check`. The global ty run reports only four unresolved `_analytics` imports in pre-existing untracked `.codex/hooks/` files outside this change.
+- [x] 4.3 Run `openspec validate normalize-responses-lite-reasoning-context --strict` and `openspec validate --specs`, then verify the implementation against this change before requesting current-head CI and Codex review.
+- [ ] 4.4 Prepare one focused PR with `Fixes #1411`, no new settings or docs surface, and monitor upstream Lite invalid-request telemetry after deployment.

--- a/openspec/changes/normalize-responses-lite-reasoning-context/tasks.md
+++ b/openspec/changes/normalize-responses-lite-reasoning-context/tasks.md
@@ -24,3 +24,4 @@
   - Changed sources and tests pass Ruff, format, scoped ty, the architecture checker, and `git diff --check`. The global ty run reports only four unresolved `_analytics` imports in pre-existing untracked `.codex/hooks/` files outside this change.
 - [x] 4.3 Run `openspec validate normalize-responses-lite-reasoning-context --strict` and `openspec validate --specs`, then verify the implementation against this change before requesting current-head CI and Codex review.
 - [ ] 4.4 Prepare one focused PR with `Fixes #1411`, no new settings or docs surface, and monitor upstream Lite invalid-request telemetry after deployment.
+  - Draft PR #1431 is prepared with `Fixes #1411`; deployment and post-deployment telemetry monitoring remain pending.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -5354,6 +5354,12 @@ async def test_backend_responses_http_bridge_lite_request_omits_synthesized_tool
             {"type": "message", "role": "developer", "content": "use repository tools"},
             {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hi"}]},
         ],
+        "reasoning": {
+            "context": "last_turn",
+            "effort": "high",
+            "summary": "auto",
+            "vendor_hint": 7,
+        },
         "stream": True,
     }
     events = await _collect_sse_events(async_client, "/backend-api/codex/responses", json_body=payload)
@@ -5363,9 +5369,15 @@ async def test_backend_responses_http_bridge_lite_request_omits_synthesized_tool
     bridge_body = json.loads(fake_upstream.sent_text[0])
     assert "tools" not in bridge_body
     # The Lite input prefix must survive and keep signaling Responses Lite.
-    assert bridge_body["input"][0]["type"] == "additional_tools"
+    assert bridge_body["input"] == payload["input"]
     client_metadata = bridge_body["client_metadata"]
     assert client_metadata["ws_request_header_x_openai_internal_codex_responses_lite"] == "true"
+    assert bridge_body["reasoning"] == {
+        "context": "all_turns",
+        "effort": "high",
+        "summary": "auto",
+        "vendor_hint": 7,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -343,6 +343,9 @@ async def test_backend_responses_preserves_responses_lite_tools_and_outputs(asyn
     # ``reasoning_effort_for_request`` at rust-v0.144.1).
     reasoning = cast("dict[str, JsonValue]", seen_payload["reasoning"])
     assert reasoning["effort"] == "max"
+    # This monkeypatch observes the validated request model before core egress;
+    # Lite context is a wire-only finalization and must not leak back into it.
+    assert "context" not in reasoning
     # The forwarded payload must keep signaling Responses Lite: the upstream
     # HTTP client derives the internal Lite header from the additional_tools
     # input prefix that survived the round trip.
@@ -352,6 +355,33 @@ async def test_backend_responses_preserves_responses_lite_tools_and_outputs(asyn
         cast("Mapping[str, JsonValue]", seen_payload),
     )
     assert upstream_headers == {proxy_client_module.CODEX_RESPONSES_LITE_HEADER: "true"}
+
+
+@pytest.mark.asyncio
+async def test_backend_responses_rejects_non_object_reasoning(async_client):
+    response = await async_client.post(
+        "/backend-api/codex/responses",
+        json={
+            "model": "gpt-5.6-sol",
+            "instructions": "",
+            "input": [
+                {
+                    "type": "additional_tools",
+                    "role": "developer",
+                    "tools": [{"type": "custom", "name": "shell"}],
+                },
+                {"role": "user", "content": "inspect"},
+            ],
+            "reasoning": ["invalid"],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["code"] == "invalid_request_error"
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] == "reasoning"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -1453,7 +1453,7 @@ def test_backend_responses_websocket_proxies_upstream_and_persists_log(
                     custom_tool_output,
                     {"role": "user", "content": [{"type": "input_text", "text": "hi"}]},
                 ],
-                "reasoning": {"effort": "high"},
+                "reasoning": {"effort": "high", "context": "all_turns"},
                 "client_metadata": {
                     "x-codex-turn-metadata": (
                         '{"installation_id":"account-installation","turn_id":"turn_123","sandbox":"workspace-write"}'
@@ -1731,6 +1731,7 @@ def test_backend_responses_websocket_lite_marker_requires_previous_response_link
             "instructions": "",
             "input": [{"role": "user", "content": [{"type": "input_text", "text": "continue"}]}],
             "client_metadata": {marker: "true"},
+            "reasoning": {"context": "last_turn", "effort": "high"},
             "stream": True,
         }
         if previous_response_id is not None:
@@ -1768,13 +1769,18 @@ def test_backend_responses_websocket_lite_marker_requires_previous_response_link
     sent_payloads = [json.loads(text) for text in fake_upstream.sent_text]
     assert len(sent_payloads) == 5
     assert cast(dict[str, object], sent_payloads[0]["client_metadata"])[marker] == "true"
+    assert sent_payloads[0]["reasoning"] == {"context": "all_turns"}
     assert cast(dict[str, object], sent_payloads[1]["client_metadata"])[marker] == "true"
+    assert sent_payloads[1]["reasoning"] == {"context": "all_turns", "effort": "high"}
     assert sent_payloads[1]["previous_response_id"] == "resp_ws_lite_1"
     assert marker not in cast(dict[str, object], sent_payloads[2].get("client_metadata", {}))
+    assert sent_payloads[2]["reasoning"] == {"context": "last_turn", "effort": "high"}
     assert sent_payloads[2]["previous_response_id"] == "resp_ws_other"
     assert marker not in cast(dict[str, object], sent_payloads[3].get("client_metadata", {}))
+    assert sent_payloads[3]["reasoning"] == {"context": "last_turn", "effort": "high"}
     assert "previous_response_id" not in sent_payloads[3]
     assert cast(dict[str, object], sent_payloads[4]["client_metadata"])[marker] == "true"
+    assert sent_payloads[4]["reasoning"] == {"context": "all_turns", "effort": "high"}
     assert sent_payloads[4]["previous_response_id"] == "resp_ws_lite_2"
 
 
@@ -1963,6 +1969,7 @@ def test_backend_responses_websocket_lite_fresh_replay_drops_marker_after_previo
     first_payloads = [json.loads(text) for text in first_upstream.sent_text]
     assert len(first_payloads) == 3
     assert cast(dict[str, object], first_payloads[2]["client_metadata"])[marker] == "true"
+    assert first_payloads[2]["reasoning"] == {"context": "all_turns"}
     assert first_payloads[2]["previous_response_id"] == "resp_ws_lite_a2"
 
     recovered_payloads = [json.loads(text) for text in recovered_upstream.sent_text]
@@ -1971,9 +1978,11 @@ def test_backend_responses_websocket_lite_fresh_replay_drops_marker_after_previo
     assert "previous_response_id" not in replay_payload
     assert replay_payload["input"] == [user_continue, assistant_ok, user_more]
     assert marker not in cast(dict[str, object], replay_payload.get("client_metadata", {}))
+    assert "reasoning" not in replay_payload
     after_replay_payload = recovered_payloads[1]
     assert after_replay_payload["previous_response_id"] == "resp_ws_lite_replay"
     assert marker not in cast(dict[str, object], after_replay_payload.get("client_metadata", {}))
+    assert "reasoning" not in after_replay_payload
 
 
 def test_backend_responses_websocket_body_lite_fresh_replay_keeps_marker_and_continuity(
@@ -2151,9 +2160,11 @@ def test_backend_responses_websocket_body_lite_fresh_replay_keeps_marker_and_con
     assert "previous_response_id" not in replay_payload
     assert replay_payload["input"] == body_lite_full_resend
     assert cast(dict[str, object], replay_payload["client_metadata"])[marker] == "true"
+    assert replay_payload["reasoning"] == {"context": "all_turns"}
     after_replay_payload = recovered_payloads[1]
     assert after_replay_payload["previous_response_id"] == "resp_ws_lite_replay"
     assert cast(dict[str, object], after_replay_payload["client_metadata"])[marker] == "true"
+    assert after_replay_payload["reasoning"] == {"context": "all_turns"}
 
 
 def test_backend_responses_websocket_lite_visible_replay_trusts_downstream_response_id(

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -5371,6 +5371,12 @@ async def test_stream_via_http_bridge_injects_durable_anchor_for_trimmable_full_
             "model": "gpt-5.4",
             "instructions": "hi",
             "input": input_items,
+            "reasoning": {
+                "context": "last_turn",
+                "effort": "high",
+                "summary": "auto",
+                "vendor_hint": 7,
+            },
         },
     )
     request_state = proxy_service._WebSocketRequestState(
@@ -5509,6 +5515,17 @@ async def test_stream_via_http_bridge_injects_durable_anchor_for_trimmable_full_
         "true",
         "true",
     ]
+    assert all(
+        frame["reasoning"]
+        == {
+            "context": "all_turns",
+            "effort": "high",
+            "summary": "auto",
+            "vendor_hint": 7,
+        }
+        for frame in prepared_frames
+    )
+    assert cast(dict[str, Any], payload.to_payload()["reasoning"])["context"] == "last_turn"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -11,6 +11,7 @@ import time
 from collections import deque
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
+from copy import deepcopy
 from datetime import timedelta
 from types import SimpleNamespace
 from typing import Any, AsyncIterator, Iterator, Literal, Protocol, Self, cast
@@ -3784,6 +3785,68 @@ def test_response_create_client_metadata_preserves_trusted_incremental_responses
     assert metadata == {"keep": "yes", marker: "true"}
 
 
+@pytest.mark.parametrize(
+    ("reasoning_present", "reasoning"),
+    [
+        pytest.param(False, None, id="omitted-reasoning"),
+        pytest.param(True, None, id="null-reasoning"),
+        pytest.param(True, {}, id="absent-context"),
+        pytest.param(True, {"context": None}, id="null-context"),
+        pytest.param(True, {"context": ""}, id="blank-context"),
+        pytest.param(True, {"context": "ALL_TURNS"}, id="differently-cased-context"),
+        pytest.param(
+            True,
+            {
+                "context": "last_turn",
+                "effort": "high",
+                "summary": "auto",
+                "vendor_hint": 7,
+            },
+            id="different-context-with-siblings",
+        ),
+        pytest.param(True, {"context": 7}, id="non-string-context"),
+        pytest.param(True, {"context": "all_turns"}, id="already-canonical"),
+    ],
+)
+def test_finalize_responses_lite_reasoning_context(
+    reasoning_present: bool,
+    reasoning: JsonValue,
+) -> None:
+    payload: dict[str, JsonValue] = {"input": []}
+    if reasoning_present:
+        payload["reasoning"] = reasoning
+
+    proxy_module._finalize_responses_lite_reasoning_context(payload, responses_lite=True)
+
+    finalized_reasoning = cast(Mapping[str, JsonValue], payload["reasoning"])
+    assert finalized_reasoning["context"] == "all_turns"
+    if isinstance(reasoning, Mapping):
+        reasoning_mapping = cast(Mapping[str, JsonValue], reasoning)
+        for key, value in reasoning_mapping.items():
+            if key != "context":
+                assert finalized_reasoning[key] == value
+    once_finalized = deepcopy(payload)
+    proxy_module._finalize_responses_lite_reasoning_context(payload, responses_lite=True)
+    assert payload == once_finalized
+
+
+def test_finalize_responses_lite_reasoning_context_is_non_lite_noop() -> None:
+    payload: dict[str, JsonValue] = {
+        "input": [],
+        "reasoning": {
+            "context": "last_turn",
+            "effort": "high",
+            "summary": "auto",
+            "vendor_hint": 7,
+        },
+    }
+    original_payload = deepcopy(payload)
+
+    proxy_module._finalize_responses_lite_reasoning_context(payload, responses_lite=False)
+
+    assert payload == original_payload
+
+
 def test_response_create_client_metadata_replaces_installation_id():
     metadata = proxy_service._response_create_client_metadata(
         {
@@ -6699,6 +6762,12 @@ async def test_stream_responses_derives_lite_http_header_from_additional_tools(m
                 proxy_module.CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY: "stale",
                 "keep": "yes",
             },
+            "reasoning": {
+                "context": "last_turn",
+                "effort": "high",
+                "summary": "auto",
+                "vendor_hint": 7,
+            },
         }
     )
     session = _WsSession(
@@ -6725,6 +6794,13 @@ async def test_stream_responses_derives_lite_http_header_from_additional_tools(m
     assert upstream_payload["client_metadata"] == {
         "keep": "yes",
     }
+    assert upstream_payload["reasoning"] == {
+        "context": "all_turns",
+        "effort": "high",
+        "summary": "auto",
+        "vendor_hint": 7,
+    }
+    assert cast(Mapping[str, JsonValue], payload.to_payload()["reasoning"])["context"] == "last_turn"
 
 
 @pytest.mark.asyncio
@@ -6770,6 +6846,7 @@ async def test_stream_responses_uses_websocket_transport_and_marks_lite_payload(
                 proxy_module.CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY: "stale",
                 "keep": "yes",
             },
+            "reasoning": {"context": None, "effort": "high", "vendor_hint": 7},
         }
     )
 
@@ -6794,7 +6871,13 @@ async def test_stream_responses_uses_websocket_transport_and_marks_lite_payload(
         "keep": "yes",
         proxy_module.CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY: "true",
     }
+    expected_request_payload["reasoning"] = {
+        "context": "all_turns",
+        "effort": "high",
+        "vendor_hint": 7,
+    }
     assert request_payload == expected_request_payload
+    assert "context" not in cast(Mapping[str, JsonValue], payload.to_payload()["reasoning"])
     upstream_headers = cast(dict[str, str], session.ws_calls[0]["headers"])
     assert proxy_module.CODEX_RESPONSES_LITE_HEADER not in {key.lower() for key in upstream_headers}
     expected_created = (
@@ -8517,8 +8600,18 @@ async def test_stream_responses_auto_transport_falls_back_to_http_when_websocket
     monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
 
     session = _SseSession(_SsePostResponse([b'data: {"type":"response.completed","response":{"id":"resp_http"}}\n\n']))
+    additional_tools = {
+        "type": "additional_tools",
+        "role": "developer",
+        "tools": [{"type": "custom", "name": "shell"}],
+    }
     payload = ResponsesRequest.model_validate(
-        {"model": "gpt-5.4", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+        {
+            "model": "gpt-5.4",
+            "instructions": "hi",
+            "input": [additional_tools, {"role": "user", "content": "hi"}],
+            "reasoning": {"context": "last_turn", "effort": "high"},
+        }
     )
 
     events = [
@@ -8534,6 +8627,13 @@ async def test_stream_responses_auto_transport_falls_back_to_http_when_websocket
 
     assert attempts["websocket"] == 1
     assert session.calls
+    upstream_headers = cast(dict[str, str], session.calls[0]["headers"])
+    assert upstream_headers[proxy_module.CODEX_RESPONSES_LITE_HEADER] == "true"
+    upstream_payload = cast(dict[str, JsonValue], session.calls[0]["json"])
+    assert upstream_payload["reasoning"] == {"context": "all_turns", "effort": "high"}
+    assert proxy_module.CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY not in cast(
+        Mapping[str, JsonValue], upstream_payload.get("client_metadata", {})
+    )
     assert events == ['data: {"type":"response.completed","response":{"id":"resp_http"}}\n\n']
 
 
@@ -8982,6 +9082,7 @@ async def test_compact_responses_derives_lite_http_header_from_additional_tools(
                 {"role": "assistant", "content": "middle context " + "y" * 500_000},
                 {"role": "user", "content": "inspect"},
             ],
+            "reasoning": {"context": "turn", "effort": "high", "vendor_hint": 7},
         }
     )
     session = _CompactSession(
@@ -9003,6 +9104,11 @@ async def test_compact_responses_derives_lite_http_header_from_additional_tools(
     upstream_payload = cast(dict[str, object], session.calls[0]["json"])
     assert cast(list[object], upstream_payload["input"])[0] == additional_tools
     assert cast(list[object], upstream_payload["input"])[1] == developer_instructions
+    assert upstream_payload["reasoning"] == {
+        "context": "all_turns",
+        "effort": "high",
+        "vendor_hint": 7,
+    }
 
 
 @pytest.mark.asyncio
@@ -16952,6 +17058,7 @@ async def test_websocket_lite_prewarm_acceptance_preserves_incremental_marker(
     first_payload = json.loads(first.text_data)
     assert first_payload["generate"] is False
     assert first_payload["client_metadata"][marker] == "true"
+    assert first_payload["reasoning"] == {"context": "all_turns"}
     assert first.request_state.request_kind == "prewarm"
     assert first.request_state.generate_false_prewarm is True
     assert continuity_state.responses_lite_model is None
@@ -16993,6 +17100,7 @@ async def test_websocket_lite_prewarm_acceptance_preserves_incremental_marker(
                     marker: "true",
                     "x-codex-turn-metadata": json.dumps({"request_kind": "turn"}),
                 },
+                "reasoning": {"context": "last_turn", "effort": "high"},
             },
         ),
         headers=prewarm_headers,
@@ -17007,6 +17115,7 @@ async def test_websocket_lite_prewarm_acceptance_preserves_incremental_marker(
     incremental_payload = json.loads(incremental.text_data)
     assert incremental.request_state.request_kind == "prewarm"
     assert incremental_payload["client_metadata"][marker] == "true"
+    assert incremental_payload["reasoning"] == {"context": "all_turns", "effort": "high"}
     incremental_turn_metadata = json.loads(incremental_payload["client_metadata"]["x-codex-turn-metadata"])
     assert incremental_turn_metadata["request_kind"] == "turn"
 
@@ -17019,6 +17128,7 @@ async def test_websocket_lite_prewarm_acceptance_preserves_incremental_marker(
                 "instructions": "",
                 "input": [{"role": "user", "content": "ordinary request"}],
                 "client_metadata": {marker: "true"},
+                "reasoning": {"context": "last_turn", "effort": "high"},
             },
         ),
         headers=prewarm_headers,
@@ -17033,6 +17143,7 @@ async def test_websocket_lite_prewarm_acceptance_preserves_incremental_marker(
     incompatible_payload = json.loads(incompatible.text_data)
     assert incompatible_payload["model"] == "gpt-5.4"
     assert marker not in incompatible_payload["client_metadata"]
+    assert incompatible_payload["reasoning"] == {"context": "last_turn", "effort": "high"}
     assert "x-codex-turn-metadata" in incompatible_payload["client_metadata"]
     assert continuity_state.responses_lite_model == "gpt-5.6-sol"
     proxy_service._record_websocket_responses_lite_acceptance(
@@ -17089,6 +17200,7 @@ async def test_websocket_lite_incremental_requires_previous_response_linkage(
         "instructions": "",
         "input": [{"role": "user", "content": "continue"}],
         "client_metadata": {marker: "true"},
+        "reasoning": {"context": "last_turn", "effort": "high"},
     }
     if previous_response_id is not None:
         payload["previous_response_id"] = previous_response_id
@@ -17106,6 +17218,7 @@ async def test_websocket_lite_incremental_requires_previous_response_linkage(
 
     prepared_payload = json.loads(prepared.text_data)
     assert marker not in prepared_payload.get("client_metadata", {})
+    assert prepared_payload["reasoning"] == {"context": "last_turn", "effort": "high"}
     assert prepared.request_state.responses_lite_model is None
     assert continuity_state.responses_lite_model == "gpt-5.6-sol"
     assert continuity_state.responses_lite_response_id == "resp_ws_lite_prewarm"
@@ -17155,6 +17268,7 @@ async def test_websocket_lite_fresh_replay_strips_trusted_marker(monkeypatch):
                     {"role": "user", "content": "with details"},
                 ],
                 "client_metadata": {marker: "true", "keep": "yes"},
+                "reasoning": {"context": "last_turn", "effort": "high"},
             },
         ),
         headers={},
@@ -17168,12 +17282,14 @@ async def test_websocket_lite_fresh_replay_strips_trusted_marker(monkeypatch):
 
     trusted_payload = json.loads(trusted.text_data)
     assert trusted_payload["client_metadata"][marker] == "true"
+    assert trusted_payload["reasoning"] == {"context": "all_turns", "effort": "high"}
     assert trusted.request_state.fresh_upstream_request_is_retry_safe
     assert trusted.request_state.fresh_upstream_request_text is not None
     replay_payload = json.loads(trusted.request_state.fresh_upstream_request_text)
     assert "previous_response_id" not in replay_payload
     assert replay_payload["input"] == trusted_payload["input"]
     assert replay_payload["client_metadata"] == {"keep": "yes"}
+    assert replay_payload["reasoning"] == {"context": "last_turn", "effort": "high"}
     # The marker-stripped fresh body is non-Lite, so swapping to it for a
     # transparent replay must also clear the Lite acceptance flag.
     assert trusted.request_state.responses_lite_model == "gpt-5.6-sol"
@@ -17196,6 +17312,7 @@ async def test_websocket_lite_fresh_replay_strips_trusted_marker(monkeypatch):
                     {"role": "user", "content": "continue"},
                 ],
                 "client_metadata": {marker: "stale", "keep": "yes"},
+                "reasoning": {"context": 7, "summary": "auto", "vendor_hint": 9},
             },
         ),
         headers={},
@@ -17209,10 +17326,20 @@ async def test_websocket_lite_fresh_replay_strips_trusted_marker(monkeypatch):
 
     body_lite_payload = json.loads(body_lite.text_data)
     assert body_lite_payload["client_metadata"][marker] == "true"
+    assert body_lite_payload["reasoning"] == {
+        "context": "all_turns",
+        "summary": "auto",
+        "vendor_hint": 9,
+    }
     assert body_lite.request_state.fresh_upstream_request_text is not None
     body_lite_replay = json.loads(body_lite.request_state.fresh_upstream_request_text)
     assert "previous_response_id" not in body_lite_replay
     assert body_lite_replay["client_metadata"][marker] == "true"
+    assert body_lite_replay["reasoning"] == {
+        "context": "all_turns",
+        "summary": "auto",
+        "vendor_hint": 9,
+    }
     assert body_lite.request_state.fresh_upstream_request_responses_lite_model == "gpt-5.6-sol"
 
 
@@ -17816,7 +17943,7 @@ async def test_prepare_websocket_full_replay_retry_text_uses_size_guard(monkeypa
         id="key_ws_trim_replay_size",
         name="ws-trim-replay-size",
         key_prefix="sk-ws-trim-size",
-        allowed_models=["gpt-5.1"],
+        allowed_models=["gpt-5.6-sol"],
         enforced_model=None,
         enforced_reasoning_effort=None,
         enforced_service_tier=None,
@@ -17831,6 +17958,11 @@ async def test_prepare_websocket_full_replay_retry_text_uses_size_guard(monkeypa
         openai_prompt_cache_key_derivation_enabled = True
 
     historical_input: list[JsonValue] = [
+        {
+            "type": "additional_tools",
+            "role": "developer",
+            "tools": [{"type": "custom", "name": "shell"}],
+        },
         {"role": "user", "content": [{"type": "input_text", "text": "old question"}]},
         {"type": "function_call_output", "call_id": "call_large", "output": "A" * 40000},
     ]
@@ -17853,8 +17985,9 @@ async def test_prepare_websocket_full_replay_retry_text_uses_size_guard(monkeypa
             dict[str, JsonValue],
             {
                 "type": "response.create",
-                "model": "gpt-5.1",
+                "model": "gpt-5.6-sol",
                 "input": [*historical_input, new_input],
+                "reasoning": {"context": "last_turn", "effort": "high"},
             },
         ),
         headers={"session_id": "turn_ws_trim_size"},
@@ -17870,12 +18003,14 @@ async def test_prepare_websocket_full_replay_retry_text_uses_size_guard(monkeypa
     fresh_payload = json.loads(prepared.request_state.fresh_upstream_request_text)
     fresh_input = cast(list[JsonValue], fresh_payload["input"])
     assert len(prepared.request_state.fresh_upstream_request_text.encode("utf-8")) <= 2048
-    assert fresh_input[1] == {
+    assert next(item for item in fresh_input if isinstance(item, dict) and item.get("call_id") == "call_large") == {
         "type": "function_call_output",
         "call_id": "call_large",
         "output": proxy_service._RESPONSE_CREATE_TOOL_OUTPUT_OMISSION_NOTICE.format(bytes=40000),
     }
     assert fresh_input[-1] == new_input
+    assert fresh_payload["client_metadata"][proxy_module.CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY] == "true"
+    assert fresh_payload["reasoning"] == {"context": "all_turns", "effort": "high"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Normalize every canonically signaled Responses Lite request to include the upstream-required `reasoning.context = "all_turns"` across HTTP, compact, WebSocket, bridge, fallback, continuity, and replay paths.

Fixes #1411.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Fixes #1411.

## Root cause

codex-lb derived and emitted the Responses Lite header or WebSocket marker from `additional_tools`, but did not enforce the matching reasoning-body invariant. This allowed the proxy to send a canonical Lite signal with an incompatible payload, producing 273 observed upstream rejections.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/normalize-responses-lite-reasoning-context/`

## Changes

- Add one idempotent wire-level finalizer that sets the exact `"all_turns"` value only after Lite disposition is trusted.
- Preserve `effort`, `summary`, unknown reasoning fields, and the reusable request model.
- Apply the invariant to raw Responses, compact, direct WebSocket, HTTP fallback, bridge, trusted continuity, and replay serialization.
- Keep non-Lite requests and untrusted or stale Lite markers unchanged.
- Add regression coverage for missing, conflicting, canonical, trusted, and untrusted context variants.

## Impact

This prevents upstream invalid-request failures for valid Responses Lite traffic. It does not change public endpoints, response schemas, database state, settings, dependencies, or Lite classification rules.

## Simplicity

- [x] Zero-config correctness fix with no new required setup
- [x] No new `CODEX_LB_*` setting
- New setting(s) and why each can't be a default: None.
- [x] No README, `.env.example`, dashboard-nav, or documentation-surface growth

## Test plan

```text
.venv/bin/pytest tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py -q
# 1,101 passed

.venv/bin/pytest tests/integration/test_http_responses_bridge.py tests/integration/test_proxy_responses.py tests/integration/test_proxy_websocket_responses.py -q -k 'not test_proxy_responses_repeated_401_after_refresh_fails_over'
# 236 passed, 1 deselected
```

The deselected test is a pre-existing slow real-refresh retry case unrelated to Lite serialization. Ruff lint/format, scoped `ty`, `git diff --check`, strict change validation, all 47 main OpenSpec specs, and local `/opsx:verify` pass. The only repo-wide local `ty` diagnostics came from pre-existing untracked `.codex/hooks` files, which are not part of this PR.

## Base synchronization

Resolved: #1430 is merged, and this branch now includes current `main` at `ed017d52`. Current-head cloud CI is green, Codex review found no major issues on `7ec5f66a`, and GitHub reports the PR `MERGEABLE/CLEAN`.

## Screenshots / output

Wire-only change; no screenshots apply. A canonically signaled Lite request containing:

```json
{"reasoning":{"effort":"max"}}
```

is forwarded as:

```json
{"reasoning":{"effort":"max","context":"all_turns"}}
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local lint and test subsets.
- [x] `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is not edited by hand.

This PR is ready for maintainer review. Merge is left to a maintainer.