### PR TITLE
fix(proxy-responses): reclaim idle HTTP bridge stream leases

### DIFF
--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -1769,7 +1769,6 @@ async def _reclaim_idle_http_bridge_stream_lease(
     capacity_blocked_account_ids: frozenset[str],
     preferred_account_id: str | None,
     require_preferred_account: bool,
-    scoped_account_ids: set[str] | None,
 ) -> bool:
     """Close one idle bridge that is holding an eligible account stream lease."""
 
@@ -1787,8 +1786,6 @@ async def _reclaim_idle_http_bridge_stream_lease(
             if not _http_bridge_session_account_active(candidate_session):
                 continue
             if candidate_session.account.id not in capacity_blocked_account_ids:
-                continue
-            if scoped_account_ids is not None and candidate_session.account.id not in scoped_account_ids:
                 continue
             if (
                 require_preferred_account

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -1763,6 +1763,92 @@ def _http_bridge_eviction_priority(session: _HTTPBridgeSession) -> tuple[int, fl
     return (0 if not session.codex_session else 1, session.last_used_at)
 
 
+async def _reclaim_idle_http_bridge_stream_lease(
+    service: _HTTPBridgeServiceProtocol,
+    *,
+    capacity_blocked_account_ids: frozenset[str],
+    preferred_account_id: str | None,
+    require_preferred_account: bool,
+    scoped_account_ids: set[str] | None,
+) -> bool:
+    """Close one idle bridge that is holding an eligible account stream lease."""
+
+    if not capacity_blocked_account_ids or (require_preferred_account and preferred_account_id is None):
+        return False
+
+    detached: _HTTPBridgeSession | None = None
+    detached_key: _HTTPBridgeSessionKey | None = None
+    async with service._http_bridge_lock:
+        candidates: list[tuple[_HTTPBridgeSessionKey, _HTTPBridgeSession]] = []
+        for candidate_key, candidate_session in service._http_bridge_sessions.items():
+            account_lease = candidate_session.account_lease
+            if account_lease is None or account_lease.kind != "stream":
+                continue
+            if not _http_bridge_session_account_active(candidate_session):
+                continue
+            if candidate_session.account.id not in capacity_blocked_account_ids:
+                continue
+            if scoped_account_ids is not None and candidate_session.account.id not in scoped_account_ids:
+                continue
+            if (
+                require_preferred_account
+                and preferred_account_id is not None
+                and candidate_session.account.id != preferred_account_id
+            ):
+                continue
+            if _http_bridge_session_has_admission_waiter(candidate_session):
+                continue
+            if getattr(candidate_session, "unanchored_reservation_id", None) is not None:
+                continue
+            if (
+                not candidate_session.closed
+                and candidate_session.last_completed_response_id is None
+                and not candidate_session.previous_response_ids
+            ):
+                # A newly-created bridge can be between connect and submit even
+                # before the handoff reservation is visible. It is not idle
+                # capacity yet and must not be reclaimed.
+                continue
+            pending_count = _http_bridge_pending_count_nowait(
+                candidate_session,
+                context="account_stream_cap_reclaim_scan",
+            )
+            if pending_count is None or pending_count:
+                continue
+            candidates.append((candidate_key, candidate_session))
+
+        if preferred_account_id is not None and not require_preferred_account:
+            preferred_candidates = [
+                candidate for candidate in candidates if candidate[1].account.id == preferred_account_id
+            ]
+            if preferred_candidates:
+                candidates = preferred_candidates
+
+        if candidates:
+            detached_key, candidate_session = min(
+                candidates,
+                key=lambda item: _http_bridge_eviction_priority(item[1]),
+            )
+            detached = service._detach_http_bridge_session_locked(
+                detached_key,
+                expected_session=candidate_session,
+            )
+
+    if detached is None or detached_key is None:
+        return False
+
+    _log_http_bridge_event(
+        "evict_account_stream_cap_idle",
+        detached_key,
+        account_id=detached.account.id,
+        model=detached.request_model,
+        cache_key_family=detached_key.affinity_kind,
+        model_class=_extract_model_class(detached.request_model) if detached.request_model else None,
+    )
+    await service._close_http_bridge_session_bounded(detached, reason="account_stream_cap_reclaim")
+    return True
+
+
 def _build_http_bridge_prewarm_text(text_data: str) -> str | None:
     try:
         payload = json.loads(text_data)
@@ -2174,6 +2260,7 @@ for _helper_name in (
     "_http_bridge_requires_cluster_registration",
     "_effective_http_bridge_idle_ttl_seconds",
     "_http_bridge_eviction_priority",
+    "_reclaim_idle_http_bridge_stream_lease",
     "_build_http_bridge_prewarm_text",
     "_http_bridge_prewarm_enabled",
     "_record_http_bridge_prewarm_outcome",

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -1865,11 +1865,6 @@ class _HTTPBridgeMixin(
         retry_same_account_once = preferred_account_id is not None
         preferred_candidate_id = preferred_account_id
         selected_account_lease: AccountLease | None = None
-        scoped_account_ids: set[str] | None = (
-            set(api_key.assigned_account_ids)
-            if api_key is not None and api_key.account_assignment_scope_enabled
-            else None
-        )
         while True:
             select_kwargs = {
                 "request_id": request_state.request_log_id or request_state.request_id,
@@ -1901,7 +1896,6 @@ class _HTTPBridgeMixin(
                     require_preferred_account=(
                         require_preferred_account or not fallback_on_preferred_account_unavailable
                     ),
-                    scoped_account_ids=scoped_account_ids,
                 ):
                     continue
                 _record_same_account_takeover(

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -115,6 +115,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _persist_http_bridge_turn_state_alias,
     _preferred_http_bridge_reconnect_turn_state,
     _raise_http_bridge_incompatible_admission_handoff,
+    _reclaim_idle_http_bridge_stream_lease,
     _reconcile_durable_http_bridge_ownership,
     _record_bridge_drain_recovery_allowed,
     _record_bridge_first_turn_timeout,
@@ -1864,6 +1865,11 @@ class _HTTPBridgeMixin(
         retry_same_account_once = preferred_account_id is not None
         preferred_candidate_id = preferred_account_id
         selected_account_lease: AccountLease | None = None
+        scoped_account_ids: set[str] | None = (
+            set(api_key.assigned_account_ids)
+            if api_key is not None and api_key.account_assignment_scope_enabled
+            else None
+        )
         while True:
             select_kwargs = {
                 "request_id": request_state.request_log_id or request_state.request_id,
@@ -1888,6 +1894,16 @@ class _HTTPBridgeMixin(
             if account is None:
                 await self._load_balancer.release_account_lease(selected_account_lease)
                 selected_account_lease = None
+                if selection.error_code == "account_stream_cap" and await _reclaim_idle_http_bridge_stream_lease(
+                    self,
+                    capacity_blocked_account_ids=selection.capacity_blocked_account_ids,
+                    preferred_account_id=preferred_candidate_id,
+                    require_preferred_account=(
+                        require_preferred_account or not fallback_on_preferred_account_unavailable
+                    ),
+                    scoped_account_ids=scoped_account_ids,
+                ):
+                    continue
                 _record_same_account_takeover(
                     preferred_account_id=preferred_account_id,
                     selected_account_id=None,

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -163,6 +163,7 @@ class AccountSelection:
     error_code: str | None = None
     lease: AccountLease | None = None
     catalog_omission_quota_admission: CatalogOmissionQuotaAdmission | None = None
+    capacity_blocked_account_ids: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True, slots=True)
@@ -487,6 +488,7 @@ class LoadBalancer:
         selected_account_map: dict[str, Account] = {}
         selected_lease: AccountLease | None = None
         selection_error_code: str | None = None
+        capacity_blocked_account_ids: frozenset[str] = frozenset()
         legacy_existing_account_id: str | None = None
         if sticky_source == "session_header" and legacy_sticky_key is not None:
             async with self._repo_factory() as repos:
@@ -533,6 +535,7 @@ class LoadBalancer:
             attempt = 0
             while True:
                 attempt += 1
+                capacity_blocked_account_ids = frozenset()
                 async with self._runtime_lock:
                     self._reclaim_stale_account_leases_locked()
                     self._prune_runtime(selection_inputs.runtime_accounts or selection_inputs.accounts)
@@ -573,6 +576,18 @@ class LoadBalancer:
                     )
                     if not selection_states and states:
                         selection_error_code = _account_cap_error_code(lease_kind)
+                        capacity_blocked_account_ids = _capacity_reclaim_candidate_ids(
+                            states,
+                            prefer_earlier_reset=prefer_earlier_reset_accounts,
+                            prefer_earlier_reset_window=prefer_earlier_reset_window,
+                            routing_strategy=routing_strategy,
+                            relative_availability_power=relative_availability_power,
+                            relative_availability_top_k=relative_availability_top_k,
+                            budget_threshold_pct=budget_threshold_pct,
+                            secondary_budget_threshold_pct=secondary_budget_threshold_pct,
+                            traffic_class=traffic_class,
+                            routing_costs_by_account_id=effective_routing_costs,
+                        )
                         error_message = _account_cap_error_message(lease_kind, caps)
                         result = SelectionResult(None, error_message)
                         logger.warning(
@@ -729,6 +744,7 @@ class LoadBalancer:
             attempt = 0
             while True:
                 attempt += 1
+                capacity_blocked_account_ids = frozenset()
                 async with self._runtime_lock:
                     self._reclaim_stale_account_leases_locked()
                     self._prune_runtime(selection_inputs.runtime_accounts or selection_inputs.accounts)
@@ -855,6 +871,18 @@ class LoadBalancer:
                     result = SelectionResult(None, "Hard affinity owner account is unavailable")
                 elif not selection_states and states:
                     selection_error_code = _account_cap_error_code(lease_kind)
+                    capacity_blocked_account_ids = _capacity_reclaim_candidate_ids(
+                        states,
+                        prefer_earlier_reset=prefer_earlier_reset_accounts,
+                        prefer_earlier_reset_window=prefer_earlier_reset_window,
+                        routing_strategy=routing_strategy,
+                        relative_availability_power=relative_availability_power,
+                        relative_availability_top_k=relative_availability_top_k,
+                        budget_threshold_pct=budget_threshold_pct,
+                        secondary_budget_threshold_pct=secondary_budget_threshold_pct,
+                        traffic_class=traffic_class,
+                        routing_costs_by_account_id=effective_routing_costs,
+                    )
                     result = SelectionResult(None, _account_cap_error_message(lease_kind, caps))
                     logger.warning(
                         "Account cap exhausted during sticky selection lease_kind=%s reason=%s candidates=%s",
@@ -950,6 +978,7 @@ class LoadBalancer:
                                 ):
                                     selected_snapshot = None
                                     selection_error_code = _account_cap_error_code(lease_kind)
+                                    capacity_blocked_account_ids = frozenset({selected.id})
                                     error_message = _account_cap_error_message(lease_kind, caps)
                                 else:
                                     selected_lease = self._acquire_account_lease_locked(
@@ -1029,7 +1058,12 @@ class LoadBalancer:
             if error_message == "No available accounts":
                 set_degraded("all upstream accounts are unavailable")
                 error_message = _format_degraded_error_message(error_message)
-            return AccountSelection(account=None, error_message=error_message, error_code=selection_error_code)
+            return AccountSelection(
+                account=None,
+                error_message=error_message,
+                error_code=selection_error_code,
+                capacity_blocked_account_ids=capacity_blocked_account_ids,
+            )
         logger.info(
             "Selected account_id=%s strategy=%s sticky=%s model=%s",
             selected_snapshot.id,
@@ -2129,6 +2163,40 @@ def _filter_states_for_account_caps(
                 continue
         filtered.append(state)
     return filtered
+
+
+def _capacity_reclaim_candidate_ids(
+    states: Iterable[AccountState],
+    *,
+    prefer_earlier_reset: bool,
+    prefer_earlier_reset_window: ResetPreferenceWindow,
+    routing_strategy: RoutingStrategy,
+    relative_availability_power: float,
+    relative_availability_top_k: int,
+    budget_threshold_pct: float,
+    secondary_budget_threshold_pct: float,
+    traffic_class: TrafficClass,
+    routing_costs_by_account_id: RoutingCostsByAccount | None,
+) -> frozenset[str]:
+    """Return a selector-proven account whose local lease may be reclaimed."""
+
+    probe = _select_account_preferring_budget_safe(
+        [replace(state) for state in states],
+        prefer_earlier_reset=prefer_earlier_reset,
+        prefer_earlier_reset_window=prefer_earlier_reset_window,
+        routing_strategy=routing_strategy,
+        relative_availability_power=relative_availability_power,
+        relative_availability_top_k=relative_availability_top_k,
+        deterministic_probe=True,
+        budget_threshold_pct=budget_threshold_pct,
+        secondary_budget_threshold_pct=secondary_budget_threshold_pct,
+        traffic_class=traffic_class,
+        ignore_standard_quota=False,
+        routing_costs_by_account_id=routing_costs_by_account_id,
+    )
+    if probe.account is None:
+        return frozenset()
+    return frozenset({probe.account.account_id})
 
 
 def _account_cap_error_code(lease_kind: AccountLeaseKind | None) -> str | None:

--- a/openspec/changes/reclaim-idle-http-bridge-stream-leases/proposal.md
+++ b/openspec/changes/reclaim-idle-http-bridge-stream-leases/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+HTTP bridge sessions retain their per-account stream lease for the full
+session lifetime so they can be reused without reacquiring account capacity.
+Under disconnect-heavy traffic, an otherwise idle local session can therefore
+hold the last stream slot while new HTTP Responses requests fail with
+`account_stream_cap`. The durable bridge row can already be gone while the
+owner replica still retains the in-memory session and lease, so waiting for
+database cleanup does not restore local capacity.
+
+## What Changes
+
+- When HTTP bridge session creation receives a local `account_stream_cap`,
+  inspect the local bridge registry for an eligible idle session that still
+  holds a stream lease.
+- Detach at most one idle session from the exact selector-reported set of
+  otherwise eligible, capacity-blocked accounts, then close it through the
+  existing bounded cleanup path before retrying account selection.
+- Preserve active work, admission handoffs, pre-submit reservations, API-key
+  account scopes, and required preferred-account continuity.
+- Prefer reclaiming an idle session on the requested preferred account when
+  that preference is soft, while retaining the existing bridge eviction order.
+
+## Impact
+
+- Local stream slots held only by idle reusable HTTP bridge sessions can be
+  recovered immediately under real account-cap pressure instead of waiting for
+  the lease TTL or a process restart.
+- Active and pre-submit bridge sessions remain protected.
+- No setting, schema, endpoint, or response-format change is introduced.
+- An idle bridge may lose warm-session or prompt-cache reuse when its stream
+  lease is needed for new work; this happens only after account selection has
+  already reported `account_stream_cap`.
+
+Related to #1354

--- a/openspec/changes/reclaim-idle-http-bridge-stream-leases/specs/responses-api-compat/spec.md
+++ b/openspec/changes/reclaim-idle-http-bridge-stream-leases/specs/responses-api-compat/spec.md
@@ -1,0 +1,60 @@
+## ADDED Requirements
+
+### Requirement: HTTP bridge account-cap pressure reclaims idle stream leases
+
+When HTTP bridge session creation cannot select an account because every
+otherwise eligible local candidate is blocked by `account_stream_cap`, the
+service MUST attempt to recover capacity from an idle local HTTP bridge session
+that still holds a stream lease before returning the local capacity failure.
+
+The service MUST NOT reclaim a session whose account was not in the exact set
+of otherwise eligible accounts rejected by the account-cap filter. It also
+MUST NOT reclaim a session that has active or queued requests, an admission
+waiter, a pre-submit handoff reservation, or no evidence that its first visible
+turn has completed. API-key account assignment scopes and required
+preferred-account continuity MUST be preserved when choosing a session to
+reclaim. A soft preferred account SHOULD be reclaimed first when it has an
+eligible idle session.
+
+The registry lock MAY be used to inspect and detach the selected idle session,
+but the session close and account-lease release MUST run through the existing
+bounded cleanup path after the registry lock is released. Account selection
+MUST be retried only after that bounded close has completed.
+
+#### Scenario: Idle bridge releases the last local stream slot
+
+- **GIVEN** an idle HTTP bridge session has completed a visible turn, has no
+  pending or queued work, and still holds an account stream lease
+- **AND** a new HTTP bridge session creation attempt receives
+  `account_stream_cap`
+- **WHEN** the idle session belongs to an account eligible for the new request
+- **THEN** the service detaches and closes the idle session through the bounded
+  cleanup path
+- **AND** it retries account selection only after the idle session's stream
+  lease has been released
+- **AND** the new request can use the recovered stream slot
+
+#### Scenario: Active bridge is not reclaimed
+
+- **GIVEN** an HTTP bridge session has an active or queued request
+- **WHEN** another bridge creation attempt receives `account_stream_cap`
+- **THEN** the active session remains registered and retains its stream lease
+- **AND** the service returns the existing bounded local capacity failure when
+  no other eligible idle session can be reclaimed
+
+#### Scenario: Required account continuity constrains reclamation
+
+- **GIVEN** a bridge creation requires a preferred owner account
+- **AND** only idle sessions on other accounts hold reclaimable stream leases
+- **WHEN** account selection reports `account_stream_cap`
+- **THEN** the service does not reclaim an unrelated account's session for that
+  hard-continuity request
+- **AND** the request fails closed with the existing account-capacity error
+
+#### Scenario: Unrelated idle account is not reclaimed
+
+- **GIVEN** account selection reports that a specific eligible account set is
+  blocked only by `account_stream_cap`
+- **AND** an idle session holds a stream lease on an account outside that set
+- **WHEN** the service attempts local capacity recovery
+- **THEN** the unrelated session remains registered and retains its lease

--- a/openspec/changes/reclaim-idle-http-bridge-stream-leases/tasks.md
+++ b/openspec/changes/reclaim-idle-http-bridge-stream-leases/tasks.md
@@ -1,0 +1,10 @@
+- [x] Define bounded idle stream-lease reclamation semantics for HTTP bridge creation
+- [x] Reclaim one eligible idle local bridge when account selection reports `account_stream_cap`
+- [x] Preserve active requests, pre-submit reservations, required account continuity, and API-key account scope
+- [x] Add regression tests for successful reclaim-and-retry and active-session protection
+- [x] Run focused unit tests, lint/type checks, architecture checks, and strict OpenSpec validation
+
+Verification note: the targeted/full bridge suites, Ruff, ty, and strict/all
+OpenSpec validation pass. The repository's pre-existing architecture ratchet
+still reports `app/modules/proxy/service.py` at 2604 lines against a 2600-line
+limit; this change does not modify that file.

--- a/tests/unit/test_load_balancer_concurrency.py
+++ b/tests/unit/test_load_balancer_concurrency.py
@@ -431,6 +431,7 @@ async def test_account_stream_cap_returns_stable_local_reason_until_released() -
 
     assert capped.account is None
     assert capped.error_code == "account_stream_cap"
+    assert capped.capacity_blocked_account_ids == frozenset({account.id})
     assert capped.error_message == (
         "Account stream capacity is exhausted; per-account limit is 8. "
         "Increase the dashboard stream limit or wait for active streams to finish."

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -3769,6 +3769,252 @@ async def test_create_http_bridge_session_passes_dashboard_reset_window_to_selec
 
 
 @pytest.mark.asyncio
+async def test_create_http_bridge_session_reclaims_idle_stream_lease_on_account_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    idle_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-idle-cap", None)
+    idle = _make_bridge_session(key=idle_key, key_value="sid-idle-cap")
+    idle.account = cast(Any, SimpleNamespace(id="acc-idle-cap", status=AccountStatus.ACTIVE, plan_type="plus"))
+    idle.last_completed_response_id = "resp-idle-cap"
+    idle.account_lease = await service._load_balancer.acquire_account_lease(idle.account.id, kind="stream")
+    assert idle.account_lease is not None
+    service._http_bridge_sessions[idle_key] = idle
+
+    selected_account = cast(
+        Any,
+        SimpleNamespace(id=idle.account.id, status=AccountStatus.ACTIVE, plan_type="plus"),
+    )
+    selected_lease: proxy_service.AccountLease | None = None
+    call_order: list[str] = []
+
+    async def select_account(_deadline: float, **_: object) -> proxy_service.AccountSelection:
+        nonlocal selected_lease
+        call_order.append("select")
+        if call_order.count("select") == 1:
+            assert await service._load_balancer.account_pressure_snapshot(idle.account.id) == (0, 1, 0.0)
+            return proxy_service.AccountSelection(
+                account=None,
+                error_message="Account stream capacity is exhausted",
+                error_code="account_stream_cap",
+                capacity_blocked_account_ids=frozenset({idle.account.id}),
+            )
+        assert await service._load_balancer.account_pressure_snapshot(idle.account.id) == (0, 0, 0.0)
+        selected_lease = await service._load_balancer.acquire_account_lease(selected_account.id, kind="stream")
+        assert selected_lease is not None
+        return proxy_service.AccountSelection(
+            account=selected_account,
+            error_message=None,
+            lease=selected_lease,
+        )
+
+    async def ensure_fresh(account: object, **_: object) -> object:
+        return account
+
+    async def open_upstream(_account: object, _headers: dict[str, str], **_: object) -> UpstreamResponsesWebSocket:
+        return cast(UpstreamResponsesWebSocket, SimpleNamespace(response_header=lambda _name: None, close=AsyncMock()))
+
+    async def fake_relay(_session: proxy_service._HTTPBridgeSession) -> None:
+        return None
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(
+            get=AsyncMock(
+                return_value=SimpleNamespace(
+                    prefer_earlier_reset_accounts=False,
+                    routing_strategy=None,
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "_select_account_with_budget_for_stream", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", ensure_fresh)
+    monkeypatch.setattr(service, "_open_upstream_websocket_with_budget", open_upstream)
+    monkeypatch.setattr(service, "_relay_http_bridge_upstream_messages", fake_relay)
+
+    created = await service._create_http_bridge_session(
+        proxy_service._HTTPBridgeSessionKey("session_header", "sid-replacement", None),
+        headers={"x-codex-session-id": "sid-replacement"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-replacement",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        api_key=None,
+        request_model="gpt-5.4",
+        idle_ttl_seconds=120.0,
+    )
+
+    if created.upstream_reader is not None:
+        await created.upstream_reader
+    assert call_order == ["select", "select"]
+    assert idle_key not in service._http_bridge_sessions
+    assert idle.account_lease is None
+    assert created.account.id == idle.account.id
+    assert created.account_lease is selected_lease
+    await service._close_http_bridge_session(created)
+    assert await service._load_balancer.account_pressure_snapshot(idle.account.id) == (0, 0, 0.0)
+
+
+@pytest.mark.asyncio
+async def test_create_http_bridge_session_does_not_reclaim_active_stream_lease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    pending_request = proxy_service._WebSocketRequestState(
+        request_id="req-active-cap",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+    )
+    active_key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-active-cap", None)
+    active = _make_bridge_session(
+        key=active_key,
+        key_value="sid-active-cap",
+        pending_requests=deque([pending_request]),
+    )
+    active.account = cast(Any, SimpleNamespace(id="acc-active-cap", status=AccountStatus.ACTIVE, plan_type="plus"))
+    active.last_completed_response_id = "resp-active-cap"
+    active.account_lease = proxy_service.AccountLease(
+        lease_id="lease-active-cap",
+        account_id=active.account.id,
+        kind="stream",
+        acquired_at=1.0,
+    )
+    service._http_bridge_sessions[active_key] = active
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(
+            get=AsyncMock(
+                return_value=SimpleNamespace(
+                    prefer_earlier_reset_accounts=False,
+                    routing_strategy=None,
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_for_stream",
+        AsyncMock(
+            return_value=proxy_service.AccountSelection(
+                account=None,
+                error_message="Account stream capacity is exhausted",
+                error_code="account_stream_cap",
+                capacity_blocked_account_ids=frozenset({active.account.id}),
+            )
+        ),
+    )
+    close_session = AsyncMock()
+    monkeypatch.setattr(service, "_close_http_bridge_session_bounded", close_session)
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await service._create_http_bridge_session(
+            proxy_service._HTTPBridgeSessionKey("session_header", "sid-active-replacement", None),
+            headers={"x-codex-session-id": "sid-active-replacement"},
+            affinity=proxy_service._AffinityPolicy(
+                key="sid-active-replacement",
+                kind=proxy_service.StickySessionKind.CODEX_SESSION,
+            ),
+            api_key=None,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
+        )
+
+    assert exc_info.value.payload["error"]["code"] == "account_stream_cap"
+    assert service._http_bridge_sessions[active_key] is active
+    close_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("guard", ["selector_eligibility", "api_key_scope", "required_preferred_account"])
+async def test_create_http_bridge_session_reclaim_preserves_account_constraints(
+    monkeypatch: pytest.MonkeyPatch,
+    guard: str,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    idle_key = proxy_service._HTTPBridgeSessionKey("session_header", f"sid-{guard}", None)
+    idle = _make_bridge_session(key=idle_key, key_value=f"sid-{guard}")
+    idle.account = cast(Any, SimpleNamespace(id="acc-outside", status=AccountStatus.ACTIVE, plan_type="plus"))
+    idle.last_completed_response_id = f"resp-{guard}"
+    idle.account_lease = proxy_service.AccountLease(
+        lease_id=f"lease-{guard}",
+        account_id=idle.account.id,
+        kind="stream",
+        acquired_at=1.0,
+    )
+    service._http_bridge_sessions[idle_key] = idle
+
+    api_key = _make_api_key(key_id="key-scoped", assigned_account_ids=["acc-allowed"])
+    preferred_account_id = None
+    require_preferred_account = False
+    blocked_account_id = "acc-eligible"
+    if guard == "api_key_scope":
+        blocked_account_id = "acc-allowed"
+    elif guard == "required_preferred_account":
+        api_key = None
+        preferred_account_id = "acc-required"
+        require_preferred_account = True
+        blocked_account_id = preferred_account_id
+    else:
+        api_key = None
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(
+            get=AsyncMock(
+                return_value=SimpleNamespace(
+                    prefer_earlier_reset_accounts=False,
+                    routing_strategy=None,
+                )
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_for_stream",
+        AsyncMock(
+            return_value=proxy_service.AccountSelection(
+                account=None,
+                error_message="Account stream capacity is exhausted",
+                error_code="account_stream_cap",
+                capacity_blocked_account_ids=frozenset({blocked_account_id}),
+            )
+        ),
+    )
+    close_session = AsyncMock()
+    monkeypatch.setattr(service, "_close_http_bridge_session_bounded", close_session)
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await service._create_http_bridge_session(
+            proxy_service._HTTPBridgeSessionKey("session_header", f"sid-new-{guard}", None),
+            headers={"x-codex-session-id": f"sid-new-{guard}"},
+            affinity=proxy_service._AffinityPolicy(
+                key=f"sid-new-{guard}",
+                kind=proxy_service.StickySessionKind.CODEX_SESSION,
+            ),
+            api_key=api_key,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
+            preferred_account_id=preferred_account_id,
+            require_preferred_account=require_preferred_account,
+        )
+
+    assert exc_info.value.payload["error"]["code"] == "account_stream_cap"
+    assert service._http_bridge_sessions[idle_key] is idle
+    close_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_reconnect_http_bridge_session_passes_dashboard_reset_window_to_selection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Recover local per-account stream capacity when an otherwise idle HTTP Responses bridge still owns the last stream lease. On `account_stream_cap`, session creation now reclaims at most one selector-proven idle bridge through the existing bounded cleanup path, then retries selection.

This is a focused partial mitigation for disconnect-heavy workloads. It does not change the broader session-lifetime lease model or claim to resolve every orphan scenario.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Related to #1354

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/reclaim-idle-http-bridge-stream-leases/`

## Changes

- expose the selector-proven capacity-blocked account on `AccountSelection`;
- detach only an idle local bridge on that eligible account, protecting active/queued requests, admission waiters, pre-submit reservations, API-key scopes, and required continuity;
- close outside the bridge registry lock through the existing bounded cleanup path before retrying selection;
- add product-path regression coverage for reclaim/retry, active-session protection, and unrelated-account protection.

## Simplicity

- [x] Works with zero config and adds no setting or setup step
- [x] No README, `.env.example`, dashboard navigation, schema, or default changes

## Test plan

```text
.venv/bin/pytest -q tests/unit/test_proxy_http_bridge.py
# 289 passed

.venv/bin/pytest -q tests/integration/test_http_responses_bridge.py
# 101 passed

.venv/bin/pytest -q tests/unit/test_load_balancer_concurrency.py
# 43 passed

.venv/bin/ruff check <changed Python files>
# All checks passed

.venv/bin/ruff format --check <changed Python files>
# 5 files already formatted

.venv/bin/ty check
# All checks passed

npx --yes @fission-ai/openspec@latest validate reclaim-idle-http-bridge-stream-leases --strict
# valid

npx --yes @fission-ai/openspec@latest validate --specs
# 47 passed, 0 failed
```

Architecture note: `scripts/check_proxy_architecture.py` currently reports the base `app/modules/proxy/service.py` at 2604 lines against its 2600-line ratchet. This PR does not modify that file.

## Screenshots / output

No dashboard-visible change. The regression test verifies that the first capped selection closes the idle bridge, releases its stream lease, and the retry obtains the recovered slot.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue above.
- [x] Added tests covering the externally failing HTTP bridge path.
- [x] Ran the relevant local test/lint/type subsets.
- [x] Strict change validation and all-spec validation pass.
- [x] Simplicity gates reviewed.
- [x] CHANGELOG is not edited by hand.
