### PR TITLE
fix(quota): normalize monthly-like usage windows

### DIFF
--- a/app/core/usage/__init__.py
+++ b/app/core/usage/__init__.py
@@ -55,6 +55,8 @@ SIBLING_FETCH_MARGIN_SECONDS = 5.0
 DEFAULT_WINDOW_MINUTES_PRIMARY = 300
 DEFAULT_WINDOW_MINUTES_SECONDARY = 10080
 DEFAULT_WINDOW_MINUTES_MONTHLY = 43200
+MONTHLY_LIKE_WINDOW_MINUTES_MIN = 28 * 24 * 60
+MONTHLY_LIKE_WINDOW_MINUTES_MAX = 32 * 24 * 60
 
 
 @dataclass(frozen=True)
@@ -79,13 +81,11 @@ def normalize_rate_limit_windows(
     primary_window: UsageWindow | None,
     secondary_window: UsageWindow | None,
 ) -> NormalizedRateLimitWindows:
-    if (
-        primary_window is not None
-        and primary_window.limit_window_seconds == DEFAULT_WINDOW_MINUTES_MONTHLY * 60
-        and secondary_window is None
-    ):
-        return NormalizedRateLimitWindows(primary=None, secondary=None, monthly=primary_window)
-    return NormalizedRateLimitWindows(primary=primary_window, secondary=secondary_window, monthly=None)
+    primary = None if _is_zero_duration_rate_limit_placeholder(primary_window) else primary_window
+    secondary = None if _is_zero_duration_rate_limit_placeholder(secondary_window) else secondary_window
+    if primary is not None and is_monthly_window_seconds(primary.limit_window_seconds):
+        return NormalizedRateLimitWindows(primary=None, secondary=secondary, monthly=primary)
+    return NormalizedRateLimitWindows(primary=primary, secondary=secondary, monthly=None)
 
 
 def _empty_cost() -> UsageCostSummary:
@@ -223,10 +223,24 @@ def is_weekly_window_minutes(window_minutes: int | None) -> bool:
 def is_monthly_window_minutes(window_minutes: int | None) -> bool:
     if window_minutes is None:
         return False
-    monthly_default = default_window_minutes("monthly")
-    if monthly_default is None:
+    return MONTHLY_LIKE_WINDOW_MINUTES_MIN <= window_minutes <= MONTHLY_LIKE_WINDOW_MINUTES_MAX
+
+
+def is_monthly_window_seconds(window_seconds: int | None) -> bool:
+    if window_seconds is None:
         return False
-    return window_minutes == monthly_default
+    return MONTHLY_LIKE_WINDOW_MINUTES_MIN * 60 <= window_seconds <= MONTHLY_LIKE_WINDOW_MINUTES_MAX * 60
+
+
+def is_zero_duration_usage_placeholder(row: UsageWindowRow | None) -> bool:
+    return (
+        row is not None
+        and row.used_percent is not None
+        and float(row.used_percent) == 0.0
+        and (row.reset_at is None or row.reset_at <= 0)
+        and row.window_minutes is not None
+        and row.window_minutes <= 0
+    )
 
 
 def is_primary_window_minutes(window_minutes: int | None) -> bool:
@@ -309,6 +323,18 @@ def _is_no_data_placeholder(row: UsageWindowRow) -> bool:
     """
     has_window = row.window_minutes is not None and row.window_minutes > 0
     return not has_window and row.reset_at is None
+
+
+def _is_zero_duration_rate_limit_placeholder(window: UsageWindow | None) -> bool:
+    return (
+        window is not None
+        and window.used_percent is not None
+        and float(window.used_percent) == 0.0
+        and (window.reset_at is None or window.reset_at <= 0)
+        and (window.reset_after_seconds is None or window.reset_after_seconds <= 0)
+        and window.limit_window_seconds is not None
+        and window.limit_window_seconds <= 0
+    )
 
 
 def _should_prefer_primary_row(primary_row: UsageWindowRow, secondary_row: UsageWindowRow) -> bool:

--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -114,12 +114,23 @@ def _account_to_summary(
 ) -> AccountSummary:
     plan_type = coerce_account_plan_type(account.plan_type, DEFAULT_PLAN)
     auth_status = _build_auth_status(account, encryptor) if include_auth else None
-    effective_primary_usage, effective_secondary_usage = _effective_usage_windows(
+    (
+        effective_primary_usage,
+        effective_secondary_usage,
+        monthly_usage,
+        observed_monthly_authoritative,
+        monthly_promoted_from_primary,
+    ) = _effective_usage_windows(
         primary_usage,
         secondary_usage,
+        monthly_usage,
     )
 
-    if monthly_usage is not None and usage_core.capacity_for_plan(plan_type, "monthly") is None:
+    if (
+        monthly_usage is not None
+        and usage_core.capacity_for_plan(plan_type, "monthly") is None
+        and not observed_monthly_authoritative
+    ):
         monthly_usage = None
     monthly_used_percent = _normalize_used_percent(monthly_usage)
     monthly_remaining_percent = usage_core.remaining_percent_from_used(monthly_used_percent)
@@ -127,11 +138,6 @@ def _account_to_summary(
         effective_primary_usage = None
         effective_secondary_usage = None
 
-    weekly_only_usage = (
-        effective_primary_usage is None
-        and primary_usage is not None
-        and usage_core.is_weekly_window_minutes(primary_usage.window_minutes)
-    )
     # Keep account payload aligned with UI semantics: weekly-only plans expose
     # their quota as secondary/7d and omit primary/5h fields.
     primary_used_percent = _normalize_used_percent(effective_primary_usage)
@@ -153,7 +159,9 @@ def _account_to_summary(
     status_runtime_reset = float(account.reset_at) if account.reset_at else None
     status_seed = account.status
     allow_missing_runtime_reset_recovery = False
-    long_quota_usage = monthly_usage or effective_secondary_usage
+    status_monthly_usage = None if monthly_promoted_from_primary else monthly_usage
+    status_monthly_used_percent = None if monthly_promoted_from_primary else monthly_used_percent
+    long_quota_usage = status_monthly_usage or effective_secondary_usage
     long_quota_available = (
         long_quota_usage is not None
         and _usage_entry_is_recent_enough(long_quota_usage.recorded_at)
@@ -165,7 +173,7 @@ def _account_to_summary(
             effective_primary_usage.window_minutes
             if effective_primary_usage is not None
             else primary_usage.window_minutes
-            if weekly_only_usage and primary_usage is not None
+            if primary_usage is not None
             else None
         )
         zero_capacity_primary_known_non_primary = (
@@ -230,8 +238,8 @@ def _account_to_summary(
         primary_used_percent=status_primary_used_percent,
         secondary_usage=effective_secondary_usage,
         secondary_used_percent=secondary_used_percent,
-        monthly_usage=monthly_usage,
-        monthly_used_percent=monthly_used_percent,
+        monthly_usage=status_monthly_usage,
+        monthly_used_percent=status_monthly_used_percent,
         runtime_reset=status_runtime_reset,
         credits_has=credits_has,
         credits_unlimited=credits_unlimited,
@@ -422,18 +430,74 @@ def _display_window_expired(entry: UsageHistory | None, now_epoch: int) -> bool:
 def _effective_usage_windows(
     primary_usage: UsageHistory | None,
     secondary_usage: UsageHistory | None,
-) -> tuple[UsageHistory | None, UsageHistory | None]:
+    monthly_usage: UsageHistory | None = None,
+) -> tuple[UsageHistory | None, UsageHistory | None, UsageHistory | None, bool, bool]:
+    primary_usage = _usage_without_zero_duration_placeholder(primary_usage)
+    secondary_usage = _usage_without_zero_duration_placeholder(secondary_usage)
+    monthly_usage = _usage_without_zero_duration_placeholder(monthly_usage)
+
+    monthly_promoted_from_primary = False
+    if primary_usage is not None and usage_core.is_monthly_window_minutes(primary_usage.window_minutes):
+        if secondary_usage is None or usage_core.is_monthly_window_minutes(secondary_usage.window_minutes):
+            if monthly_usage is None or not _usage_entry_meaningfully_newer(monthly_usage, primary_usage):
+                monthly_usage = primary_usage
+                monthly_promoted_from_primary = True
+        primary_usage = None
+
+    observed_monthly_authoritative = (
+        monthly_usage is not None
+        and usage_core.is_monthly_window_minutes(monthly_usage.window_minutes)
+        and all(
+            entry is None or _usage_entry_meaningfully_newer(monthly_usage, entry)
+            for entry in (primary_usage, secondary_usage)
+        )
+    )
+
     if primary_usage is None:
-        return None, secondary_usage
+        return (
+            None,
+            secondary_usage,
+            monthly_usage,
+            observed_monthly_authoritative,
+            monthly_promoted_from_primary,
+        )
     if not usage_core.is_weekly_window_minutes(primary_usage.window_minutes):
-        return primary_usage, secondary_usage
+        return (
+            primary_usage,
+            secondary_usage,
+            monthly_usage,
+            observed_monthly_authoritative,
+            monthly_promoted_from_primary,
+        )
     if secondary_usage is None:
-        return None, primary_usage
+        return None, primary_usage, monthly_usage, observed_monthly_authoritative, monthly_promoted_from_primary
     if usage_core.should_use_weekly_primary(
         usage_history_to_window_row(primary_usage), usage_history_to_window_row(secondary_usage)
     ):
-        return None, primary_usage
-    return None, secondary_usage
+        return None, primary_usage, monthly_usage, observed_monthly_authoritative, monthly_promoted_from_primary
+    return None, secondary_usage, monthly_usage, observed_monthly_authoritative, monthly_promoted_from_primary
+
+
+def _usage_without_zero_duration_placeholder(entry: UsageHistory | None) -> UsageHistory | None:
+    if entry is None or not usage_core.is_zero_duration_usage_placeholder(usage_history_to_window_row(entry)):
+        return entry
+    return None
+
+
+def _usage_entry_meaningfully_newer(candidate: UsageHistory, reference: UsageHistory) -> bool:
+    candidate_recorded_at = _normalized_usage_recorded_at(candidate.recorded_at)
+    reference_recorded_at = _normalized_usage_recorded_at(reference.recorded_at)
+    if candidate_recorded_at is None or reference_recorded_at is None:
+        return False
+    return (candidate_recorded_at - reference_recorded_at).total_seconds() > usage_core.SIBLING_FETCH_MARGIN_SECONDS
+
+
+def _normalized_usage_recorded_at(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(timezone.utc).replace(tzinfo=None)
 
 
 def _build_auth_status(account: Account, encryptor: TokenEncryptor) -> AccountAuthStatus:

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -2073,16 +2073,18 @@ def _build_states(
     account_map: dict[str, Account] = {}
 
     for account in accounts:
+        primary_entry = latest_primary.get(account.id)
         secondary_entry: UsageHistory | AdditionalUsageHistory | None = latest_secondary.get(account.id)
         if account.id not in ignore_standard_quota_account_ids:
             secondary_entry = _select_long_window_entry(
                 account=account,
+                primary_entry=primary_entry,
                 monthly_entry=latest_monthly.get(account.id),
                 secondary_entry=secondary_entry,
             )
         state = _state_from_account(
             account=account,
-            primary_entry=latest_primary.get(account.id),
+            primary_entry=primary_entry,
             secondary_entry=secondary_entry,
             runtime=runtime.setdefault(account.id, RuntimeState()),
         )
@@ -2276,22 +2278,38 @@ def _state_from_account(
     runtime: RuntimeState,
 ) -> AccountState:
     routing_policy = _normalize_account_routing_policy(getattr(account, "routing_policy", None))
+    if primary_entry is not None and usage_core.is_zero_duration_usage_placeholder(
+        usage_history_to_window_row(primary_entry)
+    ):
+        primary_entry = None
+    if secondary_entry is not None and usage_core.is_zero_duration_usage_placeholder(
+        usage_history_to_window_row(secondary_entry)
+    ):
+        secondary_entry = None
     primary_used = primary_entry.used_percent if primary_entry else None
     primary_reset = primary_entry.reset_at if primary_entry else None
     primary_window_minutes = primary_entry.window_minutes if primary_entry else None
     effective_secondary_entry = secondary_entry
-    if (
-        effective_secondary_entry is not None
-        and effective_secondary_entry.window == "monthly"
-        and usage_core.capacity_for_plan(account.plan_type, "monthly") is None
-    ):
-        effective_secondary_entry = None
+    status_primary_entry = primary_entry
     primary_row = usage_history_to_window_row(primary_entry) if primary_entry is not None else None
     secondary_row = usage_history_to_window_row(secondary_entry) if secondary_entry is not None else None
-    # Weekly-only accounts may not emit a dedicated secondary row; treat the
-    # weekly primary row as quota-window input for balancer decisions. When
-    # both rows exist, prefer the newer weekly snapshot.
-    if primary_row is not None and usage_core.should_use_weekly_primary(primary_row, secondary_row):
+    # Duration is authoritative for legacy/mis-slotted rows. Monthly-like and
+    # weekly-only primary rows are long-window signals, never short 5h usage.
+    if (
+        primary_entry is not None
+        and primary_row is not None
+        and usage_core.is_monthly_window_minutes(primary_row.window_minutes)
+    ):
+        if effective_secondary_entry is None or (
+            usage_core.is_monthly_window_minutes(effective_secondary_entry.window_minutes)
+            and not _usage_entry_meaningfully_newer(effective_secondary_entry, primary_entry)
+        ):
+            effective_secondary_entry = primary_entry
+        primary_used = None
+        primary_reset = None
+        primary_window_minutes = None
+        status_primary_entry = None
+    elif primary_row is not None and usage_core.should_use_weekly_primary(primary_row, secondary_row):
         effective_secondary_entry = primary_entry
         primary_used = None
         primary_reset = None
@@ -2376,7 +2394,7 @@ def _state_from_account(
             # not prove this replica observed the current one.
             early_freshness_entry = _rate_limited_freshness_entry(
                 account=account,
-                primary_entry=primary_entry,
+                primary_entry=status_primary_entry,
                 long_window_entry=effective_secondary_entry,
             )
             if early_freshness_entry is not None and early_freshness_entry.recorded_at is not None:
@@ -2394,7 +2412,7 @@ def _state_from_account(
                     and not usage_core.is_primary_window_minutes(primary_window_minutes)
                     and long_window_quota_available
                 )
-                or (primary_entry is None and long_window_quota_available)
+                or (status_primary_entry is None and long_window_quota_available)
             )
         )
     ):
@@ -2489,7 +2507,7 @@ def _state_from_account(
         elif account.status == AccountStatus.RATE_LIMITED:
             freshness_entry = _rate_limited_freshness_entry(
                 account=account,
-                primary_entry=primary_entry,
+                primary_entry=status_primary_entry,
                 long_window_entry=effective_secondary_entry,
             )
         else:
@@ -2503,7 +2521,7 @@ def _state_from_account(
     if rejected_persisted_rate_limit_reset:
         rejected_reset_freshness_entry = _rate_limited_freshness_entry(
             account=account,
-            primary_entry=primary_entry,
+            primary_entry=status_primary_entry,
             long_window_entry=effective_secondary_entry,
         )
         # One healthy window must not conceal exhaustion in another applicable
@@ -2546,6 +2564,14 @@ def _state_from_account(
         credits_balance=credits_balance,
         infer_status_from_usage=False,
     )
+    if (
+        primary_used is None
+        and effective_secondary_entry is not None
+        and usage_core.is_monthly_window_minutes(effective_secondary_entry.window_minutes)
+    ):
+        # Monthly-only accounts expose pressure through the long-window field;
+        # never mirror that value into the short-window routing signal.
+        used_percent = None
     if resetless_rate_limit_without_evidence and primary_used is None and status == AccountStatus.ACTIVE:
         status = AccountStatus.RATE_LIMITED
     if rejected_persisted_rate_limit_reset and not rejected_reset_recovery_evidence:
@@ -2596,7 +2622,10 @@ def _state_from_account(
     )
     leased_token_pressure_pct = 0.0
     long_window_key = "secondary"
-    if effective_secondary_entry is not None and effective_secondary_entry.window == "monthly":
+    if effective_secondary_entry is not None and (
+        effective_secondary_entry.window == "monthly"
+        or usage_core.is_monthly_window_minutes(effective_secondary_entry.window_minutes)
+    ):
         long_window_key = "monthly"
     capacity_credits = usage_core.capacity_for_plan(account.plan_type, long_window_key) or 0.0
     if capacity_credits > 0.0 and runtime.leased_tokens > 0:
@@ -2708,10 +2737,40 @@ def _select_long_window_entry(
     account: Account,
     monthly_entry: UsageHistory | None,
     secondary_entry: UsageHistory | AdditionalUsageHistory | None,
+    primary_entry: UsageHistory | AdditionalUsageHistory | None = None,
 ) -> UsageHistory | AdditionalUsageHistory | None:
-    if monthly_entry is not None and usage_core.capacity_for_plan(account.plan_type, "monthly") is not None:
+    if monthly_entry is None:
+        return secondary_entry
+    if usage_core.capacity_for_plan(account.plan_type, "monthly") is not None:
         return monthly_entry
-    return secondary_entry
+    if not usage_core.is_monthly_window_minutes(monthly_entry.window_minutes):
+        return secondary_entry
+    for candidate in (primary_entry, secondary_entry):
+        if candidate is None:
+            continue
+        candidate_row = usage_history_to_window_row(candidate)
+        if usage_core.is_zero_duration_usage_placeholder(candidate_row):
+            continue
+        if usage_core.is_monthly_window_minutes(candidate_row.window_minutes):
+            continue
+        if not _usage_entry_meaningfully_newer(monthly_entry, candidate):
+            return secondary_entry
+    return monthly_entry
+
+
+def _usage_entry_meaningfully_newer(candidate: _UsageWindowEntry, reference: _UsageWindowEntry) -> bool:
+    candidate_recorded_at = _usage_entry_recorded_at_utc(candidate)
+    reference_recorded_at = _usage_entry_recorded_at_utc(reference)
+    return (candidate_recorded_at - reference_recorded_at).total_seconds() > _SIBLING_FETCH_MARGIN_SECONDS
+
+
+def _usage_entry_recorded_at_utc(entry: _UsageWindowEntry) -> datetime:
+    recorded_at = entry.recorded_at
+    if recorded_at is None:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if recorded_at.tzinfo is None:
+        return recorded_at.replace(tzinfo=timezone.utc)
+    return recorded_at.astimezone(timezone.utc)
 
 
 def _rate_limited_freshness_entry(
@@ -2720,10 +2779,8 @@ def _rate_limited_freshness_entry(
     primary_entry: _UsageWindowEntry | None,
     long_window_entry: _UsageWindowEntry | None,
 ) -> _UsageWindowEntry | None:
-    if (
-        long_window_entry is not None
-        and long_window_entry.window == "monthly"
-        and usage_core.capacity_for_plan(account.plan_type, "monthly") is not None
+    if long_window_entry is not None and (
+        long_window_entry.window == "monthly" or usage_core.is_monthly_window_minutes(long_window_entry.window_minutes)
     ):
         return long_window_entry
     if primary_entry is None:

--- a/app/modules/usage/live_ingest.py
+++ b/app/modules/usage/live_ingest.py
@@ -36,15 +36,38 @@ class _QueuedSnapshot:
     snapshot: LiveRateLimitSnapshot
 
 
+def _is_zero_duration_live_placeholder(window: LiveUsageWindow | None) -> bool:
+    return (
+        window is not None
+        and float(window.used_percent) == 0.0
+        and (window.reset_at is None or window.reset_at <= 0)
+        and window.window_minutes is not None
+        and window.window_minutes <= 0
+    )
+
+
+def _normalize_live_windows(
+    snapshot: LiveRateLimitSnapshot,
+) -> tuple[LiveUsageWindow | None, LiveUsageWindow | None, LiveUsageWindow | None]:
+    primary = None if _is_zero_duration_live_placeholder(snapshot.primary) else snapshot.primary
+    secondary = None if _is_zero_duration_live_placeholder(snapshot.secondary) else snapshot.secondary
+    monthly: LiveUsageWindow | None = None
+    if primary is not None and usage_core.is_monthly_window_minutes(primary.window_minutes):
+        monthly, primary = primary, None
+    return primary, secondary, monthly
+
+
 def _fingerprint(snapshot: LiveRateLimitSnapshot) -> tuple[object, ...]:
     def window_key(window: LiveUsageWindow | None) -> tuple[object, ...] | None:
         if window is None:
             return None
         return (round(window.used_percent, 2), window.window_minutes, window.reset_at)
 
+    primary, secondary, monthly = _normalize_live_windows(snapshot)
     return (
-        window_key(snapshot.primary),
-        window_key(snapshot.secondary),
+        window_key(primary),
+        window_key(secondary),
+        window_key(monthly),
         snapshot.credits_has,
         snapshot.credits_unlimited,
         snapshot.credits_balance,
@@ -150,18 +173,7 @@ class LiveUsageIngestor:
             return
 
         snapshot = item.snapshot
-        primary = snapshot.primary
-        secondary = snapshot.secondary
-        monthly: LiveUsageWindow | None = None
-        # Mirror the poller's write-time normalization: a lone primary window
-        # with the monthly duration is the monthly-only free-plan shape and
-        # belongs in the monthly slot, not the primary one.
-        if (
-            primary is not None
-            and secondary is None
-            and primary.window_minutes == usage_core.DEFAULT_WINDOW_MINUTES_MONTHLY
-        ):
-            monthly, primary = primary, None
+        primary, secondary, monthly = _normalize_live_windows(snapshot)
         async with get_background_session() as session:
             repo = UsageRepository(session)
             if primary is not None:
@@ -181,7 +193,7 @@ class LiveUsageIngestor:
                 # Mirror the poller: credits normally ride the primary row.
                 # A secondary-only snapshot (e.g. the short window is not
                 # being reported) must still carry the fresh credit state.
-                secondary_carries_credits = primary is None
+                secondary_carries_credits = primary is None and monthly is None
                 await repo.add_entry(
                     account_id=account_id,
                     used_percent=float(secondary.used_percent),

--- a/openspec/changes/normalize-monthly-like-usage-windows/proposal.md
+++ b/openspec/changes/normalize-monthly-like-usage-windows/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Upstream Team accounts can expose their only standard quota in the primary
+slot with a duration near one calendar month rather than exactly 30 days. A
+production variant reports `43800` minutes and may include a zero-duration
+secondary placeholder. Exact `43200` checks leave that quota in the 5h slot,
+so dashboard and routing semantics misclassify a 30-day window as short-term
+pressure.
+
+## What Changes
+
+- Classify durations from 28 through 32 days as monthly-like instead of
+  requiring exact equality with 43200 minutes.
+- Ignore zero-duration, zero-usage placeholder windows before poll-time and
+  live-ingest slot normalization.
+- Promote authoritative monthly-like primary rows into monthly presentation
+  even when stored plan metadata does not advertise a monthly capacity model.
+- Preserve stale-plan protection: a meaningfully newer standard window
+  supersedes an older monthly row.
+- Treat monthly-like rows as long-window routing pressure and never as a 5h
+  signal.
+
+## Impact
+
+- Team and other plans follow the observed upstream quota duration.
+- Existing exact 30-day Free-account behavior remains supported.
+- No setting, schema, endpoint, or wire-format change is introduced.
+
+Fixes #1367

--- a/openspec/changes/normalize-monthly-like-usage-windows/specs/account-quota-presentation/spec.md
+++ b/openspec/changes/normalize-monthly-like-usage-windows/specs/account-quota-presentation/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Observed monthly-only quota is plan-agnostic
+
+Account-facing quota surfaces SHALL classify an authoritative observed window
+between 28 and 32 days as monthly-only regardless of stored account plan.
+They MUST NOT render that window as a synthetic 5h or weekly quota. A monthly
+row for a plan without configured monthly capacity MUST be ignored only when a
+meaningfully newer non-monthly standard window proves that the account has
+moved to a different quota shape.
+
+#### Scenario: Team 30-day quota renders as monthly
+
+- **GIVEN** a Team account reports a 43800-minute primary window
+- **AND** the secondary slot is a zero-duration placeholder
+- **WHEN** the account summary is built
+- **THEN** the summary exposes only the monthly quota window
+- **AND** the remaining percentage and reset belong to that observed window
+
+#### Scenario: New paid-plan windows supersede stale monthly history
+
+- **GIVEN** an account has an older monthly row from a previous quota shape
+- **AND** a non-monthly primary or secondary row is newer by more than the
+  sibling-fetch margin
+- **WHEN** the account summary is built
+- **THEN** the stale monthly row is not presented

--- a/openspec/changes/normalize-monthly-like-usage-windows/specs/account-routing/spec.md
+++ b/openspec/changes/normalize-monthly-like-usage-windows/specs/account-routing/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Monthly-like quota remains a long-window routing signal
+
+Account selection SHALL treat an authoritative observed window from 28 through
+32 days as long-window quota pressure and MUST NOT expose its usage as the
+short primary-window signal. Stored plan metadata MUST NOT by itself discard a
+fresh monthly-like row, while a meaningfully newer non-monthly standard row
+MUST supersede stale monthly history.
+
+#### Scenario: Team monthly-only pressure is not a 5h signal
+
+- **GIVEN** a Team account has a fresh 43800-minute quota row at 96% used
+- **AND** it has no real short or weekly quota row
+- **WHEN** the load balancer builds account state
+- **THEN** short-window usage and duration are absent
+- **AND** long-window usage is 96%

--- a/openspec/changes/normalize-monthly-like-usage-windows/specs/live-usage-ingestion/spec.md
+++ b/openspec/changes/normalize-monthly-like-usage-windows/specs/live-usage-ingestion/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Main usage ingestion normalizes semantic window duration
+
+The background poller and live usage ingestor MUST apply the same semantic
+normalization before persisting standard quota windows. A primary window from
+28 through 32 days MUST be persisted in the monthly slot. A zero-duration,
+zero-usage window without a reset deadline MUST be treated as a placeholder
+and MUST NOT be persisted as a real standard quota window.
+
+#### Scenario: Team monthly-like event includes a placeholder
+
+- **GIVEN** an upstream usage snapshot contains a 43800-minute primary window
+- **AND** a zero-duration, zero-usage secondary window without a reset
+- **WHEN** either standard ingestion path processes the snapshot
+- **THEN** it persists the primary measurement as monthly usage
+- **AND** it does not persist the secondary placeholder

--- a/openspec/changes/normalize-monthly-like-usage-windows/tasks.md
+++ b/openspec/changes/normalize-monthly-like-usage-windows/tasks.md
@@ -1,0 +1,11 @@
+- [x] Define a bounded monthly-like duration classifier
+- [x] Normalize poller and live-ingest windows before persistence
+- [x] Promote authoritative observed monthly rows in account summaries
+- [x] Align load-balancer short/long window semantics
+- [x] Add regression tests for the 43800-minute Team shape and stale-plan protection
+- [x] Run focused/full tests, lint, type checks, architecture checks, and strict OpenSpec validation
+
+Verification note: relevant unit and integration suites, Ruff, ty, and
+strict/all OpenSpec validation pass. The repository's pre-existing architecture
+ratchet still reports `app/modules/proxy/service.py` at 2604 lines against a
+2600-line limit; this change does not modify that file.

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -1001,6 +1001,44 @@ async def test_accounts_list_exposes_monthly_only_free_quota(async_client, db_se
 
 
 @pytest.mark.asyncio
+async def test_accounts_list_exposes_monthly_like_team_primary_as_monthly(async_client, db_setup):
+    recorded_at = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+
+        await accounts_repo.upsert(_make_account("acc_team_monthly", "team-monthly@example.com", plan_type="team"))
+        await usage_repo.add_entry(
+            "acc_team_monthly",
+            96.0,
+            window="primary",
+            reset_at=int(recorded_at.timestamp()) + 30 * 24 * 3600,
+            window_minutes=43_800,
+            recorded_at=recorded_at,
+        )
+        await usage_repo.add_entry(
+            "acc_team_monthly",
+            0.0,
+            window="secondary",
+            reset_at=None,
+            window_minutes=0,
+            recorded_at=recorded_at + timedelta(milliseconds=10),
+        )
+
+    response = await async_client.get("/api/accounts")
+    assert response.status_code == 200
+    accounts = {item["accountId"]: item for item in response.json()["accounts"]}
+
+    account = accounts["acc_team_monthly"]
+    assert account["usage"]["primaryRemainingPercent"] is None
+    assert account["usage"]["secondaryRemainingPercent"] is None
+    assert account["usage"]["monthlyRemainingPercent"] == pytest.approx(4.0)
+    assert account["windowMinutesPrimary"] is None
+    assert account["windowMinutesSecondary"] is None
+    assert account["windowMinutesMonthly"] == 43_800
+
+
+@pytest.mark.asyncio
 async def test_accounts_list_hides_expired_primary_window(async_client, db_setup):
     now_epoch = int(utcnow().replace(tzinfo=timezone.utc).timestamp())
     async with SessionLocal() as session:

--- a/tests/integration/test_live_usage_ingest.py
+++ b/tests/integration/test_live_usage_ingest.py
@@ -234,6 +234,51 @@ async def test_live_ingestor_normalizes_monthly_only_snapshots(db_setup) -> None
 
 
 @pytest.mark.asyncio
+async def test_live_ingestor_normalizes_team_monthly_like_snapshot_with_placeholder(db_setup) -> None:
+    del db_setup
+    account_id = "acc_live_team_monthly"
+    async with SessionLocal() as session:
+        account = _make_account(account_id, "live-team-monthly@example.com")
+        account.plan_type = "team"
+        await AccountsRepository(session).upsert(account)
+
+    now_epoch = int(utcnow().timestamp())
+    snapshot = LiveRateLimitSnapshot(
+        primary=LiveUsageWindow(used_percent=96.0, window_minutes=43_800, reset_at=now_epoch + 30 * 24 * 3600),
+        secondary=LiveUsageWindow(used_percent=0.0, window_minutes=0, reset_at=None),
+        credits_has=True,
+        credits_unlimited=False,
+        credits_balance=6.5,
+    )
+
+    ingestor = live_ingest.LiveUsageIngestor(queue_size=8, write_min_interval_seconds=0.0)
+    ingestor.start()
+    try:
+        ingestor.publish(snapshot, account_id=account_id)
+        deadline = asyncio.get_event_loop().time() + 5.0
+        monthly = None
+        while monthly is None and asyncio.get_event_loop().time() < deadline:
+            async with SessionLocal() as session:
+                repo = UsageRepository(session)
+                monthly = await repo.latest_entry_for_account(account_id, window="monthly")
+            if monthly is None:
+                await asyncio.sleep(0.05)
+        async with SessionLocal() as session:
+            repo = UsageRepository(session)
+            primary = await repo.latest_entry_for_account(account_id, window="primary")
+            secondary = await repo.latest_entry_for_account(account_id, window="secondary")
+    finally:
+        await ingestor.stop()
+
+    assert monthly is not None
+    assert monthly.used_percent == pytest.approx(96.0)
+    assert monthly.window_minutes == 43_800
+    assert monthly.credits_balance == pytest.approx(6.5)
+    assert primary is None
+    assert secondary is None
+
+
+@pytest.mark.asyncio
 async def test_live_ingestor_resolves_chatgpt_account_id(db_setup) -> None:
     del db_setup
     async with SessionLocal() as session:

--- a/tests/unit/test_account_mappers.py
+++ b/tests/unit/test_account_mappers.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
+from typing import cast
 
+from app.core.crypto import TokenEncryptor
 from app.db.models import Account, AccountStatus, UsageHistory
 from app.modules.accounts import mappers
 from app.modules.accounts.mappers import _effective_status_from_usage, _normalize_account_routing_policy
@@ -170,3 +172,74 @@ def test_normalize_account_routing_policy() -> None:
     assert _normalize_account_routing_policy("preserve") == "preserve"
     assert _normalize_account_routing_policy("legacy") == "normal"
     assert _normalize_account_routing_policy(None) == "normal"
+
+
+def test_account_summary_promotes_authoritative_team_monthly_like_primary() -> None:
+    recorded_at = datetime(2026, 7, 21, 0, 0, 0)
+    account = _account(AccountStatus.ACTIVE)
+    account.plan_type = "team"
+    monthly_like_primary = _primary_usage(
+        used_percent=96.0,
+        reset_at=1_800_000_000,
+        window_minutes=43_800,
+        recorded_at=recorded_at,
+    )
+    secondary_placeholder = _secondary_usage(
+        used_percent=0.0,
+        reset_at=None,
+        window_minutes=0,
+        recorded_at=recorded_at + timedelta(milliseconds=10),
+    )
+
+    summary = mappers._account_to_summary(
+        account,
+        monthly_like_primary,
+        secondary_placeholder,
+        None,
+        None,
+        None,
+        None,
+        cast(TokenEncryptor, object()),
+        include_auth=False,
+    )
+
+    assert summary.usage is not None
+    assert summary.usage.primary_remaining_percent is None
+    assert summary.usage.secondary_remaining_percent is None
+    assert summary.usage.monthly_remaining_percent == 4.0
+    assert summary.window_minutes_primary is None
+    assert summary.window_minutes_secondary is None
+    assert summary.window_minutes_monthly == 43_800
+
+
+def test_account_summary_drops_stale_monthly_row_after_newer_paid_plan_windows() -> None:
+    recorded_at = datetime(2026, 7, 21, 0, 0, 0)
+    account = _account(AccountStatus.ACTIVE)
+    account.plan_type = "team"
+    stale_monthly = UsageHistory(
+        account_id=account.id,
+        window="monthly",
+        used_percent=96.0,
+        reset_at=1_800_000_000,
+        window_minutes=43_800,
+        recorded_at=recorded_at,
+    )
+    fresh_primary = _primary_usage(recorded_at=recorded_at + timedelta(minutes=1))
+    fresh_secondary = _secondary_usage(recorded_at=recorded_at + timedelta(minutes=1))
+
+    summary = mappers._account_to_summary(
+        account,
+        fresh_primary,
+        fresh_secondary,
+        stale_monthly,
+        None,
+        None,
+        None,
+        cast(TokenEncryptor, object()),
+        include_auth=False,
+    )
+
+    assert summary.usage is not None
+    assert summary.usage.primary_remaining_percent == 60.0
+    assert summary.usage.secondary_remaining_percent == 0.0
+    assert summary.usage.monthly_remaining_percent is None

--- a/tests/unit/test_live_usage_ingest.py
+++ b/tests/unit/test_live_usage_ingest.py
@@ -30,6 +30,22 @@ def _snapshot(primary_used: float = 25.0, reset_at: int = 1_700_000_300) -> Live
     )
 
 
+def test_normalize_live_windows_promotes_team_monthly_like_primary_and_drops_placeholder() -> None:
+    snapshot = LiveRateLimitSnapshot(
+        primary=LiveUsageWindow(used_percent=96.0, window_minutes=43_800, reset_at=1_800_000_000),
+        secondary=LiveUsageWindow(used_percent=0.0, window_minutes=0, reset_at=None),
+        credits_has=None,
+        credits_unlimited=None,
+        credits_balance=None,
+    )
+
+    primary, secondary, monthly = live_ingest._normalize_live_windows(snapshot)
+
+    assert primary is None
+    assert secondary is None
+    assert monthly is snapshot.primary
+
+
 def test_parse_rate_limit_headers_reads_both_windows_and_credits() -> None:
     headers = {
         "X-Codex-Primary-Used-Percent": "25.5",

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -2175,6 +2175,64 @@ def test_state_from_account_ignores_stale_monthly_usage_after_upgrade(monkeypatc
     assert state.capacity_credits == usage_core.capacity_for_plan("plus", "secondary")
 
 
+def test_select_long_window_keeps_authoritative_team_monthly_like_usage(monkeypatch):
+    now = 1_700_000_000.0
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monthly = _make_test_usage(
+        window="monthly",
+        used_percent=96.0,
+        reset_at=int(now + 30 * 24 * 3600),
+        recorded_at=_epoch_to_naive_utc(now - 30),
+        window_minutes=43_800,
+    )
+    placeholder = _make_test_usage(
+        window="secondary",
+        used_percent=0.0,
+        reset_at=None,
+        recorded_at=_epoch_to_naive_utc(now - 30),
+        window_minutes=0,
+    )
+
+    selected_entry = _select_long_window_entry(
+        account=_make_test_account(status=AccountStatus.ACTIVE, plan_type="team"),
+        monthly_entry=monthly,
+        secondary_entry=placeholder,
+    )
+
+    assert selected_entry is monthly
+
+
+def test_state_from_account_treats_team_monthly_like_primary_as_long_window(monkeypatch):
+    now = 1_700_000_000.0
+    future_reset = int(now + 30 * 24 * 3600)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+
+    state = _state_from_account(
+        account=_make_test_account(status=AccountStatus.ACTIVE, plan_type="team"),
+        primary_entry=_make_test_usage(
+            window="primary",
+            used_percent=96.0,
+            reset_at=future_reset,
+            recorded_at=_epoch_to_naive_utc(now - 30),
+            window_minutes=43_800,
+        ),
+        secondary_entry=_make_test_usage(
+            window="secondary",
+            used_percent=0.0,
+            reset_at=None,
+            recorded_at=_epoch_to_naive_utc(now - 30),
+            window_minutes=0,
+        ),
+        runtime=RuntimeState(),
+    )
+
+    assert state.used_percent is None
+    assert state.primary_window_minutes is None
+    assert state.secondary_used_percent == 96.0
+    assert state.secondary_reset_at == future_reset
+
+
 def test_state_from_account_ignores_zero_capacity_monthly_primary_window(monkeypatch):
     now = 1_700_000_000.0
     future_reset = int(now + 14 * 24 * 3600)

--- a/tests/unit/test_usage.py
+++ b/tests/unit/test_usage.py
@@ -8,6 +8,7 @@ from app.core.usage import (
     SIBLING_FETCH_MARGIN_SECONDS,
     _should_prefer_primary_row,
     capacity_for_plan,
+    is_monthly_window_minutes,
     normalize_rate_limit_windows,
     normalize_usage_window,
     normalize_weekly_only_rows,
@@ -136,6 +137,36 @@ def test_normalize_rate_limit_windows_promotes_monthly_primary_without_secondary
     )
 
     normalized = normalize_rate_limit_windows(primary, None)
+
+    assert normalized.primary is None
+    assert normalized.secondary is None
+    assert normalized.monthly is primary
+
+
+@pytest.mark.parametrize("window_minutes", [40_320, 43_200, 43_800, 46_080])
+def test_is_monthly_window_minutes_accepts_calendar_month_like_durations(window_minutes: int) -> None:
+    assert is_monthly_window_minutes(window_minutes) is True
+
+
+@pytest.mark.parametrize("window_minutes", [None, 10_080, 40_319, 46_081])
+def test_is_monthly_window_minutes_rejects_non_monthly_durations(window_minutes: int | None) -> None:
+    assert is_monthly_window_minutes(window_minutes) is False
+
+
+def test_normalize_rate_limit_windows_promotes_team_monthly_primary_with_zero_secondary_placeholder() -> None:
+    primary = UsageWindow(
+        used_percent=96.0,
+        limit_window_seconds=43_800 * 60,
+        reset_at=1_800_000_000,
+    )
+    secondary_placeholder = UsageWindow(
+        used_percent=0.0,
+        limit_window_seconds=0,
+        reset_at=0,
+        reset_after_seconds=0,
+    )
+
+    normalized = normalize_rate_limit_windows(primary, secondary_placeholder)
 
     assert normalized.primary is None
     assert normalized.secondary is None

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -1667,6 +1667,48 @@ async def test_usage_refresh_stores_free_monthly_window_without_secondary_remap(
 
 
 @pytest.mark.asyncio
+async def test_usage_refresh_stores_team_monthly_like_window_and_ignores_zero_secondary(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
+    from app.core.config.settings import get_settings
+
+    get_settings.cache_clear()
+
+    async def stub_fetch_usage(*, access_token: str, account_id: str | None, **_: Any) -> UsagePayload:
+        del access_token, account_id
+        return UsagePayload.model_validate(
+            {
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 96.0,
+                        "reset_at": 1_800_000_000,
+                        "limit_window_seconds": 43_800 * 60,
+                    },
+                    "secondary_window": {
+                        "used_percent": 0.0,
+                        "reset_after_seconds": 0,
+                        "limit_window_seconds": 0,
+                    },
+                }
+            }
+        )
+
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", stub_fetch_usage)
+
+    usage_repo = StubUsageRepository(return_rows=True)
+    accounts_repo = StubAccountsRepository()
+    updater = UsageUpdater(usage_repo, accounts_repo=accounts_repo)
+    account = _make_account("acc_team_monthly", "workspace_team")
+    account.plan_type = "team"
+    accounts_repo.accounts_by_id[account.id] = account
+
+    await updater.refresh_accounts([account], latest_usage={})
+
+    assert [(entry.window, entry.window_minutes, entry.used_percent) for entry in usage_repo.entries] == [
+        ("monthly", 43_800, 96.0)
+    ]
+
+
+@pytest.mark.asyncio
 async def test_usage_refresh_uses_fresh_monthly_row_for_quota_freshness(monkeypatch) -> None:
     monkeypatch.setenv("CODEX_LB_USAGE_REFRESH_ENABLED", "true")
     from app.core.config.settings import get_settings


### PR DESCRIPTION
## Summary

Normalize observed calendar-month-like quota windows by duration instead of exact `43200` equality. This covers the production Team shape reported in #1367 (`43800`-minute primary plus a zero-duration secondary placeholder) across background polling, live ingestion, account presentation, and load-balancer semantics.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Fixes #1367

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful request/response path

Change directory: `openspec/changes/normalize-monthly-like-usage-windows/`

## Changes

- classify observed 28–32 day durations as monthly-like, including `43800` minutes;
- quarantine zero-duration, zero-usage placeholders before poller/live persistence;
- make poller and live-ingest normalization share the same semantics;
- surface an authoritative observed monthly-only quota even when stored plan metadata is Team/paid, while retaining newer-window stale-plan protection;
- keep monthly-only usage in the long-window routing signal and out of the 5h signal;
- add unit and product-path integration coverage for poll ingestion, live ingestion, `/api/accounts`, stale monthly history, and routing state.

## Simplicity

- [x] Works with zero config and adds no setting or setup step
- [x] No README, `.env.example`, dashboard navigation, schema, or default changes

## Test plan

```text
.venv/bin/pytest -q \
  tests/unit/test_usage.py \
  tests/unit/test_live_usage_ingest.py \
  tests/unit/test_account_mappers.py \
  tests/unit/test_usage_updater.py \
  tests/unit/test_load_balancer.py
# 384 passed

.venv/bin/pytest -q \
  tests/integration/test_live_usage_ingest.py \
  tests/integration/test_accounts_api_extended.py
# 48 passed

.venv/bin/ruff check <changed Python files>
# All checks passed

.venv/bin/ruff format --check <changed Python files>
# 11 files already formatted

.venv/bin/ty check
# All checks passed

npx --yes @fission-ai/openspec@latest validate normalize-monthly-like-usage-windows --strict
# valid

npx --yes @fission-ai/openspec@latest validate --specs
# 47 passed, 0 failed
```

Architecture note: `scripts/check_proxy_architecture.py` currently reports the base `app/modules/proxy/service.py` at 2604 lines against its 2600-line ratchet. This PR does not modify that file.

## Screenshots / output

Product-path integration coverage asserts that a Team account with a 43800-minute primary row and a zero-duration secondary placeholder returns only:

```text
monthlyRemainingPercent = 4
windowMinutesMonthly = 43800
windowMinutesPrimary = null
windowMinutesSecondary = null
```

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue above.
- [x] Added unit and integration tests covering the externally failing path.
- [x] Ran the relevant local test/lint/type subsets.
- [x] Strict change validation and all-spec validation pass.
- [x] Simplicity gates reviewed.
- [x] CHANGELOG is not edited by hand.
