### PR TITLE
fix(proxy): recover idle Codex Desktop bridge

### DIFF
--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -180,6 +180,8 @@ from app.modules.proxy.ring_membership import (
 
 logger = logging.getLogger("app.modules.proxy.service")
 _HTTP_BRIDGE_BACKGROUND_CLOSE_TIMEOUT_SECONDS = 5.0
+_HTTP_BRIDGE_EVENTLESS_RESPONSE_CREATED_MAX_SECONDS = 240.0
+_HTTP_BRIDGE_MISSING_RESPONSE_CREATED_TIMEOUT_DETAIL = "missing_response_created_timeout"
 T = TypeVar("T")
 
 _HTTP_BRIDGE_INFLIGHT_STARTED_AT_ATTR = "_codex_lb_started_at"
@@ -611,6 +613,32 @@ def _normalize_http_bridge_error_event(
 
 def _http_bridge_request_counts_against_queue(request_state: _WebSocketRequestState) -> bool:
     return not request_state.draining_until_terminal
+
+
+def _http_bridge_eventless_precreated_deadline(
+    request_state: _WebSocketRequestState,
+    *,
+    stuck_gate_retire_after_seconds: float,
+) -> float | None:
+    sent_at = request_state.response_create_sent_at
+    if (
+        request_state.transport != "http"
+        or request_state.skip_request_log
+        or not request_state.response_create_gate_acquired
+        or request_state.response_create_gate is None
+        or not request_state.awaiting_response_created
+        or sent_at is None
+        or request_state.response_id is not None
+        or request_state.latency_response_created_ms is not None
+        or request_state.response_event_count != 0
+        or request_state.downstream_visible
+        or request_state.last_downstream_sequence_number is not None
+    ):
+        return None
+    return sent_at + min(
+        float(stuck_gate_retire_after_seconds),
+        _HTTP_BRIDGE_EVENTLESS_RESPONSE_CREATED_MAX_SECONDS,
+    )
 
 
 def _http_bridge_session_has_admission_waiter(session: object | None) -> bool:
@@ -2101,6 +2129,7 @@ def _log_http_bridge_event(
         "prompt_cache_locality_miss",
         "reallocation_orphan",
         "context_overflow_rollover",
+        "missing_response_created_timeout",
     }:
         level = logging.WARNING
     logger.log(

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -2102,6 +2102,10 @@ class _HTTPBridgeMixin(
         require_same_account: bool = False,
         require_preferred_account: bool = False,
     ) -> None:
+        # A replacement reader can start before its caller resends the request.
+        # Clear the prior attempt first so an expired send timestamp cannot
+        # retire the fresh socket before the next real send re-arms it.
+        request_state.response_create_sent_at = None
         old_account_id = session.account.id
         old_upstream = session.upstream
         old_reader = session.upstream_reader if restart_reader else None

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -201,7 +201,17 @@ async def _send_http_bridge_request_text_with_archive_id(
 ) -> None:
     token = set_request_id(request_state.archive_request_id)
     try:
-        await session.upstream.send_text(text_data)
+        request_state.response_create_sent_at = _service_time().monotonic()
+        session.upstream_reader_wakeup.set()
+        try:
+            await session.upstream.send_text(text_data)
+        except BaseException:
+            # A failed or cancelled send is settled by its caller. Disarm the
+            # owner watchdog before lifecycle ownership is released so the
+            # reader cannot race that cleanup and settle the request twice.
+            request_state.response_create_sent_at = None
+            session.upstream_reader_wakeup.set()
+            raise
     finally:
         reset_request_id(token)
 
@@ -896,7 +906,7 @@ class _HTTPBridgeRequestSubmitMixin:
                     async with session.pending_lock:
                         session.pending_requests.append(warmup_state)
                     request_enqueued = True
-                    await session.upstream.send_text(warmup_text)
+                    await _send_http_bridge_request_text_with_archive_id(session, warmup_state, warmup_text)
                 while True:
                     try:
                         event_block = await asyncio.wait_for(

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -45,13 +45,17 @@ from app.modules.proxy._service.compact import (
     _sticky_key_from_compact_payload as _sticky_key_from_compact_payload,
 )
 from app.modules.proxy._service.http_bridge.helpers import (
+    _HTTP_BRIDGE_MISSING_RESPONSE_CREATED_TIMEOUT_DETAIL,
+    _http_bridge_eventless_precreated_deadline,
     _http_bridge_request_budget_seconds,
     _http_bridge_request_counts_against_queue,
     _log_http_bridge_event,
     _normalize_http_bridge_error_event,
+    _record_http_bridge_stuck_retire,
 )
 from app.modules.proxy._service.http_bridge.service_stubs import (
     _assign_websocket_response_id,
+    _await_cancelled_task,
     _build_stream_incomplete_terminal_event_for_request,
     _find_websocket_request_state_by_response_id,
     _http_error_status_from_payload,
@@ -110,6 +114,7 @@ from app.modules.proxy._service.support import (
     _event_type_from_payload,
     _HTTPBridgeSession,
     _record_response_event,
+    _WebSocketReceiveTimeout,
     _WebSocketRequestState,
 )
 from app.modules.proxy._service.support import (
@@ -211,6 +216,58 @@ def _archive_http_bridge_upstream_message(
         reset_request_id(token)
 
 
+async def _http_bridge_receive_timeout_with_eventless_deadline(
+    session: "_HTTPBridgeSession",
+    receive_timeout: _WebSocketReceiveTimeout | None,
+    *,
+    now: float,
+    stuck_gate_retire_after_seconds: float,
+) -> _WebSocketReceiveTimeout | None:
+    if session.closed:
+        return receive_timeout
+    async with session.pending_lock:
+        deadlines = [
+            deadline
+            for request_state in session.pending_requests
+            if (
+                deadline := _http_bridge_eventless_precreated_deadline(
+                    request_state,
+                    stuck_gate_retire_after_seconds=stuck_gate_retire_after_seconds,
+                )
+            )
+            is not None
+        ]
+    if not deadlines:
+        return receive_timeout
+    eventless_timeout = _WebSocketReceiveTimeout(
+        timeout_seconds=max(0.0, min(deadlines) - now),
+        error_code=_HTTP_BRIDGE_MISSING_RESPONSE_CREATED_TIMEOUT_DETAIL,
+        error_message="Upstream did not acknowledge response.create before the client-safe deadline",
+        fail_all_pending=True,
+    )
+    if receive_timeout is None or eventless_timeout.timeout_seconds <= receive_timeout.timeout_seconds:
+        return eventless_timeout
+    return receive_timeout
+
+
+async def _cancel_http_bridge_reader_child(task: asyncio.Task[Any] | None, *, label: str) -> bool:
+    if task is None:
+        return True
+    if task.done():
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.debug("HTTP bridge reader child already failed during cleanup label=%s", label, exc_info=True)
+        return True
+    try:
+        return bool(await _await_cancelled_task(task, label=label))
+    except Exception:
+        logger.debug("Failed to cancel HTTP bridge reader child label=%s", label, exc_info=True)
+        return task.done()
+
+
 class _HTTPBridgeUpstreamEventsMixin:
     async def _fail_http_bridge_reader_and_maybe_retire(
         self: Any,
@@ -219,6 +276,8 @@ class _HTTPBridgeUpstreamEventsMixin:
         error_code: str,
         error_message: str,
         penalize_account: bool = True,
+        retire_detail: str | None = None,
+        force_retire: bool = False,
     ) -> bool:
         session.closed = True
         async with session.pending_lock:
@@ -241,7 +300,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                 penalize_account=penalize_account,
             )
         finally:
-            if session.admission_waiter_count > 0:
+            if session.admission_waiter_count > 0 and not force_retire:
                 _log_http_bridge_event(
                     "retire_deferred_for_admission_waiter",
                     session.key,
@@ -253,8 +312,11 @@ class _HTTPBridgeUpstreamEventsMixin:
                     model_class=_extract_model_class(session.request_model) if session.request_model else None,
                 )
             else:
-                await self._retire_stale_pending_http_bridge_session(session, detail=error_code)
-        return session.admission_waiter_count == 0
+                await self._retire_stale_pending_http_bridge_session(
+                    session,
+                    detail=retire_detail or error_code,
+                )
+        return force_retire or session.admission_waiter_count == 0
 
     async def _relay_http_bridge_upstream_messages(
         self: Any,
@@ -262,27 +324,147 @@ class _HTTPBridgeUpstreamEventsMixin:
     ) -> None:
         runtime_settings = _service_get_settings()
         relay_upstream = session.upstream
+        receive_task: asyncio.Task[UpstreamWebSocketMessage] | None = None
+        wakeup_task: asyncio.Task[bool] | None = None
         try:
             while True:
+                # Clear before taking the deadline snapshot. A send before the
+                # clear is represented by its timestamp; a send after it leaves
+                # the event set and wakes the persistent receive wait below.
+                session.upstream_reader_wakeup.clear()
                 receive_timeout = await self._next_websocket_receive_timeout(
                     session.pending_requests,
                     pending_lock=session.pending_lock,
                     proxy_request_budget_seconds=_http_bridge_request_budget_seconds(runtime_settings),
                     stream_idle_timeout_seconds=runtime_settings.stream_idle_timeout_seconds,
                 )
-                try:
-                    if receive_timeout is None:
-                        message = await session.upstream.receive()
-                    elif receive_timeout.timeout_seconds <= 0:
-                        raise asyncio.TimeoutError()
+                stuck_gate_retire_after_seconds = float(
+                    getattr(
+                        runtime_settings,
+                        "http_responses_session_bridge_stuck_gate_retire_after_seconds",
+                        300.0,
+                    )
+                )
+                receive_timeout = await _http_bridge_receive_timeout_with_eventless_deadline(
+                    session,
+                    receive_timeout,
+                    now=_service_time().monotonic(),
+                    stuck_gate_retire_after_seconds=stuck_gate_retire_after_seconds,
+                )
+                if receive_task is None:
+                    receive_task = asyncio.create_task(session.upstream.receive())
+
+                message: UpstreamWebSocketMessage | None = None
+                timed_out = False
+                if receive_task.done():
+                    message = receive_task.result()
+                    receive_task = None
+                elif receive_timeout is not None and receive_timeout.timeout_seconds <= 0:
+                    timed_out = True
+                else:
+                    wakeup_task = asyncio.create_task(session.upstream_reader_wakeup.wait())
+                    done, _pending = await asyncio.wait(
+                        (receive_task, wakeup_task),
+                        timeout=receive_timeout.timeout_seconds if receive_timeout is not None else None,
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    if receive_task in done:
+                        message = receive_task.result()
+                        receive_task = None
+                    elif wakeup_task in done:
+                        wakeup_task.result()
+                        wakeup_task = None
+                        continue
                     else:
-                        message = await asyncio.wait_for(
-                            session.upstream.receive(),
-                            timeout=receive_timeout.timeout_seconds,
+                        timed_out = True
+                    if wakeup_task is not None:
+                        await _cancel_http_bridge_reader_child(
+                            wakeup_task,
+                            label="HTTP bridge reader wakeup wait",
                         )
-                except asyncio.TimeoutError:
+                        wakeup_task = None
+
+                if timed_out:
                     if receive_timeout is None:
-                        raise
+                        raise RuntimeError("HTTP bridge reader timed out without a timeout contract")
+                    if receive_timeout.error_code == _HTTP_BRIDGE_MISSING_RESPONSE_CREATED_TIMEOUT_DETAIL:
+                        if receive_task is not None and receive_task.done():
+                            continue
+                        async with session.lifecycle_lock:
+                            # Send-failure cleanup marks the session closed and
+                            # disarms the timestamp while holding this lock.
+                            # Do not race that caller's terminal settlement.
+                            if session.closed:
+                                continue
+                            now = _service_time().monotonic()
+                            async with session.pending_lock:
+                                if receive_task is not None and receive_task.done():
+                                    continue
+                                expired_owner = any(
+                                    deadline is not None and deadline <= now
+                                    for request_state in session.pending_requests
+                                    if (
+                                        deadline := _http_bridge_eventless_precreated_deadline(
+                                            request_state,
+                                            stuck_gate_retire_after_seconds=stuck_gate_retire_after_seconds,
+                                        )
+                                    )
+                                    is not None
+                                )
+                                if not expired_owner:
+                                    continue
+                                pending_count = len(session.pending_requests)
+                                for request_state in session.pending_requests:
+                                    if request_state.failure_phase_override is None:
+                                        request_state.failure_phase_override = "upstream"
+                                    if request_state.failure_detail_override is None:
+                                        request_state.failure_detail_override = (
+                                            _HTTP_BRIDGE_MISSING_RESPONSE_CREATED_TIMEOUT_DETAIL
+                                        )
+                            # Claim the session before cancelling receive so a
+                            # gate waiter cannot reopen this ambiguous socket.
+                            session.closed = True
+                            if receive_task is not None:
+                                receive_cancelled = await _cancel_http_bridge_reader_child(
+                                    receive_task,
+                                    label="HTTP bridge upstream receive after missing response.created",
+                                )
+                                if receive_cancelled:
+                                    receive_task = None
+                            _record_http_bridge_stuck_retire(
+                                reason=_HTTP_BRIDGE_MISSING_RESPONSE_CREATED_TIMEOUT_DETAIL,
+                                session=session,
+                            )
+                            _log_http_bridge_event(
+                                "missing_response_created_timeout",
+                                session.key,
+                                account_id=session.account.id,
+                                model=session.request_model,
+                                pending_count=pending_count,
+                                detail=_HTTP_BRIDGE_MISSING_RESPONSE_CREATED_TIMEOUT_DETAIL,
+                                cache_key_family=session.key.affinity_kind,
+                                model_class=(
+                                    _extract_model_class(session.request_model) if session.request_model else None
+                                ),
+                            )
+                            await self._fail_http_bridge_reader_and_maybe_retire(
+                                session,
+                                error_code="upstream_request_timeout",
+                                error_message=receive_timeout.error_message,
+                                penalize_account=False,
+                                retire_detail=_HTTP_BRIDGE_MISSING_RESPONSE_CREATED_TIMEOUT_DETAIL,
+                                force_retire=True,
+                            )
+                        break
+
+                    if receive_task is not None:
+                        receive_cancelled = await _cancel_http_bridge_reader_child(
+                            receive_task,
+                            label="HTTP bridge upstream receive after timeout",
+                        )
+                        if not receive_cancelled:
+                            raise RuntimeError("HTTP bridge upstream receive did not cancel after timeout")
+                        receive_task = None
                     retried = await self._retry_http_bridge_precreated_request(session)
                     if retried:
                         continue
@@ -294,6 +476,8 @@ class _HTTPBridgeUpstreamEventsMixin:
                         )
                     break
 
+                if message is None:
+                    raise RuntimeError("HTTP bridge upstream receive completed without a message")
                 if message.kind == "text" and message.text is not None:
                     session.last_upstream_close_code = None
                     if EVENT_MARKER in message.text:
@@ -348,6 +532,14 @@ class _HTTPBridgeUpstreamEventsMixin:
                     penalize_account=not account_neutral,
                 )
         finally:
+            await _cancel_http_bridge_reader_child(
+                wakeup_task,
+                label="HTTP bridge reader wakeup wait",
+            )
+            await _cancel_http_bridge_reader_child(
+                receive_task,
+                label="HTTP bridge upstream receive",
+            )
             if session.upstream is relay_upstream:
                 session.closed = True
 

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -709,6 +709,10 @@ class _WebSocketRequestState:
     latency_response_create_gate_wait_ms: int | None = None
     latency_bridge_queue_wait_ms: int | None = None
     response_create_gate_wait_started_at: float | None = None
+    # Monotonic time immediately before the current upstream response.create
+    # send. Retries replace this value so admission wait and prior attempts do
+    # not age a fresh send into the eventless owner deadline.
+    response_create_sent_at: float | None = None
     bridge_queue_wait_started_at: float | None = None
     # Monotonic deadline of the original bridge request budget. Retry and
     # recovery paths re-prepare request states with a fresh started_at, so
@@ -855,6 +859,9 @@ class _HTTPBridgeSession:
     queued_request_count: int
     last_used_at: float
     idle_ttl_seconds: float
+    # Wakes a reader that began an unbounded receive before the first request
+    # was enqueued. The reader keeps one receive task alive across wakeups.
+    upstream_reader_wakeup: asyncio.Event = field(default_factory=asyncio.Event)
     unanchored_reservation_id: str | None = None
     admission_waiter_count: int = 0
     request_service_tier: str | None = None

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -42,7 +42,7 @@ from app.core.auth.dependencies import (
 from app.core.auth.refresh import RefreshError
 from app.core.cache.invalidation import NAMESPACE_RESET_CREDITS, bump_cache_invalidation_local
 from app.core.clients.files import FileProxyError
-from app.core.clients.proxy import ProxyResponseError
+from app.core.clients.proxy import ProxyResponseError, _is_native_codex_request
 from app.core.clients.rate_limit_reset_credits import (
     ConsumeResetCreditError,
     ResetCreditFetchError,
@@ -422,16 +422,20 @@ def _has_openai_responses_shape(payload: V1ResponsesRequest | Mapping[str, JsonV
     )
 
 
-def _is_openai_sdk_request(
-    request: Request,
-    payload: V1ResponsesRequest | Mapping[str, JsonValue] | None = None,
-) -> bool:
+def _has_explicit_openai_sdk_marker(request: Request) -> bool:
     for header_name in request.headers:
         normalized_header = header_name.lower()
         if normalized_header.startswith("x-stainless-"):
             return True
     user_agent = request.headers.get("user-agent", "").lower()
-    if "openai" in user_agent:
+    return "openai" in user_agent
+
+
+def _is_openai_sdk_request(
+    request: Request,
+    payload: V1ResponsesRequest | Mapping[str, JsonValue] | None = None,
+) -> bool:
+    if _has_explicit_openai_sdk_marker(request):
         return True
     if payload is None or not _has_openai_responses_shape(payload):
         return False
@@ -627,7 +631,9 @@ async def responses(
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> Response:
+    explicit_openai_sdk_marker = _has_explicit_openai_sdk_marker(request)
     openai_sdk_request = _is_openai_sdk_request(request, payload)
+    native_codex_heartbeat = _is_native_codex_request(request.headers) and not explicit_openai_sdk_marker
     openai_compat_payload = _has_openai_responses_shape(payload)
     try:
         responses_payload = normalize_responses_request_payload(
@@ -689,6 +695,7 @@ async def responses(
         # native event ordering, while OpenAI SDK clients pointed at this
         # compatibility route need the same SSE contract enforcement as /v1.
         enforce_openai_sdk_contract=openai_sdk_request,
+        native_codex_heartbeat=native_codex_heartbeat,
     )
 
 
@@ -4257,6 +4264,7 @@ async def _stream_responses(
     forwarded_file_owner_account_id: str | None = None,
     forwarded_client_ip: str | None = None,
     enforce_openai_sdk_contract: bool = True,
+    native_codex_heartbeat: bool = False,
     prohibit_fast_mode: bool = False,
 ) -> Response:
     apply_api_key_enforcement(payload, api_key, prohibit_fast_mode=prohibit_fast_mode)
@@ -4452,8 +4460,9 @@ async def _stream_responses(
         ),
         enforce_openai_sdk_contract=enforce_openai_sdk_contract,
     )
-    keepalive_frame = CODEX_KEEPALIVE_FRAME if not enforce_openai_sdk_contract else SSE_KEEPALIVE_FRAME
-    if not enforce_openai_sdk_contract:
+    use_codex_keepalive = native_codex_heartbeat or not enforce_openai_sdk_contract
+    keepalive_frame = CODEX_KEEPALIVE_FRAME if use_codex_keepalive else SSE_KEEPALIVE_FRAME
+    if use_codex_keepalive:
         stream = _prepend_initial_sse_heartbeat(
             stream,
             keepalive_frame,

--- a/openspec/changes/recover-codex-desktop-idle-bridge/.openspec.yaml
+++ b/openspec/changes/recover-codex-desktop-idle-bridge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/recover-codex-desktop-idle-bridge/design.md
+++ b/openspec/changes/recover-codex-desktop-idle-bridge/design.md
@@ -1,0 +1,80 @@
+## Context
+
+The HTTP Responses bridge serializes upstream `response.create` submissions with a per-session gate and releases that gate when `response.created` is observed. Current `main` can retire a stale pre-created gate owner when another request later times out waiting for the gate, but it has no owner-side deadline. A lone request can therefore remain pending indefinitely after a successful WebSocket send produces no matched `response.*` event.
+
+The production request that motivated this change was eventless after its current `response.create` send and remained pending for 3,467 seconds. Codex Desktop disconnected first because its parsed-event idle timeout is 300 seconds. The backend route had classified the native request as OpenAI-SDK-shaped from its payload and `Accept` header, so periodic SSE comments never reached the parsed-event timer.
+
+Current `main` already provides terminal request settlement, whole-session retirement, a stuck-retirement Prometheus counter, lifecycle locking, native Codex identity detection, and safe later-waiter recovery. This change reuses those primitives directly and does not import PR #1394's retry-circuit, replay, coordinator, or migration surface.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Terminate an eventless request that remains pre-`response.created` before the native client's 300-second idle boundary, without requiring another gate waiter.
+- Measure the deadline from the current upstream send rather than request construction or admission wait.
+- Fail closed through existing settlement and session-retirement paths without replaying ambiguous work or moving it to another account.
+- Send parser-visible liveness to verified native Codex clients while retaining OpenAI event normalization when their payload needs it.
+- Preserve structured low-cardinality retirement metrics and logs.
+
+**Non-Goals:**
+
+- Replay a pre-visible request, retry clean upstream closes, or persist retry cooldowns across replicas.
+- Recover a request after any matched `response.*` lifecycle event; eventful missing-created recovery remains outside this narrow change.
+- Change account selection, continuity ownership, request budgets, public `/v1/responses`, or operator settings.
+- Merge PR #1394, deploy the result, or alter the current Mac mini runtime as part of this code change.
+
+## Decisions
+
+### 1. Measure from the actual current send
+
+Add one optional monotonic `response_create_sent_at` field to the in-memory request state. Set it immediately before each actual upstream `send_text` of the current `response.create`. A later send replaces the timestamp, so admission and queue time from an earlier attempt cannot make a fresh send expire immediately.
+
+This timestamp is protocol evidence, not a general request timer. Request start time is not an acceptable fallback for the proactive watchdog because a request may legitimately spend most of its budget waiting for admission before it reaches upstream.
+
+### 2. Use the existing threshold with a client-safe cap
+
+The proactive window is `min(http_responses_session_bridge_stuck_gate_retire_after_seconds, 240 seconds)`. This introduces no new setting, preserves deliberately shorter existing thresholds, and leaves at least 60 seconds before the native client's 300-second parsed-event timeout.
+
+The upstream-reader wait uses the earliest applicable deadline. The watchdog remains active when SSE keepalives are disabled because downstream liveness and upstream acceptance are separate concerns.
+
+### 3. Keep the eligibility deliberately narrow
+
+The proactive timeout applies only while the current HTTP request:
+
+- owns the response-create gate and is awaiting `response.created`;
+- has a current send timestamp;
+- has no response id or recorded `response.created` latency;
+- has no matched `response.*` lifecycle event;
+- has no downstream-visible output or sequence evidence.
+
+Leading non-response telemetry such as `codex.rate_limits` does not change those conditions. Any matched response lifecycle event protects the request from this narrow watchdog, even if it later becomes stale; handling that ambiguous state safely requires broader sibling and replay coordination and is intentionally deferred.
+
+### 4. Fail the whole bridge session closed
+
+When the deadline expires, reuse the reader-owned terminal failure and whole-session retirement path. Emit a stable `missing_response_created_timeout` detail, increment the existing stuck-retirement metric, settle every pending request exactly once, and close the bridge session.
+
+Do not transparently replay the timed-out request, submit it on another account, or mark the selected account unhealthy. Upstream acceptance is unknown, so duplicate submission and account movement are less safe than an explicit terminal failure. A later client request creates a fresh session through existing behavior.
+
+Example: a request sends at monotonic time 1,000 with the default 300-second stuck threshold. With no matched response lifecycle event, it becomes eligible at 1,240 and receives an explicit terminal failure; it does not wait for a second request or the 300-second Desktop idle timeout.
+
+### 5. Separate heartbeat identity from event normalization
+
+Continue using `_is_openai_sdk_request` to decide whether response events need the OpenAI compatibility normalizer. Separately derive verified native identity from the existing `_is_native_codex_request` allowlist. A native request without explicit SDK fingerprint markers receives `CODEX_KEEPALIVE_FRAME` even if payload-shape heuristics enable normalization.
+
+Explicit `x-stainless-*` headers or an OpenAI User-Agent retain comment liveness. Public `/v1/responses` never enables the native heartbeat override. This changes only liveness framing; it does not relax authentication, routing, payload validation, fingerprint normalization, or vendor-event filtering.
+
+## Risks / Trade-offs
+
+- **A send fails after the timestamp is set.** Existing send-error cleanup retires or settles the request before the watchdog can act; tests cover that the timestamp alone is not sufficient eligibility.
+- **A quiet upstream accepted the request but emitted no event.** The proxy returns an explicit failure rather than risking a duplicate replay. The selected account remains healthy because silence is not proof of account failure.
+- **A matched lifecycle event arrives just before timeout.** Eligibility is rechecked under the existing request/session synchronization before retirement, and any matched `response.*` event suppresses this watchdog.
+- **Whole-session retirement interrupts a healthy sibling.** This narrow design chooses fail-closed session cleanup rather than attempting unsafe sibling isolation on current `main`. Existing terminal settlement must cover every pending sibling exactly once.
+- **A client spoofs native identity.** The only benefit is an ignored vendor liveness event on the authenticated Codex backend route; explicit SDK markers still take precedence.
+
+## Migration Plan
+
+No data migration or setting change is required. Deploying a new process initializes the monotonic field on new in-memory request states. Rollback restores the previous timeout and heartbeat selection without persistent-state conversion.
+
+## Open Questions
+
+None. The scope intentionally solves only the observed eventless/no-waiter production failure.

--- a/openspec/changes/recover-codex-desktop-idle-bridge/proposal.md
+++ b/openspec/changes/recover-codex-desktop-idle-bridge/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+A production Codex Desktop request on the HTTP-to-WebSocket bridge remained pending for nearly an hour after its upstream `response.create` send produced neither `response.created` nor any matched `response.*` lifecycle event. Existing stuck-gate recovery runs only when another request later times out waiting for the gate, so a lone request can outlive the native client's 300-second parsed-event idle timeout. During the same wedge, the backend route classified the native Desktop request as an OpenAI SDK stream from its payload shape and emitted SSE comments that the Codex parser does not observe.
+
+## What Changes
+
+- Record the monotonic time of the current upstream `response.create` send.
+- Proactively expire an eventless request that remains pre-`response.created` for the smaller of the existing stuck-gate threshold and 240 seconds, even when no second gate waiter exists and periodic keepalives are disabled.
+- Fail the affected bridge session closed through existing terminal settlement and retirement paths, without transparent replay, account movement, or account-health penalties.
+- Give verified native Codex identity parser-visible `codex.keepalive` frames even when payload-shape heuristics still require OpenAI-compatible event normalization; explicit SDK markers and public `/v1/responses` retain comment liveness.
+- Add regressions for the no-waiter deadline, protected created/eventful requests, account-neutral retirement, and contrasting Desktop/SDK/public heartbeat contracts.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-admission-control`: Add a proactive, fail-closed deadline for an eventless response-create gate owner without requiring another waiter.
+- `responses-api-compat`: Require verified native Codex Desktop HTTP streams to receive parsed-event liveness frames without weakening SDK normalization.
+
+## Impact
+
+- Affected code: HTTP bridge request send timing, upstream-reader timeout/retirement, backend Responses client identity, and SSE keepalive selection.
+- Affected surfaces: `POST /backend-api/codex/responses` and its server-side upstream WebSocket bridge.
+- No new setting, dependency, database migration, public endpoint, retry circuit, durable coordinator, or OpenAI SDK contract change.
+- The change is independent of PR #1394. It fixes the observed eventless/no-waiter wedge but intentionally does not add #1394's transparent replay, clean-close retry, or cross-replica cooldown behavior.

--- a/openspec/changes/recover-codex-desktop-idle-bridge/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/recover-codex-desktop-idle-bridge/specs/proxy-admission-control/spec.md
@@ -1,0 +1,47 @@
+## MODIFIED Requirements
+
+### Requirement: Stuck HTTP bridge response-create gate sessions are retired
+
+The proxy MUST retain the existing waiter-triggered retirement behavior for stale HTTP bridge response-create gate owners and MUST additionally enforce an owner-side deadline for a visible HTTP request whose current upstream `response.create` send remains completely eventless before `response.created`. The owner-side deadline MUST be measured from a monotonic timestamp recorded immediately before the current upstream send, MUST use the smaller of the configured stuck-gate retirement threshold and 240 seconds, MUST run without a second gate waiter, and MUST remain active when periodic SSE keepalives are disabled.
+
+The owner-side watchdog MUST apply only while the request owns the response-create gate, awaits `response.created`, has neither a response id nor recorded `response.created` latency, has received no matched `response.*` lifecycle event, and has produced no downstream-visible output or sequence evidence. Non-response telemetry such as `codex.rate_limits` MUST NOT suppress this watchdog. Any matched `response.*` lifecycle event, response-created milestone, or downstream-visible evidence MUST suppress the owner-side watchdog and leave existing timeout behavior unchanged.
+
+When the owner-side deadline expires, the proxy MUST recheck eligibility, emit a structured low-cardinality log and the existing stuck-retirement Prometheus counter, terminally fail and settle every pending request exactly once, and retire the whole bridge session. It MUST NOT transparently replay the timed-out request, move it to another account, or write an account-health failure for the missing-created timeout.
+
+#### Scenario: Lone eventless gate owner is retired before the client timeout
+
+- **GIVEN** a visible HTTP bridge request owns the response-create gate
+- **AND** its current `response.create` send produced no matched `response.*` event, response id, or downstream-visible output
+- **AND** no second request waits for the gate
+- **WHEN** the smaller of the configured stuck threshold and 240 seconds elapses after the current send
+- **THEN** the proxy emits an explicit terminal failure and retires the bridge session
+- **AND** recovery occurs before the native client's 300-second parsed-event idle timeout
+
+#### Scenario: Send time rather than request age anchors the deadline
+
+- **GIVEN** a request spends most of its budget waiting for admission before it sends `response.create`
+- **WHEN** the upstream send succeeds
+- **THEN** the owner-side deadline begins from that current send
+- **AND** earlier queue or admission time does not make the request immediately stale
+
+#### Scenario: Leading telemetry does not mask an eventless owner
+
+- **GIVEN** a pre-created gate owner receives `codex.rate_limits` but no matched `response.*` lifecycle event
+- **WHEN** the owner-side deadline elapses
+- **THEN** the telemetry does not refresh or suppress the deadline
+- **AND** the proxy fails and retires the session
+
+#### Scenario: Response lifecycle evidence suppresses the narrow watchdog
+
+- **GIVEN** a pre-created request receives any matched `response.*` lifecycle event, a response id, recorded `response.created` latency, or downstream-visible output
+- **WHEN** the eventless owner-side deadline would otherwise elapse
+- **THEN** this watchdog does not retire the session
+- **AND** existing stream, request-budget, and waiter-triggered timeout behavior remains authoritative
+
+#### Scenario: Timeout is fail-closed and account-neutral
+
+- **GIVEN** an eventless pre-created owner reaches the owner-side deadline
+- **WHEN** terminal cleanup runs
+- **THEN** every pending request is settled exactly once and the whole session is retired
+- **AND** the proxy does not replay the timed-out request or submit it on another account
+- **AND** the selected account is not marked unhealthy solely because `response.created` was missing

--- a/openspec/changes/recover-codex-desktop-idle-bridge/specs/responses-api-compat/spec.md
+++ b/openspec/changes/recover-codex-desktop-idle-bridge/specs/responses-api-compat/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: HTTP bridge streams emit downstream liveness frames while pending
+
+When an HTTP bridge Responses request is waiting for upstream queue events, the system MUST emit a downstream SSE liveness frame at the configured `sse_keepalive_interval_seconds` interval so downstream clients do not disconnect before the upstream terminal frame arrives. The first generated liveness frame MUST be delayed until after the HTTP bridge startup-error probe window so a local startup `ProxyResponseError` can still be surfaced as a non-2xx HTTP response. Once a generated liveness frame is emitted, the stream MUST be considered started for later HTTP-error propagation decisions, so a subsequent upstream `response.failed` is forwarded in-stream instead of being raised as a startup HTTP error.
+
+If the pending request already has a response id, the liveness frame MAY be a `response.in_progress` SSE event for that response id. Before a response id exists, a verified native Codex client on `/backend-api/codex/responses` MUST receive an event-bearing `codex.keepalive` JSON SSE frame even when payload-shape heuristics also require OpenAI-compatible response normalization, because comment-only frames do not reset the native client's parsed-event idle timer. Native identity MUST come from the existing native User-Agent or originator allowlist and MUST NOT be inferred from continuity headers.
+
+Explicit OpenAI SDK fingerprint markers, including `x-stainless-*` headers or an OpenAI User-Agent, MUST retain precedence for heartbeat framing and MUST receive comment liveness. Public `/v1/responses` and other non-native OpenAI SDK streams MUST retain comment heartbeats before `response.created`; public stream normalization MUST preserve those comments and MUST drop `codex.*` liveness events from the OpenAI contract surface. Heartbeat selection MUST NOT disable authentication, payload validation, event normalization, fingerprint normalization, or routing policy.
+
+#### Scenario: Native Desktop shape receives parsed-event liveness
+
+- **GIVEN** Codex Desktop sends `POST /backend-api/codex/responses` with a verified native User-Agent or originator
+- **AND** its OpenAI-compatible payload and `Accept` header also trigger SDK-compatible event normalization
+- **WHEN** no upstream event arrives before a response id is known
+- **THEN** the proxy emits an event-bearing `codex.keepalive` JSON SSE frame
+- **AND** it preserves any required response-event normalization
+
+#### Scenario: Explicit SDK marker retains comment liveness
+
+- **GIVEN** a request to `/backend-api/codex/responses` carries an `x-stainless-*` header or OpenAI User-Agent
+- **WHEN** its payload also resembles a native Codex request
+- **THEN** the proxy emits an SSE comment heartbeat before `response.created`
+- **AND** it does not expose `codex.*` vendor events to the SDK stream
+
+#### Scenario: Public v1 route never exposes native vendor heartbeat
+
+- **GIVEN** a request targets public `/v1/responses`
+- **WHEN** the request is pending before `response.created`
+- **THEN** periodic liveness uses OpenAI-contract-safe comment frames
+- **AND** the first data event remains `response.created`
+
+#### Scenario: First HTTP bridge keepalive is delayed past startup probe
+
+- **GIVEN** an HTTP bridge request is waiting for upstream queue events
+- **AND** `sse_keepalive_interval_seconds` is shorter than the bridge startup-error probe window
+- **WHEN** no upstream event arrives before the configured keepalive interval
+- **THEN** the first generated keepalive is not emitted until the startup-error probe window has elapsed
+- **AND** a startup `ProxyResponseError` can still be surfaced as a non-2xx HTTP response before any keepalive commits the stream
+
+#### Scenario: HTTP bridge keepalive commits stream for later response-failed events
+
+- **GIVEN** an HTTP bridge request emits a generated keepalive as its first downstream chunk
+- **WHEN** the next upstream event is a `response.failed` with an HTTP status override
+- **THEN** the `response.failed` event is forwarded on the SSE stream
+- **AND** it is not raised as a startup HTTP error after bytes have already been emitted
+
+#### Scenario: Public Responses normalizer preserves comment keepalive blocks
+
+- **WHEN** the public `/v1/responses` stream normalizer receives an SSE comment keepalive block before a terminal event
+- **THEN** it forwards the comment keepalive block unchanged
+- **AND** it continues normalizing the subsequent Responses events normally

--- a/openspec/changes/recover-codex-desktop-idle-bridge/tasks.md
+++ b/openspec/changes/recover-codex-desktop-idle-bridge/tasks.md
@@ -1,0 +1,18 @@
+## 1. Eventless pre-created deadline
+
+- [x] 1.1 Record the current monotonic `response.create` send timestamp in HTTP bridge request state and replace it on every real send.
+- [x] 1.2 Add a pure client-safe deadline helper that uses the smaller of the existing stuck-gate threshold and 240 seconds.
+- [x] 1.3 Enforce the deadline from the upstream reader without requiring a second gate waiter or SSE keepalives; recheck narrow eventless eligibility before acting.
+- [x] 1.4 Fail and retire the whole bridge session through existing settlement, logging, and Prometheus paths without replay, account movement, or account-health writes.
+- [x] 1.5 Add focused regressions for no-waiter expiry, send-time anchoring, leading telemetry, created/eventful/downstream protection, terminal settlement, and account neutrality.
+
+## 2. Native Codex SSE liveness
+
+- [x] 2.1 Separate native heartbeat identity from payload-shape normalization while preserving explicit SDK-marker precedence and public `/v1` behavior.
+- [x] 2.2 Add endpoint-level regressions proving Desktop receives `codex.keepalive` data frames while explicit SDK and public clients retain comment/vendor-safe streams.
+
+## 3. Verification
+
+- [x] 3.1 Run focused bridge and API tests, then Ruff, formatting, type, and architecture checks.
+- [x] 3.2 Validate the change strictly and validate all repository specs.
+- [x] 3.3 Review the final diff for secrets/header leakage, account-affinity changes, replay, missing settlement, metric loss, and unrelated edits.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -1604,13 +1604,16 @@ async def test_v1_responses_http_bridge_codex_session_uses_extended_idle_ttl(asy
 
     session.last_used_at = time.monotonic() - 300.0
     async with service._http_bridge_lock:
-        service._prune_http_bridge_sessions_locked()
+        stale_sessions = service._prune_http_bridge_sessions_locked()
         assert key in service._http_bridge_sessions
+    assert stale_sessions == []
 
     session.last_used_at = time.monotonic() - 601.0
     async with service._http_bridge_lock:
-        service._prune_http_bridge_sessions_locked()
+        stale_sessions = service._prune_http_bridge_sessions_locked()
         assert key not in service._http_bridge_sessions
+    for stale_session in stale_sessions:
+        await service._close_http_bridge_session(stale_session)
 
 
 @pytest.mark.asyncio
@@ -3785,6 +3788,11 @@ async def test_v1_responses_http_bridge_reconnect_fails_when_reader_cancel_times
     async def blocking_reader_task() -> None:
         await _wait_for_event(blocker)
 
+    original_reader = bridge_session.upstream_reader
+    assert original_reader is not None
+    original_reader.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await original_reader
     blocking_reader = asyncio.create_task(blocking_reader_task())
     bridge_session.upstream_reader = blocking_reader
 
@@ -10622,7 +10630,11 @@ async def test_v1_responses_http_bridge_send_failure_returns_upstream_unavailabl
     service = get_proxy_service_for_app(app_instance)
     async with service._http_bridge_lock:
         session = next(iter(service._http_bridge_sessions.values()))
-        session.upstream = cast(proxy_module.UpstreamResponsesWebSocket, failing_upstream)
+        await _replace_http_bridge_upstream_reader(
+            service,
+            session,
+            cast(proxy_module.UpstreamResponsesWebSocket, failing_upstream),
+        )
 
     second = await async_client.post(
         "/v1/responses",

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -90,6 +90,64 @@ async def _import_account(async_client, account_id: str, email: str) -> str:
     return generate_unique_account_id(account_id, email)
 
 
+def _sse_data_events(lines: list[str]) -> list[dict]:
+    return [json.loads(line[6:]) for line in lines if line.startswith("data: ") and not line.startswith("data: [DONE]")]
+
+
+async def _request_idle_heartbeat_stream(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    route: str,
+    headers: dict[str, str],
+    account_suffix: str,
+) -> list[str]:
+    await _import_account(
+        async_client,
+        f"acc_idle_heartbeat_{account_suffix}",
+        f"idle-heartbeat-{account_suffix}@example.com",
+    )
+
+    settings = proxy_api_module.get_settings().model_copy(update={"sse_keepalive_interval_seconds": 0.005})
+    monkeypatch.setattr(proxy_api_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_api_module, "_HTTP_BRIDGE_STARTUP_ERROR_PROBE_SECONDS", 0.005)
+
+    async def fake_stream(*args, **kwargs):
+        del args, kwargs
+        await asyncio.sleep(0.04)
+        yield _sse_event(
+            {
+                "type": "codex.rate_limits",
+                "plan_type": "pro",
+                "rate_limits": {"allowed": True},
+            }
+        )
+        yield _sse_event(
+            {
+                "type": "response.completed",
+                "sequence_number": 1,
+                "response": {
+                    "id": f"resp_idle_heartbeat_{account_suffix}",
+                    "object": "response",
+                    "status": "completed",
+                    "output": [],
+                },
+            }
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.1", "input": "heartbeat", "stream": True}
+    async with async_client.stream(
+        "POST",
+        route,
+        json=payload,
+        headers={"accept": "text/event-stream", **headers},
+    ) as response:
+        assert response.status_code == 200
+        return [line async for line in response.aiter_lines() if line]
+
+
 @pytest.mark.asyncio
 async def test_proxy_compact_not_implemented(async_client, monkeypatch):
     await _import_account(async_client, "acc_compact_ni", "ni@example.com")
@@ -1204,6 +1262,99 @@ async def test_stream_responses_starts_sse_keepalive_before_first_upstream_event
     chunks = [cast(str, await asyncio.wait_for(iterator.__anext__(), timeout=0.2)) for _ in range(2)]
     assert any("response.completed" in chunk for chunk in chunks)
     assert seen_client_ip == ["203.0.113.7"]
+
+
+@pytest.mark.asyncio
+async def test_backend_desktop_openai_shape_uses_codex_heartbeat_with_sdk_normalization(
+    async_client,
+    monkeypatch,
+):
+    lines = await _request_idle_heartbeat_stream(
+        async_client,
+        monkeypatch,
+        route="/backend-api/codex/responses",
+        headers={
+            "user-agent": "Codex Desktop/0.1.0 (Mac OS 26.5.0; arm64)",
+            "originator": "Codex Desktop",
+        },
+        account_suffix="desktop_openai_shape",
+    )
+
+    assert lines[:2] == CODEX_KEEPALIVE_FRAME.strip().splitlines()
+    event_types = [event.get("type") for event in _sse_data_events(lines)]
+    standard_event_types = [event_type for event_type in event_types if event_type != "codex.keepalive"]
+    assert standard_event_types[0] == "response.created"
+    assert "codex.rate_limits" not in event_types
+    assert "response.completed" in standard_event_types
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("identity_headers", "account_suffix"),
+    [
+        pytest.param(
+            {
+                "user-agent": "Codex Desktop/0.1.0 (Mac OS 26.5.0; arm64)",
+                "originator": "Codex Desktop",
+                "x-stainless-lang": "python",
+            },
+            "desktop_stainless",
+            id="x-stainless-overrides-desktop",
+        ),
+        pytest.param(
+            {
+                "user-agent": "OpenAI/Python 2.24.0",
+                "originator": "Codex Desktop",
+            },
+            "native_originator_openai_ua",
+            id="openai-user-agent-overrides-native-originator",
+        ),
+    ],
+)
+async def test_backend_explicit_sdk_marker_uses_comment_heartbeat(
+    async_client,
+    monkeypatch,
+    identity_headers,
+    account_suffix,
+):
+    lines = await _request_idle_heartbeat_stream(
+        async_client,
+        monkeypatch,
+        route="/backend-api/codex/responses",
+        headers=identity_headers,
+        account_suffix=account_suffix,
+    )
+
+    assert lines[0] == SSE_KEEPALIVE_FRAME.strip()
+    assert CODEX_KEEPALIVE_FRAME.strip().splitlines()[0] not in lines
+    event_types = [event.get("type") for event in _sse_data_events(lines)]
+    assert event_types[0] == "response.created"
+    assert "codex.rate_limits" not in event_types
+    assert "response.completed" in event_types
+
+
+@pytest.mark.asyncio
+async def test_v1_desktop_identity_uses_comment_heartbeat_and_sdk_event_order(
+    async_client,
+    monkeypatch,
+):
+    lines = await _request_idle_heartbeat_stream(
+        async_client,
+        monkeypatch,
+        route="/v1/responses",
+        headers={
+            "user-agent": "Codex Desktop/0.1.0 (Mac OS 26.5.0; arm64)",
+            "originator": "Codex Desktop",
+        },
+        account_suffix="v1_desktop",
+    )
+
+    assert lines[0] == SSE_KEEPALIVE_FRAME.strip()
+    assert CODEX_KEEPALIVE_FRAME.strip().splitlines()[0] not in lines
+    event_types = [event.get("type") for event in _sse_data_events(lines)]
+    assert event_types[0] == "response.created"
+    assert "codex.rate_limits" not in event_types
+    assert "response.completed" in event_types
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -36,6 +36,7 @@ from app.modules.proxy import service as proxy_service
 from app.modules.proxy._service import support as proxy_support_module
 from app.modules.proxy._service.http_bridge import helpers as http_bridge_helpers_module
 from app.modules.proxy._service.http_bridge import mixin as http_bridge_mixin_module
+from app.modules.proxy._service.http_bridge import request_submit as http_bridge_request_submit_module
 from app.modules.proxy._service.http_bridge import streaming as http_bridge_streaming_module
 from app.modules.proxy.account_cache import clear_account_routing_unavailable, mark_account_routing_unavailable
 from app.modules.proxy.http_bridge_forwarding import OwnerForwardRelayFailure
@@ -92,6 +93,167 @@ def _make_bridge_session(
         queued_request_count=queued_request_count,
         last_used_at=1.0,
         idle_ttl_seconds=120.0,
+    )
+
+
+def _make_eventless_http_bridge_owner(
+    *,
+    request_id: str = "req-eventless-owner",
+    sent_at: float = 100.0,
+) -> proxy_service._WebSocketRequestState:
+    return proxy_service._WebSocketRequestState(
+        request_id=request_id,
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort="high",
+        api_key_reservation=None,
+        started_at=-10_000.0,
+        transport="http",
+        response_create_gate=asyncio.Semaphore(0),
+        response_create_gate_acquired=True,
+        awaiting_response_created=True,
+        response_create_sent_at=sent_at,
+        event_queue=asyncio.Queue(),
+    )
+
+
+def test_http_bridge_eventless_precreated_deadline_uses_current_send_and_client_safe_cap() -> None:
+    request_state = _make_eventless_http_bridge_owner()
+
+    assert (
+        http_bridge_helpers_module._http_bridge_eventless_precreated_deadline(
+            request_state,
+            stuck_gate_retire_after_seconds=300.0,
+        )
+        == 340.0
+    )
+    assert (
+        http_bridge_helpers_module._http_bridge_eventless_precreated_deadline(
+            request_state,
+            stuck_gate_retire_after_seconds=30.0,
+        )
+        == 130.0
+    )
+
+    request_state.latency_first_upstream_event_ms = 25
+    assert (
+        http_bridge_helpers_module._http_bridge_eventless_precreated_deadline(
+            request_state,
+            stuck_gate_retire_after_seconds=300.0,
+        )
+        == 340.0
+    )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    [
+        ("response_id", "resp-created"),
+        ("latency_response_created_ms", 12),
+        ("response_event_count", 1),
+        ("downstream_visible", True),
+        ("last_downstream_sequence_number", 0),
+        ("awaiting_response_created", False),
+        ("response_create_gate_acquired", False),
+        ("response_create_gate", None),
+        ("response_create_sent_at", None),
+    ],
+)
+def test_http_bridge_eventless_precreated_deadline_requires_narrow_owner_evidence(
+    field_name: str,
+    field_value: object,
+) -> None:
+    request_state = _make_eventless_http_bridge_owner()
+    setattr(request_state, field_name, field_value)
+
+    assert (
+        http_bridge_helpers_module._http_bridge_eventless_precreated_deadline(
+            request_state,
+            stuck_gate_retire_after_seconds=300.0,
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_send_replaces_timestamp_and_wakes_existing_reader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request_state = _make_eventless_http_bridge_owner(sent_at=1.0)
+    session = _make_bridge_session()
+    seen_sent_ats: list[float | None] = []
+
+    async def send_text(_text: str) -> None:
+        seen_sent_ats.append(request_state.response_create_sent_at)
+
+    session.upstream = cast(
+        UpstreamResponsesWebSocket,
+        SimpleNamespace(send_text=send_text, close=AsyncMock()),
+    )
+    monotonic_values = iter((100.0, 200.0))
+    monotonic = lambda: next(monotonic_values)  # noqa: E731
+    monkeypatch.setattr(
+        http_bridge_request_submit_module,
+        "_service_time",
+        lambda: SimpleNamespace(monotonic=monotonic),
+    )
+
+    await http_bridge_request_submit_module._send_http_bridge_request_text_with_archive_id(
+        session,
+        request_state,
+        "first",
+    )
+    session.upstream_reader_wakeup.clear()
+    await http_bridge_request_submit_module._send_http_bridge_request_text_with_archive_id(
+        session,
+        request_state,
+        "second",
+    )
+
+    assert seen_sent_ats == [100.0, 200.0]
+    assert request_state.response_create_sent_at == 200.0
+    assert session.upstream_reader_wakeup.is_set() is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", [RuntimeError("send failed"), asyncio.CancelledError()])
+async def test_http_bridge_failed_send_disarms_eventless_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: BaseException,
+) -> None:
+    request_state = _make_eventless_http_bridge_owner(sent_at=1.0)
+    session = _make_bridge_session()
+
+    async def send_text(_text: str) -> None:
+        assert request_state.response_create_sent_at == 100.0
+        raise failure
+
+    session.upstream = cast(
+        UpstreamResponsesWebSocket,
+        SimpleNamespace(send_text=send_text, close=AsyncMock()),
+    )
+    monkeypatch.setattr(
+        http_bridge_request_submit_module,
+        "_service_time",
+        lambda: SimpleNamespace(monotonic=lambda: 100.0),
+    )
+    session.upstream_reader_wakeup.clear()
+
+    with pytest.raises(type(failure)):
+        await http_bridge_request_submit_module._send_http_bridge_request_text_with_archive_id(
+            session,
+            request_state,
+            "request",
+        )
+
+    assert request_state.response_create_sent_at is None
+    assert session.upstream_reader_wakeup.is_set() is True
+    assert (
+        http_bridge_helpers_module._http_bridge_eventless_precreated_deadline(
+            request_state,
+            stuck_gate_retire_after_seconds=300.0,
+        )
+        is None
     )
 
 
@@ -3793,6 +3955,7 @@ async def test_reconnect_http_bridge_session_passes_dashboard_reset_window_to_se
         reasoning_effort=None,
         api_key_reservation=None,
         started_at=time.monotonic(),
+        response_create_sent_at=1.0,
     )
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
     monkeypatch.setattr(
@@ -3812,6 +3975,7 @@ async def test_reconnect_http_bridge_session_passes_dashboard_reset_window_to_se
     assert selection_kwargs[0]["service_tier"] == "priority"
     assert selection_kwargs[0]["preferred_account_id"] == session.account.id
     assert selection_kwargs[0]["fallback_on_preferred_account_unavailable"] is False
+    assert request_state.response_create_sent_at is None
 
 
 @pytest.mark.asyncio
@@ -14850,6 +15014,259 @@ async def test_get_or_create_http_bridge_session_replaces_live_session_when_scop
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("leading_telemetry", [False, True], ids=["silent", "leading-telemetry"])
+async def test_http_bridge_reader_wakes_and_retires_lone_eventless_owner_without_keepalives(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    leading_telemetry: bool,
+) -> None:
+    class _TrackingUpstream:
+        def __init__(self) -> None:
+            self.first_receive_started = asyncio.Event()
+            self.telemetry_ready = asyncio.Event()
+            self.receive_calls = 0
+            self.active_receives = 0
+            self.max_active_receives = 0
+            self.receive_cancellations = 0
+            self.closed = False
+            self.sent_texts: list[str] = []
+
+        async def receive(self) -> UpstreamWebSocketMessage:
+            self.receive_calls += 1
+            receive_number = self.receive_calls
+            self.active_receives += 1
+            self.max_active_receives = max(self.max_active_receives, self.active_receives)
+            self.first_receive_started.set()
+            try:
+                if leading_telemetry and receive_number == 1:
+                    await self.telemetry_ready.wait()
+                    return UpstreamWebSocketMessage(
+                        kind="text",
+                        text=json.dumps(
+                            {
+                                "type": "codex.rate_limits",
+                                "plan_type": "pro",
+                                "rate_limits": {"allowed": True, "limit_reached": False},
+                            },
+                            separators=(",", ":"),
+                        ),
+                    )
+                await asyncio.Event().wait()
+                raise AssertionError("unreachable")
+            except asyncio.CancelledError:
+                self.receive_cancellations += 1
+                raise
+            finally:
+                self.active_receives -= 1
+
+        async def send_text(self, text: str) -> None:
+            self.sent_texts.append(text)
+
+        async def close(self) -> None:
+            self.closed = True
+
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    upstream = _TrackingUpstream()
+    session = _make_bridge_session(key_value=f"eventless-{leading_telemetry}")
+    session.upstream = cast(UpstreamResponsesWebSocket, upstream)
+    service._http_bridge_sessions[session.key] = session
+    settings = _make_app_settings(
+        sse_keepalive_interval_seconds=0.0,
+        stream_idle_timeout_seconds=60.0,
+        http_responses_session_bridge_request_budget_seconds=60.0,
+        http_responses_session_bridge_stuck_gate_retire_after_seconds=0.02,
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    retry_precreated = AsyncMock(return_value=False)
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    write_request_log = AsyncMock()
+    monkeypatch.setattr(service, "_write_request_log", write_request_log)
+    record_stuck_retire = Mock()
+    monkeypatch.setattr(proxy_service, "_record_http_bridge_stuck_retire", record_stuck_retire)
+    original_fail_reader = service._fail_http_bridge_reader_and_maybe_retire
+    fail_reader = AsyncMock(wraps=original_fail_reader)
+    monkeypatch.setattr(service, "_fail_http_bridge_reader_and_maybe_retire", fail_reader)
+
+    reader_task = asyncio.create_task(service._relay_http_bridge_upstream_messages(session))
+    await asyncio.wait_for(upstream.first_receive_started.wait(), timeout=0.5)
+
+    gate = session.response_create_gate
+    await gate.acquire()
+    owner_queue: asyncio.Queue[str | None] = asyncio.Queue()
+    owner = _make_eventless_http_bridge_owner(request_id="req-lone-eventless", sent_at=0.0)
+    owner.started_at = time.monotonic() - 30.0
+    owner.response_create_sent_at = None
+    owner.response_create_gate = gate
+    owner.event_queue = owner_queue
+    owner.request_text = '{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}'
+    owner.preferred_account_id = "acc-bridge"
+    owner.excluded_account_ids.add("acc-excluded")
+    sibling_queue: asyncio.Queue[str | None] = asyncio.Queue()
+    sibling = proxy_service._WebSocketRequestState(
+        request_id="req-created-sibling",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort="high",
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        transport="http",
+        response_id="resp-created-sibling",
+        event_queue=sibling_queue,
+    )
+    async with session.pending_lock:
+        session.pending_requests.extend((owner, sibling))
+        session.queued_request_count = 2
+
+    with caplog.at_level(logging.WARNING):
+        await http_bridge_request_submit_module._send_http_bridge_request_text_with_archive_id(
+            session,
+            owner,
+            owner.request_text,
+        )
+        if leading_telemetry:
+            upstream.telemetry_ready.set()
+        await asyncio.wait_for(reader_task, timeout=1.0)
+
+    for event_queue in (owner_queue, sibling_queue):
+        event_blocks: list[str] = []
+        while (event_block := await asyncio.wait_for(event_queue.get(), timeout=0.1)) is not None:
+            event_blocks.append(event_block)
+        terminal_blocks = [block for block in event_blocks if '"code":"upstream_request_timeout"' in block]
+        assert len(terminal_blocks) == 1
+        assert event_queue.empty() is True
+
+    assert upstream.sent_texts == [owner.request_text]
+    assert upstream.max_active_receives == 1
+    assert upstream.receive_cancellations == 1
+    assert upstream.closed is True
+    assert list(session.pending_requests) == []
+    assert session.queued_request_count == 0
+    assert session.closed is True
+    assert session.key not in service._http_bridge_sessions
+    assert gate.locked() is False
+    assert owner.response_create_sent_at is not None
+    assert owner.response_create_sent_at > owner.started_at
+    assert owner.failure_phase_override == "upstream"
+    assert owner.failure_detail_override == "missing_response_created_timeout"
+    assert sibling.failure_detail_override == "missing_response_created_timeout"
+    assert owner.preferred_account_id == "acc-bridge"
+    assert owner.excluded_account_ids == {"acc-excluded"}
+    assert owner.replay_count == 0
+    assert owner.response_event_count == 0
+    if leading_telemetry:
+        assert owner.latency_first_upstream_event_ms is not None
+    retry_precreated.assert_not_awaited()
+    assert write_request_log.await_count == 2
+    assert {call.kwargs["error_code"] for call in write_request_log.await_args_list} == {"upstream_request_timeout"}
+    fail_reader.assert_awaited_once()
+    assert fail_reader.await_args.kwargs["penalize_account"] is False
+    assert fail_reader.await_args.kwargs["force_retire"] is True
+    record_stuck_retire.assert_called_once_with(
+        reason="missing_response_created_timeout",
+        session=session,
+    )
+    assert "http_bridge_event event=missing_response_created_timeout" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_eventless_timeout_yields_to_locked_send_failure_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _ControlledLifecycleLock:
+        def __init__(self) -> None:
+            self.first_waiting = asyncio.Event()
+            self.release_first = asyncio.Event()
+            self.enter_count = 0
+
+        async def __aenter__(self) -> "_ControlledLifecycleLock":
+            self.enter_count += 1
+            if self.enter_count == 1:
+                self.first_waiting.set()
+                await self.release_first.wait()
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            del args
+
+    class _ClosingUpstream:
+        def __init__(self) -> None:
+            self.release_receive = asyncio.Event()
+            self.closed = False
+
+        async def receive(self) -> UpstreamWebSocketMessage:
+            await self.release_receive.wait()
+            return UpstreamWebSocketMessage(
+                kind="close",
+                close_code=1006,
+                error="send failed",
+                error_code="proxy_network_unavailable",
+            )
+
+        async def close(self) -> None:
+            self.closed = True
+            self.release_receive.set()
+
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    upstream = _ClosingUpstream()
+    lifecycle_lock = _ControlledLifecycleLock()
+    session = _make_bridge_session(key_value="eventless-send-failure-race")
+    session.upstream = cast(UpstreamResponsesWebSocket, upstream)
+    session.lifecycle_lock = cast(Any, lifecycle_lock)
+    service._http_bridge_sessions[session.key] = session
+    settings = _make_app_settings(
+        stream_idle_timeout_seconds=60.0,
+        http_responses_session_bridge_request_budget_seconds=60.0,
+        http_responses_session_bridge_stuck_gate_retire_after_seconds=0.01,
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    monkeypatch.setattr(service, "_write_request_log", AsyncMock())
+    record_stuck_retire = Mock()
+    monkeypatch.setattr(proxy_service, "_record_http_bridge_stuck_retire", record_stuck_retire)
+    original_fail_reader = service._fail_http_bridge_reader_and_maybe_retire
+    fail_reader = AsyncMock(wraps=original_fail_reader)
+    monkeypatch.setattr(service, "_fail_http_bridge_reader_and_maybe_retire", fail_reader)
+
+    gate = session.response_create_gate
+    await gate.acquire()
+    event_queue: asyncio.Queue[str | None] = asyncio.Queue()
+    owner = _make_eventless_http_bridge_owner(
+        request_id="req-send-failure-race",
+        sent_at=time.monotonic() - 1.0,
+    )
+    owner.response_create_gate = gate
+    owner.event_queue = event_queue
+    async with session.pending_lock:
+        session.pending_requests.append(owner)
+        session.queued_request_count = 1
+
+    reader_task = asyncio.create_task(service._relay_http_bridge_upstream_messages(session))
+    await asyncio.wait_for(lifecycle_lock.first_waiting.wait(), timeout=0.5)
+
+    # The submitter owns the real lifecycle lock at this point. Its failed
+    # send disarms the timestamp and closes the session before releasing it.
+    session.closed = True
+    owner.response_create_sent_at = None
+    lifecycle_lock.release_first.set()
+    upstream.release_receive.set()
+    await asyncio.wait_for(reader_task, timeout=1.0)
+
+    event_blocks: list[str] = []
+    while (event_block := await asyncio.wait_for(event_queue.get(), timeout=0.1)) is not None:
+        event_blocks.append(event_block)
+    assert len(event_blocks) == 1
+    assert "missing_response_created_timeout" not in event_blocks[0]
+    assert owner.failure_detail_override is None
+    record_stuck_retire.assert_not_called()
+    assert fail_reader.await_count == 1
+    fail_reader_await_args = fail_reader.await_args
+    assert fail_reader_await_args is not None
+    assert fail_reader_await_args.kwargs.get("force_retire") is not True
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_reader_marks_session_closed_before_reconnect_close(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -15411,6 +15828,35 @@ async def test_http_bridge_reader_failure_keeps_waiter_count_when_draining_reque
 
     assert retired is False
     assert session.queued_request_count == 1
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_eventless_timeout_force_retires_with_admission_waiter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="eventless-force-retire")
+    session.admission_waiter_count = 1
+    fail_pending = AsyncMock()
+    retire = AsyncMock()
+    monkeypatch.setattr(service, "_fail_pending_websocket_requests", fail_pending)
+    monkeypatch.setattr(service, "_retire_stale_pending_http_bridge_session", retire)
+
+    retired = await service._fail_http_bridge_reader_and_maybe_retire(
+        session,
+        error_code="upstream_request_timeout",
+        error_message="missing response.created",
+        penalize_account=False,
+        retire_detail="missing_response_created_timeout",
+        force_retire=True,
+    )
+
+    assert retired is True
+    assert session.closed is True
+    retire.assert_awaited_once_with(session, detail="missing_response_created_timeout")
+    fail_pending_await_args = fail_pending.await_args
+    assert fail_pending_await_args is not None
+    assert fail_pending_await_args.kwargs["penalize_account"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Recover Codex Desktop HTTP bridge requests that become completely eventless before `response.created`, and keep the native client alive with parser-visible SSE frames while it waits. The implementation is self-contained on current `main` and does not depend on #1394.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Related to #1393 (partial: eventless pre-response recovery only; clean-close replay and durable cooldown remain out of scope). Related PR: #1394 (independent implementation; not a dependency).

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path and preserves the public OpenAI-compatible stream contract

Change directory: `openspec/changes/recover-codex-desktop-idle-bridge/`

## Root cause

- Stale response-create gate recovery only ran when a later request timed out waiting for the same gate. A lone request could therefore remain pending indefinitely after a successful `response.create` send produced no matched `response.*` event.
- The backend route could classify a verified native Desktop request as OpenAI-SDK-shaped from its payload and `Accept` header. It then emitted SSE comments, which do not reset the native client's parsed-event idle timer.

## Changes

- Record the monotonic time of every real HTTP bridge `response.create` send and wake the existing upstream reader when a deadline is armed or disarmed.
- Expire a narrowly eligible, completely eventless gate owner after `min(stuck_gate_threshold, 240s)` without requiring another waiter or SSE keepalives.
- Recheck lifecycle evidence under locks, settle every pending request, increment the existing stuck-retirement metric, and retire the session without replay, account movement, or account-health penalty.
- Separate native heartbeat identity from OpenAI event normalization. Verified Desktop clients receive `codex.keepalive`; explicit SDK fingerprints and public `/v1/responses` retain comment heartbeats and vendor-event filtering.
- Add race, settlement, reader-task ownership, heartbeat precedence, and public-contract regressions.

## Simplicity

- [x] Works with zero configuration and adds no setting
- [x] No new required setup step
- New setting(s): None
- [x] No README, `.env.example`, dashboard-nav, dependency, or migration growth

This is one scoped proxy failure-mode fix. It intentionally does not add transparent replay, a retry circuit, durable coordination, or cross-replica cooldown behavior.

## Test plan

```text
make test-unit
# 4259 passed, 55 skipped

uv run pytest -q tests/integration/test_proxy_api_extended.py
# 44 passed

uv run pytest -q -W error::pytest.PytestUnraisableExceptionWarning \
  tests/integration/test_http_responses_bridge.py \
  tests/integration/test_proxy_websocket_responses.py
# 176 passed; only the existing Starlette deprecation warning remains

make lint
# proxy architecture checks passed; Ruff and format passed

make typecheck
# All checks passed

openspec validate recover-codex-desktop-idle-bridge --strict --no-interactive
# valid

openspec validate --specs --no-interactive
# 47 passed, 0 failed
```

OpenSpec semantic verification: 10/10 tasks, 2/2 modified requirements, and all scenarios covered with no remaining findings.

## Screenshots / output

No dashboard-visible change.

- Verified native backend stream before `response.created`: event-bearing `codex.keepalive` SSE data frame.
- Explicit OpenAI SDK and public `/v1/responses` streams: SSE comment heartbeat; first standard data event remains `response.created`.
- Eventless bridge expiry: terminal `upstream_request_timeout` with low-cardinality `missing_response_created_timeout` retirement detail.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Related issue is linked as partial coverage; no issue is closed.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local `make` and pytest subsets.
- [x] `openspec validate --specs` passes and semantic verification is clean.
- [x] Simplicity gates reviewed.
- [x] `CHANGELOG.md` is not edited by hand.
