### PR TITLE
fix(proxy): bound raw HTTP request ingress

### DIFF
--- a/app/core/handlers/exceptions.py
+++ b/app/core/handlers/exceptions.py
@@ -31,6 +31,11 @@ from app.core.exceptions import (
     ProxyRateLimitError,
     ProxyUpstreamError,
 )
+from app.core.middleware.request_body_limit import (
+    REQUEST_BODY_TOO_LARGE_MESSAGE,
+    request_body_limit_was_exceeded,
+    request_ingress_error_response,
+)
 from app.core.runtime_logging import log_error_response
 from app.modules.proxy.images_observability import ImageRoute, record_images_route_observability
 
@@ -261,6 +266,13 @@ def add_exception_handlers(app: FastAPI) -> None:
         request: Request,
         exc: StarletteHTTPException,
     ) -> Response:
+        if request_body_limit_was_exceeded(request):
+            return request_ingress_error_response(
+                request,
+                status_code=413,
+                code="payload_too_large",
+                message=REQUEST_BODY_TOO_LARGE_MESSAGE,
+            )
         fmt = _error_format(request)
         detail = exc.detail if isinstance(exc.detail, str) else "Request failed"
         if fmt == "dashboard":

--- a/app/core/middleware/__init__.py
+++ b/app/core/middleware/__init__.py
@@ -2,6 +2,7 @@ from app.core.middleware.api_firewall import add_api_firewall_middleware
 from app.core.middleware.app_version import add_app_version_middleware
 from app.core.middleware.dashboard_auth_proxy import add_dashboard_auth_proxy_middleware
 from app.core.middleware.path_rewrite import add_backend_api_codex_v1_alias_middleware
+from app.core.middleware.request_body_limit import add_request_body_limit_middleware
 from app.core.middleware.request_decompression import add_request_decompression_middleware
 from app.core.middleware.request_id import add_request_id_middleware
 
@@ -10,6 +11,7 @@ __all__ = [
     "add_api_firewall_middleware",
     "add_backend_api_codex_v1_alias_middleware",
     "add_dashboard_auth_proxy_middleware",
+    "add_request_body_limit_middleware",
     "add_request_decompression_middleware",
     "add_request_id_middleware",
 ]

--- a/app/core/middleware/request_body_limit.py
+++ b/app/core/middleware/request_body_limit.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI
+from starlette.datastructures import Headers
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from app.core.config.settings import get_settings
+from app.core.errors import dashboard_error, openai_error
+from app.core.runtime_logging import log_error_response
+
+REQUEST_BODY_TOO_LARGE_MESSAGE = "Request body exceeds the maximum allowed size"
+
+_RESPONSES_INGRESS_PATHS = frozenset(
+    {
+        "/backend-api/codex/responses",
+        "/v1/responses",
+    }
+)
+_OPENAI_INGRESS_PATH_PREFIXES = (
+    "/api/codex",
+    "/backend-api",
+    "/internal/bridge",
+    "/v1",
+)
+_REQUEST_BODY_TOO_LARGE_STATE = "_codex_lb_request_body_too_large"
+
+logger = logging.getLogger(__name__)
+
+
+class _RequestBodyTooLarge(Exception):
+    pass
+
+
+def request_body_limit_for_path(path: str) -> int:
+    settings = get_settings()
+    if path.rstrip("/") in _RESPONSES_INGRESS_PATHS:
+        return max(settings.max_decompressed_body_bytes, settings.max_decompressed_responses_body_bytes)
+    return settings.max_decompressed_body_bytes
+
+
+def _path_belongs_to(path: str, prefix: str) -> bool:
+    return path == prefix or path.startswith(f"{prefix}/")
+
+
+def _uses_openai_ingress_errors(path: str) -> bool:
+    return any(_path_belongs_to(path, prefix) for prefix in _OPENAI_INGRESS_PATH_PREFIXES)
+
+
+def request_ingress_error_response(
+    request: Request,
+    *,
+    status_code: int,
+    code: str,
+    message: str,
+) -> JSONResponse:
+    uses_openai_errors = _uses_openai_ingress_errors(request.url.path)
+    response_code = "invalid_request_error" if uses_openai_errors and code == "invalid_request" else code
+    log_error_response(
+        logger,
+        request,
+        status_code,
+        response_code,
+        message,
+        category="openai_error_response" if uses_openai_errors else "dashboard_error_response",
+    )
+    if uses_openai_errors:
+        return JSONResponse(
+            status_code=status_code,
+            content=openai_error(response_code, message, error_type="invalid_request_error"),
+        )
+    return JSONResponse(
+        status_code=status_code,
+        content=dashboard_error(response_code, message),
+    )
+
+
+def request_body_limit_was_exceeded(request: Request) -> bool:
+    return getattr(request.state, _REQUEST_BODY_TOO_LARGE_STATE, False) is True
+
+
+def _mark_request_body_limit_exceeded(scope: Scope) -> None:
+    state = scope.setdefault("state", {})
+    state[_REQUEST_BODY_TOO_LARGE_STATE] = True
+
+
+def _is_unencoded_multipart(headers: Headers) -> bool:
+    content_type = headers.get("content-type", "")
+    media_type = content_type.partition(";")[0].strip().lower()
+    return media_type == "multipart/form-data" and headers.get("content-encoding") is None
+
+
+def _declared_content_length(headers: Headers) -> int | None:
+    value = headers.get("content-length")
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except ValueError:
+        return None
+    return parsed if parsed >= 0 else None
+
+
+class RequestBodyLimitMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        if _is_unencoded_multipart(headers):
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        limit = request_body_limit_for_path(path)
+        declared_length = _declared_content_length(headers)
+        if declared_length is not None and declared_length > limit:
+            response = request_ingress_error_response(
+                Request(scope),
+                status_code=413,
+                code="payload_too_large",
+                message=REQUEST_BODY_TOO_LARGE_MESSAGE,
+            )
+            await response(scope, receive, send)
+            return
+
+        received = 0
+        response_started = False
+
+        async def limited_receive() -> Message:
+            nonlocal received
+            message = await receive()
+            if message["type"] == "http.request":
+                received += len(message.get("body", b""))
+                if received > limit:
+                    _mark_request_body_limit_exceeded(scope)
+                    raise _RequestBodyTooLarge
+            return message
+
+        async def tracked_send(message: Message) -> None:
+            nonlocal response_started
+            if message["type"] == "http.response.start":
+                response_started = True
+            await send(message)
+
+        try:
+            await self.app(scope, limited_receive, tracked_send)
+        except _RequestBodyTooLarge:
+            if response_started:
+                raise
+            response = request_ingress_error_response(
+                Request(scope),
+                status_code=413,
+                code="payload_too_large",
+                message=REQUEST_BODY_TOO_LARGE_MESSAGE,
+            )
+            await response(scope, receive, send)
+
+
+def add_request_body_limit_middleware(app: FastAPI) -> None:
+    app.add_middleware(RequestBodyLimitMiddleware)

--- a/app/core/middleware/request_body_limit.py
+++ b/app/core/middleware/request_body_limit.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 from fastapi import FastAPI
+from starlette._utils import get_route_path
 from starlette.datastructures import Headers
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -57,7 +58,7 @@ def request_ingress_error_response(
     code: str,
     message: str,
 ) -> JSONResponse:
-    uses_openai_errors = _uses_openai_ingress_errors(request.url.path)
+    uses_openai_errors = _uses_openai_ingress_errors(get_route_path(request.scope))
     response_code = "invalid_request_error" if uses_openai_errors and code == "invalid_request" else code
     log_error_response(
         logger,
@@ -118,7 +119,7 @@ class RequestBodyLimitMiddleware:
             await self.app(scope, receive, send)
             return
 
-        path = scope.get("path", "")
+        path = get_route_path(scope)
         limit = request_body_limit_for_path(path)
         declared_length = _declared_content_length(headers)
         if declared_length is not None and declared_length > limit:

--- a/app/core/middleware/request_decompression.py
+++ b/app/core/middleware/request_decompression.py
@@ -8,17 +8,13 @@ from typing import Protocol
 
 import zstandard as zstd
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import Response
 from starlette.requests import ClientDisconnect
 
-from app.core.config.settings import get_settings
-from app.core.errors import dashboard_error
-
-_RESPONSES_DECOMPRESSION_PATHS = frozenset(
-    {
-        "/backend-api/codex/responses",
-        "/v1/responses",
-    }
+from app.core.middleware.request_body_limit import (
+    REQUEST_BODY_TOO_LARGE_MESSAGE,
+    request_body_limit_for_path,
+    request_ingress_error_response,
 )
 
 
@@ -61,15 +57,16 @@ def _decompress_deflate(data: bytes, max_size: int) -> bytes:
         # Bound output growth to avoid oversized allocations.
         while chunk:
             remaining = max_size - len(buffer)
-            if remaining == 0:
+            decompressed = decompressor.decompress(chunk, max_length=remaining + 1)
+            if len(decompressed) > remaining:
                 raise _DecompressedBodyTooLarge(max_size)
-            buffer.extend(decompressor.decompress(chunk, max_length=remaining))
+            buffer.extend(decompressed)
             chunk = decompressor.unconsumed_tail
     while True:
         remaining = max_size - len(buffer)
-        if remaining == 0:
+        drained = decompressor.decompress(b"", max_length=remaining + 1)
+        if len(drained) > remaining:
             raise _DecompressedBodyTooLarge(max_size)
-        drained = decompressor.decompress(b"", max_length=remaining)
         if not drained:
             break
         buffer.extend(drained)
@@ -104,7 +101,9 @@ def _decompress_body(data: bytes, encodings: list[str], max_size: int) -> bytes:
         elif encoding == "deflate":
             result = _decompress_deflate(result, max_size)
         elif encoding == "identity":
-            continue
+            pass
+        if len(result) > max_size:
+            raise _DecompressedBodyTooLarge(max_size)
     return result
 
 
@@ -121,13 +120,6 @@ def _replace_request_body(request: Request, body: bytes) -> None:
     request.__dict__.pop("_headers", None)
 
 
-def _max_decompressed_body_bytes_for_request(request: Request) -> int:
-    settings = get_settings()
-    if request.url.path.rstrip("/") in _RESPONSES_DECOMPRESSION_PATHS:
-        return max(settings.max_decompressed_body_bytes, settings.max_decompressed_responses_body_bytes)
-    return settings.max_decompressed_body_bytes
-
-
 def add_request_decompression_middleware(app: FastAPI) -> None:
     @app.middleware("http")
     async def request_decompression_middleware(
@@ -140,7 +132,7 @@ def add_request_decompression_middleware(app: FastAPI) -> None:
         encodings = [enc.strip().lower() for enc in content_encoding.split(",") if enc.strip()]
         if not encodings:
             return await call_next(request)
-        max_size = _max_decompressed_body_bytes_for_request(request)
+        max_size = request_body_limit_for_path(request.url.path)
         try:
             body = await request.body()
         except ClientDisconnect:
@@ -148,28 +140,25 @@ def add_request_decompression_middleware(app: FastAPI) -> None:
         try:
             decompressed = _decompress_body(body, encodings, max_size)
         except _DecompressedBodyTooLarge:
-            return JSONResponse(
+            return request_ingress_error_response(
+                request,
                 status_code=413,
-                content=dashboard_error(
-                    "payload_too_large",
-                    "Request body exceeds the maximum allowed size",
-                ),
+                code="payload_too_large",
+                message=REQUEST_BODY_TOO_LARGE_MESSAGE,
             )
         except ValueError:
-            return JSONResponse(
+            return request_ingress_error_response(
+                request,
                 status_code=400,
-                content=dashboard_error(
-                    "invalid_request",
-                    "Unsupported Content-Encoding",
-                ),
+                code="invalid_request",
+                message="Unsupported Content-Encoding",
             )
         except Exception:
-            return JSONResponse(
+            return request_ingress_error_response(
+                request,
                 status_code=400,
-                content=dashboard_error(
-                    "invalid_request",
-                    "Request body is compressed but could not be decompressed",
-                ),
+                code="invalid_request",
+                message="Request body is compressed but could not be decompressed",
             )
         _replace_request_body(request, decompressed)
         return await call_next(request)

--- a/app/core/middleware/request_decompression.py
+++ b/app/core/middleware/request_decompression.py
@@ -9,6 +9,7 @@ from typing import Protocol
 import zstandard as zstd
 from fastapi import FastAPI, Request
 from fastapi.responses import Response
+from starlette._utils import get_route_path
 from starlette.requests import ClientDisconnect
 
 from app.core.middleware.request_body_limit import (
@@ -132,7 +133,7 @@ def add_request_decompression_middleware(app: FastAPI) -> None:
         encodings = [enc.strip().lower() for enc in content_encoding.split(",") if enc.strip()]
         if not encodings:
             return await call_next(request)
-        max_size = request_body_limit_for_path(request.url.path)
+        max_size = request_body_limit_for_path(get_route_path(request.scope))
         try:
             body = await request.body()
         except ClientDisconnect:

--- a/app/main.py
+++ b/app/main.py
@@ -40,6 +40,7 @@ from app.core.middleware import (
     add_app_version_middleware,
     add_backend_api_codex_v1_alias_middleware,
     add_dashboard_auth_proxy_middleware,
+    add_request_body_limit_middleware,
     add_request_decompression_middleware,
     add_request_id_middleware,
 )
@@ -585,6 +586,7 @@ def create_app() -> FastAPI:
     add_dashboard_gzip_middleware(app)
     add_dashboard_auth_proxy_middleware(app)
     add_request_decompression_middleware(app)
+    add_request_body_limit_middleware(app)
     add_request_id_middleware(app)
     add_api_firewall_middleware(app)
     app.add_middleware(cast(Any, MetricsMiddleware), enabled=settings.metrics_enabled)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -609,6 +609,7 @@ async def wham_agent_identities_jwks(
     return await _codex_control_proxy(request, "wham/agent-identities/jwks", context, api_key)
 
 
+@router.post("/responses/", include_in_schema=False)
 @router.post(
     "/responses",
     responses={
@@ -731,6 +732,7 @@ async def responses_websocket(
     )
 
 
+@v1_router.post("/responses/", response_model=OpenAIResponseResult, include_in_schema=False)
 @v1_router.post(
     "/responses",
     response_model=OpenAIResponseResult,

--- a/openspec/changes/bound-raw-http-ingress/.openspec.yaml
+++ b/openspec/changes/bound-raw-http-ingress/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/bound-raw-http-ingress/context.md
+++ b/openspec/changes/bound-raw-http-ingress/context.md
@@ -1,0 +1,29 @@
+# Context: bounded raw HTTP ingress
+
+## Purpose
+
+This change closes the pre-routing memory-exhaustion gap for guarded HTTP requests. The existing decompression cap protects expanded data, but it runs only after the complete encoded body has been collected; unencoded JSON bodies have no equivalent ingress cap at all. Requests declaring unencoded multipart remain a documented residual gap for the standalone multipart-limits change.
+
+## Decisions and constraints
+
+- Reuse the two existing request-body settings and defaults; do not add another operator knob.
+- Count actual ASGI body chunks so `Content-Length` is an optimization, not a trust boundary.
+- Keep the larger budget for the two Responses HTTP aliases, including trailing slashes.
+- Register trailing-slash HTTP paths explicitly so chunked bodies reach admission instead of being redirected before consumption.
+- Limit raw bytes before decompression and expanded bytes after decompression.
+- Keep requests declaring unencoded multipart outside this change. The declared media type is spoofable and is not a security boundary; file-aware aggregate, parser, and per-file limits need separate requirements and compatibility tests.
+- Select the error envelope from the canonical path because the rejection can happen before router/dependency metadata is available. Proxy families include `/v1/*`, `/backend-api/*`, `/api/codex/*`, and `/internal/bridge/*`.
+- Preserve endpoint authorization for every body admitted by the ingress guard; the transport guard is not an authentication replacement.
+
+## Failure modes
+
+- A missing or false `Content-Length` cannot bypass the limit because streamed bytes are counted.
+- A single oversized chunk is rejected before downstream code receives that chunk.
+- Malformed and unsupported compression stays a client error rather than reaching route logic.
+- A syntactically malformed under-limit typed body can still fail parsing before router-level authorization; the ingress guard does not change dependency ordering.
+- A disconnect remains a disconnect; it is not converted into a payload-size response.
+- If a response has already started, the middleware does not attempt to write a competing 413 response.
+
+## Example
+
+With a 32 MiB general budget, a chunked JSON upload can deliver chunks totaling exactly 32 MiB. The next non-empty byte raises the ingress limit signal before FastAPI sees that chunk and returns HTTP 413. The same request under `/v1/*` receives an OpenAI error object with `type = invalid_request_error`; under an ordinary dashboard `/api/*` path it receives the dashboard error object.

--- a/openspec/changes/bound-raw-http-ingress/design.md
+++ b/openspec/changes/bound-raw-http-ingress/design.md
@@ -1,0 +1,73 @@
+## Context
+
+The request-decompression middleware currently reads the complete encoded body before it applies the configured decompressed-size limit. Requests without `Content-Encoding` bypass that middleware entirely, so neither path bounds raw bytes before FastAPI parses the body. The same middleware constructs dashboard error envelopes directly even when the request targets an OpenAI-compatible proxy path.
+
+The implementation must protect body parsing that occurs before route dependencies, retain the existing 32 MiB general and 128 MiB Responses defaults, avoid a new operator setting, and remain independent from future multipart resource controls.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Bound raw HTTP bytes incrementally before an over-limit chunk reaches downstream body parsing.
+- Continue bounding expanded bodies after supported request decompression.
+- Preserve the larger Responses HTTP budget and exact-boundary behavior.
+- Return the established dashboard or OpenAI-compatible error envelope for the request path.
+- Preserve client-disconnect semantics and avoid whole-body prebuffering in the new guard.
+
+**Non-Goals:**
+
+- Multipart per-file, aggregate-file, or parser limits.
+- Websocket ingress, upstream `response.create` slimming, or reverse-proxy configuration.
+- New `CODEX_LB_*` settings or changes to the existing budget defaults.
+
+## Decisions
+
+### Add a pure ASGI raw-body guard outside request decompression
+
+Register a pure ASGI middleware immediately after the request-decompression middleware. Starlette's registration order makes the new guard outer to decompression, so compressed bytes are bounded before decompression reads the body, while the existing bulkhead and other outer middleware still apply first.
+
+The guard wraps `receive`, counts each `http.request` body's actual bytes, and raises before returning the chunk that crosses the limit. A valid over-limit `Content-Length` is rejected before calling the downstream application; missing, malformed, or understated values still use streamed counting. Exact-limit requests remain valid. This avoids a second whole-body buffer and covers chunked transfers.
+
+Starlette redirects unmatched trailing-slash routes without consuming a chunked body. Register hidden trailing-slash aliases for both Responses HTTP routes so those documented equivalent paths enter the same typed-body parsing and ingress flow instead of returning 307 before the streamed limit is exercised.
+
+Alternatives rejected:
+
+- Route dependencies run after FastAPI can parse request bodies and therefore cannot protect pre-authentication parsing.
+- A `BaseHTTPMiddleware` implementation adds request-stream adaptation without providing value here; the ASGI receive contract is the boundary being limited.
+- A server-global cap cannot preserve the larger Responses budget and does not replace the expanded-body cap.
+
+### Reuse the existing route budgets and leave plain multipart unchanged
+
+The raw guard and decompressor share one path-budget selector. `/v1/responses` and `/backend-api/codex/responses`, after removing trailing slashes, use the larger of `max_decompressed_body_bytes` and `max_decompressed_responses_body_bytes`; other guarded paths use `max_decompressed_body_bytes`.
+
+Requests declaring `multipart/form-data` without `Content-Encoding` bypass this whole-body guard. Encoded multipart remains guarded because decompression otherwise creates the same raw and expansion risks. Content type is client-declared, so this exemption is not a security boundary; multipart-specific aggregate, parser, and per-file limits remain a separate change with their own compatibility analysis.
+
+### Use a private receive sentinel plus a request-scope marker
+
+FastAPI reads body and form parameters before dependencies. With the installed FastAPI and Starlette middleware stack, a receive exception raised through the inner request-decompression `BaseHTTPMiddleware` is converted into a framework HTTP 400 even when the original exception is an `HTTPException`. The receive wrapper therefore sets a private request-scope marker and raises a private sentinel exception when the limit is crossed.
+
+The existing framework HTTP-exception handler checks that marker before normal 400 formatting and restores the intended 413 for typed body/form parsing. The raw ASGI middleware catches only the exact sentinel when it escapes directly, including overflow while decompression reads the body outside FastAPI's `ExceptionMiddleware`; it emits the 413 only if no response has started. Client disconnects, cancellation, and unrelated receive failures pass through unchanged.
+
+### Centralize path-sensitive ingress error construction
+
+Ingress occurs before route metadata can reliably set `request.state.error_format`, so error format is determined from the stable path families. `/v1/*`, `/backend-api/*`, `/api/codex/*`, and `/internal/bridge/*` receive OpenAI-compatible envelopes after outer path canonicalization. Other paths retain the existing dashboard-shaped ingress envelope. Both raw overflow and decompression errors use the same constructor:
+
+- overflow: HTTP 413 with `code = payload_too_large`;
+- malformed or unsupported compression: HTTP 400, using `invalid_request_error` for OpenAI paths and `invalid_request` otherwise.
+
+OpenAI ingress errors use `type = invalid_request_error`. Existing decompression support for `gzip`, `deflate`, `zstd`, `identity`, and stacked encodings remains unchanged after the raw guard. Stacked encodings are removed in reverse header/application order, and every intermediate decoded representation remains capped.
+
+## Risks / Trade-offs
+
+- **The 128 MiB Responses budget still permits substantial per-request memory use** → Existing bulkhead/backpressure middleware remains outside the guard, and both raw and expanded representations are independently bounded by the established budget.
+- **A client can lie in `Content-Length`** → The receive wrapper always counts actual chunks even after a declared length passes the early check.
+- **A downstream component could start a response before reading a later body chunk** → The raw middleware tracks `http.response.start` and re-raises rather than attempting a second response.
+- **A client can label an unencoded body as multipart to bypass the generic guard** → The declared-media-type exemption is explicit and tested; multipart aggregate/parser/per-file controls are the standalone follow-up that closes this residual gap.
+
+## Migration Plan
+
+No data or configuration migration is required. Deploy through the normal rolling process and verify bounded dashboard and proxy requests. Rollback consists of reverting the middleware registration and associated error-format changes; existing settings remain compatible in both directions.
+
+## Open Questions
+
+None.

--- a/openspec/changes/bound-raw-http-ingress/proposal.md
+++ b/openspec/changes/bound-raw-http-ingress/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+HTTP request bodies without content encoding are currently unbounded, while compressed bodies are read fully into memory before the existing decompressed-size guard runs. A client can therefore force excessive per-request memory growth before authentication or route handling, and compression failures on proxy paths currently use the dashboard error envelope instead of the documented OpenAI-compatible envelope.
+
+## What Changes
+
+- Enforce the existing HTTP body budgets against raw request bytes while ASGI chunks are received, before oversized chunks are exposed to downstream body parsing.
+- Keep the larger existing budget for `/v1/responses` and `/backend-api/codex/responses`, including trailing-slash variants; use the general existing budget for other HTTP paths.
+- Register hidden trailing-slash HTTP aliases for both Responses paths so FastAPI does not redirect before chunked-body admission runs.
+- Preserve decompressed-size enforcement for `gzip`, `deflate`, `zstd`, `identity`, and stacked encodings so neither transfer size nor expanded size can exceed its route budget.
+- Reject oversized bodies with HTTP 413 and path-appropriate error envelopes; return OpenAI-compatible invalid-request envelopes for malformed or unsupported compression on proxy path families.
+- Leave requests declaring unencoded `multipart/form-data` outside this generic whole-body limit so multipart per-file and aggregate limits can remain a separate, standalone change.
+- Add no new setting: the guard reuses `max_decompressed_body_bytes` and `max_decompressed_responses_body_bytes`.
+
+## Capabilities
+
+### New Capabilities
+
+- `http-ingress-limits`: Defines bounded raw and decompressed HTTP request ingestion, route budgets, multipart scope, disconnect behavior, authorization handoff, and path-appropriate rejection envelopes.
+
+### Modified Capabilities
+
+- `responses-api-compat`: Defines the Responses HTTP ingress budget and OpenAI-compatible oversized-request envelope for both canonical response paths.
+
+## Impact
+
+- Affected code: HTTP ingress middleware, request decompression, shared error-envelope construction, application middleware registration, exception handling, and the two Responses HTTP route registrations.
+- Affected APIs: HTTP request parsing on dashboard and proxy routes; no websocket behavior, schema, database, dependency, new setting, or default change. The two existing decompressed-body settings also become the raw-ingress budgets for guarded requests.
+- Oversized requests that were previously allowed to consume unbounded memory will fail locally before route logic or upstream forwarding.

--- a/openspec/changes/bound-raw-http-ingress/specs/http-ingress-limits/spec.md
+++ b/openspec/changes/bound-raw-http-ingress/specs/http-ingress-limits/spec.md
@@ -1,0 +1,119 @@
+## ADDED Requirements
+
+### Requirement: Raw HTTP request ingress is bounded incrementally
+
+The service MUST enforce the applicable request-body budget against actual raw bytes received for each guarded HTTP request. It MUST reject the request before exposing a chunk that would make the cumulative raw body exceed the budget, and it MUST NOT prebuffer the complete body solely to enforce this limit.
+
+#### Scenario: Declared oversized body is rejected before downstream parsing
+
+- **WHEN** a guarded HTTP request declares a valid `Content-Length` greater than its applicable budget
+- **THEN** the service returns HTTP 413 without invoking downstream request-body parsing
+
+#### Scenario: Chunked body crosses the budget
+
+- **WHEN** a guarded HTTP request has no usable `Content-Length` and its received chunks cumulatively exceed the applicable budget
+- **THEN** the service returns HTTP 413
+- **AND** the chunk that crosses the budget is not exposed to downstream body parsing
+
+#### Scenario: Exact-boundary body is accepted by the ingress guard
+
+- **WHEN** a guarded HTTP request's actual raw body size equals its applicable budget
+- **THEN** the raw ingress guard allows the complete body to continue downstream
+
+#### Scenario: Client disconnect remains a disconnect
+
+- **WHEN** the ASGI server reports `http.disconnect` while a guarded body is being received
+- **THEN** the ingress guard propagates the disconnect without converting it into an HTTP 413 response
+
+### Requirement: HTTP ingress reuses existing budgets
+
+The service MUST use `max_decompressed_body_bytes` as the general raw and decompressed HTTP request-body budget. When an owning route capability defines a larger budget from an existing route-specific setting, the ingress guard MUST use that route budget. The HTTP ingress guard MUST NOT add another setting or change existing defaults.
+
+Requests declaring `multipart/form-data` without `Content-Encoding` MUST remain outside this generic whole-body guard. Multipart requests carrying `Content-Encoding` MUST remain guarded. The service MUST NOT treat the client-declared multipart media type as a trusted security boundary.
+
+#### Scenario: Another HTTP path uses the general budget
+
+- **WHEN** a guarded request targets any other HTTP path
+- **THEN** its raw and decompressed HTTP ingress budget is `max_decompressed_body_bytes`
+
+#### Scenario: Declared unencoded multipart remains unaffected
+
+- **WHEN** a request declares media type `multipart/form-data` and has no `Content-Encoding`
+- **THEN** the generic raw whole-body guard does not reject it based on these budgets
+
+#### Scenario: Encoded multipart remains guarded
+
+- **WHEN** a `multipart/form-data` request carries a `Content-Encoding` header
+- **THEN** the service applies both the raw and decompressed budget checks
+
+### Requirement: Encoded HTTP bodies are bounded before and after decompression
+
+For request bodies using `gzip`, `deflate`, `zstd`, `identity`, or supported stacked `Content-Encoding` values, the service MUST enforce the applicable budget independently against the encoded raw body and every intermediate and final decoded representation. The service MUST remove stacked encodings in reverse header/application order. Unsupported encodings or malformed compressed bodies MUST fail with HTTP 400.
+
+#### Scenario: Encoded raw body exceeds the budget
+
+- **WHEN** an encoded request's raw bytes exceed the applicable budget before decompression
+- **THEN** the service returns HTTP 413 before attempting to hold an unbounded encoded body
+
+#### Scenario: Expanded body exceeds the budget
+
+- **WHEN** an encoded request is within the raw budget but expands beyond the applicable decompressed budget
+- **THEN** the service returns HTTP 413
+
+#### Scenario: Supported stacked encoding remains compatible
+
+- **WHEN** a request uses a valid supported stack of `gzip`, `deflate`, `zstd`, or `identity` encodings and both representations fit the budget
+- **THEN** the service decodes the body in reverse header/application order, caps every intermediate representation, and continues request handling
+
+#### Scenario: Invalid compression is rejected
+
+- **WHEN** a request uses an unsupported content encoding or carries malformed compressed bytes
+- **THEN** the service returns HTTP 400 without invoking route logic
+
+### Requirement: HTTP ingress failures use the path-family error envelope
+
+Ingress failures on `/v1/*`, `/backend-api/*`, `/api/codex/*`, and `/internal/bridge/*` MUST use an OpenAI-compatible error envelope with `type = invalid_request_error`. Equivalent paths MUST be classified after the existing outer path canonicalization. Other ingress paths MUST retain the dashboard-compatible error envelope. Oversized requests MUST use `code = payload_too_large`; malformed or unsupported compression MUST use `code = invalid_request_error` on OpenAI paths and `code = invalid_request` on other paths.
+
+#### Scenario: OpenAI path rejects an oversized body
+
+- **WHEN** a raw or decompressed request body on an OpenAI-compatible proxy path exceeds its budget
+- **THEN** the service returns HTTP 413
+- **AND** the response has OpenAI error `code = payload_too_large` and `type = invalid_request_error`
+
+#### Scenario: OpenAI path rejects invalid compression
+
+- **WHEN** a request on an OpenAI-compatible proxy path uses unsupported or malformed compression
+- **THEN** the service returns HTTP 400
+- **AND** the response has OpenAI error `code = invalid_request_error` and `type = invalid_request_error`
+
+#### Scenario: Dashboard settings path rejects an oversized body
+
+- **WHEN** a raw or decompressed request body on `/api/settings` exceeds its budget
+- **THEN** the service returns HTTP 413
+- **AND** the response has dashboard error `code = payload_too_large`
+
+#### Scenario: Dashboard settings path rejects invalid compression
+
+- **WHEN** a request on `/api/settings` uses unsupported or malformed compression
+- **THEN** the service returns HTTP 400
+- **AND** the response has dashboard error `code = invalid_request`
+
+#### Scenario: Duplicated Codex alias is classified after canonicalization
+
+- **WHEN** an ingress failure targets `/backend-api/codex/v1/responses/`
+- **THEN** the service applies the same Responses budget and OpenAI-compatible envelope as `/backend-api/codex/responses/`
+
+### Requirement: Ingress admission preserves endpoint authorization
+
+The HTTP ingress guard MUST NOT authenticate callers or replace, bypass, or relocate existing dashboard, proxy API-key, ChatGPT-identity, or internal-bridge authorization. Requests that reach dependency resolution MUST continue through the endpoint's existing authorization path. Existing FastAPI parsing order remains unchanged, so ingress rejection or syntactically invalid typed bodies can fail before router-level authorization.
+
+#### Scenario: Admitted unauthenticated request still reaches proxy authorization
+
+- **WHEN** a syntactically valid under-limit request without required credentials targets an API-key-protected proxy route
+- **THEN** the ingress guard allows normal routing to continue
+- **AND** the existing proxy authorization rejects the request with its established authentication response
+
+#### Scenario: Declared oversized request fails before authorization
+
+- **WHEN** a request declares a body larger than its ingress budget
+- **THEN** the service returns the deterministic ingress 413 without invoking router-level authorization

--- a/openspec/changes/bound-raw-http-ingress/specs/http-ingress-limits/spec.md
+++ b/openspec/changes/bound-raw-http-ingress/specs/http-ingress-limits/spec.md
@@ -29,6 +29,8 @@ The service MUST enforce the applicable request-body budget against actual raw b
 
 The service MUST use `max_decompressed_body_bytes` as the general raw and decompressed HTTP request-body budget. When an owning route capability defines a larger budget from an existing route-specific setting, the ingress guard MUST use that route budget. The HTTP ingress guard MUST NOT add another setting or change existing defaults.
 
+Route-specific budget and error-envelope selection MUST use the application-relative route path after removing any matching ASGI `root_path` prefix.
+
 Requests declaring `multipart/form-data` without `Content-Encoding` MUST remain outside this generic whole-body guard. Multipart requests carrying `Content-Encoding` MUST remain guarded. The service MUST NOT treat the client-declared multipart media type as a trusted security boundary.
 
 #### Scenario: Another HTTP path uses the general budget
@@ -45,6 +47,13 @@ Requests declaring `multipart/form-data` without `Content-Encoding` MUST remain 
 
 - **WHEN** a `multipart/form-data` request carries a `Content-Encoding` header
 - **THEN** the service applies both the raw and decompressed budget checks
+
+#### Scenario: Mounted Responses route keeps its route-specific policy
+
+- **GIVEN** the service is mounted under a non-empty ASGI `root_path`
+- **WHEN** the request scope path includes that prefix and targets `/v1/responses` relative to the application
+- **THEN** the service applies the Responses-specific ingress budget
+- **AND** any ingress failure uses the OpenAI-compatible error envelope
 
 ### Requirement: Encoded HTTP bodies are bounded before and after decompression
 

--- a/openspec/changes/bound-raw-http-ingress/specs/responses-api-compat/spec.md
+++ b/openspec/changes/bound-raw-http-ingress/specs/responses-api-compat/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Responses HTTP ingress uses the expanded bounded budget
+
+HTTP requests to `/v1/responses` and `/backend-api/codex/responses`, including trailing-slash variants, MUST use the larger of `max_decompressed_body_bytes` and `max_decompressed_responses_body_bytes` as both the raw-body and decompressed-body ingress budget. The Responses-specific default MUST remain 128 MiB.
+
+The trailing-slash variants MUST be hidden aliases of the canonical HTTP handlers rather than redirects, so streamed bodies receive the same admission, authorization, and route behavior.
+
+If either representation exceeds that budget, the service MUST stop before route logic or upstream forwarding and return HTTP 413 with an OpenAI-compatible error envelope carrying `error.code = payload_too_large` and `error.type = invalid_request_error`.
+
+This transport-ingress 413 applies before parsing and is distinct from the existing application-level oversized-`response.create` guard. A request that fits the 128 MiB transport budget but still exceeds the upstream websocket budget after historical slimming MUST retain the existing HTTP 400 `payload_too_large` behavior and `param = input`.
+
+#### Scenario: Larger Responses request fits both ingress checks
+
+- **WHEN** a Responses HTTP request is larger than the general budget but no larger than the Responses budget in either raw or decompressed form
+- **THEN** the ingress guards allow the request to continue to Responses route handling
+
+#### Scenario: Trailing-slash Responses request is admitted without redirect
+
+- **WHEN** a client sends a chunked HTTP request to `/v1/responses/` or `/backend-api/codex/responses/`
+- **THEN** the service applies the same ingress budget and handler as the corresponding canonical path
+- **AND** it does not return a trailing-slash redirect before consuming the guarded body
+
+#### Scenario: Responses raw body exceeds its budget
+
+- **WHEN** a Responses HTTP request's raw body exceeds the Responses budget
+- **THEN** the service returns HTTP 413 with `error.code = payload_too_large` and `error.type = invalid_request_error`
+- **AND** the service does not invoke Responses route logic or forward the request upstream
+
+#### Scenario: Responses expanded body exceeds its budget
+
+- **WHEN** an encoded Responses HTTP request fits the raw budget but expands beyond the Responses budget
+- **THEN** the service returns HTTP 413 with `error.code = payload_too_large` and `error.type = invalid_request_error`
+- **AND** the service does not invoke Responses route logic or forward the request upstream
+
+#### Scenario: Post-slimming application rejection remains 400
+
+- **WHEN** a Responses HTTP request fits the raw and decompressed transport-ingress budget
+- **AND** its serialized `response.create` still exceeds the upstream websocket budget after historical slimming
+- **THEN** the existing application-level guard returns HTTP 400 with `error.code = payload_too_large`, `error.type = invalid_request_error`, and `error.param = input`

--- a/openspec/changes/bound-raw-http-ingress/tasks.md
+++ b/openspec/changes/bound-raw-http-ingress/tasks.md
@@ -1,0 +1,22 @@
+## 1. Raw ingress guard
+
+- [x] 1.1 Implement the pure ASGI raw request-body limiter with early `Content-Length` rejection, streamed chunk counting, exact-boundary behavior, disconnect passthrough, and the unencoded multipart exemption.
+- [x] 1.2 Implement the shared route-budget selector, path-family error-envelope constructor, overflow scope marker, and exact sentinel handling.
+- [x] 1.3 Register and export the limiter so canonical path rewriting and outer admission middleware run before it while request decompression runs after it; add hidden trailing-slash Responses aliases so streamed admission is not bypassed by a redirect.
+
+## 2. Decompression and framework errors
+
+- [x] 2.1 Refactor request decompression to reuse the route budget and path-sensitive error response while preserving supported and stacked encodings.
+- [x] 2.2 Teach the framework HTTP-exception handler to restore marked body overflows to HTTP 413 without changing unrelated body-parse errors.
+
+## 3. Regression coverage
+
+- [x] 3.1 Add raw ASGI unit coverage for declared and streamed overflow, exact limits, understated lengths, oversized chunks, passthrough scopes, disconnects, unrelated receive failures, response-start safety, multipart scope, route budgets, aliases, and middleware order.
+- [x] 3.2 Extend decompression tests for raw and expanded limits across `identity`, `gzip`, `deflate`, `zstd`, stacked encodings, trailing-slash Responses routes, OpenAI/dashboard error envelopes, and unchanged post-slimming HTTP 400 behavior.
+- [x] 3.3 Add integration coverage proving typed uncompressed request bodies are bounded before route dependencies while admitted requests preserve existing authorization behavior.
+
+## 4. Verification
+
+- [x] 4.1 Run strict OpenSpec validation and the targeted unit and integration suites.
+- [x] 4.2 Run Ruff, type checking, architecture checks, and diff hygiene checks; resolve all findings.
+- [x] 4.3 Verify implementation against the OpenSpec artifacts and review the final standalone diff.

--- a/tests/integration/test_request_decompression.py
+++ b/tests/integration/test_request_decompression.py
@@ -1,13 +1,24 @@
 from __future__ import annotations
 
 import json
+from collections.abc import AsyncIterator
 
 import pytest
 import zstandard as zstd
+from httpx import ASGITransport, AsyncByteStream, AsyncClient
 
 from app.core.config.settings import get_settings
 
 pytestmark = pytest.mark.integration
+
+
+class _ChunkedBody(AsyncByteStream):
+    def __init__(self, *chunks: bytes) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
 
 
 @pytest.mark.asyncio
@@ -18,10 +29,10 @@ async def test_zstd_request_decompression(async_client, monkeypatch):
     }
     body = json.dumps(payload).encode("utf-8")
 
-    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", str(len(body) + 8))
+    compressed = zstd.ZstdCompressor().compress(body)
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", str(max(len(body), len(compressed)) + 8))
     get_settings.cache_clear()
 
-    compressed = zstd.ZstdCompressor().compress(body)
     response = await async_client.put(
         "/api/settings",
         content=compressed,
@@ -54,3 +65,112 @@ async def test_zstd_request_decompression_rejects_large_payload(async_client, mo
     assert response.status_code == 413
     payload = response.json()
     assert payload["error"]["code"] == "payload_too_large"
+
+
+@pytest.mark.asyncio
+async def test_uncompressed_chunked_typed_body_is_bounded(async_client, monkeypatch):
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", "128")
+    get_settings.cache_clear()
+    body = json.dumps(
+        {
+            "stickyThreadsEnabled": True,
+            "preferEarlierResetAccounts": False,
+            "padding": "A" * 512,
+        }
+    ).encode("utf-8")
+
+    response = await async_client.put(
+        "/api/settings",
+        content=_ChunkedBody(body[:64], body[64:]),
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["error"] == {
+        "code": "payload_too_large",
+        "message": "Request body exceeds the maximum allowed size",
+    }
+
+
+@pytest.mark.asyncio
+async def test_proxy_raw_overflow_uses_openai_envelope_before_auth(async_client, monkeypatch):
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", "32")
+    get_settings.cache_clear()
+
+    response = await async_client.post(
+        "/v1/chat/completions",
+        content=b"x" * 33,
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["error"] == {
+        "message": "Request body exceeds the maximum allowed size",
+        "type": "invalid_request_error",
+        "code": "payload_too_large",
+    }
+    assert response.headers["x-app-version"]
+    assert response.headers["x-request-id"]
+
+
+@pytest.mark.asyncio
+async def test_proxy_malformed_compression_uses_openai_envelope(async_client, monkeypatch):
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", "128")
+    get_settings.cache_clear()
+
+    response = await async_client.post(
+        "/v1/chat/completions",
+        content=b"not-zstd",
+        headers={"Content-Encoding": "zstd", "Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"] == {
+        "message": "Request body is compressed but could not be decompressed",
+        "type": "invalid_request_error",
+        "code": "invalid_request_error",
+    }
+
+
+@pytest.mark.asyncio
+async def test_trailing_slash_responses_route_bounds_chunked_body_without_redirect(async_client, monkeypatch):
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", "8")
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_RESPONSES_BODY_BYTES", "32")
+    get_settings.cache_clear()
+
+    response = await async_client.post(
+        "/v1/responses/",
+        content=_ChunkedBody(b"x" * 16, b"x" * 17),
+        headers={"Content-Type": "application/json"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 413
+    assert response.headers.get("location") is None
+    assert response.json()["error"]["code"] == "payload_too_large"
+
+
+@pytest.mark.asyncio
+async def test_aliased_responses_budget_preserves_real_proxy_authorization(app_instance, monkeypatch):
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", "8")
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_RESPONSES_BODY_BYTES", "256")
+    get_settings.cache_clear()
+    body = json.dumps(
+        {
+            "model": "gpt-5.1",
+            "input": "valid body that is larger than the general ingress budget",
+        }
+    ).encode("utf-8")
+    assert 8 < len(body) <= 256
+
+    async with app_instance.router.lifespan_context(app_instance):
+        transport = ASGITransport(app=app_instance, client=("203.0.113.11", 50001))
+        async with AsyncClient(transport=transport, base_url="http://lb.example") as remote_client:
+            response = await remote_client.post(
+                "/backend-api/codex/v1/responses/",
+                content=_ChunkedBody(body[:16], body[16:]),
+                headers={"Content-Type": "application/json"},
+            )
+
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_api_key"

--- a/tests/unit/test_request_body_limit_middleware.py
+++ b/tests/unit/test_request_body_limit_middleware.py
@@ -27,7 +27,12 @@ def _configure_limits(monkeypatch: pytest.MonkeyPatch, *, general: int, response
     get_settings.cache_clear()
 
 
-def _http_scope(path: str = "/echo", *, headers: list[tuple[bytes, bytes]] | None = None) -> Scope:
+def _http_scope(
+    path: str = "/echo",
+    *,
+    root_path: str = "",
+    headers: list[tuple[bytes, bytes]] | None = None,
+) -> Scope:
     return {
         "type": "http",
         "asgi": {"version": "3.0"},
@@ -37,7 +42,7 @@ def _http_scope(path: str = "/echo", *, headers: list[tuple[bytes, bytes]] | Non
         "path": path,
         "raw_path": path.encode("ascii"),
         "query_string": b"",
-        "root_path": "",
+        "root_path": root_path,
         "headers": headers or [],
         "client": ("testclient", 50000),
         "server": ("testserver", 80),
@@ -256,6 +261,35 @@ async def test_responses_paths_use_larger_budget_including_trailing_slash(monkey
         )
         assert inner.chunks == [b"12345678"]
         assert sent[0]["status"] == 204
+
+
+@pytest.mark.asyncio
+async def test_root_path_responses_uses_route_budget_and_openai_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_limits(monkeypatch, general=5, responses=8)
+    mounted_scope = _http_scope("/api/v1/responses", root_path="/api")
+
+    admitted_inner = _BodyConsumer()
+    admitted = await _run_direct(
+        RequestBodyLimitMiddleware(admitted_inner),
+        mounted_scope,
+        _request_messages(b"12345678"),
+    )
+
+    assert admitted_inner.chunks == [b"12345678"]
+    assert admitted[0]["status"] == 204
+
+    rejected = await _run_direct(
+        RequestBodyLimitMiddleware(_BodyConsumer()),
+        {**mounted_scope, "headers": [(b"content-length", b"9")]},
+        _request_messages(b"123456789"),
+    )
+
+    assert rejected[0]["status"] == 413
+    assert _json_response_body(rejected)["error"] == {
+        "message": "Request body exceeds the maximum allowed size",
+        "type": "invalid_request_error",
+        "code": "payload_too_large",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_request_body_limit_middleware.py
+++ b/tests/unit/test_request_body_limit_middleware.py
@@ -1,0 +1,455 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from typing import cast
+
+import pytest
+from fastapi import Body, Depends, FastAPI, HTTPException
+from httpx import ASGITransport, AsyncByteStream, AsyncClient
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import Message, Receive, Scope, Send
+
+from app.core.config.settings import get_settings
+from app.core.handlers import add_exception_handlers
+from app.core.middleware.path_rewrite import BackendApiCodexV1AliasMiddleware
+from app.core.middleware.request_body_limit import RequestBodyLimitMiddleware, add_request_body_limit_middleware
+from app.core.middleware.request_decompression import add_request_decompression_middleware
+from app.main import create_app
+
+pytestmark = pytest.mark.unit
+
+
+def _configure_limits(monkeypatch: pytest.MonkeyPatch, *, general: int, responses: int | None = None) -> None:
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", str(general))
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_RESPONSES_BODY_BYTES", str(responses or general))
+    get_settings.cache_clear()
+
+
+def _http_scope(path: str = "/echo", *, headers: list[tuple[bytes, bytes]] | None = None) -> Scope:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": b"",
+        "root_path": "",
+        "headers": headers or [],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+    }
+
+
+def _request_messages(*chunks: bytes) -> list[Message]:
+    return [
+        {"type": "http.request", "body": chunk, "more_body": index < len(chunks) - 1}
+        for index, chunk in enumerate(chunks)
+    ]
+
+
+def _json_response_body(messages: list[Message]) -> dict[str, object]:
+    body = b"".join(message.get("body", b"") for message in messages if message["type"] == "http.response.body")
+    return json.loads(body)
+
+
+class _BodyConsumer:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.chunks: list[bytes] = []
+        self.message_types: list[str] = []
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        self.calls += 1
+        while True:
+            message = await receive()
+            self.message_types.append(message["type"])
+            if message["type"] != "http.request":
+                return
+            self.chunks.append(message.get("body", b""))
+            if not message.get("more_body", False):
+                break
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+
+async def _run_direct(
+    middleware: RequestBodyLimitMiddleware,
+    scope: Scope,
+    messages: list[Message],
+) -> list[Message]:
+    pending = iter(messages)
+    sent: list[Message] = []
+
+    async def receive() -> Message:
+        return next(pending)
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    await middleware(scope, receive, send)
+    return sent
+
+
+@pytest.mark.asyncio
+async def test_declared_oversize_is_rejected_without_receive_or_downstream(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_limits(monkeypatch, general=5)
+    inner = _BodyConsumer()
+    middleware = RequestBodyLimitMiddleware(inner)
+    sent: list[Message] = []
+
+    async def receive() -> Message:
+        raise AssertionError("receive must not run for a declared oversized body")
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    await middleware(_http_scope(headers=[(b"content-length", b"6")]), receive, send)
+
+    assert inner.calls == 0
+    assert sent[0]["status"] == 413
+    assert _json_response_body(sent)["error"] == {
+        "code": "payload_too_large",
+        "message": "Request body exceeds the maximum allowed size",
+    }
+
+
+@pytest.mark.asyncio
+async def test_exact_boundary_stream_is_forwarded(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_limits(monkeypatch, general=5)
+    inner = _BodyConsumer()
+
+    sent = await _run_direct(
+        RequestBodyLimitMiddleware(inner),
+        _http_scope(),
+        _request_messages(b"12", b"345"),
+    )
+
+    assert inner.chunks == [b"12", b"345"]
+    assert sent[0]["status"] == 204
+
+
+@pytest.mark.asyncio
+async def test_ingress_guard_forwards_each_allowed_chunk_without_prebuffering(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_limits(monkeypatch, general=5)
+    events: list[str] = []
+    chunks = iter(_request_messages(b"12", b"345"))
+    sent: list[Message] = []
+    source_reads = 0
+
+    async def receive() -> Message:
+        nonlocal source_reads
+        source_reads += 1
+        if source_reads == 2:
+            assert "inner:12" in events
+        events.append(f"source:{source_reads}")
+        return next(chunks)
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    async def inner(scope: Scope, receive: Receive, send: Send) -> None:
+        first = await receive()
+        events.append(f"inner:{first['body'].decode('ascii')}")
+        second = await receive()
+        events.append(f"inner:{second['body'].decode('ascii')}")
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    await RequestBodyLimitMiddleware(inner)(_http_scope(), receive, send)
+
+    assert events == ["source:1", "inner:12", "source:2", "inner:345"]
+    assert sent[0]["status"] == 204
+
+
+@pytest.mark.asyncio
+async def test_streamed_overflow_hides_crossing_chunk(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_limits(monkeypatch, general=5)
+    inner = _BodyConsumer()
+
+    sent = await _run_direct(
+        RequestBodyLimitMiddleware(inner),
+        _http_scope(),
+        _request_messages(b"12", b"3456"),
+    )
+
+    assert inner.chunks == [b"12"]
+    assert sent[0]["status"] == 413
+
+
+@pytest.mark.asyncio
+async def test_understated_content_length_cannot_bypass_stream_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_limits(monkeypatch, general=5)
+    inner = _BodyConsumer()
+
+    sent = await _run_direct(
+        RequestBodyLimitMiddleware(inner),
+        _http_scope(headers=[(b"content-length", b"1")]),
+        _request_messages(b"123", b"456"),
+    )
+
+    assert inner.chunks == [b"123"]
+    assert sent[0]["status"] == 413
+
+
+@pytest.mark.asyncio
+async def test_malformed_content_length_falls_back_to_stream_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_limits(monkeypatch, general=5)
+    inner = _BodyConsumer()
+
+    sent = await _run_direct(
+        RequestBodyLimitMiddleware(inner),
+        _http_scope(headers=[(b"content-length", b"bogus")]),
+        _request_messages(b"123", b"456"),
+    )
+
+    assert inner.chunks == [b"123"]
+    assert sent[0]["status"] == 413
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_code", "expected_type"),
+    [
+        ("/v1/chat/completions", "payload_too_large", "invalid_request_error"),
+        ("/backend-api/codex/responses", "payload_too_large", "invalid_request_error"),
+        ("/api/codex/rate-limit-reset-credits/consume", "payload_too_large", "invalid_request_error"),
+        ("/internal/bridge/responses", "payload_too_large", "invalid_request_error"),
+        ("/api/settings", "payload_too_large", None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_oversize_uses_path_family_error_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+    expected_code: str,
+    expected_type: str | None,
+) -> None:
+    _configure_limits(monkeypatch, general=5)
+    sent = await _run_direct(
+        RequestBodyLimitMiddleware(_BodyConsumer()),
+        _http_scope(path, headers=[(b"content-length", b"6")]),
+        _request_messages(b"123456"),
+    )
+
+    error = cast(dict[str, object], _json_response_body(sent)["error"])
+    assert error["code"] == expected_code
+    assert error.get("type") == expected_type
+
+
+@pytest.mark.asyncio
+async def test_responses_paths_use_larger_budget_including_trailing_slash(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_limits(monkeypatch, general=5, responses=8)
+    for path in (
+        "/v1/responses",
+        "/v1/responses/",
+        "/backend-api/codex/responses",
+        "/backend-api/codex/responses/",
+    ):
+        inner = _BodyConsumer()
+        sent = await _run_direct(
+            RequestBodyLimitMiddleware(inner),
+            _http_scope(path),
+            _request_messages(b"12345678"),
+        )
+        assert inner.chunks == [b"12345678"]
+        assert sent[0]["status"] == 204
+
+
+@pytest.mark.asyncio
+async def test_outer_alias_rewrite_selects_responses_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_limits(monkeypatch, general=5, responses=8)
+    inner = _BodyConsumer()
+    app = BackendApiCodexV1AliasMiddleware(RequestBodyLimitMiddleware(inner))
+    sent: list[Message] = []
+    pending = iter(_request_messages(b"12345678"))
+
+    async def receive() -> Message:
+        return next(pending)
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    scope = _http_scope("/backend-api/codex/v1/responses/")
+    await app(dict(scope), receive, send)
+
+    assert inner.chunks == [b"12345678"]
+    assert sent[0]["status"] == 204
+
+
+@pytest.mark.asyncio
+async def test_unencoded_multipart_is_exempt_but_encoded_multipart_is_guarded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_limits(monkeypatch, general=5)
+    multipart = (b"content-type", b"multipart/form-data; boundary=test")
+
+    plain_inner = _BodyConsumer()
+    plain_sent = await _run_direct(
+        RequestBodyLimitMiddleware(plain_inner),
+        _http_scope(headers=[multipart, (b"content-length", b"8")]),
+        _request_messages(b"12345678"),
+    )
+    assert plain_inner.chunks == [b"12345678"]
+    assert plain_sent[0]["status"] == 204
+
+    encoded_inner = _BodyConsumer()
+    encoded_sent = await _run_direct(
+        RequestBodyLimitMiddleware(encoded_inner),
+        _http_scope(headers=[multipart, (b"content-encoding", b"identity"), (b"content-length", b"8")]),
+        _request_messages(b"12345678"),
+    )
+    assert encoded_inner.calls == 0
+    assert encoded_sent[0]["status"] == 413
+
+
+@pytest.mark.asyncio
+async def test_disconnect_and_unrelated_receive_failures_are_not_converted(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_limits(monkeypatch, general=5)
+    disconnect_inner = _BodyConsumer()
+    await _run_direct(
+        RequestBodyLimitMiddleware(disconnect_inner),
+        _http_scope(),
+        [{"type": "http.disconnect"}],
+    )
+    assert disconnect_inner.message_types == ["http.disconnect"]
+
+    async def receive_failure() -> Message:
+        raise RuntimeError("receive failed")
+
+    async def send(_: Message) -> None:
+        raise AssertionError("send must not run")
+
+    with pytest.raises(RuntimeError, match="receive failed"):
+        await RequestBodyLimitMiddleware(_BodyConsumer())(_http_scope(), receive_failure, send)
+
+    async def receive_cancelled() -> Message:
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError):
+        await RequestBodyLimitMiddleware(_BodyConsumer())(_http_scope(), receive_cancelled, send)
+
+
+@pytest.mark.asyncio
+async def test_non_http_scopes_pass_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_limits(monkeypatch, general=5)
+    seen: list[Scope] = []
+
+    async def inner(scope: Scope, receive: Receive, send: Send) -> None:
+        seen.append(scope)
+
+    async def receive() -> Message:
+        return {"type": "websocket.connect"}
+
+    async def send(_: Message) -> None:
+        return None
+
+    for scope_type in ("websocket", "lifespan"):
+        scope: Scope = {"type": scope_type}
+        await RequestBodyLimitMiddleware(inner)(scope, receive, send)
+
+    assert [scope["type"] for scope in seen] == ["websocket", "lifespan"]
+
+
+@pytest.mark.asyncio
+async def test_overflow_after_response_start_does_not_send_second_start(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_limits(monkeypatch, general=5)
+    sent: list[Message] = []
+
+    async def inner(scope: Scope, receive: Receive, send: Send) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await receive()
+
+    pending = iter(_request_messages(b"123456"))
+
+    async def receive() -> Message:
+        return next(pending)
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    with pytest.raises(Exception) as exc_info:
+        await RequestBodyLimitMiddleware(inner)(_http_scope(), receive, send)
+
+    assert type(exc_info.value).__name__ == "_RequestBodyTooLarge"
+    assert [message["type"] for message in sent] == ["http.response.start"]
+
+
+class _ChunkedBody(AsyncByteStream):
+    def __init__(self, *chunks: bytes) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+def _build_typed_body_app(auth_calls: list[bool]) -> FastAPI:
+    app = FastAPI()
+    add_request_decompression_middleware(app)
+    add_request_body_limit_middleware(app)
+    add_exception_handlers(app)
+
+    async def require_auth() -> None:
+        auth_calls.append(True)
+        raise HTTPException(status_code=401, detail="missing credentials")
+
+    @app.post("/v1/typed", dependencies=[Depends(require_auth)])
+    async def typed_body(payload: dict[str, object] = Body(...)) -> dict[str, object]:
+        return payload
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_typed_chunked_body_restores_receive_overflow_to_413(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_limits(monkeypatch, general=5)
+    auth_calls: list[bool] = []
+    transport = ASGITransport(app=_build_typed_body_app(auth_calls))
+
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/v1/typed",
+            content=_ChunkedBody(b'{"x":', b'"too long"}'),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 413
+    assert response.json()["error"] == {
+        "message": "Request body exceeds the maximum allowed size",
+        "type": "invalid_request_error",
+        "code": "payload_too_large",
+    }
+    assert auth_calls == []
+
+
+@pytest.mark.asyncio
+async def test_admitted_typed_body_runs_route_authorization_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    _configure_limits(monkeypatch, general=32)
+    auth_calls: list[bool] = []
+    transport = ASGITransport(app=_build_typed_body_app(auth_calls))
+
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/v1/typed",
+            content=_ChunkedBody(b"{}"),
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 401
+    assert auth_calls == [True]
+
+
+def test_production_middleware_order_keeps_alias_and_admission_outside_body_read() -> None:
+    middleware = create_app().user_middleware
+    alias_index = next(index for index, item in enumerate(middleware) if item.cls is BackendApiCodexV1AliasMiddleware)
+    limit_index = next(index for index, item in enumerate(middleware) if item.cls is RequestBodyLimitMiddleware)
+    decompression_index = next(
+        index
+        for index, item in enumerate(middleware)
+        if item.cls is BaseHTTPMiddleware and item.kwargs.get("dispatch").__name__ == "request_decompression_middleware"
+    )
+
+    assert alias_index < limit_index < decompression_index

--- a/tests/unit/test_request_decompression_middleware.py
+++ b/tests/unit/test_request_decompression_middleware.py
@@ -13,6 +13,7 @@ from fastapi.responses import Response
 from httpx import ASGITransport, AsyncClient
 from starlette.requests import ClientDisconnect
 
+from app.core.middleware.request_body_limit import add_request_body_limit_middleware
 from app.core.middleware.request_decompression import add_request_decompression_middleware
 
 pytestmark = pytest.mark.unit
@@ -23,6 +24,7 @@ _Dispatch = Callable[[Request, Callable[[Request], Awaitable[Response]]], Awaita
 def _build_echo_app(*, touch_headers: bool = False) -> FastAPI:
     app = FastAPI()
     add_request_decompression_middleware(app)
+    add_request_body_limit_middleware(app)
 
     if touch_headers:
 
@@ -179,6 +181,169 @@ async def test_request_decompression_rejects_unsupported_encoding():
     response_data = resp.json()
     assert response_data["error"]["code"] == "invalid_request"
     assert response_data["error"]["message"] == "Unsupported Content-Encoding"
+
+
+@pytest.mark.parametrize(
+    ("encoding", "encode"),
+    [
+        ("identity", lambda body: body),
+        ("gzip", gzip.compress),
+        ("deflate", zlib.compress),
+        ("zstd", lambda body: zstd.ZstdCompressor().compress(body)),
+        ("gzip, zstd", lambda body: zstd.ZstdCompressor().compress(gzip.compress(body))),
+    ],
+)
+@pytest.mark.asyncio
+async def test_request_decompression_rejects_raw_encoded_body_over_limit(
+    monkeypatch,
+    encoding,
+    encode,
+):
+    payload = {"input": "x" * 512}
+    encoded = encode(json.dumps(payload).encode("utf-8"))
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", str(len(encoded) - 1))
+
+    transport = ASGITransport(app=_build_echo_app())
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/echo",
+            content=encoded,
+            headers={"Content-Encoding": encoding, "Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 413
+    assert response.json()["error"]["code"] == "payload_too_large"
+
+
+@pytest.mark.parametrize(
+    ("encoding", "encode"),
+    [
+        ("identity", lambda body: body),
+        ("gzip", gzip.compress),
+        ("deflate", zlib.compress),
+        ("zstd", lambda body: zstd.ZstdCompressor().compress(body)),
+        ("gzip, zstd", lambda body: zstd.ZstdCompressor().compress(gzip.compress(body))),
+    ],
+)
+@pytest.mark.asyncio
+async def test_request_decompression_allows_exact_decoded_boundary(
+    monkeypatch,
+    encoding,
+    encode,
+):
+    payload = {"input": "x" * 512}
+    body = json.dumps(payload).encode("utf-8")
+    encoded = encode(body)
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", str(len(body)))
+
+    transport = ASGITransport(app=_build_echo_app())
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/echo",
+            content=encoded,
+            headers={"Content-Encoding": encoding, "Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["data"] == payload
+
+
+@pytest.mark.parametrize(
+    ("encoding", "encode"),
+    [
+        ("identity", lambda body: body),
+        ("gzip", gzip.compress),
+        ("deflate", zlib.compress),
+        ("zstd", lambda body: zstd.ZstdCompressor().compress(body)),
+        ("gzip, zstd", lambda body: zstd.ZstdCompressor().compress(gzip.compress(body))),
+    ],
+)
+@pytest.mark.asyncio
+async def test_request_decompression_rejects_one_byte_over_decoded_boundary(
+    monkeypatch,
+    encoding,
+    encode,
+):
+    body = json.dumps({"input": "x" * 512}).encode("utf-8")
+    encoded = encode(body)
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", str(len(body) - 1))
+
+    transport = ASGITransport(app=_build_echo_app())
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/echo",
+            content=encoded,
+            headers={"Content-Encoding": encoding, "Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 413
+    assert response.json()["error"]["code"] == "payload_too_large"
+
+
+@pytest.mark.asyncio
+async def test_request_decompression_uses_openai_envelope_for_unsupported_encoding(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", "2048")
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_RESPONSES_BODY_BYTES", "2048")
+
+    transport = ASGITransport(app=_build_echo_app())
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/backend-api/codex/responses",
+            content=b"not-brotli",
+            headers={"Content-Encoding": "br", "Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"] == {
+        "message": "Unsupported Content-Encoding",
+        "type": "invalid_request_error",
+        "code": "invalid_request_error",
+    }
+
+
+@pytest.mark.asyncio
+async def test_request_decompression_uses_openai_envelope_for_malformed_body(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", "2048")
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_RESPONSES_BODY_BYTES", "2048")
+
+    transport = ASGITransport(app=_build_echo_app())
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/backend-api/codex/responses",
+            content=b"not-zstd",
+            headers={"Content-Encoding": "zstd", "Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"] == {
+        "message": "Request body is compressed but could not be decompressed",
+        "type": "invalid_request_error",
+        "code": "invalid_request_error",
+    }
+
+
+@pytest.mark.asyncio
+async def test_request_decompression_uses_openai_envelope_for_expanded_overflow(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", "128")
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_RESPONSES_BODY_BYTES", "128")
+    body = json.dumps({"input": "x" * 512}).encode("utf-8")
+    compressed = zstd.ZstdCompressor().compress(body)
+    assert len(compressed) < 128 < len(body)
+
+    transport = ASGITransport(app=_build_echo_app())
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/backend-api/codex/responses",
+            content=compressed,
+            headers={"Content-Encoding": "zstd", "Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 413
+    assert response.json()["error"] == {
+        "message": "Request body exceeds the maximum allowed size",
+        "type": "invalid_request_error",
+        "code": "payload_too_large",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_request_decompression_middleware.py
+++ b/tests/unit/test_request_decompression_middleware.py
@@ -372,6 +372,28 @@ async def test_request_decompression_allows_larger_responses_payload(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_request_decompression_allows_larger_responses_payload_under_root_path(monkeypatch):
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", "128")
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_RESPONSES_BODY_BYTES", "2048")
+
+    payload = {"input": "x" * 512}
+    body = json.dumps(payload).encode("utf-8")
+    compressed = zstd.ZstdCompressor().compress(body)
+    assert len(compressed) < 128 < len(body)
+
+    transport = ASGITransport(app=_build_echo_app(), root_path="/api")
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.post(
+            "/api/backend-api/codex/responses",
+            content=compressed,
+            headers={"Content-Encoding": "zstd", "Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["data"] == payload
+
+
+@pytest.mark.asyncio
 async def test_request_decompression_allows_larger_trailing_slash_responses_payload(monkeypatch):
     monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", "128")
     monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_RESPONSES_BODY_BYTES", "2048")


### PR DESCRIPTION
## Summary

Bound raw HTTP request ingress incrementally before FastAPI body parsing, while preserving the existing larger Responses budget and all supported decompression paths. This closes an unbounded pre-authentication memory-growth gap and returns the documented error envelope for each path family.

Root cause: unencoded bodies bypassed the decompression middleware entirely, while encoded bodies were fully collected before the decompressed-size guard ran. FastAPI could also translate a streamed receive overflow into HTTP 400 during typed-body parsing.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: None — proactive hardening identified during repository analysis.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful request path and preserves upstream-compatible request/response behavior

Change directory: `openspec/changes/bound-raw-http-ingress/`

Formal verification covers 6/6 requirements and 23/23 scenarios with 0 critical issues, warnings, or suggestions.

## Changes

- Add a pure ASGI receive wrapper that rejects oversized declared or streamed bodies before the crossing chunk reaches downstream parsing, without prebuffering the whole body.
- Reuse the existing 32 MiB general and 128 MiB Responses budgets for raw and decoded representations; plain unencoded multipart remains explicitly out of scope.
- Preserve `gzip`, `deflate`, `zstd`, `identity`, and stacked encodings while bounding every decoded stage.
- Return OpenAI-compatible ingress errors on `/v1`, `/backend-api`, `/api/codex`, and `/internal/bridge`; retain dashboard envelopes elsewhere.
- Add hidden trailing-slash aliases for both Responses HTTP routes so chunked admission cannot be bypassed by a 307 redirect.
- Preserve endpoint authorization and the existing post-slimming Responses HTTP 400 behavior.

## Simplicity

- No new setting, dependency, migration, required setup step, README section, `.env.example` entry, dashboard navigation item, or default change.
- The fix works with the existing zero-config budgets.

## Test plan

```text
uv run pytest -q   tests/unit/test_request_body_limit_middleware.py   tests/unit/test_request_decompression_middleware.py   tests/integration/test_request_decompression.py   tests/integration/test_http_responses_bridge.py::test_v1_responses_http_bridge_rejects_oversized_response_create_before_upstream
# 57 passed

uv run ruff check .
# All checks passed

uv run ruff format --check .
# 808 files already formatted

uv run ty check
# All checks passed

uv run python scripts/check_proxy_architecture.py
# proxy architecture checks passed

openspec validate bound-raw-http-ingress --strict
# valid

openspec validate --specs
# 47 passed, 0 failed
```

The full unit suite also passed before the final upstream rebase: 4,279 passed with 55 expected skips; the sandbox-restricted socket test passed separately. The final rebase touched no implementation files, and the focused 57-test suite was rerun afterward.

## Screenshots / output

No dashboard-visible change.

Oversized OpenAI-compatible requests now return:

```json
{
  "error": {
    "message": "Request body exceeds the maximum allowed size",
    "type": "invalid_request_error",
    "code": "payload_too_large"
  }
}
```

The response status is HTTP 413. Existing post-slimming `response.create` rejection remains HTTP 400 with `param = input`.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] No existing issue applies; the PR states that explicitly.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local CI subset.
- [x] OpenSpec validation passes and verification is clean.
- [x] Simplicity gates P1-P5 reviewed.
- [x] `CHANGELOG.md` is not edited by hand.
