### PR TITLE
fix(proxy): harden compact continuity recovery

### DIFF
--- a/app/core/runtime_logging.py
+++ b/app/core/runtime_logging.py
@@ -21,6 +21,10 @@ _SENSITIVE_LOG_VALUE_PATTERNS = (
     re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+"),
     re.compile(r"(?i)(authorization\s*[=:]\s*)(?!\s*bearer\b)([^,&]+)"),
 )
+_JSON_SENSITIVE_LOG_VALUE_PATTERN = re.compile(
+    r'(?i)("(?:password|passwd|pwd|token|secret|api[_-]?key|authorization)"\s*:\s*")'
+    r'(?:\\.|[^"\\])*(")'
+)
 _LOG_REDACTION = "[REDACTED]"
 
 
@@ -29,6 +33,7 @@ def _redact_log_value(value: str | None) -> str | None:
     if collapsed is None:
         return None
     redacted = collapsed
+    redacted = _JSON_SENSITIVE_LOG_VALUE_PATTERN.sub(_redact_json_secret, redacted)
     redacted = _SENSITIVE_LOG_VALUE_PATTERNS[0].sub(_redact_keyed_secret, redacted)
     redacted = _SENSITIVE_LOG_VALUE_PATTERNS[1].sub(_redact_bearer_token, redacted)
     return _SENSITIVE_LOG_VALUE_PATTERNS[2].sub(_redact_authorization_value, redacted)
@@ -36,6 +41,10 @@ def _redact_log_value(value: str | None) -> str | None:
 
 def _redact_keyed_secret(match: re.Match[str]) -> str:
     return f"{match.group(1)}{match.group(2)}{_LOG_REDACTION}"
+
+
+def _redact_json_secret(match: re.Match[str]) -> str:
+    return f"{match.group(1)}{_LOG_REDACTION}{match.group(2)}"
 
 
 def _redact_bearer_token(match: re.Match[str]) -> str:
@@ -197,14 +206,23 @@ def log_error_response(
     level = logging.ERROR if status_code >= 500 else logging.WARNING
     logger.log(
         level,
-        "%s request_id=%s method=%s path=%s status=%s",
+        "%s request_id=%s method=%s path=%s status=%s code=%s message=%s",
         category,
         get_request_id(),
         request.method,
         request.url.path,
         status_code,
+        _error_log_field(code),
+        _error_log_field(message),
         exc_info=exc_info,
     )
+
+
+def _error_log_field(value: str | None) -> str:
+    redacted = _redact_log_value(value)
+    if redacted is None:
+        return "-"
+    return json.dumps(redacted)
 
 
 def _collapse_log_value(value: str | None) -> str | None:

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -46,6 +46,7 @@ from app.modules.proxy.affinity import (
     _prompt_cache_key_from_request_model,
     _request_allows_bare_session_cap_spillover,
     _resolve_prompt_cache_key,
+    _sticky_key_from_session_header,
     _sticky_key_from_turn_state_header,
 )
 from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
@@ -612,9 +613,12 @@ class _CompactMixin:
         )
         sticky_key_source = "none"
         if affinity.kind == StickySessionKind.CODEX_SESSION:
-            sticky_key_source = (
-                "turn_state_header" if _sticky_key_from_turn_state_header(headers) is not None else "session_header"
-            )
+            if _sticky_key_from_turn_state_header(headers) is not None:
+                sticky_key_source = "turn_state_header"
+            elif _sticky_key_from_session_header(headers) is not None:
+                sticky_key_source = "session_header"
+            else:
+                sticky_key_source = "payload"
         elif affinity.key:
             sticky_key_source = "payload" if had_prompt_cache_key else "derived"
         _maybe_log_proxy_request_shape(

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -1992,6 +1992,8 @@ class _HTTPBridgeMixin(
         require_security_work_authorized: bool = False,
         require_same_account: bool = False,
         require_preferred_account: bool = False,
+        owner_rebind_affinity: _AffinityPolicy | None = None,
+        selection_affinity: _AffinityPolicy | None = None,
     ) -> None:
         # A replacement reader can start before its caller resends the request.
         # Clear the prior attempt first so an expired send timestamp cannot
@@ -2100,7 +2102,7 @@ class _HTTPBridgeMixin(
                 kind="http_bridge",
                 request_stage="reattach",
                 api_key=session.api_key,
-                affinity_policy=session.affinity,
+                affinity_policy=selection_affinity or session.affinity,
                 prefer_earlier_reset_accounts=settings.prefer_earlier_reset_accounts,
                 prefer_earlier_reset_window=_prefer_earlier_reset_window(settings),
                 routing_strategy=_routing_strategy(settings),
@@ -2207,7 +2209,8 @@ class _HTTPBridgeMixin(
                 if force_refresh and request_state.force_refresh_account_id == account.id:
                     request_state.force_refresh_account_id = None
                 connect_headers = _websocket_safe_headers_with_turn_state(
-                    session.headers, _preferred_http_bridge_reconnect_turn_state(session)
+                    session.headers,
+                    None if owner_rebind_affinity is not None else _preferred_http_bridge_reconnect_turn_state(session),
                 )
                 upstream = await self._open_upstream_websocket_with_budget(
                     account,
@@ -2229,7 +2232,12 @@ class _HTTPBridgeMixin(
                         timeout_seconds=_remaining_budget_seconds(deadline),
                     )
                     connect_headers = _websocket_safe_headers_with_turn_state(
-                        session.headers, _preferred_http_bridge_reconnect_turn_state(session)
+                        session.headers,
+                        (
+                            None
+                            if owner_rebind_affinity is not None
+                            else _preferred_http_bridge_reconnect_turn_state(session)
+                        ),
                     )
                     upstream = await self._open_upstream_websocket_with_budget(
                         account,
@@ -2274,6 +2282,22 @@ class _HTTPBridgeMixin(
                     continue
                 await release_selected_account_lease()
                 raise
+        if owner_rebind_affinity is not None:
+            await self._claim_http_bridge_replacement_before_swap(
+                session,
+                account_id=account.id,
+                upstream=upstream,
+                release_selected_account_lease=release_selected_account_lease,
+                owner_rebind_affinity=owner_rebind_affinity,
+            )
+            await self._unregister_http_bridge_turn_states(session)
+            session.affinity = selection_affinity or session.affinity
+            session.codex_session = False
+            session.upstream_turn_state = None
+            session.downstream_turn_state = None
+            session.headers = {
+                key: value for key, value in session.headers.items() if key.lower() != "x-codex-turn-state"
+            }
         try:
             await old_upstream.close()
         except Exception:

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -2291,6 +2291,11 @@ class _HTTPBridgeMixin(
                 owner_rebind_affinity=owner_rebind_affinity,
             )
             await self._unregister_http_bridge_turn_states(session)
+            await self._unregister_http_bridge_previous_response_ids(session)
+            session.last_completed_response_id = None
+            session.last_completed_input_count = 0
+            session.last_completed_input_prefix_fingerprint = None
+            session.last_pending_tool_calls.clear()
             session.affinity = selection_affinity or session.affinity
             session.codex_session = False
             session.upstream_turn_state = None

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -1400,6 +1400,7 @@ class _HTTPBridgeRequestSubmitMixin:
             kind=session.key.affinity_kind,
             key=session.key.affinity_key,
         )
+        hard_owner_bound = _http_bridge_key_strength(session.key) == "hard"
         async with session.pending_lock:
             retryable_requests = [
                 request_state
@@ -1458,7 +1459,8 @@ class _HTTPBridgeRequestSubmitMixin:
                     request_text = _prepare_websocket_request_state_for_visible_output_replay(request_state)
                     if request_text is None:
                         return False
-                    request_state.excluded_account_ids.add(session.account.id)
+                    if not hard_owner_bound:
+                        request_state.excluded_account_ids.add(session.account.id)
             else:
                 require_preferred_reconnect = account_neutral_recovery
                 request_text = _prepare_websocket_request_state_for_visible_output_replay(request_state)
@@ -1466,7 +1468,7 @@ class _HTTPBridgeRequestSubmitMixin:
                     return False
                 if account_neutral_recovery:
                     request_state.preferred_account_id = session.account.id
-                elif not request_state.file_required_preferred_account:
+                elif not request_state.file_required_preferred_account and not hard_owner_bound:
                     request_state.preferred_account_id = None
                     request_state.excluded_account_ids.add(session.account.id)
             if session.account.id in request_state.excluded_account_ids:
@@ -1485,7 +1487,13 @@ class _HTTPBridgeRequestSubmitMixin:
             model_class=_extract_model_class(session.request_model) if session.request_model else None,
         )
         try:
-            if require_preferred_reconnect:
+            if hard_owner_bound:
+                await self._reconnect_http_bridge_session(
+                    session,
+                    request_state=request_state,
+                    require_same_account=True,
+                )
+            elif require_preferred_reconnect:
                 await self._reconnect_http_bridge_session(
                     session,
                     request_state=request_state,
@@ -1719,7 +1727,11 @@ class _HTTPBridgeRequestSubmitMixin:
             )
             reconnected = True
             if session.account.id != owner_account_id:
-                if previous_session_affinity.selection_key is not None and previous_session_affinity.kind is not None:
+                if (
+                    previous_session_affinity.codex_session_source == "session_header"
+                    and previous_session_affinity.selection_key is not None
+                    and previous_session_affinity.kind is not None
+                ):
                     async with self._repo_factory() as repos:
                         await repos.sticky_sessions.upsert(
                             previous_session_affinity.selection_key,
@@ -1752,7 +1764,15 @@ class _HTTPBridgeRequestSubmitMixin:
                 if request_state in session.pending_requests:
                     session.pending_requests.remove(request_state)
                     session.queued_request_count = max(0, session.queued_request_count - 1)
-            if not reconnected:
+            if reconnected:
+                # Ownership and the replacement socket were already swapped,
+                # but response.create never reached that socket.  Retire the
+                # replacement instead of leaving a live bridge with aliases
+                # rebound to a turn that was never submitted.
+                session.upstream_control.reconnect_requested = True
+                session.upstream_control.retire_after_drain = True
+                await self._retire_http_bridge_after_drain_if_ready(session)
+            else:
                 request_state.replay_count = previous_replay_count
                 request_state.response_id = previous_response_id
                 request_state.response_event_count = previous_response_event_count

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -76,9 +76,11 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _log_http_bridge_event,
     _record_continuity_fail_closed,
     _record_http_bridge_prewarm_outcome,
+    _register_http_bridge_turn_state_aliases_locked,
     _release_http_bridge_unanchored_handoff,
 )
 from app.modules.proxy._service.http_bridge.service_stubs import (
+    _call_with_supported_optional_kwargs,
     _classify_upstream_close,
     _count_external_image_urls,
     _enforce_response_create_size_limit,
@@ -164,6 +166,7 @@ from app.modules.proxy._service.warmup import (
     _WarmupUsageSnapshot as _WarmupUsageSnapshot,
 )
 from app.modules.proxy.affinity import (
+    _AffinityPolicy,
     _extract_model_class,
     _owner_lookup_session_id_from_headers,
 )
@@ -1646,8 +1649,14 @@ class _HTTPBridgeRequestSubmitMixin:
         previous_response_event_count = request_state.response_event_count
         previous_upstream_model_output_seen = request_state.upstream_model_output_seen
         previous_affinity_policy = request_state.affinity_policy
+        previous_session_affinity = session.affinity
+        previous_session_codex_session = session.codex_session
         previous_session_upstream_turn_state = session.upstream_turn_state
         previous_session_downstream_turn_state = session.downstream_turn_state
+        previous_session_turn_state_aliases = set(session.downstream_turn_state_aliases)
+        previous_session_turn_state_alias_registration_generations = dict(
+            session.turn_state_alias_registration_generations
+        )
         previous_session_headers = session.headers
         if request_state.previous_response_id is not None:
             retry_text = _prepare_websocket_request_state_for_account_switch(request_state)
@@ -1662,9 +1671,13 @@ class _HTTPBridgeRequestSubmitMixin:
             kind=None,
             reallocate_sticky=True,
         )
-        session.upstream_turn_state = None
-        session.downstream_turn_state = None
-        session.headers = {key: value for key, value in session.headers.items() if key.lower() != "x-codex-turn-state"}
+        replacement_session_affinity = replace(
+            session.affinity,
+            key=None,
+            kind=None,
+            reallocate_sticky=True,
+            codex_session_source=None,
+        )
 
         request_state.replay_count += 1
         request_state.response_id = None
@@ -1691,13 +1704,28 @@ class _HTTPBridgeRequestSubmitMixin:
             cache_key_family=session.key.affinity_kind,
             model_class=_extract_model_class(session.request_model) if session.request_model else None,
         )
+        reconnected = False
         try:
             request_state.precreated_replay_account_id = session.account.id
-            await self._reconnect_http_bridge_session(
+            await _call_with_supported_optional_kwargs(
+                self._reconnect_http_bridge_session,
                 session,
+                optional_kwargs={
+                    "owner_rebind_affinity": previous_session_affinity,
+                    "selection_affinity": replacement_session_affinity,
+                },
                 request_state=request_state,
                 require_security_work_authorized=True,
             )
+            reconnected = True
+            if session.account.id != owner_account_id:
+                if previous_session_affinity.selection_key is not None and previous_session_affinity.kind is not None:
+                    async with self._repo_factory() as repos:
+                        await repos.sticky_sessions.upsert(
+                            previous_session_affinity.selection_key,
+                            session.account.id,
+                            kind=previous_session_affinity.kind,
+                        )
             retry_text = self._http_bridge_text_with_account_installation_id(session, request_state, retry_text)
             await _send_http_bridge_request_text_with_archive_id(session, request_state, retry_text)
             session.last_used_at = _service_time().monotonic()
@@ -1724,13 +1752,69 @@ class _HTTPBridgeRequestSubmitMixin:
                 if request_state in session.pending_requests:
                     session.pending_requests.remove(request_state)
                     session.queued_request_count = max(0, session.queued_request_count - 1)
-            request_state.replay_count = previous_replay_count
-            request_state.response_id = previous_response_id
-            request_state.response_event_count = previous_response_event_count
-            request_state.upstream_model_output_seen = previous_upstream_model_output_seen
-            request_state.deferred_reasoning_downstream_texts = []
-            request_state.affinity_policy = previous_affinity_policy
-            session.upstream_turn_state = previous_session_upstream_turn_state
-            session.downstream_turn_state = previous_session_downstream_turn_state
-            session.headers = previous_session_headers
+            if not reconnected:
+                request_state.replay_count = previous_replay_count
+                request_state.response_id = previous_response_id
+                request_state.response_event_count = previous_response_event_count
+                request_state.upstream_model_output_seen = previous_upstream_model_output_seen
+                request_state.deferred_reasoning_downstream_texts = []
+                request_state.affinity_policy = previous_affinity_policy
+                session.affinity = previous_session_affinity
+                session.codex_session = previous_session_codex_session
+                session.upstream_turn_state = previous_session_upstream_turn_state
+                session.downstream_turn_state = previous_session_downstream_turn_state
+                async with self._http_bridge_lock:
+                    session.downstream_turn_state_aliases.update(previous_session_turn_state_aliases)
+                    session.turn_state_alias_registration_generations.update(
+                        previous_session_turn_state_alias_registration_generations
+                    )
+                    _register_http_bridge_turn_state_aliases_locked(self, session)
+                session.headers = previous_session_headers
             return False
+
+    async def _claim_http_bridge_replacement_before_swap(
+        self: Any,
+        session: "_HTTPBridgeSession",
+        *,
+        account_id: str,
+        upstream: Any,
+        release_selected_account_lease: Any,
+        owner_rebind_affinity: _AffinityPolicy,
+    ) -> None:
+        if account_id == session.account.id:
+            return
+        try:
+            if owner_rebind_affinity.legacy_selection_key is not None and owner_rebind_affinity.kind is not None:
+                async with self._repo_factory() as repos:
+                    legacy_owner_id = await repos.sticky_sessions.get_account_id(
+                        owner_rebind_affinity.legacy_selection_key,
+                        kind=owner_rebind_affinity.kind,
+                        max_age_seconds=owner_rebind_affinity.max_age_seconds,
+                    )
+                if legacy_owner_id is not None and legacy_owner_id != account_id:
+                    raise ProxyResponseError(
+                        502,
+                        openai_error(
+                            "continuity_owner_conflict",
+                            "Security retry conflicts with a legacy continuity owner.",
+                            error_type="server_error",
+                        ),
+                    )
+            if session.durable_session_id is not None:
+                await _call_with_supported_optional_kwargs(
+                    self._claim_durable_http_bridge_session,
+                    session,
+                    optional_kwargs={
+                        "claim_account_id": account_id,
+                        "clear_latest_turn_state": True,
+                    },
+                    allow_takeover=True,
+                    force_owner_epoch_advance=True,
+                )
+        except BaseException:
+            try:
+                await upstream.close()
+            except Exception:
+                logger.debug("Failed to close unclaimed HTTP bridge replacement websocket", exc_info=True)
+            await release_selected_account_lease()
+            raise

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 from collections import deque
+from dataclasses import replace
 from typing import Any, Literal, Mapping, TypeVar, cast
 from uuid import uuid4
 
@@ -1636,13 +1637,40 @@ class _HTTPBridgeRequestSubmitMixin:
             return False
         if request_state.file_required_preferred_account:
             return False
+        if not _websocket_request_can_replay_before_visible_output(request_state):
+            return False
+
+        owner_account_id = session.account.id
+        previous_replay_count = request_state.replay_count
+        previous_response_id = request_state.response_id
+        previous_response_event_count = request_state.response_event_count
+        previous_upstream_model_output_seen = request_state.upstream_model_output_seen
+        previous_affinity_policy = request_state.affinity_policy
+        previous_session_upstream_turn_state = session.upstream_turn_state
+        previous_session_downstream_turn_state = session.downstream_turn_state
+        previous_session_headers = session.headers
         if request_state.previous_response_id is not None:
             retry_text = _prepare_websocket_request_state_for_account_switch(request_state)
         if retry_text is None:
             return False
 
+        request_state.preferred_account_id = None
+        request_state.excluded_account_ids.add(owner_account_id)
+        request_state.affinity_policy = replace(
+            request_state.affinity_policy,
+            key=None,
+            kind=None,
+            reallocate_sticky=True,
+        )
+        session.upstream_turn_state = None
+        session.downstream_turn_state = None
+        session.headers = {key: value for key, value in session.headers.items() if key.lower() != "x-codex-turn-state"}
+
         request_state.replay_count += 1
         request_state.response_id = None
+        request_state.response_event_count = 0
+        request_state.upstream_model_output_seen = False
+        request_state.deferred_reasoning_downstream_texts = []
         request_state.awaiting_response_created = True
         if retry_text != request_state.request_text:
             request_state.previous_response_id = None
@@ -1664,6 +1692,7 @@ class _HTTPBridgeRequestSubmitMixin:
             model_class=_extract_model_class(session.request_model) if session.request_model else None,
         )
         try:
+            request_state.precreated_replay_account_id = session.account.id
             await self._reconnect_http_bridge_session(
                 session,
                 request_state=request_state,
@@ -1695,4 +1724,13 @@ class _HTTPBridgeRequestSubmitMixin:
                 if request_state in session.pending_requests:
                     session.pending_requests.remove(request_state)
                     session.queued_request_count = max(0, session.queued_request_count - 1)
+            request_state.replay_count = previous_replay_count
+            request_state.response_id = previous_response_id
+            request_state.response_event_count = previous_response_event_count
+            request_state.upstream_model_output_seen = previous_upstream_model_output_seen
+            request_state.deferred_reasoning_downstream_texts = []
+            request_state.affinity_policy = previous_affinity_policy
+            session.upstream_turn_state = previous_session_upstream_turn_state
+            session.downstream_turn_state = previous_session_downstream_turn_state
+            session.headers = previous_session_headers
             return False

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -1715,6 +1715,7 @@ class _HTTPBridgeRequestSubmitMixin:
         reconnected = False
         try:
             request_state.precreated_replay_account_id = session.account.id
+            await self._release_request_state_account_response_create_lease(request_state)
             await _call_with_supported_optional_kwargs(
                 self._reconnect_http_bridge_session,
                 session,
@@ -1726,6 +1727,14 @@ class _HTTPBridgeRequestSubmitMixin:
                 require_security_work_authorized=True,
             )
             reconnected = True
+            settings = await _service_get_settings_cache().get()
+            request_state.account_response_create_lease = await self._acquire_account_response_create_lease_or_overload(
+                account_id=session.account.id,
+                request_id=request_state.request_id,
+                surface="http_bridge_security_retry",
+                concurrency_caps=effective_account_concurrency_caps(settings),
+            )
+            request_state.account_response_create_release = self._load_balancer.release_account_lease
             if session.account.id != owner_account_id:
                 if (
                     previous_session_affinity.codex_session_source == "session_header"

--- a/app/modules/proxy/_service/http_bridge/service_stubs.py
+++ b/app/modules/proxy/_service/http_bridge/service_stubs.py
@@ -306,7 +306,7 @@ def _websocket_safe_headers_with_turn_state(headers: Mapping[str, str], turn_sta
     filtered = {
         key: value
         for key, value in filter_inbound_websocket_headers(dict(headers)).items()
-        if key.lower() not in _response_create_compatibility_metadata_headers()
+        if key.lower() not in _response_create_compatibility_metadata_headers() and key.lower() != "x-codex-turn-state"
     }
     return cast(dict[str, str], _headers_with_turn_state(filtered, turn_state))
 

--- a/app/modules/proxy/_service/http_bridge/session_registry.py
+++ b/app/modules/proxy/_service/http_bridge/session_registry.py
@@ -423,6 +423,8 @@ class _HTTPBridgeSessionRegistryMixin:
         *,
         allow_takeover: bool,
         force_owner_epoch_advance: bool = False,
+        claim_account_id: str | None = None,
+        clear_latest_turn_state: bool = False,
     ) -> None:
         current_instance = _service_get_settings().http_responses_session_bridge_instance_id
         try:
@@ -434,10 +436,10 @@ class _HTTPBridgeSessionRegistryMixin:
                     api_key_id=session.key.api_key_id,
                     instance_id=current_instance,
                     lease_ttl_seconds=_http_bridge_durable_lease_ttl_seconds(),
-                    account_id=session.account.id,
+                    account_id=claim_account_id or session.account.id,
                     model=session.request_model,
                     service_tier=session.request_service_tier,
-                    latest_turn_state=session.downstream_turn_state,
+                    latest_turn_state=None if clear_latest_turn_state else session.downstream_turn_state,
                     latest_response_id=None,
                     allow_takeover=allow_takeover,
                     force_owner_epoch_advance=force_owner_epoch_advance or claim_attempt > 0,

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -655,8 +655,6 @@ class _HTTPBridgeUpstreamEventsMixin:
                 ):
                     matched_request_state.suppressed_duplicate_tool_call = True
                     return
-                if event_type in _MODEL_OUTPUT_EVENT_TYPES:
-                    matched_request_state.upstream_model_output_seen = True
                 if event_type in _TEXT_DELTA_EVENT_TYPES:
                     matched_request_state.downstream_visible = True
                 if event_type == "response.created" and matched_request_state.suppress_next_created_downstream:
@@ -670,6 +668,8 @@ class _HTTPBridgeUpstreamEventsMixin:
                     matched_request_state.upstream_model_output_seen = True
                     suppress_downstream_event = True
                     deferred_reasoning_prelude_event = True
+                elif event_type in _MODEL_OUTPUT_EVENT_TYPES:
+                    matched_request_state.upstream_model_output_seen = True
 
             terminal_request_state = None
             if event_type in {"response.completed", "response.failed", "response.incomplete", "error"}:

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -174,6 +174,19 @@ from app.modules.proxy.tool_call_dedupe import (
 logger = logging.getLogger("app.modules.proxy.service")
 T = TypeVar("T")
 _TEXT_DELTA_EVENT_TYPES = frozenset({"response.output_text.delta", "response.refusal.delta"})
+_MODEL_OUTPUT_EVENT_TYPES = frozenset(
+    {
+        "response.output_item.added",
+        "response.output_item.done",
+        "response.output_text.delta",
+        "response.refusal.delta",
+        "response.reasoning_text.delta",
+        "response.reasoning_summary_text.delta",
+        "response.reasoning_summary_text.done",
+        "response.function_call_arguments.delta",
+        "response.output_tool_call.delta",
+    }
+)
 _SECURITY_WORK_AUTHORIZATION_REQUIRED_CODE = "security_work_authorization_required"
 _SECURITY_WORK_RETRY_MESSAGE = (
     "Upstream flagged this request as possible cybersecurity work. "
@@ -642,6 +655,8 @@ class _HTTPBridgeUpstreamEventsMixin:
                 ):
                     matched_request_state.suppressed_duplicate_tool_call = True
                     return
+                if event_type in _MODEL_OUTPUT_EVENT_TYPES:
+                    matched_request_state.upstream_model_output_seen = True
                 if event_type in _TEXT_DELTA_EVENT_TYPES:
                     matched_request_state.downstream_visible = True
                 if event_type == "response.created" and matched_request_state.suppress_next_created_downstream:

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -111,11 +111,15 @@ from app.modules.proxy._service.support import (
     _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE,
     _HARD_HTTP_BRIDGE_AFFINITY_KINDS,  # noqa: F401
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
+    _clear_websocket_deferred_reasoning_downstream_texts,
     _clear_websocket_precreated_replay_fallback,
     _clear_websocket_request_error_overrides,
     _event_type_from_payload,
     _HTTPBridgeSession,
+    _pop_websocket_deferred_reasoning_downstream_texts,
     _record_response_event,
+    _websocket_request_can_replay_before_visible_output,
+    _websocket_should_defer_reasoning_prelude,
     _WebSocketReceiveTimeout,
     _WebSocketRequestState,
 )
@@ -580,6 +584,7 @@ class _HTTPBridgeUpstreamEventsMixin:
             matched_request_state = None
             created_request_state = None
             suppress_downstream_event = False
+            deferred_reasoning_prelude_event = False
             has_other_pending_requests = False
             grouped_previous_response_request_states: list[_WebSocketRequestState] = []
             anonymous_event_prefers_draining = event_type not in {"response.failed", "response.incomplete", "error"}
@@ -645,6 +650,11 @@ class _HTTPBridgeUpstreamEventsMixin:
                 if payload is not None:
                     payload = _rewrite_websocket_downstream_response_id(payload, matched_request_state)
                     event_block = format_sse_event(payload)
+                if _websocket_should_defer_reasoning_prelude(matched_request_state, event_type, payload):
+                    matched_request_state.deferred_reasoning_downstream_texts.append(event_block)
+                    matched_request_state.upstream_model_output_seen = True
+                    suppress_downstream_event = True
+                    deferred_reasoning_prelude_event = True
 
             terminal_request_state = None
             if event_type in {"response.completed", "response.failed", "response.incomplete", "error"}:
@@ -773,11 +783,12 @@ class _HTTPBridgeUpstreamEventsMixin:
         if len(grouped_previous_response_request_states) == 1 and terminal_request_state is None:
             terminal_request_state = grouped_previous_response_request_states[0]
 
-        if matched_request_state is terminal_request_state:
-            _record_response_event(matched_request_state, event_type)
-        else:
-            _record_response_event(matched_request_state, event_type)
-            _record_response_event(terminal_request_state, event_type)
+        if not deferred_reasoning_prelude_event:
+            if matched_request_state is terminal_request_state:
+                _record_response_event(matched_request_state, event_type)
+            else:
+                _record_response_event(matched_request_state, event_type)
+                _record_response_event(terminal_request_state, event_type)
 
         status_request_state = terminal_request_state or matched_request_state
         if status_request_state is None and is_previous_response_not_found_event:
@@ -1185,7 +1196,9 @@ class _HTTPBridgeUpstreamEventsMixin:
                     and bool(terminal_request_state.request_text)
                     and terminal_request_state.preferred_account_id != session.account.id
                     and _websocket_auth_request_can_switch_account(terminal_request_state)
+                    and _websocket_request_can_replay_before_visible_output(terminal_request_state)
                 )
+                _clear_websocket_deferred_reasoning_downstream_texts(terminal_request_state)
                 if terminal_request_state.event_queue is not None:
                     await terminal_request_state.event_queue.put(
                         format_sse_event(
@@ -1218,12 +1231,16 @@ class _HTTPBridgeUpstreamEventsMixin:
             and matched_request_state.event_queue is not None
             and not suppress_downstream_event
         ):
+            for deferred_text in _pop_websocket_deferred_reasoning_downstream_texts(matched_request_state):
+                await matched_request_state.event_queue.put(deferred_text)
             await matched_request_state.event_queue.put(event_block)
 
         if terminal_request_state is None:
             return
 
         if terminal_request_state is not matched_request_state and terminal_request_state.event_queue is not None:
+            for deferred_text in _pop_websocket_deferred_reasoning_downstream_texts(terminal_request_state):
+                await terminal_request_state.event_queue.put(deferred_text)
             await terminal_request_state.event_queue.put(event_block)
         if terminal_request_state.event_queue is not None:
             await terminal_request_state.event_queue.put(None)

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -353,6 +353,8 @@ class _StreamingRetryMixin:
         current_account_lease: AccountLease | None = None
         last_security_work_retry_error: _RetryableStreamError | None = None
         excluded_account_ids: set[str] = set()
+        transient_failed_account_id: str | None = None
+        hard_affinity_same_owner_retry_attempted = False
         deferred_capacity_account: Account | None = None
         deferred_capacity_lease: AccountLease | None = None
         preferred_account_id: str | None = None
@@ -893,6 +895,26 @@ class _StreamingRetryMixin:
                         await _release_tracked_stream_lease(deferred_capacity_lease)
                         deferred_capacity_account = None
                         deferred_capacity_lease = None
+                    if (
+                        not account
+                        and selection.error_code == "hard_affinity_saturated"
+                        and transient_failed_account_id is not None
+                        and transient_failed_account_id in excluded_account_ids
+                        and not hard_affinity_same_owner_retry_attempted
+                    ):
+                        # A hard CODEX_SESSION row can resolve only to its owner.
+                        # If the transport just excluded that same account after
+                        # a pre-visible transient failure, alternate selection is
+                        # impossible by construction. Retry the known owner once
+                        # without weakening or rebinding the durable affinity.
+                        excluded_account_ids.discard(transient_failed_account_id)
+                        hard_affinity_same_owner_retry_attempted = True
+                        _facade().logger.info(
+                            "Retrying transient stream failure on hard affinity owner request_id=%s account_id=%s",
+                            request_id,
+                            transient_failed_account_id,
+                        )
+                        continue
                     if (
                         not account
                         and (
@@ -1735,6 +1757,7 @@ class _StreamingRetryMixin:
                                 )
                                 if action == "failover_next":
                                     last_transient_exc = tex
+                                    transient_failed_account_id = account.id
                                     await _release_tracked_stream_lease(current_account_lease)
                                     current_account_lease = None
                                     excluded_account_ids.add(account.id)

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -1072,15 +1072,27 @@ def _websocket_should_defer_reasoning_prelude(
     event_type: str | None,
     payload: Mapping[str, JsonValue] | None,
 ) -> bool:
-    if request_state is None or not _websocket_is_reasoning_output_item_event(event_type, payload):
+    if request_state is None:
         return False
     if request_state.downstream_visible:
         return False
+    reasoning_output_item_event = _websocket_is_reasoning_output_item_event(event_type, payload)
     # Once a reasoning prelude starts, keep the whole prelude buffered.  The
     # first reasoning item marks upstream model output as seen so replay stays
-    # disabled; that marker must not make the next reasoning item visible.
-    if request_state.deferred_reasoning_downstream_texts:
+    # disabled; that marker must not make subsequent reasoning deltas visible.
+    if request_state.deferred_reasoning_downstream_texts and (
+        reasoning_output_item_event
+        or event_type
+        in {
+            "response.reasoning_text.delta",
+            "response.reasoning_text.done",
+            "response.reasoning_summary_text.delta",
+            "response.reasoning_summary_text.done",
+        }
+    ):
         return True
+    if not reasoning_output_item_event:
+        return False
     if request_state.upstream_model_output_seen:
         return False
     if request_state.pending_function_call_ids or request_state.pending_tool_call_types:

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -804,6 +804,7 @@ class _WebSocketRequestState:
     upstream_error_code_override: str | None = None
     error_http_status_override: int | None = None
     response_event_count: int = 0
+    upstream_model_output_seen: bool = False
     previous_response_not_found_rewritten: bool = False
     previous_response_owner_lookup_source: str | None = None
     previous_response_owner_lookup_outcome: str | None = None
@@ -837,6 +838,7 @@ class _WebSocketRequestState:
     client_ip: str | None = None
     downstream_visible: bool = False
     last_downstream_sequence_number: int | None = None
+    deferred_reasoning_downstream_texts: list[str] = field(default_factory=list)
     suppress_next_created_downstream: bool = False
     replay_downstream_response_id: str | None = None
     draining_until_terminal: bool = False
@@ -1058,6 +1060,40 @@ def _clear_websocket_precreated_replay_fallback(request_state: _WebSocketRequest
     _clear_websocket_request_error_overrides(request_state)
 
 
+def _websocket_is_reasoning_output_item_event(event_type: str | None, payload: Mapping[str, JsonValue] | None) -> bool:
+    if event_type not in {"response.output_item.added", "response.output_item.done"} or payload is None:
+        return False
+    item = payload.get("item")
+    return isinstance(item, Mapping) and item.get("type") == "reasoning"
+
+
+def _websocket_should_defer_reasoning_prelude(
+    request_state: _WebSocketRequestState | None,
+    event_type: str | None,
+    payload: Mapping[str, JsonValue] | None,
+) -> bool:
+    if request_state is None or not _websocket_is_reasoning_output_item_event(event_type, payload):
+        return False
+    if request_state.downstream_visible or request_state.upstream_model_output_seen:
+        return False
+    if request_state.pending_function_call_ids or request_state.pending_tool_call_types:
+        return False
+    return request_state.response_event_count <= 1
+
+
+def _pop_websocket_deferred_reasoning_downstream_texts(request_state: _WebSocketRequestState | None) -> list[str]:
+    if request_state is None or not request_state.deferred_reasoning_downstream_texts:
+        return []
+    deferred_texts = request_state.deferred_reasoning_downstream_texts
+    request_state.deferred_reasoning_downstream_texts = []
+    return deferred_texts
+
+
+def _clear_websocket_deferred_reasoning_downstream_texts(request_state: _WebSocketRequestState | None) -> None:
+    if request_state is not None:
+        request_state.deferred_reasoning_downstream_texts = []
+
+
 def _record_response_event(request_state: _WebSocketRequestState | None, event_type: str | None) -> None:
     if request_state is None or event_type is None or not event_type.startswith("response."):
         return
@@ -1082,6 +1118,8 @@ def _websocket_request_can_replay_before_visible_output(request_state: _WebSocke
     if request_state.last_downstream_sequence_number is not None and not sequenced_created_only_prewarm:
         return False
     if request_state.downstream_visible:
+        return False
+    if request_state.upstream_model_output_seen:
         return False
     has_retry_safe_fresh_payload = (
         request_state.fresh_upstream_request_is_retry_safe and request_state.fresh_upstream_request_text is not None

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -1074,7 +1074,14 @@ def _websocket_should_defer_reasoning_prelude(
 ) -> bool:
     if request_state is None or not _websocket_is_reasoning_output_item_event(event_type, payload):
         return False
-    if request_state.downstream_visible or request_state.upstream_model_output_seen:
+    if request_state.downstream_visible:
+        return False
+    # Once a reasoning prelude starts, keep the whole prelude buffered.  The
+    # first reasoning item marks upstream model output as seen so replay stays
+    # disabled; that marker must not make the next reasoning item visible.
+    if request_state.deferred_reasoning_downstream_texts:
+        return True
+    if request_state.upstream_model_output_seen:
         return False
     if request_state.pending_function_call_ids or request_state.pending_tool_call_types:
         return False

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -866,14 +866,21 @@ class _WebSocketMixin:
                         )
                         await _release_websocket_response_create_gate(request_state, response_create_gate)
                         continue
-                    async with pending_lock:
-                        pending_requests.append(request_state)
-                    proxy._start_request_state_api_key_reservation_heartbeat(
-                        request_state,
-                        api_key=request_state.api_key or api_key,
-                        surface="websocket",
-                    )
-                    request_state_registered = True
+                    if request_state.response_create_gate_acquired:
+                        # Ordinary pre-created replay retains its create gate.
+                        # Re-register it without trying to acquire the same
+                        # non-reentrant semaphore a second time.
+                        async with pending_lock:
+                            pending_requests.append(request_state)
+                        proxy._start_request_state_api_key_reservation_heartbeat(
+                            request_state,
+                            api_key=request_state.api_key or api_key,
+                            surface="websocket",
+                        )
+                        request_state_registered = True
+                    # A terminal security event released the create gate and
+                    # account admission.  Leave that replay unregistered so the
+                    # normal block below reacquires both before queue and send.
                 else:
                     downstream_idle_timeout_seconds = runtime_settings.proxy_downstream_websocket_idle_timeout_seconds
                     message: Any | None = None

--- a/app/modules/proxy/affinity.py
+++ b/app/modules/proxy/affinity.py
@@ -87,14 +87,7 @@ class _AffinityPolicy:
         str | None,
     ]:
         if sticky_source != "session_header":
-            return (
-                sticky_key,
-                sticky_kind,
-                reallocate_sticky,
-                sticky_max_age_seconds,
-                sticky_source,
-                legacy_sticky_key,
-            )
+            return None, None, False, sticky_max_age_seconds, None, None
         # A resolved response/file/bridge owner bypasses the new soft row, but
         # the raw compatibility row still has to be checked for conflicting
         # legacy hard ownership. Selection receives no writable sticky key, so

--- a/app/modules/proxy/affinity.py
+++ b/app/modules/proxy/affinity.py
@@ -87,7 +87,14 @@ class _AffinityPolicy:
         str | None,
     ]:
         if sticky_source != "session_header":
-            return None, None, False, sticky_max_age_seconds, None, None
+            return (
+                sticky_key,
+                sticky_kind,
+                reallocate_sticky,
+                sticky_max_age_seconds,
+                sticky_source,
+                legacy_sticky_key,
+            )
         # A resolved response/file/bridge owner bypasses the new soft row, but
         # the raw compatibility row still has to be checked for conflicting
         # legacy hard ownership. Selection receives no writable sticky key, so

--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -94,13 +94,25 @@ class DurableBridgeSessionCoordinator:
                     same_account_snapshots = [
                         snapshot for _alias_kind, snapshot in resolved_aliases if snapshot.account_id == account_id
                     ]
-                    account_snapshot = next(
-                        (snapshot for snapshot in same_account_snapshots if snapshot.latest_response_id is not None),
-                        same_account_snapshots[0],
+                    requested_response_snapshot = next(
+                        (
+                            snapshot
+                            for alias_kind, snapshot in resolved_aliases
+                            if alias_kind == _DURABLE_PREVIOUS_RESPONSE_ALIAS and snapshot.account_id == account_id
+                        ),
+                        None,
                     )
-                    # Alias priority decides otherwise equivalent snapshots, but
-                    # an existing response anchor is continuity state and must
-                    # survive a same-account blue-green handoff.
+                    account_snapshot = requested_response_snapshot or max(
+                        same_account_snapshots,
+                        key=lambda snapshot: (
+                            snapshot.latest_response_id is not None,
+                            snapshot.last_seen_at,
+                        ),
+                    )
+                    # Same-account aliases may point at different durable rows
+                    # during a handoff. Preserve an explicitly requested
+                    # response anchor; otherwise prefer the newest persisted
+                    # response anchor rather than alias-resolution order.
                     return _to_lookup(account_snapshot)
                 specific_aliases = [
                     (alias_kind, snapshot)

--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -83,7 +83,25 @@ class DurableBridgeSessionCoordinator:
                 if snapshot is not None:
                     resolved_aliases.append((alias_kind, snapshot))
             resolved_identities = {(snapshot.id, snapshot.account_id) for _alias_kind, snapshot in resolved_aliases}
+            resolved_account_ids = {
+                snapshot.account_id for _alias_kind, snapshot in resolved_aliases if snapshot.account_id is not None
+            }
+            has_ownerless_snapshot = any(snapshot.account_id is None for _alias_kind, snapshot in resolved_aliases)
             if len(resolved_identities) > 1:
+                same_account_handoff = len(resolved_account_ids) == 1 and not has_ownerless_snapshot
+                if same_account_handoff:
+                    account_id = next(iter(resolved_account_ids))
+                    same_account_snapshots = [
+                        snapshot for _alias_kind, snapshot in resolved_aliases if snapshot.account_id == account_id
+                    ]
+                    account_snapshot = next(
+                        (snapshot for snapshot in same_account_snapshots if snapshot.latest_response_id is not None),
+                        same_account_snapshots[0],
+                    )
+                    # Alias priority decides otherwise equivalent snapshots, but
+                    # an existing response anchor is continuity state and must
+                    # survive a same-account blue-green handoff.
+                    return _to_lookup(account_snapshot)
                 specific_aliases = [
                     (alias_kind, snapshot)
                     for alias_kind, snapshot in resolved_aliases

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -83,6 +83,7 @@ class DurableBridgeSessionSnapshot:
     latest_response_id: str | None
     latest_input_item_count: int | None
     latest_input_full_fingerprint: str | None
+    last_seen_at: datetime
     closed_at: datetime | None
 
 
@@ -1060,6 +1061,7 @@ _SNAPSHOT_COLUMNS = (
     HttpBridgeSessionRecord.latest_response_id,
     HttpBridgeSessionRecord.latest_input_item_count,
     HttpBridgeSessionRecord.latest_input_full_fingerprint,
+    HttpBridgeSessionRecord.last_seen_at,
     HttpBridgeSessionRecord.closed_at,
 )
 
@@ -1083,6 +1085,7 @@ def _returned_row_to_snapshot(row: Row[tuple[object, ...]]) -> DurableBridgeSess
         latest_response_id=mapping[HttpBridgeSessionRecord.latest_response_id],
         latest_input_item_count=mapping[HttpBridgeSessionRecord.latest_input_item_count],
         latest_input_full_fingerprint=mapping[HttpBridgeSessionRecord.latest_input_full_fingerprint],
+        last_seen_at=mapping[HttpBridgeSessionRecord.last_seen_at],
         closed_at=mapping[HttpBridgeSessionRecord.closed_at],
     )
 
@@ -1107,6 +1110,7 @@ def _to_snapshot(row: HttpBridgeSessionRecord | None) -> DurableBridgeSessionSna
         latest_response_id=row.latest_response_id,
         latest_input_item_count=row.latest_input_item_count,
         latest_input_full_fingerprint=row.latest_input_full_fingerprint,
+        last_seen_at=row.last_seen_at,
         closed_at=row.closed_at,
     )
 

--- a/openspec/changes/fail-closed-http-bridge-security-retry/proposal.md
+++ b/openspec/changes/fail-closed-http-bridge-security-retry/proposal.md
@@ -1,0 +1,15 @@
+## Why
+
+HTTP bridge security-work failover must not reconnect a request once the client
+has an upstream continuity anchor or model output, including deferred reasoning.
+
+## What Changes
+
+- Make HTTP bridge security retry fail closed after `response.created` or any
+  upstream model output.
+- Preserve a bounded, file-free pre-created retry while clearing stale affinity
+  and restoring state after reconnect failure.
+
+## Impact
+
+- HTTP bridge security retry and Responses compatibility contract.

--- a/openspec/changes/fail-closed-http-bridge-security-retry/proposal.md
+++ b/openspec/changes/fail-closed-http-bridge-security-retry/proposal.md
@@ -9,6 +9,9 @@ has an upstream continuity anchor or model output, including deferred reasoning.
   upstream model output.
 - Preserve a bounded, file-free pre-created retry while clearing stale affinity
   and restoring state after reconnect failure.
+- Preserve hard session-header ownership during pre-created reconnects, clear
+  stale turn-state headers, and retire partially rebound replacements when the
+  resend fails.
 
 ## Impact
 

--- a/openspec/changes/fail-closed-http-bridge-security-retry/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fail-closed-http-bridge-security-retry/specs/responses-api-compat/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: HTTP bridge security retries fail closed after an anchor or output
+
+For HTTP bridge requests, the service MUST retry security-work authorization on
+another account only before `response.created` and before any upstream model
+output. A buffered reasoning prelude counts as upstream model output even while
+it is withheld from downstream pending the security decision. The retry MUST
+clear stale turn affinity before a permitted file-free replacement attempt and
+MUST restore the original safe state if reconnect fails. File-pinned requests
+MUST NOT migrate.
+
+#### Scenario: Created HTTP bridge response is not replayed
+
+- **WHEN** an HTTP bridge request has emitted `response.created` before a
+  security-work authorization denial
+- **THEN** the service does not reconnect or resend the request on another account
+- **AND** it forwards the original terminal error
+
+#### Scenario: Deferred reasoning blocks replay
+
+- **WHEN** an HTTP bridge request buffers a reasoning prelude before a
+  security-work authorization denial
+- **THEN** that prelude blocks account-switch replay and is not emitted before
+  the terminal security decision

--- a/openspec/changes/fail-closed-http-bridge-security-retry/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fail-closed-http-bridge-security-retry/specs/responses-api-compat/spec.md
@@ -5,10 +5,14 @@
 For HTTP bridge requests, the service MUST retry security-work authorization on
 another account only before `response.created` and before any upstream model
 output. A buffered reasoning prelude counts as upstream model output even while
-it is withheld from downstream pending the security decision. The retry MUST
-clear stale turn affinity before a permitted file-free replacement attempt and
-MUST restore the original safe state if reconnect fails. File-pinned requests
-MUST NOT migrate.
+it is withheld from downstream pending the security decision. A permitted
+file-free retry MUST select the replacement with cleared request and session
+affinity, but MUST validate any raw legacy owner before changing the live
+session or its durable owner generation. On success it MUST make exactly one
+durable replacement claim before swapping the session, then clear or replace
+the session affinity and local turn-state aliases. A legacy-owner conflict MUST
+leave the original session open and unchanged. File-pinned requests MUST NOT
+migrate.
 
 #### Scenario: Created HTTP bridge response is not replayed
 
@@ -23,3 +27,11 @@ MUST NOT migrate.
   security-work authorization denial
 - **THEN** that prelude blocks account-switch replay and is not emitted before
   the terminal security decision
+
+#### Scenario: Legacy owner conflict fails before replacement mutation
+
+- **GIVEN** a session-header security retry selects an authorized replacement account
+- **AND** the raw legacy affinity row belongs to a different account
+- **WHEN** the service validates the replacement
+- **THEN** it does not claim the durable session for the replacement
+- **AND** it leaves the original account, upstream, owner generation, aliases, and open session unchanged

--- a/openspec/changes/fail-closed-http-bridge-security-retry/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fail-closed-http-bridge-security-retry/specs/responses-api-compat/spec.md
@@ -12,7 +12,17 @@ session or its durable owner generation. On success it MUST make exactly one
 durable replacement claim before swapping the session, then clear or replace
 the session affinity and local turn-state aliases. A legacy-owner conflict MUST
 leave the original session open and unchanged. File-pinned requests MUST NOT
-migrate.
+migrate. A pre-created reconnect for a hard session-header bridge MUST remain
+bound to its established account, and a replacement connection MUST NOT inherit
+a stale turn-state header when it has no replacement turn state. If a permitted
+security retry swaps durable ownership but cannot submit `response.create` on
+the replacement socket, the replacement bridge MUST be retired rather than
+left reusable with partially rebound aliases. Once a reasoning prelude is
+buffered, all following reasoning-prelude events MUST remain buffered until the
+terminal security decision.
+For a direct WebSocket security retry, the service MUST reacquire the per-session
+create gate and shared/account create admission before queuing or sending the
+replay on the authorized replacement socket.
 
 #### Scenario: Created HTTP bridge response is not replayed
 
@@ -27,6 +37,27 @@ migrate.
   security-work authorization denial
 - **THEN** that prelude blocks account-switch replay and is not emitted before
   the terminal security decision
+
+#### Scenario: Hard session reconnect preserves one owner
+
+- **GIVEN** a pre-created HTTP bridge request uses a hard session-header key
+- **WHEN** its upstream socket closes before visible output
+- **THEN** the reconnect requires the established account
+- **AND** the session turn-state and owner affinity are not cleared for migration
+
+#### Scenario: Failed replacement resend retires the bridge
+
+- **GIVEN** a permitted security retry has swapped the bridge to an authorized account
+- **WHEN** submitting `response.create` on that replacement socket fails
+- **THEN** the replacement bridge is marked for retirement
+- **AND** it is not left reusable with partially rebound continuity aliases
+
+#### Scenario: Direct WebSocket security replay reacquires admission
+
+- **GIVEN** a direct WebSocket security denial releases the first attempt's create admission
+- **WHEN** the request is replayed on an authorized replacement account
+- **THEN** the service reacquires create admission before queuing the replay
+- **AND** the replay remains subject to the normal startup timeout and serialization gate
 
 #### Scenario: Legacy owner conflict fails before replacement mutation
 

--- a/openspec/changes/fail-closed-http-bridge-security-retry/tasks.md
+++ b/openspec/changes/fail-closed-http-bridge-security-retry/tasks.md
@@ -1,3 +1,4 @@
 - [x] 1. Block security retry after a created anchor or deferred upstream reasoning output.
-- [x] 2. Clear stale turn affinity only for a permitted pre-created retry and restore it on reconnect failure.
+- [x] 2. Validate raw legacy ownership before one durable replacement claim and the session/alias swap for a permitted pre-created retry.
 - [x] 3. Cover deferred-output replay blocking and preserve pinned-request denial coverage.
+- [x] 4. Cover turn-state and session-header replacement success plus legacy-owner conflict rollback ordering.

--- a/openspec/changes/fail-closed-http-bridge-security-retry/tasks.md
+++ b/openspec/changes/fail-closed-http-bridge-security-retry/tasks.md
@@ -2,3 +2,6 @@
 - [x] 2. Validate raw legacy ownership before one durable replacement claim and the session/alias swap for a permitted pre-created retry.
 - [x] 3. Cover deferred-output replay blocking and preserve pinned-request denial coverage.
 - [x] 4. Cover turn-state and session-header replacement success plus legacy-owner conflict rollback ordering.
+- [x] 5. Keep hard session-header pre-created reconnects on their established owner and strip stale turn-state headers when no replacement turn state exists.
+- [x] 6. Retire a replacement bridge when the post-swap security resend fails, and keep an entire reasoning prelude buffered until the terminal security decision.
+- [x] 7. Reacquire direct-WebSocket create admission before queuing a security replay on the authorized replacement.

--- a/openspec/changes/fail-closed-http-bridge-security-retry/tasks.md
+++ b/openspec/changes/fail-closed-http-bridge-security-retry/tasks.md
@@ -1,0 +1,3 @@
+- [x] 1. Block security retry after a created anchor or deferred upstream reasoning output.
+- [x] 2. Clear stale turn affinity only for a permitted pre-created retry and restore it on reconnect failure.
+- [x] 3. Cover deferred-output replay blocking and preserve pinned-request denial coverage.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -1422,6 +1422,31 @@ When an upstream Responses request fails because the work requires cybersecurity
 - **THEN** codex-lb releases the request's response-create gate before scheduling the replay
 - **AND** the replay can acquire the gate instead of blocking behind the failed first attempt
 
+### Requirement: HTTP bridge security retries fail closed after an anchor or output
+
+For HTTP bridge requests, the service MUST retry security-work authorization on
+another account only before `response.created` and before any upstream model
+output. A buffered reasoning prelude counts as upstream model output even while
+it is withheld from downstream pending the security decision. The retry MUST
+clear stale turn affinity before a permitted file-free replacement attempt and
+MUST restore the original safe state if reconnect fails. File-pinned requests
+MUST NOT migrate.
+
+#### Scenario: Created HTTP bridge response is not replayed
+
+- **WHEN** an HTTP bridge request has emitted `response.created` before a
+  security-work authorization denial
+- **THEN** the service does not reconnect or resend the request on another
+  account
+- **AND** it forwards the original terminal error
+
+#### Scenario: Deferred reasoning blocks replay
+
+- **WHEN** an HTTP bridge request buffers a reasoning prelude before a
+  security-work authorization denial
+- **THEN** that prelude blocks account-switch replay and is not emitted before
+  the terminal security decision
+
 ### Requirement: Responses request compatibility controls
 
 The system SHALL accept OpenAI-compatible Responses request controls that clients may send for `/v1/responses` and `/backend-api/codex/responses` when those controls can be safely normalized before the ChatGPT-backed upstream request. Specifically, `truncation` values `"auto"` and `"disabled"` MUST pass request validation and MUST be omitted from the upstream payload because the current ChatGPT-backed path does not consume the field. Unsupported `truncation` values MUST still be rejected with HTTP 400.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -683,6 +683,20 @@ When serving HTTP `/v1/responses` or HTTP `/backend-api/codex/responses`, the se
 - **AND** same-account takeover MUST preserve the latest persisted response anchor until a replacement response id is recorded
 - **AND** normal client retries MUST NOT be stranded waiting for the old instance lease to expire
 
+When request aliases resolve to different durable rows for the same account,
+an explicitly requested previous-response alias MUST select its row even if
+that row has since advanced to a newer response id. Without an explicitly
+resolved previous-response alias, recovery MUST select the freshest row that
+contains a persisted response anchor rather than using alias enumeration order.
+
+#### Scenario: requested durable response alias survives same-account row divergence
+
+- **GIVEN** turn-state and previous-response aliases resolve to different durable rows for the same account
+- **AND** the request names the previous-response alias whose row has since advanced to a newer response id
+- **WHEN** the service resolves durable continuity
+- **THEN** it selects the row resolved by the requested previous-response alias
+- **AND** it preserves that row's latest persisted response anchor
+
 ### Requirement: Responses account selection accounts for in-flight pressure
 
 For Responses API requests, usage-based routing MUST include immediate in-process account pressure in addition to persisted usage. Account selection MUST account for in-flight response-create work, active streams, leased token/cost estimates, recent selection pressure, account health, and configured account-local caps. Selection and lease acquisition MUST be atomic with respect to other in-process selections, and the critical section MUST NOT perform database calls, network calls, sleeps, or other blocking I/O.
@@ -1427,10 +1441,14 @@ When an upstream Responses request fails because the work requires cybersecurity
 For HTTP bridge requests, the service MUST retry security-work authorization on
 another account only before `response.created` and before any upstream model
 output. A buffered reasoning prelude counts as upstream model output even while
-it is withheld from downstream pending the security decision. The retry MUST
-clear stale turn affinity before a permitted file-free replacement attempt and
-MUST restore the original safe state if reconnect fails. File-pinned requests
-MUST NOT migrate.
+it is withheld from downstream pending the security decision. A permitted
+file-free retry MUST select the replacement with cleared request and session
+affinity, but MUST validate any raw legacy owner before changing the live
+session or its durable owner generation. On success it MUST make exactly one
+durable replacement claim before swapping the session, then clear or replace
+the session affinity and local turn-state aliases. A legacy-owner conflict MUST
+leave the original session open and unchanged. File-pinned requests MUST NOT
+migrate.
 
 #### Scenario: Created HTTP bridge response is not replayed
 
@@ -1446,6 +1464,14 @@ MUST NOT migrate.
   security-work authorization denial
 - **THEN** that prelude blocks account-switch replay and is not emitted before
   the terminal security decision
+
+#### Scenario: Legacy owner conflict fails before replacement mutation
+
+- **GIVEN** a session-header security retry selects an authorized replacement account
+- **AND** the raw legacy affinity row belongs to a different account
+- **WHEN** the service validates the replacement
+- **THEN** it does not claim the durable session for the replacement
+- **AND** it leaves the original account, upstream, owner generation, aliases, and open session unchanged
 
 ### Requirement: Responses request compatibility controls
 

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -287,6 +287,129 @@ async def test_reversible_recovery_rollback_does_not_restore_reclaimed_predecess
     )
 
 
+
+@pytest.mark.asyncio
+async def test_durable_bridge_lookup_accepts_same_account_alias_session_divergence(
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    turn_owner = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-turn-owner",
+        api_key_id="key-same-account",
+        instance_id="instance-a",
+        lease_ttl_seconds=120.0,
+        account_id="acc-shared",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id=None,
+        allow_takeover=True,
+    )
+    response_owner = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-response-owner",
+        api_key_id="key-same-account",
+        instance_id="instance-b",
+        lease_ttl_seconds=120.0,
+        account_id="acc-shared",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id=None,
+        allow_takeover=True,
+    )
+    await coordinator.register_turn_state(
+        session_id=turn_owner.session_id,
+        api_key_id="key-same-account",
+        instance_id="instance-a",
+        owner_epoch=turn_owner.owner_epoch,
+        turn_state="http_turn_same_account_owner",
+        lease_ttl_seconds=120.0,
+    )
+    await coordinator.register_previous_response_id(
+        session_id=response_owner.session_id,
+        api_key_id="key-same-account",
+        instance_id="instance-b",
+        owner_epoch=response_owner.owner_epoch,
+        response_id="resp_same_account_owner",
+        lease_ttl_seconds=120.0,
+    )
+
+    lookup = await coordinator.lookup_request_targets(
+        session_key_kind="request",
+        session_key_value="req-same-account-owner",
+        api_key_id="key-same-account",
+        turn_state="http_turn_same_account_owner",
+        session_header=None,
+        previous_response_id="resp_same_account_owner",
+    )
+
+    assert lookup is not None
+    assert lookup.session_id == response_owner.session_id
+    assert lookup.account_id == "acc-shared"
+    assert lookup.latest_response_id == "resp_same_account_owner"
+
+
+@pytest.mark.asyncio
+async def test_durable_bridge_lookup_rejects_ownerless_and_live_alias_divergence(
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    ownerless = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-ownerless",
+        api_key_id="key-ownerless-conflict",
+        instance_id="instance-a",
+        lease_ttl_seconds=120.0,
+        account_id=None,
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id=None,
+        allow_takeover=True,
+    )
+    live_owner = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-live-owner",
+        api_key_id="key-ownerless-conflict",
+        instance_id="instance-b",
+        lease_ttl_seconds=120.0,
+        account_id="acc-live",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id=None,
+        allow_takeover=True,
+    )
+    await coordinator.register_turn_state(
+        session_id=ownerless.session_id,
+        api_key_id="key-ownerless-conflict",
+        instance_id="instance-a",
+        owner_epoch=ownerless.owner_epoch,
+        turn_state="http_turn_ownerless",
+        lease_ttl_seconds=120.0,
+    )
+    await coordinator.register_previous_response_id(
+        session_id=live_owner.session_id,
+        api_key_id="key-ownerless-conflict",
+        instance_id="instance-b",
+        owner_epoch=live_owner.owner_epoch,
+        response_id="resp_live_owner",
+        lease_ttl_seconds=120.0,
+    )
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await coordinator.lookup_request_targets(
+            session_key_kind="request",
+            session_key_value="req-ownerless-conflict",
+            api_key_id="key-ownerless-conflict",
+            turn_state="http_turn_ownerless",
+            session_header=None,
+            previous_response_id="resp_live_owner",
+        )
+
+    assert exc_info.value.payload["error"]["code"] == "continuity_owner_conflict"
+
+
 @pytest.mark.asyncio
 async def test_durable_bridge_lookup_rejects_conflicting_turn_and_response_aliases(
     coordinator: DurableBridgeSessionCoordinator,

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -291,6 +291,7 @@ async def test_reversible_recovery_rollback_does_not_restore_reclaimed_predecess
 @pytest.mark.asyncio
 async def test_durable_bridge_lookup_accepts_same_account_alias_session_divergence(
     coordinator: DurableBridgeSessionCoordinator,
+    async_session_factory: Callable[[], AsyncSession],
 ) -> None:
     turn_owner = await coordinator.claim_live_session(
         session_key_kind="session_header",
@@ -334,6 +335,13 @@ async def test_durable_bridge_lookup_accepts_same_account_alias_session_divergen
         response_id="resp_same_account_owner",
         lease_ttl_seconds=120.0,
     )
+    async with async_session_factory() as session:
+        await session.execute(
+            update(HttpBridgeSessionRecord)
+            .where(HttpBridgeSessionRecord.id == turn_owner.session_id)
+            .values(last_seen_at=utcnow() + timedelta(seconds=10))
+        )
+        await session.commit()
 
     lookup = await coordinator.lookup_request_targets(
         session_key_kind="request",
@@ -348,6 +356,178 @@ async def test_durable_bridge_lookup_accepts_same_account_alias_session_divergen
     assert lookup.session_id == response_owner.session_id
     assert lookup.account_id == "acc-shared"
     assert lookup.latest_response_id == "resp_same_account_owner"
+
+
+@pytest.mark.asyncio
+async def test_durable_bridge_lookup_prefers_newest_same_account_response_anchor(
+    coordinator: DurableBridgeSessionCoordinator,
+    async_session_factory: Callable[[], AsyncSession],
+) -> None:
+    turn_owner = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-turn-old-anchor",
+        api_key_id="key-newest-anchor",
+        instance_id="instance-a",
+        lease_ttl_seconds=120.0,
+        account_id="acc-shared",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id=None,
+        allow_takeover=True,
+    )
+    session_owner = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-session-new-anchor",
+        api_key_id="key-newest-anchor",
+        instance_id="instance-b",
+        lease_ttl_seconds=120.0,
+        account_id="acc-shared",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id=None,
+        allow_takeover=True,
+    )
+    await coordinator.register_turn_state(
+        session_id=turn_owner.session_id,
+        api_key_id="key-newest-anchor",
+        instance_id="instance-a",
+        owner_epoch=turn_owner.owner_epoch,
+        turn_state="turn-old-anchor",
+        lease_ttl_seconds=120.0,
+    )
+    await coordinator.register_previous_response_id(
+        session_id=turn_owner.session_id,
+        api_key_id="key-newest-anchor",
+        instance_id="instance-a",
+        owner_epoch=turn_owner.owner_epoch,
+        response_id="resp-old-anchor",
+        lease_ttl_seconds=120.0,
+    )
+    await coordinator.register_session_header(
+        session_id=session_owner.session_id,
+        api_key_id="key-newest-anchor",
+        session_header="sid-session-new-anchor",
+    )
+    await coordinator.register_previous_response_id(
+        session_id=session_owner.session_id,
+        api_key_id="key-newest-anchor",
+        instance_id="instance-b",
+        owner_epoch=session_owner.owner_epoch,
+        response_id="resp-new-anchor",
+        lease_ttl_seconds=120.0,
+    )
+    async with async_session_factory() as session:
+        await session.execute(
+            update(HttpBridgeSessionRecord)
+            .where(HttpBridgeSessionRecord.id == turn_owner.session_id)
+            .values(last_seen_at=utcnow() - timedelta(seconds=10))
+        )
+        await session.execute(
+            update(HttpBridgeSessionRecord)
+            .where(HttpBridgeSessionRecord.id == session_owner.session_id)
+            .values(last_seen_at=utcnow())
+        )
+        await session.commit()
+
+    lookup = await coordinator.lookup_request_targets(
+        session_key_kind="request",
+        session_key_value="req-newest-anchor",
+        api_key_id="key-newest-anchor",
+        turn_state="turn-old-anchor",
+        session_header="sid-session-new-anchor",
+        previous_response_id=None,
+    )
+
+    assert lookup is not None
+    assert lookup.session_id == session_owner.session_id
+    assert lookup.latest_response_id == "resp-new-anchor"
+
+
+@pytest.mark.asyncio
+async def test_durable_bridge_lookup_preserves_requested_response_alias_after_anchor_advances(
+    coordinator: DurableBridgeSessionCoordinator,
+    async_session_factory: Callable[[], AsyncSession],
+) -> None:
+    requested_owner = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-requested-anchor",
+        api_key_id="key-requested-anchor",
+        instance_id="instance-a",
+        lease_ttl_seconds=120.0,
+        account_id="acc-shared",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id=None,
+        allow_takeover=True,
+    )
+    fresher_turn_owner = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-fresher-turn",
+        api_key_id="key-requested-anchor",
+        instance_id="instance-b",
+        lease_ttl_seconds=120.0,
+        account_id="acc-shared",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id=None,
+        allow_takeover=True,
+    )
+    await coordinator.register_previous_response_id(
+        session_id=requested_owner.session_id,
+        api_key_id="key-requested-anchor",
+        instance_id="instance-a",
+        owner_epoch=requested_owner.owner_epoch,
+        response_id="resp-requested-old",
+        lease_ttl_seconds=120.0,
+    )
+    await coordinator.register_previous_response_id(
+        session_id=requested_owner.session_id,
+        api_key_id="key-requested-anchor",
+        instance_id="instance-a",
+        owner_epoch=requested_owner.owner_epoch,
+        response_id="resp-requested-latest",
+        lease_ttl_seconds=120.0,
+    )
+    await coordinator.register_turn_state(
+        session_id=fresher_turn_owner.session_id,
+        api_key_id="key-requested-anchor",
+        instance_id="instance-b",
+        owner_epoch=fresher_turn_owner.owner_epoch,
+        turn_state="turn-fresher-than-requested",
+        lease_ttl_seconds=120.0,
+    )
+    await coordinator.register_previous_response_id(
+        session_id=fresher_turn_owner.session_id,
+        api_key_id="key-requested-anchor",
+        instance_id="instance-b",
+        owner_epoch=fresher_turn_owner.owner_epoch,
+        response_id="resp-fresher-turn",
+        lease_ttl_seconds=120.0,
+    )
+    async with async_session_factory() as session:
+        await session.execute(
+            update(HttpBridgeSessionRecord)
+            .where(HttpBridgeSessionRecord.id == fresher_turn_owner.session_id)
+            .values(last_seen_at=utcnow() + timedelta(seconds=10))
+        )
+        await session.commit()
+
+    lookup = await coordinator.lookup_request_targets(
+        session_key_kind="request",
+        session_key_value="req-requested-anchor",
+        api_key_id="key-requested-anchor",
+        turn_state="turn-fresher-than-requested",
+        session_header=None,
+        previous_response_id="resp-requested-old",
+    )
+
+    assert lookup is not None
+    assert lookup.session_id == requested_owner.session_id
+    assert lookup.latest_response_id == "resp-requested-latest"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -287,7 +287,6 @@ async def test_reversible_recovery_rollback_does_not_restore_reclaimed_predecess
     )
 
 
-
 @pytest.mark.asyncio
 async def test_durable_bridge_lookup_accepts_same_account_alias_session_divergence(
     coordinator: DurableBridgeSessionCoordinator,

--- a/tests/unit/test_proxy_security_work.py
+++ b/tests/unit/test_proxy_security_work.py
@@ -8,6 +8,7 @@ import anyio
 import pytest
 
 from app.modules.proxy import service as proxy_service
+from app.modules.proxy._service.support import _websocket_request_can_replay_before_visible_output
 from tests.unit.test_proxy_utils import _make_account, _repo_factory, _RequestLogsRecorder
 
 pytestmark = pytest.mark.unit
@@ -71,3 +72,23 @@ async def test_process_websocket_security_retry_releases_response_create_gate() 
     assert request_state.response_create_gate is None
     await asyncio.wait_for(gate.acquire(), timeout=0.1)
     gate.release()
+
+
+def test_http_bridge_deferred_reasoning_blocks_previsible_replay() -> None:
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="http_security_deferred_reasoning",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        transport="http",
+        awaiting_response_created=False,
+        response_id="resp_security_deferred_reasoning",
+        response_event_count=1,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":[]}',
+        upstream_model_output_seen=True,
+        deferred_reasoning_downstream_texts=['data: {"type":"response.output_item.added"}\n\n'],
+    )
+
+    assert not _websocket_request_can_replay_before_visible_output(request_state)

--- a/tests/unit/test_proxy_security_work.py
+++ b/tests/unit/test_proxy_security_work.py
@@ -3,13 +3,27 @@ from __future__ import annotations
 import asyncio
 import json
 from collections import deque
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import anyio
 import pytest
+from fastapi import WebSocket
 
 from app.modules.proxy import service as proxy_service
-from app.modules.proxy._service.support import _websocket_request_can_replay_before_visible_output
-from tests.unit.test_proxy_utils import _make_account, _repo_factory, _RequestLogsRecorder
+from app.modules.proxy._service.support import (
+    _websocket_request_can_replay_before_visible_output,
+    _websocket_should_defer_reasoning_prelude,
+)
+from tests.unit.test_proxy_utils import (
+    _make_account,
+    _make_proxy_settings,
+    _QueuedTestUpstreamWebSocket,
+    _repo_factory,
+    _RequestLogsRecorder,
+    _SettingsCache,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -92,3 +106,164 @@ def test_http_bridge_deferred_reasoning_blocks_previsible_replay() -> None:
     )
 
     assert not _websocket_request_can_replay_before_visible_output(request_state)
+
+
+def test_http_bridge_buffers_entire_reasoning_prelude_before_security_decision() -> None:
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="http_security_multi_reasoning",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        transport="http",
+        awaiting_response_created=False,
+        response_id="resp_security_multi_reasoning",
+        response_event_count=2,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":[]}',
+        upstream_model_output_seen=True,
+        deferred_reasoning_downstream_texts=['data: {"type":"response.output_item.added"}\n\n'],
+    )
+
+    assert _websocket_should_defer_reasoning_prelude(
+        request_state,
+        event_type="response.output_item.added",
+        payload={"item": {"type": "reasoning"}},
+    )
+    assert not _websocket_request_can_replay_before_visible_output(request_state)
+
+
+@pytest.mark.asyncio
+async def test_direct_websocket_security_replay_reacquires_create_admission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _make_proxy_settings()
+    settings.stream_idle_timeout_seconds = 300.0
+    settings.proxy_downstream_websocket_idle_timeout_seconds = 120.0
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    regular_account = _make_account("acc_ws_security_gate_regular_e2e")
+    authorized_account = _make_account("acc_ws_security_gate_authorized_e2e")
+    authorized_account.security_work_authorized = True
+    cyber_message = (
+        "This chat was flagged for possible cybersecurity risk. "
+        "To get authorized for security work, join the Trusted Access for Cyber program. "
+        "https://chatgpt.com/cyber"
+    )
+    first_upstream = _QueuedTestUpstreamWebSocket(
+        [
+            SimpleNamespace(
+                kind="text",
+                text=json.dumps(
+                    {
+                        "type": "response.failed",
+                        "response": {
+                            "id": "resp_ws_security_gate_denied",
+                            "status": "failed",
+                            "error": {
+                                "code": "invalid_request_error",
+                                "type": "invalid_request_error",
+                                "message": cyber_message,
+                            },
+                        },
+                    },
+                    separators=(",", ":"),
+                ),
+                data=None,
+                close_code=None,
+                error=None,
+                error_code=None,
+            )
+        ]
+    )
+    second_upstream = _QueuedTestUpstreamWebSocket(
+        [
+            SimpleNamespace(
+                kind="text",
+                text='{"type":"response.created","response":{"id":"resp_ws_security_gate_ok","status":"in_progress"}}',
+                data=None,
+                close_code=None,
+                error=None,
+                error_code=None,
+            ),
+            SimpleNamespace(
+                kind="text",
+                text='{"type":"response.completed","response":{"id":"resp_ws_security_gate_ok","status":"completed","usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}',
+                data=None,
+                close_code=None,
+                error=None,
+                error_code=None,
+            ),
+        ]
+    )
+    connect_count = 0
+
+    async def fake_connect(_self: Any, _headers: Any, **_kwargs: Any):
+        nonlocal connect_count
+        connect_count += 1
+        if connect_count == 1:
+            return regular_account, first_upstream
+        return authorized_account, second_upstream
+
+    admission_count = 0
+    original_acquire = service._acquire_request_state_response_create_admission
+
+    async def track_acquire(request_state: Any, **kwargs: Any) -> None:
+        nonlocal admission_count
+        admission_count += 1
+        await original_acquire(request_state, **kwargs)
+
+    class _Downstream:
+        def __init__(self, request_text: str) -> None:
+            self.request_text = request_text
+            self.request_sent = False
+            self.done = asyncio.Event()
+            self.sent_text: list[str] = []
+
+        async def receive(self) -> dict[str, object]:
+            if not self.request_sent:
+                self.request_sent = True
+                return {"type": "websocket.receive", "text": self.request_text}
+            await self.done.wait()
+            return {"type": "websocket.disconnect"}
+
+        async def send_text(self, text: str) -> None:
+            self.sent_text.append(text)
+            payload = json.loads(text)
+            if payload.get("type") in {"response.completed", "response.failed", "error"}:
+                self.done.set()
+
+        async def send_bytes(self, _data: bytes) -> None:
+            return None
+
+        async def close(self, code: int = 1000, reason: str | None = None) -> None:
+            del code, reason
+            self.done.set()
+
+    monkeypatch.setattr(proxy_service.ProxyService, "_connect_proxy_websocket", fake_connect)
+    monkeypatch.setattr(service, "_acquire_request_state_response_create_admission", track_acquire)
+    monkeypatch.setattr(service, "_resolve_compact_turn_state_owner", AsyncMock(return_value=None))
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.1",
+        "instructions": "",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "security check"}]}],
+        "stream": True,
+    }
+    downstream = _Downstream(json.dumps(request_payload, separators=(",", ":")))
+
+    await service.proxy_responses_websocket(
+        cast(WebSocket, downstream),
+        {},
+        codex_session_affinity=False,
+        openai_cache_affinity=False,
+        api_key=None,
+    )
+
+    assert connect_count == 2
+    assert admission_count == 2
+    assert len(first_upstream.sent_text) == 1
+    assert len(second_upstream.sent_text) == 1
+    assert any(json.loads(text).get("type") == "response.completed" for text in downstream.sent_text)

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14148,6 +14148,7 @@ async def test_stream_responses_does_not_move_file_pinned_security_work_request(
 
 @pytest.mark.asyncio
 async def test_http_bridge_retries_security_work_warning_on_authorized_account(monkeypatch):
+    settings = _make_proxy_settings()
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     regular_account = _make_account("acc_bridge_security_regular")
@@ -14171,6 +14172,20 @@ async def test_http_bridge_retries_security_work_warning_on_authorized_account(m
 
     retry_upstream = _FakeUpstreamWebSocket()
     reconnect_calls: list[dict[str, object]] = []
+    old_create_lease = proxy_service.AccountLease(
+        lease_id="lease_bridge_security_regular",
+        account_id=regular_account.id,
+        kind="response_create",
+        acquired_at=1.0,
+    )
+    replacement_create_lease = proxy_service.AccountLease(
+        lease_id="lease_bridge_security_authorized",
+        account_id=authorized_account.id,
+        kind="response_create",
+        acquired_at=2.0,
+    )
+    release_create_lease = AsyncMock()
+    acquire_create_lease = AsyncMock(return_value=replacement_create_lease)
 
     async def fake_reconnect_http_bridge_session(
         session,
@@ -14182,6 +14197,7 @@ async def test_http_bridge_retries_security_work_warning_on_authorized_account(m
         require_preferred_account=False,
     ):
         del require_same_account, require_preferred_account
+        release_create_lease.assert_awaited_once_with(old_create_lease)
         reconnect_calls.append(
             {
                 "request_state": request_state,
@@ -14193,7 +14209,10 @@ async def test_http_bridge_retries_security_work_warning_on_authorized_account(m
         session.upstream = retry_upstream
         session.upstream_control = proxy_service._WebSocketUpstreamControl()
 
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(service, "_reconnect_http_bridge_session", fake_reconnect_http_bridge_session)
+    monkeypatch.setattr(service, "_acquire_account_response_create_lease_or_overload", acquire_create_lease)
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", release_create_lease)
 
     request_state = proxy_service._WebSocketRequestState(
         request_id="bridge_req_security",
@@ -14206,6 +14225,8 @@ async def test_http_bridge_retries_security_work_warning_on_authorized_account(m
         event_queue=asyncio.Queue(),
         transport="http",
         request_text=request_text,
+        account_response_create_lease=old_create_lease,
+        account_response_create_release=release_create_lease,
     )
     session = proxy_service._HTTPBridgeSession(
         key=proxy_service._HTTPBridgeSessionKey("turn_state_header", "turn-security", None),
@@ -14260,6 +14281,14 @@ async def test_http_bridge_retries_security_work_warning_on_authorized_account(m
     assert request_state.replay_count == 1
     assert request_state.response_id is None
     assert request_state.awaiting_response_created is True
+    acquire_create_lease.assert_awaited_once_with(
+        account_id=authorized_account.id,
+        request_id=request_state.request_id,
+        surface="http_bridge_security_retry",
+        concurrency_caps=proxy_service.effective_account_concurrency_caps(settings),
+    )
+    assert request_state.account_response_create_lease is replacement_create_lease
+    assert request_state.account_response_create_release is release_create_lease
     assert request_state.event_queue is not None
     warning_block = await request_state.event_queue.get()
     assert warning_block is not None
@@ -14268,6 +14297,61 @@ async def test_http_bridge_retries_security_work_warning_on_authorized_account(m
     assert warning["warning"]["code"] == "security_work_authorization_required"
     assert warning["warning"]["action"] == "retry_security_work_authorized"
     assert request_state.event_queue.empty()
+
+
+@pytest.mark.parametrize(
+    "item_type",
+    [
+        "apply_patch_call",
+        "code_interpreter_call",
+        "computer_call",
+        "custom_tool_call",
+        "image_generation_call",
+    ],
+)
+@pytest.mark.asyncio
+async def test_http_bridge_marks_every_visible_output_item_before_security_replay(item_type: str) -> None:
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="bridge_req_visible_output_item",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        response_id="resp_visible_output_item",
+        awaiting_response_created=False,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        request_text='{"type":"response.create","model":"gpt-5.1","input":"check"}',
+    )
+    upstream = AsyncMock()
+    upstream.archive_received = MagicMock()
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "visible-output-item", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_visible_output_item"),
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=1.0,
+        idle_ttl_seconds=300.0,
+    )
+    payload = {
+        "type": "response.output_item.added",
+        "response_id": request_state.response_id,
+        "item": {"id": "item_visible_output", "call_id": "call_visible_output", "type": item_type},
+    }
+
+    await service._process_http_bridge_upstream_text(session, json.dumps(payload, separators=(",", ":")))
+
+    assert request_state.upstream_model_output_seen is True
+    assert proxy_service._websocket_request_can_replay_before_visible_output(request_state) is False
 
 
 @pytest.mark.asyncio
@@ -32111,6 +32195,97 @@ async def test_reconnect_http_bridge_session_reuses_same_account_stream_lease(mo
     assert session.upstream is new_upstream
     assert session.catalog_omission_quota_admission is quota_admission
     release_account_lease.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_http_bridge_security_rebind_clears_previous_response_state(monkeypatch):
+    settings = _make_proxy_settings()
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    rejected_account = _make_account("acc_bridge_rebind_rejected")
+    authorized_account = _make_account("acc_bridge_rebind_authorized")
+    authorized_account.security_work_authorized = True
+    old_upstream = AsyncMock()
+    new_upstream = SimpleNamespace(response_header=lambda _name: None)
+    affinity = proxy_service._AffinityPolicy(
+        key="sid-security-rebind",
+        kind=StickySessionKind.CODEX_SESSION,
+        codex_session_source="session_header",
+    )
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_service.time, "monotonic", lambda: 10.0)
+    monkeypatch.setattr(
+        service._load_balancer,
+        "select_account",
+        AsyncMock(
+            return_value=AccountSelection(
+                account=authorized_account,
+                error_message=None,
+            )
+        ),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=authorized_account))
+    monkeypatch.setattr(service, "_open_upstream_websocket_with_budget", AsyncMock(return_value=new_upstream))
+    claim_replacement = AsyncMock()
+    monkeypatch.setattr(service, "_claim_http_bridge_replacement_before_swap", claim_replacement)
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_security_rebind",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=10.0,
+        excluded_account_ids={rejected_account.id},
+    )
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-security-rebind", None)
+    session = proxy_service._HTTPBridgeSession(
+        key=key,
+        headers={"session_id": "sid-security-rebind", "x-codex-turn-state": "turn-rejected"},
+        affinity=affinity,
+        request_model="gpt-5.1",
+        account=rejected_account,
+        upstream=old_upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=1.0,
+        idle_ttl_seconds=300.0,
+        codex_session=True,
+        upstream_turn_state="turn-rejected",
+        downstream_turn_state="turn-rejected",
+        previous_response_ids={"resp-rejected"},
+        last_completed_response_id="resp-rejected",
+        last_completed_input_count=7,
+        last_completed_input_prefix_fingerprint="fingerprint-rejected",
+        last_pending_tool_calls={"call-rejected": "function_call"},
+    )
+    service._http_bridge_sessions[key] = session
+    service._http_bridge_previous_response_index[("resp-rejected", None)] = key
+
+    await service._reconnect_http_bridge_session(
+        session,
+        request_state=request_state,
+        require_security_work_authorized=True,
+        owner_rebind_affinity=affinity,
+        selection_affinity=proxy_service._AffinityPolicy(reallocate_sticky=True),
+    )
+
+    claim_replacement.assert_awaited_once()
+    assert session.account is authorized_account
+    assert session.previous_response_ids == set()
+    assert ("resp-rejected", None) not in service._http_bridge_previous_response_index
+    assert session.last_completed_response_id is None
+    assert session.last_completed_input_count == 0
+    assert session.last_completed_input_prefix_fingerprint is None
+    assert session.last_pending_tool_calls == {}
+    assert session.codex_session is False
+    assert session.upstream_turn_state is None
+    assert session.downstream_turn_state is None
+    assert "x-codex-turn-state" not in {header.lower() for header in session.headers}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14361,6 +14361,76 @@ async def test_http_bridge_marks_every_visible_output_item_before_security_repla
     assert request_state.event_queue.empty() is expected_deferred
 
 
+@pytest.mark.parametrize(
+    "delta_type",
+    [
+        "response.reasoning_text.delta",
+        "response.reasoning_text.done",
+        "response.reasoning_summary_text.delta",
+        "response.reasoning_summary_text.done",
+    ],
+)
+@pytest.mark.asyncio
+async def test_http_bridge_keeps_reasoning_deltas_buffered_after_prelude(
+    delta_type: str,
+) -> None:
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="bridge_req_reasoning_prelude",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        response_id="resp_reasoning_prelude",
+        awaiting_response_created=False,
+        event_queue=asyncio.Queue(),
+        transport="http",
+        request_text='{"type":"response.create","model":"gpt-5.1","input":"check"}',
+    )
+    upstream = AsyncMock()
+    upstream.archive_received = MagicMock()
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "reasoning-prelude", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_reasoning_prelude"),
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=1.0,
+        idle_ttl_seconds=300.0,
+    )
+    reasoning_item = {
+        "type": "response.output_item.added",
+        "response_id": request_state.response_id,
+        "item": {"id": "item_reasoning", "type": "reasoning"},
+    }
+    reasoning_delta = {
+        "type": delta_type,
+        "response_id": request_state.response_id,
+        "delta": "private reasoning",
+        "text": "private reasoning",
+    }
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(reasoning_item, separators=(",", ":")),
+    )
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(reasoning_delta, separators=(",", ":")),
+    )
+
+    assert len(request_state.deferred_reasoning_downstream_texts) == 2
+    assert request_state.event_queue is not None
+    assert request_state.event_queue.empty()
+
+
 @pytest.mark.asyncio
 async def test_http_bridge_token_invalidated_retries_then_fails_over(monkeypatch):
     request_logs = _RequestLogsRecorder()

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -3674,6 +3674,48 @@ async def test_compact_turn_state_owner_is_a_strict_selection_constraint(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_compact_previous_response_owner_ignores_legacy_session_header_affinity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    owner = _make_account("acc_compact_previous_response_owner")
+    request_logs.response_owner_by_id[("resp_compact_owner", None, "sid-root")] = owner.id
+    select_account = AsyncMock(return_value=AccountSelection(account=owner, error_message=None))
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=owner))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock())
+    monkeypatch.setattr(
+        proxy_service,
+        "core_compact_responses",
+        AsyncMock(return_value=CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})),
+    )
+
+    payload = ResponsesCompactRequest.model_validate(
+        {
+            "model": "gpt-5.6-terra",
+            "instructions": "summarize",
+            "input": [],
+            "previous_response_id": "resp_compact_owner",
+        }
+    )
+    await service.compact_responses(payload, {"session_id": "sid-root"}, codex_session_affinity=True)
+
+    assert request_logs.lookup_calls == [("resp_compact_owner", None, "sid-root")]
+    assert select_account.await_count == 1
+    assert select_account.await_args is not None
+    assert select_account.await_args.kwargs["required_account_id"] == owner.id
+    assert select_account.await_args.kwargs["sticky_key"] is None
+    assert select_account.await_args.kwargs["sticky_kind"] == proxy_service.StickySessionKind.CODEX_SESSION
+    assert select_account.await_args.kwargs["sticky_source"] == "session_header"
+    assert select_account.await_args.kwargs["legacy_sticky_key"] == "sid-root"
+
+
+@pytest.mark.asyncio
 async def test_compact_registered_synthesized_turn_state_is_a_strict_selection_constraint(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -9997,8 +10039,8 @@ def test_logged_error_json_response_emits_proxy_error_log(caplog):
     assert response.status_code == 502
     assert "proxy_error_response request_id=req_proxy_error_1" in caplog.text
     assert "method=POST path=/v1/responses status=502" in caplog.text
-    assert "code=upstream_error" not in caplog.text
-    assert "message=provider failed" not in caplog.text
+    assert 'code="upstream_error"' in caplog.text
+    assert 'message="provider failed"' in caplog.text
 
 
 @pytest.mark.asyncio
@@ -14937,7 +14979,9 @@ async def test_http_bridge_reports_missing_security_work_pool_before_original_wa
 
     assert list(session.pending_requests) == []
     assert session.queued_request_count == 0
-    assert request_state.replay_count == 1
+    # The reconnect failed before replacement ownership was established, so
+    # the retry bookkeeping returns to the original safe state.
+    assert request_state.replay_count == 0
     assert request_state.event_queue is not None
     retry_warning_block = await request_state.event_queue.get()
     missing_pool_warning_block = await request_state.event_queue.get()
@@ -30150,18 +30194,27 @@ async def test_select_account_with_budget_intersects_cap_spillover_with_request_
     assert select_account.await_args.kwargs["spill_bare_session_on_account_cap"] is expected_spillover
 
 
+@pytest.mark.parametrize(
+    ("sticky_source", "sticky_key"),
+    [
+        ("session_header", "bare-session"),
+        ("turn_state", "turn-state-session"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_select_account_with_budget_ignores_bare_mapping_for_preferred_owner(
+async def test_select_account_with_budget_ignores_sticky_mapping_for_preferred_owner(
     monkeypatch: pytest.MonkeyPatch,
+    sticky_source: proxy_service._CodexSessionSource,
+    sticky_key: str,
 ) -> None:
     settings = _make_proxy_settings()
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     owner = _make_account("acc-cap-preferred-owner")
     select_account = AsyncMock(return_value=AccountSelection(account=owner, error_message=None))
     session_policy = proxy_service._AffinityPolicy(
-        key="bare-session",
+        key=sticky_key,
         kind=proxy_service.StickySessionKind.CODEX_SESSION,
-        codex_session_source="session_header",
+        codex_session_source=sticky_source,
     )
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
@@ -30187,9 +30240,14 @@ async def test_select_account_with_budget_ignores_bare_mapping_for_preferred_own
     assert select_account.await_args.kwargs["account_ids"] is None
     assert select_account.await_args.kwargs["required_account_id"] == owner.id
     assert select_account.await_args.kwargs["sticky_key"] is None
-    assert select_account.await_args.kwargs["sticky_kind"] == proxy_service.StickySessionKind.CODEX_SESSION
-    assert select_account.await_args.kwargs["sticky_source"] == "session_header"
-    assert select_account.await_args.kwargs["legacy_sticky_key"] == "bare-session"
+    if sticky_source == "session_header":
+        assert select_account.await_args.kwargs["sticky_kind"] == proxy_service.StickySessionKind.CODEX_SESSION
+        assert select_account.await_args.kwargs["sticky_source"] == "session_header"
+        assert select_account.await_args.kwargs["legacy_sticky_key"] == sticky_key
+    else:
+        assert select_account.await_args.kwargs["sticky_kind"] is None
+        assert select_account.await_args.kwargs["sticky_source"] is None
+        assert select_account.await_args.kwargs["legacy_sticky_key"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -52,7 +52,7 @@ from app.core.upstream_proxy import ResolvedProxyEndpoint, ResolvedUpstreamRoute
 from app.core.utils.request_id import get_request_id, reset_request_id, set_request_id
 from app.core.utils.sse import parse_sse_data_json
 from app.core.utils.time import utcnow
-from app.db.models import Account, AccountStatus, ModelSource
+from app.db.models import Account, AccountStatus, ModelSource, StickySessionKind
 from app.modules.accounts import auth_manager as auth_manager_module
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.repository import ApiKeysRepository
@@ -14998,6 +14998,303 @@ async def test_http_bridge_reports_missing_security_work_pool_before_original_wa
     assert original_failure["type"] == "response.failed"
     assert original_failure["response"]["error"]["message"] == cyber_message
     assert await request_state.event_queue.get() is None
+
+
+@pytest.mark.parametrize("sticky_source", ["turn_state", "session_header"])
+@pytest.mark.asyncio
+async def test_http_bridge_security_retry_clears_codex_affinity_and_turn_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+    sticky_source: str,
+) -> None:
+    sticky_sessions = AsyncMock()
+    sticky_sessions.get_account_id.return_value = None
+
+    class _TrackingRepoContext:
+        def __init__(self) -> None:
+            self._repos = ProxyRepositories(
+                accounts=cast(AccountsRepository, AsyncMock()),
+                usage=cast(UsageRepository, AsyncMock()),
+                request_logs=cast(RequestLogsRepository, _RequestLogsRecorder()),
+                sticky_sessions=cast(StickySessionsRepository, sticky_sessions),
+                api_keys=cast(ApiKeysRepository, AsyncMock()),
+                additional_usage=cast(AdditionalUsageRepository, AsyncMock()),
+            )
+
+        async def __aenter__(self) -> ProxyRepositories:
+            return self._repos
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    service = proxy_service.ProxyService(_TrackingRepoContext)
+    rejected_account = _make_account("acc_bridge_security_rejected")
+    authorized_account = _make_account("acc_bridge_security_authorized")
+    authorized_account.security_work_authorized = True
+    request_text = '{"type":"response.create","model":"gpt-5.1","input":[]}'
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="bridge_req_security_codex_affinity",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        awaiting_response_created=True,
+        transport="http",
+        request_text=request_text,
+        affinity_policy=proxy_service._AffinityPolicy(
+            key="turn-security-rejected",
+            kind=StickySessionKind.CODEX_SESSION,
+            codex_session_source=cast(Any, sticky_source),
+        ),
+    )
+    key = proxy_service._HTTPBridgeSessionKey("turn_state_header", "turn-security-rejected", None)
+    session = proxy_service._HTTPBridgeSession(
+        key=key,
+        headers={"x-codex-turn-state": "turn-security-rejected"},
+        affinity=proxy_service._AffinityPolicy(
+            key="turn-security-rejected",
+            kind=StickySessionKind.CODEX_SESSION,
+            codex_session_source=cast(Any, sticky_source),
+        ),
+        request_model="gpt-5.1",
+        account=rejected_account,
+        upstream=cast(proxy_service.UpstreamResponsesWebSocket, SimpleNamespace()),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=1.0,
+        idle_ttl_seconds=300.0,
+        codex_session=True,
+        upstream_turn_state="upstream-security-rejected",
+        downstream_turn_state="turn-security-rejected",
+        durable_session_id="durable-security-rejected",
+        durable_owner_epoch=4,
+    )
+    session.downstream_turn_state_aliases.add("turn-security-rejected")
+    session.turn_state_alias_registration_generations["turn-security-rejected"] = 1
+    service._http_bridge_sessions[key] = session
+    service._http_bridge_turn_state_index[("turn-security-rejected", None)] = key
+
+    original_affinity = session.affinity
+    replacement_upstream = AsyncMock()
+    durable_claims: list[tuple[str | None, bool]] = []
+
+    async def fake_claim_durable(
+        target_session,
+        *,
+        allow_takeover,
+        force_owner_epoch_advance=False,
+        claim_account_id=None,
+        clear_latest_turn_state=False,
+    ):
+        assert target_session is session
+        assert allow_takeover is True
+        assert force_owner_epoch_advance is True
+        durable_claims.append((claim_account_id, clear_latest_turn_state))
+        target_session.durable_owner_epoch = 5
+
+    async def fake_reconnect(
+        target_session,
+        *,
+        request_state,
+        require_security_work_authorized=False,
+        owner_rebind_affinity=None,
+        selection_affinity=None,
+    ):
+        assert target_session is session
+        assert request_state.excluded_account_ids == {rejected_account.id}
+        assert request_state.affinity_policy.key is None
+        # The raw legacy conflict check and durable replacement claim happen
+        # before any live session continuity field is swapped.
+        assert target_session.affinity == original_affinity
+        assert target_session.codex_session is True
+        assert target_session.downstream_turn_state == "turn-security-rejected"
+        assert target_session.downstream_turn_state_aliases == {"turn-security-rejected"}
+        assert service._http_bridge_turn_state_index[("turn-security-rejected", None)] == key
+        assert target_session.headers["x-codex-turn-state"] == "turn-security-rejected"
+        assert owner_rebind_affinity == original_affinity
+        assert selection_affinity is not None
+        assert selection_affinity.key is None
+        assert selection_affinity.kind is None
+        assert require_security_work_authorized is True
+        await service._claim_http_bridge_replacement_before_swap(
+            target_session,
+            account_id=authorized_account.id,
+            upstream=replacement_upstream,
+            release_selected_account_lease=AsyncMock(),
+            owner_rebind_affinity=cast(proxy_service._AffinityPolicy, owner_rebind_affinity),
+        )
+        await service._unregister_http_bridge_turn_states(target_session)
+        target_session.affinity = selection_affinity
+        target_session.codex_session = False
+        target_session.upstream_turn_state = None
+        target_session.downstream_turn_state = None
+        target_session.headers = {
+            header: value for header, value in target_session.headers.items() if header.lower() != "x-codex-turn-state"
+        }
+        target_session.account = authorized_account
+
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", fake_claim_durable)
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", fake_reconnect)
+    monkeypatch.setattr(
+        service,
+        "_http_bridge_text_with_account_installation_id",
+        lambda _session, _request_state, text: text,
+    )
+    monkeypatch.setattr(proxy_http_bridge_request_submit, "_send_http_bridge_request_text_with_archive_id", AsyncMock())
+
+    assert await service._retry_http_bridge_security_work_request(session, request_state)
+    assert session.account is authorized_account
+    assert durable_claims == [(authorized_account.id, True)]
+    assert session.durable_owner_epoch == 5
+    assert session.affinity.key is None
+    assert session.affinity.kind is None
+    assert session.downstream_turn_state_aliases == set()
+    assert ("turn-security-rejected", None) not in service._http_bridge_turn_state_index
+    assert "x-codex-turn-state" not in session.headers
+    sticky_sessions.upsert.assert_awaited_once_with(
+        original_affinity.selection_key,
+        authorized_account.id,
+        kind=StickySessionKind.CODEX_SESSION,
+    )
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_security_retry_legacy_conflict_precedes_durable_claim_and_session_swap() -> None:
+    rejected_account = _make_account("acc_bridge_security_legacy_owner")
+    authorized_account = _make_account("acc_bridge_security_legacy_replacement")
+    sticky_sessions = AsyncMock()
+    sticky_sessions.get_account_id.return_value = rejected_account.id
+
+    class _TrackingRepoContext:
+        def __init__(self) -> None:
+            self._repos = ProxyRepositories(
+                accounts=cast(AccountsRepository, AsyncMock()),
+                usage=cast(UsageRepository, AsyncMock()),
+                request_logs=cast(RequestLogsRepository, _RequestLogsRecorder()),
+                sticky_sessions=cast(StickySessionsRepository, sticky_sessions),
+                api_keys=cast(ApiKeysRepository, AsyncMock()),
+                additional_usage=cast(AdditionalUsageRepository, AsyncMock()),
+            )
+
+        async def __aenter__(self) -> ProxyRepositories:
+            return self._repos
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+    service = proxy_service.ProxyService(_TrackingRepoContext)
+    original_upstream = AsyncMock()
+    replacement_upstream = AsyncMock()
+    affinity = proxy_service._AffinityPolicy(
+        key="sid-security-legacy",
+        kind=StickySessionKind.CODEX_SESSION,
+        codex_session_source="session_header",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-security-legacy", None),
+        headers={"x-codex-turn-state": "turn-security-legacy"},
+        affinity=affinity,
+        request_model="gpt-5.1",
+        account=rejected_account,
+        upstream=original_upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=1.0,
+        idle_ttl_seconds=300.0,
+        codex_session=True,
+        upstream_turn_state="turn-security-legacy",
+        downstream_turn_state="turn-security-legacy",
+        durable_session_id="durable-security-legacy",
+        durable_owner_epoch=9,
+    )
+    session.downstream_turn_state_aliases.add("turn-security-legacy")
+    durable_claim = AsyncMock()
+    release_selected_lease = AsyncMock()
+    service._claim_durable_http_bridge_session = durable_claim
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service._claim_http_bridge_replacement_before_swap(
+            session,
+            account_id=authorized_account.id,
+            upstream=replacement_upstream,
+            release_selected_account_lease=release_selected_lease,
+            owner_rebind_affinity=affinity,
+        )
+
+    assert exc_info.value.payload["error"]["code"] == "continuity_owner_conflict"
+    durable_claim.assert_not_awaited()
+    replacement_upstream.close.assert_awaited_once_with()
+    release_selected_lease.assert_awaited_once_with()
+    original_upstream.close.assert_not_awaited()
+    assert session.account is rejected_account
+    assert session.upstream is original_upstream
+    assert session.affinity == affinity
+    assert session.durable_owner_epoch == 9
+    assert session.downstream_turn_state == "turn-security-legacy"
+    assert session.downstream_turn_state_aliases == {"turn-security-legacy"}
+    assert session.closed is False
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_security_retry_restores_codex_affinity_and_turn_aliases_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    rejected_account = _make_account("acc_bridge_security_restore")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="bridge_req_security_restore",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        awaiting_response_created=True,
+        transport="http",
+        request_text='{"type":"response.create","model":"gpt-5.1","input":[]}',
+    )
+    key = proxy_service._HTTPBridgeSessionKey("turn_state_header", "turn-security-restore", None)
+    affinity = proxy_service._AffinityPolicy(key="turn-security-restore", kind=StickySessionKind.CODEX_SESSION)
+    session = proxy_service._HTTPBridgeSession(
+        key=key,
+        headers={"x-codex-turn-state": "turn-security-restore"},
+        affinity=affinity,
+        request_model="gpt-5.1",
+        account=rejected_account,
+        upstream=cast(proxy_service.UpstreamResponsesWebSocket, SimpleNamespace()),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=1.0,
+        idle_ttl_seconds=300.0,
+        codex_session=True,
+        upstream_turn_state="upstream-security-restore",
+        downstream_turn_state="turn-security-restore",
+    )
+    session.downstream_turn_state_aliases.add("turn-security-restore")
+    session.turn_state_alias_registration_generations["turn-security-restore"] = 1
+    service._http_bridge_sessions[key] = session
+    service._http_bridge_turn_state_index[("turn-security-restore", None)] = key
+
+    async def fail_reconnect(*_args, **_kwargs):
+        raise proxy_module.ProxyResponseError(503, openai_error("no_accounts", "no authorized accounts"))
+
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", fail_reconnect)
+
+    assert not await service._retry_http_bridge_security_work_request(session, request_state)
+    assert session.affinity == affinity
+    assert session.codex_session is True
+    assert session.downstream_turn_state == "turn-security-restore"
+    assert session.downstream_turn_state_aliases == {"turn-security-restore"}
+    assert service._http_bridge_turn_state_index[("turn-security-restore", None)] == key
+    assert session.headers["x-codex-turn-state"] == "turn-security-restore"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12987,6 +12987,61 @@ async def test_stream_responses_first_idle_timeout_surfaces_timeout_when_no_fail
 
 
 @pytest.mark.asyncio
+async def test_stream_responses_retries_hard_owner_after_transient_exclusion(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_direct_hard_owner_retry")
+    selections: list[set[str]] = []
+    stream_attempts = 0
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+
+    async def select_account(**kwargs: object) -> AccountSelection:
+        excluded = set(cast(set[str] | None, kwargs.get("exclude_account_ids")) or set())
+        selections.append(excluded)
+        if account.id in excluded:
+            return AccountSelection(
+                account=None,
+                error_message="Hard affinity owner account is unavailable",
+                error_code="hard_affinity_saturated",
+            )
+        return AccountSelection(account=account, error_message=None)
+
+    async def fake_stream(*_args: object, **_kwargs: object):
+        nonlocal stream_attempts
+        stream_attempts += 1
+        if stream_attempts == 1:
+            raise proxy_module.ProxyResponseError(
+                502,
+                openai_error("upstream_error", "temporary upstream failure"),
+            )
+        yield 'data: {"type":"response.completed","response":{"id":"resp_hard_owner_retry"}}\n\n'
+
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(service, "_ensure_fresh", AsyncMock(return_value=account))
+    monkeypatch.setattr(
+        service,
+        "_handle_stream_error",
+        AsyncMock(return_value={"failure_class": "retryable_transient"}),
+    )
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_stream)
+
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.6-sol", "instructions": "inspect image", "input": [], "stream": True}
+    )
+
+    chunks = [chunk async for chunk in service.stream_responses(payload, {"session_id": "sid-hard-owner"})]
+
+    event = json.loads(chunks[-1].split("data: ", 1)[1])
+    assert event["type"] == "response.completed"
+    assert event["response"]["id"] == "resp_hard_owner_retry"
+    assert selections == [set(), {account.id}, set()]
+    assert stream_attempts == 2
+
+
+@pytest.mark.asyncio
 async def test_stream_responses_empty_upstream_emits_terminal_failure(monkeypatch):
     settings = _make_proxy_settings()
     request_logs = _RequestLogsRecorder()

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -65,6 +65,7 @@ from app.modules.proxy._service import compact as proxy_compact_service
 from app.modules.proxy._service import support as proxy_support
 from app.modules.proxy._service import warmup as proxy_warmup_service
 from app.modules.proxy._service.http_bridge import request_submit as proxy_http_bridge_request_submit
+from app.modules.proxy._service.http_bridge import service_stubs as proxy_http_bridge_service_stubs
 from app.modules.proxy._service.streaming import helpers as streaming_helpers_module
 from app.modules.proxy._service.streaming import retry as streaming_retry_module
 from app.modules.proxy._service.support import (
@@ -15154,11 +15155,75 @@ async def test_http_bridge_security_retry_clears_codex_affinity_and_turn_aliases
     assert session.downstream_turn_state_aliases == set()
     assert ("turn-security-rejected", None) not in service._http_bridge_turn_state_index
     assert "x-codex-turn-state" not in session.headers
-    sticky_sessions.upsert.assert_awaited_once_with(
-        original_affinity.selection_key,
-        authorized_account.id,
-        kind=StickySessionKind.CODEX_SESSION,
+    if sticky_source == "session_header":
+        sticky_sessions.upsert.assert_awaited_once_with(
+            original_affinity.selection_key,
+            authorized_account.id,
+            kind=StickySessionKind.CODEX_SESSION,
+        )
+    else:
+        sticky_sessions.upsert.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_security_retry_retires_rebound_session_when_resend_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    rejected_account = _make_account("acc_bridge_security_resend_rejected")
+    authorized_account = _make_account("acc_bridge_security_resend_authorized")
+    authorized_account.security_work_authorized = True
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="bridge_req_security_resend_failure",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        awaiting_response_created=True,
+        transport="http",
+        request_text='{"type":"response.create","model":"gpt-5.1","input":[]}',
     )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "security-resend-failure", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=rejected_account,
+        upstream=cast(proxy_service.UpstreamResponsesWebSocket, SimpleNamespace()),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=1.0,
+        idle_ttl_seconds=300.0,
+    )
+
+    async def fake_reconnect(target_session, **_kwargs):
+        target_session.account = authorized_account
+
+    retire = AsyncMock()
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", fake_reconnect)
+    monkeypatch.setattr(service, "_retire_http_bridge_after_drain_if_ready", retire)
+    monkeypatch.setattr(
+        service,
+        "_http_bridge_text_with_account_installation_id",
+        lambda _session, _request_state, text: text,
+    )
+    monkeypatch.setattr(
+        proxy_http_bridge_request_submit,
+        "_send_http_bridge_request_text_with_archive_id",
+        AsyncMock(side_effect=RuntimeError("replacement socket closed before response.create")),
+    )
+
+    assert not await service._retry_http_bridge_security_work_request(session, request_state)
+    assert session.account is authorized_account
+    assert list(session.pending_requests) == []
+    assert session.queued_request_count == 0
+    assert session.upstream_control.reconnect_requested is True
+    assert session.upstream_control.retire_after_drain is True
+    retire.assert_awaited_once_with(session)
 
 
 @pytest.mark.asyncio
@@ -34816,6 +34881,65 @@ async def test_retry_http_bridge_precreated_request_migrates_only_safe_initial_t
     assert session.downstream_turn_state == expected_turn_state
     assert session.headers.get("x-codex-turn-state") == expected_turn_state
     upstream.send_text.assert_awaited_once_with(request_state.request_text)
+
+
+@pytest.mark.asyncio
+async def test_retry_http_bridge_precreated_request_keeps_hard_session_owner_bound(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_bridge_hard_session_owner")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_hard_session_retry",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        awaiting_response_created=True,
+        request_text='{"type":"response.create","model":"gpt-5.6-sol","input":"retry"}',
+    )
+    upstream = AsyncMock()
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "hard-session-key", None),
+        headers={"session_id": "hard-session-key", "x-codex-turn-state": "hard-turn-state"},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.6-sol",
+        account=account,
+        upstream=upstream,
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+        upstream_turn_state="hard-turn-state",
+        downstream_turn_state="hard-turn-state",
+    )
+    reconnect = AsyncMock(return_value=None)
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
+
+    assert await service._retry_http_bridge_precreated_request(session) is True
+
+    reconnect.assert_awaited_once_with(
+        session,
+        request_state=request_state,
+        require_same_account=True,
+    )
+    assert request_state.preferred_account_id is None
+    assert request_state.excluded_account_ids == set()
+    assert session.upstream_turn_state == "hard-turn-state"
+    assert session.downstream_turn_state == "hard-turn-state"
+    assert session.headers["x-codex-turn-state"] == "hard-turn-state"
+
+
+def test_websocket_safe_headers_clear_stale_turn_state_when_replacement_has_none() -> None:
+    headers = proxy_http_bridge_service_stubs._websocket_safe_headers_with_turn_state(
+        {"session_id": "hard-session-key", "X-Codex-Turn-State": "stale-owner-turn"},
+        None,
+    )
+
+    assert headers["session_id"] == "hard-session-key"
+    assert "x-codex-turn-state" not in {key.lower() for key in headers}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -14300,17 +14300,21 @@ async def test_http_bridge_retries_security_work_warning_on_authorized_account(m
 
 
 @pytest.mark.parametrize(
-    "item_type",
+    ("item_type", "expected_deferred"),
     [
-        "apply_patch_call",
-        "code_interpreter_call",
-        "computer_call",
-        "custom_tool_call",
-        "image_generation_call",
+        ("apply_patch_call", False),
+        ("code_interpreter_call", False),
+        ("computer_call", False),
+        ("custom_tool_call", False),
+        ("image_generation_call", False),
+        ("reasoning", True),
     ],
 )
 @pytest.mark.asyncio
-async def test_http_bridge_marks_every_visible_output_item_before_security_replay(item_type: str) -> None:
+async def test_http_bridge_marks_every_visible_output_item_before_security_replay(
+    item_type: str,
+    expected_deferred: bool,
+) -> None:
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     request_state = proxy_service._WebSocketRequestState(
         request_id="bridge_req_visible_output_item",
@@ -14352,6 +14356,9 @@ async def test_http_bridge_marks_every_visible_output_item_before_security_repla
 
     assert request_state.upstream_model_output_seen is True
     assert proxy_service._websocket_request_can_replay_before_visible_output(request_state) is False
+    assert bool(request_state.deferred_reasoning_downstream_texts) is expected_deferred
+    assert request_state.event_queue is not None
+    assert request_state.event_queue.empty() is expected_deferred
 
 
 @pytest.mark.asyncio
@@ -30703,7 +30710,7 @@ async def test_select_account_with_budget_intersects_cap_spillover_with_request_
     ],
 )
 @pytest.mark.asyncio
-async def test_select_account_with_budget_ignores_sticky_mapping_for_preferred_owner(
+async def test_select_account_with_budget_reconciles_sticky_mapping_for_preferred_owner(
     monkeypatch: pytest.MonkeyPatch,
     sticky_source: proxy_service._CodexSessionSource,
     sticky_key: str,
@@ -30740,14 +30747,15 @@ async def test_select_account_with_budget_ignores_sticky_mapping_for_preferred_o
     assert select_account.await_args is not None
     assert select_account.await_args.kwargs["account_ids"] is None
     assert select_account.await_args.kwargs["required_account_id"] == owner.id
-    assert select_account.await_args.kwargs["sticky_key"] is None
     if sticky_source == "session_header":
+        assert select_account.await_args.kwargs["sticky_key"] is None
         assert select_account.await_args.kwargs["sticky_kind"] == proxy_service.StickySessionKind.CODEX_SESSION
         assert select_account.await_args.kwargs["sticky_source"] == "session_header"
         assert select_account.await_args.kwargs["legacy_sticky_key"] == sticky_key
     else:
-        assert select_account.await_args.kwargs["sticky_kind"] is None
-        assert select_account.await_args.kwargs["sticky_source"] is None
+        assert select_account.await_args.kwargs["sticky_key"] == sticky_key
+        assert select_account.await_args.kwargs["sticky_kind"] == proxy_service.StickySessionKind.CODEX_SESSION
+        assert select_account.await_args.kwargs["sticky_source"] == "turn_state"
         assert select_account.await_args.kwargs["legacy_sticky_key"] is None
 
 

--- a/tests/unit/test_structured_logging.py
+++ b/tests/unit/test_structured_logging.py
@@ -8,6 +8,7 @@ import pytest
 from app.core.runtime_logging import (
     JsonFormatter,
     UtcDefaultFormatter,
+    _error_log_field,
     _redact_log_value,
     build_log_config,
 )
@@ -29,6 +30,25 @@ def test_redact_log_value_masks_basic_authorization_credentials():
     redacted = _redact_log_value(value)
 
     assert redacted == "Authorization: [REDACTED], status=failed"
+
+
+def test_error_log_field_quotes_redacted_field_values():
+    value = "temporary failure status=200 request_id=req-1 api_key=abc123"
+
+    field = _error_log_field(value)
+
+    assert field == '"temporary failure status=200 request_id=req-1 api_key=[REDACTED]"'
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ('provider error {"api_key":"sk-secret"}', 'provider error {"api_key":"[REDACTED]"}'),
+        ('provider error {"authorization":"Basic dXNlcjpwYXNz"}', 'provider error {"authorization":"[REDACTED]"}'),
+    ],
+)
+def test_error_log_field_redacts_json_style_secrets(value, expected):
+    assert _error_log_field(value) == json.dumps(expected)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Harden compact and HTTP-bridge continuity recovery so previous-response, turn-state, and session-header owners remain fail-closed across reconnects, replicas, and blue/green handoff.

Current head: `a6e018ad2ab95572ae3afdce8591d4839a2a2259` rebased onto `e6270f3ff6140d1f2c09bbd7820487f398de6fd2`.

## Changes

- preserve current-main strict durable identity and account-neutral recovery rules;
- retain same-account durable handoff and explicit previous-response owner preference;
- keep ownerless or ambiguous durable recovery fail-closed;
- move durable claim/turn-state clearing through the current `session_registry.py` owner;
- preserve hard-owner retry constraints while allowing soft, non-file affinity reallocation;
- retain current security-lineage and continuity behavior from main.

## Validation

- affected unit suites: 918 passed;
- cache-locality and multi-instance integration selection: 13 passed;
- post-format durable focused selection: 45 passed;
- Ruff, Ruff format, and `ty` passed;
- proxy architecture check passed;
- strict OpenSpec validation passed for `fail-closed-http-bridge-security-retry`;
- `git diff --check` passed.

Hosted checks and current-head review evidence remain authoritative for merge.
