### PR TITLE
fix(shutdown): drain audit and fleet tasks

### DIFF
--- a/app/core/audit/service.py
+++ b/app/core/audit/service.py
@@ -5,6 +5,7 @@ import json
 import logging
 from collections.abc import Mapping, Sequence
 
+from app.core.shutdown import wait_for_tasks_to_drain
 from app.core.utils.request_id import get_request_id
 from app.db.models import AuditLog
 from app.db.session import get_session
@@ -28,6 +29,8 @@ _REDACTED_DETAIL_KEYS = frozenset(
 type AuditDetailScalar = str | int | float | bool | None
 type AuditDetailValue = AuditDetailScalar | Sequence[AuditDetailScalar]
 type AuditDetails = Mapping[str, AuditDetailValue]
+
+_AUDIT_LOG_TASKS: set[asyncio.Task[None]] = set()
 
 
 def _sanitize_details(details: AuditDetails | None) -> dict[str, AuditDetailValue] | None:
@@ -55,7 +58,34 @@ class AuditService:
         details: AuditDetails | None = None,
         request_id: str | None = None,
     ) -> None:
-        asyncio.create_task(_write_audit_log(action, actor_ip, details, request_id or get_request_id()))
+        task = asyncio.create_task(
+            _write_audit_log(action, actor_ip, details, request_id or get_request_id()),
+            name=f"audit-log-{action}",
+        )
+        _AUDIT_LOG_TASKS.add(task)
+        task.add_done_callback(_handle_audit_log_task_done)
+
+
+async def drain_audit_log_tasks(timeout_seconds: float) -> bool:
+    pending = await wait_for_tasks_to_drain(_AUDIT_LOG_TASKS, timeout_seconds)
+    for task in sorted(pending, key=lambda pending_task: pending_task.get_name()):
+        logger.warning("Audit log task did not drain before shutdown: %s", task.get_name())
+    return not pending
+
+
+def _handle_audit_log_task_done(task: asyncio.Task[None]) -> None:
+    try:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.warning(
+                "Audit log task failed unexpectedly: %s",
+                task.get_name(),
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+    finally:
+        _AUDIT_LOG_TASKS.discard(task)
 
 
 async def _write_audit_log(

--- a/app/core/audit/service.py
+++ b/app/core/audit/service.py
@@ -5,7 +5,7 @@ import json
 import logging
 from collections.abc import Mapping, Sequence
 
-from app.core.shutdown import wait_for_tasks_to_drain
+from app.core.shutdown import is_control_plane_task_admission_open, wait_for_tasks_to_drain
 from app.core.utils.request_id import get_request_id
 from app.db.models import AuditLog
 from app.db.session import get_session
@@ -58,6 +58,9 @@ class AuditService:
         details: AuditDetails | None = None,
         request_id: str | None = None,
     ) -> None:
+        if not is_control_plane_task_admission_open():
+            logger.warning("Audit log task rejected after shutdown admission closed: %s", action)
+            return
         task = asyncio.create_task(
             _write_audit_log(action, actor_ip, details, request_id or get_request_id()),
             name=f"audit-log-{action}",

--- a/app/core/shutdown.py
+++ b/app/core/shutdown.py
@@ -81,4 +81,4 @@ async def wait_for_tasks_to_drain(
 
         _, still_pending = await asyncio.wait(pending, timeout=remaining)
         if still_pending:
-            return still_pending
+            return {task for task in tasks if not task.done()}

--- a/app/core/shutdown.py
+++ b/app/core/shutdown.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections.abc import Collection
+from typing import TypeVar
+
+_TaskResultT = TypeVar("_TaskResultT")
 
 _draining: bool = False
 _bridge_drain_active: bool = False
@@ -52,3 +56,29 @@ async def wait_for_in_flight_drain(timeout_seconds: float, poll_interval_seconds
     while get_in_flight() > 0 and time.monotonic() < deadline:
         await asyncio.sleep(poll_interval_seconds)
     return get_in_flight() == 0
+
+
+async def wait_for_tasks_to_drain(
+    tasks: Collection[asyncio.Task[_TaskResultT]],
+    timeout_seconds: float,
+) -> set[asyncio.Task[_TaskResultT]]:
+    """Wait until a live task collection is stable or its deadline expires."""
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_seconds
+    while True:
+        pending = {task for task in tasks if not task.done()}
+        if not pending:
+            # Let done callbacks run before declaring a live registry empty.
+            await asyncio.sleep(0)
+            pending = {task for task in tasks if not task.done()}
+            if not pending:
+                return set()
+
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            return pending
+
+        _, still_pending = await asyncio.wait(pending, timeout=remaining)
+        if still_pending:
+            return still_pending

--- a/app/core/shutdown.py
+++ b/app/core/shutdown.py
@@ -10,13 +10,24 @@ _TaskResultT = TypeVar("_TaskResultT")
 _draining: bool = False
 _bridge_drain_active: bool = False
 _in_flight: int = 0
+_control_plane_task_admission_open: bool = True
 
 
 def reset() -> None:
-    global _draining, _bridge_drain_active, _in_flight
+    global _draining, _bridge_drain_active, _in_flight, _control_plane_task_admission_open
     _draining = False
     _bridge_drain_active = False
     _in_flight = 0
+    _control_plane_task_admission_open = True
+
+
+def close_control_plane_task_admission() -> None:
+    global _control_plane_task_admission_open
+    _control_plane_task_admission_open = False
+
+
+def is_control_plane_task_admission_open() -> bool:
+    return _control_plane_task_admission_open
 
 
 def set_draining(val: bool = True) -> None:

--- a/app/main.py
+++ b/app/main.py
@@ -136,18 +136,40 @@ async def _release_leader_lease_within(timeout: float) -> None:
 
 
 async def _drain_detached_control_plane_tasks(timeout_seconds: float) -> None:
-    results = await asyncio.gather(
-        drain_audit_log_tasks(timeout_seconds),
-        fleet_api.drain_background_refresh_tasks(timeout_seconds),
-        return_exceptions=True,
-    )
-    for task_kind, result in zip(("audit log", "fleet refresh"), results, strict=True):
-        if isinstance(result, BaseException):
-            logger.warning(
-                "Failed to drain %s tasks during shutdown",
-                task_kind,
-                exc_info=(type(result), result, result.__traceback__),
-            )
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_seconds
+    clean_passes = 0
+
+    while clean_passes < 2:
+        remaining = max(0.0, deadline - loop.time())
+        results = await asyncio.gather(
+            drain_audit_log_tasks(remaining),
+            fleet_api.drain_background_refresh_tasks(remaining),
+            return_exceptions=True,
+        )
+
+        clean_pass = True
+        for task_kind, result in zip(("audit log", "fleet refresh"), results, strict=True):
+            if isinstance(result, BaseException):
+                clean_pass = False
+                logger.warning(
+                    "Failed to drain %s tasks during shutdown",
+                    task_kind,
+                    exc_info=(type(result), result, result.__traceback__),
+                )
+            elif result is False:
+                clean_pass = False
+
+        if not clean_pass:
+            return
+
+        clean_passes += 1
+
+        # A done callback may enqueue sibling audit/fleet work after both
+        # registries looked empty. One extra stable pass catches that before
+        # HTTP clients and DB engines are torn down.
+        if clean_passes < 2:
+            await asyncio.sleep(0)
 
 
 class _MetricsServer(Protocol):

--- a/app/main.py
+++ b/app/main.py
@@ -52,6 +52,7 @@ from app.core.resilience.bulkhead import BulkheadMiddleware, get_bulkhead
 from app.core.resilience.memory_monitor import configure as configure_memory_monitor
 from app.core.retention.scheduler import build_data_retention_scheduler
 from app.core.scheduling.leader_election import get_leader_election
+from app.core.shutdown import close_control_plane_task_admission
 from app.core.usage.refresh_scheduler import build_usage_refresh_scheduler
 from app.core.usage.reset_credits_refresh_scheduler import build_rate_limit_reset_credits_scheduler
 from app.core.utils.time import utcnow
@@ -136,6 +137,9 @@ async def _release_leader_lease_within(timeout: float) -> None:
 
 
 async def _drain_detached_control_plane_tasks(timeout_seconds: float) -> None:
+    # Closing admission is synchronous with producer checks on the event loop,
+    # so no task can appear after the stable drain passes complete.
+    close_control_plane_task_admission()
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout_seconds
     clean_passes = 0
@@ -507,6 +511,10 @@ async def lifespan(app: FastAPI):
         shutdown_state.set_bridge_drain_active(True)
         shutdown_state.set_draining(True)
         drained = await shutdown_state.wait_for_in_flight_drain(timeout_seconds=settings.shutdown_drain_timeout_seconds)
+        # No await separates the timeout result from this cutoff. A slow
+        # request therefore either registered its task before the barrier or
+        # is prevented from starting new audit/fleet database work afterward.
+        shutdown_state.close_control_plane_task_admission()
         if not drained:
             logger.warning("Drain timeout reached, proceeding with shutdown")
 
@@ -616,7 +624,6 @@ async def lifespan(app: FastAPI):
             except Exception:
                 logger.exception("Metrics server stopped with an error")
             finally:
-                shutdown_state.reset()
                 mark_process_dead()
                 await close_db()
 

--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,7 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
 from starlette.staticfiles import StaticFiles
 
+from app.core.audit.service import drain_audit_log_tasks
 from app.core.auth.guardian import build_auth_guardian_scheduler
 from app.core.balancer import configure_replica_salt
 from app.core.bootstrap import ensure_auto_bootstrap_token, log_bootstrap_token
@@ -132,6 +133,21 @@ async def _release_leader_lease_within(timeout: float) -> None:
     exc = release_task.exception()
     if exc is not None:
         logger.warning("Failed to release scheduler leader lease during shutdown", exc_info=exc)
+
+
+async def _drain_detached_control_plane_tasks(timeout_seconds: float) -> None:
+    results = await asyncio.gather(
+        drain_audit_log_tasks(timeout_seconds),
+        fleet_api.drain_background_refresh_tasks(timeout_seconds),
+        return_exceptions=True,
+    )
+    for task_kind, result in zip(("audit log", "fleet refresh"), results, strict=True):
+        if isinstance(result, BaseException):
+            logger.warning(
+                "Failed to drain %s tasks during shutdown",
+                task_kind,
+                exc_info=(type(result), result, result.__traceback__),
+            )
 
 
 class _MetricsServer(Protocol):
@@ -519,6 +535,12 @@ async def lifespan(app: FastAPI):
 
         if metrics_server is not None:
             metrics_server.should_exit = True
+
+        # Detached control-plane work must finish while usage singleflight,
+        # shared HTTP clients, and both database engines are still available.
+        # The replica heartbeat is already stopped/staled so this grace period
+        # does not extend its active bridge-ring lifetime.
+        await _drain_detached_control_plane_tasks(settings.shutdown_drain_timeout_seconds)
 
         # Start the single process-level lease-renewal keeper BEFORE stopping any
         # scheduler. Schedulers are stopped one at a time and only the final

--- a/app/modules/fleet/api.py
+++ b/app/modules/fleet/api.py
@@ -7,7 +7,8 @@ from fastapi import APIRouter, Depends, Security
 
 from app.core.auth.dependencies import set_dashboard_error_format, validate_usage_api_key
 from app.core.config.settings_cache import get_settings_cache
-from app.core.shutdown import wait_for_tasks_to_drain
+from app.core.exceptions import DashboardServiceUnavailableError
+from app.core.shutdown import is_control_plane_task_admission_open, wait_for_tasks_to_drain
 from app.core.utils.time import utcnow
 from app.db.models import AccountStatus
 from app.db.session import get_background_session
@@ -31,6 +32,8 @@ router = APIRouter(
 )
 
 _REFRESH_SKIP_STATUSES = {AccountStatus.PAUSED, AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED}
+# Every route-owned refresh is registered at creation. Caller cancellation only
+# changes who observes its outcome; it does not establish task ownership.
 _BACKGROUND_REFRESH_TASKS: set[asyncio.Task[FleetRefreshResponse]] = set()
 
 
@@ -99,14 +102,17 @@ async def refresh_fleet_usage(
 ) -> FleetRefreshResponse:
     """Request a bounded usage refresh using codex-lb's normal refresh rules."""
 
+    if not is_control_plane_task_admission_open():
+        raise DashboardServiceUnavailableError("Server is draining")
     task = asyncio.create_task(
         _refresh_fleet_usage_with_owned_session(_visible_account_ids(api_key)),
         name="fleet-usage-refresh",
     )
+    _BACKGROUND_REFRESH_TASKS.add(task)
+    task.add_done_callback(_discard_refresh_task)
     try:
         return await asyncio.shield(task)
     except asyncio.CancelledError:
-        _BACKGROUND_REFRESH_TASKS.add(task)
         task.add_done_callback(_handle_cancelled_refresh_task_done)
         raise
 
@@ -151,6 +157,10 @@ def _handle_cancelled_refresh_task_done(task: asyncio.Task[FleetRefreshResponse]
         _log_cancelled_refresh_task_exception(task)
     finally:
         _BACKGROUND_REFRESH_TASKS.discard(task)
+
+
+def _discard_refresh_task(task: asyncio.Task[FleetRefreshResponse]) -> None:
+    _BACKGROUND_REFRESH_TASKS.discard(task)
 
 
 def _log_cancelled_refresh_task_exception(task: asyncio.Task[FleetRefreshResponse]) -> None:

--- a/app/modules/fleet/api.py
+++ b/app/modules/fleet/api.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, Security
 
 from app.core.auth.dependencies import set_dashboard_error_format, validate_usage_api_key
 from app.core.config.settings_cache import get_settings_cache
+from app.core.shutdown import wait_for_tasks_to_drain
 from app.core.utils.time import utcnow
 from app.db.models import AccountStatus
 from app.db.session import get_background_session
@@ -136,6 +137,13 @@ async def _refresh_fleet_usage_with_owned_session(visible_account_ids: list[str]
             attempted_count=len(eligible_accounts),
             generated_at=utcnow(),
         )
+
+
+async def drain_background_refresh_tasks(timeout_seconds: float) -> bool:
+    pending = await wait_for_tasks_to_drain(_BACKGROUND_REFRESH_TASKS, timeout_seconds)
+    for task in sorted(pending, key=lambda pending_task: pending_task.get_name()):
+        logger.warning("Fleet refresh task did not drain before shutdown: %s", task.get_name())
+    return not pending
 
 
 def _handle_cancelled_refresh_task_done(task: asyncio.Task[FleetRefreshResponse]) -> None:

--- a/openspec/changes/drain-audit-fleet-tasks/.openspec.yaml
+++ b/openspec/changes/drain-audit-fleet-tasks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/drain-audit-fleet-tasks/context.md
+++ b/openspec/changes/drain-audit-fleet-tasks/context.md
@@ -4,7 +4,7 @@
 
 Audit writes are deliberately detached so dashboard mutations and authentication responses do not pay for a second database commit. Fleet refreshes are deliberately shielded so a client disconnect does not interrupt a refresh that already owns its own database session. This change preserves those latency and ownership choices while connecting both task classes to graceful shutdown.
 
-It covers only `AuditService.log_async()` and cancelled-request `POST /api/fleet/refresh` work. Proxy persistence, periodic schedulers, OAuth polling, and abrupt process death keep their existing lifecycle contracts.
+It covers only `AuditService.log_async()` and `POST /api/fleet/refresh` work. Proxy persistence, periodic schedulers, OAuth polling, and abrupt process death keep their existing lifecycle contracts.
 
 ## Decision rationale and constraints
 
@@ -12,13 +12,18 @@ The existing shutdown timeout is reused because the operator has already chosen 
 
 Fleet draining must happen before the usage scheduler stops: that stop cancels the process-wide usage singleflight, including work used by the fleet endpoint. It must also happen before shared HTTP clients close. Audit draining must happen before database disposal. Running both together at the earlier boundary satisfies all three constraints.
 
+The in-flight wait is a grace period, not proof that every handler exited. Its timeout must therefore be followed immediately by a synchronous producer cutoff. The gate is independent of the HTTP draining flag: a request that entered before draining may continue, but after cutoff it cannot enqueue a new audit write and cannot start a fleet refresh. Every fleet refresh accepted before cutoff is placed in its registry before the route first awaits it, so later caller cancellation cannot make it invisible to shutdown.
+
 ## Failure modes
 
 - A completed task that failed is removed and its exception is consumed so asyncio does not emit an unowned-task warning.
+- A late asynchronous audit producer is skipped without constructing its database coroutine and logs the rejected action.
+- A late fleet producer receives the dashboard `503 service_unavailable` envelope without starting a refresh task or background session.
 - A drain wrapper failure is isolated; the other task class still receives its grace period.
 - A task that outlives the configured timeout is named in logs and shutdown proceeds. Forced termination can still lose it, which is unchanged and outside the graceful guarantee.
 - The drain helper rechecks the live registry after completion callbacks run so it does not declare success during their scheduling turn.
+- The lifecycle coordinator requires two clean audit/fleet passes with one event-loop yield between them, but both passes share the original absolute timeout.
 
 ## Concrete example
 
-An operator restarts codex-lb just after changing a setting while a fleet dashboard disconnects from a manual refresh. The setting response has already returned and its audit INSERT is pending; the fleet refresh continues in a background session. Shutdown first quiesces requests, then waits for both tracked tasks concurrently. If they finish within the configured 30-second default, the audit row is committed and the fleet session closes before usage singleflight, HTTP clients, or database engines are torn down.
+An operator restarts codex-lb while an account-import handler is paused and a fleet refresh is running. The in-flight grace period expires, so shutdown closes task admission and begins its bounded control-plane drain. The fleet caller disconnects only afterward, but the refresh was already registered at creation and remains owned. When the account-import handler resumes, its late audit call returns immediately and reports that it was rejected rather than opening a database coroutine. If the fleet task finishes within the configured 30-second default, its session closes before usage singleflight, HTTP clients, or database engines are torn down.

--- a/openspec/changes/drain-audit-fleet-tasks/context.md
+++ b/openspec/changes/drain-audit-fleet-tasks/context.md
@@ -1,0 +1,24 @@
+# Detached control-plane task lifecycle
+
+## Purpose and scope
+
+Audit writes are deliberately detached so dashboard mutations and authentication responses do not pay for a second database commit. Fleet refreshes are deliberately shielded so a client disconnect does not interrupt a refresh that already owns its own database session. This change preserves those latency and ownership choices while connecting both task classes to graceful shutdown.
+
+It covers only `AuditService.log_async()` and cancelled-request `POST /api/fleet/refresh` work. Proxy persistence, periodic schedulers, OAuth polling, and abrupt process death keep their existing lifecycle contracts.
+
+## Decision rationale and constraints
+
+The existing shutdown timeout is reused because the operator has already chosen how long a graceful drain may wait. Both drains run concurrently, so adding the second task class does not double that configured grace period. Module-owned registries keep audit and fleet failure messages specific and avoid introducing a generic task-management subsystem.
+
+Fleet draining must happen before the usage scheduler stops: that stop cancels the process-wide usage singleflight, including work used by the fleet endpoint. It must also happen before shared HTTP clients close. Audit draining must happen before database disposal. Running both together at the earlier boundary satisfies all three constraints.
+
+## Failure modes
+
+- A completed task that failed is removed and its exception is consumed so asyncio does not emit an unowned-task warning.
+- A drain wrapper failure is isolated; the other task class still receives its grace period.
+- A task that outlives the configured timeout is named in logs and shutdown proceeds. Forced termination can still lose it, which is unchanged and outside the graceful guarantee.
+- The drain helper rechecks the live registry after completion callbacks run so it does not declare success during their scheduling turn.
+
+## Concrete example
+
+An operator restarts codex-lb just after changing a setting while a fleet dashboard disconnects from a manual refresh. The setting response has already returned and its audit INSERT is pending; the fleet refresh continues in a background session. Shutdown first quiesces requests, then waits for both tracked tasks concurrently. If they finish within the configured 30-second default, the audit row is committed and the fleet session closes before usage singleflight, HTTP clients, or database engines are torn down.

--- a/openspec/changes/drain-audit-fleet-tasks/design.md
+++ b/openspec/changes/drain-audit-fleet-tasks/design.md
@@ -1,0 +1,58 @@
+## Context
+
+`AuditService.log_async()` creates an unreferenced task that writes through the main database engine. `POST /api/fleet/refresh` shields refresh work from caller cancellation and retains the task only after cancellation, but its module-level task set has no shutdown consumer. The application already rejects and drains in-flight HTTP requests, drains proxy persistence, and later stops the usage singleflight before closing the shared HTTP clients and both database engines.
+
+The change must preserve the response-latency contract: audit calls remain fire-and-forget, and an ordinary fleet request still waits for its requested refresh. It must also share the existing `shutdown_drain_timeout_seconds` budget rather than add an operator setting.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give every detached audit write and cancelled-request fleet refresh a strong owner until completion.
+- Wait for both task classes concurrently during graceful shutdown, before usage singleflight, HTTP-client, and database teardown.
+- Consume task outcomes, remove completed tasks deterministically, and isolate one task class's failure from the other drain.
+- Bound the normal drain wait with the existing shutdown timeout and identify overdue tasks in logs.
+
+**Non-Goals:**
+
+- Changing audit payloads, fleet refresh policy, or endpoint response schemas.
+- Making detached writes durable across process crashes or forced termination.
+- Replacing the existing proxy persistence drain or creating a general background-job framework.
+- Adding a new timeout or configuration surface.
+
+## Decisions
+
+### Keep module-owned task registries
+
+Audit and fleet each retain a typed `set[asyncio.Task[...]]`. Creation registers the task before control returns to the event loop, and a done callback consumes its outcome before discarding it. This follows the existing fleet and proxy ownership pattern while keeping task-specific failure messages in the owning module.
+
+A queue or process-wide task manager was considered, but it would broaden the change and obscure which shutdown contract applies to each task class.
+
+### Share one small shutdown wait primitive
+
+`app.core.shutdown` will expose a typed helper that repeatedly snapshots unfinished tasks, waits only until one absolute deadline, yields one event-loop turn for done callbacks, and returns any tasks still pending. Rechecking after callbacks avoids a one-shot snapshot race without coupling logging policy to the helper.
+
+Each module wraps that primitive, logs its own overdue task names, and returns whether it drained completely. Tasks are not force-cancelled when the grace period expires: cancellation can itself outlive the deadline because database session rollback/close is shielded, and fleet refresh uses shielded usage singleflight work. The later usage-scheduler stop remains the existing cancellation backstop for overdue fleet refresh work.
+
+### Drain both task classes concurrently and before usage teardown
+
+The lifespan runs the two module drains concurrently with `return_exceptions=True`. This gives both classes the same wall-clock grace period and ensures an unexpected failure in one drain cannot skip the other. The call is placed after in-flight and proxy-persistence draining and after the replica heartbeat has stopped/been marked stale, but before scheduler shutdown. At that point normal request producers have quiesced and the replica no longer extends its active ring lifetime, while fleet work still has its HTTP client and usage singleflight available and audit work still has its database engine.
+
+### Preserve bounded degraded shutdown
+
+If the deadline expires, the owning module logs every still-pending task and shutdown proceeds through the existing teardown. This preserves the configured upper bound and makes the degraded case observable. The normal graceful path removes the database race by finishing these tasks before any shared client or engine is disposed.
+
+## Risks / Trade-offs
+
+- **A task can exceed the configured drain timeout** → log its stable task name and proceed exactly as the existing proxy persistence drain does; forced process termination remains outside the graceful guarantee.
+- **A done callback or drain wrapper fails unexpectedly** → consume task exceptions in the owner and use `gather(..., return_exceptions=True)` at the lifecycle boundary so the peer drain still runs.
+- **Tasks appear while a drain is finishing** → in-flight requests are quiesced first, and the shared helper yields/rechecks the live registry before declaring success.
+- **Shutdown latency increases** → only already-running detached work is awaited, both classes drain concurrently, and the existing timeout caps the normal wait.
+
+## Migration Plan
+
+Code-only and zero-config. Deploy through the normal rolling restart path. Rollback is a source revert; there is no schema or persisted-state migration.
+
+## Open Questions
+
+None.

--- a/openspec/changes/drain-audit-fleet-tasks/design.md
+++ b/openspec/changes/drain-audit-fleet-tasks/design.md
@@ -1,6 +1,8 @@
 ## Context
 
-`AuditService.log_async()` creates an unreferenced task that writes through the main database engine. `POST /api/fleet/refresh` shields refresh work from caller cancellation and retains the task only after cancellation, but its module-level task set has no shutdown consumer. The application already rejects and drains in-flight HTTP requests, drains proxy persistence, and later stops the usage singleflight before closing the shared HTTP clients and both database engines.
+`AuditService.log_async()` creates an unreferenced task that writes through the main database engine. `POST /api/fleet/refresh` shields refresh work from caller cancellation and originally retained the task only after cancellation, but its module-level task set had no shutdown consumer. The application already rejects and drains in-flight HTTP requests, drains proxy persistence, and later stops the usage singleflight before closing the shared HTTP clients and both database engines.
+
+The in-flight drain is bounded and can legitimately time out while a handler is paused before either producer. A one-shot audit/fleet drain can then observe empty registries before the late handler creates work. Rechecking a live set cannot close this producer race by itself; shutdown needs a linearization point after which new control-plane tasks are not admitted.
 
 The change must preserve the response-latency contract: audit calls remain fire-and-forget, and an ordinary fleet request still waits for its requested refresh. It must also share the existing `shutdown_drain_timeout_seconds` budget rather than add an operator setting.
 
@@ -8,23 +10,32 @@ The change must preserve the response-latency contract: audit calls remain fire-
 
 **Goals:**
 
-- Give every detached audit write and cancelled-request fleet refresh a strong owner until completion.
+- Give every detached audit write and every fleet refresh a strong owner until completion.
+- Atomically stop audit/fleet task admission after the in-flight drain attempt so late handlers cannot create resource work after the control-plane drain.
 - Wait for both task classes concurrently during graceful shutdown, before usage singleflight, HTTP-client, and database teardown.
 - Consume task outcomes, remove completed tasks deterministically, and isolate one task class's failure from the other drain.
 - Bound the normal drain wait with the existing shutdown timeout and identify overdue tasks in logs.
 
 **Non-Goals:**
 
-- Changing audit payloads, fleet refresh policy, or endpoint response schemas.
+- Changing audit payloads, ordinary fleet refresh policy, or response schemas.
 - Making detached writes durable across process crashes or forced termination.
 - Replacing the existing proxy persistence drain or creating a general background-job framework.
 - Adding a new timeout or configuration surface.
 
 ## Decisions
 
+### Close admission synchronously before draining control-plane tasks
+
+`app.core.shutdown` owns a control-plane task-admission boolean separate from the mutable HTTP draining state. Immediately after `wait_for_in_flight_drain()` returns—successfully or by timeout—the lifespan closes admission on the next synchronous line, before logging or awaiting any other shutdown step. The final control-plane drain closes it again defensively.
+
+Audit and fleet producers check the gate before constructing their coroutine. The check, task creation, and registry insertion contain no `await`, and the shutdown cutoff runs on the same event-loop thread. A producer is therefore ordered either before the cutoff, with its task registered for draining, or after the cutoff, with no task or resource coroutine created.
+
+`reset()` reopens admission for a new lifespan. Shutdown no longer calls `reset()` in the resource-teardown tail, so timed-out request handlers cannot regain admission before `close_db()`. Tests reset this process-global state before and after each case.
+
 ### Keep module-owned task registries
 
-Audit and fleet each retain a typed `set[asyncio.Task[...]]`. Creation registers the task before control returns to the event loop, and a done callback consumes its outcome before discarding it. This follows the existing fleet and proxy ownership pattern while keeping task-specific failure messages in the owning module.
+Audit and fleet each retain a typed `set[asyncio.Task[...]]`. Creation registers the task before control returns to the event loop. The awaiting caller or task-specific callback consumes or observes the outcome, and a done callback discards ownership. Fleet registration happens for every accepted refresh at creation; caller cancellation only adds cancellation-specific exception reporting and does not establish ownership. This follows the existing fleet and proxy ownership pattern while keeping task-specific failure messages in the owning module.
 
 A queue or process-wide task manager was considered, but it would broaden the change and obscure which shutdown contract applies to each task class.
 
@@ -36,7 +47,9 @@ Each module wraps that primitive, logs its own overdue task names, and returns w
 
 ### Drain both task classes concurrently and before usage teardown
 
-The lifespan runs the two module drains concurrently with `return_exceptions=True`. This gives both classes the same wall-clock grace period and ensures an unexpected failure in one drain cannot skip the other. The call is placed after in-flight and proxy-persistence draining and after the replica heartbeat has stopped/been marked stale, but before scheduler shutdown. At that point normal request producers have quiesced and the replica no longer extends its active ring lifetime, while fleet work still has its HTTP client and usage singleflight available and audit work still has its database engine.
+The lifespan runs the two module drains concurrently with `return_exceptions=True`. This gives both classes the same wall-clock grace period and ensures an unexpected failure in one drain cannot skip the other. The coordinator requires two clean passes, yielding once between them, while sharing one absolute `shutdown_drain_timeout_seconds` deadline. The extra pass catches sibling work scheduled by completion callbacks without extending the operator's timeout; an exception or overdue result ends the resweep and preserves degraded shutdown.
+
+The call is placed after the in-flight drain attempt and proxy-persistence draining and after the replica heartbeat has stopped/been marked stale, but before scheduler shutdown. Timed-out handlers may still exist, but the admission barrier prevents them from adding new audit/fleet work; all accepted fleet work was registered at creation. The replica no longer extends its active ring lifetime, while tracked fleet work still has its HTTP client and usage singleflight available and audit work still has its database engine.
 
 ### Preserve bounded degraded shutdown
 
@@ -46,7 +59,9 @@ If the deadline expires, the owning module logs every still-pending task and shu
 
 - **A task can exceed the configured drain timeout** → log its stable task name and proceed exactly as the existing proxy persistence drain does; forced process termination remains outside the graceful guarantee.
 - **A done callback or drain wrapper fails unexpectedly** → consume task exceptions in the owner and use `gather(..., return_exceptions=True)` at the lifecycle boundary so the peer drain still runs.
-- **Tasks appear while a drain is finishing** → in-flight requests are quiesced first, and the shared helper yields/rechecks the live registry before declaring success.
+- **A handler survives the in-flight timeout** → the synchronous admission barrier either captured its already-registered work or rejects its later producer call before coroutine creation.
+- **A task completes while a drain is finishing** → the shared helper yields/rechecks the live registry before declaring success.
+- **A completion callback schedules sibling work after both module drains look clean** → the coordinator yields and requires a second clean pass within the original absolute deadline.
 - **Shutdown latency increases** → only already-running detached work is awaited, both classes drain concurrently, and the existing timeout caps the normal wait.
 
 ## Migration Plan

--- a/openspec/changes/drain-audit-fleet-tasks/proposal.md
+++ b/openspec/changes/drain-audit-fleet-tasks/proposal.md
@@ -2,10 +2,15 @@
 
 Detached audit-log writes and fleet refreshes can still be using database sessions when graceful shutdown disposes the application engines. Audit rows can therefore be lost, and cancelled fleet requests can race teardown even though their refresh work intentionally continues in the background.
 
+An in-flight request can also outlive `shutdown_drain_timeout_seconds`. Without an admission cutoff, that late handler can create audit or fleet work after shutdown has already observed both task registries as empty, recreating the same resource-teardown race.
+
 ## What Changes
 
 - Track every detached audit-log write until it completes, including failure cleanup.
-- Expose bounded drains for pending audit-log writes and cancelled-request fleet refreshes.
+- Track every fleet refresh from task creation, before caller cancellation can affect ownership.
+- Close a synchronous audit/fleet task-admission barrier immediately after the in-flight drain attempt and keep it closed through resource teardown.
+- Skip and report post-cutoff asynchronous audit writes, and reject post-cutoff fleet refreshes with the existing dashboard `503 service_unavailable` envelope before creating resource work.
+- Expose bounded drains for pending audit-log writes and fleet refreshes.
 - Run both drains during application shutdown before usage singleflight, HTTP, and database teardown.
 - Report tasks that do not finish within the existing shutdown drain timeout without adding configuration or changing request latency.
 
@@ -17,10 +22,10 @@ Detached audit-log writes and fleet refreshes can still be using database sessio
 
 ### Modified Capabilities
 
-- `fleet-summary`: require cancelled-request fleet refreshes to remain owned and to participate in graceful shutdown.
+- `fleet-summary`: require every accepted fleet refresh to remain owned from creation and to participate in graceful shutdown.
 
 ## Impact
 
-- **Runtime**: `app/core/audit/service.py`, `app/modules/fleet/api.py`, and `app/main.py`.
-- **Tests**: audit task lifecycle, fleet refresh drain/timeout behavior, failure isolation, and shutdown ordering.
+- **Runtime**: `app/core/shutdown.py`, `app/core/audit/service.py`, `app/modules/fleet/api.py`, and `app/main.py`.
+- **Tests**: audit task lifecycle and post-cutoff rejection, fleet ownership/503/drain behavior, failure isolation, and late-cancellation shutdown ordering through HTTP middleware.
 - **Operations**: graceful shutdown may wait for these existing detached tasks, bounded by `shutdown_drain_timeout_seconds`; no new setting or migration.

--- a/openspec/changes/drain-audit-fleet-tasks/proposal.md
+++ b/openspec/changes/drain-audit-fleet-tasks/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Detached audit-log writes and fleet refreshes can still be using database sessions when graceful shutdown disposes the application engines. Audit rows can therefore be lost, and cancelled fleet requests can race teardown even though their refresh work intentionally continues in the background.
+
+## What Changes
+
+- Track every detached audit-log write until it completes, including failure cleanup.
+- Expose bounded drains for pending audit-log writes and cancelled-request fleet refreshes.
+- Run both drains during application shutdown before usage singleflight, HTTP, and database teardown.
+- Report tasks that do not finish within the existing shutdown drain timeout without adding configuration or changing request latency.
+
+## Capabilities
+
+### New Capabilities
+
+- `audit-logging`: define ownership and graceful-shutdown durability for asynchronous audit-log writes.
+
+### Modified Capabilities
+
+- `fleet-summary`: require cancelled-request fleet refreshes to remain owned and to participate in graceful shutdown.
+
+## Impact
+
+- **Runtime**: `app/core/audit/service.py`, `app/modules/fleet/api.py`, and `app/main.py`.
+- **Tests**: audit task lifecycle, fleet refresh drain/timeout behavior, failure isolation, and shutdown ordering.
+- **Operations**: graceful shutdown may wait for these existing detached tasks, bounded by `shutdown_drain_timeout_seconds`; no new setting or migration.

--- a/openspec/changes/drain-audit-fleet-tasks/specs/audit-logging/spec.md
+++ b/openspec/changes/drain-audit-fleet-tasks/specs/audit-logging/spec.md
@@ -19,7 +19,16 @@ The system MUST execute `AuditService.log_async()` writes in tracked background 
 
 ### Requirement: Graceful shutdown drains pending audit writes
 
-Graceful shutdown MUST wait for tracked audit-log tasks for up to `shutdown_drain_timeout_seconds` before closing shared database resources. The drain MUST include tasks that complete or become visible while task-completion callbacks are running. If the deadline expires, the system MUST report each audit task that did not drain before continuing shutdown.
+Immediately after the in-flight drain attempt returns, graceful shutdown MUST synchronously close asynchronous audit-task admission before any further shutdown await. An `AuditService.log_async()` call after this cutoff MUST remain non-blocking, MUST report the rejected action, and MUST NOT construct a write coroutine or task. Graceful shutdown MUST wait for audit-log tasks accepted before the cutoff for up to `shutdown_drain_timeout_seconds` before closing shared database resources. The drain MUST include tasks that complete or become visible while task-completion callbacks are running. If the deadline expires, the system MUST report each audit task that did not drain before continuing shutdown.
+
+#### Scenario: Late audit producer is rejected after in-flight timeout
+
+- **GIVEN** an HTTP handler remains alive after the in-flight drain timeout
+- **AND** graceful shutdown has closed control-plane task admission
+- **WHEN** the handler calls `AuditService.log_async()`
+- **THEN** the call returns without waiting
+- **AND** the rejected action is reported
+- **AND** no audit write coroutine or task is created
 
 #### Scenario: Shutdown preserves a pending audit row
 

--- a/openspec/changes/drain-audit-fleet-tasks/specs/audit-logging/spec.md
+++ b/openspec/changes/drain-audit-fleet-tasks/specs/audit-logging/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Asynchronous audit writes remain owned until completion
+
+The system MUST execute `AuditService.log_async()` writes in tracked background tasks without making the calling request wait for database persistence. Each task MUST remain strongly owned until it finishes, and success, cancellation, or failure MUST remove it from the tracked set. An unexpected task failure MUST be consumed and reported rather than becoming an unobserved task exception.
+
+#### Scenario: Audit logging remains fire-and-forget
+
+- **GIVEN** an audit-log database write is blocked
+- **WHEN** application code calls `AuditService.log_async()`
+- **THEN** the call returns before the database write completes
+- **AND** the pending write remains tracked until completion
+
+#### Scenario: Failed audit task is cleaned up
+
+- **WHEN** an asynchronous audit task fails unexpectedly
+- **THEN** the failure is reported
+- **AND** the completed task is removed from the tracked set
+
+### Requirement: Graceful shutdown drains pending audit writes
+
+Graceful shutdown MUST wait for tracked audit-log tasks for up to `shutdown_drain_timeout_seconds` before closing shared database resources. The drain MUST include tasks that complete or become visible while task-completion callbacks are running. If the deadline expires, the system MUST report each audit task that did not drain before continuing shutdown.
+
+#### Scenario: Shutdown preserves a pending audit row
+
+- **GIVEN** an asynchronous audit write is still pending when graceful shutdown begins
+- **WHEN** the write completes within the configured drain timeout
+- **THEN** shutdown waits for the write
+- **AND** shared database resources remain open until the write finishes
+
+#### Scenario: Overdue audit write is reported
+
+- **GIVEN** an asynchronous audit write remains pending for the full configured drain timeout
+- **WHEN** graceful shutdown drains audit tasks
+- **THEN** the drain reports that task as overdue
+- **AND** shutdown is allowed to continue

--- a/openspec/changes/drain-audit-fleet-tasks/specs/fleet-summary/spec.md
+++ b/openspec/changes/drain-audit-fleet-tasks/specs/fleet-summary/spec.md
@@ -1,8 +1,8 @@
 ## ADDED Requirements
 
-### Requirement: Detached fleet refreshes participate in graceful shutdown
+### Requirement: Fleet refreshes participate in graceful shutdown
 
-When a `POST /api/fleet/refresh` caller is cancelled after its refresh has started, the system MUST keep the refresh strongly owned so its dedicated session can finish and be closed. Graceful shutdown MUST wait for all such tracked refreshes for up to `shutdown_drain_timeout_seconds` before stopping usage-refresh singleflight work or closing shared HTTP and database resources. If the deadline expires, the system MUST report each fleet refresh that did not drain before continuing shutdown.
+The system MUST strongly own every accepted `POST /api/fleet/refresh` task from creation until its dedicated session has finished and closed, regardless of whether its caller remains attached. Task creation and registry insertion MUST occur synchronously before the route first awaits the task. Graceful shutdown MUST wait for all such tracked refreshes for up to `shutdown_drain_timeout_seconds` before stopping usage-refresh singleflight work or closing shared HTTP and database resources. If the deadline expires, the system MUST report each fleet refresh that did not drain before continuing shutdown.
 
 #### Scenario: Caller cancellation does not orphan fleet refresh work
 
@@ -10,6 +10,13 @@ When a `POST /api/fleet/refresh` caller is cancelled after its refresh has start
 - **WHEN** the requesting client disconnects or its request task is cancelled
 - **THEN** the refresh continues independently of the cancelled caller
 - **AND** it remains tracked until its session exits
+
+#### Scenario: Shutdown begins before caller cancellation
+
+- **GIVEN** a fleet refresh was accepted and its caller remains attached
+- **WHEN** the in-flight drain times out and graceful shutdown starts draining fleet tasks
+- **THEN** the refresh is already present in the fleet task registry
+- **AND** cancelling the caller afterward does not remove the refresh from shutdown ownership
 
 #### Scenario: Shutdown waits for a detached fleet refresh
 
@@ -24,3 +31,15 @@ When a `POST /api/fleet/refresh` caller is cancelled after its refresh has start
 - **WHEN** graceful shutdown drains fleet tasks
 - **THEN** the drain reports that task as overdue
 - **AND** shutdown is allowed to continue
+
+### Requirement: Post-cutoff fleet refreshes are rejected before resource work
+
+Immediately after the in-flight drain attempt returns, graceful shutdown MUST synchronously close fleet task admission before any further shutdown await. A `POST /api/fleet/refresh` request that reaches its producer after this cutoff MUST return the dashboard `503 service_unavailable` error envelope and MUST NOT create a refresh coroutine, task, background session, or other refresh resource work.
+
+#### Scenario: Late fleet producer receives service unavailable
+
+- **GIVEN** graceful shutdown has closed control-plane task admission
+- **WHEN** an authenticated caller requests `POST /api/fleet/refresh`
+- **THEN** the response status is 503
+- **AND** the dashboard error code is `service_unavailable`
+- **AND** no fleet refresh task or background session starts

--- a/openspec/changes/drain-audit-fleet-tasks/specs/fleet-summary/spec.md
+++ b/openspec/changes/drain-audit-fleet-tasks/specs/fleet-summary/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Detached fleet refreshes participate in graceful shutdown
+
+When a `POST /api/fleet/refresh` caller is cancelled after its refresh has started, the system MUST keep the refresh strongly owned so its dedicated session can finish and be closed. Graceful shutdown MUST wait for all such tracked refreshes for up to `shutdown_drain_timeout_seconds` before stopping usage-refresh singleflight work or closing shared HTTP and database resources. If the deadline expires, the system MUST report each fleet refresh that did not drain before continuing shutdown.
+
+#### Scenario: Caller cancellation does not orphan fleet refresh work
+
+- **GIVEN** a fleet refresh is running in its dedicated session
+- **WHEN** the requesting client disconnects or its request task is cancelled
+- **THEN** the refresh continues independently of the cancelled caller
+- **AND** it remains tracked until its session exits
+
+#### Scenario: Shutdown waits for a detached fleet refresh
+
+- **GIVEN** a cancelled-request fleet refresh is still pending when graceful shutdown begins
+- **WHEN** the refresh completes within the configured drain timeout
+- **THEN** shutdown waits for the refresh
+- **AND** usage singleflight, shared HTTP clients, and database engines remain available until it finishes
+
+#### Scenario: Overdue fleet refresh is reported
+
+- **GIVEN** a detached fleet refresh remains pending for the full configured drain timeout
+- **WHEN** graceful shutdown drains fleet tasks
+- **THEN** the drain reports that task as overdue
+- **AND** shutdown is allowed to continue

--- a/openspec/changes/drain-audit-fleet-tasks/tasks.md
+++ b/openspec/changes/drain-audit-fleet-tasks/tasks.md
@@ -17,3 +17,9 @@
 - [x] 3.1 Run focused unit/integration tests plus Ruff format/check and ty for changed Python files.
 - [x] 3.2 Run strict OpenSpec validation, architecture/simplicity gates, and relevant broader test suites.
 - [x] 3.3 Perform an adversarial lifecycle review and reconcile every requirement/scenario with implementation evidence.
+
+## 4. P1 review follow-up: post-timeout admission race
+
+- [x] 4.1 Close a synchronous audit/fleet task-admission barrier immediately after in-flight draining, keep it closed through resource teardown, and own every fleet refresh task from creation.
+- [x] 4.2 Cover post-cutoff audit rejection, fleet ownership before caller cancellation, the fleet route's 503 contract, and the real late-cancellation lifespan race through in-flight HTTP middleware.
+- [x] 4.3 Re-run focused and broader tests, static checks, strict OpenSpec validation, architecture/simplicity gates, and an adversarial standalone-diff review.

--- a/openspec/changes/drain-audit-fleet-tasks/tasks.md
+++ b/openspec/changes/drain-audit-fleet-tasks/tasks.md
@@ -1,0 +1,19 @@
+## 1. Task ownership and drains
+
+- [x] 1.1 Add a typed, deadline-bounded task-set drain primitive that rechecks after completion callbacks run.
+- [x] 1.2 Track every asynchronous audit-log write, consume its result, and expose an audit-specific shutdown drain.
+- [x] 1.3 Expose a fleet refresh shutdown drain over the existing cancelled-request task registry.
+- [x] 1.4 Drain audit and fleet tasks concurrently in the application lifespan before usage singleflight, HTTP, and database teardown, isolating drain failures.
+
+## 2. Regression coverage
+
+- [x] 2.1 Cover task-set completion, callback recheck, and timeout behavior.
+- [x] 2.2 Cover audit fire-and-forget ownership, successful drain, unexpected failure cleanup, and timeout reporting.
+- [x] 2.3 Cover cancelled-request fleet refresh draining, timeout reporting, and task cleanup.
+- [x] 2.4 Cover lifecycle ordering and prove one failing drain does not skip the other.
+
+## 3. Verification
+
+- [x] 3.1 Run focused unit/integration tests plus Ruff format/check and ty for changed Python files.
+- [x] 3.2 Run strict OpenSpec validation, architecture/simplicity gates, and relevant broader test suites.
+- [x] 3.3 Perform an adversarial lifecycle review and reconcile every requirement/scenario with implementation evidence.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -335,3 +335,13 @@ def _reset_hot_path_caches():
     _reset_global_state()
     yield
     _reset_global_state()
+
+
+@pytest.fixture(autouse=True)
+def _reset_shutdown_task_admission():
+    """Keep the process-global shutdown admission barrier test-local."""
+    from app.core import shutdown as shutdown_state
+
+    shutdown_state.reset()
+    yield
+    shutdown_state.reset()

--- a/tests/integration/test_fleet_summary_api.py
+++ b/tests/integration/test_fleet_summary_api.py
@@ -16,6 +16,7 @@ from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.api_keys.service import ApiKeyCreateData, ApiKeyData, ApiKeysService
 from app.modules.fleet import api as fleet_api
+from app.modules.fleet.schemas import FleetRefreshResponse
 from app.modules.usage.repository import UsageRepository
 
 pytestmark = pytest.mark.integration
@@ -1097,15 +1098,36 @@ async def test_fleet_refresh_owns_session_until_shielded_refresh_finishes(db_set
 
     assert not session_exited.is_set()
     assert len(fleet_api._BACKGROUND_REFRESH_TASKS) == 1
+    drain = asyncio.create_task(fleet_api.drain_background_refresh_tasks(timeout_seconds=1))
+    await asyncio.sleep(0)
+    assert not drain.done()
+
     allow_refresh_finish.set()
+    assert await drain is True
     await asyncio.wait_for(session_exited.wait(), timeout=1)
-    await asyncio.wait_for(_wait_for_background_refresh_tasks_to_drain(), timeout=1)
 
     assert session_was_open_during_refresh == [True]
     assert invalidations == ["rate_limit_headers", "account_selection"]
     assert fleet_api._BACKGROUND_REFRESH_TASKS == set()
 
 
-async def _wait_for_background_refresh_tasks_to_drain() -> None:
-    while fleet_api._BACKGROUND_REFRESH_TASKS:
-        await asyncio.sleep(0)
+@pytest.mark.asyncio
+async def test_fleet_refresh_drain_reports_overdue_task(caplog: pytest.LogCaptureFixture) -> None:
+    fleet_api._BACKGROUND_REFRESH_TASKS.clear()
+    allow_refresh_finish = asyncio.Event()
+
+    async def blocked_refresh() -> FleetRefreshResponse:
+        await allow_refresh_finish.wait()
+        return FleetRefreshResponse(usage_written=False, account_count=0, attempted_count=0, generated_at=utcnow())
+
+    task = asyncio.create_task(blocked_refresh(), name="fleet-usage-refresh")
+    fleet_api._BACKGROUND_REFRESH_TASKS.add(task)
+    task.add_done_callback(fleet_api._handle_cancelled_refresh_task_done)
+
+    with caplog.at_level("WARNING", logger=fleet_api.__name__):
+        assert await fleet_api.drain_background_refresh_tasks(timeout_seconds=0) is False
+
+    assert "Fleet refresh task did not drain before shutdown: fleet-usage-refresh" in caplog.text
+    allow_refresh_finish.set()
+    assert await fleet_api.drain_background_refresh_tasks(timeout_seconds=1) is True
+    assert fleet_api._BACKGROUND_REFRESH_TASKS == set()

--- a/tests/integration/test_fleet_summary_api.py
+++ b/tests/integration/test_fleet_summary_api.py
@@ -7,6 +7,7 @@ from datetime import timedelta, timezone
 
 import pytest
 
+from app.core import shutdown as shutdown_state
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
@@ -1018,6 +1019,35 @@ async def test_fleet_refresh_respects_account_scoped_api_key(async_client, db_se
 
 
 @pytest.mark.asyncio
+async def test_fleet_refresh_rejects_post_cutoff_work_with_dashboard_503(
+    async_client,
+    db_setup,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plain_key = await _create_api_key("fleet-refresh-post-cutoff-key")
+
+    def unexpected_refresh(_: list[str] | None) -> None:
+        raise AssertionError("post-cutoff fleet refresh coroutine was created")
+
+    monkeypatch.setattr(fleet_api, "_refresh_fleet_usage_with_owned_session", unexpected_refresh)
+    shutdown_state.close_control_plane_task_admission()
+
+    response = await async_client.post(
+        "/api/fleet/refresh",
+        headers={"Authorization": f"Bearer {plain_key}"},
+    )
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "error": {
+            "code": "service_unavailable",
+            "message": "Server is draining",
+        }
+    }
+    assert fleet_api._BACKGROUND_REFRESH_TASKS == set()
+
+
+@pytest.mark.asyncio
 async def test_fleet_refresh_owns_session_until_shielded_refresh_finishes(db_setup, monkeypatch):
     fleet_api._BACKGROUND_REFRESH_TASKS.clear()
     await _seed_account_with_windows(
@@ -1091,13 +1121,17 @@ async def test_fleet_refresh_owns_session_until_shielded_refresh_finishes(db_set
     )
     await asyncio.wait_for(refresh_started.wait(), timeout=1)
 
+    assert len(fleet_api._BACKGROUND_REFRESH_TASKS) == 1
+    owned_refresh_task = next(iter(fleet_api._BACKGROUND_REFRESH_TASKS))
+    assert not owned_refresh_task.done()
+
     request_task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await request_task
     await asyncio.sleep(0)
 
     assert not session_exited.is_set()
-    assert len(fleet_api._BACKGROUND_REFRESH_TASKS) == 1
+    assert fleet_api._BACKGROUND_REFRESH_TASKS == {owned_refresh_task}
     drain = asyncio.create_task(fleet_api.drain_background_refresh_tasks(timeout_seconds=1))
     await asyncio.sleep(0)
     assert not drain.done()

--- a/tests/unit/test_audit_trail.py
+++ b/tests/unit/test_audit_trail.py
@@ -11,6 +11,7 @@ import pytest
 from sqlalchemy import select
 
 import app.core.audit.service as audit_service_module
+from app.core import shutdown as shutdown_state
 from app.core.auth import generate_unique_account_id
 from app.core.utils.time import utcnow
 from app.db.models import AuditLog
@@ -132,6 +133,32 @@ async def test_audit_log_async_is_fire_and_forget(monkeypatch: pytest.MonkeyPatc
     allow_write_finish.set()
     assert await drain is True
     assert audit_service_module._AUDIT_LOG_TASKS == set()
+
+
+def test_audit_log_async_rejects_post_cutoff_work_without_creating_a_task(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def unexpected_write(*args, **kwargs) -> None:
+        _ = (args, kwargs)
+        raise AssertionError("post-cutoff audit write coroutine was created")
+
+    def unexpected_task(*args, **kwargs) -> None:
+        _ = (args, kwargs)
+        raise AssertionError("post-cutoff audit task was created")
+
+    monkeypatch.setattr(audit_service_module, "_write_audit_log", unexpected_write)
+    monkeypatch.setattr(audit_service_module.asyncio, "create_task", unexpected_task)
+    shutdown_state.close_control_plane_task_admission()
+
+    started_at = perf_counter()
+    with caplog.at_level(logging.WARNING, logger=audit_service_module.__name__):
+        audit_service_module.AuditService.log_async("post_cutoff_settings_change")
+    elapsed = perf_counter() - started_at
+
+    assert elapsed < 0.05
+    assert audit_service_module._AUDIT_LOG_TASKS == set()
+    assert "Audit log task rejected after shutdown admission closed: post_cutoff_settings_change" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_audit_trail.py
+++ b/tests/unit/test_audit_trail.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import logging
 from collections.abc import Mapping
 from time import perf_counter
 
@@ -101,14 +102,15 @@ async def test_audit_log_async_is_fire_and_forget(monkeypatch: pytest.MonkeyPatc
     tasks: list[asyncio.Task[None]] = []
     original_create_task = asyncio.create_task
     started = asyncio.Event()
+    allow_write_finish = asyncio.Event()
 
     async def slow_write(action: str, actor_ip: str | None, details: dict | None, request_id: str | None) -> None:
         _ = (action, actor_ip, details, request_id)
         started.set()
-        await asyncio.sleep(0.2)
+        await allow_write_finish.wait()
 
-    def capture_task(coro):
-        task = original_create_task(coro)
+    def capture_task(coro, *, name=None, context=None):
+        task = original_create_task(coro, name=name, context=context)
         tasks.append(task)
         return task
 
@@ -121,7 +123,60 @@ async def test_audit_log_async_is_fire_and_forget(monkeypatch: pytest.MonkeyPatc
 
     assert elapsed < 0.05
     await asyncio.wait_for(started.wait(), timeout=0.1)
-    await asyncio.gather(*tasks)
+    assert set(tasks) <= audit_service_module._AUDIT_LOG_TASKS
+
+    drain = asyncio.create_task(audit_service_module.drain_audit_log_tasks(timeout_seconds=1))
+    await asyncio.sleep(0)
+    assert not drain.done()
+
+    allow_write_finish.set()
+    assert await drain is True
+    assert audit_service_module._AUDIT_LOG_TASKS == set()
+
+
+@pytest.mark.asyncio
+async def test_audit_log_task_failure_is_consumed_and_cleaned_up(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def fail_write(action: str, actor_ip: str | None, details: dict | None, request_id: str | None) -> None:
+        _ = (action, actor_ip, details, request_id)
+        raise RuntimeError("unexpected audit failure")
+
+    monkeypatch.setattr(audit_service_module, "_write_audit_log", fail_write)
+
+    with caplog.at_level(logging.WARNING, logger=audit_service_module.__name__):
+        audit_service_module.AuditService.log_async("failure_test")
+        assert await audit_service_module.drain_audit_log_tasks(timeout_seconds=1) is True
+
+    assert audit_service_module._AUDIT_LOG_TASKS == set()
+    assert "Audit log task failed unexpectedly: audit-log-failure_test" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_audit_log_drain_reports_overdue_task(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    started = asyncio.Event()
+    allow_write_finish = asyncio.Event()
+
+    async def blocked_write(action: str, actor_ip: str | None, details: dict | None, request_id: str | None) -> None:
+        _ = (action, actor_ip, details, request_id)
+        started.set()
+        await allow_write_finish.wait()
+
+    monkeypatch.setattr(audit_service_module, "_write_audit_log", blocked_write)
+    audit_service_module.AuditService.log_async("timeout_test")
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    with caplog.at_level(logging.WARNING, logger=audit_service_module.__name__):
+        assert await audit_service_module.drain_audit_log_tasks(timeout_seconds=0) is False
+
+    assert "Audit log task did not drain before shutdown: audit-log-timeout_test" in caplog.text
+    allow_write_finish.set()
+    assert await audit_service_module.drain_audit_log_tasks(timeout_seconds=1) is True
+    assert audit_service_module._AUDIT_LOG_TASKS == set()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_graceful_shutdown.py
+++ b/tests/unit/test_graceful_shutdown.py
@@ -63,6 +63,43 @@ async def test_wait_for_tasks_to_drain_returns_pending_at_deadline() -> None:
 
 
 @pytest.mark.asyncio
+async def test_wait_for_tasks_to_drain_resnapshots_registry_at_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    initial_gate = asyncio.Event()
+    late_gate = asyncio.Event()
+
+    async def wait_for_gate(gate: asyncio.Event) -> None:
+        await gate.wait()
+
+    initial_task = asyncio.create_task(wait_for_gate(initial_gate), name="initial-task")
+    tasks = {initial_task}
+    late_task: asyncio.Task[None] | None = None
+
+    async def add_late_task_then_timeout(
+        pending: set[asyncio.Task[None]],
+        *,
+        timeout: float,
+    ) -> tuple[set[asyncio.Task[None]], set[asyncio.Task[None]]]:
+        nonlocal late_task
+        assert timeout > 0
+        late_task = asyncio.create_task(wait_for_gate(late_gate), name="late-task")
+        tasks.add(late_task)
+        return set(), pending
+
+    monkeypatch.setattr(shutdown_state.asyncio, "wait", add_late_task_then_timeout)
+
+    overdue = await wait_for_tasks_to_drain(tasks, timeout_seconds=1)
+
+    assert late_task is not None
+    assert overdue == {initial_task, late_task}
+
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_control_plane_drains_are_failure_isolated(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,

--- a/tests/unit/test_graceful_shutdown.py
+++ b/tests/unit/test_graceful_shutdown.py
@@ -124,6 +124,38 @@ async def test_control_plane_drains_are_failure_isolated(
 
 
 @pytest.mark.asyncio
+async def test_control_plane_drain_requires_stable_clean_pass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    audit_calls = 0
+    fleet_calls = 0
+    late_fleet_seen = False
+
+    async def drain_audit(_: float) -> bool:
+        nonlocal audit_calls
+        audit_calls += 1
+        return True
+
+    async def drain_fleet(_: float) -> bool:
+        nonlocal fleet_calls, late_fleet_seen
+        fleet_calls += 1
+        if fleet_calls == 1:
+            await asyncio.sleep(0)
+            return True
+        late_fleet_seen = True
+        return True
+
+    monkeypatch.setattr(app_main, "drain_audit_log_tasks", drain_audit)
+    monkeypatch.setattr(app_main.fleet_api, "drain_background_refresh_tasks", drain_fleet)
+
+    await _drain_detached_control_plane_tasks(1)
+
+    assert audit_calls == 2
+    assert fleet_calls == 2
+    assert late_fleet_seen is True
+
+
+@pytest.mark.asyncio
 async def test_release_leader_lease_within_returns_when_release_wedged(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_graceful_shutdown.py
+++ b/tests/unit/test_graceful_shutdown.py
@@ -222,15 +222,24 @@ async def test_release_leader_lease_within_swallows_release_error(
 
 
 @pytest.fixture(autouse=True)
-def reset_shutdown_state() -> None:
-    setattr(shutdown_state, "_draining", False)
-    setattr(shutdown_state, "_in_flight", 0)
+def reset_shutdown_state():  # noqa: ANN201
+    shutdown_state.reset()
+    yield
+    shutdown_state.reset()
 
 
 def test_set_draining_updates_shutdown_state() -> None:
     shutdown_state.set_draining(True)
 
     assert shutdown_state._draining is True
+
+
+def test_reset_reopens_control_plane_task_admission() -> None:
+    shutdown_state.close_control_plane_task_admission()
+
+    shutdown_state.reset()
+
+    assert shutdown_state.is_control_plane_task_admission_open() is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_graceful_shutdown.py
+++ b/tests/unit/test_graceful_shutdown.py
@@ -1,16 +1,89 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from importlib import import_module
 
 import pytest
 
-from app.main import InFlightMiddleware, _release_leader_lease_within
+from app.core.shutdown import wait_for_tasks_to_drain
+from app.main import InFlightMiddleware, _drain_detached_control_plane_tasks, _release_leader_lease_within
 
 app_main = import_module("app.main")
 shutdown_state = import_module("app.core.shutdown")
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_wait_for_tasks_to_drain_rechecks_tasks_added_by_done_callback() -> None:
+    tasks: set[asyncio.Task[None]] = set()
+    followup_started = asyncio.Event()
+    allow_followup_finish = asyncio.Event()
+
+    async def finish_immediately() -> None:
+        return None
+
+    async def followup() -> None:
+        followup_started.set()
+        await allow_followup_finish.wait()
+
+    first = asyncio.create_task(finish_immediately())
+    tasks.add(first)
+
+    def spawn_followup(_: asyncio.Task[None]) -> None:
+        task = asyncio.create_task(followup())
+        tasks.add(task)
+        task.add_done_callback(tasks.discard)
+
+    first.add_done_callback(spawn_followup)
+    first.add_done_callback(tasks.discard)
+
+    drain = asyncio.create_task(wait_for_tasks_to_drain(tasks, timeout_seconds=1))
+    await asyncio.wait_for(followup_started.wait(), timeout=1)
+    await asyncio.sleep(0)
+    assert not drain.done()
+
+    allow_followup_finish.set()
+    assert await drain == set()
+    assert tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_tasks_to_drain_returns_pending_at_deadline() -> None:
+    gate = asyncio.Event()
+    task = asyncio.create_task(gate.wait(), name="deadline-test-task")
+
+    pending = await wait_for_tasks_to_drain({task}, timeout_seconds=0)
+
+    assert pending == {task}
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_control_plane_drains_are_failure_isolated(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fleet_drained = asyncio.Event()
+
+    async def fail_audit_drain(_: float) -> bool:
+        raise RuntimeError("audit drain failed")
+
+    async def drain_fleet(_: float) -> bool:
+        fleet_drained.set()
+        return True
+
+    monkeypatch.setattr(app_main, "drain_audit_log_tasks", fail_audit_drain)
+    monkeypatch.setattr(app_main.fleet_api, "drain_background_refresh_tasks", drain_fleet)
+
+    with caplog.at_level(logging.WARNING, logger="app.main"):
+        await _drain_detached_control_plane_tasks(1)
+
+    assert fleet_drained.is_set()
+    assert "Failed to drain audit log tasks during shutdown" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_otel.py
+++ b/tests/unit/test_otel.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, Mock
 import aiohttp
 import anyio
 import pytest
+from httpx import ASGITransport, AsyncClient
 
 import app.core.tracing.otel as otel
 import app.modules.proxy.service as proxy_module
@@ -251,9 +252,18 @@ class _DummyScheduler:
 @pytest.mark.asyncio
 async def test_lifespan_drains_actual_audit_and_cancelled_fleet_tasks_before_resource_close(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     import app.core.startup as startup_module
     import app.main as main
+    from app.core import shutdown as shutdown_state
+    from app.core.auth.dependencies import (
+        require_dashboard_write_access,
+        validate_dashboard_session,
+        validate_usage_api_key,
+    )
+    from app.dependencies import get_accounts_context
+    from app.modules.accounts.schemas import AccountImportResponse
 
     settings = Settings(
         otel_enabled=False,
@@ -274,10 +284,15 @@ async def test_lifespan_drains_actual_audit_and_cancelled_fleet_tasks_before_res
     lifespan_entered = asyncio.Event()
     begin_shutdown = asyncio.Event()
     ring_marked_stale = asyncio.Event()
+    final_control_plane_drain_started = asyncio.Event()
     audit_write_started = asyncio.Event()
     allow_audit_write = asyncio.Event()
+    audit_route_started = asyncio.Event()
+    allow_audit_route_finish = asyncio.Event()
     fleet_refresh_started = asyncio.Event()
     allow_fleet_refresh = asyncio.Event()
+    fleet_refresh_finished = asyncio.Event()
+    audit_write_actions: list[str] = []
 
     async def _mark_stale(*args, **kwargs) -> None:
         _ = (args, kwargs)
@@ -305,12 +320,14 @@ async def test_lifespan_drains_actual_audit_and_cancelled_fleet_tasks_before_res
         request_id: str | None,
     ) -> None:
         _ = (action, actor_ip, details, request_id)
+        audit_write_actions.append(action)
         audit_write_started.set()
         await allow_audit_write.wait()
 
     async def _blocked_fleet_refresh(_: list[str] | None) -> FleetRefreshResponse:
         fleet_refresh_started.set()
         await allow_fleet_refresh.wait()
+        fleet_refresh_finished.set()
         return FleetRefreshResponse(
             usage_written=False,
             account_count=0,
@@ -319,10 +336,60 @@ async def test_lifespan_drains_actual_audit_and_cancelled_fleet_tasks_before_res
         )
 
     async def _close_http_client() -> None:
+        assert fleet_refresh_finished.is_set()
+        assert not shutdown_state.is_control_plane_task_admission_open()
         call_order.append("close_http_client")
 
     async def _close_db() -> None:
+        assert fleet_refresh_finished.is_set()
+        assert not shutdown_state.is_control_plane_task_admission_open()
         call_order.append("close_db")
+
+    class _BlockedAccountsService:
+        async def import_account(self, raw: bytes) -> AccountImportResponse:
+            assert raw == b"{}"
+            audit_route_started.set()
+            await allow_audit_route_finish.wait()
+            return AccountImportResponse(
+                account_id="late-audit-account",
+                email="late-audit@example.com",
+                plan_type="plus",
+                status="active",
+            )
+
+    fleet_api_key = ApiKeyData(
+        id="lifespan-fleet-key",
+        name="lifespan fleet key",
+        key_prefix="lifespan-fleet",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+
+    async def _allow_dashboard_access() -> None:
+        return None
+
+    async def _accounts_context_override() -> SimpleNamespace:
+        return SimpleNamespace(service=_BlockedAccountsService())
+
+    async def _fleet_api_key_override() -> ApiKeyData:
+        return fleet_api_key
+
+    async def _force_in_flight_timeout(*, timeout_seconds: float) -> bool:
+        assert timeout_seconds == 5
+        assert shutdown_state.get_in_flight() == 2
+        return False
+
+    original_control_plane_drain = main._drain_detached_control_plane_tasks
+
+    async def _track_control_plane_drain(timeout_seconds: float) -> None:
+        final_control_plane_drain_started.set()
+        await original_control_plane_drain(timeout_seconds)
 
     init_db = AsyncMock()
     init_db.side_effect = _init_db
@@ -350,6 +417,13 @@ async def test_lifespan_drains_actual_audit_and_cancelled_fleet_tasks_before_res
     monkeypatch.setattr(main, "build_model_refresh_scheduler", lambda: model_scheduler)
     monkeypatch.setattr(main, "build_sticky_session_cleanup_scheduler", lambda: sticky_scheduler)
     monkeypatch.setattr(main, "RingMembershipService", lambda session_factory: ring_service)
+    monkeypatch.setattr(shutdown_state, "wait_for_in_flight_drain", _force_in_flight_timeout)
+    monkeypatch.setattr(main, "_drain_detached_control_plane_tasks", _track_control_plane_drain)
+    monkeypatch.setitem(main.app.dependency_overrides, validate_dashboard_session, _allow_dashboard_access)
+    monkeypatch.setitem(main.app.dependency_overrides, require_dashboard_write_access, _allow_dashboard_access)
+    monkeypatch.setitem(main.app.dependency_overrides, get_accounts_context, _accounts_context_override)
+    monkeypatch.setitem(main.app.dependency_overrides, validate_usage_api_key, _fleet_api_key_override)
+    caplog.set_level(logging.WARNING, logger=audit_service_module.__name__)
 
     async def _run_lifespan() -> None:
         async with main.lifespan(main.app):
@@ -363,6 +437,7 @@ async def test_lifespan_drains_actual_audit_and_cancelled_fleet_tasks_before_res
 
     await asyncio.wait_for(lifespan_entered.wait(), timeout=1)
     assert startup_module._startup_complete is True
+    assert shutdown_state.is_control_plane_task_admission_open() is True
     assert usage_scheduler.started is True
     assert api_key_limit_reset_scheduler.started is True
     assert model_scheduler.started is True
@@ -372,48 +447,56 @@ async def test_lifespan_drains_actual_audit_and_cancelled_fleet_tasks_before_res
     await asyncio.wait_for(audit_write_started.wait(), timeout=1)
     audit_task = next(iter(audit_service_module._AUDIT_LOG_TASKS))
 
-    fleet_request_task = asyncio.create_task(
-        main.fleet_api.refresh_fleet_usage(
-            api_key=ApiKeyData(
-                id="lifespan-fleet-key",
-                name="lifespan fleet key",
-                key_prefix="lifespan-fleet",
-                allowed_models=None,
-                enforced_model=None,
-                enforced_reasoning_effort=None,
-                enforced_service_tier=None,
-                expires_at=None,
-                is_active=True,
-                created_at=utcnow(),
-                last_used_at=None,
+    transport = ASGITransport(app=main.app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        fleet_request_task = asyncio.create_task(client.post("/api/fleet/refresh"))
+        audit_request_task = asyncio.create_task(
+            client.post(
+                "/api/accounts/import",
+                files={"auth_json": ("auth.json", b"{}", "application/json")},
             )
         )
-    )
-    await asyncio.wait_for(fleet_refresh_started.wait(), timeout=1)
-    fleet_request_task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await fleet_request_task
-    await asyncio.sleep(0)
-    fleet_task = next(iter(main.fleet_api._BACKGROUND_REFRESH_TASKS))
+        await asyncio.wait_for(fleet_refresh_started.wait(), timeout=1)
+        await asyncio.wait_for(audit_route_started.wait(), timeout=1)
 
-    begin_shutdown.set()
-    await asyncio.wait_for(ring_marked_stale.wait(), timeout=1)
-    await asyncio.sleep(0)
+        assert shutdown_state.get_in_flight() == 2
+        assert len(main.fleet_api._BACKGROUND_REFRESH_TASKS) == 1
+        fleet_task = next(iter(main.fleet_api._BACKGROUND_REFRESH_TASKS))
 
-    assert not lifespan_task.done()
-    close_http_client.assert_not_awaited()
-    close_db.assert_not_awaited()
+        begin_shutdown.set()
+        await asyncio.wait_for(ring_marked_stale.wait(), timeout=1)
+        await asyncio.wait_for(final_control_plane_drain_started.wait(), timeout=1)
 
-    allow_audit_write.set()
-    await asyncio.wait_for(audit_task, timeout=1)
-    await asyncio.sleep(0)
-    assert not lifespan_task.done()
-    close_http_client.assert_not_awaited()
-    close_db.assert_not_awaited()
+        assert shutdown_state.is_control_plane_task_admission_open() is False
+        assert not lifespan_task.done()
+        close_http_client.assert_not_awaited()
+        close_db.assert_not_awaited()
 
-    allow_fleet_refresh.set()
-    await asyncio.wait_for(fleet_task, timeout=1)
-    await asyncio.wait_for(lifespan_task, timeout=1)
+        fleet_request_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await fleet_request_task
+        assert main.fleet_api._BACKGROUND_REFRESH_TASKS == {fleet_task}
+
+        allow_audit_route_finish.set()
+        audit_response = await asyncio.wait_for(audit_request_task, timeout=1)
+        assert audit_response.status_code == 200
+        assert audit_write_actions == ["lifespan_shutdown_test"]
+        assert "Audit log task rejected after shutdown admission closed: account_created" in caplog.text
+
+        assert not lifespan_task.done()
+        close_http_client.assert_not_awaited()
+        close_db.assert_not_awaited()
+
+        allow_audit_write.set()
+        await asyncio.wait_for(audit_task, timeout=1)
+        await asyncio.sleep(0)
+        assert not lifespan_task.done()
+        close_http_client.assert_not_awaited()
+        close_db.assert_not_awaited()
+
+        allow_fleet_refresh.set()
+        await asyncio.wait_for(fleet_task, timeout=1)
+        await asyncio.wait_for(lifespan_task, timeout=1)
 
     init_db.assert_awaited_once()
     init_background_db.assert_called_once()
@@ -425,6 +508,7 @@ async def test_lifespan_drains_actual_audit_and_cancelled_fleet_tasks_before_res
     assert call_order[:2] == ["init_db", "init_background_db"]
     assert call_order.index("mark_ring_stale") < call_order.index("close_http_client")
     assert call_order.index("mark_ring_stale") < call_order.index("close_db")
+    assert shutdown_state.is_control_plane_task_admission_open() is False
     assert audit_service_module._AUDIT_LOG_TASKS == set()
     assert main.fleet_api._BACKGROUND_REFRESH_TASKS == set()
     assert usage_scheduler.stopped is True

--- a/tests/unit/test_otel.py
+++ b/tests/unit/test_otel.py
@@ -17,13 +17,17 @@ import pytest
 
 import app.core.tracing.otel as otel
 import app.modules.proxy.service as proxy_module
+from app.core.audit import service as audit_service_module
 from app.core.clients.proxy import ProxyResponseError
 from app.core.clients.proxy_websocket import UpstreamResponsesWebSocket
 from app.core.config.settings import Settings
 from app.core.runtime_logging import JsonFormatter
 from app.core.usage import refresh_scheduler as refresh_scheduler_module
+from app.core.utils.time import utcnow
 from app.db.models import AccountStatus
 from app.dependencies import get_proxy_service_for_app
+from app.modules.api_keys.service import ApiKeyData
+from app.modules.fleet.schemas import FleetRefreshResponse
 from app.modules.usage import updater as usage_updater_module
 
 pytestmark = pytest.mark.unit
@@ -245,7 +249,9 @@ class _DummyScheduler:
 
 
 @pytest.mark.asyncio
-async def test_lifespan_runs_normally_when_otel_is_disabled(monkeypatch: pytest.MonkeyPatch):
+async def test_lifespan_drains_actual_audit_and_cancelled_fleet_tasks_before_resource_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import app.core.startup as startup_module
     import app.main as main
 
@@ -253,7 +259,7 @@ async def test_lifespan_runs_normally_when_otel_is_disabled(monkeypatch: pytest.
         otel_enabled=False,
         otel_exporter_endpoint="",
         metrics_enabled=False,
-        shutdown_drain_timeout_seconds=0,
+        shutdown_drain_timeout_seconds=5,
     )
     settings_cache = SimpleNamespace(
         invalidate=AsyncMock(),
@@ -265,10 +271,18 @@ async def test_lifespan_runs_normally_when_otel_is_disabled(monkeypatch: pytest.
     model_scheduler = _DummyScheduler()
     sticky_scheduler = _DummyScheduler()
     call_order: list[str] = []
+    lifespan_entered = asyncio.Event()
+    begin_shutdown = asyncio.Event()
+    ring_marked_stale = asyncio.Event()
+    audit_write_started = asyncio.Event()
+    allow_audit_write = asyncio.Event()
+    fleet_refresh_started = asyncio.Event()
+    allow_fleet_refresh = asyncio.Event()
 
     async def _mark_stale(*args, **kwargs) -> None:
         _ = (args, kwargs)
         call_order.append("mark_ring_stale")
+        ring_marked_stale.set()
 
     ring_service = SimpleNamespace(
         register=AsyncMock(),
@@ -284,15 +298,25 @@ async def test_lifespan_runs_normally_when_otel_is_disabled(monkeypatch: pytest.
     def _init_background_db() -> None:
         call_order.append("init_background_db")
 
-    async def _drain_audit_tasks(timeout_seconds: float) -> bool:
-        assert timeout_seconds == settings.shutdown_drain_timeout_seconds
-        call_order.append("drain_audit_tasks")
-        return True
+    async def _blocked_audit_write(
+        action: str,
+        actor_ip: str | None,
+        details: audit_service_module.AuditDetails | None,
+        request_id: str | None,
+    ) -> None:
+        _ = (action, actor_ip, details, request_id)
+        audit_write_started.set()
+        await allow_audit_write.wait()
 
-    async def _drain_fleet_tasks(timeout_seconds: float) -> bool:
-        assert timeout_seconds == settings.shutdown_drain_timeout_seconds
-        call_order.append("drain_fleet_tasks")
-        return True
+    async def _blocked_fleet_refresh(_: list[str] | None) -> FleetRefreshResponse:
+        fleet_refresh_started.set()
+        await allow_fleet_refresh.wait()
+        return FleetRefreshResponse(
+            usage_written=False,
+            account_count=0,
+            attempted_count=0,
+            generated_at=utcnow(),
+        )
 
     async def _close_http_client() -> None:
         call_order.append("close_http_client")
@@ -319,21 +343,77 @@ async def test_lifespan_runs_normally_when_otel_is_disabled(monkeypatch: pytest.
     monkeypatch.setattr(main, "verify_encryption_key_fingerprint", AsyncMock(return_value=None))
     monkeypatch.setattr(main, "close_http_client", close_http_client)
     monkeypatch.setattr(main, "close_db", close_db)
-    monkeypatch.setattr(main, "drain_audit_log_tasks", _drain_audit_tasks)
-    monkeypatch.setattr(main.fleet_api, "drain_background_refresh_tasks", _drain_fleet_tasks)
+    monkeypatch.setattr(audit_service_module, "_write_audit_log", _blocked_audit_write)
+    monkeypatch.setattr(main.fleet_api, "_refresh_fleet_usage_with_owned_session", _blocked_fleet_refresh)
     monkeypatch.setattr(main, "build_usage_refresh_scheduler", lambda: usage_scheduler)
     monkeypatch.setattr(main, "build_api_key_limit_reset_scheduler", lambda: api_key_limit_reset_scheduler)
     monkeypatch.setattr(main, "build_model_refresh_scheduler", lambda: model_scheduler)
     monkeypatch.setattr(main, "build_sticky_session_cleanup_scheduler", lambda: sticky_scheduler)
     monkeypatch.setattr(main, "RingMembershipService", lambda session_factory: ring_service)
 
-    async with main.lifespan(main.app):
-        await asyncio.sleep(0)
-        assert startup_module._startup_complete is True
-        assert usage_scheduler.started is True
-        assert api_key_limit_reset_scheduler.started is True
-        assert model_scheduler.started is True
-        assert sticky_scheduler.started is True
+    async def _run_lifespan() -> None:
+        async with main.lifespan(main.app):
+            await asyncio.sleep(0)
+            lifespan_entered.set()
+            await begin_shutdown.wait()
+
+    assert audit_service_module._AUDIT_LOG_TASKS == set()
+    assert main.fleet_api._BACKGROUND_REFRESH_TASKS == set()
+    lifespan_task = asyncio.create_task(_run_lifespan())
+
+    await asyncio.wait_for(lifespan_entered.wait(), timeout=1)
+    assert startup_module._startup_complete is True
+    assert usage_scheduler.started is True
+    assert api_key_limit_reset_scheduler.started is True
+    assert model_scheduler.started is True
+    assert sticky_scheduler.started is True
+
+    audit_service_module.AuditService.log_async("lifespan_shutdown_test")
+    await asyncio.wait_for(audit_write_started.wait(), timeout=1)
+    audit_task = next(iter(audit_service_module._AUDIT_LOG_TASKS))
+
+    fleet_request_task = asyncio.create_task(
+        main.fleet_api.refresh_fleet_usage(
+            api_key=ApiKeyData(
+                id="lifespan-fleet-key",
+                name="lifespan fleet key",
+                key_prefix="lifespan-fleet",
+                allowed_models=None,
+                enforced_model=None,
+                enforced_reasoning_effort=None,
+                enforced_service_tier=None,
+                expires_at=None,
+                is_active=True,
+                created_at=utcnow(),
+                last_used_at=None,
+            )
+        )
+    )
+    await asyncio.wait_for(fleet_refresh_started.wait(), timeout=1)
+    fleet_request_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await fleet_request_task
+    await asyncio.sleep(0)
+    fleet_task = next(iter(main.fleet_api._BACKGROUND_REFRESH_TASKS))
+
+    begin_shutdown.set()
+    await asyncio.wait_for(ring_marked_stale.wait(), timeout=1)
+    await asyncio.sleep(0)
+
+    assert not lifespan_task.done()
+    close_http_client.assert_not_awaited()
+    close_db.assert_not_awaited()
+
+    allow_audit_write.set()
+    await asyncio.wait_for(audit_task, timeout=1)
+    await asyncio.sleep(0)
+    assert not lifespan_task.done()
+    close_http_client.assert_not_awaited()
+    close_db.assert_not_awaited()
+
+    allow_fleet_refresh.set()
+    await asyncio.wait_for(fleet_task, timeout=1)
+    await asyncio.wait_for(lifespan_task, timeout=1)
 
     init_db.assert_awaited_once()
     init_background_db.assert_called_once()
@@ -343,12 +423,10 @@ async def test_lifespan_runs_normally_when_otel_is_disabled(monkeypatch: pytest.
     settings_cache.invalidate.assert_awaited_once()
     rate_limit_cache.invalidate.assert_awaited_once()
     assert call_order[:2] == ["init_db", "init_background_db"]
-    assert call_order.index("mark_ring_stale") < call_order.index("drain_audit_tasks")
-    assert call_order.index("mark_ring_stale") < call_order.index("drain_fleet_tasks")
-    assert call_order.index("drain_audit_tasks") < call_order.index("close_http_client")
-    assert call_order.index("drain_fleet_tasks") < call_order.index("close_http_client")
-    assert call_order.index("drain_audit_tasks") < call_order.index("close_db")
-    assert call_order.index("drain_fleet_tasks") < call_order.index("close_db")
+    assert call_order.index("mark_ring_stale") < call_order.index("close_http_client")
+    assert call_order.index("mark_ring_stale") < call_order.index("close_db")
+    assert audit_service_module._AUDIT_LOG_TASKS == set()
+    assert main.fleet_api._BACKGROUND_REFRESH_TASKS == set()
     assert usage_scheduler.stopped is True
     assert api_key_limit_reset_scheduler.stopped is True
     assert model_scheduler.stopped is True

--- a/tests/unit/test_otel.py
+++ b/tests/unit/test_otel.py
@@ -264,14 +264,19 @@ async def test_lifespan_runs_normally_when_otel_is_disabled(monkeypatch: pytest.
     api_key_limit_reset_scheduler = _DummyScheduler()
     model_scheduler = _DummyScheduler()
     sticky_scheduler = _DummyScheduler()
+    call_order: list[str] = []
+
+    async def _mark_stale(*args, **kwargs) -> None:
+        _ = (args, kwargs)
+        call_order.append("mark_ring_stale")
+
     ring_service = SimpleNamespace(
         register=AsyncMock(),
-        mark_stale=AsyncMock(),
+        mark_stale=AsyncMock(side_effect=_mark_stale),
         unregister=AsyncMock(),
         heartbeat=AsyncMock(),
         list_active=AsyncMock(return_value=[]),
     )
-    call_order: list[str] = []
 
     async def _init_db() -> None:
         call_order.append("init_db")
@@ -279,12 +284,28 @@ async def test_lifespan_runs_normally_when_otel_is_disabled(monkeypatch: pytest.
     def _init_background_db() -> None:
         call_order.append("init_background_db")
 
+    async def _drain_audit_tasks(timeout_seconds: float) -> bool:
+        assert timeout_seconds == settings.shutdown_drain_timeout_seconds
+        call_order.append("drain_audit_tasks")
+        return True
+
+    async def _drain_fleet_tasks(timeout_seconds: float) -> bool:
+        assert timeout_seconds == settings.shutdown_drain_timeout_seconds
+        call_order.append("drain_fleet_tasks")
+        return True
+
+    async def _close_http_client() -> None:
+        call_order.append("close_http_client")
+
+    async def _close_db() -> None:
+        call_order.append("close_db")
+
     init_db = AsyncMock()
     init_db.side_effect = _init_db
     init_background_db = Mock(side_effect=_init_background_db)
     init_http_client = AsyncMock()
-    close_http_client = AsyncMock()
-    close_db = AsyncMock()
+    close_http_client = AsyncMock(side_effect=_close_http_client)
+    close_db = AsyncMock(side_effect=_close_db)
 
     monkeypatch.setattr(main, "get_settings", lambda: settings)
     monkeypatch.setattr(main, "get_settings_cache", lambda: settings_cache)
@@ -298,6 +319,8 @@ async def test_lifespan_runs_normally_when_otel_is_disabled(monkeypatch: pytest.
     monkeypatch.setattr(main, "verify_encryption_key_fingerprint", AsyncMock(return_value=None))
     monkeypatch.setattr(main, "close_http_client", close_http_client)
     monkeypatch.setattr(main, "close_db", close_db)
+    monkeypatch.setattr(main, "drain_audit_log_tasks", _drain_audit_tasks)
+    monkeypatch.setattr(main.fleet_api, "drain_background_refresh_tasks", _drain_fleet_tasks)
     monkeypatch.setattr(main, "build_usage_refresh_scheduler", lambda: usage_scheduler)
     monkeypatch.setattr(main, "build_api_key_limit_reset_scheduler", lambda: api_key_limit_reset_scheduler)
     monkeypatch.setattr(main, "build_model_refresh_scheduler", lambda: model_scheduler)
@@ -320,6 +343,12 @@ async def test_lifespan_runs_normally_when_otel_is_disabled(monkeypatch: pytest.
     settings_cache.invalidate.assert_awaited_once()
     rate_limit_cache.invalidate.assert_awaited_once()
     assert call_order[:2] == ["init_db", "init_background_db"]
+    assert call_order.index("mark_ring_stale") < call_order.index("drain_audit_tasks")
+    assert call_order.index("mark_ring_stale") < call_order.index("drain_fleet_tasks")
+    assert call_order.index("drain_audit_tasks") < call_order.index("close_http_client")
+    assert call_order.index("drain_fleet_tasks") < call_order.index("close_http_client")
+    assert call_order.index("drain_audit_tasks") < call_order.index("close_db")
+    assert call_order.index("drain_fleet_tasks") < call_order.index("close_db")
     assert usage_scheduler.stopped is True
     assert api_key_limit_reset_scheduler.stopped is True
     assert model_scheduler.stopped is True


### PR DESCRIPTION
## Summary

Track detached audit writes and cancelled-request fleet refreshes until completion, then drain both task classes during graceful shutdown before their database, HTTP, and usage-singleflight dependencies are torn down.

This closes a shutdown race that could lose audit rows or let fleet work outlive its owned resources, while preserving fire-and-forget request latency and reusing the existing bounded drain timeout.

Review follow-up: the drain now requires a second stable clean pass before HTTP/database teardown, so late audit/fleet tasks queued after the first empty snapshot are re-swept while their dependencies are still alive.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: none; this is a proactive lifecycle fix found during a shutdown audit.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/drain-audit-fleet-tasks/`

## Changes

- Keep every asynchronous audit write strongly owned, consume failures, and expose an audit-specific bounded drain.
- Drain the existing cancelled-request fleet refresh registry and report overdue task names.
- Run both drains concurrently after request/bridge quiescing but before scheduler, HTTP client, and database teardown; isolate either drain's failure from the other.
- Re-sweep the control-plane drain after a clean pass so late sibling tasks are caught before resource teardown.
- Add regression coverage for callback-created tasks, timeout behavior, failure cleanup, fleet session ownership, stable clean drain passes, and lifecycle ordering.

## Simplicity

- [x] Works with zero configuration and preserves existing defaults.
- [x] Adds no setting, required setup step, README section, `.env.example` entry, or dashboard navigation item.
- [x] Reuses `shutdown_drain_timeout_seconds` and introduces no new operator surface.

## Test plan

```text
uv run pytest tests/unit/test_graceful_shutdown.py::test_control_plane_drain_requires_stable_clean_pass tests/unit/test_graceful_shutdown.py::test_control_plane_drains_are_failure_isolated tests/unit/test_otel.py::test_lifespan_drains_actual_audit_and_cancelled_fleet_tasks_before_resource_close -q
3 passed

uv run pytest tests/unit/test_graceful_shutdown.py tests/unit/test_otel.py tests/unit/test_audit_trail.py tests/integration/test_fleet_summary_api.py -q
70 passed

uv run ruff check app/main.py tests/unit/test_graceful_shutdown.py
All checks passed

git diff --check
passed
```

Previous branch verification before this review follow-up:

```text
focused shutdown/audit/fleet/OTel suites: 68 passed
full unit suite: 4246 passed, 55 skipped
affected fleet integration file: 33 passed
Ruff check + format check: passed
ty: passed
proxy architecture check: passed
simplicity budget check: passed
openspec validate drain-audit-fleet-tasks --strict: passed
openspec validate --specs: 47/47 specs passed
formal OpenSpec verification: 0 critical, 0 warning, 0 suggestion
git diff --check: passed
```

## Screenshots / output

Not applicable: no dashboard or external response surface changes.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] No related issue currently covers this focused shutdown race.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local CI subsets.
- [x] Strict OpenSpec validation and formal verification are clean.
- [x] Reviewed all five simplicity gates in `PRINCIPLES.md`.
- [x] `CHANGELOG.md` is not edited by hand.
