### PR TITLE
ci(db): run PostgreSQL migration lock tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ POSTGRES_PYTEST_TARGETS := \
 	tests/integration/test_migrations.py::test_postgresql_migration_contract_policy_and_drift_match \
 	tests/integration/test_migrations.py::test_postgresql_upgrade_head_from_empty_database \
 	tests/integration/test_migrations.py::test_postgresql_startup_migration_auto_remap_legacy_head \
+	tests/integration/test_migration_serialization.py::test_concurrent_upgrades_on_fresh_postgresql_database_apply_head_exactly_once \
+	tests/integration/test_migration_serialization.py::test_postgresql_run_upgrade_times_out_when_advisory_lock_is_held \
 	tests/integration/test_usage_repository.py::test_latest_by_account_primary_query_plan_uses_normalized_window_index_postgresql \
 	tests/integration/test_repositories.py::test_accounts_upsert_with_merge_enabled_serializes_concurrent_same_email \
 	tests/integration/test_sticky_sessions_api.py::test_durable_bridge_owned_alias_registration_is_epoch_fenced \


### PR DESCRIPTION
## Summary

Include the two existing PostgreSQL-only migration serialization tests in `make test-postgres`, which is the PostgreSQL test entry point used by CI.

The tests already cover concurrent fresh-database upgrades and advisory-lock timeout behavior, but the default SQLite shards skip them and the explicit PostgreSQL target list did not select them. This change makes those regressions part of the required PostgreSQL lane.

## Type of change

- [ ] `fix:` — bug fix
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor
- [ ] `docs:` — documentation only
- [x] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: none; this is a focused CI coverage gap found during the project audit.

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [x] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

## Changes

- Add the concurrent PostgreSQL upgrade test to `POSTGRES_PYTEST_TARGETS`.
- Add the PostgreSQL advisory migration-lock timeout test to `POSTGRES_PYTEST_TARGETS`.
- Keep the existing test implementation and CI topology unchanged.

## Simplicity

- [x] No settings, defaults, setup steps, docs sections, environment examples, or dashboard navigation items are added.
- [x] The change only extends the existing required PostgreSQL test lane.

## Test plan

```text
make -n test-postgres: both exact migration-serialization node IDs selected
direct execution under the default SQLite test config: 2 skipped by the expected PostgreSQL-only markers
Ruff check + format check: passed
ty: passed
proxy architecture check: passed
simplicity budget check: passed
git diff --check: passed
```

The PR's `Tests (pytest, PostgreSQL)` check supplies the PostgreSQL service and executes both selected tests against it.

## Screenshots / output

Not applicable: CI-only change.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] No related issue currently covers this focused CI gap.
- [x] Existing tests cover the behavior; this PR activates them in PostgreSQL CI.
- [x] Ran the relevant local CI subsets.
- [x] OpenSpec is not applicable to this CI-only selection change.
- [x] Reviewed all five simplicity gates in `PRINCIPLES.md`.
- [x] `CHANGELOG.md` is not edited by hand.
