### PR TITLE
perf(usage): scope refresh work to selected account

### DIFF
--- a/app/core/usage/refresh_scheduler.py
+++ b/app/core/usage/refresh_scheduler.py
@@ -5,7 +5,7 @@ import contextlib
 import importlib
 import logging
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Collection
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, AsyncIterator, Protocol, TypeVar, cast
@@ -56,7 +56,12 @@ class _RecoverableAccountsRepository(Protocol):
 
 
 class _LatestUsageRepository(Protocol):
-    async def latest_by_account(self, window: str | None = None) -> dict[str, UsageHistory]: ...
+    async def latest_by_account(
+        self,
+        window: str | None = None,
+        *,
+        account_ids: Collection[str] | None = None,
+    ) -> dict[str, UsageHistory]: ...
 
 
 class _BackgroundLimitWarmupRepository:
@@ -173,10 +178,18 @@ class UsageRefreshScheduler:
                 async with get_background_session() as session:
                     usage_repo = UsageRepository(session)
                     accounts_repo = AccountsRepository(session)
-                    before_primary = await usage_repo.latest_by_account(window="primary")
-                    before_secondary = await usage_repo.latest_by_account(window="secondary")
                     accounts = _ordered_usage_refresh_accounts(await accounts_repo.list_accounts())
                     selected_account, cycle_complete = self._select_next_account(accounts)
+                    if selected_account is not None:
+                        selected_account_ids = [selected_account.id]
+                        before_primary = await usage_repo.latest_by_account(
+                            window="primary",
+                            account_ids=selected_account_ids,
+                        )
+                        before_secondary = await usage_repo.latest_by_account(
+                            window="secondary",
+                            account_ids=selected_account_ids,
+                        )
                     detach_session_objects(session)
                 account_count = len(accounts)
                 if selected_account is None:
@@ -191,10 +204,19 @@ class UsageRefreshScheduler:
                         usage_repo = UsageRepository(session)
                         accounts_repo = AccountsRepository(session)
                         settings_repo = SettingsRepository(session)
-                        after_primary = await usage_repo.latest_by_account(window="primary")
-                        after_secondary = await usage_repo.latest_by_account(window="secondary")
+                        after_primary = await usage_repo.latest_by_account(
+                            window="primary",
+                            account_ids=selected_account_ids,
+                        )
+                        after_secondary = await usage_repo.latest_by_account(
+                            window="secondary",
+                            account_ids=selected_account_ids,
+                        )
                         dashboard_settings = await settings_repo.get_or_create()
                         refreshed_accounts = await accounts_repo.list_accounts(refresh_existing=True)
+                        refreshed_selected_accounts = [
+                            account for account in refreshed_accounts if account.id == selected_account.id
+                        ]
                         detach_session_objects(session)
                     warmup_service = LimitWarmupService(
                         cast(Any, _BackgroundLimitWarmupRepository()),
@@ -205,7 +227,8 @@ class UsageRefreshScheduler:
                         ),
                     )
                     await warmup_service.run_after_usage_refresh(
-                        accounts=refreshed_accounts,
+                        accounts=refreshed_selected_accounts,
+                        stagger_accounts=refreshed_accounts,
                         settings=dashboard_settings,
                         before_primary=before_primary,
                         before_secondary=before_secondary,
@@ -220,7 +243,7 @@ class UsageRefreshScheduler:
                         await reconcile_recoverable_account_statuses(
                             accounts_repo=accounts_repo,
                             usage_repo=usage_repo,
-                            accounts=refreshed_accounts,
+                            accounts=refreshed_selected_accounts,
                         )
                 if cycle_complete:
                     await _invalidate_usage_refresh_caches()
@@ -285,9 +308,10 @@ async def reconcile_recoverable_account_statuses(
     if not candidates:
         return 0
 
-    latest_primary = await usage_repo.latest_by_account(window="primary")
-    latest_secondary = await usage_repo.latest_by_account(window="secondary")
-    latest_monthly = await usage_repo.latest_by_account(window="monthly")
+    candidate_ids = [account.id for account in candidates]
+    latest_primary = await usage_repo.latest_by_account(window="primary", account_ids=candidate_ids)
+    latest_secondary = await usage_repo.latest_by_account(window="secondary", account_ids=candidate_ids)
+    latest_monthly = await usage_repo.latest_by_account(window="monthly", account_ids=candidate_ids)
 
     recovered = 0
     for account in candidates:

--- a/app/modules/limit_warmup/service.py
+++ b/app/modules/limit_warmup/service.py
@@ -317,6 +317,7 @@ class LimitWarmupService:
         self,
         *,
         accounts: list[Account],
+        stagger_accounts: list[Account] | None = None,
         settings: DashboardSettings,
         before_primary: dict[str, UsageHistory],
         before_secondary: dict[str, UsageHistory],
@@ -338,8 +339,11 @@ class LimitWarmupService:
             raise RuntimeError("LimitWarmupService requires a sender")
         send_tasks: dict[asyncio.Task[LimitWarmupSendOutcome], AccountLimitWarmup] = {}
         send_semaphore = asyncio.Semaphore(_MAX_CONCURRENT_WARMUP_SENDS)
+        stagger_source = accounts if stagger_accounts is None else stagger_accounts
         staggered_accounts = [
-            account for account in accounts if _account_is_safe_candidate(account) and account.limit_warmup_enabled
+            account
+            for account in stagger_source
+            if _account_is_safe_candidate(account) and account.limit_warmup_enabled
         ]
         now = utcnow()
 

--- a/openspec/changes/refresh-selected-account-usage/.openspec.yaml
+++ b/openspec/changes/refresh-selected-account-usage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/refresh-selected-account-usage/design.md
+++ b/openspec/changes/refresh-selected-account-usage/design.md
@@ -1,0 +1,59 @@
+## Context
+
+`UsageRefreshScheduler` has two distinct scopes today. Its rotation is already account-at-a-time, but the read phase loads primary and secondary snapshots for every account before choosing the slot. After a successful write, it again loads fleet-wide snapshots, evaluates warm-up with every account, and gives recovery a fleet-wide repository. `UsageRepository.latest_by_account()` already supports `account_ids`, so no query or schema primitive is missing.
+
+The scheduler must retain three existing invariants: the full eligible roster determines deterministic rotation, staggered-idle warm-up phases use a stable fleet cohort, and every upstream operation runs after the originating `AsyncSession` has closed. The newly merged #1376 Force Probe settlement is a separate, operator-driven path and remains unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make recurring usage-history work proportional to one selected account per scheduler slice.
+- Ensure usage refresh, warm-up candidate evaluation, and recoverable-status reconciliation cannot spill into an unrelated account during that slice.
+- Preserve deterministic account rotation, staggered-idle warm-up phase calculation, credential-slot ownership checks, per-account failure isolation, and session lifecycle safety.
+- Cover the scheduler through both focused tests and a real repository-backed integration path.
+
+**Non-Goals:**
+
+- Batch usage writes or commits; that is an independent transaction-focused improvement.
+- Change retention, rollups, indexes, dashboard reads, Force Probe, fleet refresh, or request-time refresh behavior.
+- Add settings, migrations, dependencies, APIs, or cross-account failover to background refresh.
+
+## Decisions
+
+### Select the slot before reading usage history
+
+The scheduler will load the small account roster, choose one account, and only then request primary and secondary snapshots with `account_ids=[selected_account.id]`. This uses the repository's existing indexed account filter and avoids introducing another read API.
+
+Alternative considered: keep fleet-wide snapshots and slice the returned dictionaries in memory. That preserves outputs but leaves the expensive database work from #708 untouched.
+
+### Separate warm-up evaluation scope from its stagger cohort
+
+After a successful selected-account refresh, the scheduler will reload current account rows so opt-in and status changes remain visible. `LimitWarmupService.run_after_usage_refresh()` will receive the selected current account as its evaluation set and the full current roster only as an optional stagger cohort. Warm-up attempts and sends are therefore possible only for the selected account, while `_staggered_idle_due()` retains the same phase calculation across all eligible warm-up accounts.
+
+Alternative considered: pass only the selected account through the existing parameter. That would make every account appear to be slot zero in the rolling warm-up cycle and change prestart behavior. Passing the full roster as evaluation input was also rejected because it needlessly queries attempts and evaluates unrelated accounts.
+
+### Filter recovery at the repository boundary
+
+`reconcile_recoverable_account_statuses()` will derive recoverable candidate ids first and pass them to each primary, secondary, and monthly latest-usage lookup. The scheduler will call it with only the selected current account. This retains compare-and-set status writes while proving that unrelated rows cannot participate.
+
+Alternative considered: filter only the returned dictionaries. That would still execute fleet-wide history lookups and would not address the performance failure mode.
+
+### Preserve sequential ownership and session boundaries
+
+The scheduler continues to await one `UsageUpdater.refresh_accounts([selected])` call per slice. It will not substitute another account on failure. Read sessions are closed and ORM rows detached before upstream usage or warm-up traffic begins; existing background repository adapters continue to create independent sessions for any concurrent warm-up tasks.
+
+## Risks / Trade-offs
+
+- [Risk] Separating warm-up candidates from the stagger cohort could accidentally shift phase ordering. → Keep the full refreshed roster as the cohort and add a regression that only the selected account is evaluated while all eligible account ids remain in phase calculation.
+- [Risk] An account can be deleted or become ineligible during its upstream refresh. → Reload the selected account afterward; if it no longer exists, skip warm-up and recovery instead of falling back to another account.
+- [Risk] A per-account refresh failure leaves that slot without new data. → Preserve current behavior: do not cross account boundaries in the same slice; the deterministic rotation advances normally on later slices.
+- [Trade-off] The accounts table is still read for rotation and post-refresh warm-up cohort freshness. This bounded control-plane read is independent of `usage_history` size and avoids changing warm-up semantics.
+
+## Migration Plan
+
+No data or configuration migration is required. Deploy normally. Rollback restores fleet-wide scheduler reads without altering stored data.
+
+## Open Questions
+
+None.

--- a/openspec/changes/refresh-selected-account-usage/proposal.md
+++ b/openspec/changes/refresh-selected-account-usage/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The background usage scheduler already chooses one account per staggered slot, but it still reads latest usage for the full fleet and can re-evaluate unrelated accounts after that one refresh. On installations with many accounts and a large `usage_history` table, this multiplies the recurring database work identified in #708 even though only one credential slot can produce new usage in that tick.
+
+## What Changes
+
+- Scope each scheduler tick's before/after usage lookups to the selected account.
+- Scope post-refresh warm-up and recoverable-status evaluation to that same account while retaining the fleet roster only where deterministic rotation or warm-up phase calculation requires it.
+- Preserve the selected account's credential ownership, existing per-account failure handling, cache invalidation cadence, and the rule that database sessions close before upstream network I/O.
+- Add regressions at the scheduler and repository-backed product path proving unrelated accounts are neither fetched nor mutated.
+- Keep usage-write transaction batching, retention, rollups, and dashboard query optimization outside this change so the PR is self-contained.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `usage-refresh-policy`: Require every staggered background scheduler tick to read and evaluate usage only for its selected account while preserving account ownership and rotation semantics.
+
+## Impact
+
+- Affected code: `app/core/usage/refresh_scheduler.py`, its latest-usage repository protocol, and the limit-warm-up service's candidate/cohort input.
+- Affected tests: scheduler/recovery unit tests and repository-backed usage-refresh integration coverage.
+- No API, schema, migration, setting, dependency, dashboard, or deployment change.

--- a/openspec/changes/refresh-selected-account-usage/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/refresh-selected-account-usage/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,55 @@
+## MODIFIED Requirements
+
+### Requirement: Background usage refresh is staggered across accounts
+
+Background usage refresh MUST distribute account refresh attempts across the configured usage refresh interval instead of refreshing every eligible account in one burst. Each scheduler slice MUST attempt at most one eligible account. Over a full cycle, all eligible accounts SHOULD be considered once.
+
+Each slice MUST select its account before reading usage history and MUST scope its latest-usage lookups, updater input, warm-up candidate evaluation, and recoverable-status evaluation to that selected account. The scheduler MAY retain the full eligible account roster only to choose the deterministic rotation and calculate staggered warm-up phases; that roster MUST NOT cause usage-history reads, upstream refresh attempts, warm-up sends, or status mutations for an unrelated account in the slice. A selected-account refresh failure MUST NOT trigger same-slice fallback to another account. Database sessions used to load scheduler state MUST close before upstream network I/O begins, and concurrent follow-up work MUST NOT share an `AsyncSession`.
+
+#### Scenario: Scheduler refreshes one account per slice
+
+- **GIVEN** two active accounts are eligible for usage refresh
+- **WHEN** the scheduler runs consecutive refresh slices
+- **THEN** the first slice attempts one account
+- **AND** the second slice attempts the other account
+- **AND** cache invalidation for usage-derived routing state runs at the cycle boundary
+
+#### Scenario: Unrefreshable accounts are skipped by scheduler rotation
+
+- **GIVEN** one account is active
+- **AND** one account is deactivated
+- **AND** one account requires re-authentication
+- **WHEN** the scheduler builds the refresh rotation
+- **THEN** only the active account is considered
+
+#### Scenario: Selected slot scopes usage history and follow-up work
+
+- **GIVEN** two eligible accounts have stored primary, secondary, and monthly usage
+- **AND** the first account is selected for the current scheduler slice
+- **WHEN** the scheduler reads before/after usage and evaluates warm-up and recoverable status
+- **THEN** every usage-history lookup is filtered to the first account
+- **AND** only the first account is passed to usage refresh, warm-up candidate evaluation, and recoverable-status evaluation
+- **AND** the second account cannot be mutated or contacted during that slice
+
+#### Scenario: Warm-up phase cohort does not widen evaluation scope
+
+- **GIVEN** multiple warm-up-enabled accounts participate in staggered-idle phase calculation
+- **AND** one account is selected for the current usage-refresh slice
+- **WHEN** refreshed usage is evaluated for warm-up
+- **THEN** the phase calculation retains the eligible fleet cohort
+- **AND** only the selected account can create a warm-up attempt or send warm-up traffic
+
+#### Scenario: Selected-account failure does not fail over within the slice
+
+- **GIVEN** two accounts are eligible for scheduler rotation
+- **AND** the first account is selected
+- **WHEN** that account's usage refresh fails
+- **THEN** the scheduler does not attempt the second account in the same slice
+- **AND** the second account remains eligible for its normal later slice
+
+#### Scenario: Scheduler session closes before selected-account network work
+
+- **GIVEN** the scheduler loaded the account roster and selected account usage
+- **WHEN** the selected account's upstream refresh starts
+- **THEN** the scheduler read session is already closed
+- **AND** any concurrent warm-up follow-up owns an independent database session

--- a/openspec/changes/refresh-selected-account-usage/tasks.md
+++ b/openspec/changes/refresh-selected-account-usage/tasks.md
@@ -1,0 +1,21 @@
+## 1. Scheduler Scope
+
+- [x] 1.1 Select the account before loading usage snapshots and filter before/after latest-usage queries to that account id.
+- [x] 1.2 Reload post-refresh account state while passing only the selected current account to warm-up and recoverable-status evaluation.
+- [x] 1.3 Filter recovery primary, secondary, and monthly lookups at the repository boundary to recoverable candidate ids.
+
+## 2. Warm-up Cohort Preservation
+
+- [x] 2.1 Separate `LimitWarmupService` candidate accounts from the optional full-roster stagger cohort without changing default callers.
+- [x] 2.2 Prove staggered phase calculation retains all eligible ids while attempts and sends remain selected-account-only.
+
+## 3. Regression Coverage
+
+- [x] 3.1 Add scheduler unit regressions for selected-account query scope, ownership, failure isolation, rotation, and closed-session network handoff.
+- [x] 3.2 Add a repository-backed scheduler integration test proving unrelated usage rows and accounts never enter the selected slice.
+
+## 4. Verification
+
+- [x] 4.1 Run focused scheduler, recovery, warm-up, updater, and usage-repository tests.
+- [x] 4.2 Run the proportional full unit/integration baseline plus Ruff, formatting, type checking, architecture, simplicity, and diff checks.
+- [x] 4.3 Validate OpenSpec strictly and perform semantic verification against every requirement and scenario.

--- a/tests/integration/test_usage_refresh_scheduler_scope.py
+++ b/tests/integration/test_usage_refresh_scheduler_scope.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable, Collection
+from typing import cast
+
+import pytest
+
+from app.core.crypto import TokenEncryptor
+from app.core.usage import refresh_scheduler as refresh_scheduler_module
+from app.core.utils.time import utcnow
+from app.db.models import Account, AccountStatus, UsageHistory
+from app.db.session import SessionLocal
+from app.modules.accounts.repository import AccountsRepository
+from app.modules.usage.repository import UsageRepository
+
+pytestmark = pytest.mark.integration
+
+
+def _account(
+    account_id: str,
+    *,
+    status: AccountStatus,
+    reset_at: int | None = None,
+    blocked_at: int | None = None,
+) -> Account:
+    encryptor = TokenEncryptor()
+    return Account(
+        id=account_id,
+        chatgpt_account_id=f"workspace-{account_id}",
+        email=f"{account_id}@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access"),
+        refresh_token_encrypted=encryptor.encrypt("refresh"),
+        id_token_encrypted=encryptor.encrypt("id"),
+        last_refresh=utcnow(),
+        status=status,
+        reset_at=reset_at,
+        blocked_at=blocked_at,
+        limit_warmup_enabled=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_scheduler_repository_path_scopes_selected_account_history_and_followups(
+    db_setup,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    del db_setup
+    now = utcnow()
+    selected = _account(
+        "acc_a",
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=int(time.time()) + 3600,
+        blocked_at=int(time.time()),
+    )
+    unrelated = _account("acc_b", status=AccountStatus.ACTIVE)
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+        await accounts_repo.upsert(selected)
+        await accounts_repo.upsert(unrelated)
+        for account, used_percent in ((selected, 10.0), (unrelated, 90.0)):
+            await usage_repo.add_entry(
+                account.id,
+                used_percent,
+                window="primary",
+                recorded_at=now,
+                reset_at=int(time.time()) + 3600,
+                window_minutes=300,
+            )
+            await usage_repo.add_entry(
+                account.id,
+                used_percent,
+                window="secondary",
+                recorded_at=now,
+                reset_at=int(time.time()) + 7200,
+                window_minutes=10_080,
+            )
+            await usage_repo.add_entry(
+                account.id,
+                used_percent,
+                window="monthly",
+                recorded_at=now,
+                reset_at=int(time.time()) + 10_800,
+                window_minutes=43_200,
+            )
+
+    query_scopes: list[tuple[str | None, tuple[str, ...] | None]] = []
+    updater_calls: list[tuple[list[str], set[str]]] = []
+    warmup_calls: list[dict[str, object]] = []
+    original_latest_by_account = UsageRepository.latest_by_account
+
+    async def _tracked_latest_by_account(
+        self: UsageRepository,
+        window: str | None = None,
+        *,
+        account_ids: Collection[str] | None = None,
+    ) -> dict[str, UsageHistory]:
+        query_scopes.append((window, tuple(account_ids) if account_ids is not None else None))
+        return await original_latest_by_account(self, window, account_ids=account_ids)
+
+    class _Leader:
+        async def run_if_leader(self, fn: Callable[[], Awaitable[object]]) -> object:
+            return await fn()
+
+    class _Updater:
+        async def refresh_accounts(
+            self,
+            accounts: list[Account],
+            latest_usage: dict[str, UsageHistory],
+        ) -> bool:
+            updater_calls.append(([account.id for account in accounts], set(latest_usage)))
+            return True
+
+    class _WarmupService:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        async def run_after_usage_refresh(self, **kwargs: object) -> None:
+            warmup_calls.append(kwargs)
+
+    monkeypatch.setattr(UsageRepository, "latest_by_account", _tracked_latest_by_account)
+    monkeypatch.setattr(refresh_scheduler_module, "_get_leader_election", lambda: _Leader())
+    monkeypatch.setattr(refresh_scheduler_module, "build_background_usage_updater", lambda: _Updater())
+    monkeypatch.setattr(refresh_scheduler_module, "LimitWarmupService", _WarmupService)
+
+    scheduler = refresh_scheduler_module.UsageRefreshScheduler(interval_seconds=60, enabled=True)
+
+    assert await scheduler._refresh_once() == 30.0
+    assert updater_calls == [([selected.id], {selected.id})]
+    assert query_scopes == [
+        ("primary", (selected.id,)),
+        ("secondary", (selected.id,)),
+        ("primary", (selected.id,)),
+        ("secondary", (selected.id,)),
+        ("primary", (selected.id,)),
+        ("secondary", (selected.id,)),
+        ("monthly", (selected.id,)),
+    ]
+    assert len(warmup_calls) == 1
+    assert [account.id for account in cast("list[Account]", warmup_calls[0]["accounts"])] == [selected.id]
+    assert {account.id for account in cast("list[Account]", warmup_calls[0]["stagger_accounts"])} == {
+        selected.id,
+        unrelated.id,
+    }
+    for snapshot_name in ("before_primary", "before_secondary", "after_primary", "after_secondary"):
+        assert set(cast("dict[str, UsageHistory]", warmup_calls[0][snapshot_name])) <= {selected.id}
+
+    async with SessionLocal() as session:
+        persisted_selected = await AccountsRepository(session).get_by_id(selected.id)
+        persisted_unrelated = await AccountsRepository(session).get_by_id(unrelated.id)
+    assert persisted_selected is not None
+    assert persisted_selected.status == AccountStatus.RATE_LIMITED
+    assert persisted_unrelated is not None
+    assert persisted_unrelated.status == AccountStatus.ACTIVE

--- a/tests/unit/test_limit_warmup.py
+++ b/tests/unit/test_limit_warmup.py
@@ -74,8 +74,10 @@ class FakeWarmupRepo:
     def __init__(self) -> None:
         self.rows: list[AccountLimitWarmup] = []
         self.next_id = 1
+        self.latest_requests: list[list[str]] = []
 
     async def latest_by_account(self, account_ids: list[str]) -> dict[str, AccountLimitWarmup]:
+        self.latest_requests.append(list(account_ids))
         result: dict[str, AccountLimitWarmup] = {}
         for row in self.rows:
             if row.account_id in account_ids:
@@ -1061,6 +1063,39 @@ async def test_staggered_idle_warmup_prestarts_once_per_cycle(monkeypatch) -> No
     assert repo.rows[0].window == "primary_idle"
     assert repo.rows[0].reset_at == 18_000
     assert repo.rows[0].status == "succeeded"
+
+
+@pytest.mark.asyncio
+async def test_staggered_idle_cohort_does_not_widen_candidate_evaluation(monkeypatch) -> None:
+    now = datetime.fromtimestamp(6000, tz=timezone.utc).replace(tzinfo=None)
+    monkeypatch.setattr(limit_warmup_service, "utcnow", lambda: now)
+    repo = FakeWarmupRepo()
+    sender = FakeSender()
+    service = LimitWarmupService(repo, FakeRequestLogsRepo(), sender=sender)
+    cohort = [_account("acc_1"), _account("acc_2"), _account("acc_3")]
+    selected = cohort[1]
+
+    await service.run_after_usage_refresh(
+        accounts=[selected],
+        stagger_accounts=cohort,
+        settings=_settings(limit_warmup_staggered_idle_enabled=True),
+        before_primary={selected.id: _usage(selected.id, used_percent=0, reset_at=18_000)},
+        before_secondary={},
+        after_primary={
+            selected.id: _usage(
+                selected.id,
+                used_percent=0,
+                reset_at=18_000,
+                recorded_at=now,
+            )
+        },
+        after_secondary={},
+        refresh_started_at=now,
+    )
+
+    assert repo.latest_requests == [[selected.id]]
+    assert sender.calls == [(selected.id, "gpt-5.1-codex-mini")]
+    assert [row.account_id for row in repo.rows] == [selected.id]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_usage_refresh_scheduler_recovery.py
+++ b/tests/unit/test_usage_refresh_scheduler_recovery.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Collection
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, cast
@@ -120,13 +120,26 @@ class StubUsageRepository:
         self._primary = primary or {}
         self._secondary = secondary or {}
         self._monthly = monthly or {}
+        self.queries: list[tuple[str | None, tuple[str, ...] | None]] = []
 
-    async def latest_by_account(self, window: str | None = None) -> dict[str, UsageHistory]:
+    async def latest_by_account(
+        self,
+        window: str | None = None,
+        *,
+        account_ids: Collection[str] | None = None,
+    ) -> dict[str, UsageHistory]:
+        normalized_account_ids = tuple(account_ids) if account_ids is not None else None
+        self.queries.append((window, normalized_account_ids))
         if window == "secondary":
-            return self._secondary
-        if window == "monthly":
-            return self._monthly
-        return self._primary
+            rows = self._secondary
+        elif window == "monthly":
+            rows = self._monthly
+        else:
+            rows = self._primary
+        if normalized_account_ids is None:
+            return rows
+        allowed = set(normalized_account_ids)
+        return {account_id: entry for account_id, entry in rows.items() if account_id in allowed}
 
 
 class MutatingAccountsRepository(StubAccountsRepository):
@@ -134,6 +147,51 @@ class MutatingAccountsRepository(StubAccountsRepository):
         account = next(iter(self._accounts.values()))
         account.reset_at = 42
         return await super().update_status_if_current(*args, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_recoverable_account_statuses_scopes_latest_usage_to_candidates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 1_700_000_000.0
+    future_reset = int(now + 3600)
+    selected = _make_account(
+        "acc_selected",
+        status=AccountStatus.RATE_LIMITED,
+        reset_at=future_reset,
+        blocked_at=int(now - 30),
+    )
+    unrelated = _make_account("acc_unrelated", status=AccountStatus.ACTIVE)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.time.time", lambda: now)
+    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
+    monkeypatch.setattr("app.modules.proxy.load_balancer.utcnow", lambda: _epoch_to_naive_utc(now))
+
+    usage_repo = StubUsageRepository(
+        primary={
+            account.id: _make_usage(
+                account.id,
+                window="primary",
+                used_percent=10.0,
+                reset_at=future_reset,
+                recorded_at=_epoch_to_naive_utc(now - 10),
+                window_minutes=300,
+            )
+            for account in (selected, unrelated)
+        }
+    )
+
+    recovered = await refresh_scheduler_module.reconcile_recoverable_account_statuses(
+        accounts_repo=StubAccountsRepository([selected, unrelated]),
+        usage_repo=usage_repo,
+        accounts=[selected, unrelated],
+    )
+
+    assert recovered == 0
+    assert usage_repo.queries == [
+        ("primary", (selected.id,)),
+        ("secondary", (selected.id,)),
+        ("monthly", (selected.id,)),
+    ]
 
 
 @pytest.mark.asyncio
@@ -782,7 +840,13 @@ async def test_refresh_once_closes_read_session_before_usage_fetch(monkeypatch: 
         def __init__(self, _session: object) -> None:
             pass
 
-        async def latest_by_account(self, window: str | None = None) -> dict[str, UsageHistory]:
+        async def latest_by_account(
+            self,
+            window: str | None = None,
+            *,
+            account_ids: Collection[str] | None = None,
+        ) -> dict[str, UsageHistory]:
+            assert account_ids == [account.id]
             return {}
 
     class _AccountsRepo:
@@ -847,7 +911,12 @@ async def test_refresh_once_cancellation_closes_read_session(monkeypatch: pytest
         def __init__(self, _session: object) -> None:
             pass
 
-        async def latest_by_account(self, window: str | None = None) -> dict[str, UsageHistory]:
+        async def latest_by_account(
+            self,
+            window: str | None = None,
+            *,
+            account_ids: Collection[str] | None = None,
+        ) -> dict[str, UsageHistory]:
             return {}
 
     class _AccountsRepo:
@@ -884,3 +953,144 @@ async def test_refresh_once_cancellation_closes_read_session(monkeypatch: pytest
         await task
 
     await asyncio.wait_for(session_closed.wait(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_refresh_slices_scope_queries_and_followups_to_selected_account(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    accounts = [
+        _make_account("acc_a", status=AccountStatus.ACTIVE),
+        _make_account("acc_b", status=AccountStatus.ACTIVE),
+    ]
+    usage = {
+        (account.id, window): _make_usage(
+            account.id,
+            window=window,
+            used_percent=10.0,
+            reset_at=1_800_000_000,
+            recorded_at=datetime(2026, 1, 1),
+            window_minutes=300 if window == "primary" else 10_080,
+        )
+        for account in accounts
+        for window in ("primary", "secondary")
+    }
+    open_sessions = 0
+    query_scopes: list[tuple[str | None, tuple[str, ...]]] = []
+    updater_calls: list[str] = []
+    warmup_calls: list[dict[str, object]] = []
+    invalidations = 0
+
+    class _Leader:
+        async def run_if_leader(self, fn: Callable[[], Awaitable[object]]) -> object:
+            return await fn()
+
+    class _UsageRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        async def latest_by_account(
+            self,
+            window: str | None = None,
+            *,
+            account_ids: Collection[str] | None = None,
+        ) -> dict[str, UsageHistory]:
+            assert account_ids is not None
+            normalized_ids = tuple(account_ids)
+            query_scopes.append((window, normalized_ids))
+            return {
+                account_id: usage[(account_id, window or "primary")]
+                for account_id in normalized_ids
+                if (account_id, window or "primary") in usage
+            }
+
+    class _AccountsRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        async def list_accounts(self, *, refresh_existing: bool = False) -> list[Account]:
+            return accounts
+
+    class _SettingsRepo:
+        def __init__(self, _session: object) -> None:
+            pass
+
+        async def get_or_create(self) -> object:
+            return object()
+
+    class _Updater:
+        async def refresh_accounts(
+            self,
+            selected_accounts: list[Account],
+            latest_usage: dict[str, UsageHistory],
+        ) -> bool:
+            assert open_sessions == 0
+            assert len(selected_accounts) == 1
+            selected = selected_accounts[0]
+            assert set(latest_usage) == {selected.id}
+            updater_calls.append(selected.id)
+            return len(updater_calls) == 2
+
+    class _WarmupService:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        async def run_after_usage_refresh(self, **kwargs: object) -> None:
+            assert open_sessions == 0
+            warmup_calls.append(kwargs)
+
+    class _Session:
+        def expunge_all(self) -> None:
+            return None
+
+    @asynccontextmanager
+    async def _background_session():
+        nonlocal open_sessions
+        open_sessions += 1
+        try:
+            yield _Session()
+        finally:
+            open_sessions -= 1
+
+    async def _invalidate() -> None:
+        nonlocal invalidations
+        invalidations += 1
+
+    monkeypatch.setattr(refresh_scheduler_module, "_get_leader_election", lambda: _Leader())
+    monkeypatch.setattr(refresh_scheduler_module, "get_background_session", _background_session)
+    monkeypatch.setattr(refresh_scheduler_module, "UsageRepository", _UsageRepo)
+    monkeypatch.setattr(refresh_scheduler_module, "AccountsRepository", _AccountsRepo)
+    monkeypatch.setattr(refresh_scheduler_module, "SettingsRepository", _SettingsRepo)
+    monkeypatch.setattr(refresh_scheduler_module, "build_background_usage_updater", lambda: _Updater())
+    monkeypatch.setattr(refresh_scheduler_module, "LimitWarmupService", _WarmupService)
+    monkeypatch.setattr(refresh_scheduler_module, "_invalidate_usage_refresh_caches", _invalidate)
+
+    scheduler = refresh_scheduler_module.UsageRefreshScheduler(interval_seconds=60, enabled=True)
+
+    assert await scheduler._refresh_once() == 30.0
+    assert updater_calls == ["acc_a"]
+    assert query_scopes == [
+        ("primary", ("acc_a",)),
+        ("secondary", ("acc_a",)),
+    ]
+    assert warmup_calls == []
+    assert invalidations == 0
+
+    assert await scheduler._refresh_once() == 30.0
+    assert updater_calls == ["acc_a", "acc_b"]
+    assert query_scopes[-4:] == [
+        ("primary", ("acc_b",)),
+        ("secondary", ("acc_b",)),
+        ("primary", ("acc_b",)),
+        ("secondary", ("acc_b",)),
+    ]
+    assert len(warmup_calls) == 1
+    assert [account.id for account in cast("list[Account]", warmup_calls[0]["accounts"])] == ["acc_b"]
+    assert [account.id for account in cast("list[Account]", warmup_calls[0]["stagger_accounts"])] == [
+        "acc_a",
+        "acc_b",
+    ]
+    assert set(cast("dict[str, UsageHistory]", warmup_calls[0]["before_primary"])) == {"acc_b"}
+    assert set(cast("dict[str, UsageHistory]", warmup_calls[0]["after_primary"])) == {"acc_b"}
+    assert invalidations == 1
+    assert open_sessions == 0


### PR DESCRIPTION
## Summary

Scope each usage-refresh slice to the one account selected by the scheduler instead of reading fleet-wide usage history and running downstream recovery work across every account.

This is intentionally independent from the follow-up transaction batching work: this PR reduces the query/work set, while a separate PR will reduce commits and SQLite lock churn inside one account snapshot.

Related to #708 (partial performance fix; does not close the issue).

## Type of change

- [ ] `fix:` — bug fix
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor
- [x] `perf:` — performance improvement
- [ ] `docs:` / `chore:` / `ci:` / `build:`
- [ ] **Breaking change**

## OpenSpec

Change: `openspec/changes/refresh-selected-account-usage/`

The delta requires each scheduler slice to:

- query before/after usage only for the selected account;
- pass only that account to usage update, warmup evaluation, and status recovery;
- preserve full-fleet ordering only where rotation and stagger-slot calculation require it;
- keep background database sessions isolated and closed.

## Changes

- Filter primary/secondary usage snapshots to the selected account.
- Filter recovery history queries to the candidate account IDs.
- Restrict updater, warmup evaluation, and status recovery to the selected account.
- Preserve the full ordered account list only for scheduler rotation and warmup staggering.
- Add route-level/integration and unit regressions for query scope, warmup staggering, recovery, failure isolation, and session ownership.

## Independence

- Based directly on current `upstream/main` at `6da1f48b`.
- Does not contain or depend on the separate usage-snapshot transaction change.
- Does not overlap merged #1376 or #1283.

## Verification

- Focused usage suites: 174 passed, 1 PostgreSQL-only skip.
- Full unit suite: 4,309 passed, 55 skipped.
- Integration core: 1,400 passed, 9 environment/PostgreSQL skips.
- Loopback-only sandbox test: passed separately with loopback access.
- Ruff check and format: passed.
- `ty`: passed.
- Architecture, simplicity, and diff checks: passed.
- Strict OpenSpec validation: 47/47 main specs; change tasks 10/10 complete.
- Formal requirement/scenario verification: 1/1 requirement and 6/6 scenarios covered.

## Simplicity

- No new settings, required setup, README sections, `.env.example` entries, or dashboard navigation.
- No dashboard-visible change; screenshots are not applicable.
