### PR TITLE
fix(uploads): bound multipart request resources

### DIFF
--- a/app/core/handlers/exceptions.py
+++ b/app/core/handlers/exceptions.py
@@ -12,6 +12,7 @@ from fastapi.exception_handlers import (
 )
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response
+from starlette._utils import get_route_path
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from app.core.errors import dashboard_error, openai_error
@@ -31,17 +32,26 @@ from app.core.exceptions import (
     ProxyRateLimitError,
     ProxyUpstreamError,
 )
+from app.core.middleware.multipart_content_encoding import (
+    UnsupportedMultipartContentEncoding,
+    multipart_error_response,
+)
 from app.core.middleware.request_body_limit import (
     REQUEST_BODY_TOO_LARGE_MESSAGE,
     request_body_limit_was_exceeded,
     request_ingress_error_response,
 )
+from app.core.multipart import MultipartPayloadTooLarge
 from app.core.runtime_logging import log_error_response
-from app.modules.proxy.images_observability import ImageRoute, record_images_route_observability
+from app.modules.proxy.images_observability import (
+    IMAGE_ROUTE_MODEL_STATE,
+    IMAGE_ROUTE_STARTED_AT_STATE,
+    IMAGE_ROUTE_STREAM_STATE,
+    ImageRoute,
+    record_images_route_observability,
+)
 
 logger = logging.getLogger(__name__)
-
-_IMAGE_ROUTE_STARTED_AT_STATE = "_codex_lb_image_route_started_at"
 
 _OPENAI_EXCEPTION_TYPES: tuple[type[AppError], ...] = (
     ProxyAuthError,
@@ -84,6 +94,7 @@ _IMAGE_ROUTE_PATHS: dict[str, ImageRoute] = {
     "/v1/images/edits": "edits",
     "/backend-api/codex/images/edits": "edits",
 }
+_CODEX_JSON_IMAGE_EDIT_PATH = "/backend-api/codex/images/edits"
 
 
 def _image_route_from_path(path: str) -> ImageRoute | None:
@@ -99,9 +110,11 @@ async def _image_request_model_and_stream(request: Request, route: ImageRoute) -
     model: str | None = None
     stream = False
 
-    # Generations is always JSON; the codex edits alias also accepts a JSON
-    # payload (unlike the multipart /v1 edits surface).
-    if route == "generations" or _is_json_request(request):
+    # Generations is always JSON; only the codex edits alias accepts a JSON
+    # payload. The /v1 edits surface must never consume its body here, even
+    # when a client supplies the wrong Content-Type before authorization.
+    is_codex_json_edit = get_route_path(request.scope) == _CODEX_JSON_IMAGE_EDIT_PATH and _is_json_request(request)
+    if route == "generations" or is_codex_json_edit:
         try:
             payload: Any = await request.json()
         except Exception:
@@ -113,14 +126,18 @@ async def _image_request_model_and_stream(request: Request, route: ImageRoute) -
             stream = payload.get("stream") is True
         return model, stream
 
-    try:
-        form = await request.form()
-    except Exception:
+    if route == "edits":
+        # Multipart edit bodies are parsed only inside the authorized handler.
+        # Pre-handler errors use bounded unknown/false labels rather than
+        # consuming and spooling an unauthenticated upload for observability.
+        parsed_model = getattr(request.state, IMAGE_ROUTE_MODEL_STATE, None)
+        if isinstance(parsed_model, str) and parsed_model:
+            model = parsed_model
+        parsed_stream = getattr(request.state, IMAGE_ROUTE_STREAM_STATE, None)
+        if isinstance(parsed_stream, bool):
+            stream = parsed_stream
         return model, stream
-    model_value = form.get("model")
-    if isinstance(model_value, str) and model_value:
-        model = model_value
-    stream = form.get("stream") in {"true", "True", "1", "yes", "on"}
+
     return model, stream
 
 
@@ -130,13 +147,13 @@ async def _record_image_route_exception_observability(
     status: int,
     outcome: str,
 ) -> None:
-    path = request.url.path
+    path = get_route_path(request.scope)
     route = _image_route_from_path(path)
     if route is None:
         return
 
     model, stream = await _image_request_model_and_stream(request, route)
-    started_at = getattr(request.state, _IMAGE_ROUTE_STARTED_AT_STATE, None)
+    started_at = getattr(request.state, IMAGE_ROUTE_STARTED_AT_STATE, None)
     if not isinstance(started_at, float):
         started_at = time.perf_counter()
 
@@ -156,9 +173,45 @@ def add_exception_handlers(app: FastAPI) -> None:
         request: Request,
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
-        if _image_route_from_path(request.url.path) is not None:
-            setattr(request.state, _IMAGE_ROUTE_STARTED_AT_STATE, time.perf_counter())
+        if _image_route_from_path(get_route_path(request.scope)) is not None:
+            setattr(request.state, IMAGE_ROUTE_STARTED_AT_STATE, time.perf_counter())
         return await call_next(request)
+
+    @app.exception_handler(MultipartPayloadTooLarge)
+    async def multipart_payload_too_large_handler(
+        request: Request,
+        exc: MultipartPayloadTooLarge,
+    ) -> JSONResponse:
+        await _record_image_route_exception_observability(
+            request,
+            status=413,
+            outcome="invalid_request",
+        )
+        return multipart_error_response(
+            request,
+            status_code=413,
+            code="payload_too_large",
+            message=exc.message,
+            param=exc.param,
+        )
+
+    @app.exception_handler(UnsupportedMultipartContentEncoding)
+    async def unsupported_multipart_content_encoding_handler(
+        request: Request,
+        exc: UnsupportedMultipartContentEncoding,
+    ) -> JSONResponse:
+        del exc
+        await _record_image_route_exception_observability(
+            request,
+            status=400,
+            outcome="invalid_request",
+        )
+        return multipart_error_response(
+            request,
+            status_code=400,
+            code="invalid_request",
+            message="Compressed multipart uploads are not supported",
+        )
 
     # --- Domain exceptions: OpenAI envelope ---
 
@@ -289,6 +342,12 @@ def add_exception_handlers(app: FastAPI) -> None:
                 content=dashboard_error(f"http_{exc.status_code}", detail),
             )
         if fmt == "openai":
+            if exc.status_code == 400 and _image_route_from_path(get_route_path(request.scope)) == "edits":
+                await _record_image_route_exception_observability(
+                    request,
+                    status=400,
+                    outcome="invalid_request",
+                )
             error_type = "invalid_request_error"
             code = "invalid_request_error"
             if exc.status_code == 401:

--- a/app/core/middleware/__init__.py
+++ b/app/core/middleware/__init__.py
@@ -1,6 +1,7 @@
 from app.core.middleware.api_firewall import add_api_firewall_middleware
 from app.core.middleware.app_version import add_app_version_middleware
 from app.core.middleware.dashboard_auth_proxy import add_dashboard_auth_proxy_middleware
+from app.core.middleware.multipart_content_encoding import add_multipart_content_encoding_middleware
 from app.core.middleware.path_rewrite import add_backend_api_codex_v1_alias_middleware
 from app.core.middleware.request_body_limit import add_request_body_limit_middleware
 from app.core.middleware.request_decompression import add_request_decompression_middleware
@@ -11,6 +12,7 @@ __all__ = [
     "add_api_firewall_middleware",
     "add_backend_api_codex_v1_alias_middleware",
     "add_dashboard_auth_proxy_middleware",
+    "add_multipart_content_encoding_middleware",
     "add_request_body_limit_middleware",
     "add_request_decompression_middleware",
     "add_request_id_middleware",

--- a/app/core/middleware/multipart_content_encoding.py
+++ b/app/core/middleware/multipart_content_encoding.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI
+from starlette._utils import get_route_path
+from starlette.datastructures import Headers
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from app.core.errors import dashboard_error, openai_error
+from app.core.runtime_logging import log_error_response
+
+_LIMITED_MULTIPART_PATHS = frozenset(
+    {
+        "/api/accounts/import",
+        "/backend-api/transcribe",
+        "/v1/audio/transcriptions",
+        "/v1/images/edits",
+    }
+)
+_OPENAI_MULTIPART_PATH_PREFIXES = ("/backend-api", "/v1")
+_CONTENT_ENCODING_GATE_HANDLED_STATE = "_codex_lb_multipart_content_encoding_gate_handled"
+_UNSUPPORTED_CONTENT_ENCODING_STATE = "_codex_lb_unsupported_multipart_content_encoding"
+
+logger = logging.getLogger(__name__)
+
+
+def _canonical_route_path(scope: Scope) -> str:
+    path = get_route_path(scope)
+    if path != "/":
+        path = path.rstrip("/")
+    return path
+
+
+class UnsupportedMultipartContentEncoding(Exception):
+    pass
+
+
+def is_route_owned_multipart_operation(scope: Scope) -> bool:
+    return scope.get("method") == "POST" and _canonical_route_path(scope) in _LIMITED_MULTIPART_PATHS
+
+
+def _uses_openai_multipart_errors(scope: Scope) -> bool:
+    path = _canonical_route_path(scope)
+    return any(path == prefix or path.startswith(f"{prefix}/") for prefix in _OPENAI_MULTIPART_PATH_PREFIXES)
+
+
+def multipart_error_response(
+    request: Request,
+    *,
+    status_code: int,
+    code: str,
+    message: str,
+    param: str | None = None,
+) -> JSONResponse:
+    uses_openai_errors = _uses_openai_multipart_errors(request.scope)
+    response_code = "invalid_request_error" if uses_openai_errors and code == "invalid_request" else code
+    log_error_response(
+        logger,
+        request,
+        status_code,
+        response_code,
+        message,
+        category="openai_error_response" if uses_openai_errors else "dashboard_error_response",
+    )
+    if uses_openai_errors:
+        error = openai_error(response_code, message, error_type="invalid_request_error")
+        if param is not None:
+            error["error"]["param"] = param
+        return JSONResponse(status_code=status_code, content=error)
+    return JSONResponse(status_code=status_code, content=dashboard_error(response_code, message))
+
+
+def _without_content_encoding(scope: Scope, *, unsupported: bool = False) -> Scope:
+    copied = dict(scope)
+    copied["headers"] = [
+        (name, value) for name, value in scope.get("headers", []) if name.lower() != b"content-encoding"
+    ]
+    state = dict(scope.get("state", {}))
+    state[_CONTENT_ENCODING_GATE_HANDLED_STATE] = True
+    if unsupported:
+        state[_UNSUPPORTED_CONTENT_ENCODING_STATE] = True
+    copied["state"] = state
+    return copied
+
+
+def multipart_content_encoding_gate_was_applied(scope: Scope) -> bool:
+    return scope.get("state", {}).get(_CONTENT_ENCODING_GATE_HANDLED_STATE) is True
+
+
+def raise_for_unsupported_multipart_content_encoding(request: Request) -> None:
+    if getattr(request.state, _UNSUPPORTED_CONTENT_ENCODING_STATE, False) is True:
+        raise UnsupportedMultipartContentEncoding
+
+
+class MultipartContentEncodingMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        if not is_route_owned_multipart_operation(scope):
+            await self.app(scope, receive, send)
+            return
+
+        content_encoding_values = headers.getlist("content-encoding")
+        if not content_encoding_values:
+            await self.app(scope, receive, send)
+            return
+        encodings = [
+            encoding.strip().lower()
+            for value in content_encoding_values
+            for encoding in value.split(",")
+            if encoding.strip()
+        ]
+        if not encodings or all(value == "identity" for value in encodings):
+            await self.app(_without_content_encoding(scope), receive, send)
+            return
+        await self.app(_without_content_encoding(scope, unsupported=True), receive, send)
+
+
+def add_multipart_content_encoding_middleware(app: FastAPI) -> None:
+    app.add_middleware(MultipartContentEncodingMiddleware)

--- a/app/core/middleware/request_body_limit.py
+++ b/app/core/middleware/request_body_limit.py
@@ -11,6 +11,10 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.core.config.settings import get_settings
 from app.core.errors import dashboard_error, openai_error
+from app.core.middleware.multipart_content_encoding import (
+    is_route_owned_multipart_operation,
+    multipart_content_encoding_gate_was_applied,
+)
 from app.core.runtime_logging import log_error_response
 
 REQUEST_BODY_TOO_LARGE_MESSAGE = "Request body exceeds the maximum allowed size"
@@ -115,7 +119,8 @@ class RequestBodyLimitMiddleware:
             return
 
         headers = Headers(scope=scope)
-        if _is_unencoded_multipart(headers):
+        route_owned_multipart = is_route_owned_multipart_operation(scope) and _is_unencoded_multipart(headers)
+        if multipart_content_encoding_gate_was_applied(scope) or route_owned_multipart:
             await self.app(scope, receive, send)
             return
 

--- a/app/core/multipart.py
+++ b/app/core/multipart.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, AsyncIterator, Collection
+from contextlib import asynccontextmanager, suppress
+from dataclasses import dataclass
+
+from python_multipart.exceptions import MultipartParseError
+from starlette.datastructures import FormData, Headers, UploadFile
+from starlette.exceptions import HTTPException
+from starlette.formparsers import MultiPartException, MultiPartParser
+from starlette.requests import Request
+
+from app.core.multipart_fields import raise_upload_validation
+
+__all__ = [
+    "ACCOUNT_IMPORT_MULTIPART_POLICY",
+    "IMAGE_EDITS_MULTIPART_POLICY",
+    "TRANSCRIPTION_MULTIPART_POLICY",
+    "MultipartPayloadTooLarge",
+    "MultipartPolicy",
+    "bounded_multipart_form",
+    "read_bounded_upload",
+]
+
+_MIB = 1024 * 1024
+_PAYLOAD_TOO_LARGE_MESSAGE = "Multipart payload exceeds the allowed size."
+_INVALID_MULTIPART_MESSAGE = "Invalid multipart request."
+
+
+@dataclass(frozen=True, slots=True)
+class MultipartPolicy:
+    max_body_bytes: int
+    max_file_bytes: int
+    max_aggregate_file_bytes: int
+    max_files: int
+    max_fields: int
+    max_text_part_bytes: int
+
+    def __post_init__(self) -> None:
+        limits = (
+            self.max_body_bytes,
+            self.max_file_bytes,
+            self.max_aggregate_file_bytes,
+            self.max_files,
+            self.max_fields,
+            self.max_text_part_bytes,
+        )
+        if any(limit < 0 for limit in limits):
+            raise ValueError("Multipart limits must be non-negative")
+
+
+ACCOUNT_IMPORT_MULTIPART_POLICY = MultipartPolicy(
+    max_body_bytes=2 * _MIB,
+    max_file_bytes=_MIB,
+    max_aggregate_file_bytes=_MIB,
+    max_files=1,
+    max_fields=0,
+    max_text_part_bytes=0,
+)
+
+TRANSCRIPTION_MULTIPART_POLICY = MultipartPolicy(
+    max_body_bytes=32 * _MIB,
+    max_file_bytes=25_000_000,
+    max_aggregate_file_bytes=25_000_000,
+    max_files=1,
+    max_fields=32,
+    max_text_part_bytes=256 * 1024,
+)
+
+IMAGE_EDITS_MULTIPART_POLICY = MultipartPolicy(
+    max_body_bytes=64 * _MIB,
+    max_file_bytes=49_999_999,
+    max_aggregate_file_bytes=49_999_999,
+    max_files=17,
+    max_fields=32,
+    max_text_part_bytes=256 * 1024,
+)
+
+
+def _normalize_param(param: str | None) -> str | None:
+    if param == "image[]":
+        return "image"
+    return param
+
+
+class MultipartPayloadTooLarge(MultiPartException):
+    def __init__(self, *, param: str | None = None) -> None:
+        super().__init__(_PAYLOAD_TOO_LARGE_MESSAGE)
+        self.param = _normalize_param(param)
+
+
+async def _counted_request_stream(request: Request, max_body_bytes: int) -> AsyncGenerator[bytes, None]:
+    streamed_bytes = 0
+    async for chunk in request.stream():
+        streamed_bytes += len(chunk)
+        if streamed_bytes > max_body_bytes:
+            raise MultipartPayloadTooLarge()
+        yield chunk
+
+
+def _usable_content_length(headers: Headers) -> int | None:
+    raw_length = headers.get("content-length")
+    if raw_length is None:
+        return None
+    try:
+        declared_length = int(raw_length)
+    except ValueError:
+        return None
+    return declared_length if declared_length >= 0 else None
+
+
+def _is_multipart_form_data(headers: Headers) -> bool:
+    content_type = headers.get("content-type", "")
+    media_type = content_type.split(";", 1)[0].strip().lower()
+    return media_type == "multipart/form-data"
+
+
+class _BoundedMultiPartParser(MultiPartParser):
+    def __init__(
+        self,
+        headers: Headers,
+        stream: AsyncGenerator[bytes, None],
+        policy: MultipartPolicy,
+        typed_upload_fields: Collection[str],
+    ) -> None:
+        super().__init__(
+            headers,
+            stream,
+            max_files=policy.max_files,
+            max_fields=policy.max_fields,
+            max_part_size=policy.max_text_part_bytes,
+        )
+        self._policy = policy
+        self._typed_upload_fields = frozenset(typed_upload_fields)
+        self._current_file_bytes = 0
+        self._aggregate_file_bytes = 0
+
+    def on_part_begin(self) -> None:
+        super().on_part_begin()
+        self._current_file_bytes = 0
+
+    def on_headers_finished(self) -> None:
+        try:
+            super().on_headers_finished()
+        except MultiPartException:
+            if self._current_fields > self.max_fields and self._current_part.field_name in self._typed_upload_fields:
+                raise_upload_validation(self._current_part.field_name)
+            raise
+
+    def on_part_data(self, data: bytes, start: int, end: int) -> None:
+        part_bytes = end - start
+        current_part = self._current_part
+        if current_part.file is None:
+            if len(current_part.data) + part_bytes > self._policy.max_text_part_bytes:
+                raise MultipartPayloadTooLarge()
+        else:
+            param = _normalize_param(current_part.field_name)
+            if self._current_file_bytes + part_bytes > self._policy.max_file_bytes:
+                raise MultipartPayloadTooLarge(param=param)
+            if self._aggregate_file_bytes + part_bytes > self._policy.max_aggregate_file_bytes:
+                raise MultipartPayloadTooLarge(param=param)
+            self._current_file_bytes += part_bytes
+            self._aggregate_file_bytes += part_bytes
+        super().on_part_data(data, start, end)
+
+    def close_created_files(self) -> None:
+        files = self._files_to_close_on_error
+        self._files_to_close_on_error = []
+        for file in files:
+            with suppress(OSError):
+                file.close()
+
+
+def _multipart_bad_request(exc: MultiPartException | MultipartParseError | OSError) -> HTTPException:
+    if isinstance(exc, MultiPartException):
+        detail = exc.message
+    else:
+        detail = _INVALID_MULTIPART_MESSAGE
+    return HTTPException(status_code=400, detail=detail)
+
+
+async def _parse_with_cleanup(parser: _BoundedMultiPartParser) -> FormData:
+    try:
+        return await parser.parse()
+    except BaseException:
+        parser.close_created_files()
+        raise
+
+
+@asynccontextmanager
+async def bounded_multipart_form(
+    request: Request,
+    policy: MultipartPolicy,
+    *,
+    typed_upload_fields: Collection[str] = (),
+) -> AsyncIterator[FormData]:
+    if not _is_multipart_form_data(request.headers):
+        empty_form = FormData()
+        try:
+            yield empty_form
+        finally:
+            await empty_form.close()
+        return
+
+    declared_length = _usable_content_length(request.headers)
+    if declared_length is not None and declared_length > policy.max_body_bytes:
+        raise MultipartPayloadTooLarge()
+
+    parser = _BoundedMultiPartParser(
+        request.headers,
+        _counted_request_stream(request, policy.max_body_bytes),
+        policy,
+        typed_upload_fields,
+    )
+    try:
+        try:
+            form = await _parse_with_cleanup(parser)
+        except MultipartPayloadTooLarge:
+            raise
+        except (MultiPartException, MultipartParseError, OSError) as exc:
+            raise _multipart_bad_request(exc) from exc
+
+        try:
+            yield form
+        finally:
+            await form.close()
+    finally:
+        parser.close_created_files()
+
+
+async def read_bounded_upload(upload: UploadFile, max_bytes: int, param: str | None) -> bytes:
+    if max_bytes < 0:
+        raise ValueError("Upload limit must be non-negative")
+    data = await upload.read(max_bytes + 1)
+    if len(data) > max_bytes:
+        raise MultipartPayloadTooLarge(param=param)
+    return data

--- a/app/core/multipart_fields.py
+++ b/app/core/multipart_fields.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import NoReturn
+
+from fastapi.exceptions import RequestValidationError
+from starlette.datastructures import FormData, UploadFile
+
+
+def _raise_field_validation(field: str, *, error_type: str, message: str, value: object = None) -> NoReturn:
+    raise RequestValidationError(
+        [
+            {
+                "type": error_type,
+                "loc": ("body", field),
+                "msg": message,
+                "input": value,
+            }
+        ]
+    )
+
+
+def raise_upload_validation(field: str, *, value: object = None) -> NoReturn:
+    _raise_field_validation(
+        field,
+        error_type="value_error",
+        message="Expected one uploaded file",
+        value=value,
+    )
+
+
+def required_upload(form: FormData, field: str) -> UploadFile:
+    values = form.getlist(field)
+    if not values:
+        _raise_field_validation(field, error_type="missing", message="Field required")
+    if len(values) != 1 or not isinstance(values[0], UploadFile):
+        raise_upload_validation(field, value=values)
+    return values[0]
+
+
+def optional_upload(form: FormData, field: str) -> UploadFile | None:
+    values = form.getlist(field)
+    if not values:
+        return None
+    if len(values) != 1 or not isinstance(values[0], UploadFile):
+        raise_upload_validation(field, value=values)
+    return values[0]
+
+
+def required_text(form: FormData, field: str) -> str:
+    value = form.get(field)
+    if value is None:
+        _raise_field_validation(field, error_type="missing", message="Field required")
+    if not isinstance(value, str):
+        _raise_field_validation(field, error_type="string_type", message="Input should be a valid string", value=value)
+    return value
+
+
+def optional_text(form: FormData, field: str) -> str | None:
+    value = form.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        _raise_field_validation(field, error_type="string_type", message="Input should be a valid string", value=value)
+    return value
+
+
+def ordered_uploads(form: FormData, fields: Iterable[str]) -> list[UploadFile]:
+    allowed = frozenset(fields)
+    uploads: list[UploadFile] = []
+    for field, value in form.multi_items():
+        if field not in allowed:
+            continue
+        if not isinstance(value, UploadFile):
+            _raise_field_validation(
+                field,
+                error_type="value_error",
+                message="Expected an uploaded file",
+                value=value,
+            )
+        uploads.append(value)
+    return uploads
+
+
+def ordered_text_items(form: FormData, *, excluded_fields: Iterable[str] = ()) -> list[tuple[str, str]]:
+    excluded = frozenset(excluded_fields)
+    return [(field, value) for field, value in form.multi_items() if field not in excluded and isinstance(value, str)]
+
+
+def uploaded_file_items(form: FormData) -> list[tuple[str, UploadFile]]:
+    return [(field, value) for field, value in form.multi_items() if isinstance(value, UploadFile)]

--- a/app/main.py
+++ b/app/main.py
@@ -41,6 +41,7 @@ from app.core.middleware import (
     add_app_version_middleware,
     add_backend_api_codex_v1_alias_middleware,
     add_dashboard_auth_proxy_middleware,
+    add_multipart_content_encoding_middleware,
     add_request_body_limit_middleware,
     add_request_decompression_middleware,
     add_request_id_middleware,
@@ -644,6 +645,7 @@ def create_app() -> FastAPI:
     add_dashboard_auth_proxy_middleware(app)
     add_request_decompression_middleware(app)
     add_request_body_limit_middleware(app)
+    add_multipart_content_encoding_middleware(app)
     add_request_id_middleware(app)
     add_api_firewall_middleware(app)
     app.add_middleware(cast(Any, MetricsMiddleware), enabled=settings.metrics_enabled)

--- a/app/modules/accounts/api.py
+++ b/app/modules/accounts/api.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, File, Request, Response, UploadFile
+from fastapi import APIRouter, Depends, Request, Response
 
 from app.core.audit.service import AuditService
 from app.core.auth.dependencies import (
@@ -18,6 +18,9 @@ from app.core.exceptions import (
     DashboardNotFoundError,
     DashboardUpstreamError,
 )
+from app.core.middleware.multipart_content_encoding import raise_for_unsupported_multipart_content_encoding
+from app.core.multipart import ACCOUNT_IMPORT_MULTIPART_POLICY, bounded_multipart_form, read_bounded_upload
+from app.core.multipart_fields import required_upload
 from app.core.upstream_proxy import UpstreamProxyRouteError
 from app.dependencies import AccountsContext, get_accounts_context, get_proxy_service_for_app
 from app.modules.accounts.repository import AccountIdentityConflictError
@@ -60,6 +63,38 @@ router = APIRouter(
     tags=["dashboard"],
     dependencies=[Depends(validate_dashboard_session), Depends(set_dashboard_error_format)],
 )
+
+_ACCOUNT_IMPORT_OPENAPI_EXTRA = {
+    "requestBody": {
+        "required": True,
+        "content": {
+            "multipart/form-data": {
+                "schema": {
+                    "type": "object",
+                    "title": "Body_import_account_api_accounts_import_post",
+                    "required": ["auth_json"],
+                    "properties": {
+                        "auth_json": {
+                            "type": "string",
+                            "contentMediaType": "application/octet-stream",
+                            "title": "Auth Json",
+                        }
+                    },
+                }
+            }
+        },
+    },
+    "responses": {
+        "422": {
+            "description": "Validation Error",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/HTTPValidationError"},
+                }
+            },
+        }
+    },
+}
 
 
 @router.get("", response_model=AccountsResponse)
@@ -211,14 +246,28 @@ async def export_account_opencode_auth(
     return result
 
 
-@router.post("/import", response_model=AccountImportResponse)
+@router.post(
+    "/import",
+    response_model=AccountImportResponse,
+    openapi_extra=_ACCOUNT_IMPORT_OPENAPI_EXTRA,
+)
 async def import_account(
     request: Request,
-    auth_json: UploadFile = File(...),
     _write_access=Depends(require_dashboard_write_access),
     context: AccountsContext = Depends(get_accounts_context),
 ) -> AccountImportResponse:
-    raw = await auth_json.read()
+    raise_for_unsupported_multipart_content_encoding(request)
+    async with bounded_multipart_form(
+        request,
+        ACCOUNT_IMPORT_MULTIPART_POLICY,
+        typed_upload_fields=("auth_json",),
+    ) as form:
+        auth_json = required_upload(form, "auth_json")
+        raw = await read_bounded_upload(
+            auth_json,
+            max_bytes=ACCOUNT_IMPORT_MULTIPART_POLICY.max_file_bytes,
+            param="auth_json",
+        )
     try:
         response = await context.service.import_account(raw)
         AuditService.log_async(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -6,7 +6,7 @@ import logging
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Mapping
 from contextlib import asynccontextmanager
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from json import JSONDecodeError
 from typing import Any, Final, Literal, cast
@@ -16,14 +16,11 @@ from fastapi import (
     APIRouter,
     Body,
     Depends,
-    File,
-    Form,
     HTTPException,
     Path,
     Request,
     Response,
     Security,
-    UploadFile,
     WebSocket,
 )
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -72,6 +69,22 @@ from app.core.exceptions import (
     ProxyUpstreamError,
 )
 from app.core.metrics.prometheus import PROMETHEUS_AVAILABLE, bridge_public_contract_error_total
+from app.core.middleware.multipart_content_encoding import raise_for_unsupported_multipart_content_encoding
+from app.core.multipart import (
+    IMAGE_EDITS_MULTIPART_POLICY,
+    TRANSCRIPTION_MULTIPART_POLICY,
+    bounded_multipart_form,
+    read_bounded_upload,
+)
+from app.core.multipart_fields import (
+    optional_text,
+    optional_upload,
+    ordered_text_items,
+    ordered_uploads,
+    required_text,
+    required_upload,
+    uploaded_file_items,
+)
 from app.core.openai.chat_requests import ChatCompletionsRequest
 from app.core.openai.chat_responses import (
     ChatCompletion,
@@ -184,7 +197,11 @@ from app.modules.proxy.account_cache import get_account_selection_cache
 from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
 from app.modules.proxy.helpers import _rate_limit_details
 from app.modules.proxy.http_bridge_forwarding import parse_forwarded_request
-from app.modules.proxy.images_observability import record_images_route_observability
+from app.modules.proxy.images_observability import (
+    IMAGE_ROUTE_MODEL_STATE,
+    IMAGE_ROUTE_STREAM_STATE,
+    record_images_route_observability,
+)
 from app.modules.proxy.request_policy import (
     apply_api_key_enforcement,
     apply_api_key_enforcement_to_chat_payload,
@@ -323,6 +340,181 @@ internal_router = APIRouter(
 )
 
 _TRANSCRIPTION_MODEL = "gpt-4o-transcribe"
+_OPENAPI_VALIDATION_ERROR_RESPONSE: Final[dict[str, Any]] = {
+    "description": "Validation Error",
+    "content": {
+        "application/json": {
+            "schema": {"$ref": "#/components/schemas/HTTPValidationError"},
+        }
+    },
+}
+_BACKEND_TRANSCRIBE_OPENAPI_EXTRA: Final[dict[str, Any]] = {
+    "requestBody": {
+        "required": True,
+        "content": {
+            "multipart/form-data": {
+                "schema": {
+                    "type": "object",
+                    "title": "Body_backend_transcribe_backend_api_transcribe_post",
+                    "required": ["file"],
+                    "properties": {
+                        "file": {
+                            "type": "string",
+                            "contentMediaType": "application/octet-stream",
+                            "title": "File",
+                        },
+                        "prompt": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "title": "Prompt",
+                        },
+                    },
+                }
+            }
+        },
+    },
+    "responses": {"422": _OPENAPI_VALIDATION_ERROR_RESPONSE},
+}
+_V1_AUDIO_TRANSCRIPTIONS_OPENAPI_EXTRA: Final[dict[str, Any]] = {
+    "requestBody": {
+        "required": True,
+        "content": {
+            "multipart/form-data": {
+                "schema": {
+                    "type": "object",
+                    "title": "Body_v1_audio_transcriptions_v1_audio_transcriptions_post",
+                    "required": ["model", "file"],
+                    "properties": {
+                        "model": {"type": "string", "title": "Model"},
+                        "file": {
+                            "type": "string",
+                            "contentMediaType": "application/octet-stream",
+                            "title": "File",
+                        },
+                        "prompt": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "title": "Prompt",
+                        },
+                    },
+                }
+            }
+        },
+    },
+    "responses": {"422": _OPENAPI_VALIDATION_ERROR_RESPONSE},
+}
+_V1_IMAGES_EDITS_OPENAPI_EXTRA: Final[dict[str, Any]] = {
+    "requestBody": {
+        "required": True,
+        "content": {
+            "multipart/form-data": {
+                "schema": {
+                    "type": "object",
+                    "title": "Body_v1_images_edits_v1_images_edits_post",
+                    "required": ["prompt"],
+                    "properties": {
+                        "model": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "title": "Model",
+                        },
+                        "prompt": {"type": "string", "title": "Prompt"},
+                        "image": {
+                            "anyOf": [
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "contentMediaType": "application/octet-stream",
+                                    },
+                                },
+                                {"type": "null"},
+                            ],
+                            "title": "Image",
+                        },
+                        "image[]": {
+                            "anyOf": [
+                                {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "contentMediaType": "application/octet-stream",
+                                    },
+                                },
+                                {"type": "null"},
+                            ],
+                            "title": "Image[]",
+                        },
+                        "mask": {
+                            "anyOf": [
+                                {
+                                    "type": "string",
+                                    "contentMediaType": "application/octet-stream",
+                                },
+                                {"type": "null"},
+                            ],
+                            "title": "Mask",
+                        },
+                        "n": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "title": "N",
+                        },
+                        "size": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "title": "Size",
+                        },
+                        "quality": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "title": "Quality",
+                        },
+                        "background": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "title": "Background",
+                        },
+                        "output_format": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "title": "Output Format",
+                        },
+                        "output_compression": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "title": "Output Compression",
+                        },
+                        "moderation": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "title": "Moderation",
+                        },
+                        "partial_images": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "title": "Partial Images",
+                        },
+                        "stream": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "title": "Stream",
+                        },
+                        "input_fidelity": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "title": "Input Fidelity",
+                        },
+                        "user": {
+                            "anyOf": [{"type": "string"}, {"type": "null"}],
+                            "title": "User",
+                        },
+                    },
+                }
+            }
+        },
+    },
+    "responses": {"422": _OPENAPI_VALIDATION_ERROR_RESPONSE},
+}
+
+
+@dataclass(frozen=True, slots=True)
+class _ParsedTranscriptionMultipart:
+    audio_bytes: bytes
+    filename: str
+    content_type: str | None
+    model: str | None
+    prompt: str | None
+    ordered_text_fields: tuple[tuple[str, str], ...]
+
+
 _UNAVAILABLE_SELECTION_ERROR_CODES = {
     "no_accounts",
     "no_plan_support_for_model",
@@ -1608,18 +1800,16 @@ async def _load_accounts_by_id(session: AsyncSession, account_ids: set[str]) -> 
     return list(result.scalars().all())
 
 
-@transcribe_router.post("/transcribe")
+@transcribe_router.post("/transcribe", openapi_extra=_BACKEND_TRANSCRIBE_OPENAPI_EXTRA)
 async def backend_transcribe(
     request: Request,
-    file: UploadFile = File(...),
-    prompt: str | None = Form(None),
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> JSONResponse:
+    multipart = await _parse_transcription_multipart(request, require_model=False)
     return await _transcribe_request(
         request=request,
-        file=file,
-        prompt=prompt,
+        multipart=multipart,
         context=context,
         api_key=api_key,
     )
@@ -1722,15 +1912,18 @@ async def backend_files_finalize(
     return JSONResponse(content=result)
 
 
-@v1_router.post("/audio/transcriptions")
+@v1_router.post(
+    "/audio/transcriptions",
+    openapi_extra=_V1_AUDIO_TRANSCRIPTIONS_OPENAPI_EXTRA,
+)
 async def v1_audio_transcriptions(
     request: Request,
-    model: str = Form(...),
-    file: UploadFile = File(...),
-    prompt: str | None = Form(None),
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> Response:
+    multipart = await _parse_transcription_multipart(request, require_model=True)
+    assert multipart.model is not None
+    model = multipart.model
     source = await _select_audio_transcriptions_model_source(model, api_key)
     if source is not None:
         validate_model_access(api_key, model)
@@ -1738,7 +1931,7 @@ async def v1_audio_transcriptions(
         return await _source_audio_transcription_response(
             request=request,
             model=model,
-            file=file,
+            multipart=multipart,
             source=source,
             api_key=api_key,
             rate_limit_headers=rate_limit_headers,
@@ -1751,8 +1944,7 @@ async def v1_audio_transcriptions(
         )
     return await _transcribe_request(
         request=request,
-        file=file,
-        prompt=prompt,
+        multipart=multipart,
         context=context,
         api_key=api_key,
     )
@@ -1796,38 +1988,142 @@ def _record_images_edit_early_rejection(
     )
 
 
-@v1_router.post("/images/edits", response_model=None)
+def _images_edit_invalid_request_response(
+    request: Request,
+    *,
+    message: str,
+    param: str,
+    model: str | None,
+    stream: bool,
+    started_at: float,
+) -> JSONResponse:
+    _record_images_edit_early_rejection(
+        model=model,
+        stream=stream,
+        started_at=started_at,
+    )
+    return _logged_error_json_response(
+        request,
+        400,
+        images_service_module.make_invalid_request_error(message, param=param),
+    )
+
+
+@v1_router.post(
+    "/images/edits",
+    response_model=None,
+    openapi_extra=_V1_IMAGES_EDITS_OPENAPI_EXTRA,
+)
 async def v1_images_edits(
     request: Request,
-    # All typed form fields below are bound as raw strings so FastAPI
-    # never 422s on malformed input (e.g. ``n=abc``). Pydantic on
-    # ``V1ImagesEditsForm`` coerces and validates them and surfaces any
-    # failure as an OpenAI-shape ``invalid_request_error`` envelope.
-    model: str | None = Form(None),
-    prompt: str = Form(...),
-    # Accept either the OpenAI canonical ``image`` form key (single or
-    # repeated) or the ``image[]`` array-style key that some OpenAI SDKs
-    # / HTTP clients emit when sending multiple files. Both are bound as
-    # ``list[UploadFile] = File(None)`` and merged below; at least one
-    # entry must be present after the merge.
-    image: list[UploadFile] | None = File(None),
-    image_brackets: list[UploadFile] | None = File(None, alias="image[]"),
-    mask: UploadFile | None = File(None),
-    n: str | None = Form(None),
-    size: str | None = Form(None),
-    quality: str | None = Form(None),
-    background: str | None = Form(None),
-    output_format: str | None = Form(None),
-    output_compression: str | None = Form(None),
-    moderation: str | None = Form(None),
-    partial_images: str | None = Form(None),
-    stream: str | None = Form(None),
-    input_fidelity: str | None = Form(None),
-    user: str | None = Form(None),
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> Response:
     started_at = time.perf_counter()
+    raise_for_unsupported_multipart_content_encoding(request)
+
+    async with bounded_multipart_form(request, IMAGE_EDITS_MULTIPART_POLICY) as form:
+        model = optional_text(form, "model")
+        stream = optional_text(form, "stream")
+        observability_stream = _coerce_image_form_stream_for_observability(stream)
+        setattr(request.state, IMAGE_ROUTE_MODEL_STATE, model)
+        setattr(request.state, IMAGE_ROUTE_STREAM_STATE, observability_stream)
+
+        prompt = required_text(form, "prompt")
+        n = optional_text(form, "n")
+        size = optional_text(form, "size")
+        quality = optional_text(form, "quality")
+        background = optional_text(form, "background")
+        output_format = optional_text(form, "output_format")
+        output_compression = optional_text(form, "output_compression")
+        moderation = optional_text(form, "moderation")
+        partial_images = optional_text(form, "partial_images")
+        input_fidelity = optional_text(form, "input_fidelity")
+        user = optional_text(form, "user")
+
+        file_items = uploaded_file_items(form)
+        unknown_file = next(
+            (field for field, _upload in file_items if field not in {"image", "image[]", "mask"}),
+            None,
+        )
+        if unknown_file is not None:
+            return _images_edit_invalid_request_response(
+                request,
+                message=f"Unknown file field '{unknown_file}'.",
+                param=unknown_file,
+                model=model,
+                stream=observability_stream,
+                started_at=started_at,
+            )
+
+        merged_images = ordered_uploads(form, ("image", "image[]"))
+        if len(merged_images) > 16:
+            return _images_edit_invalid_request_response(
+                request,
+                message="At most 16 image parts are allowed.",
+                param="image",
+                model=model,
+                stream=observability_stream,
+                started_at=started_at,
+            )
+        if not merged_images:
+            return _images_edit_invalid_request_response(
+                request,
+                message="At least one ``image`` (or ``image[]``) multipart part is required.",
+                param="image",
+                model=model,
+                stream=observability_stream,
+                started_at=started_at,
+            )
+
+        mask_values = form.getlist("mask")
+        if len(mask_values) > 1:
+            return _images_edit_invalid_request_response(
+                request,
+                message="At most one mask part is allowed.",
+                param="mask",
+                model=model,
+                stream=observability_stream,
+                started_at=started_at,
+            )
+        mask = optional_upload(form, "mask")
+
+        images_payload: list[tuple[bytes, str | None]] = []
+        for upload in merged_images:
+            data = await read_bounded_upload(
+                upload,
+                max_bytes=IMAGE_EDITS_MULTIPART_POLICY.max_file_bytes,
+                param="image",
+            )
+            if not data:
+                return _images_edit_invalid_request_response(
+                    request,
+                    message="image part is empty",
+                    param="image",
+                    model=model,
+                    stream=observability_stream,
+                    started_at=started_at,
+                )
+            images_payload.append((data, upload.content_type))
+
+        mask_payload: tuple[bytes, str | None] | None = None
+        if mask is not None:
+            mask_data = await read_bounded_upload(
+                mask,
+                max_bytes=IMAGE_EDITS_MULTIPART_POLICY.max_file_bytes,
+                param="mask",
+            )
+            if not mask_data:
+                return _images_edit_invalid_request_response(
+                    request,
+                    message="mask part is empty",
+                    param="mask",
+                    model=model,
+                    stream=observability_stream,
+                    started_at=started_at,
+                )
+            mask_payload = (mask_data, mask.content_type)
+
     raw_form: dict[str, object] = {
         "model": model,
         "prompt": prompt,
@@ -1862,77 +2158,10 @@ async def v1_images_edits(
     except ValidationError as exc:
         _record_images_edit_early_rejection(
             model=model,
-            stream=_coerce_image_form_stream_for_observability(stream),
+            stream=observability_stream,
             started_at=started_at,
         )
         return _logged_error_json_response(request, 400, openai_validation_error(exc))
-
-    # Merge ``image`` and ``image[]`` into a single ordered list. Both
-    # form keys are accepted so OpenAI SDKs and HTTP clients that pick
-    # either convention work without modification.
-    merged_images: list[UploadFile] = []
-    if image:
-        merged_images.extend(image)
-    if image_brackets:
-        merged_images.extend(image_brackets)
-    if not merged_images:
-        _record_images_edit_early_rejection(
-            model=form_payload.model,
-            stream=bool(form_payload.stream),
-            started_at=started_at,
-        )
-        return _logged_error_json_response(
-            request,
-            400,
-            images_service_module.make_invalid_request_error(
-                "At least one ``image`` (or ``image[]``) multipart part is required.",
-                param="image",
-            ),
-        )
-
-    images_payload: list[tuple[bytes, str | None]] = []
-    for upload in merged_images:
-        try:
-            data = await upload.read()
-        finally:
-            await upload.close()
-        if not data:
-            _record_images_edit_early_rejection(
-                model=form_payload.model,
-                stream=bool(form_payload.stream),
-                started_at=started_at,
-            )
-            return _logged_error_json_response(
-                request,
-                400,
-                images_service_module.make_invalid_request_error(
-                    "image part is empty",
-                    param="image",
-                ),
-            )
-        images_payload.append((data, upload.content_type))
-
-    mask_payload: tuple[bytes, str | None] | None = None
-    if mask is not None:
-        try:
-            data = await mask.read()
-        finally:
-            await mask.close()
-        if not data:
-            _record_images_edit_early_rejection(
-                model=form_payload.model,
-                stream=bool(form_payload.stream),
-                started_at=started_at,
-            )
-            return _logged_error_json_response(
-                request,
-                400,
-                images_service_module.make_invalid_request_error(
-                    "mask part is empty",
-                    param="mask",
-                ),
-            )
-        mask_payload = (data, mask.content_type)
 
     return await _proxy_images_edit_request(
         request=request,
@@ -3472,19 +3701,40 @@ def _allowed_source_ids_for_api_key(api_key: ApiKeyData | None) -> set[str] | No
     return set(api_key.assigned_source_ids)
 
 
+async def _parse_transcription_multipart(
+    request: Request,
+    *,
+    require_model: bool,
+) -> _ParsedTranscriptionMultipart:
+    raise_for_unsupported_multipart_content_encoding(request)
+    async with bounded_multipart_form(request, TRANSCRIPTION_MULTIPART_POLICY) as form:
+        model = required_text(form, "model") if require_model else None
+        file = required_upload(form, "file")
+        prompt = optional_text(form, "prompt")
+        audio_bytes = await read_bounded_upload(
+            file,
+            max_bytes=TRANSCRIPTION_MULTIPART_POLICY.max_file_bytes,
+            param="file",
+        )
+        return _ParsedTranscriptionMultipart(
+            audio_bytes=audio_bytes,
+            filename=file.filename or "audio.wav",
+            content_type=file.content_type,
+            model=model,
+            prompt=prompt,
+            ordered_text_fields=tuple(ordered_text_items(form, excluded_fields=("file",))),
+        )
+
+
 async def _source_audio_transcription_response(
     *,
     request: Request,
     model: str,
-    file: UploadFile,
+    multipart: _ParsedTranscriptionMultipart,
     source: ModelSource,
     api_key: ApiKeyData | None,
     rate_limit_headers: Mapping[str, str],
 ) -> Response:
-    # Read the downstream form and file before reserving usage: a parse or
-    # upload failure here must not leave the API key's budget held.
-    fields = await _audio_transcription_form_fields(request)
-    audio_bytes = await file.read()
     reservation = await _enforce_request_limits(
         api_key,
         request_model=model,
@@ -3493,10 +3743,10 @@ async def _source_audio_transcription_response(
     try:
         result = await forward_source_audio_transcription(
             source,
-            audio_bytes=audio_bytes,
-            filename=file.filename or "audio.wav",
-            content_type=file.content_type,
-            fields=fields,
+            audio_bytes=multipart.audio_bytes,
+            filename=multipart.filename,
+            content_type=multipart.content_type,
+            fields=list(multipart.ordered_text_fields),
         )
     except ModelSourceForwardingError as exc:
         await _release_reservation(reservation)
@@ -3585,17 +3835,6 @@ async def _source_audio_transcription_response(
     if result.content_type is not None:
         headers["content-type"] = result.content_type
     return Response(content=result.body, status_code=200, headers=headers)
-
-
-async def _audio_transcription_form_fields(request: Request) -> list[tuple[str, str]]:
-    form = await request.form()
-    fields: list[tuple[str, str]] = []
-    for key, value in form.multi_items():
-        if key == "file":
-            continue
-        if isinstance(value, str):
-            fields.append((key, value))
-    return fields
 
 
 async def _source_responses_response(
@@ -4817,8 +5056,7 @@ async def _synthetic_compaction_response_stream(
 async def _transcribe_request(
     *,
     request: Request,
-    file: UploadFile,
-    prompt: str | None,
+    multipart: _ParsedTranscriptionMultipart,
     context: ProxyContext,
     api_key: ApiKeyData | None,
 ) -> JSONResponse:
@@ -4830,12 +5068,11 @@ async def _transcribe_request(
     )
     rate_limit_headers = await _rate_limit_headers_for_request(context, api_key)
     try:
-        audio_bytes = await file.read()
         result = await context.service.transcribe(
-            audio_bytes=audio_bytes,
-            filename=file.filename or "audio.wav",
-            content_type=file.content_type,
-            prompt=prompt,
+            audio_bytes=multipart.audio_bytes,
+            filename=multipart.filename,
+            content_type=multipart.content_type,
+            prompt=multipart.prompt,
             headers=request.headers,
             api_key=api_key,
         )

--- a/app/modules/proxy/images_observability.py
+++ b/app/modules/proxy/images_observability.py
@@ -14,6 +14,9 @@ from app.core.openai.images import is_supported_image_model
 logger = logging.getLogger("app.modules.proxy.api")
 
 ImageRoute = Literal["generations", "edits"]
+IMAGE_ROUTE_STARTED_AT_STATE = "_codex_lb_image_route_started_at"
+IMAGE_ROUTE_MODEL_STATE = "_codex_lb_image_route_model"
+IMAGE_ROUTE_STREAM_STATE = "_codex_lb_image_route_stream"
 
 
 def _bounded_model_label(model: str | None) -> str:

--- a/openspec/changes/bound-multipart-uploads/.openspec.yaml
+++ b/openspec/changes/bound-multipart-uploads/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/bound-multipart-uploads/design.md
+++ b/openspec/changes/bound-multipart-uploads/design.md
@@ -1,0 +1,82 @@
+## Context
+
+FastAPI 0.136.1 parses every declared `File`/`Form` body before it solves router or endpoint dependencies. Starlette 1.3.1 spools file parts after 1 MiB but applies `max_part_size` only to non-file fields, with defaults of 1,000 files and 1,000 fields. The affected handlers then call unbounded `UploadFile.read()`, and image edits create additional base64 and request-model copies.
+
+The four affected surfaces have different compatibility contracts: dashboard `auth_json` import, native and OpenAI-compatible transcription, and OpenAI-compatible image edits. The Codex JSON image-edit alias and the direct-to-SAS files protocol are not multipart and are outside this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Bound temporary-disk, multipart parser, and handler heap exposure with deterministic zero-configuration limits.
+- Authenticate before any multipart body is consumed or spooled.
+- Count actual streamed bytes so chunked bodies and understated `Content-Length` values cannot bypass admission.
+- Preserve successful upload semantics, source-model form forwarding, OpenAPI request-body descriptions, path-family error envelopes, disconnects, cancellation, and image observability.
+- Release every temporary file before account persistence, usage reservation, account selection, or upstream forwarding.
+
+**Non-Goals:**
+
+- Add operator-tunable upload settings, change the Starlette spool threshold, inspect media contents, or restrict filename/MIME values.
+- Limit the non-multipart Codex image alias or direct-to-SAS file uploads.
+- Add a process-wide aggregate upload/concurrency budget.
+- Add dedicated multipart parsers or route-specific upload budgets outside the four exact operations.
+
+## Decisions
+
+### Parse inside authorized handlers
+
+The affected handlers will no longer declare FastAPI `File` or `Form` parameters. They will accept `Request`, let existing router and endpoint dependencies complete, and then call a shared bounded parser. Their OpenAPI multipart request bodies will be retained explicitly.
+
+This is preferred over a custom `APIRoute` that pre-populates `request._form`: a pre-parser can bound each request but still spools unauthenticated data. It is also preferred over `request.form(max_part_size=...)`, because the pinned Starlette version does not apply that value to file parts.
+
+### Use a shared counted Starlette parser
+
+A core multipart module will wrap `request.stream()` with a cumulative body counter and subclass `MultiPartParser` to enforce file, aggregate-file, and text-part byte limits before the crossing bytes are queued for spool writes. Starlette's native parser continues to own boundary parsing and closes partially-created files on parser errors. A context manager closes successful `FormData` on every exit.
+
+The helper will reject a valid declared `Content-Length` above the route budget, but it will always count actual chunks. Because Starlette closes partial files only for its own parser and OS errors, the wrapper will also close every parser-owned spool on any `BaseException` before re-raising `ClientDisconnect`, `CancelledError`, or another non-limit failure unchanged. Handlers will still perform a bounded `limit + 1` read as a defense-in-depth check, copy the required bytes/text values, and close the form before invoking service or upstream logic.
+
+### Apply fixed protocol policies
+
+| Surface | Multipart body | File bytes | Aggregate binary | Files | Fields | Text part |
+|---|---:|---:|---:|---:|---:|---:|
+| account import | 2 MiB | 1 MiB | 1 MiB | 1 | 0 | n/a |
+| either transcription route | 32 MiB | 25,000,000 | 25,000,000 | 1 | 32 | 256 KiB |
+| image edits | 64 MiB | 49,999,999 | 49,999,999 | 17 | 32 | 256 KiB |
+
+Image file counts are additionally classified by field: `image` and `image[]` share a maximum of 16, `mask` has a maximum of one, and unknown file fields are invalid. The mask participates in both per-file and aggregate binary limits.
+
+Fixed defaults avoid growing the `CODEX_LB_*` configuration surface. The audio cap uses an inclusive 25,000,000-byte local interpretation of the public 25 MB upload contract. The image cap implements the public “less than 50 MB” wording literally and applies the same strict ceiling to the aggregate because codex-lb retains all binaries and base64 copies simultaneously.
+
+The image aggregate is a resource-safety ceiling, not a promise that every payload below it fits the default 15 MiB internal `response.create` transport. The existing downstream size guard remains authoritative after base64/JSON expansion and can reject a smaller admitted upload with its established `payload_too_large` behavior.
+
+### Reject encoded multipart before decompression
+
+A small pure-ASGI middleware, registered outside the existing decompression middleware, will recognize only `POST` on the four canonical application-relative paths, regardless of the declared media type. It will remove the `Content-Encoding` header from a copied scope and place a private unsupported-encoding marker on non-identity requests without reading the body. After existing route authorization succeeds, the handler checks that marker and returns the 400 response before multipart parsing. Unauthorized requests therefore retain 401/403 precedence, `identity` remains a no-op, compressed bytes never reach the decompression layer, and other methods keep their existing behavior.
+
+### Compose route-owned admission with generic raw ingress
+
+After outer path canonicalization, the effective production order is multipart content-encoding gate, generic raw-body guard, then request decompression. For either `identity` or a non-identity value, the exact-path gate removes the header and places an internal handled marker on the copied scope without reading the body. The generic raw guard honors that marker independently of the client-declared media type. `identity` therefore reaches the authorized bounded parser and its dedicated multipart body budget; for a non-identity encoding, the authorized handler rejects the unsupported marker before parsing.
+
+This is a narrow route-owned exception even when the declared `Content-Length` exceeds the generic raw budget. The account, transcription, and image-edit contracts remain authoritative for their four exact `POST` operations. An unencoded multipart request bypasses generic admission only when the same exact operation predicate selects its dedicated bounded parser. Every request on every other route remains under generic raw admission regardless of its declared media type, and encoded requests also retain decompressed-body admission.
+
+### Keep byte and shape errors distinct
+
+Body, file, aggregate-binary, and text-part byte failures return HTTP 413 with `code = payload_too_large`. Proxy routes use `type = invalid_request_error` and attach the known file parameter when applicable; account import uses the dashboard envelope. Multipart syntax and part-count/shape errors remain HTTP 400, while missing required typed-equivalent parts retain the existing dashboard 422 or proxy 400 validation contract.
+
+Non-identity multipart content encoding returns HTTP 400 with the path-family invalid-request envelope after authorization. Image-edit auth, encoding, and parser failures record exactly one bounded route-completion observation without parsing multipart solely to derive observability labels; pre-parse labels use `model = unknown` and `stream = false`.
+
+## Risks / Trade-offs
+
+- **[Private framework integration changes in a future Starlette release]** → Keep the parser subclass narrow and add version-near tests for callback ordering, file rollover, cleanup, disconnect, and cancellation.
+- **[Legitimate large uploads begin failing]** → Use public/protocol-aligned file limits, document the stricter aggregate image budget in OpenSpec, and return deterministic 413 envelopes.
+- **[Manual extraction drifts from prior FastAPI coercion]** → Reuse existing Pydantic validation, preserve multi-item order for source transcription fields, and add before/after contract regressions for missing, duplicate, bracketed, and malformed parts.
+- **[64 MiB image requests can still amplify in memory]** → Enforce a 50,000,000-byte aggregate binary cap, close spools before base64 conversion, and retain the existing downstream `response.create` guard.
+- **[Concurrent admitted uploads still multiply the per-request budget]** → Existing proxy/dashboard bulkheads remain the concurrency boundary; a global byte semaphore is a separate change.
+
+## Migration Plan
+
+No database or configuration migration is required. Deploy the parser, middleware, handler extraction, and tests together. Rollback is a code rollback; clients that receive the new 413 response can retry with a smaller file without server-side cleanup.
+
+## Open Questions
+
+None.

--- a/openspec/changes/bound-multipart-uploads/proposal.md
+++ b/openspec/changes/bound-multipart-uploads/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The account-import, transcription, and image-edit multipart routes accept unbounded file parts. FastAPI currently parses and spools those parts before route authorization, and the handlers then read the complete files into memory, allowing unauthenticated disk pressure and authenticated disk or heap exhaustion.
+
+## What Changes
+
+- Parse the four multipart upload surfaces only after their existing dashboard or proxy authorization dependencies have succeeded.
+- Enforce fixed, zero-configuration limits against declared and actually streamed multipart bytes, individual file parts, text parts, part counts, and route-specific aggregate image bytes.
+- Limit account imports to one 1 MiB `auth_json` file inside a 2 MiB multipart request.
+- Limit transcription uploads to one 25,000,000-byte audio file inside a 32 MiB multipart request.
+- Limit image edits to 16 source images plus one mask, with less than 50,000,000 binary bytes inside a 64 MiB multipart request.
+- Return path-family HTTP 413 `payload_too_large` errors for byte-limit failures while retaining established validation behavior for malformed or missing parts.
+- Close multipart spool files before database or upstream work and on every parsing, disconnect, cancellation, or limit-failure path.
+- Reject compressed multipart bodies on these routes before the decompression layer can prebuffer them; `identity` remains a no-op.
+
+## Capabilities
+
+### New Capabilities
+
+- `account-import`: Dashboard `auth_json` multipart import shape, authorization order, resource limits, cleanup, and error contract.
+
+### Modified Capabilities
+
+- `audio-transcriptions-compat`: Add bounded multipart parsing and upload limits to both native and OpenAI-compatible transcription routes.
+- `images-api-compat`: Add bounded multipart parsing, source-image and mask count limits, and binary aggregate limits to image edits.
+- `http-ingress-limits`: Restrict multipart exemptions to exact route-owned bounded operations while keeping every unrelated request under generic admission.
+
+## Impact
+
+The change affects the shared multipart parsing layer, request middleware ordering, account import, transcription, image edits, framework error mapping, OpenAPI request-body descriptions, and their unit/integration coverage. It adds no runtime setting or dependency. When composed with the generic raw HTTP ingress guard, the four route-owned multipart operations retain authorization and their dedicated body budgets as the admission boundary; every other multipart request retains generic raw admission, including unencoded bodies carrying a spoofed multipart media type.

--- a/openspec/changes/bound-multipart-uploads/specs/account-import/spec.md
+++ b/openspec/changes/bound-multipart-uploads/specs/account-import/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Account auth imports are authorized and bounded
+
+`POST /api/accounts/import` MUST authenticate the dashboard session and require dashboard write access before reading any request-body bytes. It MUST accept exactly one file part named `auth_json`, no text parts, a file size no greater than 1 MiB (1,048,576 bytes), and a complete multipart body no greater than 2 MiB (2,097,152 bytes).
+
+The service MUST enforce the body limit against both a usable declared `Content-Length` and the actual streamed bytes. It MUST enforce the file limit before retaining bytes beyond the limit, close every multipart spool before account persistence or import-time network work begins, and add no new runtime setting.
+
+This route-owned policy MUST take precedence over the generic raw HTTP body budget for `POST /api/accounts/import`. Its exact-path content-encoding gate MUST run outside the generic raw and decompression guards regardless of the declared media type. Requests handled by that gate, and unencoded requests declared as multipart, MUST NOT be rejected by the generic guards before dashboard authorization or the dedicated parser applies this capability's body limit. An unencoded request that does not declare multipart remains under generic admission and MAY be rejected there before authorization. This exception MUST NOT change generic ingress behavior for any other operation.
+
+Byte-limit failures MUST return HTTP 413 with dashboard error `code = payload_too_large`. Missing or non-file `auth_json` input MUST retain the dashboard validation envelope, while malformed multipart syntax or additional parts MUST return a dashboard-compatible HTTP 400 without invoking account import logic.
+
+#### Scenario: Unauthorized import does not consume the body
+
+- **WHEN** a request without a valid dashboard session or write permission targets account import
+- **THEN** the existing authentication or permission response is returned before the ASGI request body is consumed
+- **AND** no multipart temporary file is created
+
+#### Scenario: Valid bounded auth file imports normally
+
+- **WHEN** an authorized operator uploads exactly one valid `auth_json` file and both file and multipart body are within their limits
+- **THEN** the existing account identity, persistence, usage-refresh, cache-invalidation, and audit behavior continues
+- **AND** the multipart spool is closed before persistence or network work begins
+
+#### Scenario: Declared or streamed account-import body exceeds its limit
+
+- **WHEN** a usable `Content-Length` exceeds 2 MiB or actual streamed multipart bytes cross 2 MiB
+- **THEN** the service returns HTTP 413 with dashboard error `code = payload_too_large`
+- **AND** it does not parse credentials, mutate an account, refresh usage, invalidate caches, or write a success audit event
+
+#### Scenario: Auth file exceeds its limit
+
+- **WHEN** the `auth_json` file part exceeds 1 MiB while the multipart body is otherwise valid
+- **THEN** the service returns HTTP 413 with dashboard error `code = payload_too_large`
+- **AND** bytes beyond the file limit are not retained in a multipart spool or handler buffer
+
+#### Scenario: Account import has an invalid multipart shape
+
+- **WHEN** an import omits a file-valued `auth_json` part or includes duplicate, additional file, or text parts
+- **THEN** the service returns the established dashboard validation or bad-request envelope
+- **AND** account import logic is not invoked
+
+#### Scenario: Compressed account import is rejected without prebuffering
+
+- **GIVEN** account import has passed dashboard session and write authorization
+- **WHEN** it declares a non-identity `Content-Encoding`
+- **THEN** the service returns HTTP 400 with dashboard error `code = invalid_request` before reading the request body
+- **AND** a no-op `identity` encoding is handled as an ordinary multipart request governed by the 2 MiB dedicated body limit
+
+#### Scenario: Generic ingress does not preempt encoded account-import authorization
+
+- **GIVEN** an account-import request fails dashboard session or write authorization
+- **WHEN** it declares a non-identity `Content-Encoding` and a `Content-Length` greater than the generic raw HTTP budget
+- **THEN** the existing authentication or permission response is returned instead of a generic HTTP 413 or encoded-body HTTP 400
+- **AND** the request body is not consumed
+
+#### Scenario: Disconnect and cancellation clean up parsing
+
+- **WHEN** the client disconnects or request processing is cancelled during account multipart parsing
+- **THEN** every created spool is closed
+- **AND** the disconnect or cancellation propagates without being converted to HTTP 413

--- a/openspec/changes/bound-multipart-uploads/specs/audio-transcriptions-compat/spec.md
+++ b/openspec/changes/bound-multipart-uploads/specs/audio-transcriptions-compat/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Transcription multipart uploads are authorized and bounded
+
+`POST /backend-api/transcribe` and `POST /v1/audio/transcriptions` MUST complete their existing proxy authorization dependencies before reading multipart body bytes. Each request MUST contain exactly one file part no greater than 25,000,000 bytes, no more than 32 text fields of at most 256 KiB each, and a complete multipart body no greater than 32 MiB (33,554,432 bytes).
+
+The service MUST enforce the body limit against both a usable declared `Content-Length` and actual streamed bytes. It MUST enforce file and text limits before retaining crossing bytes, close multipart spools before usage reservation, account selection, or upstream forwarding, preserve ordered text-field forwarding for configured model sources, and add no new runtime setting.
+
+This route-owned policy MUST take precedence over the generic raw HTTP body budget for both transcription operations. Their exact-path content-encoding gate MUST run outside the generic raw and decompression guards regardless of the declared media type. Requests handled by that gate, and unencoded requests declared as multipart, MUST NOT be rejected by the generic guards before proxy authorization or the dedicated parser applies this capability's body limit. An unencoded request that does not declare multipart remains under generic admission and MAY be rejected there before authorization. This exception MUST NOT change generic ingress behavior for any other operation.
+
+Byte-limit failures MUST return HTTP 413 with OpenAI error `code = payload_too_large` and `type = invalid_request_error`; a file-part failure MUST set `param = file`. Multipart syntax, count, and required-field failures MUST retain OpenAI-compatible invalid-request behavior and MUST NOT reserve usage or call upstream.
+
+#### Scenario: Unauthorized transcription does not consume the body
+
+- **WHEN** a transcription request fails the existing proxy API-key authorization
+- **THEN** the authentication response is returned before the ASGI request body is consumed
+- **AND** no multipart temporary file is created
+
+#### Scenario: Bounded native transcription remains compatible
+
+- **WHEN** an authorized `/backend-api/transcribe` request supplies one audio file within 25,000,000 bytes, an optional bounded prompt, and a multipart body within 32 MiB
+- **THEN** the service forwards the same audio bytes, filename, content type, and prompt through the existing transcription pipeline
+
+#### Scenario: Bounded source-model transcription preserves fields
+
+- **WHEN** an authorized `/v1/audio/transcriptions` request selects a configured model source and all multipart limits are satisfied
+- **THEN** the service forwards the audio file and the ordered non-file form fields through the existing source pipeline
+
+#### Scenario: Declared or streamed transcription body exceeds its limit
+
+- **WHEN** a usable `Content-Length` exceeds 32 MiB or actual streamed multipart bytes cross 32 MiB
+- **THEN** the service returns HTTP 413 with OpenAI error `code = payload_too_large` and `type = invalid_request_error`
+- **AND** no usage reservation, account selection, or upstream request occurs
+
+#### Scenario: Transcription file exceeds its limit
+
+- **WHEN** the audio file part exceeds 25,000,000 bytes
+- **THEN** the service returns HTTP 413 with OpenAI error `code = payload_too_large`, `type = invalid_request_error`, and `param = file`
+- **AND** bytes beyond the file limit are not retained in a spool or handler buffer
+
+#### Scenario: Transcription field resources are bounded
+
+- **WHEN** a request exceeds 32 text fields, one file part, or 256 KiB in any text part
+- **THEN** the service rejects the request with the documented OpenAI-compatible count or byte-limit response
+- **AND** it does not invoke transcription route logic
+
+#### Scenario: Compressed transcription is rejected without prebuffering
+
+- **GIVEN** the transcription request has passed proxy authorization
+- **WHEN** either transcription route declares a non-identity `Content-Encoding`
+- **THEN** the service returns HTTP 400 with OpenAI error `code = invalid_request_error` and `type = invalid_request_error` before reading the request body
+- **AND** a no-op `identity` encoding is handled as an ordinary multipart request governed by the 32 MiB dedicated body limit
+
+#### Scenario: Generic ingress does not preempt encoded transcription authorization
+
+- **GIVEN** a request to either transcription route fails proxy authorization
+- **WHEN** it declares a non-identity `Content-Encoding` and a `Content-Length` greater than the generic raw HTTP budget
+- **THEN** the existing authentication response is returned instead of a generic HTTP 413 or encoded-body HTTP 400
+- **AND** the request body is not consumed
+
+#### Scenario: Transcription cleanup preserves transport failures
+
+- **WHEN** parsing succeeds, fails a limit, encounters malformed multipart, receives a client disconnect, or is cancelled
+- **THEN** every created multipart spool is closed
+- **AND** disconnect and cancellation are not converted to HTTP 413

--- a/openspec/changes/bound-multipart-uploads/specs/http-ingress-limits/spec.md
+++ b/openspec/changes/bound-multipart-uploads/specs/http-ingress-limits/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Multipart ingress exceptions are exact and route-owned
+
+The generic raw HTTP body guard MUST exempt an unencoded `multipart/form-data` request only when the request is `POST` to `/api/accounts/import`, `/backend-api/transcribe`, `/v1/audio/transcriptions`, or `/v1/images/edits`, including their application-relative trailing-slash and mounted equivalents. Each exempt operation MUST apply its capability-defined authorization-before-read contract and dedicated bounded multipart parser.
+
+For the same exact operations, an outer content-encoding gate MUST remove `Content-Encoding` and mark the copied request scope as route-owned without reading the body. The generic raw and decompression guards MUST honor that internal marker regardless of the declared media type so `identity` reaches dedicated multipart admission and non-identity encoding reaches the post-authorization rejection path.
+
+The client-declared multipart media type MUST NOT exempt any other method or path. Every unrelated unencoded or encoded multipart request MUST remain under generic raw admission, and encoded requests MUST also retain generic decompressed-body admission.
+
+#### Scenario: Exact unencoded multipart operation uses its dedicated parser
+
+- **WHEN** an unencoded multipart request targets one of the four exact route-owned `POST` operations
+- **THEN** generic admission does not preempt operation authorization
+- **AND** the operation's dedicated multipart body limit remains authoritative
+
+#### Scenario: Exact encoded operation preserves authorization precedence
+
+- **WHEN** a request with `Content-Encoding` targets one of the four exact route-owned `POST` operations and declares either multipart or another media type
+- **THEN** the outer gate marks the request without consuming its body
+- **AND** generic raw or decompressed-body admission does not preempt operation authorization or its encoded-body contract
+
+#### Scenario: Unrelated multipart media type grants no exemption
+
+- **WHEN** an unencoded or encoded request outside the four exact route-owned `POST` operations declares `multipart/form-data`
+- **THEN** the generic raw-body budget remains enforced
+- **AND** an oversized declared body is rejected before downstream parsing

--- a/openspec/changes/bound-multipart-uploads/specs/images-api-compat/spec.md
+++ b/openspec/changes/bound-multipart-uploads/specs/images-api-compat/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Image edit multipart uploads are authorized and bounded
+
+`POST /v1/images/edits` MUST complete its existing proxy authorization dependencies before reading multipart body bytes. It MUST accept at most 16 source-image file parts across `image` and `image[]`, at most one `mask`, no unknown file-part names, no more than 32 text fields of at most 256 KiB each, every individual file smaller than 50,000,000 bytes, fewer than 50,000,000 bytes across all source images and the mask, and a complete multipart body no greater than 64 MiB (67,108,864 bytes).
+
+The service MUST enforce the body limit against both a usable declared `Content-Length` and actual streamed bytes. It MUST enforce file, aggregate-binary, and text limits before retaining crossing bytes, close multipart spools before usage reservation, account selection, base64 conversion, or internal Responses forwarding, and add no new runtime setting.
+
+This route-owned policy MUST take precedence over the generic raw HTTP body budget for `POST /v1/images/edits`. Its exact-path content-encoding gate MUST run outside the generic raw and decompression guards regardless of the declared media type. Requests handled by that gate, and unencoded requests declared as multipart, MUST NOT be rejected by the generic guards before proxy authorization or the dedicated parser applies this capability's body limit. An unencoded request that does not declare multipart remains under generic admission and MAY be rejected there before authorization. This exception MUST NOT change generic ingress behavior for any other operation.
+
+Byte-limit failures MUST return HTTP 413 with OpenAI error `code = payload_too_large` and `type = invalid_request_error`; a known file-part failure MUST set `param = image` or `param = mask`. Multipart syntax, count, and required-field failures MUST retain OpenAI-compatible invalid-request behavior. Every parser rejection MUST emit exactly one bounded image-route observation with HTTP status and `outcome = invalid_request`.
+
+#### Scenario: Unauthorized image edit does not consume the body
+
+- **WHEN** an image-edit request fails the existing proxy API-key authorization
+- **THEN** the authentication response is returned before the ASGI request body is consumed
+- **AND** no multipart temporary file is created
+- **AND** exactly one auth-error route observation is recorded without parsing the multipart body, using bounded pre-parse labels
+
+#### Scenario: Bounded image edit remains compatible
+
+- **WHEN** an authorized image-edit request supplies at least one source image, an optional mask, required text fields, and all parts are within their limits
+- **THEN** the service preserves the ordered `image` and `image[]` bytes, content types, mask, and validated form fields through the existing image-edit pipeline
+
+#### Scenario: Source image count combines canonical and bracketed keys
+
+- **WHEN** the combined number of `image` and `image[]` file parts exceeds 16, the request contains more than one `mask`, or an unknown file-part name is present
+- **THEN** the service returns an OpenAI-compatible HTTP 400 invalid-request response
+- **AND** no image bytes are base64-encoded or forwarded internally
+
+#### Scenario: Declared or streamed image-edit body exceeds its limit
+
+- **WHEN** a usable `Content-Length` exceeds 64 MiB or actual streamed multipart bytes cross 64 MiB
+- **THEN** the service returns HTTP 413 with OpenAI error `code = payload_too_large` and `type = invalid_request_error`
+- **AND** no usage reservation, account selection, base64 conversion, or internal Responses request occurs
+
+#### Scenario: Image binary limit is exceeded
+
+- **WHEN** one source image or mask reaches 50,000,000 bytes, or their combined binary bytes reach 50,000,000
+- **THEN** the service returns HTTP 413 with OpenAI error `code = payload_too_large`, `type = invalid_request_error`, and the applicable `image` or `mask` parameter
+- **AND** bytes beyond the applicable limit are not retained in a spool or handler buffer
+
+#### Scenario: Image text-field resources are bounded
+
+- **WHEN** an image-edit request exceeds 32 text fields or 256 KiB in any text part
+- **THEN** the service rejects the request with the documented OpenAI-compatible count or byte-limit response
+- **AND** it records one invalid-request route observation without invoking image-edit route logic
+
+#### Scenario: Compressed image edit is rejected without prebuffering
+
+- **GIVEN** image edit has passed proxy authorization
+- **WHEN** it declares a non-identity `Content-Encoding`
+- **THEN** the service returns HTTP 400 with OpenAI error `code = invalid_request_error` and `type = invalid_request_error` before reading the request body
+- **AND** a no-op `identity` encoding is handled as an ordinary multipart request governed by the 64 MiB dedicated body limit
+- **AND** exactly one invalid-request route observation is recorded without parsing the multipart body
+
+#### Scenario: Generic ingress does not preempt encoded image-edit authorization
+
+- **GIVEN** an image-edit request fails proxy authorization
+- **WHEN** it declares a non-identity `Content-Encoding` and a `Content-Length` greater than the generic raw HTTP budget
+- **THEN** the existing authentication response is returned instead of a generic HTTP 413 or encoded-body HTTP 400
+- **AND** the request body is not consumed
+- **AND** exactly one auth-error route observation is recorded
+
+#### Scenario: Image-edit cleanup preserves transport failures
+
+- **WHEN** parsing succeeds, fails a limit, encounters malformed multipart, receives a client disconnect, or is cancelled
+- **THEN** every created multipart spool is closed
+- **AND** disconnect and cancellation are not converted to HTTP 413

--- a/openspec/changes/bound-multipart-uploads/tasks.md
+++ b/openspec/changes/bound-multipart-uploads/tasks.md
@@ -1,0 +1,32 @@
+## 1. Shared multipart admission
+
+- [x] 1.1 Implement immutable route policies, the counted request stream, bounded Starlette parser callbacks, exact byte/count failures, bounded file reads, and guaranteed `FormData` cleanup.
+- [x] 1.2 Add path-family multipart limit/error handling plus a POST/path-scoped content-encoding marker that preserves auth precedence and `identity`, prevents decompression body reads, normalizes mounted paths, and leaves other methods/routes untouched.
+- [x] 1.3 Add reusable typed-equivalent field extraction and explicit OpenAPI multipart request bodies without restoring FastAPI pre-dependency form parsing.
+
+## 2. Authorized route integration
+
+- [x] 2.1 Move account `auth_json` parsing after dashboard session/write authorization, require the bounded one-file shape, and close its spool before service, persistence, refresh, or audit work.
+- [x] 2.2 Move native and `/v1` transcription parsing after proxy authorization, preserve native prompt and ordered source-model form fields, and close spools before reservation, selection, or upstream forwarding.
+- [x] 2.3 Move `/v1/images/edits` parsing after proxy authorization, merge `image`/`image[]` in order, enforce image/mask/count/aggregate limits, preserve Pydantic validation, and record auth/encoding/parser rejections once without pre-auth form parsing.
+
+## 3. Regression coverage
+
+- [x] 3.1 Add shared unit coverage for declared, chunked, understated, exact, and crossing body/file/text/aggregate limits; file/field counts; spool rollover and cleanup; malformed input; disconnect; cancellation; `root_path`; auth-precedence content encoding; wrong methods/media types; and unrelated routes.
+- [x] 3.2 Add account-import integration coverage for auth-before-read, exact and oversized uploads, invalid shapes, dashboard envelopes, cleanup before service work, and absence of persistence/audit side effects.
+- [x] 3.3 Add both transcription-route regressions for byte-identical small/exact uploads, 25 MiB and 32 MiB failures, missing/extra parts, ordered source fields, no pre-rejection reservations/upstream calls, and OpenAI envelopes.
+- [x] 3.4 Add image-edit regressions for combined `image`/`image[]` ordering and count, one mask, unknown files, per-file and aggregate boundaries, text/body limits, empty-part compatibility, no internal forwarding, cleanup, and one 413 observation.
+- [x] 3.5 Add ratchets proving every FastAPI multipart route has an explicit policy, canonical OpenAPI request bodies remain present, and the non-multipart Codex image/files surfaces are unaffected.
+
+## 4. Verification
+
+- [x] 4.1 Run strict OpenSpec validation and all targeted multipart, account, transcription, image, middleware, SDK-compatibility, and observability suites.
+- [x] 4.2 Run the complete unit and integration baselines in the repository's CI-equivalent shard configuration.
+- [x] 4.3 Run Ruff check/format, ty, architecture and simplicity checks, OpenAPI diff review, and diff hygiene checks.
+- [x] 4.4 Verify the implementation semantically against every OpenSpec scenario and review the final standalone diff against current upstream `main`.
+
+## 5. Mainline ingress composition
+
+- [x] 5.1 Merge the current raw-ingress baseline, reconcile middleware registration, and document the exact-route authorization-first carve-out while keeping every unrelated multipart request under generic admission.
+- [x] 5.2 Add a production-stack regression proving middleware order, auth-first unencoded and encoded handling on all four dedicated operations, dedicated handling of `identity`, and generic guarding of unrelated multipart regardless of encoding.
+- [x] 5.3 Run the combined multipart/raw/decompression suites and all repository readiness gates against the merged result.

--- a/openspec/changes/bound-raw-http-ingress/context.md
+++ b/openspec/changes/bound-raw-http-ingress/context.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This change closes the pre-routing memory-exhaustion gap for guarded HTTP requests. The existing decompression cap protects expanded data, but it runs only after the complete encoded body has been collected; unencoded JSON bodies have no equivalent ingress cap at all. Requests declaring unencoded multipart remain a documented residual gap for the standalone multipart-limits change.
+This change closes the pre-routing memory-exhaustion gap for guarded HTTP requests. The existing decompression cap protects expanded data, but it runs only after the complete encoded body has been collected; unencoded JSON bodies have no equivalent ingress cap at all. Route-owned multipart operations can use dedicated bounded parsers, but a client-declared multipart media type alone cannot safely exempt any other route from generic admission.
 
 ## Decisions and constraints
 
@@ -11,7 +11,7 @@ This change closes the pre-routing memory-exhaustion gap for guarded HTTP reques
 - Keep the larger budget for the two Responses HTTP aliases, including trailing slashes.
 - Register trailing-slash HTTP paths explicitly so chunked bodies reach admission instead of being redirected before consumption.
 - Limit raw bytes before decompression and expanded bytes after decompression.
-- Keep requests declaring unencoded multipart outside this change. The declared media type is spoofable and is not a security boundary; file-aware aggregate, parser, and per-file limits need separate requirements and compatibility tests.
+- Exempt unencoded multipart only on exact operations that own file-aware aggregate, parser, and per-file limits. Keep every other request under generic admission regardless of a spoofable declared media type.
 - Select the error envelope from the canonical path because the rejection can happen before router/dependency metadata is available. Proxy families include `/v1/*`, `/backend-api/*`, `/api/codex/*`, and `/internal/bridge/*`.
 - Preserve endpoint authorization for every body admitted by the ingress guard; the transport guard is not an authentication replacement.
 

--- a/openspec/changes/bound-raw-http-ingress/design.md
+++ b/openspec/changes/bound-raw-http-ingress/design.md
@@ -36,11 +36,11 @@ Alternatives rejected:
 - A `BaseHTTPMiddleware` implementation adds request-stream adaptation without providing value here; the ASGI receive contract is the boundary being limited.
 - A server-global cap cannot preserve the larger Responses budget and does not replace the expanded-body cap.
 
-### Reuse the existing route budgets and leave plain multipart unchanged
+### Reuse the existing budgets and scope multipart exemptions to owned routes
 
 The raw guard and decompressor share one path-budget selector. `/v1/responses` and `/backend-api/codex/responses`, after removing trailing slashes, use the larger of `max_decompressed_body_bytes` and `max_decompressed_responses_body_bytes`; other guarded paths use `max_decompressed_body_bytes`.
 
-Requests declaring `multipart/form-data` without `Content-Encoding` bypass this whole-body guard. Encoded multipart remains guarded because decompression otherwise creates the same raw and expansion risks. Content type is client-declared, so this exemption is not a security boundary; multipart-specific aggregate, parser, and per-file limits remain a separate change with their own compatibility analysis.
+Client-declared `multipart/form-data` is not itself an exemption because an unrelated typed-body route would otherwise consume a mislabeled body before authorization. Only unencoded multipart on an exact operation with a route-owned bounded parser bypasses the generic guard. When that capability also supplies an outer content-encoding gate, the gate marks its handled scope independently of the declared media type; the generic guard honors only that exact operation predicate or internal marker. All other unencoded and encoded multipart requests remain guarded.
 
 ### Use a private receive sentinel plus a request-scope marker
 
@@ -55,14 +55,14 @@ Ingress occurs before route metadata can reliably set `request.state.error_forma
 - overflow: HTTP 413 with `code = payload_too_large`;
 - malformed or unsupported compression: HTTP 400, using `invalid_request_error` for OpenAI paths and `invalid_request` otherwise.
 
-OpenAI ingress errors use `type = invalid_request_error`. Existing decompression support for `gzip`, `deflate`, `zstd`, `identity`, and stacked encodings remains unchanged after the raw guard. Stacked encodings are removed in reverse header/application order, and every intermediate decoded representation remains capped.
+OpenAI ingress errors use `type = invalid_request_error`. Existing decompression support for `gzip`, `deflate`, `zstd`, `identity`, and stacked encodings remains unchanged after the raw guard for requests under generic admission. Stacked encodings are removed in reverse header/application order, and every intermediate decoded representation remains capped. Exact route-owned exceptions follow their owning capability's post-authorization encoded-body contract instead.
 
 ## Risks / Trade-offs
 
 - **The 128 MiB Responses budget still permits substantial per-request memory use** → Existing bulkhead/backpressure middleware remains outside the guard, and both raw and expanded representations are independently bounded by the established budget.
 - **A client can lie in `Content-Length`** → The receive wrapper always counts actual chunks even after a declared length passes the early check.
 - **A downstream component could start a response before reading a later body chunk** → The raw middleware tracks `http.response.start` and re-raises rather than attempting a second response.
-- **A client can label an unencoded body as multipart to bypass the generic guard** → The declared-media-type exemption is explicit and tested; multipart aggregate/parser/per-file controls are the standalone follow-up that closes this residual gap.
+- **A client can label an unrelated body as multipart to seek an exemption** → Generic admission keys the exception to the exact route-owned operation rather than trusting `Content-Type`; every other operation remains guarded.
 
 ## Migration Plan
 

--- a/openspec/changes/bound-raw-http-ingress/proposal.md
+++ b/openspec/changes/bound-raw-http-ingress/proposal.md
@@ -9,7 +9,7 @@ HTTP request bodies without content encoding are currently unbounded, while comp
 - Register hidden trailing-slash HTTP aliases for both Responses paths so FastAPI does not redirect before chunked-body admission runs.
 - Preserve decompressed-size enforcement for `gzip`, `deflate`, `zstd`, `identity`, and stacked encodings so neither transfer size nor expanded size can exceed its route budget.
 - Reject oversized bodies with HTTP 413 and path-appropriate error envelopes; return OpenAI-compatible invalid-request envelopes for malformed or unsupported compression on proxy path families.
-- Leave requests declaring unencoded `multipart/form-data` outside this generic whole-body limit so multipart per-file and aggregate limits can remain a separate, standalone change.
+- Allow only exact route-owned multipart operations with dedicated bounded parsers to bypass the generic whole-body limit; a multipart `Content-Type` on any other operation remains generically guarded.
 - Add no new setting: the guard reuses `max_decompressed_body_bytes` and `max_decompressed_responses_body_bytes`.
 
 ## Capabilities

--- a/openspec/changes/bound-raw-http-ingress/specs/http-ingress-limits/spec.md
+++ b/openspec/changes/bound-raw-http-ingress/specs/http-ingress-limits/spec.md
@@ -31,22 +31,36 @@ The service MUST use `max_decompressed_body_bytes` as the general raw and decomp
 
 Route-specific budget and error-envelope selection MUST use the application-relative route path after removing any matching ASGI `root_path` prefix.
 
-Requests declaring `multipart/form-data` without `Content-Encoding` MUST remain outside this generic whole-body guard. Multipart requests carrying `Content-Encoding` MUST remain guarded. The service MUST NOT treat the client-declared multipart media type as a trusted security boundary.
+The generic guard MUST apply to requests solely because they declare `multipart/form-data`; the client-declared media type MUST NOT grant an exemption. An owning route capability MAY define an exact method/path-scoped authorization-before-read contract and dedicated bounded multipart parser. Only unencoded multipart requests to that exact operation, or requests marked by its outer content-encoding gate, MAY bypass generic admission. The gate MUST identify its operation independently of the declared media type, remove the encoding and mark the scope as handled without consuming the body, and the exception MUST NOT apply to any other operation.
 
 #### Scenario: Another HTTP path uses the general budget
 
 - **WHEN** a guarded request targets any other HTTP path
 - **THEN** its raw and decompressed HTTP ingress budget is `max_decompressed_body_bytes`
 
-#### Scenario: Declared unencoded multipart remains unaffected
+#### Scenario: Route-owned unencoded multipart uses dedicated admission
 
-- **WHEN** a request declares media type `multipart/form-data` and has no `Content-Encoding`
-- **THEN** the generic raw whole-body guard does not reject it based on these budgets
+- **GIVEN** an exact operation has a capability-defined authorization-before-read contract and dedicated bounded multipart parser
+- **WHEN** an unencoded request to that operation declares media type `multipart/form-data`
+- **THEN** the generic raw whole-body guard does not preempt operation authorization or its dedicated parser limit
+
+#### Scenario: Unrelated unencoded multipart remains guarded
+
+- **WHEN** an unencoded request outside a route-owned multipart operation declares media type `multipart/form-data`
+- **THEN** the service applies the generic raw-body budget
+- **AND** the declared media type alone does not bypass admission
 
 #### Scenario: Encoded multipart remains guarded
 
-- **WHEN** a `multipart/form-data` request carries a `Content-Encoding` header
+- **WHEN** a `multipart/form-data` request outside a route-owned multipart exception carries a `Content-Encoding` header
 - **THEN** the service applies both the raw and decompressed budget checks
+
+#### Scenario: Route-owned multipart admission can preserve authorization precedence
+
+- **GIVEN** an exact operation has a capability-defined outer content-encoding gate, authorization-before-read contract, and dedicated bounded multipart parser
+- **WHEN** an encoded request targets that operation, regardless of its declared media type
+- **THEN** the generic raw and decompressed-body guards do not preempt operation authorization or its dedicated parser limit
+- **AND** encoded multipart requests to all other operations remain guarded
 
 #### Scenario: Mounted Responses route keeps its route-specific policy
 
@@ -57,26 +71,26 @@ Requests declaring `multipart/form-data` without `Content-Encoding` MUST remain 
 
 ### Requirement: Encoded HTTP bodies are bounded before and after decompression
 
-For request bodies using `gzip`, `deflate`, `zstd`, `identity`, or supported stacked `Content-Encoding` values, the service MUST enforce the applicable budget independently against the encoded raw body and every intermediate and final decoded representation. The service MUST remove stacked encodings in reverse header/application order. Unsupported encodings or malformed compressed bodies MUST fail with HTTP 400.
+For request bodies using `gzip`, `deflate`, `zstd`, `identity`, or supported stacked `Content-Encoding` values that remain under generic ingress admission, the service MUST enforce the applicable budget independently against the encoded raw body and every intermediate and final decoded representation. The service MUST remove stacked encodings in reverse header/application order. Unsupported encodings or malformed compressed bodies under generic admission MUST fail with HTTP 400. Exact route-owned exceptions MUST instead follow their owning capability's authorization and encoded-body rejection contract.
 
 #### Scenario: Encoded raw body exceeds the budget
 
-- **WHEN** an encoded request's raw bytes exceed the applicable budget before decompression
+- **WHEN** a generic-guarded encoded request's raw bytes exceed the applicable budget before decompression
 - **THEN** the service returns HTTP 413 before attempting to hold an unbounded encoded body
 
 #### Scenario: Expanded body exceeds the budget
 
-- **WHEN** an encoded request is within the raw budget but expands beyond the applicable decompressed budget
+- **WHEN** a generic-guarded encoded request is within the raw budget but expands beyond the applicable decompressed budget
 - **THEN** the service returns HTTP 413
 
 #### Scenario: Supported stacked encoding remains compatible
 
-- **WHEN** a request uses a valid supported stack of `gzip`, `deflate`, `zstd`, or `identity` encodings and both representations fit the budget
+- **WHEN** a generic-guarded request uses a valid supported stack of `gzip`, `deflate`, `zstd`, or `identity` encodings and both representations fit the budget
 - **THEN** the service decodes the body in reverse header/application order, caps every intermediate representation, and continues request handling
 
 #### Scenario: Invalid compression is rejected
 
-- **WHEN** a request uses an unsupported content encoding or carries malformed compressed bytes
+- **WHEN** a generic-guarded request uses an unsupported content encoding or carries malformed compressed bytes
 - **THEN** the service returns HTTP 400 without invoking route logic
 
 ### Requirement: HTTP ingress failures use the path-family error envelope
@@ -122,7 +136,7 @@ The HTTP ingress guard MUST NOT authenticate callers or replace, bypass, or relo
 - **THEN** the ingress guard allows normal routing to continue
 - **AND** the existing proxy authorization rejects the request with its established authentication response
 
-#### Scenario: Declared oversized request fails before authorization
+#### Scenario: Declared oversized generic-guarded request fails before authorization
 
-- **WHEN** a request declares a body larger than its ingress budget
+- **WHEN** a guarded request outside a route-owned admission exception declares a body larger than its ingress budget
 - **THEN** the service returns the deterministic ingress 413 without invoking router-level authorization

--- a/openspec/changes/bound-raw-http-ingress/tasks.md
+++ b/openspec/changes/bound-raw-http-ingress/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Raw ingress guard
 
-- [x] 1.1 Implement the pure ASGI raw request-body limiter with early `Content-Length` rejection, streamed chunk counting, exact-boundary behavior, disconnect passthrough, and the unencoded multipart exemption.
+- [x] 1.1 Implement the pure ASGI raw request-body limiter with early `Content-Length` rejection, streamed chunk counting, exact-boundary behavior, disconnect passthrough, and an exact route-owned unencoded multipart exemption.
 - [x] 1.2 Implement the shared route-budget selector, path-family error-envelope constructor, overflow scope marker, and exact sentinel handling.
 - [x] 1.3 Register and export the limiter so canonical path rewriting and outer admission middleware run before it while request decompression runs after it; add hidden trailing-slash Responses aliases so streamed admission is not bypassed by a redirect.
 
@@ -11,7 +11,7 @@
 
 ## 3. Regression coverage
 
-- [x] 3.1 Add raw ASGI unit coverage for declared and streamed overflow, exact limits, understated lengths, oversized chunks, passthrough scopes, disconnects, unrelated receive failures, response-start safety, multipart scope, route budgets, aliases, and middleware order.
+- [x] 3.1 Add raw ASGI unit coverage for declared and streamed overflow, exact limits, understated lengths, oversized chunks, passthrough scopes, disconnects, unrelated receive failures, response-start safety, route-owned and unrelated multipart scope, route budgets, aliases, and middleware order.
 - [x] 3.2 Extend decompression tests for raw and expanded limits across `identity`, `gzip`, `deflate`, `zstd`, stacked encodings, trailing-slash Responses routes, OpenAI/dashboard error envelopes, and unchanged post-slimming HTTP 400 behavior.
 - [x] 3.3 Add integration coverage proving typed uncompressed request bodies are bounded before route dependencies while admitted requests preserve existing authorization behavior.
 

--- a/tests/integration/test_account_import_multipart.py
+++ b/tests/integration/test_account_import_multipart.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from httpx import AsyncByteStream
+from starlette.datastructures import UploadFile
+
+import app.modules.accounts.api as accounts_api_module
+from app.core.auth.dependencies import require_dashboard_write_access
+from app.core.exceptions import DashboardPermissionError
+from app.modules.accounts.schemas import AccountImportResponse
+
+pytestmark = pytest.mark.integration
+
+_MIB = 1024 * 1024
+
+
+class _NeverReadStream(AsyncByteStream):
+    def __init__(self) -> None:
+        self.iterated = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        self.iterated = True
+        raise AssertionError("request body must not be consumed")
+        yield b""  # pragma: no cover
+
+
+def _import_response() -> AccountImportResponse:
+    return AccountImportResponse(
+        account_id="acc_bounded_import",
+        email="bounded-import@example.com",
+        plan_type="plus",
+        status="active",
+    )
+
+
+@pytest.mark.asyncio
+async def test_account_import_auth_failure_does_not_read_multipart_body(
+    app_instance,
+    async_client,
+) -> None:
+    async def reject_write_access() -> None:
+        raise DashboardPermissionError(
+            "Read-only dashboard access cannot modify dashboard state",
+            code="read_only_access",
+        )
+
+    stream = _NeverReadStream()
+    app_instance.dependency_overrides[require_dashboard_write_access] = reject_write_access
+    try:
+        response = await async_client.post(
+            "/api/accounts/import",
+            content=stream,
+            headers={"content-type": "multipart/form-data; boundary=never-read"},
+        )
+    finally:
+        app_instance.dependency_overrides.pop(require_dashboard_write_access, None)
+
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "read_only_access"
+    assert stream.iterated is False
+
+
+@pytest.mark.asyncio
+async def test_account_import_rejects_compressed_body_after_auth_without_reading(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_import(*_args: object, **_kwargs: object) -> AccountImportResponse:
+        raise AssertionError("compressed upload must not reach account import")
+
+    monkeypatch.setattr("app.modules.accounts.service.AccountsService.import_account", fail_import)
+    stream = _NeverReadStream()
+
+    response = await async_client.post(
+        "/api/accounts/import",
+        content=stream,
+        headers={
+            "content-type": "multipart/form-data; boundary=never-read",
+            "content-encoding": "gzip",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_request"
+    assert stream.iterated is False
+
+
+@pytest.mark.asyncio
+async def test_account_import_allows_exact_file_limit_and_closes_spool_before_service(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    closed_uploads: list[UploadFile] = []
+    original_close = UploadFile.close
+
+    async def record_close(upload: UploadFile) -> None:
+        await original_close(upload)
+        closed_uploads.append(upload)
+
+    async def import_account(_service: object, raw: bytes) -> AccountImportResponse:
+        assert len(raw) == _MIB
+        assert len(closed_uploads) == 1
+        assert closed_uploads[0].file.closed
+        return _import_response()
+
+    audit_events: list[str] = []
+    monkeypatch.setattr(UploadFile, "close", record_close)
+    monkeypatch.setattr("app.modules.accounts.service.AccountsService.import_account", import_account)
+    monkeypatch.setattr(
+        accounts_api_module.AuditService,
+        "log_async",
+        lambda event, **_kwargs: audit_events.append(event),
+    )
+
+    response = await async_client.post(
+        "/api/accounts/import",
+        files={"auth_json": ("auth.json", b"x" * _MIB, "application/json")},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["accountId"] == "acc_bounded_import"
+    assert audit_events == ["account_created"]
+
+
+@pytest.mark.asyncio
+async def test_account_import_file_limit_rejects_without_service_or_audit_side_effects(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service_calls = 0
+    audit_calls = 0
+
+    async def import_account(*_args: object, **_kwargs: object) -> AccountImportResponse:
+        nonlocal service_calls
+        service_calls += 1
+        return _import_response()
+
+    def record_audit(*_args: object, **_kwargs: object) -> None:
+        nonlocal audit_calls
+        audit_calls += 1
+
+    monkeypatch.setattr("app.modules.accounts.service.AccountsService.import_account", import_account)
+    monkeypatch.setattr(accounts_api_module.AuditService, "log_async", record_audit)
+
+    response = await async_client.post(
+        "/api/accounts/import",
+        files={"auth_json": ("auth.json", b"x" * (_MIB + 1), "application/json")},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["error"]["code"] == "payload_too_large"
+    assert service_calls == 0
+    assert audit_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_account_import_declared_body_limit_rejects_without_service_work(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service_calls = 0
+
+    async def import_account(*_args: object, **_kwargs: object) -> AccountImportResponse:
+        nonlocal service_calls
+        service_calls += 1
+        return _import_response()
+
+    monkeypatch.setattr("app.modules.accounts.service.AccountsService.import_account", import_account)
+
+    response = await async_client.post(
+        "/api/accounts/import",
+        files={"auth_json": ("auth.json", b"{}", "application/json")},
+        headers={"content-length": str(2 * _MIB + 1)},
+    )
+
+    assert response.status_code == 413
+    assert response.json()["error"]["code"] == "payload_too_large"
+    assert service_calls == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_parts",
+    [
+        {
+            "data": {"unexpected": "value"},
+            "files": {"auth_json": ("auth.json", b"{}", "application/json")},
+        },
+        {
+            "files": [
+                ("auth_json", ("first.json", b"{}", "application/json")),
+                ("auth_json", ("second.json", b"{}", "application/json")),
+            ],
+        },
+    ],
+    ids=["additional-text-part", "duplicate-file-part"],
+)
+async def test_account_import_rejects_additional_parts_before_service(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+    request_parts: dict[str, object],
+) -> None:
+    async def fail_import(*_args: object, **_kwargs: object) -> AccountImportResponse:
+        raise AssertionError("invalid multipart shape must not reach account import")
+
+    monkeypatch.setattr("app.modules.accounts.service.AccountsService.import_account", fail_import)
+
+    response = await async_client.post("/api/accounts/import", **request_parts)
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "http_400"
+
+
+@pytest.mark.asyncio
+async def test_account_import_missing_file_retains_dashboard_validation_envelope(async_client) -> None:
+    response = await async_client.post(
+        "/api/accounts/import",
+        content=b"--empty--\r\n",
+        headers={"content-type": "multipart/form-data; boundary=empty"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_error"
+
+
+@pytest.mark.asyncio
+async def test_account_import_missing_content_type_retains_dashboard_validation_envelope(async_client) -> None:
+    response = await async_client.post("/api/accounts/import", content=b"not multipart")
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_error"
+
+
+@pytest.mark.asyncio
+async def test_account_import_text_auth_json_retains_dashboard_validation_envelope(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_import(*_args: object, **_kwargs: object) -> AccountImportResponse:
+        raise AssertionError("text auth_json must not reach account import")
+
+    monkeypatch.setattr("app.modules.accounts.service.AccountsService.import_account", fail_import)
+
+    response = await async_client.post(
+        "/api/accounts/import",
+        files={"auth_json": (None, "{}", "application/json")},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_error"

--- a/tests/integration/test_model_source_routing.py
+++ b/tests/integration/test_model_source_routing.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import asyncio
 import socket
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable
+from tempfile import SpooledTemporaryFile
 from typing import TypeAlias, cast
 
 import pytest
+import starlette.formparsers as starlette_formparsers
 from aiohttp import web
 from aiohttp.multipart import BodyPartReader
 from sqlalchemy import select
@@ -90,6 +92,19 @@ async def _enable_api_key_auth(async_client) -> None:
 _UpstreamHandler: TypeAlias = Callable[[web.Request], Awaitable[web.StreamResponse]]
 
 
+def _record_multipart_spools(monkeypatch: pytest.MonkeyPatch) -> list[SpooledTemporaryFile[bytes]]:
+    original = starlette_formparsers.SpooledTemporaryFile
+    spools: list[SpooledTemporaryFile[bytes]] = []
+
+    def create_spool(*, max_size: int) -> SpooledTemporaryFile[bytes]:
+        spool = original(max_size=max_size)
+        spools.append(spool)
+        return spool
+
+    monkeypatch.setattr(starlette_formparsers, "SpooledTemporaryFile", create_spool)
+    return spools
+
+
 @pytest.fixture
 async def source_upstream() -> AsyncIterator[Callable[[_UpstreamHandler], Awaitable[str]]]:
     runners: list[web.AppRunner] = []
@@ -112,15 +127,23 @@ async def source_upstream() -> AsyncIterator[Callable[[_UpstreamHandler], Awaita
 
 
 @pytest.mark.asyncio
-async def test_source_audio_transcription_routes_multipart_and_settles_usage(async_client, source_upstream):
+async def test_source_audio_transcription_routes_multipart_and_settles_usage(
+    async_client,
+    source_upstream,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     await _enable_api_key_auth(async_client)
     captured: dict[str, object] = {}
+    spools: list[SpooledTemporaryFile[bytes]] = []
 
     async def transcribe(request: web.Request) -> web.Response:
+        assert spools
+        assert all(spool.closed for spool in spools)
         captured["path"] = request.path
         captured["authorization"] = request.headers.get("authorization")
         reader = await request.multipart()
         fields: dict[str, list[str]] = {}
+        field_items: list[tuple[str, str]] = []
         while True:
             next_part = await reader.next()
             if next_part is None:
@@ -132,8 +155,11 @@ async def test_source_audio_transcription_routes_multipart_and_settles_usage(asy
                 captured["file_content_type"] = part.headers.get("Content-Type")
                 continue
             if part.name is not None:
-                fields.setdefault(part.name, []).append(await part.text())
+                value = await part.text()
+                fields.setdefault(part.name, []).append(value)
+                field_items.append((part.name, value))
         captured["fields"] = fields
+        captured["field_items"] = field_items
         return web.json_response(
             {
                 "text": "hello from source asr",
@@ -167,12 +193,18 @@ async def test_source_audio_transcription_routes_multipart_and_settles_usage(asy
     )
     assert created.status_code == 200
     key = created.json()["key"]
+    spools = _record_multipart_spools(monkeypatch)
 
     response = await async_client.post(
         "/v1/audio/transcriptions",
         headers={"Authorization": f"Bearer {key}"},
-        data={"model": model, "prompt": "domain words", "response_format": "json"},
-        files={"file": ("sample.wav", b"\x01\x02\x03", "audio/wav")},
+        files=[
+            ("model", (None, model)),
+            ("prompt", (None, "first context")),
+            ("response_format", (None, "json")),
+            ("prompt", (None, "domain words")),
+            ("file", ("sample.wav", b"\x01\x02\x03", "audio/wav")),
+        ],
     )
 
     assert response.status_code == 200
@@ -184,9 +216,15 @@ async def test_source_audio_transcription_routes_multipart_and_settles_usage(asy
     assert captured["file_content_type"] == "audio/wav"
     assert captured["fields"] == {
         "model": [model],
-        "prompt": ["domain words"],
+        "prompt": ["first context", "domain words"],
         "response_format": ["json"],
     }
+    assert captured["field_items"] == [
+        ("model", model),
+        ("prompt", "first context"),
+        ("response_format", "json"),
+        ("prompt", "domain words"),
+    ]
 
     async with SessionLocal() as session:
         result = await session.execute(select(RequestLog).where(RequestLog.model == model))

--- a/tests/integration/test_proxy_images.py
+++ b/tests/integration/test_proxy_images.py
@@ -12,18 +12,32 @@ from __future__ import annotations
 import base64
 import json
 import logging
+from collections.abc import AsyncIterator
 from typing import Any, cast
 
 import pytest
+from httpx import AsyncByteStream
+from starlette.datastructures import UploadFile
 from starlette.responses import JSONResponse
 
 import app.modules.proxy.api as proxy_api_module
 import app.modules.proxy.service as proxy_module
 from app.core.config.settings import Settings
 from app.core.exceptions import ProxyModelNotAllowed, ProxyRateLimitError
+from app.core.multipart import MultipartPolicy
 from app.db.models import DashboardSettings
 
 pytestmark = pytest.mark.integration
+
+
+class _NeverReadStream(AsyncByteStream):
+    def __init__(self) -> None:
+        self.iterated = False
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        self.iterated = True
+        raise AssertionError("request body must not be consumed")
+        yield b""  # pragma: no cover
 
 
 def _encode_jwt(payload: dict) -> str:
@@ -597,6 +611,349 @@ async def test_images_generations_failed_image_returns_5xx(async_client, monkeyp
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "content_type",
+    ["multipart/form-data; boundary=never-read", "application/json"],
+    ids=["multipart", "wrong-json-content-type"],
+)
+async def test_v1_images_edits_auth_rejection_does_not_read_body_and_records_once(
+    async_client,
+    caplog,
+    content_type: str,
+) -> None:
+    await _enable_api_key_auth(async_client)
+    stream = _NeverReadStream()
+
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/v1/images/edits",
+            content=stream,
+            headers={"content-type": content_type},
+        )
+
+    assert response.status_code == 401
+    assert stream.iterated is False
+    message = "images_route_complete route=edits model=unknown stream=false status=401 outcome=auth_error"
+    assert caplog.text.count(message) == 1
+
+
+@pytest.mark.asyncio
+async def test_v1_images_edits_compressed_rejection_does_not_read_body_and_records_once(
+    async_client,
+    caplog,
+) -> None:
+    stream = _NeverReadStream()
+
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/v1/images/edits",
+            content=stream,
+            headers={
+                "content-type": "multipart/form-data; boundary=never-read",
+                "content-encoding": "gzip",
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_request_error"
+    assert stream.iterated is False
+    message = "images_route_complete route=edits model=unknown stream=false status=400 outcome=invalid_request"
+    assert caplog.text.count(message) == 1
+
+
+@pytest.mark.asyncio
+async def test_v1_images_edits_missing_content_type_retains_openai_validation_and_records_once(
+    async_client,
+    caplog,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        response = await async_client.post("/v1/images/edits", content=b"not multipart")
+
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["code"] == "invalid_request_error"
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] == "prompt"
+    message = "images_route_complete route=edits model=unknown stream=false status=400 outcome=invalid_request"
+    assert caplog.text.count(message) == 1
+
+
+@pytest.mark.asyncio
+async def test_v1_images_edits_preserves_mixed_image_order_and_closes_spools_before_pipeline(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    closed_uploads: list[UploadFile] = []
+    original_close = UploadFile.close
+    captured: dict[str, object] = {}
+
+    async def record_close(upload: UploadFile) -> None:
+        await original_close(upload)
+        closed_uploads.append(upload)
+
+    async def fake_proxy_images_edit_request(**kwargs: object) -> JSONResponse:
+        assert len(closed_uploads) == 3
+        assert all(upload.file.closed for upload in closed_uploads)
+        captured.update(kwargs)
+        return JSONResponse({"ok": True})
+
+    monkeypatch.setattr(UploadFile, "close", record_close)
+    monkeypatch.setattr(proxy_api_module, "_proxy_images_edit_request", fake_proxy_images_edit_request)
+
+    response = await async_client.post(
+        "/v1/images/edits",
+        files=[
+            ("image[]", ("first.png", b"first", "image/png")),
+            ("prompt", (None, "keep order")),
+            ("image", ("second.webp", b"second", "image/webp")),
+            ("mask", ("mask.png", b"mask", "image/png")),
+        ],
+    )
+
+    assert response.status_code == 200
+    assert captured["images"] == [(b"first", "image/png"), (b"second", "image/webp")]
+    assert captured["mask"] == (b"mask", "image/png")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("files", "expected_param"),
+    [
+        (
+            [("image", (f"{index}.png", b"x", "image/png")) for index in range(17)]
+            + [("prompt", (None, "too many images"))],
+            "image",
+        ),
+        (
+            [
+                ("image", ("image.png", b"x", "image/png")),
+                ("mask", ("first-mask.png", b"x", "image/png")),
+                ("mask", ("second-mask.png", b"x", "image/png")),
+                ("prompt", (None, "too many masks")),
+            ],
+            "mask",
+        ),
+        (
+            [
+                ("image", ("image.png", b"x", "image/png")),
+                ("attachment", ("unknown.bin", b"x", "application/octet-stream")),
+                ("prompt", (None, "unknown file")),
+            ],
+            "attachment",
+        ),
+    ],
+    ids=["combined-image-count", "mask-count", "unknown-file-field"],
+)
+async def test_v1_images_edits_rejects_invalid_file_shapes_before_pipeline(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+    files: list[tuple[str, tuple[str | None, bytes | str, str] | tuple[None, str]]],
+    expected_param: str,
+) -> None:
+    async def fail_proxy_images_edit_request(**_kwargs: object) -> JSONResponse:
+        raise AssertionError("invalid file shape must not reach image pipeline")
+
+    monkeypatch.setattr(proxy_api_module, "_proxy_images_edit_request", fail_proxy_images_edit_request)
+
+    response = await async_client.post("/v1/images/edits", files=files)
+
+    assert response.status_code == 400
+    assert response.json()["error"]["param"] == expected_param
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("image", "mask", "expected_param"),
+    [
+        (b"12345", None, "image"),
+        (b"1234", b"123", "mask"),
+    ],
+    ids=["per-file", "aggregate"],
+)
+async def test_v1_images_edits_binary_limits_return_one_413_without_pipeline_work(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog,
+    image: bytes,
+    mask: bytes | None,
+    expected_param: str,
+) -> None:
+    monkeypatch.setattr(
+        proxy_api_module,
+        "IMAGE_EDITS_MULTIPART_POLICY",
+        MultipartPolicy(
+            max_body_bytes=4096,
+            max_file_bytes=4,
+            max_aggregate_file_bytes=6,
+            max_files=17,
+            max_fields=32,
+            max_text_part_bytes=32,
+        ),
+    )
+
+    async def fail_proxy_images_edit_request(**_kwargs: object) -> JSONResponse:
+        raise AssertionError("oversized upload must not reach image pipeline")
+
+    monkeypatch.setattr(proxy_api_module, "_proxy_images_edit_request", fail_proxy_images_edit_request)
+    files: list[tuple[str, tuple[str | None, bytes | str, str] | tuple[None, str]]] = [
+        ("image", ("image.png", image, "image/png")),
+        ("prompt", (None, "bounded")),
+    ]
+    if mask is not None:
+        files.append(("mask", ("mask.png", mask, "image/png")))
+
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        response = await async_client.post("/v1/images/edits", files=files)
+
+    assert response.status_code == 413
+    body = response.json()
+    assert body["error"]["code"] == "payload_too_large"
+    assert body["error"]["param"] == expected_param
+    message = "images_route_complete route=edits model=unknown stream=false status=413 outcome=invalid_request"
+    assert caplog.text.count(message) == 1
+
+
+@pytest.mark.asyncio
+async def test_v1_images_edits_allows_exact_small_binary_policy_boundary(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        proxy_api_module,
+        "IMAGE_EDITS_MULTIPART_POLICY",
+        MultipartPolicy(
+            max_body_bytes=4096,
+            max_file_bytes=4,
+            max_aggregate_file_bytes=6,
+            max_files=17,
+            max_fields=32,
+            max_text_part_bytes=32,
+        ),
+    )
+    captured: dict[str, object] = {}
+
+    async def fake_proxy_images_edit_request(**kwargs: object) -> JSONResponse:
+        captured.update(kwargs)
+        return JSONResponse({"ok": True})
+
+    monkeypatch.setattr(proxy_api_module, "_proxy_images_edit_request", fake_proxy_images_edit_request)
+
+    response = await async_client.post(
+        "/v1/images/edits",
+        files=[
+            ("image", ("image.png", b"1234", "image/png")),
+            ("mask", ("mask.png", b"12", "image/png")),
+            ("prompt", (None, "bounded")),
+        ],
+    )
+
+    assert response.status_code == 200
+    assert captured["images"] == [(b"1234", "image/png")]
+    assert captured["mask"] == (b"12", "image/png")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("policy", "prompt"),
+    [
+        (
+            MultipartPolicy(
+                max_body_bytes=64,
+                max_file_bytes=16,
+                max_aggregate_file_bytes=16,
+                max_files=17,
+                max_fields=32,
+                max_text_part_bytes=32,
+            ),
+            "body",
+        ),
+        (
+            MultipartPolicy(
+                max_body_bytes=4096,
+                max_file_bytes=16,
+                max_aggregate_file_bytes=16,
+                max_files=17,
+                max_fields=32,
+                max_text_part_bytes=4,
+            ),
+            "12345",
+        ),
+    ],
+    ids=["body", "text-part"],
+)
+async def test_v1_images_edits_body_and_text_limits_reject_before_pipeline(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+    policy: MultipartPolicy,
+    prompt: str,
+) -> None:
+    monkeypatch.setattr(proxy_api_module, "IMAGE_EDITS_MULTIPART_POLICY", policy)
+
+    async def fail_proxy_images_edit_request(**_kwargs: object) -> JSONResponse:
+        raise AssertionError("oversized multipart input must not reach image pipeline")
+
+    monkeypatch.setattr(proxy_api_module, "_proxy_images_edit_request", fail_proxy_images_edit_request)
+
+    response = await async_client.post(
+        "/v1/images/edits",
+        files=[
+            ("image", ("image.png", b"1234", "image/png")),
+            ("prompt", (None, prompt)),
+        ],
+    )
+
+    assert response.status_code == 413
+    assert response.json()["error"]["code"] == "payload_too_large"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("image", "mask", "expected_param"),
+    [(b"", None, "image"), (b"image", b"", "mask")],
+    ids=["empty-image", "empty-mask"],
+)
+async def test_v1_images_edits_rejects_empty_binary_parts_before_pipeline(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+    image: bytes,
+    mask: bytes | None,
+    expected_param: str,
+) -> None:
+    async def fail_proxy_images_edit_request(**_kwargs: object) -> JSONResponse:
+        raise AssertionError("empty multipart input must not reach image pipeline")
+
+    monkeypatch.setattr(proxy_api_module, "_proxy_images_edit_request", fail_proxy_images_edit_request)
+    files: list[tuple[str, tuple[str | None, bytes | str, str] | tuple[None, str]]] = [
+        ("image", ("image.png", image, "image/png")),
+        ("prompt", (None, "empty part")),
+    ]
+    if mask is not None:
+        files.append(("mask", ("mask.png", mask, "image/png")))
+
+    response = await async_client.post("/v1/images/edits", files=files)
+
+    assert response.status_code == 400
+    assert response.json()["error"]["param"] == expected_param
+
+
+@pytest.mark.asyncio
+async def test_v1_images_edits_malformed_multipart_records_one_invalid_request(
+    async_client,
+    caplog,
+) -> None:
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
+        response = await async_client.post(
+            "/v1/images/edits",
+            content=b"not multipart",
+            headers={"content-type": "multipart/form-data; boundary=broken"},
+        )
+
+    assert response.status_code == 400
+    message = "images_route_complete route=edits model=unknown stream=false status=400 outcome=invalid_request"
+    assert caplog.text.count(message) == 1
+
+
+@pytest.mark.asyncio
 async def test_backend_codex_images_edits_requires_native_image_data_urls(async_client, caplog):
     with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
         response = await async_client.post(
@@ -876,10 +1233,10 @@ async def test_images_edits_missing_image_records_route_observability(async_clie
     with caplog.at_level(logging.WARNING, logger="app.modules.proxy.api"):
         response = await async_client.post(
             "/v1/images/edits",
-            data={
-                "model": "gpt-image-2",
-                "prompt": "hi",
-            },
+            files=[
+                ("model", (None, "gpt-image-2")),
+                ("prompt", (None, "hi")),
+            ],
         )
     assert response.status_code == 400
     body = response.json()

--- a/tests/integration/test_proxy_transcriptions.py
+++ b/tests/integration/test_proxy_transcriptions.py
@@ -2,18 +2,47 @@ from __future__ import annotations
 
 import base64
 import json
+from collections.abc import AsyncIterator
+from tempfile import SpooledTemporaryFile
 
 import pytest
+import starlette.formparsers as starlette_formparsers
+from httpx import AsyncByteStream
 from sqlalchemy import update
 
+import app.modules.proxy.api as proxy_api
 import app.modules.proxy.service as proxy_module
 from app.core.auth.refresh import RefreshError
 from app.core.errors import openai_error
+from app.core.multipart import TRANSCRIPTION_MULTIPART_POLICY
 from app.core.openai.model_registry import ReasoningLevel, UpstreamModel, get_model_registry
 from app.db.models import ApiKeyLimit
 from app.db.session import SessionLocal
 
 pytestmark = pytest.mark.integration
+
+
+class _CountingBody(AsyncByteStream):
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+        self.iterations = 0
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        self.iterations += 1
+        yield self.body
+
+
+def _record_spools(monkeypatch: pytest.MonkeyPatch) -> list[SpooledTemporaryFile[bytes]]:
+    original = starlette_formparsers.SpooledTemporaryFile
+    spools: list[SpooledTemporaryFile[bytes]] = []
+
+    def create_spool(*, max_size: int) -> SpooledTemporaryFile[bytes]:
+        spool = original(max_size=max_size)
+        spools.append(spool)
+        return spool
+
+    monkeypatch.setattr(starlette_formparsers, "SpooledTemporaryFile", create_spool)
+    return spools
 
 
 def _encode_jwt(payload: dict) -> str:
@@ -45,6 +74,19 @@ async def _import_account(async_client, account_id: str, email: str) -> None:
     assert response.status_code == 200
 
 
+async def _enable_api_key_auth(async_client) -> None:
+    response = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": False,
+            "preferEarlierResetAccounts": False,
+            "totpRequiredOnLogin": False,
+            "apiKeyAuthEnabled": True,
+        },
+    )
+    assert response.status_code == 200
+
+
 def _make_upstream_model(slug: str) -> UpstreamModel:
     return UpstreamModel(
         slug=slug,
@@ -65,6 +107,148 @@ def _make_upstream_model(slug: str) -> UpstreamModel:
         available_in_plans=frozenset({"plus"}),
         raw={},
     )
+
+
+@pytest.mark.asyncio
+async def test_transcription_openapi_preserves_explicit_multipart_contract(app_instance) -> None:
+    schemas = {
+        "/backend-api/transcribe": {
+            "type": "object",
+            "title": "Body_backend_transcribe_backend_api_transcribe_post",
+            "required": ["file"],
+            "properties": {
+                "file": {
+                    "type": "string",
+                    "contentMediaType": "application/octet-stream",
+                    "title": "File",
+                },
+                "prompt": {
+                    "anyOf": [{"type": "string"}, {"type": "null"}],
+                    "title": "Prompt",
+                },
+            },
+        },
+        "/v1/audio/transcriptions": {
+            "type": "object",
+            "title": "Body_v1_audio_transcriptions_v1_audio_transcriptions_post",
+            "required": ["model", "file"],
+            "properties": {
+                "model": {"type": "string", "title": "Model"},
+                "file": {
+                    "type": "string",
+                    "contentMediaType": "application/octet-stream",
+                    "title": "File",
+                },
+                "prompt": {
+                    "anyOf": [{"type": "string"}, {"type": "null"}],
+                    "title": "Prompt",
+                },
+            },
+        },
+    }
+
+    openapi = app_instance.openapi()
+    for path, expected_schema in schemas.items():
+        request_body = openapi["paths"][path]["post"]["requestBody"]
+        assert request_body["required"] is True
+        assert request_body["content"]["multipart/form-data"]["schema"] == expected_schema
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ["/backend-api/transcribe", "/v1/audio/transcriptions"])
+async def test_transcription_auth_rejection_does_not_consume_multipart_body(async_client, endpoint: str) -> None:
+    await _enable_api_key_auth(async_client)
+    body = _CountingBody(b"multipart body must remain unread")
+
+    response = await async_client.post(
+        endpoint,
+        content=body,
+        headers={"Content-Type": "multipart/form-data; boundary=unused"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "invalid_api_key"
+    assert body.iterations == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ["/backend-api/transcribe", "/v1/audio/transcriptions"])
+async def test_transcription_encoded_body_rejects_after_auth_without_consuming_body(
+    async_client,
+    endpoint: str,
+) -> None:
+    await _enable_api_key_auth(async_client)
+    created = await async_client.post("/api/api-keys/", json={"name": f"encoded-{endpoint}"})
+    assert created.status_code == 200
+    body = _CountingBody(b"compressed bytes must remain unread")
+
+    response = await async_client.post(
+        endpoint,
+        content=body,
+        headers={
+            "Authorization": f"Bearer {created.json()['key']}",
+            "Content-Type": "multipart/form-data; boundary=unused",
+            "Content-Encoding": "gzip",
+        },
+    )
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["error"]["code"] == "invalid_request_error"
+    assert payload["error"]["type"] == "invalid_request_error"
+    assert body.iterations == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("endpoint", "expected_param"),
+    [("/backend-api/transcribe", "file"), ("/v1/audio/transcriptions", "model")],
+)
+async def test_transcription_missing_content_type_retains_openai_validation(
+    async_client,
+    endpoint: str,
+    expected_param: str,
+) -> None:
+    response = await async_client.post(endpoint, content=b"not multipart")
+
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["code"] == "invalid_request_error"
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] == expected_param
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ["/backend-api/transcribe", "/v1/audio/transcriptions"])
+async def test_transcription_declared_body_limit_rejects_before_reservation_or_body_read(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint: str,
+) -> None:
+    reservation_calls = 0
+
+    async def unexpected_reservation(*args, **kwargs):
+        nonlocal reservation_calls
+        reservation_calls += 1
+        raise AssertionError("multipart admission must precede usage reservation")
+
+    monkeypatch.setattr(proxy_api, "_enforce_request_limits", unexpected_reservation)
+    body = _CountingBody(b"body is rejected from its declared length")
+    response = await async_client.post(
+        endpoint,
+        content=body,
+        headers={
+            "Content-Type": "multipart/form-data; boundary=unused",
+            "Content-Length": str(TRANSCRIPTION_MULTIPART_POLICY.max_body_bytes + 1),
+        },
+    )
+
+    assert response.status_code == 413
+    payload = response.json()
+    assert payload["error"]["code"] == "payload_too_large"
+    assert payload["error"]["type"] == "invalid_request_error"
+    assert body.iterations == 0
+    assert reservation_calls == 0
 
 
 @pytest.mark.asyncio
@@ -108,6 +292,130 @@ async def test_backend_transcribe_forwards_file_and_prompt(async_client, monkeyp
     assert captured["prompt"] == "speaker says hello"
     assert captured["access_token"] == "access-token"
     assert captured["account_id"] == "acc_transcribe_backend"
+
+
+@pytest.mark.asyncio
+async def test_backend_transcribe_exact_file_limit_closes_spool_before_reservation_and_service(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spools = _record_spools(monkeypatch)
+    payload = b"x" * TRANSCRIPTION_MULTIPART_POLICY.max_file_bytes
+    events: list[str] = []
+
+    async def fake_reservation(*args, **kwargs):
+        del args, kwargs
+        assert spools
+        assert all(spool.closed for spool in spools)
+        events.append("reservation")
+        return None
+
+    async def fake_transcribe(
+        self,
+        *,
+        audio_bytes: bytes,
+        filename: str,
+        content_type: str | None,
+        prompt: str | None,
+        headers,
+        api_key=None,
+    ):
+        del self, headers, api_key
+        assert spools
+        assert all(spool.closed for spool in spools)
+        events.append("service")
+        assert audio_bytes == payload
+        assert filename == "exact.wav"
+        assert content_type == "audio/wav"
+        assert prompt == "exact boundary"
+        return {"text": "exact upload accepted"}
+
+    monkeypatch.setattr(proxy_api, "_enforce_request_limits", fake_reservation)
+    monkeypatch.setattr(proxy_module.ProxyService, "transcribe", fake_transcribe)
+
+    response = await async_client.post(
+        "/backend-api/transcribe",
+        data={"prompt": "exact boundary"},
+        files={"file": ("exact.wav", payload, "audio/wav")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"text": "exact upload accepted"}
+    assert events == ["reservation", "service"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ["/backend-api/transcribe", "/v1/audio/transcriptions"])
+async def test_transcription_file_limit_rejects_before_selection_reservation_or_upstream(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint: str,
+) -> None:
+    calls: list[str] = []
+
+    async def unexpected_call(*args, **kwargs):
+        del args, kwargs
+        calls.append("unexpected")
+        raise AssertionError("oversized upload must not invoke route side effects")
+
+    monkeypatch.setattr(proxy_api, "_select_audio_transcriptions_model_source", unexpected_call)
+    monkeypatch.setattr(proxy_api, "_enforce_request_limits", unexpected_call)
+    monkeypatch.setattr(proxy_module.ProxyService, "transcribe", unexpected_call)
+    payload = b"x" * (TRANSCRIPTION_MULTIPART_POLICY.max_file_bytes + 1)
+    data = {"model": "gpt-4o-transcribe"} if endpoint.startswith("/v1/") else None
+
+    response = await async_client.post(
+        endpoint,
+        data=data,
+        files={"file": ("oversized.wav", payload, "audio/wav")},
+    )
+
+    assert response.status_code == 413
+    error = response.json()["error"]
+    assert error["code"] == "payload_too_large"
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] == "file"
+    assert calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint", ["/backend-api/transcribe", "/v1/audio/transcriptions"])
+@pytest.mark.parametrize("invalid_shape", ["missing_file", "extra_file"])
+async def test_transcription_invalid_file_shape_has_no_route_side_effects(
+    async_client,
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint: str,
+    invalid_shape: str,
+) -> None:
+    calls: list[str] = []
+
+    async def unexpected_call(*args, **kwargs):
+        del args, kwargs
+        calls.append("unexpected")
+        raise AssertionError("invalid multipart shape must not invoke route side effects")
+
+    monkeypatch.setattr(proxy_api, "_select_audio_transcriptions_model_source", unexpected_call)
+    monkeypatch.setattr(proxy_api, "_enforce_request_limits", unexpected_call)
+    monkeypatch.setattr(proxy_module.ProxyService, "transcribe", unexpected_call)
+    fields = [("model", (None, "gpt-4o-transcribe"))] if endpoint.startswith("/v1/") else []
+    if invalid_shape == "missing_file":
+        fields.append(("prompt", (None, "missing audio")))
+    else:
+        fields.extend(
+            [
+                ("file", ("audio.wav", b"audio", "audio/wav")),
+                ("extra", ("extra.wav", b"extra", "audio/wav")),
+            ]
+        )
+
+    response = await async_client.post(endpoint, files=fields)
+
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["code"] == "invalid_request_error"
+    if invalid_shape == "missing_file":
+        assert error["param"] == "file"
+    assert calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_graceful_shutdown.py
+++ b/tests/unit/test_graceful_shutdown.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Iterator
 from importlib import import_module
 
 import pytest
@@ -222,7 +223,7 @@ async def test_release_leader_lease_within_swallows_release_error(
 
 
 @pytest.fixture(autouse=True)
-def reset_shutdown_state():  # noqa: ANN201
+def reset_shutdown_state() -> Iterator[None]:
     shutdown_state.reset()
     yield
     shutdown_state.reset()

--- a/tests/unit/test_multipart.py
+++ b/tests/unit/test_multipart.py
@@ -1,0 +1,552 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import FrozenInstanceError, dataclass
+from io import BytesIO
+from tempfile import SpooledTemporaryFile
+from typing import cast
+
+import pytest
+import starlette.formparsers as starlette_formparsers
+from fastapi.exceptions import RequestValidationError
+from starlette.datastructures import UploadFile
+from starlette.exceptions import HTTPException
+from starlette.requests import ClientDisconnect, Request
+from starlette.types import Message, Receive, Scope
+
+from app.core.multipart import (
+    ACCOUNT_IMPORT_MULTIPART_POLICY,
+    IMAGE_EDITS_MULTIPART_POLICY,
+    TRANSCRIPTION_MULTIPART_POLICY,
+    MultipartPayloadTooLarge,
+    MultipartPolicy,
+    bounded_multipart_form,
+    read_bounded_upload,
+)
+
+pytestmark = pytest.mark.unit
+
+_BOUNDARY = "codex-lb-boundary"
+_MIB = 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class _Part:
+    name: str
+    data: bytes
+    filename: str | None = None
+    content_type: str = "application/octet-stream"
+
+
+class _TrackedSpool(SpooledTemporaryFile[bytes]):
+    bytes_at_close: bytes | None
+
+    def __init__(self, *, max_size: int) -> None:
+        super().__init__(max_size=max_size)
+        self.bytes_at_close = None
+
+    def close(self) -> None:
+        if not self.closed:
+            position = self.tell()
+            self.seek(0)
+            self.bytes_at_close = self.read()
+            self.seek(position)
+        super().close()
+
+
+class _RecordingUpload(UploadFile):
+    def __init__(self, data: bytes) -> None:
+        super().__init__(BytesIO(data), filename="upload.bin", size=len(data))
+        self.requested_sizes: list[int] = []
+
+    async def read(self, size: int = -1) -> bytes:
+        self.requested_sizes.append(size)
+        return await super().read(size)
+
+
+def _policy(
+    *,
+    max_body_bytes: int = 4096,
+    max_file_bytes: int = 64,
+    max_aggregate_file_bytes: int = 128,
+    max_files: int = 4,
+    max_fields: int = 4,
+    max_text_part_bytes: int = 64,
+) -> MultipartPolicy:
+    return MultipartPolicy(
+        max_body_bytes=max_body_bytes,
+        max_file_bytes=max_file_bytes,
+        max_aggregate_file_bytes=max_aggregate_file_bytes,
+        max_files=max_files,
+        max_fields=max_fields,
+        max_text_part_bytes=max_text_part_bytes,
+    )
+
+
+def _multipart_body(*parts: _Part, boundary: str = _BOUNDARY) -> bytes:
+    body = bytearray()
+    for part in parts:
+        body.extend(f"--{boundary}\r\n".encode())
+        disposition = f'Content-Disposition: form-data; name="{part.name}"'
+        if part.filename is not None:
+            disposition += f'; filename="{part.filename}"'
+        body.extend(f"{disposition}\r\n".encode())
+        if part.filename is not None:
+            body.extend(f"Content-Type: {part.content_type}\r\n".encode())
+        body.extend(b"\r\n")
+        body.extend(part.data)
+        body.extend(b"\r\n")
+    body.extend(f"--{boundary}--\r\n".encode())
+    return bytes(body)
+
+
+def _request(
+    chunks: list[bytes],
+    *,
+    content_length: int | str | None = None,
+    content_type: str = f"multipart/form-data; boundary={_BOUNDARY}",
+) -> tuple[Request, list[int]]:
+    messages: list[Message] = [
+        {"type": "http.request", "body": chunk, "more_body": index < len(chunks) - 1}
+        for index, chunk in enumerate(chunks)
+    ]
+    receive_calls: list[int] = []
+
+    async def receive() -> Message:
+        receive_calls.append(1)
+        if messages:
+            return messages.pop(0)
+        return {"type": "http.disconnect"}
+
+    headers = [(b"content-type", content_type.encode("latin-1"))]
+    if content_length is not None:
+        headers.append((b"content-length", str(content_length).encode("ascii")))
+    scope = cast(
+        Scope,
+        {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/upload",
+            "raw_path": b"/upload",
+            "query_string": b"",
+            "root_path": "",
+            "headers": headers,
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+        },
+    )
+    return Request(scope, receive=cast(Receive, receive)), receive_calls
+
+
+def _interrupted_request(first_chunk: bytes, *, cancel: bool) -> Request:
+    calls = 0
+
+    async def receive() -> Message:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return {"type": "http.request", "body": first_chunk, "more_body": True}
+        if cancel:
+            raise asyncio.CancelledError
+        return {"type": "http.disconnect"}
+
+    request, _ = _request([b""])
+    return Request(request.scope, receive=cast(Receive, receive))
+
+
+def _track_spools(monkeypatch: pytest.MonkeyPatch) -> list[_TrackedSpool]:
+    spools: list[_TrackedSpool] = []
+
+    def create_spool(*, max_size: int) -> _TrackedSpool:
+        spool = _TrackedSpool(max_size=max_size)
+        spools.append(spool)
+        return spool
+
+    monkeypatch.setattr(starlette_formparsers, "SpooledTemporaryFile", create_spool)
+    return spools
+
+
+def test_route_policies_are_fixed_and_immutable() -> None:
+    assert ACCOUNT_IMPORT_MULTIPART_POLICY == _policy(
+        max_body_bytes=2 * _MIB,
+        max_file_bytes=_MIB,
+        max_aggregate_file_bytes=_MIB,
+        max_files=1,
+        max_fields=0,
+        max_text_part_bytes=0,
+    )
+    assert TRANSCRIPTION_MULTIPART_POLICY == _policy(
+        max_body_bytes=32 * _MIB,
+        max_file_bytes=25_000_000,
+        max_aggregate_file_bytes=25_000_000,
+        max_files=1,
+        max_fields=32,
+        max_text_part_bytes=256 * 1024,
+    )
+    assert IMAGE_EDITS_MULTIPART_POLICY == _policy(
+        max_body_bytes=64 * _MIB,
+        max_file_bytes=49_999_999,
+        max_aggregate_file_bytes=49_999_999,
+        max_files=17,
+        max_fields=32,
+        max_text_part_bytes=256 * 1024,
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        setattr(ACCOUNT_IMPORT_MULTIPART_POLICY, "max_files", 2)
+
+
+@pytest.mark.asyncio
+async def test_declared_body_limit_rejects_before_consuming_request() -> None:
+    body = _multipart_body(_Part("file", b"ok", filename="audio.wav"))
+    request, receive_calls = _request([body], content_length=len(body) + 1)
+
+    with pytest.raises(MultipartPayloadTooLarge) as exc_info:
+        async with bounded_multipart_form(request, _policy(max_body_bytes=len(body))):
+            pytest.fail("declared oversized body should not parse")
+
+    assert exc_info.value.param is None
+    assert receive_calls == []
+
+
+@pytest.mark.asyncio
+async def test_invalid_declared_length_is_ignored_when_actual_body_is_bounded() -> None:
+    body = _multipart_body(_Part("file", b"ok", filename="audio.wav"))
+    request, receive_calls = _request([body], content_length="not-a-number")
+
+    async with bounded_multipart_form(request, _policy(max_body_bytes=len(body))) as form:
+        upload = form["file"]
+        assert isinstance(upload, UploadFile)
+        assert await upload.read() == b"ok"
+
+    assert receive_calls == [1]
+    assert upload.file.closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content_type", [None, "application/json"])
+async def test_non_multipart_media_yields_empty_form_without_consuming_body(
+    content_type: str | None,
+) -> None:
+    request, receive_calls = _request(
+        [b"body must remain unread"],
+        content_length=10_000,
+        content_type=content_type or "",
+    )
+    if content_type is None:
+        request.scope["headers"] = [
+            (name, value) for name, value in request.scope["headers"] if name != b"content-type"
+        ]
+
+    async with bounded_multipart_form(request, _policy(max_body_bytes=1)) as form:
+        assert list(form.multi_items()) == []
+
+    assert receive_calls == []
+
+
+@pytest.mark.asyncio
+async def test_actual_body_allows_exact_limit() -> None:
+    body = _multipart_body(_Part("file", b"ok", filename="audio.wav"))
+    split = len(body) // 2
+    request, _ = _request([body[:split], body[split:]], content_length=1)
+
+    async with bounded_multipart_form(request, _policy(max_body_bytes=len(body))) as form:
+        upload = form["file"]
+        assert isinstance(upload, UploadFile)
+        assert await upload.read() == b"ok"
+
+
+@pytest.mark.asyncio
+async def test_understated_length_cannot_bypass_streamed_body_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spools = _track_spools(monkeypatch)
+    body = _multipart_body(_Part("file", b"x" * 32, filename="audio.wav"))
+    header_end = body.index(b"\r\n\r\n") + 4
+    crossing_at = header_end + 16
+    request, receive_calls = _request([body[:crossing_at], body[crossing_at:]], content_length=1)
+
+    with pytest.raises(MultipartPayloadTooLarge) as exc_info:
+        async with bounded_multipart_form(request, _policy(max_body_bytes=crossing_at)):
+            pytest.fail("actual streamed bytes should remain authoritative")
+
+    assert exc_info.value.param is None
+    assert receive_calls == [1, 1]
+    assert len(spools) == 1
+    assert spools[0].closed
+
+
+@pytest.mark.asyncio
+async def test_file_limit_allows_exact_bytes_and_closes_form() -> None:
+    body = _multipart_body(_Part("image[]", b"1234", filename="image.png"))
+    request, _ = _request([body])
+
+    async with bounded_multipart_form(
+        request,
+        _policy(max_file_bytes=4, max_aggregate_file_bytes=4),
+    ) as form:
+        upload = form["image[]"]
+        assert isinstance(upload, UploadFile)
+        assert not upload.file.closed
+        assert await read_bounded_upload(upload, 4, "image[]") == b"1234"
+
+    assert upload.file.closed
+
+
+@pytest.mark.asyncio
+async def test_file_limit_rejects_crossing_bytes_before_spool_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spools = _track_spools(monkeypatch)
+    body = _multipart_body(_Part("image[]", b"12345", filename="image.png"))
+    request, _ = _request([body])
+
+    with pytest.raises(MultipartPayloadTooLarge) as exc_info:
+        async with bounded_multipart_form(
+            request,
+            _policy(max_file_bytes=4, max_aggregate_file_bytes=10),
+        ):
+            pytest.fail("oversized file should not parse")
+
+    assert exc_info.value.param == "image"
+    assert len(spools) == 1
+    assert spools[0].closed
+    assert len(spools[0].bytes_at_close or b"") <= 4
+
+
+@pytest.mark.asyncio
+async def test_aggregate_file_limit_rejects_and_closes_every_spool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spools = _track_spools(monkeypatch)
+    body = _multipart_body(
+        _Part("image", b"123", filename="first.png"),
+        _Part("mask", b"456", filename="mask.png"),
+    )
+    request, _ = _request([body])
+
+    with pytest.raises(MultipartPayloadTooLarge) as exc_info:
+        async with bounded_multipart_form(
+            request,
+            _policy(max_file_bytes=4, max_aggregate_file_bytes=5),
+        ):
+            pytest.fail("aggregate oversized files should not parse")
+
+    assert exc_info.value.param == "mask"
+    assert len(spools) == 2
+    assert all(spool.closed for spool in spools)
+    assert sum(len(spool.bytes_at_close or b"") for spool in spools) <= 5
+
+
+@pytest.mark.asyncio
+async def test_aggregate_and_part_counts_allow_exact_limits() -> None:
+    body = _multipart_body(
+        _Part("first", b"12", filename="first.bin"),
+        _Part("label", b"a"),
+        _Part("second", b"345", filename="second.bin"),
+        _Part("prompt", b"b"),
+    )
+    request, _ = _request([body])
+    policy = _policy(
+        max_file_bytes=3,
+        max_aggregate_file_bytes=5,
+        max_files=2,
+        max_fields=2,
+        max_text_part_bytes=1,
+    )
+
+    async with bounded_multipart_form(request, policy) as form:
+        first = form["first"]
+        second = form["second"]
+        assert isinstance(first, UploadFile)
+        assert isinstance(second, UploadFile)
+        assert await first.read() == b"12"
+        assert await second.read() == b"345"
+        assert form["label"] == "a"
+        assert form["prompt"] == "b"
+
+    assert first.file.closed
+    assert second.file.closed
+
+
+@pytest.mark.asyncio
+async def test_text_part_limit_allows_exact_and_rejects_crossing_bytes() -> None:
+    exact_body = _multipart_body(_Part("prompt", b"1234"))
+    exact_request, _ = _request([exact_body])
+
+    async with bounded_multipart_form(exact_request, _policy(max_text_part_bytes=4)) as form:
+        assert form["prompt"] == "1234"
+
+    oversized_body = _multipart_body(_Part("prompt", b"12345"))
+    oversized_request, _ = _request([oversized_body])
+    with pytest.raises(MultipartPayloadTooLarge) as exc_info:
+        async with bounded_multipart_form(oversized_request, _policy(max_text_part_bytes=4)):
+            pytest.fail("oversized text part should not parse")
+    assert exc_info.value.param is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("parts", "policy", "detail"),
+    [
+        (
+            (_Part("first", b"1", filename="1.bin"), _Part("second", b"2", filename="2.bin")),
+            _policy(max_files=1),
+            "Too many files",
+        ),
+        (
+            (_Part("first", b"1"), _Part("second", b"2")),
+            _policy(max_fields=1),
+            "Too many fields",
+        ),
+    ],
+)
+async def test_part_count_failures_map_to_http_400(
+    parts: tuple[_Part, ...],
+    policy: MultipartPolicy,
+    detail: str,
+) -> None:
+    request, _ = _request([_multipart_body(*parts)])
+
+    with pytest.raises(HTTPException) as exc_info:
+        async with bounded_multipart_form(request, policy):
+            pytest.fail("excess parts should not parse")
+
+    assert exc_info.value.status_code == 400
+    assert detail in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_typed_upload_text_field_uses_validation_and_closes_prior_spool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spools = _track_spools(monkeypatch)
+    body = _multipart_body(
+        _Part("other", b"file", filename="other.bin"),
+        _Part("auth_json", b"{}"),
+    )
+    request, _ = _request([body])
+
+    with pytest.raises(RequestValidationError) as exc_info:
+        async with bounded_multipart_form(
+            request,
+            _policy(max_files=1, max_fields=0, max_text_part_bytes=0),
+            typed_upload_fields=("auth_json",),
+        ):
+            pytest.fail("text-valued upload field should not parse")
+
+    assert exc_info.value.errors()[0]["loc"] == ("body", "auth_json")
+    assert len(spools) == 1
+    assert spools[0].closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("body", "content_type"),
+    [
+        (b"", "multipart/form-data"),
+        (b"not-a-multipart-body", f"multipart/form-data; boundary={_BOUNDARY}"),
+    ],
+)
+async def test_malformed_multipart_maps_to_http_400(body: bytes, content_type: str) -> None:
+    request, _ = _request([body], content_type=content_type)
+
+    with pytest.raises(HTTPException) as exc_info:
+        async with bounded_multipart_form(request, _policy()):
+            pytest.fail("malformed multipart should not parse")
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_parser_oserror_maps_to_http_400_and_closes_spool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spools = _track_spools(monkeypatch)
+
+    async def fail_write(self: UploadFile, data: bytes) -> None:
+        raise OSError("disk failed")
+
+    monkeypatch.setattr(UploadFile, "write", fail_write)
+    body = _multipart_body(_Part("file", b"audio", filename="audio.wav"))
+    request, _ = _request([body])
+
+    with pytest.raises(HTTPException) as exc_info:
+        async with bounded_multipart_form(request, _policy()):
+            pytest.fail("spool write failure should not parse")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Invalid multipart request."
+    assert len(spools) == 1
+    assert spools[0].closed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel", [False, True], ids=["disconnect", "cancellation"])
+async def test_transport_interruptions_propagate_and_close_partial_spools(
+    monkeypatch: pytest.MonkeyPatch,
+    cancel: bool,
+) -> None:
+    spools = _track_spools(monkeypatch)
+    body = _multipart_body(_Part("file", b"x" * 64, filename="audio.wav"))
+    header_end = body.index(b"\r\n\r\n") + 4
+    request = _interrupted_request(body[: header_end + 32], cancel=cancel)
+    expected_error = asyncio.CancelledError if cancel else ClientDisconnect
+
+    with pytest.raises(expected_error):
+        async with bounded_multipart_form(request, _policy()):
+            pytest.fail("interrupted multipart should not parse")
+
+    assert len(spools) == 1
+    assert spools[0].closed
+
+
+@pytest.mark.asyncio
+async def test_form_cleanup_runs_when_consumer_raises() -> None:
+    body = _multipart_body(_Part("file", b"ok", filename="audio.wav"))
+    request, _ = _request([body])
+    upload: UploadFile | None = None
+
+    with pytest.raises(RuntimeError, match="consumer failed"):
+        async with bounded_multipart_form(request, _policy()) as form:
+            value = form["file"]
+            assert isinstance(value, UploadFile)
+            upload = value
+            raise RuntimeError("consumer failed")
+
+    assert upload is not None
+    assert upload.file.closed
+
+
+@pytest.mark.asyncio
+async def test_large_file_rolls_to_disk_and_is_closed_after_context() -> None:
+    payload = b"x" * (_MIB + 1)
+    body = _multipart_body(_Part("file", payload, filename="large.bin"))
+    request, _ = _request([body])
+    policy = _policy(
+        max_body_bytes=len(body),
+        max_file_bytes=len(payload),
+        max_aggregate_file_bytes=len(payload),
+    )
+
+    async with bounded_multipart_form(request, policy) as form:
+        upload = form["file"]
+        assert isinstance(upload, UploadFile)
+        assert getattr(upload.file, "_rolled", False) is True
+        assert await read_bounded_upload(upload, len(payload), "file") == payload
+
+    assert upload.file.closed
+
+
+@pytest.mark.asyncio
+async def test_bounded_read_uses_limit_plus_one_and_normalizes_param() -> None:
+    upload = _RecordingUpload(b"12345")
+
+    with pytest.raises(MultipartPayloadTooLarge) as exc_info:
+        await read_bounded_upload(upload, 4, "image[]")
+
+    assert upload.requested_sizes == [5]
+    assert exc_info.value.param == "image"

--- a/tests/unit/test_multipart_content_encoding_middleware.py
+++ b/tests/unit/test_multipart_content_encoding_middleware.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+
+import pytest
+from httpx import ASGITransport, AsyncByteStream, AsyncClient
+from starlette.datastructures import Headers
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.types import Message, Scope
+
+from app.core.auth.dependencies import validate_dashboard_session, validate_proxy_api_key
+from app.core.config.settings import get_settings
+from app.core.exceptions import DashboardPermissionError, ProxyAuthError
+from app.core.middleware.firewall_cache import get_firewall_ip_cache
+from app.core.middleware.multipart_content_encoding import (
+    MultipartContentEncodingMiddleware,
+    UnsupportedMultipartContentEncoding,
+    multipart_error_response,
+    raise_for_unsupported_multipart_content_encoding,
+)
+from app.core.middleware.path_rewrite import BackendApiCodexV1AliasMiddleware
+from app.core.middleware.request_body_limit import RequestBodyLimitMiddleware
+from app.main import create_app
+
+pytestmark = pytest.mark.unit
+
+_DEDICATED_MULTIPART_PATHS = (
+    "/api/accounts/import",
+    "/backend-api/transcribe",
+    "/v1/audio/transcriptions",
+    "/v1/images/edits",
+)
+
+
+def _scope(
+    path: str,
+    *,
+    content_type: bytes = b"multipart/form-data; boundary=test",
+    content_encoding: bytes | None = b"gzip",
+    root_path: str = "",
+) -> Scope:
+    headers = [(b"content-type", content_type)]
+    if content_encoding is not None:
+        headers.append((b"content-encoding", content_encoding))
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": b"",
+        "root_path": root_path,
+        "headers": headers,
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+    }
+
+
+async def _run(scope: Scope) -> tuple[list[Message], list[Headers], list[bool], int]:
+    sent: list[Message] = []
+    downstream_headers: list[Headers] = []
+    downstream_unsupported: list[bool] = []
+    receive_calls = 0
+
+    async def receive() -> Message:
+        nonlocal receive_calls
+        receive_calls += 1
+        return {"type": "http.request", "body": b"body", "more_body": False}
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    async def inner(inner_scope: Scope, receive, send) -> None:
+        downstream_headers.append(Headers(scope=inner_scope))
+        try:
+            raise_for_unsupported_multipart_content_encoding(Request(inner_scope))
+        except UnsupportedMultipartContentEncoding:
+            downstream_unsupported.append(True)
+        else:
+            downstream_unsupported.append(False)
+        message = await receive()
+        assert message["type"] == "http.request"
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    await MultipartContentEncodingMiddleware(inner)(scope, receive, send)
+    return sent, downstream_headers, downstream_unsupported, receive_calls
+
+
+@pytest.mark.asyncio
+async def test_encoded_upload_is_marked_and_removed_before_decompression() -> None:
+    sent, downstream, unsupported, receive_calls = await _run(_scope("/v1/images/edits"))
+
+    assert sent[0]["status"] == 204
+    assert downstream[0].get("content-encoding") is None
+    assert unsupported == [True]
+    assert receive_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_encoding_gate_does_not_read_body_before_authorization() -> None:
+    receive_calls = 0
+    sent: list[Message] = []
+
+    async def receive() -> Message:
+        nonlocal receive_calls
+        receive_calls += 1
+        raise AssertionError("encoding admission must not read the request body")
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    async def inner(scope: Scope, receive, send) -> None:
+        del receive
+        with pytest.raises(UnsupportedMultipartContentEncoding):
+            raise_for_unsupported_multipart_content_encoding(Request(scope))
+        await send({"type": "http.response.start", "status": 401, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    await MultipartContentEncodingMiddleware(inner)(_scope("/api/accounts/import"), receive, send)
+
+    assert sent[0]["status"] == 401
+    assert receive_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_identity_is_removed_without_consuming_or_replacing_body() -> None:
+    sent, downstream, unsupported, receive_calls = await _run(
+        _scope("/backend-api/transcribe", content_encoding=b" identity, identity ")
+    )
+
+    assert sent[0]["status"] == 204
+    assert len(downstream) == 1
+    assert downstream[0].get("content-encoding") is None
+    assert unsupported == [False]
+    assert receive_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_duplicate_content_encoding_headers_are_combined() -> None:
+    scope = _scope("/v1/images/edits", content_encoding=b"identity")
+    headers = list(scope["headers"])
+    headers.append((b"content-encoding", b"gzip"))
+    scope["headers"] = headers
+
+    sent, downstream, unsupported, receive_calls = await _run(scope)
+
+    assert sent[0]["status"] == 204
+    assert downstream[0].getlist("content-encoding") == []
+    assert unsupported == [True]
+    assert receive_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_mounted_and_trailing_slash_path_is_classified_application_relative() -> None:
+    sent, downstream, unsupported, receive_calls = await _run(
+        _scope("/prefix/v1/audio/transcriptions/", root_path="/prefix")
+    )
+
+    assert sent[0]["status"] == 204
+    assert downstream[0].get("content-encoding") is None
+    assert unsupported == [True]
+    assert receive_calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope", [_scope("/v1/chat/completions"), _scope("/v1/images/edits", content_encoding=None)])
+async def test_unrelated_or_unencoded_requests_pass_through(scope: Scope) -> None:
+    sent, downstream, unsupported, receive_calls = await _run(scope)
+
+    assert sent[0]["status"] == 204
+    assert len(downstream) == 1
+    assert unsupported == [False]
+    assert receive_calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content_type", [b"application/json", b""])
+async def test_protected_path_marks_encoding_even_when_content_type_is_not_multipart(content_type: bytes) -> None:
+    sent, downstream, unsupported, receive_calls = await _run(_scope("/v1/images/edits", content_type=content_type))
+
+    assert sent[0]["status"] == 204
+    assert downstream[0].get("content-encoding") is None
+    assert unsupported == [True]
+    assert receive_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_wrong_method_is_untouched() -> None:
+    scope = _scope("/v1/images/edits")
+    scope["method"] = "GET"
+
+    sent, downstream, unsupported, receive_calls = await _run(scope)
+
+    assert sent[0]["status"] == 204
+    assert downstream[0].get("content-encoding") == "gzip"
+    assert unsupported == [False]
+    assert receive_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_non_http_scope_passes_through() -> None:
+    seen: list[str] = []
+
+    async def inner(scope: Scope, receive, send) -> None:
+        del receive, send
+        seen.append(scope["type"])
+
+    async def receive() -> Message:
+        return {"type": "websocket.connect"}
+
+    async def send(_: Message) -> None:
+        return None
+
+    await MultipartContentEncodingMiddleware(inner)({"type": "websocket"}, receive, send)
+
+    assert seen == ["websocket"]
+
+
+@pytest.mark.parametrize(
+    ("path", "root_path", "expected_code", "expected_type"),
+    [
+        ("/prefix/api/accounts/import", "/prefix", "invalid_request", None),
+        ("/prefix/v1/images/edits", "/prefix", "invalid_request_error", "invalid_request_error"),
+    ],
+)
+def test_multipart_error_envelope_uses_application_relative_mounted_path(
+    path: str,
+    root_path: str,
+    expected_code: str,
+    expected_type: str | None,
+) -> None:
+    response = multipart_error_response(
+        Request(_scope(path, root_path=root_path)),
+        status_code=400,
+        code="invalid_request",
+        message="invalid upload",
+    )
+
+    payload = json.loads(bytes(response.body))
+    assert payload["error"]["code"] == expected_code
+    assert payload["error"].get("type") == expected_type
+
+
+class _TrackingBody(AsyncByteStream):
+    def __init__(self, body: bytes) -> None:
+        self.body = body
+        self.iterations = 0
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        self.iterations += 1
+        yield self.body
+
+
+def _configure_tiny_generic_ingress_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_BODY_BYTES", "5")
+    monkeypatch.setenv("CODEX_LB_MAX_DECOMPRESSED_RESPONSES_BODY_BYTES", "5")
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", _DEDICATED_MULTIPART_PATHS)
+@pytest.mark.parametrize(
+    ("content_type", "content_encoding"),
+    [
+        ("multipart/form-data; boundary=unused", None),
+        ("multipart/form-data; boundary=unused", "identity"),
+        ("multipart/form-data; boundary=unused", "gzip"),
+        ("application/json", "identity"),
+        ("application/json", "gzip"),
+    ],
+)
+async def test_production_stack_keeps_dedicated_uploads_auth_first_above_generic_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+    content_type: str,
+    content_encoding: str | None,
+) -> None:
+    _configure_tiny_generic_ingress_budget(monkeypatch)
+    await get_firewall_ip_cache().set("127.0.0.1", True)
+    authorization_calls: list[str] = []
+    body = _TrackingBody(b"unread")
+
+    async def reject_dashboard(request: Request) -> None:
+        authorization_calls.append(request.url.path)
+        raise DashboardPermissionError("read only", code="read_only_access")
+
+    async def reject_proxy(request: Request) -> None:
+        authorization_calls.append(request.url.path)
+        raise ProxyAuthError("missing API key")
+
+    app = create_app()
+    app.dependency_overrides[validate_dashboard_session] = reject_dashboard
+    app.dependency_overrides[validate_proxy_api_key] = reject_proxy
+    transport = ASGITransport(app=app)
+
+    try:
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            headers = {
+                "Content-Type": content_type,
+                "Content-Length": "6",
+            }
+            if content_encoding is not None:
+                headers["Content-Encoding"] = content_encoding
+            response = await client.post(path, content=body, headers=headers)
+    finally:
+        get_settings.cache_clear()
+
+    assert response.status_code == (403 if path.startswith("/api/") else 401)
+    assert authorization_calls == [path]
+    assert body.iterations == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content_encoding", [None, "identity", "gzip"])
+async def test_production_stack_keeps_unrelated_multipart_under_generic_guard(
+    monkeypatch: pytest.MonkeyPatch,
+    content_encoding: str | None,
+) -> None:
+    _configure_tiny_generic_ingress_budget(monkeypatch)
+    await get_firewall_ip_cache().set("127.0.0.1", True)
+    authorization_calls: list[str] = []
+    body = _TrackingBody(b"unread")
+
+    async def reject_proxy(request: Request) -> None:
+        authorization_calls.append(request.url.path)
+        raise ProxyAuthError("missing API key")
+
+    app = create_app()
+    app.dependency_overrides[validate_proxy_api_key] = reject_proxy
+    transport = ASGITransport(app=app)
+
+    try:
+        async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+            headers = {
+                "Content-Type": "multipart/form-data; boundary=unused",
+                "Content-Length": "6",
+            }
+            if content_encoding is not None:
+                headers["Content-Encoding"] = content_encoding
+            response = await client.post("/v1/chat/completions", content=body, headers=headers)
+    finally:
+        get_settings.cache_clear()
+
+    assert response.status_code == 413
+    assert response.json()["error"]["code"] == "payload_too_large"
+    assert authorization_calls == []
+    assert body.iterations == 0
+
+
+def test_production_middleware_order_composes_route_and_generic_ingress_guards() -> None:
+    middleware = create_app().user_middleware
+    alias_index = next(index for index, item in enumerate(middleware) if item.cls is BackendApiCodexV1AliasMiddleware)
+    multipart_index = next(
+        index for index, item in enumerate(middleware) if item.cls is MultipartContentEncodingMiddleware
+    )
+    limit_index = next(index for index, item in enumerate(middleware) if item.cls is RequestBodyLimitMiddleware)
+    decompression_index = next(
+        index
+        for index, item in enumerate(middleware)
+        if item.cls is BaseHTTPMiddleware and item.kwargs.get("dispatch").__name__ == "request_decompression_middleware"
+    )
+
+    assert alias_index < multipart_index < limit_index < decompression_index

--- a/tests/unit/test_multipart_openapi.py
+++ b/tests/unit/test_multipart_openapi.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.main import create_app
+
+pytestmark = pytest.mark.unit
+
+_MULTIPART_OPERATIONS = {
+    ("/api/accounts/import", "post"),
+    ("/backend-api/transcribe", "post"),
+    ("/v1/audio/transcriptions", "post"),
+    ("/v1/images/edits", "post"),
+}
+
+
+def _nullable_string(title: str) -> dict[str, Any]:
+    return {
+        "anyOf": [{"type": "string"}, {"type": "null"}],
+        "title": title,
+    }
+
+
+def _binary(title: str) -> dict[str, Any]:
+    return {
+        "type": "string",
+        "contentMediaType": "application/octet-stream",
+        "title": title,
+    }
+
+
+def _binary_array(title: str) -> dict[str, Any]:
+    return {
+        "anyOf": [
+            {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "contentMediaType": "application/octet-stream",
+                },
+            },
+            {"type": "null"},
+        ],
+        "title": title,
+    }
+
+
+def _request_schema(openapi: dict[str, Any], path: str) -> dict[str, Any]:
+    request_body = openapi["paths"][path]["post"]["requestBody"]
+    assert set(request_body) == {"content", "required"}
+    assert request_body["required"] is True
+    assert set(request_body["content"]) == {"multipart/form-data"}
+    schema = request_body["content"]["multipart/form-data"]["schema"]
+    if "$ref" not in schema:
+        return schema
+    component_name = schema["$ref"].rsplit("/", 1)[-1]
+    return openapi["components"]["schemas"][component_name]
+
+
+def test_all_fastapi_multipart_operations_have_an_explicit_bounded_policy_surface() -> None:
+    openapi = create_app().openapi()
+    actual = {
+        (path, method)
+        for path, path_item in openapi["paths"].items()
+        for method, operation in path_item.items()
+        if isinstance(operation, dict) and "multipart/form-data" in operation.get("requestBody", {}).get("content", {})
+    }
+
+    assert actual == _MULTIPART_OPERATIONS
+
+
+def test_multipart_request_body_schemas_remain_semantically_identical() -> None:
+    openapi = create_app().openapi()
+
+    assert _request_schema(openapi, "/api/accounts/import") == {
+        "type": "object",
+        "title": "Body_import_account_api_accounts_import_post",
+        "required": ["auth_json"],
+        "properties": {"auth_json": _binary("Auth Json")},
+    }
+    assert _request_schema(openapi, "/backend-api/transcribe") == {
+        "type": "object",
+        "title": "Body_backend_transcribe_backend_api_transcribe_post",
+        "required": ["file"],
+        "properties": {
+            "file": _binary("File"),
+            "prompt": _nullable_string("Prompt"),
+        },
+    }
+    assert _request_schema(openapi, "/v1/audio/transcriptions") == {
+        "type": "object",
+        "title": "Body_v1_audio_transcriptions_v1_audio_transcriptions_post",
+        "required": ["model", "file"],
+        "properties": {
+            "model": {"type": "string", "title": "Model"},
+            "file": _binary("File"),
+            "prompt": _nullable_string("Prompt"),
+        },
+    }
+
+    optional_image_fields = {
+        "model": "Model",
+        "n": "N",
+        "size": "Size",
+        "quality": "Quality",
+        "background": "Background",
+        "output_format": "Output Format",
+        "output_compression": "Output Compression",
+        "moderation": "Moderation",
+        "partial_images": "Partial Images",
+        "stream": "Stream",
+        "input_fidelity": "Input Fidelity",
+        "user": "User",
+    }
+    image_properties = {field: _nullable_string(title) for field, title in optional_image_fields.items()}
+    image_properties.update(
+        {
+            "prompt": {"type": "string", "title": "Prompt"},
+            "image": _binary_array("Image"),
+            "image[]": _binary_array("Image[]"),
+            "mask": {
+                "anyOf": [
+                    {
+                        "type": "string",
+                        "contentMediaType": "application/octet-stream",
+                    },
+                    {"type": "null"},
+                ],
+                "title": "Mask",
+            },
+        }
+    )
+    assert _request_schema(openapi, "/v1/images/edits") == {
+        "type": "object",
+        "title": "Body_v1_images_edits_v1_images_edits_post",
+        "required": ["prompt"],
+        "properties": image_properties,
+    }
+
+
+def test_non_multipart_codex_image_and_file_surfaces_are_unchanged() -> None:
+    openapi = create_app().openapi()
+
+    assert "/backend-api/codex/images/edits" not in openapi["paths"]
+    files_body = openapi["paths"]["/backend-api/files"]["post"]["requestBody"]
+    assert files_body == {
+        "required": True,
+        "content": {
+            "application/json": {
+                "schema": {"$ref": "#/components/schemas/FileCreateRequest"},
+            }
+        },
+    }

--- a/tests/unit/test_request_body_limit_middleware.py
+++ b/tests/unit/test_request_body_limit_middleware.py
@@ -314,29 +314,43 @@ async def test_outer_alias_rewrite_selects_responses_budget(monkeypatch: pytest.
 
 
 @pytest.mark.asyncio
-async def test_unencoded_multipart_is_exempt_but_encoded_multipart_is_guarded(
+async def test_only_route_owned_unencoded_multipart_is_exempt_from_generic_guard(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _configure_limits(monkeypatch, general=5)
     multipart = (b"content-type", b"multipart/form-data; boundary=test")
 
-    plain_inner = _BodyConsumer()
-    plain_sent = await _run_direct(
-        RequestBodyLimitMiddleware(plain_inner),
-        _http_scope(headers=[multipart, (b"content-length", b"8")]),
+    route_owned_inner = _BodyConsumer()
+    route_owned_sent = await _run_direct(
+        RequestBodyLimitMiddleware(route_owned_inner),
+        _http_scope("/v1/images/edits", headers=[multipart, (b"content-length", b"8")]),
         _request_messages(b"12345678"),
     )
-    assert plain_inner.chunks == [b"12345678"]
-    assert plain_sent[0]["status"] == 204
+    assert route_owned_inner.chunks == [b"12345678"]
+    assert route_owned_sent[0]["status"] == 204
 
-    encoded_inner = _BodyConsumer()
-    encoded_sent = await _run_direct(
-        RequestBodyLimitMiddleware(encoded_inner),
-        _http_scope(headers=[multipart, (b"content-encoding", b"identity"), (b"content-length", b"8")]),
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("content_encoding", [None, b"identity", b"gzip"])
+async def test_unrelated_multipart_remains_under_generic_guard(
+    monkeypatch: pytest.MonkeyPatch,
+    content_encoding: bytes | None,
+) -> None:
+    _configure_limits(monkeypatch, general=5)
+    headers = [(b"content-type", b"multipart/form-data; boundary=test")]
+    if content_encoding is not None:
+        headers.append((b"content-encoding", content_encoding))
+    headers.append((b"content-length", b"8"))
+    inner = _BodyConsumer()
+
+    sent = await _run_direct(
+        RequestBodyLimitMiddleware(inner),
+        _http_scope("/v1/chat/completions", headers=headers),
         _request_messages(b"12345678"),
     )
-    assert encoded_inner.calls == 0
-    assert encoded_sent[0]["status"] == 413
+
+    assert inner.calls == 0
+    assert sent[0]["status"] == 413
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Bound the multipart upload surfaces that currently let authenticated callers consume unbounded disk or memory: account auth import, both transcription routes, and `/v1/images/edits`.

Parsing now happens only after the existing authorization dependencies, enforces declared and streamed body limits plus per-file/aggregate/text/count limits, closes every spool before persistence or upstream work, and preserves each route family's existing external error envelope.

## Type of change

- [x] `fix:` — security/resource-exhaustion bug fix
- [ ] `feat:`
- [ ] `refactor:`
- [ ] `docs:` / `chore:` / `ci:` / `build:`
- [ ] **Breaking change**

Linked issue: none; this is a focused security hardening item found during the project audit.

## OpenSpec

Change: `openspec/changes/bound-multipart-uploads/`

The change defines independent limits and compatibility scenarios for:

- account import: 2 MiB body, 1 MiB `auth_json`, exactly one file part;
- audio transcription: 32 MiB body, 25,000,000-byte file, bounded text fields;
- image edits: 64 MiB body, fewer than 50,000,000 aggregate binary bytes, bounded image/mask counts and text fields.

## Changes

- Add one reusable streaming multipart parser with immutable route policies.
- Enforce usable `Content-Length` and actual streamed bytes without retaining crossing bytes.
- Preserve dashboard 422/400/413 envelopes and OpenAI-compatible invalid-request/413 envelopes.
- Reject non-identity multipart `Content-Encoding` after auth but before body consumption; normalize duplicate/comma-separated encodings safely.
- Preserve trailing-slash/root-path routing, ordered model-source transcription fields, image ordering, and image-route observability.
- Keep OpenAPI request-body contracts after removing FastAPI's eager `File`/`Form` parsing.
- Guarantee spool cleanup on success, parse errors, limit errors, disconnect, and cancellation.

## Security and compatibility details

- Unauthorized requests do not consume or spool multipart bodies.
- Wrong or missing multipart media types return established validation/bad-request envelopes instead of a 500.
- `/v1/images/edits` observability does not read JSON or multipart bytes before authorization.
- No usage reservation, account selection, persistence, audit-success event, base64 conversion, or upstream call occurs after parser rejection.

## Independence

- Based directly on current `upstream/main` at `6da1f48b`.
- Contains no commits or code from the other improvement PRs.
- One scoped capability despite the larger test/OpenSpec diff; no unrelated behavior is included.

## Verification

- Relevant unit/integration/model-routing/image/transcription/account suites: 166 passed.
- Ruff check and format: 818 files passed.
- `ty`: passed.
- Architecture and simplicity checks: passed.
- Strict change validation and all 47 main OpenSpec specs: passed.
- Formal semantic verification: 3/3 requirements, 23/23 scenarios, 0 findings.
- Independent final audit fixed three additional edge cases: pre-auth image body reads, duplicate `identity,gzip` encoding bypass, and missing/non-multipart Content-Type 500s.
- `git diff --check`: passed.

## Simplicity

- Zero configuration and no new `CODEX_LB_*` setting.
- No README, `.env.example`, dashboard navigation, schema, migration, or frontend change.
- Screenshots are not applicable.
