### PR TITLE
perf(usage): persist account snapshots transactionally

### DIFF
--- a/app/modules/usage/background_repository.py
+++ b/app/modules/usage/background_repository.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from app.db.models import UsageHistory
 from app.db.session import detach_session_objects, get_background_session
-from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
+from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository, UsageWindowWrite
 
 
 class BackgroundUsageRepository:
@@ -50,6 +50,22 @@ class BackgroundUsageRepository:
             )
             detach_session_objects(session)
             return entry
+
+    async def add_account_snapshot(
+        self,
+        account_id: str,
+        windows: Collection[UsageWindowWrite],
+        *,
+        recorded_at: datetime | None = None,
+    ) -> list[UsageHistory]:
+        async with get_background_session() as session:
+            entries = await UsageRepository(session).add_account_snapshot(
+                account_id,
+                windows,
+                recorded_at=recorded_at,
+            )
+            detach_session_objects(session)
+            return entries
 
 
 class BackgroundAdditionalUsageRepository:

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -40,6 +40,17 @@ class UsageHistorySnapshot:
 
 
 @dataclass(frozen=True, slots=True)
+class UsageWindowWrite:
+    window: str
+    used_percent: float
+    reset_at: int | None = None
+    window_minutes: int | None = None
+    credits_has: bool | None = None
+    credits_unlimited: bool | None = None
+    credits_balance: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class _BulkHistoryCacheMetadata:
     row_count: int
     max_id: int
@@ -610,6 +621,42 @@ class UsageRepository:
             await self._session.commit()
             await self._session.refresh(entry)
         return entry
+
+    async def add_account_snapshot(
+        self,
+        account_id: str,
+        windows: Collection[UsageWindowWrite],
+        *,
+        recorded_at: datetime | None = None,
+    ) -> list[UsageHistory]:
+        """Persist one account's standard usage windows atomically."""
+        if not windows:
+            return []
+        captured_at = recorded_at or utcnow()
+        entries = [
+            UsageHistory(
+                account_id=account_id,
+                used_percent=window.used_percent,
+                input_tokens=None,
+                output_tokens=None,
+                window=window.window,
+                reset_at=window.reset_at,
+                window_minutes=window.window_minutes,
+                credits_has=window.credits_has,
+                credits_unlimited=window.credits_unlimited,
+                credits_balance=window.credits_balance,
+                recorded_at=captured_at,
+            )
+            for window in windows
+        ]
+        self._session.add_all(entries)
+        try:
+            async with sqlite_writer_section():
+                await self._session.commit()
+        except BaseException:
+            await self._session.rollback()
+            raise
+        return entries
 
     async def aggregate_since(
         self,

--- a/app/modules/usage/updater.py
+++ b/app/modules/usage/updater.py
@@ -35,7 +35,7 @@ from app.modules.accounts.repository import AccountsRepository as SessionAccount
 from app.modules.proxy.account_cache import get_account_selection_cache, mark_account_routing_unavailable
 from app.modules.usage.additional_quota_keys import canonicalize_additional_quota_key
 from app.modules.usage.background_repository import BackgroundAdditionalUsageRepository, BackgroundUsageRepository
-from app.modules.usage.repository import AdditionalUsageRepository
+from app.modules.usage.repository import AdditionalUsageRepository, UsageWindowWrite
 from app.modules.usage.repository import UsageRepository as SessionUsageRepository
 
 logger = logging.getLogger(__name__)
@@ -49,20 +49,13 @@ class UsageRepositoryPort(Protocol):
         window: str | None = None,
     ) -> UsageHistory | None: ...
 
-    async def add_entry(
+    async def add_account_snapshot(
         self,
         account_id: str,
-        used_percent: float,
-        input_tokens: int | None = None,
-        output_tokens: int | None = None,
+        windows: Collection[UsageWindowWrite],
+        *,
         recorded_at: datetime | None = None,
-        window: str | None = None,
-        reset_at: int | None = None,
-        window_minutes: int | None = None,
-        credits_has: bool | None = None,
-        credits_unlimited: bool | None = None,
-        credits_balance: float | None = None,
-    ) -> UsageHistory | None: ...
+    ) -> list[UsageHistory]: ...
 
 
 class AdditionalUsageRepositoryPort(Protocol):
@@ -690,49 +683,49 @@ class UsageUpdater:
             additional_synced = self._additional_usage_repo is not None and payload.additional_rate_limits is not None
             return AccountRefreshResult(usage_written=additional_synced)
         credits_has, credits_unlimited, credits_balance = _credits_snapshot(payload)
-        usage_written = False
+        snapshot_windows: list[UsageWindowWrite] = []
 
         if primary and primary.used_percent is not None:
-            entry = await self._usage_repo.add_entry(
-                account_id=account.id,
-                used_percent=float(primary.used_percent),
-                input_tokens=None,
-                output_tokens=None,
-                window="primary",
-                reset_at=_reset_at(primary.reset_at, primary.reset_after_seconds, now_epoch),
-                window_minutes=_window_minutes(primary.limit_window_seconds),
-                credits_has=credits_has,
-                credits_unlimited=credits_unlimited,
-                credits_balance=credits_balance,
+            snapshot_windows.append(
+                UsageWindowWrite(
+                    window="primary",
+                    used_percent=float(primary.used_percent),
+                    reset_at=_reset_at(primary.reset_at, primary.reset_after_seconds, now_epoch),
+                    window_minutes=_window_minutes(primary.limit_window_seconds),
+                    credits_has=credits_has,
+                    credits_unlimited=credits_unlimited,
+                    credits_balance=credits_balance,
+                )
             )
-            usage_written = usage_written or _usage_entry_written(entry)
 
         if secondary and secondary.used_percent is not None:
-            entry = await self._usage_repo.add_entry(
-                account_id=account.id,
-                used_percent=float(secondary.used_percent),
-                input_tokens=None,
-                output_tokens=None,
-                window="secondary",
-                reset_at=_reset_at(secondary.reset_at, secondary.reset_after_seconds, now_epoch),
-                window_minutes=_window_minutes(secondary.limit_window_seconds),
+            snapshot_windows.append(
+                UsageWindowWrite(
+                    window="secondary",
+                    used_percent=float(secondary.used_percent),
+                    reset_at=_reset_at(secondary.reset_at, secondary.reset_after_seconds, now_epoch),
+                    window_minutes=_window_minutes(secondary.limit_window_seconds),
+                )
             )
-            usage_written = usage_written or _usage_entry_written(entry)
 
         if monthly and monthly.used_percent is not None:
-            entry = await self._usage_repo.add_entry(
-                account_id=account.id,
-                used_percent=float(monthly.used_percent),
-                input_tokens=None,
-                output_tokens=None,
-                window="monthly",
-                reset_at=_reset_at(monthly.reset_at, monthly.reset_after_seconds, now_epoch),
-                window_minutes=_window_minutes(monthly.limit_window_seconds),
-                credits_has=credits_has,
-                credits_unlimited=credits_unlimited,
-                credits_balance=credits_balance,
+            snapshot_windows.append(
+                UsageWindowWrite(
+                    window="monthly",
+                    used_percent=float(monthly.used_percent),
+                    reset_at=_reset_at(monthly.reset_at, monthly.reset_after_seconds, now_epoch),
+                    window_minutes=_window_minutes(monthly.limit_window_seconds),
+                    credits_has=credits_has,
+                    credits_unlimited=credits_unlimited,
+                    credits_balance=credits_balance,
+                )
             )
-            usage_written = usage_written or _usage_entry_written(entry)
+
+        entries = await self._usage_repo.add_account_snapshot(
+            account.id,
+            snapshot_windows,
+        )
+        usage_written = any(_usage_entry_written(entry) for entry in entries)
         await self._recover_quota_status_from_usage(account, primary=primary, secondary=secondary, monthly=monthly)
         return AccountRefreshResult(usage_written=usage_written)
 

--- a/openspec/changes/persist-usage-snapshot-transactionally/.openspec.yaml
+++ b/openspec/changes/persist-usage-snapshot-transactionally/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/persist-usage-snapshot-transactionally/design.md
+++ b/openspec/changes/persist-usage-snapshot-transactionally/design.md
@@ -1,0 +1,54 @@
+## Context
+
+`UsageUpdater` normalizes one account's `/wham/usage` response into as many as three standard history rows. It currently calls `UsageRepository.add_entry()` once per window. Every call acquires the SQLite writer section and commits independently, so a two-window response performs two durable transactions and a failure can leave only the earlier row visible.
+
+The updater is used with two repository ownership models. Request-scoped callers provide repositories backed by a caller-owned `AsyncSession`; the background scheduler uses an adapter that opens a short-lived background session for each repository operation. The batch operation must preserve both ownership models and must not make independent live-ingest writes wait for a refresh-only API.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Persist the normalized primary, secondary, and applicable monthly rows from one account response atomically.
+- Acquire the SQLite writer section and commit exactly once for a non-empty standard snapshot.
+- Give every standard row in the snapshot one capture timestamp.
+- Roll back failed snapshot writes without closing a caller-owned session.
+- Let the background adapter own exactly one session for the full snapshot write.
+
+**Non-Goals:**
+
+- Changing which account the scheduler refreshes or how often it refreshes.
+- Changing additional per-model usage-history synchronization, identity metadata, or account-status reconciliation.
+- Replacing independent single-row persistence used by live usage ingestion.
+- Adding a migration, setting, or dashboard/API surface.
+
+## Decisions
+
+### Add a typed account-snapshot repository operation
+
+Introduce a small immutable write model for one normalized standard window and add an `add_account_snapshot` operation to the usage repository contract. `UsageUpdater` will collect every present normalized standard window first and call that operation once.
+
+This keeps transaction ownership in the repository instead of exposing `commit=False` flags or transaction primitives to the updater. Reusing `add_entry()` in a loop was rejected because it preserves the current partial-commit behavior; changing `add_entry()` to stop committing was rejected because live-ingest and other existing callers rely on it as a complete persistence operation.
+
+### Use one timestamp and one explicit rollback boundary
+
+The repository will resolve `recorded_at` once, stage every row on its existing session, acquire one SQLite writer section, and commit once. If staging or commit raises, it will roll back that session before re-raising. The repository will not close the session, so request-scoped callers retain ownership and can continue using it after a handled failure.
+
+The background adapter will open one background session, delegate the whole operation to the session-backed repository, detach returned rows, and then let the background-session context close its own session. Opening a separate session per row was rejected because it cannot provide an atomic snapshot.
+
+### Keep additional usage synchronization separate
+
+Additional per-model limits have independent retention semantics and a separate repository contract. Folding that synchronization into this change would broaden the transaction and require redesigning both repositories. This focused change makes the high-frequency standard rows reported in issue #708 atomic while leaving additional usage behavior unchanged.
+
+## Risks / Trade-offs
+
+- [Risk] A transaction now contains up to three inserts instead of one, holding the SQLite writer section slightly longer. -> The total lock time is lower than repeated lock/commit cycles, and the batch is strictly bounded to the standard windows of one account.
+- [Risk] A failure in one window now discards rows that previously might have committed. -> Atomic rollback prevents mixed-time snapshots; the next scheduled refresh retries the complete account.
+- [Risk] Test doubles that implement the repository protocol must model the batch operation. -> Keep the DTO and method narrow and update the shared updater stub so existing behavioral tests still assert the emitted rows.
+
+## Migration Plan
+
+No schema or data migration is required. Deploying the code changes only the transaction boundary for new rows. Rolling back restores per-row commits; rows already written by either version remain compatible.
+
+## Open Questions
+
+None.

--- a/openspec/changes/persist-usage-snapshot-transactionally/proposal.md
+++ b/openspec/changes/persist-usage-snapshot-transactionally/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+A single successful `/wham/usage` response can produce primary, secondary, and monthly history rows, but each row is currently committed under its own SQLite writer section. That multiplies durable commits and lock acquisitions while also allowing readers to observe only part of one upstream snapshot if a later row fails.
+
+## What Changes
+
+- Persist all standard usage-window rows derived from one account response with one repository call and one database transaction.
+- Give every row in that account snapshot the same capture timestamp.
+- Roll back the entire standard-window snapshot when any row cannot be persisted, leaving the caller-owned session usable.
+- Keep independent single-row ingestion paths and additional per-model usage-history semantics unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `usage-refresh-policy`: define atomic persistence for the standard usage windows returned for one account refresh.
+
+## Impact
+
+- Affected code: `app/modules/usage/repository.py`, the background usage repository adapter, and `app/modules/usage/updater.py`.
+- Affected storage: inserts into `usage_history`; no schema or migration changes.
+- APIs, configuration, dashboard rendering, and upstream request cadence remain unchanged.

--- a/openspec/changes/persist-usage-snapshot-transactionally/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/persist-usage-snapshot-transactionally/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Standard usage refresh snapshots persist atomically
+
+For one account's successful upstream usage response, the system MUST persist every available normalized standard usage window (`primary`, `secondary`, and any applicable `monthly` window) in one database transaction. All standard rows from that response MUST use the same capture timestamp. If any standard row cannot be persisted or the transaction cannot commit, the system MUST roll back the transaction so none of that response's standard rows becomes visible, and a caller-owned database session MUST remain open and reusable. This atomic unit applies to standard `usage_history` rows; additional per-model usage history and independent live-ingest writes retain their existing persistence contracts.
+
+#### Scenario: Multi-window response commits as one snapshot
+
+- **WHEN** a successful account usage response contains multiple normalized standard windows
+- **THEN** the system persists all of those standard rows in one transaction with one shared capture timestamp
+
+#### Scenario: Later row failure leaves no partial snapshot
+
+- **WHEN** persistence fails after at least one standard row from an account response has been staged
+- **THEN** the system rolls back the transaction and no standard row from that response is visible
+
+#### Scenario: Caller retains its session after rollback
+
+- **WHEN** a caller-owned session is used for a standard usage snapshot and the snapshot transaction fails
+- **THEN** the repository leaves that session open and reusable after rolling back the failed transaction

--- a/openspec/changes/persist-usage-snapshot-transactionally/tasks.md
+++ b/openspec/changes/persist-usage-snapshot-transactionally/tasks.md
@@ -1,0 +1,20 @@
+## 1. Transactional Repository Operation
+
+- [x] 1.1 Add a typed standard-window write model and a session-backed repository operation that stages one account snapshot, commits once, and rolls back failures.
+- [x] 1.2 Add the background repository adapter that owns one session for the complete snapshot and detaches returned rows before closing it.
+
+## 2. Usage Refresh Integration
+
+- [x] 2.1 Change `UsageUpdater` to collect normalized standard windows and persist them through one snapshot operation without changing additional-usage behavior.
+- [x] 2.2 Preserve `usage_written`, credits, reset metadata, and normalized monthly-window behavior through the batch path.
+
+## 3. Regression Coverage
+
+- [x] 3.1 Add updater coverage proving a multi-window payload is submitted as one shared-timestamp snapshot.
+- [x] 3.2 Add repository coverage proving one commit, atomic rollback after a staged partial failure, and caller-session reuse.
+- [x] 3.3 Add background-adapter coverage proving one owned session spans the complete snapshot and closes only after returned rows are detached.
+
+## 4. Verification
+
+- [x] 4.1 Run focused usage updater/repository/background tests, then the appropriate broader unit suite.
+- [x] 4.2 Run Ruff format/check, `ty`, strict OpenSpec validation, and repository architecture/simplicity/diff gates.

--- a/tests/unit/test_usage_snapshot_repository.py
+++ b/tests/unit/test_usage_snapshot_repository.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Collection
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import event, func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.db.models import Account, AccountStatus, Base, UsageHistory
+from app.modules.usage import background_repository as background_repository_module
+from app.modules.usage.background_repository import BackgroundUsageRepository
+from app.modules.usage.repository import UsageRepository, UsageWindowWrite
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+def _account(account_id: str) -> Account:
+    return Account(
+        id=account_id,
+        email=f"{account_id}@example.com",
+        plan_type="plus",
+        access_token_encrypted=b"access",
+        refresh_token_encrypted=b"refresh",
+        id_token_encrypted=b"id",
+        last_refresh=datetime(2026, 7, 22, tzinfo=timezone.utc),
+        status=AccountStatus.ACTIVE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_account_snapshot_commits_all_windows_once_with_one_timestamp(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_factory() as session:
+        session.add(_account("acc_snapshot"))
+        await session.commit()
+        commit_count = 0
+
+        def record_commit(_: object) -> None:
+            nonlocal commit_count
+            commit_count += 1
+
+        event.listen(session.sync_session, "after_commit", record_commit)
+        captured_at = datetime(2026, 7, 22, 12, 0, tzinfo=timezone.utc)
+        try:
+            rows = await UsageRepository(session).add_account_snapshot(
+                "acc_snapshot",
+                [
+                    UsageWindowWrite(
+                        window="primary",
+                        used_percent=12.5,
+                        reset_at=100,
+                        window_minutes=300,
+                        credits_has=True,
+                        credits_balance=42.5,
+                    ),
+                    UsageWindowWrite(
+                        window="secondary",
+                        used_percent=55.0,
+                        reset_at=200,
+                        window_minutes=10080,
+                    ),
+                ],
+                recorded_at=captured_at,
+            )
+        finally:
+            event.remove(session.sync_session, "after_commit", record_commit)
+
+        assert commit_count == 1
+        assert [row.window for row in rows] == ["primary", "secondary"]
+        assert {row.recorded_at for row in rows} == {captured_at}
+        session.expunge_all()
+        persisted_rows = list(
+            (
+                await session.scalars(
+                    select(UsageHistory)
+                    .where(UsageHistory.account_id == "acc_snapshot")
+                    .order_by(UsageHistory.id.asc())
+                )
+            ).all()
+        )
+        assert [row.window for row in persisted_rows] == ["primary", "secondary"]
+        assert {row.recorded_at for row in persisted_rows} == {captured_at.replace(tzinfo=None)}
+
+
+@pytest.mark.asyncio
+async def test_add_account_snapshot_rolls_back_partial_flush_and_keeps_caller_session_reusable(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_factory() as session:
+        session.add(_account("acc_rollback"))
+        await session.commit()
+        inserted_windows: list[str | None] = []
+        rollback_count = 0
+
+        def reject_secondary(_: object, __: object, target: UsageHistory) -> None:
+            inserted_windows.append(target.window)
+            if target.window == "secondary":
+                raise RuntimeError("injected secondary-row failure")
+
+        def record_rollback(_: object) -> None:
+            nonlocal rollback_count
+            rollback_count += 1
+
+        event.listen(UsageHistory, "before_insert", reject_secondary)
+        event.listen(session.sync_session, "after_rollback", record_rollback)
+        try:
+            with pytest.raises(RuntimeError, match="injected secondary-row failure"):
+                await UsageRepository(session).add_account_snapshot(
+                    "acc_rollback",
+                    [
+                        UsageWindowWrite(window="primary", used_percent=10.0),
+                        UsageWindowWrite(window="secondary", used_percent=20.0),
+                    ],
+                )
+        finally:
+            event.remove(UsageHistory, "before_insert", reject_secondary)
+            event.remove(session.sync_session, "after_rollback", record_rollback)
+
+        assert inserted_windows == ["primary", "secondary"]
+        assert rollback_count == 1
+        assert (
+            await session.scalar(select(func.count(UsageHistory.id)).where(UsageHistory.account_id == "acc_rollback"))
+            == 0
+        )
+
+        rows = await UsageRepository(session).add_account_snapshot(
+            "acc_rollback",
+            [UsageWindowWrite(window="primary", used_percent=30.0)],
+        )
+        assert len(rows) == 1
+        assert (
+            await session.scalar(select(func.count(UsageHistory.id)).where(UsageHistory.account_id == "acc_rollback"))
+            == 1
+        )
+
+
+@pytest.mark.asyncio
+async def test_background_snapshot_uses_one_owned_session_until_rows_are_detached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = object()
+    events: list[str] = []
+    persisted_rows = [
+        UsageHistory(
+            id=1,
+            account_id="acc_background",
+            window="primary",
+            used_percent=10.0,
+            recorded_at=datetime(2026, 7, 22, tzinfo=timezone.utc),
+        )
+    ]
+
+    @asynccontextmanager
+    async def recording_background_session() -> AsyncIterator[object]:
+        events.append("session_open")
+        try:
+            yield session
+        finally:
+            events.append("session_close")
+
+    class RecordingUsageRepository:
+        def __init__(self, provided_session: object) -> None:
+            assert provided_session is session
+            events.append("repository_created")
+
+        async def add_account_snapshot(
+            self,
+            account_id: str,
+            windows: Collection[UsageWindowWrite],
+            *,
+            recorded_at: datetime | None = None,
+        ) -> list[UsageHistory]:
+            assert account_id == "acc_background"
+            assert [window.window for window in windows] == ["primary", "secondary"]
+            assert recorded_at is not None
+            events.append("snapshot_persisted")
+            return persisted_rows
+
+    def record_detach(provided_session: object) -> None:
+        assert provided_session is session
+        events.append("rows_detached")
+
+    monkeypatch.setattr(background_repository_module, "get_background_session", recording_background_session)
+    monkeypatch.setattr(background_repository_module, "UsageRepository", RecordingUsageRepository)
+    monkeypatch.setattr(background_repository_module, "detach_session_objects", record_detach)
+
+    rows = await BackgroundUsageRepository().add_account_snapshot(
+        "acc_background",
+        [
+            UsageWindowWrite(window="primary", used_percent=10.0),
+            UsageWindowWrite(window="secondary", used_percent=20.0),
+        ],
+        recorded_at=datetime(2026, 7, 22, tzinfo=timezone.utc),
+    )
+
+    assert rows is persisted_rows
+    assert events == [
+        "session_open",
+        "repository_created",
+        "snapshot_persisted",
+        "rows_detached",
+        "session_close",
+    ]

--- a/tests/unit/test_usage_updater.py
+++ b/tests/unit/test_usage_updater.py
@@ -19,6 +19,7 @@ from app.core.usage.models import UsagePayload
 from app.db.models import Account, AccountStatus, UsageHistory
 from app.modules.usage import updater as usage_updater_module
 from app.modules.usage.additional_quota_keys import canonicalize_additional_quota_key
+from app.modules.usage.repository import UsageWindowWrite
 from app.modules.usage.updater import UsageUpdater
 
 pytestmark = pytest.mark.unit
@@ -112,6 +113,15 @@ async def test_refresh_accounts_owned_singleflight_session_outlives_caller_cance
             credits_balance: float | None = None,
         ) -> UsageHistory | None:
             return None
+
+        async def add_account_snapshot(
+            self,
+            account_id: str,
+            windows: Collection[UsageWindowWrite],
+            *,
+            recorded_at: datetime | None = None,
+        ) -> list[UsageHistory]:
+            return []
 
     class InnerUsageRepository(OuterUsageRepository):
         def __init__(self, session) -> None:
@@ -230,6 +240,15 @@ async def test_owned_singleflight_reload_skips_account_that_became_ineligible(
             credits_balance: float | None = None,
         ) -> UsageHistory | None:
             return None
+
+        async def add_account_snapshot(
+            self,
+            account_id: str,
+            windows: Collection[UsageWindowWrite],
+            *,
+            recorded_at: datetime | None = None,
+        ) -> list[UsageHistory]:
+            return []
 
     class InnerUsageRepository(OuterUsageRepository):
         def __init__(self, session) -> None:
@@ -381,9 +400,17 @@ class UsageEntry:
     credits_balance: float | None
 
 
+@dataclass(frozen=True, slots=True)
+class UsageSnapshotCall:
+    account_id: str
+    windows: tuple[UsageWindowWrite, ...]
+    recorded_at: datetime
+
+
 class StubUsageRepository:
     def __init__(self, *, return_rows: bool = False) -> None:
         self.entries: list[UsageEntry] = []
+        self.snapshot_calls: list[UsageSnapshotCall] = []
         self._return_rows = return_rows
         self._next_id = 1
 
@@ -460,6 +487,39 @@ class StubUsageRepository:
         )
         self._next_id += 1
         return entry
+
+    async def add_account_snapshot(
+        self,
+        account_id: str,
+        windows: Collection[UsageWindowWrite],
+        *,
+        recorded_at: datetime | None = None,
+    ) -> list[UsageHistory]:
+        captured_at = recorded_at or datetime.now(tz=timezone.utc)
+        snapshot_windows = tuple(windows)
+        self.snapshot_calls.append(
+            UsageSnapshotCall(
+                account_id=account_id,
+                windows=snapshot_windows,
+                recorded_at=captured_at,
+            )
+        )
+        rows: list[UsageHistory] = []
+        for window in snapshot_windows:
+            entry = await self.add_entry(
+                account_id,
+                window.used_percent,
+                recorded_at=captured_at,
+                window=window.window,
+                reset_at=window.reset_at,
+                window_minutes=window.window_minutes,
+                credits_has=window.credits_has,
+                credits_unlimited=window.credits_unlimited,
+                credits_balance=window.credits_balance,
+            )
+            if entry is not None:
+                rows.append(entry)
+        return rows
 
 
 @dataclass(frozen=True, slots=True)
@@ -2527,7 +2587,12 @@ async def test_usage_updater_persists_primary_and_secondary_usage(monkeypatch) -
 
     await updater.refresh_accounts([acc], latest_usage={})
 
+    assert len(usage_repo.snapshot_calls) == 1
+    snapshot_call = usage_repo.snapshot_calls[0]
+    assert snapshot_call.account_id == "acc_test"
+    assert [window.window for window in snapshot_call.windows] == ["primary", "secondary"]
     assert len(usage_repo.entries) == 2
+    assert {entry.recorded_at for entry in usage_repo.entries} == {snapshot_call.recorded_at}
     by_window = {entry.window: entry for entry in usage_repo.entries}
 
     primary = by_window["primary"]


### PR DESCRIPTION
## Summary

Persists the primary, secondary, and monthly standard usage rows derived from one account response as one atomic snapshot. This reduces repeated SQLite writer/commit cycles and prevents partially visible snapshots when a later row fails.

This PR is intentionally standalone from #1446: it changes only the persistence boundary, not account-selection or refresh scheduling.

## Type of change

- [x] `perf:` — performance improvement
- [ ] Breaking change

Linked issue: Related to #708

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] This PR touches a codex-faithful path

Change directory: `openspec/changes/persist-usage-snapshot-transactionally/`

## Changes

- add a typed `UsageWindowWrite` model and one repository operation for a complete standard account snapshot
- assign one capture timestamp, acquire the SQLite writer section once, and commit once for up to three rows
- roll back the complete snapshot on failure while leaving caller-owned sessions open and reusable
- keep one background session for the whole batch and preserve additional/per-model and live-ingest behavior

## Simplicity

- [x] Works with zero configuration
- [x] Adds no setting, setup step, README section, `.env.example` entry, dashboard nav item, or default change

## Test plan

- focused usage repository/updater/background coverage: 150 passed, 1 PostgreSQL-only skip
- full unit suite: 4309 passed, 55 skipped
- Ruff check and format check
- `ty` type checking
- architecture, simplicity-budget, and diff checks
- strict OpenSpec validation and formal change verification: 1 requirement / 3 scenarios, no findings

## Screenshots / output

Not applicable: no dashboard or external API surface changes.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue above without closing it; this is partial coverage.
- [x] Added or updated regression tests.
- [x] Ran the relevant local CI gates and the full unit suite.
- [x] Strict OpenSpec validation and verification pass.
- [x] Simplicity gates reviewed.
- [x] CHANGELOG is not edited by hand.