### PR TITLE
perf(automations): bound run-history query work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ POSTGRES_PYTEST_TARGETS := \
 	tests/integration/test_migration_serialization.py::test_concurrent_upgrades_on_fresh_postgresql_database_apply_head_exactly_once \
 	tests/integration/test_migration_serialization.py::test_postgresql_run_upgrade_times_out_when_advisory_lock_is_held \
 	tests/integration/test_usage_repository.py::test_latest_by_account_primary_query_plan_uses_normalized_window_index_postgresql \
+	tests/integration/test_automations_history_queries.py \
 	tests/integration/test_repositories.py::test_accounts_upsert_with_merge_enabled_serializes_concurrent_same_email \
 	tests/integration/test_sticky_sessions_api.py::test_durable_bridge_owned_alias_registration_is_epoch_fenced \
 	tests/integration/test_proxy_api_extended.py::test_proxy_stream_usage_limit_returns_http_error \

--- a/app/modules/automations/repository.py
+++ b/app/modules/automations/repository.py
@@ -6,10 +6,11 @@ from datetime import datetime, timedelta
 from hashlib import sha1
 from uuid import uuid4
 
-from sqlalchemy import and_, case, delete, exists, func, insert, literal, or_, select, update
+from sqlalchemy import and_, case, delete, exists, func, insert, literal, or_, select, union_all, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
+from sqlalchemy.sql.selectable import CTE
 
 from app.core.config.settings import get_settings
 from app.core.utils.time import utcnow
@@ -107,8 +108,6 @@ class AutomationJobsFilterOptionsRecord:
 class AutomationRunsFilterOptionsRecord:
     account_ids: list[str]
     models: list[str]
-    statuses: list[str]
-    triggers: list[str]
 
 
 class AutomationsRepository:
@@ -1099,19 +1098,15 @@ class AutomationsRepository:
             for run, job_name, model, reasoning_effort in result.all()
         ]
 
-    async def list_run_cycles_page(
+    def _build_grouped_run_candidates(
         self,
         *,
-        limit: int,
-        offset: int,
-        now_utc: datetime,
-        search: str | None = None,
-        account_ids: Sequence[str] | None = None,
-        models: Sequence[str] | None = None,
-        statuses: Sequence[str] | None = None,
-        triggers: Sequence[str] | None = None,
-        job_ids: Sequence[str] | None = None,
-    ) -> tuple[list[AutomationRunRecord], int]:
+        search: str | None,
+        account_ids: Sequence[str] | None,
+        models: Sequence[str] | None,
+        triggers: Sequence[str] | None,
+        job_ids: Sequence[str] | None,
+    ) -> tuple[CTE, CTE]:
         conditions = self._build_run_conditions(
             search=search,
             account_ids=None,
@@ -1123,28 +1118,93 @@ class AutomationsRepository:
         filtered_runs_stmt = select(
             AutomationRun.id.label("run_id"),
             AutomationRun.cycle_key.label("cycle_key"),
-            AutomationRun.trigger.label("trigger"),
             AutomationRun.status.label("status"),
-            AutomationRun.account_id.label("account_id"),
             AutomationRun.started_at.label("started_at"),
-            AutomationRun.finished_at.label("finished_at"),
-            AutomationRun.scheduled_for.label("scheduled_for"),
-            AutomationRun.cycle_window_end.label("cycle_window_end"),
-            AutomationRun.cycle_expected_accounts.label("cycle_expected_accounts"),
-            AutomationRun.attempt_count.label("attempt_count"),
-            AutomationJob.include_paused_accounts.label("include_paused_accounts"),
         ).join(AutomationJob, AutomationJob.id == AutomationRun.job_id)
         if conditions:
             filtered_runs_stmt = filtered_runs_stmt.where(and_(*conditions))
         grouped_account_match = self._build_grouped_run_account_match(account_ids=account_ids)
         if grouped_account_match is not None:
             filtered_runs_stmt = filtered_runs_stmt.where(grouped_account_match)
-        filtered_runs = filtered_runs_stmt.subquery()
-        candidate_cycles = select(filtered_runs.c.cycle_key).distinct().subquery()
+        filtered_runs = filtered_runs_stmt.cte("filtered_automation_runs")
+        candidate_cycles = select(filtered_runs.c.cycle_key).distinct().cte("candidate_automation_run_cycles")
+        ranked_representatives = select(
+            filtered_runs.c.run_id,
+            filtered_runs.c.cycle_key,
+            filtered_runs.c.status.label("fallback_status"),
+            func.row_number()
+            .over(
+                partition_by=filtered_runs.c.cycle_key,
+                order_by=(filtered_runs.c.started_at.desc(), filtered_runs.c.run_id.desc()),
+            )
+            .label("cycle_rank"),
+        ).cte("ranked_automation_run_representatives")
+        return candidate_cycles, ranked_representatives
 
-        cycle_runs_stmt = (
+    def _build_lightweight_run_cycle_scope(
+        self,
+        *,
+        search: str | None,
+        account_ids: Sequence[str] | None,
+        models: Sequence[str] | None,
+        triggers: Sequence[str] | None,
+        job_ids: Sequence[str] | None,
+    ) -> CTE:
+        candidate_cycles, ranked_representatives = self._build_grouped_run_candidates(
+            search=search,
+            account_ids=account_ids,
+            models=models,
+            triggers=triggers,
+            job_ids=job_ids,
+        )
+        cycle_order = (
             select(
-                AutomationRun.id.label("run_id"),
+                AutomationRun.cycle_key.label("cycle_key"),
+                func.max(case((AutomationRun.trigger == "manual", 1), else_=0)).label("has_manual_trigger"),
+                func.min(case((AutomationRun.trigger == "manual", AutomationRun.scheduled_for), else_=None)).label(
+                    "manual_cycle_started_at"
+                ),
+                func.min(case((AutomationRun.trigger != "manual", AutomationRun.started_at), else_=None)).label(
+                    "non_manual_cycle_started_at"
+                ),
+            )
+            .join(candidate_cycles, candidate_cycles.c.cycle_key == AutomationRun.cycle_key)
+            .group_by(AutomationRun.cycle_key)
+            .cte("automation_run_cycle_order")
+        )
+        return (
+            select(
+                ranked_representatives.c.run_id,
+                ranked_representatives.c.cycle_key,
+                case(
+                    (cycle_order.c.has_manual_trigger == 1, cycle_order.c.manual_cycle_started_at),
+                    else_=cycle_order.c.non_manual_cycle_started_at,
+                ).label("cycle_started_at"),
+            )
+            .join(cycle_order, cycle_order.c.cycle_key == ranked_representatives.c.cycle_key)
+            .where(ranked_representatives.c.cycle_rank == 1)
+            .cte("automation_run_cycle_scope")
+        )
+
+    def _build_full_run_cycle_scope(
+        self,
+        *,
+        now_utc: datetime,
+        search: str | None,
+        account_ids: Sequence[str] | None,
+        models: Sequence[str] | None,
+        triggers: Sequence[str] | None,
+        job_ids: Sequence[str] | None,
+    ) -> CTE:
+        candidate_cycles, ranked_representatives = self._build_grouped_run_candidates(
+            search=search,
+            account_ids=account_ids,
+            models=models,
+            triggers=triggers,
+            job_ids=job_ids,
+        )
+        cycle_runs = (
+            select(
                 AutomationRun.cycle_key.label("cycle_key"),
                 AutomationRun.trigger.label("trigger"),
                 AutomationRun.status.label("status"),
@@ -1161,10 +1221,9 @@ class AutomationsRepository:
             .join(AutomationJob, AutomationJob.id == AutomationRun.job_id)
             .join(candidate_cycles, candidate_cycles.c.cycle_key == AutomationRun.cycle_key)
             .outerjoin(Account, Account.id == AutomationRun.account_id)
+            .cte("automation_runs_for_candidate_cycles")
         )
-        cycle_runs = cycle_runs_stmt.subquery()
-
-        snapshot_accounts_stmt = (
+        snapshot_accounts = (
             select(
                 AutomationRunCycleAccount.cycle_key.label("cycle_key"),
                 func.count(func.distinct(AutomationRunCycleAccount.account_id)).label("included_accounts"),
@@ -1199,21 +1258,8 @@ class AutomationsRepository:
                 )
             )
             .group_by(AutomationRunCycleAccount.cycle_key)
+            .cte("eligible_automation_run_cycle_accounts")
         )
-        snapshot_accounts = snapshot_accounts_stmt.subquery()
-
-        ranked_stmt = select(
-            filtered_runs.c.run_id,
-            filtered_runs.c.cycle_key,
-            filtered_runs.c.status.label("fallback_status"),
-            func.row_number()
-            .over(
-                partition_by=filtered_runs.c.cycle_key,
-                order_by=(filtered_runs.c.started_at.desc(), filtered_runs.c.run_id.desc()),
-            )
-            .label("cycle_rank"),
-        )
-        ranked = ranked_stmt.subquery()
 
         countable_outcome = or_(
             cycle_runs.c.account_id.is_not(None),
@@ -1244,61 +1290,61 @@ class AutomationsRepository:
             (and_(cycle_runs.c.status != "running", visible_countable_outcome), 1),
             else_=0,
         )
-
-        cycle_agg_stmt = select(
-            cycle_runs.c.cycle_key.label("cycle_key"),
-            func.max(case((cycle_runs.c.trigger == "manual", 1), else_=0)).label("has_manual_trigger"),
-            func.min(case((cycle_runs.c.trigger == "manual", cycle_runs.c.scheduled_for), else_=None)).label(
-                "manual_cycle_started_at"
-            ),
-            func.min(case((cycle_runs.c.trigger != "manual", cycle_runs.c.started_at), else_=None)).label(
-                "non_manual_cycle_started_at"
-            ),
-            func.sum(completed_countable_run).label("completed_accounts"),
-            func.sum(case((and_(visible_countable_outcome, cycle_runs.c.status == "success"), 1), else_=0)).label(
-                "success_count"
-            ),
-            func.sum(case((and_(visible_countable_outcome, cycle_runs.c.status == "failed"), 1), else_=0)).label(
-                "failed_count"
-            ),
-            func.sum(case((and_(visible_countable_outcome, cycle_runs.c.status == "partial"), 1), else_=0)).label(
-                "partial_count"
-            ),
-            func.sum(case((and_(~hidden_manual_placeholder, cycle_runs.c.status == "running"), 1), else_=0)).label(
-                "running_count"
-            ),
-            func.sum(case((visible_countable_outcome, 1), else_=0)).label("visible_accounts"),
-            func.max(func.coalesce(cycle_runs.c.cycle_expected_accounts, 0)).label("snapshot_expected_accounts"),
-            func.max(func.coalesce(cycle_runs.c.cycle_window_end, cycle_runs.c.scheduled_for)).label("window_end"),
-        ).group_by(cycle_runs.c.cycle_key)
-        cycle_agg = cycle_agg_stmt.subquery()
-
-        cycle_rows_stmt = (
+        cycle_aggregate = (
             select(
-                ranked.c.run_id,
-                ranked.c.cycle_key,
+                cycle_runs.c.cycle_key.label("cycle_key"),
+                func.max(case((cycle_runs.c.trigger == "manual", 1), else_=0)).label("has_manual_trigger"),
+                func.min(case((cycle_runs.c.trigger == "manual", cycle_runs.c.scheduled_for), else_=None)).label(
+                    "manual_cycle_started_at"
+                ),
+                func.min(case((cycle_runs.c.trigger != "manual", cycle_runs.c.started_at), else_=None)).label(
+                    "non_manual_cycle_started_at"
+                ),
+                func.sum(completed_countable_run).label("completed_accounts"),
+                func.sum(case((and_(visible_countable_outcome, cycle_runs.c.status == "success"), 1), else_=0)).label(
+                    "success_count"
+                ),
+                func.sum(case((and_(visible_countable_outcome, cycle_runs.c.status == "failed"), 1), else_=0)).label(
+                    "failed_count"
+                ),
+                func.sum(case((and_(visible_countable_outcome, cycle_runs.c.status == "partial"), 1), else_=0)).label(
+                    "partial_count"
+                ),
+                func.sum(case((and_(~hidden_manual_placeholder, cycle_runs.c.status == "running"), 1), else_=0)).label(
+                    "running_count"
+                ),
+                func.sum(case((visible_countable_outcome, 1), else_=0)).label("visible_accounts"),
+                func.max(func.coalesce(cycle_runs.c.cycle_expected_accounts, 0)).label("snapshot_expected_accounts"),
+                func.max(func.coalesce(cycle_runs.c.cycle_window_end, cycle_runs.c.scheduled_for)).label("window_end"),
+            )
+            .group_by(cycle_runs.c.cycle_key)
+            .cte("automation_run_cycle_aggregate")
+        )
+        cycle_rows = (
+            select(
+                ranked_representatives.c.run_id,
+                ranked_representatives.c.cycle_key,
                 case(
-                    (cycle_agg.c.has_manual_trigger == 1, cycle_agg.c.manual_cycle_started_at),
-                    else_=cycle_agg.c.non_manual_cycle_started_at,
+                    (cycle_aggregate.c.has_manual_trigger == 1, cycle_aggregate.c.manual_cycle_started_at),
+                    else_=cycle_aggregate.c.non_manual_cycle_started_at,
                 ).label("cycle_started_at"),
-                cycle_agg.c.has_manual_trigger,
-                ranked.c.fallback_status,
-                cycle_agg.c.completed_accounts,
-                cycle_agg.c.success_count,
-                cycle_agg.c.failed_count,
-                cycle_agg.c.partial_count,
-                cycle_agg.c.running_count,
-                cycle_agg.c.visible_accounts.label("expected_accounts"),
-                cycle_agg.c.window_end,
+                cycle_aggregate.c.has_manual_trigger,
+                ranked_representatives.c.fallback_status,
+                cycle_aggregate.c.completed_accounts,
+                cycle_aggregate.c.success_count,
+                cycle_aggregate.c.failed_count,
+                cycle_aggregate.c.partial_count,
+                cycle_aggregate.c.running_count,
+                cycle_aggregate.c.visible_accounts.label("expected_accounts"),
+                cycle_aggregate.c.window_end,
                 snapshot_accounts.c.included_accounts,
             )
-            .join(cycle_agg, cycle_agg.c.cycle_key == ranked.c.cycle_key)
-            .outerjoin(snapshot_accounts, snapshot_accounts.c.cycle_key == ranked.c.cycle_key)
-            .where(ranked.c.cycle_rank == 1)
+            .join(cycle_aggregate, cycle_aggregate.c.cycle_key == ranked_representatives.c.cycle_key)
+            .outerjoin(snapshot_accounts, snapshot_accounts.c.cycle_key == ranked_representatives.c.cycle_key)
+            .where(ranked_representatives.c.cycle_rank == 1)
+            .cte("automation_run_cycle_status_inputs")
         )
-        cycle_rows = cycle_rows_stmt.subquery()
-
-        expected_accounts_expr = case(
+        expected_accounts = case(
             (cycle_rows.c.has_manual_trigger == 1, cycle_rows.c.expected_accounts),
             (
                 func.coalesce(cycle_rows.c.included_accounts, cycle_rows.c.expected_accounts)
@@ -1307,16 +1353,15 @@ class AutomationsRepository:
             ),
             else_=cycle_rows.c.expected_accounts,
         )
-
-        effective_total_expr = case(
-            (expected_accounts_expr > cycle_rows.c.completed_accounts, expected_accounts_expr),
+        effective_total = case(
+            (expected_accounts > cycle_rows.c.completed_accounts, expected_accounts),
             else_=cycle_rows.c.completed_accounts,
         )
-        pending_expr = effective_total_expr - cycle_rows.c.completed_accounts
-        effective_status_expr = case(
+        pending = effective_total - cycle_rows.c.completed_accounts
+        effective_status = case(
             (cycle_rows.c.running_count > 0, "running"),
-            (and_(pending_expr > 0, now_utc <= cycle_rows.c.window_end), "running"),
-            (pending_expr > 0, case((cycle_rows.c.completed_accounts > 0, "partial"), else_="failed")),
+            (and_(pending > 0, now_utc <= cycle_rows.c.window_end), "running"),
+            (pending > 0, case((cycle_rows.c.completed_accounts > 0, "partial"), else_="failed")),
             (
                 and_(
                     cycle_rows.c.success_count > 0,
@@ -1343,45 +1388,95 @@ class AutomationsRepository:
             (cycle_rows.c.partial_count > 0, "partial"),
             else_=cycle_rows.c.fallback_status,
         ).label("effective_status")
-
-        cycles_with_status_stmt = select(
+        return select(
             cycle_rows.c.run_id,
             cycle_rows.c.cycle_key,
             cycle_rows.c.cycle_started_at,
-            effective_status_expr,
-        )
-        if statuses:
-            cycles_with_status_stmt = cycles_with_status_stmt.where(effective_status_expr.in_(list(statuses)))
-        cycles_with_status = cycles_with_status_stmt.subquery()
+            effective_status,
+        ).cte("automation_run_cycle_scope")
 
-        page_ids_stmt = (
-            select(cycles_with_status.c.run_id)
-            .order_by(cycles_with_status.c.cycle_started_at.desc(), cycles_with_status.c.run_id.desc())
+    async def list_run_cycles_page(
+        self,
+        *,
+        limit: int,
+        offset: int,
+        now_utc: datetime,
+        search: str | None = None,
+        account_ids: Sequence[str] | None = None,
+        models: Sequence[str] | None = None,
+        statuses: Sequence[str] | None = None,
+        triggers: Sequence[str] | None = None,
+        job_ids: Sequence[str] | None = None,
+    ) -> tuple[list[AutomationRunRecord], int]:
+        if statuses:
+            full_cycle_scope = self._build_full_run_cycle_scope(
+                now_utc=now_utc,
+                search=search,
+                account_ids=account_ids,
+                models=models,
+                triggers=triggers,
+                job_ids=job_ids,
+            )
+            cycle_scope = (
+                select(
+                    full_cycle_scope.c.run_id,
+                    full_cycle_scope.c.cycle_key,
+                    full_cycle_scope.c.cycle_started_at,
+                )
+                .where(full_cycle_scope.c.effective_status.in_(list(statuses)))
+                .cte("matching_automation_run_cycles")
+            )
+        else:
+            cycle_scope = self._build_lightweight_run_cycle_scope(
+                search=search,
+                account_ids=account_ids,
+                models=models,
+                triggers=triggers,
+                job_ids=job_ids,
+            )
+
+        page_scope = (
+            select(
+                cycle_scope.c.run_id,
+                cycle_scope.c.cycle_started_at,
+                func.count().over().label("total_count"),
+            )
+            .order_by(cycle_scope.c.cycle_started_at.desc(), cycle_scope.c.run_id.desc())
             .offset(offset)
             .limit(limit)
+            .cte("automation_run_cycle_page")
         )
-        run_ids_rows = await self._session.execute(page_ids_stmt)
-        run_ids = [value for (value,) in run_ids_rows.all() if value]
-        if not run_ids:
-            count_stmt = select(func.count()).select_from(cycles_with_status)
-            total = int((await self._session.execute(count_stmt)).scalar_one() or 0)
+        rows = (
+            await self._session.execute(
+                select(
+                    AutomationRun,
+                    AutomationJob.name,
+                    AutomationJob.model,
+                    AutomationJob.reasoning_effort,
+                    page_scope.c.total_count,
+                )
+                .join(page_scope, page_scope.c.run_id == AutomationRun.id)
+                .join(AutomationJob, AutomationJob.id == AutomationRun.job_id)
+                .order_by(page_scope.c.cycle_started_at.desc(), page_scope.c.run_id.desc())
+            )
+        ).all()
+        if rows:
+            total = int(rows[0].total_count or 0)
+            runs = [
+                self._run_from_model(
+                    run,
+                    job_name=job_name,
+                    model=model,
+                    reasoning_effort=reasoning_effort,
+                )
+                for run, job_name, model, reasoning_effort, _total_count in rows
+            ]
+            return runs, total
+
+        if offset > 0:
+            total = int((await self._session.execute(select(func.count()).select_from(cycle_scope))).scalar_one() or 0)
             return [], total
-
-        runs_stmt = (
-            select(AutomationRun, AutomationJob.name, AutomationJob.model, AutomationJob.reasoning_effort)
-            .join(AutomationJob, AutomationJob.id == AutomationRun.job_id)
-            .where(AutomationRun.id.in_(run_ids))
-        )
-        runs_rows = await self._session.execute(runs_stmt)
-        runs_by_id = {
-            run.id: self._run_from_model(run, job_name=job_name, model=model, reasoning_effort=reasoning_effort)
-            for run, job_name, model, reasoning_effort in runs_rows.all()
-        }
-        ordered_runs = [runs_by_id[run_id] for run_id in run_ids if run_id in runs_by_id]
-
-        count_stmt = select(func.count()).select_from(cycles_with_status)
-        total = int((await self._session.execute(count_stmt)).scalar_one() or 0)
-        return ordered_runs, total
+        return [], 0
 
     async def list_run_filter_options(
         self,
@@ -1395,306 +1490,70 @@ class AutomationsRepository:
         job_ids: Sequence[str] | None = None,
     ) -> AutomationRunsFilterOptionsRecord:
         if statuses:
-            conditions = self._build_run_conditions(
+            cycle_scope = self._build_full_run_cycle_scope(
+                now_utc=now_utc or utcnow(),
                 search=search,
-                account_ids=None,
+                account_ids=account_ids,
                 models=models,
-                statuses=None,
                 triggers=triggers,
                 job_ids=job_ids,
             )
-            filtered_runs_stmt = select(
-                AutomationRun.id.label("run_id"),
-                AutomationRun.cycle_key.label("cycle_key"),
-                AutomationRun.status.label("status"),
-                AutomationRun.account_id.label("account_id"),
-                AutomationRun.started_at.label("started_at"),
-                AutomationRun.finished_at.label("finished_at"),
-                AutomationRun.scheduled_for.label("scheduled_for"),
-                AutomationRun.cycle_window_end.label("cycle_window_end"),
-                AutomationRun.cycle_expected_accounts.label("cycle_expected_accounts"),
-                AutomationRun.trigger.label("trigger"),
-                AutomationRun.attempt_count.label("attempt_count"),
-                AutomationJob.include_paused_accounts.label("include_paused_accounts"),
-            ).join(AutomationJob, AutomationJob.id == AutomationRun.job_id)
-            if conditions:
-                filtered_runs_stmt = filtered_runs_stmt.where(and_(*conditions))
-            grouped_account_match = self._build_grouped_run_account_match(account_ids=account_ids)
-            if grouped_account_match is not None:
-                filtered_runs_stmt = filtered_runs_stmt.where(grouped_account_match)
-            filtered_runs = filtered_runs_stmt.subquery()
-            candidate_cycles = select(filtered_runs.c.cycle_key).distinct().subquery()
-
-            cycle_runs_stmt = (
+            matching_cycles = (
+                select(cycle_scope.c.cycle_key)
+                .where(cycle_scope.c.effective_status.in_(list(statuses)))
+                .cte("matching_automation_run_cycles")
+            )
+            facet_source = (
                 select(
-                    AutomationRun.id.label("run_id"),
-                    AutomationRun.cycle_key.label("cycle_key"),
-                    AutomationRun.status.label("status"),
                     AutomationRun.account_id.label("account_id"),
-                    AutomationRun.started_at.label("started_at"),
-                    AutomationRun.finished_at.label("finished_at"),
-                    AutomationRun.scheduled_for.label("scheduled_for"),
-                    AutomationRun.cycle_window_end.label("cycle_window_end"),
-                    AutomationRun.cycle_expected_accounts.label("cycle_expected_accounts"),
-                    AutomationRun.trigger.label("trigger"),
-                    AutomationRun.attempt_count.label("attempt_count"),
-                    AutomationJob.include_paused_accounts.label("include_paused_accounts"),
-                    Account.status.label("account_status"),
+                    func.coalesce(AutomationRun.model, AutomationJob.model).label("model"),
                 )
                 .join(AutomationJob, AutomationJob.id == AutomationRun.job_id)
-                .join(candidate_cycles, candidate_cycles.c.cycle_key == AutomationRun.cycle_key)
-                .outerjoin(Account, Account.id == AutomationRun.account_id)
-            )
-            cycle_runs = cycle_runs_stmt.subquery()
-
-            snapshot_accounts_stmt = (
-                select(
-                    AutomationRunCycleAccount.cycle_key.label("cycle_key"),
-                    func.count(func.distinct(AutomationRunCycleAccount.account_id)).label("included_accounts"),
-                )
-                .join(candidate_cycles, candidate_cycles.c.cycle_key == AutomationRunCycleAccount.cycle_key)
-                .join(AutomationRunCycle, AutomationRunCycle.cycle_key == AutomationRunCycleAccount.cycle_key)
-                .outerjoin(Account, Account.id == AutomationRunCycleAccount.account_id)
-                .outerjoin(
-                    AutomationRun,
-                    and_(
-                        AutomationRun.cycle_key == AutomationRunCycleAccount.cycle_key,
-                        or_(
-                            and_(
-                                AutomationRunCycleAccount.slot_key.is_not(None),
-                                AutomationRun.slot_key == AutomationRunCycleAccount.slot_key,
-                            ),
-                            and_(
-                                AutomationRunCycleAccount.slot_key.is_(None),
-                                AutomationRun.account_id == AutomationRunCycleAccount.account_id,
-                            ),
-                        ),
-                    ),
-                )
-                .where(
-                    or_(
-                        AutomationRun.id.is_not(None),
-                        Account.status == AccountStatus.ACTIVE,
-                        and_(
-                            Account.status == AccountStatus.PAUSED,
-                            AutomationRunCycle.include_paused_accounts.is_(True),
-                        ),
-                    )
-                )
-                .group_by(AutomationRunCycleAccount.cycle_key)
-            )
-            snapshot_accounts = snapshot_accounts_stmt.subquery()
-
-            ranked_stmt = select(
-                filtered_runs.c.run_id,
-                filtered_runs.c.cycle_key,
-                filtered_runs.c.status.label("fallback_status"),
-                func.row_number()
-                .over(
-                    partition_by=filtered_runs.c.cycle_key,
-                    order_by=(filtered_runs.c.started_at.desc(), filtered_runs.c.run_id.desc()),
-                )
-                .label("cycle_rank"),
-            )
-            ranked = ranked_stmt.subquery()
-
-            countable_outcome = or_(
-                cycle_runs.c.account_id.is_not(None),
-                cycle_runs.c.trigger == "scheduled",
-                cycle_runs.c.attempt_count > 0,
-            )
-            account_is_eligible = and_(
-                cycle_runs.c.account_id.is_not(None),
-                or_(
-                    cycle_runs.c.status != "running",
-                    cycle_runs.c.account_status == AccountStatus.ACTIVE,
-                    and_(
-                        cycle_runs.c.account_status == AccountStatus.PAUSED,
-                        cycle_runs.c.include_paused_accounts.is_(True),
-                    ),
-                ),
-            )
-            hidden_manual_placeholder = and_(
-                cycle_runs.c.trigger == "manual",
-                cycle_runs.c.status == "running",
-                cycle_runs.c.finished_at.is_(None),
-                cycle_runs.c.attempt_count == 0,
-                cycle_runs.c.started_at <= cycle_runs.c.scheduled_for,
-                ~account_is_eligible,
-            )
-            visible_countable_outcome = and_(countable_outcome, ~hidden_manual_placeholder)
-            completed_countable_run = case(
-                (and_(cycle_runs.c.status != "running", visible_countable_outcome), 1),
-                else_=0,
-            )
-
-            cycle_agg_stmt = select(
-                cycle_runs.c.cycle_key.label("cycle_key"),
-                func.max(case((cycle_runs.c.trigger == "manual", 1), else_=0)).label("has_manual_trigger"),
-                func.sum(completed_countable_run).label("completed_accounts"),
-                func.sum(case((and_(visible_countable_outcome, cycle_runs.c.status == "success"), 1), else_=0)).label(
-                    "success_count"
-                ),
-                func.sum(case((and_(visible_countable_outcome, cycle_runs.c.status == "failed"), 1), else_=0)).label(
-                    "failed_count"
-                ),
-                func.sum(case((and_(visible_countable_outcome, cycle_runs.c.status == "partial"), 1), else_=0)).label(
-                    "partial_count"
-                ),
-                func.sum(case((and_(~hidden_manual_placeholder, cycle_runs.c.status == "running"), 1), else_=0)).label(
-                    "running_count"
-                ),
-                func.sum(case((visible_countable_outcome, 1), else_=0)).label("visible_accounts"),
-                func.max(func.coalesce(cycle_runs.c.cycle_expected_accounts, 0)).label("snapshot_expected_accounts"),
-                func.max(func.coalesce(cycle_runs.c.cycle_window_end, cycle_runs.c.scheduled_for)).label("window_end"),
-            ).group_by(cycle_runs.c.cycle_key)
-            cycle_agg = cycle_agg_stmt.subquery()
-
-            cycle_rows_stmt = (
-                select(
-                    ranked.c.cycle_key,
-                    cycle_agg.c.has_manual_trigger,
-                    ranked.c.fallback_status,
-                    cycle_agg.c.completed_accounts,
-                    cycle_agg.c.success_count,
-                    cycle_agg.c.failed_count,
-                    cycle_agg.c.partial_count,
-                    cycle_agg.c.running_count,
-                    cycle_agg.c.visible_accounts.label("expected_accounts"),
-                    cycle_agg.c.window_end,
-                    snapshot_accounts.c.included_accounts,
-                )
-                .join(cycle_agg, cycle_agg.c.cycle_key == ranked.c.cycle_key)
-                .outerjoin(snapshot_accounts, snapshot_accounts.c.cycle_key == ranked.c.cycle_key)
-                .where(ranked.c.cycle_rank == 1)
-            )
-            cycle_rows = cycle_rows_stmt.subquery()
-
-            expected_accounts_expr = case(
-                (cycle_rows.c.has_manual_trigger == 1, cycle_rows.c.expected_accounts),
-                (
-                    func.coalesce(cycle_rows.c.included_accounts, cycle_rows.c.expected_accounts)
-                    > cycle_rows.c.expected_accounts,
-                    func.coalesce(cycle_rows.c.included_accounts, cycle_rows.c.expected_accounts),
-                ),
-                else_=cycle_rows.c.expected_accounts,
-            )
-            effective_total_expr = case(
-                (expected_accounts_expr > cycle_rows.c.completed_accounts, expected_accounts_expr),
-                else_=cycle_rows.c.completed_accounts,
-            )
-            pending_expr = effective_total_expr - cycle_rows.c.completed_accounts
-            now = now_utc or utcnow()
-            effective_status_expr = case(
-                (cycle_rows.c.running_count > 0, "running"),
-                (and_(pending_expr > 0, now <= cycle_rows.c.window_end), "running"),
-                (pending_expr > 0, case((cycle_rows.c.completed_accounts > 0, "partial"), else_="failed")),
-                (
-                    and_(
-                        cycle_rows.c.success_count > 0,
-                        cycle_rows.c.failed_count == 0,
-                        cycle_rows.c.partial_count == 0,
-                    ),
-                    "success",
-                ),
-                (
-                    and_(
-                        cycle_rows.c.success_count > 0,
-                        or_(cycle_rows.c.failed_count > 0, cycle_rows.c.partial_count > 0),
-                    ),
-                    "partial",
-                ),
-                (
-                    and_(
-                        cycle_rows.c.failed_count > 0,
-                        cycle_rows.c.success_count == 0,
-                        cycle_rows.c.partial_count == 0,
-                    ),
-                    "failed",
-                ),
-                (cycle_rows.c.partial_count > 0, "partial"),
-                else_=cycle_rows.c.fallback_status,
-            )
-            matching_cycles = select(cycle_rows.c.cycle_key).where(effective_status_expr.in_(list(statuses))).subquery()
-
-            account_stmt = (
-                select(AutomationRun.account_id)
-                .distinct()
                 .join(matching_cycles, matching_cycles.c.cycle_key == AutomationRun.cycle_key)
-                .where(AutomationRun.account_id.is_not(None))
-                .order_by(AutomationRun.account_id.asc())
-            )
-            model_stmt = (
-                select(func.coalesce(AutomationRun.model, AutomationJob.model))
-                .select_from(AutomationRun)
-                .distinct()
-                .join(AutomationJob, AutomationJob.id == AutomationRun.job_id)
-                .join(matching_cycles, matching_cycles.c.cycle_key == AutomationRun.cycle_key)
-                .order_by(func.coalesce(AutomationRun.model, AutomationJob.model).asc())
-            )
-            status_stmt = (
-                select(AutomationRun.status)
-                .distinct()
-                .join(matching_cycles, matching_cycles.c.cycle_key == AutomationRun.cycle_key)
-                .order_by(AutomationRun.status.asc())
-            )
-            trigger_stmt = (
-                select(AutomationRun.trigger)
-                .distinct()
-                .join(matching_cycles, matching_cycles.c.cycle_key == AutomationRun.cycle_key)
-                .order_by(AutomationRun.trigger.asc())
+                .cte("automation_run_option_source")
             )
         else:
             conditions = self._build_run_conditions(
                 search=search,
                 account_ids=account_ids,
                 models=models,
-                statuses=statuses,
+                statuses=None,
                 triggers=triggers,
                 job_ids=job_ids,
             )
-            account_stmt = (
-                select(AutomationRun.account_id)
-                .distinct()
-                .join(AutomationJob, AutomationJob.id == AutomationRun.job_id)
-                .where(AutomationRun.account_id.is_not(None))
-                .order_by(AutomationRun.account_id.asc())
-            )
-            model_stmt = (
-                select(func.coalesce(AutomationRun.model, AutomationJob.model))
-                .select_from(AutomationRun)
-                .distinct()
-                .join(AutomationJob, AutomationJob.id == AutomationRun.job_id)
-                .order_by(func.coalesce(AutomationRun.model, AutomationJob.model).asc())
-            )
-            status_stmt = (
-                select(AutomationRun.status)
-                .distinct()
-                .join(AutomationJob, AutomationJob.id == AutomationRun.job_id)
-                .order_by(AutomationRun.status.asc())
-            )
-            trigger_stmt = (
-                select(AutomationRun.trigger)
-                .distinct()
-                .join(AutomationJob, AutomationJob.id == AutomationRun.job_id)
-                .order_by(AutomationRun.trigger.asc())
-            )
+            facet_source_stmt = select(
+                AutomationRun.account_id.label("account_id"),
+                func.coalesce(AutomationRun.model, AutomationJob.model).label("model"),
+            ).join(AutomationJob, AutomationJob.id == AutomationRun.job_id)
             if conditions:
-                clause = and_(*conditions)
-                account_stmt = account_stmt.where(clause)
-                model_stmt = model_stmt.where(clause)
-                status_stmt = status_stmt.where(clause)
-                trigger_stmt = trigger_stmt.where(clause)
+                facet_source_stmt = facet_source_stmt.where(and_(*conditions))
+            facet_source = facet_source_stmt.cte("automation_run_option_source")
 
-        account_rows = await self._session.execute(account_stmt)
-        model_rows = await self._session.execute(model_stmt)
-        status_rows = await self._session.execute(status_stmt)
-        trigger_rows = await self._session.execute(trigger_stmt)
+        account_facet = (
+            select(
+                literal("account").label("facet"),
+                facet_source.c.account_id.label("value"),
+            )
+            .where(facet_source.c.account_id.is_not(None))
+            .distinct()
+        )
+        model_facet = (
+            select(
+                literal("model").label("facet"),
+                facet_source.c.model.label("value"),
+            )
+            .where(facet_source.c.model.is_not(None))
+            .distinct()
+        )
+        facets = union_all(account_facet, model_facet).subquery("automation_run_option_facets")
+        rows = (
+            await self._session.execute(
+                select(facets.c.facet, facets.c.value).order_by(facets.c.facet.asc(), facets.c.value.asc())
+            )
+        ).all()
         return AutomationRunsFilterOptionsRecord(
-            account_ids=[value for (value,) in account_rows.all() if value],
-            models=[value for (value,) in model_rows.all() if value],
-            statuses=[value for (value,) in status_rows.all() if value],
-            triggers=[value for (value,) in trigger_rows.all() if value],
+            account_ids=[value for facet, value in rows if facet == "account" and value],
+            models=[value for facet, value in rows if facet == "model" and value],
         )
 
     async def get_latest_runs_by_job_ids(self, job_ids: Sequence[str]) -> dict[str, AutomationRunRecord]:

--- a/openspec/changes/archive/2026-07-22-optimize-automation-run-history-queries/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-22-optimize-automation-run-history-queries/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/archive/2026-07-22-optimize-automation-run-history-queries/context.md
+++ b/openspec/changes/archive/2026-07-22-optimize-automation-run-history-queries/context.md
@@ -1,0 +1,53 @@
+# Automation run-history query context
+
+## Purpose
+
+The dashboard polls grouped automation history every 15 seconds and its filter options every 30 seconds. This change reduces repeated database work while keeping the public API and every established cycle-status rule unchanged.
+
+## Measured baseline
+
+The benchmark used warm-cache synthetic data representative of a busy installation: 40 jobs, 100 accounts, 10,000 cycles, 80,000 run rows, and 80,000 cycle-snapshot members.
+
+| Query | SQLite before | Query refactor | PostgreSQL 17 before | Query refactor |
+|---|---:|---:|---:|---:|
+| Page, no filters | 500 ms | 74 ms | 200 ms | 96 ms |
+| Page, account filter | 191 ms | 36 ms | 73 ms | 20 ms |
+| Page, search | 431 ms | 102 ms | 292 ms | 73 ms |
+| Options, `status=success` | 1,155 ms | not separately captured | 1,042 ms | 294 ms |
+
+For a status-filtered PostgreSQL page, the current page statement took about 280 ms and the repeated count another 247 ms. Each traversed approximately 480,000 run rows through five `automation_runs` scan nodes. Each existing option facet repeated a graph with roughly 500,000 row visits and six run scan nodes; sort/hash work spilled to temporary storage.
+
+These are controlled synthetic measurements, not production latency promises. They identify the repeated aggregation as the dominant cost and provide a reproducible scale target for regression tests.
+
+## Constraints and decisions
+
+- A candidate cycle is selected by search/model/trigger/job/account filters before whole-cycle status is derived.
+- A representative run is the latest matching run by `(started_at DESC, id DESC)`.
+- Manual cycle order uses the minimum manual `scheduled_for`; scheduled cycle order uses the first non-manual `started_at`.
+- Model matching uses the run snapshot with the job model only as the legacy fallback.
+- Grouped account filtering can match an observed run or a cycle-snapshot member.
+- Effective status remains dynamic: current eligibility, `include_paused_accounts`, pending windows, hidden manual placeholders, completed/deleted outcomes, and attempt count all matter.
+- An empty page beyond the final offset still reports the exact total.
+- Options without a status filter evaluate account/model facets directly on matching runs. With a status filter, observed runs or snapshot membership may qualify a candidate cycle, then account/model facets expand over observed runs in the status-matching cycles; snapshot-only account IDs are not synthesized into output.
+
+## Failed alternatives
+
+Three natural indexes were tested: `automation_runs(cycle_key, started_at DESC, id DESC)`, `automation_run_cycle_accounts(account_id, cycle_key)`, and `automation_runs(cycle_key, account_id)`. They improved most end-to-end queries by only 0–6% on SQLite and approximately 0% on PostgreSQL, apart from about 13% on the isolated account case. At the benchmark size they consumed roughly 11 MB and would add maintenance to every automation write.
+
+A database view does not change the plan. A materialized or denormalized summary becomes stale when time crosses a cycle window or account eligibility changes, so it requires broad dual-write, invalidation, reconciliation, migration, and backfill machinery.
+
+## Failure modes
+
+- A careless lightweight path can sort a cycle by its latest account attempt instead of the cycle's established manual/scheduled start.
+- Applying filters to all cycle rows instead of only candidate selection can rewrite effective status.
+- Loading representatives after the page query permits rows and total to come from different snapshots under concurrent scheduler writes.
+- Removing the offset fallback can report total zero for a valid history page beyond its end.
+- Combining option facets without a stable kind discriminator can mix account IDs and model names.
+
+## Concrete example
+
+Suppose a manual cycle has two attempts. A search term matches only the later attempt, while the earlier attempt supplies the cycle's original `scheduled_for`. The optimized query still chooses the later matching row as the representative, orders the cycle by the original manual start, derives status from every visible cycle member only when status filtering is requested, and returns the page row plus exact total from one statement.
+
+## Separate follow-up
+
+After page selection, `_enrich_runs_with_progress()` can issue several queries per unique cycle (roughly 100 additional selects for a page of 25 cycles). Batching that enrichment is valuable but is deliberately excluded so this PR remains one concern wide and reviewable.

--- a/openspec/changes/archive/2026-07-22-optimize-automation-run-history-queries/design.md
+++ b/openspec/changes/archive/2026-07-22-optimize-automation-run-history-queries/design.md
@@ -1,0 +1,69 @@
+## Context
+
+`AutomationsRepository.list_run_cycles_page()` currently builds the complete effective-cycle-status graph for every request, even when no status filter is present. It then executes one statement for page IDs, a second statement for representative run rows, and a third statement for the total; the page and total each repeat the same expensive aggregation.
+
+`list_run_filter_options()` duplicates that status graph and expands it into four independent facet statements. The service consumes only the account and model facets because status and trigger options come from canonical enums. Warm-cache measurements at 10,000 cycles / 80,000 runs show that repeated full-history work, rather than a missing index, dominates both SQLite and PostgreSQL.
+
+The query contract is unusually subtle: candidate-cycle filters apply before whole-cycle status calculation, manual and scheduled cycles use different ordering timestamps, account filters can match snapshot-only members, and effective status depends on current account eligibility and time. The refactor must reduce repeated work without changing those semantics or introducing backend-specific SQL.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the common no-status grouped-history page avoid dynamic eligibility/status aggregation.
+- Keep one authoritative builder for the full effective-status graph used by status-filtered pages and options.
+- Return representative rows and exact totals from one SQL snapshot for non-empty pages.
+- Reduce repository page selection from three statements to one and filter-option facets from four statements to one.
+- Preserve behavior on SQLite and PostgreSQL, including existing filter asymmetries.
+
+**Non-Goals:**
+
+- Changing API parameters, response schemas, polling cadence, or dashboard rendering.
+- Changing cycle-status, account-eligibility, representative-run, or ordering semantics.
+- Adding indexes, schema columns, cached summaries, database views, or migrations.
+- Batching `_enrich_runs_with_progress()`; that independent per-cycle enrichment hot path remains a separate follow-up.
+- Unifying the historical account-facet semantics between requests with and without a status filter.
+
+## Decisions
+
+### Split lightweight cycle selection from dynamic status calculation
+
+When `statuses` is empty, build only the filtered-run scope, distinct candidate cycles, representative-run ranking, and the minimum cycle aggregation required for correct ordering. The lightweight path does not join current account state or compute pending/visible outcome counts.
+
+When `statuses` is present, use the existing full eligibility and effective-status calculation. Extract that graph into a private builder shared by page and options code so hidden manual placeholders, pending windows, deleted/completed accounts, and paused-account policy cannot drift between endpoints.
+
+Keeping the current full graph for status-filtered requests was chosen over persisting status because effective status changes with wall-clock time and account state even when no automation row is written.
+
+### Select page rows and total together
+
+Use `COUNT(*) OVER ()` on the ordered cycle scope and join the representative `AutomationRun` plus job metadata in the same statement. A non-empty result therefore carries one exact total from the same database snapshot as its rows.
+
+An offset beyond the final row has no window result from which to read the total. In that uncommon case, execute one count statement over the same cycle scope. Returning an incorrect zero or changing the public offset contract was rejected.
+
+### Load only consumed option facets in one portable statement
+
+Build account and model facet selects over the matching run/cycle scope, tag them with a literal facet kind, and combine them with `UNION ALL`. Execute the combined statement once and group values in Python. Status and trigger options remain the service's canonical complete enums; querying distinct stored values for them is redundant and can hide valid choices when history is sparse.
+
+Without a status filter, account filters and both facets are evaluated directly on matching `AutomationRun` rows. With a status filter, either an observed run or snapshot membership may qualify a candidate cycle; effective status is computed over the whole cycle, and account/model facets are then expanded from observed `AutomationRun` rows in matching cycles. Snapshot-only account IDs qualify candidates but are not synthesized into facet output. Unifying that asymmetry would be an observable behavior change and is outside this performance PR.
+
+### Do not add speculative indexes or denormalized summaries
+
+Trials of `(cycle_key, started_at DESC, id DESC)`, `(account_id, cycle_key)`, and `(cycle_key, account_id)` indexes improved representative benchmarks by 0–6% in most cases while adding about 11 MB at 80,000 rows and increasing write amplification. They do not eliminate repeated full-history aggregation.
+
+A persisted cycle summary would need backfill and invalidation for time passage, account pause/reactivation/rate-limit/deletion, placeholder hiding, snapshot membership changes, and claim reclamation. That risk is disproportionate when a query-only change removes the dominant work.
+
+## Risks / Trade-offs
+
+- [Risk] The lightweight and full scopes return different representatives or ordering. -> Share candidate-cycle and representative-run primitives and add characterization tests for manual/scheduled ordering, ties, search, model snapshots, account membership, and all filter dimensions.
+- [Risk] A window count is unavailable for an offset beyond the last page. -> Use one explicit count fallback only when the page statement returns no row.
+- [Risk] SQL accepted by SQLite behaves differently on PostgreSQL. -> Use SQLAlchemy Core constructs supported by both and run the same API/query-count suite against both backends.
+- [Risk] Refactoring the duplicated status graph changes hidden-placeholder or eligibility semantics. -> Move the existing expressions without simplifying them and retain the full status regression matrix.
+- [Risk] Query-count assertions become brittle. -> Ratchet only the repository statements this change owns; exclude later progress enrichment from the count contract.
+
+## Migration Plan
+
+No data or schema migration is required. Deploy the query refactor with the application. Rollback restores the previous repository implementation and reads the same tables without compatibility work.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-07-22-optimize-automation-run-history-queries/proposal.md
+++ b/openspec/changes/archive/2026-07-22-optimize-automation-run-history-queries/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Grouped automation run history repeatedly aggregates the full matching history before pagination, then repeats substantially the same work for totals and filter options. At 10,000 cycles / 80,000 runs this costs hundreds of milliseconds per poll on both SQLite and PostgreSQL even though the common unfiltered page does not need dynamic cycle-status computation.
+
+## What Changes
+
+- Use a lightweight grouped-history query when no effective-status filter is requested, while preserving cycle selection, representative-run, ordering, and pagination semantics.
+- Keep the full dynamic eligibility/status calculation for status-filtered requests, but centralize it so page and options queries cannot diverge.
+- Return page rows and their exact total from one database snapshot; retain a bounded count fallback only when an offset is beyond the final page.
+- Load the representative run in the page statement instead of issuing a second run lookup.
+- Load only the account and model option facets consumed by the service, using one portable query rather than four repeated aggregations.
+- Add SQLite and PostgreSQL regression coverage for semantics and query counts, plus representative large-history benchmark and query-plan evidence.
+- Add no schema, migration, setting, dependency, or API-shape change.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `automations`: require grouped run-history pages and filter options to preserve the existing dynamic cycle semantics while producing snapshot-consistent results with bounded database round trips.
+
+## Impact
+
+- Affected code: `app/modules/automations/repository.py` and the narrow service/options mapping if needed.
+- Affected tests: automation API integration coverage on SQLite and PostgreSQL, plus query-count ratchets and benchmark/query-plan evidence.
+- API request parameters and response schemas remain unchanged.
+- Database models and the Alembic graph remain unchanged; no backfill or downgrade is required.

--- a/openspec/changes/archive/2026-07-22-optimize-automation-run-history-queries/specs/automations/spec.md
+++ b/openspec/changes/archive/2026-07-22-optimize-automation-run-history-queries/specs/automations/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Grouped run-history selection is bounded and snapshot-consistent
+
+The grouped automation run-history repository MUST preserve existing candidate-cycle filtering, representative-run selection, cycle ordering, effective-status calculation, and filter-option semantics on SQLite and PostgreSQL while bounding repeated database work. For a non-empty grouped page, page selection, representative-run loading, and exact total calculation MUST use one database statement so rows and total come from one statement snapshot. When an offset is beyond the final row, the repository MAY execute one additional count statement to preserve the exact-total contract. Account and model filter-option facets MUST be loaded with no more than one database statement; status and trigger options MUST continue to come from their canonical complete enums.
+
+#### Scenario: Common page skips dynamic status aggregation
+
+- **WHEN** grouped run history is requested without an effective-status filter
+- **THEN** candidate cycles and their representatives are selected without computing current account eligibility or effective cycle status
+- **AND** search, account, model, trigger, and job filters retain their existing candidate-cycle semantics
+- **AND** manual and scheduled cycles retain their existing ordering rules
+
+#### Scenario: Status-filtered page keeps dynamic cycle semantics
+
+- **GIVEN** cycle status depends on visible accounts, current eligibility, paused-account policy, pending-window time, completed outcomes, or hidden manual placeholders
+- **WHEN** grouped run history is filtered by effective status
+- **THEN** the page uses the full dynamic status calculation over each selected candidate cycle
+- **AND** the returned cycles match the same effective statuses as before the query refactor
+
+#### Scenario: Non-empty page rows and total share one snapshot
+
+- **WHEN** a grouped run-history offset returns at least one cycle
+- **THEN** representative run rows and the exact matching total are returned by one repository database statement
+- **AND** the total describes the same statement snapshot as the returned rows
+
+#### Scenario: Offset beyond the final page keeps exact total
+
+- **GIVEN** matching cycle history exists
+- **WHEN** the requested offset is beyond the final matching cycle
+- **THEN** the response contains no items
+- **AND** it reports the exact non-zero total using at most one bounded count fallback
+
+#### Scenario: Representative and ordering semantics survive filtering
+
+- **GIVEN** a cycle contains multiple attempts and only a subset matches the request filters
+- **WHEN** the grouped page is selected
+- **THEN** the representative is the latest matching run by `started_at` and `id`
+- **AND** the cycle order is derived from the complete cycle's established manual or scheduled start rule
+- **AND** model filtering uses the execution snapshot rather than a job's later model value
+
+#### Scenario: Filter options use one facet query
+
+- **WHEN** automation run filter options are requested with any supported filter combination
+- **THEN** account and model facets are loaded in no more than one repository database statement
+- **AND** status and trigger choices remain the canonical complete sets even when stored history is sparse
+- **AND** without an effective-status filter, account and model facets are derived directly from matching run rows
+- **AND** with an effective-status filter, observed runs or snapshot membership may qualify a cycle before account and model facets expand over all observed run rows in status-matching cycles
+- **AND** snapshot-only account IDs are not synthesized into the returned account facet

--- a/openspec/changes/archive/2026-07-22-optimize-automation-run-history-queries/tasks.md
+++ b/openspec/changes/archive/2026-07-22-optimize-automation-run-history-queries/tasks.md
@@ -1,0 +1,26 @@
+## 1. Characterize the existing contract
+
+- [x] 1.1 Add focused regression coverage for candidate-cycle filters, representative selection, manual/scheduled ordering, model snapshots, account snapshot membership, dynamic statuses, and empty offsets.
+- [x] 1.2 Add repository query-count capture that distinguishes grouped page selection and filter-option facets from later progress enrichment.
+
+## 2. Consolidate grouped page selection
+
+- [x] 2.1 Extract shared candidate-cycle and representative-run query primitives without changing filter semantics.
+- [x] 2.2 Add the lightweight no-status cycle scope and keep the existing eligibility/effective-status expressions in one reusable full-status scope.
+- [x] 2.3 Return representative run rows and `COUNT(*) OVER ()` totals in one page statement, with one exact-count fallback only for an empty out-of-range offset.
+
+## 3. Consolidate filter options
+
+- [x] 3.1 Narrow the repository option record to the account and model facets consumed by the service while retaining canonical service-level status and trigger choices.
+- [x] 3.2 Combine account and model facet selection into one portable tagged query and preserve the existing status/no-status account semantics.
+
+## 4. Cross-backend regression and performance evidence
+
+- [x] 4.1 Prove SQLite semantics and ratchet a non-empty grouped page to one selection statement, an out-of-range page to at most two, and option facets to one.
+- [x] 4.2 Run the same semantic and query-count coverage on PostgreSQL, wire the focused contract tests into `POSTGRES_PYTEST_TARGETS`, and capture representative before/after query-plan or benchmark evidence.
+
+## 5. Verification
+
+- [x] 5.1 Run focused automation repository/API tests and the appropriate broader unit/integration suites.
+- [x] 5.2 Run Ruff format/check, `ty`, architecture, simplicity, diff checks, and strict OpenSpec validation.
+- [x] 5.3 Formally verify every requirement/scenario against implementation evidence and perform an adversarial standalone-diff review.

--- a/openspec/specs/automations/spec.md
+++ b/openspec/specs/automations/spec.md
@@ -207,6 +207,54 @@ The system MUST persist run history rows and expose them via dashboard APIs so o
 - **THEN** the status filter uses the cycle status computed from visible per-account rows
 - **AND** it does not match the cycle as running because of the hidden placeholder
 
+### Requirement: Grouped run-history selection is bounded and snapshot-consistent
+
+The grouped automation run-history repository MUST preserve existing candidate-cycle filtering, representative-run selection, cycle ordering, effective-status calculation, and filter-option semantics on SQLite and PostgreSQL while bounding repeated database work. For a non-empty grouped page, page selection, representative-run loading, and exact total calculation MUST use one database statement so rows and total come from one statement snapshot. When an offset is beyond the final row, the repository MAY execute one additional count statement to preserve the exact-total contract. Account and model filter-option facets MUST be loaded with no more than one database statement; status and trigger options MUST continue to come from their canonical complete enums.
+
+#### Scenario: Common page skips dynamic status aggregation
+
+- **WHEN** grouped run history is requested without an effective-status filter
+- **THEN** candidate cycles and their representatives are selected without computing current account eligibility or effective cycle status
+- **AND** search, account, model, trigger, and job filters retain their existing candidate-cycle semantics
+- **AND** manual and scheduled cycles retain their existing ordering rules
+
+#### Scenario: Status-filtered page keeps dynamic cycle semantics
+
+- **GIVEN** cycle status depends on visible accounts, current eligibility, paused-account policy, pending-window time, completed outcomes, or hidden manual placeholders
+- **WHEN** grouped run history is filtered by effective status
+- **THEN** the page uses the full dynamic status calculation over each selected candidate cycle
+- **AND** the returned cycles match the same effective statuses as before the query refactor
+
+#### Scenario: Non-empty page rows and total share one snapshot
+
+- **WHEN** a grouped run-history offset returns at least one cycle
+- **THEN** representative run rows and the exact matching total are returned by one repository database statement
+- **AND** the total describes the same statement snapshot as the returned rows
+
+#### Scenario: Offset beyond the final page keeps exact total
+
+- **GIVEN** matching cycle history exists
+- **WHEN** the requested offset is beyond the final matching cycle
+- **THEN** the response contains no items
+- **AND** it reports the exact non-zero total using at most one bounded count fallback
+
+#### Scenario: Representative and ordering semantics survive filtering
+
+- **GIVEN** a cycle contains multiple attempts and only a subset matches the request filters
+- **WHEN** the grouped page is selected
+- **THEN** the representative is the latest matching run by `started_at` and `id`
+- **AND** the cycle order is derived from the complete cycle's established manual or scheduled start rule
+- **AND** model filtering uses the execution snapshot rather than a job's later model value
+
+#### Scenario: Filter options use one facet query
+
+- **WHEN** automation run filter options are requested with any supported filter combination
+- **THEN** account and model facets are loaded in no more than one repository database statement
+- **AND** status and trigger choices remain the canonical complete sets even when stored history is sparse
+- **AND** without an effective-status filter, account and model facets are derived directly from matching run rows
+- **AND** with an effective-status filter, observed runs or snapshot membership may qualify a cycle before account and model facets expand over all observed run rows in status-matching cycles
+- **AND** snapshot-only account IDs are not synthesized into the returned account facet
+
 ### Requirement: Automation pings do not mutate durable user continuity
 
 Automation ping execution MUST avoid creating or mutating durable sticky-thread/codex-session continuity used by end-user traffic.
@@ -215,4 +263,3 @@ Automation ping execution MUST avoid creating or mutating durable sticky-thread/
 
 - **WHEN** an automation ping run is executed
 - **THEN** existing durable sticky-thread/codex-session mappings for user conversations remain unchanged
-

--- a/tests/integration/test_automations_history_queries.py
+++ b/tests/integration/test_automations_history_queries.py
@@ -1,0 +1,526 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import event, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import (
+    Account,
+    AccountStatus,
+    AutomationJob,
+    AutomationRun,
+    AutomationRunCycle,
+    AutomationRunCycleAccount,
+)
+from app.db.session import SessionLocal, engine
+from app.modules.automations.repository import AutomationsRepository
+
+pytestmark = pytest.mark.integration
+
+
+@dataclass(frozen=True, slots=True)
+class _HistorySeed:
+    now: datetime
+    job_id: str
+    manual_cycle_key: str
+    manual_representative_id: str
+    scheduled_cycle_keys: tuple[str, str]
+    snapshot_only_account_id: str
+    observed_account_ids: tuple[str, str]
+
+
+@contextmanager
+def _capture_select_statements() -> Iterator[list[str]]:
+    statements: list[str] = []
+
+    def _before_cursor_execute(
+        _connection,
+        _cursor,
+        statement: str,
+        _parameters,
+        _context,
+        _executemany: bool,
+    ) -> None:
+        if statement.lstrip().upper().startswith(("SELECT", "WITH")):
+            statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", _before_cursor_execute)
+    try:
+        yield statements
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _before_cursor_execute)
+
+
+async def _seed_history() -> _HistorySeed:
+    base = datetime(2026, 6, 1, 10, 0, 0)
+    now = base + timedelta(days=1)
+    account_a = "history-query-a"
+    account_b = "history-query-b"
+    snapshot_only = "history-query-snapshot-only"
+    job_id = "history-query-job"
+    manual_cycle = f"manual:{job_id}:manual-cycle"
+    scheduled_early = f"scheduled:{job_id}:2026-06-01T10:10:00"
+    scheduled_later = f"scheduled:{job_id}:2026-06-01T10:20:00"
+
+    accounts = [
+        Account(
+            id=account_id,
+            chatgpt_account_id=f"chatgpt-{account_id}",
+            email=f"{account_id}@example.com",
+            plan_type="plus",
+            access_token_encrypted=b"access",
+            refresh_token_encrypted=b"refresh",
+            id_token_encrypted=b"id",
+            last_refresh=base,
+            status=status,
+            deactivation_reason=None,
+        )
+        for account_id, status in (
+            (account_a, AccountStatus.ACTIVE),
+            (account_b, AccountStatus.ACTIVE),
+            (snapshot_only, AccountStatus.RATE_LIMITED),
+        )
+    ]
+    job = AutomationJob(
+        id=job_id,
+        name="History query contract",
+        enabled=False,
+        schedule_type="daily",
+        schedule_time="05:00",
+        schedule_timezone="UTC",
+        schedule_days="mon,tue,wed,thu,fri,sat,sun",
+        schedule_threshold_minutes=0,
+        include_paused_accounts=False,
+        account_scope_all=False,
+        model="model-v2",
+        reasoning_effort=None,
+        prompt="current prompt",
+        created_at=base,
+        updated_at=now,
+    )
+    cycles = [
+        AutomationRunCycle(
+            cycle_key=manual_cycle,
+            job_id=job_id,
+            trigger="manual",
+            cycle_expected_accounts=3,
+            cycle_window_end=base + timedelta(minutes=5),
+            include_paused_accounts=False,
+            created_at=base,
+        ),
+        AutomationRunCycle(
+            cycle_key=scheduled_early,
+            job_id=job_id,
+            trigger="scheduled",
+            cycle_expected_accounts=2,
+            cycle_window_end=base + timedelta(minutes=15),
+            include_paused_accounts=False,
+            created_at=base + timedelta(minutes=10),
+        ),
+        AutomationRunCycle(
+            cycle_key=scheduled_later,
+            job_id=job_id,
+            trigger="scheduled",
+            cycle_expected_accounts=1,
+            cycle_window_end=base + timedelta(minutes=25),
+            include_paused_accounts=False,
+            created_at=base + timedelta(minutes=20),
+        ),
+    ]
+    cycle_accounts = [
+        AutomationRunCycleAccount(
+            cycle_key=manual_cycle,
+            account_id=account_id,
+            slot_key=None,
+            position=position,
+            scheduled_for=base,
+        )
+        for position, account_id in enumerate((account_a, account_b, snapshot_only))
+    ]
+    cycle_accounts.extend(
+        [
+            AutomationRunCycleAccount(
+                cycle_key=scheduled_early,
+                account_id=account_a,
+                slot_key="scheduled-early-a",
+                position=0,
+                scheduled_for=base + timedelta(minutes=10),
+            ),
+            AutomationRunCycleAccount(
+                cycle_key=scheduled_early,
+                account_id=account_b,
+                slot_key="scheduled-early-b",
+                position=1,
+                scheduled_for=base + timedelta(minutes=11),
+            ),
+            AutomationRunCycleAccount(
+                cycle_key=scheduled_later,
+                account_id=account_a,
+                slot_key="scheduled-later-a",
+                position=0,
+                scheduled_for=base + timedelta(minutes=20),
+            ),
+        ]
+    )
+    runs = [
+        AutomationRun(
+            id="manual-a-success",
+            job_id=job_id,
+            trigger="manual",
+            slot_key="manual-success-slot",
+            cycle_key=manual_cycle,
+            cycle_expected_accounts=3,
+            cycle_window_end=base + timedelta(minutes=5),
+            model="z-model",
+            reasoning_effort="high",
+            prompt="snapshot prompt",
+            scheduled_for=base,
+            started_at=base + timedelta(minutes=60),
+            finished_at=base + timedelta(minutes=60, seconds=1),
+            status="success",
+            account_id=account_a,
+            error_code=None,
+            error_message=None,
+            attempt_count=1,
+        ),
+        AutomationRun(
+            id="manual-failed-latest",
+            job_id=job_id,
+            trigger="manual",
+            slot_key="manual-failed-slot",
+            cycle_key=manual_cycle,
+            cycle_expected_accounts=3,
+            cycle_window_end=base + timedelta(minutes=5),
+            model="a-model",
+            reasoning_effort="medium",
+            prompt="snapshot prompt",
+            scheduled_for=base + timedelta(seconds=10),
+            started_at=base + timedelta(minutes=60),
+            finished_at=base + timedelta(minutes=60, seconds=2),
+            status="failed",
+            account_id=account_b,
+            error_code="needle-error",
+            error_message="needle failure",
+            attempt_count=1,
+        ),
+        AutomationRun(
+            id="scheduled-early-first",
+            job_id=job_id,
+            trigger="scheduled",
+            slot_key="scheduled-early-a",
+            cycle_key=scheduled_early,
+            cycle_expected_accounts=2,
+            cycle_window_end=base + timedelta(minutes=15),
+            model="model-v1",
+            reasoning_effort=None,
+            prompt="snapshot prompt",
+            scheduled_for=base + timedelta(minutes=10),
+            started_at=base + timedelta(minutes=10),
+            finished_at=base + timedelta(minutes=10, seconds=5),
+            status="success",
+            account_id=account_a,
+            error_code=None,
+            error_message=None,
+            attempt_count=1,
+        ),
+        AutomationRun(
+            id="scheduled-early-late-attempt",
+            job_id=job_id,
+            trigger="scheduled",
+            slot_key="scheduled-early-b",
+            cycle_key=scheduled_early,
+            cycle_expected_accounts=2,
+            cycle_window_end=base + timedelta(minutes=15),
+            model="model-v1",
+            reasoning_effort=None,
+            prompt="snapshot prompt",
+            scheduled_for=base + timedelta(minutes=11),
+            started_at=base + timedelta(minutes=50),
+            finished_at=base + timedelta(minutes=50, seconds=5),
+            status="success",
+            account_id=account_b,
+            error_code=None,
+            error_message=None,
+            attempt_count=1,
+        ),
+        AutomationRun(
+            id="scheduled-later",
+            job_id=job_id,
+            trigger="scheduled",
+            slot_key="scheduled-later-a",
+            cycle_key=scheduled_later,
+            cycle_expected_accounts=1,
+            cycle_window_end=base + timedelta(minutes=25),
+            model="model-v1",
+            reasoning_effort=None,
+            prompt="snapshot prompt",
+            scheduled_for=base + timedelta(minutes=20),
+            started_at=base + timedelta(minutes=20),
+            finished_at=base + timedelta(minutes=20, seconds=5),
+            status="failed",
+            account_id=account_a,
+            error_code="later-error",
+            error_message="later failure",
+            attempt_count=1,
+        ),
+    ]
+
+    async with SessionLocal() as session:
+        session.add_all([*accounts, job, *cycles, *cycle_accounts, *runs])
+        await session.commit()
+
+    return _HistorySeed(
+        now=now,
+        job_id=job_id,
+        manual_cycle_key=manual_cycle,
+        manual_representative_id="manual-failed-latest",
+        scheduled_cycle_keys=(scheduled_early, scheduled_later),
+        snapshot_only_account_id=snapshot_only,
+        observed_account_ids=(account_a, account_b),
+    )
+
+
+async def _seed_paused_policy_cycles(session: AsyncSession, seed: _HistorySeed) -> tuple[str, str]:
+    await session.execute(
+        update(Account).where(Account.id == seed.snapshot_only_account_id).values(status=AccountStatus.PAUSED)
+    )
+    due_times = (seed.now - timedelta(hours=2), seed.now - timedelta(hours=1))
+    cycle_keys = tuple(f"scheduled:{seed.job_id}:{due.isoformat()}" for due in due_times)
+    rows: list[AutomationRunCycle | AutomationRunCycleAccount | AutomationRun] = []
+    for position, (cycle_key, due, include_paused, model) in enumerate(
+        zip(
+            cycle_keys,
+            due_times,
+            (False, True),
+            ("paused-excluded-model", "paused-included-model"),
+            strict=True,
+        )
+    ):
+        active_slot = f"paused-policy-{position}-active"
+        paused_slot = f"paused-policy-{position}-paused"
+        rows.extend(
+            [
+                AutomationRunCycle(
+                    cycle_key=cycle_key,
+                    job_id=seed.job_id,
+                    trigger="scheduled",
+                    cycle_expected_accounts=2,
+                    cycle_window_end=due + timedelta(minutes=5),
+                    include_paused_accounts=include_paused,
+                    created_at=due,
+                ),
+                AutomationRunCycleAccount(
+                    cycle_key=cycle_key,
+                    account_id=seed.observed_account_ids[0],
+                    slot_key=active_slot,
+                    position=0,
+                    scheduled_for=due,
+                ),
+                AutomationRunCycleAccount(
+                    cycle_key=cycle_key,
+                    account_id=seed.snapshot_only_account_id,
+                    slot_key=paused_slot,
+                    position=1,
+                    scheduled_for=due + timedelta(minutes=1),
+                ),
+                AutomationRun(
+                    id=f"paused-policy-{position}-success",
+                    job_id=seed.job_id,
+                    trigger="scheduled",
+                    slot_key=active_slot,
+                    cycle_key=cycle_key,
+                    cycle_expected_accounts=2,
+                    cycle_window_end=due + timedelta(minutes=5),
+                    model=model,
+                    reasoning_effort=None,
+                    prompt="paused policy snapshot",
+                    scheduled_for=due,
+                    started_at=due,
+                    finished_at=due + timedelta(seconds=5),
+                    status="success",
+                    account_id=seed.observed_account_ids[0],
+                    error_code=None,
+                    error_message=None,
+                    attempt_count=1,
+                ),
+            ]
+        )
+    session.add_all(rows)
+    await session.commit()
+    return cycle_keys[0], cycle_keys[1]
+
+
+@pytest.mark.asyncio
+async def test_grouped_history_preserves_filters_order_and_bounded_page_queries(db_setup):
+    del db_setup
+    seed = await _seed_history()
+
+    async with SessionLocal() as session:
+        repository = AutomationsRepository(session)
+        with _capture_select_statements() as statements:
+            rows, total = await repository.list_run_cycles_page(
+                limit=25,
+                offset=0,
+                now_utc=seed.now,
+            )
+
+        assert len(statements) == 1
+        assert total == 3
+        assert [row.cycle_key for row in rows] == [
+            seed.scheduled_cycle_keys[1],
+            seed.scheduled_cycle_keys[0],
+            seed.manual_cycle_key,
+        ]
+        assert rows[1].id == "scheduled-early-late-attempt"
+        assert rows[2].id == seed.manual_representative_id
+        assert not re.search(r"\b(?:FROM|JOIN) accounts\b", statements[0], flags=re.IGNORECASE)
+        assert "automation_run_cycle_accounts" not in statements[0].lower()
+
+        with _capture_select_statements() as statements:
+            empty_rows, empty_total = await repository.list_run_cycles_page(
+                limit=25,
+                offset=100,
+                now_utc=seed.now,
+            )
+        assert empty_rows == []
+        assert empty_total == 3
+        assert len(statements) == 2
+
+        search_rows, search_total = await repository.list_run_cycles_page(
+            limit=25,
+            offset=0,
+            now_utc=seed.now,
+            search="needle",
+        )
+        assert search_total == 1
+        assert [row.id for row in search_rows] == [seed.manual_representative_id]
+
+        account_rows, account_total = await repository.list_run_cycles_page(
+            limit=25,
+            offset=0,
+            now_utc=seed.now,
+            account_ids=[seed.snapshot_only_account_id],
+        )
+        assert account_total == 1
+        assert [row.cycle_key for row in account_rows] == [seed.manual_cycle_key]
+        assert account_rows[0].id == seed.manual_representative_id
+
+        snapshot_rows, snapshot_total = await repository.list_run_cycles_page(
+            limit=25,
+            offset=0,
+            now_utc=seed.now,
+            models=["model-v1"],
+        )
+        assert snapshot_total == 2
+        assert {row.cycle_key for row in snapshot_rows} == set(seed.scheduled_cycle_keys)
+
+        current_model_rows, current_model_total = await repository.list_run_cycles_page(
+            limit=25,
+            offset=0,
+            now_utc=seed.now,
+            models=["model-v2"],
+        )
+        assert current_model_rows == []
+        assert current_model_total == 0
+
+        scheduled_rows, scheduled_total = await repository.list_run_cycles_page(
+            limit=25,
+            offset=0,
+            now_utc=seed.now,
+            triggers=["scheduled"],
+            job_ids=["history-query-job"],
+        )
+        assert scheduled_total == 2
+        assert {row.cycle_key for row in scheduled_rows} == set(seed.scheduled_cycle_keys)
+
+        missing_rows, missing_total = await repository.list_run_cycles_page(
+            limit=25,
+            offset=0,
+            now_utc=seed.now,
+            job_ids=["missing-job"],
+        )
+        assert missing_rows == []
+        assert missing_total == 0
+
+        with _capture_select_statements() as statements:
+            partial_rows, partial_total = await repository.list_run_cycles_page(
+                limit=25,
+                offset=0,
+                now_utc=seed.now,
+                search="needle",
+                statuses=["partial"],
+            )
+        assert len(statements) == 1
+        assert partial_total == 1
+        assert [row.cycle_key for row in partial_rows] == [seed.manual_cycle_key]
+
+        paused_excluded_cycle, paused_included_cycle = await _seed_paused_policy_cycles(session, seed)
+        excluded_rows, excluded_total = await repository.list_run_cycles_page(
+            limit=25,
+            offset=0,
+            now_utc=seed.now,
+            models=["paused-excluded-model"],
+            statuses=["success"],
+        )
+        assert excluded_total == 1
+        assert [row.cycle_key for row in excluded_rows] == [paused_excluded_cycle]
+
+        included_rows, included_total = await repository.list_run_cycles_page(
+            limit=25,
+            offset=0,
+            now_utc=seed.now,
+            models=["paused-included-model"],
+            statuses=["partial"],
+        )
+        assert included_total == 1
+        assert [row.cycle_key for row in included_rows] == [paused_included_cycle]
+
+
+@pytest.mark.asyncio
+async def test_history_option_facets_preserve_status_snapshot_asymmetry_in_one_query(db_setup):
+    del db_setup
+    seed = await _seed_history()
+
+    async with SessionLocal() as session:
+        repository = AutomationsRepository(session)
+        with _capture_select_statements() as statements:
+            direct_options = await repository.list_run_filter_options(
+                now_utc=seed.now,
+                account_ids=[seed.snapshot_only_account_id],
+            )
+        assert len(statements) == 1
+        assert direct_options.account_ids == []
+        assert direct_options.models == []
+
+        with _capture_select_statements() as statements:
+            status_options = await repository.list_run_filter_options(
+                now_utc=seed.now,
+                account_ids=[seed.snapshot_only_account_id],
+                statuses=["partial"],
+            )
+        assert len(statements) == 1
+        assert status_options.account_ids == sorted(seed.observed_account_ids)
+        assert seed.snapshot_only_account_id not in status_options.account_ids
+        assert status_options.models == ["a-model", "z-model"]
+
+
+@pytest.mark.asyncio
+async def test_history_options_keep_canonical_statuses_and_triggers_with_sparse_history(db_setup, async_client):
+    del db_setup
+    seed = await _seed_history()
+    response = await async_client.get(
+        "/api/automations/runs/options",
+        params={"accountId": seed.snapshot_only_account_id, "status": "partial"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["accountIds"] == sorted(seed.observed_account_ids)
+    assert payload["models"] == ["a-model", "z-model"]
+    assert payload["statuses"] == ["running", "success", "failed", "partial"]
+    assert payload["triggers"] == ["scheduled", "manual"]


### PR DESCRIPTION
## Summary

Bound the repeated SQL work behind grouped automation run history without changing API shape or cycle semantics. The common no-status page now skips dynamic account eligibility aggregation, non-empty pages return representatives plus exact totals in one statement, and account/model options use one tagged facet query.

This PR is self-contained and does not depend on another PR.

## Type of change

- [x] `perf:` — performance improvement with no API contract change
- [ ] **Breaking change**

Linked issue: None — proactive performance hardening.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path

Change directory: `openspec/changes/archive/2026-07-22-optimize-automation-run-history-queries/`

## Changes

- Share candidate-cycle and representative-run primitives between lightweight and full-status query scopes.
- Select representative run rows and `COUNT(*) OVER ()` totals in one statement; use one exact-count fallback only for an empty out-of-range offset.
- Replace four option-facet statements with one portable tagged `UNION ALL` query while preserving status/no-status account semantics and database collation order.
- Add SQLite/PostgreSQL contract tests for query counts, filters, snapshot membership, model snapshots, ordering, paused policy, canonical enums, and whole-cycle status.
- Add the focused contract suite to the required PostgreSQL CI target and archive the verified OpenSpec change.

## Simplicity

- [x] Works with zero config and adds no setting or setup step.
- [x] Adds no README section, `.env.example` entry, or dashboard navigation item.
- [x] Adds no migration, dependency, schema field, cache, or denormalized state.

## Test plan

```text
pytest tests/integration/test_automations_history_queries.py tests/integration/test_automations_api.py
89 passed

CODEX_LB_TEST_DATABASE_URL=postgresql+asyncpg://... pytest tests/integration/test_automations_history_queries.py
3 passed on PostgreSQL 16

pytest tests/unit
4294 passed, 55 skipped; the one sandbox-blocked loopback smoke test passed when rerun with loopback access

ruff check .
ruff format --check .
ty check
python scripts/check_proxy_architecture.py
python .github/scripts/check_simplicity_budgets.py
openspec validate --all --strict
82 passed, 0 failed after rebase onto current upstream/main
```

Formal OpenSpec verification: 0 critical, 0 warnings, 0 suggestions.

## Screenshots / output

Not applicable; no dashboard-visible or public API-shape change.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] No issue is claimed or closed by this proactive improvement.
- [x] Added tests covering the change on SQLite and PostgreSQL.
- [x] Ran the relevant local CI subsets.
- [x] `openspec validate --specs` passes and formal verification is clean.
- [x] Simplicity gates reviewed against PRINCIPLES.md P1-P5.
- [x] CHANGELOG was not edited.
