### PR TITLE
feat(ui): header brand back to /dashboard on click

### DIFF
--- a/frontend/src/components/layout/app-header.tsx
+++ b/frontend/src/components/layout/app-header.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ChevronDown, Eye, EyeOff, LogIn, LogOut, Menu } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { NavLink, useLocation } from "react-router-dom";
+import { Link, NavLink, useLocation } from "react-router-dom";
 
 import { CodexLogo } from "@/components/brand/codex-logo";
 import { LanguageToggle, LanguageToggleMobile } from "@/components/layout/language-toggle";
@@ -90,14 +90,17 @@ export function AppHeader({
     >
       <div className="mx-auto flex w-full max-w-[1500px] items-center justify-between gap-4">
         {/* Brand */}
-        <div className="flex min-w-0 flex-1 items-center gap-2.5">
+        <Link
+          to="/dashboard"
+          className="flex min-w-0 flex-1 items-center gap-2.5 rounded-lg no-underline transition-colors hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
           <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-primary/15 to-primary/5">
             <CodexLogo size={20} className="text-primary" />
           </div>
           <div className="min-w-0">
             <p className="truncate text-sm font-semibold tracking-tight">Codex LB</p>
           </div>
-        </div>
+        </Link>
 
         {/* Desktop nav pills */}
         <nav className="hidden items-center rounded-lg border border-border/50 bg-muted/40 p-0.5 sm:flex">

--- a/openspec/changes/header-brand-navigate-to-dashboard/.openspec.yaml
+++ b/openspec/changes/header-brand-navigate-to-dashboard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-22

--- a/openspec/changes/header-brand-navigate-to-dashboard/proposal.md
+++ b/openspec/changes/header-brand-navigate-to-dashboard/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The app header brand area (logo + "Codex LB" text) was a plain `<div>` with no
+interaction. Operators already on a sub-page had to use the nav pills to return
+to the dashboard; a click on the brand area — a common web convention — did
+nothing.
+
+## What Changes
+
+- The header brand area becomes a `<Link to="/dashboard">` so clicking the logo
+  or "Codex LB" text navigates back to the dashboard.
+- Visual presentation is unchanged: the same logo, gradient background, and
+  text styling are preserved inside the link wrapper.
+- Keyboard accessibility and focus-ring behavior follow existing project link
+  conventions via `focus-visible:ring-2 focus-visible:ring-ring`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `frontend-architecture`: the app header brand area SHALL be a clickable link
+  navigating to `/dashboard`.
+
+## Impact
+
+`frontend/src/components/layout/app-header.tsx` only. No API, database, proxy,
+or test changes. Existing header tests that rely on the brand area being a plain
+`<div>` may need their selectors updated.

--- a/openspec/changes/header-brand-navigate-to-dashboard/specs/frontend-architecture/spec.md
+++ b/openspec/changes/header-brand-navigate-to-dashboard/specs/frontend-architecture/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: App header brand links to dashboard
+
+The app header brand area SHALL render a `<Link to="/dashboard">` wrapping the
+logo and "Codex LB" text so that clicking the brand navigates back to the
+dashboard home page. The link SHALL preserve the existing visual layout (logo
+size, gradient background, text styling) and SHALL include keyboard
+focus-visible ring styling matching the project's existing interactive-element
+conventions.
+
+#### Scenario: Brand click navigates to dashboard
+
+- **WHEN** an operator clicks the header brand area (logo or "Codex LB" text)
+- **THEN** the SPA navigates to `/dashboard`
+
+#### Scenario: Brand link is keyboard-accessible
+
+- **WHEN** an operator tabs to the header brand
+- **THEN** the brand area receives a visible focus ring
+- **AND** pressing Enter navigates to `/dashboard`
+
+#### Scenario: Brand link preserves visual appearance
+
+- **WHEN** the header renders
+- **THEN** the logo and "Codex LB" text appear visually identical to the prior
+  non-interactive `<div>` layout

--- a/openspec/changes/header-brand-navigate-to-dashboard/tasks.md
+++ b/openspec/changes/header-brand-navigate-to-dashboard/tasks.md
@@ -1,0 +1,11 @@
+## 1. Implementation
+
+- [x] 1.1 Replace the header brand `<div>` with `<Link to="/dashboard">`
+- [x] 1.2 Import `Link` from `react-router-dom` (add to existing import)
+- [x] 1.3 Add focus-visible ring and transition classes per project conventions
+
+## 2. Validation
+
+- [x] 2.1 Verify brand click navigates to `/dashboard` from any sub-page
+- [x] 2.2 Verify keyboard focus ring is visible on tab
+- [x] 2.3 Run `openspec validate --specs`


### PR DESCRIPTION
<!--
Thanks for contributing to codex-lb! 🙏
Fill in the sections below. Delete sections that don't apply.
-->

## Summary

Make the Codex LB brand/logo area in the app header a clickable link that navigates back to `/dashboard`.

## Type of change

<!-- Check the box that matches your PR. Commit titles must follow Conventional Commits. -->

- [x] `feat:` — new user-facing feature or capability

Linked issue: <!-- e.g. Closes #123, Fixes #456 -->

## OpenSpec

<!--
codex-lb is OpenSpec-first. If this PR changes observable behavior, requirements,
contracts, or schema, it needs an OpenSpec change under openspec/changes/<change>/.

If this PR touches an upstream-mimicking code path (Codex CLI / ChatGPT request
shape, image pipeline, response.create framing, etc.), it must stay
**codex-faithful** — i.e. preserve the exact wire format the real upstream
emits. Call out anything that intentionally diverges, and link the spec section
that records the divergence.
-->

- [ ] This PR includes / updates an OpenSpec change
- [x] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: <!-- openspec/changes/<change>/ -->

## Changes

<!-- Bulleted list of the substantive changes. Group by area if multiple. -->

- Wrapped the brand area (`CodexLogo` + "Codex LB" text) in `app-header.tsx` with a `<Link to="/dashboard">` so clicking it navigates to the dashboard.
- Added `focus-visible` and `hover:opacity-80` styling for keyboard accessibility and visual feedback.

## Simplicity

<!-- See PRINCIPLES.md. Delete this section if the PR adds no setting, no README
     section, no dashboard nav item, and changes no default. -->

- [x] New feature defaults to **off** or works with **zero config**
- [x] No new required setup step (or maintainer approval via `simplicity-budget-approved` label)
- New setting(s) and why each can't be a default: N/A
- [x] README sections / `.env.example` / dashboard nav within budget (or `simplicity-budget-approved` label requested)

## Test plan

<!--
How did you verify this works? Paste the commands you ran and the relevant outputs.
Required: unit tests for new logic, integration tests for new endpoints.
-->

```
# Manual: click the brand/logo in the header and verify navigation to /dashboard
```

## Screenshots / output
<img width="180" height="48" alt="螢幕截圖 2026-07-22 12 03 38" src="https://github.com/user-attachments/assets/6f3e907e-d9d6-4d61-8fd8-f7e7605bd68c" />
This will become clickable and going back to /dashboard

