### PR TITLE
feat(helm): make ExternalSecret remote refs configurable

### DIFF
--- a/deploy/helm/codex-lb/README.md
+++ b/deploy/helm/codex-lb/README.md
@@ -112,7 +112,9 @@ Use External Secrets Operator to materialize credentials.
 Key properties:
 
 - `externalSecrets.enabled=true`
+- requires External Secrets Operator v0.17.0 or newer (the first release that serves `external-secrets.io/v1`)
 - DB credentials are not assumed to exist at render time
+- remote secret keys and optional JSON properties are configurable independently
 - migration Job remains `post-install,pre-upgrade`
 - application pods keep the schema gate initContainer enabled and wait for schema head before starting the app container
 
@@ -135,6 +137,26 @@ helm upgrade --install codex-lb deploy/helm/codex-lb/ \
 ```
 
 </details>
+
+By default, both values are read from JSON properties in a remote secret named
+after the release. Providers such as Infisical commonly store each value as an
+individual secret instead. Configure absolute keys and clear the property fields
+for that layout:
+
+```yaml
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  remoteRefs:
+    databaseUrl:
+      key: /apps/codex-lb/DATABASE_URL
+      property: ""
+    encryptionKey:
+      key: /apps/codex-lb/ENCRYPTION_KEY
+      property: ""
+```
 
 ## Quick Start
 

--- a/deploy/helm/codex-lb/templates/externalsecret.yaml
+++ b/deploy/helm/codex-lb/templates/externalsecret.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.externalSecrets.enabled }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ include "codex-lb.fullname" . }}
@@ -19,12 +19,20 @@ spec:
     name: {{ include "codex-lb.secretName" . }}
     creationPolicy: Owner
   data:
+    {{- /* Explicitly nulled overrides fall back to the chart-default layout. */}}
+    {{- $remoteRefs := .Values.externalSecrets.remoteRefs | default dict }}
+    {{- $databaseUrlRef := $remoteRefs.databaseUrl | default dict }}
+    {{- $encryptionKeyRef := $remoteRefs.encryptionKey | default dict }}
     - secretKey: {{ .Values.auth.secretKeys.databaseUrl }}
       remoteRef:
-        key: {{ include "codex-lb.fullname" . }}
-        property: database-url
+        key: {{ default (include "codex-lb.fullname" .) $databaseUrlRef.key | quote }}
+        {{- with hasKey $databaseUrlRef "property" | ternary $databaseUrlRef.property "database-url" }}
+        property: {{ . | quote }}
+        {{- end }}
     - secretKey: {{ .Values.auth.secretKeys.encryptionKey }}
       remoteRef:
-        key: {{ include "codex-lb.fullname" . }}
-        property: encryption-key
+        key: {{ default (include "codex-lb.fullname" .) $encryptionKeyRef.key | quote }}
+        {{- with hasKey $encryptionKeyRef "property" | ternary $encryptionKeyRef.property "encryption-key" }}
+        property: {{ . | quote }}
+        {{- end }}
 {{- end }}

--- a/deploy/helm/codex-lb/values.schema.json
+++ b/deploy/helm/codex-lb/values.schema.json
@@ -130,7 +130,26 @@
     "externalSecrets": {
       "type": "object",
       "properties": {
-        "enabled": { "type": "boolean" }
+        "enabled": { "type": "boolean" },
+        "remoteRefs": {
+          "type": "object",
+          "properties": {
+            "databaseUrl": {
+              "type": "object",
+              "properties": {
+                "key": { "type": "string" },
+                "property": { "type": "string" }
+              }
+            },
+            "encryptionKey": {
+              "type": "object",
+              "properties": {
+                "key": { "type": "string" },
+                "property": { "type": "string" }
+              }
+            }
+          }
+        }
       }
     },
     "rollout": {

--- a/deploy/helm/codex-lb/values.yaml
+++ b/deploy/helm/codex-lb/values.yaml
@@ -197,6 +197,17 @@ externalSecrets:
     kind: SecretStore
   # @param externalSecrets.refreshInterval How often to refresh the secret
   refreshInterval: 1h
+  remoteRefs:
+    databaseUrl:
+      # @param externalSecrets.remoteRefs.databaseUrl.key Remote secret key for the database URL (empty defaults to the release fullname)
+      key: ""
+      # @param externalSecrets.remoteRefs.databaseUrl.property Optional JSON property containing the database URL
+      property: database-url
+    encryptionKey:
+      # @param externalSecrets.remoteRefs.encryptionKey.key Remote secret key for the encryption key (empty defaults to the release fullname)
+      key: ""
+      # @param externalSecrets.remoteRefs.encryptionKey.property Optional JSON property containing the encryption key
+      property: encryption-key
 rollout:
   reloader:
     # @param rollout.reloader.enabled Add Stakater Reloader annotations so pod restarts follow Secret/ConfigMap updates

--- a/openspec/changes/customize-external-secret-refs/proposal.md
+++ b/openspec/changes/customize-external-secret-refs/proposal.md
@@ -1,0 +1,29 @@
+# Change: customize-external-secret-refs
+
+## Why
+
+The Helm chart assumes the database URL and encryption key are JSON properties
+in one remote secret named after the release. Secret stores such as Infisical
+commonly model them as separate secrets at provider-specific paths, forcing
+operators to maintain a duplicate ExternalSecret outside the chart. The chart
+also renders the retired `external-secrets.io/v1beta1` API, which is not served
+by current External Secrets Operator installations.
+
+## What Changes
+
+- Render chart-managed ExternalSecret resources with `external-secrets.io/v1`.
+- Allow the database URL and encryption key to configure independent remote
+  keys and optional JSON properties.
+- Preserve the existing release-name and JSON-property behavior by default.
+- Document and test an Infisical-style individual-secret layout.
+
+## Impact
+
+- Affected spec: `deployment-installation`
+- Affected code: Helm values, schema, template, chart documentation, and chart
+  rendering tests
+- Existing values remain compatible; the generated ExternalSecret API advances
+  from the retired beta version to the stable version. Clusters must run
+  External Secrets Operator v0.17.0 or newer — the first release that serves
+  `external-secrets.io/v1`; older operators cannot apply the rendered
+  resource, and the chart README documents this floor.

--- a/openspec/changes/customize-external-secret-refs/specs/deployment-installation/spec.md
+++ b/openspec/changes/customize-external-secret-refs/specs/deployment-installation/spec.md
@@ -1,0 +1,33 @@
+# deployment-installation Delta
+
+## ADDED Requirements
+
+### Requirement: External secret references support provider-native layouts
+
+When `externalSecrets.enabled=true`, the Helm chart MUST render an
+`external-secrets.io/v1` ExternalSecret. The database URL and encryption key
+MUST each accept an independent remote key and an optional JSON property. An
+empty remote key MUST default to the release fullname, and the default
+properties MUST preserve the existing `database-url` and `encryption-key` JSON
+layout. Explicitly nulled remote reference overrides MUST render the default
+layout instead of failing the template.
+
+#### Scenario: Existing JSON secret layout remains the default
+
+- **WHEN** external secrets mode is enabled without remote reference overrides
+- **THEN** both target keys read from the remote secret named after the release
+- **AND** they extract the `database-url` and `encryption-key` JSON properties
+- **AND** the rendered ExternalSecret uses `external-secrets.io/v1`
+
+#### Scenario: Individual remote secrets need no JSON property
+
+- **WHEN** an operator configures separate absolute remote keys for the database URL and encryption key
+- **AND** leaves both property values empty
+- **THEN** each target key reads the complete value of its configured remote secret
+- **AND** the rendered remote references omit `property`
+
+#### Scenario: Nulled overrides fall back to the default layout
+
+- **WHEN** an operator explicitly nulls `externalSecrets.remoteRefs` or one of its subtrees
+- **THEN** rendering succeeds
+- **AND** the affected target keys use the release fullname and their default JSON properties

--- a/openspec/changes/customize-external-secret-refs/tasks.md
+++ b/openspec/changes/customize-external-secret-refs/tasks.md
@@ -1,0 +1,14 @@
+# Tasks: customize-external-secret-refs
+
+## 1. Helm contract
+
+- [x] 1.1 Render chart-managed ExternalSecret resources with the stable API
+- [x] 1.2 Add independent remote key and optional property values for both required credentials
+- [x] 1.3 Preserve the existing remote secret layout as the zero-config default
+- [x] 1.4 Render the default layout when remote reference overrides are explicitly nulled
+
+## 2. Documentation and verification
+
+- [x] 2.1 Document an individual-secret Infisical example
+- [x] 2.2 Add rendering coverage for defaults and property-free absolute keys
+- [x] 2.3 Run focused Helm tests and strict OpenSpec validation

--- a/tests/unit/test_helm_external_secrets.py
+++ b/tests/unit/test_helm_external_secrets.py
@@ -106,6 +106,86 @@ def test_external_secrets_upgrade_keeps_startup_migration_disabled_and_runs_hook
     assert '"helm.sh/hook": "post-install,pre-upgrade"' in rendered
 
 
+def test_external_secret_uses_v1_api_and_default_json_properties() -> None:
+    rendered = _helm_template(
+        "--show-only",
+        "templates/externalsecret.yaml",
+        "--set",
+        "externalSecrets.enabled=true",
+        "--set",
+        "externalSecrets.secretStoreRef.name=test-store",
+    )
+
+    (external_secret,) = _helm_documents(rendered)
+    assert external_secret["apiVersion"] == "external-secrets.io/v1"
+    assert external_secret["spec"]["data"] == [
+        {
+            "secretKey": "database-url",
+            "remoteRef": {"key": "codex-lb", "property": "database-url"},
+        },
+        {
+            "secretKey": "encryption-key",
+            "remoteRef": {"key": "codex-lb", "property": "encryption-key"},
+        },
+    ]
+
+
+def test_external_secret_supports_individual_remote_secret_keys() -> None:
+    rendered = _helm_template(
+        "--show-only",
+        "templates/externalsecret.yaml",
+        "--set",
+        "externalSecrets.enabled=true",
+        "--set",
+        "externalSecrets.secretStoreRef.name=infisical",
+        "--set-string",
+        "externalSecrets.remoteRefs.databaseUrl.key=/apps/codex-lb/DATABASE_URL",
+        "--set",
+        "externalSecrets.remoteRefs.databaseUrl.property=",
+        "--set-string",
+        "externalSecrets.remoteRefs.encryptionKey.key=/apps/codex-lb/ENCRYPTION_KEY",
+        "--set",
+        "externalSecrets.remoteRefs.encryptionKey.property=",
+    )
+
+    (external_secret,) = _helm_documents(rendered)
+    assert external_secret["spec"]["data"] == [
+        {
+            "secretKey": "database-url",
+            "remoteRef": {"key": "/apps/codex-lb/DATABASE_URL"},
+        },
+        {
+            "secretKey": "encryption-key",
+            "remoteRef": {"key": "/apps/codex-lb/ENCRYPTION_KEY"},
+        },
+    ]
+
+
+def test_external_secret_nulled_remote_refs_render_default_layout() -> None:
+    rendered = _helm_template(
+        "--show-only",
+        "templates/externalsecret.yaml",
+        "--set",
+        "externalSecrets.enabled=true",
+        "--set",
+        "externalSecrets.secretStoreRef.name=test-store",
+        "--set",
+        "externalSecrets.remoteRefs=null",
+    )
+
+    (external_secret,) = _helm_documents(rendered)
+    assert external_secret["spec"]["data"] == [
+        {
+            "secretKey": "database-url",
+            "remoteRef": {"key": "codex-lb", "property": "database-url"},
+        },
+        {
+            "secretKey": "encryption-key",
+            "remoteRef": {"key": "codex-lb", "property": "encryption-key"},
+        },
+    ]
+
+
 def test_upgrade_renders_legacy_deployment_cleanup_hook_for_statefulset_migration() -> None:
     rendered = _helm_template(
         "--is-upgrade",


### PR DESCRIPTION
## Summary

Makes the chart-managed ExternalSecret's remote references configurable — independent remote keys and optional JSON properties for the database URL and encryption key — so providers like Infisical that store each credential as an individual secret work without a hand-maintained ExternalSecret outside the chart. Also advances the rendered API from the retired `external-secrets.io/v1beta1` to the stable `external-secrets.io/v1`.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change** (also append `!` after the type, e.g. `feat!:` or include `BREAKING CHANGE:` footer)

Linked issue: none

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/customize-external-secret-refs/`

## Changes

- **Helm template** (`deploy/helm/codex-lb/templates/externalsecret.yaml`)
  - Render `external-secrets.io/v1` instead of the retired `v1beta1`. This sets an External Secrets Operator floor of **v0.17.0** (first release serving `v1`); documented in the chart README and the OpenSpec proposal.
  - `externalSecrets.remoteRefs.{databaseUrl,encryptionKey}.{key,property}` values: empty `key` defaults to the release fullname; empty `property` omits the field so the whole remote secret value is used.
  - Nil-safe lookups: explicitly nulled `remoteRefs` (or subtrees) render the chart-default layout instead of failing with a nil-pointer template error.
- **Values + schema**: new `externalSecrets.remoteRefs` block with defaults preserving the existing single-secret JSON layout (`database-url` / `encryption-key` properties on a release-named remote secret); matching `values.schema.json` entries.
- **Docs**: chart README documents the ESO v0.17.0 floor and an Infisical-style individual-secret example.
- **Tests**: three new rendering tests — default layout on `v1`, property-free absolute keys, and nulled-override fallback.
- **OpenSpec**: `customize-external-secret-refs` change with proposal, tasks, and a `deployment-installation` delta spec covering all three scenarios.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config** — default rendering is byte-identical to the previous layout apart from the API version
- [x] No new required setup step (or maintainer approval via `simplicity-budget-approved` label)
- New setting(s) and why each can't be a default: `externalSecrets.remoteRefs.*` Helm values (not `CODEX_LB_*` env settings) → remote secret paths are provider-specific (e.g. Infisical stores each credential at its own path), so no single default can describe them; the defaults reproduce the existing layout exactly
- [x] README sections / `.env.example` / dashboard nav within budget (or `simplicity-budget-approved` label requested) — no root-README, `.env.example`, or dashboard changes; only the chart README's existing external-secrets section is extended

## Test plan

```
# helm chart rendering tests (pytest shells out to `helm template`)
pytest tests/unit/test_helm_external_secrets.py -q
# → 45 passed

# strict OpenSpec validation
openspec validate customize-external-secret-refs --strict
# → Change 'customize-external-secret-refs' is valid
openspec validate --specs
# → Totals: 47 passed, 0 failed (47 items)
```

Also manually verified `helm template` renders for: zero-config default, Infisical-style absolute keys with cleared properties, `remoteRefs: null`, a nulled subtree, and a nulled property — all render valid manifests.

## Screenshots / output

Default (unchanged layout, stable API):

```yaml
apiVersion: external-secrets.io/v1
kind: ExternalSecret
spec:
  data:
    - secretKey: database-url
      remoteRef:
        key: "codex-lb"
        property: "database-url"
    - secretKey: encryption-key
      remoteRef:
        key: "codex-lb"
        property: "encryption-key"
```

Infisical-style individual secrets (`key` set, `property` cleared):

```yaml
  data:
    - secretKey: database-url
      remoteRef:
        key: "/apps/codex-lb/DATABASE_URL"
    - secretKey: encryption-key
      remoteRef:
        key: "/apps/codex-lb/ENCRYPTION_KEY"
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [ ] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
