### PR TITLE
fix(compact): elide observed inline images at wire cap

### DIFF
--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -46,7 +46,7 @@ _COMPACT_TOOL_CALL_ITEM_TYPES = frozenset({"function_call", "custom_tool_call", 
 _COMPACT_TOOL_CALL_OUTPUT_ITEM_TYPES = frozenset(
     {"function_call_output", "custom_tool_call_output", "apply_patch_call_output"}
 )
-_COMPACT_INLINE_IMAGE_DATA_URL_RE = re.compile(r"data:image/[^,\s]+,[A-Za-z0-9+/=_-]+")
+_COMPACT_INLINE_IMAGE_DATA_URL_RE = re.compile(r"""data:image/[^,\s]+,[^\s"'<>]+""")
 _GOAL_CONTINUATION_CONTEXT_PREFIX = '<codex_internal_context source="goal">'
 _PLAN_MODE_CONTEXT_PREFIX = "<collaboration_mode># Plan Mode"
 
@@ -165,34 +165,23 @@ def extract_input_file_ids(input_value: JsonValue) -> set[str]:
     if not is_json_list(input_value):
         return set()
     file_ids: set[str] = set()
-    for item in input_value:
-        if not is_json_mapping(item):
-            continue
-        item_mapping = item
-        if _is_input_file_with_id(item_mapping):
-            file_id = item_mapping.get("file_id")
-            if isinstance(file_id, str) and file_id:
-                file_ids.add(file_id)
-        image_file_id = _input_image_file_reference(item_mapping)
-        if image_file_id is not None:
-            file_ids.add(image_file_id)
-        content = item_mapping.get("content")
-        if is_json_list(content):
-            parts: list[JsonValue] = content
-        elif is_json_mapping(content):
-            parts = [content]
-        else:
-            parts = []
-        for part in parts:
-            if not is_json_mapping(part):
-                continue
-            if _is_input_file_with_id(part):
-                file_id = part.get("file_id")
+
+    def collect(value: JsonValue) -> None:
+        if is_json_mapping(value):
+            if _is_input_file_with_id(value):
+                file_id = value.get("file_id")
                 if isinstance(file_id, str) and file_id:
                     file_ids.add(file_id)
-            image_file_id = _input_image_file_reference(part)
+            image_file_id = _input_image_file_reference(value)
             if image_file_id is not None:
                 file_ids.add(image_file_id)
+            for child in value.values():
+                collect(child)
+        elif is_json_list(value):
+            for child in value:
+                collect(child)
+
+    collect(input_value)
     return file_ids
 
 
@@ -966,29 +955,30 @@ def _trim_compact_input_for_upstream(payload: MutableJsonObject) -> None:
     )
     required_input = _compact_trimmed_input_with_markers(input_value, token_counts, required_indices)
     required_tokens = _estimated_json_tokens(required_input)
-    if required_tokens > _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS:
-        rewritten_input, images_elided = _compact_elide_required_tool_output_images(
+    rewritten_input, images_elided = _compact_elide_required_tool_output_images(
+        input_value,
+        required_indices=required_indices,
+    )
+    if images_elided:
+        input_value = rewritten_input
+        payload["input"] = input_value
+        if _estimated_json_tokens(input_value) <= _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS:
+            return
+        token_counts = [_estimated_json_array_item_tokens(item) for item in input_value]
+        head_count = _compact_trim_prefix_count(token_counts)
+        preserved_indices = _compact_state_anchor_indices(input_value)
+        required_indices = set(preserved_indices)
+        if input_value:
+            required_indices.add(len(input_value) - 1)
+        required_indices = _compact_reconciled_tool_call_indices(
             input_value,
+            required_indices,
+            token_counts=token_counts,
+            token_budget=sum(token_counts),
             required_indices=required_indices,
         )
-        if images_elided:
-            input_value = rewritten_input
-            payload["input"] = input_value
-            token_counts = [_estimated_json_array_item_tokens(item) for item in input_value]
-            head_count = _compact_trim_prefix_count(token_counts)
-            preserved_indices = _compact_state_anchor_indices(input_value)
-            required_indices = set(preserved_indices)
-            if input_value:
-                required_indices.add(len(input_value) - 1)
-            required_indices = _compact_reconciled_tool_call_indices(
-                input_value,
-                required_indices,
-                token_counts=token_counts,
-                token_budget=sum(token_counts),
-                required_indices=required_indices,
-            )
-            required_input = _compact_trimmed_input_with_markers(input_value, token_counts, required_indices)
-            required_tokens = _estimated_json_tokens(required_input)
+        required_input = _compact_trimmed_input_with_markers(input_value, token_counts, required_indices)
+        required_tokens = _estimated_json_tokens(required_input)
     if required_tokens > _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS:
         raise ClientPayloadError(
             "Compact input exceeds the upstream size limit and cannot be trimmed "

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -795,6 +795,9 @@ _POISONED_LOCAL_COMPACT_FALLBACK_TEXT = "Local compact fallback preserved the la
 _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS = 100_000
 _COMPACT_UPSTREAM_HEAD_ESTIMATED_TOKENS = 12_000
 _ESTIMATED_CHARS_PER_TOKEN = 4
+_COMPACT_OMITTED_INLINE_IMAGE_TEXT = (
+    "[compact trim] Omitted inline image bytes that were already observed before compaction"
+)
 
 
 def _strip_unsupported_fields(payload: MutableJsonObject) -> MutableJsonObject:
@@ -962,6 +965,29 @@ def _trim_compact_input_for_upstream(payload: MutableJsonObject) -> None:
     required_input = _compact_trimmed_input_with_markers(input_value, token_counts, required_indices)
     required_tokens = _estimated_json_tokens(required_input)
     if required_tokens > _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS:
+        rewritten_input, images_elided = _compact_elide_required_tool_output_images(
+            input_value,
+            required_indices=required_indices,
+        )
+        if images_elided:
+            input_value = rewritten_input
+            payload["input"] = input_value
+            token_counts = [_estimated_json_array_item_tokens(item) for item in input_value]
+            head_count = _compact_trim_prefix_count(token_counts)
+            preserved_indices = _compact_state_anchor_indices(input_value)
+            required_indices = set(preserved_indices)
+            if input_value:
+                required_indices.add(len(input_value) - 1)
+            required_indices = _compact_reconciled_tool_call_indices(
+                input_value,
+                required_indices,
+                token_counts=token_counts,
+                token_budget=sum(token_counts),
+                required_indices=required_indices,
+            )
+            required_input = _compact_trimmed_input_with_markers(input_value, token_counts, required_indices)
+            required_tokens = _estimated_json_tokens(required_input)
+    if required_tokens > _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS:
         raise ClientPayloadError(
             "Compact input exceeds the upstream size limit and cannot be trimmed "
             "without removing required state anchors.",
@@ -1019,6 +1045,65 @@ def _trim_compact_input_for_upstream(payload: MutableJsonObject) -> None:
     if trimmed_input is input_value:
         return
     payload["input"] = trimmed_input
+
+
+def _compact_elide_required_tool_output_images(
+    input_value: list[JsonValue],
+    *,
+    required_indices: set[int],
+) -> tuple[list[JsonValue], bool]:
+    rewritten: list[JsonValue] = []
+    changed = False
+    for index, item in enumerate(input_value):
+        if (
+            index in required_indices
+            and is_json_mapping(item)
+            and item.get("type") in _COMPACT_TOOL_CALL_OUTPUT_ITEM_TYPES
+        ):
+            rewritten_item, item_changed = _compact_elide_inline_images(item)
+            rewritten.append(rewritten_item)
+            changed = changed or item_changed
+        else:
+            rewritten.append(item)
+    return rewritten, changed
+
+
+def _compact_elide_inline_images(value: JsonValue) -> tuple[JsonValue, bool]:
+    """Replace inline image bytes with an explicit compact-only text marker.
+
+    The model has already observed these images during the live turn. Re-sending
+    their data URLs to the compact endpoint can make an otherwise recoverable
+    thread permanently uncompactable, especially when the latest required tool
+    output contains a screenshot. File-backed image references remain intact.
+    """
+
+    if is_json_mapping(value):
+        if value.get("type") == "input_image":
+            image_url = value.get("image_url")
+            if isinstance(image_url, str) and image_url.startswith("data:image/"):
+                return (
+                    {
+                        "type": "input_text",
+                        "text": f"{_COMPACT_OMITTED_INLINE_IMAGE_TEXT} ({len(image_url)} encoded characters).",
+                    },
+                    True,
+                )
+        rewritten_mapping: JsonObject = {}
+        changed = False
+        for key, item in value.items():
+            rewritten_item, item_changed = _compact_elide_inline_images(item)
+            rewritten_mapping[key] = rewritten_item
+            changed = changed or item_changed
+        return rewritten_mapping, changed
+    if is_json_list(value):
+        rewritten: list[JsonValue] = []
+        changed = False
+        for item in value:
+            rewritten_item, item_changed = _compact_elide_inline_images(item)
+            rewritten.append(rewritten_item)
+            changed = changed or item_changed
+        return rewritten, changed
+    return value, False
 
 
 def _compact_fit_selected_indices_to_wire_budget(

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -1107,9 +1107,7 @@ def _compact_elide_inline_images(value: JsonValue) -> tuple[JsonValue, bool]:
         return rewritten, changed
     if isinstance(value, str) and "data:image/" in value:
         rewritten_value, replacements = _COMPACT_INLINE_IMAGE_DATA_URL_RE.subn(
-            lambda match: (
-                f"{_COMPACT_OMITTED_INLINE_IMAGE_TEXT} ({len(match.group(0))} encoded characters)."
-            ),
+            lambda match: f"{_COMPACT_OMITTED_INLINE_IMAGE_TEXT} ({len(match.group(0))} encoded characters).",
             value,
         )
         if replacements:

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import cast
@@ -45,6 +46,7 @@ _COMPACT_TOOL_CALL_ITEM_TYPES = frozenset({"function_call", "custom_tool_call", 
 _COMPACT_TOOL_CALL_OUTPUT_ITEM_TYPES = frozenset(
     {"function_call_output", "custom_tool_call_output", "apply_patch_call_output"}
 )
+_COMPACT_INLINE_IMAGE_DATA_URL_RE = re.compile(r"data:image/[^,\s]+,[A-Za-z0-9+/=_-]+")
 _GOAL_CONTINUATION_CONTEXT_PREFIX = '<codex_internal_context source="goal">'
 _PLAN_MODE_CONTEXT_PREFIX = "<collaboration_mode># Plan Mode"
 
@@ -1103,6 +1105,15 @@ def _compact_elide_inline_images(value: JsonValue) -> tuple[JsonValue, bool]:
             rewritten.append(rewritten_item)
             changed = changed or item_changed
         return rewritten, changed
+    if isinstance(value, str) and "data:image/" in value:
+        rewritten_value, replacements = _COMPACT_INLINE_IMAGE_DATA_URL_RE.subn(
+            lambda match: (
+                f"{_COMPACT_OMITTED_INLINE_IMAGE_TEXT} ({len(match.group(0))} encoded characters)."
+            ),
+            value,
+        )
+        if replacements:
+            return rewritten_value, True
     return value, False
 
 

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -46,7 +46,6 @@ _COMPACT_TOOL_CALL_ITEM_TYPES = frozenset({"function_call", "custom_tool_call", 
 _COMPACT_TOOL_CALL_OUTPUT_ITEM_TYPES = frozenset(
     {"function_call_output", "custom_tool_call_output", "apply_patch_call_output"}
 )
-_COMPACT_INLINE_IMAGE_DATA_URL_RE = re.compile(r"""data:image/[^,\s]+,[^\s"'<>]+""")
 _GOAL_CONTINUATION_CONTEXT_PREFIX = '<codex_internal_context source="goal">'
 _PLAN_MODE_CONTEXT_PREFIX = "<collaboration_mode># Plan Mode"
 
@@ -795,6 +794,7 @@ _ESTIMATED_CHARS_PER_TOKEN = 4
 _COMPACT_OMITTED_INLINE_IMAGE_TEXT = (
     "[compact trim] Omitted inline image bytes that were already observed before compaction"
 )
+_COMPACT_INLINE_IMAGE_DATA_URL_RE = re.compile(r"""data:image/[^,\s]+,[^\s"'<>]+""")
 
 
 def _strip_unsupported_fields(payload: MutableJsonObject) -> MutableJsonObject:

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -153,10 +153,12 @@ def _input_image_file_reference(item: Mapping[str, JsonValue]) -> str | None:
 def extract_input_file_ids(input_value: JsonValue) -> set[str]:
     """Return all ``file_id`` strings referenced by ``input_file`` / ``input_image`` items.
 
-    Walks both top-level items and nested role-message ``content`` parts,
-    matching the shapes accepted by ``ResponsesRequest.input`` /
-    ``ResponsesCompactRequest.input``. Returns an empty set when the
-    input is a plain string or has no ``input_file`` parts. Used by the
+    Walks top-level input items, role-message ``content`` parts, and retained
+    tool-output content, matching the actual reference shapes accepted by
+    ``ResponsesRequest.input`` / ``ResponsesCompactRequest.input``. Tool
+    metadata and arbitrary nested objects are deliberately not references.
+    Returns an empty set when the input is a plain string or has no
+    ``input_file`` parts. Used by the
     ``/responses`` flow to look up account pins recorded by
     ``POST /backend-api/files`` so the response request lands on the
     upstream account that registered the file (the upstream contract is
@@ -166,22 +168,26 @@ def extract_input_file_ids(input_value: JsonValue) -> set[str]:
         return set()
     file_ids: set[str] = set()
 
-    def collect(value: JsonValue) -> None:
-        if is_json_mapping(value):
-            if _is_input_file_with_id(value):
-                file_id = value.get("file_id")
-                if isinstance(file_id, str) and file_id:
-                    file_ids.add(file_id)
-            image_file_id = _input_image_file_reference(value)
-            if image_file_id is not None:
-                file_ids.add(image_file_id)
-            for child in value.values():
-                collect(child)
-        elif is_json_list(value):
-            for child in value:
-                collect(child)
+    def collect_part(part: JsonValue) -> None:
+        if not is_json_mapping(part):
+            return
+        if _is_input_file_with_id(part):
+            file_id = part.get("file_id")
+            if isinstance(file_id, str) and file_id:
+                file_ids.add(file_id)
+        image_file_id = _input_image_file_reference(part)
+        if image_file_id is not None:
+            file_ids.add(image_file_id)
 
-    collect(input_value)
+    for item in input_value:
+        if not is_json_mapping(item):
+            continue
+        collect_part(item)
+        for part in _json_parts(item.get("content")):
+            collect_part(part)
+        if item.get("type") in _COMPACT_TOOL_CALL_OUTPUT_ITEM_TYPES:
+            for part in _json_parts(item.get("output")):
+                collect_part(part)
     return file_ids
 
 
@@ -908,53 +914,17 @@ def _trim_compact_input_for_upstream(payload: MutableJsonObject) -> None:
     input_value = payload.get("input")
     if not is_json_list(input_value):
         return
-    token_counts = [_estimated_json_array_item_tokens(item) for item in input_value]
     total_tokens = _estimated_json_tokens(input_value)
     if total_tokens <= _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS:
         return
 
-    head_count = _compact_trim_prefix_count(token_counts)
-    state_anchor_indices = _compact_state_anchor_indices(input_value)
-    marker_tokens = _estimated_json_array_item_tokens(_compact_trim_marker(omitted_items=0, omitted_tokens=0))
-    wire_budget = max(0, _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS - marker_tokens)
+    losslessly_trimmed_input = _compact_losslessly_trim_input(input_value)
+    if losslessly_trimmed_input is not None:
+        payload["input"] = losslessly_trimmed_input
+        return
 
-    side_effect_indices = _compact_side_effect_anchor_indices(input_value)
-    unusable_side_effect_indices = {
-        index
-        for index, item in enumerate(input_value)
-        if is_json_mapping(item)
-        and _compact_item_is_side_effect_anchor(item)
-        and (not isinstance(item.get("call_id"), str) or not item["call_id"])
-    }
-    # Keep priority side effects as complete call/output units before spending
-    # the remaining budget on ordinary head/tail context.  Otherwise a large
-    # recent message can leave room for a call but not its output, causing
-    # reconciliation to drop the historical side effect that would fit after
-    # trimming that ordinary message.
-    side_effect_indices = _compact_reconciled_tool_call_indices(
-        input_value,
-        side_effect_indices,
-        token_counts=token_counts,
-        token_budget=sum(token_counts),
-    )
-    required_indices = set(state_anchor_indices)
-    if input_value:
-        required_indices.add(len(input_value) - 1)
-    if required_indices & unusable_side_effect_indices:
-        raise ClientPayloadError(
-            "Compact input cannot retain a required side-effect call without a usable call_id.",
-            param="input",
-            code="responses_compact_input_too_large",
-        )
-    required_indices = _compact_reconciled_tool_call_indices(
-        input_value,
-        required_indices,
-        token_counts=token_counts,
-        token_budget=sum(token_counts),
-        required_indices=required_indices,
-    )
-    required_input = _compact_trimmed_input_with_markers(input_value, token_counts, required_indices)
-    required_tokens = _estimated_json_tokens(required_input)
+    token_counts = [_estimated_json_array_item_tokens(item) for item in input_value]
+    required_indices = _compact_required_indices(input_value, token_counts)
     rewritten_input, images_elided = _compact_elide_required_tool_output_images(
         input_value,
         required_indices=required_indices,
@@ -964,28 +934,49 @@ def _trim_compact_input_for_upstream(payload: MutableJsonObject) -> None:
         payload["input"] = input_value
         if _estimated_json_tokens(input_value) <= _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS:
             return
-        token_counts = [_estimated_json_array_item_tokens(item) for item in input_value]
-        head_count = _compact_trim_prefix_count(token_counts)
-        preserved_indices = _compact_state_anchor_indices(input_value)
-        required_indices = set(preserved_indices)
-        if input_value:
-            required_indices.add(len(input_value) - 1)
-        required_indices = _compact_reconciled_tool_call_indices(
-            input_value,
-            required_indices,
-            token_counts=token_counts,
-            token_budget=sum(token_counts),
-            required_indices=required_indices,
-        )
-        required_input = _compact_trimmed_input_with_markers(input_value, token_counts, required_indices)
-        required_tokens = _estimated_json_tokens(required_input)
-    if required_tokens > _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS:
+        losslessly_trimmed_input = _compact_losslessly_trim_input(input_value)
+        if losslessly_trimmed_input is not None:
+            payload["input"] = losslessly_trimmed_input
+            return
+    raise ClientPayloadError(
+        "Compact input exceeds the upstream size limit and cannot be trimmed without removing required state anchors.",
+        param="input",
+        code="responses_compact_input_too_large",
+    )
+
+
+def _compact_losslessly_trim_input(input_value: list[JsonValue]) -> list[JsonValue] | None:
+    """Return a budget-fitting context selection without changing any retained bytes."""
+
+    token_counts = [_estimated_json_array_item_tokens(item) for item in input_value]
+    head_count = _compact_trim_prefix_count(token_counts)
+    state_anchor_indices = _compact_state_anchor_indices(input_value)
+    marker_tokens = _estimated_json_array_item_tokens(_compact_trim_marker(omitted_items=0, omitted_tokens=0))
+    side_effect_indices = _compact_side_effect_anchor_indices(input_value)
+    unusable_side_effect_indices = {
+        index
+        for index, item in enumerate(input_value)
+        if is_json_mapping(item)
+        and _compact_item_is_side_effect_anchor(item)
+        and (not isinstance(item.get("call_id"), str) or not item["call_id"])
+    }
+    side_effect_indices = _compact_reconciled_tool_call_indices(
+        input_value,
+        side_effect_indices,
+        token_counts=token_counts,
+        token_budget=sum(token_counts),
+    )
+    required_indices = _compact_required_indices(input_value, token_counts, preserved_indices=state_anchor_indices)
+    if required_indices & unusable_side_effect_indices:
         raise ClientPayloadError(
-            "Compact input exceeds the upstream size limit and cannot be trimmed "
-            "without removing required state anchors.",
+            "Compact input cannot retain a required side-effect call without a usable call_id.",
             param="input",
             code="responses_compact_input_too_large",
         )
+    required_input = _compact_trimmed_input_with_markers(input_value, token_counts, required_indices)
+    if _estimated_json_tokens(required_input) > _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS:
+        return None
+    wire_budget = max(0, _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS - marker_tokens)
     side_effect_indices &= _compact_reconciled_tool_call_indices(
         input_value,
         required_indices | side_effect_indices,
@@ -1029,14 +1020,28 @@ def _trim_compact_input_for_upstream(payload: MutableJsonObject) -> None:
     )
     trimmed_tokens = _estimated_json_tokens(trimmed_input)
     if trimmed_tokens > _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS:
-        raise ClientPayloadError(
-            "Compact input still exceeds the upstream size limit after retaining required compact context.",
-            param="input",
-            code="responses_compact_input_too_large",
-        )
-    if trimmed_input is input_value:
-        return
-    payload["input"] = trimmed_input
+        return None
+    return trimmed_input
+
+
+def _compact_required_indices(
+    input_value: list[JsonValue],
+    token_counts: list[int],
+    *,
+    preserved_indices: set[int] | None = None,
+) -> set[int]:
+    if preserved_indices is None:
+        preserved_indices = _compact_state_anchor_indices(input_value)
+    required_indices = set(preserved_indices)
+    if input_value:
+        required_indices.add(len(input_value) - 1)
+    return _compact_reconciled_tool_call_indices(
+        input_value,
+        required_indices,
+        token_counts=token_counts,
+        token_budget=sum(token_counts),
+        required_indices=required_indices,
+    )
 
 
 def _compact_elide_required_tool_output_images(
@@ -1077,6 +1082,17 @@ def _compact_elide_inline_images(value: JsonValue) -> tuple[JsonValue, bool]:
                     {
                         "type": "input_text",
                         "text": f"{_COMPACT_OMITTED_INLINE_IMAGE_TEXT} ({len(image_url)} encoded characters).",
+                    },
+                    True,
+                )
+        if value.get("type") == "image_url":
+            image_url = value.get("image_url")
+            url = image_url.get("url") if is_json_mapping(image_url) else image_url
+            if isinstance(url, str) and url.startswith("data:image/"):
+                return (
+                    {
+                        "type": "text",
+                        "text": f"{_COMPACT_OMITTED_INLINE_IMAGE_TEXT} ({len(url)} encoded characters).",
                     },
                     True,
                 )

--- a/app/modules/proxy/_service/file_ops.py
+++ b/app/modules/proxy/_service/file_ops.py
@@ -247,7 +247,10 @@ class _FileOpsMixin:
         proxy = cast(_FileOpsServiceProtocol, self)
         del headers
 
-        file_ids = extract_input_file_ids(payload.input)
+        input_value = payload.input
+        if isinstance(payload, ResponsesCompactRequest):
+            input_value = payload.to_payload().get("input")
+        file_ids = extract_input_file_ids(input_value)
         if not file_ids:
             return None
 

--- a/openspec/changes/allow-compact-inline-image-elision/proposal.md
+++ b/openspec/changes/allow-compact-inline-image-elision/proposal.md
@@ -9,10 +9,13 @@ with `responses_compact_input_too_large`.
 
 ## What Changes
 
-- Replace inline data-URL image parts with an explicit textual omission marker
-  only while preparing an oversized compact request.
+- Replace inline data-URL images inside required function, custom, and
+  apply-patch tool outputs with an explicit textual omission marker only while
+  preparing an oversized compact request.
 - Preserve the surrounding tool call/output identities and all textual content.
-- Leave file-backed image references and ordinary non-compact requests unchanged.
+- Leave accepted `input_file` references and ordinary non-compact requests unchanged.
+- Keep hosted `computer_call_output` screenshots fail-closed until a
+  schema-valid compact placeholder is defined.
 - Keep fail-closed behavior for required oversized non-image content.
 
 ## Impact

--- a/openspec/changes/allow-compact-inline-image-elision/proposal.md
+++ b/openspec/changes/allow-compact-inline-image-elision/proposal.md
@@ -12,6 +12,9 @@ with `responses_compact_input_too_large`.
 - Replace inline data-URL images inside required function, custom, and
   apply-patch tool outputs with an explicit textual omission marker only while
   preparing an oversized compact request.
+- Prefer lossless context selection before eliding image bytes; when a legacy
+  Chat `image_url` part must be elided, replace the whole part with a valid
+  Chat text part rather than writing a marker into its URL field.
 - Preserve the surrounding tool call/output identities and all textual content.
 - Leave accepted `input_file` references and ordinary non-compact requests unchanged.
 - Keep hosted `computer_call_output` screenshots fail-closed until a

--- a/openspec/changes/allow-compact-inline-image-elision/proposal.md
+++ b/openspec/changes/allow-compact-inline-image-elision/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+Long-running image-heavy Codex sessions can reach terminal compaction with a
+required latest tool output containing a large inline data-URL image. The model
+already observed the image during the live turn, but the compact request must
+retain the latest tool call/output pair. Retaining the raw image bytes can exceed
+the compact wire cap and permanently terminate an otherwise recoverable thread
+with `responses_compact_input_too_large`.
+
+## What Changes
+
+- Replace inline data-URL image parts with an explicit textual omission marker
+  only while preparing an oversized compact request.
+- Preserve the surrounding tool call/output identities and all textual content.
+- Leave file-backed image references and ordinary non-compact requests unchanged.
+- Keep fail-closed behavior for required oversized non-image content.
+
+## Impact
+
+- Affected spec: `responses-api-compat`.
+- Affected code: compact request preparation in `app/core/openai/requests.py`.
+- No schema, account-selection, or normal Responses wire behavior changes.

--- a/openspec/changes/allow-compact-inline-image-elision/specs/responses-api-compat/spec.md
+++ b/openspec/changes/allow-compact-inline-image-elision/specs/responses-api-compat/spec.md
@@ -12,10 +12,12 @@ MUST NOT weaken fail-closed handling for oversized textual state.
 #### Scenario: Oversized inline image does not poison terminal compaction
 
 - **WHEN** compact input exceeds the upstream limit because a required latest
-  tool output contains an inline data-URL image that the model already observed
+  eligible required tool output contains an inline data-URL image that the model already observed
 - **THEN** compact preparation retains the tool call and output identities
 - **AND** replaces only the inline image bytes with an explicit textual omission marker
 - **AND** preserves the other textual parts of the tool output
-- **AND** file-backed image references remain unchanged
+- **AND** accepted file-backed `input_file` references remain unchanged
+- **AND** hosted `computer_call_output` screenshots remain fail-closed until a
+  schema-valid compact placeholder is defined
 - **AND** non-image required content that cannot fit still returns
   `responses_compact_input_too_large`

--- a/openspec/changes/allow-compact-inline-image-elision/specs/responses-api-compat/spec.md
+++ b/openspec/changes/allow-compact-inline-image-elision/specs/responses-api-compat/spec.md
@@ -14,7 +14,10 @@ MUST NOT weaken fail-closed handling for oversized textual state.
 - **WHEN** compact input exceeds the upstream limit because a required latest
   eligible required tool output contains an inline data-URL image that the model already observed
 - **THEN** compact preparation retains the tool call and output identities
+- **AND** first uses lossless context trimming when that can fit the request
 - **AND** replaces only the inline image bytes with an explicit textual omission marker
+- **AND** replaces an eligible legacy Chat `image_url` content part as a whole
+  with a schema-valid text part before any generic string substitution
 - **AND** preserves the other textual parts of the tool output
 - **AND** accepted file-backed `input_file` references remain unchanged
 - **AND** hosted `computer_call_output` screenshots remain fail-closed until a

--- a/openspec/changes/allow-compact-inline-image-elision/specs/responses-api-compat/spec.md
+++ b/openspec/changes/allow-compact-inline-image-elision/specs/responses-api-compat/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Responses Lite follow-up transformations fail closed
+
+After a request is classified as Responses Lite shaped, the service MUST
+preserve required Lite state through compact preparation, MUST validate the
+final transformed compact input against the upstream JSON wire budget, and MUST
+avoid permanently poisoning a thread when already-observed inline image bytes
+alone make a required latest tool result too large. The image-byte relaxation
+MUST NOT weaken fail-closed handling for oversized textual state.
+
+#### Scenario: Oversized inline image does not poison terminal compaction
+
+- **WHEN** compact input exceeds the upstream limit because a required latest
+  tool output contains an inline data-URL image that the model already observed
+- **THEN** compact preparation retains the tool call and output identities
+- **AND** replaces only the inline image bytes with an explicit textual omission marker
+- **AND** preserves the other textual parts of the tool output
+- **AND** file-backed image references remain unchanged
+- **AND** non-image required content that cannot fit still returns
+  `responses_compact_input_too_large`

--- a/openspec/changes/allow-compact-inline-image-elision/tasks.md
+++ b/openspec/changes/allow-compact-inline-image-elision/tasks.md
@@ -1,0 +1,11 @@
+## 1. Compact preparation
+
+- [x] 1.1 Elide inline data-URL image bytes only when compact input is oversized.
+- [x] 1.2 Preserve tool call/output identity, text parts, and file-backed images.
+- [x] 1.3 Retain fail-closed handling for oversized required non-image content.
+
+## 2. Validation
+
+- [x] 2.1 Add the exact required-latest-tool-output regression.
+- [x] 2.2 Add a negative control for file-backed image references.
+- [x] 2.3 Prove the terminal compact route; retain live helper-deployed smoke as rollout evidence.

--- a/openspec/changes/allow-compact-inline-image-elision/tasks.md
+++ b/openspec/changes/allow-compact-inline-image-elision/tasks.md
@@ -1,11 +1,12 @@
 ## 1. Compact preparation
 
 - [x] 1.1 Elide inline data-URL image bytes only when compact input is oversized.
-- [x] 1.2 Preserve tool call/output identity, text parts, and file-backed images.
+- [x] 1.2 Preserve tool call/output identity, text parts, and accepted `input_file` references.
 - [x] 1.3 Retain fail-closed handling for oversized required non-image content.
+- [x] 1.4 Retain fail-closed handling for hosted computer screenshots whose schema cannot carry a text marker.
 
 ## 2. Validation
 
 - [x] 2.1 Add the exact required-latest-tool-output regression.
-- [x] 2.2 Add a negative control for file-backed image references.
+- [x] 2.2 Add negative controls for accepted `input_file` references and hosted computer screenshots.
 - [x] 2.3 Prove the terminal compact route; retain live helper-deployed smoke as rollout evidence.

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -346,6 +346,72 @@ async def test_proxy_compact_success(async_client, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_proxy_compact_ignores_file_pin_from_trimmed_optional_history(async_client, monkeypatch):
+    for raw_account_id, email in (
+        ("acc_compact_trim_file_owner", "compact-trim-file-owner@example.com"),
+        ("acc_compact_trim_selected", "compact-trim-selected@example.com"),
+    ):
+        auth_json = _make_auth_json(raw_account_id, email)
+        response = await async_client.post(
+            "/api/accounts/import",
+            files={"auth_json": ("auth.json", json.dumps(auth_json), "application/json")},
+        )
+        assert response.status_code == 200
+
+    from app.dependencies import get_proxy_service_for_app
+
+    service = get_proxy_service_for_app(async_client._transport.app)
+    async with SessionLocal() as session:
+        accounts = (await session.execute(select(Account).order_by(Account.id))).scalars().all()
+    file_owner = next(account for account in accounts if account.chatgpt_account_id == "acc_compact_trim_file_owner")
+    selected_account = next(
+        account for account in accounts if account.chatgpt_account_id == "acc_compact_trim_selected"
+    )
+    await service._pin_file_account("file_compact_trimmed_optional", file_owner.id)
+
+    seen: dict[str, object] = {}
+
+    async def fake_select_account(self, deadline, **kwargs):
+        del self, deadline
+        seen["preferred_account_id"] = kwargs.get("preferred_account_id")
+        return proxy_module.AccountSelection(account=selected_account, error_message=None)
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del headers, access_token
+        seen["upstream_account_id"] = account_id
+        seen["upstream_payload"] = payload
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget_compatible", fake_select_account)
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {"role": "user", "content": "stable prelude"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": "x" * 500_000},
+                        {"type": "input_file", "file_id": "file_compact_trimmed_optional"},
+                    ],
+                },
+                {"role": "user", "content": "continue after compaction"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert seen["preferred_account_id"] is None
+    assert seen["upstream_account_id"] == "acc_compact_trim_selected"
+    upstream_payload = seen["upstream_payload"].to_payload()
+    assert "file_compact_trimmed_optional" not in json.dumps(upstream_payload)
+
+
+@pytest.mark.asyncio
 async def test_proxy_compact_normalizes_summary_output_for_codex_remote_v2(async_client, monkeypatch):
     email = "compact-v2-summary@example.com"
     raw_account_id = "acc_compact_v2_summary"

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -16,6 +16,7 @@ from app.core.auth import generate_unique_account_id
 from app.core.clients.proxy import ProxyResponseError
 from app.core.errors import openai_error
 from app.core.openai.models import CompactResponsePayload, OpenAIResponsePayload
+from app.core.openai.requests import ResponsesCompactRequest
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus
 from app.db.session import SessionLocal
@@ -407,7 +408,7 @@ async def test_proxy_compact_ignores_file_pin_from_trimmed_optional_history(asyn
     assert response.status_code == 200
     assert seen["preferred_account_id"] is None
     assert seen["upstream_account_id"] == "acc_compact_trim_selected"
-    upstream_payload = seen["upstream_payload"].to_payload()
+    upstream_payload = cast(ResponsesCompactRequest, seen["upstream_payload"]).to_payload()
     assert "file_compact_trimmed_optional" not in json.dumps(upstream_payload)
 
 

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -531,7 +531,10 @@ async def test_proxy_responses_repeated_401_after_refresh_fails_over(async_clien
 
 
 @pytest.mark.asyncio
-async def test_proxy_responses_compaction_trigger_streams_single_compaction_item(async_client, monkeypatch):
+async def test_proxy_responses_compaction_trigger_elides_required_tool_image_and_streams_item(
+    async_client,
+    monkeypatch,
+):
     email = "compact-trigger@example.com"
     raw_account_id = "acc_compact_trigger"
     auth_json = _make_auth_json(raw_account_id, email)
@@ -577,8 +580,9 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
 
     async def fake_compact(payload, headers, access_token, account_id, **kwargs):
         del headers, access_token, kwargs
-        seen_payload["payload"] = payload.model_dump(mode="json", exclude_none=True)
-        seen_payload["input"] = payload.input
+        wire_payload = payload.to_payload()
+        seen_payload["payload"] = wire_payload
+        seen_payload["input"] = wire_payload["input"]
         seen_payload["model"] = payload.model
         seen_payload["previous_response_id"] = getattr(payload, "previous_response_id", None)
         seen_payload["conversation"] = getattr(payload, "conversation", None)
@@ -603,6 +607,23 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
         "instructions": "compact this turn",
         "input": [
             {"role": "user", "content": "hello"},
+            {
+                "type": "custom_tool_call",
+                "name": "view_image",
+                "call_id": "call_route_image",
+                "input": "{}",
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call_route_image",
+                "output": [
+                    {"type": "input_text", "text": "Image Size: 1512x982."},
+                    {
+                        "type": "input_image",
+                        "image_url": "data:image/png;base64," + "A" * 500_000,
+                    },
+                ],
+            },
             {"type": "compaction_trigger"},
         ],
         "previous_response_id": "resp_compact_anchor",
@@ -623,7 +644,14 @@ async def test_proxy_responses_compaction_trigger_streams_single_compaction_item
     assert [event["type"] for event in events] == ["response.output_item.done", "response.completed"]
     assert selection_preferred_ids == [owner_account.id]
     assert seen_payload["model"] == "gpt-5.1"
-    assert seen_payload["input"] == [{"role": "user", "content": "hello"}]
+    compact_input = cast(list[Mapping[str, object]], seen_payload["input"])
+    assert compact_input[0] == {"role": "user", "content": "hello"}
+    assert compact_input[1]["call_id"] == "call_route_image"
+    assert compact_input[2]["call_id"] == "call_route_image"
+    compact_input_json = json.dumps(compact_input)
+    assert "Image Size: 1512x982." in compact_input_json
+    assert "Omitted inline image bytes that were already observed before compaction" in compact_input_json
+    assert "data:image/png;base64" not in compact_input_json
     assert seen_payload["previous_response_id"] == "resp_compact_anchor"
     assert seen_payload["account_id"] == raw_account_id
     compact_payload = cast(Mapping[str, object], seen_payload["payload"])

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -1375,6 +1375,132 @@ def test_compact_trimming_rejects_oversized_latest_item():
     assert raised.value.code == "responses_compact_input_too_large"
 
 
+def test_compact_trimming_elides_inline_image_from_required_latest_tool_output():
+    latest_call = {
+        "type": "custom_tool_call",
+        "name": "view_image",
+        "call_id": "call-latest-image",
+        "input": "{}",
+    }
+    latest_output = {
+        "type": "custom_tool_call_output",
+        "call_id": "call-latest-image",
+        "output": [
+            {"type": "input_text", "text": "Image Size: 1512x982."},
+            {
+                "type": "input_image",
+                "detail": "original",
+                "image_url": "data:image/png;base64," + "A" * 500_000,
+            },
+        ],
+    }
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+            {"role": "user", "content": "inspect the canvas"},
+            latest_call,
+            latest_output,
+        ],
+    }
+
+    dumped_input = ResponsesCompactRequest.model_validate(payload).to_payload()["input"]
+
+    assert isinstance(dumped_input, list)
+    assert latest_call in dumped_input
+    dumped_output = next(
+        item for item in dumped_input if isinstance(item, dict) and item.get("type") == "custom_tool_call_output"
+    )
+    assert dumped_output["output"] == [
+        {"type": "input_text", "text": "Image Size: 1512x982."},
+        {
+            "type": "input_text",
+            "text": (
+                "[compact trim] Omitted inline image bytes that were already observed before compaction "
+                "(500022 encoded characters)."
+            ),
+        },
+    ]
+    assert "data:image/png;base64" not in json.dumps(dumped_input)
+    wire_bytes = len(json.dumps(dumped_input, ensure_ascii=True, sort_keys=True).encode("utf-8"))
+    assert wire_bytes <= _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS * _ESTIMATED_CHARS_PER_TOKEN
+
+
+def test_compact_trimming_elides_mapping_shaped_required_tool_image_output():
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+            {
+                "type": "custom_tool_call",
+                "name": "view_image",
+                "call_id": "call-mapping-image",
+                "input": "{}",
+            },
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call-mapping-image",
+                "output": {
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64," + "A" * 500_000,
+                },
+            },
+        ],
+    }
+
+    dumped_input = ResponsesCompactRequest.model_validate(payload).to_payload()["input"]
+
+    assert isinstance(dumped_input, list)
+    dumped_output = cast(Mapping[str, object], dumped_input[-1])
+    assert dumped_output["output"] == {
+        "type": "input_text",
+        "text": (
+            "[compact trim] Omitted inline image bytes that were already observed before compaction "
+            "(500022 encoded characters)."
+        ),
+    }
+
+
+def test_compact_trimming_keeps_file_backed_image_reference():
+    file_image = {"type": "input_image", "file_id": "file-canvas"}
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+            {"role": "assistant", "content": "x" * 500_000},
+            {"role": "user", "content": [file_image]},
+        ],
+    }
+
+    dumped_input = ResponsesCompactRequest.model_validate(payload).to_payload()["input"]
+
+    assert isinstance(dumped_input, list)
+    latest_item = cast(Mapping[str, object], dumped_input[-1])
+    assert file_image in cast(list[object], latest_item["content"])
+
+
+def test_compact_trimming_keeps_latest_unobserved_user_inline_image():
+    latest_image = {
+        "type": "input_image",
+        "image_url": "data:image/png;base64,AAAA",
+    }
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+            {"role": "assistant", "content": "x" * 500_000},
+            {"role": "user", "content": [latest_image]},
+        ],
+    }
+
+    dumped_input = ResponsesCompactRequest.model_validate(payload).to_payload()["input"]
+
+    assert isinstance(dumped_input, list)
+    latest_item = cast(Mapping[str, object], dumped_input[-1])
+    assert latest_image in cast(list[object], latest_item["content"])
+    assert "Omitted inline image bytes" not in json.dumps(dumped_input)
+
+
 def test_compact_trimming_preserves_latest_unmatched_tool_call():
     latest_call = {
         "type": "function_call",

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -1482,7 +1482,7 @@ def test_compact_trimming_elides_percent_encoded_image_url_in_string_output():
     assert "Omitted inline image bytes" in json.dumps(dumped_input)
 
 
-def test_compact_image_elision_keeps_other_input_when_rewritten_request_fits():
+def test_compact_trimming_prefers_lossless_context_trim_before_inline_image_elision():
     payload = {
         "model": "gpt-5.6-sol",
         "instructions": "",
@@ -1500,8 +1500,78 @@ def test_compact_image_elision_keeps_other_input_when_rewritten_request_fits():
     dumped_input = ResponsesCompactRequest.model_validate(payload).to_payload()["input"]
 
     assert isinstance(dumped_input, list)
-    assert dumped_input[0] == payload["input"][0]
-    assert not any(isinstance(item, dict) and item.get("type") == "message" for item in dumped_input)
+    assert dumped_input[0] != payload["input"][0]
+    assert "data:image/png;base64" in json.dumps(dumped_input)
+    assert "Omitted inline image bytes" not in json.dumps(dumped_input)
+    assert any(isinstance(item, dict) and item.get("type") == "message" for item in dumped_input)
+
+
+def test_compact_trimming_elides_structured_chat_image_url_as_text_part():
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+            {"type": "function_call", "name": "capture", "call_id": "call-chat-image", "arguments": "{}"},
+            {
+                "type": "function_call_output",
+                "call_id": "call-chat-image",
+                "output": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64," + "A" * 500_000, "detail": "high"},
+                    }
+                ],
+            },
+        ],
+    }
+
+    dumped_input = ResponsesCompactRequest.model_validate(payload).to_payload()["input"]
+
+    assert isinstance(dumped_input, list)
+    dumped_output = cast(Mapping[str, object], dumped_input[-1])
+    assert dumped_output["output"] == [
+        {
+            "type": "text",
+            "text": (
+                "[compact trim] Omitted inline image bytes that were already observed before compaction "
+                "(500022 encoded characters)."
+            ),
+        }
+    ]
+
+
+def test_compact_trimming_elides_bare_chat_image_url_as_text_part():
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+            {"type": "function_call", "name": "capture", "call_id": "call-bare-chat-image", "arguments": "{}"},
+            {
+                "type": "function_call_output",
+                "call_id": "call-bare-chat-image",
+                "output": [
+                    {
+                        "type": "image_url",
+                        "image_url": "data:image/png;base64," + "A" * 500_000,
+                    }
+                ],
+            },
+        ],
+    }
+
+    dumped_input = ResponsesCompactRequest.model_validate(payload).to_payload()["input"]
+
+    assert isinstance(dumped_input, list)
+    dumped_output = cast(Mapping[str, object], dumped_input[-1])
+    assert dumped_output["output"] == [
+        {
+            "type": "text",
+            "text": (
+                "[compact trim] Omitted inline image bytes that were already observed before compaction "
+                "(500022 encoded characters)."
+            ),
+        }
+    ]
 
 
 def test_compact_trimming_keeps_accepted_file_reference_while_eliding_inline_image():
@@ -2695,7 +2765,7 @@ def test_extract_input_file_ids_string_input_returns_empty_set():
     assert extract_input_file_ids("Hello world") == set()
 
 
-def test_extract_input_file_ids_finds_top_level_and_nested_ids():
+def test_extract_input_file_ids_finds_actual_input_references_but_not_tool_metadata():
     input_value: list[JsonValue] = [
         {
             "role": "user",
@@ -2714,6 +2784,24 @@ def test_extract_input_file_ids_finds_top_level_and_nested_ids():
             "type": "custom_tool_call_output",
             "call_id": "call-file",
             "output": [{"type": "input_file", "file_id": "file_tool_output"}],
+        },
+        {
+            "type": "custom_tool_call",
+            "call_id": "call-metadata",
+            "input": {"type": "input_file", "file_id": "file_call_metadata"},
+        },
+        {
+            "type": "additional_tools",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "parameters": {
+                            "properties": {"fake_file": {"type": "input_file", "file_id": "file_tool_schema"}}
+                        }
+                    },
+                }
+            ],
         },
     ]
     assert extract_input_file_ids(input_value) == {"file_a", "file_b", "file_c", "file_tool_output"}

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -1461,14 +1461,21 @@ def test_compact_trimming_elides_mapping_shaped_required_tool_image_output():
     }
 
 
-def test_compact_trimming_keeps_file_backed_image_reference():
-    file_image = {"type": "input_image", "file_id": "file-canvas"}
+def test_compact_trimming_keeps_accepted_file_reference_while_eliding_inline_image():
+    file_reference = {"type": "input_file", "file_id": "file-canvas"}
     payload = {
         "model": "gpt-5.6-sol",
         "instructions": "",
         "input": [
-            {"role": "assistant", "content": "x" * 500_000},
-            {"role": "user", "content": [file_image]},
+            {"type": "custom_tool_call", "name": "view_image", "call_id": "call-file", "input": "{}"},
+            {
+                "type": "custom_tool_call_output",
+                "call_id": "call-file",
+                "output": [
+                    file_reference,
+                    {"type": "input_image", "image_url": "data:image/png;base64," + "A" * 500_000},
+                ],
+            },
         ],
     }
 
@@ -1476,7 +1483,61 @@ def test_compact_trimming_keeps_file_backed_image_reference():
 
     assert isinstance(dumped_input, list)
     latest_item = cast(Mapping[str, object], dumped_input[-1])
-    assert file_image in cast(list[object], latest_item["content"])
+    assert file_reference in cast(list[object], latest_item["output"])
+    assert "data:image/png;base64" not in json.dumps(dumped_input)
+
+
+def test_compact_trimming_keeps_hosted_computer_screenshot_fail_closed():
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+            {
+                "type": "computer_call",
+                "call_id": "call-computer",
+                "action": {"type": "screenshot"},
+            },
+            {
+                "type": "computer_call_output",
+                "call_id": "call-computer",
+                "output": {
+                    "type": "computer_screenshot",
+                    "image_url": "data:image/png;base64," + "A" * 500_000,
+                },
+            },
+        ],
+    }
+
+    with pytest.raises(ClientPayloadError) as raised:
+        ResponsesCompactRequest.model_validate(payload).to_payload()
+
+    assert raised.value.code == "responses_compact_input_too_large"
+    assert raised.value.param == "input"
+
+
+def test_compact_trimming_elides_data_url_inside_string_tool_output():
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+            {"type": "function_call", "name": "capture", "call_id": "call-string", "arguments": "{}"},
+            {
+                "type": "function_call_output",
+                "call_id": "call-string",
+                "output": "prefix data:image/png;base64," + "A" * 500_000 + " suffix",
+            },
+        ],
+    }
+
+    dumped_input = ResponsesCompactRequest.model_validate(payload).to_payload()["input"]
+
+    assert isinstance(dumped_input, list)
+    dumped_output = cast(Mapping[str, object], dumped_input[-1])
+    output = cast(str, dumped_output["output"])
+    assert output.startswith("prefix ")
+    assert output.endswith(" suffix")
+    assert "Omitted inline image bytes" in output
+    assert "data:image/png;base64" not in output
 
 
 def test_compact_trimming_keeps_latest_unobserved_user_inline_image():

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -1461,6 +1461,49 @@ def test_compact_trimming_elides_mapping_shaped_required_tool_image_output():
     }
 
 
+def test_compact_trimming_elides_percent_encoded_image_url_in_string_output():
+    image_url = "data:image/svg+xml,%3Csvg%3E" + "%20" * 170_000 + "%3C/svg%3E"
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+            {"type": "function_call", "name": "render", "call_id": "call-svg", "arguments": "{}"},
+            {
+                "type": "function_call_output",
+                "call_id": "call-svg",
+                "output": f"rendered {image_url}",
+            },
+        ],
+    }
+
+    dumped_input = ResponsesCompactRequest.model_validate(payload).to_payload()["input"]
+
+    assert "data:image/svg+xml" not in json.dumps(dumped_input)
+    assert "Omitted inline image bytes" in json.dumps(dumped_input)
+
+
+def test_compact_image_elision_keeps_other_input_when_rewritten_request_fits():
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+            {"role": "user", "content": "retain-middle-" + "x" * 250_000},
+            {"type": "function_call", "name": "render", "call_id": "call-fit", "arguments": "{}"},
+            {
+                "type": "function_call_output",
+                "call_id": "call-fit",
+                "output": "data:image/png;base64," + "A" * 300_000,
+            },
+        ],
+    }
+
+    dumped_input = ResponsesCompactRequest.model_validate(payload).to_payload()["input"]
+
+    assert isinstance(dumped_input, list)
+    assert dumped_input[0] == payload["input"][0]
+    assert not any(isinstance(item, dict) and item.get("type") == "message" for item in dumped_input)
+
+
 def test_compact_trimming_keeps_accepted_file_reference_while_eliding_inline_image():
     file_reference = {"type": "input_file", "file_id": "file-canvas"}
     payload = {
@@ -2667,8 +2710,13 @@ def test_extract_input_file_ids_finds_top_level_and_nested_ids():
         {"type": "input_file", "file_id": "file_a"},
         {"type": "input_file", "file_id": ""},
         {"type": "input_file"},
+        {
+            "type": "custom_tool_call_output",
+            "call_id": "call-file",
+            "output": [{"type": "input_file", "file_id": "file_tool_output"}],
+        },
     ]
-    assert extract_input_file_ids(input_value) == {"file_a", "file_b", "file_c"}
+    assert extract_input_file_ids(input_value) == {"file_a", "file_b", "file_c", "file_tool_output"}
 
 
 def test_input_image_file_reference_returns_file_id_from_input_image_file_id():


### PR DESCRIPTION
## Summary

Prevent eligible image-heavy Codex tool results from poisoning terminal
compaction. When an oversized required function, custom, or apply-patch tool
output contains an already-observed inline data-URL image, compact preparation
keeps the call/output identity and surrounding text while replacing only those
image bytes with an explicit omission marker.

Current head: `e3dde57931a8074e86e51a22c4b6fda628025e51`.

## Root cause

The required latest call/output pair can exceed the compact endpoint's wire
budget solely because it carries hundreds of kilobytes of image data. The
previous fail-closed guard then returned `responses_compact_input_too_large`,
permanently wedging an otherwise recoverable thread.

## Changes

- try lossless required-state selection first;
- elide data-URL images only inside eligible required tool-output items;
- handle structured `input_image` parts plus base64 and percent-encoded data
  URLs in string outputs;
- preserve call IDs, surrounding text, all otherwise-fitting context, and
  account-pinned nested `input_file` references;
- leave latest user images and normal Responses requests unchanged;
- keep oversized text and hosted `computer_call_output` screenshots
  fail-closed until a schema-valid computer screenshot placeholder exists;
- keep the image-elision constants isolated so the rebased change composes
  cleanly with current request-normalization work.

## Validation

- focused compact request suite: 151 passed, including the terminal
  compaction-trigger route and retained-file-routing regressions;
- Ruff and `ty` passed for the touched Python;
- strict OpenSpec validation previously passed for
  `allow-compact-inline-image-elision`.

Hosted checks on the current head remain authoritative for merge.
