### PR TITLE
fix(useragent): fixing the unexpected category on useragent group

### DIFF
--- a/app/db/alembic/versions/20260722_000000_backfill_request_log_useragent_families.py
+++ b/app/db/alembic/versions/20260722_000000_backfill_request_log_useragent_families.py
@@ -1,0 +1,40 @@
+"""backfill request log useragent families
+
+Revision ID: 20260722_000000_backfill_request_log_useragent_families
+Revises: 20260720_000000_add_request_log_conversation_id
+Create Date: 2026-07-22 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260722_000000_backfill_request_log_useragent_families"
+down_revision = "20260720_000000_add_request_log_conversation_id"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    dialect_name = op.get_bind().dialect.name
+    if dialect_name == "postgresql":
+        op.execute(
+            sa.text(
+                "UPDATE request_logs "
+                "SET useragent_group = substring(useragent from 1 for position('/' in useragent) - 1) "
+                "WHERE useragent IS NOT NULL AND position('/' in useragent) > 0"
+            )
+        )
+    else:
+        op.execute(
+            sa.text(
+                "UPDATE request_logs "
+                "SET useragent_group = substr(useragent, 1, instr(useragent, '/') - 1) "
+                "WHERE useragent IS NOT NULL AND instr(useragent, '/') > 0"
+            )
+        )
+
+
+def downgrade() -> None:
+    pass

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -458,6 +458,8 @@ def _request_log_useragent_fields(headers: Mapping[str, str]) -> tuple[str | Non
         return None, None
     first_token = useragent.split(maxsplit=1)[0]
     useragent_group = first_token.split("/", 1)[0].strip() or None
+    if "/" in useragent:
+        useragent_group = useragent.split("/", 1)[0]
     return useragent, useragent_group
 
 

--- a/openspec/changes/fix-useragent-migration-unicode-whitespace/design.md
+++ b/openspec/changes/fix-useragent-migration-unicode-whitespace/design.md
@@ -1,0 +1,69 @@
+## Context
+
+Request-log grouping currently takes the first whitespace-delimited token before
+splitting on `/`. Consequently, a header such as `Codex Desktop/0.142.4` is
+recorded with the family `Codex`, although the delimiter-defined family is
+`Codex Desktop`. Historical `request_logs.useragent_group` values require the
+same correction.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Derive a user-agent family from the complete substring before the first `/`.
+- Keep slash-free input behavior unchanged.
+- Backfill only non-null stored user-agent values that contain `/`, without
+  whitespace trimming or other preprocessing.
+
+**Non-Goals:**
+
+- Parsing arbitrary user-agent grammar beyond the first `/` delimiter.
+- Changing the persisted raw `useragent` value.
+- Updating stored values with no `/`.
+
+## Decisions
+
+### Use the first slash in the normalized header as the family boundary
+
+The request-log helper will retain its existing missing/blank-header
+normalization, then derive the group from the substring before the first `/`,
+rather than first splitting on whitespace. This matches the stated
+client-family contract for product names containing spaces. Retaining the
+slash-free path avoids changing its existing behavior.
+
+Alternative: retain first-token parsing. This is rejected because it truncates
+multi-word product names such as `Codex Desktop`.
+
+### Backfill with a delimiter-gated database expression
+
+The Alembic revision will update `useragent_group` only where `useragent` is
+non-null and contains `/`, assigning the database substring before that slash.
+The expression operates on stored text directly and performs no trim,
+normalization, or preprocessing.
+
+Alternative: backfill every non-null row and rely on a substring function's
+no-delimiter result. This is rejected because slash-free rows must remain
+untouched.
+
+## Risks / Trade-offs
+
+- [Database substring syntax differs by dialect] → Use the migration project's
+  established dialect-aware migration pattern and verify upgrade behavior on
+  supported test databases.
+- [Runtime and historical values have different whitespace treatment] → The
+  runtime path retains its established missing/blank-header normalization,
+  while the migration derives groups directly from stored text as required.
+
+## Migration Plan
+
+1. Add a revision after the current Alembic head.
+2. Update eligible historical rows with the first-slash family expression.
+3. Verify the revision upgrades to a single Alembic head and preserves
+   slash-free and null rows.
+4. Roll back the revision through its downgrade path if deployment must be
+   reversed; the stored backfill values may remain because the source
+   `useragent` values are unchanged and the correction is repeatable.
+
+## Open Questions
+
+None.

--- a/openspec/changes/fix-useragent-migration-unicode-whitespace/proposal.md
+++ b/openspec/changes/fix-useragent-migration-unicode-whitespace/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Request logs currently classify `Codex Desktop/...` as `Codex` because grouping stops at whitespace before it considers the product-version delimiter. This loses the actual client family in reports and existing request-log rows.
+
+## What Changes
+
+- Derive request-log `useragent_group` from all characters before the first `/` in the inbound `User-Agent` value.
+- Preserve the existing handling for values without `/`.
+- Add an Alembic data migration that backfills only non-null `useragent` rows containing `/`, without trimming or other whitespace preprocessing.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-runtime-observability`: Request-log user-agent grouping uses the complete pre-slash client family rather than the first whitespace-delimited token.
+
+## Impact
+
+- `app/modules/proxy/_service/support.py` request-log user-agent extraction
+- `request_logs.useragent_group` historical data through a new Alembic revision
+- Proxy user-agent extraction tests and migration validation

--- a/openspec/changes/fix-useragent-migration-unicode-whitespace/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/fix-useragent-migration-unicode-whitespace/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Request logs persist prompt-client user-agent metadata
+The proxy MUST persist prompt-client user-agent metadata on `request_logs` for both HTTP and WebSocket Responses traffic. Each persisted row MUST store the full inbound `User-Agent` header value when present and a derived `useragent_group` value. When the inbound header contains `/`, `useragent_group` MUST be the complete sequence of characters before its first `/`; when it contains no `/`, the existing group extraction behavior MUST remain unchanged. When the inbound header is missing or blank after trimming, both persisted values MUST be `null`.
+
+#### Scenario: Historical request-log user-agent families are backfilled without normalization
+- **WHEN** the user-agent family migration processes historical `request_logs` rows
+- **THEN** rows whose `useragent` is non-null and contains `/` MUST have `useragent_group` set to the exact unprocessed full prefix before the first `/`
+- **AND** rows whose `useragent` is `null` or contains no `/` MUST remain unchanged
+
+#### Scenario: HTTP request log stores user-agent metadata
+- **WHEN** an HTTP or HTTP/SSE proxy request includes `User-Agent: opencode/1.15.13 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14`
+- **THEN** the persisted `request_logs` row stores `useragent = "opencode/1.15.13 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14"`
+- **AND** the persisted row stores `useragent_group = "opencode"`
+
+#### Scenario: Multi-word product family retains its full prefix
+- **WHEN** an HTTP or HTTP/SSE proxy request includes `User-Agent: Codex Desktop/0.142.4`
+- **THEN** the persisted `request_logs` row stores `useragent_group = "Codex Desktop"`
+
+#### Scenario: WebSocket request log stores user-agent metadata
+- **WHEN** a proxied WebSocket Responses session is opened with `User-Agent: opencode/1.15.13 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.14`
+- **THEN** the persisted `request_logs` row for that request stores the full header in `useragent`
+- **AND** the persisted row stores `useragent_group = "opencode"`
+
+#### Scenario: Missing or blank user-agent remains null
+- **WHEN** a proxied HTTP or WebSocket request omits the `User-Agent` header or sends only blank whitespace
+- **THEN** the persisted `request_logs` row stores `useragent = null`
+- **AND** the persisted row stores `useragent_group = null`

--- a/openspec/changes/fix-useragent-migration-unicode-whitespace/tasks.md
+++ b/openspec/changes/fix-useragent-migration-unicode-whitespace/tasks.md
@@ -1,0 +1,15 @@
+## 1. Runtime grouping
+
+- [x] 1.1 Update request-log user-agent grouping so slash-delimited families retain the complete pre-slash prefix while slash-free behavior remains unchanged.
+- [x] 1.2 Add focused unit coverage for `Codex Desktop/...` and preserve existing null, blank, and slash-free cases.
+
+## 2. Historical data migration
+
+- [x] 2.1 Add an Alembic revision after the current head that backfills `useragent_group` from the unprocessed pre-slash substring only for non-null `useragent` rows containing `/`.
+- [x] 2.2 Verify migration behavior preserves null and slash-free rows and does not trim stored values.
+
+## 3. Validation
+
+- [x] 3.3 Add focused PostgreSQL migration-expression coverage.
+- [x] 3.1 Run the focused proxy user-agent tests and Alembic head/upgrade validation.
+- [x] 3.2 Run `openspec validate --specs` and mark completed tasks.

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -475,6 +475,90 @@ def test_request_logs_transport_stays_in_additive_migration_chain(tmp_path: Path
         assert "transport" in columns
 
 
+def test_request_log_useragent_family_migration_backfills_only_slash_values(tmp_path: Path) -> None:
+    db_path = tmp_path / "request-log-useragent-families.db"
+    url = _db_url(db_path)
+    parent_revision = "20260720_000000_add_request_log_conversation_id"
+    target_revision = "20260722_000000_backfill_request_log_useragent_families"
+
+    run_upgrade(url, parent_revision, bootstrap_legacy=False)
+    engine = create_engine(to_sync_database_url(url), future=True)
+    try:
+        with engine.begin() as connection:
+            connection.execute(
+                text(
+                    "INSERT INTO request_logs (request_id, model, status, useragent, useragent_group) "
+                    "VALUES (:request_id, :model, :status, :useragent, :useragent_group)"
+                ),
+                [
+                    {
+                        "request_id": "slash",
+                        "model": "gpt-5",
+                        "status": "success",
+                        "useragent": "Codex Desktop/0.142.4",
+                        "useragent_group": "Codex",
+                    },
+                    {
+                        "request_id": "whitespace",
+                        "model": "gpt-5",
+                        "status": "success",
+                        "useragent": " Codex Desktop/0.142.4",
+                        "useragent_group": "Codex",
+                    },
+                    {
+                        "request_id": "slash-free",
+                        "model": "gpt-5",
+                        "status": "success",
+                        "useragent": "CodexCLI",
+                        "useragent_group": "sentinel-slash-free",
+                    },
+                    {
+                        "request_id": "null",
+                        "model": "gpt-5",
+                        "status": "success",
+                        "useragent": None,
+                        "useragent_group": "sentinel-null",
+                    },
+                ],
+            )
+    finally:
+        engine.dispose()
+
+    run_upgrade(url, target_revision, bootstrap_legacy=False)
+    engine = create_engine(to_sync_database_url(url), future=True)
+    try:
+        with engine.begin() as connection:
+            groups = dict(connection.execute(text("SELECT request_id, useragent_group FROM request_logs")).all())
+    finally:
+        engine.dispose()
+
+    assert groups == {
+        "slash": "Codex Desktop",
+        "whitespace": " Codex Desktop",
+        "slash-free": "sentinel-slash-free",
+        "null": "sentinel-null",
+    }
+
+
+def test_request_log_useragent_family_migration_selects_postgresql_expression(monkeypatch) -> None:
+    migration = importlib.import_module(
+        "app.db.alembic.versions.20260722_000000_backfill_request_log_useragent_families"
+    )
+    fake_bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+    selected_statements: list[object] = []
+
+    monkeypatch.setattr(migration.op, "get_bind", lambda: fake_bind)
+    monkeypatch.setattr(migration.op, "execute", selected_statements.append)
+
+    migration.upgrade()
+
+    assert len(selected_statements) == 1
+    sql = str(selected_statements[0])
+    assert "substring(useragent from 1 for position('/' in useragent) - 1)" in sql
+    assert "WHERE useragent IS NOT NULL AND position('/' in useragent) > 0" in sql
+    assert "trim" not in sql.lower()
+
+
 def test_request_logs_response_lookup_migration_handles_preexisting_session_id_column(tmp_path: Path) -> None:
     db_path = tmp_path / "request-logs-session-id-drift.db"
     url = _db_url(db_path)

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -528,7 +528,10 @@ def test_request_log_useragent_family_migration_backfills_only_slash_values(tmp_
     engine = create_engine(to_sync_database_url(url), future=True)
     try:
         with engine.begin() as connection:
-            groups = dict(connection.execute(text("SELECT request_id, useragent_group FROM request_logs")).all())
+            groups = {
+                row.request_id: row.useragent_group
+                for row in connection.execute(text("SELECT request_id, useragent_group FROM request_logs")).all()
+            }
     finally:
         engine.dispose()
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1296,6 +1296,21 @@ def test_request_log_useragent_fields_extract_full_value_and_group() -> None:
     )
 
 
+def test_request_log_useragent_fields_preserve_multi_word_family() -> None:
+    useragent, useragent_group = proxy_service._request_log_useragent_fields(
+        {"User-Agent": "Codex Desktop/0.142.4"}
+    )
+
+    assert useragent == "Codex Desktop/0.142.4"
+    assert useragent_group == "Codex Desktop"
+
+    slash_free_useragent, slash_free_group = proxy_service._request_log_useragent_fields(
+        {"User-Agent": "CodexCLI"}
+    )
+    assert slash_free_useragent == "CodexCLI"
+    assert slash_free_group == "CodexCLI"
+
+
 def test_request_log_useragent_fields_accept_lowercase_header_name() -> None:
     assert proxy_service._request_log_useragent_fields(
         {

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1297,16 +1297,12 @@ def test_request_log_useragent_fields_extract_full_value_and_group() -> None:
 
 
 def test_request_log_useragent_fields_preserve_multi_word_family() -> None:
-    useragent, useragent_group = proxy_service._request_log_useragent_fields(
-        {"User-Agent": "Codex Desktop/0.142.4"}
-    )
+    useragent, useragent_group = proxy_service._request_log_useragent_fields({"User-Agent": "Codex Desktop/0.142.4"})
 
     assert useragent == "Codex Desktop/0.142.4"
     assert useragent_group == "Codex Desktop"
 
-    slash_free_useragent, slash_free_group = proxy_service._request_log_useragent_fields(
-        {"User-Agent": "CodexCLI"}
-    )
+    slash_free_useragent, slash_free_group = proxy_service._request_log_useragent_fields({"User-Agent": "CodexCLI"})
     assert slash_free_useragent == "CodexCLI"
     assert slash_free_group == "CodexCLI"
 


### PR DESCRIPTION
## Summary

Fix request-log user-agent grouping so `Codex Desktop/0.142.4` is recorded as `Codex Desktop`, rather than truncating the client family to `Codex`.

Adds an Alembic migration to correct existing request-log groups.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: N/A

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path (image pipeline, request/response
      shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/fix-useragent-migration-unicode-whitespace/`

## Changes

- Derive `useragent_group` from the complete prefix before the first `/`, preserving multi-word client families such as `Codex Desktop`.
- Preserve the existing behavior for user-agent values without `/`.
- Add an Alembic migration that backfills `request_logs.useragent_group` for stored non-null user-agent values containing `/`.
- Preserve null and slash-free historical values without normalization or trimming.
- Add focused runtime and migration tests, including PostgreSQL expression coverage.

## Test plan

```sh
uv run pytest tests/unit/test_proxy_utils.py::test_request_log_useragent_fields_preserve_multi_word_family -q
uv run pytest tests/unit/test_db_migrate.py::test_request_log_useragent_family_migration_backfills_only_slash_values -q
uv run pytest tests/unit/test_db_migrate.py::test_request_log_useragent_family_migration_selects_postgresql_expression -q
openspec validate --specs
```
<img width="480" height="253" alt="螢幕截圖 2026-07-20 15 57 45" src="https://github.com/user-attachments/assets/7275ac1f-7c14-4675-b571-e907c8660edc" />  
Before   
<img width="474" height="241" alt="螢幕截圖 2026-07-20 16 08 21" src="https://github.com/user-attachments/assets/5d5ff675-93dc-4a2d-9f46-1b0ec157700f" />  
After