### PR TITLE
feat(helm): support creating an application-specific Gateway

### DIFF
--- a/deploy/helm/codex-lb/README.md
+++ b/deploy/helm/codex-lb/README.md
@@ -558,6 +558,43 @@ custom rules, the chart preserves their order and adds the codex-lb Service as
 the backend of every rule. Referenced extension resources must be valid for the
 HTTPRoute namespace according to the selected Gateway implementation.
 
+### Application-specific Gateway
+
+By default the HTTPRoute attaches to an existing (typically shared) Gateway via
+`gatewayApi.parentRefs`. Set `gatewayApi.gateway.create=true` to instead render
+a Gateway dedicated to this release in the release namespace; the HTTPRoute
+then attaches to it automatically and `gatewayApi.parentRefs` is ignored.
+
+```yaml
+gatewayApi:
+  enabled: true
+  gateway:
+    create: true
+    gatewayClassName: envoy
+  hostnames:
+    - codex-lb.example.com
+```
+
+`gatewayApi.gateway.gatewayClassName` is required when `create=true`. Without
+`gatewayApi.gateway.listeners` the Gateway gets a single HTTP listener on port
+80; set `listeners` explicitly for TLS or non-default ports:
+
+```yaml
+gatewayApi:
+  enabled: true
+  gateway:
+    create: true
+    gatewayClassName: envoy
+    listeners:
+      - name: https
+        port: 443
+        protocol: HTTPS
+        tls:
+          mode: Terminate
+          certificateRefs:
+            - name: codex-lb-tls
+```
+
 ### nginx annotations and responses sticky routing
 
 All nginx-specific annotations are gated behind `ingress.nginx.enabled=true` and render as **one coherent set**: the streaming-safety annotations (proxy buffering off, 3600s read/send timeouts, 50m body size, HTTP/1.1) and the sticky-hash annotations always appear together. Enabling ingress on an nginx class without `ingress.nginx.enabled=true` renders no nginx annotations at all — which means the controller's defaults (60s read timeout, 1m body cap) apply and will cut long-lived SSE/WebSocket streams.

--- a/deploy/helm/codex-lb/README.md
+++ b/deploy/helm/codex-lb/README.md
@@ -558,42 +558,9 @@ custom rules, the chart preserves their order and adds the codex-lb Service as
 the backend of every rule. Referenced extension resources must be valid for the
 HTTPRoute namespace according to the selected Gateway implementation.
 
-### Application-specific Gateway
-
-By default the HTTPRoute attaches to an existing (typically shared) Gateway via
-`gatewayApi.parentRefs`. Set `gatewayApi.gateway.create=true` to instead render
-a Gateway dedicated to this release in the release namespace; the HTTPRoute
-then attaches to it automatically and `gatewayApi.parentRefs` is ignored.
-
-```yaml
-gatewayApi:
-  enabled: true
-  gateway:
-    create: true
-    gatewayClassName: envoy
-  hostnames:
-    - codex-lb.example.com
-```
-
-`gatewayApi.gateway.gatewayClassName` is required when `create=true`. Without
-`gatewayApi.gateway.listeners` the Gateway gets a single HTTP listener on port
-80; set `listeners` explicitly for TLS or non-default ports:
-
-```yaml
-gatewayApi:
-  enabled: true
-  gateway:
-    create: true
-    gatewayClassName: envoy
-    listeners:
-      - name: https
-        port: 443
-        protocol: HTTPS
-        tls:
-          mode: Terminate
-          certificateRefs:
-            - name: codex-lb-tls
-```
+For application-specific Gateway setup, see the
+[Kubernetes deployment guide](../../../docs/deployment/kubernetes.md#application-specific-gateway)
+and the [owning OpenSpec change](../../../openspec/changes/create-application-gateway/).
 
 ### nginx annotations and responses sticky routing
 

--- a/deploy/helm/codex-lb/templates/gateway.yaml
+++ b/deploy/helm/codex-lb/templates/gateway.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.gatewayApi.enabled .Values.gatewayApi.gateway.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ include "codex-lb.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "codex-lb.labels" . | nindent 4 }}
+  {{- with .Values.gatewayApi.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  gatewayClassName: {{ required "gatewayApi.gateway.gatewayClassName is required when gatewayApi.gateway.create=true" .Values.gatewayApi.gateway.gatewayClassName }}
+  listeners:
+    {{- if .Values.gatewayApi.gateway.listeners }}
+    {{- toYaml .Values.gatewayApi.gateway.listeners | nindent 4 }}
+    {{- else }}
+    - name: http
+      port: 80
+      protocol: HTTP
+    {{- end }}
+{{- end }}

--- a/deploy/helm/codex-lb/templates/httproute.yaml
+++ b/deploy/helm/codex-lb/templates/httproute.yaml
@@ -12,7 +12,11 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
+    {{- if .Values.gatewayApi.gateway.create }}
+    - name: {{ include "codex-lb.fullname" . }}
+    {{- else }}
     {{- toYaml .Values.gatewayApi.parentRefs | nindent 4 }}
+    {{- end }}
   {{- if .Values.gatewayApi.hostnames }}
   hostnames:
     {{- toYaml .Values.gatewayApi.hostnames | nindent 4 }}

--- a/deploy/helm/codex-lb/values.schema.json
+++ b/deploy/helm/codex-lb/values.schema.json
@@ -84,6 +84,18 @@
       "type": "object",
       "properties": {
         "enabled": { "type": "boolean" },
+        "gateway": {
+          "type": "object",
+          "properties": {
+            "create": { "type": "boolean" },
+            "gatewayClassName": { "type": "string" },
+            "annotations": { "type": "object" },
+            "listeners": {
+              "type": "array",
+              "items": { "type": "object" }
+            }
+          }
+        },
         "rules": {
           "type": "array",
           "items": {

--- a/deploy/helm/codex-lb/values.yaml
+++ b/deploy/helm/codex-lb/values.yaml
@@ -358,7 +358,16 @@ ingress:
 gatewayApi:
   # @param gatewayApi.enabled Enable Gateway API HTTPRoute
   enabled: false
-  # @param gatewayApi.parentRefs Gateway parent references
+  gateway:
+    # @param gatewayApi.gateway.create Create an application-specific Gateway for this release instead of attaching to an existing shared Gateway
+    create: false
+    # @param gatewayApi.gateway.gatewayClassName GatewayClass name for the chart-managed Gateway (required when create=true)
+    gatewayClassName: ""
+    # @param gatewayApi.gateway.annotations Annotations for the chart-managed Gateway
+    annotations: {}
+    # @param gatewayApi.gateway.listeners Listeners for the chart-managed Gateway (empty = one HTTP listener on port 80)
+    listeners: []
+  # @param gatewayApi.parentRefs Gateway parent references (ignored when gatewayApi.gateway.create=true)
   parentRefs:
     - name: gateway
       namespace: gateway-system

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -74,6 +74,29 @@ forward-auth middleware.
 Extension resources must be valid for the release namespace according to the
 Gateway implementation.
 
+## Application-specific Gateway
+
+When no shared Gateway exists (or the release should not depend on one), set
+`gatewayApi.gateway.create=true` to render a Gateway dedicated to this release
+in the release namespace. The chart's HTTPRoute attaches to it automatically
+and `gatewayApi.parentRefs` is ignored:
+
+```yaml
+gatewayApi:
+  enabled: true
+  gateway:
+    create: true
+    gatewayClassName: envoy
+  hostnames:
+    - codex-lb.example.com
+```
+
+`gatewayApi.gateway.gatewayClassName` is required when `create=true`. The
+Gateway defaults to a single HTTP listener on port 80; override
+`gatewayApi.gateway.listeners` for TLS or other ports. See the
+[Helm chart README](https://github.com/Soju06/codex-lb/blob/main/deploy/helm/codex-lb/README.md)
+for a TLS listener example.
+
 ## Full chart reference
 
 For external database, production config, ingress, observability, and more see the

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -93,9 +93,7 @@ gatewayApi:
 
 `gatewayApi.gateway.gatewayClassName` is required when `create=true`. The
 Gateway defaults to a single HTTP listener on port 80; override
-`gatewayApi.gateway.listeners` for TLS or other ports. See the
-[Helm chart README](https://github.com/Soju06/codex-lb/blob/main/deploy/helm/codex-lb/README.md)
-for a TLS listener example.
+`gatewayApi.gateway.listeners` for TLS or other ports.
 
 ## Full chart reference
 

--- a/openspec/changes/create-application-gateway/.openspec.yaml
+++ b/openspec/changes/create-application-gateway/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/create-application-gateway/proposal.md
+++ b/openspec/changes/create-application-gateway/proposal.md
@@ -1,0 +1,26 @@
+# Create an application-specific Gateway from the Helm chart
+
+## Why
+
+The Helm chart's Gateway API support only renders an HTTPRoute that attaches
+to a pre-existing Gateway through `gatewayApi.parentRefs`. Operators without a
+shared cluster Gateway must hand-manage one outside the chart before the
+HTTPRoute can bind, which breaks the chart's self-contained install contract.
+
+## What Changes
+
+- Add an optional `gatewayApi.gateway.create` mode that renders a Gateway
+  dedicated to the release in the release namespace.
+- Require an operator-supplied `gatewayApi.gateway.gatewayClassName` when the
+  chart-managed Gateway is enabled.
+- Default the chart-managed Gateway to a single HTTP listener on port 80 and
+  allow operator-defined listeners (for example HTTPS with certificate refs).
+- Attach the chart's HTTPRoute to the chart-managed Gateway automatically,
+  ignoring `gatewayApi.parentRefs` in this mode.
+- Preserve the existing parentRefs-based attachment when the mode is off.
+
+## Impact
+
+- **Spec**: `deployment-networking`
+- **Helm**: optional chart-managed Gateway rendering; defaults are unchanged.
+- **Runtime/UI**: no application, database, migration, or dashboard changes.

--- a/openspec/changes/create-application-gateway/specs/deployment-networking/spec.md
+++ b/openspec/changes/create-application-gateway/specs/deployment-networking/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Helm chart can create an application-specific Gateway
+
+The Helm chart MUST allow operators to render a Gateway API `Gateway`
+dedicated to the release in the release namespace instead of attaching to a
+pre-existing shared Gateway. The mode MUST be optional and default off,
+preserving the existing `gatewayApi.parentRefs` attachment. When enabled, the
+chart MUST require an operator-supplied GatewayClass name, MUST default the
+Gateway to a single HTTP listener on port 80 while honoring operator-defined
+listeners verbatim, and MUST attach the chart-managed HTTPRoute to the
+chart-managed Gateway while ignoring `gatewayApi.parentRefs`.
+
+#### Scenario: Chart-managed Gateway with default listener
+
+- **GIVEN** `gatewayApi.enabled=true`
+- **AND** `gatewayApi.gateway.create=true` with a GatewayClass name
+- **WHEN** the chart renders its Gateway API resources
+- **THEN** a Gateway named after the release renders in the release namespace
+  with the configured GatewayClass and one HTTP listener on port 80
+- **AND** the HTTPRoute's only parent reference is the chart-managed Gateway
+
+#### Scenario: Operator-defined listeners
+
+- **GIVEN** `gatewayApi.gateway.create=true` with a GatewayClass name
+- **AND** `gatewayApi.gateway.listeners` contains an HTTPS listener with TLS
+  configuration
+- **WHEN** the chart renders the Gateway
+- **THEN** the configured listeners replace the default HTTP listener verbatim
+
+#### Scenario: Missing GatewayClass name fails rendering
+
+- **GIVEN** `gatewayApi.gateway.create=true`
+- **AND** `gatewayApi.gateway.gatewayClassName` is empty
+- **WHEN** the chart renders
+- **THEN** rendering fails with an error naming
+  `gatewayApi.gateway.gatewayClassName`
+
+#### Scenario: Default configuration keeps existing Gateway attachment
+
+- **GIVEN** `gatewayApi.enabled=true`
+- **AND** `gatewayApi.gateway.create` is unset
+- **WHEN** the chart renders its Gateway API resources
+- **THEN** no Gateway resource renders
+- **AND** the HTTPRoute attaches to the operator-supplied
+  `gatewayApi.parentRefs`

--- a/openspec/changes/create-application-gateway/tasks.md
+++ b/openspec/changes/create-application-gateway/tasks.md
@@ -1,0 +1,20 @@
+## 1. Contract
+
+- [x] 1.1 Define the optional chart-managed application-specific Gateway under
+  `deployment-networking`.
+- [x] 1.2 Preserve the existing parentRefs-based HTTPRoute attachment as the
+  zero-configuration default.
+
+## 2. Implementation
+
+- [x] 2.1 Render a release-scoped Gateway with a required GatewayClass name,
+  default HTTP listener, and operator-defined listener override.
+- [x] 2.2 Attach the chart-managed HTTPRoute to the chart-managed Gateway when
+  the mode is enabled.
+- [x] 2.3 Add chart values schema, user documentation, and Helm rendering
+  tests.
+
+## 3. Verification
+
+- [x] 3.1 Run focused Helm unit tests and chart linting.
+- [x] 3.2 Run OpenSpec validation and the relevant local CI checks.

--- a/tests/unit/test_helm_external_secrets.py
+++ b/tests/unit/test_helm_external_secrets.py
@@ -539,6 +539,103 @@ def test_gateway_api_renders_ordered_path_matches_and_filters() -> None:
     assert rules[1]["backendRefs"] == [{"name": "codex-lb", "port": 2455}]
 
 
+def test_gateway_api_can_create_application_specific_gateway() -> None:
+    rendered = _helm_template(
+        "--show-only",
+        "templates/gateway.yaml",
+        "--set",
+        "gatewayApi.enabled=true",
+        "--set",
+        "gatewayApi.gateway.create=true",
+        "--set",
+        "gatewayApi.gateway.gatewayClassName=envoy",
+    )
+
+    (gateway,) = _helm_documents(rendered)
+    assert gateway["apiVersion"] == "gateway.networking.k8s.io/v1"
+    assert gateway["kind"] == "Gateway"
+    assert gateway["metadata"]["name"] == "codex-lb"
+    assert gateway["spec"]["gatewayClassName"] == "envoy"
+    assert gateway["spec"]["listeners"] == [{"name": "http", "port": 80, "protocol": "HTTP"}]
+
+
+def test_gateway_api_httproute_attaches_to_chart_managed_gateway() -> None:
+    rendered = _helm_template(
+        "--show-only",
+        "templates/httproute.yaml",
+        "--set",
+        "gatewayApi.enabled=true",
+        "--set",
+        "gatewayApi.gateway.create=true",
+        "--set",
+        "gatewayApi.gateway.gatewayClassName=envoy",
+        "--set-string",
+        "gatewayApi.parentRefs[0].name=shared-gateway",
+        "--set-string",
+        "gatewayApi.parentRefs[0].namespace=gateway-system",
+    )
+
+    (route,) = _helm_documents(rendered)
+    assert route["spec"]["parentRefs"] == [{"name": "codex-lb"}]
+
+
+def test_gateway_api_gateway_supports_custom_listeners() -> None:
+    rendered = _helm_template(
+        "--show-only",
+        "templates/gateway.yaml",
+        "--set",
+        "gatewayApi.enabled=true",
+        "--set",
+        "gatewayApi.gateway.create=true",
+        "--set",
+        "gatewayApi.gateway.gatewayClassName=envoy",
+        "--set-string",
+        "gatewayApi.gateway.listeners[0].name=https",
+        "--set",
+        "gatewayApi.gateway.listeners[0].port=443",
+        "--set-string",
+        "gatewayApi.gateway.listeners[0].protocol=HTTPS",
+        "--set-string",
+        "gatewayApi.gateway.listeners[0].tls.mode=Terminate",
+        "--set-string",
+        "gatewayApi.gateway.listeners[0].tls.certificateRefs[0].name=codex-lb-tls",
+    )
+
+    (gateway,) = _helm_documents(rendered)
+    assert gateway["spec"]["listeners"] == [
+        {
+            "name": "https",
+            "port": 443,
+            "protocol": "HTTPS",
+            "tls": {"mode": "Terminate", "certificateRefs": [{"name": "codex-lb-tls"}]},
+        }
+    ]
+
+
+def test_gateway_api_gateway_requires_gateway_class_name() -> None:
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        _helm_template(
+            "--set",
+            "gatewayApi.enabled=true",
+            "--set",
+            "gatewayApi.gateway.create=true",
+        )
+
+    assert "gatewayApi.gateway.gatewayClassName" in excinfo.value.stderr
+
+
+def test_gateway_api_does_not_render_gateway_by_default() -> None:
+    rendered = _helm_template(
+        "--set",
+        "gatewayApi.enabled=true",
+    )
+
+    documents = _helm_documents(rendered)
+    assert all(document.get("kind") != "Gateway" for document in documents)
+    (route,) = [document for document in documents if document.get("kind") == "HTTPRoute"]
+    assert route["spec"]["parentRefs"] == [{"name": "gateway", "namespace": "gateway-system"}]
+
+
 def test_bundled_kind_smoke_preserves_primary_ingress_paths() -> None:
     script = (_REPO_ROOT / "scripts" / "helm-kind-smoke.sh").read_text()
 


### PR DESCRIPTION
## Summary

Adds `gatewayApi.gateway.create` so the chart can render an application-specific Gateway API `Gateway` scoped to the release, instead of requiring a pre-existing shared/global Gateway for the HTTPRoute to attach to.

## Type of change

- [x] `feat:` — new user-facing feature or capability

Linked issue: none — no open issue; feature request from operator usage.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/create-application-gateway/`

## Changes

- **Helm**: new `templates/gateway.yaml` renders a release-scoped `Gateway` when `gatewayApi.gateway.create=true`, with a required `gatewayApi.gateway.gatewayClassName`, optional `annotations`, and a default single HTTP listener on port 80 that `gatewayApi.gateway.listeners` replaces verbatim (e.g. for HTTPS/TLS). `gatewayClassName` stays required because the Gateway API has no default-class mechanism (unlike Ingress) — `spec.gatewayClassName` is a mandatory field on the CRD.
- **Helm**: `templates/httproute.yaml` attaches the HTTPRoute to the chart-managed Gateway automatically in this mode; `gatewayApi.parentRefs` is ignored (and documented as such). Default behavior (`create=false`) is byte-for-byte unchanged.
- **Schema/Docs**: `values.schema.json` covers the new `gatewayApi.gateway` block; chart README and `docs/deployment/kubernetes.md` document the mode with plain-HTTP and TLS-listener examples, linking back to the `deployment-networking` spec page.
- **OpenSpec**: `create-application-gateway` change adds the requirement + scenarios to `deployment-networking` (chart-managed Gateway, custom listeners, missing GatewayClass fails render, default keeps parentRefs attachment).
- **Tests**: five new Helm rendering tests in `tests/unit/test_helm_external_secrets.py` covering the default listener render, HTTPRoute attachment override, custom TLS listeners, the required-GatewayClass failure, and no-Gateway-by-default.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config**
- [x] No new required setup step (or maintainer approval via `simplicity-budget-approved` label)
- New setting(s) and why each can't be a default:
  - `gatewayApi.gateway.create` → opt-in switch; defaults off so existing parentRefs-based installs are untouched.
  - `gatewayApi.gateway.gatewayClassName` → Gateway API has no default-GatewayClass convention and `spec.gatewayClassName` is required by the CRD; the chart cannot guess the cluster's implementation, so rendering fails fast with a named error instead of shipping a broken Gateway.
  - `gatewayApi.gateway.listeners` / `gatewayApi.gateway.annotations` → optional overrides; sensible default (HTTP :80, none) applies when unset.
- [x] README sections / `.env.example` / dashboard nav within budget (no new top-level README sections; docs extend the existing Gateway API sections)

## Test plan

```
$ .venv/bin/python -m pytest tests/unit/test_helm_external_secrets.py -q
52 passed in 8.20s

$ make helm-check          # helm-lint + helm-template + helm-kubeconform
Summary: 18 resources found parsing stdin - Valid: 18, Invalid: 0, Errors: 0, Skipped: 0   # 1.32.0
Summary: 18 resources found parsing stdin - Valid: 18, Invalid: 0, Errors: 0, Skipped: 0   # 1.35.0

# kubeconform with the new mode enabled (gateway.create=true, gatewayClassName=envoy):
Summary: 19 resources found parsing stdin - Valid: 19, Invalid: 0, Errors: 0, Skipped: 0

$ openspec validate --specs                                # 47 passed, 0 failed
$ openspec validate create-application-gateway --strict    # Change is valid
```

## Screenshots / output

Example render (`gatewayApi.enabled=true`, `gatewayApi.gateway.create=true`, `gatewayClassName=istio`):

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: codex-lb
  namespace: "default"
spec:
  gatewayClassName: istio
  listeners:
    - name: http
      port: 80
      protocol: HTTP
```

The HTTPRoute's `parentRefs` becomes `[{name: codex-lb}]` in this mode; with `create=false` it stays exactly as configured via `gatewayApi.parentRefs`.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally (`make helm-check` + focused pytest + ruff).
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
