### PR TITLE
fix(ci): use locked Ruff for lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,8 @@ frontend-build: frontend-install
 
 .PHONY: lint typecheck architecture-check
 lint: architecture-check
-	uvx ruff check .
-	uvx ruff format --check .
+	uv run --frozen ruff check .
+	uv run --frozen ruff format --check .
 
 architecture-check:
 	python scripts/check_proxy_architecture.py


### PR DESCRIPTION
## Summary

Run Ruff through the project's frozen dependency environment instead of an
unpinned `uvx` invocation.

This keeps `make lint` reproducible across CI runs and prevents a newly
released Ruff version from failing unrelated pull requests before the project
lock is intentionally updated.

## Problem

`uvx ruff` resolved Ruff `0.16.0` in CI while the project lock resolves Ruff
`0.15.22`. The newer Markdown formatter flags six files already present on
`main`, causing `Lint (ruff)` and `CI Required` to fail on otherwise unrelated
PRs, including #1463.

## Changes

- Replace `uvx ruff check .` with `uv run --frozen ruff check .`.
- Replace `uvx ruff format --check .` with
  `uv run --frozen ruff format --check .`.
- Keep the existing Ruff configuration and source files unchanged.

## Test plan

- `uv run --frozen ruff --version` - `ruff 0.15.22`
- `uv run --frozen ruff check .` - passed
- `uv run --frozen ruff format --check .` - 834 files already formatted
- `uv run --frozen python scripts/check_proxy_architecture.py` - passed

The architecture checker unit file has one existing Windows-only assertion
that expects POSIX path separators; the architecture command itself passes.

## OpenSpec

Not required. This changes CI tool resolution only and does not alter product,
API, schema, routing, dashboard, or compatibility behavior.

## Checklist

- [x] Conventional Commit and PR title
- [x] Focused two-line CI change
- [x] No source, generated output, version, or changelog changes
- [x] Frozen Ruff check and format gates pass
