### PR TITLE
fix(ci): run ruff from the locked environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ test-dashboard-browser-smoke: frontend-build frontend-playwright-chromium
 
 .PHONY: lint typecheck architecture-check
 lint: architecture-check
-	uvx ruff check .
-	uvx ruff format --check .
+	uv run ruff check .
+	uv run ruff format --check .
 
 architecture-check:
 	python scripts/check_proxy_architecture.py


### PR DESCRIPTION
## Problem

`CI Required` is red on every main commit merged today (e.g. [run 30064365055](https://github.com/Soju06/codex-lb/actions/runs/30064365055) at 5c16ab1b). `make lint` runs ruff via unpinned `uvx ruff`, which resolved to ruff **0.16.0** (released yesterday). Its `format --check` newly considers `.agents/skills/project-conventions/conventions.md` (unchanged since February) reformat-worthy, so lint fails on files no PR touched. This is toolchain drift, not a regression from the merged PRs — with the locked ruff **0.15.22** (uv.lock), `ruff format --check .` passes all 837 files.

## Fix

Switch the two lint invocations from `uvx ruff` to `uv run ruff`, matching how every other Makefile target already runs locked tools (`uv run ty`, `uv run pytest`; `uvx --from build==1.3.0` is version-pinned). Future ruff upgrades then land explicitly through Dependabot lockfile bumps with CI visibility instead of drifting silently.

## Verification

- `uv run ruff check .` → All checks passed!
- `uv run ruff format --check .` → 837 files already formatted
- `uv run python scripts/check_proxy_architecture.py` → passed

No behavior/API/settings change, so no OpenSpec delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)