### PR TITLE
ci(release): sync uv.lock on release-please branches

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,22 +29,37 @@ jobs:
       # release-please bumps pyproject.toml but cannot regenerate uv.lock, so the
       # stable/beta release guards fail until the lockfile records the new project
       # version. Sync it here so release PRs are mergeable without a manual commit.
+      # The branch is resolved from the canonical open release PR (not the action's
+      # update-only `pr` output) so a rerun after a failed sync still repairs it.
+      - name: Find open release PR branch
+        id: release-branch
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          branch=$(gh pr list --repo "${{ github.repository }}" --state open \
+            --label "autorelease: pending" --json headRefName,headRepositoryOwner \
+            --jq '[.[]
+                   | select(.headRefName | startswith("release-please--"))
+                   | select(.headRepositoryOwner.login == "${{ github.repository_owner }}")
+                  ][0].headRefName // empty')
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
       - name: Checkout release branch
-        if: ${{ steps.release-please.outputs.pr }}
+        if: ${{ steps.release-branch.outputs.branch != '' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: ${{ fromJSON(steps.release-please.outputs.pr).headBranchName }}
+          ref: ${{ steps.release-branch.outputs.branch }}
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Set up uv
-        if: ${{ steps.release-please.outputs.pr }}
+        if: ${{ steps.release-branch.outputs.branch != '' }}
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
         with:
           python-version: "3.13"
           enable-cache: true
 
       - name: Sync uv.lock with the release version
-        if: ${{ steps.release-please.outputs.pr }}
+        if: ${{ steps.release-branch.outputs.branch != '' }}
         run: |
           uv lock
           if git diff --quiet -- uv.lock; then

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,8 +19,40 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Run release-please
+        id: release-please
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json
+
+      # release-please bumps pyproject.toml but cannot regenerate uv.lock, so the
+      # stable/beta release guards fail until the lockfile records the new project
+      # version. Sync it here so release PRs are mergeable without a manual commit.
+      - name: Checkout release branch
+        if: ${{ steps.release-please.outputs.pr }}
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ fromJSON(steps.release-please.outputs.pr).headBranchName }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - name: Set up uv
+        if: ${{ steps.release-please.outputs.pr }}
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990
+        with:
+          python-version: "3.13"
+          enable-cache: true
+
+      - name: Sync uv.lock with the release version
+        if: ${{ steps.release-please.outputs.pr }}
+        run: |
+          uv lock
+          if git diff --quiet -- uv.lock; then
+            echo "uv.lock already in sync"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore(release): sync uv.lock with the release version"
+          git push


### PR DESCRIPTION
## Problem

release-please bumps `pyproject.toml`, `app/__init__.py`, the Helm chart, and `frontend/package.json`, but cannot regenerate `uv.lock`. The stable/beta release guards correctly require all release-managed version files to agree, so **every release PR arrives failing its guards** until a maintainer pushes a manual `uv lock` commit. This recurred on the v1.22.0 release PR (#1330): guard failure `uv.lock='1.21.0'` vs everything else at `1.22.0`.

## Fix

After the release-please step, when a release PR exists: check out its branch, run `uv lock`, and push the sync commit if the lockfile changed. The push uses the same `RELEASE_PLEASE_TOKEN` (a PAT), so CI re-runs on the new head — no recursive workflow risk since this workflow only triggers on pushes to `main`. Action SHAs match the pins already used in `ci.yml`.

## Verification

- `fromJSON(steps.release-please.outputs.pr).headBranchName` is the documented output shape of release-please-action v4.
- Behavior is a no-op when `uv.lock` is already in sync (guard: `git diff --quiet -- uv.lock`).
- Manual equivalent of this step was exercised today on #1330 (commit 554c412e) and turned the guards green.

CI/release tooling only — no app behavior change, no OpenSpec delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)