### PR TITLE
feat(proxy): route client session identity with one-shot side-call bypass

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -735,8 +735,13 @@ def _build_upstream_headers(
     access_token: str,
     account_id: str | None,
     accept: str = "text/event-stream",
+    *,
+    preserve_client_session_identity: bool = True,
 ) -> dict[str, str]:
-    headers = filter_inbound_headers(inbound, preserve_client_session_identity=False)
+    headers = filter_inbound_headers(
+        inbound,
+        preserve_client_session_identity=preserve_client_session_identity,
+    )
     native = _is_native_codex_request(headers)
     lower_keys = {key.lower() for key in headers}
     if "x-request-id" not in lower_keys and "request-id" not in lower_keys:
@@ -2789,7 +2794,12 @@ async def _stream_responses_with_session(
         upstream_headers = _build_upstream_websocket_headers(headers, access_token, account_id)
         method = "GET"
     else:
-        upstream_headers = _build_upstream_headers(headers, access_token, account_id)
+        upstream_headers = _build_upstream_headers(
+            headers,
+            access_token,
+            account_id,
+            preserve_client_session_identity=False,
+        )
         _apply_responses_lite_http_header(upstream_headers, payload_dict)
         method = "POST"
     upstream_headers = apply_codex_installation_headers(upstream_headers, codex_installation_id)
@@ -3057,7 +3067,12 @@ async def _stream_responses_with_session(
         transport = "http"
         payload_dict = http_payload_dict
         payload_json = json.dumps(payload_dict, ensure_ascii=True, separators=(",", ":"))
-        upstream_headers = _build_upstream_headers(headers, access_token, account_id)
+        upstream_headers = _build_upstream_headers(
+            headers,
+            access_token,
+            account_id,
+            preserve_client_session_identity=False,
+        )
         _apply_responses_lite_http_header(upstream_headers, payload_dict)
         upstream_headers = apply_codex_installation_headers(upstream_headers, codex_installation_id)
         method = "POST"
@@ -3595,6 +3610,7 @@ class _CompactCommandTransport:
             self.access_token,
             upstream_account_id,
             accept="application/json",
+            preserve_client_session_identity=False,
         )
         pre_request_started_at = time.monotonic()
         compact_timeout_seconds = _effective_compact_total_timeout(settings.upstream_compact_timeout_seconds)

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -95,6 +95,13 @@ CODEX_TURN_METADATA_HEADER = "x-codex-turn-metadata"
 CODEX_LB_REQUIRED_CAPABILITY_HEADER = "x-codex-lb-required-capability"
 CODEX_RESPONSES_LITE_HEADER = "x-openai-internal-codex-responses-lite"
 CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY = "ws_request_header_x_openai_internal_codex_responses_lite"
+CLIENT_SESSION_IDENTITY_HEADERS = (
+    "x-session-affinity",
+    "x-session-id",
+    "x-opencode-session",
+    "x-claude-code-agent-id",
+    "x-claude-remote-session-id",
+)
 
 IGNORE_INBOUND_HEADERS = {
     "authorization",
@@ -537,8 +544,10 @@ class CodexControlRequestPrivacyPolicy(Enum):
         return self is CodexControlRequestPrivacyPolicy.PRIVATE_REALTIME
 
 
-def _should_drop_inbound_header(name: str) -> bool:
+def _should_drop_inbound_header(name: str, *, preserve_client_session_identity: bool) -> bool:
     normalized = name.lower()
+    if not preserve_client_session_identity and normalized in CLIENT_SESSION_IDENTITY_HEADERS:
+        return True
     if normalized in IGNORE_INBOUND_HEADERS:
         return True
     if normalized in INTERNAL_OPENAI_UPSTREAM_HEADERS:
@@ -550,8 +559,19 @@ def _should_drop_inbound_header(name: str) -> bool:
     return False
 
 
-def filter_inbound_headers(headers: Mapping[str, str]) -> dict[str, str]:
-    return {key: value for key, value in headers.items() if not _should_drop_inbound_header(key)}
+def filter_inbound_headers(
+    headers: Mapping[str, str],
+    *,
+    preserve_client_session_identity: bool = False,
+) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in headers.items()
+        if not _should_drop_inbound_header(
+            key,
+            preserve_client_session_identity=preserve_client_session_identity,
+        )
+    }
 
 
 def _rewrite_turn_metadata_installation_id(value: JsonValue, codex_installation_id: str | None) -> JsonValue:

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -562,7 +562,7 @@ def _should_drop_inbound_header(name: str, *, preserve_client_session_identity: 
 def filter_inbound_headers(
     headers: Mapping[str, str],
     *,
-    preserve_client_session_identity: bool = False,
+    preserve_client_session_identity: bool = True,
 ) -> dict[str, str]:
     return {
         key: value
@@ -736,7 +736,7 @@ def _build_upstream_headers(
     account_id: str | None,
     accept: str = "text/event-stream",
 ) -> dict[str, str]:
-    headers = filter_inbound_headers(inbound)
+    headers = filter_inbound_headers(inbound, preserve_client_session_identity=False)
     native = _is_native_codex_request(headers)
     lower_keys = {key.lower() for key in headers}
     if "x-request-id" not in lower_keys and "request-id" not in lower_keys:
@@ -793,7 +793,7 @@ def _build_upstream_websocket_headers(
             token.strip().lower() for token in value.split(",") if isinstance(value, str) and token.strip()
         )
     blocked_header_names = _HOP_BY_HOP_HEADER_NAMES | connected_header_tokens
-    filtered = filter_inbound_headers(inbound)
+    filtered = filter_inbound_headers(inbound, preserve_client_session_identity=False)
     headers = {key: value for key, value in filtered.items() if key.lower() not in blocked_header_names}
     native = _is_native_codex_request(headers)
     lower_keys = {key.lower() for key in headers}

--- a/app/core/clients/proxy_websocket.py
+++ b/app/core/clients/proxy_websocket.py
@@ -511,8 +511,15 @@ def _connection_header_tokens(headers: Mapping[str, str]) -> set[str]:
     return tokens
 
 
-def filter_inbound_websocket_headers(headers: Mapping[str, str]) -> dict[str, str]:
-    filtered = filter_inbound_headers(headers)
+def filter_inbound_websocket_headers(
+    headers: Mapping[str, str],
+    *,
+    preserve_client_session_identity: bool = False,
+) -> dict[str, str]:
+    filtered = filter_inbound_headers(
+        headers,
+        preserve_client_session_identity=preserve_client_session_identity,
+    )
     blocked_header_names = _WEBSOCKET_HOP_BY_HOP_HEADERS | _connection_header_tokens(filtered)
     return {key: value for key, value in filtered.items() if key.lower() not in blocked_header_names}
 
@@ -524,8 +531,12 @@ def _build_upstream_websocket_headers(
     *,
     include_responses_beta: bool = True,
     normalize_non_native_fingerprint: bool = True,
+    preserve_client_session_identity: bool = False,
 ) -> dict[str, str]:
-    headers = filter_inbound_websocket_headers(inbound)
+    headers = filter_inbound_websocket_headers(
+        inbound,
+        preserve_client_session_identity=preserve_client_session_identity,
+    )
     # ``filter_inbound_websocket_headers`` strips ``x-codex-installation-id`` because it
     # lives in ``IGNORE_INBOUND_HEADERS``. Callers normalize the selected account's
     # canonical installation id onto the inbound headers before connecting (mirroring the
@@ -574,6 +585,7 @@ def _build_upstream_live_websocket_headers(
         account_id,
         include_responses_beta=False,
         normalize_non_native_fingerprint=False,
+        preserve_client_session_identity=True,
     )
     beta_value = _pop_header_case_insensitive(headers, "openai-beta")
     if beta_value:

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -79,6 +79,19 @@ def normalize_tool_choice(choice: JsonValue | None) -> JsonValue | None:
     return choice
 
 
+def normalize_empty_tool_map(value: JsonValue) -> JsonValue:
+    """Normalize the ``tools: {}`` wire shape to an empty tool list.
+
+    OpenCode's title/compaction side calls declare tool-lessness with an
+    empty JSON object (``tools: {}``) instead of an empty array. Treat that
+    shape as equivalent to ``tools: []`` so such payloads validate and reach
+    the tool-less request paths; non-empty tool maps stay rejected.
+    """
+    if is_json_mapping(value) and not value:
+        return []
+    return value
+
+
 def validate_tool_types(tools: list[JsonValue], *, allow_builtin_tools: bool = False) -> list[JsonValue]:
     normalized_tools: list[JsonValue] = []
     for tool in tools:
@@ -675,6 +688,11 @@ class ResponsesRequest(BaseModel):
             return value
         stripped = value.strip()
         return stripped or None
+
+    @field_validator("tools", mode="before")
+    @classmethod
+    def _normalize_tools_wire_shape(cls, value: JsonValue) -> JsonValue:
+        return normalize_empty_tool_map(value)
 
     @field_validator("tools")
     @classmethod

--- a/app/core/openai/v1_requests.py
+++ b/app/core/openai/v1_requests.py
@@ -9,6 +9,7 @@ from app.core.openai.requests import (
     ResponsesReasoning,
     ResponsesRequest,
     ResponsesTextControls,
+    normalize_empty_tool_map,
     validate_tool_types,
 )
 from app.core.types import JsonValue
@@ -48,6 +49,11 @@ class V1ResponsesRequest(BaseModel):
     @classmethod
     def _ensure_store_false(cls, value: bool | None) -> bool | None:
         return False
+
+    @field_validator("tools", mode="before")
+    @classmethod
+    def _normalize_tools_wire_shape(cls, value: JsonValue) -> JsonValue:
+        return normalize_empty_tool_map(value)
 
     @field_validator("tools")
     @classmethod

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -429,7 +429,7 @@ def _sticky_key_for_compact_request(
     elif (
         session_affinity := _bare_codex_session_affinity(
             headers,
-            enabled=codex_session_affinity,
+            include_codex_names=codex_session_affinity,
             allow_cap_spillover=_request_allows_bare_session_cap_spillover(payload),
         )
     ) is not None:

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -58,6 +58,7 @@ from app.core.openai.models import OpenAIEvent
 from app.core.openai.parsing import parse_sse_event
 from app.core.openai.requests import (
     ResponsesRequest,
+    responses_input_uses_lite_tools,
 )
 from app.core.resilience.overload import local_overload_error
 from app.core.types import JsonValue
@@ -960,7 +961,7 @@ def _http_bridge_request_is_unanchored_one_shot(
     """
     if forwarded_request:
         return False
-    if payload.tools:
+    if payload.tools or responses_input_uses_lite_tools(payload.input):
         return False
     if not _session_identity_is_client_declared(headers):
         return False

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -165,6 +165,7 @@ from app.modules.proxy.affinity import (
     _AffinityPolicy,
     _extract_model_class,
     _request_allows_bare_session_cap_spillover,
+    _session_identity_is_client_declared,
     _sticky_key_from_session_header,
     _sticky_key_from_turn_state_header,
 )
@@ -950,17 +951,18 @@ def _http_bridge_request_is_unanchored_one_shot(
     ``tools: []``, while every real agent turn carries its tool list (Codex
     CLI attaches tools to every turn). Such one-shots gain nothing from a
     persistent bridge WebSocket and would otherwise fork an independent
-    bridge lane per overlap. The request must carry a client session
+    bridge lane per overlap. The identity must come from a client-declared
     identity header — that is what routes side calls into the agent
-    session's bridge in the first place; anonymous requests keep their
-    existing bridge behavior. Native Codex clients are excluded so their
-    websocket-mode behavior stays codex-faithful.
+    session's bridge in the first place; anonymous requests and Codex-name
+    session headers keep their existing bridge behavior. Native Codex
+    clients are excluded so their websocket-mode behavior stays
+    codex-faithful.
     """
     if forwarded_request:
         return False
     if payload.tools:
         return False
-    if _sticky_key_from_session_header(headers) is None:
+    if not _session_identity_is_client_declared(headers):
         return False
     if _sticky_key_from_turn_state_header(headers) is not None:
         return False

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -23,6 +23,7 @@ from app.core.clients.proxy import (  # noqa: F401  # noqa: F401
     _as_image_fetch_session,
     _inline_content_images,
     _inline_input_image_urls,
+    _is_native_codex_request,
     _ws_transport_payload_budget_bytes,
     filter_inbound_headers,
     pop_compact_timeout_overrides,
@@ -163,6 +164,7 @@ from app.modules.proxy.account_cache import is_account_routing_unavailable
 from app.modules.proxy.affinity import (
     _AffinityPolicy,
     _extract_model_class,
+    _request_allows_bare_session_cap_spillover,
     _sticky_key_from_session_header,
     _sticky_key_from_turn_state_header,
 )
@@ -931,6 +933,40 @@ def _http_bridge_parallel_fork_key(
         owner_check_applied=False,
     )
     return fork_key
+
+
+def _http_bridge_request_is_unanchored_one_shot(
+    payload: "ResponsesRequest",
+    headers: Mapping[str, str],
+    *,
+    forwarded_request: bool,
+) -> bool:
+    """Whether a request is a self-contained, tool-less one-shot completion.
+
+    Agent clients send side calls (title, summary, compaction) on the same
+    session identity as their agent turns, but without tool definitions or
+    continuity anchors: OpenCode's title and compaction calls send
+    ``tools: {}``, OpenClaw's usage-rollup and transcript summaries send
+    ``tools: []``, while every real agent turn carries its tool list (Codex
+    CLI attaches tools to every turn). Such one-shots gain nothing from a
+    persistent bridge WebSocket and would otherwise fork an independent
+    bridge lane per overlap. The request must carry a client session
+    identity header — that is what routes side calls into the agent
+    session's bridge in the first place; anonymous requests keep their
+    existing bridge behavior. Native Codex clients are excluded so their
+    websocket-mode behavior stays codex-faithful.
+    """
+    if forwarded_request:
+        return False
+    if payload.tools:
+        return False
+    if _sticky_key_from_session_header(headers) is None:
+        return False
+    if _sticky_key_from_turn_state_header(headers) is not None:
+        return False
+    if _is_native_codex_request(headers):
+        return False
+    return _request_allows_bare_session_cap_spillover(payload)
 
 
 def _http_bridge_request_needs_unanchored_handoff(

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -550,7 +550,7 @@ class _HTTPBridgeStreamingMixin:
     ) -> AsyncIterator[str]:
         _maybe_log_proxy_request_payload("stream_http", payload, headers)
         proxy_api_authorization = _header_value_case_insensitive(headers, "authorization")
-        filtered = filter_inbound_headers(headers)
+        filtered = filter_inbound_headers(headers, preserve_client_session_identity=True)
         return self._stream_http_bridge_or_retry(
             payload,
             filtered,

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -139,6 +139,7 @@ from app.modules.proxy._service.observability import (
 from app.modules.proxy._service.observability import (
     _truncate_identifier as _truncate_identifier,
 )
+from app.modules.proxy._service.streaming.retry import _resolved_configured_stream_transport
 from app.modules.proxy._service.support import (
     _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS,
     _HARD_HTTP_BRIDGE_AFFINITY_KINDS,  # noqa: F401
@@ -599,7 +600,12 @@ class _HTTPBridgeStreamingMixin:
         capacity_startup_ready_event: asyncio.Event | None = None,
     ) -> AsyncIterator[str]:
         dashboard_settings = await _service_get_settings_cache().get()
-        runtime_config = _http_bridge_runtime_config(dashboard_settings, _service_get_settings())
+        base_settings = _service_get_settings()
+        runtime_config = _http_bridge_runtime_config(dashboard_settings, base_settings)
+        configured_stream_transport, _explicit_stream_transport = _resolved_configured_stream_transport(
+            dashboard_settings,
+            base_settings,
+        )
         request_id = ensure_request_id()
         self._raise_for_unsupported_input_image_references(payload)
         payload_size_estimate_bytes = len(
@@ -617,7 +623,7 @@ class _HTTPBridgeStreamingMixin:
             ("signed forwarding context", forwarded_file_owner_account_id),
             ("local file pin", local_file_owner_account_id),
         )
-        ws_payload_budget_bytes = _ws_transport_payload_budget_bytes(_service_get_settings())
+        ws_payload_budget_bytes = _ws_transport_payload_budget_bytes(base_settings)
         if runtime_config.enabled and payload_size_estimate_bytes > ws_payload_budget_bytes:
             logger.info(
                 "stream_responses bypassing http bridge for large payload size=%s budget=%s request_id=%s",
@@ -641,7 +647,7 @@ class _HTTPBridgeStreamingMixin:
         if (
             runtime_config.enabled
             and force_upstream_stream_transport is None
-            and _service_get_settings().upstream_stream_transport != "websocket"
+            and configured_stream_transport != "websocket"
             and _http_bridge_request_is_unanchored_one_shot(
                 payload,
                 headers,

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -139,7 +139,6 @@ from app.modules.proxy._service.observability import (
 from app.modules.proxy._service.observability import (
     _truncate_identifier as _truncate_identifier,
 )
-from app.modules.proxy._service.streaming.retry import _resolved_configured_stream_transport
 from app.modules.proxy._service.support import (
     _ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS,
     _HARD_HTTP_BRIDGE_AFFINITY_KINDS,  # noqa: F401
@@ -151,6 +150,7 @@ from app.modules.proxy._service.support import (
     _HTTPBridgeSession,
     _HTTPBridgeSessionKey,
     _is_local_account_cap_code,
+    _resolved_configured_stream_transport,
     _signal_propagated_capacity_startup_ready,
     _signal_propagated_capacity_startup_wait,
     _ttft_event_visible_at,

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -74,6 +74,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_payload_looks_like_full_resend,
     _http_bridge_payload_without_previous_response_id,
     _http_bridge_request_budget_seconds,
+    _http_bridge_request_is_unanchored_one_shot,
     _http_bridge_request_needs_unanchored_handoff,
     _http_bridge_request_stage,
     _http_bridge_runtime_config,
@@ -636,6 +637,27 @@ class _HTTPBridgeStreamingMixin:
                 image_generation_request,
                 request_id,
             )
+            runtime_config = dataclasses.replace(runtime_config, enabled=False)
+        if (
+            runtime_config.enabled
+            and force_upstream_stream_transport is None
+            and _service_get_settings().upstream_stream_transport != "websocket"
+            and _http_bridge_request_is_unanchored_one_shot(
+                payload,
+                headers,
+                forwarded_request=forwarded_request,
+            )
+        ):
+            # Tool-less, self-contained side calls (title, summary, compaction)
+            # gain nothing from a persistent bridge WebSocket and would fork an
+            # independent bridge lane per overlap with the agent's main turn.
+            # An explicit websocket upstream transport override keeps the
+            # bridge: bypassing there would open a fresh WebSocket per request.
+            logger.info(
+                "stream_responses bypassing http bridge for unanchored one-shot request request_id=%s",
+                request_id,
+            )
+            force_upstream_stream_transport = "http"
             runtime_config = dataclasses.replace(runtime_config, enabled=False)
         if not runtime_config.enabled:
             stream_with_retry = cast(Callable[..., AsyncIterator[str]], self._stream_with_retry)

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -145,6 +145,7 @@ from app.modules.proxy._service.support import (
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
     _account_capacity_wait_payload,
     _account_selection_recovery_sleep_seconds_from_message,
+    _effective_http_downstream_transport_policy,
     _event_type_from_payload,
     _HTTPBridgeOwnerForward,
     _HTTPBridgeSession,
@@ -606,6 +607,9 @@ class _HTTPBridgeStreamingMixin:
             dashboard_settings,
             base_settings,
         )
+        effective_downstream_transport_policy, _policy_override_applied = _effective_http_downstream_transport_policy(
+            api_key, dashboard_settings, base_settings
+        )
         request_id = ensure_request_id()
         self._raise_for_unsupported_input_image_references(payload)
         payload_size_estimate_bytes = len(
@@ -648,6 +652,10 @@ class _HTTPBridgeStreamingMixin:
             runtime_config.enabled
             and force_upstream_stream_transport is None
             and configured_stream_transport != "websocket"
+            and not (
+                configured_stream_transport == "auto"
+                and effective_downstream_transport_policy.strip().lower() == "always_websocket"
+            )
             and _http_bridge_request_is_unanchored_one_shot(
                 payload,
                 headers,
@@ -657,8 +665,8 @@ class _HTTPBridgeStreamingMixin:
             # Tool-less, self-contained side calls (title, summary, compaction)
             # gain nothing from a persistent bridge WebSocket and would fork an
             # independent bridge lane per overlap with the agent's main turn.
-            # An explicit websocket upstream transport override keeps the
-            # bridge: bypassing there would open a fresh WebSocket per request.
+            # Explicit websocket transport and the always-websocket policy keep
+            # the bridge: bypassing there would open a fresh socket per request.
             logger.info(
                 "stream_responses bypassing http bridge for unanchored one-shot request request_id=%s",
                 request_id,

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -450,7 +450,11 @@ class _StreamingMixin(_StreamingRetryMixin):
     ) -> AsyncIterator[str]:
         proxy = cast(_StreamingServiceProtocol, self)
         _maybe_log_proxy_request_payload("stream", payload, headers)
-        filtered = _facade().filter_inbound_headers(headers)
+        # Client session identity headers must survive this internal filter:
+        # ``_stream_with_retry`` derives request-log conversation metadata and
+        # session sticky affinity from them. They are stripped at upstream
+        # egress by ``_build_upstream_headers`` / the websocket header builders.
+        filtered = _facade().filter_inbound_headers(headers, preserve_client_session_identity=True)
         return proxy._stream_with_retry(
             payload,
             filtered,

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -40,6 +40,7 @@ from app.modules.proxy._service.support import (
     _account_capacity_wait_payload,
     _account_selection_recovery_sleep_seconds,
     _request_log_client_fields,
+    _resolved_configured_stream_transport,
     _RetryableStreamError,
     _signal_propagated_capacity_startup_wait,
     _stream_settlement_error_payload,
@@ -163,13 +164,6 @@ def _effective_http_downstream_transport_policy(
         return dashboard_policy, False
     base_policy = getattr(base_settings, "http_downstream_transport_policy", _HTTP_DOWNSTREAM_TRANSPORT_POLICY_DEFAULT)
     return base_policy, False
-
-
-def _resolved_configured_stream_transport(dashboard_settings: Any, base_settings: Any) -> tuple[str, bool]:
-    configured = getattr(dashboard_settings, "upstream_stream_transport", "default")
-    if configured == "default":
-        configured = getattr(base_settings, "upstream_stream_transport", "auto")
-    return configured, configured in ("http", "websocket")
 
 
 async def _iter_account_capacity_recovery_wait(

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -39,6 +39,7 @@ from app.modules.proxy._service.support import (
     _LOCAL_ACCOUNT_CAP_ERROR_CODES,
     _account_capacity_wait_payload,
     _account_selection_recovery_sleep_seconds,
+    _effective_http_downstream_transport_policy,
     _request_log_client_fields,
     _resolved_configured_stream_transport,
     _RetryableStreamError,
@@ -75,7 +76,6 @@ from app.modules.proxy.load_balancer import AccountLease, AccountSelection
 
 _REQUEST_TRANSPORT_HTTP = "http"
 _REQUEST_TRANSPORT_WEBSOCKET = "websocket"
-_HTTP_DOWNSTREAM_TRANSPORT_POLICY_DEFAULT = "smart"
 _HTTP_DOWNSTREAM_TRANSPORT_POLICIES = frozenset({"smart", "always_http", "always_websocket", "pinned"})
 
 logger = logging.getLogger(__name__)
@@ -149,21 +149,6 @@ def _verified_cross_transport_fresh_replay(
     ):
         return None
     return payload.model_copy(update={"previous_response_id": None})
-
-
-def _effective_http_downstream_transport_policy(
-    api_key: ApiKeyData | None,
-    dashboard_settings: Any,
-    base_settings: Any,
-) -> tuple[str, bool]:
-    override = getattr(api_key, "transport_policy_override", None) if api_key is not None else None
-    if override is not None:
-        return override, True
-    dashboard_policy = getattr(dashboard_settings, "http_downstream_transport_policy", None)
-    if isinstance(dashboard_policy, str) and dashboard_policy:
-        return dashboard_policy, False
-    base_policy = getattr(base_settings, "http_downstream_transport_policy", _HTTP_DOWNSTREAM_TRANSPORT_POLICY_DEFAULT)
-    return base_policy, False
 
 
 async def _iter_account_capacity_recovery_wait(

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -450,6 +450,20 @@ def _resolved_configured_stream_transport(dashboard_settings: Any, base_settings
     return configured, configured in ("http", "websocket")
 
 
+def _effective_http_downstream_transport_policy(
+    api_key: ApiKeyData | None,
+    dashboard_settings: Any,
+    base_settings: Any,
+) -> tuple[str, bool]:
+    override = getattr(api_key, "transport_policy_override", None) if api_key is not None else None
+    if override is not None:
+        return override, True
+    dashboard_policy = getattr(dashboard_settings, "http_downstream_transport_policy", None)
+    if isinstance(dashboard_policy, str) and dashboard_policy:
+        return dashboard_policy, False
+    return getattr(base_settings, "http_downstream_transport_policy", "smart"), False
+
+
 _CONVERSATION_HEADERS_BY_USERAGENT_PREFIX = (
     ("opencode", ("x-parent-session-id", "x-opencode-session", "x-session-id", "x-session-affinity")),
     ("codex", ("thread-id",)),

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -443,6 +443,13 @@ def _supported_optional_kwargs(
     return kwargs
 
 
+def _resolved_configured_stream_transport(dashboard_settings: Any, base_settings: Any) -> tuple[str, bool]:
+    configured = getattr(dashboard_settings, "upstream_stream_transport", "default")
+    if configured == "default":
+        configured = getattr(base_settings, "upstream_stream_transport", "auto")
+    return configured, configured in ("http", "websocket")
+
+
 _CONVERSATION_HEADERS_BY_USERAGENT_PREFIX = (
     ("opencode", ("x-parent-session-id", "x-opencode-session", "x-session-id", "x-session-affinity")),
     ("codex", ("thread-id",)),

--- a/app/modules/proxy/affinity.py
+++ b/app/modules/proxy/affinity.py
@@ -251,9 +251,34 @@ def _sticky_key_from_payload(payload: ResponsesRequest) -> str | None:
     return stripped or None
 
 
+# Client-declared session identity headers, in precedence order. The Codex
+# CLI names come first (codex-faithful), then the identity headers other
+# agent clients send with each provider request: OpenCode and OpenClaw send
+# `x-session-affinity` / `x-session-id` (OpenCode also `x-opencode-session`
+# to opencode-branded providers), Claude Code sends `x-claude-code-agent-id`
+# per agent and `x-claude-remote-session-id` for remote sessions. Parent
+# identity headers (`x-parent-session-id`, `x-codex-parent-thread-id`,
+# `x-claude-code-parent-agent-id`, `x-openai-subagent`) are deliberately
+# excluded: keying on the parent would collapse every subagent onto one
+# session. `x-client-request-id` is excluded because clients also populate
+# it with per-request ids, so it is not a stable session identity.
+_SESSION_IDENTITY_HEADERS = (
+    "session_id",
+    "session-id",
+    "x-codex-session-id",
+    "x-codex-conversation-id",
+    "thread-id",
+    "x-session-affinity",
+    "x-session-id",
+    "x-opencode-session",
+    "x-claude-code-agent-id",
+    "x-claude-remote-session-id",
+)
+
+
 def _sticky_key_from_session_header(headers: Mapping[str, str]) -> str | None:
     normalized = {key.lower(): value for key, value in headers.items()}
-    for key in ("session_id", "session-id", "x-codex-session-id", "x-codex-conversation-id", "thread-id"):
+    for key in _SESSION_IDENTITY_HEADERS:
         value = normalized.get(key)
         if not isinstance(value, str):
             continue

--- a/app/modules/proxy/affinity.py
+++ b/app/modules/proxy/affinity.py
@@ -262,18 +262,21 @@ def _sticky_key_from_payload(payload: ResponsesRequest) -> str | None:
 # excluded: keying on the parent would collapse every subagent onto one
 # session. `x-client-request-id` is excluded because clients also populate
 # it with per-request ids, so it is not a stable session identity.
-_SESSION_IDENTITY_HEADERS = (
+_CODEX_SESSION_IDENTITY_HEADERS = (
     "session_id",
     "session-id",
     "x-codex-session-id",
     "x-codex-conversation-id",
     "thread-id",
+)
+_CLIENT_SESSION_IDENTITY_HEADERS = (
     "x-session-affinity",
     "x-session-id",
     "x-opencode-session",
     "x-claude-code-agent-id",
     "x-claude-remote-session-id",
 )
+_SESSION_IDENTITY_HEADERS = _CODEX_SESSION_IDENTITY_HEADERS + _CLIENT_SESSION_IDENTITY_HEADERS
 
 
 def _sticky_key_from_session_header(headers: Mapping[str, str]) -> str | None:
@@ -286,6 +289,21 @@ def _sticky_key_from_session_header(headers: Mapping[str, str]) -> str | None:
         if stripped:
             return stripped
     return None
+
+
+def _session_identity_is_client_declared(headers: Mapping[str, str]) -> bool:
+    """Whether the request's session identity comes from a client identity header.
+
+    True only when a client-declared identity header carries the identity and
+    no Codex name is present: Codex-name flows are bridge-centric and keep
+    their existing routing even for tool-less payloads.
+    """
+    normalized = {key.lower(): value for key, value in headers.items()}
+
+    def _has(names: tuple[str, ...]) -> bool:
+        return any(isinstance(normalized.get(name), str) and normalized[name].strip() for name in names)
+
+    return _has(_CLIENT_SESSION_IDENTITY_HEADERS) and not _has(_CODEX_SESSION_IDENTITY_HEADERS)
 
 
 def _sticky_key_from_turn_state_header(headers: Mapping[str, str]) -> str | None:

--- a/app/modules/proxy/affinity.py
+++ b/app/modules/proxy/affinity.py
@@ -21,7 +21,10 @@ from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest, 
 from app.core.types import JsonValue
 from app.db.models import StickySessionKind
 from app.modules.api_keys.service import ApiKeyData
-from app.modules.proxy.replay_safety import responses_input_items_are_self_contained_fresh_replay
+from app.modules.proxy.replay_safety import (
+    responses_input_items_are_self_contained_fresh_replay,
+    responses_payload_is_account_neutral_fresh_replay,
+)
 
 # This typed provenance is a routing capability: callers must never recover it
 # from key text, because a client-controlled turn state can mimic any prefix.
@@ -343,12 +346,10 @@ def _request_allows_bare_session_cap_spillover(
     payload: ResponsesRequest | ResponsesCompactRequest,
 ) -> bool:
     if isinstance(payload, ResponsesRequest):
-        previous_response_id = payload.previous_response_id
-        conversation = payload.conversation
-    else:
-        extra = payload.model_extra or {}
-        previous_response_id = extra.get("previous_response_id")
-        conversation = extra.get("conversation")
+        return responses_payload_is_account_neutral_fresh_replay(payload.to_payload())
+    extra = payload.model_extra or {}
+    previous_response_id = extra.get("previous_response_id")
+    conversation = extra.get("conversation")
     # A lookup miss does not make an upstream-stored object portable. Selection
     # must remain fail-closed for every owner-bearing payload shape.
     return not (

--- a/app/modules/proxy/affinity.py
+++ b/app/modules/proxy/affinity.py
@@ -350,6 +350,7 @@ def _request_allows_bare_session_cap_spillover(
     extra = payload.model_extra or {}
     previous_response_id = extra.get("previous_response_id")
     conversation = extra.get("conversation")
+    prompt = extra.get("prompt")
     # A lookup miss does not make an upstream-stored object portable. Selection
     # must remain fail-closed for every owner-bearing payload shape.
     return not (
@@ -357,6 +358,7 @@ def _request_allows_bare_session_cap_spillover(
         or (isinstance(previous_response_id, str) and bool(previous_response_id.strip()))
         or (conversation is not None and not isinstance(conversation, str))
         or (isinstance(conversation, str) and bool(conversation.strip()))
+        or prompt not in (None, "")
         or extract_input_file_ids(payload.input)
         or (
             isinstance(payload.input, list)

--- a/app/modules/proxy/affinity.py
+++ b/app/modules/proxy/affinity.py
@@ -288,9 +288,17 @@ def _sticky_key_from_session_header(
     headers: Mapping[str, str],
     *,
     include_codex_names: bool = True,
+    include_client_names: bool = True,
 ) -> str | None:
     normalized = {key.lower(): value for key, value in headers.items()}
-    names = _SESSION_IDENTITY_HEADERS if include_codex_names else _CLIENT_SESSION_IDENTITY_HEADERS
+    if include_codex_names and include_client_names:
+        names = _SESSION_IDENTITY_HEADERS
+    elif include_codex_names:
+        names = _CODEX_SESSION_IDENTITY_HEADERS
+    elif include_client_names:
+        names = _CLIENT_SESSION_IDENTITY_HEADERS
+    else:
+        names = ()
     for key in names:
         value = normalized.get(key)
         if not isinstance(value, str):
@@ -329,9 +337,14 @@ def _bare_codex_session_affinity(
     headers: Mapping[str, str],
     *,
     include_codex_names: bool,
+    include_client_names: bool = True,
     allow_cap_spillover: bool,
 ) -> _AffinityPolicy | None:
-    session_key = _sticky_key_from_session_header(headers, include_codex_names=include_codex_names)
+    session_key = _sticky_key_from_session_header(
+        headers,
+        include_codex_names=include_codex_names,
+        include_client_names=include_client_names,
+    )
     if session_key is None:
         return None
     return _AffinityPolicy(
@@ -395,6 +408,7 @@ def _sticky_key_for_codex_control_request(
     session_affinity = _bare_codex_session_affinity(
         headers,
         include_codex_names=codex_session_affinity,
+        include_client_names=False,
         allow_cap_spillover=False,
     )
     if session_affinity is not None:

--- a/app/modules/proxy/affinity.py
+++ b/app/modules/proxy/affinity.py
@@ -18,8 +18,10 @@ from uuid import uuid4
 
 from app.core.config.settings import get_settings
 from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest, extract_input_file_ids
+from app.core.types import JsonValue
 from app.db.models import StickySessionKind
 from app.modules.api_keys.service import ApiKeyData
+from app.modules.proxy.replay_safety import responses_input_items_are_self_contained_fresh_replay
 
 # This typed provenance is a routing capability: callers must never recover it
 # from key text, because a client-controlled turn state can mimic any prefix.
@@ -355,6 +357,10 @@ def _request_allows_bare_session_cap_spillover(
         or (conversation is not None and not isinstance(conversation, str))
         or (isinstance(conversation, str) and bool(conversation.strip()))
         or extract_input_file_ids(payload.input)
+        or (
+            isinstance(payload.input, list)
+            and not responses_input_items_are_self_contained_fresh_replay(cast(list[JsonValue], payload.input))
+        )
     )
 
 

--- a/app/modules/proxy/affinity.py
+++ b/app/modules/proxy/affinity.py
@@ -279,9 +279,14 @@ _CLIENT_SESSION_IDENTITY_HEADERS = (
 _SESSION_IDENTITY_HEADERS = _CODEX_SESSION_IDENTITY_HEADERS + _CLIENT_SESSION_IDENTITY_HEADERS
 
 
-def _sticky_key_from_session_header(headers: Mapping[str, str]) -> str | None:
+def _sticky_key_from_session_header(
+    headers: Mapping[str, str],
+    *,
+    include_codex_names: bool = True,
+) -> str | None:
     normalized = {key.lower(): value for key, value in headers.items()}
-    for key in _SESSION_IDENTITY_HEADERS:
+    names = _SESSION_IDENTITY_HEADERS if include_codex_names else _CLIENT_SESSION_IDENTITY_HEADERS
+    for key in names:
         value = normalized.get(key)
         if not isinstance(value, str):
             continue
@@ -318,12 +323,10 @@ def _sticky_key_from_turn_state_header(headers: Mapping[str, str]) -> str | None
 def _bare_codex_session_affinity(
     headers: Mapping[str, str],
     *,
-    enabled: bool,
+    include_codex_names: bool,
     allow_cap_spillover: bool,
 ) -> _AffinityPolicy | None:
-    if not enabled:
-        return None
-    session_key = _sticky_key_from_session_header(headers)
+    session_key = _sticky_key_from_session_header(headers, include_codex_names=include_codex_names)
     if session_key is None:
         return None
     return _AffinityPolicy(
@@ -382,7 +385,7 @@ def _sticky_key_for_codex_control_request(
         )
     session_affinity = _bare_codex_session_affinity(
         headers,
-        enabled=codex_session_affinity,
+        include_codex_names=codex_session_affinity,
         allow_cap_spillover=False,
     )
     if session_affinity is not None:
@@ -496,7 +499,7 @@ def _sticky_key_for_responses_request(
     elif (
         session_affinity := _bare_codex_session_affinity(
             headers,
-            enabled=codex_session_affinity,
+            include_codex_names=codex_session_affinity,
             allow_cap_spillover=_request_allows_bare_session_cap_spillover(payload),
         )
     ) is not None:

--- a/app/modules/proxy/continuity.py
+++ b/app/modules/proxy/continuity.py
@@ -18,6 +18,14 @@ _HTTP_BRIDGE_SESSION_AFFINITY_HEADERS = frozenset(
         "x-codex-conversation-id",
         "x-codex-session-id",
         "x-codex-turn-state",
+        # Client-declared session identity recognized by affinity parsing;
+        # must be stripped alongside the Codex names so an account-neutral
+        # replay cannot re-register the alias on a fresh upstream account.
+        "x-session-affinity",
+        "x-session-id",
+        "x-opencode-session",
+        "x-claude-code-agent-id",
+        "x-claude-remote-session-id",
     }
 )
 

--- a/app/modules/proxy/http_bridge_forwarding.py
+++ b/app/modules/proxy/http_bridge_forwarding.py
@@ -187,7 +187,7 @@ def build_owner_forward_headers(
     payload: ResponsesRequest,
     context: HTTPBridgeForwardContext,
 ) -> dict[str, str]:
-    filtered = filter_inbound_headers(headers)
+    filtered = filter_inbound_headers(headers, preserve_client_session_identity=True)
     # Per the hop-by-hop contract, also drop any header named by the inbound
     # Connection header in addition to the fixed unsafe set.
     connection_value = next(

--- a/openspec/changes/route-client-session-identity-headers/proposal.md
+++ b/openspec/changes/route-client-session-identity-headers/proposal.md
@@ -1,0 +1,30 @@
+# Route client-declared session identity headers as process-session affinity
+
+## Why
+
+Agent clients identify each session — including every subagent session — with a header on each provider request, but codex-lb's affinity parsing only recognizes the Codex CLI names (`session_id`, `session-id`, `x-codex-session-id`, `x-codex-conversation-id`, `thread-id`). OpenCode sends `x-session-affinity` / `X-Session-Id` (and `x-opencode-session`), OpenClaw sends `x-session-affinity` alongside `session_id`, and Claude Code sends `x-claude-code-agent-id` / `x-claude-remote-session-id` — none recognized for routing (OpenCode's are consumed only for request-log conversation grouping). Unrecognized clients fall through to derived prompt-cache affinity, whose key hashes the shared system-prompt prefix, so every subagent of one parent collapses onto a single sticky account. On a live deployment this concentrated 24 concurrent subagent streams on one account while five other accounts sat nearly idle, because each subagent's turns became continuity-bound to the collapsed account after its first turn.
+
+## What Changes
+
+- The session-affinity header list gains the identity headers the surveyed clients send per session: `x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, `x-claude-remote-session-id`. The existing Codex names keep precedence, so no Codex CLI request routes differently.
+- Each client session (including each subagent) thereby carries its own bare process-session key: first turns select an account independently under the existing cap-filtered, usage-weighted selection with #1382 bare-session cap spillover, so parallel subagents distribute across eligible accounts instead of collapsing onto one prompt-cache account.
+- Parent identity headers (`x-parent-session-id`, `x-codex-parent-thread-id`, `x-claude-code-parent-agent-id`, `x-openai-subagent`) and per-request ids (`x-client-request-id`) are explicitly excluded from session identity: parent keys would re-collapse subagents; request ids are not stable session identity.
+- The account-neutral replay header strip set drops the new headers alongside the Codex names so a fresh-account replay cannot re-register the alias.
+- None of the new headers are added to the upstream forwarding allowlist; they remain proxy-local.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `sticky-session-operations`: Define the recognized client session identity header set, its precedence, and the parent/request-id exclusions for bare process-session affinity.
+
+## Impact
+
+- `app/modules/proxy/affinity.py`: recognized header list.
+- `app/modules/proxy/continuity.py`: account-neutral replay strip set.
+- Behavior change for OpenCode/OpenClaw/Claude Code-style clients only: requests that previously derived prompt-cache affinity now carry per-session bare affinity. Codex CLI routing is unchanged (its headers keep precedence). Existing sticky rows are unaffected; new sessions simply key by their declared identity.
+- No setting, migration, dashboard, or API schema change.

--- a/openspec/changes/route-client-session-identity-headers/proposal.md
+++ b/openspec/changes/route-client-session-identity-headers/proposal.md
@@ -10,7 +10,7 @@ Agent clients identify each session — including every subagent session — wit
 - Each client session (including each subagent) thereby carries its own bare process-session key: first turns select an account independently under the existing cap-filtered, usage-weighted selection with #1382 bare-session cap spillover, so parallel subagents distribute across eligible accounts instead of collapsing onto one prompt-cache account.
 - Parent identity headers (`x-parent-session-id`, `x-codex-parent-thread-id`, `x-claude-code-parent-agent-id`, `x-openai-subagent`) and per-request ids (`x-client-request-id`) are explicitly excluded from session identity: parent keys would re-collapse subagents; request ids are not stable session identity.
 - The account-neutral replay header strip set drops the new headers alongside the Codex names so a fresh-account replay cannot re-register the alias.
-- None of the new headers are added to the upstream forwarding allowlist; they remain proxy-local.
+- None of the new headers are added to Responses upstream forwarding; they remain proxy-local for Responses traffic without changing non-Responses protocols that already use the same names as upstream metadata.
 
 ## Capabilities
 

--- a/openspec/changes/route-client-session-identity-headers/specs/responses-api-compat/spec.md
+++ b/openspec/changes/route-client-session-identity-headers/specs/responses-api-compat/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Tool-less one-shot requests bypass the HTTP bridge
+
+When the HTTP responses bridge is enabled, a request that carries a recognized client session identity header and is self-contained and tool-less — no `tools`, no `previous_response_id`, no incoming turn-state header, no nonblank `conversation`, and no input file references — MUST bypass the bridge for that request only and be sent over raw HTTP upstream, provided the request is not a forwarded bridge request, does not originate from a native Codex client (native Codex clients keep websocket-mode behavior), and `upstream_stream_transport` is not explicitly `websocket`. Requests without a session identity header MUST keep their existing bridge behavior. Agent clients send such side calls (title generation, summaries, compaction) on the same session identity as their agent turns; routing them through the bridge would fork an independent bridge lane per overlap with the agent's in-flight turn while gaining nothing from a persistent WebSocket.
+
+#### Scenario: Title-generation side call skips the bridge
+
+- **GIVEN** the HTTP responses bridge is enabled and `upstream_stream_transport` is `auto`
+- **AND** an OpenCode title-generation request arrives with session identity headers, no tools, and no continuity anchors
+- **WHEN** the request is routed
+- **THEN** the bridge is bypassed for that request and it is sent over raw HTTP upstream
+- **AND** no bridge session or fork lane is created for it
+
+#### Scenario: Agent turns with tools keep the bridge
+
+- **GIVEN** the HTTP responses bridge is enabled
+- **WHEN** a request carrying tool definitions arrives on the same session identity
+- **THEN** the request routes through the bridge as before
+
+#### Scenario: Native Codex clients keep websocket-mode behavior
+
+- **GIVEN** a request whose `originator` header names a native Codex client
+- **WHEN** the request is tool-less and unanchored
+- **THEN** the bridge is not bypassed for that request
+
+#### Scenario: Explicit websocket transport keeps the bridge
+
+- **GIVEN** `upstream_stream_transport` is explicitly `websocket`
+- **WHEN** a tool-less self-contained request arrives
+- **THEN** the bridge is not bypassed for that request
+
+#### Scenario: Anonymous requests keep existing bridge behavior
+
+- **GIVEN** a tool-less self-contained request with no session identity header
+- **WHEN** the request is routed
+- **THEN** the bridge is not bypassed for that request

--- a/openspec/changes/route-client-session-identity-headers/specs/responses-api-compat/spec.md
+++ b/openspec/changes/route-client-session-identity-headers/specs/responses-api-compat/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Tool-less one-shot requests bypass the HTTP bridge
 
-When the HTTP responses bridge is enabled, a request that carries a recognized client session identity header and is self-contained and tool-less — no `tools`, no `previous_response_id`, no incoming turn-state header, no nonblank `conversation`, and no input file references — MUST bypass the bridge for that request only and be sent over raw HTTP upstream, provided the request is not a forwarded bridge request, does not originate from a native Codex client (native Codex clients keep websocket-mode behavior), and `upstream_stream_transport` is not explicitly `websocket`. Requests without a session identity header MUST keep their existing bridge behavior. Agent clients send such side calls (title generation, summaries, compaction) on the same session identity as their agent turns; routing them through the bridge would fork an independent bridge lane per overlap with the agent's in-flight turn while gaining nothing from a persistent WebSocket.
+When the HTTP responses bridge is enabled, a request whose session identity comes from a client-declared identity header (`x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, `x-claude-remote-session-id`, with no Codex-name session header present) and that is self-contained and tool-less — no `tools`, no `previous_response_id`, no incoming turn-state header, no nonblank `conversation`, and no input file references — MUST bypass the bridge for that request only and be sent over raw HTTP upstream, provided the request is not a forwarded bridge request, does not originate from a native Codex client (native Codex clients keep websocket-mode behavior), and `upstream_stream_transport` is not explicitly `websocket`. Requests without a session identity header, and requests carrying a Codex-name session header (`session_id`, `session-id`, `x-codex-session-id`, `x-codex-conversation-id`, `thread-id` — bridge-centric Codex-protocol flows), MUST keep their existing bridge behavior. Agent clients send such side calls (title generation, summaries, compaction) on the same session identity as their agent turns; routing them through the bridge would fork an independent bridge lane per overlap with the agent's in-flight turn while gaining nothing from a persistent WebSocket.
 
 #### Scenario: Title-generation side call skips the bridge
 
@@ -33,5 +33,11 @@ When the HTTP responses bridge is enabled, a request that carries a recognized c
 #### Scenario: Anonymous requests keep existing bridge behavior
 
 - **GIVEN** a tool-less self-contained request with no session identity header
+- **WHEN** the request is routed
+- **THEN** the bridge is not bypassed for that request
+
+#### Scenario: Codex-name session headers keep existing bridge behavior
+
+- **GIVEN** a tool-less self-contained request carrying a `session_id` or `thread-id` header
 - **WHEN** the request is routed
 - **THEN** the bridge is not bypassed for that request

--- a/openspec/changes/route-client-session-identity-headers/specs/responses-api-compat/spec.md
+++ b/openspec/changes/route-client-session-identity-headers/specs/responses-api-compat/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Tool-less one-shot requests bypass the HTTP bridge
 
-When the HTTP responses bridge is enabled, a request whose session identity comes from a client-declared identity header (`x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, `x-claude-remote-session-id`, with no Codex-name session header present) and that is self-contained and tool-less — no `tools`, no `previous_response_id`, no incoming turn-state header, no nonblank `conversation`, no input file references, and no account-scoped hosted input items — MUST bypass the bridge for that request only and be sent over raw HTTP upstream, provided the request is not a forwarded bridge request, does not originate from a native Codex client (native Codex clients keep websocket-mode behavior), and `upstream_stream_transport` is not explicitly `websocket`. Requests without a session identity header, and requests carrying a Codex-name session header (`session_id`, `session-id`, `x-codex-session-id`, `x-codex-conversation-id`, `thread-id` — bridge-centric Codex-protocol flows), MUST keep their existing bridge behavior. Agent clients send such side calls (title generation, summaries, compaction) on the same session identity as their agent turns; routing them through the bridge would fork an independent bridge lane per overlap with the agent's in-flight turn while gaining nothing from a persistent WebSocket.
+When the HTTP responses bridge is enabled, a request whose session identity comes from a client-declared identity header (`x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, `x-claude-remote-session-id`, with no Codex-name session header present) and that is self-contained and tool-less — no `tools`, no `previous_response_id`, no incoming turn-state header, no nonblank `conversation`, no stored `prompt`, no input file references, and no account-scoped hosted input items — MUST bypass the bridge for that request only and be sent over raw HTTP upstream, provided the request is not a forwarded bridge request, does not originate from a native Codex client (native Codex clients keep websocket-mode behavior), and `upstream_stream_transport` is not explicitly `websocket`. Requests without a session identity header, and requests carrying a Codex-name session header (`session_id`, `session-id`, `x-codex-session-id`, `x-codex-conversation-id`, `thread-id` — bridge-centric Codex-protocol flows), MUST keep their existing bridge behavior. Agent clients send such side calls (title generation, summaries, compaction) on the same session identity as their agent turns; routing them through the bridge would fork an independent bridge lane per overlap with the agent's in-flight turn while gaining nothing from a persistent WebSocket.
 
 #### Scenario: Title-generation side call skips the bridge
 
@@ -33,6 +33,13 @@ When the HTTP responses bridge is enabled, a request whose session identity come
 #### Scenario: Account-scoped hosted input keeps the bridge
 
 - **GIVEN** a client-identified tool-less request containing `item_reference` or `file_search_call`
+- **WHEN** the request is routed
+- **THEN** the bridge is not bypassed
+- **AND** bare-session cap spillover to another account is disabled
+
+#### Scenario: Stored prompt keeps the bridge
+
+- **GIVEN** a client-identified tool-less request containing a non-empty stored `prompt`
 - **WHEN** the request is routed
 - **THEN** the bridge is not bypassed
 - **AND** bare-session cap spillover to another account is disabled

--- a/openspec/changes/route-client-session-identity-headers/specs/responses-api-compat/spec.md
+++ b/openspec/changes/route-client-session-identity-headers/specs/responses-api-compat/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Tool-less one-shot requests bypass the HTTP bridge
 
-When the HTTP responses bridge is enabled, a request whose session identity comes from a client-declared identity header (`x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, `x-claude-remote-session-id`, with no Codex-name session header present) and that is self-contained and tool-less — no `tools`, no `previous_response_id`, no incoming turn-state header, no nonblank `conversation`, no stored `prompt`, no input file references, and no account-scoped hosted input items — MUST bypass the bridge for that request only and be sent over raw HTTP upstream, provided the request is not a forwarded bridge request, does not originate from a native Codex client (native Codex clients keep websocket-mode behavior), and `upstream_stream_transport` is not explicitly `websocket`. Requests without a session identity header, and requests carrying a Codex-name session header (`session_id`, `session-id`, `x-codex-session-id`, `x-codex-conversation-id`, `thread-id` — bridge-centric Codex-protocol flows), MUST keep their existing bridge behavior. Agent clients send such side calls (title generation, summaries, compaction) on the same session identity as their agent turns; routing them through the bridge would fork an independent bridge lane per overlap with the agent's in-flight turn while gaining nothing from a persistent WebSocket.
+When the HTTP responses bridge is enabled, a request whose session identity comes from a client-declared identity header (`x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, `x-claude-remote-session-id`, with no Codex-name session header present) and that is self-contained and tool-less — no `tools`, no `previous_response_id`, no incoming turn-state header, no nonblank `conversation`, no stored `prompt`, no input file references, and no account-scoped hosted input items — MUST bypass the bridge for that request only and be sent over raw HTTP upstream, provided the request is not a forwarded bridge request, does not originate from a native Codex client (native Codex clients keep websocket-mode behavior), `upstream_stream_transport` is not explicitly `websocket`, and an `auto` upstream transport does not have an effective `always_websocket` downstream policy. The effective downstream policy MUST apply the existing per-API-key override precedence. Requests without a session identity header, and requests carrying a Codex-name session header (`session_id`, `session-id`, `x-codex-session-id`, `x-codex-conversation-id`, `thread-id` — bridge-centric Codex-protocol flows), MUST keep their existing bridge behavior. Agent clients send such side calls (title generation, summaries, compaction) on the same session identity as their agent turns; routing them through the bridge would fork an independent bridge lane per overlap with the agent's in-flight turn while gaining nothing from a persistent WebSocket.
 
 #### Scenario: Title-generation side call skips the bridge
 
@@ -27,6 +27,13 @@ When the HTTP responses bridge is enabled, a request whose session identity come
 #### Scenario: Explicit websocket transport keeps the bridge
 
 - **GIVEN** `upstream_stream_transport` is explicitly `websocket`
+- **WHEN** a tool-less self-contained request arrives
+- **THEN** the bridge is not bypassed for that request
+
+#### Scenario: Always-websocket policy keeps the bridge
+
+- **GIVEN** `upstream_stream_transport` is `auto`
+- **AND** the effective global or per-API-key `http_downstream_transport_policy` is `always_websocket`
 - **WHEN** a tool-less self-contained request arrives
 - **THEN** the bridge is not bypassed for that request
 

--- a/openspec/changes/route-client-session-identity-headers/specs/responses-api-compat/spec.md
+++ b/openspec/changes/route-client-session-identity-headers/specs/responses-api-compat/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Tool-less one-shot requests bypass the HTTP bridge
 
-When the HTTP responses bridge is enabled, a request whose session identity comes from a client-declared identity header (`x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, `x-claude-remote-session-id`, with no Codex-name session header present) and that is self-contained and tool-less — no `tools`, no `previous_response_id`, no incoming turn-state header, no nonblank `conversation`, and no input file references — MUST bypass the bridge for that request only and be sent over raw HTTP upstream, provided the request is not a forwarded bridge request, does not originate from a native Codex client (native Codex clients keep websocket-mode behavior), and `upstream_stream_transport` is not explicitly `websocket`. Requests without a session identity header, and requests carrying a Codex-name session header (`session_id`, `session-id`, `x-codex-session-id`, `x-codex-conversation-id`, `thread-id` — bridge-centric Codex-protocol flows), MUST keep their existing bridge behavior. Agent clients send such side calls (title generation, summaries, compaction) on the same session identity as their agent turns; routing them through the bridge would fork an independent bridge lane per overlap with the agent's in-flight turn while gaining nothing from a persistent WebSocket.
+When the HTTP responses bridge is enabled, a request whose session identity comes from a client-declared identity header (`x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, `x-claude-remote-session-id`, with no Codex-name session header present) and that is self-contained and tool-less — no `tools`, no `previous_response_id`, no incoming turn-state header, no nonblank `conversation`, no input file references, and no account-scoped hosted input items — MUST bypass the bridge for that request only and be sent over raw HTTP upstream, provided the request is not a forwarded bridge request, does not originate from a native Codex client (native Codex clients keep websocket-mode behavior), and `upstream_stream_transport` is not explicitly `websocket`. Requests without a session identity header, and requests carrying a Codex-name session header (`session_id`, `session-id`, `x-codex-session-id`, `x-codex-conversation-id`, `thread-id` — bridge-centric Codex-protocol flows), MUST keep their existing bridge behavior. Agent clients send such side calls (title generation, summaries, compaction) on the same session identity as their agent turns; routing them through the bridge would fork an independent bridge lane per overlap with the agent's in-flight turn while gaining nothing from a persistent WebSocket.
 
 #### Scenario: Title-generation side call skips the bridge
 
@@ -29,6 +29,13 @@ When the HTTP responses bridge is enabled, a request whose session identity come
 - **GIVEN** `upstream_stream_transport` is explicitly `websocket`
 - **WHEN** a tool-less self-contained request arrives
 - **THEN** the bridge is not bypassed for that request
+
+#### Scenario: Account-scoped hosted input keeps the bridge
+
+- **GIVEN** a client-identified tool-less request containing `item_reference` or `file_search_call`
+- **WHEN** the request is routed
+- **THEN** the bridge is not bypassed
+- **AND** bare-session cap spillover to another account is disabled
 
 #### Scenario: Anonymous requests keep existing bridge behavior
 

--- a/openspec/changes/route-client-session-identity-headers/specs/responses-api-compat/spec.md
+++ b/openspec/changes/route-client-session-identity-headers/specs/responses-api-compat/spec.md
@@ -41,3 +41,20 @@ When the HTTP responses bridge is enabled, a request whose session identity come
 - **GIVEN** a tool-less self-contained request carrying a `session_id` or `thread-id` header
 - **WHEN** the request is routed
 - **THEN** the bridge is not bypassed for that request
+
+### Requirement: Empty tool map normalizes to an empty tool list
+
+`/responses` request validation MUST treat a `tools` field sent as an empty JSON object (`tools: {}`) as equivalent to `tools: []` on both the codex-native and OpenAI-compat validation paths, so such requests validate and count as tool-less (including for the one-shot bypass predicate). OpenCode's title and compaction side calls declare tool-lessness with this empty-map wire shape. Non-empty tool maps MUST continue to be rejected as invalid payloads.
+
+#### Scenario: OpenCode empty tool map side call validates as tool-less
+
+- **GIVEN** an OpenCode title or compaction side call whose body carries `tools: {}` and client-declared session identity headers
+- **WHEN** the request is validated at `/responses`
+- **THEN** validation succeeds and the request's tool list is empty
+- **AND** the request is treated as tool-less by the one-shot bypass predicate
+
+#### Scenario: Non-empty tool maps stay rejected
+
+- **GIVEN** a `/responses` request whose `tools` field is a non-empty JSON object
+- **WHEN** the request is validated
+- **THEN** the request is rejected as an invalid payload

--- a/openspec/changes/route-client-session-identity-headers/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/route-client-session-identity-headers/specs/sticky-session-operations/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Client-declared session identity headers key bare process-session affinity
+
+The service MUST recognize client-declared session identity headers as the bare process-session affinity key, checked in this precedence order: `session_id`, `session-id`, `x-codex-session-id`, `x-codex-conversation-id`, `thread-id` (the Codex CLI names, unchanged and first), then `x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, `x-claude-remote-session-id`. The first header present with a nonblank value MUST supply the key, so a request carrying both a Codex name and a client identity header routes exactly as before this requirement existed. Sessions keyed by these headers MUST carry the same bare process-session semantics defined elsewhere in this capability: soft locality, cap spillover for self-contained payloads, and no ownership evidence.
+
+Parent identity headers — `x-parent-session-id`, `x-codex-parent-thread-id`, `x-claude-code-parent-agent-id`, and `x-openai-subagent` — MUST NOT supply the session affinity key: a parent key would collapse every subagent of one parent onto a single session. `x-client-request-id` MUST NOT supply the key because clients also populate it with per-request identifiers.
+
+The account-neutral replay header filter MUST strip the recognized client identity headers alongside the Codex names so a replay dispatched to a fresh account cannot re-register the downstream alias. The recognized client identity headers MUST NOT be forwarded upstream.
+
+#### Scenario: Subagent sessions route independently
+
+- **GIVEN** two OpenCode subagent requests that share a system-prompt prefix but carry distinct `x-session-affinity` values
+- **WHEN** each subagent's first turn selects an account
+- **THEN** each request keys its own bare process-session affinity
+- **AND** neither request collapses onto the other's account via derived prompt-cache affinity
+
+#### Scenario: Codex names keep precedence
+
+- **GIVEN** a request carrying both `session_id` and `x-session-affinity`
+- **WHEN** the session affinity key is derived
+- **THEN** the `session_id` value supplies the key
+
+#### Scenario: Parent identity does not key affinity
+
+- **GIVEN** a request carrying only `x-parent-session-id`, `x-codex-parent-thread-id`, `x-claude-code-parent-agent-id`, or `x-openai-subagent`
+- **WHEN** the session affinity key is derived
+- **THEN** no session affinity key is produced
+
+#### Scenario: Account-neutral replay strips client identity headers
+
+- **GIVEN** an account-neutral replay for a session keyed by `x-session-affinity`
+- **WHEN** the replay's session-creation headers are built
+- **THEN** every recognized client identity header is absent
+- **AND** unrelated headers such as `user-agent` are preserved

--- a/openspec/changes/route-client-session-identity-headers/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/route-client-session-identity-headers/specs/sticky-session-operations/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Client-declared session identity headers key bare process-session affinity
 
-The service MUST recognize client-declared session identity headers as the bare process-session affinity key, checked in this precedence order: `session_id`, `session-id`, `x-codex-session-id`, `x-codex-conversation-id`, `thread-id` (the Codex CLI names, unchanged and first), then `x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, `x-claude-remote-session-id`. The first header present with a nonblank value MUST supply the key, so a request carrying both a Codex name and a client identity header routes exactly as before this requirement existed. Sessions keyed by these headers MUST carry the same bare process-session semantics defined elsewhere in this capability: soft locality, cap spillover for self-contained payloads, and no ownership evidence.
+The service MUST recognize client-declared session identity headers as the bare process-session affinity key on every Responses API entry point, including `/v1/responses`, checked in this precedence order: `session_id`, `session-id`, `x-codex-session-id`, `x-codex-conversation-id`, `thread-id` (the Codex CLI names, unchanged and first where Codex session affinity is enabled), then `x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, `x-claude-remote-session-id`. The client-specific names MUST remain enabled when Codex session affinity is disabled. The first eligible header present with a nonblank value MUST supply the key, so a Codex-affinity request carrying both a Codex name and a client identity header routes exactly as before this requirement existed. Sessions keyed by these headers MUST carry the same bare process-session semantics defined elsewhere in this capability: soft locality, cap spillover for self-contained payloads, and no ownership evidence.
 
 Parent identity headers — `x-parent-session-id`, `x-codex-parent-thread-id`, `x-claude-code-parent-agent-id`, and `x-openai-subagent` — MUST NOT supply the session affinity key: a parent key would collapse every subagent of one parent onto a single session. `x-client-request-id` MUST NOT supply the key because clients also populate it with per-request identifiers.
 
@@ -14,6 +14,13 @@ The account-neutral replay header filter MUST strip the recognized client identi
 - **WHEN** each subagent's first turn selects an account
 - **THEN** each request keys its own bare process-session affinity
 - **AND** neither request collapses onto the other's account via derived prompt-cache affinity
+
+#### Scenario: Public Responses route honors client identity
+
+- **GIVEN** a `/v1/responses` request carrying `x-session-id` and a shared prompt-cache key
+- **WHEN** Codex session affinity is disabled for that route
+- **THEN** the client session value supplies the bare process-session affinity key
+- **AND** the shared prompt-cache key does not collapse distinct client sessions
 
 #### Scenario: Codex names keep precedence
 

--- a/openspec/changes/route-client-session-identity-headers/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/route-client-session-identity-headers/specs/sticky-session-operations/spec.md
@@ -47,3 +47,10 @@ The account-neutral replay header filter MUST strip the recognized client identi
 - **WHEN** the request streams upstream over the direct HTTP path
 - **THEN** the persisted request log records the conversation id from the identity header
 - **AND** the recognized client identity headers are absent from the upstream request headers
+
+#### Scenario: Owner forwarding retains client identity
+
+- **GIVEN** a Responses request carrying client identity is forwarded to its HTTP bridge owner replica
+- **WHEN** the internal owner-forward headers are built
+- **THEN** the client identity headers are retained for affinity and request logging on the owner
+- **AND** the owner strips them only when building the Responses upstream request

--- a/openspec/changes/route-client-session-identity-headers/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/route-client-session-identity-headers/specs/sticky-session-operations/spec.md
@@ -6,7 +6,7 @@ The service MUST recognize client-declared session identity headers as the bare 
 
 Parent identity headers — `x-parent-session-id`, `x-codex-parent-thread-id`, `x-claude-code-parent-agent-id`, and `x-openai-subagent` — MUST NOT supply the session affinity key: a parent key would collapse every subagent of one parent onto a single session. `x-client-request-id` MUST NOT supply the key because clients also populate it with per-request identifiers.
 
-The account-neutral replay header filter MUST strip the recognized client identity headers alongside the Codex names so a replay dispatched to a fresh account cannot re-register the downstream alias. The recognized client identity headers MUST NOT be forwarded upstream. Stripping MUST apply at upstream egress (and in the account-neutral replay filter) only: internal request handling MUST retain these headers so request-log conversation metadata (see `proxy-runtime-observability`) and session affinity derivation still observe them.
+The account-neutral replay header filter MUST strip the recognized client identity headers alongside the Codex names so a replay dispatched to a fresh account cannot re-register the downstream alias. The recognized client identity headers MUST NOT be forwarded on Responses upstream egress. Stripping MUST apply at Responses upstream egress (and in the account-neutral replay filter) only: internal request handling MUST retain these headers so request-log conversation metadata (see `proxy-runtime-observability`) and session affinity derivation still observe them. Non-Responses protocols that already use the same header names as upstream protocol metadata MUST retain their existing contracts.
 
 #### Scenario: Subagent sessions route independently
 

--- a/openspec/changes/route-client-session-identity-headers/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/route-client-session-identity-headers/specs/sticky-session-operations/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Client-declared session identity headers key bare process-session affinity
 
-The service MUST recognize client-declared session identity headers as the bare process-session affinity key on every Responses API entry point, including `/v1/responses`, checked in this precedence order: `session_id`, `session-id`, `x-codex-session-id`, `x-codex-conversation-id`, `thread-id` (the Codex CLI names, unchanged and first where Codex session affinity is enabled), then `x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, `x-claude-remote-session-id`. The client-specific names MUST remain enabled when Codex session affinity is disabled. The first eligible header present with a nonblank value MUST supply the key, so a Codex-affinity request carrying both a Codex name and a client identity header routes exactly as before this requirement existed. Sessions keyed by these headers MUST carry the same bare process-session semantics defined elsewhere in this capability: soft locality, cap spillover for self-contained payloads, and no ownership evidence.
+The service MUST recognize client-declared session identity headers as the bare process-session affinity key on every Responses API entry point, including `/v1/responses`, checked in this precedence order: `session_id`, `session-id`, `x-codex-session-id`, `x-codex-conversation-id`, `thread-id` (the Codex CLI names, unchanged and first where Codex session affinity is enabled), then `x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, `x-claude-remote-session-id`. The client-specific names MUST remain enabled when Codex session affinity is disabled. The first eligible header present with a nonblank value MUST supply the key, so a Codex-affinity request carrying both a Codex name and a client identity header routes exactly as before this requirement existed. Sessions keyed by these headers MUST carry the same bare process-session semantics defined elsewhere in this capability: soft locality, cap spillover for self-contained payloads, and no ownership evidence. A standard Responses or compact request carrying a non-empty stored `prompt` MUST NOT spill to another account under an account cap.
 
 Parent identity headers — `x-parent-session-id`, `x-codex-parent-thread-id`, `x-claude-code-parent-agent-id`, and `x-openai-subagent` — MUST NOT supply the session affinity key: a parent key would collapse every subagent of one parent onto a single session. `x-client-request-id` MUST NOT supply the key because clients also populate it with per-request identifiers.
 
@@ -54,3 +54,9 @@ The account-neutral replay header filter MUST strip the recognized client identi
 - **WHEN** the internal owner-forward headers are built
 - **THEN** the client identity headers are retained for affinity and request logging on the owner
 - **AND** the owner strips them only when building the Responses upstream request
+
+#### Scenario: Compact stored prompt remains account-bound
+
+- **GIVEN** a `/v1/responses/compact` request carrying client identity and a non-empty stored `prompt`
+- **WHEN** its mapped account is at the response-create cap
+- **THEN** bare-session cap spillover to another account is disabled

--- a/openspec/changes/route-client-session-identity-headers/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/route-client-session-identity-headers/specs/sticky-session-operations/spec.md
@@ -6,7 +6,7 @@ The service MUST recognize client-declared session identity headers as the bare 
 
 Parent identity headers — `x-parent-session-id`, `x-codex-parent-thread-id`, `x-claude-code-parent-agent-id`, and `x-openai-subagent` — MUST NOT supply the session affinity key: a parent key would collapse every subagent of one parent onto a single session. `x-client-request-id` MUST NOT supply the key because clients also populate it with per-request identifiers.
 
-The account-neutral replay header filter MUST strip the recognized client identity headers alongside the Codex names so a replay dispatched to a fresh account cannot re-register the downstream alias. The recognized client identity headers MUST NOT be forwarded upstream.
+The account-neutral replay header filter MUST strip the recognized client identity headers alongside the Codex names so a replay dispatched to a fresh account cannot re-register the downstream alias. The recognized client identity headers MUST NOT be forwarded upstream. Stripping MUST apply at upstream egress (and in the account-neutral replay filter) only: internal request handling MUST retain these headers so request-log conversation metadata (see `proxy-runtime-observability`) and session affinity derivation still observe them.
 
 #### Scenario: Subagent sessions route independently
 
@@ -33,3 +33,10 @@ The account-neutral replay header filter MUST strip the recognized client identi
 - **WHEN** the replay's session-creation headers are built
 - **THEN** every recognized client identity header is absent
 - **AND** unrelated headers such as `user-agent` are preserved
+
+#### Scenario: Direct HTTP streaming still logs the OpenCode conversation id
+
+- **GIVEN** the HTTP responses bridge is disabled and an OpenCode request carries `x-opencode-session`
+- **WHEN** the request streams upstream over the direct HTTP path
+- **THEN** the persisted request log records the conversation id from the identity header
+- **AND** the recognized client identity headers are absent from the upstream request headers

--- a/openspec/changes/route-client-session-identity-headers/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/route-client-session-identity-headers/specs/sticky-session-operations/spec.md
@@ -6,7 +6,7 @@ The service MUST recognize client-declared session identity headers as the bare 
 
 Parent identity headers — `x-parent-session-id`, `x-codex-parent-thread-id`, `x-claude-code-parent-agent-id`, and `x-openai-subagent` — MUST NOT supply the session affinity key: a parent key would collapse every subagent of one parent onto a single session. `x-client-request-id` MUST NOT supply the key because clients also populate it with per-request identifiers.
 
-The account-neutral replay header filter MUST strip the recognized client identity headers alongside the Codex names so a replay dispatched to a fresh account cannot re-register the downstream alias. The recognized client identity headers MUST NOT be forwarded on Responses upstream egress. Stripping MUST apply at Responses upstream egress (and in the account-neutral replay filter) only: internal request handling MUST retain these headers so request-log conversation metadata (see `proxy-runtime-observability`) and session affinity derivation still observe them. Non-Responses protocols that already use the same header names as upstream protocol metadata MUST retain their existing contracts.
+The account-neutral replay header filter MUST strip the recognized client identity headers alongside the Codex names so a replay dispatched to a fresh account cannot re-register the downstream alias. The recognized client identity headers MUST NOT be forwarded on Responses upstream egress. Stripping MUST apply at Responses upstream egress (and in the account-neutral replay filter) only: internal request handling MUST retain these headers so request-log conversation metadata (see `proxy-runtime-observability`) and Responses session affinity derivation still observe them. Client-specific identity headers MUST NOT supply affinity for non-Responses control requests. Non-Responses protocols that already use the same header names as upstream protocol metadata MUST retain their existing contracts.
 
 #### Scenario: Subagent sessions route independently
 
@@ -60,3 +60,10 @@ The account-neutral replay header filter MUST strip the recognized client identi
 - **GIVEN** a `/v1/responses/compact` request carrying client identity and a non-empty stored `prompt`
 - **WHEN** its mapped account is at the response-create cap
 - **THEN** bare-session cap spillover to another account is disabled
+
+#### Scenario: Control metadata does not key Responses affinity
+
+- **GIVEN** a non-Responses control request carrying only `x-session-id`
+- **WHEN** its account is selected
+- **THEN** the client-specific identity value does not supply session affinity
+- **AND** the header remains available as upstream protocol metadata

--- a/openspec/changes/route-client-session-identity-headers/tasks.md
+++ b/openspec/changes/route-client-session-identity-headers/tasks.md
@@ -1,0 +1,15 @@
+# Tasks
+
+## 1. Session identity recognition
+
+- [x] 1.1 Add `x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, and `x-claude-remote-session-id` to the session-affinity header list, after the Codex names.
+- [x] 1.2 Document the parent-header and request-id exclusions at the definition site.
+
+## 2. Replay hygiene
+
+- [x] 2.1 Strip the new headers in the account-neutral replay header filter.
+
+## 3. Tests
+
+- [x] 3.1 Recognition, precedence, and exclusion coverage for the new headers.
+- [x] 3.2 Account-neutral replay strip coverage for the new headers.

--- a/openspec/changes/route-client-session-identity-headers/tasks.md
+++ b/openspec/changes/route-client-session-identity-headers/tasks.md
@@ -9,7 +9,12 @@
 
 - [x] 2.1 Strip the new headers in the account-neutral replay header filter.
 
-## 3. Tests
+## 3. One-shot side-call bypass
 
-- [x] 3.1 Recognition, precedence, and exclusion coverage for the new headers.
-- [x] 3.2 Account-neutral replay strip coverage for the new headers.
+- [x] 3.1 Bypass the bridge (raw HTTP upstream) for session-identified, tool-less, self-contained one-shots; exclude forwarded requests, native Codex clients, anonymous requests, and explicit `websocket` transport.
+
+## 4. Tests
+
+- [x] 4.1 Recognition, precedence, and exclusion coverage for the new headers.
+- [x] 4.2 Account-neutral replay strip coverage for the new headers.
+- [x] 4.3 One-shot predicate coverage: side calls bypass; tools, anchors, files, native Codex, forwarded, and anonymous requests keep the bridge.

--- a/openspec/changes/route-client-session-identity-headers/tasks.md
+++ b/openspec/changes/route-client-session-identity-headers/tasks.md
@@ -16,6 +16,7 @@
 
 - [x] 3.1 Bypass the bridge (raw HTTP upstream) for session-identified, tool-less, self-contained one-shots; exclude forwarded requests, native Codex clients, anonymous requests, and explicit `websocket` transport.
 - [x] 3.2 Normalize the `tools: {}` wire shape (OpenCode title/compaction side calls) to `tools: []` on both `/responses` validation paths so empty tool maps reach the bypass; keep non-empty tool maps rejected.
+- [x] 3.3 Keep account-scoped hosted input on the bridge and disable bare-session cap spillover for it.
 
 ## 4. Tests
 
@@ -25,3 +26,4 @@
 - [x] 4.4 Empty tool map coverage: `tools: {}` validates as tool-less at the `/responses` route and reaches the one-shot bypass; non-empty tool maps stay rejected.
 - [x] 4.5 Public Responses affinity coverage: client identity overrides shared prompt-cache affinity while Codex session affinity is disabled.
 - [x] 4.6 Replica forwarding coverage: internal owner-forward headers retain client identity until Responses upstream egress.
+- [x] 4.7 Account-scoped hosted-input coverage: such requests neither bypass the bridge nor spill across accounts.

--- a/openspec/changes/route-client-session-identity-headers/tasks.md
+++ b/openspec/changes/route-client-session-identity-headers/tasks.md
@@ -23,3 +23,4 @@
 - [x] 4.3 One-shot predicate coverage: side calls bypass; tools, anchors, files, native Codex, forwarded, and anonymous requests keep the bridge.
 - [x] 4.4 Empty tool map coverage: `tools: {}` validates as tool-less at the `/responses` route and reaches the one-shot bypass; non-empty tool maps stay rejected.
 - [x] 4.5 Public Responses affinity coverage: client identity overrides shared prompt-cache affinity while Codex session affinity is disabled.
+- [x] 4.6 Replica forwarding coverage: internal owner-forward headers retain client identity until Responses upstream egress.

--- a/openspec/changes/route-client-session-identity-headers/tasks.md
+++ b/openspec/changes/route-client-session-identity-headers/tasks.md
@@ -11,6 +11,7 @@
 - [x] 2.1 Strip the new headers in the account-neutral replay header filter.
 - [x] 2.2 Strip client session identity at Responses upstream egress only; internal filters preserve the headers so request-log conversation metadata and session affinity still observe them, while non-Responses protocol metadata remains unchanged.
 - [x] 2.3 Make generic inbound filtering preserve client identity by default; only Responses HTTP and WebSocket egress opt into stripping.
+- [x] 2.4 Keep the shared HTTP header builder preserving identity by default; Responses and compact callers explicitly opt into stripping.
 
 ## 3. One-shot side-call bypass
 

--- a/openspec/changes/route-client-session-identity-headers/tasks.md
+++ b/openspec/changes/route-client-session-identity-headers/tasks.md
@@ -19,6 +19,7 @@
 - [x] 3.2 Normalize the `tools: {}` wire shape (OpenCode title/compaction side calls) to `tools: []` on both `/responses` validation paths so empty tool maps reach the bypass; keep non-empty tool maps rejected.
 - [x] 3.3 Keep account-scoped hosted input on the bridge and disable bare-session cap spillover for it.
 - [x] 3.4 Keep stored-prompt requests on the bridge and disable bare-session cap spillover for them.
+- [x] 3.5 Keep one-shot requests on the bridge when `auto` transport resolves under an effective `always_websocket` policy.
 
 ## 4. Tests
 
@@ -30,3 +31,4 @@
 - [x] 4.6 Replica forwarding coverage: internal owner-forward headers retain client identity until Responses upstream egress.
 - [x] 4.7 Account-scoped hosted-input coverage: such requests neither bypass the bridge nor spill across accounts.
 - [x] 4.8 Stored-prompt coverage: such requests neither bypass the bridge nor spill across accounts.
+- [x] 4.9 Always-websocket coverage: global and per-API-key policy keep one-shot requests on the bridge.

--- a/openspec/changes/route-client-session-identity-headers/tasks.md
+++ b/openspec/changes/route-client-session-identity-headers/tasks.md
@@ -12,9 +12,11 @@
 ## 3. One-shot side-call bypass
 
 - [x] 3.1 Bypass the bridge (raw HTTP upstream) for session-identified, tool-less, self-contained one-shots; exclude forwarded requests, native Codex clients, anonymous requests, and explicit `websocket` transport.
+- [x] 3.2 Normalize the `tools: {}` wire shape (OpenCode title/compaction side calls) to `tools: []` on both `/responses` validation paths so empty tool maps reach the bypass; keep non-empty tool maps rejected.
 
 ## 4. Tests
 
 - [x] 4.1 Recognition, precedence, and exclusion coverage for the new headers.
 - [x] 4.2 Account-neutral replay strip coverage for the new headers.
 - [x] 4.3 One-shot predicate coverage: side calls bypass; tools, anchors, files, native Codex, forwarded, and anonymous requests keep the bridge.
+- [x] 4.4 Empty tool map coverage: `tools: {}` validates as tool-less at the `/responses` route and reaches the one-shot bypass; non-empty tool maps stay rejected.

--- a/openspec/changes/route-client-session-identity-headers/tasks.md
+++ b/openspec/changes/route-client-session-identity-headers/tasks.md
@@ -8,6 +8,7 @@
 ## 2. Replay hygiene
 
 - [x] 2.1 Strip the new headers in the account-neutral replay header filter.
+- [x] 2.2 Strip client session identity at upstream egress only; internal filters preserve the headers so request-log conversation metadata and session affinity still observe them.
 
 ## 3. One-shot side-call bypass
 

--- a/openspec/changes/route-client-session-identity-headers/tasks.md
+++ b/openspec/changes/route-client-session-identity-headers/tasks.md
@@ -10,6 +10,7 @@
 
 - [x] 2.1 Strip the new headers in the account-neutral replay header filter.
 - [x] 2.2 Strip client session identity at Responses upstream egress only; internal filters preserve the headers so request-log conversation metadata and session affinity still observe them, while non-Responses protocol metadata remains unchanged.
+- [x] 2.3 Make generic inbound filtering preserve client identity by default; only Responses HTTP and WebSocket egress opt into stripping.
 
 ## 3. One-shot side-call bypass
 

--- a/openspec/changes/route-client-session-identity-headers/tasks.md
+++ b/openspec/changes/route-client-session-identity-headers/tasks.md
@@ -20,6 +20,7 @@
 - [x] 3.3 Keep account-scoped hosted input on the bridge and disable bare-session cap spillover for it.
 - [x] 3.4 Keep stored-prompt requests on the bridge and disable bare-session cap spillover for them.
 - [x] 3.5 Keep one-shot requests on the bridge when `auto` transport resolves under an effective `always_websocket` policy.
+- [x] 3.6 Keep compact stored-prompt requests account-bound under account caps.
 
 ## 4. Tests
 
@@ -32,3 +33,4 @@
 - [x] 4.7 Account-scoped hosted-input coverage: such requests neither bypass the bridge nor spill across accounts.
 - [x] 4.8 Stored-prompt coverage: such requests neither bypass the bridge nor spill across accounts.
 - [x] 4.9 Always-websocket coverage: global and per-API-key policy keep one-shot requests on the bridge.
+- [x] 4.10 Stored-prompt spillover coverage includes standard Responses and compact request models.

--- a/openspec/changes/route-client-session-identity-headers/tasks.md
+++ b/openspec/changes/route-client-session-identity-headers/tasks.md
@@ -8,7 +8,7 @@
 ## 2. Replay hygiene
 
 - [x] 2.1 Strip the new headers in the account-neutral replay header filter.
-- [x] 2.2 Strip client session identity at upstream egress only; internal filters preserve the headers so request-log conversation metadata and session affinity still observe them.
+- [x] 2.2 Strip client session identity at Responses upstream egress only; internal filters preserve the headers so request-log conversation metadata and session affinity still observe them, while non-Responses protocol metadata remains unchanged.
 
 ## 3. One-shot side-call bypass
 

--- a/openspec/changes/route-client-session-identity-headers/tasks.md
+++ b/openspec/changes/route-client-session-identity-headers/tasks.md
@@ -18,6 +18,7 @@
 - [x] 3.1 Bypass the bridge (raw HTTP upstream) for session-identified, tool-less, self-contained one-shots; exclude forwarded requests, native Codex clients, anonymous requests, and explicit `websocket` transport.
 - [x] 3.2 Normalize the `tools: {}` wire shape (OpenCode title/compaction side calls) to `tools: []` on both `/responses` validation paths so empty tool maps reach the bypass; keep non-empty tool maps rejected.
 - [x] 3.3 Keep account-scoped hosted input on the bridge and disable bare-session cap spillover for it.
+- [x] 3.4 Keep stored-prompt requests on the bridge and disable bare-session cap spillover for them.
 
 ## 4. Tests
 
@@ -28,3 +29,4 @@
 - [x] 4.5 Public Responses affinity coverage: client identity overrides shared prompt-cache affinity while Codex session affinity is disabled.
 - [x] 4.6 Replica forwarding coverage: internal owner-forward headers retain client identity until Responses upstream egress.
 - [x] 4.7 Account-scoped hosted-input coverage: such requests neither bypass the bridge nor spill across accounts.
+- [x] 4.8 Stored-prompt coverage: such requests neither bypass the bridge nor spill across accounts.

--- a/openspec/changes/route-client-session-identity-headers/tasks.md
+++ b/openspec/changes/route-client-session-identity-headers/tasks.md
@@ -5,6 +5,7 @@
 - [x] 1.1 Add `x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, and `x-claude-remote-session-id` to the session-affinity header list, after the Codex names.
 - [x] 1.2 Document the parent-header and request-id exclusions at the definition site.
 - [x] 1.3 Recognize client-specific session identity on every Responses API entry point independently of the Codex-only affinity switch.
+- [x] 1.4 Exclude client-specific identity aliases from non-Responses control-request affinity while preserving Codex-name routing.
 
 ## 2. Replay hygiene
 
@@ -34,3 +35,4 @@
 - [x] 4.8 Stored-prompt coverage: such requests neither bypass the bridge nor spill across accounts.
 - [x] 4.9 Always-websocket coverage: global and per-API-key policy keep one-shot requests on the bridge.
 - [x] 4.10 Stored-prompt spillover coverage includes standard Responses and compact request models.
+- [x] 4.11 Control-request coverage proves client-specific identity remains upstream metadata without supplying affinity.

--- a/openspec/changes/route-client-session-identity-headers/tasks.md
+++ b/openspec/changes/route-client-session-identity-headers/tasks.md
@@ -4,6 +4,7 @@
 
 - [x] 1.1 Add `x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, and `x-claude-remote-session-id` to the session-affinity header list, after the Codex names.
 - [x] 1.2 Document the parent-header and request-id exclusions at the definition site.
+- [x] 1.3 Recognize client-specific session identity on every Responses API entry point independently of the Codex-only affinity switch.
 
 ## 2. Replay hygiene
 
@@ -21,3 +22,4 @@
 - [x] 4.2 Account-neutral replay strip coverage for the new headers.
 - [x] 4.3 One-shot predicate coverage: side calls bypass; tools, anchors, files, native Codex, forwarded, and anonymous requests keep the bridge.
 - [x] 4.4 Empty tool map coverage: `tools: {}` validates as tool-less at the `/responses` route and reaches the one-shot bypass; non-empty tool maps stay rejected.
+- [x] 4.5 Public Responses affinity coverage: client identity overrides shared prompt-cache affinity while Codex session affinity is disabled.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -4819,10 +4819,14 @@ async def test_forwarded_priority_prompt_cache_mismatch_forks_on_canonical_owner
         original_affinity_key=canonical_key.affinity_key,
     )
     forward_headers = build_owner_forward_headers(
-        headers={"x-request-id": "forwarded-priority-request"},
+        headers={
+            "x-request-id": "forwarded-priority-request",
+            "x-opencode-session": "forwarded-opencode-session",
+        },
         payload=priority_payload,
         context=forward_context,
     )
+    assert forward_headers["x-opencode-session"] == "forwarded-opencode-session"
 
     try:
         creator_response = await async_client.post(

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -473,6 +473,56 @@ async def test_backend_responses_accepts_opencode_empty_tool_map(async_client, m
 
 
 @pytest.mark.asyncio
+async def test_backend_responses_direct_stream_persists_opencode_conversation_id(async_client, monkeypatch):
+    # With the HTTP bridge disabled (autouse fixture), /responses streams
+    # through ``stream_responses`` -> ``_stream_with_retry``. The internal
+    # header filter must preserve client session identity headers so the
+    # request log still records the OpenCode conversation id; upstream egress
+    # strips them in ``_build_upstream_headers``.
+    raw_account_id = "acc_responses_opencode_conv_log"
+    auth_json = _make_auth_json(raw_account_id, "responses-opencode-conv-log@example.com")
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del payload, headers, access_token, account_id, base_url, raise_for_status, kwargs
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_opencode_conv_log",'
+            '"object":"response","status":"completed","usage":{"input_tokens":2,"output_tokens":1}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    request_payload = {
+        "model": "gpt-5.6",
+        "instructions": "t",
+        "input": "Generate a title for this conversation:",
+        "stream": True,
+    }
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=request_payload,
+        headers={
+            "user-agent": "opencode/1.18.3 (darwin arm64)",
+            "x-opencode-session": "ses_conv_log",
+            "x-session-id": "ses_conv_log",
+        },
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    event = _extract_first_event(lines)
+    assert event["type"] == "response.completed"
+
+    async with SessionLocal() as session:
+        result = await session.execute(select(RequestLog).where(RequestLog.request_id == "resp_opencode_conv_log"))
+        log = result.scalar_one()
+    assert log.conversation_id == "ses_conv_log"
+
+
+@pytest.mark.asyncio
 async def test_backend_responses_preserves_non_message_developer_directive(async_client, monkeypatch):
     raw_account_id = "acc_future_directive"
     auth_json = _make_auth_json(raw_account_id, "future-directive@example.com")

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -428,6 +428,51 @@ async def test_backend_responses_forwards_explicit_empty_tools(async_client, mon
 
 
 @pytest.mark.asyncio
+async def test_backend_responses_accepts_opencode_empty_tool_map(async_client, monkeypatch):
+    # OpenCode's title/compaction side calls declare tool-lessness with an
+    # empty tool map (``tools: {}``) on the wire. The route must normalize
+    # that shape to ``tools: []`` instead of rejecting the payload as
+    # invalid, so these side calls reach the tool-less one-shot bypass
+    # (see tests/unit/test_http_bridge_one_shot_bypass.py).
+    raw_account_id = "acc_responses_empty_tool_map"
+    auth_json = _make_auth_json(raw_account_id, "responses-empty-tool-map@example.com")
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payload: dict[str, object] = {}
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del headers, access_token, account_id, base_url, raise_for_status, kwargs
+        seen_payload.update(payload.to_payload())
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_empty_tool_map",'
+            '"object":"response","status":"completed","usage":{"input_tokens":2,"output_tokens":1}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    request_payload = {
+        "model": "gpt-5.6",
+        "instructions": "t",
+        "input": "Generate a title for this conversation:",
+        "tools": {},
+        "stream": True,
+    }
+    async with async_client.stream(
+        "POST",
+        "/backend-api/codex/responses",
+        json=request_payload,
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    event = _extract_first_event(lines)
+    assert event["type"] == "response.completed"
+    assert seen_payload["tools"] == []
+
+
+@pytest.mark.asyncio
 async def test_backend_responses_preserves_non_message_developer_directive(async_client, monkeypatch):
     raw_account_id = "acc_future_directive"
     auth_json = _make_auth_json(raw_account_id, "future-directive@example.com")

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -523,6 +523,56 @@ async def test_backend_responses_direct_stream_persists_opencode_conversation_id
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_uses_client_session_identity_for_affinity(async_client, monkeypatch):
+    raw_account_id = "acc_v1_client_session_affinity"
+    auth_json = _make_auth_json(raw_account_id, "v1-client-session-affinity@example.com")
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    observed_affinity: dict[str, object] = {}
+    original_affinity = streaming_retry_module._sticky_key_for_responses_request
+
+    def recording_affinity(*args, **kwargs):
+        policy = original_affinity(*args, **kwargs)
+        observed_affinity["key"] = policy.key
+        observed_affinity["kind"] = policy.kind
+        return policy
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del payload, headers, access_token, account_id, base_url, raise_for_status, kwargs
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_v1_client_affinity",'
+            '"object":"response","status":"completed","usage":{"input_tokens":2,"output_tokens":1}}}\n\n'
+        )
+
+    monkeypatch.setattr(streaming_retry_module, "_sticky_key_for_responses_request", recording_affinity)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    request_payload = {
+        "model": "gpt-5.6",
+        "instructions": "hi",
+        "input": "hello",
+        "prompt_cache_key": "shared-cache-key",
+        "stream": True,
+    }
+    async with async_client.stream(
+        "POST",
+        "/v1/responses",
+        json=request_payload,
+        headers={"x-session-id": "client-session"},
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    assert _extract_first_event(lines)["type"] == "response.completed"
+    assert observed_affinity == {
+        "key": "client-session",
+        "kind": proxy_module.StickySessionKind.CODEX_SESSION,
+    }
+
+
+@pytest.mark.asyncio
 async def test_backend_responses_preserves_non_message_developer_directive(async_client, monkeypatch):
     raw_account_id = "acc_future_directive"
     auth_json = _make_auth_json(raw_account_id, "future-directive@example.com")

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -282,7 +282,7 @@ async def test_codex_control_request_uses_codex_client_when_route_is_resolved(ro
         method="GET",
         payload=None,
         query_params={"limit": "1"},
-        headers={"accept": "application/json"},
+        headers={"accept": "application/json", "x-session-id": "control-session"},
         access_token="access",
         account_id="chatgpt_account",
         base_url="https://chatgpt.test",
@@ -295,6 +295,7 @@ async def test_codex_control_request_uses_codex_client_when_route_is_resolved(ro
     assert response.body == b'{"ok": true}'
     assert client.calls[0]["url"] == "https://chatgpt.test/codex/sessions"
     assert client.calls[0]["route"] is route
+    assert client.calls[0]["headers"]["x-session-id"] == "control-session"
     assert trace.endpoint_id == "ep_1"
 
 

--- a/tests/unit/test_http_bridge_forwarding.py
+++ b/tests/unit/test_http_bridge_forwarding.py
@@ -358,6 +358,28 @@ def test_build_owner_forward_headers_drops_client_supplied_bridge_headers() -> N
     assert headers["x-openai-client-version"] == "1.2.3"
 
 
+def test_build_owner_forward_headers_preserves_client_session_identity() -> None:
+    payload = _payload()
+    context = HTTPBridgeForwardContext(
+        origin_instance="instance-a",
+        target_instance="instance-b",
+        codex_session_affinity=False,
+        downstream_turn_state=None,
+    )
+
+    headers = build_owner_forward_headers(
+        headers={
+            "x-session-id": "client-session",
+            "x-opencode-session": "opencode-session",
+        },
+        payload=payload,
+        context=context,
+    )
+
+    assert headers["x-session-id"] == "client-session"
+    assert headers["x-opencode-session"] == "opencode-session"
+
+
 def test_owner_forward_primary_signature_verifiable_by_pre_1203_owner() -> None:
     # ROLLOUT SHIM coverage (new origin -> pre-#1203 owner): an owner running
     # code that predates the tamper-proofing header recomputes the primary

--- a/tests/unit/test_http_bridge_one_shot_bypass.py
+++ b/tests/unit/test_http_bridge_one_shot_bypass.py
@@ -74,3 +74,14 @@ def test_forwarded_requests_are_excluded() -> None:
 def test_requests_without_session_identity_keep_bridge_behavior() -> None:
     assert not _is_one_shot(_payload(), {})
     assert not _is_one_shot(_payload(), {"user-agent": "opencode/1.18.3"})
+
+
+def test_codex_name_session_headers_keep_bridge_behavior() -> None:
+    # Codex-name identity means a bridge-centric Codex-protocol flow, even
+    # when the payload happens to be tool-less.
+    assert not _is_one_shot(_payload(), {"session_id": "sid_codex"})
+    assert not _is_one_shot(_payload(), {"thread-id": "thread_codex"})
+    assert not _is_one_shot(
+        _payload(),
+        {**_OPENCODE_HEADERS, "session_id": "sid_codex"},
+    )

--- a/tests/unit/test_http_bridge_one_shot_bypass.py
+++ b/tests/unit/test_http_bridge_one_shot_bypass.py
@@ -1,0 +1,76 @@
+"""Tool-less, self-contained one-shot requests bypass the HTTP bridge."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.openai.requests import ResponsesRequest
+from app.modules.proxy._service.http_bridge import helpers as http_bridge_helpers_module
+
+pytestmark = pytest.mark.unit
+
+_OPENCODE_HEADERS = {
+    "user-agent": "opencode/1.18.3 (darwin arm64)",
+    "x-session-affinity": "ses_side_call",
+    "x-session-id": "ses_side_call",
+}
+
+
+def _payload(**extra: object) -> ResponsesRequest:
+    return ResponsesRequest.model_validate(
+        {"model": "gpt-5.6-sol", "instructions": "t", "input": "Generate a title for this conversation:", **extra}
+    )
+
+
+def _is_one_shot(payload: ResponsesRequest, headers: dict[str, str], *, forwarded_request: bool = False) -> bool:
+    return http_bridge_helpers_module._http_bridge_request_is_unanchored_one_shot(
+        payload,
+        headers,
+        forwarded_request=forwarded_request,
+    )
+
+
+def test_tool_less_side_call_is_one_shot() -> None:
+    assert _is_one_shot(_payload(), _OPENCODE_HEADERS)
+    assert _is_one_shot(_payload(tools=[]), _OPENCODE_HEADERS)
+
+
+def test_agent_turns_with_tools_are_not_one_shot() -> None:
+    payload = _payload(tools=[{"type": "function", "name": "bash", "parameters": {"type": "object"}}])
+    assert not _is_one_shot(payload, _OPENCODE_HEADERS)
+
+
+def test_continuity_bearing_requests_are_not_one_shot() -> None:
+    assert not _is_one_shot(_payload(previous_response_id="resp_1"), _OPENCODE_HEADERS)
+    assert not _is_one_shot(_payload(conversation="conv_1"), _OPENCODE_HEADERS)
+    assert not _is_one_shot(
+        _payload(),
+        {**_OPENCODE_HEADERS, "x-codex-turn-state": "turn-state-token"},
+    )
+
+
+def test_file_pinned_requests_are_not_one_shot() -> None:
+    payload = _payload(
+        input=[
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_file", "file_id": "file-abc123"}],
+            }
+        ]
+    )
+    assert not _is_one_shot(payload, _OPENCODE_HEADERS)
+
+
+def test_native_codex_clients_are_excluded() -> None:
+    headers = {**_OPENCODE_HEADERS, "originator": "codex_cli_rs"}
+    assert not _is_one_shot(_payload(), headers)
+
+
+def test_forwarded_requests_are_excluded() -> None:
+    assert not _is_one_shot(_payload(), _OPENCODE_HEADERS, forwarded_request=True)
+
+
+def test_requests_without_session_identity_keep_bridge_behavior() -> None:
+    assert not _is_one_shot(_payload(), {})
+    assert not _is_one_shot(_payload(), {"user-agent": "opencode/1.18.3"})

--- a/tests/unit/test_http_bridge_one_shot_bypass.py
+++ b/tests/unit/test_http_bridge_one_shot_bypass.py
@@ -128,12 +128,29 @@ def test_codex_name_session_headers_keep_bridge_behavior() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dashboard_websocket_override_keeps_one_shot_on_bridge(
+@pytest.mark.parametrize(
+    ("configured_transport", "dashboard_policy", "api_key_policy"),
+    [
+        pytest.param("websocket", "smart", None, id="explicit-websocket"),
+        pytest.param("auto", "always_websocket", None, id="global-always-websocket"),
+        pytest.param("auto", "smart", "always_websocket", id="per-key-always-websocket"),
+    ],
+)
+async def test_websocket_transport_policy_keeps_one_shot_on_bridge(
     monkeypatch: pytest.MonkeyPatch,
+    configured_transport: str,
+    dashboard_policy: str,
+    api_key_policy: str | None,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     base_settings = proxy_service.get_settings().model_copy(update={"upstream_stream_transport": "auto"})
-    dashboard_settings = base_settings.model_copy(update={"upstream_stream_transport": "websocket"})
+    dashboard_settings = base_settings.model_copy(
+        update={
+            "upstream_stream_transport": configured_transport,
+            "http_downstream_transport_policy": dashboard_policy,
+        }
+    )
+    api_key = cast(Any, SimpleNamespace(transport_policy_override=api_key_policy))
     monkeypatch.setattr(
         proxy_service,
         "get_settings_cache",
@@ -159,7 +176,7 @@ async def test_dashboard_websocket_override_keeps_one_shot_on_bridge(
         yield "data: bridge\n\n"
 
     async def forbidden_retry(*_args: object, **_kwargs: object):
-        raise AssertionError("explicit websocket transport must keep the bridge")
+        raise AssertionError("websocket transport policy must keep the bridge")
         yield "data: retry\n\n"
 
     monkeypatch.setattr(service, "_stream_via_http_bridge", stream_via_bridge)
@@ -173,7 +190,7 @@ async def test_dashboard_websocket_override_keeps_one_shot_on_bridge(
             codex_session_affinity=True,
             propagate_http_errors=False,
             openai_cache_affinity=False,
-            api_key=None,
+            api_key=api_key,
             api_key_reservation=None,
             suppress_text_done_events=False,
         )

--- a/tests/unit/test_http_bridge_one_shot_bypass.py
+++ b/tests/unit/test_http_bridge_one_shot_bypass.py
@@ -96,6 +96,12 @@ def test_account_scoped_hosted_items_are_not_one_shot(item_type: str) -> None:
     assert not _is_one_shot(payload, _OPENCODE_HEADERS)
 
 
+def test_stored_prompt_requests_are_not_one_shot() -> None:
+    payload = _payload(prompt={"id": "pmpt_123"})
+
+    assert not _is_one_shot(payload, _OPENCODE_HEADERS)
+
+
 def test_native_codex_clients_are_excluded() -> None:
     headers = {**_OPENCODE_HEADERS, "originator": "codex_cli_rs"}
     assert not _is_one_shot(_payload(), headers)

--- a/tests/unit/test_http_bridge_one_shot_bypass.py
+++ b/tests/unit/test_http_bridge_one_shot_bypass.py
@@ -41,6 +41,13 @@ def test_tool_less_side_call_is_one_shot() -> None:
     assert _is_one_shot(_payload(tools=[]), _OPENCODE_HEADERS)
 
 
+def test_empty_tool_map_side_call_is_one_shot() -> None:
+    # OpenCode's title/compaction side calls declare tool-lessness with an
+    # empty tool map (``tools: {}``) on the wire; request validation
+    # normalizes that shape to ``[]`` so these payloads reach the bypass.
+    assert _is_one_shot(_payload(tools={}), _OPENCODE_HEADERS)
+
+
 def test_agent_turns_with_tools_are_not_one_shot() -> None:
     payload = _payload(tools=[{"type": "function", "name": "bash", "parameters": {"type": "object"}}])
     assert not _is_one_shot(payload, _OPENCODE_HEADERS)

--- a/tests/unit/test_http_bridge_one_shot_bypass.py
+++ b/tests/unit/test_http_bridge_one_shot_bypass.py
@@ -89,6 +89,13 @@ def test_file_pinned_requests_are_not_one_shot() -> None:
     assert not _is_one_shot(payload, _OPENCODE_HEADERS)
 
 
+@pytest.mark.parametrize("item_type", ["item_reference", "file_search_call"])
+def test_account_scoped_hosted_items_are_not_one_shot(item_type: str) -> None:
+    payload = _payload(input=[{"type": item_type, "id": "hosted-item"}])
+
+    assert not _is_one_shot(payload, _OPENCODE_HEADERS)
+
+
 def test_native_codex_clients_are_excluded() -> None:
     headers = {**_OPENCODE_HEADERS, "originator": "codex_cli_rs"}
     assert not _is_one_shot(_payload(), headers)

--- a/tests/unit/test_http_bridge_one_shot_bypass.py
+++ b/tests/unit/test_http_bridge_one_shot_bypass.py
@@ -40,6 +40,20 @@ def test_agent_turns_with_tools_are_not_one_shot() -> None:
     assert not _is_one_shot(payload, _OPENCODE_HEADERS)
 
 
+def test_responses_lite_agent_turns_with_tools_are_not_one_shot() -> None:
+    payload = _payload(
+        input=[
+            {
+                "type": "additional_tools",
+                "role": "developer",
+                "tools": [{"type": "function", "name": "bash", "parameters": {"type": "object"}}],
+            },
+            {"role": "user", "content": "Run the command"},
+        ]
+    )
+    assert not _is_one_shot(payload, _OPENCODE_HEADERS)
+
+
 def test_continuity_bearing_requests_are_not_one_shot() -> None:
     assert not _is_one_shot(_payload(previous_response_id="resp_1"), _OPENCODE_HEADERS)
     assert not _is_one_shot(_payload(conversation="conv_1"), _OPENCODE_HEADERS)

--- a/tests/unit/test_http_bridge_one_shot_bypass.py
+++ b/tests/unit/test_http_bridge_one_shot_bypass.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+from contextlib import nullcontext
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
 import pytest
 
 from app.core.openai.requests import ResponsesRequest
+from app.modules.proxy import service as proxy_service
 from app.modules.proxy._service.http_bridge import helpers as http_bridge_helpers_module
 
 pytestmark = pytest.mark.unit
@@ -99,3 +105,58 @@ def test_codex_name_session_headers_keep_bridge_behavior() -> None:
         _payload(),
         {**_OPENCODE_HEADERS, "session_id": "sid_codex"},
     )
+
+
+@pytest.mark.asyncio
+async def test_dashboard_websocket_override_keeps_one_shot_on_bridge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    base_settings = proxy_service.get_settings().model_copy(update={"upstream_stream_transport": "auto"})
+    dashboard_settings = base_settings.model_copy(update={"upstream_stream_transport": "websocket"})
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(get=AsyncMock(return_value=dashboard_settings)),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: base_settings)
+    monkeypatch.setattr(
+        proxy_service,
+        "_http_bridge_runtime_config",
+        lambda _dashboard, _base: proxy_service._HTTPBridgeRuntimeConfig(
+            enabled=True,
+            idle_ttl_seconds=30.0,
+            codex_idle_ttl_seconds=30.0,
+            max_sessions=8,
+            queue_limit=16,
+            prompt_cache_idle_ttl_seconds=30.0,
+            gateway_safe_mode=False,
+        ),
+    )
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+
+    async def stream_via_bridge(*_args: object, **_kwargs: object):
+        yield "data: bridge\n\n"
+
+    async def forbidden_retry(*_args: object, **_kwargs: object):
+        raise AssertionError("explicit websocket transport must keep the bridge")
+        yield "data: retry\n\n"
+
+    monkeypatch.setattr(service, "_stream_via_http_bridge", stream_via_bridge)
+    monkeypatch.setattr(service, "_stream_with_retry", forbidden_retry)
+
+    output = [
+        line
+        async for line in service._stream_http_bridge_or_retry(
+            _payload(),
+            _OPENCODE_HEADERS,
+            codex_session_affinity=True,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+        )
+    ]
+
+    assert output == ["data: bridge\n\n"]

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9880,6 +9880,24 @@ def test_sticky_key_for_responses_request_uses_bounded_cache_affinity():
     assert policy.max_age_seconds == 300
 
 
+def test_sticky_key_for_responses_request_uses_client_identity_when_codex_affinity_is_disabled():
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+    payload.prompt_cache_key = "shared-cache-key"
+
+    policy = proxy_service._sticky_key_for_responses_request(
+        payload,
+        headers={"session_id": "ignored-codex-session", "x-session-id": "client-session"},
+        codex_session_affinity=False,
+        openai_cache_affinity=True,
+        openai_cache_affinity_max_age_seconds=300,
+        sticky_threads_enabled=False,
+    )
+
+    assert policy.key == "client-session"
+    assert policy.kind == proxy_service.StickySessionKind.CODEX_SESSION
+    assert policy.spill_on_account_cap is True
+
+
 def test_sticky_key_for_responses_request_keeps_sticky_threads_durable():
     payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
     payload.prompt_cache_key = "thread_123"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -25,6 +25,7 @@ import pytest
 from aiohttp.client_exceptions import ClientConnectorCertificateError
 from aiohttp.client_reqrep import ConnectionKey, RequestInfo
 from fastapi import WebSocket
+from pydantic import ValidationError
 from starlette.requests import Request
 from starlette.responses import StreamingResponse
 from websockets.exceptions import ConnectionClosedError
@@ -2026,6 +2027,41 @@ def test_normalize_responses_request_payload_without_codex_compat_preserves_imag
     )
 
     assert request.tools == [{"type": "image_generation", "output_format": "png"}]
+
+
+def test_normalize_responses_request_payload_accepts_empty_tool_map():
+    # OpenCode's title/compaction side calls send ``tools: {}`` on the wire;
+    # both the codex-native and openai-compat validation paths must treat the
+    # empty tool map as ``tools: []`` instead of rejecting the payload.
+    for openai_compat in (False, True):
+        payload: dict[str, JsonValue] = {
+            "model": "gpt-5.4",
+            "instructions": "t",
+            "input": "Generate a title for this conversation:",
+            "tools": {},
+        }
+
+        request = proxy_request_policy.normalize_responses_request_payload(
+            payload,
+            openai_compat=openai_compat,
+        )
+
+        assert request.tools == []
+
+
+def test_normalize_responses_request_payload_rejects_non_empty_tool_map():
+    payload: dict[str, JsonValue] = {
+        "model": "gpt-5.4",
+        "instructions": "t",
+        "input": "hi",
+        "tools": {"bash": {"type": "function"}},
+    }
+
+    with pytest.raises(ValidationError):
+        proxy_request_policy.normalize_responses_request_payload(
+            payload,
+            openai_compat=False,
+        )
 
 
 def test_normalize_responses_request_payload_preserves_explicit_image_generation_choice():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1367,7 +1367,12 @@ def test_build_upstream_headers_strips_preserved_client_session_identity() -> No
         }
     )
 
-    headers = _build_upstream_headers(preserved, "token", "acc_2")
+    headers = _build_upstream_headers(
+        preserved,
+        "token",
+        "acc_2",
+        preserve_client_session_identity=False,
+    )
 
     lower_keys = {key.lower() for key in headers}
     assert "x-session-affinity" not in lower_keys

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5566,7 +5566,25 @@ async def test_codex_control_request_persists_conversation_id_and_passes_dashboa
     assert response.body == b'{"ok":true}'
     assert selection_kwargs[0]["prefer_earlier_reset_accounts"] is True
     assert selection_kwargs[0]["prefer_earlier_reset_window"] == "primary"
+    affinity = cast(proxy_service._AffinityPolicy, selection_kwargs[0]["affinity_policy"])
+    assert affinity.key == "conv-control"
     assert upstream_headers["x-session-id"] == "control-session-metadata"
+
+    response = await service.codex_control_request(
+        "control",
+        method="POST",
+        payload=None,
+        query_params={},
+        headers={
+            "User-Agent": "codex/1.2",
+            "x-session-id": "control-session-metadata-only",
+        },
+    )
+
+    assert response.status_code == 200
+    affinity = cast(proxy_service._AffinityPolicy, selection_kwargs[1]["affinity_policy"])
+    assert affinity.key is None
+    assert upstream_headers["x-session-id"] == "control-session-metadata-only"
     assert await service.drain_persistence_tasks(timeout_seconds=1)
     assert request_logs.calls[0]["conversation_id"] == "conv-control"
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1354,6 +1354,28 @@ def test_filter_inbound_headers_strips_client_session_identity_only_at_egress() 
     assert preserved == headers
 
 
+def test_build_upstream_headers_strips_preserved_client_session_identity() -> None:
+    # Service-layer filters preserve client session identity headers so
+    # request logging and sticky affinity keep seeing them; the upstream
+    # egress builder must still strip them.
+    preserved = filter_inbound_headers(
+        {
+            "X-Session-Affinity": "affinity",
+            "X-Session-Id": "session",
+            "X-OpenCode-Session": "opencode",
+            "User-Agent": "opencode/1.18.3",
+        },
+        preserve_client_session_identity=True,
+    )
+
+    headers = _build_upstream_headers(preserved, "token", "acc_2")
+
+    lower_keys = {key.lower() for key in headers}
+    assert "x-session-affinity" not in lower_keys
+    assert "x-session-id" not in lower_keys
+    assert "x-opencode-session" not in lower_keys
+
+
 def test_request_log_useragent_fields_extract_full_value_and_group() -> None:
     assert proxy_service._request_log_useragent_fields(
         {

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10026,6 +10026,29 @@ def test_bare_session_cap_spillover_is_revoked_by_account_scoped_payload(
     assert policy.require_unambiguous_account is ("conversation" in owner_payload)
 
 
+@pytest.mark.parametrize("item_type", ["item_reference", "file_search_call"])
+def test_bare_session_cap_spillover_is_revoked_by_account_scoped_hosted_input(item_type: str) -> None:
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "hi",
+            "input": [{"type": item_type, "id": "hosted-item"}],
+        }
+    )
+
+    policy = proxy_service._sticky_key_for_responses_request(
+        payload,
+        headers={"x-session-id": "client-session"},
+        codex_session_affinity=False,
+        openai_cache_affinity=False,
+        openai_cache_affinity_max_age_seconds=300,
+        sticky_threads_enabled=False,
+    )
+
+    assert policy.kind == proxy_service.StickySessionKind.CODEX_SESSION
+    assert policy.spill_on_account_cap is False
+
+
 def test_codex_session_selection_keys_are_namespaced_by_source() -> None:
     session_policy = proxy_service._AffinityPolicy(
         key="same-raw-value",

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10054,8 +10054,11 @@ def test_bare_session_cap_spillover_is_revoked_by_account_scoped_hosted_input(it
     assert policy.spill_on_account_cap is False
 
 
-def test_bare_session_cap_spillover_is_revoked_by_stored_prompt() -> None:
-    payload = ResponsesRequest.model_validate(
+@pytest.mark.parametrize("request_type", [ResponsesRequest, ResponsesCompactRequest])
+def test_bare_session_cap_spillover_is_revoked_by_stored_prompt(
+    request_type: type[ResponsesRequest] | type[ResponsesCompactRequest],
+) -> None:
+    payload = request_type.model_validate(
         {
             "model": "gpt-5.6-sol",
             "instructions": "hi",
@@ -10064,14 +10067,24 @@ def test_bare_session_cap_spillover_is_revoked_by_stored_prompt() -> None:
         }
     )
 
-    policy = proxy_service._sticky_key_for_responses_request(
-        payload,
-        headers={"x-session-id": "client-session"},
-        codex_session_affinity=False,
-        openai_cache_affinity=False,
-        openai_cache_affinity_max_age_seconds=300,
-        sticky_threads_enabled=False,
-    )
+    if isinstance(payload, ResponsesRequest):
+        policy = proxy_service._sticky_key_for_responses_request(
+            payload,
+            headers={"x-session-id": "client-session"},
+            codex_session_affinity=False,
+            openai_cache_affinity=False,
+            openai_cache_affinity_max_age_seconds=300,
+            sticky_threads_enabled=False,
+        )
+    else:
+        policy = proxy_service._sticky_key_for_compact_request(
+            payload,
+            headers={"x-session-id": "client-session"},
+            codex_session_affinity=False,
+            openai_cache_affinity=False,
+            openai_cache_affinity_max_age_seconds=300,
+            sticky_threads_enabled=False,
+        )
 
     assert policy.kind == proxy_service.StickySessionKind.CODEX_SESSION
     assert policy.spill_on_account_cap is False

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10054,6 +10054,29 @@ def test_bare_session_cap_spillover_is_revoked_by_account_scoped_hosted_input(it
     assert policy.spill_on_account_cap is False
 
 
+def test_bare_session_cap_spillover_is_revoked_by_stored_prompt() -> None:
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "hi",
+            "input": [],
+            "prompt": {"id": "pmpt_123"},
+        }
+    )
+
+    policy = proxy_service._sticky_key_for_responses_request(
+        payload,
+        headers={"x-session-id": "client-session"},
+        codex_session_affinity=False,
+        openai_cache_affinity=False,
+        openai_cache_affinity_max_age_seconds=300,
+        sticky_threads_enabled=False,
+    )
+
+    assert policy.kind == proxy_service.StickySessionKind.CODEX_SESSION
+    assert policy.spill_on_account_cap is False
+
+
 def test_codex_session_selection_keys_are_namespaced_by_source() -> None:
     session_policy = proxy_service._AffinityPolicy(
         key="same-raw-value",

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1336,6 +1336,23 @@ def test_filter_inbound_headers_strips_internal_capability_header():
     assert filtered["X-Custom"] == "preserved"
 
 
+def test_filter_inbound_headers_strips_client_session_identity_only_at_egress() -> None:
+    headers = {
+        "X-Session-Affinity": "affinity",
+        "X-Session-Id": "session",
+        "X-OpenCode-Session": "opencode",
+        "X-Claude-Code-Agent-Id": "agent",
+        "X-Claude-Remote-Session-Id": "remote",
+        "User-Agent": "opencode/1.18.3",
+    }
+
+    filtered = filter_inbound_headers(headers)
+    preserved = filter_inbound_headers(headers, preserve_client_session_identity=True)
+
+    assert {key.lower() for key in filtered} == {"user-agent"}
+    assert preserved == headers
+
+
 def test_request_log_useragent_fields_extract_full_value_and_group() -> None:
     assert proxy_service._request_log_useragent_fields(
         {

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -9977,6 +9977,60 @@ def test_sticky_key_from_session_header_accepts_aliases_in_priority_order():
     )
 
 
+def test_sticky_key_from_session_header_accepts_client_identity_headers():
+    # OpenCode / OpenClaw
+    assert proxy_service._sticky_key_from_session_header({"x-session-affinity": "ses_oc1"}) == "ses_oc1"
+    assert proxy_service._sticky_key_from_session_header({"X-Session-Id": "ses_oc2"}) == "ses_oc2"
+    assert proxy_service._sticky_key_from_session_header({"x-opencode-session": "ses_oc3"}) == "ses_oc3"
+    # Claude Code
+    assert proxy_service._sticky_key_from_session_header({"x-claude-code-agent-id": "agent_1"}) == "agent_1"
+    assert proxy_service._sticky_key_from_session_header({"x-claude-remote-session-id": "remote_1"}) == "remote_1"
+    # Codex names keep precedence over client identity headers.
+    assert (
+        proxy_service._sticky_key_from_session_header({"x-session-affinity": "ses_oc1", "session_id": "sid_codex"})
+        == "sid_codex"
+    )
+
+
+def test_sticky_key_from_session_header_ignores_parent_and_request_id_headers():
+    # Parent identity would collapse every subagent onto one session key.
+    assert (
+        proxy_service._sticky_key_from_session_header(
+            {
+                "x-parent-session-id": "parent_a",
+                "x-codex-parent-thread-id": "parent_b",
+                "x-claude-code-parent-agent-id": "parent_c",
+                "x-openai-subagent": "review",
+            }
+        )
+        is None
+    )
+    # Per-request ids are not stable session identity.
+    assert proxy_service._sticky_key_from_session_header({"x-client-request-id": "req_1"}) is None
+    assert (
+        proxy_service._sticky_key_from_session_header({"x-parent-session-id": "parent_a", "x-session-id": "own_1"})
+        == "own_1"
+    )
+
+
+def test_account_neutral_replay_strips_client_identity_headers():
+    from app.modules.proxy.continuity import without_http_bridge_session_affinity_headers
+
+    stripped = without_http_bridge_session_affinity_headers(
+        {
+            "session_id": "sid",
+            "x-session-affinity": "ses_1",
+            "X-Session-Id": "ses_1",
+            "x-opencode-session": "ses_1",
+            "x-claude-code-agent-id": "agent_1",
+            "x-claude-remote-session-id": "remote_1",
+            "x-parent-session-id": "parent_1",
+            "user-agent": "opencode/1.18.3",
+        }
+    )
+    assert set(stripped) == {"x-parent-session-id", "user-agent"}
+
+
 def test_owner_lookup_session_id_from_headers_prefers_turn_state_then_session_aliases():
     assert proxy_service._owner_lookup_session_id_from_headers({"x-codex-turn-state": "turn_1"}) == "turn_1"
     assert (

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1337,7 +1337,7 @@ def test_filter_inbound_headers_strips_internal_capability_header():
     assert filtered["X-Custom"] == "preserved"
 
 
-def test_filter_inbound_headers_strips_client_session_identity_only_at_egress() -> None:
+def test_filter_inbound_headers_preserves_client_session_identity_by_default() -> None:
     headers = {
         "X-Session-Affinity": "affinity",
         "X-Session-Id": "session",
@@ -1347,11 +1347,11 @@ def test_filter_inbound_headers_strips_client_session_identity_only_at_egress() 
         "User-Agent": "opencode/1.18.3",
     }
 
-    filtered = filter_inbound_headers(headers)
-    preserved = filter_inbound_headers(headers, preserve_client_session_identity=True)
+    preserved = filter_inbound_headers(headers)
+    stripped = filter_inbound_headers(headers, preserve_client_session_identity=False)
 
-    assert {key.lower() for key in filtered} == {"user-agent"}
     assert preserved == headers
+    assert {key.lower() for key in stripped} == {"user-agent"}
 
 
 def test_build_upstream_headers_strips_preserved_client_session_identity() -> None:
@@ -1364,8 +1364,7 @@ def test_build_upstream_headers_strips_preserved_client_session_identity() -> No
             "X-Session-Id": "session",
             "X-OpenCode-Session": "opencode",
             "User-Agent": "opencode/1.18.3",
-        },
-        preserve_client_session_identity=True,
+        }
     )
 
     headers = _build_upstream_headers(preserved, "token", "acc_2")
@@ -5532,12 +5531,14 @@ async def test_codex_control_request_persists_conversation_id_and_passes_dashboa
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     account = _make_account("acc_codex_control")
     selection_kwargs: list[dict[str, object]] = []
+    upstream_headers: dict[str, str] = {}
 
     async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
         selection_kwargs.append(kwargs)
         return AccountSelection(account=account, error_message=None)
 
-    async def codex_control_request(*_args: object, **_kwargs: object) -> proxy_module.CodexControlResponse:
+    async def codex_control_request(*_args: object, **kwargs: object) -> proxy_module.CodexControlResponse:
+        upstream_headers.update(cast(dict[str, str], kwargs["headers"]))
         return proxy_module.CodexControlResponse(status_code=200, body=b'{"ok":true}', headers={})
 
     monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
@@ -5549,13 +5550,18 @@ async def test_codex_control_request_persists_conversation_id_and_passes_dashboa
         method="POST",
         payload=None,
         query_params={},
-        headers={"User-Agent": "codex/1.2", "thread-id": "conv-control"},
+        headers={
+            "User-Agent": "codex/1.2",
+            "thread-id": "conv-control",
+            "x-session-id": "control-session-metadata",
+        },
     )
 
     assert response.status_code == 200
     assert response.body == b'{"ok":true}'
     assert selection_kwargs[0]["prefer_earlier_reset_accounts"] is True
     assert selection_kwargs[0]["prefer_earlier_reset_window"] == "primary"
+    assert upstream_headers["x-session-id"] == "control-session-metadata"
     assert await service.drain_persistence_tasks(timeout_seconds=1)
     assert request_logs.calls[0]["conversation_id"] == "conv-control"
 

--- a/tests/unit/test_proxy_websocket_client.py
+++ b/tests/unit/test_proxy_websocket_client.py
@@ -1469,6 +1469,7 @@ def test_responses_websocket_builder_normalizes_non_native_sdk_fingerprint():
         "originator": "sdk",
         "Version": "9.9.9",
         "openai-beta": "responses_websockets=2026-02-06",
+        "x-session-id": "proxy-local-session",
     }
     with patch.object(proxy_module.get_codex_version_cache(), "cached_version_or_default", return_value="0.142.0"):
         headers = _build_upstream_websocket_headers(inbound, "tok", "acct-1")
@@ -1480,6 +1481,7 @@ def test_responses_websocket_builder_normalizes_non_native_sdk_fingerprint():
     assert headers["originator"] == "codex_cli_rs"
     assert headers["version"] == "0.142.0"
     assert "Version" not in headers
+    assert "x-session-id" not in lowered
     assert headers["ChatGPT-Account-Id"] == "acct-1"
     assert "chatgpt-account-id" not in headers
     # The responses websocket beta header is still appended.


### PR DESCRIPTION
## Summary

Recognizes the session identity headers that OpenCode, OpenClaw, and Claude Code send with each provider request as bare process-session affinity keys, so every client session — including each subagent — routes independently instead of collapsing onto a single prompt-cache account. Additionally bypasses the HTTP bridge for session-identified, tool-less one-shot side calls (title/summary/compaction), which otherwise fork an independent bridge lane per overlap with the agent's in-flight turn.

## Type of change

- [x] `feat:` — new user-facing feature or capability

Linked issue: none (diagnosed on a live deployment; details below)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/route-client-session-identity-headers/`

## Motivation (live evidence)

On a live deployment, one OpenCode parent session fanned out ~20 subagents. Affinity parsing recognizes only the Codex CLI header names, so these requests fell through to derived prompt-cache affinity — whose key hashes the shared system-prompt prefix — and **every subagent collapsed onto the same sticky account**. That account pinned 24 concurrent streams (the full configured cluster cap) while five other accounts sat nearly idle, and each subagent's later turns were continuity-bound to the collapsed account.

The clients already declare per-session identity on every request:

| Client | Own-session identity headers | Parent identity (excluded) |
|---|---|---|
| Codex CLI 0.144.4 | `session_id`, `thread-id` (already recognized) | `x-codex-parent-thread-id`, `x-openai-subagent` |
| OpenCode 1.18.x | `x-session-affinity`, `X-Session-Id` (+ `x-opencode-session`) | `x-parent-session-id` |
| OpenClaw | `session_id` (already recognized), `x-session-affinity`, `x-session-id` (openrouter compat) | — |
| Claude Code 2.1.x | `x-claude-code-agent-id`, `x-claude-remote-session-id` | `x-claude-code-parent-agent-id` |
| Hermes Agent | none sent to providers (documented; no change possible proxy-side) | — |

## Changes

- `app/modules/proxy/affinity.py`: the session-affinity header list gains `x-session-affinity`, `x-session-id`, `x-opencode-session`, `x-claude-code-agent-id`, `x-claude-remote-session-id` — **after** the Codex names, so no Codex CLI request routes differently. Parent identity headers and `x-client-request-id` are excluded with documented reasons (parent keys would re-collapse subagents; request ids are not stable session identity).
- `app/modules/proxy/continuity.py`: the account-neutral replay strip set drops the new headers alongside the Codex names, so a fresh-account replay cannot re-register the alias.
- Sessions keyed by these headers get the existing bare process-session semantics (#1382): soft locality, cap spillover for self-contained payloads, no ownership evidence. First turns of parallel subagents therefore distribute across eligible accounts under the cap-filtered, usage-weighted selection.
- The new headers stay proxy-local and are stripped at both Responses HTTP and WebSocket upstream egress. On current `main`, these headers are otherwise forwarded because inbound filtering is denylist-based, so this PR also tightens upstream egress while preserving them long enough for affinity selection and request logging. Non-Responses protocols such as the Live sideband retain established session-metadata forwarding.
- **One-shot side-call bypass** (`http_bridge/helpers.py`, `streaming.py`): live deployment of the header routing surfaced a follow-on effect — side calls (title, summary, compaction) share the agent's session identity but carry no tools or continuity anchors, so each one overlapping the agent's in-flight turn forked an `internal_unanchored_parallel` bridge lane (~20 idle lanes/hour from one sequential agent, each holding a stream-cap slot for its idle TTL). Verified across client sources: OpenCode's title and compaction calls send `tools: {}` (`session/prompt.ts:231`, `session/compaction.ts:392`), OpenClaw's usage-rollup/transcript summaries send `tools: []`, while every real agent turn carries its tool list (Codex CLI attaches tools to every turn, `client.rs:846`). Session-identified, tool-less, self-contained requests now bypass the bridge to raw HTTP upstream — same mechanism as the existing image/oversize bypass. Excluded: anonymous requests (no session header), forwarded bridge requests, native Codex originators (websocket-mode stays codex-faithful), and deployments with explicit `upstream_stream_transport=websocket` (per the transport-override precedence requirement).

## Simplicity

- [x] New feature defaults to **off** or works with **zero config** — zero config; behavior changes only for clients that already send these headers.
- [x] No new required setup step
- New setting(s) and why each can't be a default: **none**.
- [x] README sections / `.env.example` / dashboard nav within budget — none touched.

## Test plan

```
.venv/bin/python -m pytest tests/unit/test_proxy_utils.py tests/unit/test_proxy_http_bridge.py tests/unit/test_http_bridge_one_shot_bypass.py -q   # 1262 passed
.venv/bin/python -m pytest tests/unit/test_settings_reference.py -q                                  # 4 passed
.venv/bin/ruff check app/ && .venv/bin/ty check
```

New coverage: recognition and Codex-name precedence for each new header, parent-header and request-id exclusion, account-neutral replay stripping of the new names, and the one-shot bypass predicate (side calls bypass; tools, anchors, files, native Codex, forwarded, and anonymous requests keep the bridge).

## Screenshots / output

Proxy behavior before (live logs): all subagent selections shared one `sticky_kind=prompt_cache` account; the account pinned 24/24 cluster-wide stream slots with `candidates=1` cap rejections while other accounts idled. After: each subagent request carries its own `x-session-affinity`-keyed bare session, so first turns select accounts independently and saturation requires exhausting every eligible account, not one.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above. *(no existing issue)*
- [x] Added or updated tests covering the change.
- [x] Ran ruff + ty + targeted unit suites locally (openspec CLI unavailable locally; validation deferred to CI).
- [x] If touching specs: delta spec follows the archived-change format for `sticky-session-operations`.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).

<!-- ci-retrigger: b0392506-attempt-2 -->