### PR TITLE
fix(proxy): sequence synthetic Responses failures

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -6444,6 +6444,7 @@ async def _normalize_public_responses_stream(
     terminal_seen = False
     done_seen = False
     contract_violation_kind: str | None = None
+    next_sequence_number = 0
     seen_text_delta_keys: set[tuple[str | None, int | None]] = set()
     # Collect output items from streamed ``response.output_item.added`` /
     # ``response.output_item.done`` events so the terminal
@@ -6497,6 +6498,19 @@ async def _normalize_public_responses_stream(
         finally:
             pre_created_buffer.clear()
 
+    def normalize_public_failure_sequence(payload: dict[str, JsonValue]) -> dict[str, JsonValue]:
+        nonlocal next_sequence_number
+        sequence_number = payload.get("sequence_number")
+        if isinstance(sequence_number, int) and not isinstance(sequence_number, bool):
+            next_sequence_number = max(next_sequence_number, sequence_number + 1)
+            return payload
+        if enforce_openai_sdk_contract and payload.get("type") == "response.failed":
+            normalized_payload = dict(payload)
+            normalized_payload["sequence_number"] = next_sequence_number
+            next_sequence_number += 1
+            return normalized_payload
+        return payload
+
     async for event_block in stream:
         if event_block.strip() == "data: [DONE]":
             done_seen = True
@@ -6538,6 +6552,7 @@ async def _normalize_public_responses_stream(
             contract_violation_kind = contract_violation_kind or violation_kind
         if normalized_payload is None:
             continue
+        normalized_payload = normalize_public_failure_sequence(normalized_payload)
         event_type = normalized_payload.get("type")
         if not enforce_openai_sdk_contract and (
             event_type == "error" or is_json_mapping(normalized_payload.get("error"))
@@ -6565,7 +6580,11 @@ async def _normalize_public_responses_stream(
             elif _should_buffer_public_pre_created_event(event_type):
                 if len(pre_created_buffer) >= _PUBLIC_RESPONSES_PRE_CREATED_BUFFER_LIMIT:
                     error_kind = contract_violation_kind or "upstream_stream_truncated"
-                    for formatted_payload in _public_response_failed_event_blocks(error_kind, include_created=True):
+                    for formatted_payload in _public_response_failed_event_blocks(
+                        error_kind,
+                        include_created=True,
+                        sequence_number=next_sequence_number,
+                    ):
                         yield formatted_payload
                     return
                 pre_created_buffer.append(normalized_payload)
@@ -6575,11 +6594,16 @@ async def _normalize_public_responses_stream(
                     for formatted_payload in _public_response_failed_event_blocks_from_error(
                         normalized_payload,
                         include_created=True,
+                        sequence_number=next_sequence_number,
                     ):
                         yield formatted_payload
                     return
                 error_kind = contract_violation_kind or "upstream_stream_truncated"
-                for formatted_payload in _public_response_failed_event_blocks(error_kind, include_created=True):
+                for formatted_payload in _public_response_failed_event_blocks(
+                    error_kind,
+                    include_created=True,
+                    sequence_number=next_sequence_number,
+                ):
                     yield formatted_payload
                 return
 
@@ -6587,6 +6611,7 @@ async def _normalize_public_responses_stream(
             for formatted_payload in _public_response_failed_event_blocks_from_error(
                 normalized_payload,
                 include_created=not created_emitted,
+                sequence_number=next_sequence_number,
             ):
                 yield formatted_payload
             return
@@ -6618,7 +6643,11 @@ async def _normalize_public_responses_stream(
         "upstream_stream_truncated" if enforce_openai_sdk_contract else "stream_incomplete"
     )
     include_created = enforce_openai_sdk_contract and not created_emitted
-    for formatted_payload in _public_response_failed_event_blocks(error_kind, include_created=include_created):
+    for formatted_payload in _public_response_failed_event_blocks(
+        error_kind,
+        include_created=include_created,
+        sequence_number=next_sequence_number if enforce_openai_sdk_contract else None,
+    ):
         yield formatted_payload
 
 
@@ -6630,7 +6659,12 @@ def _should_buffer_public_pre_created_event(event_type: str) -> bool:
     )
 
 
-def _public_response_failed_event_blocks(error_kind: str, *, include_created: bool) -> list[str]:
+def _public_response_failed_event_blocks(
+    error_kind: str,
+    *,
+    include_created: bool,
+    sequence_number: int | None,
+) -> list[str]:
     failed_payload = cast(
         dict[str, JsonValue],
         response_failed_event(
@@ -6639,6 +6673,8 @@ def _public_response_failed_event_blocks(error_kind: str, *, include_created: bo
             response_id=f"resp_{error_kind}",
         ),
     )
+    if sequence_number is not None:
+        failed_payload["sequence_number"] = sequence_number
     blocks: list[str] = []
     if include_created:
         synthetic_created = _synthetic_response_created_envelope(failed_payload)
@@ -6652,6 +6688,7 @@ def _public_response_failed_event_blocks_from_error(
     payload: dict[str, JsonValue],
     *,
     include_created: bool,
+    sequence_number: int,
 ) -> list[str]:
     envelope = _parse_event_error_envelope(payload)
     error = envelope.error
@@ -6678,6 +6715,7 @@ def _public_response_failed_event_blocks_from_error(
             error_param=error.param,
         ),
     )
+    failed_payload["sequence_number"] = sequence_number
     blocks: list[str] = []
     if include_created:
         synthetic_created = _synthetic_response_created_envelope(failed_payload)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -6498,18 +6498,26 @@ async def _normalize_public_responses_stream(
         finally:
             pre_created_buffer.clear()
 
-    def normalize_public_failure_sequence(payload: dict[str, JsonValue]) -> dict[str, JsonValue]:
+    def normalize_public_failure_sequence(
+        payload: dict[str, JsonValue],
+        *,
+        reserve_created_sequence: bool,
+    ) -> tuple[dict[str, JsonValue], int | None]:
         nonlocal next_sequence_number
         sequence_number = payload.get("sequence_number")
         if isinstance(sequence_number, int) and not isinstance(sequence_number, bool):
             next_sequence_number = max(next_sequence_number, sequence_number + 1)
-            return payload
+            return payload, None
         if enforce_openai_sdk_contract and payload.get("type") == "response.failed":
+            created_sequence_number: int | None = None
+            if reserve_created_sequence:
+                created_sequence_number = next_sequence_number
+                next_sequence_number += 1
             normalized_payload = dict(payload)
             normalized_payload["sequence_number"] = next_sequence_number
             next_sequence_number += 1
-            return normalized_payload
-        return payload
+            return normalized_payload, created_sequence_number
+        return payload, None
 
     async for event_block in stream:
         if event_block.strip() == "data: [DONE]":
@@ -6552,8 +6560,21 @@ async def _normalize_public_responses_stream(
             contract_violation_kind = contract_violation_kind or violation_kind
         if normalized_payload is None:
             continue
-        normalized_payload = normalize_public_failure_sequence(normalized_payload)
         event_type = normalized_payload.get("type")
+        synthetic_created = None
+        if (
+            enforce_openai_sdk_contract
+            and not created_emitted
+            and isinstance(event_type, str)
+            and event_type != "response.created"
+        ):
+            synthetic_created = _synthetic_response_created_envelope(normalized_payload)
+        normalized_payload, synthetic_created_sequence = normalize_public_failure_sequence(
+            normalized_payload,
+            reserve_created_sequence=synthetic_created is not None,
+        )
+        if synthetic_created is not None and synthetic_created_sequence is not None:
+            synthetic_created["sequence_number"] = synthetic_created_sequence
         if not enforce_openai_sdk_contract and (
             event_type == "error" or is_json_mapping(normalized_payload.get("error"))
         ):
@@ -6570,7 +6591,6 @@ async def _normalize_public_responses_stream(
                     yield formatted_payload
                 continue
 
-            synthetic_created = _synthetic_response_created_envelope(normalized_payload)
             if synthetic_created is not None:
                 yield format_sse_event(synthetic_created)
                 created_emitted = True

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -6694,11 +6694,13 @@ def _public_response_failed_event_blocks(
         ),
     )
     if sequence_number is not None:
-        failed_payload["sequence_number"] = sequence_number
+        failed_payload["sequence_number"] = sequence_number + int(include_created)
     blocks: list[str] = []
     if include_created:
         synthetic_created = _synthetic_response_created_envelope(failed_payload)
         if synthetic_created is not None:
+            if sequence_number is not None:
+                synthetic_created["sequence_number"] = sequence_number
             blocks.append(format_sse_event(synthetic_created))
     blocks.append(format_sse_event(failed_payload))
     return blocks
@@ -6735,11 +6737,12 @@ def _public_response_failed_event_blocks_from_error(
             error_param=error.param,
         ),
     )
-    failed_payload["sequence_number"] = sequence_number
+    failed_payload["sequence_number"] = sequence_number + int(include_created)
     blocks: list[str] = []
     if include_created:
         synthetic_created = _synthetic_response_created_envelope(failed_payload)
         if synthetic_created is not None:
+            synthetic_created["sequence_number"] = sequence_number
             blocks.append(format_sse_event(synthetic_created))
     blocks.append(format_sse_event(failed_payload))
     return blocks

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -6507,6 +6507,8 @@ async def _normalize_public_responses_stream(
         sequence_number = payload.get("sequence_number")
         if isinstance(sequence_number, int) and not isinstance(sequence_number, bool):
             next_sequence_number = max(next_sequence_number, sequence_number + 1)
+            if enforce_openai_sdk_contract and reserve_created_sequence and payload.get("type") == "response.failed":
+                return payload, sequence_number - 1
             return payload, None
         if enforce_openai_sdk_contract and payload.get("type") == "response.failed":
             created_sequence_number: int | None = None

--- a/openspec/changes/sequence-public-response-failures/.openspec.yaml
+++ b/openspec/changes/sequence-public-response-failures/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/sequence-public-response-failures/proposal.md
+++ b/openspec/changes/sequence-public-response-failures/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Public `/v1/responses` streams can synthesize a terminal `response.failed`
+after an upstream stream or bridge ends without `response.completed`. Those
+synthetic events currently omit `sequence_number`. OpenAI SDK clients that
+require a numeric sequence classify the terminal failure as an unknown chunk,
+then report a clean EOF with an unknown finish reason instead of the proxy
+error.
+
+## What Changes
+
+- Track the next public Responses sequence while normalizing SSE events.
+- Assign the next numeric sequence to terminal `response.failed` events that
+  omit it or carry a non-numeric value.
+- Preserve valid upstream sequence numbers and Codex-private stream behavior.
+- Cover bridge failures after reasoning output and reused bridge sessions.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: synthetic public terminal failures remain parseable
+  by strict OpenAI SDK Responses clients.
+
+## Impact
+
+- Code: `app/modules/proxy/api.py`
+- Tests: `tests/unit/test_proxy_api_responses_contract.py`,
+  `tests/integration/test_http_responses_bridge.py`
+- Specs: `openspec/specs/responses-api-compat/spec.md`

--- a/openspec/changes/sequence-public-response-failures/proposal.md
+++ b/openspec/changes/sequence-public-response-failures/proposal.md
@@ -12,6 +12,8 @@ error.
 - Track the next public Responses sequence while normalizing SSE events.
 - Assign the next numeric sequence to terminal `response.failed` events that
   omit it or carry a non-numeric value.
+- Give a synthesized leading `response.created` and its following failure
+  distinct consecutive sequences.
 - Preserve valid upstream sequence numbers and Codex-private stream behavior.
 - Cover bridge failures after reasoning output and reused bridge sessions.
 

--- a/openspec/changes/sequence-public-response-failures/specs/responses-api-compat/spec.md
+++ b/openspec/changes/sequence-public-response-failures/specs/responses-api-compat/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Public synthetic Responses failures carry numeric sequences
+
+Public streaming `POST /v1/responses` MUST emit every terminal
+`response.failed` with a finite integer `sequence_number` so
+strict OpenAI SDK Responses parsers recognize the terminal failure. If the
+upstream or proxy-generated event omits a finite integer sequence, the public
+normalizer MUST assign the next sequence after all finite integer sequences it
+has observed in the same downstream stream. If no finite integer sequence has
+been observed, numbering MUST begin at zero.
+
+The public normalizer MUST preserve an existing finite integer
+`sequence_number` and advance its next-sequence watermark accordingly. This
+repair MUST NOT change Codex-private backend stream shapes.
+
+#### Scenario: Bridge failure after reasoning remains parseable
+
+- **GIVEN** public `/v1/responses` has emitted sequenced reasoning events
+- **WHEN** the upstream bridge closes before a terminal response
+- **THEN** the downstream terminal `response.failed` carries the next numeric
+  `sequence_number`
+- **AND** a strict OpenAI SDK parser recognizes it as a terminal failure
+
+#### Scenario: Failure without prior sequence starts at zero
+
+- **GIVEN** public `/v1/responses` has not emitted a finite integer sequence
+- **WHEN** the proxy emits a terminal `response.failed` without one
+- **THEN** the terminal event carries `sequence_number = 0`
+
+#### Scenario: Valid upstream failure sequence remains unchanged
+
+- **GIVEN** an upstream terminal `response.failed` carries a finite integer
+  `sequence_number`
+- **WHEN** the public normalizer forwards the event
+- **THEN** it preserves that sequence number unchanged
+
+#### Scenario: Backend Codex stream shape remains unchanged
+
+- **GIVEN** a Codex-private backend Responses stream carries an unsequenced
+  terminal failure
+- **WHEN** the stream is served without the public OpenAI SDK contract
+- **THEN** the proxy does not add a public compatibility sequence

--- a/openspec/changes/sequence-public-response-failures/specs/responses-api-compat/spec.md
+++ b/openspec/changes/sequence-public-response-failures/specs/responses-api-compat/spec.md
@@ -7,8 +7,11 @@ Public streaming `POST /v1/responses` MUST emit every terminal
 strict OpenAI SDK Responses parsers recognize the terminal failure. If the
 upstream or proxy-generated event omits a finite integer sequence, the public
 normalizer MUST assign the next sequence after all finite integer sequences it
-has observed in the same downstream stream. If no finite integer sequence has
-been observed, numbering MUST begin at zero.
+has observed in the same downstream stream. If it also synthesizes a leading
+`response.created` from that failure, the created event MUST consume the next
+sequence and the failure MUST use the following sequence so both events have
+distinct values. Otherwise, if no finite integer sequence has been observed,
+failure numbering MUST begin at zero.
 
 The public normalizer MUST preserve an existing finite integer
 `sequence_number` and advance its next-sequence watermark accordingly. This
@@ -22,10 +25,19 @@ repair MUST NOT change Codex-private backend stream shapes.
   `sequence_number`
 - **AND** a strict OpenAI SDK parser recognizes it as a terminal failure
 
-#### Scenario: Failure without prior sequence starts at zero
+#### Scenario: Leading failure follows synthesized created sequence
 
 - **GIVEN** public `/v1/responses` has not emitted a finite integer sequence
-- **WHEN** the proxy emits a terminal `response.failed` without one
+- **WHEN** an unsequenced leading `response.failed` requires a synthesized
+  `response.created`
+- **THEN** the created event carries `sequence_number = 0`
+- **AND** the terminal failure carries `sequence_number = 1`
+
+#### Scenario: Failure after an unsequenced created event starts at zero
+
+- **GIVEN** public `/v1/responses` has emitted an unsequenced
+  `response.created` and no finite integer sequence
+- **WHEN** the proxy synthesizes a terminal `response.failed`
 - **THEN** the terminal event carries `sequence_number = 0`
 
 #### Scenario: Valid upstream failure sequence remains unchanged

--- a/openspec/changes/sequence-public-response-failures/specs/responses-api-compat/spec.md
+++ b/openspec/changes/sequence-public-response-failures/specs/responses-api-compat/spec.md
@@ -46,6 +46,8 @@ repair MUST NOT change Codex-private backend stream shapes.
   `sequence_number`
 - **WHEN** the public normalizer forwards the event
 - **THEN** it preserves that sequence number unchanged
+- **AND** if it must synthesize a leading `response.created`, that event uses
+  the immediately preceding integer sequence
 
 #### Scenario: Backend Codex stream shape remains unchanged
 

--- a/openspec/changes/sequence-public-response-failures/tasks.md
+++ b/openspec/changes/sequence-public-response-failures/tasks.md
@@ -1,0 +1,12 @@
+## 1. Public stream normalization
+
+- [x] 1.1 Track the next numeric sequence across public Responses SSE events.
+- [x] 1.2 Sequence terminal `response.failed` events that omit a valid number.
+- [x] 1.3 Preserve valid upstream sequences and backend Codex stream shapes.
+
+## 2. Validation
+
+- [x] 2.1 Add focused public normalizer sequence regressions.
+- [x] 2.2 Cover bridge failure after reasoning on fresh and reused sessions.
+- [x] 2.3 Verify compatibility with OpenCode's pinned OpenAI AI SDK parser.
+- [x] 2.4 Run focused tests, lint, type checking, bridge checks, and OpenSpec validation.

--- a/openspec/changes/sequence-public-response-failures/tasks.md
+++ b/openspec/changes/sequence-public-response-failures/tasks.md
@@ -6,7 +6,8 @@
 
 ## 2. Validation
 
-- [x] 2.1 Add focused public normalizer sequence regressions.
+- [x] 2.1 Add focused public normalizer sequence regressions, including unique
+      synthesized created/failure sequences.
 - [x] 2.2 Cover bridge failure after reasoning on fresh and reused sessions.
 - [x] 2.3 Verify compatibility with OpenCode's pinned OpenAI AI SDK parser.
 - [x] 2.4 Run focused tests, lint, type checking, bridge checks, and OpenSpec validation.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -520,6 +520,71 @@ class _CreatedThenCloseUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
         await self._messages.put(_FakeUpstreamMessage("close", close_code=1011))
 
 
+class _ReasoningThenAbruptCloseUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
+    async def send_text(self, text: str) -> None:
+        self.sent_text.append(text)
+        response_id = f"resp_reasoning_then_close_{len(self.sent_text)}"
+        reasoning_id = f"rs_reasoning_then_close_{len(self.sent_text)}"
+        events = [
+            {
+                "type": "response.created",
+                "sequence_number": 0,
+                "response": {"id": response_id, "object": "response", "status": "in_progress"},
+            },
+            {
+                "type": "response.output_item.added",
+                "sequence_number": 1,
+                "response_id": response_id,
+                "output_index": 0,
+                "item": {
+                    "id": reasoning_id,
+                    "type": "reasoning",
+                    "summary": [],
+                    "encrypted_content": None,
+                },
+            },
+            {
+                "type": "response.reasoning_summary_part.added",
+                "sequence_number": 2,
+                "response_id": response_id,
+                "item_id": reasoning_id,
+                "output_index": 0,
+                "summary_index": 0,
+                "part": {"type": "summary_text", "text": ""},
+            },
+            {
+                "type": "response.reasoning_summary_text.delta",
+                "sequence_number": 3,
+                "response_id": response_id,
+                "item_id": reasoning_id,
+                "output_index": 0,
+                "summary_index": 0,
+                "delta": "Reviewing the final integration result.",
+            },
+        ]
+        for event in events:
+            await self._messages.put(
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(event, separators=(",", ":")),
+                )
+            )
+        await self._messages.put(
+            _FakeUpstreamMessage(
+                "error",
+                error="no close frame received or sent",
+            )
+        )
+
+
+class _CompleteThenReasoningAbruptCloseUpstreamWebSocket(_ReasoningThenAbruptCloseUpstreamWebSocket):
+    async def send_text(self, text: str) -> None:
+        if not self.sent_text:
+            await _FakeBridgeUpstreamWebSocket.send_text(self, text)
+            return
+        await super().send_text(text)
+
+
 class _ErrorOnlyUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
     async def send_text(self, text: str) -> None:
         self.sent_text.append(text)
@@ -10624,7 +10689,50 @@ async def test_v1_responses_http_bridge_prunes_idle_session_before_reuse(app_ins
 
 
 @pytest.mark.asyncio
-async def test_v1_responses_http_bridge_stream_failure_remains_valid_sse(async_client, monkeypatch):
+@pytest.mark.parametrize(
+    ("upstream_type", "prime_reused_session", "expected_event_types", "expected_failure_sequence"),
+    [
+        (
+            _CreatedThenCloseUpstreamWebSocket,
+            False,
+            ["response.created", "response.failed"],
+            0,
+        ),
+        (
+            _ReasoningThenAbruptCloseUpstreamWebSocket,
+            False,
+            [
+                "response.created",
+                "response.output_item.added",
+                "response.reasoning_summary_part.added",
+                "response.reasoning_summary_text.delta",
+                "response.failed",
+            ],
+            4,
+        ),
+        (
+            _CompleteThenReasoningAbruptCloseUpstreamWebSocket,
+            True,
+            [
+                "response.created",
+                "response.output_item.added",
+                "response.reasoning_summary_part.added",
+                "response.reasoning_summary_text.delta",
+                "response.failed",
+            ],
+            4,
+        ),
+    ],
+    ids=["created-then-close", "reasoning-then-abrupt-close", "reused-reasoning-then-abrupt-close"],
+)
+async def test_v1_responses_http_bridge_stream_failure_remains_valid_sse(
+    async_client,
+    monkeypatch,
+    upstream_type,
+    prime_reused_session,
+    expected_event_types,
+    expected_failure_sequence,
+):
     _install_bridge_settings(monkeypatch, enabled=True)
     account_id = await _import_account(
         async_client,
@@ -10632,7 +10740,7 @@ async def test_v1_responses_http_bridge_stream_failure_remains_valid_sse(async_c
         "http-bridge-sse-failure@example.com",
     )
     account = await _get_account(account_id)
-    upstream = _CreatedThenCloseUpstreamWebSocket()
+    upstream = upstream_type()
 
     async def fake_select_account_with_budget(
         self,
@@ -10691,9 +10799,24 @@ async def test_v1_responses_http_bridge_stream_failure_remains_valid_sse(async_c
     monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
     monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
 
+    headers = {"x-codex-turn-state": "turn-sse-failure"} if prime_reused_session else {}
+    if prime_reused_session:
+        prime = await async_client.post(
+            "/v1/responses",
+            headers=headers,
+            json={
+                "model": "gpt-5.1",
+                "instructions": "Return exactly OK.",
+                "input": "prime-sse-session",
+                "prompt_cache_key": "sse-failure-key",
+            },
+        )
+        assert prime.status_code == 200
+
     async with async_client.stream(
         "POST",
         "/v1/responses",
+        headers=headers,
         json={
             "model": "gpt-5.1",
             "instructions": "Return exactly OK.",
@@ -10706,8 +10829,9 @@ async def test_v1_responses_http_bridge_stream_failure_remains_valid_sse(async_c
         lines = [line async for line in response.aiter_lines() if line.startswith("data: ")]
 
     events = [json.loads(line[6:]) for line in lines if line[6:] != "[DONE]"]
-    assert [event["type"] for event in events] == ["response.created", "response.failed"]
+    assert [event["type"] for event in events] == expected_event_types
     assert events[0]["response"]["id"] == events[-1]["response"]["id"]
+    assert events[-1]["sequence_number"] == expected_failure_sequence
     assert events[-1]["response"]["error"]["code"] == "stream_incomplete"
 
 

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -874,6 +874,88 @@ async def test_normalize_public_responses_stream_synthesizes_response_created_on
 
 
 @pytest.mark.asyncio
+async def test_normalize_public_responses_stream_sequences_unsequenced_leading_failure() -> None:
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                'data: {"type":"response.failed","response":{"id":"resp_err","object":"response",'
+                '"status":"failed","error":{"code":"stream_incomplete","message":"closed"}}}\n\n'
+            )
+        )
+    ]
+
+    payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
+    failed = next(payload for payload in payloads if payload and payload.get("type") == "response.failed")
+    assert failed["sequence_number"] == 0
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_sequences_failure_after_reasoning() -> None:
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                (
+                    'data: {"type":"response.created","sequence_number":7,'
+                    '"response":{"id":"resp_err","object":"response","status":"in_progress","output":[]}}\n\n'
+                ),
+                (
+                    'data: {"type":"response.reasoning_summary_text.delta","sequence_number":8,'
+                    '"item_id":"rs_1","output_index":0,"summary_index":0,"delta":"Checking."}\n\n'
+                ),
+                (
+                    'data: {"type":"response.failed","response":{"id":"resp_err","object":"response",'
+                    '"status":"failed","error":{"code":"stream_incomplete","message":"closed"}}}\n\n'
+                ),
+            )
+        )
+    ]
+
+    payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
+    failed = next(payload for payload in payloads if payload and payload.get("type") == "response.failed")
+    assert failed["sequence_number"] == 9
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_preserves_failure_sequence() -> None:
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                (
+                    'data: {"type":"response.failed","sequence_number":12,'
+                    '"response":{"id":"resp_err","object":"response","status":"failed",'
+                    '"error":{"code":"stream_incomplete","message":"closed"}}}\n\n'
+                )
+            )
+        )
+    ]
+
+    payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
+    failed = next(payload for payload in payloads if payload and payload.get("type") == "response.failed")
+    assert failed["sequence_number"] == 12
+
+
+@pytest.mark.asyncio
+async def test_normalize_public_responses_stream_codex_route_preserves_unsequenced_failure() -> None:
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                'data: {"type":"response.failed","response":{"id":"resp_err","object":"response",'
+                '"status":"failed","error":{"code":"stream_incomplete","message":"closed"}}}\n\n'
+            ),
+            enforce_openai_sdk_contract=False,
+        )
+    ]
+
+    failed = proxy_api_module._parse_sse_payload(blocks[0])
+    assert failed is not None
+    assert "sequence_number" not in failed
+
+
+@pytest.mark.asyncio
 async def test_normalize_public_responses_stream_drops_precreated_output_when_envelope_arrives() -> None:
     """A: public /v1 must never attach anonymous pre-created output to a later response.
 

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -874,7 +874,7 @@ async def test_normalize_public_responses_stream_synthesizes_response_created_on
 
 
 @pytest.mark.asyncio
-async def test_normalize_public_responses_stream_sequences_unsequenced_leading_failure() -> None:
+async def test_normalize_public_responses_stream_sequences_created_before_unsequenced_leading_failure() -> None:
     blocks = [
         block
         async for block in proxy_api_module._normalize_public_responses_stream(
@@ -886,8 +886,10 @@ async def test_normalize_public_responses_stream_sequences_unsequenced_leading_f
     ]
 
     payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
+    created = next(payload for payload in payloads if payload and payload.get("type") == "response.created")
     failed = next(payload for payload in payloads if payload and payload.get("type") == "response.failed")
-    assert failed["sequence_number"] == 0
+    assert created["sequence_number"] == 0
+    assert failed["sequence_number"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -891,6 +891,30 @@ async def test_normalize_public_responses_stream_sequences_unsequenced_leading_f
 
 
 @pytest.mark.asyncio
+async def test_normalize_public_responses_stream_replaces_non_integer_failure_sequence() -> None:
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(
+                (
+                    'data: {"type":"response.created","sequence_number":7,'
+                    '"response":{"id":"resp_err","object":"response","status":"in_progress","output":[]}}\n\n'
+                ),
+                (
+                    'data: {"type":"response.failed","sequence_number":"error",'
+                    '"response":{"id":"resp_err","object":"response","status":"failed",'
+                    '"error":{"code":"stream_incomplete","message":"closed"}}}\n\n'
+                ),
+            )
+        )
+    ]
+
+    payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
+    failed = next(payload for payload in payloads if payload and payload.get("type") == "response.failed")
+    assert failed["sequence_number"] == 8
+
+
+@pytest.mark.asyncio
 async def test_normalize_public_responses_stream_sequences_failure_after_reasoning() -> None:
     blocks = [
         block

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -368,9 +368,11 @@ async def test_normalize_public_responses_stream_appends_response_failed_on_inva
     created_payload = proxy_api_module._parse_sse_payload(blocks[0])
     assert created_payload is not None
     assert created_payload["type"] == "response.created"
+    assert created_payload["sequence_number"] == 0
     payload = proxy_api_module._parse_sse_payload(blocks[1])
     assert payload is not None
     assert payload["type"] == "response.failed"
+    assert payload["sequence_number"] == 1
     response = payload["response"]
     assert isinstance(response, dict)
     error = response["error"]
@@ -395,6 +397,7 @@ async def test_normalize_public_responses_stream_preserves_initial_error_details
     payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
     payloads = [payload for payload in payloads if payload is not None]
     assert [payload["type"] for payload in payloads] == ["response.created", "response.failed"]
+    assert [payload["sequence_number"] for payload in payloads] == [0, 1]
     response = payloads[1]["response"]
     assert isinstance(response, dict)
     error = response["error"]

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -947,13 +947,17 @@ async def test_normalize_public_responses_stream_sequences_failure_after_reasoni
 
 
 @pytest.mark.asyncio
-async def test_normalize_public_responses_stream_preserves_failure_sequence() -> None:
+@pytest.mark.parametrize(("failure_sequence", "created_sequence"), [(12, 11), (0, -1)])
+async def test_normalize_public_responses_stream_preserves_failure_sequence(
+    failure_sequence: int,
+    created_sequence: int,
+) -> None:
     blocks = [
         block
         async for block in proxy_api_module._normalize_public_responses_stream(
             _iter_blocks(
                 (
-                    'data: {"type":"response.failed","sequence_number":12,'
+                    f'data: {{"type":"response.failed","sequence_number":{failure_sequence},'
                     '"response":{"id":"resp_err","object":"response","status":"failed",'
                     '"error":{"code":"stream_incomplete","message":"closed"}}}\n\n'
                 )
@@ -962,8 +966,10 @@ async def test_normalize_public_responses_stream_preserves_failure_sequence() ->
     ]
 
     payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks]
+    created = next(payload for payload in payloads if payload and payload.get("type") == "response.created")
     failed = next(payload for payload in payloads if payload and payload.get("type") == "response.failed")
-    assert failed["sequence_number"] == 12
+    assert created["sequence_number"] == created_sequence
+    assert failed["sequence_number"] == failure_sequence
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Ensure terminal `response.failed` events emitted on public `/v1/responses`
streams carry a numeric `sequence_number`. Strict OpenAI SDK clients can then
parse and surface the proxy failure instead of treating it as an unknown chunk
followed by a clean EOF.

This is the focused replacement for #1463 requested in maintainer review. It
contains only the reviewed sequencing fix and its regression coverage, rebased
onto current `main`.

Related to #1393. This fixes public terminal-error propagation for one observed
failure mode; it does not prevent the upstream WebSocket close or close the
broader bridge-recovery issue.

## Changes

- Track the next observed integer sequence in the public SSE normalizer.
- Assign that next integer to terminal failures whose sequence is missing or
  non-integer.
- Give a synthesized leading `response.created` and its following failure
  distinct consecutive sequences.
- Preserve valid upstream failure sequences.
- Keep Codex-private backend streams unchanged.
- Cover leading failures, non-integer sentinels, failures after reasoning,
  fresh bridge sessions, and reused bridge sessions.

## Scope

- The first two commits are patch-equivalent to the reviewed `0048148d` and
  `82a9c0e6` commits from #1463; `e9af977a` addresses the focused Codex finding
  on their synthesized leading-event sequence.
- The unrelated fork-retirement commit `060fe87c` is excluded and remains
  associated with #1354.
- The later fresh-reattach stabilization commit `9679e670` is also excluded.
- The Ruff CI fix is already on `main` through #1465 and is not duplicated.

## OpenSpec

Change directory: `openspec/changes/sequence-public-response-failures/`

## Verification

- `uv run pytest tests/unit/test_proxy_api_responses_contract.py -q` - 53 passed
- Focused HTTP bridge route regression - 3 passed
- Full Responses bridge/WebSocket integration slice - 184 passed
- `uv run --frozen ruff check .` - passed
- `uv run --frozen ruff format --check .` - 837 files already formatted
- Changed-file `uv run ty check` - passed
- `uv run python scripts/check_proxy_architecture.py` - passed
- `openspec validate sequence-public-response-failures --strict` - passed
- `openspec validate --specs` - 47 passed

Repository-wide Ty on Windows reports five existing POSIX-only API diagnostics
in unchanged files (`os.killpg`, `signal.SIGKILL`, and `os.fork`); changed-file
Ty passes.

## Non-goals

- This PR does not disable the HTTP Responses session bridge.
- This PR does not replay requests after downstream-visible output.
- This PR does not include stream-lease retirement or fresh-reattach work.
- This PR does not prevent or mask the underlying upstream WebSocket close.

## Checklist

- [x] Conventional Commit title
- [x] Focused unit and integration regression coverage
- [x] OpenSpec change included and strictly validated
- [x] No settings, setup steps, README sections, or dashboard surfaces added
- [x] No changelog or version changes
