### PR TITLE
chore: release v1.23.0-beta.1

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.22.0"  # x-release-please-version
+__version__ = "1.23.0-beta.1"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.22.0
-appVersion: 1.22.0
+version: 1.23.0-beta.1
+appVersion: 1.23.0-beta.1
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.22.0",
+  "version": "1.23.0-beta.1",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.22.0"
+version = "1.23.0-beta.1"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.22.0"
+version = "1.23.0-beta.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.23.0-beta.1 for the 1.23.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.23.0-beta.1 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1472; no manual beta workflow dispatch is required.

## Changes since v1.22.0
- feat(rollups): permanent hourly usage rollups with raw live-tail reads (#1478) (
f85fbc)

## Release-candidate validation
Validated candidate: 0d2347d596fa28ffe75b5a02f44443b262642b1d

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates — CI green at 0d2347d5 (unit, integration-core 1-3, PostgreSQL, e2e, migration checks; integration-bridge initial FAILURE was a runner-timing flake: `test_v1_responses_http_bridge_forks_incompatible_prompt_cache_waiter_without_retiring_creator` TimeoutError on CI, passes 3/3 locally at 0d2347d5 in ~1s, and the identical tree passed on main f85fbcbd)
- [x] Frontend tests/build — CI green at 0d2347d5 (eslint, tsc, vitest+coverage, vite build, Playwright dashboard smoke)
- [x] Wheel/package validation — CI `Package (build)` green at 0d2347d5 (sdist/wheel build + verify)
- [x] Docker/container smoke — image built locally from 0d2347d5 (sha256:d9bfe7ace20e); booted against a scratch postgres:18-alpine: alembic upgraded an empty DB to head `20260724_000000_add_request_usage_time_rollups`, all three rollup tables created, `/` 200, `/v1/models` and `/api/runtime/version` 401 (auth enforced)
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required — this beta deploys to the production pool immediately after publish for the 48h soak mandated by the release-channel policy; live-path verification happens there with rollback runbook staged (deploy.sh)

## Install after publish
```bash
uvx --from "codex-lb==1.23.0b1" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.23.0-beta.1
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.23.0-beta.1 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.23.0.

