### PR TITLE
fix(proxy): avoid stale anchor on durable full resend

### DIFF
--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -866,6 +866,7 @@ class _HTTPBridgeStreamingMixin:
         durable_full_resend_fresh_payload: ResponsesRequest | None = None
         durable_full_resend_is_account_neutral: bool | None = None
         durable_full_resend_retains_prior_output = False
+        durable_full_resend_starts_fresh_bridge = False
         force_local_recovery_creation = False
         payload_looks_like_full_resend = _http_bridge_payload_looks_like_full_resend(payload)
         durable_anchor_trimmable = durable_lookup is not None and _input_prefix_matches_stored_context(
@@ -940,31 +941,30 @@ class _HTTPBridgeStreamingMixin:
                 and durable_lookup.latest_response_id is not None
                 and (not payload_looks_like_full_resend or durable_anchor_trimmable)
             ):
-                effective_payload = payload.model_copy(
-                    update={"previous_response_id": durable_lookup.latest_response_id}
-                )
-                proxy_injected_previous_response_id = True
-                _fresh_request_state, fresh_upstream_request_text = prepare_bridge_request(payload)
-                del _fresh_request_state
-                _log_http_bridge_event(
-                    "fresh_reattach_anchor_injected",
-                    bridge_session_key,
-                    account_id=None,
-                    model=payload.model,
-                    detail=f"response_id={durable_lookup.latest_response_id}",
-                    cache_key_family=bridge_session_key.affinity_kind,
-                    model_class=_extract_model_class(payload.model) if payload.model else None,
-                )
                 if payload_looks_like_full_resend:
+                    durable_full_resend_starts_fresh_bridge = True
                     _log_http_bridge_event(
-                        "durable_full_resend_anchor_injected",
+                        "fresh_reattach_full_resend_without_anchor",
                         bridge_session_key,
                         account_id=None,
                         model=payload.model,
-                        detail=(
-                            f"response_id={durable_lookup.latest_response_id} "
-                            f"stored_items={durable_full_resend_anchor_count}"
-                        ),
+                        detail=f"stored_items={durable_full_resend_anchor_count}",
+                        cache_key_family=bridge_session_key.affinity_kind,
+                        model_class=_extract_model_class(payload.model) if payload.model else None,
+                    )
+                else:
+                    effective_payload = payload.model_copy(
+                        update={"previous_response_id": durable_lookup.latest_response_id}
+                    )
+                    proxy_injected_previous_response_id = True
+                    _fresh_request_state, fresh_upstream_request_text = prepare_bridge_request(payload)
+                    del _fresh_request_state
+                    _log_http_bridge_event(
+                        "fresh_reattach_anchor_injected",
+                        bridge_session_key,
+                        account_id=None,
+                        model=payload.model,
+                        detail=f"response_id={durable_lookup.latest_response_id}",
                         cache_key_family=bridge_session_key.affinity_kind,
                         model_class=_extract_model_class(payload.model) if payload.model else None,
                     )
@@ -1593,7 +1593,8 @@ class _HTTPBridgeStreamingMixin:
                 return
         session = session_or_forward
         if (
-            durable_full_resend_anchor_count is not None
+            not durable_full_resend_starts_fresh_bridge
+            and durable_full_resend_anchor_count is not None
             and durable_full_resend_anchor_fingerprint is not None
             and durable_lookup is not None
             and durable_lookup.latest_response_id is not None

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -877,6 +877,16 @@ class _HTTPBridgeStreamingMixin:
         if durable_lookup is not None and payload_looks_like_full_resend and durable_anchor_trimmable:
             durable_full_resend_anchor_count = durable_lookup.latest_input_item_count
             durable_full_resend_anchor_fingerprint = durable_lookup.latest_input_full_fingerprint
+            if isinstance(payload.input, list) and durable_full_resend_anchor_count is not None:
+                replay_projection = project_responses_input_for_account_neutral_fresh_replay(
+                    cast(list[JsonValue], payload.input),
+                    stored_count=durable_full_resend_anchor_count,
+                )
+                if replay_projection is not None:
+                    durable_full_resend_retains_prior_output = responses_input_suffix_retains_prior_output(
+                        replay_projection.input_items,
+                        stored_count=replay_projection.stored_prefix_count,
+                    )
         durable_model_transition_lookup = (
             durable_lookup
             if durable_lookup is not None and not _http_bridge_models_compatible(durable_lookup.model, payload.model)
@@ -941,7 +951,7 @@ class _HTTPBridgeStreamingMixin:
                 and durable_lookup.latest_response_id is not None
                 and (not payload_looks_like_full_resend or durable_anchor_trimmable)
             ):
-                if payload_looks_like_full_resend:
+                if payload_looks_like_full_resend and durable_full_resend_retains_prior_output:
                     durable_full_resend_starts_fresh_bridge = True
                     _log_http_bridge_event(
                         "fresh_reattach_full_resend_without_anchor",

--- a/openspec/changes/avoid-stale-durable-reattach-anchor/.openspec.yaml
+++ b/openspec/changes/avoid-stale-durable-reattach-anchor/.openspec.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven

--- a/openspec/changes/avoid-stale-durable-reattach-anchor/design.md
+++ b/openspec/changes/avoid-stale-durable-reattach-anchor/design.md
@@ -1,0 +1,45 @@
+## Context
+
+Durable bridge state records both the last owner account and latest upstream response ID. When a hard session returns after its in-memory upstream WebSocket is gone, codex-lb currently injects that response ID into a fresh upstream request. If the client sent full history, codex-lb also trims the verified stored prefix and sends only the suffix.
+
+Production evidence shows the ChatGPT upstream can silently ignore that stale response anchor on a new WebSocket. This reproduced both when a request recovered locally after its prior workload owner disappeared and after replacement workloads were fully ready. The existing 240-second eventless watchdog eventually fails closed, but OpenCode often cancels and retries earlier, recreating the same session-scoped failure. Forking succeeds because the fork sends full context without the durable anchor.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Avoid stale-anchor submission when a fresh bridge already has verified complete context.
+- Preserve the durable owner account and hard-affinity identity.
+- Preserve anchor injection for incremental follow-ups that cannot stand alone.
+- Keep post-send ambiguity fail-closed.
+
+**Non-Goals:**
+
+- Move a hard-continuity request to another account.
+- Replay a request after an eventless timeout or uncertain upstream acceptance.
+- Treat arbitrary client history as complete without the existing count-and-fingerprint proof.
+- Change watchdog timing or account-health policy.
+
+## Decisions
+
+### 1. Prefer verified context only for a fresh upstream bridge
+
+The no-anchor path applies only when durable lookup found no live local session and no active remote owner, the incoming request has no explicit `previous_response_id` or conversation handle, and its full-resend prefix matches the durable input count and fingerprint. The durable lookup remains active for owner-account routing.
+
+### 2. Do not seed the new session with the stale response ID
+
+The newly created bridge starts a fresh upstream conversation from the complete client payload. It must not copy the old durable response ID into the in-memory session before submission, because session-level anchor injection would recreate the same stale request. A successful response establishes the new bridge's normal response anchor.
+
+### 3. Preserve incremental recovery
+
+If the request is not a verified full resend, the durable response ID remains the only available context representation. Existing anchor injection and fail-closed handling stay unchanged.
+
+## Risks / Trade-offs
+
+- The full resend can be larger than the trimmed anchored request, but it is used only during fresh reattach and is the same complete payload the client already supplied.
+- A malformed or incomplete resend could lose context, so eligibility continues to require the existing exact durable prefix proof.
+- The old anchor may still be valid, but avoiding it on a fresh connection removes an unnecessary ephemeral dependency while retaining the owner account.
+
+## Example
+
+A durable row records 83 input items and `resp_old`. A returning client sends those 83 items plus four new items. With no live bridge owner, codex-lb verifies the 83-item prefix, opens a new bridge on the recorded account, and sends all 87 items without `previous_response_id`. A client that sends only the four new items still receives `resp_old` as its reattach anchor.

--- a/openspec/changes/avoid-stale-durable-reattach-anchor/proposal.md
+++ b/openspec/changes/avoid-stale-durable-reattach-anchor/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Multiple production OpenCode sessions repeatedly became silent after codex-lb recreated their HTTP bridge on a fresh upstream WebSocket. The same failure reproduced during workload replacement and again after both replacement pods were ready: the client supplied a full conversation resend whose prefix matched durable context, but codex-lb replaced that context with the latest durable `previous_response_id`. The fresh upstream connection emitted no `response.created` or error for that old anchor, so each turn remained pending until either the client cancelled or the bridge watchdog expired.
+
+## What Changes
+
+- When no live bridge owner exists and a hard-continuity request contains a fingerprint-verified full resend, keep routing to the durable owner account but submit the complete request without injecting the old durable `previous_response_id`.
+- Continue injecting the durable anchor for incremental requests that need it to preserve context.
+- Do not replay timed-out or otherwise ambiguously accepted work.
+- Add regression coverage for both the full-resend fresh path and the existing incremental reattach path.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: Prefer a verified client full resend over an ephemeral durable response anchor when creating a fresh upstream bridge.
+
+## Impact
+
+- Affected code: HTTP bridge durable reattach request preparation.
+- Affected surface: streaming HTTP Responses requests with hard session continuity after their live upstream bridge is gone.
+- No new account-movement path, schema change, setting, dependency, or transparent post-send replay.

--- a/openspec/changes/avoid-stale-durable-reattach-anchor/specs/responses-api-compat/spec.md
+++ b/openspec/changes/avoid-stale-durable-reattach-anchor/specs/responses-api-compat/spec.md
@@ -2,16 +2,26 @@
 
 ### Requirement: HTTP bridge MUST support fresh upstream reattach from durable continuity
 
-When a bridged HTTP request arrives for a valid hard continuity key but no live local session or active remote owner remains, the service MUST retain the durable owner account for routing. If the client supplies a full resend whose stored prefix matches the durable input count and fingerprint, the service MUST submit that complete payload on the fresh upstream bridge without injecting the durable `previous_response_id`. Otherwise, when the request needs the durable response anchor to represent prior context, the service MUST preserve existing durable-anchor reattach behavior. The service MUST NOT replay a request after uncertain upstream acceptance.
+When a bridged HTTP request arrives for a valid hard continuity key but no live local session or active remote owner remains, the service MUST retain the durable owner account for routing. If the client supplies a full resend whose stored prefix matches the durable input count and fingerprint and whose suffix proves that prior assistant or tool output is retained before the new input, the service MUST submit that complete payload on the fresh upstream bridge without injecting the durable `previous_response_id`. Otherwise, when the request needs the durable response anchor to represent prior context, the service MUST preserve existing durable-anchor reattach behavior. The service MUST NOT replay a request after uncertain upstream acceptance.
 
 #### Scenario: verified full resend starts a fresh owner-bound bridge without stale anchor
 
 - **GIVEN** a hard session's durable record contains an owner account, latest response ID, input count, and input fingerprint
 - **AND** no live local bridge or active remote owner remains
 - **WHEN** the client sends a full resend whose stored prefix matches both the durable count and fingerprint
+- **AND** the suffix retains prior assistant or tool output before the new input
 - **THEN** the service opens the fresh bridge on the durable owner account
 - **AND** it submits the complete client input without `previous_response_id`
 - **AND** it does not trim the verified prefix from that submission
+
+#### Scenario: incomplete full resend still uses durable anchor
+
+- **GIVEN** a hard session's durable record contains an owner account, latest response ID, input count, and input fingerprint
+- **AND** no live local bridge or active remote owner remains
+- **WHEN** the client resends the stored input prefix followed by new input without retained prior assistant or tool output
+- **THEN** the service injects the durable latest response ID as the reattach anchor
+- **AND** it trims the verified stored prefix before submission
+- **AND** it remains on the durable owner account
 
 #### Scenario: incremental reattach still uses durable anchor
 

--- a/openspec/changes/avoid-stale-durable-reattach-anchor/specs/responses-api-compat/spec.md
+++ b/openspec/changes/avoid-stale-durable-reattach-anchor/specs/responses-api-compat/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: HTTP bridge MUST support fresh upstream reattach from durable continuity
+
+When a bridged HTTP request arrives for a valid hard continuity key but no live local session or active remote owner remains, the service MUST retain the durable owner account for routing. If the client supplies a full resend whose stored prefix matches the durable input count and fingerprint, the service MUST submit that complete payload on the fresh upstream bridge without injecting the durable `previous_response_id`. Otherwise, when the request needs the durable response anchor to represent prior context, the service MUST preserve existing durable-anchor reattach behavior. The service MUST NOT replay a request after uncertain upstream acceptance.
+
+#### Scenario: verified full resend starts a fresh owner-bound bridge without stale anchor
+
+- **GIVEN** a hard session's durable record contains an owner account, latest response ID, input count, and input fingerprint
+- **AND** no live local bridge or active remote owner remains
+- **WHEN** the client sends a full resend whose stored prefix matches both the durable count and fingerprint
+- **THEN** the service opens the fresh bridge on the durable owner account
+- **AND** it submits the complete client input without `previous_response_id`
+- **AND** it does not trim the verified prefix from that submission
+
+#### Scenario: incremental reattach still uses durable anchor
+
+- **GIVEN** a hard session's durable record contains an owner account and latest response ID
+- **AND** no live local bridge or active remote owner remains
+- **WHEN** the client sends an incremental follow-up that is not a verified full resend
+- **THEN** the service injects the durable latest response ID as the reattach anchor
+- **AND** it remains on the durable owner account
+
+#### Scenario: eventless accepted request is not replayed
+
+- **GIVEN** a bridge request has already been sent upstream
+- **WHEN** the upstream emits no response lifecycle event before the eventless watchdog expires
+- **THEN** the service fails and retires the bridge session through the existing fail-closed path
+- **AND** it does not replay the ambiguously accepted request

--- a/openspec/changes/avoid-stale-durable-reattach-anchor/tasks.md
+++ b/openspec/changes/avoid-stale-durable-reattach-anchor/tasks.md
@@ -1,0 +1,14 @@
+## 1. Specification
+
+- [x] 1.1 Define verified full-resend behavior for fresh durable bridge reattach.
+
+## 2. Implementation
+
+- [x] 2.1 Keep durable owner routing while skipping stale anchor injection for a verified full resend on a fresh bridge.
+- [x] 2.2 Prevent the stale durable response ID from being re-injected at session level on that path.
+
+## 3. Verification
+
+- [x] 3.1 Add a regression proving a verified full resend is submitted complete and unanchored on fresh reattach.
+- [x] 3.2 Preserve regression coverage proving incremental reattach still injects the durable anchor.
+- [x] 3.3 Run focused tests, Ruff, and OpenSpec validation where available.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -6355,17 +6355,23 @@ async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("retains_prior_output", [False, True])
 async def test_stream_via_http_bridge_uses_trimmable_full_resend_without_durable_anchor(
     monkeypatch: pytest.MonkeyPatch,
+    retains_prior_output: bool,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
-    input_items = [
+    stored_input_items = [
         {
             "type": "additional_tools",
             "role": "developer",
             "tools": [{"type": "custom", "name": "shell"}],
         },
         {"role": "user", "content": "hello"},
+    ]
+    input_items = [
+        *stored_input_items,
+        *([{"role": "assistant", "content": "hello back"}] if retains_prior_output else []),
         {"role": "user", "content": "follow up"},
     ]
     payload = proxy_service.ResponsesRequest.model_validate(
@@ -6477,10 +6483,8 @@ async def test_stream_via_http_bridge_uses_trimmable_full_resend_without_durable
                 state=HttpBridgeSessionState.ACTIVE,
                 latest_turn_state="http_turn_1",
                 latest_response_id="resp_latest",
-                latest_input_item_count=2,
-                latest_input_full_fingerprint=proxy_service._fingerprint_input_items(
-                    cast(list[Any], payload.input)[:2]
-                ),
+                latest_input_item_count=len(stored_input_items),
+                latest_input_full_fingerprint=proxy_service._fingerprint_input_items(stored_input_items),
             )
         ),
     )
@@ -6514,13 +6518,23 @@ async def test_stream_via_http_bridge_uses_trimmable_full_resend_without_durable
     ]
 
     assert chunks == []
-    assert prepared_previous_response_ids == [None]
-    assert prepared_input_lengths == [3]
+    assert prepared_previous_response_ids == ([None] if retains_prior_output else [None, "resp_latest", "resp_latest"])
+    assert prepared_input_lengths == (
+        [len(input_items)] if retains_prior_output else [len(input_items), len(input_items), 1]
+    )
     assert all("tools" not in frame for frame in prepared_frames)
-    assert prepared_frames[-1]["input"] == input_items
+    if retains_prior_output:
+        assert [item["role"] for item in prepared_frames[-1]["input"]] == [
+            "developer",
+            "user",
+            "assistant",
+            "user",
+        ]
+    else:
+        assert prepared_frames[-1]["input"] == [input_items[-1]]
     assert [frame["client_metadata"][CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY] for frame in prepared_frames] == [
         "true",
-    ]
+    ] * len(prepared_frames)
     assert all(
         frame["reasoning"]
         == {

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -6355,7 +6355,7 @@ async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_
 
 
 @pytest.mark.asyncio
-async def test_stream_via_http_bridge_injects_durable_anchor_for_trimmable_full_resend(
+async def test_stream_via_http_bridge_uses_trimmable_full_resend_without_durable_anchor(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
@@ -6514,13 +6514,11 @@ async def test_stream_via_http_bridge_injects_durable_anchor_for_trimmable_full_
     ]
 
     assert chunks == []
-    assert prepared_previous_response_ids == [None, "resp_latest", "resp_latest"]
-    assert prepared_input_lengths == [3, 3, 1]
+    assert prepared_previous_response_ids == [None]
+    assert prepared_input_lengths == [3]
     assert all("tools" not in frame for frame in prepared_frames)
-    assert prepared_frames[-1]["input"] == [input_items[-1]]
+    assert prepared_frames[-1]["input"] == input_items
     assert [frame["client_metadata"][CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY] for frame in prepared_frames] == [
-        "true",
-        "true",
         "true",
     ]
     assert all(
@@ -7887,7 +7885,7 @@ async def test_stream_via_http_bridge_clears_injected_anchor_after_owner_unavail
         assert prepared_previous_response_ids == [None, None, None]
         assert forwarded_payloads == [payload]
     else:
-        assert prepared_previous_response_ids[-2:] == ["resp_latest", None]
+        assert prepared_previous_response_ids[-2:] == [None, None]
         assert forwarded_payloads == []
     assert get_or_create_kwargs[-1]["allow_forward_to_owner"] is False
     assert get_or_create_kwargs[-1]["exclude_account_ids"] == {"acc-1"}
@@ -16733,7 +16731,7 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
     first_call = get_or_create.await_args_list[0]
     second_call = get_or_create.await_args_list[1]
     third_call = get_or_create.await_args_list[2]
-    assert first_call.kwargs["previous_response_id"] == ("resp_completed_anchor" if stored_model is None else None)
+    assert first_call.kwargs["previous_response_id"] is None
     assert first_call.kwargs["preferred_account_id"] == "acc-owner"
     assert first_call.kwargs["allow_forward_to_owner"] is True
     assert second_call.kwargs["previous_response_id"] is None

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -6361,7 +6361,7 @@ async def test_stream_via_http_bridge_uses_trimmable_full_resend_without_durable
     retains_prior_output: bool,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
-    stored_input_items = [
+    stored_input_items: list[proxy_service.JsonValue] = [
         {
             "type": "additional_tools",
             "role": "developer",


### PR DESCRIPTION
## Summary

Avoid reusing a durable `previous_response_id` when a hard-continuity client provides a fingerprint-verified full resend on a newly created upstream bridge. Production sessions showed that the stale anchor could be silently ignored on a fresh WebSocket, leaving OpenCode turns pending until cancellation or the eventless watchdog.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: No issue filed; this fixes a production incident reproduced across multiple OpenCode sessions.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/avoid-stale-durable-reattach-anchor/`

## Changes

- Keep durable owner-account routing while submitting a verified full resend complete and without the stale durable response anchor.
- Continue injecting the durable anchor for incremental reattach requests and retain existing fail-closed no-replay behavior.
- Update bridge regressions for the fresh full-resend and incremental paths.

## Test plan

```text
.venv/bin/pytest tests/unit/test_proxy_http_bridge.py
364 passed

.venv/bin/ruff check app/modules/proxy/_service/http_bridge/streaming.py tests/unit/test_proxy_http_bridge.py
.venv/bin/ruff format --check app/modules/proxy/_service/http_bridge/streaming.py tests/unit/test_proxy_http_bridge.py
.venv/bin/ty check app/modules/proxy/_service/http_bridge/streaming.py
All checks passed

npx --yes @fission-ai/openspec validate avoid-stale-durable-reattach-anchor --strict
Change 'avoid-stale-durable-reattach-anchor' is valid

npx --yes @fission-ai/openspec validate --specs
47 passed, 0 failed
```

## Screenshots / output

Before, affected fresh reattach requests logged `durable_full_resend_anchor_injected` and then emitted no upstream response lifecycle event. The regression now proves the complete verified input is submitted once with no `previous_response_id`; incremental reattach remains anchored.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above (no issue was filed for this production incident).
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local test, lint, format, and type-check subset.
- [x] If touching specs: `openspec validate --specs` passes and the change is strictly valid.
- [x] Simplicity gates reviewed: no setting, setup step, default, README section, `.env.example`, or dashboard navigation change.
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
