### PR TITLE
feat(helm): allow Grafana dashboard title overrides

### DIFF
--- a/deploy/helm/codex-lb/README.md
+++ b/deploy/helm/codex-lb/README.md
@@ -416,18 +416,6 @@ helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb \
   --set externalDatabase.url='postgresql+asyncpg://user:pass@db.example.com:5432/codexlb'
 ```
 
-**Optional Grafana hierarchy:** sidecars that map annotation paths to nested
-folders can render concise dashboard names under an installation-specific path:
-
-```yaml
-metrics:
-  grafanaDashboard:
-    folder: Applications/Codex LB
-    titles:
-      codex-lb.json: Overview
-      ttft-breakdown.json: TTFT Breakdown
-```
-
 ### Graceful Shutdown Tuning
 
 Graceful shutdown coordinates three timeout parameters to drain in-flight requests and session bridge connections:

--- a/deploy/helm/codex-lb/README.md
+++ b/deploy/helm/codex-lb/README.md
@@ -404,6 +404,10 @@ metrics:
     enabled: true                  # Alerting rules
   grafanaDashboard:
     enabled: true                  # Pre-built dashboards
+    folder: Applications/Codex LB  # Nested folder path (when supported by the sidecar)
+    titles:
+      codex-lb.json: Overview
+      ttft-breakdown.json: TTFT Breakdown
 externalSecrets:
   enabled: true                    # Use External Secrets Operator
 ```

--- a/deploy/helm/codex-lb/README.md
+++ b/deploy/helm/codex-lb/README.md
@@ -404,10 +404,6 @@ metrics:
     enabled: true                  # Alerting rules
   grafanaDashboard:
     enabled: true                  # Pre-built dashboards
-    folder: Applications/Codex LB  # Nested folder path (when supported by the sidecar)
-    titles:
-      codex-lb.json: Overview
-      ttft-breakdown.json: TTFT Breakdown
 externalSecrets:
   enabled: true                    # Use External Secrets Operator
 ```
@@ -418,6 +414,18 @@ Install with:
 helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb \
   -f deploy/helm/codex-lb/values-prod.yaml \
   --set externalDatabase.url='postgresql+asyncpg://user:pass@db.example.com:5432/codexlb'
+```
+
+**Optional Grafana hierarchy:** sidecars that map annotation paths to nested
+folders can render concise dashboard names under an installation-specific path:
+
+```yaml
+metrics:
+  grafanaDashboard:
+    folder: Applications/Codex LB
+    titles:
+      codex-lb.json: Overview
+      ttft-breakdown.json: TTFT Breakdown
 ```
 
 ### Graceful Shutdown Tuning

--- a/deploy/helm/codex-lb/templates/grafana-dashboard.yaml
+++ b/deploy/helm/codex-lb/templates/grafana-dashboard.yaml
@@ -11,7 +11,11 @@ metadata:
     grafana_folder: {{ .Values.metrics.grafanaDashboard.folder | quote }}
 data:
   {{- range $path, $_ := .Files.Glob "dashboards/*.json" }}
+  {{- $dashboard := $.Files.Get $path | fromJson }}
+  {{- with index $.Values.metrics.grafanaDashboard.titles (base $path) }}
+  {{- $_ := set $dashboard "title" . }}
+  {{- end }}
   {{ base $path }}: |-
-    {{ $.Files.Get $path | nindent 4 }}
+    {{ $dashboard | toPrettyJson | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/deploy/helm/codex-lb/templates/grafana-dashboard.yaml
+++ b/deploy/helm/codex-lb/templates/grafana-dashboard.yaml
@@ -11,11 +11,15 @@ metadata:
     grafana_folder: {{ .Values.metrics.grafanaDashboard.folder | quote }}
 data:
   {{- range $path, $_ := .Files.Glob "dashboards/*.json" }}
+  {{- $filename := base $path }}
+  {{- if hasKey $.Values.metrics.grafanaDashboard.titles $filename }}
   {{- $dashboard := $.Files.Get $path | fromJson }}
-  {{- with index $.Values.metrics.grafanaDashboard.titles (base $path) }}
-  {{- $_ := set $dashboard "title" . }}
-  {{- end }}
-  {{ base $path }}: |-
+  {{- $_ := set $dashboard "title" (index $.Values.metrics.grafanaDashboard.titles $filename) }}
+  {{ $filename }}: |-
     {{ $dashboard | toPrettyJson | nindent 4 }}
+  {{- else }}
+  {{ $filename }}: |-
+    {{ $.Files.Get $path | nindent 4 }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/deploy/helm/codex-lb/values.yaml
+++ b/deploy/helm/codex-lb/values.yaml
@@ -416,6 +416,10 @@ metrics:
     enabled: false
     # @param metrics.grafanaDashboard.folder Grafana dashboard folder label
     folder: codex-lb
+    # @param metrics.grafanaDashboard.titles Dashboard title overrides keyed by JSON filename
+    titles:
+      codex-lb.json: codex-lb
+      ttft-breakdown.json: codex-lb TTFT Breakdown
 
 # @section Tracing parameters
 tracing:

--- a/deploy/helm/codex-lb/values.yaml
+++ b/deploy/helm/codex-lb/values.yaml
@@ -417,9 +417,7 @@ metrics:
     # @param metrics.grafanaDashboard.folder Grafana dashboard folder label
     folder: codex-lb
     # @param metrics.grafanaDashboard.titles Dashboard title overrides keyed by JSON filename
-    titles:
-      codex-lb.json: codex-lb
-      ttft-breakdown.json: codex-lb TTFT Breakdown
+    titles: {}
 
 # @section Tracing parameters
 tracing:

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -95,6 +95,26 @@ gatewayApi:
 Gateway defaults to a single HTTP listener on port 80; override
 `gatewayApi.gateway.listeners` for TLS or other ports.
 
+## Grafana dashboard hierarchy
+
+The chart can assign concise titles to its packaged dashboards without copying
+their JSON. When the Grafana sidecar maps annotation paths to filesystem-backed
+nested folders, the following values produce `Applications / Codex LB /
+Overview` and `Applications / Codex LB / TTFT Breakdown`:
+
+```yaml
+metrics:
+  grafanaDashboard:
+    enabled: true
+    folder: Applications/Codex LB
+    titles:
+      codex-lb.json: Overview
+      ttft-breakdown.json: TTFT Breakdown
+```
+
+The title map is keyed by the JSON filenames packaged in the chart. Omitting it
+preserves the default dashboard titles.
+
 ## Full chart reference
 
 For external database, production config, ingress, observability, and more see the

--- a/openspec/changes/configure-grafana-dashboard-titles/.openspec.yaml
+++ b/openspec/changes/configure-grafana-dashboard-titles/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-25

--- a/openspec/changes/configure-grafana-dashboard-titles/proposal.md
+++ b/openspec/changes/configure-grafana-dashboard-titles/proposal.md
@@ -1,0 +1,20 @@
+# Configure Grafana dashboard titles
+
+## Why
+
+The Helm chart exposes a Grafana folder annotation but hard-codes the titles of
+its provisioned dashboards. Operators cannot use concise titles inside an
+installation-specific folder hierarchy without maintaining copies of the
+dashboard JSON.
+
+## What Changes
+
+- Add dashboard title overrides keyed by the packaged JSON filename.
+- Preserve the existing titles by default.
+- Apply configured titles while rendering the dashboard ConfigMap.
+
+## Impact
+
+- **Spec**: `deployment-installation`
+- **Helm**: optional Grafana dashboard title configuration; defaults are unchanged.
+- **Runtime/UI**: no application or built-in dashboard changes.

--- a/openspec/changes/configure-grafana-dashboard-titles/specs/deployment-installation/spec.md
+++ b/openspec/changes/configure-grafana-dashboard-titles/specs/deployment-installation/spec.md
@@ -22,3 +22,4 @@ dashboard titles.
 - **WHEN** the chart renders the Grafana dashboard ConfigMap
 - **THEN** the overview title remains `codex-lb`
 - **AND** the TTFT title remains `codex-lb TTFT Breakdown`
+- **AND** each ConfigMap value remains byte-identical to the chart's raw-file rendering

--- a/openspec/changes/configure-grafana-dashboard-titles/specs/deployment-installation/spec.md
+++ b/openspec/changes/configure-grafana-dashboard-titles/specs/deployment-installation/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Helm Grafana dashboard titles are configurable
+
+The Helm chart MUST allow operators to override the titles of packaged Grafana
+dashboards by JSON filename. The default values MUST preserve the packaged
+dashboard titles.
+
+#### Scenario: Operator uses concise titles in a folder hierarchy
+
+- **GIVEN** Grafana dashboard provisioning is enabled
+- **AND** title overrides map `codex-lb.json` to `Overview` and
+  `ttft-breakdown.json` to `TTFT Breakdown`
+- **WHEN** the chart renders the Grafana dashboard ConfigMap
+- **THEN** each dashboard JSON document contains its configured title
+- **AND** dashboard UIDs and all panel definitions remain unchanged
+
+#### Scenario: Default titles remain compatible
+
+- **GIVEN** Grafana dashboard provisioning is enabled
+- **AND** the operator does not customize dashboard titles
+- **WHEN** the chart renders the Grafana dashboard ConfigMap
+- **THEN** the overview title remains `codex-lb`
+- **AND** the TTFT title remains `codex-lb TTFT Breakdown`

--- a/openspec/changes/configure-grafana-dashboard-titles/tasks.md
+++ b/openspec/changes/configure-grafana-dashboard-titles/tasks.md
@@ -1,0 +1,14 @@
+## 1. Contract
+
+- [x] 1.1 Define filename-keyed Grafana dashboard title overrides.
+- [x] 1.2 Preserve existing titles by default.
+
+## 2. Implementation
+
+- [x] 2.1 Apply configured titles when rendering packaged dashboard JSON.
+- [x] 2.2 Document the title values and add a Helm rendering regression test.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused Helm rendering test and chart linting.
+- [x] 3.2 Run strict OpenSpec validation.

--- a/tests/unit/test_helm_replica_artifacts.py
+++ b/tests/unit/test_helm_replica_artifacts.py
@@ -136,16 +136,17 @@ def test_grafana_dashboard_titles_can_be_overridden() -> None:
         for document in _helm_documents(default_rendered)
         if document["kind"] == "ConfigMap" and document["metadata"]["name"] == "codex-lb-dashboard"
     )
-    assert json.loads(default_config["data"]["codex-lb.json"])["title"] == "codex-lb"
-    assert json.loads(default_config["data"]["ttft-breakdown.json"])["title"] == "codex-lb TTFT Breakdown"
+    raw_dashboard_values = {
+        dashboard_path.name: "\n" + dashboard_path.read_text().removesuffix("\n")
+        for dashboard_path in (_CHART_DIR / "dashboards").glob("*.json")
+    }
+    assert default_config["data"] == raw_dashboard_values
 
     rendered = _helm_template(
         "--set",
         "metrics.grafanaDashboard.enabled=true",
         "--set-string",
         r"metrics.grafanaDashboard.titles.codex-lb\.json=Overview",
-        "--set-string",
-        r"metrics.grafanaDashboard.titles.ttft-breakdown\.json=TTFT Breakdown",
     )
     dashboard_config = next(
         document
@@ -154,7 +155,7 @@ def test_grafana_dashboard_titles_can_be_overridden() -> None:
     )
 
     assert json.loads(dashboard_config["data"]["codex-lb.json"])["title"] == "Overview"
-    assert json.loads(dashboard_config["data"]["ttft-breakdown.json"])["title"] == "TTFT Breakdown"
+    assert dashboard_config["data"]["ttft-breakdown.json"] == raw_dashboard_values["ttft-breakdown.json"]
 
 
 def _prod_overlay_args(*args: str) -> tuple[str, ...]:

--- a/tests/unit/test_helm_replica_artifacts.py
+++ b/tests/unit/test_helm_replica_artifacts.py
@@ -134,14 +134,10 @@ def test_grafana_dashboard_titles_can_be_overridden() -> None:
     default_config = next(
         document
         for document in _helm_documents(default_rendered)
-        if document["kind"] == "ConfigMap"
-        and document["metadata"]["name"] == "codex-lb-dashboard"
+        if document["kind"] == "ConfigMap" and document["metadata"]["name"] == "codex-lb-dashboard"
     )
     assert json.loads(default_config["data"]["codex-lb.json"])["title"] == "codex-lb"
-    assert (
-        json.loads(default_config["data"]["ttft-breakdown.json"])["title"]
-        == "codex-lb TTFT Breakdown"
-    )
+    assert json.loads(default_config["data"]["ttft-breakdown.json"])["title"] == "codex-lb TTFT Breakdown"
 
     rendered = _helm_template(
         "--set",
@@ -154,15 +150,11 @@ def test_grafana_dashboard_titles_can_be_overridden() -> None:
     dashboard_config = next(
         document
         for document in _helm_documents(rendered)
-        if document["kind"] == "ConfigMap"
-        and document["metadata"]["name"] == "codex-lb-dashboard"
+        if document["kind"] == "ConfigMap" and document["metadata"]["name"] == "codex-lb-dashboard"
     )
 
     assert json.loads(dashboard_config["data"]["codex-lb.json"])["title"] == "Overview"
-    assert (
-        json.loads(dashboard_config["data"]["ttft-breakdown.json"])["title"]
-        == "TTFT Breakdown"
-    )
+    assert json.loads(dashboard_config["data"]["ttft-breakdown.json"])["title"] == "TTFT Breakdown"
 
 
 def _prod_overlay_args(*args: str) -> tuple[str, ...]:

--- a/tests/unit/test_helm_replica_artifacts.py
+++ b/tests/unit/test_helm_replica_artifacts.py
@@ -11,6 +11,7 @@ Covers the artifact-level defects that shipped broken multi-replica deployments:
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import subprocess
@@ -123,6 +124,45 @@ def _helm_notes(*args: str) -> str:
 
 def _helm_documents(rendered: str) -> list[dict]:
     return [document for document in yaml.safe_load_all(rendered) if document]
+
+
+def test_grafana_dashboard_titles_can_be_overridden() -> None:
+    default_rendered = _helm_template(
+        "--set",
+        "metrics.grafanaDashboard.enabled=true",
+    )
+    default_config = next(
+        document
+        for document in _helm_documents(default_rendered)
+        if document["kind"] == "ConfigMap"
+        and document["metadata"]["name"] == "codex-lb-dashboard"
+    )
+    assert json.loads(default_config["data"]["codex-lb.json"])["title"] == "codex-lb"
+    assert (
+        json.loads(default_config["data"]["ttft-breakdown.json"])["title"]
+        == "codex-lb TTFT Breakdown"
+    )
+
+    rendered = _helm_template(
+        "--set",
+        "metrics.grafanaDashboard.enabled=true",
+        "--set-string",
+        r"metrics.grafanaDashboard.titles.codex-lb\.json=Overview",
+        "--set-string",
+        r"metrics.grafanaDashboard.titles.ttft-breakdown\.json=TTFT Breakdown",
+    )
+    dashboard_config = next(
+        document
+        for document in _helm_documents(rendered)
+        if document["kind"] == "ConfigMap"
+        and document["metadata"]["name"] == "codex-lb-dashboard"
+    )
+
+    assert json.loads(dashboard_config["data"]["codex-lb.json"])["title"] == "Overview"
+    assert (
+        json.loads(dashboard_config["data"]["ttft-breakdown.json"])["title"]
+        == "TTFT Breakdown"
+    )
 
 
 def _prod_overlay_args(*args: str) -> tuple[str, ...]:


### PR DESCRIPTION
## Summary

Allow Helm operators to override packaged Grafana dashboard titles so concise names can be used inside installation-specific folder hierarchies without vendoring dashboard JSON.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: None; this is a focused fork contribution for optional Helm customization.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/configure-grafana-dashboard-titles/`

## Changes

- Add `metrics.grafanaDashboard.titles`, keyed by packaged JSON filename, with backward-compatible defaults.
- Apply title overrides while rendering the dashboard ConfigMap and cover default/custom output with a Helm regression test.
- Document a nested `Applications/Codex LB` example.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config**
- [x] No new required setup step
- New setting(s) and why each can't be a default: `metrics.grafanaDashboard.titles` is installation-specific; defaults preserve the existing titles exactly.
- [x] README sections / `.env.example` / dashboard nav within budget

## Test plan

```text
nix shell nixpkgs#uv --command uv run pytest tests/unit/test_helm_replica_artifacts.py -k grafana_dashboard_titles -q
1 passed, 19 deselected

helm lint deploy/helm/codex-lb --set metrics.grafanaDashboard.enabled=true
1 chart(s) linted, 0 chart(s) failed

npx -y @fission-ai/openspec@latest validate configure-grafana-dashboard-titles --strict
Change 'configure-grafana-dashboard-titles' is valid

npx -y @fission-ai/openspec@latest validate --specs
Totals: 47 passed, 0 failed (47 items)
```

## Screenshots / output

Before:

```text
codex-lb
codex-lb TTFT Breakdown
```

Rendered with the documented overrides:

```text
Applications / Codex LB / Overview
Applications / Codex LB / TTFT Breakdown
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above; no issue was requested for this fork contribution.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local CI subset locally.
- [x] If touching specs: OpenSpec strict change validation and `validate --specs` pass.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
