### PR TITLE
fix(proxy): preserve fresh bridge full resends

### DIFF
--- a/app/db/alembic/versions/20260725_000000_add_http_bridge_pending_tool_calls.py
+++ b/app/db/alembic/versions/20260725_000000_add_http_bridge_pending_tool_calls.py
@@ -1,0 +1,43 @@
+"""add HTTP bridge durable pending tool call manifest
+
+Revision ID: 20260725_000000_add_http_bridge_pending_tool_calls
+Revises: 20260724_000000_add_request_usage_time_rollups
+Create Date: 2026-07-25
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+revision = "20260725_000000_add_http_bridge_pending_tool_calls"
+down_revision = "20260724_000000_add_request_usage_time_rollups"
+branch_labels = None
+depends_on = None
+
+_TABLE = "http_bridge_sessions"
+_COLUMN = "latest_pending_tool_calls_json"
+
+
+def _columns(connection: Connection) -> set[str]:
+    inspector = sa.inspect(connection)
+    if not inspector.has_table(_TABLE):
+        return set()
+    return {str(column["name"]) for column in inspector.get_columns(_TABLE) if column.get("name") is not None}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if _COLUMN in _columns(bind):
+        return
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.add_column(sa.Column(_COLUMN, sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if _COLUMN not in _columns(bind):
+        return
+    with op.batch_alter_table(_TABLE) as batch_op:
+        batch_op.drop_column(_COLUMN)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1696,6 +1696,7 @@ class HttpBridgeSessionRecord(Base):
     latest_response_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     latest_input_item_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     latest_input_full_fingerprint: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    latest_pending_tool_calls_json: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -634,6 +634,7 @@ class AccountsRepository:
                 latest_response_id=None,
                 latest_input_item_count=None,
                 latest_input_full_fingerprint=None,
+                latest_pending_tool_calls_json=None,
             )
         )
 

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -1547,6 +1547,7 @@ async def _persist_http_bridge_previous_response_alias(
     registration_generation: int,
     input_item_count: int | None,
     input_full_fingerprint: str | None,
+    pending_tool_calls: Mapping[str, str] | None,
     instance_id: str,
     lease_ttl_seconds: float,
     local_alias_was_published: bool = True,
@@ -1562,6 +1563,7 @@ async def _persist_http_bridge_previous_response_alias(
             lease_ttl_seconds=lease_ttl_seconds,
             input_item_count=input_item_count,
             input_full_fingerprint=input_full_fingerprint,
+            pending_tool_calls=pending_tool_calls,
         )
     except Exception:
         logger.warning("Failed to persist durable HTTP bridge previous_response_id alias", exc_info=True)

--- a/app/modules/proxy/_service/http_bridge/protocol.py
+++ b/app/modules/proxy/_service/http_bridge/protocol.py
@@ -77,6 +77,7 @@ class _HTTPBridgeServiceProtocol(Protocol):
         *,
         input_item_count: int | None = None,
         input_full_fingerprint: str | None = None,
+        pending_tool_calls: Mapping[str, str] | None = None,
     ) -> bool: ...
     def _schedule_http_bridge_session_closes(
         self,

--- a/app/modules/proxy/_service/http_bridge/session_registry.py
+++ b/app/modules/proxy/_service/http_bridge/session_registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Mapping
 
 from app.core.clients.proxy import ProxyResponseError
 from app.core.config.settings import Settings
@@ -212,6 +213,7 @@ class _HTTPBridgeSessionRegistryMixin:
         *,
         input_item_count: int | None = None,
         input_full_fingerprint: str | None = None,
+        pending_tool_calls: Mapping[str, str] | None = None,
     ) -> bool:
         if _requires_durable_recovery_alias_serialization(session):
             async with session.recovery_alias_lock:
@@ -220,12 +222,14 @@ class _HTTPBridgeSessionRegistryMixin:
                     response_id,
                     input_item_count=input_item_count,
                     input_full_fingerprint=input_full_fingerprint,
+                    pending_tool_calls=pending_tool_calls,
                 )
         return await self._register_http_bridge_previous_response_id_impl(
             session,
             response_id,
             input_item_count=input_item_count,
             input_full_fingerprint=input_full_fingerprint,
+            pending_tool_calls=pending_tool_calls,
         )
 
     async def _register_http_bridge_previous_response_id_impl(
@@ -235,6 +239,7 @@ class _HTTPBridgeSessionRegistryMixin:
         *,
         input_item_count: int | None = None,
         input_full_fingerprint: str | None = None,
+        pending_tool_calls: Mapping[str, str] | None = None,
     ) -> bool:
         stripped_response_id = response_id.strip()
         if not stripped_response_id:
@@ -290,6 +295,7 @@ class _HTTPBridgeSessionRegistryMixin:
             registration_generation=registration_generation,
             input_item_count=input_item_count,
             input_full_fingerprint=input_full_fingerprint,
+            pending_tool_calls=pending_tool_calls,
             instance_id=_service_get_settings().http_responses_session_bridge_instance_id,
             lease_ttl_seconds=_http_bridge_durable_lease_ttl_seconds(),
             local_alias_was_published=not defer_durable_publication,

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -931,7 +931,7 @@ class _HTTPBridgeStreamingMixin:
                 durable_lookup=durable_lookup,
             )
             forwards_to_active_owner = await self._http_bridge_can_forward_to_active_owner(durable_lookup)
-            if (
+            fresh_reattach_can_use_durable_anchor = (
                 not live_local_session_exists
                 and not forwards_to_active_owner
                 and payload.previous_response_id is None
@@ -939,7 +939,20 @@ class _HTTPBridgeStreamingMixin:
                 and bridge_session_key.strength == "hard"
                 and durable_lookup.latest_response_id is not None
                 and (not payload_looks_like_full_resend or durable_anchor_trimmable)
-            ):
+            )
+            if fresh_reattach_can_use_durable_anchor and payload_looks_like_full_resend:
+                # The client already supplied a complete fresh request. Adding
+                # a durable anchor here can strand it on the new WebSocket.
+                _log_http_bridge_event(
+                    "fresh_reattach_full_resend_preserved",
+                    bridge_session_key,
+                    account_id=durable_lookup.account_id,
+                    model=payload.model,
+                    detail="outcome=client_unanchored_full_resend",
+                    cache_key_family=bridge_session_key.affinity_kind,
+                    model_class=_extract_model_class(payload.model) if payload.model else None,
+                )
+            elif fresh_reattach_can_use_durable_anchor:
                 effective_payload = payload.model_copy(
                     update={"previous_response_id": durable_lookup.latest_response_id}
                 )
@@ -955,19 +968,6 @@ class _HTTPBridgeStreamingMixin:
                     cache_key_family=bridge_session_key.affinity_kind,
                     model_class=_extract_model_class(payload.model) if payload.model else None,
                 )
-                if payload_looks_like_full_resend:
-                    _log_http_bridge_event(
-                        "durable_full_resend_anchor_injected",
-                        bridge_session_key,
-                        account_id=None,
-                        model=payload.model,
-                        detail=(
-                            f"response_id={durable_lookup.latest_response_id} "
-                            f"stored_items={durable_full_resend_anchor_count}"
-                        ),
-                        cache_key_family=bridge_session_key.affinity_kind,
-                        model_class=_extract_model_class(payload.model) if payload.model else None,
-                    )
         account_neutral_recovery = is_http_bridge_account_neutral_replay(
             kind=bridge_session_key.affinity_kind,
             key=bridge_session_key.affinity_key,
@@ -1593,7 +1593,8 @@ class _HTTPBridgeStreamingMixin:
                 return
         session = session_or_forward
         if (
-            durable_full_resend_anchor_count is not None
+            proxy_injected_previous_response_id
+            and durable_full_resend_anchor_count is not None
             and durable_full_resend_anchor_fingerprint is not None
             and durable_lookup is not None
             and durable_lookup.latest_response_id is not None

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -207,6 +207,7 @@ from app.modules.proxy.helpers import (
 )
 from app.modules.proxy.replay_safety import (
     project_responses_input_for_account_neutral_fresh_replay,
+    responses_input_suffix_matches_pending_tool_calls,
     responses_input_suffix_retains_prior_output,
     responses_payload_is_account_neutral_fresh_replay,
 )
@@ -865,6 +866,7 @@ class _HTTPBridgeStreamingMixin:
         durable_full_resend_anchor_fingerprint: str | None = None
         durable_full_resend_fresh_payload: ResponsesRequest | None = None
         durable_full_resend_is_account_neutral: bool | None = None
+        durable_full_resend_has_safe_fresh_context = False
         durable_full_resend_retains_prior_output = False
         force_local_recovery_creation = False
         payload_looks_like_full_resend = _http_bridge_payload_looks_like_full_resend(payload)
@@ -876,6 +878,23 @@ class _HTTPBridgeStreamingMixin:
         if durable_lookup is not None and payload_looks_like_full_resend and durable_anchor_trimmable:
             durable_full_resend_anchor_count = durable_lookup.latest_input_item_count
             durable_full_resend_anchor_fingerprint = durable_lookup.latest_input_full_fingerprint
+            if isinstance(payload.input, list) and durable_full_resend_anchor_count is not None:
+                replay_projection = project_responses_input_for_account_neutral_fresh_replay(
+                    cast(list[JsonValue], payload.input),
+                    stored_count=durable_full_resend_anchor_count,
+                )
+                if replay_projection is not None:
+                    durable_full_resend_has_safe_fresh_context = responses_input_suffix_retains_prior_output(
+                        replay_projection.input_items,
+                        stored_count=replay_projection.stored_prefix_count,
+                    ) or (
+                        durable_lookup.latest_pending_tool_calls is not None
+                        and responses_input_suffix_matches_pending_tool_calls(
+                            replay_projection.input_items,
+                            stored_count=replay_projection.stored_prefix_count,
+                            pending_tool_calls=durable_lookup.latest_pending_tool_calls,
+                        )
+                    )
         durable_model_transition_lookup = (
             durable_lookup
             if durable_lookup is not None and not _http_bridge_models_compatible(durable_lookup.model, payload.model)
@@ -940,7 +959,11 @@ class _HTTPBridgeStreamingMixin:
                 and durable_lookup.latest_response_id is not None
                 and (not payload_looks_like_full_resend or durable_anchor_trimmable)
             )
-            if fresh_reattach_can_use_durable_anchor and payload_looks_like_full_resend:
+            if (
+                fresh_reattach_can_use_durable_anchor
+                and payload_looks_like_full_resend
+                and durable_full_resend_has_safe_fresh_context
+            ):
                 # The client already supplied a complete fresh request. Adding
                 # a durable anchor here can strand it on the new WebSocket.
                 _log_http_bridge_event(

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -188,6 +188,12 @@ _MODEL_OUTPUT_EVENT_TYPES = frozenset(
         "response.output_tool_call.delta",
     }
 )
+_UNSUPPORTED_DURABLE_TOOL_CALL_ITEM_TYPES = frozenset(
+    {
+        "computer_call",
+        "mcp_approval_request",
+    }
+)
 
 
 def _record_http_bridge_tool_call_lifecycle(
@@ -204,6 +210,13 @@ def _record_http_bridge_tool_call_lifecycle(
         return
     item_type = item.get("type")
     if not isinstance(item_type, str):
+        request_state.tool_call_manifest_invalid = True
+        return
+    if item_type in _UNSUPPORTED_DURABLE_TOOL_CALL_ITEM_TYPES:
+        # These calls require client-provided continuation state but are not
+        # representable by the direct function/custom/apply-patch replay proof.
+        # Persisting only a parallel supported call would make a partial suffix
+        # look complete, so keep the whole durable manifest unknown.
         request_state.tool_call_manifest_invalid = True
         return
     if item_type not in _PENDING_TOOL_CALL_ITEM_TYPES:
@@ -235,6 +248,8 @@ def _response_completed_tool_call_types(payload: dict[str, JsonValue] | None) ->
             return None
         item_type = item.get("type")
         if not isinstance(item_type, str):
+            return None
+        if item_type in _UNSUPPORTED_DURABLE_TOOL_CALL_ITEM_TYPES:
             return None
         if item_type not in _PENDING_TOOL_CALL_ITEM_TYPES:
             continue

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -200,6 +200,7 @@ def _record_http_bridge_tool_call_lifecycle(
         return
     item = payload.get("item") if isinstance(payload, dict) else None
     if not isinstance(item, dict):
+        request_state.tool_call_manifest_invalid = True
         return
     item_type = item.get("type")
     if not isinstance(item_type, str):

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -110,6 +110,7 @@ from app.modules.proxy._service.observability import (
 from app.modules.proxy._service.support import (
     _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE,
     _HARD_HTTP_BRIDGE_AFFINITY_KINDS,  # noqa: F401
+    _PENDING_TOOL_CALL_ITEM_TYPES,
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
     _clear_websocket_deferred_reasoning_downstream_texts,
     _clear_websocket_precreated_replay_fallback,
@@ -187,6 +188,79 @@ _MODEL_OUTPUT_EVENT_TYPES = frozenset(
         "response.output_tool_call.delta",
     }
 )
+
+
+def _record_http_bridge_tool_call_lifecycle(
+    request_state: _WebSocketRequestState,
+    *,
+    event_type: str | None,
+    payload: dict[str, JsonValue] | None,
+) -> None:
+    if event_type not in {"response.output_item.added", "response.output_item.done"}:
+        return
+    item = payload.get("item") if isinstance(payload, dict) else None
+    if not isinstance(item, dict):
+        return
+    item_type = item.get("type")
+    if not isinstance(item_type, str):
+        request_state.tool_call_manifest_invalid = True
+        return
+    if item_type not in _PENDING_TOOL_CALL_ITEM_TYPES:
+        return
+    call_id = item.get("call_id")
+    if not isinstance(call_id, str) or not call_id:
+        request_state.tool_call_manifest_invalid = True
+        return
+    target = (
+        request_state.added_tool_call_types
+        if event_type == "response.output_item.added"
+        else request_state.pending_tool_call_types
+    )
+    existing = target.get(call_id)
+    if existing is not None:
+        request_state.tool_call_manifest_invalid = True
+        return
+    target[call_id] = item_type
+
+
+def _response_completed_tool_call_types(payload: dict[str, JsonValue] | None) -> dict[str, str] | None:
+    response = payload.get("response") if isinstance(payload, dict) else None
+    output = response.get("output") if isinstance(response, dict) else None
+    if not isinstance(output, list):
+        return None
+    result: dict[str, str] = {}
+    for item in output:
+        if not isinstance(item, dict):
+            return None
+        item_type = item.get("type")
+        if not isinstance(item_type, str):
+            return None
+        if item_type not in _PENDING_TOOL_CALL_ITEM_TYPES:
+            continue
+        call_id = item.get("call_id")
+        if not isinstance(call_id, str) or not call_id:
+            return None
+        existing = result.get(call_id)
+        if existing is not None:
+            return None
+        result[call_id] = item_type
+    return result
+
+
+def _durable_pending_tool_call_manifest(
+    request_state: _WebSocketRequestState,
+    payload: dict[str, JsonValue] | None,
+) -> dict[str, str] | None:
+    terminal_calls = _response_completed_tool_call_types(payload)
+    if request_state.tool_call_manifest_invalid or terminal_calls is None:
+        return None
+    if request_state.added_tool_call_types != request_state.pending_tool_call_types:
+        return None
+    if terminal_calls and terminal_calls != request_state.pending_tool_call_types:
+        return None
+    return dict(request_state.pending_tool_call_types)
+
+
 _SECURITY_WORK_AUTHORIZATION_REQUIRED_CODE = "security_work_authorization_required"
 _SECURITY_WORK_RETRY_MESSAGE = (
     "Upstream flagged this request as possible cybersecurity work. "
@@ -641,6 +715,11 @@ class _HTTPBridgeUpstreamEventsMixin:
                 if actual_service_tier is not None:
                     matched_request_state.actual_service_tier = actual_service_tier
                     matched_request_state.service_tier = actual_service_tier
+                _record_http_bridge_tool_call_lifecycle(
+                    matched_request_state,
+                    event_type=event_type,
+                    payload=payload,
+                )
                 completed_tool_call = _response_output_item_done_tool_call(payload)
                 if completed_tool_call is not None:
                     completed_call_id, completed_call_type = completed_tool_call
@@ -1105,6 +1184,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                 input_full_fingerprint=(
                     matched_request_state.input_full_fingerprint if matched_request_state.input_item_count > 0 else None
                 ),
+                pending_tool_calls=_durable_pending_tool_call_manifest(matched_request_state, payload),
             )
             if not alias_registered and is_http_bridge_account_neutral_replay(
                 kind=session.key.affinity_kind,

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -832,6 +832,8 @@ class _WebSocketRequestState:
     suppressed_duplicate_tool_call: bool = False
     pending_function_call_ids: list[str] = field(default_factory=list)
     pending_tool_call_types: dict[str, str] = field(default_factory=dict)
+    added_tool_call_types: dict[str, str] = field(default_factory=dict)
+    tool_call_manifest_invalid: bool = False
     seen_tool_call_keys: dict[ToolCallDedupeKey, None] = field(default_factory=dict)
     input_item_count: int = 0
     input_full_fingerprint: str | None = None

--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Callable, Sequence
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
@@ -41,6 +41,7 @@ class DurableBridgeLookup:
     latest_input_item_count: int | None = None
     latest_input_full_fingerprint: str | None = None
     model: str | None = None
+    latest_pending_tool_calls: dict[str, str] | None = None
 
     def lease_is_active(self, *, now: datetime) -> bool:
         if self.owner_instance_id is None:
@@ -239,6 +240,7 @@ class DurableBridgeSessionCoordinator:
         latest_response_id: str | None = None,
         latest_input_item_count: int | None = None,
         latest_input_full_fingerprint: str | None = None,
+        latest_pending_tool_calls: Mapping[str, str] | None = None,
         state: HttpBridgeSessionState | None = None,
     ) -> DurableBridgeLookup | None:
         del api_key_id
@@ -252,6 +254,7 @@ class DurableBridgeSessionCoordinator:
                 latest_response_id=latest_response_id,
                 latest_input_item_count=latest_input_item_count,
                 latest_input_full_fingerprint=latest_input_full_fingerprint,
+                latest_pending_tool_calls=latest_pending_tool_calls,
                 state=state,
             )
         if snapshot is None:
@@ -358,6 +361,7 @@ class DurableBridgeSessionCoordinator:
         lease_ttl_seconds: float,
         input_item_count: int | None = None,
         input_full_fingerprint: str | None = None,
+        pending_tool_calls: Mapping[str, str] | None = None,
     ) -> DurableBridgeAliasRegistration:
         api_key_scope = durable_bridge_api_key_scope(api_key_id)
         async with self._session() as session:
@@ -372,6 +376,7 @@ class DurableBridgeSessionCoordinator:
                 latest_response_id=response_id,
                 latest_input_item_count=input_item_count,
                 latest_input_full_fingerprint=input_full_fingerprint,
+                latest_pending_tool_calls=pending_tool_calls,
             )
 
     async def register_session_header(
@@ -415,4 +420,5 @@ def _to_lookup(snapshot: DurableBridgeSessionSnapshot) -> DurableBridgeLookup:
         latest_input_item_count=snapshot.latest_input_item_count,
         latest_input_full_fingerprint=snapshot.latest_input_full_fingerprint,
         model=snapshot.model,
+        latest_pending_tool_calls=snapshot.latest_pending_tool_calls,
     )

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+import json
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import StrEnum
@@ -65,6 +66,37 @@ def durable_bridge_hash(value: str) -> str:
     return sha256(value.encode("utf-8")).hexdigest()
 
 
+def _encode_pending_tool_calls(response_id: str, value: Mapping[str, str] | None) -> str | None:
+    if value is None:
+        return None
+    return json.dumps(
+        {"response_id": response_id, "calls": dict(sorted(value.items()))},
+        separators=(",", ":"),
+    )
+
+
+def _decode_pending_tool_calls(response_id: str | None, value: str | None) -> dict[str, str] | None:
+    if response_id is None or value is None:
+        return None
+    try:
+        payload = json.loads(value)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict) or payload.get("response_id") != response_id:
+        return None
+    calls = payload.get("calls")
+    if not isinstance(calls, dict):
+        return None
+    result: dict[str, str] = {}
+    for call_id, call_type in calls.items():
+        if not isinstance(call_id, str) or not call_id.strip():
+            return None
+        if not isinstance(call_type, str) or not call_type.strip():
+            return None
+        result[call_id] = call_type
+    return result
+
+
 @dataclass(frozen=True, slots=True)
 class DurableBridgeSessionSnapshot:
     id: str
@@ -85,6 +117,7 @@ class DurableBridgeSessionSnapshot:
     latest_input_full_fingerprint: str | None
     last_seen_at: datetime
     closed_at: datetime | None
+    latest_pending_tool_calls: dict[str, str] | None = None
 
 
 class DurableBridgeRepository:
@@ -274,6 +307,7 @@ class DurableBridgeRepository:
                     existing.latest_response_id = latest_response_id
                     existing.latest_input_item_count = None
                     existing.latest_input_full_fingerprint = None
+                    existing.latest_pending_tool_calls_json = None
                 elif owner_changed:
                     if latest_turn_state is not None:
                         existing.latest_turn_state = latest_turn_state
@@ -281,6 +315,7 @@ class DurableBridgeRepository:
                         existing.latest_response_id = latest_response_id
                         existing.latest_input_item_count = None
                         existing.latest_input_full_fingerprint = None
+                        existing.latest_pending_tool_calls_json = None
                 else:
                     if latest_turn_state is not None:
                         existing.latest_turn_state = latest_turn_state
@@ -288,6 +323,7 @@ class DurableBridgeRepository:
                         existing.latest_response_id = latest_response_id
                         existing.latest_input_item_count = None
                         existing.latest_input_full_fingerprint = None
+                        existing.latest_pending_tool_calls_json = None
                 existing.last_seen_at = now
                 existing.closed_at = None
                 await self._session.commit()
@@ -306,6 +342,7 @@ class DurableBridgeRepository:
         latest_response_id: str | None = None,
         latest_input_item_count: int | None = None,
         latest_input_full_fingerprint: str | None = None,
+        latest_pending_tool_calls: Mapping[str, str] | None = None,
         state: HttpBridgeSessionState | None = None,
     ) -> DurableBridgeSessionSnapshot | None:
         """Renew the lease with a single fenced UPDATE.
@@ -322,6 +359,10 @@ class DurableBridgeRepository:
             values["latest_turn_state"] = latest_turn_state
         if latest_response_id is not None:
             values["latest_response_id"] = latest_response_id
+            values["latest_pending_tool_calls_json"] = _encode_pending_tool_calls(
+                latest_response_id,
+                latest_pending_tool_calls,
+            )
             if latest_input_item_count is None or latest_input_full_fingerprint is None:
                 values["latest_input_item_count"] = None
                 values["latest_input_full_fingerprint"] = None
@@ -629,6 +670,7 @@ class DurableBridgeRepository:
         latest_response_id: str | None = None,
         latest_input_item_count: int | None = None,
         latest_input_full_fingerprint: str | None = None,
+        latest_pending_tool_calls: Mapping[str, str] | None = None,
     ) -> DurableBridgeAliasRegistration:
         """Register continuity only while the caller still owns the durable row."""
 
@@ -644,6 +686,10 @@ class DurableBridgeRepository:
                 session_values["latest_response_id"] = latest_response_id
                 session_values["latest_input_item_count"] = latest_input_item_count
                 session_values["latest_input_full_fingerprint"] = latest_input_full_fingerprint
+                session_values["latest_pending_tool_calls_json"] = _encode_pending_tool_calls(
+                    latest_response_id,
+                    latest_pending_tool_calls,
+                )
             elif latest_input_item_count is not None and latest_input_full_fingerprint is not None:
                 session_values["latest_input_item_count"] = latest_input_item_count
                 session_values["latest_input_full_fingerprint"] = latest_input_full_fingerprint
@@ -1061,6 +1107,7 @@ _SNAPSHOT_COLUMNS = (
     HttpBridgeSessionRecord.latest_response_id,
     HttpBridgeSessionRecord.latest_input_item_count,
     HttpBridgeSessionRecord.latest_input_full_fingerprint,
+    HttpBridgeSessionRecord.latest_pending_tool_calls_json,
     HttpBridgeSessionRecord.last_seen_at,
     HttpBridgeSessionRecord.closed_at,
 )
@@ -1085,6 +1132,10 @@ def _returned_row_to_snapshot(row: Row[tuple[object, ...]]) -> DurableBridgeSess
         latest_response_id=mapping[HttpBridgeSessionRecord.latest_response_id],
         latest_input_item_count=mapping[HttpBridgeSessionRecord.latest_input_item_count],
         latest_input_full_fingerprint=mapping[HttpBridgeSessionRecord.latest_input_full_fingerprint],
+        latest_pending_tool_calls=_decode_pending_tool_calls(
+            mapping[HttpBridgeSessionRecord.latest_response_id],
+            mapping[HttpBridgeSessionRecord.latest_pending_tool_calls_json],
+        ),
         last_seen_at=mapping[HttpBridgeSessionRecord.last_seen_at],
         closed_at=mapping[HttpBridgeSessionRecord.closed_at],
     )
@@ -1110,6 +1161,10 @@ def _to_snapshot(row: HttpBridgeSessionRecord | None) -> DurableBridgeSessionSna
         latest_response_id=row.latest_response_id,
         latest_input_item_count=row.latest_input_item_count,
         latest_input_full_fingerprint=row.latest_input_full_fingerprint,
+        latest_pending_tool_calls=_decode_pending_tool_calls(
+            row.latest_response_id,
+            row.latest_pending_tool_calls_json,
+        ),
         last_seen_at=row.last_seen_at,
         closed_at=row.closed_at,
     )

--- a/app/modules/proxy/replay_safety.py
+++ b/app/modules/proxy/replay_safety.py
@@ -182,6 +182,8 @@ def _project_account_neutral_replay_item(item: JsonValue) -> JsonValue | None:
         return item
 
     item_type = item.get("type")
+    if item_type is not None and not isinstance(item_type, str):
+        return item
     if item_type == "reasoning" or (
         item_type in _ACCOUNT_NEUTRAL_REPLAY_OMITTED_ITEM_TYPES and item.get("status") == "completed"
     ):
@@ -309,6 +311,42 @@ def responses_input_suffix_retains_prior_output(
     return retained_output_seen and fresh_followup_seen and not pending_suffix_calls
 
 
+def responses_input_suffix_matches_pending_tool_calls(
+    input_items: list[JsonValue],
+    *,
+    stored_count: int,
+    pending_tool_calls: Mapping[str, str],
+) -> bool:
+    """Prove the suffix exactly settles the durable prior-response call manifest."""
+
+    if stored_count <= 0 or len(input_items) <= stored_count or not pending_tool_calls:
+        return False
+    prefix_state = _direct_tool_call_prefix_state(input_items[:stored_count])
+    if prefix_state is None or prefix_state[1] & pending_tool_calls.keys():
+        return False
+    suffix = input_items[stored_count:]
+    if not all(
+        isinstance(item, dict)
+        and isinstance(item.get("type"), str)
+        and item.get("type") in (_TOOL_CALL_TYPES | _TOOL_CALL_TYPE_BY_OUTPUT_TYPE.keys())
+        for item in suffix
+    ):
+        return False
+    if not responses_input_items_are_self_contained_fresh_replay(suffix):
+        return False
+    suffix_calls: dict[str, str] = {}
+    suffix_outputs: dict[str, str] = {}
+    for item in cast(list[dict[str, JsonValue]], suffix):
+        item_type = cast(str, item["type"])
+        call_id = cast(str, item["call_id"])
+        if item_type in _TOOL_CALL_TYPES:
+            suffix_calls[call_id] = item_type
+        else:
+            suffix_outputs[call_id] = _TOOL_CALL_TYPE_BY_OUTPUT_TYPE[item_type]
+    expected = dict(pending_tool_calls)
+    return suffix_calls == expected and suffix_outputs == expected
+
+
 def _direct_tool_call_prefix_state(
     input_items: list[JsonValue],
 ) -> tuple[deque[tuple[str, str]], set[str]] | None:
@@ -318,6 +356,8 @@ def _direct_tool_call_prefix_state(
         if not isinstance(item, dict):
             return None
         item_type_value = item.get("type")
+        if item_type_value is not None and not isinstance(item_type_value, str):
+            return None
         item_type = item_type_value if isinstance(item_type_value, str) else None
         if item_type in _TOOL_CALL_TYPES:
             if item.get("status") not in (None, "completed"):

--- a/openspec/changes/preserve-fresh-bridge-full-resends/.openspec.yaml
+++ b/openspec/changes/preserve-fresh-bridge-full-resends/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-24

--- a/openspec/changes/preserve-fresh-bridge-full-resends/proposal.md
+++ b/openspec/changes/preserve-fresh-bridge-full-resends/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+When an OpenCode HTTP Responses conversation loses its live bridge, codex-lb
+currently injects the durable `previous_response_id` into a client-unanchored
+full resend before opening a fresh upstream WebSocket. Upstream can leave that
+anchored `response.create` completely eventless. Production telemetry in #1485
+captured seven consecutive 240-second `missing_response_created_timeout`
+failures in one hour for the same tool-heavy conversation, each with no
+`response.created` or other upstream event.
+
+The incoming full resend is already the client's requested fresh representation
+of the conversation. Adding an anchor changes that request and can strand it on
+a response id that the new WebSocket does not acknowledge.
+
+## What Changes
+
+- Preserve a client-unanchored full resend when its stored prefix matches the
+  durable conversation and neither a reusable local bridge nor a forwardable
+  remote owner exists.
+- Open the fresh bridge on the durable owner with the original hard affinity,
+  without adding `previous_response_id` or trimming the full resend.
+- Avoid seeding the newly created session with the old durable response before
+  its first request, which would otherwise re-inject the same anchor at the
+  session-level optimization.
+- Emit a structured bridge event when the original full resend is preserved.
+- Add unit and public `/v1/responses` route regression coverage.
+- Leave live-session trimming, client-supplied anchors, owner-unavailable
+  recovery, and account-neutral replay rules unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: A verified client-unanchored full resend remains
+  unanchored for the first request on a fresh durable HTTP bridge.
+
+## Impact
+
+- Affected code: HTTP Responses bridge durable reattach preparation in
+  `app/modules/proxy/_service/http_bridge/streaming.py`.
+- Affected tests: focused HTTP bridge unit coverage and the public
+  `/v1/responses` integration route.
+- No public endpoint, response schema, database schema, setting, dependency, or
+  cross-account routing behavior changes.

--- a/openspec/changes/preserve-fresh-bridge-full-resends/proposal.md
+++ b/openspec/changes/preserve-fresh-bridge-full-resends/proposal.md
@@ -8,15 +8,28 @@ captured seven consecutive 240-second `missing_response_created_timeout`
 failures in one hour for the same tool-heavy conversation, each with no
 `response.created` or other upstream event.
 
-The incoming full resend is already the client's requested fresh representation
-of the conversation. Adding an anchor changes that request and can strand it on
-a response id that the new WebSocket does not acknowledge.
+The affected full resend carries complete direct tool call/output pairs after
+the verified stored prefix, so it can continue the tool loop without the old
+response anchor. Adding an anchor changes that request and can strand it on a
+response id that the new WebSocket does not acknowledge. Ordinary cumulative
+prompts that omit prior assistant output must remain anchored to avoid losing
+conversation context.
 
 ## What Changes
 
 - Preserve a client-unanchored full resend when its stored prefix matches the
-  durable conversation and neither a reusable local bridge nor a forwardable
-  remote owner exists.
+  durable conversation, its projected suffix either retains completed
+  assistant output before fresh user input or is a self-contained direct tool
+  call/output loop that exactly settles the durable prior-response call
+  manifest, and neither a reusable local bridge nor a forwardable remote owner
+  exists.
+- Persist the complete prior-response tool-call ID/type manifest atomically with
+  each durable previous-response alias. A manifest is known only when every
+  observed tool-call `output_item.added` reaches a matching `output_item.done`
+  and terminal output does not reveal another call. The serialized manifest is
+  bound to its response ID so an older rolling-upgrade writer cannot leave stale
+  calls attached to a newer response. Existing or incomplete rows remain
+  anchored.
 - Open the fresh bridge on the durable owner with the original hard affinity,
   without adding `previous_response_id` or trimming the full resend.
 - Avoid seeding the newly created session with the old durable response before
@@ -35,14 +48,17 @@ a response id that the new WebSocket does not acknowledge.
 
 ### Modified Capabilities
 
-- `responses-api-compat`: A verified client-unanchored full resend remains
-  unanchored for the first request on a fresh durable HTTP bridge.
+- `responses-api-compat`: A verified client-unanchored full resend with complete
+  retained response context remains unanchored for the first request on a fresh
+  durable HTTP bridge.
 
 ## Impact
 
-- Affected code: HTTP Responses bridge durable reattach preparation in
-  `app/modules/proxy/_service/http_bridge/streaming.py`.
-- Affected tests: focused HTTP bridge unit coverage and the public
-  `/v1/responses` integration route.
-- No public endpoint, response schema, database schema, setting, dependency, or
-  cross-account routing behavior changes.
+- Affected code: HTTP Responses bridge durable reattach preparation, durable
+  bridge state persistence, and the bridge-session migration.
+- Affected tests: durable session persistence, replay-safety and HTTP bridge
+  unit coverage, migration checks, and the public `/v1/responses` route.
+- Adds one nullable internal `http_bridge_sessions` text column. Existing rows
+  require no backfill and fail closed to anchored behavior.
+- No public endpoint, response schema, setting, dependency, or cross-account
+  routing behavior changes.

--- a/openspec/changes/preserve-fresh-bridge-full-resends/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-fresh-bridge-full-resends/specs/responses-api-compat/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Fresh durable HTTP bridge preserves client-unanchored full resends
+
+The service MUST preserve a client-unanchored full resend as the first request
+on a fresh durable HTTP bridge. This applies when the request resolves a hard
+durable conversation, has no client-supplied `previous_response_id`, has a
+stored prefix matching that durable conversation, and has neither a reusable
+local bridge nor a forwardable remote owner. The service MUST submit the
+original full resend without adding `previous_response_id`, MUST retain the
+durable preferred owner and hard affinity, MUST NOT move the request through
+account-neutral replay, and MUST NOT trim the stored prefix before that first
+send.
+
+The service MUST NOT seed the newly created local session with the old durable
+response in a way that re-injects the anchor before the original full resend is
+submitted. Once the fresh request completes, ordinary live-session continuity
+and trimming MAY resume from the newly completed response. Incremental requests
+that rely on durable history, client-supplied anchors, owner-unavailable
+handling, and existing account-neutral replay eligibility remain unchanged.
+
+#### Scenario: Full resend opens a fresh bridge without a durable anchor
+
+- **GIVEN** a client-unanchored full resend has a verified stored prefix for a hard durable conversation
+- **AND** no reusable local bridge or forwardable remote owner exists
+- **WHEN** the service creates a fresh upstream WebSocket on the durable owner
+- **THEN** its first `response.create` omits `previous_response_id`
+- **AND** its input contains the original full resend
+- **AND** its hard session affinity is retained
+
+#### Scenario: Tool-loop resend does not require an assistant-message replay boundary
+
+- **GIVEN** a verified client-unanchored full resend continues a tool loop without a completed assistant-message boundary
+- **WHEN** it starts on a fresh durable bridge
+- **THEN** the service submits the original request once on the durable owner
+- **AND** retained-output checks used for cross-account replay do not block or rewrite that first send
+
+#### Scenario: Live bridge trimming remains unchanged
+
+- **GIVEN** the durable conversation still has a reusable live bridge
+- **WHEN** a trimmable full resend continues that live session
+- **THEN** the existing session-level anchor and prefix-trimming behavior remains available

--- a/openspec/changes/preserve-fresh-bridge-full-resends/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-fresh-bridge-full-resends/specs/responses-api-compat/spec.md
@@ -6,11 +6,32 @@ The service MUST preserve a client-unanchored full resend as the first request
 on a fresh durable HTTP bridge. This applies when the request resolves a hard
 durable conversation, has no client-supplied `previous_response_id`, has a
 stored prefix matching that durable conversation, and has neither a reusable
-local bridge nor a forwardable remote owner. The service MUST submit the
-original full resend without adding `previous_response_id`, MUST retain the
-durable preferred owner and hard affinity, MUST NOT move the request through
-account-neutral replay, and MUST NOT trim the stored prefix before that first
-send.
+local bridge nor a forwardable remote owner. The input projected through the
+existing fresh-replay bookkeeping filter MUST also either retain completed
+assistant output before fresh user input or have a suffix consisting only of
+complete, self-contained direct tool call/output pairs that exactly match a
+durable manifest of every call ID and call type emitted by the prior response.
+The manifest MUST include every observed tool-call `output_item.added` event,
+MUST require a matching `output_item.done` event with the same call ID and type,
+MUST reconcile any tool calls present in terminal response output, and MUST be
+persisted atomically with that response's durable alias. An incomplete,
+conflicting, or malformed lifecycle MUST persist an unknown manifest rather
+than a partial one. Duplicate call IDs in added, done, or terminal output MUST
+invalidate the manifest even when their call types match. The serialized
+manifest MUST bind its call map to the exact durable response ID, and a response
+ID mismatch MUST be treated as an unknown manifest so rolling-upgrade writers
+that do not know the manifest column cannot leave stale calls on a newer
+response.
+The service MUST submit that safe original full resend without adding
+`previous_response_id`, MUST retain the durable preferred owner and hard
+affinity, MUST NOT move the request through account-neutral replay, and MUST NOT
+trim the stored prefix before that first send.
+
+If the matching cumulative input omits prior output, contains an incomplete or
+orphaned tool call/output sequence, omits any call in the durable manifest,
+reuses a stored-prefix call ID, has no known durable manifest, or otherwise
+lacks either safe context shape, the service MUST retain the existing
+durable-anchor injection and prefix trimming behavior.
 
 The service MUST NOT seed the newly created local session with the old durable
 response in a way that re-injects the anchor before the original full resend is
@@ -21,7 +42,7 @@ handling, and existing account-neutral replay eligibility remain unchanged.
 
 #### Scenario: Full resend opens a fresh bridge without a durable anchor
 
-- **GIVEN** a client-unanchored full resend has a verified stored prefix for a hard durable conversation
+- **GIVEN** a client-unanchored full resend has a verified stored prefix and retained completed assistant output for a hard durable conversation
 - **AND** no reusable local bridge or forwardable remote owner exists
 - **WHEN** the service creates a fresh upstream WebSocket on the durable owner
 - **THEN** its first `response.create` omits `previous_response_id`
@@ -30,10 +51,46 @@ handling, and existing account-neutral replay eligibility remain unchanged.
 
 #### Scenario: Tool-loop resend does not require an assistant-message replay boundary
 
-- **GIVEN** a verified client-unanchored full resend continues a tool loop without a completed assistant-message boundary
+- **GIVEN** a verified client-unanchored full resend continues a tool loop with complete self-contained direct call/output pairs but no completed assistant-message boundary
+- **AND** those calls and outputs exactly settle the durable prior-response call manifest
 - **WHEN** it starts on a fresh durable bridge
 - **THEN** the service submits the original request once on the durable owner
 - **AND** retained-output checks used for cross-account replay do not block or rewrite that first send
+
+#### Scenario: Omitted parallel tool call remains anchored
+
+- **GIVEN** the durable prior-response manifest contains two parallel call IDs
+- **WHEN** a matching cumulative input carries a complete call/output pair for only one ID
+- **THEN** the service retains the durable `previous_response_id`
+- **AND** it does not classify the suffix as a complete tool-loop resend
+
+#### Scenario: Incomplete tool-call lifecycle keeps manifest unknown
+
+- **GIVEN** a response emits added events for two parallel tool calls
+- **AND** only one call reaches a matching done event before `response.completed`
+- **WHEN** the durable response alias is persisted
+- **THEN** its tool-call manifest is unknown rather than a one-call partial manifest
+- **AND** a later direct tool-loop full resend remains anchored
+
+#### Scenario: Legacy durable row remains anchored
+
+- **GIVEN** a durable response row predates the call-manifest migration or otherwise has an unknown manifest
+- **WHEN** a matching cumulative input contains direct tool call/output items without a completed assistant-message boundary
+- **THEN** the service retains the durable `previous_response_id`
+
+#### Scenario: Older writer advances response without manifest
+
+- **GIVEN** a durable row has a response-bound tool-call manifest
+- **WHEN** an older rolling-upgrade writer advances `latest_response_id` without updating the manifest column
+- **THEN** readers treat the mismatched manifest as unknown
+- **AND** a later direct tool-loop full resend remains anchored
+
+#### Scenario: Cumulative prompt without prior output remains anchored
+
+- **GIVEN** a matching cumulative input contains fresh user input but omits the prior assistant output
+- **WHEN** no reusable bridge exists for its hard durable conversation
+- **THEN** the service retains the durable `previous_response_id`
+- **AND** it trims the verified stored prefix through the existing anchored path
 
 #### Scenario: Live bridge trimming remains unchanged
 

--- a/openspec/changes/preserve-fresh-bridge-full-resends/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-fresh-bridge-full-resends/specs/responses-api-compat/spec.md
@@ -22,6 +22,10 @@ manifest MUST bind its call map to the exact durable response ID, and a response
 ID mismatch MUST be treated as an unknown manifest so rolling-upgrade writers
 that do not know the manifest column cannot leave stale calls on a newer
 response.
+If a response contains a client-settled call type that the direct tool-loop
+proof cannot represent, including `computer_call` or `mcp_approval_request`,
+the service MUST treat the entire manifest as unknown rather than persist a
+partial manifest for any parallel supported calls.
 The service MUST submit that safe original full resend without adding
 `previous_response_id`, MUST retain the durable preferred owner and hard
 affinity, MUST NOT move the request through account-neutral replay, and MUST NOT
@@ -71,6 +75,13 @@ handling, and existing account-neutral replay eligibility remain unchanged.
 - **WHEN** the durable response alias is persisted
 - **THEN** its tool-call manifest is unknown rather than a one-call partial manifest
 - **AND** a later direct tool-loop full resend remains anchored
+
+#### Scenario: Unsupported parallel client-settled call keeps manifest unknown
+
+- **GIVEN** a response emits a supported direct call and a parallel client-settled call that the replay proof cannot represent
+- **WHEN** the durable response alias is persisted
+- **THEN** its tool-call manifest is unknown rather than a partial supported-call manifest
+- **AND** a later resend that settles only the supported call remains anchored
 
 #### Scenario: Legacy durable row remains anchored
 

--- a/openspec/changes/preserve-fresh-bridge-full-resends/tasks.md
+++ b/openspec/changes/preserve-fresh-bridge-full-resends/tasks.md
@@ -14,7 +14,7 @@
 
 - [x] 3.1 Update focused unit coverage to assert one unanchored full-resend preparation on the durable owner.
 - [x] 3.2 Add public `/v1/responses` coverage for a completed bridge followed by a full resend on a fresh upstream WebSocket.
-- [x] 3.3 Cover exact manifest settlement, omitted parallel calls, stored-prefix call-ID reuse, lifecycle duplicates, response-ID mismatch, persistence round-trip, and account-change clearing.
+- [x] 3.3 Cover exact manifest settlement, omitted parallel calls, unsupported mixed client-settled calls, stored-prefix call-ID reuse, lifecycle duplicates, response-ID mismatch, persistence round-trip, and account-change clearing.
 
 ## 4. Verification and handoff
 

--- a/openspec/changes/preserve-fresh-bridge-full-resends/tasks.md
+++ b/openspec/changes/preserve-fresh-bridge-full-resends/tasks.md
@@ -1,22 +1,24 @@
 ## 1. Define the fresh-bridge contract
 
-- [x] 1.1 Specify that a verified client-unanchored full resend remains unanchored on the durable owner when no reusable bridge exists.
+- [x] 1.1 Specify that a verified client-unanchored full resend with retained completed output or a self-contained direct tool loop remains unanchored on the durable owner when no reusable bridge exists.
 - [x] 1.2 Keep incremental continuations, client-supplied anchors, owner-unavailable handling, and account-neutral replay out of scope.
 
 ## 2. Preserve the original request
 
-- [x] 2.1 Skip durable anchor injection for a verified full resend while retaining hard affinity and the durable preferred owner.
+- [x] 2.1 Skip durable anchor injection only for a verified full resend with safe retained context while retaining hard affinity and the durable preferred owner.
 - [x] 2.2 Prevent session-level anchor re-injection before the first request on the newly created bridge.
 - [x] 2.3 Emit a structured event for the preserved fresh full resend.
+- [x] 2.4 Persist the complete prior-response tool-call manifest atomically with the durable response alias only after added/done lifecycle reconciliation, and leave legacy or incomplete rows fail-closed.
 
 ## 3. Regression coverage
 
 - [x] 3.1 Update focused unit coverage to assert one unanchored full-resend preparation on the durable owner.
 - [x] 3.2 Add public `/v1/responses` coverage for a completed bridge followed by a full resend on a fresh upstream WebSocket.
+- [x] 3.3 Cover exact manifest settlement, omitted parallel calls, stored-prefix call-ID reuse, lifecycle duplicates, response-ID mismatch, persistence round-trip, and account-change clearing.
 
 ## 4. Verification and handoff
 
 - [x] 4.1 Run focused unit and HTTP bridge integration tests.
-- [x] 4.2 Run Ruff, formatting, changed-file type checks, proxy architecture checks, and OpenSpec validation.
+- [x] 4.2 Run Ruff, formatting, changed-file type checks, proxy architecture checks, migration checks, and OpenSpec validation.
   - Changed paths pass Ty. Full Ty reports only five existing Windows/POSIX diagnostics for `os.killpg`, `signal.SIGKILL`, and `os.fork` in untouched smoke and refresh-claim tests.
 - [ ] 4.3 Open a focused upstream PR linked to the production issue and wait for current-head required CI before requesting Codex review.

--- a/openspec/changes/preserve-fresh-bridge-full-resends/tasks.md
+++ b/openspec/changes/preserve-fresh-bridge-full-resends/tasks.md
@@ -1,0 +1,22 @@
+## 1. Define the fresh-bridge contract
+
+- [x] 1.1 Specify that a verified client-unanchored full resend remains unanchored on the durable owner when no reusable bridge exists.
+- [x] 1.2 Keep incremental continuations, client-supplied anchors, owner-unavailable handling, and account-neutral replay out of scope.
+
+## 2. Preserve the original request
+
+- [x] 2.1 Skip durable anchor injection for a verified full resend while retaining hard affinity and the durable preferred owner.
+- [x] 2.2 Prevent session-level anchor re-injection before the first request on the newly created bridge.
+- [x] 2.3 Emit a structured event for the preserved fresh full resend.
+
+## 3. Regression coverage
+
+- [x] 3.1 Update focused unit coverage to assert one unanchored full-resend preparation on the durable owner.
+- [x] 3.2 Add public `/v1/responses` coverage for a completed bridge followed by a full resend on a fresh upstream WebSocket.
+
+## 4. Verification and handoff
+
+- [x] 4.1 Run focused unit and HTTP bridge integration tests.
+- [x] 4.2 Run Ruff, formatting, changed-file type checks, proxy architecture checks, and OpenSpec validation.
+  - Changed paths pass Ty. Full Ty reports only five existing Windows/POSIX diagnostics for `os.killpg`, `signal.SIGKILL`, and `os.fork` in untouched smoke and refresh-claim tests.
+- [ ] 4.3 Open a focused upstream PR linked to the production issue and wait for current-head required CI before requesting Codex review.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -7017,6 +7017,104 @@ async def test_v1_responses_http_bridge_opens_fresh_session_for_previous_respons
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_http_bridge_preserves_full_resend_before_fresh_bridge_send(async_client, monkeypatch):
+    _install_bridge_settings(monkeypatch, enabled=True)
+    account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_preserve_fresh_reattach",
+        "http-bridge-preserve-fresh-reattach@example.com",
+    )
+    account = await _get_account(account_id)
+    first_upstream = _ClosingBridgeUpstreamWebSocket("resp_preserve_source")
+    replay_upstream = _FakeBridgeUpstreamWebSocket("resp_preserve_replay")
+    upstreams = [first_upstream, replay_upstream]
+    connect_headers: list[dict[str, str]] = []
+
+    async def fake_select_account_with_budget(self, deadline, **kwargs):
+        del self, deadline, kwargs
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del access_token, account_id_header, base_url, session
+        connect_headers.append(dict(headers))
+        return upstreams[len(connect_headers) - 1]
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    session_headers = {"x-codex-session-id": "fresh-reattach-full-resend"}
+    historical_input = [
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "first question"}],
+        }
+    ]
+    first = await asyncio.wait_for(
+        async_client.post(
+            "/v1/responses",
+            json={
+                "model": "gpt-5.1",
+                "instructions": "Return exactly OK.",
+                "input": historical_input,
+            },
+            headers=session_headers,
+        ),
+        timeout=_TEST_SYNC_TIMEOUT_SECONDS,
+    )
+    assert first.status_code == 200, first.text
+
+    full_resend = [
+        *historical_input,
+        {
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": "first result",
+        },
+    ]
+    second = await asyncio.wait_for(
+        async_client.post(
+            "/v1/responses",
+            json={
+                "model": "gpt-5.1",
+                "instructions": "Return exactly OK.",
+                "input": full_resend,
+            },
+            headers=session_headers,
+        ),
+        timeout=_TEST_SYNC_TIMEOUT_SECONDS,
+    )
+
+    assert second.status_code == 200, second.text
+    assert second.json()["id"] == "resp_preserve_replay_1"
+    assert len(connect_headers) == 2
+    replay_connect_headers = {key.lower(): value for key, value in connect_headers[1].items()}
+    assert replay_connect_headers["x-codex-session-id"] == session_headers["x-codex-session-id"]
+    assert len(first_upstream.sent_text) == 1
+    assert len(replay_upstream.sent_text) == 1
+    replay_payload = json.loads(replay_upstream.sent_text[0])
+    assert "previous_response_id" not in replay_payload
+    assert replay_payload["input"] == full_resend
+
+
+@pytest.mark.asyncio
 async def test_v1_responses_http_bridge_reports_unavailable_required_owner_when_other_account_exists(
     async_client, monkeypatch
 ):

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -371,6 +371,10 @@ class _FakeBridgeUpstreamWebSocket:
 class _InterruptedCustomToolUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
     """First response completes with an unresolved ``custom_tool_call``."""
 
+    def __init__(self, response_id_prefix: str = "resp_bridge", *, emit_added: bool = False) -> None:
+        super().__init__(response_id_prefix)
+        self._emit_added = emit_added
+
     async def send_text(self, text: str) -> None:
         self.sent_text.append(text)
         response_id = f"resp_bridge_custom_{len(self.sent_text)}"
@@ -387,6 +391,28 @@ class _InterruptedCustomToolUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
             )
         )
         if len(self.sent_text) == 1:
+            if self._emit_added:
+                await self._messages.put(
+                    _FakeUpstreamMessage(
+                        "text",
+                        text=json.dumps(
+                            {
+                                "type": "response.output_item.added",
+                                "response_id": response_id,
+                                "item": {
+                                    "id": "ctc_shell",
+                                    "type": "custom_tool_call",
+                                    "status": "in_progress",
+                                    "call_id": "call_custom_shell",
+                                    "name": "shell",
+                                    "input": "",
+                                },
+                                "output_index": 0,
+                            },
+                            separators=(",", ":"),
+                        ),
+                    )
+                )
             await self._messages.put(
                 _FakeUpstreamMessage(
                     "text",
@@ -438,6 +464,15 @@ class _InterruptedCustomToolUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
                 ),
             )
         )
+
+
+class _ClosingInterruptedCustomToolUpstreamWebSocket(_InterruptedCustomToolUpstreamWebSocket):
+    def __init__(self, response_id_prefix: str = "resp_bridge") -> None:
+        super().__init__(response_id_prefix, emit_added=True)
+
+    async def send_text(self, text: str) -> None:
+        await super().send_text(text)
+        await self._messages.put(_FakeUpstreamMessage("close", close_code=1000))
 
 
 class _ClosingBridgeUpstreamWebSocket(_FakeBridgeUpstreamWebSocket):
@@ -7025,7 +7060,7 @@ async def test_v1_responses_http_bridge_preserves_full_resend_before_fresh_bridg
         "http-bridge-preserve-fresh-reattach@example.com",
     )
     account = await _get_account(account_id)
-    first_upstream = _ClosingBridgeUpstreamWebSocket("resp_preserve_source")
+    first_upstream = _ClosingInterruptedCustomToolUpstreamWebSocket("resp_preserve_source")
     replay_upstream = _FakeBridgeUpstreamWebSocket("resp_preserve_replay")
     upstreams = [first_upstream, replay_upstream]
     connect_headers: list[dict[str, str]] = []
@@ -7078,15 +7113,15 @@ async def test_v1_responses_http_bridge_preserves_full_resend_before_fresh_bridg
     full_resend = [
         *historical_input,
         {
-            "type": "function_call",
-            "call_id": "call_1",
-            "name": "lookup",
-            "arguments": "{}",
+            "type": "custom_tool_call",
+            "call_id": "call_custom_shell",
+            "name": "shell",
+            "input": "pwd",
         },
         {
-            "type": "function_call_output",
-            "call_id": "call_1",
-            "output": "first result",
+            "type": "custom_tool_call_output",
+            "call_id": "call_custom_shell",
+            "output": "/workspace",
         },
     ]
     second = await asyncio.wait_for(

--- a/tests/integration/test_repositories.py
+++ b/tests/integration/test_repositories.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import timedelta
 
 import pytest
@@ -453,6 +454,13 @@ def _add_durable_bridge_session(session: AsyncSession, *, account_id: str, sessi
         latest_response_id=response_id,
         latest_input_item_count=3,
         latest_input_full_fingerprint="a" * 64,
+        latest_pending_tool_calls_json=json.dumps(
+            {
+                "response_id": response_id,
+                "calls": {"call_stale": "function_call"},
+            },
+            separators=(",", ":"),
+        ),
         last_seen_at=utcnow(),
     )
     session.add(record)
@@ -512,6 +520,7 @@ def _assert_bridge_session_closed_without_continuity(record: HttpBridgeSessionRe
     assert record.latest_response_id is None
     assert record.latest_input_item_count is None
     assert record.latest_input_full_fingerprint is None
+    assert record.latest_pending_tool_calls_json is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -1830,6 +1830,7 @@ async def test_durable_bridge_previous_response_records_completed_input_prefix(
         lease_ttl_seconds=60.0,
         input_item_count=3,
         input_full_fingerprint="a" * 64,
+        pending_tool_calls={"call_shell": "custom_tool_call", "call_lookup": "function_call"},
     )
 
     lookup = await coordinator.lookup_request_targets(
@@ -1845,6 +1846,63 @@ async def test_durable_bridge_previous_response_records_completed_input_prefix(
     assert lookup.latest_response_id == "resp_prefix"
     assert lookup.latest_input_item_count == 3
     assert lookup.latest_input_full_fingerprint == "a" * 64
+    assert lookup.latest_pending_tool_calls == {
+        "call_lookup": "function_call",
+        "call_shell": "custom_tool_call",
+    }
+
+
+@pytest.mark.asyncio
+async def test_durable_bridge_pending_tool_calls_are_bound_to_response_id(
+    coordinator: DurableBridgeSessionCoordinator,
+    async_session_factory: Callable[[], AsyncSession],
+) -> None:
+    claimed = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-manifest-response",
+        api_key_id=None,
+        instance_id="instance-a",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id=None,
+        allow_takeover=True,
+    )
+    await coordinator.register_previous_response_id(
+        session_id=claimed.session_id,
+        api_key_id=None,
+        instance_id="instance-a",
+        owner_epoch=claimed.owner_epoch,
+        response_id="resp_manifest_old",
+        lease_ttl_seconds=60.0,
+        input_item_count=1,
+        input_full_fingerprint="b" * 64,
+        pending_tool_calls={"call_old": "function_call"},
+    )
+
+    # Simulate a rolling-upgrade writer that predates the manifest column.
+    async with async_session_factory() as session:
+        await session.execute(
+            update(HttpBridgeSessionRecord)
+            .where(HttpBridgeSessionRecord.id == claimed.session_id)
+            .values(latest_response_id="resp_manifest_new")
+        )
+        await session.commit()
+
+    lookup = await coordinator.lookup_request_targets(
+        session_key_kind="session_header",
+        session_key_value="sid-manifest-response",
+        api_key_id=None,
+        turn_state=None,
+        session_header="sid-manifest-response",
+        previous_response_id=None,
+    )
+
+    assert lookup is not None
+    assert lookup.latest_response_id == "resp_manifest_new"
+    assert lookup.latest_pending_tool_calls is None
 
 
 @pytest.mark.asyncio
@@ -1879,6 +1937,7 @@ async def test_durable_bridge_takeover_with_account_change_clears_stale_aliases(
         owner_epoch=claimed.owner_epoch,
         response_id="resp_old",
         lease_ttl_seconds=60.0,
+        pending_tool_calls={"call_old": "function_call"},
     )
     await coordinator.release_live_session(
         session_id=claimed.session_id,
@@ -1904,6 +1963,7 @@ async def test_durable_bridge_takeover_with_account_change_clears_stale_aliases(
     assert reclaimed.owner_instance_id == "instance-b"
     assert reclaimed.latest_turn_state is None
     assert reclaimed.latest_response_id is None
+    assert reclaimed.latest_pending_tool_calls is None
 
     stale_by_turn_state = await coordinator.lookup_request_targets(
         session_key_kind="request",

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -39,6 +39,7 @@ from app.modules.proxy._service.http_bridge import helpers as http_bridge_helper
 from app.modules.proxy._service.http_bridge import mixin as http_bridge_mixin_module
 from app.modules.proxy._service.http_bridge import request_submit as http_bridge_request_submit_module
 from app.modules.proxy._service.http_bridge import streaming as http_bridge_streaming_module
+from app.modules.proxy._service.http_bridge import upstream_events as http_bridge_upstream_events_module
 from app.modules.proxy.account_cache import clear_account_routing_unavailable, mark_account_routing_unavailable
 from app.modules.proxy.continuity import (
     is_http_bridge_account_neutral_replay,
@@ -2299,6 +2300,154 @@ def test_http_error_status_from_payload_accepts_official_status_code_alias() -> 
     }
 
     assert proxy_service._http_error_status_from_payload(payload) == 400
+
+
+def test_durable_tool_call_manifest_requires_complete_added_and_done_lifecycle() -> None:
+    state = proxy_service._WebSocketRequestState(
+        request_id="req-manifest",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+    )
+
+    def record(event_type: str, call_id: str) -> None:
+        http_bridge_upstream_events_module._record_http_bridge_tool_call_lifecycle(
+            state,
+            event_type=event_type,
+            payload={
+                "type": event_type,
+                "item": {
+                    "type": "function_call",
+                    "call_id": call_id,
+                    "name": "lookup",
+                    "arguments": "{}",
+                },
+            },
+        )
+
+    record("response.output_item.added", "call_1")
+    record("response.output_item.added", "call_2")
+    record("response.output_item.done", "call_1")
+
+    assert (
+        http_bridge_upstream_events_module._durable_pending_tool_call_manifest(
+            state,
+            {"type": "response.completed", "response": {"output": []}},
+        )
+        is None
+    )
+
+    malformed_state = proxy_service._WebSocketRequestState(
+        request_id="req-malformed-manifest",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+    )
+    http_bridge_upstream_events_module._record_http_bridge_tool_call_lifecycle(
+        malformed_state,
+        event_type="response.output_item.added",
+        payload={
+            "type": "response.output_item.added",
+            "item": {"type": [], "call_id": "call_malformed"},
+        },
+    )
+    assert malformed_state.tool_call_manifest_invalid is True
+    assert (
+        http_bridge_upstream_events_module._durable_pending_tool_call_manifest(
+            malformed_state,
+            {"type": "response.completed", "response": {"output": [{"type": []}]}},
+        )
+        is None
+    )
+
+    record("response.output_item.done", "call_2")
+    assert http_bridge_upstream_events_module._durable_pending_tool_call_manifest(
+        state,
+        {"type": "response.completed", "response": {"output": []}},
+    ) == {"call_1": "function_call", "call_2": "function_call"}
+
+    duplicate_state = proxy_service._WebSocketRequestState(
+        request_id="req-duplicate-manifest",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+    )
+    duplicate_event: dict[str, proxy_service.JsonValue] = {
+        "type": "response.output_item.added",
+        "item": {
+            "type": "function_call",
+            "call_id": "call_duplicate",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+    }
+    http_bridge_upstream_events_module._record_http_bridge_tool_call_lifecycle(
+        duplicate_state,
+        event_type="response.output_item.added",
+        payload=duplicate_event,
+    )
+    http_bridge_upstream_events_module._record_http_bridge_tool_call_lifecycle(
+        duplicate_state,
+        event_type="response.output_item.added",
+        payload=duplicate_event,
+    )
+    assert duplicate_state.tool_call_manifest_invalid is True
+
+
+def test_durable_tool_call_manifest_rejects_unobserved_terminal_call() -> None:
+    state = proxy_service._WebSocketRequestState(
+        request_id="req-terminal-manifest",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+    )
+
+    assert (
+        http_bridge_upstream_events_module._durable_pending_tool_call_manifest(
+            state,
+            {
+                "type": "response.completed",
+                "response": {
+                    "output": [
+                        {
+                            "type": "function_call",
+                            "call_id": "call_unobserved",
+                            "name": "lookup",
+                            "arguments": "{}",
+                        }
+                    ]
+                },
+            },
+        )
+        is None
+    )
+
+    state.added_tool_call_types = {"call_duplicate": "function_call"}
+    state.pending_tool_call_types = {"call_duplicate": "function_call"}
+    duplicate_terminal_call: dict[str, proxy_service.JsonValue] = {
+        "type": "function_call",
+        "call_id": "call_duplicate",
+        "name": "lookup",
+        "arguments": "{}",
+    }
+    assert (
+        http_bridge_upstream_events_module._durable_pending_tool_call_manifest(
+            state,
+            {
+                "type": "response.completed",
+                "response": {"output": [duplicate_terminal_call, duplicate_terminal_call]},
+            },
+        )
+        is None
+    )
 
 
 @pytest.mark.asyncio
@@ -6355,19 +6504,60 @@ async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_
 
 
 @pytest.mark.asyncio
-async def test_stream_via_http_bridge_preserves_trimmable_full_resend_on_fresh_bridge(
+@pytest.mark.parametrize(
+    ("suffix_items", "pending_tool_calls", "preserves_full_resend"),
+    [
+        pytest.param(
+            [
+                {"role": "assistant", "content": "hello back"},
+                {"role": "user", "content": "follow up"},
+            ],
+            None,
+            True,
+            id="retained-assistant-output",
+        ),
+        pytest.param(
+            [
+                {
+                    "type": "function_call",
+                    "call_id": "call-1",
+                    "name": "lookup",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call-1",
+                    "output": "result",
+                },
+            ],
+            {"call-1": "function_call"},
+            True,
+            id="self-contained-tool-loop",
+        ),
+        pytest.param(
+            [{"role": "user", "content": "revise that answer"}],
+            None,
+            False,
+            id="missing-prior-output",
+        ),
+    ],
+)
+async def test_stream_via_http_bridge_preserves_only_safe_trimmable_full_resend_on_fresh_bridge(
     monkeypatch: pytest.MonkeyPatch,
+    suffix_items: list[proxy_service.JsonValue],
+    pending_tool_calls: dict[str, str] | None,
+    preserves_full_resend: bool,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
-    input_items = [
+    stored_input_items: list[proxy_service.JsonValue] = [
         {
             "type": "additional_tools",
             "role": "developer",
             "tools": [{"type": "custom", "name": "shell"}],
         },
         {"role": "user", "content": "hello"},
-        {"role": "user", "content": "follow up"},
     ]
+    input_items = [*stored_input_items, *suffix_items]
     payload = proxy_service.ResponsesRequest.model_validate(
         {
             "model": "gpt-5.4",
@@ -6422,6 +6612,7 @@ async def test_stream_via_http_bridge_preserves_trimmable_full_resend_on_fresh_b
             **kwargs,
         )
         prepared_frames.append(json.loads(text_data))
+        request_state.previous_response_id = prepared_payload.previous_response_id
         return request_state, text_data
 
     session = proxy_service._HTTPBridgeSession(
@@ -6477,10 +6668,9 @@ async def test_stream_via_http_bridge_preserves_trimmable_full_resend_on_fresh_b
                 state=HttpBridgeSessionState.ACTIVE,
                 latest_turn_state="http_turn_1",
                 latest_response_id="resp_latest",
-                latest_input_item_count=2,
-                latest_input_full_fingerprint=proxy_service._fingerprint_input_items(
-                    cast(list[Any], payload.input)[:2]
-                ),
+                latest_input_item_count=len(stored_input_items),
+                latest_input_full_fingerprint=proxy_service._fingerprint_input_items(stored_input_items),
+                latest_pending_tool_calls=pending_tool_calls,
             )
         ),
     )
@@ -6491,6 +6681,7 @@ async def test_stream_via_http_bridge_preserves_trimmable_full_resend_on_fresh_b
         account_neutral_classifier,
     )
     monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
+    monkeypatch.setattr(service, "_resolve_websocket_previous_response_owner", AsyncMock(return_value="acc-1"))
     get_or_create = AsyncMock(return_value=session)
     monkeypatch.setattr(service, "_get_or_create_http_bridge_session", get_or_create)
     monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
@@ -6515,13 +6706,19 @@ async def test_stream_via_http_bridge_preserves_trimmable_full_resend_on_fresh_b
     ]
 
     assert chunks == []
-    assert prepared_previous_response_ids == [None]
-    assert prepared_input_lengths == [3]
+    assert prepared_previous_response_ids == ([None] if preserves_full_resend else [None, "resp_latest", "resp_latest"])
+    assert prepared_input_lengths == (
+        [len(input_items)] if preserves_full_resend else [len(input_items), len(input_items), len(suffix_items)]
+    )
     assert all("tools" not in frame for frame in prepared_frames)
-    assert prepared_frames[-1]["input"] == input_items
+    normalized_input_items = cast(list[proxy_service.JsonValue], payload.input)
+    expected_input_items = (
+        normalized_input_items if preserves_full_resend else normalized_input_items[-len(suffix_items) :]
+    )
+    assert prepared_frames[-1]["input"] == expected_input_items
     assert [frame["client_metadata"][CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY] for frame in prepared_frames] == [
         "true",
-    ]
+    ] * len(prepared_frames)
     assert all(
         frame["reasoning"]
         == {
@@ -6535,9 +6732,9 @@ async def test_stream_via_http_bridge_preserves_trimmable_full_resend_on_fresh_b
     assert cast(dict[str, Any], payload.to_payload()["reasoning"])["context"] == "last_turn"
     creation = get_or_create.await_args
     assert creation is not None
-    assert creation.kwargs["previous_response_id"] is None
+    assert creation.kwargs["previous_response_id"] == (None if preserves_full_resend else "resp_latest")
     assert creation.kwargs["preferred_account_id"] == "acc-1"
-    assert session.last_completed_response_id is None
+    assert session.last_completed_response_id == (None if preserves_full_resend else "resp_latest")
     account_neutral_classifier.assert_not_called()
 
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -2414,6 +2414,30 @@ def test_durable_tool_call_manifest_requires_complete_added_and_done_lifecycle()
     )
     assert duplicate_state.tool_call_manifest_invalid is True
 
+    duplicate_done_state = proxy_service._WebSocketRequestState(
+        request_id="req-duplicate-done-manifest",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+    )
+    duplicate_done_event = {
+        **duplicate_event,
+        "type": "response.output_item.done",
+    }
+    for event_type, event_payload in (
+        ("response.output_item.added", duplicate_event),
+        ("response.output_item.done", duplicate_done_event),
+        ("response.output_item.done", duplicate_done_event),
+    ):
+        http_bridge_upstream_events_module._record_http_bridge_tool_call_lifecycle(
+            duplicate_done_state,
+            event_type=event_type,
+            payload=event_payload,
+        )
+    assert duplicate_done_state.tool_call_manifest_invalid is True
+
 
 def test_durable_tool_call_manifest_rejects_unobserved_terminal_call() -> None:
     state = proxy_service._WebSocketRequestState(
@@ -2463,6 +2487,70 @@ def test_durable_tool_call_manifest_rejects_unobserved_terminal_call() -> None:
         )
         is None
     )
+
+
+def test_durable_tool_call_manifest_rejects_mixed_client_settled_call_types() -> None:
+    state = proxy_service._WebSocketRequestState(
+        request_id="req-mixed-client-settled-manifest",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+    )
+    function_item: dict[str, proxy_service.JsonValue] = {
+        "type": "function_call",
+        "call_id": "call_function",
+        "name": "lookup",
+        "arguments": "{}",
+    }
+    for event_type in ("response.output_item.added", "response.output_item.done"):
+        http_bridge_upstream_events_module._record_http_bridge_tool_call_lifecycle(
+            state,
+            event_type=event_type,
+            payload={"type": event_type, "item": function_item},
+        )
+
+    assert (
+        http_bridge_upstream_events_module._durable_pending_tool_call_manifest(
+            state,
+            {
+                "type": "response.completed",
+                "response": {
+                    "output": [
+                        function_item,
+                        {
+                            "type": "computer_call",
+                            "call_id": "call_computer",
+                            "action": {"type": "screenshot"},
+                        },
+                    ]
+                },
+            },
+        )
+        is None
+    )
+
+    lifecycle_state = proxy_service._WebSocketRequestState(
+        request_id="req-unsupported-lifecycle-manifest",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+    )
+    http_bridge_upstream_events_module._record_http_bridge_tool_call_lifecycle(
+        lifecycle_state,
+        event_type="response.output_item.added",
+        payload={
+            "type": "response.output_item.added",
+            "item": {
+                "type": "mcp_approval_request",
+                "id": "approval_1",
+            },
+        },
+    )
+    assert lifecycle_state.tool_call_manifest_invalid is True
 
 
 @pytest.mark.asyncio
@@ -6611,6 +6699,24 @@ async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_
             {"call-1": "function_call"},
             True,
             id="self-contained-tool-loop",
+        ),
+        pytest.param(
+            [
+                {
+                    "type": "function_call",
+                    "call_id": "call-1",
+                    "name": "lookup",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call-1",
+                    "output": "result",
+                },
+            ],
+            None,
+            False,
+            id="tool-loop-with-unknown-manifest",
         ),
         pytest.param(
             [{"role": "user", "content": "revise that answer"}],

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -6355,7 +6355,7 @@ async def test_stream_via_http_bridge_does_not_inject_durable_previous_response_
 
 
 @pytest.mark.asyncio
-async def test_stream_via_http_bridge_injects_durable_anchor_for_trimmable_full_resend(
+async def test_stream_via_http_bridge_preserves_trimmable_full_resend_on_fresh_bridge(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
@@ -6491,7 +6491,8 @@ async def test_stream_via_http_bridge_injects_durable_anchor_for_trimmable_full_
         account_neutral_classifier,
     )
     monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
-    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", AsyncMock(return_value=session))
+    get_or_create = AsyncMock(return_value=session)
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", get_or_create)
     monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock())
     monkeypatch.setattr(service, "_detach_http_bridge_request", AsyncMock())
 
@@ -6514,13 +6515,11 @@ async def test_stream_via_http_bridge_injects_durable_anchor_for_trimmable_full_
     ]
 
     assert chunks == []
-    assert prepared_previous_response_ids == [None, "resp_latest", "resp_latest"]
-    assert prepared_input_lengths == [3, 3, 1]
+    assert prepared_previous_response_ids == [None]
+    assert prepared_input_lengths == [3]
     assert all("tools" not in frame for frame in prepared_frames)
-    assert prepared_frames[-1]["input"] == [input_items[-1]]
+    assert prepared_frames[-1]["input"] == input_items
     assert [frame["client_metadata"][CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY] for frame in prepared_frames] == [
-        "true",
-        "true",
         "true",
     ]
     assert all(
@@ -6534,6 +6533,11 @@ async def test_stream_via_http_bridge_injects_durable_anchor_for_trimmable_full_
         for frame in prepared_frames
     )
     assert cast(dict[str, Any], payload.to_payload()["reasoning"])["context"] == "last_turn"
+    creation = get_or_create.await_args
+    assert creation is not None
+    assert creation.kwargs["previous_response_id"] is None
+    assert creation.kwargs["preferred_account_id"] == "acc-1"
+    assert session.last_completed_response_id is None
     account_neutral_classifier.assert_not_called()
 
 
@@ -7714,7 +7718,7 @@ async def test_stream_via_http_bridge_proves_fallback_owner_key_before_legacy_fo
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("forward_to_active_owner", [False, True], ids=["local_create", "owner_forward"])
-async def test_stream_via_http_bridge_clears_injected_anchor_after_owner_unavailable_fresh_resend(
+async def test_stream_via_http_bridge_replays_unanchored_full_resend_after_owner_unavailable(
     monkeypatch: pytest.MonkeyPatch,
     forward_to_active_owner: bool,
 ) -> None:
@@ -7887,7 +7891,7 @@ async def test_stream_via_http_bridge_clears_injected_anchor_after_owner_unavail
         assert prepared_previous_response_ids == [None, None, None]
         assert forwarded_payloads == [payload]
     else:
-        assert prepared_previous_response_ids[-2:] == ["resp_latest", None]
+        assert prepared_previous_response_ids == [None, None]
         assert forwarded_payloads == []
     assert get_or_create_kwargs[-1]["allow_forward_to_owner"] is False
     assert get_or_create_kwargs[-1]["exclude_account_ids"] == {"acc-1"}
@@ -16733,7 +16737,7 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
     first_call = get_or_create.await_args_list[0]
     second_call = get_or_create.await_args_list[1]
     third_call = get_or_create.await_args_list[2]
-    assert first_call.kwargs["previous_response_id"] == ("resp_completed_anchor" if stored_model is None else None)
+    assert first_call.kwargs["previous_response_id"] is None
     assert first_call.kwargs["preferred_account_id"] == "acc-owner"
     assert first_call.kwargs["allow_forward_to_owner"] is True
     assert second_call.kwargs["previous_response_id"] is None

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -2356,6 +2356,21 @@ def test_durable_tool_call_manifest_requires_complete_added_and_done_lifecycle()
         },
     )
     assert malformed_state.tool_call_manifest_invalid is True
+
+    missing_item_state = proxy_service._WebSocketRequestState(
+        request_id="req-missing-item-manifest",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+    )
+    http_bridge_upstream_events_module._record_http_bridge_tool_call_lifecycle(
+        missing_item_state,
+        event_type="response.output_item.done",
+        payload={"type": "response.output_item.done"},
+    )
+    assert missing_item_state.tool_call_manifest_invalid is True
     assert (
         http_bridge_upstream_events_module._durable_pending_tool_call_manifest(
             malformed_state,
@@ -2448,6 +2463,69 @@ def test_durable_tool_call_manifest_rejects_unobserved_terminal_call() -> None:
         )
         is None
     )
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_malformed_tool_lifecycle_persists_unknown_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    register_previous = AsyncMock(return_value=True)
+    monkeypatch.setattr(service, "_register_http_bridge_previous_response_id", register_previous)
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", AsyncMock())
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-malformed-lifecycle",
+        response_id="resp_malformed_lifecycle",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        transport="http",
+        skip_request_log=True,
+    )
+    session = _make_bridge_session(
+        key_value="bridge-malformed-lifecycle",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+    valid_item = {
+        "type": "function_call",
+        "call_id": "call_1",
+        "name": "lookup",
+        "arguments": "{}",
+    }
+
+    for event in (
+        {
+            "type": "response.output_item.added",
+            "response_id": "resp_malformed_lifecycle",
+            "item": valid_item,
+        },
+        {
+            "type": "response.output_item.done",
+            "response_id": "resp_malformed_lifecycle",
+            "item": valid_item,
+        },
+        {
+            "type": "response.output_item.added",
+            "response_id": "resp_malformed_lifecycle",
+        },
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_malformed_lifecycle",
+                "object": "response",
+                "status": "completed",
+                "output": [],
+            },
+        },
+    ):
+        await service._process_http_bridge_upstream_text(session, json.dumps(event, separators=(",", ":")))
+
+    registration = register_previous.await_args
+    assert registration is not None
+    assert registration.kwargs["pending_tool_calls"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_replay_safety.py
+++ b/tests/unit/test_replay_safety.py
@@ -10,6 +10,7 @@ from app.modules.proxy.continuity import (
 )
 from app.modules.proxy.replay_safety import (
     project_responses_input_for_account_neutral_fresh_replay,
+    responses_input_suffix_matches_pending_tool_calls,
     responses_input_suffix_retains_prior_output,
     responses_payload_is_account_neutral_fresh_replay,
 )
@@ -587,6 +588,143 @@ def test_full_resend_suffix_rejects_missing_or_misordered_context(
         responses_input_suffix_retains_prior_output(
             [*stored_input, *suffix],
             stored_count=len(stored_input),
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize(
+    ("suffix", "pending_tool_calls", "expected"),
+    [
+        pytest.param(
+            [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "lookup",
+                    "arguments": "{}",
+                },
+                {"type": "function_call_output", "call_id": "call_1", "output": "result"},
+            ],
+            {"call_1": "function_call"},
+            True,
+            id="complete-tool-loop",
+        ),
+        pytest.param(
+            [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "lookup",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "custom_tool_call",
+                    "call_id": "call_2",
+                    "name": "shell",
+                    "input": "pwd",
+                },
+                {"type": "function_call_output", "call_id": "call_1", "output": "result"},
+                {"type": "custom_tool_call_output", "call_id": "call_2", "output": "/workspace"},
+            ],
+            {"call_1": "function_call", "call_2": "custom_tool_call"},
+            True,
+            id="complete-parallel-tool-loop",
+        ),
+        pytest.param(
+            [{"role": "user", "content": "revise that answer"}],
+            {"call_1": "function_call"},
+            False,
+            id="missing-output",
+        ),
+        pytest.param(
+            [{"type": [], "call_id": "call_1"}],
+            {"call_1": "function_call"},
+            False,
+            id="malformed-item-type",
+        ),
+        pytest.param(
+            [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "lookup",
+                    "arguments": "{}",
+                }
+            ],
+            {"call_1": "function_call"},
+            False,
+            id="unsettled-call",
+        ),
+        pytest.param(
+            [{"type": "function_call_output", "call_id": "call_1", "output": "orphan"}],
+            {"call_1": "function_call"},
+            False,
+            id="orphan-output",
+        ),
+        pytest.param(
+            [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "lookup",
+                    "arguments": "{}",
+                },
+                {"type": "function_call_output", "call_id": "call_1", "output": "partial"},
+            ],
+            {"call_1": "function_call", "call_2": "function_call"},
+            False,
+            id="omitted-parallel-call",
+        ),
+    ],
+)
+def test_full_resend_suffix_accepts_only_self_contained_tool_loops(
+    suffix: list[JsonValue],
+    pending_tool_calls: dict[str, str],
+    expected: bool,
+) -> None:
+    stored_input: list[JsonValue] = [{"role": "user", "content": "first question"}]
+    projection = project_responses_input_for_account_neutral_fresh_replay(
+        [*stored_input, *suffix],
+        stored_count=len(stored_input),
+    )
+
+    assert projection is not None
+    assert (
+        responses_input_suffix_matches_pending_tool_calls(
+            projection.input_items,
+            stored_count=projection.stored_prefix_count,
+            pending_tool_calls=pending_tool_calls,
+        )
+        is expected
+    )
+
+
+def test_full_resend_tool_loop_manifest_rejects_call_id_reused_from_stored_prefix() -> None:
+    stored_input: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "lookup",
+            "arguments": "{}",
+        },
+        {"type": "function_call_output", "call_id": "call_1", "output": "old"},
+    ]
+    suffix: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "lookup_again",
+            "arguments": "{}",
+        },
+        {"type": "function_call_output", "call_id": "call_1", "output": "new"},
+    ]
+
+    assert (
+        responses_input_suffix_matches_pending_tool_calls(
+            [*stored_input, *suffix],
+            stored_count=len(stored_input),
+            pending_tool_calls={"call_1": "function_call"},
         )
         is False
     )


### PR DESCRIPTION
## Summary

Preserve a client-unanchored full resend when a hard durable HTTP bridge must open a fresh upstream WebSocket and the request proves it exactly settles the response-bound direct-tool manifest. Ordinary cumulative input remains anchored.

This fixes the production tool-loop failure in #1485, where ownership loss caused the complete resend to be prefix-trimmed and replayed with an injected durable anchor. Upstream emitted no first event, and the request ended as `missing_response_created_timeout` after about 240 seconds.

Supersedes #1486 because that PR's cross-fork head could not be updated by this account despite `maintainerCanModify=true`. This branch preserves all commits and authorship from @e1ektr0 and adds the independently audited fail-closed follow-up from `83d31b36`.

Fixes #1485. Related to #1393 and #1486.

## OpenSpec

- [x] Includes `openspec/changes/preserve-fresh-bridge-full-resends/`
- [x] Preserves the codex-faithful upstream-equivalent path
- [x] Strict change validation and all-spec validation pass

## Changes

- Persist a response-ID-bound manifest of prior direct tool calls with the durable bridge alias.
- Preserve a complete client resend only when its suffix exactly settles that manifest.
- Keep ordinary cumulative prompts anchored unless prior assistant output is retained.
- Fail closed for legacy/malformed state, incomplete or duplicate lifecycle events, omitted parallel calls, unknown call types, mixed unsupported `computer_call` / `mcp_approval_request` output, prefix call-ID reuse, and rolling-upgrade response mismatches.
- Clear the manifest together with response/prefix continuity during account invalidation.
- Add the nullable `http_bridge_sessions.latest_pending_tool_calls_json` migration; unknown historical rows remain anchored, so no backfill is required.
- Add public HTTP bridge, durable repository, replay-safety, lifecycle, account-invalidation, and owner-loss regressions.

## Simplicity

- [x] Zero configuration
- [x] No new setting, dependency, endpoint, response schema, dashboard surface, README section, `.env.example` entry, or navigation item
- [x] One proxy continuity concern despite the migration and externally failing route coverage

## Verification on exact head `83d31b36`

- 575 focused bridge/replay/durable unit tests passed.
- 108 public HTTP bridge integration tests passed.
- Both account-invalidation integration regressions passed.
- Migration suite: 34 passed; 5 PostgreSQL-only cases skipped locally and delegated to GitHub CI.
- Ruff, format, changed-file Ty, proxy architecture, strict OpenSpec change validation, and all 47 specs passed.
- Three independent lifecycle, migration, and spec/test reviews found no remaining issue.

Controlled owner-loss runtime proof persisted a response-bound one-call manifest on replica A, killed A, allowed its lease to expire, and sent the complete resend to fresh replica B. Replica B logged `fresh_reattach_full_resend_preserved` and returned `200 OK` with exact `OK` text in 2.6 seconds. The timeout count remained at 28 with zero new occurrences.

The deployed runtime subsequently recorded 196 successes, one cancellation, zero new `missing_response_created_timeout` events, green live/ready health, and zero restarts.

## Merge gates

- [ ] Current-head GitHub CI, including PostgreSQL migration coverage
- [ ] Current-head `@codex review`
- [ ] `mergeable=CLEAN`
- [ ] Maintainer merge; this PR will not be self-merged
