### PR TITLE
feat (report-ui): ability to set chart visibility

### DIFF
--- a/frontend/src/features/reports/components/reports-filters.test.tsx
+++ b/frontend/src/features/reports/components/reports-filters.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ReportsFilters, type ReportsFiltersState } from "./reports-filters";
+import { REPORT_CHART_DEFINITIONS } from "../hooks/use-report-chart-visibility";
 
 const FILTERS: ReportsFiltersState = {
   startDate: "2026-06-01",
@@ -11,6 +12,15 @@ const FILTERS: ReportsFiltersState = {
   model: "",
   useragent: "",
 };
+
+const ALL_CHART_IDS = REPORT_CHART_DEFINITIONS.map(({ id }) => id);
+const ALL_CHART_LABELS = [
+  "Cost by Day",
+  "Tokens by Day",
+  "Time to First Token",
+  "Tokens per Second",
+  "Queue Wait",
+];
 
 describe("ReportsFilters", () => {
   afterEach(() => {
@@ -27,6 +37,8 @@ describe("ReportsFilters", () => {
         accountOptions={[{ value: "acc_one", label: "Primary account", isEmail: false }]}
         modelOptions={[]}
         useragentOptions={[]}
+        visibleChartIds={ALL_CHART_IDS}
+        onVisibleChartIdsChange={vi.fn()}
         onPresetSelect={vi.fn()}
         onFiltersChange={onFiltersChange}
       />,
@@ -51,6 +63,8 @@ describe("ReportsFilters", () => {
           { value: "gpt-5.2", label: "gpt-5.2" },
         ]}
         useragentOptions={[]}
+        visibleChartIds={ALL_CHART_IDS}
+        onVisibleChartIdsChange={vi.fn()}
         onPresetSelect={vi.fn()}
         onFiltersChange={onFiltersChange}
       />,
@@ -78,6 +92,8 @@ describe("ReportsFilters", () => {
           { value: "CLI", label: "CLI" },
           { value: "SDK", label: "SDK" },
         ]}
+        visibleChartIds={ALL_CHART_IDS}
+        onVisibleChartIdsChange={vi.fn()}
         onPresetSelect={vi.fn()}
         onFiltersChange={onFiltersChange}
       />,
@@ -103,6 +119,8 @@ describe("ReportsFilters", () => {
         accountOptions={[]}
         modelOptions={[]}
         useragentOptions={[]}
+        visibleChartIds={ALL_CHART_IDS}
+        onVisibleChartIdsChange={vi.fn()}
         onPresetSelect={onPresetSelect}
         onFiltersChange={onFiltersChange}
       />,
@@ -132,6 +150,8 @@ describe("ReportsFilters", () => {
         accountOptions={[]}
         modelOptions={[]}
         useragentOptions={[]}
+        visibleChartIds={ALL_CHART_IDS}
+        onVisibleChartIdsChange={vi.fn()}
         onPresetSelect={vi.fn()}
         onFiltersChange={vi.fn()}
       />,
@@ -155,6 +175,8 @@ describe("ReportsFilters", () => {
         accountOptions={[]}
         modelOptions={[]}
         useragentOptions={[]}
+        visibleChartIds={ALL_CHART_IDS}
+        onVisibleChartIdsChange={vi.fn()}
         onPresetSelect={vi.fn()}
         onFiltersChange={vi.fn()}
       />,
@@ -172,6 +194,8 @@ describe("ReportsFilters", () => {
         accountOptions={[]}
         modelOptions={[]}
         useragentOptions={[]}
+        visibleChartIds={ALL_CHART_IDS}
+        onVisibleChartIdsChange={vi.fn()}
         onPresetSelect={vi.fn()}
         onFiltersChange={vi.fn()}
       />,
@@ -187,5 +211,118 @@ describe("ReportsFilters", () => {
     expect(dateInputs[0]).toHaveAttribute("aria-describedby", descriptionId);
     expect(dateInputs[1]).toHaveAttribute("aria-describedby", descriptionId);
     expect(message).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("summarizes the default chart selection", () => {
+    render(
+      <ReportsFilters
+        filters={FILTERS}
+        selectedPresetDays={7}
+        accountOptions={[]}
+        modelOptions={[]}
+        useragentOptions={[]}
+        visibleChartIds={ALL_CHART_IDS}
+        onVisibleChartIdsChange={vi.fn()}
+        onPresetSelect={vi.fn()}
+        onFiltersChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Charts (5)" })).toBeInTheDocument();
+  });
+
+  it("places the chart selector before the start date", () => {
+    const { container } = render(
+      <ReportsFilters
+        filters={FILTERS}
+        selectedPresetDays={7}
+        accountOptions={[]}
+        modelOptions={[]}
+        useragentOptions={[]}
+        visibleChartIds={ALL_CHART_IDS}
+        onVisibleChartIdsChange={vi.fn()}
+        onPresetSelect={vi.fn()}
+        onFiltersChange={vi.fn()}
+      />,
+    );
+
+    const chartButton = screen.getByRole("button", { name: "Charts (5)" });
+    const startDate = container.querySelector('input[name="report-start-date"]');
+
+    expect(startDate).not.toBeNull();
+    expect(chartButton.compareDocumentPosition(startDate!)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
+  it("exposes chart options in canonical order", async () => {
+    const user = userEvent.setup();
+    render(
+      <ReportsFilters
+        filters={FILTERS}
+        selectedPresetDays={7}
+        accountOptions={[]}
+        modelOptions={[]}
+        useragentOptions={[]}
+        visibleChartIds={ALL_CHART_IDS}
+        onVisibleChartIdsChange={vi.fn()}
+        onPresetSelect={vi.fn()}
+        onFiltersChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Charts (5)" }));
+
+    expect(screen.getAllByRole("menuitemcheckbox").map((item) => item.textContent)).toEqual(
+      ALL_CHART_LABELS,
+    );
+  });
+
+  it("returns the other four chart IDs when Queue Wait is toggled off", async () => {
+    const user = userEvent.setup();
+    const onVisibleChartIdsChange = vi.fn();
+    render(
+      <ReportsFilters
+        filters={FILTERS}
+        selectedPresetDays={7}
+        accountOptions={[]}
+        modelOptions={[]}
+        useragentOptions={[]}
+        visibleChartIds={ALL_CHART_IDS}
+        onVisibleChartIdsChange={onVisibleChartIdsChange}
+        onPresetSelect={vi.fn()}
+        onFiltersChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Charts (5)" }));
+    await user.click(screen.getByRole("menuitemcheckbox", { name: "Queue Wait" }));
+
+    expect(onVisibleChartIdsChange).toHaveBeenCalledWith(
+      ALL_CHART_IDS.filter((id) => id !== "queueWait"),
+    );
+  });
+
+  it("keeps all chart options available when the selection is empty", async () => {
+    const user = userEvent.setup();
+    render(
+      <ReportsFilters
+        filters={FILTERS}
+        selectedPresetDays={7}
+        accountOptions={[]}
+        modelOptions={[]}
+        useragentOptions={[]}
+        visibleChartIds={[]}
+        onVisibleChartIdsChange={vi.fn()}
+        onPresetSelect={vi.fn()}
+        onFiltersChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Charts" }));
+
+    expect(screen.getAllByRole("menuitemcheckbox").map((item) => item.textContent)).toEqual(
+      ALL_CHART_LABELS,
+    );
   });
 });

--- a/frontend/src/features/reports/components/reports-filters.tsx
+++ b/frontend/src/features/reports/components/reports-filters.tsx
@@ -6,6 +6,10 @@ import {
   type MultiSelectOption,
 } from "@/features/dashboard/components/filters/multi-select-filter";
 import { isReportDateRangeValid, localDateISO } from "../date";
+import {
+  REPORT_CHART_DEFINITIONS,
+  type ReportChartId,
+} from "../hooks/use-report-chart-visibility";
 
 export type ReportsFiltersState = {
   startDate: string;
@@ -21,8 +25,10 @@ export type ReportsFiltersProps = {
   accountOptions: MultiSelectOption[];
   modelOptions: MultiSelectOption[];
   useragentOptions: MultiSelectOption[];
+  visibleChartIds: ReportChartId[];
   onPresetSelect: (days: number) => void;
   onFiltersChange: (filters: ReportsFiltersState) => void;
+  onVisibleChartIdsChange: (ids: string[]) => void;
 };
 
 const PRESETS = [
@@ -37,10 +43,16 @@ export function ReportsFilters({
   accountOptions,
   modelOptions,
   useragentOptions,
+  visibleChartIds,
   onPresetSelect,
   onFiltersChange,
+  onVisibleChartIdsChange,
 }: ReportsFiltersProps) {
   const { t } = useTranslation();
+  const chartOptions = REPORT_CHART_DEFINITIONS.map(({ id, labelKey }) => ({
+    value: id,
+    label: t(labelKey),
+  }));
   const maxDate = localDateISO();
   const dateRangeErrorId = useId();
   const isDateRangeInvalid = !isReportDateRangeValid(
@@ -89,6 +101,13 @@ export function ReportsFilters({
         onChange={(useragents) =>
           onFiltersChange({ ...filters, useragent: useragents.at(-1) ?? "" })
         }
+      />
+
+      <MultiSelectFilter
+        label={t("reports.filters.charts")}
+        values={visibleChartIds}
+        options={chartOptions}
+        onChange={onVisibleChartIdsChange}
       />
 
       <div className="ml-auto flex flex-col items-end gap-1">

--- a/frontend/src/features/reports/components/reports-page.test.tsx
+++ b/frontend/src/features/reports/components/reports-page.test.tsx
@@ -8,6 +8,7 @@ import type { ReportsResponse } from "@/features/reports/schemas";
 import { listAccounts } from "@/features/accounts/api";
 import { getBrowserReportsTimeZone } from "@/features/reports/date";
 import { useReports } from "@/features/reports/hooks/use-reports";
+import { REPORT_CHART_VISIBILITY_STORAGE_KEY } from "@/features/reports/hooks/use-report-chart-visibility";
 import { ReportsPage } from "./reports-page";
 
 vi.mock("@/features/accounts/api", () => ({
@@ -527,6 +528,148 @@ describe("ReportsPage", () => {
     const useragentCard = await screen.findByText("Distribution by UserAgent");
 
     expect(modelCard.compareDocumentPosition(useragentCard)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it("renders a saved chart subset without changing reports query inputs", async () => {
+    window.localStorage.setItem(
+      REPORT_CHART_VISIBILITY_STORAGE_KEY,
+      JSON.stringify(["costByDay"]),
+    );
+    useReportsMock.mockReturnValue(
+      asUseReportsResult({
+        data: EMPTY_REPORT,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    );
+
+    renderWithProviders(<ReportsPage />);
+
+    expect(
+      await screen.findByText("Cost by Day", {
+        selector: "div.text-sm.font-semibold.text-foreground",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Tokens by Day")).not.toBeInTheDocument();
+    expect(screen.queryByText("Time to First Token")).not.toBeInTheDocument();
+    expect(screen.queryByText("Tokens per Second")).not.toBeInTheDocument();
+    expect(screen.queryByText("Queue Wait")).not.toBeInTheDocument();
+    expect(screen.getByText("Total Cost")).toBeInTheDocument();
+    expect(screen.getByText("Distribution by Model")).toBeInTheDocument();
+    expect(screen.getByText("Daily Breakdown")).toBeInTheDocument();
+
+    for (const [filters] of useReportsMock.mock.calls) {
+      expect(filters).not.toHaveProperty("visibleChartIds");
+    }
+  });
+
+  it("renders all five line charts by default", async () => {
+    useReportsMock.mockReturnValue(
+      asUseReportsResult({
+        data: EMPTY_REPORT,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    );
+
+    renderWithProviders(<ReportsPage />);
+
+    for (const heading of [
+      "Cost by Day",
+      "Tokens by Day",
+      "Time to First Token",
+      "Tokens per Second",
+      "Queue Wait",
+    ]) {
+      expect(await screen.findByText(heading)).toBeInTheDocument();
+    }
+  });
+
+  it("renders the selected Cost by Day and Queue Wait charts", async () => {
+    window.localStorage.setItem(
+      REPORT_CHART_VISIBILITY_STORAGE_KEY,
+      JSON.stringify(["queueWait", "costByDay"]),
+    );
+    useReportsMock.mockReturnValue(
+      asUseReportsResult({
+        data: EMPTY_REPORT,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    );
+
+    renderWithProviders(<ReportsPage />);
+
+    expect(await screen.findByText("Cost by Day")).toBeInTheDocument();
+    expect(await screen.findByText("Queue Wait")).toBeInTheDocument();
+    expect(screen.queryByText("Tokens by Day")).not.toBeInTheDocument();
+    expect(screen.queryByText("Time to First Token")).not.toBeInTheDocument();
+    expect(screen.queryByText("Tokens per Second")).not.toBeInTheDocument();
+  });
+
+  it("keeps summaries and non-line charts when every line chart is hidden", async () => {
+    const user = userEvent.setup();
+    useReportsMock.mockReturnValue(
+      asUseReportsResult({
+        data: EMPTY_REPORT,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    );
+
+    renderWithProviders(<ReportsPage />);
+
+    await user.click(screen.getByRole("button", { name: "Charts (5)" }));
+    for (const chartOption of screen.getAllByRole("menuitemcheckbox")) {
+      await user.click(chartOption);
+    }
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByText("Cost by Day")).not.toBeInTheDocument();
+    expect(screen.queryByText("Tokens by Day")).not.toBeInTheDocument();
+    expect(screen.queryByText("Time to First Token")).not.toBeInTheDocument();
+    expect(screen.queryByText("Tokens per Second")).not.toBeInTheDocument();
+    expect(screen.queryByText("Queue Wait")).not.toBeInTheDocument();
+    expect(screen.getByText("Total Cost")).toBeInTheDocument();
+    expect(screen.getByText("Distribution by Model")).toBeInTheDocument();
+    expect(screen.getByText("Distribution by UserAgent")).toBeInTheDocument();
+    expect(screen.getByText("Daily Breakdown")).toBeInTheDocument();
+    expect(window.localStorage.getItem(REPORT_CHART_VISIBILITY_STORAGE_KEY)).toBe(
+      JSON.stringify([]),
+    );
+  });
+
+  it("does not change reports query calls when chart visibility changes", async () => {
+    const user = userEvent.setup();
+    useReportsMock.mockReturnValue(
+      asUseReportsResult({
+        data: EMPTY_REPORT,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    );
+
+    renderWithProviders(
+      <ReportsPage initialFilters={{ model: "gpt-5.1", useragent: "CLI" }} />,
+    );
+
+    await screen.findByText("Cost by Day");
+    const callCountBeforeToggle = useReportsMock.mock.calls.length;
+    const callsBeforeToggle = useReportsMock.mock.calls.slice(-2).map(
+      ([filters, timeZone]) => [filters, timeZone],
+    );
+    await user.click(screen.getByRole("button", { name: "Charts (5)" }));
+    await user.click(
+      screen.getByRole("menuitemcheckbox", { name: "Queue Wait" }),
+    );
+
+    expect(useReportsMock.mock.calls.length).toBeGreaterThan(callCountBeforeToggle);
+    expect(useReportsMock.mock.calls.slice(-2)).toEqual(callsBeforeToggle);
   });
 
   it("keeps the model and user-agent metric toggles independent", async () => {

--- a/frontend/src/features/reports/components/reports-page.tsx
+++ b/frontend/src/features/reports/components/reports-page.tsx
@@ -6,6 +6,7 @@ import { AlertMessage } from "@/components/alert-message";
 import { Button } from "@/components/ui/button";
 import { listAccounts } from "@/features/accounts/api";
 import { useReports } from "@/features/reports/hooks/use-reports";
+import { useReportChartVisibility } from "@/features/reports/hooks/use-report-chart-visibility";
 import { getErrorMessageOrNull } from "@/utils/errors";
 import { ReportsFilters, type ReportsFiltersState } from "./reports-filters";
 import { ReportsSummaryCards } from "./reports-summary-cards";
@@ -89,6 +90,7 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
   const [reportsTimeZone, setReportsTimeZone] = useState<string | undefined>(() =>
     getBrowserReportsTimeZone(),
   );
+  const { visibleChartIds, setVisibleChartIds } = useReportChartVisibility();
 
   useEffect(() => {
     const refreshReportsTimeZone = () => {
@@ -217,8 +219,10 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
         accountOptions={accountOptions}
         modelOptions={modelOptions}
         useragentOptions={useragentOptions}
+        visibleChartIds={visibleChartIds}
         onPresetSelect={handlePresetSelect}
         onFiltersChange={handleFiltersChange}
+        onVisibleChartIdsChange={setVisibleChartIds}
       />
 
       {mainReportsError ? (
@@ -247,43 +251,55 @@ export function ReportsPage({ initialFilters }: ReportsPageProps = {}) {
             summary={reportsQuery.data.summary}
             comparison={reportsQuery.data.comparison}
           />
-          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-            <Suspense fallback={<div className="h-[270px] rounded-xl border bg-card" />}>
-              <CostPerDayChart
-                startDate={filters.startDate}
-                endDate={filters.endDate}
-                data={reportsQuery.data.daily}
-              />
-            </Suspense>
-            <Suspense fallback={<div className="h-[270px] rounded-xl border bg-card" />}>
-              <TokensPerDayChart
-                startDate={filters.startDate}
-                endDate={filters.endDate}
-                data={reportsQuery.data.daily}
-              />
-            </Suspense>
-            <Suspense fallback={<div className="h-[270px] rounded-xl border bg-card" />}>
-              <TimeToFirstTokenChart
-                startDate={filters.startDate}
-                endDate={filters.endDate}
-                data={reportsQuery.data.daily}
-              />
-            </Suspense>
-            <Suspense fallback={<div className="h-[270px] rounded-xl border bg-card" />}>
-              <TokensPerSecondChart
-                startDate={filters.startDate}
-                endDate={filters.endDate}
-                data={reportsQuery.data.daily}
-              />
-            </Suspense>
-            <Suspense fallback={<div className="h-[270px] rounded-xl border bg-card" />}>
-              <QueueWaitChart
-                startDate={filters.startDate}
-                endDate={filters.endDate}
-                data={reportsQuery.data.daily}
-              />
-            </Suspense>
-          </div>
+          {visibleChartIds.length > 0 ? (
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+              {visibleChartIds.includes("costByDay") ? (
+                <Suspense fallback={<div className="h-[270px] rounded-xl border bg-card" />}>
+                  <CostPerDayChart
+                    startDate={filters.startDate}
+                    endDate={filters.endDate}
+                    data={reportsQuery.data.daily}
+                  />
+                </Suspense>
+              ) : null}
+              {visibleChartIds.includes("tokensByDay") ? (
+                <Suspense fallback={<div className="h-[270px] rounded-xl border bg-card" />}>
+                  <TokensPerDayChart
+                    startDate={filters.startDate}
+                    endDate={filters.endDate}
+                    data={reportsQuery.data.daily}
+                  />
+                </Suspense>
+              ) : null}
+              {visibleChartIds.includes("timeToFirstToken") ? (
+                <Suspense fallback={<div className="h-[270px] rounded-xl border bg-card" />}>
+                  <TimeToFirstTokenChart
+                    startDate={filters.startDate}
+                    endDate={filters.endDate}
+                    data={reportsQuery.data.daily}
+                  />
+                </Suspense>
+              ) : null}
+              {visibleChartIds.includes("tokensPerSecond") ? (
+                <Suspense fallback={<div className="h-[270px] rounded-xl border bg-card" />}>
+                  <TokensPerSecondChart
+                    startDate={filters.startDate}
+                    endDate={filters.endDate}
+                    data={reportsQuery.data.daily}
+                  />
+                </Suspense>
+              ) : null}
+              {visibleChartIds.includes("queueWait") ? (
+                <Suspense fallback={<div className="h-[270px] rounded-xl border bg-card" />}>
+                  <QueueWaitChart
+                    startDate={filters.startDate}
+                    endDate={filters.endDate}
+                    data={reportsQuery.data.daily}
+                  />
+                </Suspense>
+              ) : null}
+            </div>
+          ) : null}
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
             <div className="space-y-4 lg:col-span-1">
               <Suspense fallback={<div className="h-[220px] rounded-xl border bg-card" />}>

--- a/frontend/src/features/reports/hooks/use-report-chart-visibility.test.tsx
+++ b/frontend/src/features/reports/hooks/use-report-chart-visibility.test.tsx
@@ -1,0 +1,95 @@
+import { renderHook, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  REPORT_CHART_DEFINITIONS,
+  REPORT_CHART_VISIBILITY_STORAGE_KEY,
+  useReportChartVisibility,
+} from "./use-report-chart-visibility";
+
+const KEY = REPORT_CHART_VISIBILITY_STORAGE_KEY;
+const ALL_IDS = REPORT_CHART_DEFINITIONS.map(({ id }) => id);
+
+describe("useReportChartVisibility", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("defaults to all five charts and writes the default", () => {
+    const { result } = renderHook(() => useReportChartVisibility());
+
+    expect(result.current.visibleChartIds).toEqual(ALL_IDS);
+    expect(JSON.parse(localStorage.getItem(KEY) ?? "null")).toEqual(ALL_IDS);
+  });
+
+  it("restores known IDs in canonical order and removes duplicates", () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify(["queueWait", "costByDay", "costByDay"]),
+    );
+
+    const { result } = renderHook(() => useReportChartVisibility());
+
+    expect(result.current.visibleChartIds).toEqual(["costByDay", "queueWait"]);
+  });
+
+  it("discards unknown IDs and preserves an empty array", () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify(["unknown", "tokensPerSecond"]),
+    );
+    const subset = renderHook(() => useReportChartVisibility());
+
+    expect(subset.result.current.visibleChartIds).toEqual(["tokensPerSecond"]);
+
+    subset.unmount();
+    localStorage.setItem(KEY, JSON.stringify([]));
+    const empty = renderHook(() => useReportChartVisibility());
+
+    expect(empty.result.current.visibleChartIds).toEqual([]);
+  });
+
+  it("falls back for malformed and structurally invalid values", () => {
+    for (const value of [
+      "not-json",
+      JSON.stringify({}),
+      JSON.stringify(["costByDay", 1]),
+    ]) {
+      localStorage.setItem(KEY, value);
+      const { result, unmount } = renderHook(() => useReportChartVisibility());
+
+      expect(result.current.visibleChartIds).toEqual(ALL_IDS);
+      unmount();
+    }
+  });
+
+  it("defaults to all charts when storage reads throw during initialization", () => {
+    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(
+      () => {
+        throw new Error("storage unavailable");
+      },
+    );
+
+    try {
+      const { result } = renderHook(() => useReportChartVisibility());
+
+      expect(result.current.visibleChartIds).toEqual(ALL_IDS);
+    } finally {
+      getItem.mockRestore();
+    }
+  });
+
+  it("updates in memory when localStorage writes throw", () => {
+    const { result } = renderHook(() => useReportChartVisibility());
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(
+      () => {
+        throw new Error("storage unavailable");
+      },
+    );
+
+    act(() => result.current.setVisibleChartIds(["queueWait"]));
+
+    expect(result.current.visibleChartIds).toEqual(["queueWait"]);
+    setItem.mockRestore();
+  });
+});

--- a/frontend/src/features/reports/hooks/use-report-chart-visibility.ts
+++ b/frontend/src/features/reports/hooks/use-report-chart-visibility.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+
+export const REPORT_CHART_DEFINITIONS = [
+  { id: "costByDay", labelKey: "reports.charts.costByDay" },
+  { id: "tokensByDay", labelKey: "reports.charts.tokensByDay" },
+  { id: "timeToFirstToken", labelKey: "reports.charts.timeToFirstToken" },
+  { id: "tokensPerSecond", labelKey: "reports.charts.tokensPerSecond" },
+  { id: "queueWait", labelKey: "reports.charts.queueWait" },
+] as const;
+
+export type ReportChartId = (typeof REPORT_CHART_DEFINITIONS)[number]["id"];
+
+export const REPORT_CHART_VISIBILITY_STORAGE_KEY =
+  "codex-lb-reports-visible-charts";
+
+const REPORT_CHART_IDS = REPORT_CHART_DEFINITIONS.map(({ id }) => id);
+
+function allReportChartIds(): ReportChartId[] {
+  return [...REPORT_CHART_IDS];
+}
+
+export function normalizeReportChartIds(
+  ids: readonly string[],
+): ReportChartId[] {
+  const requestedIds = new Set(ids);
+  return REPORT_CHART_IDS.filter((id) => requestedIds.has(id));
+}
+
+function readInitialReportChartIds(): ReportChartId[] {
+  try {
+    const storedValue = localStorage.getItem(
+      REPORT_CHART_VISIBILITY_STORAGE_KEY,
+    );
+    if (storedValue === null) {
+      return allReportChartIds();
+    }
+
+    const parsedValue: unknown = JSON.parse(storedValue);
+    if (
+      !Array.isArray(parsedValue) ||
+      !parsedValue.every((id): id is string => typeof id === "string")
+    ) {
+      return allReportChartIds();
+    }
+
+    return normalizeReportChartIds(parsedValue);
+  } catch {
+    return allReportChartIds();
+  }
+}
+
+export function useReportChartVisibility(): {
+  visibleChartIds: ReportChartId[];
+  setVisibleChartIds: (ids: readonly string[]) => void;
+} {
+  const [visibleChartIds, setVisibleChartIdsState] = useState<ReportChartId[]>(
+    readInitialReportChartIds,
+  );
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        REPORT_CHART_VISIBILITY_STORAGE_KEY,
+        JSON.stringify(visibleChartIds),
+      );
+    } catch {
+      // Storage failures should not prevent the in-memory preference from updating.
+    }
+  }, [visibleChartIds]);
+
+  const setVisibleChartIds = (ids: readonly string[]) => {
+    setVisibleChartIdsState(normalizeReportChartIds(ids));
+  };
+
+  return { visibleChartIds, setVisibleChartIds };
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -915,6 +915,7 @@
   "reports.errors.data": "Failed to load report data: {{error}}",
   "reports.errors.options": "Failed to load model and user-agent options: {{error}}",
   "reports.errors.partial": "Some report data could not be loaded. Try reloading.",
+  "reports.filters.charts": "Charts",
   "reports.filters.endDate": "End date",
   "reports.filters.invalidDateRange": "Start date must be on or before end date.",
   "reports.filters.startDate": "Start date",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -913,6 +913,7 @@
   "reports.errors.data": "report data를 불러오지 못했습니다: {{error}}",
   "reports.errors.options": "Model 및 User Agent 옵션을 불러오지 못했습니다: {{error}}",
   "reports.errors.partial": "일부 report data를 불러오지 못했습니다. 다시 불러오세요.",
+  "reports.filters.charts": "차트",
   "reports.filters.endDate": "종료일",
   "reports.filters.invalidDateRange": "시작일은 종료일보다 빠르거나 같아야 합니다.",
   "reports.filters.startDate": "시작일",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -913,6 +913,7 @@
   "reports.errors.data": "加载报表数据失败：{{error}}",
   "reports.errors.options": "加载 Model 和 User Agent 选项失败：{{error}}",
   "reports.errors.partial": "部分报表数据无法加载。请重试。",
+  "reports.filters.charts": "图表",
   "reports.filters.endDate": "结束日期",
   "reports.filters.invalidDateRange": "开始日期必须早于或等于结束日期。",
   "reports.filters.startDate": "开始日期",

--- a/openspec/changes/archive/2026-07-26-reports-chart-visibility-filter/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-26-reports-chart-visibility-filter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/archive/2026-07-26-reports-chart-visibility-filter/proposal.md
+++ b/openspec/changes/archive/2026-07-26-reports-chart-visibility-filter/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The Reports page currently always renders all five line charts. Operators need
+to control which line-chart cards are visible and retain that preference in
+browser-local storage without changing the report data request.
+
+## What Changes
+
+- Add a persisted browser-local line-chart visibility preference for Reports.
+- Add a multi-select immediately left of the existing date-range controls,
+  using the existing localized chart headers as its options.
+- Render only the selected line-chart cards while keeping the combined
+  `/api/reports` request unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `frontend-architecture`
+
+## Impact
+
+There are no API, backend, schema, dependency, summary, donut, or table
+changes. The summary, donut, and table sections remain unchanged, and the
+existing combined `/api/reports` request continues to provide the complete
+report payload.

--- a/openspec/changes/archive/2026-07-26-reports-chart-visibility-filter/specs/frontend-architecture/spec.md
+++ b/openspec/changes/archive/2026-07-26-reports-chart-visibility-filter/specs/frontend-architecture/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Reports exposes a persisted line-chart visibility filter
+
+The `/reports` page MUST expose a visible multi-select immediately before the
+date controls. Its options MUST use the localized existing chart-header keys
+`reports.charts.costByDay`, `reports.charts.tokensByDay`,
+`reports.charts.timeToFirstToken`, `reports.charts.tokensPerSecond`, and
+`reports.charts.queueWait`. The multi-select filter label MUST use the
+`reports.filters.charts` key, and that key MUST be provided in each of
+`en.json`, `ko.json`, and `zh-CN.json`. All five options MUST be selected by
+default.
+Selected line-chart cards MUST render, deselected line-chart cards MUST NOT
+render, and an empty selection MUST be valid. Summary, donut, and table
+sections MUST remain visible regardless of line-chart selection.
+
+#### Scenario: Reports selects all line charts by default
+
+- **WHEN** the `/reports` page loads without a saved visibility preference
+- **THEN** the multi-select has all five chart options selected
+- **AND** all five line-chart cards render
+- **AND** the summary, donut, and table sections remain visible
+
+#### Scenario: Reports renders a partial selection
+
+- **GIVEN** the operator selects only Cost by Day and Queue Wait
+- **WHEN** the Reports page renders
+- **THEN** only those two line-chart cards render
+- **AND** the other three line-chart cards do not render
+- **AND** the summary, donut, and table sections remain visible
+
+#### Scenario: Reports permits an empty selection
+
+- **GIVEN** the operator deselects all five chart options
+- **WHEN** the Reports page renders
+- **THEN** no line-chart cards render
+- **AND** the summary, donut, and table sections remain visible
+
+#### Scenario: Reports provides the chart filter label in every required locale
+
+- **WHEN** the frontend locale resources are checked
+- **THEN** `en.json` provides a `reports.filters.charts` label
+- **AND** `ko.json` provides a `reports.filters.charts` label
+- **AND** `zh-CN.json` provides a `reports.filters.charts` label
+
+### Requirement: Reports safely persists visibility
+
+Reports MUST store the selected chart IDs as a JSON array under the exact
+localStorage key `codex-lb-reports-visible-charts`. The only known chart IDs
+MUST be the following five, in this canonical order: `costByDay`,
+`tokensByDay`, `timeToFirstToken`, `tokensPerSecond`, `queueWait`. This
+canonical order MUST be used for normalization, persistence, and rendering.
+Missing storage MUST default to all five known chart IDs. A valid array MUST
+be filtered to known IDs, deduplicated, and normalized to canonical chart
+order; an empty array MUST remain empty. Malformed JSON, non-array values,
+arrays containing any non-string values, and localStorage access failures MUST
+default to all five known chart IDs. Storage failures MUST NOT disable
+current-session in-memory visibility changes.
+
+#### Scenario: Reports restores a persisted subset
+
+- **GIVEN** localStorage contains a valid JSON array with the IDs for Tokens by
+  Day and Queue Wait
+- **WHEN** the `/reports` page initializes
+- **THEN** those two chart options are selected
+- **AND** their line-chart cards render
+- **AND** the other three line-chart cards do not render
+
+#### Scenario: Reports ignores unknown IDs and normalizes persisted values
+
+- **GIVEN** localStorage contains a valid JSON array with known IDs in a
+  non-canonical order, duplicate known IDs, and unknown IDs
+- **WHEN** the `/reports` page initializes
+- **THEN** unknown IDs are ignored
+- **AND** duplicate IDs occur only once
+- **AND** the selected IDs are normalized to canonical chart order
+
+### Requirement: Visibility does not narrow data fetching
+
+Changing chart visibility MUST NOT change Reports filter values, the TanStack
+Query key, request parameters, response schema, or response parsing. Reports
+MUST continue requesting the complete `GET /api/reports` payload and MUST NOT
+send a chart-specific API parameter.
+
+#### Scenario: Visibility changes leave the report query unchanged
+
+- **GIVEN** Reports has loaded the complete `GET /api/reports` payload
+- **WHEN** the operator changes the selected chart visibility
+- **THEN** the Reports filter values remain unchanged
+- **AND** the TanStack Query key and request parameters remain unchanged
+- **AND** the complete report payload remains requested and parsed using the
+  existing response schema

--- a/openspec/changes/archive/2026-07-26-reports-chart-visibility-filter/tasks.md
+++ b/openspec/changes/archive/2026-07-26-reports-chart-visibility-filter/tasks.md
@@ -1,0 +1,15 @@
+## 1. OpenSpec and visibility state
+
+- [x] 1.1 Add and validate the chart visibility OpenSpec change.
+- [x] 1.2 Add canonical chart definitions and safe localStorage state with tests.
+
+## 2. Reports UI
+
+- [x] 2.1 Add localized chart-filter labels and the controlled multi-select.
+- [x] 2.2 Render only selected line charts without changing query inputs.
+- [x] 2.3 Add regressions for persistence, empty selection, and unaffected sections.
+
+## 3. Verification
+
+- [x] 3.1 Run focused Reports frontend tests.
+- [x] 3.2 Run frontend typecheck, lint, build, and OpenSpec validation.

--- a/openspec/specs/frontend-architecture/spec.md
+++ b/openspec/specs/frontend-architecture/spec.md
@@ -778,6 +778,97 @@ The `/reports` page SHALL expose visible filter controls for `7d`, `30d`, and `9
 - **WHEN** an authenticated operator opens `/reports`
 - **THEN** the start date and end date inputs prevent selecting a date later than the browser's current local calendar date
 
+### Requirement: Reports exposes a persisted line-chart visibility filter
+
+The `/reports` page MUST expose a visible multi-select immediately before the
+date controls. Its options MUST use the localized existing chart-header keys
+`reports.charts.costByDay`, `reports.charts.tokensByDay`,
+`reports.charts.timeToFirstToken`, `reports.charts.tokensPerSecond`, and
+`reports.charts.queueWait`. The multi-select filter label MUST use the
+`reports.filters.charts` key, and that key MUST be provided in each of
+`en.json`, `ko.json`, and `zh-CN.json`. All five options MUST be selected by
+default.
+Selected line-chart cards MUST render, deselected line-chart cards MUST NOT
+render, and an empty selection MUST be valid. Summary, donut, and table
+sections MUST remain visible regardless of line-chart selection.
+
+#### Scenario: Reports selects all line charts by default
+
+- **WHEN** the `/reports` page loads without a saved visibility preference
+- **THEN** the multi-select has all five chart options selected
+- **AND** all five line-chart cards render
+- **AND** the summary, donut, and table sections remain visible
+
+#### Scenario: Reports renders a partial selection
+
+- **GIVEN** the operator selects only Cost by Day and Queue Wait
+- **WHEN** the Reports page renders
+- **THEN** only those two line-chart cards render
+- **AND** the other three line-chart cards do not render
+- **AND** the summary, donut, and table sections remain visible
+
+#### Scenario: Reports permits an empty selection
+
+- **GIVEN** the operator deselects all five chart options
+- **WHEN** the Reports page renders
+- **THEN** no line-chart cards render
+- **AND** the summary, donut, and table sections remain visible
+
+#### Scenario: Reports provides the chart filter label in every required locale
+
+- **WHEN** the frontend locale resources are checked
+- **THEN** `en.json` provides a `reports.filters.charts` label
+- **AND** `ko.json` provides a `reports.filters.charts` label
+- **AND** `zh-CN.json` provides a `reports.filters.charts` label
+
+### Requirement: Reports safely persists visibility
+
+Reports MUST store the selected chart IDs as a JSON array under the exact
+localStorage key `codex-lb-reports-visible-charts`. The only known chart IDs
+MUST be the following five, in this canonical order: `costByDay`,
+`tokensByDay`, `timeToFirstToken`, `tokensPerSecond`, `queueWait`. This
+canonical order MUST be used for normalization, persistence, and rendering.
+Missing storage MUST default to all five known chart IDs. A valid array MUST
+be filtered to known IDs, deduplicated, and normalized to canonical chart
+order; an empty array MUST remain empty. Malformed JSON, non-array values,
+arrays containing any non-string values, and localStorage access failures MUST
+default to all five known chart IDs. Storage failures MUST NOT disable
+current-session in-memory visibility changes.
+
+#### Scenario: Reports restores a persisted subset
+
+- **GIVEN** localStorage contains a valid JSON array with the IDs for Tokens by
+  Day and Queue Wait
+- **WHEN** the `/reports` page initializes
+- **THEN** those two chart options are selected
+- **AND** their line-chart cards render
+- **AND** the other three line-chart cards do not render
+
+#### Scenario: Reports ignores unknown IDs and normalizes persisted values
+
+- **GIVEN** localStorage contains a valid JSON array with known IDs in a
+  non-canonical order, duplicate known IDs, and unknown IDs
+- **WHEN** the `/reports` page initializes
+- **THEN** unknown IDs are ignored
+- **AND** duplicate IDs occur only once
+- **AND** the selected IDs are normalized to canonical chart order
+
+### Requirement: Visibility does not narrow data fetching
+
+Changing chart visibility MUST NOT change Reports filter values, the TanStack
+Query key, request parameters, response schema, or response parsing. Reports
+MUST continue requesting the complete `GET /api/reports` payload and MUST NOT
+send a chart-specific API parameter.
+
+#### Scenario: Visibility changes leave the report query unchanged
+
+- **GIVEN** Reports has loaded the complete `GET /api/reports` payload
+- **WHEN** the operator changes the selected chart visibility
+- **THEN** the Reports filter values remain unchanged
+- **AND** the TanStack Query key and request parameters remain unchanged
+- **AND** the complete report payload remains requested and parsed using the
+  existing response schema
+
 ### Requirement: Reports page preserves reports query parameter names
 
 Requests from `/reports` to `GET /api/reports` SHALL use the query parameter names `startDate`, `endDate`, `accountId`, and `model`.


### PR DESCRIPTION
## Summary

Adds a persisted multi-select "Charts" filter to the Reports page so operators can show/hide individual line-chart cards (Cost by Day, Tokens by Day, Time to First Token, Tokens per Second, Queue Wait). Selection is stored in localStorage and normalizes to a canonical chart order.

## Type of change

- [x] `feat:` — new user-facing feature or capability

Linked issue: <!-- e.g. Closes #123, Fixes #456 -->

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/archive/2026-07-26-reports-chart-visibility-filter/`

## Changes

- New `useReportChartVisibility` hook with localStorage-backed persistence (`codex-lb-reports-visible-charts`), normalization to canonical chart order, and graceful fallback to all-five-selected on parse/storage errors
- `ReportsFilters` gains a "Charts" multi-select filter (label key: `reports.filters.charts`, localized in en/ko/zh-CN)
- `ReportsPage` conditionally renders only selected line-chart cards; summary cards, donut charts, and table sections remain unconditional
- Visibility changes do not alter the TanStack Query key, API request, or response schema — the full `/api/reports` payload is always fetched
- Unit tests for the hook, filter component, and page-level behavior
- Spec additions in `openspec/specs/frontend-architecture/spec.md`

## Simplicity

- [x] New feature defaults to **off** or works with **zero config**
- [x] No new required setup step (or maintainer approval via `simplicity-budget-approved` label)
- New setting(s) and why each can't be a default: N/A — no new setting
- [x] README sections / `.env.example` / dashboard nav within budget (or `simplicity-budget-approved` label requested)

## Test plan

```
# uv run pytest -q --ignore=tests/e2e 2>/dev/null; npm --prefix frontend test -- --run 2>/dev/null
```

<img width="1427" height="800" alt="螢幕截圖 2026-07-26 03 30 43" src="https://github.com/user-attachments/assets/2eaf680f-31a9-416c-86aa-63493a87718b" />

