### PR TITLE
chore: release v1.23.0-beta.2

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.23.0-beta.1"  # x-release-please-version
+__version__ = "1.23.0-beta.2"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.23.0-beta.1
-appVersion: 1.23.0-beta.1
+version: 1.23.0-beta.2
+appVersion: 1.23.0-beta.2
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.23.0-beta.1",
+  "version": "1.23.0-beta.2",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.23.0-beta.1"
+version = "1.23.0-beta.2"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.23.0-beta.1"
+version = "1.23.0-beta.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.23.0-beta.2 for the 1.23.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.23.0-beta.2 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1472; no manual beta workflow dispatch is required.

## Changes since v1.23.0-beta.1
- fix(proxy): sequence synthetic Responses failures (#1479) (6f6af9b)
- feat(helm): support creating an application-specific Gateway (#1462) (
846120)
- feat(report-ui): add per-chart visibility filter (
a2adfa)
- feat(proxy): support Codex Live Voice sideband (#1492) (
aa642f)

## Release-candidate validation
Validated candidate: 1f40580c5d328a9a65d66b19b5c3953757012654

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates — CI green at 1f40580c (unit, integration-core 1-3 + required, PostgreSQL, migration checks sqlite+postgres: 34/34 non-guard checks success)
- [x] Frontend tests/build — CI green at 1f40580c (lint, typecheck, frontend-build, dashboard-browser-smoke)
- [x] Wheel/package validation — CI `Package (build)` green at 1f40580c (sdist/wheel build + verify)
- [x] Docker/container smoke — image built locally from 1f40580c (sha256:71a6049dbce7); booted against a scratch postgres:18-alpine: alembic migrated an empty DB to head `20260724_000000_add_request_usage_time_rollups` (no schema delta vs beta.1), 49 tables created, `/` 200, `/v1/models` and `/api/runtime/version` 401 (auth enforced), 0 error signatures in logs
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required — this beta deploys to the production pool immediately after publish for the 48h soak mandated by the release-channel policy; live-path verification happens there with rollback runbook staged (deploy.sh; image-swap-only cutover, no migration delta from beta.1)

## Install after publish
```bash
uvx --from "codex-lb==1.23.0b2" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.23.0-beta.2
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.23.0-beta.2 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.23.0.

