### PR TITLE
fix(auth): restrict guest access to sensitive request data

### DIFF
--- a/app/core/auth/dependencies.py
+++ b/app/core/auth/dependencies.py
@@ -236,13 +236,17 @@ async def require_dashboard_write_access(request: Request) -> DashboardPrincipal
     return principal
 
 
-async def require_dashboard_admin_access(request: Request) -> DashboardPrincipal:
-    principal = await validate_dashboard_session(request)
+def ensure_dashboard_admin_access(principal: DashboardPrincipal) -> None:
     if principal.role != DashboardRole.ADMIN:
         raise DashboardPermissionError(
             "Admin dashboard access is required to view sensitive data",
             code="admin_access_required",
         )
+
+
+async def require_dashboard_admin_access(request: Request) -> DashboardPrincipal:
+    principal = await validate_dashboard_session(request)
+    ensure_dashboard_admin_access(principal)
     return principal
 
 

--- a/app/core/auth/dependencies.py
+++ b/app/core/auth/dependencies.py
@@ -236,6 +236,16 @@ async def require_dashboard_write_access(request: Request) -> DashboardPrincipal
     return principal
 
 
+async def require_dashboard_admin_access(request: Request) -> DashboardPrincipal:
+    principal = await validate_dashboard_session(request)
+    if principal.role != DashboardRole.ADMIN:
+        raise DashboardPermissionError(
+            "Admin dashboard access is required to view sensitive data",
+            code="admin_access_required",
+        )
+    return principal
+
+
 def get_dashboard_request_auth_mode() -> DashboardAuthMode:
     from app.core.config.settings import get_settings
 

--- a/app/modules/conversation_archive/api.py
+++ b/app/modules/conversation_archive/api.py
@@ -6,7 +6,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.concurrency import run_in_threadpool
 
-from app.core.auth.dependencies import set_dashboard_error_format, validate_dashboard_session
+from app.core.auth.dependencies import require_dashboard_admin_access, set_dashboard_error_format
 from app.modules.conversation_archive import service
 from app.modules.conversation_archive.schemas import (
     ConversationArchiveFileResponse,
@@ -17,7 +17,7 @@ from app.modules.conversation_archive.schemas import (
 router = APIRouter(
     prefix="/api/conversation-archive",
     tags=["dashboard"],
-    dependencies=[Depends(validate_dashboard_session), Depends(set_dashboard_error_format)],
+    dependencies=[Depends(require_dashboard_admin_access), Depends(set_dashboard_error_format)],
 )
 
 

--- a/app/modules/request_logs/api.py
+++ b/app/modules/request_logs/api.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, Depends, Query
 
+from app.core.auth.dashboard_access import DashboardPrincipal, DashboardRole
 from app.core.auth.dependencies import set_dashboard_error_format, validate_dashboard_session
 from app.dependencies import RequestLogsContext, get_request_logs_context
 from app.modules.request_logs.schemas import (
@@ -51,6 +52,7 @@ async def list_request_logs(
     model_option: list[str] | None = Query(default=None, alias="modelOption"),
     since: datetime | None = Query(default=None),
     until: datetime | None = Query(default=None),
+    principal: DashboardPrincipal = Depends(validate_dashboard_session),
     context: RequestLogsContext = Depends(get_request_logs_context),
 ) -> RequestLogsResponse:
     parsed_options: list[ServiceRequestLogModelOption] | None = None
@@ -70,6 +72,7 @@ async def list_request_logs(
         models=model,
         reasoning_efforts=reasoning_effort,
         status=status,
+        include_sensitive_metadata=principal.role == DashboardRole.ADMIN,
     )
     return RequestLogsResponse(
         requests=page.requests,

--- a/app/modules/request_logs/api.py
+++ b/app/modules/request_logs/api.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, Query
 
 from app.core.auth.dashboard_access import DashboardPrincipal, DashboardRole
 from app.core.auth.dependencies import set_dashboard_error_format, validate_dashboard_session
+from app.core.exceptions import DashboardPermissionError
 from app.dependencies import RequestLogsContext, get_request_logs_context
 from app.modules.request_logs.schemas import (
     RequestLogApiKeyOption,
@@ -55,6 +56,12 @@ async def list_request_logs(
     principal: DashboardPrincipal = Depends(validate_dashboard_session),
     context: RequestLogsContext = Depends(get_request_logs_context),
 ) -> RequestLogsResponse:
+    if conversation_id is not None and principal.role != DashboardRole.ADMIN:
+        raise DashboardPermissionError(
+            "Admin dashboard access is required to view sensitive data",
+            code="admin_access_required",
+        )
+
     parsed_options: list[ServiceRequestLogModelOption] | None = None
     if model_option:
         parsed = [_parse_model_option(value) for value in model_option]

--- a/app/modules/request_logs/api.py
+++ b/app/modules/request_logs/api.py
@@ -5,8 +5,11 @@ from datetime import datetime
 from fastapi import APIRouter, Depends, Query
 
 from app.core.auth.dashboard_access import DashboardPrincipal, DashboardRole
-from app.core.auth.dependencies import set_dashboard_error_format, validate_dashboard_session
-from app.core.exceptions import DashboardPermissionError
+from app.core.auth.dependencies import (
+    ensure_dashboard_admin_access,
+    set_dashboard_error_format,
+    validate_dashboard_session,
+)
 from app.dependencies import RequestLogsContext, get_request_logs_context
 from app.modules.request_logs.schemas import (
     RequestLogApiKeyOption,
@@ -56,11 +59,8 @@ async def list_request_logs(
     principal: DashboardPrincipal = Depends(validate_dashboard_session),
     context: RequestLogsContext = Depends(get_request_logs_context),
 ) -> RequestLogsResponse:
-    if conversation_id is not None and principal.role != DashboardRole.ADMIN:
-        raise DashboardPermissionError(
-            "Admin dashboard access is required to view sensitive data",
-            code="admin_access_required",
-        )
+    if conversation_id is not None:
+        ensure_dashboard_admin_access(principal)
 
     parsed_options: list[ServiceRequestLogModelOption] | None = None
     if model_option:

--- a/app/modules/request_logs/mappers.py
+++ b/app/modules/request_logs/mappers.py
@@ -30,26 +30,31 @@ def log_status(log: RequestLog) -> str:
     return normalize_log_status(log.status, log.error_code)
 
 
-def to_request_log_entry(log: RequestLog, *, api_key_name: str | None = None) -> RequestLogEntry:
+def to_request_log_entry(
+    log: RequestLog,
+    *,
+    api_key_name: str | None = None,
+    include_sensitive_metadata: bool,
+) -> RequestLogEntry:
     log_like = typing_cast(RequestLogLike, log)
     cost_breakdown = cost_breakdown_from_log(log_like, precision=6)
     return RequestLogEntry(
         requested_at=log.requested_at,
-        conversation_id=log.conversation_id,
+        conversation_id=log.conversation_id if include_sensitive_metadata else None,
         account_id=log.account_id,
         plan_type=log.plan_type,
         api_key_id=log.api_key_id,
         api_key_name=api_key_name,
         request_id=log.request_id,
-        archive_request_id=log.archive_request_id,
+        archive_request_id=log.archive_request_id if include_sensitive_metadata else None,
         request_kind=log.request_kind,
         model=log.model,
         source=log.source,
         model_source_id=log.model_source_id,
         model_source_kind=log.model_source_kind,
-        useragent=log.useragent,
+        useragent=log.useragent if include_sensitive_metadata else None,
         useragent_group=log.useragent_group,
-        client_ip=log.client_ip,
+        client_ip=log.client_ip if include_sensitive_metadata else None,
         transport=log.transport,
         upstream_transport=log.upstream_transport,
         service_tier=log.service_tier,

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -747,6 +747,8 @@ class RequestLogsRepository:
         include_error_other: bool = True,
         error_codes_in: list[str] | None = None,
         error_codes_excluding: list[str] | None = None,
+        *,
+        include_sensitive_metadata: bool = True,
     ) -> RequestLogsResult:
         filters = self._build_filters(
             search=search,
@@ -763,6 +765,7 @@ class RequestLogsRepository:
             error_codes_in=error_codes_in,
             error_codes_excluding=error_codes_excluding,
             exclude_soft_deleted=True,
+            include_sensitive_metadata=include_sensitive_metadata,
         )
 
         stmt = select(RequestLog).order_by(RequestLog.requested_at.desc(), RequestLog.id.desc())
@@ -797,6 +800,7 @@ class RequestLogsRepository:
             include_error_other,
             tuple(sorted(error_codes_in)) if error_codes_in else None,
             tuple(sorted(error_codes_excluding)) if error_codes_excluding else None,
+            include_sensitive_metadata,
         )
         total = _cached_recent_count(cache_key)
         if total is None:
@@ -993,6 +997,7 @@ class RequestLogsRepository:
         error_codes_in: list[str] | None = None,
         error_codes_excluding: list[str] | None = None,
         exclude_soft_deleted: bool = False,
+        include_sensitive_metadata: bool = True,
     ) -> _RequestLogFilters:
         conditions = []
         if exclude_soft_deleted:
@@ -1045,28 +1050,28 @@ class RequestLogsRepository:
             conditions.append(or_(*status_conditions))
         if search:
             search_pattern = f"%{search}%"
-            conditions.append(
-                or_(
-                    RequestLog.account_id.ilike(search_pattern),
-                    Account.email.ilike(search_pattern),
-                    RequestLog.request_id.ilike(search_pattern),
-                    RequestLog.model.ilike(search_pattern),
-                    RequestLog.reasoning_effort.ilike(search_pattern),
-                    RequestLog.source.ilike(search_pattern),
-                    RequestLog.client_ip.ilike(search_pattern),
-                    RequestLog.status.ilike(search_pattern),
-                    RequestLog.error_code.ilike(search_pattern),
-                    RequestLog.error_message.ilike(search_pattern),
-                    RequestLog.api_key_id.ilike(search_pattern),
-                    ApiKey.name.ilike(search_pattern),
-                    cast(RequestLog.requested_at, String).ilike(search_pattern),
-                    cast(RequestLog.input_tokens, String).ilike(search_pattern),
-                    cast(RequestLog.output_tokens, String).ilike(search_pattern),
-                    cast(RequestLog.cached_input_tokens, String).ilike(search_pattern),
-                    cast(RequestLog.reasoning_tokens, String).ilike(search_pattern),
-                    cast(RequestLog.latency_ms, String).ilike(search_pattern),
-                )
-            )
+            search_conditions = [
+                RequestLog.account_id.ilike(search_pattern),
+                Account.email.ilike(search_pattern),
+                RequestLog.request_id.ilike(search_pattern),
+                RequestLog.model.ilike(search_pattern),
+                RequestLog.reasoning_effort.ilike(search_pattern),
+                RequestLog.source.ilike(search_pattern),
+                RequestLog.status.ilike(search_pattern),
+                RequestLog.error_code.ilike(search_pattern),
+                RequestLog.error_message.ilike(search_pattern),
+                RequestLog.api_key_id.ilike(search_pattern),
+                ApiKey.name.ilike(search_pattern),
+                cast(RequestLog.requested_at, String).ilike(search_pattern),
+                cast(RequestLog.input_tokens, String).ilike(search_pattern),
+                cast(RequestLog.output_tokens, String).ilike(search_pattern),
+                cast(RequestLog.cached_input_tokens, String).ilike(search_pattern),
+                cast(RequestLog.reasoning_tokens, String).ilike(search_pattern),
+                cast(RequestLog.latency_ms, String).ilike(search_pattern),
+            ]
+            if include_sensitive_metadata:
+                search_conditions.append(RequestLog.client_ip.ilike(search_pattern))
+            conditions.append(or_(*search_conditions))
             return _RequestLogFilters(conditions=conditions, needs_related_search_joins=True)
         return _RequestLogFilters(conditions=conditions, needs_related_search_joins=False)
 

--- a/app/modules/request_logs/service.py
+++ b/app/modules/request_logs/service.py
@@ -91,6 +91,7 @@ class RequestLogsService:
             include_error_other=status_filter.include_error_other,
             error_codes_in=status_filter.error_codes_in,
             error_codes_excluding=status_filter.error_codes_excluding,
+            include_sensitive_metadata=include_sensitive_metadata,
         )
         logs = result.logs
         total = result.total

--- a/app/modules/request_logs/service.py
+++ b/app/modules/request_logs/service.py
@@ -68,6 +68,8 @@ class RequestLogsService:
         models: list[str] | None = None,
         reasoning_efforts: list[str] | None = None,
         status: list[str] | None = None,
+        *,
+        include_sensitive_metadata: bool,
     ) -> RequestLogsPage:
         status_filter = _map_status_filter(status)
         normalized_model_options = (
@@ -105,6 +107,7 @@ class RequestLogsService:
             to_request_log_entry(
                 log,
                 api_key_name=api_key_name_by_id.get(log.api_key_id or ""),
+                include_sensitive_metadata=include_sensitive_metadata,
             )
             for log in logs
         ]

--- a/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { useAuthStore } from "@/features/auth/hooks/use-auth";
 import { RecentRequestsTable } from "@/features/dashboard/components/recent-requests-table";
 
 const ISO = "2026-01-01T12:00:00+00:00";
@@ -56,6 +57,11 @@ describe("RecentRequestsTable", () => {
   beforeEach(() => {
     toastSuccess.mockReset();
     toastError.mockReset();
+    useAuthStore.setState({
+      role: "admin",
+      permissions: ["read", "write"],
+      canWrite: true,
+    });
   });
 
   afterEach(() => {
@@ -278,6 +284,67 @@ describe("RecentRequestsTable", () => {
   it("renders empty state", () => {
     render(<RecentRequestsTable {...PAGINATION_PROPS} total={0} accounts={[]} requests={[]} />);
     expect(screen.getByText("No request logs match the current filters.")).toBeInTheDocument();
+  });
+
+  it("hides identifying metadata and archive controls from guests", () => {
+    useAuthStore.setState({
+      role: "guest",
+      permissions: ["read"],
+      canWrite: false,
+    });
+
+    render(
+      <RecentRequestsTable
+        {...PAGINATION_PROPS}
+        accounts={[]}
+        requests={[
+          {
+            requestedAt: ISO,
+            accountId: null,
+            planType: null,
+            apiKeyName: null,
+            apiKeyId: null,
+            requestId: "req-guest",
+            archiveRequestId: null,
+            conversationId: null,
+            requestKind: "normal",
+            model: "gpt-5.1",
+            source: null,
+            serviceTier: null,
+            requestedServiceTier: null,
+            actualServiceTier: null,
+            transport: "http",
+            useragent: null,
+            useragentGroup: "codex-cli",
+            clientIp: null,
+            status: "ok",
+            errorCode: null,
+            errorMessage: null,
+            ...NULL_FAILURE_METADATA,
+            tokens: 120,
+            inputTokens: 100,
+            outputTokens: 20,
+            outputTokensRaw: 20,
+            latencyFirstTokenMs: 50,
+            latencyQueueMs: null,
+            cachedInputTokens: 0,
+            reasoningEffort: null,
+            costUsd: 0.01,
+            costBreakdown: null,
+            latencyMs: 250,
+          },
+        ]}
+      />,
+    );
+
+    const dialog = openRequestDetails();
+
+    expect(within(dialog).getByText("req-guest")).toBeInTheDocument();
+    expect(within(dialog).getByText("gpt-5.1")).toBeInTheDocument();
+    expect(within(dialog).queryByText("User Agent")).not.toBeInTheDocument();
+    expect(within(dialog).queryByText("Client IP")).not.toBeInTheDocument();
+    expect(within(dialog).queryByText("Conversation ID")).not.toBeInTheDocument();
+    expect(within(dialog).queryByTestId("request-archive-panel")).not.toBeInTheDocument();
   });
 
   it("shows warmup marker only for warmup rows", () => {

--- a/frontend/src/features/dashboard/components/recent-requests-table.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.tsx
@@ -27,6 +27,7 @@ import {
 import { PaginationControls } from "@/features/dashboard/components/filters/pagination-controls";
 import { RequestArchivePanel } from "@/features/conversation-archive/components/request-archive-panel";
 import type { AccountSummary, RequestLog } from "@/features/dashboard/schemas";
+import { useAuthStore } from "@/features/auth/hooks/use-auth";
 import { REQUEST_STATUS_LABELS } from "@/utils/constants";
 import {
   formatDateTimeInline,
@@ -175,6 +176,7 @@ export function RecentRequestsTable({
   const { t } = useTranslation();
   const [selectedRequest, setSelectedRequest] = useState<RequestLog | null>(null);
   const blurred = usePrivacyStore((s) => s.blurred);
+  const isAdmin = useAuthStore((state) => state.role === "admin");
   const selectedRequestCostSummary = formatRequestCostSummary(selectedRequest, t);
 
   const accountLabelMap = useMemo(() => {
@@ -422,62 +424,68 @@ export function RecentRequestsTable({
                 <RequestDetailField label={t("dashboard.requests.columns.time")} value={selectedRequest ? formatDateTimeInline(selectedRequest.requestedAt) : "—"} />
                 <RequestDetailField label={t("dashboard.requestDetails.errorCode")} value={selectedRequest?.errorCode ?? "—"} mono />
               </div>
-              <RequestDetailField
-                label={t("dashboard.requestDetails.userAgent")}
-                value={selectedRequest?.useragent ?? "—"}
-                copyValue={selectedRequest?.useragent ?? undefined}
-                copyLabel={t("dashboard.requestDetails.copyUserAgent")}
-                compactCopy
-              />
-              <div className="grid gap-3 sm:grid-cols-2">
+              {isAdmin ? (
                 <RequestDetailField
-                  label={t("dashboard.requestDetails.clientIp")}
-                  value={selectedRequest?.clientIp ?? "—"}
-                  copyValue={selectedRequest?.clientIp ?? undefined}
-                  copyLabel={t("dashboard.requestDetails.copyClientIp")}
+                  label={t("dashboard.requestDetails.userAgent")}
+                  value={selectedRequest?.useragent ?? "—"}
+                  copyValue={selectedRequest?.useragent ?? undefined}
+                  copyLabel={t("dashboard.requestDetails.copyUserAgent")}
                   compactCopy
                 />
-                <div className="space-y-1">
-                  <div className="flex items-center gap-2">
-                    <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">
-                      {t("dashboard.requestDetails.conversationId")}
+              ) : null}
+              {isAdmin ? (
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <RequestDetailField
+                    label={t("dashboard.requestDetails.clientIp")}
+                    value={selectedRequest?.clientIp ?? "—"}
+                    copyValue={selectedRequest?.clientIp ?? undefined}
+                    copyLabel={t("dashboard.requestDetails.copyClientIp")}
+                    compactCopy
+                  />
+                  <div className="space-y-1">
+                    <div className="flex items-center gap-2">
+                      <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground/80">
+                        {t("dashboard.requestDetails.conversationId")}
+                      </div>
+                      {selectedRequest?.conversationId ? (
+                        <CopyButton value={selectedRequest.conversationId} label={t("dashboard.requestDetails.copyConversationId")} iconOnly />
+                      ) : null}
                     </div>
-                    {selectedRequest?.conversationId ? (
-                      <CopyButton value={selectedRequest.conversationId} label={t("dashboard.requestDetails.copyConversationId")} iconOnly />
-                    ) : null}
-                  </div>
-                  <div className="flex flex-col items-start gap-2">
-                    {selectedRequest?.conversationId ? (
-                      onConversationClick ? (
-                        <button
-                          type="button"
-                          className="max-w-[200px] truncate text-left text-sm leading-relaxed text-primary hover:text-primary/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm"
-                          title={selectedRequest.conversationId}
-                          onClick={() => {
-                            setSelectedRequest(null);
-                            onConversationClick(selectedRequest?.conversationId ?? "");
-                          }}
-                          aria-label={t("dashboard.filters.conversationFilterAria", { id: selectedRequest.conversationId })}
-                        >
-                          {selectedRequest.conversationId}
-                        </button>
+                    <div className="flex flex-col items-start gap-2">
+                      {selectedRequest?.conversationId ? (
+                        onConversationClick ? (
+                          <button
+                            type="button"
+                            className="max-w-[200px] truncate text-left text-sm leading-relaxed text-primary hover:text-primary/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm"
+                            title={selectedRequest.conversationId}
+                            onClick={() => {
+                              setSelectedRequest(null);
+                              onConversationClick(selectedRequest?.conversationId ?? "");
+                            }}
+                            aria-label={t("dashboard.filters.conversationFilterAria", { id: selectedRequest.conversationId })}
+                          >
+                            {selectedRequest.conversationId}
+                          </button>
+                        ) : (
+                          <p className="max-w-[200px] truncate text-sm leading-relaxed" title={selectedRequest.conversationId ?? undefined}>
+                            {selectedRequest.conversationId}
+                          </p>
+                        )
                       ) : (
-                        <p className="max-w-[200px] truncate text-sm leading-relaxed" title={selectedRequest.conversationId ?? undefined}>
-                          {selectedRequest.conversationId}
-                        </p>
-                      )
-                    ) : (
-                      <p className="min-w-0 flex-1 break-all text-sm leading-relaxed">—</p>
-                    )}
+                        <p className="min-w-0 flex-1 break-all text-sm leading-relaxed">—</p>
+                      )}
+                    </div>
                   </div>
                 </div>
-              </div>
+              ) : null}
             </div>
 
-            <RequestArchivePanel
-              requestId={selectedRequest?.archiveRequestId ?? selectedRequest?.requestId}
-              requestedAt={selectedRequest?.requestedAt}
-            />
+            {isAdmin ? (
+              <RequestArchivePanel
+                requestId={selectedRequest?.archiveRequestId ?? selectedRequest?.requestId}
+                requestedAt={selectedRequest?.requestedAt}
+              />
+            ) : null}
 
             {selectedRequestCostSummary ? (
               <div className="space-y-2">

--- a/openspec/changes/restrict-guest-sensitive-request-data/.openspec.yaml
+++ b/openspec/changes/restrict-guest-sensitive-request-data/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/restrict-guest-sensitive-request-data/design.md
+++ b/openspec/changes/restrict-guest-sensitive-request-data/design.md
@@ -1,0 +1,42 @@
+## Context
+
+Dashboard authentication currently distinguishes `admin` and `guest`, but every authenticated GET route shares the same broad read gate. Conversation archives contain full request and response bodies, while request-log rows expose client IP, full User-Agent, conversation ID, and the archive lookup ID. Guests still need the non-identifying operational fields and aggregates that make the read-only dashboard useful.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Deny every conversation-archive API request unless the dashboard principal is an admin.
+- Preserve request-log rows and aggregate metrics for guests while replacing raw identifying request metadata with null values.
+- Keep the admin API and request-detail experience unchanged.
+- Avoid presenting archive controls or redacted identifying fields in the guest UI.
+
+**Non-Goals:**
+
+- Changing persistence, retention, archive creation, or proxy routing.
+- Redacting low-cardinality `useragentGroup`, request metrics, status, model, token, latency, or cost fields.
+- Redesigning the wider dashboard guest-access model.
+
+## Decisions
+
+### Use an explicit admin dependency for sensitive read routes
+
+Add `require_dashboard_admin_access` beside the existing dashboard session and write dependencies. It validates the session, then rejects non-admin principals with a stable `admin_access_required` permission error. The conversation-archive router uses this dependency for all endpoints.
+
+Using the write-access dependency was rejected because archive reads are not mutations and its `read_only_access` message would describe the failure incorrectly.
+
+### Redact at the request-log response mapping boundary
+
+The request-log endpoint passes the resolved principal into the service as an explicit `include_sensitive_metadata` decision. The mapper emits null for `clientIp`, full `useragent`, `conversationId`, and `archiveRequestId` for guests while retaining persisted values and all non-sensitive fields.
+
+Repository filtering and persistence remain unchanged. Redacting at the response mapping boundary gives one typed enforcement point and keeps aggregate queries identical for admins and guests.
+
+### Hide sensitive request-detail UI by role
+
+The request-detail component reads the authenticated dashboard role. Admins retain the existing User Agent, Client IP, Conversation ID, and archive panel. Guests do not mount or render those elements. Backend redaction remains authoritative; the UI change prevents misleading placeholders and avoidable denied archive requests.
+
+## Risks / Trade-offs
+
+- [Risk] A future request-log identifying field could be added without joining the redaction set. → Keep the sensitive-field list explicit in the role-aware mapper test and OpenSpec requirement.
+- [Risk] Client-side role state could be stale. → Backend response redaction and archive authorization are authoritative and do not rely on the UI.
+- [Trade-off] Guests lose conversation drill-down and archive inspection. → They retain request rows, model/status/token/cost/latency fields, `useragentGroup`, and aggregate dashboard/report statistics.

--- a/openspec/changes/restrict-guest-sensitive-request-data/design.md
+++ b/openspec/changes/restrict-guest-sensitive-request-data/design.md
@@ -8,6 +8,7 @@ Dashboard authentication currently distinguishes `admin` and `guest`, but every 
 
 - Deny every conversation-archive API request unless the dashboard principal is an admin.
 - Preserve request-log rows and aggregate metrics for guests while replacing raw identifying request metadata with null values.
+- Deny guest use of the dedicated conversation-ID filter so redacted conversation membership and aggregates cannot be queried.
 - Keep the admin API and request-detail experience unchanged.
 - Avoid presenting archive controls or redacted identifying fields in the guest UI.
 
@@ -33,6 +34,12 @@ The service threads the same decision into repository filter construction. Guest
 
 Persistence remains unchanged. Keeping the role decision explicit across filter construction and response mapping provides typed enforcement points while preserving non-sensitive filters and aggregates for both roles.
 
+### Fail closed when a guest supplies the dedicated conversation filter
+
+The request-log API rejects a guest request that supplies `conversation_id` with HTTP 403 and the stable `admin_access_required` error code before querying the request-log service. Admins retain the existing filter, matching rows, request count, and aggregated cost response.
+
+Ignoring the guest parameter was rejected because it would silently return a broader dataset than requested. Passing it through was rejected because the filtered row count and conversation aggregate would disclose whether a redacted conversation identifier exists.
+
 ### Hide sensitive request-detail UI by role
 
 The request-detail component reads the authenticated dashboard role. Admins retain the existing User Agent, Client IP, Conversation ID, and archive panel. Guests do not mount or render those elements. Backend redaction remains authoritative; the UI change prevents misleading placeholders and avoidable denied archive requests.
@@ -41,5 +48,6 @@ The request-detail component reads the authenticated dashboard role. Admins reta
 
 - [Risk] A future request-log identifying field could be added without joining the redaction set. → Keep the sensitive-field list explicit in the role-aware mapper test and OpenSpec requirement.
 - [Risk] A redacted request-log field could remain searchable and become a membership oracle. → Pass the role decision into filter construction and test guest and admin search behavior at the API boundary.
+- [Risk] A dedicated identifying filter could expose membership or aggregates even when row fields are redacted. → Reject guest `conversation_id` filtering at the API boundary and cover both roles in a public API regression test.
 - [Risk] Client-side role state could be stale. → Backend response redaction and archive authorization are authoritative and do not rely on the UI.
 - [Trade-off] Guests lose conversation drill-down and archive inspection. → They retain request rows, model/status/token/cost/latency fields, `useragentGroup`, and aggregate dashboard/report statistics.

--- a/openspec/changes/restrict-guest-sensitive-request-data/design.md
+++ b/openspec/changes/restrict-guest-sensitive-request-data/design.md
@@ -25,11 +25,13 @@ Add `require_dashboard_admin_access` beside the existing dashboard session and w
 
 Using the write-access dependency was rejected because archive reads are not mutations and its `read_only_access` message would describe the failure incorrectly.
 
-### Redact at the request-log response mapping boundary
+### Redact at the request-log response boundary and exclude sensitive search branches
 
 The request-log endpoint passes the resolved principal into the service as an explicit `include_sensitive_metadata` decision. The mapper emits null for `clientIp`, full `useragent`, `conversationId`, and `archiveRequestId` for guests while retaining persisted values and all non-sensitive fields.
 
-Repository filtering and persistence remain unchanged. Redacting at the response mapping boundary gives one typed enforcement point and keeps aggregate queries identical for admins and guests.
+The service threads the same decision into repository filter construction. Guest text search excludes the `client_ip` predicate so redacted values cannot be reconstructed as a membership oracle; admin search retains the existing client-IP behavior. The role decision is also part of the short-lived filtered-count cache key so an admin result cannot leak through a guest count lookup.
+
+Persistence remains unchanged. Keeping the role decision explicit across filter construction and response mapping provides typed enforcement points while preserving non-sensitive filters and aggregates for both roles.
 
 ### Hide sensitive request-detail UI by role
 
@@ -38,5 +40,6 @@ The request-detail component reads the authenticated dashboard role. Admins reta
 ## Risks / Trade-offs
 
 - [Risk] A future request-log identifying field could be added without joining the redaction set. → Keep the sensitive-field list explicit in the role-aware mapper test and OpenSpec requirement.
+- [Risk] A redacted request-log field could remain searchable and become a membership oracle. → Pass the role decision into filter construction and test guest and admin search behavior at the API boundary.
 - [Risk] Client-side role state could be stale. → Backend response redaction and archive authorization are authoritative and do not rely on the UI.
 - [Trade-off] Guests lose conversation drill-down and archive inspection. → They retain request rows, model/status/token/cost/latency fields, `useragentGroup`, and aggregate dashboard/report statistics.

--- a/openspec/changes/restrict-guest-sensitive-request-data/proposal.md
+++ b/openspec/changes/restrict-guest-sensitive-request-data/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Dashboard guests currently inherit broad read access that includes full conversation archives and raw request identifiers. Those surfaces contain substantially more sensitive data than the aggregate operational statistics guests need.
+
+## What Changes
+
+- Require an admin dashboard principal for every conversation-archive endpoint.
+- Keep request-log rows readable by guests, but redact raw client IP, user-agent, conversation ID, and archive lookup ID values.
+- Hide archive controls and raw identifying request metadata from guest dashboard views while preserving aggregate statistics.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `admin-auth`: Narrow guest read access for sensitive observability data.
+- `proxy-runtime-observability`: Define role-aware exposure of archives and raw request metadata.
+- `frontend-architecture`: Keep guest request-log views free of archive controls and raw identifying fields.
+
+## Impact
+
+Affected areas are dashboard authorization dependencies, conversation-archive routes, the request-log API response mapping, request-log detail UI, and focused backend/frontend authorization tests. Persistence, proxy routing, retention, and aggregate statistics are unchanged.

--- a/openspec/changes/restrict-guest-sensitive-request-data/proposal.md
+++ b/openspec/changes/restrict-guest-sensitive-request-data/proposal.md
@@ -6,6 +6,7 @@ Dashboard guests currently inherit broad read access that includes full conversa
 
 - Require an admin dashboard principal for every conversation-archive endpoint.
 - Keep request-log rows readable by guests, but redact raw client IP, user-agent, conversation ID, and archive lookup ID values.
+- Reject the dedicated request-log `conversation_id` filter for guests while preserving admin filtering and conversation aggregates.
 - Hide archive controls and raw identifying request metadata from guest dashboard views while preserving aggregate statistics.
 
 ## Capabilities
@@ -22,4 +23,4 @@ None.
 
 ## Impact
 
-Affected areas are dashboard authorization dependencies, conversation-archive routes, the request-log API response mapping, request-log detail UI, and focused backend/frontend authorization tests. Persistence, proxy routing, retention, and aggregate statistics are unchanged.
+Affected areas are dashboard authorization dependencies, conversation-archive routes, the request-log API response mapping and filtering boundary, request-log detail UI, and focused backend/frontend authorization tests. Persistence, proxy routing, retention, and admin aggregate statistics are unchanged.

--- a/openspec/changes/restrict-guest-sensitive-request-data/specs/admin-auth/spec.md
+++ b/openspec/changes/restrict-guest-sensitive-request-data/specs/admin-auth/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Dashboard guest access is read-only
 
-The system SHALL support a dashboard `guest` role with permission to read guest-safe dashboard data and without permission to read admin-only sensitive data or mutate state. Full conversation archives MUST require an `admin` principal. The system SHALL continue to treat password-authenticated, trusted-header, disabled-auth, and local bootstrap users as `admin` principals with read and write permissions.
+The system SHALL support a dashboard `guest` role with permission to read guest-safe dashboard data and without permission to read admin-only sensitive data or mutate state. Full conversation archives and request-log filtering by a dedicated conversation identifier MUST require an `admin` principal. The system SHALL continue to treat password-authenticated, trusted-header, disabled-auth, and local bootstrap users as `admin` principals with read and write permissions.
 
 #### Scenario: Guest can read guest-safe dashboard APIs
 
@@ -16,6 +16,12 @@ The system SHALL support a dashboard `guest` role with permission to read guest-
 - **WHEN** a guest principal requests any conversation-archive endpoint
 - **THEN** the system returns HTTP 403 with error code `admin_access_required`
 - **AND** no archive file metadata, payload, headers, or other archive record data is returned
+
+#### Scenario: Guest cannot filter request logs by conversation identifier
+
+- **WHEN** a guest principal requests request logs with the dedicated `conversation_id` filter
+- **THEN** the system returns HTTP 403 with error code `admin_access_required`
+- **AND** no filtered rows, request count, or aggregated conversation cost is returned
 
 #### Scenario: Guest cannot mutate dashboard state
 

--- a/openspec/changes/restrict-guest-sensitive-request-data/specs/admin-auth/spec.md
+++ b/openspec/changes/restrict-guest-sensitive-request-data/specs/admin-auth/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Dashboard guest access is read-only
+
+The system SHALL support a dashboard `guest` role with permission to read guest-safe dashboard data and without permission to read admin-only sensitive data or mutate state. Full conversation archives MUST require an `admin` principal. The system SHALL continue to treat password-authenticated, trusted-header, disabled-auth, and local bootstrap users as `admin` principals with read and write permissions.
+
+#### Scenario: Guest can read guest-safe dashboard APIs
+
+- **WHEN** guest access is enabled and a guest principal requests a guest-safe dashboard GET endpoint
+- **THEN** the request succeeds using read-only dashboard access
+- **AND** the session response identifies the principal as `guest`
+- **AND** the session response includes only the `read` permission
+
+#### Scenario: Guest cannot read conversation archives
+
+- **WHEN** a guest principal requests any conversation-archive endpoint
+- **THEN** the system returns HTTP 403 with error code `admin_access_required`
+- **AND** no archive file metadata, payload, headers, or other archive record data is returned
+
+#### Scenario: Guest cannot mutate dashboard state
+
+- **WHEN** guest access is enabled and a guest principal requests a dashboard mutating endpoint
+- **THEN** the system returns HTTP 403 with error code `read_only_access`
+- **AND** no dashboard state is changed

--- a/openspec/changes/restrict-guest-sensitive-request-data/specs/frontend-architecture/spec.md
+++ b/openspec/changes/restrict-guest-sensitive-request-data/specs/frontend-architecture/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Guest request details hide sensitive metadata and archives
+
+The Request Details dialog MUST render full User Agent, Client IP, Conversation ID controls, and the conversation archive panel only for an admin dashboard principal. It MUST omit those fields and MUST NOT mount the archive panel for a guest principal. Request status, model, transport, timing, token, cost, and error details MUST remain available to guests.
+
+#### Scenario: Guest opens request details
+
+- **GIVEN** the authenticated dashboard principal has role `guest`
+- **WHEN** the guest opens a request-log detail dialog
+- **THEN** the dialog does not render User Agent, Client IP, Conversation ID, or archive controls
+- **AND** it continues to render the non-identifying operational request details
+
+#### Scenario: Admin opens request details
+
+- **GIVEN** the authenticated dashboard principal has role `admin`
+- **WHEN** the admin opens a request-log detail dialog
+- **THEN** the dialog renders the identifying metadata fields when present
+- **AND** it mounts the archive panel using `archiveRequestId` with the existing `requestId` fallback

--- a/openspec/changes/restrict-guest-sensitive-request-data/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/restrict-guest-sensitive-request-data/specs/proxy-runtime-observability/spec.md
@@ -44,7 +44,7 @@ Request-log search MUST match persisted `client_ip` values for an admin principa
 
 ### Requirement: Guest request logs redact raw identifying metadata
 
-The dashboard request-log API MUST return request rows and non-identifying operational metrics to a guest principal, but MUST serialize `clientIp`, full `useragent`, `conversationId`, and `archiveRequestId` as null and MUST NOT use those redacted values to match guest text searches. It MUST retain those values for an admin principal. The lower-cardinality `useragentGroup`, status, model, token, latency, and cost fields MAY remain available to guests.
+The dashboard request-log API MUST return request rows and non-identifying operational metrics to a guest principal, but MUST serialize `clientIp`, full `useragent`, `conversationId`, and `archiveRequestId` as null and MUST NOT use those redacted values to match guest text searches. It MUST reject a guest request that supplies the dedicated `conversation_id` filter with HTTP 403 and error code `admin_access_required`. It MUST retain the identifying values and existing conversation filtering and aggregate response for an admin principal. The lower-cardinality `useragentGroup`, status, model, token, latency, and cost fields MAY remain available to guests outside a dedicated conversation filter.
 
 #### Scenario: Guest reads operational request rows without raw identifiers
 
@@ -58,3 +58,17 @@ The dashboard request-log API MUST return request rows and non-identifying opera
 - **GIVEN** a persisted request log contains a client IP, full User-Agent, conversation ID, and archive lookup ID
 - **WHEN** an admin principal requests `GET /api/request-logs`
 - **THEN** the response contains the persisted values
+
+#### Scenario: Guest conversation filter fails closed
+
+- **GIVEN** persisted request logs contain a redacted conversation ID
+- **WHEN** a guest principal requests `GET /api/request-logs` with that `conversation_id`
+- **THEN** the response is HTTP 403 with error code `admin_access_required`
+- **AND** no filtered row count or aggregated conversation cost is returned
+
+#### Scenario: Admin retains conversation filtering and aggregates
+
+- **GIVEN** persisted request logs contain a conversation ID
+- **WHEN** an admin principal requests `GET /api/request-logs` with that `conversation_id`
+- **THEN** only matching request rows are returned
+- **AND** the response retains the matching request count and aggregated conversation cost

--- a/openspec/changes/restrict-guest-sensitive-request-data/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/restrict-guest-sensitive-request-data/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Full upstream conversation archive
+The proxy MUST provide an opt-in durable archive of Codex-to-upstream conversation traffic. When enabled, the archive MUST write gzip-compressed newline-delimited JSON records for upstream request payloads, streamed Responses events, compact response payloads, and websocket text or binary frames without performing gzip file I/O in the request event loop during normal operation. The archive writer queue MUST be bounded and MUST apply synchronous write backpressure instead of growing without limit when the background writer is saturated. Archive records MUST include request id, timestamp, direction, traffic kind, transport, account id when known, upstream target metadata, redacted headers, and the full payload or frame body. Credential-bearing headers such as authorization, cookies, proxy authorization, token headers, and API key headers MUST be redacted before persistence. JSON records MUST preserve non-ASCII payload text as UTF-8 rather than Unicode escape sequences. When disabled, no archive file MUST be created by the archive writer. Admin request-log API rows MUST expose an `archiveRequestId` lookup key when the persisted log id can differ from the archive record request id; guest rows MUST redact that key.
+
+#### Scenario: operator enables archive for audit
+- **WHEN** `CODEX_LB_CONVERSATION_ARCHIVE_ENABLED=true`
+- **AND** a Codex Responses request is proxied upstream
+- **THEN** the archive records both the outbound upstream payload and inbound upstream events or response body as gzip JSONL
+- **AND** credential-bearing headers are stored as redacted values
+
+#### Scenario: archive remains disabled by default
+- **WHEN** the archive setting is not enabled
+- **THEN** the archive writer does not create conversation archive files
+
+#### Scenario: admin views archived traffic
+- **GIVEN** conversation archive files exist as `.jsonl.gz` or legacy `.jsonl`
+- **WHEN** an authenticated dashboard admin opens an existing request log detail
+- **THEN** the dashboard can find matching archive records by request id across archive files and display payload plus metadata for that request
+
+#### Scenario: response-id request logs keep admin archive lookup
+- **WHEN** a successful proxied request stores a downstream response id in the request-log `requestId`
+- **AND** the conversation archive stored records under the original request context id
+- **THEN** the admin request-log API response includes `archiveRequestId` with the original archive lookup id
+- **AND** the persisted `requestId` remains available for response-id continuity lookup
+
+## ADDED Requirements
+
+### Requirement: Guest request logs redact raw identifying metadata
+
+The dashboard request-log API MUST return request rows and non-identifying operational metrics to a guest principal, but MUST serialize `clientIp`, full `useragent`, `conversationId`, and `archiveRequestId` as null. It MUST retain those values for an admin principal. The lower-cardinality `useragentGroup`, status, model, token, latency, and cost fields MAY remain available to guests.
+
+#### Scenario: Guest reads operational request rows without raw identifiers
+
+- **GIVEN** a persisted request log contains a client IP, full User-Agent, conversation ID, archive lookup ID, model, status, tokens, latency, and cost
+- **WHEN** a guest principal requests `GET /api/request-logs`
+- **THEN** the response row has null `clientIp`, `useragent`, `conversationId`, and `archiveRequestId`
+- **AND** the response retains the row's non-identifying operational fields
+
+#### Scenario: Admin retains raw request metadata
+
+- **GIVEN** a persisted request log contains a client IP, full User-Agent, conversation ID, and archive lookup ID
+- **WHEN** an admin principal requests `GET /api/request-logs`
+- **THEN** the response contains the persisted values

--- a/openspec/changes/restrict-guest-sensitive-request-data/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/restrict-guest-sensitive-request-data/specs/proxy-runtime-observability/spec.md
@@ -24,11 +24,27 @@ The proxy MUST provide an opt-in durable archive of Codex-to-upstream conversati
 - **THEN** the admin request-log API response includes `archiveRequestId` with the original archive lookup id
 - **AND** the persisted `requestId` remains available for response-id continuity lookup
 
+### Requirement: Request-log search matches client IP
+
+Request-log search MUST match persisted `client_ip` values for an admin principal. For a guest principal, request-log search MUST NOT inspect or match persisted `client_ip` values.
+
+#### Scenario: Admin searches by client IP
+
+- **GIVEN** a request log row has `client_ip = "203.0.113.7"`
+- **WHEN** an admin principal searches request logs for `203.0.113.7`
+- **THEN** the matching request log row is returned
+
+#### Scenario: Guest cannot search by redacted client IP
+
+- **GIVEN** a request log row has `client_ip = "203.0.113.7"` and no non-sensitive field matching `203.0.113`
+- **WHEN** a guest principal searches request logs for `203.0.113`
+- **THEN** the request log row is not returned
+
 ## ADDED Requirements
 
 ### Requirement: Guest request logs redact raw identifying metadata
 
-The dashboard request-log API MUST return request rows and non-identifying operational metrics to a guest principal, but MUST serialize `clientIp`, full `useragent`, `conversationId`, and `archiveRequestId` as null. It MUST retain those values for an admin principal. The lower-cardinality `useragentGroup`, status, model, token, latency, and cost fields MAY remain available to guests.
+The dashboard request-log API MUST return request rows and non-identifying operational metrics to a guest principal, but MUST serialize `clientIp`, full `useragent`, `conversationId`, and `archiveRequestId` as null and MUST NOT use those redacted values to match guest text searches. It MUST retain those values for an admin principal. The lower-cardinality `useragentGroup`, status, model, token, latency, and cost fields MAY remain available to guests.
 
 #### Scenario: Guest reads operational request rows without raw identifiers
 

--- a/openspec/changes/restrict-guest-sensitive-request-data/tasks.md
+++ b/openspec/changes/restrict-guest-sensitive-request-data/tasks.md
@@ -3,6 +3,7 @@
 - [x] 1.1 Add an explicit admin-only dashboard read dependency and apply it to all conversation-archive routes.
 - [x] 1.2 Redact client IP, full User-Agent, conversation ID, and archive lookup ID from guest request-log responses while preserving admin responses and operational metrics.
 - [x] 1.3 Exclude persisted client IP from guest request-log search while preserving admin client-IP search.
+- [x] 1.4 Reject guest use of the dedicated request-log `conversation_id` filter while preserving admin filtering and aggregates.
 
 ## 2. Dashboard presentation
 
@@ -14,3 +15,4 @@
 - [x] 3.2 Add frontend regression coverage for guest-hidden sensitive details and unchanged admin details.
 - [x] 3.3 Run focused backend/frontend tests, lint or type checks for touched code, and strict OpenSpec validation.
 - [x] 3.4 Add API regression coverage proving guest client-IP search is blocked while admin search remains available.
+- [x] 3.5 Add public API regression coverage proving guest `conversation_id` filtering fails closed while admin behavior remains available.

--- a/openspec/changes/restrict-guest-sensitive-request-data/tasks.md
+++ b/openspec/changes/restrict-guest-sensitive-request-data/tasks.md
@@ -2,6 +2,7 @@
 
 - [x] 1.1 Add an explicit admin-only dashboard read dependency and apply it to all conversation-archive routes.
 - [x] 1.2 Redact client IP, full User-Agent, conversation ID, and archive lookup ID from guest request-log responses while preserving admin responses and operational metrics.
+- [x] 1.3 Exclude persisted client IP from guest request-log search while preserving admin client-IP search.
 
 ## 2. Dashboard presentation
 
@@ -12,3 +13,4 @@
 - [x] 3.1 Add backend regression tests for guest archive denial, guest metadata redaction, and unchanged admin data.
 - [x] 3.2 Add frontend regression coverage for guest-hidden sensitive details and unchanged admin details.
 - [x] 3.3 Run focused backend/frontend tests, lint or type checks for touched code, and strict OpenSpec validation.
+- [x] 3.4 Add API regression coverage proving guest client-IP search is blocked while admin search remains available.

--- a/openspec/changes/restrict-guest-sensitive-request-data/tasks.md
+++ b/openspec/changes/restrict-guest-sensitive-request-data/tasks.md
@@ -1,0 +1,14 @@
+## 1. Backend authorization and redaction
+
+- [x] 1.1 Add an explicit admin-only dashboard read dependency and apply it to all conversation-archive routes.
+- [x] 1.2 Redact client IP, full User-Agent, conversation ID, and archive lookup ID from guest request-log responses while preserving admin responses and operational metrics.
+
+## 2. Dashboard presentation
+
+- [x] 2.1 Hide identifying request-detail fields and the archive panel for guest principals while preserving the admin view.
+
+## 3. Focused verification
+
+- [x] 3.1 Add backend regression tests for guest archive denial, guest metadata redaction, and unchanged admin data.
+- [x] 3.2 Add frontend regression coverage for guest-hidden sensitive details and unchanged admin details.
+- [x] 3.3 Run focused backend/frontend tests, lint or type checks for touched code, and strict OpenSpec validation.

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -199,6 +199,38 @@ async def _assert_guest_write_denied(client: AsyncClient) -> None:
     assert blocked_quota_planner_cancel.json()["error"]["code"] == "read_only_access"
 
 
+async def _assert_guest_archive_read_denied(client: AsyncClient) -> None:
+    blocked_archive = await client.get("/api/conversation-archive/files")
+    assert blocked_archive.status_code == 403
+    assert blocked_archive.json()["error"]["code"] == "admin_access_required"
+
+    blocked_archive_records = await client.get(
+        "/api/conversation-archive/records",
+        params={"requestId": "guest-hidden"},
+    )
+    assert blocked_archive_records.status_code == 403
+    blocked_archive_payload = blocked_archive_records.json()
+    assert blocked_archive_payload["error"]["code"] == "admin_access_required"
+    assert not {"records", "payload", "headers"} & blocked_archive_payload.keys()
+
+
+@pytest.mark.asyncio
+async def test_conversation_archive_routes_remain_available_to_admin(async_client):
+    files = await async_client.get("/api/conversation-archive/files")
+    assert files.status_code == 200
+    assert isinstance(files.json(), list)
+
+    records = await async_client.get(
+        "/api/conversation-archive/records",
+        params={"requestId": "admin-fixture"},
+    )
+    assert records.status_code == 200
+    payload = records.json()
+    assert payload["records"] == []
+    assert payload["total"] == 0
+    assert payload["hasMore"] is False
+
+
 @pytest.mark.asyncio
 async def test_session_branch_allows_without_password_and_blocks_without_session(async_client):
     public_mode = await async_client.get("/api/settings")
@@ -553,6 +585,7 @@ async def test_passwordless_guest_access_allows_remote_reads_and_blocks_writes(a
             assert session_payload["guestPasswordRequired"] is False
 
             await _assert_guest_write_denied(remote_client)
+            await _assert_guest_archive_read_denied(remote_client)
 
             passwordless_login = await remote_client.post("/api/dashboard-auth/guest/login", json={})
             assert passwordless_login.status_code == 200
@@ -671,6 +704,7 @@ async def test_guest_password_login_allows_remote_reads_and_blocks_writes(app_in
             assert refresh_payload["guestPasswordRequired"] is True
 
             await _assert_guest_write_denied(remote_client)
+            await _assert_guest_archive_read_denied(remote_client)
 
             totp_setup = await remote_client.post("/api/dashboard-auth/totp/setup/start", json={})
             assert totp_setup.status_code == 401

--- a/tests/integration/test_request_logs_api.py
+++ b/tests/integration/test_request_logs_api.py
@@ -305,6 +305,53 @@ async def test_request_logs_api_redacts_sensitive_metadata_for_guest_and_preserv
 
 
 @pytest.mark.asyncio
+async def test_request_logs_api_excludes_client_ip_from_guest_search_and_preserves_admin_search(
+    app_instance,
+    async_client,
+    db_setup,
+    monkeypatch,
+):
+    from app.modules.request_logs import repository as logs_repository_module
+
+    del db_setup
+    monkeypatch.setattr(logs_repository_module, "_COUNT_CACHE_TTL_SECONDS", 30.0)
+    logs_repository_module._clear_recent_count_cache()
+    async with SessionLocal() as session:
+        logs_repo = RequestLogsRepository(session)
+        await logs_repo.add_log(
+            account_id=None,
+            request_id="req_ip_search_target",
+            model="gpt-5.1",
+            input_tokens=100,
+            output_tokens=20,
+            latency_ms=250,
+            status="success",
+            error_code=None,
+            client_ip="203.0.113.17",
+        )
+
+    try:
+        app_instance.dependency_overrides[validate_dashboard_session] = guest_principal
+        try:
+            guest_response = await async_client.get("/api/request-logs?search=203.0.113")
+        finally:
+            app_instance.dependency_overrides.pop(validate_dashboard_session, None)
+
+        assert guest_response.status_code == 200
+        assert guest_response.json()["requests"] == []
+        assert guest_response.json()["total"] == 0
+
+        admin_response = await async_client.get("/api/request-logs?search=203.0.113")
+        assert admin_response.status_code == 200
+        assert [entry["requestId"] for entry in admin_response.json()["requests"]] == [
+            "req_ip_search_target",
+        ]
+        assert admin_response.json()["total"] == 1
+    finally:
+        logs_repository_module._clear_recent_count_cache()
+
+
+@pytest.mark.asyncio
 async def test_request_logs_api_lists_limit_warmup_rows(async_client, db_setup):
     async with SessionLocal() as session:
         accounts_repo = AccountsRepository(session)

--- a/tests/integration/test_request_logs_api.py
+++ b/tests/integration/test_request_logs_api.py
@@ -4,6 +4,8 @@ from datetime import timedelta
 
 import pytest
 
+from app.core.auth.dashboard_access import guest_principal
+from app.core.auth.dependencies import validate_dashboard_session
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, ApiKey, ModelSource, RequestLog
@@ -247,6 +249,59 @@ async def test_request_logs_api_returns_useragent_fields(async_client, db_setup)
     assert older["useragent"] is None
     assert older["useragentGroup"] is None
     assert older["clientIp"] is None
+
+
+@pytest.mark.asyncio
+async def test_request_logs_api_redacts_sensitive_metadata_for_guest_and_preserves_admin(
+    app_instance,
+    async_client,
+    db_setup,
+):
+    del db_setup
+    async with SessionLocal() as session:
+        logs_repo = RequestLogsRepository(session)
+        await logs_repo.add_log(
+            account_id=None,
+            request_id="req_guest_visible",
+            archive_request_id="archive_guest_hidden",
+            conversation_id="conversation_guest_hidden",
+            model="gpt-5.1",
+            input_tokens=100,
+            output_tokens=20,
+            latency_ms=250,
+            status="success",
+            error_code=None,
+            useragent="codex-cli/1.2.3 runtime/node",
+            useragent_group="codex-cli",
+            client_ip="203.0.113.17",
+        )
+
+    app_instance.dependency_overrides[validate_dashboard_session] = guest_principal
+    try:
+        guest_response = await async_client.get("/api/request-logs?limit=1")
+    finally:
+        app_instance.dependency_overrides.pop(validate_dashboard_session, None)
+
+    assert guest_response.status_code == 200
+    guest_entry = guest_response.json()["requests"][0]
+    assert guest_entry["requestId"] == "req_guest_visible"
+    assert guest_entry["archiveRequestId"] is None
+    assert guest_entry["conversationId"] is None
+    assert guest_entry["useragent"] is None
+    assert guest_entry["clientIp"] is None
+    assert guest_entry["useragentGroup"] == "codex-cli"
+    assert guest_entry["model"] == "gpt-5.1"
+    assert guest_entry["status"] == "ok"
+    assert guest_entry["tokens"] == 120
+    assert guest_entry["latencyMs"] == 250
+
+    admin_response = await async_client.get("/api/request-logs?limit=1")
+    assert admin_response.status_code == 200
+    admin_entry = admin_response.json()["requests"][0]
+    assert admin_entry["archiveRequestId"] == "archive_guest_hidden"
+    assert admin_entry["conversationId"] == "conversation_guest_hidden"
+    assert admin_entry["useragent"] == "codex-cli/1.2.3 runtime/node"
+    assert admin_entry["clientIp"] == "203.0.113.17"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_request_logs_api.py
+++ b/tests/integration/test_request_logs_api.py
@@ -352,6 +352,56 @@ async def test_request_logs_api_excludes_client_ip_from_guest_search_and_preserv
 
 
 @pytest.mark.asyncio
+async def test_request_logs_api_rejects_guest_conversation_filter_and_preserves_admin_aggregates(
+    app_instance,
+    async_client,
+    db_setup,
+):
+    del db_setup
+    async with SessionLocal() as session:
+        logs_repo = RequestLogsRepository(session)
+        await logs_repo.add_log(
+            account_id=None,
+            request_id="req_conversation_filter_target",
+            conversation_id="conversation-filter-target",
+            model="gpt-5.1",
+            input_tokens=100,
+            output_tokens=20,
+            latency_ms=250,
+            status="success",
+            error_code=None,
+            cost_usd=4.25,
+        )
+
+    app_instance.dependency_overrides[validate_dashboard_session] = guest_principal
+    try:
+        guest_response = await async_client.get(
+            "/api/request-logs",
+            params={"conversation_id": "conversation-filter-target"},
+        )
+    finally:
+        app_instance.dependency_overrides.pop(validate_dashboard_session, None)
+
+    assert guest_response.status_code == 403
+    assert guest_response.json()["error"]["code"] == "admin_access_required"
+
+    admin_response = await async_client.get(
+        "/api/request-logs",
+        params={"conversation_id": "conversation-filter-target"},
+    )
+    assert admin_response.status_code == 200
+    admin_payload = admin_response.json()
+    assert [entry["requestId"] for entry in admin_payload["requests"]] == [
+        "req_conversation_filter_target",
+    ]
+    assert admin_payload["total"] == 1
+    assert admin_payload["conversation"] == {
+        "requestCount": 1,
+        "aggregatedCostUsd": 4.25,
+    }
+
+
+@pytest.mark.asyncio
 async def test_request_logs_api_lists_limit_warmup_rows(async_client, db_setup):
     async with SessionLocal() as session:
         accounts_repo = AccountsRepository(session)

--- a/tests/unit/test_dashboard_auth_dependencies.py
+++ b/tests/unit/test_dashboard_auth_dependencies.py
@@ -7,8 +7,9 @@ import pytest
 from starlette.requests import Request
 
 import app.core.auth.dependencies as auth_dependencies
+from app.core.auth.dashboard_access import admin_principal, guest_principal
 from app.core.auth.dashboard_mode import DashboardAuthMode
-from app.core.exceptions import DashboardAuthError
+from app.core.exceptions import DashboardAuthError, DashboardPermissionError
 
 pytestmark = pytest.mark.unit
 
@@ -58,3 +59,31 @@ async def test_validate_dashboard_session_blocks_passwordless_guest_fallback_in_
 
     assert exc_info.value.code == "proxy_auth_required"
     assert getattr(request.state, "dashboard_principal", None) is None
+
+
+@pytest.mark.asyncio
+async def test_require_dashboard_admin_access_rejects_guest(monkeypatch):
+    request = _build_request("/api/conversation-archive/files")
+    monkeypatch.setattr(
+        auth_dependencies,
+        "validate_dashboard_session",
+        AsyncMock(return_value=guest_principal()),
+    )
+
+    with pytest.raises(DashboardPermissionError, match="Admin dashboard access is required") as exc_info:
+        await auth_dependencies.require_dashboard_admin_access(request)
+
+    assert exc_info.value.code == "admin_access_required"
+
+
+@pytest.mark.asyncio
+async def test_require_dashboard_admin_access_allows_admin(monkeypatch):
+    request = _build_request("/api/conversation-archive/files")
+    principal = admin_principal(auth_mode=DashboardAuthMode.STANDARD)
+    monkeypatch.setattr(
+        auth_dependencies,
+        "validate_dashboard_session",
+        AsyncMock(return_value=principal),
+    )
+
+    assert await auth_dependencies.require_dashboard_admin_access(request) is principal


### PR DESCRIPTION
## Summary

Restricts guest access to sensitive request data while preserving privacy-safe operational and aggregate statistics. Full conversation archives and raw identifying request metadata are now admin-only.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: Related to #1477

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/restrict-guest-sensitive-request-data/`

The change remains active through merge. Strict change validation, strict main-spec validation, and implementation/spec verification passed.

## Changes

- Require admin access for all full conversation-archive read routes.
- Redact client IP, full User-Agent, conversation ID, and archive lookup ID from guest request-log responses while retaining safe operational and aggregate fields.
- Hide sensitive request details and the conversation-archive panel from guests while preserving the existing admin view.
- Add focused backend and frontend regression coverage.
- Do not change retention, archive persistence, proxy routing, or status indicators.

## Simplicity

- [x] No new required setup step
- [x] No new setting, README section, `.env.example` entry, dashboard navigation item, or default change
- [x] Dashboard-visible behavior is documented with the sanitized before/after pair below

## Test plan

- Focused Python guest/archive/request-log suites: 73 passed.
- Focused recent-requests-table frontend suite: 21 passed.
- Ruff on touched backend paths: passed.
- `ty check app`, frontend ESLint, typecheck, and build: passed.
- `openspec validate restrict-guest-sensitive-request-data --strict`: passed.
- `openspec validate --specs --strict`: 47/47 specs passed.
- OpenSpec implementation verification: 6/6 tasks, 3 requirements, and 11 scenarios verified.
- Independent standards and spec reviews for `09ae76d2bcbe9342c3d4ba29ff36eec5d2487724`: clean.

The full local command `uv run pre-commit run local-ci --hook-stage manual --all-files` was attempted and exited 1. Its failure detail was not durably retained, so this PR does not claim a green full local CI result; run-owned cleanup passed.

Current `upstream/main` also has a red [CI Required job](https://github.com/Soju06/codex-lb/actions/runs/30205667840/job/89803750872): the runner timed out pulling `postgres:16` from Docker Hub before tests began. Publication is proceeding with that external base-side infrastructure blocker disclosed; readiness and merge still require green CI on the current PR head.

## Screenshots / output

![Before](https://github.com/user-attachments/assets/12522527-09ef-4262-a0eb-4c08cefd4442)

![After](https://github.com/user-attachments/assets/9fb0844c-200a-4f64-8a84-e281b803f8e9)
