### PR TITLE
chore: release v1.23.0-beta.3

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.23.0-beta.2"  # x-release-please-version
+__version__ = "1.23.0-beta.3"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.23.0-beta.2
-appVersion: 1.23.0-beta.2
+version: 1.23.0-beta.3
+appVersion: 1.23.0-beta.3
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.23.0-beta.2",
+  "version": "1.23.0-beta.3",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.23.0-beta.2"
+version = "1.23.0-beta.3"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.23.0b2"
+version = "1.23.0-beta.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.23.0-beta.3 for the 1.23.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.23.0-beta.3 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1472; no manual beta workflow dispatch is required.

## Changes since v1.23.0-beta.2
- fix(proxy): extend websocket stream budget (#1353) (de2c5fc)
- fix(proxy): preserve fresh bridge full resends (#1486) (
b5a515)
- feat(ui): complete zh-CN dashboard translations (#1436) (
79a42c)
- fix(auth): restrict guest access to sensitive request data (#1497) (
73aa50)
- fix(reports): use local days for daily averages (#1525) (
eefce1)
- fix(helm): calculate aggregate 5xx error rate (#1522) (
b883d6)
- fix(db): correct PostgreSQL pool budget (#1519) (
68a2bc)
- fix(http-bridge): wait before retrying model capacity (#1395) (
448b23)
- fix(proxy): release idle bridge sessions' account stream leases (#1476) (
934904)
- fix(proxy): spill unanchored forks on account caps (#1499) (
028425)
- fix(proxy): attribute bridge failure fan-out request logs to each request's API key (#1540) (
3fe0d6)
- fix(cost): openai updates the terra and luna's cost (#1553) (
c1d189)
- feat(proxy): add durable capability lineage for reconnect (#1562) (
151c42)
- fix(proxy): surface forwarded compact settlement failures (#1561) (
2176b1)
- feat(helm): allow Grafana dashboard title overrides (#1482) (
266fbe)
- feat(ui): separate service and usage health status (#1495) (
6b1f47)
- feat(ui): warn when request log retention is disabled (#1496) (
d2dc91)
- feat(dashboard): Add conversation list on dashboard and details dialog (#1477) (
c539a2)
- fix(http-bridge): stabilize silent and clean-close recovery (#1394) (
a66f79)
- fix(proxy): sequence websocket health after settlement (#1558) (
d77011)
- fix(cache): recover invalidation after failed prime (#1544) (
ba5a28)
- fix(proxy-responses): tolerate structured content type values (#1566) (
8600a6)
- fix(proxy): preserve terminal delivery across detach (#1527) (
4694a5)
- fix(compact): elide observed inline images at wire cap (#1457) (
8d154e)
- fix(proxy): classify tool-search missing-tool-output rejections (#1531) (
773964)
- fix(proxy): keep upstream request-shape rejections account neutral (#1532) (
24d12f)
- fix(proxy): preserve websocket connect errors (#1517) (
2ba5f9)
- fix(proxy): retry detached API key release (#1545) (
35e09f)
- fix(proxy): strip replayed tool call namespaces (#1578) (
7c456d)
- fix(quota): release reservations on header failure (#1559) (
783665)
- fix(proxy): drain active WebSocket turns on shutdown (#1520) (
66b919)
- fix(proxy): preserve developer-interleaved fresh resends (#1537) (
201281)
- fix(usage): confirm workspace-less paid to free plan downgrades (#1491) (
927a3c)
- fix(proxy): bound upstream streams that never send response headers (#1611) (
af5051)
- fix(quota): warm free monthly resets (#1504) (
dc9f9d)
- fix(proxy): purge stale hard codex_session mappings pinned to a durably unavailable owner (#1417) (
b1d27b)
- fix(proxy): clear durable bridge anchor after stuck eventless timeout (#1563) (
4c04e5)
- fix(db): release SQLite handles before file mutations (#1526) (
58c5ea)
- fix(proxy): attribute websocket request kind per turn (#1602) (
e3bc44)
- perf(dashboard): bound projection history fetch per account (#1613) (
09e1b5)
- perf(request-logs): serve listing totals from the demand rollup plus raw tail (#1615) (
778c53)
- perf(usage): probe additional-usage latest reads instead of DISTINCT ON scans (#1614) (
54881d)
- perf(dashboard): serve conversation metrics from an hourly presence rollup (#1616) (
80df35)

## Release-candidate validation
Validated candidate: d73db4bc5fa1d55ef4fa4de16c169cdf10d66969

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates — CI green at d73db4bc (unit, integration-core 1-3 + required, integration-bridge on rerun of a known runner flake, PostgreSQL, migration checks sqlite+postgres; all non-guard checks success)
- [x] Frontend tests/build — CI green at d73db4bc (frontend lint/typecheck/tests/build, dashboard browser smoke)
- [x] Wheel/package validation — CI `Package (build)` green at d73db4bc (sdist/wheel build + verify)
- [x] Docker/container smoke — image built locally from d73db4bc (sha256:0fdbd70278d0); booted against a scratch postgres:18-alpine: alembic migrated an empty DB to head `20260806_010000_add_conversation_presence_rollup` (54 tables; `request_conversation_hourly_rollups`, `conversation_folded_through` state column, and both `ix_additional_usage_alias_*_latest` expression indexes present), `/` 200, `/api/runtime/version` and `/v1/models` 401 (auth enforced), 0 error signatures in logs beyond the probes' own 401s
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required — this beta deploys to the production pool immediately after publish for the soak mandated by the release-channel policy; live-path verification happens there with rollback runbook staged (deploy.sh image-swap cutover; the schema delta is additive-only — new satellite table, one state column, two CONCURRENTLY-built indexes — with tested downgrade)

## Install after publish
```bash
uvx --from "codex-lb==1.23.0b3" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.23.0-beta.3
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.23.0-beta.3 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.23.0.