### PR TITLE
fix(proxy): spill unanchored forks on account caps

### DIFF
--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -148,6 +148,7 @@ from app.modules.proxy._service.support import (
     _HTTPBridgeOwnerForward,
     _HTTPBridgeSession,
     _HTTPBridgeSessionKey,
+    _is_local_account_cap_code,
     _signal_propagated_capacity_startup_ready,
     _signal_propagated_capacity_startup_wait,
     _ttft_event_visible_at,
@@ -190,6 +191,7 @@ from app.modules.proxy.affinity import (
     _AffinityPolicy,
     _extract_model_class,
     _prompt_cache_key_from_request_model,
+    _request_allows_bare_session_cap_spillover,
     _sticky_key_for_responses_request,
     _sticky_key_from_session_header,
     _sticky_key_from_turn_state_header,
@@ -246,6 +248,22 @@ def _http_bridge_account_capacity_wait_seconds(exc: ProxyResponseError) -> float
     return _account_selection_recovery_sleep_seconds_from_message(
         message,
         error_code=code,
+    )
+
+
+def _http_bridge_unanchored_fork_can_spill_on_cap(
+    *,
+    error_code: str | None,
+    affinity_kind: str,
+    payload: ResponsesRequest,
+    preferred_account_id: str | None,
+) -> bool:
+    return (
+        _is_local_account_cap_code(error_code)
+        and affinity_kind == "internal_unanchored_parallel"
+        and preferred_account_id is not None
+        and payload.previous_response_id is None
+        and _request_allows_bare_session_cap_spillover(payload)
     )
 
 
@@ -1143,6 +1161,7 @@ class _HTTPBridgeStreamingMixin:
             without_http_bridge_session_affinity_headers(headers) if account_neutral_recovery else dict(headers)
         )
         fresh_replay_excluded_account_ids: set[str] = set()
+        unanchored_fork_spill_attempted = False
 
         def owner_unavailable_allows_account_neutral_replay(exc: ProxyResponseError) -> bool:
             nonlocal durable_full_resend_fresh_payload
@@ -1307,6 +1326,28 @@ class _HTTPBridgeStreamingMixin:
                 )
             except ProxyResponseError as exc:
                 if not owner_unavailable_allows_account_neutral_replay(exc):
+                    exc_code, _exc_message = _proxy_error_code_message(exc)
+                    if not unanchored_fork_spill_attempted and _http_bridge_unanchored_fork_can_spill_on_cap(
+                        error_code=exc_code,
+                        affinity_kind=bridge_session_key.affinity_kind,
+                        payload=effective_payload,
+                        preferred_account_id=request_state.preferred_account_id,
+                    ):
+                        unanchored_fork_spill_attempted = True
+                        _log_http_bridge_event(
+                            "unanchored_fork_cap_spill",
+                            bridge_session_key,
+                            account_id=request_state.preferred_account_id,
+                            model=effective_payload.model,
+                            detail=f"reason={exc_code}, outcome=retry_without_preferred_account",
+                            cache_key_family=bridge_session_key.affinity_kind,
+                            model_class=_extract_model_class(effective_payload.model)
+                            if effective_payload.model
+                            else None,
+                        )
+                        request_state.preferred_account_id = None
+                        preferred_account_has_continuity_provenance = False
+                        continue
                     wait_plan = _http_bridge_capacity_wait_plan(exc, request_deadline=request_deadline)
                     if wait_plan is not None:
                         bounded_wait_seconds, account_capacity_wait_seconds, message = wait_plan

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -255,12 +255,14 @@ def _http_bridge_unanchored_fork_can_spill_on_cap(
     *,
     error_code: str | None,
     affinity_kind: str,
+    original_request_unanchored: bool,
     payload: ResponsesRequest,
     preferred_account_id: str | None,
 ) -> bool:
     return (
         _is_local_account_cap_code(error_code)
         and affinity_kind == "internal_unanchored_parallel"
+        and original_request_unanchored
         and preferred_account_id is not None
         and payload.previous_response_id is None
         and _request_allows_bare_session_cap_spillover(payload)
@@ -1330,6 +1332,7 @@ class _HTTPBridgeStreamingMixin:
                     if not unanchored_fork_spill_attempted and _http_bridge_unanchored_fork_can_spill_on_cap(
                         error_code=exc_code,
                         affinity_kind=bridge_session_key.affinity_kind,
+                        original_request_unanchored=original_request_unanchored,
                         payload=effective_payload,
                         preferred_account_id=request_state.preferred_account_id,
                     ):

--- a/openspec/changes/spill-unanchored-forks-on-account-cap/.openspec.yaml
+++ b/openspec/changes/spill-unanchored-forks-on-account-cap/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/spill-unanchored-forks-on-account-cap/proposal.md
+++ b/openspec/changes/spill-unanchored-forks-on-account-cap/proposal.md
@@ -7,7 +7,7 @@ Self-contained unanchored parallel forks have no continuity owner, but a preferr
 ## What Changes
 
 - When session creation rejects a self-contained `internal_unanchored_parallel` fork with a local account-cap error, drop its preferred-account hint once and retry selection.
-- Keep owner-bearing payloads pinned by requiring no previous response, conversation, or input file reference.
+- Keep owner-bearing requests pinned by requiring no previous response, conversation, input file reference, turn-state owner, or anchored forwarding context.
 - Record the retry with the stable `unanchored_fork_cap_spill` bridge event.
 
 ## Capabilities

--- a/openspec/changes/spill-unanchored-forks-on-account-cap/proposal.md
+++ b/openspec/changes/spill-unanchored-forks-on-account-cap/proposal.md
@@ -1,0 +1,26 @@
+# Spill unanchored forks from capped preferred accounts
+
+## Why
+
+Self-contained unanchored parallel forks have no continuity owner, but a preferred-account cap currently sends them into the account-capacity wait even when another eligible account has headroom. This unnecessarily stalls fork work and contributes to the stream-cap starvation reported in #1354.
+
+## What Changes
+
+- When session creation rejects a self-contained `internal_unanchored_parallel` fork with a local account-cap error, drop its preferred-account hint once and retry selection.
+- Keep owner-bearing payloads pinned by requiring no previous response, conversation, or input file reference.
+- Record the retry with the stable `unanchored_fork_cap_spill` bridge event.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-admission-control`: Allow self-contained unanchored forks to spill from a capped preferred account before waiting for capacity.
+
+## Impact
+
+- `app/modules/proxy/_service/http_bridge/streaming.py`: one-shot preferred-account removal and reselection.
+- No setting, database migration, dashboard, or API schema change.

--- a/openspec/changes/spill-unanchored-forks-on-account-cap/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/spill-unanchored-forks-on-account-cap/specs/proxy-admission-control/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Account-local Responses work is capped before upstream creation
+
+For `/v1/responses`, `/backend-api/codex/responses`, and compact Responses traffic, the proxy MUST enforce account-local response-create and streaming concurrency limits in addition to process-wide admission limits, and the configured limits MUST be cluster-wide per-account targets enforced across all replicas rather than per-replica allowances. Because per-account caps are partitioned per replica via the bridge ring and cannot be safely partitioned across intra-pod worker processes, each instance MUST run a single worker process; horizontal scaling is achieved by adding replicas. The default account response-create cap MUST be 4 and the default account stream cap MUST be 8 unless operators configure a different value.
+
+When an account is at either cap, new soft-affinity work MUST prefer another eligible account before returning local overload. A bare process-session mapping MAY supply soft locality only while the request is self-contained, pre-visible, and has no required owner. Account-cap spillover MUST be decided during account selection and MUST NOT switch an account after a request enters shared transport, replay, or durable bridge ownership. Hard-continuity work MUST remain on its required owner and MAY fail closed when that owner is saturated. Hard Codex ownership rows MUST bypass soft sticky fallback/reallocation so pressure cannot delete or rewrite them.
+
+An unanchored parallel fork bridge session whose payload is self-contained (no `previous_response_id`, no `conversation`, and no input file references) carries no continuity ownership. When its preferred account is rejected by a local account cap (`account_stream_cap` or `account_response_create_cap`) during session creation, the proxy MUST drop the preferred-account hint exactly once for that request and retry account selection among eligible accounts before entering the recoverable account-capacity wait. Payloads that carry any continuity owner signal MUST NOT spill and MUST keep the existing preferred-owner behavior.
+
+#### Scenario: Soft work avoids saturated account
+
+- **GIVEN** account A is at its account response-create cap
+- **AND** account B is eligible and below cap
+- **WHEN** a self-contained `/v1/responses` request has only bare process-session affinity to account A
+- **THEN** the proxy selects account B instead of queueing on account A
+
+#### Scenario: Hard continuity owner saturation fails closed
+
+- **GIVEN** a follow-up request requires a specific previous-response owner account
+- **AND** that account is at its account stream or response-create cap
+- **WHEN** no safe continuity-preserving alternative exists
+- **THEN** the proxy returns a bounded local overload/continuity failure
+- **AND** the failure reason is stable and low-cardinality
+
+#### Scenario: Late WebSocket cap race does not retire shared work
+
+- **GIVEN** a request has entered an upstream WebSocket shared with another in-flight response
+- **WHEN** a later account response-create lease acquisition loses a capacity race
+- **THEN** the proxy rejects only the newly unadmitted request with the existing local-cap failure
+- **AND** it does not retire or switch the shared upstream WebSocket to spill that request
+
+#### Scenario: Existing bridge ownership is not replaced by cap spillover
+
+- **GIVEN** a session header resolves to a live or durable HTTP bridge owner
+- **WHEN** that owner's account or response-create gate is saturated
+- **THEN** the request follows the existing hard bridge-capacity behavior
+- **AND** account-cap spillover does not publish a replacement bridge under the same canonical identity
+
+#### Scenario: Unanchored parallel fork spills off a capped preferred account
+
+- **GIVEN** an unanchored parallel fork bridge session creation whose payload carries no previous response, conversation, or input file reference
+- **AND** its preferred account is rejected with `account_stream_cap`
+- **AND** another eligible account is below its stream cap
+- **WHEN** session creation retries selection after dropping the preferred-account hint
+- **THEN** the fork session is created on the eligible account instead of waiting on the capped account
+
+#### Scenario: Owner-bearing fork payloads do not spill
+
+- **GIVEN** a parallel fork bridge session creation whose payload carries a `previous_response_id`
+- **WHEN** its preferred account is rejected with a local account cap
+- **THEN** the preferred-account hint is kept and the existing preferred-owner behavior applies

--- a/openspec/changes/spill-unanchored-forks-on-account-cap/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/spill-unanchored-forks-on-account-cap/specs/proxy-admission-control/spec.md
@@ -6,7 +6,7 @@ For `/v1/responses`, `/backend-api/codex/responses`, and compact Responses traff
 
 When an account is at either cap, new soft-affinity work MUST prefer another eligible account before returning local overload. A bare process-session mapping MAY supply soft locality only while the request is self-contained, pre-visible, and has no required owner. Account-cap spillover MUST be decided during account selection and MUST NOT switch an account after a request enters shared transport, replay, or durable bridge ownership. Hard-continuity work MUST remain on its required owner and MAY fail closed when that owner is saturated. Hard Codex ownership rows MUST bypass soft sticky fallback/reallocation so pressure cannot delete or rewrite them.
 
-An unanchored parallel fork bridge session whose payload is self-contained (no `previous_response_id`, no `conversation`, and no input file references) carries no continuity ownership. When its preferred account is rejected by a local account cap (`account_stream_cap` or `account_response_create_cap`) during session creation, the proxy MUST drop the preferred-account hint exactly once for that request and retry account selection among eligible accounts before entering the recoverable account-capacity wait. Payloads that carry any continuity owner signal MUST NOT spill and MUST keep the existing preferred-owner behavior.
+An unanchored parallel fork bridge session whose payload is self-contained (no `previous_response_id`, no `conversation`, and no input file references) and whose current request context has no turn-state owner or anchored forwarding provenance carries no continuity ownership. When its preferred account is rejected by a local account cap (`account_stream_cap` or `account_response_create_cap`) during session creation, the proxy MUST drop the preferred-account hint exactly once for that request and retry account selection among eligible accounts before entering the recoverable account-capacity wait. Requests that carry any continuity owner signal MUST NOT spill and MUST keep the existing preferred-owner behavior, even when durable alias lookup resolves to an `internal_unanchored_parallel` canonical key.
 
 #### Scenario: Soft work avoids saturated account
 
@@ -50,3 +50,10 @@ An unanchored parallel fork bridge session whose payload is self-contained (no `
 - **GIVEN** a parallel fork bridge session creation whose payload carries a `previous_response_id`
 - **WHEN** its preferred account is rejected with a local account cap
 - **THEN** the preferred-account hint is kept and the existing preferred-owner behavior applies
+
+#### Scenario: Turn-state aliases do not spill through an unanchored canonical key
+
+- **GIVEN** a request carries a turn-state alias whose durable row resolves to an `internal_unanchored_parallel` canonical key
+- **AND** that row has a latest turn state but no latest response ID
+- **WHEN** its owner account is rejected with a local account cap
+- **THEN** the preferred-account hint is kept and the request does not spill to another account

--- a/openspec/changes/spill-unanchored-forks-on-account-cap/tasks.md
+++ b/openspec/changes/spill-unanchored-forks-on-account-cap/tasks.md
@@ -2,11 +2,11 @@
 
 ## 1. Fork spillover
 
-- [x] 1.1 Detect self-contained unanchored parallel forks rejected by a local account cap.
+- [x] 1.1 Detect self-contained unanchored parallel forks rejected by a local account cap without crossing turn-state or forwarding ownership.
 - [x] 1.2 Drop the preferred-account hint once and retry account selection.
 - [x] 1.3 Emit a stable bridge event for the spill.
 
 ## 2. Tests
 
 - [x] 2.1 Cover eligible and owner-bearing predicate cases.
-- [x] 2.2 Exercise the HTTP bridge path through capped preferred-account selection and successful reselection.
+- [x] 2.2 Exercise the HTTP bridge path through capped preferred-account selection, successful reselection, and turn-state-owned rejection.

--- a/openspec/changes/spill-unanchored-forks-on-account-cap/tasks.md
+++ b/openspec/changes/spill-unanchored-forks-on-account-cap/tasks.md
@@ -1,0 +1,12 @@
+# Tasks
+
+## 1. Fork spillover
+
+- [x] 1.1 Detect self-contained unanchored parallel forks rejected by a local account cap.
+- [x] 1.2 Drop the preferred-account hint once and retry account selection.
+- [x] 1.3 Emit a stable bridge event for the spill.
+
+## 2. Tests
+
+- [x] 2.1 Cover eligible and owner-bearing predicate cases.
+- [x] 2.2 Exercise the HTTP bridge path through capped preferred-account selection and successful reselection.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -19548,3 +19548,177 @@ async def test_cancel_api_key_reservation_heartbeat_task_does_not_wait_for_task_
     await asyncio.sleep(0)
 
     assert task.cancelled()
+
+
+def test_unanchored_fork_cap_spill_predicate() -> None:
+    self_contained = proxy_service.ResponsesRequest.model_validate(
+        {"model": "gpt-5.6-sol", "instructions": "test", "input": "hello"}
+    )
+    anchored = self_contained.model_copy(update={"previous_response_id": "resp_123"})
+
+    assert http_bridge_streaming_module._http_bridge_unanchored_fork_can_spill_on_cap(
+        error_code="account_stream_cap",
+        affinity_kind="internal_unanchored_parallel",
+        payload=self_contained,
+        preferred_account_id="acct-1",
+    )
+    assert http_bridge_streaming_module._http_bridge_unanchored_fork_can_spill_on_cap(
+        error_code="account_response_create_cap",
+        affinity_kind="internal_unanchored_parallel",
+        payload=self_contained,
+        preferred_account_id="acct-1",
+    )
+    assert not http_bridge_streaming_module._http_bridge_unanchored_fork_can_spill_on_cap(
+        error_code="account_stream_cap",
+        affinity_kind="internal_unanchored_parallel",
+        payload=anchored,
+        preferred_account_id="acct-1",
+    )
+    assert not http_bridge_streaming_module._http_bridge_unanchored_fork_can_spill_on_cap(
+        error_code="account_stream_cap",
+        affinity_kind="session_header",
+        payload=self_contained,
+        preferred_account_id="acct-1",
+    )
+    assert not http_bridge_streaming_module._http_bridge_unanchored_fork_can_spill_on_cap(
+        error_code="upstream_unavailable",
+        affinity_kind="internal_unanchored_parallel",
+        payload=self_contained,
+        preferred_account_id="acct-1",
+    )
+    assert not http_bridge_streaming_module._http_bridge_unanchored_fork_can_spill_on_cap(
+        error_code="account_stream_cap",
+        affinity_kind="internal_unanchored_parallel",
+        payload=self_contained,
+        preferred_account_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_http_bridge_or_retry_spills_unanchored_fork_from_capped_preferred_account(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {"model": "gpt-5.6-sol", "instructions": "test", "input": "hello"}
+    )
+    fork_key = proxy_service._HTTPBridgeSessionKey(
+        "internal_unanchored_parallel",
+        "fork-request-scope",
+        None,
+    )
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-fork-cap-spill",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        event_queue=asyncio.Queue(),
+        transport="http",
+    )
+    replacement_session = _make_bridge_session(key=fork_key, key_value=fork_key.affinity_key)
+    replacement_session.account = cast(
+        Any,
+        SimpleNamespace(id="acc-available", status=AccountStatus.ACTIVE),
+    )
+    cap_error = ProxyResponseError(
+        429,
+        openai_error(
+            "account_stream_cap",
+            "Account stream capacity is exhausted",
+            error_type="rate_limit_error",
+        ),
+    )
+    preferred_account_ids: list[str | None] = []
+
+    def fake_prepare(
+        prepared_payload: proxy_service.ResponsesRequest,
+        _headers: dict[str, str] | Any,
+        *,
+        api_key: proxy_service.ApiKeyData | None,
+        api_key_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        request_id: str,
+        client_ip: str | None = None,
+    ) -> tuple[proxy_service._WebSocketRequestState, str]:
+        del prepared_payload, api_key, api_key_reservation, request_id, client_ip
+        return request_state, '{"type":"response.create"}'
+
+    async def fake_get_or_create(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: object,
+    ) -> proxy_service._HTTPBridgeSession:
+        assert key == fork_key
+        preferred_account_ids.append(cast(str | None, kwargs["preferred_account_id"]))
+        if len(preferred_account_ids) == 1:
+            raise cap_error
+        return replacement_session
+
+    async def fake_stream_events(*args: object, **kwargs: object):
+        del args, kwargs
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    dashboard_settings = SimpleNamespace(
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=1800,
+    )
+    runtime_config = SimpleNamespace(
+        enabled=True,
+        idle_ttl_seconds=120.0,
+        codex_idle_ttl_seconds=1800.0,
+        max_sessions=8,
+        queue_limit=4,
+        prompt_cache_idle_ttl_seconds=120.0,
+        gateway_safe_mode=False,
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-fork",
+        canonical_kind=fork_key.affinity_kind,
+        canonical_key=fork_key.affinity_key,
+        api_key_scope="__anonymous__",
+        account_id="acc-capped",
+        owner_instance_id="instance-a",
+        owner_epoch=1,
+        lease_expires_at=proxy_service.utcnow() + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state=None,
+        latest_response_id=None,
+        model="gpt-5.6-sol",
+    )
+
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_service_get_settings_cache",
+        lambda: SimpleNamespace(get=AsyncMock(return_value=dashboard_settings)),
+    )
+    monkeypatch.setattr(http_bridge_streaming_module, "_service_get_settings", _make_app_settings)
+    monkeypatch.setattr(http_bridge_streaming_module, "_http_bridge_runtime_config", lambda *args: runtime_config)
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_http_bridge_can_forward_to_active_owner", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_http_bridge_or_retry(
+            payload,
+            {},
+            codex_session_affinity=False,
+            propagate_http_errors=True,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            forwarded_request=True,
+            forwarded_original_request_unanchored=True,
+            forwarded_affinity_kind=fork_key.affinity_kind,
+            forwarded_affinity_key=fork_key.affinity_key,
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert preferred_account_ids == ["acc-capped", None]
+    assert request_state.preferred_account_id is None

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -19559,44 +19559,59 @@ def test_unanchored_fork_cap_spill_predicate() -> None:
     assert http_bridge_streaming_module._http_bridge_unanchored_fork_can_spill_on_cap(
         error_code="account_stream_cap",
         affinity_kind="internal_unanchored_parallel",
+        original_request_unanchored=True,
         payload=self_contained,
         preferred_account_id="acct-1",
     )
     assert http_bridge_streaming_module._http_bridge_unanchored_fork_can_spill_on_cap(
         error_code="account_response_create_cap",
         affinity_kind="internal_unanchored_parallel",
+        original_request_unanchored=True,
         payload=self_contained,
         preferred_account_id="acct-1",
     )
     assert not http_bridge_streaming_module._http_bridge_unanchored_fork_can_spill_on_cap(
         error_code="account_stream_cap",
         affinity_kind="internal_unanchored_parallel",
+        original_request_unanchored=True,
         payload=anchored,
         preferred_account_id="acct-1",
     )
     assert not http_bridge_streaming_module._http_bridge_unanchored_fork_can_spill_on_cap(
         error_code="account_stream_cap",
         affinity_kind="session_header",
+        original_request_unanchored=True,
         payload=self_contained,
         preferred_account_id="acct-1",
     )
     assert not http_bridge_streaming_module._http_bridge_unanchored_fork_can_spill_on_cap(
         error_code="upstream_unavailable",
         affinity_kind="internal_unanchored_parallel",
+        original_request_unanchored=True,
         payload=self_contained,
         preferred_account_id="acct-1",
     )
     assert not http_bridge_streaming_module._http_bridge_unanchored_fork_can_spill_on_cap(
         error_code="account_stream_cap",
         affinity_kind="internal_unanchored_parallel",
+        original_request_unanchored=True,
         payload=self_contained,
         preferred_account_id=None,
+    )
+    assert not http_bridge_streaming_module._http_bridge_unanchored_fork_can_spill_on_cap(
+        error_code="account_stream_cap",
+        affinity_kind="internal_unanchored_parallel",
+        original_request_unanchored=False,
+        payload=self_contained,
+        preferred_account_id="acct-1",
     )
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("turn_state_owned", [False, True])
 async def test_stream_http_bridge_or_retry_spills_unanchored_fork_from_capped_preferred_account(
     monkeypatch: pytest.MonkeyPatch,
+    turn_state_owned: bool,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     payload = proxy_service.ResponsesRequest.model_validate(
@@ -19681,7 +19696,7 @@ async def test_stream_http_bridge_or_retry_spills_unanchored_fork_from_capped_pr
         owner_epoch=1,
         lease_expires_at=proxy_service.utcnow() + timedelta(seconds=60),
         state=HttpBridgeSessionState.ACTIVE,
-        latest_turn_state=None,
+        latest_turn_state="http_turn_owned" if turn_state_owned else None,
         latest_response_id=None,
         model="gpt-5.6-sol",
     )
@@ -19693,6 +19708,7 @@ async def test_stream_http_bridge_or_retry_spills_unanchored_fork_from_capped_pr
     )
     monkeypatch.setattr(http_bridge_streaming_module, "_service_get_settings", _make_app_settings)
     monkeypatch.setattr(http_bridge_streaming_module, "_http_bridge_runtime_config", lambda *args: runtime_config)
+    monkeypatch.setattr(http_bridge_streaming_module, "_http_bridge_account_capacity_wait_seconds", lambda _exc: None)
     monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
     monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
     monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=False))
@@ -19701,24 +19717,30 @@ async def test_stream_http_bridge_or_retry_spills_unanchored_fork_from_capped_pr
     monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
     monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
 
-    chunks = [
-        chunk
-        async for chunk in service._stream_http_bridge_or_retry(
-            payload,
-            {},
-            codex_session_affinity=False,
-            propagate_http_errors=True,
-            openai_cache_affinity=False,
-            api_key=None,
-            api_key_reservation=None,
-            suppress_text_done_events=False,
-            forwarded_request=True,
-            forwarded_original_request_unanchored=True,
-            forwarded_affinity_kind=fork_key.affinity_kind,
-            forwarded_affinity_key=fork_key.affinity_key,
-        )
-    ]
+    stream = service._stream_http_bridge_or_retry(
+        payload,
+        {"x-codex-turn-state": "http_turn_owned"} if turn_state_owned else {},
+        codex_session_affinity=turn_state_owned,
+        propagate_http_errors=True,
+        openai_cache_affinity=False,
+        api_key=None,
+        api_key_reservation=None,
+        suppress_text_done_events=False,
+        forwarded_request=not turn_state_owned,
+        forwarded_original_request_unanchored=not turn_state_owned,
+        forwarded_affinity_kind=fork_key.affinity_kind if not turn_state_owned else None,
+        forwarded_affinity_key=fork_key.affinity_key if not turn_state_owned else None,
+    )
 
-    assert chunks == ['data: {"type":"response.completed"}\n\n']
-    assert preferred_account_ids == ["acc-capped", None]
-    assert request_state.preferred_account_id is None
+    if turn_state_owned:
+        with pytest.raises(ProxyResponseError) as exc_info:
+            async for _chunk in stream:
+                pass
+        assert exc_info.value is cap_error
+        assert preferred_account_ids == ["acc-capped"]
+        assert request_state.preferred_account_id == "acc-capped"
+    else:
+        chunks = [chunk async for chunk in stream]
+        assert chunks == ['data: {"type":"response.completed"}\n\n']
+        assert preferred_account_ids == ["acc-capped", None]
+        assert request_state.preferred_account_id is None


### PR DESCRIPTION
## Summary

Lets self-contained unanchored parallel forks retry account selection without a capped preferred-account hint, while preserving all continuity-bearing ownership. This is the requested concern 2 split from #1474.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Related to #1354. This is a partial mitigation and does not close the turn-scoped lease root issue. Reuses the bare-session spillover predicate introduced by #1382.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/spill-unanchored-forks-on-account-cap/`

## Changes

- Detect self-contained `internal_unanchored_parallel` forks rejected by a local account cap.
- Drop the preferred-account hint once and retry selection among eligible accounts.
- Keep previous-response, conversation, and input-file owner signals pinned.
- Emit the stable `unanchored_fork_cap_spill` bridge event.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config**
- [x] No new required setup step
- New setting(s) and why each cannot be a default: none. The change reuses the existing self-contained payload predicate.
- [x] README sections / `.env.example` / dashboard nav within budget

## Test plan

```
.venv/bin/python -m pytest tests/unit/test_proxy_http_bridge.py -q  # 377 passed
.venv/bin/python -m ruff check app/modules/proxy/_service/http_bridge/streaming.py tests/unit/test_proxy_http_bridge.py
.venv/bin/python -m ruff format --check app/modules/proxy/_service/http_bridge/streaming.py tests/unit/test_proxy_http_bridge.py
.venv/bin/ty check app/modules/proxy/_service/http_bridge/streaming.py
npx --yes @fission-ai/openspec@latest validate spill-unanchored-forks-on-account-cap --strict
npx --yes @fission-ai/openspec@latest validate --specs --strict
```

## Screenshots / output

Proxy behavior only. The bridge-level regression starts with preferred account `acc-capped`, receives `account_stream_cap`, retries with no preferred-account hint, and completes on `acc-available`.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [ ] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally. Targeted pytest, Ruff, formatting, and ty checks passed as listed above.
- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean. Strict OpenSpec change and main-spec validation passed; `/opsx:verify` was not run.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).