### PR TITLE
fix(proxy): bound account-capacity waits

### DIFF
--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -141,7 +141,11 @@ from app.modules.proxy._service.http_bridge.service_stubs import (
     _websocket_safe_headers_with_turn_state,
 )
 from app.modules.proxy._service.http_bridge.session_registry import _HTTPBridgeSessionRegistryMixin
-from app.modules.proxy._service.http_bridge.streaming import _HTTPBridgeStreamingMixin
+from app.modules.proxy._service.http_bridge.streaming import (
+    _http_bridge_account_capacity_wait_deadline,
+    _http_bridge_terminal_capacity_error,
+    _HTTPBridgeStreamingMixin,
+)
 from app.modules.proxy._service.http_bridge.upstream_events import _HTTPBridgeUpstreamEventsMixin
 from app.modules.proxy._service.observability import (
     _hash_identifier as _hash_identifier,
@@ -2097,9 +2101,12 @@ class _HTTPBridgeMixin(
             await release_selected_account_lease()
 
         while True:
+            reconnect_deadline = deadline
+            if request_state.account_capacity_wait_deadline is not None:
+                reconnect_deadline = min(reconnect_deadline, request_state.account_capacity_wait_deadline)
             reuse_current_account_lease = preferred_candidate_id == session.account.id and bool(session.account_lease)
             selection = await self._select_account_with_budget_for_stream(
-                deadline,
+                reconnect_deadline,
                 request_id=request_state.request_log_id or request_state.request_id,
                 kind="http_bridge",
                 request_stage="reattach",
@@ -2127,13 +2134,28 @@ class _HTTPBridgeMixin(
             account = selection.account
             if account is None:
                 await release_selected_account_lease()
+                status_code = 429 if _is_local_account_cap_code(selection.error_code) else 503
+                selection_error = ProxyResponseError(
+                    status_code,
+                    openai_error(
+                        selection.error_code or "no_accounts",
+                        selection.error_message or "No active accounts available",
+                        error_type="rate_limit_error" if status_code == 429 else "server_error",
+                    ),
+                )
+                capacity_wait_deadline = _http_bridge_account_capacity_wait_deadline(
+                    request_state,
+                    selection_error,
+                )
+                if capacity_wait_deadline is not None:
+                    reconnect_deadline = min(deadline, capacity_wait_deadline)
                 if account_neutral_recovery and selection.error_code == CONTINUITY_OWNER_UNAVAILABLE:
                     raise _http_bridge_previous_response_owner_unavailable_error()
                 if (
                     reuse_current_account_lease
                     and not hard_close_account_bound
                     and required_preferred_account_id is None
-                    and _remaining_budget_seconds(deadline) > 0
+                    and _remaining_budget_seconds(reconnect_deadline) > 0
                 ):
                     preferred_candidate_id = None
                     continue
@@ -2143,9 +2165,12 @@ class _HTTPBridgeMixin(
                     kind="http_bridge",
                     request_stage="reattach",
                     model=session.request_model,
-                    max_sleep_seconds=_remaining_budget_seconds(deadline),
+                    max_sleep_seconds=_remaining_budget_seconds(reconnect_deadline),
                     request_state=request_state,
                 ):
+                    if _remaining_budget_seconds(reconnect_deadline) <= 0:
+                        record_selected_account_takeover(None)
+                        raise _http_bridge_terminal_capacity_error(request_state, selection_error)
                     excluded_account_ids.update(request_state.excluded_account_ids)
                     if required_preferred_account_id in excluded_account_ids:
                         raise _http_bridge_previous_response_owner_unavailable_error()
@@ -2171,15 +2196,7 @@ class _HTTPBridgeMixin(
                         preferred_candidate_id = None
                     continue
                 record_selected_account_takeover(None)
-                status_code = 429 if _is_local_account_cap_code(selection.error_code) else 503
-                raise ProxyResponseError(
-                    status_code,
-                    openai_error(
-                        selection.error_code or "no_accounts",
-                        selection.error_message or "No active accounts available",
-                        error_type="rate_limit_error" if status_code == 429 else "server_error",
-                    ),
-                )
+                raise _http_bridge_terminal_capacity_error(request_state, selection_error)
             if required_preferred_account_id is not None and account.id != required_preferred_account_id:
                 if selection.lease is not None:
                     await self._load_balancer.release_account_lease(selection.lease)
@@ -2206,7 +2223,7 @@ class _HTTPBridgeMixin(
                 account = await self._ensure_fresh_with_budget(
                     account,
                     force=force_refresh,
-                    timeout_seconds=_remaining_budget_seconds(deadline),
+                    timeout_seconds=_remaining_budget_seconds(reconnect_deadline),
                 )
                 if force_refresh and request_state.force_refresh_account_id == account.id:
                     request_state.force_refresh_account_id = None
@@ -2217,21 +2234,21 @@ class _HTTPBridgeMixin(
                 upstream = await self._open_upstream_websocket_with_budget(
                     account,
                     connect_headers,
-                    timeout_seconds=_remaining_budget_seconds(deadline),
+                    timeout_seconds=_remaining_budget_seconds(reconnect_deadline),
                     request_state=request_state,
                 )
                 _copy_websocket_route_metadata_to_session(session, request_state)
                 record_selected_account_takeover(account.id)
                 break
             except ProxyResponseError as exc:
-                if exc.status_code != 401 or _remaining_budget_seconds(deadline) <= 0:
+                if exc.status_code != 401 or _remaining_budget_seconds(reconnect_deadline) <= 0:
                     await release_selected_account_lease()
                     raise
                 try:
                     account = await self._ensure_fresh_with_budget(
                         account,
                         force=True,
-                        timeout_seconds=_remaining_budget_seconds(deadline),
+                        timeout_seconds=_remaining_budget_seconds(reconnect_deadline),
                     )
                     connect_headers = _websocket_safe_headers_with_turn_state(
                         session.headers,
@@ -2244,7 +2261,7 @@ class _HTTPBridgeMixin(
                     upstream = await self._open_upstream_websocket_with_budget(
                         account,
                         connect_headers,
-                        timeout_seconds=_remaining_budget_seconds(deadline),
+                        timeout_seconds=_remaining_budget_seconds(reconnect_deadline),
                         request_state=request_state,
                     )
                     _copy_websocket_route_metadata_to_session(session, request_state)
@@ -2265,7 +2282,7 @@ class _HTTPBridgeMixin(
             except RefreshError as exc:
                 if exc.is_permanent:
                     await self._load_balancer.mark_permanent_failure(account, exc.code)
-                if selected_is_preferred and _remaining_budget_seconds(deadline) > 0:
+                if selected_is_preferred and _remaining_budget_seconds(reconnect_deadline) > 0:
                     if retry_same_account_once and not exc.is_permanent:
                         retry_same_account_once = False
                         await release_selected_account_lease()
@@ -2275,7 +2292,7 @@ class _HTTPBridgeMixin(
                 await release_selected_account_lease()
                 raise
             except (aiohttp.ClientError, asyncio.TimeoutError):
-                if selected_is_preferred and _remaining_budget_seconds(deadline) > 0:
+                if selected_is_preferred and _remaining_budget_seconds(reconnect_deadline) > 0:
                     if retry_same_account_once:
                         retry_same_account_once = False
                         await release_selected_account_lease()

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -1521,6 +1521,11 @@ class _HTTPBridgeRequestSubmitMixin:
             # owner retire the whole session with the typed, non-replayable
             # failure instead of falling back to the earlier close reason.
             raise
+        except ProxyResponseError as exc:
+            if exc is request_state.account_capacity_wait_error:
+                raise
+            logger.warning("HTTP bridge retry on fresh upstream failed", exc_info=True)
+            return False
         except Exception:
             logger.warning("HTTP bridge retry on fresh upstream failed", exc_info=True)
             return False

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -218,6 +218,11 @@ logger = logging.getLogger("app.modules.proxy.service")
 T = TypeVar("T")
 _REQUEST_TRANSPORT_HTTP = "http"
 _RESPONSE_CREATE_GATE_RETRY_SLEEP_SECONDS = 10.0
+# Ceiling on the recoverable account-capacity wait; surfaces the 429 cap
+# envelope while the client is still connected instead of holding the
+# request for the full bridge request budget. Gate-contention waits are
+# exempt (the in-flight turn legitimately holds the gate).
+_ACCOUNT_CAPACITY_WAIT_MAX_SECONDS = 120.0
 
 
 def _http_bridge_payload_is_account_neutral_fresh_replay(payload: ResponsesRequest) -> bool:
@@ -269,18 +274,67 @@ def _http_bridge_unanchored_fork_can_spill_on_cap(
     )
 
 
+def _http_bridge_capacity_wait_deadline(request_state: _WebSocketRequestState) -> float:
+    """Per-request ceiling for account-capacity waits, anchored at first use.
+
+    Without a ceiling the bridge request budget (default 7200s) lets a capped
+    account hold a request far past any client timeout, so the client dies
+    without ever seeing the 429 cap envelope.
+    """
+    if request_state.account_capacity_wait_deadline is None:
+        request_state.account_capacity_wait_deadline = _service_time().monotonic() + _ACCOUNT_CAPACITY_WAIT_MAX_SECONDS
+    return request_state.account_capacity_wait_deadline
+
+
+def _http_bridge_account_capacity_wait_deadline(
+    request_state: _WebSocketRequestState,
+    exc: ProxyResponseError,
+) -> float | None:
+    code, _message = _proxy_error_code_message(exc)
+    if code == "response_create_gate_timeout":
+        return None
+    if _is_local_account_cap_code(code) and request_state.account_capacity_wait_error is None:
+        request_state.account_capacity_wait_error = exc
+    if request_state.account_capacity_wait_error is None:
+        return None
+    return _http_bridge_capacity_wait_deadline(request_state)
+
+
+def _http_bridge_terminal_capacity_error(
+    request_state: _WebSocketRequestState,
+    exc: ProxyResponseError,
+) -> ProxyResponseError:
+    original_cap_error = request_state.account_capacity_wait_error
+    if original_cap_error is None:
+        return exc
+    code, _message = _proxy_error_code_message(exc)
+    if code == "response_create_gate_timeout":
+        return exc
+    if _is_local_account_cap_code(code) or _http_bridge_account_capacity_wait_seconds(exc) is not None:
+        return original_cap_error
+    return exc
+
+
 def _http_bridge_capacity_wait_plan(
     exc: ProxyResponseError,
     *,
     request_deadline: float,
+    capacity_wait_deadline: float | None = None,
 ) -> tuple[float, float, str | None] | None:
     account_capacity_wait_seconds = _http_bridge_account_capacity_wait_seconds(exc)
     if account_capacity_wait_seconds is None:
         return None
-    remaining_budget_seconds = max(0.0, request_deadline - _service_time().monotonic())
+    code, message = _proxy_error_code_message(exc)
+    effective_deadline = request_deadline
+    if capacity_wait_deadline is not None and code != "response_create_gate_timeout":
+        # Account-capacity waits are additionally bounded by the configured
+        # ceiling so a capped account surfaces its 429 envelope while the
+        # client is still connected; gate contention keeps budget-bounded
+        # semantics because the in-flight turn legitimately holds the gate.
+        effective_deadline = min(request_deadline, capacity_wait_deadline)
+    remaining_budget_seconds = max(0.0, effective_deadline - _service_time().monotonic())
     if remaining_budget_seconds <= 0:
         return None
-    code, message = _proxy_error_code_message(exc)
     bounded_wait_seconds = min(account_capacity_wait_seconds, remaining_budget_seconds)
     if code == "response_create_gate_timeout":
         # Reserve the tail of the request budget for one final gate
@@ -292,6 +346,20 @@ def _http_bridge_capacity_wait_plan(
             max(0.0, remaining_budget_seconds - attempt_reserve_seconds),
         )
     return bounded_wait_seconds, account_capacity_wait_seconds, message
+
+
+def _http_bridge_capacity_wait_expired(
+    request_state: _WebSocketRequestState,
+    exc: ProxyResponseError,
+    *,
+    request_deadline: float,
+) -> bool:
+    """Whether either the bridge budget or local-cap wait ceiling has elapsed."""
+    capacity_wait_deadline = _http_bridge_account_capacity_wait_deadline(request_state, exc)
+    effective_deadline = (
+        request_deadline if capacity_wait_deadline is None else min(request_deadline, capacity_wait_deadline)
+    )
+    return _service_time().monotonic() >= effective_deadline
 
 
 def _http_bridge_can_replace_retired_gate_session(
@@ -573,6 +641,46 @@ class _HTTPBridgeStreamingMixin:
             capacity_startup_ready_event=capacity_startup_ready_event,
         )
 
+    async def _write_account_cap_overload_request_log(
+        self: Any,
+        *,
+        request_state: _WebSocketRequestState,
+        exc: ProxyResponseError,
+        account_id: str | None,
+    ) -> None:
+        """Record a terminal account-capacity overload before session creation.
+
+        These failures raise before any submission or settlement runs, so the
+        normal settlement-time request logging never sees them; without this
+        row the dashboard is blind to capacity-wait 429s.
+        """
+        error_code, error_message = _proxy_error_code_message(exc)
+        if not _is_local_account_cap_code(error_code):
+            return
+        try:
+            await self._write_request_log(
+                account_id=account_id,
+                api_key=request_state.api_key,
+                request_id=request_state.request_log_id or request_state.request_id,
+                model=request_state.model or "",
+                latency_ms=int(max(0.0, _service_time().monotonic() - request_state.started_at) * 1000),
+                status="error",
+                error_code=error_code,
+                error_message=error_message,
+                failure_phase="account_capacity_wait",
+                reasoning_effort=request_state.reasoning_effort,
+                transport=request_state.transport,
+                requested_service_tier=request_state.requested_service_tier,
+                actual_service_tier=request_state.actual_service_tier,
+                session_id=request_state.session_id,
+                useragent=request_state.useragent,
+                useragent_group=request_state.useragent_group,
+                conversation_id=request_state.conversation_id,
+                client_ip=request_state.client_ip,
+            )
+        except Exception:
+            logger.warning("Failed to record account-capacity overload request log", exc_info=True)
+
     async def _stream_http_bridge_or_retry(
         self: Any,
         payload: ResponsesRequest,
@@ -743,9 +851,10 @@ class _HTTPBridgeStreamingMixin:
             request_payload: ResponsesRequest,
             *,
             reservation: ApiKeyUsageReservationData | None = api_key_reservation,
+            previous_request_state: _WebSocketRequestState | None = None,
         ) -> tuple[_WebSocketRequestState, str]:
             if bridge_uses_responses_lite:
-                request_state, text_data = self._prepare_http_bridge_request(
+                prepared_request = self._prepare_http_bridge_request(
                     request_payload,
                     headers,
                     api_key=api_key,
@@ -755,7 +864,7 @@ class _HTTPBridgeStreamingMixin:
                     preserve_responses_lite_client_metadata=True,
                 )
             else:
-                request_state, text_data = self._prepare_http_bridge_request(
+                prepared_request = self._prepare_http_bridge_request(
                     request_payload,
                     headers,
                     api_key=api_key,
@@ -763,6 +872,10 @@ class _HTTPBridgeStreamingMixin:
                     request_id=request_id,
                     client_ip=client_ip,
                 )
+            request_state, text_data = prepared_request
+            if previous_request_state is not None:
+                request_state.account_capacity_wait_deadline = previous_request_state.account_capacity_wait_deadline
+                request_state.account_capacity_wait_error = previous_request_state.account_capacity_wait_error
             request_state.capacity_startup_wait_event = capacity_startup_wait_event
             request_state.capacity_startup_ready_event = capacity_startup_ready_event
             return request_state, text_data
@@ -1178,6 +1291,14 @@ class _HTTPBridgeStreamingMixin:
             request_state.fresh_upstream_request_is_retry_safe = False
         settings = _service_get_settings()
         request_deadline = request_state.started_at + _http_bridge_request_budget_seconds(settings)
+
+        async def write_terminal_account_cap_overload(exc: ProxyResponseError) -> None:
+            await self._write_account_cap_overload_request_log(
+                request_state=request_state,
+                exc=exc,
+                account_id=None,
+            )
+
         session_creation_headers = (
             without_http_bridge_session_affinity_headers(headers) if account_neutral_recovery else dict(headers)
         )
@@ -1267,7 +1388,10 @@ class _HTTPBridgeStreamingMixin:
             fresh_payload = durable_full_resend_fresh_payload
             if fresh_payload is None:
                 raise RuntimeError("account-neutral replay projection missing after eligibility check")
-            request_state, text_data = prepare_bridge_request(fresh_payload)
+            request_state, text_data = prepare_bridge_request(
+                fresh_payload,
+                previous_request_state=request_state,
+            )
             request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
             request_state.affinity_policy = affinity
             request_state.excluded_account_ids.update(fresh_replay_excluded_account_ids)
@@ -1370,7 +1494,11 @@ class _HTTPBridgeStreamingMixin:
                         request_state.preferred_account_id = None
                         preferred_account_has_continuity_provenance = False
                         continue
-                    wait_plan = _http_bridge_capacity_wait_plan(exc, request_deadline=request_deadline)
+                    wait_plan = _http_bridge_capacity_wait_plan(
+                        exc,
+                        request_deadline=request_deadline,
+                        capacity_wait_deadline=_http_bridge_account_capacity_wait_deadline(request_state, exc),
+                    )
                     if wait_plan is not None:
                         bounded_wait_seconds, account_capacity_wait_seconds, message = wait_plan
                         logger.info(
@@ -1390,10 +1518,26 @@ class _HTTPBridgeStreamingMixin:
                             request_state=request_state,
                         ):
                             yield line
-                        if _service_time().monotonic() >= request_deadline:
-                            raise
+                        if _http_bridge_capacity_wait_expired(
+                            request_state,
+                            exc,
+                            request_deadline=request_deadline,
+                        ):
+                            terminal_exc = _http_bridge_terminal_capacity_error(request_state, exc)
+                            await self._write_account_cap_overload_request_log(
+                                request_state=request_state,
+                                exc=terminal_exc,
+                                account_id=None,
+                            )
+                            raise terminal_exc
                         continue
-                    raise
+                    terminal_exc = _http_bridge_terminal_capacity_error(request_state, exc)
+                    await self._write_account_cap_overload_request_log(
+                        request_state=request_state,
+                        exc=terminal_exc,
+                        account_id=None,
+                    )
+                    raise terminal_exc
                 switch_to_account_neutral_replay()
                 continue
             break
@@ -1615,9 +1759,17 @@ class _HTTPBridgeStreamingMixin:
                             switch_to_account_neutral_replay()
                             owner_forward_fresh_replay = True
                             continue
-                        wait_plan = _http_bridge_capacity_wait_plan(capacity_exc, request_deadline=request_deadline)
+                        wait_plan = _http_bridge_capacity_wait_plan(
+                            capacity_exc,
+                            request_deadline=request_deadline,
+                            capacity_wait_deadline=_http_bridge_account_capacity_wait_deadline(
+                                request_state, capacity_exc
+                            ),
+                        )
                         if wait_plan is None:
-                            raise
+                            terminal_exc = _http_bridge_terminal_capacity_error(request_state, capacity_exc)
+                            await write_terminal_account_cap_overload(terminal_exc)
+                            raise terminal_exc
                         bounded_wait_seconds, account_capacity_wait_seconds, message = wait_plan
                         logger.info(
                             "Waiting for an account to recover before retrying HTTP bridge recovery session creation "
@@ -1639,8 +1791,14 @@ class _HTTPBridgeStreamingMixin:
                             request_state=request_state,
                         ):
                             yield line
-                        if _service_time().monotonic() >= request_deadline:
-                            raise
+                        if _http_bridge_capacity_wait_expired(
+                            request_state,
+                            capacity_exc,
+                            request_deadline=request_deadline,
+                        ):
+                            terminal_exc = _http_bridge_terminal_capacity_error(request_state, capacity_exc)
+                            await write_terminal_account_cap_overload(terminal_exc)
+                            raise terminal_exc
                         continue
                     break
                 _record_bridge_reattach(
@@ -1733,6 +1891,7 @@ class _HTTPBridgeStreamingMixin:
                     retry_request_state, retry_text_data = prepare_bridge_request(
                         recovery_payload,
                         reservation=retry_api_key_reservation,
+                        previous_request_state=request_state,
                     )
                     retry_request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
                     retry_request_state.affinity_policy = affinity
@@ -1833,7 +1992,10 @@ class _HTTPBridgeStreamingMixin:
                 update={"previous_response_id": session.last_completed_response_id}
             )
             proxy_injected_previous_response_id = True
-            request_state, text_data = prepare_bridge_request(effective_payload)
+            request_state, text_data = prepare_bridge_request(
+                effective_payload,
+                previous_request_state=request_state,
+            )
             request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
             request_state.affinity_policy = affinity
             request_state.transport = _REQUEST_TRANSPORT_HTTP
@@ -1913,7 +2075,10 @@ class _HTTPBridgeStreamingMixin:
             # guard, the stored input context, and the usage budget all
             # observe the input actually sent upstream.
             previous_request_state = request_state
-            request_state, text_data = prepare_bridge_request(submit_payload)
+            request_state, text_data = prepare_bridge_request(
+                submit_payload,
+                previous_request_state=previous_request_state,
+            )
             request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
             request_state.affinity_policy = affinity
             if downstream_turn_state is not None:
@@ -2044,9 +2209,17 @@ class _HTTPBridgeStreamingMixin:
                             exclude_account_ids=request_state.excluded_account_ids or None,
                         )
                     except ProxyResponseError as capacity_exc:
-                        wait_plan = _http_bridge_capacity_wait_plan(capacity_exc, request_deadline=request_deadline)
+                        wait_plan = _http_bridge_capacity_wait_plan(
+                            capacity_exc,
+                            request_deadline=request_deadline,
+                            capacity_wait_deadline=_http_bridge_account_capacity_wait_deadline(
+                                request_state, capacity_exc
+                            ),
+                        )
                         if wait_plan is None:
-                            raise
+                            terminal_exc = _http_bridge_terminal_capacity_error(request_state, capacity_exc)
+                            await write_terminal_account_cap_overload(terminal_exc)
+                            raise terminal_exc
                         bounded_wait_seconds, account_capacity_wait_seconds, message = wait_plan
                         logger.info(
                             "Waiting for an account to recover before replacing retired HTTP bridge gate "
@@ -2065,8 +2238,14 @@ class _HTTPBridgeStreamingMixin:
                             request_state=request_state,
                         ):
                             yield line
-                        if _service_time().monotonic() >= request_deadline:
-                            raise
+                        if _http_bridge_capacity_wait_expired(
+                            request_state,
+                            capacity_exc,
+                            request_deadline=request_deadline,
+                        ):
+                            terminal_exc = _http_bridge_terminal_capacity_error(request_state, capacity_exc)
+                            await write_terminal_account_cap_overload(terminal_exc)
+                            raise terminal_exc
                         continue
                     break
                 if initial_handoff_scope_id is not None:
@@ -2148,9 +2327,17 @@ class _HTTPBridgeStreamingMixin:
                             exclude_account_ids=request_state.excluded_account_ids or None,
                         )
                     except ProxyResponseError as capacity_exc:
-                        wait_plan = _http_bridge_capacity_wait_plan(capacity_exc, request_deadline=request_deadline)
+                        wait_plan = _http_bridge_capacity_wait_plan(
+                            capacity_exc,
+                            request_deadline=request_deadline,
+                            capacity_wait_deadline=_http_bridge_account_capacity_wait_deadline(
+                                request_state, capacity_exc
+                            ),
+                        )
                         if wait_plan is None:
-                            raise
+                            terminal_exc = _http_bridge_terminal_capacity_error(request_state, capacity_exc)
+                            await write_terminal_account_cap_overload(terminal_exc)
+                            raise terminal_exc
                         bounded_wait_seconds, account_capacity_wait_seconds, message = wait_plan
                         logger.info(
                             "Waiting for an account to recover before retrying HTTP bridge soft reroute session "
@@ -2169,8 +2356,14 @@ class _HTTPBridgeStreamingMixin:
                             request_state=request_state,
                         ):
                             yield line
-                        if _service_time().monotonic() >= request_deadline:
-                            raise
+                        if _http_bridge_capacity_wait_expired(
+                            request_state,
+                            capacity_exc,
+                            request_deadline=request_deadline,
+                        ):
+                            terminal_exc = _http_bridge_terminal_capacity_error(request_state, capacity_exc)
+                            await write_terminal_account_cap_overload(terminal_exc)
+                            raise terminal_exc
                         continue
                     break
                 retry_events: AsyncGenerator[str, None] = self._stream_http_bridge_session_events(
@@ -2337,9 +2530,15 @@ class _HTTPBridgeStreamingMixin:
                         exclude_account_ids=request_state.excluded_account_ids or None,
                     )
                 except ProxyResponseError as capacity_exc:
-                    wait_plan = _http_bridge_capacity_wait_plan(capacity_exc, request_deadline=request_deadline)
+                    wait_plan = _http_bridge_capacity_wait_plan(
+                        capacity_exc,
+                        request_deadline=request_deadline,
+                        capacity_wait_deadline=_http_bridge_account_capacity_wait_deadline(request_state, capacity_exc),
+                    )
                     if wait_plan is None:
-                        raise
+                        terminal_exc = _http_bridge_terminal_capacity_error(request_state, capacity_exc)
+                        await write_terminal_account_cap_overload(terminal_exc)
+                        raise terminal_exc
                     bounded_wait_seconds, account_capacity_wait_seconds, message = wait_plan
                     logger.info(
                         "Waiting for an account to recover before retrying HTTP bridge local recovery session "
@@ -2359,8 +2558,14 @@ class _HTTPBridgeStreamingMixin:
                         request_state=request_state,
                     ):
                         yield line
-                    if _service_time().monotonic() >= request_deadline:
-                        raise
+                    if _http_bridge_capacity_wait_expired(
+                        request_state,
+                        capacity_exc,
+                        request_deadline=request_deadline,
+                    ):
+                        terminal_exc = _http_bridge_terminal_capacity_error(request_state, capacity_exc)
+                        await write_terminal_account_cap_overload(terminal_exc)
+                        raise terminal_exc
                     continue
                 break
             _record_bridge_reattach(path=recovery_path, outcome="success")
@@ -2388,6 +2593,7 @@ class _HTTPBridgeStreamingMixin:
                 retry_request_state, retry_text_data = prepare_bridge_request(
                     retry_payload,
                     reservation=retry_api_key_reservation,
+                    previous_request_state=request_state,
                 )
                 retry_request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
                 if downstream_turn_state is not None:
@@ -2473,6 +2679,14 @@ class _HTTPBridgeStreamingMixin:
         if request_deadline is None:
             request_deadline = request_state.started_at + _http_bridge_request_budget_seconds(_service_get_settings())
         request_state.bridge_request_deadline = request_deadline
+
+        async def write_terminal_account_cap_overload(exc: ProxyResponseError) -> None:
+            await self._write_account_cap_overload_request_log(
+                request_state=request_state,
+                exc=exc,
+                account_id=session.account.id,
+            )
+
         account_neutral_recovery = is_http_bridge_account_neutral_replay(
             kind=session.key.affinity_kind,
             key=session.key.affinity_key,
@@ -2496,11 +2710,18 @@ class _HTTPBridgeStreamingMixin:
                         queue_limit=queue_limit,
                     )
             except ProxyResponseError as exc:
+                capacity_wait_deadline = _http_bridge_account_capacity_wait_deadline(request_state, exc)
                 if request_state.bridge_soft_capacity_reroute_allowed:
                     raise
-                wait_plan = _http_bridge_capacity_wait_plan(exc, request_deadline=request_deadline)
+                wait_plan = _http_bridge_capacity_wait_plan(
+                    exc,
+                    request_deadline=request_deadline,
+                    capacity_wait_deadline=capacity_wait_deadline,
+                )
                 if wait_plan is None:
-                    raise
+                    terminal_exc = _http_bridge_terminal_capacity_error(request_state, exc)
+                    await write_terminal_account_cap_overload(terminal_exc)
+                    raise terminal_exc
                 bounded_wait_seconds, account_capacity_wait_seconds, message = wait_plan
                 exc_code, _exc_message = _proxy_error_code_message(exc)
                 gate_contention = exc_code == "response_create_gate_timeout"
@@ -2548,8 +2769,14 @@ class _HTTPBridgeStreamingMixin:
                     if gate_contention:
                         async with session.pending_lock:
                             session.queued_request_count = max(0, session.queued_request_count - 1)
-                if _service_time().monotonic() >= request_deadline:
-                    raise
+                if _http_bridge_capacity_wait_expired(
+                    request_state,
+                    exc,
+                    request_deadline=request_deadline,
+                ):
+                    terminal_exc = _http_bridge_terminal_capacity_error(request_state, exc)
+                    await write_terminal_account_cap_overload(terminal_exc)
+                    raise terminal_exc
                 if gate_contention and session.closed:
                     raise
                 continue

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -877,6 +877,8 @@ class _WebSocketRequestState:
     account_capacity_wait_reason: str | None = None
     account_capacity_wait_started_at: float | None = None
     account_capacity_wait_retry_after_seconds: float | None = None
+    account_capacity_wait_deadline: float | None = None
+    account_capacity_wait_error: ProxyResponseError | None = None
     capacity_startup_wait_event: asyncio.Event | None = None
     capacity_startup_ready_event: asyncio.Event | None = None
 

--- a/openspec/changes/bound-account-capacity-wait/.openspec.yaml
+++ b/openspec/changes/bound-account-capacity-wait/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-27

--- a/openspec/changes/bound-account-capacity-wait/proposal.md
+++ b/openspec/changes/bound-account-capacity-wait/proposal.md
@@ -1,0 +1,28 @@
+# Bound HTTP bridge account-capacity waits
+
+## Why
+
+Requests that exhaust an account concurrency cap enter a recoverable capacity wait bounded only by the HTTP bridge request budget, which defaults to 7200 seconds. A live deployment showed requests parked in the retry loop for over eight minutes, after which clients timed out without receiving the existing HTTP 429 cap envelope. Because these failures happen before submission, they were also absent from request logs.
+
+## What Changes
+
+- Bound recoverable HTTP bridge account-capacity waits by a fixed 120-second per-request ceiling in addition to the bridge request budget.
+- Preserve the first local-cap error and deadline across re-prepared request states and subsequent recoverable errors.
+- Keep `response_create_gate_timeout` waits bounded only by the bridge request budget.
+- Surface and record the original `account_stream_cap` or `account_response_create_cap` failure when the ceiling expires.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-admission-control`: Define a bounded account-capacity wait for bridged Responses work and terminal request-log visibility.
+
+## Impact
+
+- `app/modules/proxy/_service/http_bridge/streaming.py`: bounded capacity waits, original-cap error propagation, and terminal request logging.
+- `app/modules/proxy/_service/support.py`: per-request capacity deadline and original error state.
+- No new setting, database migration, dashboard, or API schema change. Existing error envelopes and reason codes are reused.

--- a/openspec/changes/bound-account-capacity-wait/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/bound-account-capacity-wait/specs/proxy-admission-control/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Account-local Responses work is capped before upstream creation
+
+For `/v1/responses`, `/backend-api/codex/responses`, and compact Responses traffic, the proxy MUST enforce account-local response-create and streaming concurrency limits in addition to process-wide admission limits, and the configured limits MUST be cluster-wide per-account targets enforced across all replicas rather than per-replica allowances. Because per-account caps are partitioned per replica via the bridge ring and cannot be safely partitioned across intra-pod worker processes, each instance MUST run a single worker process; horizontal scaling is achieved by adding replicas. The default account response-create cap MUST be 4 and the default account stream cap MUST be 8 unless operators configure a different value.
+
+When an account is at either cap, new soft-affinity work MUST prefer another eligible account before returning local overload. A bare process-session mapping MAY supply soft locality only while the request is self-contained, pre-visible, and has no required owner. Account-cap spillover MUST be decided during account selection and MUST NOT switch an account after a request enters shared transport, replay, or durable bridge ownership. Hard-continuity work MUST remain on its required owner and MAY fail closed when that owner is saturated. Hard Codex ownership rows MUST bypass soft sticky fallback/reallocation so pressure cannot delete or rewrite them.
+
+The recoverable account-capacity wait entered by bridged Responses session creation and recovery when every eligible account is capped MUST be bounded by a fixed 120-second ceiling in addition to the bridge request budget, anchored per request at the first local-capacity wait. The original local-cap error and deadline MUST remain active across request-state re-preparation and subsequent recoverable waits, except that per-session response-create gate waits (`response_create_gate_timeout`) MUST remain bounded by the bridge request budget only. When the bound expires, the proxy MUST surface the original HTTP 429 local-cap error envelope (`account_stream_cap` or `account_response_create_cap`) and MUST record the terminal failure in the request log with the local-cap error code and `account_capacity_wait` failure phase.
+
+#### Scenario: Soft work avoids saturated account
+
+- **GIVEN** account A is at its account response-create cap
+- **AND** account B is eligible and below cap
+- **WHEN** a self-contained `/v1/responses` request has only bare process-session affinity to account A
+- **THEN** the proxy selects account B instead of queueing on account A
+
+#### Scenario: Hard continuity owner saturation fails closed
+
+- **GIVEN** a follow-up request requires a specific previous-response owner account
+- **AND** that account is at its account stream or response-create cap
+- **WHEN** no safe continuity-preserving alternative exists
+- **THEN** the proxy returns a bounded local overload/continuity failure
+- **AND** the failure reason is stable and low-cardinality
+
+#### Scenario: Late WebSocket cap race does not retire shared work
+
+- **GIVEN** a request has entered an upstream WebSocket shared with another in-flight response
+- **WHEN** a later account response-create lease acquisition loses a capacity race
+- **THEN** the proxy rejects only the newly unadmitted request with the existing local-cap failure
+- **AND** it does not retire or switch the shared upstream WebSocket to spill that request
+
+#### Scenario: Existing bridge ownership is not replaced by cap spillover
+
+- **GIVEN** a session header resolves to a live or durable HTTP bridge owner
+- **WHEN** that owner's account or response-create gate is saturated
+- **THEN** the request follows the existing hard bridge-capacity behavior
+- **AND** account-cap spillover does not publish a replacement bridge under the same canonical identity
+
+#### Scenario: Account-capacity wait surfaces the cap error at the ceiling
+
+- **GIVEN** every eligible account for a bridged Responses request stays at its stream cap
+- **WHEN** the recoverable account-capacity wait exceeds the 120-second ceiling
+- **THEN** the request fails with HTTP 429 and `error.code = "account_stream_cap"`
+- **AND** the connection is still open to deliver the error envelope
+- **AND** a request-log row records the failure with `error.code = "account_stream_cap"` and `failure_phase = "account_capacity_wait"`
+
+#### Scenario: Gate contention is not bounded by the capacity ceiling
+
+- **GIVEN** a bridged Responses request waiting on a per-session response-create gate held by an in-flight turn
+- **WHEN** the wait exceeds the 120-second account-capacity ceiling
+- **THEN** the gate wait continues, bounded by the bridge request budget only

--- a/openspec/changes/bound-account-capacity-wait/tasks.md
+++ b/openspec/changes/bound-account-capacity-wait/tasks.md
@@ -1,0 +1,14 @@
+# Tasks
+
+## 1. Bounded account-capacity wait
+
+- [x] 1.1 Add a fixed 120-second account-capacity wait ceiling without adding a setting.
+- [x] 1.2 Clamp account-capacity waits while leaving `response_create_gate_timeout` waits budget-bounded.
+- [x] 1.3 Preserve the first local-cap deadline and error across recovery and request-state preparation.
+- [x] 1.4 Surface the original HTTP 429 cap envelope when the ceiling expires.
+- [x] 1.5 Record terminal capacity overloads in request logs before raising.
+- [x] 1.6 Re-check the effective deadline after bounded sleeps before retrying.
+
+## 2. Tests
+
+- [x] 2.1 Cover deadline clamping, preservation, terminal error propagation, gate-wait exemption, and request-log visibility.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -1780,6 +1780,62 @@ async def test_http_bridge_submit_waits_for_local_account_capacity(
 
 
 @pytest.mark.asyncio
+async def test_reused_http_bridge_capacity_failure_logs_current_request_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="sid-reused-capacity")
+    session.headers = {
+        "user-agent": "stale-client/1.0",
+        "x-parent-session-id": "stale-conversation",
+    }
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-reused-capacity",
+        request_log_id="req-public-reused-capacity",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        transport="http",
+        useragent="opencode/1.18.3",
+        useragent_group="opencode",
+        conversation_id="current-conversation",
+        client_ip="10.0.0.9",
+    )
+    capacity_error = _account_stream_cap_error()
+    write_request_log = AsyncMock()
+    monkeypatch.setattr(service, "_submit_http_bridge_request", AsyncMock(side_effect=capacity_error))
+    monkeypatch.setattr(service, "_write_request_log", write_request_log)
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_http_bridge_capacity_wait_plan",
+        lambda *_args, **_kwargs: None,
+    )
+
+    with pytest.raises(ProxyResponseError):
+        async for _ in service._stream_http_bridge_session_events(
+            session,
+            request_state=request_state,
+            text_data='{"type":"response.create"}',
+            queue_limit=4,
+            propagate_http_errors=True,
+            downstream_turn_state=None,
+        ):
+            pass
+
+    write_request_log.assert_awaited_once()
+    assert write_request_log.await_args is not None
+    kwargs = write_request_log.await_args.kwargs
+    assert kwargs["request_id"] == "req-public-reused-capacity"
+    assert kwargs["account_id"] == session.account.id
+    assert kwargs["useragent"] == "opencode/1.18.3"
+    assert kwargs["useragent_group"] == "opencode"
+    assert kwargs["conversation_id"] == "current-conversation"
+    assert kwargs["client_ip"] == "10.0.0.9"
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_submit_waits_for_response_create_gate_contention(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2137,6 +2193,8 @@ async def test_http_bridge_submit_gate_contention_still_reroutes_soft_sessions(
 
     assert exc_info.value is gate_timeout_error
     assert submit.await_count == 1
+    assert request_state.account_capacity_wait_error is None
+    assert request_state.account_capacity_wait_deadline is None
 
 
 @pytest.mark.asyncio
@@ -2178,6 +2236,20 @@ async def test_http_bridge_submit_leaves_soft_capacity_for_session_reroute(monke
 
     assert exc_info.value is capacity_error
     assert submit.await_count == 1
+    assert request_state.account_capacity_wait_error is capacity_error
+    assert request_state.account_capacity_wait_deadline is not None
+    later_capacity_error = ProxyResponseError(
+        429,
+        openai_error(
+            "account_stream_cap",
+            "Account stream concurrency limit reached",
+            error_type="rate_limit_error",
+        ),
+    )
+    assert (
+        http_bridge_streaming_module._http_bridge_terminal_capacity_error(request_state, later_capacity_error)
+        is capacity_error
+    )
 
 
 @pytest.mark.asyncio
@@ -2238,6 +2310,86 @@ async def test_http_bridge_submit_capacity_wait_uses_original_request_deadline(
     assert exc_info.value is capacity_error
     assert waited == [1.0]
     assert submit.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_submit_capacity_wait_preserves_first_cap_across_later_recoverable_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="sid-submit-cap-envelope")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-submit-cap-envelope",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=99.5,
+        transport="http",
+        event_queue=asyncio.Queue(),
+    )
+    capacity_error = ProxyResponseError(
+        429,
+        openai_error(
+            "account_response_create_cap",
+            "Account response-create concurrency limit reached",
+            error_type="rate_limit_error",
+        ),
+    )
+    later_recoverable_error = ProxyResponseError(
+        429,
+        openai_error(
+            "rate_limit_exceeded",
+            "Rate limit exceeded. Try again in 30s",
+            error_type="rate_limit_error",
+        ),
+    )
+    submit = AsyncMock(side_effect=[capacity_error, later_recoverable_error])
+    write_overload_log = AsyncMock()
+    clock = [100.0]
+    waited: list[float] = []
+
+    async def fake_capacity_wait(**kwargs: object):
+        waited.append(cast(float, kwargs["sleep_seconds"]))
+        clock[0] += waited[-1]
+        if False:
+            yield ""
+
+    monkeypatch.setattr(service, "_submit_http_bridge_request", submit)
+    monkeypatch.setattr(service, "_write_account_cap_overload_request_log", write_overload_log)
+    monkeypatch.setattr(http_bridge_streaming_module, "_ACCOUNT_CAPACITY_WAIT_MAX_SECONDS", 2.0)
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_http_bridge_account_capacity_wait_seconds",
+        lambda exc: 0.5 if exc is capacity_error else 30.0,
+    )
+    monkeypatch.setattr(http_bridge_streaming_module, "_iter_account_capacity_wait_sse", fake_capacity_wait)
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_service_time",
+        lambda: SimpleNamespace(monotonic=lambda: clock[0]),
+    )
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        async for _ in service._stream_http_bridge_session_events(
+            session,
+            request_state=request_state,
+            text_data='{"type":"response.create"}',
+            queue_limit=4,
+            propagate_http_errors=True,
+            downstream_turn_state=None,
+            request_deadline=200.0,
+        ):
+            pass
+
+    assert exc_info.value is capacity_error
+    assert waited == pytest.approx([0.5, 1.5])
+    assert submit.await_count == 2
+    write_overload_log.assert_awaited_once_with(
+        request_state=request_state,
+        exc=capacity_error,
+        account_id=session.account.id,
+    )
 
 
 def _make_api_key(
@@ -4939,8 +5091,18 @@ async def test_stream_via_http_bridge_keeps_sse_alive_while_session_creation_wai
 
 
 @pytest.mark.asyncio
-async def test_stream_via_http_bridge_stops_session_creation_retry_after_budget_wait(
+@pytest.mark.parametrize(
+    ("error_code", "request_budget_seconds", "capacity_wait_max_seconds"),
+    [
+        pytest.param("no_accounts", 1.0, 120.0, id="bridge-budget"),
+        pytest.param("account_stream_cap", 120.0, 1.0, id="account-capacity-ceiling"),
+    ],
+)
+async def test_stream_via_http_bridge_stops_session_creation_retry_after_effective_deadline(
     monkeypatch: pytest.MonkeyPatch,
+    error_code: str,
+    request_budget_seconds: float,
+    capacity_wait_max_seconds: float,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     settings = SimpleNamespace(
@@ -4951,8 +5113,8 @@ async def test_stream_via_http_bridge_stops_session_creation_retry_after_budget_
     )
     get_or_create = AsyncMock(
         side_effect=ProxyResponseError(
-            503,
-            openai_error("no_accounts", "Rate limit exceeded. Try again in 120s"),
+            429 if error_code == "account_stream_cap" else 503,
+            openai_error(error_code, "Rate limit exceeded. Try again in 120s"),
         )
     )
     now = 100.0
@@ -4991,8 +5153,8 @@ async def test_stream_via_http_bridge_stops_session_creation_retry_after_budget_
         proxy_service,
         "get_settings",
         lambda: _make_app_settings(
-            proxy_request_budget_seconds=1.0,
-            http_responses_session_bridge_request_budget_seconds=1.0,
+            proxy_request_budget_seconds=request_budget_seconds,
+            http_responses_session_bridge_request_budget_seconds=request_budget_seconds,
         ),
     )
     monkeypatch.setattr(
@@ -5003,10 +5165,17 @@ async def test_stream_via_http_bridge_stops_session_creation_retry_after_budget_
     monkeypatch.setattr(http_bridge_streaming_module.asyncio, "sleep", fake_sleep)
     monkeypatch.setattr(http_bridge_streaming_module, "_http_bridge_account_capacity_wait_seconds", lambda _exc: 120.0)
     monkeypatch.setattr(http_bridge_streaming_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 120.0)
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_ACCOUNT_CAPACITY_WAIT_MAX_SECONDS",
+        capacity_wait_max_seconds,
+    )
     monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
     monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
     monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=None))
     monkeypatch.setattr(service, "_get_or_create_http_bridge_session", get_or_create)
+    write_request_log = AsyncMock()
+    monkeypatch.setattr(service, "_write_request_log", write_request_log)
 
     payload = proxy_service.ResponsesRequest.model_validate(
         {"model": "gpt-5.4", "instructions": "hi", "input": [], "stream": True}
@@ -5036,6 +5205,13 @@ async def test_stream_via_http_bridge_stops_session_creation_retry_after_budget_
     assert keepalive["type"] == "codex.keepalive"
     assert keepalive["status"] == "waiting_for_account_capacity"
     assert get_or_create.await_count == 1
+    if error_code == "account_stream_cap":
+        assert request_state.account_capacity_wait_deadline == pytest.approx(now)
+        assert write_request_log.await_args is not None
+        assert write_request_log.await_args.kwargs["error_code"] == "account_stream_cap"
+    else:
+        assert request_state.account_capacity_wait_deadline is None
+        write_request_log.assert_not_awaited()
 
 
 def test_http_bridge_session_key_infers_strength_from_affinity_kind() -> None:
@@ -5738,6 +5914,68 @@ async def test_reconnect_http_bridge_session_uses_bridge_budget_for_capacity_wai
 
     assert sleep_calls
     assert sleep_calls[0]["max_sleep_seconds"] == pytest.approx(119.5)
+
+
+@pytest.mark.asyncio
+async def test_reconnect_http_bridge_session_surfaces_local_cap_at_capacity_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session()
+    settings = SimpleNamespace(
+        prefer_earlier_reset_accounts=False,
+        prefer_earlier_reset_window="secondary",
+        routing_strategy="usage_weighted",
+    )
+    now = 100.5
+    selection_deadlines: list[float] = []
+    sleep_calls: list[dict[str, object]] = []
+
+    async def select_account(deadline: float, **_kwargs: object) -> proxy_service.AccountSelection:
+        selection_deadlines.append(deadline)
+        return proxy_service.AccountSelection(
+            account=None,
+            error_message="Account stream capacity is exhausted",
+            error_code="account_stream_cap",
+        )
+
+    async def sleep_for_recovery(*_args: object, **kwargs: object) -> bool:
+        nonlocal now
+        sleep_calls.append(kwargs)
+        now = 220.5
+        return True
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-reconnect-cap-deadline",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=100.0,
+    )
+    monkeypatch.setattr(proxy_service.time, "monotonic", lambda: now)
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_request_budget_seconds=7200.0),
+    )
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: SimpleNamespace(get=AsyncMock(return_value=settings)),
+    )
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_account)
+    monkeypatch.setattr(http_bridge_mixin_module, "_sleep_for_account_selection_recovery", sleep_for_recovery)
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await service._reconnect_http_bridge_session(session, request_state=request_state)
+
+    assert exc_info.value is request_state.account_capacity_wait_error
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.payload["error"]["code"] == "account_stream_cap"
+    assert selection_deadlines == pytest.approx([7300.0])
+    assert [call["max_sleep_seconds"] for call in sleep_calls] == pytest.approx([120.0])
+    assert request_state.account_capacity_wait_deadline == pytest.approx(220.5)
 
 
 @pytest.mark.asyncio
@@ -10497,8 +10735,10 @@ async def test_http_bridge_local_owner_rejects_aliases_for_distinct_live_session
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_capacity", [False, True])
 async def test_stream_via_http_bridge_reacquires_api_key_reservation_after_owner_forward_failure(
     monkeypatch: pytest.MonkeyPatch,
+    terminal_capacity: bool,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     started_at = time.monotonic()
@@ -10589,6 +10829,7 @@ async def test_stream_via_http_bridge_reacquires_api_key_reservation_after_owner
     )
 
     submitted_reservations: list[proxy_service.ApiKeyUsageReservationData | None] = []
+    submitted_capacity_wait_deadlines: list[float | None] = []
 
     async def fake_forward_http_bridge_request_to_owner(**kwargs: object):
         del kwargs
@@ -10604,6 +10845,7 @@ async def test_stream_via_http_bridge_reacquires_api_key_reservation_after_owner
     ) -> None:
         del _session, text_data, queue_limit
         submitted_reservations.append(request_state.api_key_reservation)
+        submitted_capacity_wait_deadlines.append(request_state.account_capacity_wait_deadline)
         event_queue = request_state.event_queue
         assert event_queue is not None
 
@@ -10616,8 +10858,11 @@ async def test_stream_via_http_bridge_reacquires_api_key_reservation_after_owner
 
     reserve_retry = AsyncMock(return_value=retried_reservation)
     capacity_unavailable = ProxyResponseError(
-        503,
-        proxy_service.openai_error("no_accounts", "Rate limit exceeded. Try again in 120s"),
+        429,
+        proxy_service.openai_error(
+            "account_stream_cap",
+            "Account stream capacity is exhausted",
+        ),
     )
     get_or_create = AsyncMock(side_effect=[owner_forward, capacity_unavailable, session_retry])
 
@@ -10653,24 +10898,36 @@ async def test_stream_via_http_bridge_reacquires_api_key_reservation_after_owner
     monkeypatch.setattr(http_bridge_streaming_module, "_http_bridge_account_capacity_wait_seconds", lambda _exc: 0.001)
     monkeypatch.setattr(http_bridge_streaming_module, "_ACCOUNT_SELECTION_RECOVERY_HEARTBEAT_SECONDS", 0.001)
     monkeypatch.setattr(http_bridge_streaming_module, "_http_bridge_startup_keepalive_grace_seconds", lambda: 0.001)
-
-    chunks = [
-        chunk
-        async for chunk in service._stream_via_http_bridge(
-            payload,
-            headers={"x-codex-session-id": "sid-123"},
-            codex_session_affinity=True,
-            propagate_http_errors=False,
-            openai_cache_affinity=False,
-            api_key=api_key,
-            api_key_reservation=initial_reservation,
-            suppress_text_done_events=False,
-            idle_ttl_seconds=120.0,
-            codex_idle_ttl_seconds=900.0,
-            max_sessions=8,
-            queue_limit=4,
+    write_overload_log = AsyncMock()
+    monkeypatch.setattr(service, "_write_account_cap_overload_request_log", write_overload_log)
+    if terminal_capacity:
+        monkeypatch.setattr(
+            http_bridge_streaming_module, "_http_bridge_capacity_wait_plan", lambda *_args, **_kwargs: None
         )
-    ]
+
+    stream = service._stream_via_http_bridge(
+        payload,
+        headers={"x-codex-session-id": "sid-123"},
+        codex_session_affinity=True,
+        propagate_http_errors=False,
+        openai_cache_affinity=False,
+        api_key=api_key,
+        api_key_reservation=initial_reservation,
+        suppress_text_done_events=False,
+        idle_ttl_seconds=120.0,
+        codex_idle_ttl_seconds=900.0,
+        max_sessions=8,
+        queue_limit=4,
+    )
+    if terminal_capacity:
+        with pytest.raises(ProxyResponseError) as exc_info:
+            async for _chunk in stream:
+                pass
+        assert exc_info.value is capacity_unavailable
+        write_overload_log.assert_awaited_once()
+        return
+
+    chunks = [chunk async for chunk in stream]
 
     keepalive = proxy_service.parse_sse_data_json(chunks[0])
     assert keepalive is not None
@@ -10680,7 +10937,10 @@ async def test_stream_via_http_bridge_reacquires_api_key_reservation_after_owner
     assert get_or_create.await_count == 3
     assert prepare_reservations == [initial_reservation, retried_reservation]
     assert submitted_reservations == [retried_reservation]
+    assert submitted_capacity_wait_deadlines == [request_state_initial.account_capacity_wait_deadline]
+    assert submitted_capacity_wait_deadlines[0] is not None
     reserve_retry.assert_awaited_once()
+    write_overload_log.assert_not_awaited()
 
 
 async def _run_owner_forward_recovery_with_session(
@@ -16156,6 +16416,48 @@ async def test_submit_http_bridge_request_waits_for_closed_session_retirement_be
 
 
 @pytest.mark.asyncio
+async def test_submit_http_bridge_request_propagates_terminal_cap_from_closed_session_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session()
+    session.closed = True
+    service._http_bridge_sessions[session.key] = session
+    cap_error = _account_stream_cap_error()
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-closed-reconnect-cap",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create","model":"gpt-5.4","input":"new"}',
+        transport="http",
+        skip_request_log=True,
+    )
+
+    async def reconnect(*_args: object, **_kwargs: object) -> None:
+        request_state.account_capacity_wait_error = cap_error
+        raise cap_error
+
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await service._submit_http_bridge_request(
+            session,
+            request_state=request_state,
+            text_data=request_state.request_text or "{}",
+            queue_limit=8,
+        )
+
+    assert exc_info.value is cap_error
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.payload["error"]["code"] == "account_stream_cap"
+
+
+@pytest.mark.asyncio
 async def test_submit_http_bridge_request_does_not_send_after_retirement_between_validation_and_send() -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     request_state = proxy_service._WebSocketRequestState(
@@ -20348,3 +20650,163 @@ async def test_stream_http_bridge_or_retry_spills_unanchored_fork_from_capped_pr
         assert chunks == ['data: {"type":"response.completed"}\n\n']
         assert preferred_account_ids == ["acc-capped", None]
         assert request_state.preferred_account_id is None
+
+
+def _account_stream_cap_error() -> ProxyResponseError:
+    return ProxyResponseError(
+        429,
+        openai_error(
+            "account_stream_cap",
+            "Account stream capacity is exhausted; this replica's share is 4 of the per-account limit 8 "
+            "across 2 replicas. Increase the dashboard stream limit or wait for active streams to finish.",
+            error_type="rate_limit_error",
+        ),
+    )
+
+
+def test_http_bridge_capacity_wait_plan_clamps_account_capacity_wait() -> None:
+    exc = _account_stream_cap_error()
+    now = time.monotonic()
+
+    unbounded = http_bridge_streaming_module._http_bridge_capacity_wait_plan(exc, request_deadline=now + 7200.0)
+    assert unbounded is not None
+
+    clamped = http_bridge_streaming_module._http_bridge_capacity_wait_plan(
+        exc,
+        request_deadline=now + 7200.0,
+        capacity_wait_deadline=now + 5.0,
+    )
+    assert clamped is not None
+    assert clamped[0] <= 5.0
+
+    expired = http_bridge_streaming_module._http_bridge_capacity_wait_plan(
+        exc,
+        request_deadline=now + 7200.0,
+        capacity_wait_deadline=now - 1.0,
+    )
+    assert expired is None
+
+
+def test_http_bridge_capacity_wait_plan_gate_timeout_ignores_ceiling(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_proxy_admission_wait_timeout_seconds",
+        lambda settings=None: 10.0,
+    )
+    exc = http_bridge_helpers_module._http_bridge_startup_wait_timeout_error(
+        "http_bridge_response_create_gate",
+        code="response_create_gate_timeout",
+    )
+    now = time.monotonic()
+
+    plan = http_bridge_streaming_module._http_bridge_capacity_wait_plan(
+        exc,
+        request_deadline=now + 120.0,
+        capacity_wait_deadline=now - 1.0,
+    )
+    assert plan is not None
+
+
+def test_gate_timeout_does_not_start_account_capacity_wait_deadline() -> None:
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-gate-wait-deadline",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+    )
+    gate_timeout = http_bridge_helpers_module._http_bridge_startup_wait_timeout_error(
+        "http_bridge_response_create_gate",
+        code="response_create_gate_timeout",
+    )
+
+    assert http_bridge_streaming_module._http_bridge_account_capacity_wait_deadline(request_state, gate_timeout) is None
+    assert request_state.account_capacity_wait_deadline is None
+    capacity_deadline = http_bridge_streaming_module._http_bridge_account_capacity_wait_deadline(
+        request_state,
+        _account_stream_cap_error(),
+    )
+    assert capacity_deadline is not None
+    assert http_bridge_streaming_module._http_bridge_account_capacity_wait_deadline(request_state, gate_timeout) is None
+    assert request_state.account_capacity_wait_deadline == capacity_deadline
+
+
+def test_http_bridge_capacity_wait_deadline_anchors_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(http_bridge_streaming_module, "_ACCOUNT_CAPACITY_WAIT_MAX_SECONDS", 50.0)
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-capacity-wait-deadline",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+    )
+
+    first = http_bridge_streaming_module._http_bridge_capacity_wait_deadline(request_state)
+    second = http_bridge_streaming_module._http_bridge_capacity_wait_deadline(request_state)
+
+    assert first == second
+    assert first == pytest.approx(time.monotonic() + 50.0, abs=1.0)
+
+
+@pytest.mark.asyncio
+async def test_account_cap_overload_writes_request_log() -> None:
+    mixin = http_bridge_streaming_module._HTTPBridgeStreamingMixin
+    fake_self = SimpleNamespace(_write_request_log=AsyncMock())
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-cap-log",
+        request_log_id="req-public-cap-log",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic() - 120.0,
+        transport="http",
+        session_id="ses-cap-log",
+        useragent="opencode/1.18.3",
+        useragent_group="opencode",
+        conversation_id="parent-1",
+        client_ip="10.0.0.9",
+    )
+
+    await mixin._write_account_cap_overload_request_log(
+        fake_self,
+        request_state=request_state,
+        exc=_account_stream_cap_error(),
+        account_id=None,
+    )
+
+    fake_self._write_request_log.assert_awaited_once()
+    kwargs = fake_self._write_request_log.await_args.kwargs
+    assert kwargs["status"] == "error"
+    assert kwargs["error_code"] == "account_stream_cap"
+    assert kwargs["failure_phase"] == "account_capacity_wait"
+    assert kwargs["request_id"] == "req-public-cap-log"
+    assert kwargs["account_id"] is None
+    assert kwargs["useragent_group"] == "opencode"
+    assert kwargs["conversation_id"] == "parent-1"
+    assert kwargs["latency_ms"] >= 119_000
+
+
+@pytest.mark.asyncio
+async def test_non_cap_errors_do_not_write_capacity_overload_log() -> None:
+    mixin = http_bridge_streaming_module._HTTPBridgeStreamingMixin
+    fake_self = SimpleNamespace(_write_request_log=AsyncMock())
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-other",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+    )
+
+    await mixin._write_account_cap_overload_request_log(
+        fake_self,
+        request_state=request_state,
+        exc=ProxyResponseError(502, openai_error("upstream_unavailable", "nope")),
+        account_id=None,
+    )
+
+    fake_self._write_request_log.assert_not_awaited()


### PR DESCRIPTION
## Summary

Bounds recoverable HTTP bridge account-capacity waits so clients receive the original 429 cap envelope while still connected, and records terminal pre-submission cap failures in request logs. This is the requested concern 1 split from #1474.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Related to #1354. This is a partial mitigation and does not close the turn-scoped lease root issue.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/bound-account-capacity-wait/`

## Changes

- Bound recoverable account-capacity waits to a fixed 120-second per-request ceiling.
- Preserve the first local-cap deadline and 429 envelope across recovery and re-prepared request states.
- Record terminal failures with `failure_phase=account_capacity_wait`.
- Keep `response_create_gate_timeout` waits bounded only by the bridge request budget.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config**
- [x] No new required setup step
- New setting(s) and why each cannot be a default: none. A fixed ceiling avoids expanding the settings surface.
- [x] README sections / `.env.example` / dashboard nav within budget

## Test plan

```
.venv/bin/python -m pytest tests/unit/test_proxy_http_bridge.py -q  # 384 passed
.venv/bin/python -m ruff check app/modules/proxy/_service/http_bridge/streaming.py app/modules/proxy/_service/support.py tests/unit/test_proxy_http_bridge.py
.venv/bin/python -m ruff format --check app/modules/proxy/_service/http_bridge/streaming.py app/modules/proxy/_service/support.py tests/unit/test_proxy_http_bridge.py
.venv/bin/ty check app/modules/proxy/_service/http_bridge/streaming.py app/modules/proxy/_service/support.py
npx --yes @fission-ai/openspec@latest validate bound-account-capacity-wait --strict
npx --yes @fission-ai/openspec@latest validate --specs --strict
```

## Screenshots / output

Proxy behavior only. When the account-capacity ceiling expires, the open connection receives the original HTTP 429 `account_stream_cap` or `account_response_create_cap` envelope and the request log records `failure_phase=account_capacity_wait`.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [ ] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally. Targeted pytest, Ruff, formatting, and ty checks passed as listed above.
- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean. Strict OpenSpec change and main-spec validation passed; `/opsx:verify` was not run.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).