### PR TITLE
fix(proxy): preserve websocket connect errors

### DIFF
--- a/app/core/clients/codex.py
+++ b/app/core/clients/codex.py
@@ -251,9 +251,11 @@ class CodexClient:
         for index, endpoint in enumerate(endpoints):
             candidate = route.with_endpoint(endpoint, tuple(endpoints[index + 1 :]))
             context: Any | None = None
+            entered_context: Any | None = None
             try:
                 if endpoint.scheme.startswith("socks"):
                     websocket, context = await _open_ws_via_socks_proxy(url, endpoint, **kwargs)
+                    entered_context = context
                 else:
                     context = self._session.ws_connect(
                         url,
@@ -262,16 +264,20 @@ class CodexClient:
                     )
                     if asyncio.iscoroutine(context):
                         context = await context
-                    websocket = await context.__aenter__() if hasattr(context, "__aenter__") else context
+                    if hasattr(context, "__aenter__"):
+                        websocket = await context.__aenter__()
+                        entered_context = context
+                    else:
+                        websocket = context
                 return CodexWebSocketResult(
                     websocket,
-                    context if hasattr(context, "__aenter__") else None,
+                    entered_context,
                     candidate,
                     index > 0,
                 )
             except Exception as exc:
-                if context is not None and hasattr(context, "__aexit__"):
-                    await context.__aexit__(None, None, None)
+                if entered_context is not None and hasattr(entered_context, "__aexit__"):
+                    await entered_context.__aexit__(None, None, None)
                 handshake_status = _transport_error_status_code(exc)
                 if handshake_status is not None and not retry_handshake_status:
                     raise _transport_error(

--- a/openspec/changes/archive/2026-07-28-preserve-websocket-connect-errors/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-28-preserve-websocket-connect-errors/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/archive/2026-07-28-preserve-websocket-connect-errors/context.md
+++ b/openspec/changes/archive/2026-07-28-preserve-websocket-connect-errors/context.md
@@ -1,0 +1,46 @@
+# WebSocket Connect Error Preservation Context
+
+## Purpose and scope
+
+The normative routing contract is in the delta for
+[`upstream-proxy-routing`](specs/upstream-proxy-routing/spec.md). This change is
+limited to the lifecycle of the context returned by the routed Codex WebSocket
+client. It does not change endpoint selection, retry eligibility, health
+settlement, or downstream error envelopes.
+
+## Decision and alternatives
+
+The client records successful context entry and invokes `__aexit__` only for a
+context it actually entered. This mirrors Python's `async with` protocol:
+`__aexit__` is not called when `__aenter__` fails. Removing all cleanup from the
+error path would also avoid the reported crash, but would make ownership
+ambiguous if a later operation ever fails after successful entry. Catching and
+discarding the cleanup `AttributeError` was rejected because it would encode an
+aiohttp implementation detail and could hide other lifecycle defects.
+
+## Constraints and failure modes
+
+- The original failure must still be converted to a credential-safe
+  `CodexTransportError`; proxy credentials and raw route URLs must not appear in
+  the message.
+- Handshake-status and network-error fallback controls keep their existing
+  semantics.
+- A failed `__aenter__` owns its partial-resource cleanup, as required by the
+  asynchronous context manager contract.
+- Successfully opened WebSockets retain their current caller-owned context and
+  close behavior.
+
+## Example
+
+An HTTP proxy restart causes aiohttp's awaitable WebSocket request context to
+raise `ClientProxyConnectionError` before it stores a response in `_resp`.
+codex-lb must classify that connection failure and either try the next endpoint
+or return a credential-safe transport error. It must not call `__aexit__` on
+the unentered context and replace the failure with an `_resp` `AttributeError`.
+
+## Operational notes
+
+No rollout setting or migration is required. After deployment, upstream proxy
+disconnects may still fail requests, but logs and callers will receive the real
+classified connection failure instead of a cleanup crash, making ordinary
+network recovery and diagnostics effective again.

--- a/openspec/changes/archive/2026-07-28-preserve-websocket-connect-errors/design.md
+++ b/openspec/changes/archive/2026-07-28-preserve-websocket-connect-errors/design.md
@@ -1,0 +1,66 @@
+## Context
+
+`aiohttp.ClientSession.ws_connect()` returns an awaitable asynchronous context
+manager. Its internal response is initialized only after the connection
+coroutine succeeds. `CodexClient.open_ws_with_route_metadata()` currently keeps
+that unentered manager in `context`; when awaiting it raises, the shared error
+path calls `context.__aexit__()` and aiohttp fails while accessing the missing
+response. The cleanup exception bypasses the existing credential-safe transport
+classification and route fallback logic.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Follow asynchronous context manager ownership semantics during WebSocket
+  connection setup.
+- Preserve the original connect or handshake failure for existing transport
+  classification and fallback controls.
+- Retain current cleanup behavior for any context that was entered
+  successfully.
+
+**Non-Goals:**
+
+- Change endpoint selection, account selection, retry budgets, or health
+  penalties.
+- Special-case aiohttp's private `_resp` attribute or suppress arbitrary
+  cleanup failures.
+- Change successful WebSocket ownership or close behavior.
+
+## Decisions
+
+Track context entry explicitly for each route attempt. Set the entered context
+only after `__aenter__()` returns successfully, and invoke `__aexit__()` from
+the error path only when that marker is present.
+
+This follows the behavior of `async with`, which does not call `__aexit__` when
+`__aenter__` raises. It is preferable to checking for `_resp`, because `_resp`
+is an aiohttp implementation detail, and preferable to deleting cleanup
+entirely, because explicit ownership remains correct if later code gains a
+failure point after successful entry.
+
+The regression uses an in-memory aiohttp-style awaitable context manager. Its
+connection coroutine raises without opening a socket, and its `__aexit__`
+method records any invalid cleanup attempt. This exercises the public routed
+client behavior without relying on an external network.
+
+## Risks / Trade-offs
+
+- A context manager with a broken `__aenter__` that expects its caller to invoke
+  `__aexit__` could retain partial state. Such a contract is incompatible with
+  Python's context manager protocol; the regression intentionally follows the
+  standard protocol used by aiohttp.
+- Entry state adds one local variable per route attempt. Keeping it local avoids
+  sharing ownership across fallback endpoints.
+- Errors raised by cleanup after a genuinely successful entry retain normal
+  context manager behavior and may supersede a later error; there is currently
+  no throwing operation between successful entry and returning the result.
+
+## Migration Plan
+
+No migration or feature flag is required. Deploy as a patch-level client
+lifecycle correction. Rollback is the ordinary code rollback.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-07-28-preserve-websocket-connect-errors/proposal.md
+++ b/openspec/changes/archive/2026-07-28-preserve-websocket-connect-errors/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+When an aiohttp WebSocket connection attempt fails before its request context
+manager has been entered, the Codex client calls that context manager's
+`__aexit__` method anyway. aiohttp then raises an `AttributeError` that masks
+the real connection failure and prevents the normal routed transport error
+classification and fallback behavior.
+
+## What Changes
+
+- Track whether an upstream WebSocket context manager was entered successfully
+  before attempting to exit it during error cleanup.
+- Preserve the original connection failure for credential-safe
+  `CodexTransportError` classification and configured same-pool fallback.
+- Add regression coverage for an awaitable aiohttp-style context manager whose
+  connection coroutine fails before entry completes.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `upstream-proxy-routing`: Routed WebSocket connection failures remain
+  observable as the original credential-safe transport failure and follow the
+  configured fallback policy.
+
+## Impact
+
+- `app/core/clients/codex.py`
+- `tests/unit/test_codex_client.py`
+- No public API, configuration, dependency, database, or dashboard changes.

--- a/openspec/changes/archive/2026-07-28-preserve-websocket-connect-errors/specs/upstream-proxy-routing/spec.md
+++ b/openspec/changes/archive/2026-07-28-preserve-websocket-connect-errors/specs/upstream-proxy-routing/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Routed WebSocket connection failures preserve transport errors
+
+The Codex upstream client MUST invoke an asynchronous WebSocket context
+manager's exit method only after that context manager has been entered
+successfully. If context entry fails, the client MUST preserve the original
+connection or handshake failure for credential-safe transport classification
+and MUST apply the configured same-pool endpoint fallback policy to that
+failure.
+
+#### Scenario: Connection failure before context entry is not masked
+
+- **GIVEN** an awaitable WebSocket context manager whose connection attempt fails before entry completes
+- **WHEN** the Codex upstream client opens the routed WebSocket
+- **THEN** the client does not invoke the unentered context manager's exit method
+- **AND** it returns a credential-safe transport error classified from the original connection failure
+- **AND** it does not replace that failure with a cleanup exception
+
+#### Scenario: Unmasked failure can use the next route endpoint
+
+- **GIVEN** a routed WebSocket connection whose first endpoint fails before context entry
+- **AND** same-pool network-error fallback is enabled
+- **WHEN** another endpoint remains in the resolved route
+- **THEN** the client attempts the next endpoint
+- **AND** the first endpoint's unentered context manager is not exited
+
+#### Scenario: Successfully entered context retains caller-owned cleanup
+
+- **GIVEN** a routed WebSocket context manager enters successfully
+- **WHEN** the client returns the opened WebSocket and its context to the caller
+- **THEN** the caller can exit the returned context using the existing ownership contract

--- a/openspec/changes/archive/2026-07-28-preserve-websocket-connect-errors/tasks.md
+++ b/openspec/changes/archive/2026-07-28-preserve-websocket-connect-errors/tasks.md
@@ -1,0 +1,14 @@
+## 1. WebSocket Context Lifecycle
+
+- [x] 1.1 Track successful asynchronous context entry per routed WebSocket attempt.
+- [x] 1.2 Exit a WebSocket context during error cleanup only when the client entered it successfully.
+
+## 2. Regression Coverage
+
+- [x] 2.1 Add an in-memory awaitable context regression that fails before entry and proves the original transport error is preserved.
+- [x] 2.2 Verify endpoint fallback and successful caller-owned cleanup retain their existing behavior.
+
+## 3. Validation
+
+- [x] 3.1 Run the focused Codex client unit tests, lint, formatting, and type checks.
+- [x] 3.2 Run strict OpenSpec validation and verify implementation-to-spec coherence.

--- a/openspec/specs/upstream-proxy-routing/context.md
+++ b/openspec/specs/upstream-proxy-routing/context.md
@@ -1,0 +1,48 @@
+# Upstream Proxy Routing Context
+
+## Purpose and scope
+
+The normative contract is in [spec.md](spec.md). Upstream proxy routing binds
+credentialed Codex operations to resolved routes while keeping endpoint
+credentials out of errors and request logs. This context focuses on transport
+ownership during routed WebSocket setup; account selection and proxy-pool
+configuration are outside its scope.
+
+## WebSocket context ownership
+
+aiohttp exposes WebSocket setup as an awaitable asynchronous context manager.
+The caller owns its exit path only after entry succeeds. codex-lb therefore
+tracks successful entry for each route endpoint independently and never exits a
+manager whose connection coroutine or `__aenter__` failed.
+
+This follows Python's `async with` protocol instead of checking aiohttp private
+state such as `_resp`. It also keeps successful WebSocket cleanup caller-owned,
+so the connection remains open after the routed client returns it.
+
+## Constraints and failure modes
+
+- Connection and handshake errors remain credential-safe and identify only the
+  configured endpoint id.
+- Existing handshake-status and network-error fallback controls decide whether
+  another endpoint is attempted.
+- Failed context entry owns any partial-resource cleanup. Calling `__aexit__`
+  after failed entry can itself raise and mask the transport failure.
+- A successful context must still be returned to the consuming WebSocket layer
+  for exactly-once close handling.
+
+## Example
+
+Suppose an HTTP proxy restarts while codex-lb opens an upstream WebSocket.
+aiohttp raises `ClientProxyConnectionError` before assigning a response to its
+request context. codex-lb classifies that original error and can try the next
+endpoint in the resolved route. It does not call the unentered context's exit
+method, which would otherwise replace the useful failure with an internal
+attribute error.
+
+## Operational notes
+
+No setting or migration controls this lifecycle rule. A proxy outage can still
+surface as an upstream-unavailable response after fallback is exhausted, but
+operators should see the classified connection failure rather than a cleanup
+crash. That distinction allows existing network-recovery and route-health
+diagnostics to operate on the actual failure.

--- a/openspec/specs/upstream-proxy-routing/spec.md
+++ b/openspec/specs/upstream-proxy-routing/spec.md
@@ -65,3 +65,33 @@ Dashboard upstream proxy pool member mutations MUST reject attempts to add an en
 - **THEN** the API MUST return a dashboard validation error
 - **AND** it MUST NOT return an unhandled server error.
 
+### Requirement: Routed WebSocket connection failures preserve transport errors
+
+The Codex upstream client MUST invoke an asynchronous WebSocket context
+manager's exit method only after that context manager has been entered
+successfully. If context entry fails, the client MUST preserve the original
+connection or handshake failure for credential-safe transport classification
+and MUST apply the configured same-pool endpoint fallback policy to that
+failure.
+
+#### Scenario: Connection failure before context entry is not masked
+
+- **GIVEN** an awaitable WebSocket context manager whose connection attempt fails before entry completes
+- **WHEN** the Codex upstream client opens the routed WebSocket
+- **THEN** the client does not invoke the unentered context manager's exit method
+- **AND** it returns a credential-safe transport error classified from the original connection failure
+- **AND** it does not replace that failure with a cleanup exception
+
+#### Scenario: Unmasked failure can use the next route endpoint
+
+- **GIVEN** a routed WebSocket connection whose first endpoint fails before context entry
+- **AND** same-pool network-error fallback is enabled
+- **WHEN** another endpoint remains in the resolved route
+- **THEN** the client attempts the next endpoint
+- **AND** the first endpoint's unentered context manager is not exited
+
+#### Scenario: Successfully entered context retains caller-owned cleanup
+
+- **GIVEN** a routed WebSocket context manager enters successfully
+- **WHEN** the client returns the opened WebSocket and its context to the caller
+- **THEN** the caller can exit the returned context using the existing ownership contract

--- a/tests/unit/test_codex_client.py
+++ b/tests/unit/test_codex_client.py
@@ -9,7 +9,7 @@ import pytest
 from aiohttp.client_reqrep import ConnectionKey
 from python_socks import ProxyType
 
-from app.core.clients.codex import CodexClient, require_route_or_direct_egress_opt_in
+from app.core.clients.codex import CodexClient, CodexTransportError, require_route_or_direct_egress_opt_in
 from app.core.upstream_proxy import ResolvedProxyEndpoint, ResolvedUpstreamRoute
 from tests.unit._proxy_test_helpers import runtime_basic_auth_url
 
@@ -288,27 +288,87 @@ async def test_websocket_network_error_can_disable_route_fallback(
 
 @pytest.mark.asyncio
 async def test_websocket_network_error_uses_route_fallback_by_default(
+    monkeypatch: pytest.MonkeyPatch,
     route: ResolvedUpstreamRoute,
 ) -> None:
-    class _FailFirstNetworkSession:
-        def __init__(self) -> None:
-            self.calls: list[dict[str, Any]] = []
+    connection_key = ConnectionKey("proxy.test", 8080, False, False, None, None, None)
+    session = aiohttp.ClientSession()
+    calls: list[dict[str, Any]] = []
 
-        def ws_connect(self, url: str, **kwargs: Any) -> object:
-            self.calls.append({"url": url, **kwargs})
-            if len(self.calls) == 1:
-                raise OSError("network unavailable")
-            return object()
+    async def fake_ws_connect(url: str, **kwargs: Any) -> object:
+        calls.append({"url": url, **kwargs})
+        if len(calls) == 1:
+            raise aiohttp.ClientProxyConnectionError(connection_key, ConnectionRefusedError("connection refused"))
+        return object()
 
-    session = _FailFirstNetworkSession()
-    result = await CodexClient(session).open_ws_with_route_metadata(
-        "wss://upstream.test",
-        route=route,
-    )
+    monkeypatch.setattr(session, "_ws_connect", fake_ws_connect)
+    client = CodexClient(session)
+    try:
+        result = await client.open_ws_with_route_metadata(
+            "wss://upstream.test",
+            route=route,
+        )
+    finally:
+        await client.close()
 
-    assert len(session.calls) == 2
+    assert len(calls) == 2
     assert result.fallback_used is True
     assert result.route.endpoint_id == "ep_2"
+
+
+@pytest.mark.asyncio
+async def test_websocket_awaitable_connect_failure_preserves_original_transport_error(
+    monkeypatch: pytest.MonkeyPatch,
+    route: ResolvedUpstreamRoute,
+) -> None:
+    connection_key = ConnectionKey("proxy.test", 8080, False, False, None, None, None)
+    session = aiohttp.ClientSession()
+    calls: list[dict[str, Any]] = []
+
+    async def fail_ws_connect(url: str, **kwargs: Any) -> object:
+        calls.append({"url": url, **kwargs})
+        raise aiohttp.ClientProxyConnectionError(connection_key, ConnectionRefusedError("connection refused"))
+
+    monkeypatch.setattr(session, "_ws_connect", fail_ws_connect)
+    client = CodexClient(session)
+    try:
+        with pytest.raises(CodexTransportError) as exc_info:
+            await client.open_ws_with_route_metadata(
+                "wss://upstream.test",
+                route=route,
+                retry_network_errors=False,
+            )
+    finally:
+        await client.close()
+
+    assert str(exc_info.value) == (
+        "Codex upstream websocket failed via proxy endpoint ep_1: ClientProxyConnectionError"
+    )
+    assert exc_info.value.failure_phase == "connect"
+    assert exc_info.value.retryable_same_contract is False
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_websocket_success_returns_caller_owned_entered_context(
+    route: ResolvedUpstreamRoute,
+) -> None:
+    class _WsContextSession:
+        def __init__(self) -> None:
+            self.context = _WsContext()
+
+        def ws_connect(self, *_args: object, **_kwargs: object) -> _WsContext:
+            return self.context
+
+    session = _WsContextSession()
+    result = await CodexClient(session).open_ws_with_route_metadata("wss://upstream.test", route=route)
+
+    assert result.websocket is session.context.websocket
+    assert result.context is session.context
+
+    await result.context.__aexit__(None, None, None)
+
+    assert session.context.exited is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fix routed Codex WebSocket setup so an aiohttp asynchronous context manager is exited only after successful entry. This preserves the original `ClientProxyConnectionError` instead of masking it with `_BaseRequestContextManager._resp` `AttributeError`, allowing the existing credential-safe classification and same-pool fallback logic to run.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Related to #1314 (partial enabling fix; this PR does not close the broader cross-account failover issue).

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/archive/2026-07-28-preserve-websocket-connect-errors/`

## Changes

- Track successful WebSocket context entry independently for each route endpoint and clean up only owned contexts.
- Exercise the real aiohttp-style awaitable request context without network access, covering terminal connect failure, same-pool fallback, and successful caller-owned cleanup.
- Add, verify, sync, and archive the `upstream-proxy-routing` OpenSpec requirement and stable context.

## Simplicity

- No new setting, environment variable, setup step, migration, dependency, README section, dashboard navigation item, default change, or dashboard-visible surface.
- P1-P5 remain unchanged; no simplicity budget exception is needed.

## Test plan

```text
.venv/bin/pytest -q tests/unit/test_codex_client.py
24 passed

.venv/bin/pytest -q -ra tests/unit/test_codex_client.py tests/unit/test_codex_upstream_paths.py tests/unit/test_proxy_websocket_client.py
95 passed

.venv/bin/ruff check .
All checks passed

.venv/bin/ruff format --check .
847 files already formatted

.venv/bin/ty check
All checks passed

.venv/bin/python scripts/check_proxy_architecture.py
proxy architecture checks passed

npx --yes @fission-ai/openspec@1.6.0 validate preserve-websocket-connect-errors --strict
Change 'preserve-websocket-connect-errors' is valid

npx --yes @fission-ai/openspec@1.6.0 validate --specs
48 passed, 0 failed
```

A full `tests/unit` run was also attempted, but CPython 3.13.3 exited 139 in the unrelated `tests/unit/test_db_migrate.py::test_check_schema_drift_ignores_sqlite_real_float_reflection_for_sticky_thresholds` Alembic traversal. That test passed when rerun alone (`1 passed`), so the full-suite attempt is intentionally not reported as green; cloud CI remains authoritative.

## Screenshots / output

Before:

```text
AttributeError: 'aiohttp.client._BaseRequestContextManager' object has no attribute '_resp'
```

After the same failed-proxy reproduction:

```text
CodexTransportError: Codex upstream websocket failed via proxy endpoint dead-proxy: ClientProxyConnectionError
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local lint, type, architecture, and unit-test subsets.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
