### PR TITLE
fix(db): correct PostgreSQL pool budget

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from app.codex_sessions_retag import RetagResult, default_codex_home, retag_codex_sessions
+from app.core.config.settings import get_settings
 
 if TYPE_CHECKING:
     from app.core.runtime_logging import LogConfig
@@ -99,6 +100,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     timeout_keep_alive = _parse_server_timeout_keep_alive(args.timeout_keep_alive)
     ws_max_size = _parse_server_ws_max_size(args.ws_max_size)
     os.environ["PORT"] = str(port)
+    workers = get_settings().workers_per_instance
 
     _load_uvicorn().run(
         "app.main:app",
@@ -108,6 +110,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         ssl_keyfile=args.ssl_keyfile,
         timeout_keep_alive=timeout_keep_alive,
         ws_max_size=ws_max_size,
+        workers=workers,
         proxy_headers=False,
         log_config=_build_log_config(),
     )

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -5,6 +5,7 @@ import logging
 import os
 import sqlite3
 from contextlib import asynccontextmanager
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, AsyncIterator, Awaitable, Callable, Protocol, TypeVar
 
@@ -35,6 +36,17 @@ _SQLITE_BUSY_TIMEOUT_SECONDS = _SQLITE_BUSY_TIMEOUT_MS / 1000
 # ``database_pool_size`` / ``database_max_overflow``.
 _POSTGRES_POOL_TIMEOUT_SECONDS = 30.0
 _POSTGRES_POOL_RECYCLE_SECONDS = 1800
+
+
+class _PostgresPooledEngineRole(StrEnum):
+    REQUEST_PATH = "request_path"
+    BACKGROUND_TASK = "background_task"
+
+
+# The owned launcher pins one worker per replica. Derive its two-engine
+# PostgreSQL budget from the roles that the real creation paths must declare.
+_POSTGRES_POOLED_ENGINE_ROLES = tuple(_PostgresPooledEngineRole)
+_POSTGRES_POOLED_ENGINES_PER_WORKER = len(_POSTGRES_POOLED_ENGINE_ROLES)
 
 
 def _is_sqlite_url(url: str) -> bool:
@@ -88,6 +100,16 @@ def _postgres_async_engine_kwargs(url: str) -> dict[str, object]:
     return kwargs
 
 
+def _create_postgres_async_engine(url: str, *, role: _PostgresPooledEngineRole) -> AsyncEngine:
+    if not isinstance(role, _PostgresPooledEngineRole):
+        raise TypeError(f"PostgreSQL engine role must be declared in {_PostgresPooledEngineRole.__name__}")
+    return create_async_engine(
+        url,
+        echo=False,
+        **_postgres_async_engine_kwargs(url),
+    )
+
+
 def _sqlite_file_async_engine_kwargs() -> dict[str, object]:
     return {
         "poolclass": NullPool,
@@ -109,27 +131,31 @@ def _configure_sqlite_engine(engine: Engine, *, enable_wal: bool) -> None:
             cursor.close()
 
 
-if _is_sqlite_url(_settings.database_url):
-    is_sqlite_memory = _is_sqlite_memory_url(_settings.database_url)
+def _create_main_engine(url: str) -> AsyncEngine:
+    if not _is_sqlite_url(url):
+        return _create_postgres_async_engine(
+            url,
+            role=_PostgresPooledEngineRole.REQUEST_PATH,
+        )
+
+    is_sqlite_memory = _is_sqlite_memory_url(url)
     if is_sqlite_memory:
-        engine = create_async_engine(
-            _settings.database_url,
+        main_engine = create_async_engine(
+            url,
             echo=False,
             connect_args={"timeout": _SQLITE_BUSY_TIMEOUT_SECONDS},
         )
     else:
-        engine = create_async_engine(
-            _settings.database_url,
+        main_engine = create_async_engine(
+            url,
             echo=False,
             **_sqlite_file_async_engine_kwargs(),
         )
-    _configure_sqlite_engine(engine.sync_engine, enable_wal=not is_sqlite_memory)
-else:
-    engine = create_async_engine(
-        _settings.database_url,
-        echo=False,
-        **_postgres_async_engine_kwargs(_settings.database_url),
-    )
+    _configure_sqlite_engine(main_engine.sync_engine, enable_wal=not is_sqlite_memory)
+    return main_engine
+
+
+engine = _create_main_engine(_settings.database_url)
 
 SessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
@@ -252,10 +278,9 @@ def init_background_db(url: str | None = None) -> None:
         )
         _configure_sqlite_engine(_background_engine.sync_engine, enable_wal=not is_sqlite_memory)
     else:
-        _background_engine = create_async_engine(
+        _background_engine = _create_postgres_async_engine(
             db_url,
-            echo=False,
-            **_postgres_async_engine_kwargs(db_url),
+            role=_PostgresPooledEngineRole.BACKGROUND_TASK,
         )
 
     _background_session_factory = async_sessionmaker(_background_engine, expire_on_commit=False, class_=AsyncSession)

--- a/deploy/helm/codex-lb/README.md
+++ b/deploy/helm/codex-lb/README.md
@@ -261,13 +261,23 @@ networkPolicy:
 
 ## Connection Pool Sizing
 
-Each pod keeps its own SQLAlchemy pool.
+Normative contracts: [database backends](../../../openspec/specs/database-backends/)
+and [deployment installation](../../../openspec/specs/deployment-installation/).
+
+Each supported pod runs one application worker with two independent SQLAlchemy
+pools: one for request-path work and one for background tasks.
 
 ```
-total_connections = (databasePoolSize + databaseMaxOverflow) × replicas
+total_connections = (databasePoolSize + databaseMaxOverflow) × 2 pools × 1 worker × replicas
 ```
 
-Keep this within your PostgreSQL `max_connections` budget or place PgBouncer in front of the database.
+Keep this within your PostgreSQL `max_connections` budget, including capacity
+for migrations and administrative clients, or place PgBouncer in front of the
+database.
+
+The owned `app.cli` launcher explicitly pins Uvicorn to one worker, so
+`WEB_CONCURRENCY` does not multiply pools. Custom Uvicorn/Gunicorn multi-worker
+launchers are unsupported; scale through replicas or the HPA.
 
 ## Production Workload
 
@@ -344,23 +354,29 @@ A static ring is incompatible with autoscaling and must list exactly the Statefu
 
 ### Connection Pool Budget
 
-Each pod maintains its own SQLAlchemy connection pool. The total connections across all replicas must fit within PostgreSQL's `max_connections`:
+Each supported pod maintains one worker with two independent SQLAlchemy
+connection pools: the request pool and the background-task pool. The total
+connections across all replicas must leave room within PostgreSQL's
+`max_connections` for reserved slots, migrations, and operations:
 
 ```
-(databasePoolSize + databaseMaxOverflow) × maxReplicas ≤ PostgreSQL max_connections
+(databasePoolSize + databaseMaxOverflow) × 2 × 1 × maxReplicas ≤ PostgreSQL max_connections - reserve
 ```
 
 **Example for `values-prod.yaml`:**
 
 ```yaml
 config:
-  databasePoolSize: 3
-  databaseMaxOverflow: 2
+  databasePoolSize: 1
+  databaseMaxOverflow: 1
 autoscaling:
   maxReplicas: 20
 ```
 
-Calculation: `(3 + 2) × 20 = 100` connections, which fits within PostgreSQL's default `max_connections=100`.
+Calculation: `(1 + 1) × 2 × 20 = 80` application connections. This fits
+within PostgreSQL's default `max_connections=100` while reserving 20
+raw server slots: three default superuser-reserved slots, two simultaneous
+migrator connections, and fifteen further operational connections.
 
 **Tuning:**
 

--- a/deploy/helm/codex-lb/values-prod.yaml
+++ b/deploy/helm/codex-lb/values-prod.yaml
@@ -45,9 +45,10 @@ ingress:
   certManager:
     enabled: true
 config:
-  # Connection pool budget: (databasePoolSize + databaseMaxOverflow) × maxReplicas ≤ PostgreSQL max_connections
-  # For maxReplicas=20: (3+2)×20=100 = PG default max_connections
-  databasePoolSize: 3
-  databaseMaxOverflow: 2
+  # Each supported replica has one worker with two pools. For maxReplicas=20:
+  # (databasePoolSize + databaseMaxOverflow) × 2 × 1 × 20 = (1+1)×2×20 = 80.
+  # This fits PG's default max_connections=100 and reserves 20 connections for DB operations.
+  databasePoolSize: 1
+  databaseMaxOverflow: 1
 externalSecrets:
   enabled: true

--- a/deploy/helm/codex-lb/values.yaml
+++ b/deploy/helm/codex-lb/values.yaml
@@ -124,12 +124,13 @@ config:
   # @param config.databaseMigrateOnStartup Disable auto-migration (migration Job handles it)
   databaseMigrateOnStartup: false
   # @param config.databasePoolSize SQLAlchemy connection pool size
-  # Connection pool budget: (databasePoolSize + databaseMaxOverflow) × maxReplicas MUST be ≤ PostgreSQL max_connections (default 100)
-  # Default (5+5)×10=100 fits HPA maxReplicas=10 against PG default max_connections.
-  # Prod overlay uses (3+2)×20=100. Increase PG max_connections or deploy PgBouncer if more concurrency is needed.
-  databasePoolSize: 5
+  # Each supported replica has one worker with two pools (request + background).
+  # Reserve 20 of PostgreSQL's default 100 slots for PG internals, migrations, and operations.
+  # Default (3+1)×2×1×10=80. Prod uses (1+1)×2×1×20=80.
+  # Increase PG max_connections or deploy PgBouncer if more concurrency is needed.
+  databasePoolSize: 3
   # @param config.databaseMaxOverflow SQLAlchemy connection pool max overflow
-  databaseMaxOverflow: 5
+  databaseMaxOverflow: 1
   # @param config.upstreamBaseUrl Override OpenAI upstream base URL (empty = default)
   upstreamBaseUrl: ""
   # @param config.upstreamConnectTimeout Upstream connection timeout seconds

--- a/openspec/changes/fix-postgres-pool-budget/.openspec.yaml
+++ b/openspec/changes/fix-postgres-pool-budget/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/fix-postgres-pool-budget/design.md
+++ b/openspec/changes/fix-postgres-pool-budget/design.md
@@ -1,0 +1,32 @@
+## Context
+
+A PostgreSQL replica creates one request-path engine at import time and a separate background engine during startup. Both engines use the configured `database_pool_size` and `database_max_overflow`, so the worst-case per-replica capacity is twice the configured per-engine capacity. Helm currently documents and sizes only one pool.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Derive the engine-count budget from the declared PostgreSQL engine roles used by the real creation paths.
+- Keep the owned server launcher on the supported one-worker-per-replica topology even when `WEB_CONCURRENCY` is present.
+- Use the complete two-engine topology in Helm capacity guidance and policy tests.
+- Keep default and production HPA ceilings at 80 application connections, leaving 20 raw server slots for PostgreSQL reservations, migrations, and operations.
+
+**Non-Goals:**
+
+- Changing which workloads use the background engine.
+- Reintroducing independently configurable background-pool settings.
+- Adding runtime discovery of PostgreSQL `max_connections`, a pooler, or a new setting.
+
+## Decisions
+
+- Keep both engines identically sized. The background pool was intentionally isolated for burst traffic, and splitting one configured pool asymmetrically would silently change the established setting semantics.
+- Declare request-path and background-task PostgreSQL engine roles and require both creation paths to use a role-validating factory. Derive the per-worker engine count from those roles, so adding a declared role changes the budget automatically.
+- Explicitly pass `workers=1` to Uvicorn in `app.cli`. The project supports one worker per replica and horizontal scaling through replicas; pinning the owned launcher prevents Uvicorn from interpreting `WEB_CONCURRENCY` as an implicit multi-worker request without attempting worker auto-detection.
+- Size chart defaults at `(3 + 1) * 2 * 10 = 80`. Keep the production overlay at `(1 + 1) * 2 * 20 = 80`. A 20-slot raw reserve covers PostgreSQL's default three superuser-reserved slots, the migration path's two-connection peak (advisory-lock holder plus operation connection), and fifteen further operational connections.
+- Test the budget from parsed Helm values against the role-derived runtime count, exercise both real engine creation paths, and verify that the owned CLI pins one worker even when `WEB_CONCURRENCY` is set.
+
+## Risks / Trade-offs
+
+- [Smaller pools can increase checkout waits during spikes] → Preserve three steady plus one overflow connection per default-chart engine, one steady plus one overflow per production engine, and retain the existing 30-second checkout timeout; operators with a larger server budget can tune upward using the documented formula.
+- [A future pooled engine could invalidate Helm math] → Require every PostgreSQL application engine to declare a role through the shared factory and derive policy-test engine count from the role enum.
+- [A custom launcher can still create multiple workers] → Keep custom multi-worker Uvicorn/Gunicorn topologies explicitly unsupported; only the owned `app.cli` launcher and Helm workload are pinned and budgeted.

--- a/openspec/changes/fix-postgres-pool-budget/proposal.md
+++ b/openspec/changes/fix-postgres-pool-budget/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Each application replica creates two independently pooled PostgreSQL engines, but Helm's documented capacity formula counts only one. At the production HPA ceiling this can admit roughly twice the documented connection budget and exhaust a default PostgreSQL server.
+
+## What Changes
+
+- Make the two-pool-per-replica topology explicit in the shared engine configuration.
+- Pin the owned server launcher to the supported one-worker topology so `WEB_CONCURRENCY` cannot silently multiply pools.
+- Correct Helm capacity guidance and default/production values so the HPA ceiling leaves room for PostgreSQL-reserved slots, migrations, and operations.
+- Add regression coverage that binds actual runtime engine roles, Helm values, and documented capacity math.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `database-backends`: Define the aggregate PostgreSQL connection budget across both per-replica engines.
+- `deployment-installation`: Require Helm sizing guidance and production defaults to account for both engines.
+
+## Impact
+
+Affected surfaces are `app/db/session.py`, `app/cli.py`, Helm defaults and production overlay, Helm documentation, OpenSpec database/deployment contracts, and focused unit/policy tests. No API, schema, migration, dependency, or production mutation is involved.

--- a/openspec/changes/fix-postgres-pool-budget/specs/database-backends/spec.md
+++ b/openspec/changes/fix-postgres-pool-budget/specs/database-backends/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: PostgreSQL connection budgets include every pooled engine
+
+The application SHALL define its per-worker PostgreSQL connection capacity as the configured per-engine pool capacity multiplied by the declared set of independently pooled engine roles. The request-path and background-task engine creation paths MUST each use the shared role-aware PostgreSQL engine factory, and the engine-count budget MUST be derived from those declared roles. The owned server launcher MUST run the supported one worker per replica explicitly, rather than allowing `WEB_CONCURRENCY` to multiply worker processes and their pools.
+
+#### Scenario: One replica reaches configured pool capacity
+
+- **WHEN** both declared PostgreSQL engine roles in one application worker reach `database_pool_size + database_max_overflow`
+- **THEN** the worker's aggregate application connection capacity is `2 * (database_pool_size + database_max_overflow)`
+- **AND** both engines were created through the role-aware factory counted by that formula
+
+#### Scenario: WEB_CONCURRENCY cannot multiply owned-launcher pools
+
+- **GIVEN** `WEB_CONCURRENCY` is greater than 1
+- **WHEN** the application starts through the owned `app.cli` launcher used by Helm
+- **THEN** the launcher explicitly starts one Uvicorn worker
+- **AND** the replica creates only the request-path and background-task pools
+- **AND** operators MUST scale supported deployments through replicas rather than custom multi-worker launchers
+
+#### Scenario: Test database disables pooling
+
+- **WHEN** `CODEX_LB_TEST_DATABASE_URL` selects `NullPool`
+- **THEN** pool sizing controls and the production pooled-engine budget do not apply to that test engine

--- a/openspec/changes/fix-postgres-pool-budget/specs/deployment-installation/spec.md
+++ b/openspec/changes/fix-postgres-pool-budget/specs/deployment-installation/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Helm PostgreSQL capacity guidance accounts for both application pools
+
+Helm sizing documentation and production-oriented values SHALL calculate maximum application PostgreSQL connections as `(databasePoolSize + databaseMaxOverflow) * 2 pooled engines * 1 supported worker * maxReplicas`. Values described as fitting PostgreSQL's default `max_connections=100` MUST reserve at least 20 raw server slots for PostgreSQL-reserved connections, the migration path's two-connection peak, administration, and transient non-application clients.
+
+#### Scenario: Default chart reaches its HPA ceiling
+
+- **WHEN** the default chart scales to `autoscaling.maxReplicas`
+- **THEN** both application pools across all replicas require no more than 80 PostgreSQL connections
+- **AND** at least 20 raw server slots remain outside the application-pool budget
+
+#### Scenario: Production overlay reaches its HPA ceiling
+
+- **WHEN** `values-prod.yaml` scales to `autoscaling.maxReplicas`
+- **THEN** both application pools across all replicas require no more than 80 PostgreSQL connections
+- **AND** at least 20 raw server slots remain available for PostgreSQL reservations, migrations, administration, and transient non-application clients

--- a/openspec/changes/fix-postgres-pool-budget/tasks.md
+++ b/openspec/changes/fix-postgres-pool-budget/tasks.md
@@ -1,0 +1,22 @@
+## 1. Runtime contract
+
+- [x] 1.1 Define and document the two pooled PostgreSQL engines per application replica in `app/db/session.py`.
+- [x] 1.2 Add focused unit coverage for aggregate per-replica pool capacity.
+
+## 2. Helm capacity policy
+
+- [x] 2.1 Correct default and production Helm pool values and all connection-budget formulas.
+- [x] 2.2 Add policy tests that calculate default and production HPA budgets from parsed values and the runtime engine count.
+
+## 3. Verification
+
+- [x] 3.1 Run focused unit and Helm policy tests.
+- [x] 3.2 Run strict OpenSpec validation, formatting/lint checks, diff checks, and final status review.
+
+## 4. PR-readiness remediation
+
+- [x] 4.1 Correct the remaining main OpenSpec context formula and document the one-worker budget topology.
+- [x] 4.2 Give both default and production Helm profiles a 20-connection raw reserve at their HPA ceilings.
+- [x] 4.3 Bind real PostgreSQL engine creation to declared roles and pin the owned Uvicorn launcher to one worker.
+- [x] 4.4 Add focused runtime, `WEB_CONCURRENCY`, Helm budget, template-plumbing, and documentation regression tests.
+- [x] 4.5 Re-run focused tests and proportional static/OpenSpec verification without installing dependencies.

--- a/openspec/specs/database-backends/context.md
+++ b/openspec/specs/database-backends/context.md
@@ -18,6 +18,7 @@ For higher concurrency or infrastructure-managed deployments, PostgreSQL support
 - PostgreSQL example URL: `postgresql+asyncpg://codex_lb:codex_lb@127.0.0.1:5432/codex_lb`
 - Pool sizing (`database_pool_size`, `database_max_overflow`) applies to PostgreSQL engine creation; the pool checkout timeout (30 s) and connection recycle window (1800 s) are fixed constants in `app/db/session.py` (issue #1340 phase 3).
 - The background/request-adjacent DB engine always derives its pool sizing from `database_pool_size` and `database_max_overflow`; it isolates background-task checkouts rather than being sized independently.
+- A supported application replica runs one worker with two independently pooled PostgreSQL engine roles (request path and background tasks), so its maximum application connection count is `2 * (database_pool_size + database_max_overflow)`. The owned CLI pins one Uvicorn worker even if `WEB_CONCURRENCY` is present; custom multi-worker launchers are unsupported.
 
 ## Example
 

--- a/openspec/specs/deployment-installation/context.md
+++ b/openspec/specs/deployment-installation/context.md
@@ -148,9 +148,12 @@ Phase 3 (10 removed):
   timeout fixed 30.0 s and recycle window fixed 1800 s
   (`_POSTGRES_POOL_*` constants in `app/db/session.py`).
   `CODEX_LB_DATABASE_POOL_SIZE` / `CODEX_LB_DATABASE_MAX_OVERFLOW` stay:
-  PostgreSQL HA operators must budget
-  `(pool_size + max_overflow) x replicas <= max_connections`, and the
-  Helm chart pins both.
+  PostgreSQL HA operators must budget both independently pooled engines in
+  every supported one-worker replica:
+  `(pool_size + max_overflow) x 2 x replicas`, while reserving server
+  connections for PostgreSQL internals, migrations, and operations. The owned
+  CLI launcher pins one worker; custom multi-worker launchers are unsupported.
+  The Helm chart pins both pool inputs.
 - Soft-drain/probe thresholds (6): drain at 85%/90%, error window 60 s /
   count 2, probe quiet 60 s, success streak 3. They encode the
   deterministic-failover design and interlock — raising one without the

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -36,7 +36,36 @@ def test_main_passes_timestamped_log_config(monkeypatch):
     assert formatters["access"]["fmt"].startswith("%(asctime)s ")
     assert kwargs["timeout_keep_alive"] == 7200
     assert kwargs["ws_max_size"] == 128 * 1024 * 1024
+    assert kwargs["workers"] == 1
     assert kwargs["proxy_headers"] is False
+
+
+def test_main_pins_one_worker_when_web_concurrency_requests_more(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(sys, "argv", ["codex-lb"])
+    monkeypatch.setenv("WEB_CONCURRENCY", "4")
+    monkeypatch.setattr(cli, "_load_uvicorn", lambda: SimpleNamespace(run=fake_run))
+
+    cli.main()
+
+    assert captured["kwargs"]["workers"] == 1
+
+
+def test_main_validates_selected_port_before_loading_uvicorn(monkeypatch):
+    def fail_load_uvicorn():
+        pytest.fail("Uvicorn must not load when the selected port conflicts with the metrics port")
+
+    monkeypatch.setenv("PORT", "2455")
+    monkeypatch.setenv("CODEX_LB_METRICS_PORT", "9090")
+    monkeypatch.setattr(cli, "_load_uvicorn", fail_load_uvicorn)
+
+    with pytest.raises(ValueError, match="metrics_port must not match the main application port \\(9090\\)"):
+        cli.main(["--port", "9090"])
 
 
 def test_main_passes_custom_keep_alive_timeout(monkeypatch):

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -188,6 +188,72 @@ def test_postgres_engine_kwargs_use_fixed_timeout_and_recycle_constants(monkeypa
     assert kwargs["pool_recycle"] == session_module._POSTGRES_POOL_RECYCLE_SECONDS == 1800
 
 
+def test_postgres_engine_factory_rejects_undeclared_role() -> None:
+    with pytest.raises(TypeError, match="must be declared"):
+        session_module._create_postgres_async_engine(
+            "postgresql+asyncpg://u:p@h/db",
+            role=cast(Any, "undeclared"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_postgres_creation_paths_cover_every_budgeted_engine_role_once(monkeypatch) -> None:
+    database_url = "postgresql+asyncpg://u:p@h/db"
+    created_roles: list[session_module._PostgresPooledEngineRole] = []
+    original_factory = session_module._create_postgres_async_engine
+
+    monkeypatch.setattr(
+        session_module,
+        "_settings",
+        _FakeSettings(
+            database_url=database_url,
+            database_pool_size=3,
+            database_max_overflow=2,
+        ),
+    )
+    monkeypatch.delenv("CODEX_LB_TEST_DATABASE_URL", raising=False)
+
+    def recording_factory(
+        url: str,
+        *,
+        role: session_module._PostgresPooledEngineRole,
+    ) -> session_module.AsyncEngine:
+        created_roles.append(role)
+        return original_factory(url, role=role)
+
+    monkeypatch.setattr(session_module, "_create_postgres_async_engine", recording_factory)
+    main_engine = session_module._create_main_engine(database_url)
+    try:
+        session_module.init_background_db(database_url)
+
+        assert tuple(created_roles) == session_module._POSTGRES_POOLED_ENGINE_ROLES
+        assert session_module._POSTGRES_POOLED_ENGINES_PER_WORKER == len(created_roles) == 2
+    finally:
+        await main_engine.dispose()
+        if session_module._background_engine is not None:
+            await session_module._background_engine.dispose()
+        session_module._background_engine = None
+        session_module._background_session_factory = None
+
+
+@pytest.mark.asyncio
+async def test_postgres_test_engines_keep_declared_roles_but_disable_pooling(monkeypatch) -> None:
+    monkeypatch.setenv("CODEX_LB_TEST_DATABASE_URL", "1")
+    engines = [
+        session_module._create_postgres_async_engine(
+            "postgresql+asyncpg://u:p@h/db",
+            role=role,
+        )
+        for role in session_module._POSTGRES_POOLED_ENGINE_ROLES
+    ]
+
+    try:
+        assert all(isinstance(engine.pool, NullPool) for engine in engines)
+    finally:
+        for engine in engines:
+            await engine.dispose()
+
+
 def test_postgres_engine_kwargs_use_nullpool_under_test_db_url(monkeypatch) -> None:
     """The CODEX_LB_TEST_DATABASE_URL escape hatch keeps NullPool semantics —
     pool_pre_ping/recycle are irrelevant when each session opens a fresh

--- a/tests/unit/test_helm_replica_artifacts.py
+++ b/tests/unit/test_helm_replica_artifacts.py
@@ -21,6 +21,7 @@ import pytest
 import yaml
 
 from app.core.config.settings import Settings
+from app.db.session import _POSTGRES_POOLED_ENGINES_PER_WORKER
 
 pytestmark = pytest.mark.unit
 
@@ -30,6 +31,11 @@ _CHART_README = _CHART_DIR / "README.md"
 _SMOKE_SCRIPT = _REPO_ROOT / "scripts" / "helm-kind-smoke.sh"
 _ENV_EXAMPLE = _REPO_ROOT / ".env.example"
 _HTTP_PORT = 2455
+_POSTGRES_DEFAULT_MAX_CONNECTIONS = 100
+_POSTGRES_DEFAULT_SUPERUSER_RESERVED_CONNECTIONS = 3
+_MIGRATOR_PEAK_CONNECTIONS = 2
+_REQUIRED_RAW_CONNECTION_RESERVE = 20
+_SUPPORTED_WORKERS_PER_REPLICA = 1
 _DEPENDENCY_BUILD_COMPLETE = False
 
 
@@ -143,6 +149,102 @@ def _staging_overlay_args(*args: str) -> tuple[str, ...]:
         "externalDatabase.url=postgresql+asyncpg://test:test@localhost/test",
         *args,
     )
+
+
+def _connection_budget(values: dict) -> int:
+    config = values["config"]
+    autoscaling = values["autoscaling"]
+    return (
+        (config["databasePoolSize"] + config["databaseMaxOverflow"])
+        * _POSTGRES_POOLED_ENGINES_PER_WORKER
+        * _SUPPORTED_WORKERS_PER_REPLICA
+        * autoscaling["maxReplicas"]
+    )
+
+
+def test_helm_pool_budgets_count_both_postgres_engines() -> None:
+    defaults = yaml.safe_load((_CHART_DIR / "values.yaml").read_text())
+    production = yaml.safe_load((_CHART_DIR / "values-prod.yaml").read_text())
+    merged_production = {
+        **defaults,
+        **production,
+        "config": {**defaults["config"], **production["config"]},
+        "autoscaling": {**defaults["autoscaling"], **production["autoscaling"]},
+    }
+
+    for values in (defaults, merged_production):
+        budget = _connection_budget(values)
+        reserve = _POSTGRES_DEFAULT_MAX_CONNECTIONS - budget
+
+        assert budget == 80
+        assert reserve >= _REQUIRED_RAW_CONNECTION_RESERVE
+        assert reserve >= _POSTGRES_DEFAULT_SUPERUSER_RESERVED_CONNECTIONS + _MIGRATOR_PEAK_CONNECTIONS
+
+
+def test_helm_pool_budget_values_flow_to_runtime_and_hpa_templates() -> None:
+    configmap = (_CHART_DIR / "templates" / "configmap.yaml").read_text()
+    deployment = (_CHART_DIR / "templates" / "deployment.yaml").read_text()
+    hpa = (_CHART_DIR / "templates" / "hpa.yaml").read_text()
+
+    assert "CODEX_LB_DATABASE_POOL_SIZE: {{ .Values.config.databasePoolSize" in configmap
+    assert "CODEX_LB_DATABASE_MAX_OVERFLOW: {{ .Values.config.databaseMaxOverflow" in configmap
+    assert re.search(r"command:\s+- python\s+- -m\s+- app\.cli", deployment)
+    assert "maxReplicas: {{ .Values.autoscaling.maxReplicas }}" in hpa
+
+
+def test_pool_budget_documentation_names_both_engines_one_worker_and_reserve() -> None:
+    readme = _CHART_README.read_text()
+    deployment_context = (_REPO_ROOT / "openspec" / "specs" / "deployment-installation" / "context.md").read_text()
+    database_context = (_REPO_ROOT / "openspec" / "specs" / "database-backends" / "context.md").read_text()
+
+    assert "× 2 pools × 1 worker × replicas" in readme
+    assert "WEB_CONCURRENCY" in readme
+    assert "reserving 20" in readme
+    assert "../../../openspec/specs/database-backends/" in readme
+    assert "../../../openspec/specs/deployment-installation/" in readme
+    assert "(pool_size + max_overflow) x 2 x replicas" in deployment_context
+    assert "one worker with two independently pooled PostgreSQL engine roles" in database_context
+
+
+def test_default_profile_renders_budgeted_pool_values_and_hpa_ceiling() -> None:
+    configmap_rendered = _helm_template("--show-only", "templates/configmap.yaml")
+    hpa_rendered = _helm_template(
+        "--set",
+        "autoscaling.enabled=true",
+        "--show-only",
+        "templates/hpa.yaml",
+    )
+    (configmap,) = _helm_documents(configmap_rendered)
+    (hpa,) = _helm_documents(hpa_rendered)
+
+    assert configmap["data"]["CODEX_LB_DATABASE_POOL_SIZE"] == "3"
+    assert configmap["data"]["CODEX_LB_DATABASE_MAX_OVERFLOW"] == "1"
+    assert hpa["spec"]["maxReplicas"] == 10
+
+
+def test_prod_overlay_renders_budgeted_pool_values_and_hpa_ceiling() -> None:
+    configmap_rendered = _helm_template(
+        *_prod_overlay_args("--show-only", "templates/configmap.yaml"),
+    )
+    deployment_rendered = _helm_template(
+        *_prod_overlay_args("--show-only", "templates/deployment.yaml"),
+    )
+    hpa_rendered = _helm_template(
+        *_prod_overlay_args("--show-only", "templates/hpa.yaml"),
+    )
+    (configmap,) = _helm_documents(configmap_rendered)
+    (deployment,) = _helm_documents(deployment_rendered)
+    (hpa,) = _helm_documents(hpa_rendered)
+    (application_container,) = (
+        container
+        for container in deployment["spec"]["template"]["spec"]["containers"]
+        if container["name"] == "codex-lb"
+    )
+
+    assert configmap["data"]["CODEX_LB_DATABASE_POOL_SIZE"] == "1"
+    assert configmap["data"]["CODEX_LB_DATABASE_MAX_OVERFLOW"] == "1"
+    assert application_container["command"][:3] == ["python", "-m", "app.cli"]
+    assert hpa["spec"]["maxReplicas"] == 20
 
 
 def _http_port_rules(policy: dict) -> list[dict]:


### PR DESCRIPTION
## Summary

Correct the PostgreSQL connection budget so it counts both independently pooled engines created by each application replica. Pin the project-owned launcher to one worker and size the default and production Helm profiles to stay within 80 application connections at their HPA ceilings, leaving 20 server slots for PostgreSQL reservations, migrations, and operations.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: None — no matching issue or pull request; searches recorded

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/fix-postgres-pool-budget/`

## Changes

- Derive per-worker PostgreSQL capacity from the declared request and background engine roles, and require both creation paths to use the role-aware factory.
- Force the owned Uvicorn launcher to one worker even when `WEB_CONCURRENCY` is set.
- Correct Helm defaults, production values, operator guidance, OpenSpec context, and policy tests to budget both pools and preserve a 20-connection reserve.

## Simplicity

- [x] Works with zero configuration
- [x] No new required setup step
- New setting(s) and why each can't be a default: None
- [x] No README section, `.env.example`, or dashboard navigation growth

## Test plan

```text
uv run --frozen pytest -p no:cacheprovider -q tests/unit/test_cli.py tests/unit/test_db_session.py tests/unit/test_helm_replica_artifacts.py
# 85 passed

make helm-check
# Seven lint profiles and seven template profiles passed; kubeconform validated 18/18 resources for Kubernetes 1.32 and 1.35

openspec validate fix-postgres-pool-budget --strict
# valid

openspec validate --specs --strict
# 48 passed, 0 failed
```

The committed candidate also passed independent local code and specification review. Full local CI was not completed; the PR's required GitHub CI remains mandatory.

## Screenshots / output

Not applicable — this change does not alter dashboard rendering.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above — N/A; the bounded issue and PR searches found no match.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local test, Helm, and policy gates listed above.
- [x] If touching specs: strict OpenSpec validation passes and `/opsx:verify` is clean.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
