### PR TITLE
fix(helm): calculate aggregate 5xx error rate

### DIFF
--- a/deploy/helm/codex-lb/dashboards/codex-lb.json
+++ b/deploy/helm/codex-lb/dashboards/codex-lb.json
@@ -200,7 +200,7 @@
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
           },
-          "expr": "rate(codex_lb_requests_total{namespace=\"$namespace\",status=~\"5..\"}[5m]) / rate(codex_lb_requests_total{namespace=\"$namespace\"}[5m])",
+          "expr": "(sum(rate(codex_lb_requests_total{namespace=\"$namespace\",job=~\"$job\",status=~\"5..\"}[5m])) or vector(0)) / sum(rate(codex_lb_requests_total{namespace=\"$namespace\",job=~\"$job\"}[5m]))",
           "legendFormat": "Error Rate",
           "refId": "A"
         }

--- a/deploy/helm/codex-lb/templates/prometheusrule.yaml
+++ b/deploy/helm/codex-lb/templates/prometheusrule.yaml
@@ -16,8 +16,13 @@ spec:
         - alert: CodexLBHighErrorRate
           expr: |
             (
-              rate(codex_lb_requests_total{status=~"5.."}[5m])
-              / rate(codex_lb_requests_total[5m])
+              sum by (namespace, job) (
+                rate(codex_lb_requests_total{status=~"5.."}[5m])
+              )
+              /
+              sum by (namespace, job) (
+                rate(codex_lb_requests_total[5m])
+              )
             ) > 0.05
           for: 5m
           labels:

--- a/openspec/changes/fix-promql-5xx-error-rate/.openspec.yaml
+++ b/openspec/changes/fix-promql-5xx-error-rate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/fix-promql-5xx-error-rate/design.md
+++ b/openspec/changes/fix-promql-5xx-error-rate/design.md
@@ -1,0 +1,86 @@
+## Context
+
+`codex_lb_requests_total` is split across request labels such as `status`,
+`method`, and `path`, plus scrape-time labels such as `namespace`, `job`, and
+replica identity. Prometheus binary operators match vectors by label set. The
+shipped expressions divide before aggregation, so a 5xx numerator series can
+match the identical 5xx series in the denominator and produce approximately
+100% even when most requests succeed.
+
+The Prometheus alert must preserve independent alert instances for each
+Kubernetes namespace and Prometheus job. The Grafana stat must instead produce
+one aggregate value for the namespace and job selected by the dashboard
+operator.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Calculate the 5xx share from separately aggregated error and total request
+  rates over the same five-minute window.
+- Preserve the alert threshold, duration, and isolation by namespace and job.
+- Apply the dashboard's namespace and job selections to both operands.
+- Show 0% in Grafana when selected traffic is positive but no 5xx series
+  exists.
+
+**Non-Goals:**
+
+- Change the request metric, its labels, the five-minute window, the alert
+  threshold, or the alert duration.
+- Define an error share when selected total traffic is absent or has zero
+  rate.
+- Add settings, dependencies, runtime behavior, dashboards, or deployment
+  actions beyond the two existing monitoring artifacts.
+
+## Decisions
+
+### Aggregate each operand before division
+
+The alert uses `sum by (namespace, job)` independently for the 5xx and total
+rates before dividing them. This removes status, request, and replica
+dimensions while retaining the two labels that define an alert instance.
+Vector matching then compares one error-rate series with one total-rate series
+for the same namespace and job.
+
+Using a binary `ignoring(status)` modifier was rejected because it would leave
+other request and replica dimensions in the vectors and could create
+many-to-one matching or duplicated denominators.
+
+### Produce one symmetrically filtered Grafana value
+
+The dashboard applies the selected namespace and job matchers to both rate
+selectors, sums each operand without grouping labels, and divides the resulting
+single-series vectors. The numerator alone falls back with `or vector(0)`.
+Consequently, positive selected traffic with no 5xx series evaluates to 0%,
+while an absent denominator remains no-data and a zero-rate denominator
+remains undefined instead of fabricating a healthy value. The job selector is
+a regex matcher so Grafana's All value continues to work; the single-select
+namespace remains an equality matcher.
+
+Clamping or defaulting the denominator was rejected because an error share is
+not defined when there is no selected traffic.
+
+### Lock the distributed artifact contract in focused tests
+
+Configuration tests extract the named alert expression and the named Grafana
+panel target, then compare their normalized or exact PromQL. This catches a
+future return to divide-before-aggregate semantics as well as asymmetric
+dashboard filters. A deterministic isolated Prometheus and Grafana fixture
+provides direct before/after rendering evidence for the shipped dashboard.
+
+## Risks / Trade-offs
+
+- **No or zero selected traffic can render no-data or an undefined value.**
+  This is deliberate because the ratio has no meaningful denominator; the
+  change does not alter Grafana's existing `lastNotNull` reduction behavior,
+  which can retain an older value over the selected time range.
+- **An absent 5xx alert series produces no alert instance.** This is the
+  correct result when no 5xx requests exist; Grafana alone needs an explicit
+  zero for its visible stat.
+- **The regression tests intentionally bind exact query structure.** This is
+  appropriate for shipped configuration artifacts whose vector semantics can
+  change through small textual edits; equivalent rewrites must update the
+  contract test deliberately.
+
+No data migration is required. Rollback consists of restoring the prior chart
+artifacts; request metrics and stored data are unchanged.

--- a/openspec/changes/fix-promql-5xx-error-rate/proposal.md
+++ b/openspec/changes/fix-promql-5xx-error-rate/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The shipped Prometheus alert and Grafana stat divide per-status request series
+without first combining the status dimension. A 5xx series can therefore divide
+by the identical 5xx series in the denominator and report approximately 100%
+instead of the actual share of failed requests.
+
+## What Changes
+
+- Calculate the 5xx share from separately aggregated error and total request
+  rates.
+- Keep alert instances isolated by Kubernetes namespace and Prometheus job while
+  aggregating request, status, and replica dimensions.
+- Make the Grafana stat honor its namespace and job selections and display 0%
+  when successful traffic exists before any 5xx series has been created.
+- Add focused configuration regressions for both distributed monitoring
+  artifacts.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-runtime-observability`: Defines the operator-facing Prometheus alert
+  and Grafana dashboard contracts for aggregate HTTP 5xx error share.
+
+## Impact
+
+The change is limited to the Helm chart's `PrometheusRule`, bundled Grafana
+dashboard, their configuration tests, and this OpenSpec change. It adds no
+setting, dependency, API, schema, migration, navigation item, or production
+rollout action.

--- a/openspec/changes/fix-promql-5xx-error-rate/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/fix-promql-5xx-error-rate/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Shipped high-error-rate alert uses aggregate request share
+
+The shipped `CodexLBHighErrorRate` alert MUST calculate, independently for each
+namespace and job, the sum of five-minute 5xx request rates divided by the sum
+of all five-minute request rates. Method, path, status, instance, replica, and
+other non-scope labels MUST be aggregated before division. The alert MUST
+compare the aggregate ratio to 0.05 and MUST require it to remain above that
+threshold for five minutes.
+
+#### Scenario: Mixed success and error series produce their aggregate share
+
+- **GIVEN** one namespace and job have positive 2xx and 5xx request rates
+- **WHEN** the high-error-rate alert expression is evaluated
+- **THEN** the ratio equals the sum of 5xx request rates divided by the sum of
+  all request rates
+- **AND** the ratio is not 1 unless all requests in that group are 5xx
+
+#### Scenario: Alert groups remain isolated
+
+- **GIVEN** request series exist for more than one namespace or job
+- **WHEN** the high-error-rate alert expression is evaluated
+- **THEN** each namespace and job pair has an independent aggregate ratio
+- **AND** traffic from one pair is not included in another pair
+
+#### Scenario: Threshold and duration apply to the aggregate ratio
+
+- **GIVEN** one namespace and job have an aggregate 5xx share above 0.05
+- **WHEN** that aggregate share remains above 0.05 for five minutes
+- **THEN** `CodexLBHighErrorRate` fires for that namespace and job pair
+
+### Requirement: Bundled Grafana 5xx stat uses selected aggregate request share
+
+The bundled Grafana `Error Rate (5xx)` stat MUST apply the selected namespace
+and job filters to both operands, aggregate all remaining request-series labels
+before division, and display the resulting 5xx share as one value. When the
+selected total request rate is positive but no matching 5xx series exists, the
+stat MUST display 0%.
+
+#### Scenario: Selected mixed traffic produces one aggregate value
+
+- **GIVEN** the selected namespace and job have positive 2xx and 5xx request
+  rates across one or more request or replica label combinations
+- **WHEN** the Grafana error-rate stat is evaluated
+- **THEN** it displays the sum of selected 5xx request rates divided by the sum
+  of all selected request rates
+
+#### Scenario: Dashboard selection filters both operands
+
+- **GIVEN** request series exist inside and outside the selected namespace and
+  job
+- **WHEN** the Grafana error-rate stat is evaluated
+- **THEN** both the 5xx numerator and total denominator exclude traffic outside
+  the selected namespace and job
+
+#### Scenario: Success-only traffic displays zero
+
+- **GIVEN** the selected scope has a positive successful-request rate
+- **AND** no matching 5xx series exists
+- **WHEN** the Grafana error-rate stat is evaluated
+- **THEN** the stat displays 0%

--- a/openspec/changes/fix-promql-5xx-error-rate/tasks.md
+++ b/openspec/changes/fix-promql-5xx-error-rate/tasks.md
@@ -1,0 +1,16 @@
+## 1. Monitoring contract
+
+- [x] 1.1 Add the aggregate 5xx-share requirements and design decisions to
+  OpenSpec.
+- [x] 1.2 Update the Prometheus alert to aggregate request series before
+  division while retaining namespace and job alert groups.
+- [x] 1.3 Update the Grafana stat to aggregate before division, apply symmetric
+  namespace and job filters, and handle an absent 5xx series.
+
+## 2. Regression and evidence
+
+- [x] 2.1 Add focused configuration regressions for the shipped alert and
+  dashboard queries.
+- [x] 2.2 Capture and independently privacy-review deterministic before/after
+  rendering from an isolated local Prometheus and Grafana fixture.
+- [x] 2.3 Run focused tests, formatting checks, and strict OpenSpec validation.

--- a/tests/unit/test_helm_monitoring_artifacts.py
+++ b/tests/unit/test_helm_monitoring_artifacts.py
@@ -1,0 +1,38 @@
+"""Regression tests for Helm monitoring artifact queries."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CHART_DIR = _REPO_ROOT / "deploy" / "helm" / "codex-lb"
+
+
+def test_high_error_rate_alert_aggregates_request_series_before_division() -> None:
+    prometheus_rule = (_CHART_DIR / "templates" / "prometheusrule.yaml").read_text()
+    match = re.search(
+        r"(?ms)^\s*- alert: CodexLBHighErrorRate\n\s+expr: \|\n(?P<expr>.*?)(?=^\s+for: 5m$)",
+        prometheus_rule,
+    )
+
+    assert match is not None
+    assert " ".join(match.group("expr").split()) == (
+        '( sum by (namespace, job) ( rate(codex_lb_requests_total{status=~"5.."}[5m]) )'
+        " / sum by (namespace, job) ( rate(codex_lb_requests_total[5m]) ) ) > 0.05"
+    )
+
+
+def test_grafana_error_rate_aggregates_request_series_before_division() -> None:
+    dashboard = json.loads((_CHART_DIR / "dashboards" / "codex-lb.json").read_text())
+    error_rate_panel = next(panel for panel in dashboard["panels"] if panel["title"] == "Error Rate (5xx)")
+
+    assert error_rate_panel["targets"][0]["expr"] == (
+        '(sum(rate(codex_lb_requests_total{namespace="$namespace",job=~"$job",status=~"5.."}[5m]))'
+        ' or vector(0)) / sum(rate(codex_lb_requests_total{namespace="$namespace",job=~"$job"}[5m]))'
+    )


### PR DESCRIPTION
## Summary

Fix the Prometheus alert and Grafana `Error Rate (5xx)` stat to calculate the 5xx share after aggregating request series. This prevents a matching 5xx series from being divided by itself and reporting approximately 100% instead of the real error share.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: None — independently reproduced; no matching issue or pull request.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/fix-promql-5xx-error-rate/`

## Changes

- Aggregate the Prometheus alert numerator and denominator independently while preserving namespace/job alert instances.
- Apply Grafana namespace/job filters symmetrically and display 0% for positive success-only traffic before a 5xx series exists.
- Add focused configuration regressions and the operator-facing OpenSpec contract.

## Simplicity

- [x] No new setting, required setup, README section, `.env.example` entry, dashboard navigation item, or default change.
- [x] Dashboard evidence uses an isolated deterministic local fixture.

## Test plan

- `tests/unit/test_helm_monitoring_artifacts.py`: 2 passed.
- Focused Ruff check and format check: passed.
- `openspec validate fix-promql-5xx-error-rate --strict`: valid.
- `openspec validate --specs --strict`: 48 passed, 0 failed.
- `/opsx:verify fix-promql-5xx-error-rate`: clean (6/6 tasks, 2/2 requirements, 6/6 scenarios).
- Independent committed-diff review: no findings.
- Repository-wide local CI was not completed: local verification infrastructure stopped before product tests; required GitHub CI remains the integration gate.

## Screenshots / output

Before:

![Before](https://github.com/user-attachments/assets/d607faa5-fef9-421a-80a4-f82d2eb8aa8b)

After:

![After](https://github.com/user-attachments/assets/59ae66bc-6b92-48eb-8ae2-2db3d2c98554)

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [ ] Linked the related issue / discussion above — no matching issue or pull request exists; independently reproduced.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant focused local test, lint, and formatting subset.
- [x] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is not edited by hand.
