### PR TITLE
fix(fleet): report usage refresh timestamp

### DIFF
--- a/app/modules/accounts/mappers.py
+++ b/app/modules/accounts/mappers.py
@@ -112,6 +112,7 @@ def _account_to_summary(
     is_email_duplicate: bool = False,
     reset_credits_snapshot: RateLimitResetCreditsSnapshot | None = None,
 ) -> AccountSummary:
+    usage_refreshed_at = _latest_usage_recorded_at(primary_usage, secondary_usage, monthly_usage)
     plan_type = coerce_account_plan_type(account.plan_type, DEFAULT_PLAN)
     auth_status = _build_auth_status(account, encryptor) if include_auth else None
     effective_primary_usage, effective_secondary_usage = _effective_usage_windows(
@@ -252,7 +253,7 @@ def _account_to_summary(
         reset_at_primary = None
         window_minutes_primary = None
 
-    return AccountSummary(
+    summary = AccountSummary(
         account_id=account.id,
         chatgpt_account_id=account.chatgpt_account_id,
         email=account.email,
@@ -296,6 +297,8 @@ def _account_to_summary(
         available_reset_credits=reset_credits_snapshot.available_count if reset_credits_snapshot else 0,
         reset_credit_nearest_expires_at=(reset_credits_snapshot.nearest_expires_at if reset_credits_snapshot else None),
     )
+    summary._usage_refreshed_at = usage_refreshed_at
+    return summary
 
 
 def _normalize_account_routing_policy(value: str | None) -> str:
@@ -478,6 +481,11 @@ def _normalize_used_percent(entry: UsageHistory | None) -> float | None:
     if not entry:
         return None
     return entry.used_percent
+
+
+def _latest_usage_recorded_at(*entries: UsageHistory | None) -> datetime | None:
+    recorded_at_values = [entry.recorded_at for entry in entries if entry is not None and entry.recorded_at is not None]
+    return max(recorded_at_values, default=None)
 
 
 def _extract_credit_status(

--- a/app/modules/accounts/schemas.py
+++ b/app/modules/accounts/schemas.py
@@ -80,6 +80,8 @@ class AccountAdditionalQuota(DashboardModel):
 
 
 class AccountSummary(DashboardModel):
+    _usage_refreshed_at: datetime | None = PrivateAttr(default=None)
+
     account_id: str
     chatgpt_account_id: str | None = None
     email: str
@@ -128,6 +130,11 @@ class AccountSummary(DashboardModel):
     # otherwise the latest persisted primary usage_history count from /wham/usage.
     available_reset_credits: int = 0
     reset_credit_nearest_expires_at: datetime | None = None
+
+    def usage_refreshed_at_for_fleet(self) -> datetime | None:
+        """Return internal usage freshness without expanding the accounts API."""
+
+        return self._usage_refreshed_at
 
 
 class AccountsResponse(DashboardModel):

--- a/app/modules/fleet/mappers.py
+++ b/app/modules/fleet/mappers.py
@@ -35,6 +35,7 @@ def fleet_account_summary_from_account(
             reset_at=account.reset_at_secondary if include_usage else None,
             window_minutes=account.window_minutes_secondary if include_usage else None,
         ),
+        usage_refreshed_at=account.usage_refreshed_at_for_fleet() if include_usage else None,
         last_refresh_at=account.last_refresh_at if include_usage else None,
     )
 

--- a/app/modules/fleet/schemas.py
+++ b/app/modules/fleet/schemas.py
@@ -25,6 +25,7 @@ class FleetAccountSummary(DashboardModel):
     plan_type: str
     primary: FleetWindowSummary
     secondary: FleetWindowSummary
+    usage_refreshed_at: datetime | None = None
     last_refresh_at: datetime | None = None
 
 

--- a/openspec/changes/add-fleet-usage-refreshed-at/.openspec.yaml
+++ b/openspec/changes/add-fleet-usage-refreshed-at/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/add-fleet-usage-refreshed-at/design.md
+++ b/openspec/changes/add-fleet-usage-refreshed-at/design.md
@@ -1,0 +1,78 @@
+## Context
+
+`GET /api/fleet/summary` currently projects `AccountSummary.last_refresh_at`,
+which originates from `Account.last_refresh` and therefore describes OAuth
+credential refresh. `AccountsService.list_accounts()` already loads the latest
+primary, secondary, and monthly usage rows used to build each account summary,
+but the account response intentionally does not expose their persistence time.
+
+The fleet contract needs the newest of those existing `recorded_at` values
+without adding a query or changing the broader dashboard accounts response.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add an explicit nullable usage-snapshot freshness timestamp to fleet summary
+  accounts.
+- Derive it from already loaded standard usage rows.
+- Preserve the existing usage-visibility boundary and `lastRefreshAt`
+  semantics.
+- Prove that successful operator-triggered usage writes advance usage
+  freshness independently of OAuth refresh.
+
+**Non-Goals:**
+
+- Rename or remove `lastRefreshAt`.
+- Add storage, migrations, queries, refresh scheduling, or new refresh paths.
+- Change OAuth, probe, or usage-refresh behavior.
+- Change the dashboard accounts API or dashboard rendering.
+- Include additional-quota samples or refactor usage loading.
+
+## Decisions
+
+### Carry usage freshness as non-serialized account-summary metadata
+
+The account mapper will calculate the newest `recorded_at` across the primary,
+secondary, and monthly rows passed to it. It will store that value in a Pydantic
+private attribute on `AccountSummary` and expose a read-only accessor for the
+fleet mapper. Private metadata follows the existing `AccountProbeResponse`
+pattern and prevents the internal bridge from becoming a new
+`GET /api/accounts` response field.
+
+The fleet response schema alone gains the public `usageRefreshedAt` field.
+
+Alternatives considered:
+
+- Query usage history again in the fleet route. Rejected because the needed
+  rows are already loaded and the accepted contract forbids another query.
+- Add a serialized field to `AccountSummary`. Rejected because that would
+  broaden the dashboard accounts API beyond the accepted fleet-only scope.
+- Reimplement account and usage loading in the fleet module. Rejected because
+  it would duplicate account mapping and usage-window semantics.
+
+### Reuse the existing fleet usage-visibility switch
+
+The fleet mapper will emit the internal timestamp only when `include_usage` is
+true. When the API key or global privacy setting hides usage, the field will be
+`null`, matching the existing treatment of quota windows and `lastRefreshAt`.
+
+### Treat refresh advancement as a consequence of a successful usage write
+
+Force Probe and `POST /api/fleet/refresh` already persist standard usage
+snapshots through the shared updater. No refresh orchestration changes are
+needed. Regression tests will observe a later fleet summary after each path
+writes a newer snapshot and will prove `lastRefreshAt` stays unchanged when the
+OAuth token was not refreshed.
+
+## Risks / Trade-offs
+
+- **Private metadata is lost if a summary is reconstructed elsewhere** → Only
+  the existing account mapper creates fleet inputs, and focused tests cover
+  both serialization boundaries.
+- **Naive SQLite timestamps and aware timestamps are mixed** → Compare only
+  database-loaded `UsageHistory.recorded_at` values from the same session
+  conventions; dashboard serialization already renders naive values as UTC.
+- **A refresh legitimately skips or writes no usage** → The timestamp remains
+  unchanged, preserving the existing refresh policy rather than manufacturing
+  freshness.

--- a/openspec/changes/add-fleet-usage-refreshed-at/proposal.md
+++ b/openspec/changes/add-fleet-usage-refreshed-at/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Fleet consumers currently receive `lastRefreshAt`, but that timestamp tracks
+OAuth credential refresh rather than the quota snapshot returned in `primary`
+and `secondary`. Consumers need an explicit freshness timestamp for the usage
+values without changing the existing auth-refresh contract.
+
+## What Changes
+
+- Add nullable `usageRefreshedAt` to each `GET /api/fleet/summary` account.
+- Derive the value from the newest `recorded_at` among the standard usage
+  samples already loaded for the summary, without another database query.
+- Apply the existing fleet usage-visibility policy to the new field.
+- Keep `lastRefreshAt` unchanged as the OAuth token-refresh timestamp.
+- Cover successful Force Probe and fleet refresh writes advancing usage
+  freshness without advancing auth freshness.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `fleet-summary`: Distinguish usage-snapshot freshness from OAuth token
+  refresh in the per-account fleet summary contract.
+
+## Impact
+
+The change is limited to account-to-fleet response mapping, the fleet response
+schema, focused fleet/probe regressions, and the fleet-summary specification.
+It adds no migration, persisted field, database query, setting, scheduling
+change, dashboard change, or dependency.

--- a/openspec/changes/add-fleet-usage-refreshed-at/specs/fleet-summary/spec.md
+++ b/openspec/changes/add-fleet-usage-refreshed-at/specs/fleet-summary/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Fleet summary distinguishes usage freshness from auth refresh
+
+Each account returned by `GET /api/fleet/summary` SHALL include nullable
+`usageRefreshedAt`. When usage is visible and standard usage samples exist, the
+field MUST equal the newest `recorded_at` among the usage samples already
+loaded to build that account summary. Computing the field MUST NOT add a
+database query.
+
+`lastRefreshAt` SHALL remain backward compatible and SHALL continue to
+represent the account's OAuth token-refresh timestamp. The existing fleet
+usage-visibility policy SHALL govern `usageRefreshedAt`; the field MUST be
+`null` when usage is hidden. The response MUST continue to exclude sensitive
+fleet data.
+
+#### Scenario: Summary reports the newest loaded usage sample
+
+- **GIVEN** an account has loaded standard usage samples with different `recorded_at` values
+- **WHEN** an authorized client calls `GET /api/fleet/summary`
+- **THEN** the account's `usageRefreshedAt` equals the newest sample timestamp
+- **AND** `lastRefreshAt` continues to equal the OAuth token-refresh timestamp
+
+#### Scenario: Account has no usage sample
+
+- **GIVEN** an account has no standard usage sample
+- **WHEN** an authorized client calls `GET /api/fleet/summary`
+- **THEN** the account's `usageRefreshedAt` is `null`
+
+#### Scenario: Usage visibility is disabled
+
+- **WHEN** a valid API key cannot view fleet usage
+- **OR** the global API-key quota privacy setting hides upstream quota data
+- **THEN** `GET /api/fleet/summary` returns `usageRefreshedAt: null`
+- **AND** no hidden usage or sensitive fleet data is exposed
+
+#### Scenario: Successful Force Probe advances usage freshness independently
+
+- **GIVEN** an account has an existing usage sample and OAuth refresh timestamp
+- **WHEN** a successful Force Probe persists a newer standard usage sample without refreshing the OAuth token
+- **THEN** a later fleet summary reports a later `usageRefreshedAt`
+- **AND** reports the unchanged `lastRefreshAt`
+
+#### Scenario: Successful fleet refresh advances usage freshness independently
+
+- **GIVEN** an account has an existing usage sample and OAuth refresh timestamp
+- **WHEN** `POST /api/fleet/refresh` persists a newer standard usage sample without refreshing the OAuth token
+- **THEN** a later fleet summary reports a later `usageRefreshedAt`
+- **AND** reports the unchanged `lastRefreshAt`

--- a/openspec/changes/add-fleet-usage-refreshed-at/tasks.md
+++ b/openspec/changes/add-fleet-usage-refreshed-at/tasks.md
@@ -1,0 +1,15 @@
+## 1. Fleet freshness contract
+
+- [x] 1.1 Carry the newest already-loaded standard usage `recorded_at` as non-serialized account-summary metadata.
+- [x] 1.2 Add `usageRefreshedAt` to the fleet account schema and apply the existing usage-visibility redaction while preserving `lastRefreshAt`.
+
+## 2. Regression coverage
+
+- [x] 2.1 Cover newest-sample selection, absent samples, response shape, usage redaction, and separation from OAuth refresh.
+- [x] 2.2 Prove a successful Force Probe usage write advances `usageRefreshedAt` without changing `lastRefreshAt`.
+- [x] 2.3 Prove a successful `POST /api/fleet/refresh` usage write advances `usageRefreshedAt` without changing `lastRefreshAt`.
+
+## 3. Validation
+
+- [x] 3.1 Run the focused mapper, fleet-summary, and probe regressions plus affected lint, type, format, and diff checks.
+- [x] 3.2 Run strict scoped OpenSpec validation and verify implementation/spec/task coherence.

--- a/tests/integration/test_accounts_api_probe.py
+++ b/tests/integration/test_accounts_api_probe.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+from datetime import timedelta
 from unittest.mock import AsyncMock
 
 import pytest
@@ -9,9 +10,12 @@ import pytest
 from app.core.auth import generate_unique_account_id
 from app.core.auth.refresh import RefreshError
 from app.core.usage.models import UsagePayload
+from app.core.utils.time import utcnow
+from app.db.session import SessionLocal
 from app.modules.accounts import api as accounts_api
 from app.modules.accounts.schemas import AccountProbeResponse
 from app.modules.accounts.service import AccountsService
+from app.modules.usage.repository import UsageRepository
 from app.modules.usage.updater import AccountRefreshResult, UsageUpdater
 
 pytestmark = pytest.mark.integration
@@ -41,6 +45,12 @@ async def _import_test_account(async_client, *, email: str, account_id: str, pla
     response = await async_client.post("/api/accounts/import", files=files)
     assert response.status_code == 200, response.text
     return generate_unique_account_id(account_id, email)
+
+
+async def _create_fleet_api_key(async_client, *, name: str) -> str:
+    response = await async_client.post("/api/api-keys/", json={"name": name})
+    assert response.status_code == 200, response.text
+    return response.json()["key"]
 
 
 @pytest.mark.asyncio
@@ -138,6 +148,79 @@ async def test_probe_active_account_returns_snapshot(async_client, monkeypatch):
         account_id=account_id,
         http_status=200,
     )
+
+
+@pytest.mark.asyncio
+async def test_force_probe_advances_fleet_usage_timestamp_without_token_refresh(async_client, monkeypatch):
+    async def _fake_probe(self, *, access_token, chatgpt_account_id, model):  # noqa: ARG001
+        return 200
+
+    async def _fake_fetch_usage(**_kwargs):
+        return UsagePayload.model_validate(
+            {
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 25.0,
+                        "reset_after_seconds": 300,
+                        "limit_window_seconds": 18_000,
+                    },
+                    "secondary_window": {
+                        "used_percent": 40.0,
+                        "reset_after_seconds": 3600,
+                        "limit_window_seconds": 604_800,
+                    },
+                }
+            }
+        )
+
+    account_id = await _import_test_account(
+        async_client,
+        email="probe-usage-freshness@example.com",
+        account_id="acc_probe_usage_freshness",
+    )
+    old_recorded_at = utcnow() - timedelta(hours=2)
+    async with SessionLocal() as session:
+        usage_repo = UsageRepository(session)
+        await usage_repo.add_entry(
+            account_id,
+            10.0,
+            recorded_at=old_recorded_at,
+            window="primary",
+            window_minutes=300,
+        )
+        await usage_repo.add_entry(
+            account_id,
+            20.0,
+            recorded_at=old_recorded_at,
+            window="secondary",
+            window_minutes=10_080,
+        )
+
+    plain_key = await _create_fleet_api_key(async_client, name="probe-usage-freshness-key")
+    headers = {"Authorization": f"Bearer {plain_key}"}
+    before_response = await async_client.get("/api/fleet/summary", headers=headers)
+    assert before_response.status_code == 200, before_response.text
+    before = next(item for item in before_response.json()["accounts"] if item["accountId"] == account_id)
+
+    monkeypatch.setattr(AccountsService, "_send_probe_request", _fake_probe)
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", _fake_fetch_usage)
+    record_probe_result = AsyncMock()
+    proxy_service = type("_ProbeRecorder", (), {"record_account_probe_result": record_probe_result})()
+    monkeypatch.setattr(accounts_api, "get_proxy_service_for_app", lambda app: proxy_service)
+
+    probe_response = await async_client.post(f"/api/accounts/{account_id}/probe")
+    assert probe_response.status_code == 200, probe_response.text
+
+    after_response = await async_client.get("/api/fleet/summary", headers=headers)
+    assert after_response.status_code == 200, after_response.text
+    after = next(item for item in after_response.json()["accounts"] if item["accountId"] == account_id)
+
+    before_usage_refreshed_at = before["usageRefreshedAt"]
+    after_usage_refreshed_at = after["usageRefreshedAt"]
+    assert before_usage_refreshed_at is not None
+    assert after_usage_refreshed_at is not None
+    assert after_usage_refreshed_at > before_usage_refreshed_at
+    assert after["lastRefreshAt"] == before["lastRefreshAt"]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_fleet_summary_api.py
+++ b/tests/integration/test_fleet_summary_api.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import asyncio
 import json
 from contextlib import asynccontextmanager
-from datetime import timedelta, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
 from app.core import shutdown as shutdown_state
+from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
+from app.core.usage.models import UsagePayload
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, RequestKind, RequestLog, StickySession, StickySessionKind
 from app.db.session import SessionLocal
@@ -119,6 +121,8 @@ async def _seed_account_with_windows(
     primary_reset_at: int,
     secondary_reset_at: int,
     status: AccountStatus = AccountStatus.ACTIVE,
+    primary_recorded_at: datetime | None = None,
+    secondary_recorded_at: datetime | None = None,
 ) -> None:
     async with SessionLocal() as session:
         accounts_repo = AccountsRepository(session)
@@ -130,6 +134,7 @@ async def _seed_account_with_windows(
             window="primary",
             reset_at=primary_reset_at,
             window_minutes=_PRIMARY_WINDOW_MINUTES,
+            recorded_at=primary_recorded_at,
         )
         await usage_repo.add_entry(
             account_id,
@@ -137,6 +142,7 @@ async def _seed_account_with_windows(
             window="secondary",
             reset_at=secondary_reset_at,
             window_minutes=_SECONDARY_WINDOW_MINUTES,
+            recorded_at=secondary_recorded_at,
         )
 
 
@@ -264,6 +270,8 @@ async def test_fleet_summary_rejects_invalid_api_key(async_client, db_setup):
 @pytest.mark.asyncio
 async def test_fleet_summary_returns_minimal_projection_with_valid_key(async_client, db_setup):
     plain_key = await _create_api_key("fleet-summary-key")
+    primary_recorded_at = datetime(2026, 1, 1, 12, 0, 0)
+    secondary_recorded_at = datetime(2026, 1, 1, 12, 1, 0)
     now_epoch = int(utcnow().replace(tzinfo=timezone.utc).timestamp())
     primary_reset = now_epoch + 300
     secondary_reset = now_epoch + 5 * 24 * 3600
@@ -274,6 +282,8 @@ async def test_fleet_summary_returns_minimal_projection_with_valid_key(async_cli
         secondary_used_percent=20.0,
         primary_reset_at=primary_reset,
         secondary_reset_at=secondary_reset,
+        primary_recorded_at=primary_recorded_at,
+        secondary_recorded_at=secondary_recorded_at,
     )
 
     response = await async_client.get(
@@ -292,6 +302,8 @@ async def test_fleet_summary_returns_minimal_projection_with_valid_key(async_cli
     assert account["status"] == "active"
     assert account["planType"] == "plus"
     assert account["lastRefreshAt"] is not None
+    assert account["usageRefreshedAt"] == "2026-01-01T12:01:00Z"
+    assert account["usageRefreshedAt"] != account["lastRefreshAt"]
     assert account["primary"]["remainingPercent"] == 62
     assert account["primary"]["windowMinutes"] == _PRIMARY_WINDOW_MINUTES
     assert account["primary"]["resetAt"] is not None
@@ -332,6 +344,7 @@ async def test_fleet_summary_omits_sensitive_fields(async_client, db_setup):
         "planType",
         "primary",
         "secondary",
+        "usageRefreshedAt",
         "lastRefreshAt",
     }
 
@@ -391,6 +404,7 @@ async def test_fleet_summary_hides_usage_when_key_disables_account_pool_usage(as
     assert account["accountId"] == "acc_usage_hidden"
     assert account["email"] == "usage-hidden@example.com"
     assert account["status"] == "active"
+    assert account["usageRefreshedAt"] is None
     assert account["lastRefreshAt"] is None
     assert account["primary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
     assert account["secondary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
@@ -418,6 +432,7 @@ async def test_fleet_summary_hides_usage_when_key_only_allows_upstream_limits(as
     assert account["accountId"] == "acc_upstream_only"
     assert account["email"] == "upstream-only@example.com"
     assert account["status"] == "active"
+    assert account["usageRefreshedAt"] is None
     assert account["lastRefreshAt"] is None
     assert account["primary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
     assert account["secondary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
@@ -443,6 +458,7 @@ async def test_fleet_summary_hides_usage_when_key_omits_upstream_limits(async_cl
     assert response.status_code == 200
     account = response.json()["accounts"][0]
     assert account["accountId"] == "acc_usage_hidden"
+    assert account["usageRefreshedAt"] is None
     assert account["lastRefreshAt"] is None
     assert account["primary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
     assert account["secondary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
@@ -474,6 +490,7 @@ async def test_fleet_summary_hides_usage_when_global_api_key_quota_privacy_enabl
     assert response.status_code == 200
     account = response.json()["accounts"][0]
     assert account["accountId"] == "acc_global_usage_hidden"
+    assert account["usageRefreshedAt"] is None
     assert account["lastRefreshAt"] is None
     assert account["primary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
     assert account["secondary"] == {"remainingPercent": None, "resetAt": None, "windowMinutes": None}
@@ -966,6 +983,68 @@ async def test_fleet_refresh_uses_route_local_usage_updater_and_invalidates_on_w
     assert refresh_calls == [["acc_refresh_write"]]
     assert updater_session_ids == background_session_ids
     assert invalidations == ["rate_limit_headers", "account_selection"]
+
+
+@pytest.mark.asyncio
+async def test_fleet_refresh_advances_usage_timestamp_without_token_refresh(
+    async_client,
+    db_setup,
+    monkeypatch,
+):
+    old_recorded_at = utcnow() - timedelta(hours=2)
+    await _seed_account_with_windows(
+        "acc_refresh_freshness",
+        "refresh-freshness@example.com",
+        primary_used_percent=10.0,
+        secondary_used_percent=20.0,
+        primary_reset_at=1735862400,
+        secondary_reset_at=1736467200,
+        primary_recorded_at=old_recorded_at,
+        secondary_recorded_at=old_recorded_at,
+    )
+    plain_key = await _create_api_key("fleet-refresh-freshness-key")
+    headers = {"Authorization": f"Bearer {plain_key}"}
+
+    before_response = await async_client.get("/api/fleet/summary", headers=headers)
+    assert before_response.status_code == 200, before_response.text
+    before = before_response.json()["accounts"][0]
+
+    async def _fake_fetch_usage(**_kwargs):
+        return UsagePayload.model_validate(
+            {
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 25.0,
+                        "reset_after_seconds": 300,
+                        "limit_window_seconds": 18_000,
+                    },
+                    "secondary_window": {
+                        "used_percent": 40.0,
+                        "reset_after_seconds": 3600,
+                        "limit_window_seconds": 604_800,
+                    },
+                }
+            }
+        )
+
+    refresh_settings = get_settings().model_copy(update={"usage_refresh_enabled": True})
+    monkeypatch.setattr("app.modules.usage.updater.get_settings", lambda: refresh_settings)
+    monkeypatch.setattr("app.modules.usage.updater.fetch_usage", _fake_fetch_usage)
+
+    refresh_response = await async_client.post("/api/fleet/refresh", headers=headers)
+    assert refresh_response.status_code == 200, refresh_response.text
+    assert refresh_response.json()["usageWritten"] is True
+
+    after_response = await async_client.get("/api/fleet/summary", headers=headers)
+    assert after_response.status_code == 200, after_response.text
+    after = after_response.json()["accounts"][0]
+
+    before_usage_refreshed_at = before["usageRefreshedAt"]
+    after_usage_refreshed_at = after["usageRefreshedAt"]
+    assert before_usage_refreshed_at is not None
+    assert after_usage_refreshed_at is not None
+    assert after_usage_refreshed_at > before_usage_refreshed_at
+    assert after["lastRefreshAt"] == before["lastRefreshAt"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_account_mappers.py
+++ b/tests/unit/test_account_mappers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from app.core.crypto import TokenEncryptor
 from app.db.models import Account, AccountStatus, UsageHistory
 from app.modules.accounts import mappers
 from app.modules.accounts.mappers import _effective_status_from_usage, _normalize_account_routing_policy
@@ -37,6 +38,32 @@ def test_extract_credit_status_uses_freshest_sample() -> None:
     )
 
     assert mappers._extract_credit_status(stale, fresh) == (False, False, 0.0)
+
+
+def test_account_summary_carries_freshest_usage_timestamp_without_serializing_it() -> None:
+    primary_recorded_at = datetime(2026, 1, 1, 12, 0, 0)
+    secondary_recorded_at = datetime(2026, 1, 1, 12, 1, 0)
+
+    summary = mappers.build_account_summaries(
+        accounts=[_account(AccountStatus.ACTIVE)],
+        primary_usage={"account-1": _primary_usage(recorded_at=primary_recorded_at)},
+        secondary_usage={"account-1": _secondary_usage(recorded_at=secondary_recorded_at)},
+        encryptor=TokenEncryptor(),
+    )[0]
+
+    assert summary.usage_refreshed_at_for_fleet() == secondary_recorded_at
+    assert "usageRefreshedAt" not in summary.model_dump(mode="json", by_alias=True)
+
+
+def test_account_summary_has_no_usage_timestamp_without_samples() -> None:
+    summary = mappers.build_account_summaries(
+        accounts=[_account(AccountStatus.ACTIVE)],
+        primary_usage={},
+        secondary_usage={},
+        encryptor=TokenEncryptor(),
+    )[0]
+
+    assert summary.usage_refreshed_at_for_fleet() is None
 
 
 def _account(status: AccountStatus = AccountStatus.QUOTA_EXCEEDED) -> Account:


### PR DESCRIPTION
## Summary

Add an explicit per-account usage freshness timestamp to
`GET /api/fleet/summary` so fleet consumers no longer need to interpret the
OAuth-oriented `lastRefreshAt` as quota freshness.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Fixes #1461

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/add-fleet-usage-refreshed-at/`

## Changes

- Add nullable `usageRefreshedAt` to each fleet-summary account, derived from
  the newest `recorded_at` among the standard usage samples already loaded for
  that account.
- Keep `lastRefreshAt` unchanged as the OAuth token-refresh timestamp and
  apply the existing usage-visibility policy to the new field.
- Add focused regressions for newest-sample selection, privacy redaction,
  Force Probe, and `POST /api/fleet/refresh`.

## Simplicity

- [x] Works with zero config and changes no default
- [x] No new required setup step
- New setting(s) and why each can't be a default: none
- [x] README, `.env.example`, and dashboard navigation are unchanged

## Test plan

```text
.venv/bin/python -m pytest -q tests/unit/test_account_mappers.py tests/integration/test_fleet_summary_api.py tests/integration/test_accounts_api_probe.py
# 41 passed

.venv/bin/ruff check <touched Python files>
.venv/bin/ruff format --check <touched Python files>
.venv/bin/ty check app/modules/accounts/{schemas,mappers}.py app/modules/fleet/{schemas,mappers}.py
openspec validate add-fleet-usage-refreshed-at --type change --strict --no-interactive
openspec validate fleet-summary --type spec --strict --no-interactive
git diff --check
```

Independent candidate review: Standards clean; Spec clean.

Intentionally not run locally: the full `local-ci` / full test matrix. Required
GitHub CI remains the authoritative integration gate.

## Screenshots / output

No dashboard rendering changes.

```json
{
  "usageRefreshedAt": "2026-07-28T12:34:56Z",
  "lastRefreshAt": "2026-07-27T08:00:00Z"
}
```

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue.
- [x] Added focused tests covering the change.
- [x] Ran the relevant local test, lint, type, format, and diff checks.
- [x] Scoped OpenSpec validation passes.
- [x] Simplicity gates reviewed; P5 is not applicable because the dashboard is unchanged.
- [x] `CHANGELOG.md` is not edited.
