### PR TITLE
fix(reports): use local days for daily averages

### DIFF
--- a/app/modules/reports/service.py
+++ b/app/modules/reports/service.py
@@ -97,8 +97,6 @@ class ReportsService:
             useragent_group,
         )
 
-        day_count = max((end_at.date() - start_at.date()).days, 1)
-
         model_total = sum(m.cost_usd for m in by_model)
         useragent_total = sum(u.cost_usd for u in by_useragent)
         comparison = ReportComparison(
@@ -120,8 +118,8 @@ class ReportsService:
                 total_errors=summary.total_errors,
                 active_accounts=summary.active_accounts,
                 total_conversations=summary.conversation_count,
-                avg_cost_per_day=round(summary.total_cost_usd / day_count, 4),
-                avg_requests_per_day=round(summary.total_requests / day_count, 2),
+                avg_cost_per_day=round(summary.total_cost_usd / window_days, 4),
+                avg_requests_per_day=round(summary.total_requests / window_days, 2),
             ),
             comparison=comparison,
             daily=daily,

--- a/openspec/changes/fix-reports-local-day-averages/.openspec.yaml
+++ b/openspec/changes/fix-reports-local-day-averages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/fix-reports-local-day-averages/design.md
+++ b/openspec/changes/fix-reports-local-day-averages/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The timezone-aware Reports implementation introduced in PR #990 already
+computes `window_days` from the selected local `start_date` and `end_date`.
+It then converts local-midnight boundaries to UTC for repository filtering and
+daily bucketing. A later average calculation incorrectly derives a second day
+count from the UTC boundary dates, so offset changes can turn a two-day local
+selection into a divisor of one or three.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make both per-day summary averages use the existing inclusive local
+  `window_days` value.
+- Prove both affected Casablanca transitions and unchanged control zones at
+  the `ReportsService` response seam.
+- Preserve every repository input and every other report response field.
+
+**Non-Goals:**
+
+- Changing timezone resolution or invalid-timezone fallback.
+- Changing UTC filter boundaries, repository queries, daily bucketing,
+  comparison semantics, range limits, schemas, or frontend rendering.
+- Refactoring unrelated Reports code.
+
+## Decisions
+
+### Reuse the existing local calendar window length
+
+The service will divide both totals by `window_days`, the value already used
+for range validation and previous-window sizing. Recomputing from UTC
+boundaries is rejected because those boundaries represent elapsed filter
+instants, not the number of selected local calendar dates.
+
+### Cover the service contract with one parameterized regression
+
+A repository double will return fixed totals of 60 cost units and 30 requests
+for two selected local days. The regression will cover both Casablanca offset
+changes plus UTC, a stable Casablanca offset, and invalid-zone UTC fallback.
+A new route-level test is not added because the route delegates this
+calculation unchanged and existing integration tests already cover
+serialization, timezone boundaries, filters, totals, daily rows, comparison,
+and range validation.
+
+## Risks / Trade-offs
+
+- **Risk: a narrow arithmetic fix could mask a boundary regression.** The
+  implementation leaves all boundary construction and repository calls
+  untouched, while focused existing integration tests are rerun.
+- **Trade-off: the repository double does not exercise SQL.** SQL behavior is
+  outside the defect and remains covered by the existing Reports API and
+  repository suites.

--- a/openspec/changes/fix-reports-local-day-averages/proposal.md
+++ b/openspec/changes/fix-reports-local-day-averages/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Reports currently derive the per-day average divisor from UTC-converted filter
+boundaries. For inclusive local calendar ranges that cross some IANA offset
+changes, this makes `avgCostPerDay` and `avgRequestsPerDay` use one or three
+days even though the operator selected two.
+
+## What Changes
+
+- Calculate both per-day report averages from the exact inclusive local
+  calendar range selected by `start_date` and `end_date`.
+- Add focused service coverage for both affected Casablanca transitions and
+  unchanged UTC, stable-offset, and invalid-timezone behavior.
+- Preserve report filtering, daily bucketing, totals, comparisons, range
+  validation, and all other report metrics.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `frontend-architecture`: Define the local-calendar divisor used by the
+  Reports API per-day summary averages.
+
+## Impact
+
+- Backend: `app/modules/reports/service.py`
+- Tests: `tests/unit/test_reports_service.py`
+- API contract: `GET /api/reports` summary averages only
+- No schema, migration, repository, dependency, setting, or frontend code
+  changes

--- a/openspec/changes/fix-reports-local-day-averages/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-reports-local-day-averages/specs/frontend-architecture/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Reports per-day averages use the inclusive local calendar window
+
+`GET /api/reports` MUST calculate `summary.avgCostPerDay` and
+`summary.avgRequestsPerDay` by dividing the current report totals by exactly
+`(end_date - start_date).days + 1`. The divisor MUST represent the selected
+inclusive local calendar-date window and MUST NOT be derived from the
+UTC-converted filter boundaries.
+
+#### Scenario: Offset-to-zero transition keeps a two-day divisor
+
+- **WHEN** an operator requests `2026-02-15` through `2026-02-16` in
+  `Africa/Casablanca` and the report totals are 60 cost units and 30 requests
+- **THEN** `avgCostPerDay` is `30`
+- **AND** `avgRequestsPerDay` is `15`
+
+#### Scenario: Offset-from-zero transition keeps a two-day divisor
+
+- **WHEN** an operator requests `2026-03-22` through `2026-03-23` in
+  `Africa/Casablanca` and the report totals are 60 cost units and 30 requests
+- **THEN** `avgCostPerDay` is `30`
+- **AND** `avgRequestsPerDay` is `15`

--- a/openspec/changes/fix-reports-local-day-averages/tasks.md
+++ b/openspec/changes/fix-reports-local-day-averages/tasks.md
@@ -1,0 +1,22 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add a parameterized `ReportsService` regression for both Casablanca
+  offset transitions plus UTC, stable-offset Casablanca, and invalid-zone
+  fallback controls using fixed two-day totals.
+- [x] 1.2 Confirm the affected transition cases fail on the original
+  UTC-derived divisor before applying the fix.
+
+## 2. Service Fix
+
+- [x] 2.1 Make both per-day averages use the existing inclusive local
+  `window_days` value without changing repository inputs or other report
+  fields.
+
+## 3. Verification
+
+- [x] 3.1 Run the service regression and focused existing Reports API tests for
+  timezone boundaries, fallback, filters, totals, daily rows, comparison, and
+  range limits.
+- [x] 3.2 Run affected Ruff, type, OpenSpec, diff, and worktree-status checks.
+- [x] 3.3 Capture privacy-safe deterministic before/after dashboard evidence
+  for an affected Casablanca range and verify the resulting media.

--- a/tests/unit/test_reports_service.py
+++ b/tests/unit/test_reports_service.py
@@ -14,6 +14,72 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("start_date", "end_date", "report_timezone"),
+    [
+        pytest.param(
+            date(2026, 2, 15),
+            date(2026, 2, 16),
+            "Africa/Casablanca",
+            id="casablanca-offset-to-zero",
+        ),
+        pytest.param(
+            date(2026, 3, 22),
+            date(2026, 3, 23),
+            "Africa/Casablanca",
+            id="casablanca-offset-from-zero",
+        ),
+        pytest.param(date(2026, 6, 1), date(2026, 6, 2), "UTC", id="utc"),
+        pytest.param(
+            date(2026, 6, 1),
+            date(2026, 6, 2),
+            "Africa/Casablanca",
+            id="casablanca-stable-offset",
+        ),
+        pytest.param(
+            date(2026, 6, 1),
+            date(2026, 6, 2),
+            "Mars/Olympus_Mons",
+            id="invalid-zone-utc-fallback",
+        ),
+    ],
+)
+async def test_get_reports_averages_use_inclusive_local_calendar_days(
+    start_date: date,
+    end_date: date,
+    report_timezone: str,
+) -> None:
+    summary = SimpleNamespace(
+        total_cost_usd=60.0,
+        total_input_tokens=0,
+        total_output_tokens=0,
+        total_cached_tokens=0,
+        total_requests=30,
+        conversation_count=0,
+        total_errors=0,
+        active_accounts=1,
+    )
+    repo = SimpleNamespace(
+        aggregate_summary=AsyncMock(side_effect=[summary, summary]),
+        aggregate_daily_rows=AsyncMock(return_value=[]),
+        aggregate_by_model=AsyncMock(return_value=[]),
+        aggregate_by_account=AsyncMock(return_value=[]),
+        aggregate_by_useragent=AsyncMock(return_value=[]),
+        earliest_report_activity_at=AsyncMock(return_value=None),
+    )
+    service = ReportsService(cast(ReportsRepository, repo))
+
+    result = await service.get_reports(
+        start_date=start_date,
+        end_date=end_date,
+        report_timezone=report_timezone,
+    )
+
+    assert result.summary.avg_cost_per_day == 30.0
+    assert result.summary.avg_requests_per_day == 15.0
+
+
+@pytest.mark.asyncio
 async def test_get_reports_rejects_oversized_range_after_applying_default_end_date(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Keep `GET /api/reports` per-day summary averages aligned with the selected inclusive local calendar range.
- Reuse the service's existing `window_days` value for `avgCostPerDay` and `avgRequestsPerDay`.
- Add focused regression coverage for both affected `Africa/Casablanca` offset transitions plus unchanged control zones.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: N/A — no matching upstream issue was found.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/fix-reports-local-day-averages/`

## Changes

- Divide both per-day averages by exactly `(end_date - start_date).days + 1`.
- Leave timezone resolution, invalid-zone fallback, UTC filter boundaries, repository queries, daily bucketing, comparisons, totals, and range limits unchanged.
- Cover the two Casablanca transitions that previously produced divisors of three and one, along with UTC, stable-offset Casablanca, and invalid-zone fallback controls.
- Keep the regression at the `ReportsService` response seam; the route and response schema are unchanged, and focused existing API tests cover the preserved HTTP path.

## Related work

This builds on the timezone-aware Reports work introduced in [#990](https://github.com/Soju06/codex-lb/pull/990) by Jacky Fong ([@huzky-v](https://github.com/huzky-v)). That PR established local-date inputs and UTC filter conversion; this PR only corrects the downstream average divisor and does not replace that earlier work.

## Simplicity

- [x] Works with zero config and changes no default setup path
- [x] Adds no required setup step or setting
- New setting(s) and why each can't be a default: none
- [x] Adds no README section, `.env.example` entry, or dashboard navigation item
- [x] Includes real before/after pixels for the dashboard-visible summary values

## Test plan

```text
uv run --no-sync pytest -q tests/unit/test_reports_service.py
# 8 passed

uv run --no-sync pytest -q \
  tests/integration/test_reports_api.py::test_reports_api_includes_end_date_until_next_midnight \
  tests/integration/test_reports_api.py::test_reports_api_interprets_dates_in_requested_timezone \
  tests/integration/test_reports_api.py::test_reports_api_falls_back_to_utc_for_invalid_timezone \
  tests/integration/test_reports_api.py::test_reports_api_returns_previous_window_comparison_for_complete_history \
  tests/integration/test_reports_api.py::test_reports_api_applies_account_and_model_filters \
  tests/integration/test_reports_api.py::test_reports_api_summary_counts_range_accounts_and_calendar_days \
  tests/integration/test_reports_api.py::test_reports_api_rejects_oversized_date_ranges
# 7 passed

uv run --no-sync ruff check app/modules/reports/service.py tests/unit/test_reports_service.py
uv run --no-sync ruff format --check app/modules/reports/service.py tests/unit/test_reports_service.py
uv run --no-sync ty check app/modules/reports/service.py tests/unit/test_reports_service.py
openspec validate fix-reports-local-day-averages --type change --strict --no-interactive
openspec validate --specs --strict --no-interactive
git diff --check upstream/main..HEAD
```

OpenSpec verification: 6/6 tasks complete, 1/1 requirement implemented, and 2/2 scenarios covered with no critical findings or warnings.

Full local CI was intentionally not run for this Standard-risk arithmetic fix; required GitHub CI remains the authoritative integration gate.

## Screenshots / output

Deterministic `Africa/Casablanca` fixture for `2026-02-15` through `2026-02-16`, with totals held at `$60` and `30` requests. No production or personal data is present.

| Before: UTC-derived divisor of 3 | After: inclusive local divisor of 2 |
| --- | --- |
| ![Reports before: average cost 20 dollars per day and 10 requests per day](https://github.com/user-attachments/assets/6cfa1f08-357c-4be9-ad65-c34a1a809ccd) | ![Reports after: average cost 30 dollars per day and 15 requests per day](https://github.com/user-attachments/assets/517256f6-0945-4c15-94db-ae88d1035c21) |

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Related work and the absence of a matching issue are recorded above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant focused local test, lint, type, format, and spec subset.
- [x] `openspec validate --specs` passes and scoped OpenSpec verification is clean.
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is not edited by hand.
