### PR TITLE
fix(proxy): classify tool-search missing-tool-output rejections

### DIFF
--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2106,6 +2106,7 @@ _MISSING_TOOL_OUTPUT_MESSAGE_PREFIXES = (
     "no tool output found for function call call_",
     "no tool output found for custom tool call call_",
     "no tool output found for apply patch call call_",
+    "no tool output found for tool search call call_",
 )
 
 

--- a/openspec/changes/classify-tool-search-missing-tool-output/proposal.md
+++ b/openspec/changes/classify-tool-search-missing-tool-output/proposal.md
@@ -1,0 +1,63 @@
+# Classify the tool-search missing-tool-output rejection
+
+## Why
+
+Upstream rejects an anchored Responses request whose input contains a
+`tool_search_call` without its matching `tool_search_output` with:
+
+```json
+{"type":"error","status":400,
+ "error":{"type":"invalid_request_error",
+          "message":"No tool output found for tool search call call_xxx",
+          "param":"input"}}
+```
+
+`_MISSING_TOOL_OUTPUT_MESSAGE_PREFIXES` in `app/modules/proxy/service.py`
+enumerates only the `function call`, `custom tool call`, and `apply patch call`
+wordings, so `_is_missing_tool_output_error` returns `False` for the tool-search
+wording. The raw upstream 400 is then forwarded verbatim to the client, the
+continuity fail-closed counter is never recorded, and on a multiplexed HTTP
+bridge or WebSocket session the anonymous error event is no longer preferentially
+matched to the request that carries `previous_response_id`, so it can be
+attributed to an unrelated pending request on the same socket.
+
+This is the same enumeration gap #1168 fixed for the custom-tool and
+apply-patch wordings; `tool_search_call` / `tool_search_output` are already
+modelled elsewhere in the proxy (`app/modules/proxy/replay_safety.py`), so the
+item type is real, only the classifier list is stale.
+
+## What Changes
+
+- Add the `No tool output found for tool search call call_` prefix to the
+  missing-tool-output classifier so the existing masking, continuity
+  fail-closed recording, and anonymous-event matching engage for the
+  tool-search wording exactly as they do for the other three.
+- Keep the `web search call` wording unclassified: `web_search_call` is a
+  hosted, server-executed item with no `call_id`-addressed client output, so
+  there is nothing for the continuity recovery paths to do with it.
+- Add regression coverage for the classifier and for the HTTP-bridge masking
+  surface.
+
+## Non-goals
+
+- Synthesising an interrupted `tool_search_output` item.
+  `_PENDING_TOOL_CALL_OUTPUT_ITEM_TYPE_BY_CALL_TYPE` is deliberately left
+  unchanged: `tool_search_output` does not have the
+  `{"output": "<text>"}` shape that
+  `_synthetic_interrupted_function_call_output` emits (it carries a `tools`
+  list), so extending the synthesiser would require asserting an upstream
+  payload shape this repo cannot verify, and a wrong shape would turn a
+  maskable 400 into a different, unmaskable one.
+
+## Issue Trace
+
+- Refs #1168
+
+## Impact
+
+- **Spec**: `responses-api-compat`
+- **Behavior**: the tool-search missing-tool-output 400 is masked as a
+  retryable continuity failure instead of leaking upstream's raw message and
+  call id downstream.
+- **Persistence/UI**: no database, migration, configuration, or dashboard
+  changes.

--- a/openspec/changes/classify-tool-search-missing-tool-output/specs/responses-api-compat/spec.md
+++ b/openspec/changes/classify-tool-search-missing-tool-output/specs/responses-api-compat/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Missing-tool-output classification covers all tool call variants
+The service MUST classify an upstream `invalid_request_error` with `param=input` whose message starts with `No tool output found for function call call_`, `No tool output found for custom tool call call_`, `No tool output found for apply patch call call_`, or `No tool output found for tool search call call_` as a missing-tool-output continuity error, so the existing masking and retry recovery paths engage instead of forwarding the raw upstream 400 downstream. The hosted `No tool output found for web search call` wording MUST NOT be classified, because a `web_search_call` is executed upstream and carries no client-addressable tool output.
+
+#### Scenario: custom tool call variant is masked on the HTTP bridge
+- **WHEN** upstream emits `invalid_request_error` with `param=input` and message `No tool output found for custom tool call call_x`
+- **AND** the pending bridge request carries `previous_response_id`
+- **THEN** the service rewrites the error to a retryable `stream_incomplete` continuity failure
+- **AND** the raw upstream message and call id are not exposed downstream
+
+#### Scenario: tool search call variant is masked on the HTTP bridge
+- **WHEN** upstream emits `invalid_request_error` with `param=input` and message `No tool output found for tool search call call_x`
+- **AND** the pending bridge request carries `previous_response_id`
+- **THEN** the service rewrites the error to a retryable `stream_incomplete` continuity failure
+- **AND** the raw upstream message and call id are not exposed downstream
+
+#### Scenario: hosted web search wording stays unclassified
+- **WHEN** upstream emits `invalid_request_error` with `param=input` and a message starting `No tool output found for web search call`
+- **THEN** the service does not treat it as a missing-tool-output continuity error

--- a/openspec/changes/classify-tool-search-missing-tool-output/tasks.md
+++ b/openspec/changes/classify-tool-search-missing-tool-output/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] Extend the missing-tool-output message classifier with the tool-search wording.
+- [x] Keep the hosted `web search call` wording unclassified.
+- [x] Add classifier and HTTP-bridge masking regression coverage.
+- [x] Run focused unit tests, lint/format, type check, architecture check, diff check, and strict OpenSpec validation.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -2231,13 +2231,23 @@ The service MUST track tool-call items completed by a streamed response that may
 - **AND** if upstream rejects it with a missing-tool-output error, the extended classifier masks it as a retryable continuity failure instead of surfacing the raw upstream 400
 
 ### Requirement: Missing-tool-output classification covers all tool call variants
-The service MUST classify an upstream `invalid_request_error` with `param=input` whose message starts with `No tool output found for function call call_`, `No tool output found for custom tool call call_`, or `No tool output found for apply patch call call_` as a missing-tool-output continuity error, so the existing masking and retry recovery paths engage instead of forwarding the raw upstream 400 downstream.
+The service MUST classify an upstream `invalid_request_error` with `param=input` whose message starts with `No tool output found for function call call_`, `No tool output found for custom tool call call_`, `No tool output found for apply patch call call_`, or `No tool output found for tool search call call_` as a missing-tool-output continuity error, so the existing masking and retry recovery paths engage instead of forwarding the raw upstream 400 downstream. The hosted `No tool output found for web search call` wording MUST NOT be classified, because a `web_search_call` is executed upstream and carries no client-addressable tool output.
 
 #### Scenario: custom tool call variant is masked on the HTTP bridge
 - **WHEN** upstream emits `invalid_request_error` with `param=input` and message `No tool output found for custom tool call call_x`
 - **AND** the pending bridge request carries `previous_response_id`
 - **THEN** the service rewrites the error to a retryable `stream_incomplete` continuity failure
 - **AND** the raw upstream message and call id are not exposed downstream
+
+#### Scenario: tool search call variant is masked on the HTTP bridge
+- **WHEN** upstream emits `invalid_request_error` with `param=input` and message `No tool output found for tool search call call_x`
+- **AND** the pending bridge request carries `previous_response_id`
+- **THEN** the service rewrites the error to a retryable `stream_incomplete` continuity failure
+- **AND** the raw upstream message and call id are not exposed downstream
+
+#### Scenario: hosted web search wording stays unclassified
+- **WHEN** upstream emits `invalid_request_error` with `param=input` and a message starting `No tool output found for web search call`
+- **THEN** the service does not treat it as a missing-tool-output continuity error
 
 ### Requirement: Non-message system and developer input items are preserved
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -15960,6 +15960,84 @@ async def test_process_http_bridge_upstream_text_masks_missing_custom_tool_outpu
 
 
 @pytest.mark.asyncio
+async def test_process_http_bridge_upstream_text_masks_missing_tool_search_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    finalize_request_state = AsyncMock()
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-missing-tool-search",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=1.0,
+        previous_response_id="resp_missing_tool_search",
+        event_queue=asyncio.Queue(),
+        transport="http",
+        skip_request_log=True,
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("session_header", "sid-tool-search-123", None),
+        headers={"x-codex-session-id": "sid-tool-search-123"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-tool-search-123",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=1.0,
+        idle_ttl_seconds=120.0,
+    )
+
+    await service._process_http_bridge_upstream_text(
+        session,
+        json.dumps(
+            {
+                "type": "error",
+                "status": 400,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "invalid_request_error",
+                    "message": "No tool output found for tool search call call_missing_tool_search_output.",
+                    "param": "input",
+                },
+            },
+            separators=(",", ":"),
+        ),
+    )
+
+    event_queue = request_state.event_queue
+    assert event_queue is not None
+    event_block = await event_queue.get()
+    assert event_block is not None
+    assert await event_queue.get() is None
+    payload = proxy_service.parse_sse_data_json(event_block)
+    assert isinstance(payload, dict)
+    response = payload.get("response")
+    assert isinstance(response, dict)
+    error = response.get("error")
+    assert isinstance(error, dict)
+    assert payload["type"] == "response.failed"
+    assert error["code"] == "stream_incomplete"
+    assert "call_missing_tool_search_output" not in json.dumps(payload)
+    assert request_state.error_http_status_override == 502
+
+    assert session.upstream_control.reconnect_requested is True
+    assert session.pending_requests == deque()
+    assert finalize_request_state.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_process_http_bridge_upstream_text_does_not_mask_unmatched_missing_tool_output_across_chains(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -19700,6 +19700,7 @@ async def test_prepare_websocket_response_create_request_fills_interrupted_pendi
         ("No tool output found for function call call_abc.", True),
         ("No tool output found for custom tool call call_abc.", True),
         ("No tool output found for apply patch call call_abc.", True),
+        ("No tool output found for tool search call call_abc.", True),
         ("No tool output found for web search call ws_abc.", False),
         ("Previous response with id 'resp_abc' not found.", False),
     ],


### PR DESCRIPTION
## Summary

`_MISSING_TOOL_OUTPUT_MESSAGE_PREFIXES` (`app/modules/proxy/service.py:2105`) enumerates only the `function call`, `custom tool call`, and `apply patch call` wordings, so `_is_missing_tool_output_error` returns `False` for upstream's fourth wording:

```json
{"type":"error","status":400,
 "error":{"type":"invalid_request_error",
          "message":"No tool output found for tool search call call_XXXX",
          "param":"input"}}
```

That unclassified 400 skips every consumer of the classifier: the raw upstream message and call id leak downstream instead of the `stream_incomplete` continuity rewrite (`_service/websocket/helpers.py:1041`/`:1303`, `_service/streaming/helpers.py:511`), `_record_continuity_fail_closed(reason="missing_tool_output")` is never recorded, and on a multiplexed HTTP bridge or WebSocket session the anonymous error event loses its `prefer_previous_response_not_found` matching (`_service/http_bridge/upstream_events.py:670`, `_service/websocket/mixin.py:605`) and can be attributed to a pending request that did not cause it.

Same enumeration gap as #1168. That fix made its sites 1 and 2 table-driven via `_PENDING_TOOL_CALL_OUTPUT_ITEM_TYPE_BY_CALL_TYPE` (`_service/support.py:60`); only site 3, the classifier's fixed wording list, is still hard-coded.

`tool_search_call` / `tool_search_output` are already modelled in-repo (`app/modules/proxy/replay_safety.py:20-22`, shapes fixed by `tests/unit/test_replay_safety.py:187-203`), so the item type is real — only the wording list was stale.

Refs #1168, #1530.

## Changes

- add `no tool output found for tool search call call_` to `_MISSING_TOOL_OUTPUT_MESSAGE_PREFIXES`, so the existing masking, continuity fail-closed recording, and anonymous-event matching engage for the tool-search wording exactly as they do for the other three;
- keep the hosted `web search call` wording unclassified (a `web_search_call` is executed upstream and has no `call_id`-addressed client output) and pin that with the spec and the existing negative test case;
- update `openspec/specs/responses-api-compat/spec.md` — "Missing-tool-output classification covers all tool call variants" — with the fourth wording, the hosted-web-search exclusion, and a bridge-masking scenario;
- add the OpenSpec change `classify-tool-search-missing-tool-output`;
- regression coverage: the classifier parametrisation gains the tool-search wording, and `tests/unit/test_proxy_http_bridge.py` gains `test_process_http_bridge_upstream_text_masks_missing_tool_search_output`, mirroring the existing custom-tool-call masking test (rewritten to `stream_incomplete`, `error_http_status_override == 502`, reconnect requested, call id absent from the downstream payload).

Deliberately **not** changed: `_PENDING_TOOL_CALL_OUTPUT_ITEM_TYPE_BY_CALL_TYPE` is left alone. `tool_search_output` carries a `tools` list rather than the `{"output": "<text>"}` field that `_synthetic_interrupted_function_call_output` (`_service/response_create.py:363`) emits for every table entry, so extending the synthesiser would mean asserting an upstream payload shape this repo cannot verify — and a wrong shape turns a maskable 400 into a different, unmaskable one. It would also silently pull `tool_search_call` into `_TTFT_OUTPUT_ITEM_TYPES` (`_service/support.py:67`). #1530 raises the shape question (synthesise `{"tools": []}` vs. drop the orphaned call, which `replay_safety.py` already proves upstream accepts) for maintainer decision.

## Validation

- `tests/unit` + `tests/test_request_logs_options_api.py`: 5013 passed, 65 skipped;
- affected focused suites (`test_proxy_utils.py`, `test_proxy_http_bridge.py`, `test_replay_safety.py`): 1412 passed;
- `uv run ruff check .` passed; `uv run ruff format --check .` passed (847 files);
- `uv run ty check` passed;
- `python scripts/check_proxy_architecture.py` passed;
- `openspec validate classify-tool-search-missing-tool-output --strict` valid; `openspec validate --specs` 48/48 passed;
- `git diff --check` passed.

Not run locally: integration/e2e/PostgreSQL/Helm/frontend jobs. Hosted CI is authoritative for those.
