### PR TITLE
fix(proxy): keep upstream request-shape rejections account neutral

### DIFF
--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -782,6 +782,32 @@ async def _select_account_with_budget_for_stream(proxy: Any, deadline: float, **
     return await selector(deadline, **kwargs)
 
 
+def _is_account_neutral_request_rejection(
+    *,
+    code: str,
+    http_status: int | None,
+    message: str | None,
+) -> bool:
+    """Return whether upstream rejected the request payload, not the account.
+
+    A payload-shape rejection reproduces identically on every account, so it
+    must never mutate one account's health: otherwise a single client looping
+    on a self-inconsistent conversation drives its serving accounts into
+    ``error_count`` backoff and starves unrelated tenants.
+
+    Keep this set narrow. Not every upstream ``invalid_request_error`` is
+    account neutral -- the model-entitlement rejection matched by
+    ``_is_account_model_unsupported_error`` is genuinely account scoped -- so
+    membership is decided by the specific classified message, never by the
+    ``invalid_request_error`` code alone.
+    """
+    if code != "invalid_request_error":
+        return False
+    if http_status is not None and http_status != 400:
+        return False
+    return bool(_facade()._is_missing_tool_output_message(message))
+
+
 async def _handle_stream_error(
     proxy: Any,
     account: Account,
@@ -798,6 +824,18 @@ async def _handle_stream_error(
         phase="first_event",
     )
     if _facade()._is_account_neutral_error_code(code):
+        return classified
+    if _is_account_neutral_request_rejection(
+        code=code,
+        http_status=http_status,
+        message=error.get("message"),
+    ):
+        _facade().logger.info(
+            "Skipped account error penalty for account-neutral request rejection account_id=%s request_id=%s code=%s",
+            "<redacted>" if privacy_policy.redacts_sensitive_details else account.id,
+            get_request_id(),
+            code,
+        )
         return classified
     if classified["failure_class"] == "rate_limit":
         await proxy._load_balancer.mark_rate_limit(account, error)

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -2109,16 +2109,22 @@ _MISSING_TOOL_OUTPUT_MESSAGE_PREFIXES = (
 )
 
 
+def _is_missing_tool_output_message(message: str | None) -> bool:
+    if message is None:
+        return False
+    normalized = " ".join(message.lower().split())
+    return normalized.startswith(_MISSING_TOOL_OUTPUT_MESSAGE_PREFIXES)
+
+
 def _is_missing_tool_output_error(
     *,
     code: str | None,
     param: str | None,
     message: str | None,
 ) -> bool:
-    if code != "invalid_request_error" or param != "input" or message is None:
+    if code != "invalid_request_error" or param != "input":
         return False
-    normalized = " ".join(message.lower().split())
-    return normalized.startswith(_MISSING_TOOL_OUTPUT_MESSAGE_PREFIXES)
+    return _is_missing_tool_output_message(message)
 
 
 def _is_previous_response_not_found_error(

--- a/openspec/changes/keep-request-shape-rejections-account-neutral/proposal.md
+++ b/openspec/changes/keep-request-shape-rejections-account-neutral/proposal.md
@@ -1,0 +1,92 @@
+# Keep request-shape rejections account neutral
+
+## Why
+
+`_handle_stream_error` (`app/modules/proxy/_service/streaming/helpers.py`) is the
+single call site of `LoadBalancer.record_error`. It skips the penalty only when
+`_is_account_neutral_error_code(code)` matches, and that predicate covers local
+overload, process-network, `proxy_unavailable`, and
+`responses_compact_input_too_large`. An upstream `invalid_request_error` is
+therefore charged to whichever account happened to serve the request — including
+the missing-tool-output 400 that upstream raises when the *client's* input array
+references a tool call with no matching tool output.
+
+That 400 reproduces identically on every account, and a client that keeps
+re-sending the same self-inconsistent conversation reproduces it on every
+retry. The penalty then compounds through routing:
+
+1. `app/core/balancer/logic.py` puts an account with `error_count >= 3` into
+   `min(300, 30 * 2 ** (error_count - 3))` seconds of error backoff and moves it
+   to `in_error_backoff` instead of `available`.
+2. The backoff rescue only fires when `len(in_error_backoff) > 1` or a
+   hard-blocked account also exists.
+3. `app/modules/proxy/_load_balancer/sticky_selection.py` narrows the candidate
+   set of a hard Codex-session sticky request to the single resolved owner
+   account. That single-element pool can never satisfy the rescue condition, so
+   selection returns `hard_affinity_saturated` and the request fails with an
+   immediate 502 — no failover, no wait.
+
+So one client's poisoned conversation degrades shared account health and 502s
+unrelated, hard-pinned sessions on the same fleet. These 502s fail before an
+account is assigned, so they are largely invisible in `request_logs`.
+
+Field evidence over one 24h window on a shared deployment: ~25.7k upstream 400s
+all attributable to a single repeated tool-call id from one client, matched 1:1
+by `Recorded transient account error code=invalid_request_error` log lines, and
+~2.2k 502s of which 72% were `hard_affinity_saturated` — 95% of those belonging
+to a tenant that never sent the offending payload. One five-minute window served
+zero successful requests.
+
+## What Changes
+
+- `_handle_stream_error` MUST NOT mutate account health for an upstream
+  rejection of the request payload itself. A new narrow predicate,
+  `_is_account_neutral_request_rejection`, gates the skip on
+  `invalid_request_error` + HTTP 400 (or unknown status) + a classified
+  missing-tool-output message, and logs the skip so the decision stays
+  observable.
+- Classification (`classify_upstream_failure`), the failover decision, and the
+  client-visible error are unchanged: `non_retryable` still surfaces, and the
+  existing continuity masking paths still rewrite the error where they already
+  did.
+- `_is_missing_tool_output_error` is split so its message test
+  (`_is_missing_tool_output_message`) is reusable without a `param` value, since
+  `UpstreamError` does not carry `param`.
+
+## Design note: why not neutralize `invalid_request_error` wholesale
+
+Some 400s carrying `invalid_request_error` are genuinely account scoped — the
+model-entitlement rejection `The '<model>' model is not supported when using
+Codex with a ChatGPT account.` (#876) is the in-repo example, already matched by
+`_is_account_model_unsupported_error`. Gating on the code alone would stop a
+genuinely unusable account from backing off. Gating on `param == "input"` was
+also rejected: account-scoped hosted state can appear under `param=input`
+(`file_id`, `item_reference`, and the other
+`_ACCOUNT_SCOPED_HOSTED_INPUT_TYPES`), so `param=input` does not prove account
+independence. The invariant this change asserts is narrower and provable from
+the payload alone:
+
+> An error that would reproduce identically on every account MUST NOT mutate one
+> account's health.
+
+## Non-goals
+
+- Letting hard-sticky selection rescue a single-element `in_error_backoff`. A
+  hard-pinned session has no alternative account by construction, so the rescue
+  condition `len(in_error_backoff) > 1 or hard_blocked_exists` is unreachable
+  for it; that is a separate routing-policy decision and is deliberately not
+  bundled here.
+- Changing the client-visible status or body for any rejection.
+
+## Issue Trace
+
+- Refs #1505, #876, #1168
+
+## Impact
+
+- **Spec**: `account-routing`
+- **Behavior**: a malformed client payload no longer drives its serving accounts
+  into error backoff, so hard-pinned sessions on unrelated accounts stop
+  receiving `hard_affinity_saturated` 502s.
+- **Persistence/UI**: no database, migration, configuration, or dashboard
+  changes.

--- a/openspec/changes/keep-request-shape-rejections-account-neutral/specs/account-routing/spec.md
+++ b/openspec/changes/keep-request-shape-rejections-account-neutral/specs/account-routing/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Upstream rejections of the request payload are account neutral
+
+When upstream rejects a request because of the request payload itself, the proxy MUST NOT mutate the selected account's health: it MUST NOT record a transient account error, a rate-limit penalty, a quota penalty, or a permanent failure for that account. An upstream failure qualifies as a payload rejection only when it would reproduce identically on every account. The proxy MUST decide membership from the classified upstream message, never from the `invalid_request_error` code alone, and MUST require the upstream HTTP status to be 400 whenever a status is known. An upstream missing-tool-output rejection — the `invalid_request_error` whose message identifies a tool call with no matching tool output — MUST qualify. An account-scoped `invalid_request_error`, including the model-entitlement rejection `The '<model>' model is not supported when using Codex with a ChatGPT account.`, MUST NOT qualify and MUST keep its existing account-health handling. Skipping the penalty MUST be logged so the decision is observable, and MUST NOT change the failure classification, the failover decision, or the status and body returned to the client.
+
+#### Scenario: Missing-tool-output rejection leaves account health untouched
+
+- **GIVEN** account A is selected for a request whose input references a tool call with no matching tool output
+- **WHEN** upstream returns HTTP 400 `invalid_request_error` with a missing-tool-output message
+- **THEN** the proxy does not increment account A's transient error count and does not mark it rate-limited, quota-exceeded, or permanently failed
+- **AND** the failure is still classified `non_retryable` and surfaced to the client unchanged
+
+#### Scenario: Repeated client payload rejection cannot starve unrelated sessions
+
+- **GIVEN** one client repeatedly re-sends the same payload that upstream rejects for a missing tool output
+- **WHEN** those requests are served by accounts shared with other sessions
+- **THEN** no serving account enters error backoff because of that payload
+- **AND** a session hard-pinned to one of those accounts is not failed with a saturated-hard-affinity selection error caused by that payload
+
+#### Scenario: Model-entitlement rejection still penalizes the account
+
+- **GIVEN** account A cannot use the requested model
+- **WHEN** upstream returns HTTP 400 `invalid_request_error` stating the model is not supported for a ChatGPT account
+- **THEN** the proxy records the account-health penalty for account A as before

--- a/openspec/changes/keep-request-shape-rejections-account-neutral/tasks.md
+++ b/openspec/changes/keep-request-shape-rejections-account-neutral/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] Specify that upstream rejections of the request payload are account neutral.
+- [x] Add the narrow request-rejection predicate and gate `_handle_stream_error` on it, with an observable skip log.
+- [x] Keep account-scoped `invalid_request_error` rejections penalizing.
+- [x] Add regression coverage for the predicate and for both penalty outcomes.
+- [x] Run focused unit tests, lint/format, type check, architecture check, diff check, and strict OpenSpec validation.

--- a/openspec/specs/account-routing/spec.md
+++ b/openspec/specs/account-routing/spec.md
@@ -201,6 +201,30 @@ When upstream returns rate-limit or quota-exhaustion evidence for a selected acc
 - **THEN** it marks account A as rate-limited or cooling down
 - **AND** it does not create model-scoped or transport-scoped upstream cooldown buckets without upstream evidence
 
+### Requirement: Upstream rejections of the request payload are account neutral
+
+When upstream rejects a request because of the request payload itself, the proxy MUST NOT mutate the selected account's health: it MUST NOT record a transient account error, a rate-limit penalty, a quota penalty, or a permanent failure for that account. An upstream failure qualifies as a payload rejection only when it would reproduce identically on every account. The proxy MUST decide membership from the classified upstream message, never from the `invalid_request_error` code alone, and MUST require the upstream HTTP status to be 400 whenever a status is known. An upstream missing-tool-output rejection — the `invalid_request_error` whose message identifies a tool call with no matching tool output — MUST qualify. An account-scoped `invalid_request_error`, including the model-entitlement rejection `The '<model>' model is not supported when using Codex with a ChatGPT account.`, MUST NOT qualify and MUST keep its existing account-health handling. Skipping the penalty MUST be logged so the decision is observable, and MUST NOT change the failure classification, the failover decision, or the status and body returned to the client.
+
+#### Scenario: Missing-tool-output rejection leaves account health untouched
+
+- **GIVEN** account A is selected for a request whose input references a tool call with no matching tool output
+- **WHEN** upstream returns HTTP 400 `invalid_request_error` with a missing-tool-output message
+- **THEN** the proxy does not increment account A's transient error count and does not mark it rate-limited, quota-exceeded, or permanently failed
+- **AND** the failure is still classified `non_retryable` and surfaced to the client unchanged
+
+#### Scenario: Repeated client payload rejection cannot starve unrelated sessions
+
+- **GIVEN** one client repeatedly re-sends the same payload that upstream rejects for a missing tool output
+- **WHEN** those requests are served by accounts shared with other sessions
+- **THEN** no serving account enters error backoff because of that payload
+- **AND** a session hard-pinned to one of those accounts is not failed with a saturated-hard-affinity selection error caused by that payload
+
+#### Scenario: Model-entitlement rejection still penalizes the account
+
+- **GIVEN** account A cannot use the requested model
+- **WHEN** upstream returns HTTP 400 `invalid_request_error` stating the model is not supported for a ChatGPT account
+- **THEN** the proxy records the account-health penalty for account A as before
+
 ### Requirement: Stale in-memory account sessions must not stay routable
 
 The service MUST remove accounts from routing when they are paused, deleted,

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -202,6 +202,114 @@ async def test_process_network_failure_does_not_update_account_health() -> None:
     service._handle_stream_error.assert_not_awaited()
 
 
+@pytest.mark.parametrize(
+    ("code", "http_status", "message", "expected"),
+    [
+        (
+            "invalid_request_error",
+            400,
+            "No tool output found for function call call_abc.",
+            True,
+        ),
+        (
+            "invalid_request_error",
+            400,
+            "No tool output found for custom tool call call_abc.",
+            True,
+        ),
+        (
+            "invalid_request_error",
+            400,
+            "No tool output found for apply patch call call_abc.",
+            True,
+        ),
+        (
+            "invalid_request_error",
+            None,
+            "No tool output found for function call call_abc.",
+            True,
+        ),
+        # A model-entitlement rejection is account scoped and must stay
+        # penalizing even though it shares the invalid_request_error code.
+        (
+            "invalid_request_error",
+            400,
+            "The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.",
+            False,
+        ),
+        ("invalid_request_error", 400, None, False),
+        # Only a genuine 400 proves upstream rejected the payload itself.
+        (
+            "invalid_request_error",
+            500,
+            "No tool output found for function call call_abc.",
+            False,
+        ),
+        ("server_error", 400, "No tool output found for function call call_abc.", False),
+    ],
+)
+def test_is_account_neutral_request_rejection(
+    code: str,
+    http_status: int | None,
+    message: str | None,
+    expected: bool,
+) -> None:
+    assert (
+        streaming_helpers_module._is_account_neutral_request_rejection(
+            code=code,
+            http_status=http_status,
+            message=message,
+        )
+        is expected
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_tool_output_rejection_does_not_penalize_account() -> None:
+    load_balancer = SimpleNamespace(
+        record_error=AsyncMock(),
+        mark_rate_limit=AsyncMock(),
+        mark_quota_exceeded=AsyncMock(),
+        mark_permanent_failure=AsyncMock(),
+    )
+    proxy = SimpleNamespace(_load_balancer=load_balancer)
+
+    classified = await streaming_helpers_module._handle_stream_error(
+        proxy,
+        cast(Account, SimpleNamespace(id="acc-1")),
+        {"message": "No tool output found for custom tool call call_poisoned."},
+        "invalid_request_error",
+        400,
+    )
+
+    assert classified["failure_class"] == "non_retryable"
+    load_balancer.record_error.assert_not_awaited()
+    load_balancer.mark_rate_limit.assert_not_awaited()
+    load_balancer.mark_quota_exceeded.assert_not_awaited()
+    load_balancer.mark_permanent_failure.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_account_scoped_invalid_request_error_still_penalizes_account() -> None:
+    load_balancer = SimpleNamespace(
+        record_error=AsyncMock(),
+        mark_rate_limit=AsyncMock(),
+        mark_quota_exceeded=AsyncMock(),
+        mark_permanent_failure=AsyncMock(),
+    )
+    proxy = SimpleNamespace(_load_balancer=load_balancer)
+
+    await streaming_helpers_module._handle_stream_error(
+        proxy,
+        cast(Account, SimpleNamespace(id="acc-1")),
+        {"message": "The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."},
+        "invalid_request_error",
+        400,
+    )
+
+    load_balancer.record_error.assert_awaited_once()
+
+
 def test_websocket_archive_request_context_clears_unmatched_frame_request_id():
     token = set_request_id("req_previous_response")
     try:


### PR DESCRIPTION
## Summary

`_handle_stream_error` (`app/modules/proxy/_service/streaming/helpers.py:785`) is the only call site of `LoadBalancer.record_error` in the app, and it skips the account-health penalty only when `_is_account_neutral_error_code(code)` matches — local overload, process-network, `proxy_unavailable`, `responses_compact_input_too_large` (`_service/support.py:1307`). An upstream `invalid_request_error` is therefore charged to whichever account served the request, including the missing-tool-output 400 that upstream raises when the **client's own** input array references a tool call with no matching output.

That 400 reproduces identically on every account and on every retry, and the penalty compounds through routing:

1. `app/core/balancer/logic.py:484` — `error_count >= 3` puts the account into `min(300, 30 * 2 ** (error_count - 3))` seconds of backoff and appends it to `in_error_backoff` instead of `available`.
2. `logic.py:519` — the rescue back out of backoff needs `len(in_error_backoff) > 1 or (in_error_backoff and hard_blocked_exists)`, and `hard_blocked_exists` (`:507`) excludes accounts already in `in_error_backoff`.
3. `app/modules/proxy/_load_balancer/sticky_selection.py:356-361` — a hard Codex-session sticky request with a resolved owner is narrowed to that single account. With one candidate, `in_error_backoff` can only have length 1 and `hard_blocked_exists` is `False` by construction, so step 2 is structurally unreachable: `sticky_selection.py:436` returns `hard_affinity_saturated` and `load_balancer.py:709/721` turns it into an immediate 502 — no failover, no wait.

Net effect: one client's poisoned conversation degrades shared account health and 502s unrelated, hard-pinned sessions. Field evidence over one 24h window on a shared deployment: ~25.7k upstream 400s from a single repeated tool-call id, matched 1:1 by `Recorded transient account error code=invalid_request_error`, and ~2.2k 502s of which 72% were `hard_affinity_saturated`, ~95% of those belonging to a tenant that never sent the offending payload. Only 11 of those 1,583 reached `request_logs` — selection fails before an account is assigned, so the failure is nearly invisible on the dashboard.

Full write-up: #1530.

The invariant this asserts:

> **An error that would reproduce identically on every account must never mutate one account's health.**

Refs #1530, #1505, #876, #1168.

## Changes

- add `_is_account_neutral_request_rejection` (`_service/streaming/helpers.py`) and gate `_handle_stream_error` on it before any health mutation, so a payload rejection records no transient error, rate-limit, quota, or permanent-failure penalty. The skip is logged (`Skipped account error penalty for account-neutral request rejection …`) so the decision stays observable alongside the existing `Recorded transient account error` line;
- keep the predicate deliberately narrow — `invalid_request_error` **and** HTTP 400 whenever a status is known **and** a classified missing-tool-output message. Membership is decided by the message, never by the code alone, so the account-scoped `invalid_request_error` from #876 (`The '<model>' model is not supported when using Codex with a ChatGPT account.`, matched by `_is_account_model_unsupported_error`) keeps backing its account off;
- split `_is_missing_tool_output_error` into `_is_missing_tool_output_message` + the existing `code`/`param` gate, because `UpstreamError` (`app/core/balancer/types.py`) carries `message` but no `param`. Behaviour of the existing classifier is unchanged;
- add the `account-routing` requirement "Upstream rejections of the request payload are account neutral" plus the OpenSpec change `keep-request-shape-rejections-account-neutral`;
- regression coverage in `tests/unit/test_proxy_utils.py`: a parametrised predicate table (missing-tool-output at 400 and at unknown status → neutral; the #876 model-entitlement message, a 500, a non-`invalid_request_error` code, and a `None` message → not neutral), plus two `_handle_stream_error` tests asserting that a missing-tool-output 400 awaits none of `record_error` / `mark_rate_limit` / `mark_quota_exceeded` / `mark_permanent_failure` while still classifying `non_retryable`, and that the model-entitlement 400 still awaits `record_error` exactly once.

`classify_upstream_failure`, `failover_decision`, and the status/body returned to the client are untouched. `invalid_request_error` already classifies `non_retryable` → `failover_decision` returns `"surface"`, so there was never failover amplification to remove; the only behaviour change is that a bogus health signal is no longer produced.

Deliberately **not** included, to keep the diff reviewable:

- `previous_response_not_found` is left penalizing. It is arguably anchor bookkeeping rather than account fault, but a stale anchor *is* account-scoped state, so that is a separate judgement call (raised in #1530).
- Letting hard-sticky selection rescue a single-element `in_error_backoff`. A hard-pinned session has no alternative account by construction, so the rescue condition is structurally unreachable for it — but that changes routing policy, whereas this PR only stops the bogus signal at the source. Proposed separately in #1530.

## Validation

- `tests/unit` + `tests/test_request_logs_options_api.py`: 5021 passed, 65 skipped;
- affected focused suites (`test_proxy_utils.py`, `test_proxy_http_bridge.py`, `test_proxy_api_websocket_auth.py`, `test_load_balancer_concurrency.py`, `test_proxy_load_balancer_refresh.py`): 1477 passed, 3 skipped;
- `uv run ruff check .` passed; `uv run ruff format --check .` passed (847 files);
- `uv run ty check` passed;
- `python scripts/check_proxy_architecture.py` passed;
- `openspec validate keep-request-shape-rejections-account-neutral --strict` valid; `openspec validate --specs` 48/48 passed;
- `git diff --check` passed.

Not run locally: integration/e2e/PostgreSQL/Helm/frontend jobs. Hosted CI is authoritative for those.
