### PR TITLE
chore: normalize line endings and ignore local recovery artifacts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Normalize text files to LF to stop CRLF-only dirty churn.
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ frontend/coverage/
 .local/
 .worktrees/
 certs/
+/backups/
+encryption.key.backup
 
 .codex-lb/
 .sisyphus/


### PR DESCRIPTION
## Summary

Normalize tracked text to LF and keep local recovery artifacts out of ordinary Git staging. This prevents CRLF-only dirty churn while adding defense-in-depth for root backup directories and encryption-key backups.

This PR is intentionally draft until the full GitHub CI gate completes.

## Type of change

- [x] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] Breaking change

Linked issue: N/A

## OpenSpec

- [x] Not applicable — docs / CI / chore only

## Changes

- add `* text=auto eol=lf` in `.gitattributes`
- ignore root `/backups/` and exact `encryption.key.backup` files at any depth

## Test plan

Passed locally:

- `git diff --check`
- exact `git check-ignore --no-index` assertions for root and nested paths
- Git attribute/binary integrity audit (3,308 tracked text files already canonical LF; 26 binary files remain binary; renormalization audit changes no tracked content beyond this PR)
- `uv run python -X utf8 scripts/check_proxy_architecture.py`
- `uv run ruff check .`
- `uv run ruff format --check .`

Windows differential unit evidence:

- patch branch full unit slice: `4,986 passed, 66 skipped, 24 failed`
- UTF-8 failed-only rerun resolved 5 locale failures and left 19 Windows/platform/environment failures
- the exact same 19 node IDs were run against an untouched detached `b91d9bb` base worktree and all 19 failed there too, with the same failure classes (`os.fork`, Windows path/permission/lock behavior, host optional-dependency/proxy environment)
- therefore the local failures are baseline/environmental, not a passing result and not evidence of a regression introduced by this two-file patch

Full Linux GitHub CI remains the required gate. Its `CI` and `Simplicity budgets` workflows are currently awaiting upstream maintainer approval and have not run.

## Checklist

- [x] Title uses Conventional Commits format.
- [x] No OpenSpec change is required for this repository-hygiene-only patch.
- [x] Simplicity gates reviewed; no setting, setup step, README section, or dashboard surface is added.
- [x] CHANGELOG is not edited.
- [ ] Full CI is green.
- [x] `@codex review` findings are resolved on the final head.