### PR TITLE
fix(proxy): attribute bridge failure fan-out request logs to each request's API key

### DIFF
--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -4788,7 +4788,10 @@ class _WebSocketMixin:
                     )
             await proxy._write_request_log(
                 account_id=account_id_value,
-                api_key=api_key,
+                # HTTP-bridge callers fan a shared session failure out to
+                # requests from multiple API keys, so they pass api_key=None;
+                # each request_state carries its own authenticated key.
+                api_key=request_state.api_key or api_key,
                 request_id=request_state.response_id or request_state.request_log_id or request_state.request_id,
                 archive_request_id=request_state.archive_request_id,
                 model=request_state.model or "",

--- a/openspec/changes/attribute-bridge-failure-request-logs/proposal.md
+++ b/openspec/changes/attribute-bridge-failure-request-logs/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Error request-log rows written by the HTTP-bridge failure fan-out
+(`_fail_pending_websocket_requests`) store `api_key_id = NULL` even though the
+request was authenticated. The bridge session is shared across API keys, so
+its failure callers pass a session-level `api_key=None`, and the fan-out uses
+that instead of each pending request's own key. In production every
+`transport=http / upstream_transport=websocket` error in this family
+(`stream_incomplete`, `upstream_request_timeout`, `upstream_unavailable`,
+`upstream_rejected_input`, ...) is unattributed — 522 rows over 7 days — so
+dashboard and API queries filtered by key silently miss them. This violates
+the existing `api-keys` requirement "RequestLog API key reference"
+(authenticated requests SHALL record `api_key_id`).
+
+## What Changes
+
+- The bridge failure fan-out attributes each pending request's log row to
+  that request's own authenticated key (`request_state.api_key`), falling
+  back to the caller-provided key only when the request state carries none.
+- No behavior change for direct WebSocket callers, which already pass the
+  connection-level key: per-request attribution takes precedence and is
+  identical there.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `api-keys`: clarify that the RequestLog API key reference requirement also
+  holds for error rows written by shared-session (bridge) failure fan-out.
+
+## Impact
+
+- Code: `app/modules/proxy/_service/websocket/mixin.py`
+- Tests: `tests/unit/test_websocket_upstream_transport_observability.py`
+- Specs: `openspec/specs/api-keys/spec.md`

--- a/openspec/changes/attribute-bridge-failure-request-logs/proposal.md
+++ b/openspec/changes/attribute-bridge-failure-request-logs/proposal.md
@@ -35,5 +35,8 @@ None.
 ## Impact
 
 - Code: `app/modules/proxy/_service/websocket/mixin.py`
-- Tests: `tests/unit/test_websocket_upstream_transport_observability.py`
+- Tests: `tests/unit/test_websocket_upstream_transport_observability.py`,
+  `tests/integration/test_http_responses_bridge.py` (route-level regression at
+  the externally failing surface: authenticated `/v1/responses` bridge send
+  failure → persisted `RequestLog.api_key_id`)
 - Specs: `openspec/specs/api-keys/spec.md`

--- a/openspec/changes/attribute-bridge-failure-request-logs/specs/api-keys/spec.md
+++ b/openspec/changes/attribute-bridge-failure-request-logs/specs/api-keys/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: RequestLog API key reference
+
+The system SHALL record the `api_key_id` in the `request_logs` table for proxy
+requests authenticated with an API key. The field MUST be NULL when API key
+auth is disabled or the request is unauthenticated. This applies to error rows
+as well as successes: when a shared upstream session (e.g. an HTTP-bridge
+session multiplexing requests from multiple API keys) fails its pending
+requests, each request's log row MUST be attributed to that request's own
+authenticated key.
+
+#### Scenario: Authenticated request logged
+
+- **WHEN** a proxy request is authenticated with API key `key-123` and completes
+- **THEN** the `request_logs` entry has `api_key_id = "key-123"`
+
+#### Scenario: Unauthenticated request logged
+
+- **WHEN** API key auth is disabled and a proxy request completes
+- **THEN** the `request_logs` entry has `api_key_id = NULL`
+
+#### Scenario: Bridge failure fan-out preserves per-request key attribution
+
+- **GIVEN** an HTTP-bridge session holds a pending request authenticated with
+  API key `key-123`
+- **WHEN** the session fails its pending requests (upstream close, send
+  failure, request timeout, or local terminal error)
+- **THEN** the request's `request_logs` error entry has
+  `api_key_id = "key-123"` even though the session-level failure path has no
+  single key of its own

--- a/openspec/changes/attribute-bridge-failure-request-logs/tasks.md
+++ b/openspec/changes/attribute-bridge-failure-request-logs/tasks.md
@@ -7,5 +7,8 @@
 
 - [x] 2.1 Add a regression: bridge failure fan-out with `api_key=None` still
       attributes the pending request's own key.
+- [x] 2.1b Add a route-level regression: an authenticated `/v1/responses`
+      bridge request failing through the fan-out (upstream send failure)
+      persists its `RequestLog.api_key_id`.
 - [x] 2.2 Run focused tests, lint, type checking, and strict OpenSpec
       validation.

--- a/openspec/changes/attribute-bridge-failure-request-logs/tasks.md
+++ b/openspec/changes/attribute-bridge-failure-request-logs/tasks.md
@@ -1,0 +1,11 @@
+## 1. Bridge failure fan-out attribution
+
+- [x] 1.1 Attribute each pending request's error log row to
+      `request_state.api_key`, with the caller-provided key as fallback.
+
+## 2. Validation
+
+- [x] 2.1 Add a regression: bridge failure fan-out with `api_key=None` still
+      attributes the pending request's own key.
+- [x] 2.2 Run focused tests, lint, type checking, and strict OpenSpec
+      validation.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -30,7 +30,7 @@ from app.core.utils.request_id import (
     set_request_scope_id,
 )
 from app.core.utils.time import utcnow
-from app.db.models import Account, AccountStatus, DashboardSettings
+from app.db.models import Account, AccountStatus, DashboardSettings, RequestLog
 from app.db.session import SessionLocal
 from app.dependencies import get_proxy_service_for_app
 from app.modules.proxy._service import support as proxy_support
@@ -11034,6 +11034,141 @@ async def test_v1_responses_http_bridge_stream_failure_remains_valid_sse(
     assert events[0]["response"]["id"] == events[-1]["response"]["id"]
     assert events[-1]["sequence_number"] == expected_failure_sequence
     assert events[-1]["response"]["error"]["code"] == "stream_incomplete"
+
+
+@pytest.mark.asyncio
+async def test_v1_responses_http_bridge_upstream_failure_attributes_api_key_in_request_log(
+    async_client,
+    app_instance,
+    monkeypatch,
+):
+    """An authenticated bridge request that fails through the session failure
+    fan-out (upstream send failure) must persist its request-log error row
+    with the request's api_key_id — the fan-out has no session-level key."""
+    _install_bridge_settings(monkeypatch, enabled=True)
+    account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_key_attribution",
+        "http-bridge-key-attribution@example.com",
+    )
+    account = await _get_account(account_id)
+    upstream = _FakeBridgeUpstreamWebSocket()
+    failing_upstream = _FailingSendThenCloseUpstreamWebSocket()
+
+    response = await async_client.put("/api/settings", json={"apiKeyAuthEnabled": True})
+    assert response.status_code == 200
+    response = await async_client.post("/api/api-keys/", json={"name": "bridge-key-attribution"})
+    assert response.status_code == 200
+    api_key_id = response.json()["id"]
+    api_key_token = response.json()["key"]
+
+    async def fake_select_account_with_budget(
+        self,
+        deadline,
+        *,
+        request_id,
+        kind,
+        request_stage="first_turn",
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset_accounts,
+        routing_strategy,
+        model,
+        exclude_account_ids=None,
+        additional_limit_name=None,
+        api_key=None,
+        preferred_account_id=None,
+    ):
+        del preferred_account_id
+        del (
+            self,
+            deadline,
+            request_id,
+            kind,
+            request_stage,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset_accounts,
+            routing_strategy,
+            model,
+            exclude_account_ids,
+            additional_limit_name,
+        )
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        return upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    auth_headers = {"Authorization": f"Bearer {api_key_token}"}
+    first = await async_client.post(
+        "/v1/responses",
+        headers=auth_headers,
+        json={
+            "model": "gpt-5.1",
+            "instructions": "Return exactly OK.",
+            "input": "hello",
+            "prompt_cache_key": "bridge-key-attribution",
+        },
+    )
+    assert first.status_code == 200
+    first_body = first.json()
+
+    service = get_proxy_service_for_app(app_instance)
+    async with service._http_bridge_lock:
+        session = next(iter(service._http_bridge_sessions.values()))
+        await _replace_http_bridge_upstream_reader(
+            service,
+            session,
+            cast(proxy_module.UpstreamWebSocket, failing_upstream),
+        )
+
+    second = await async_client.post(
+        "/v1/responses",
+        headers=auth_headers,
+        json={
+            "model": "gpt-5.1",
+            "instructions": "Return exactly OK.",
+            "input": "hello-again",
+            "prompt_cache_key": "bridge-key-attribution",
+            "previous_response_id": first_body["id"],
+        },
+    )
+    assert second.status_code == 502
+
+    # The failure fan-out schedules the log write from detached cleanup, which
+    # can register after a single drain call returns, so poll until it lands.
+    rows: list[RequestLog] = []
+    deadline = time.monotonic() + _TEST_SYNC_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        assert await service.drain_persistence_tasks(timeout_seconds=10)
+        async with SessionLocal() as session:
+            rows = list((await session.execute(select(RequestLog).where(RequestLog.status == "error"))).scalars().all())
+        if rows:
+            break
+        await asyncio.sleep(0.05)
+    assert len(rows) == 1
+    assert rows[0].account_id == account_id
+    assert rows[0].api_key_id == api_key_id
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_websocket_upstream_transport_observability.py
+++ b/tests/unit/test_websocket_upstream_transport_observability.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import time
 from collections import deque
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -11,6 +12,7 @@ import anyio
 import pytest
 
 from app.core.crypto import TokenEncryptor
+from app.modules.api_keys.service import ApiKeyData
 from app.modules.proxy._service.support import (
     _REQUEST_TRANSPORT_HTTP,
     _REQUEST_TRANSPORT_WEBSOCKET,
@@ -400,3 +402,52 @@ async def test_fail_pending_websocket_requests_records_bridge_upstream_transport
             "status": "error",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_fail_pending_websocket_requests_attributes_request_state_api_key(monkeypatch):
+    """Bridge failure fan-out passes api_key=None at the session level; each
+    pending request's log row must still be attributed to that request's own
+    authenticated key (request_state.api_key)."""
+    service = _DummyWebSocketService()
+    monkeypatch.setattr(websocket_mixin_module, "_record_upstream_transport_decision", lambda **_labels: None)
+
+    request_key = ApiKeyData(
+        id="key_bridge_pending",
+        name="bridge-key",
+        key_prefix="sk-bridge",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        last_used_at=None,
+    )
+    request_state = _WebSocketRequestState(
+        request_id="ws_bridge_pending_key",
+        request_log_id="resp_bridge_pending_key_log",
+        response_id="resp_bridge_pending_key",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        api_key=request_key,
+        started_at=time.monotonic(),
+        transport=_REQUEST_TRANSPORT_HTTP,
+        upstream_transport=_REQUEST_TRANSPORT_WEBSOCKET,
+    )
+
+    await service._fail_pending_websocket_requests(
+        account_id_value="acc_bridge",
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        error_code="stream_incomplete",
+        error_message="Upstream websocket closed before response.completed",
+        api_key=None,
+        response_create_gate=asyncio.Semaphore(1),
+    )
+
+    assert len(service.request_log_calls) == 1
+    assert service.request_log_calls[0]["api_key"] is request_key


### PR DESCRIPTION
Fixes #1539

## Why

Error request-log rows written by the HTTP-bridge failure fan-out store `api_key_id = NULL` even for authenticated requests. In production, every bridge-path (`transport=http / upstream_transport=websocket`) error row in the `stream_incomplete` / `upstream_request_timeout` / `upstream_unavailable` / `upstream_rejected_input` family is unattributed (522 rows over 7 days), so dashboard and API queries filtered by key silently miss them — while the 81k success rows on the same path attribute fine. This violates the existing `api-keys` requirement **RequestLog API key reference**.

## What

All four HTTP-bridge callers of `_fail_pending_websocket_requests` pass `api_key=None` (correctly — a shared bridge session can hold pending requests from multiple keys), but the per-request log write used that session-level parameter instead of each pending request's own key. One-line fix: attribute the row to `request_state.api_key or api_key`, the same idiom the terminal-event path (`_finalize_websocket_request_state`) and other `websocket/mixin.py` sites already use. Direct-WS callers that pass a connection-level key are unaffected (`request_state.api_key` is populated from the same key there).

- `app/modules/proxy/_service/websocket/mixin.py`: per-request key attribution in the failure fan-out.
- `tests/unit/test_websocket_upstream_transport_observability.py`: regression — fan-out with `api_key=None` must attribute the pending request's own key (fails on `main`, passes here).
- `openspec/changes/attribute-bridge-failure-request-logs/`: proposal + tasks + `api-keys` delta adding the bridge failure fan-out scenario to the RequestLog API key reference requirement.

## Validation

- `pytest tests/unit` — 5,123 passed, 3 skipped
- `make lint` (architecture check, ruff check/format) — clean
- `make typecheck` (ty) — clean
- `openspec validate attribute-bridge-failure-request-logs --strict` and `openspec validate --specs` — valid (48/48)

No settings, schema, or dashboard-surface changes; behavior change is limited to previously-NULL `api_key_id` values on bridge failure rows now being populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)