### PR TITLE
fix(proxy): sequence websocket health after settlement

### DIFF
--- a/app/modules/proxy/_service/api_key_usage.py
+++ b/app/modules/proxy/_service/api_key_usage.py
@@ -358,16 +358,31 @@ class _ApiKeyUsageMixin:
             api_key=api_key,
             api_key_reservation=api_key_reservation,
             request_id=request_id,
+            release_on_failure=not wait_for_settlement,
         )
         if wait_for_settlement:
             # Ordering-sensitive callers (the websocket error path) must
             # commit the settlement before load-balancer health writes; they
             # opt into waiting while everything else stays detached.
+            settlement_committed = False
             with anyio.CancelScope(shield=True):
-                try:
-                    await asyncio.shield(task)
-                except Exception:  # failures release via the tracking callback
-                    pass
+                while True:
+                    try:
+                        settlement_committed = await asyncio.shield(task)
+                        break
+                    except asyncio.CancelledError:
+                        # Caller cancellation must not race fallback release
+                        # against the still-running settlement transaction.
+                        if task.cancelled():
+                            break
+                    except Exception:
+                        break
+                if not settlement_committed:
+                    return await self._release_unsettled_stream_api_key_usage(
+                        api_key=api_key,
+                        api_key_reservation=api_key_reservation,
+                        request_id=request_id,
+                    )
         return True
 
     def _track_stream_usage_settlement_task(
@@ -377,9 +392,17 @@ class _ApiKeyUsageMixin:
         api_key: ApiKeyData,
         api_key_reservation: ApiKeyUsageReservationData,
         request_id: str,
+        release_on_failure: bool = True,
     ) -> None:
         proxy = cast(_ApiKeyUsageServiceProtocol, self)
         proxy._background_cleanup_tasks.add(cast(asyncio.Task[None], task))
+
+        async def _release_after_failed_settlement() -> None:
+            await self._release_unsettled_stream_api_key_usage(
+                api_key=api_key,
+                api_key_reservation=api_key_reservation,
+                request_id=request_id,
+            )
 
         def _settlement_done(done_task: asyncio.Task[bool]) -> None:
             proxy._background_cleanup_tasks.discard(cast(asyncio.Task[None], done_task))
@@ -391,16 +414,12 @@ class _ApiKeyUsageMixin:
                     api_key.id,
                     request_id,
                 )
-                release_coro = self._release_unsettled_stream_api_key_usage(
-                    api_key=api_key,
-                    api_key_reservation=api_key_reservation,
-                    request_id=request_id,
-                )
-                self._schedule_cancel_safe_cleanup(
-                    release_coro,
-                    action="release_stream_api_key_reservation_after_cancelled_settlement",
-                    request_id=request_id,
-                )
+                if release_on_failure:
+                    self._schedule_cancel_safe_cleanup(
+                        _release_after_failed_settlement(),
+                        action="release_stream_api_key_reservation_after_cancelled_settlement",
+                        request_id=request_id,
+                    )
             except Exception as exc:
                 logger.warning(
                     "Stream API key settlement task failed key_id=%s request_id=%s",
@@ -409,14 +428,9 @@ class _ApiKeyUsageMixin:
                     exc_info=(type(exc), exc, exc.__traceback__),
                 )
             else:
-                if not settled:
-                    release_coro = self._release_unsettled_stream_api_key_usage(
-                        api_key=api_key,
-                        api_key_reservation=api_key_reservation,
-                        request_id=request_id,
-                    )
+                if not settled and release_on_failure:
                     self._schedule_cancel_safe_cleanup(
-                        release_coro,
+                        _release_after_failed_settlement(),
                         action="release_stream_api_key_reservation_after_failed_settlement",
                         request_id=request_id,
                     )
@@ -456,7 +470,7 @@ class _ApiKeyUsageMixin:
         api_key: ApiKeyData,
         api_key_reservation: ApiKeyUsageReservationData,
         request_id: str,
-    ) -> None:
+    ) -> bool:
         proxy = cast(_ApiKeyUsageServiceProtocol, self)
         with anyio.CancelScope(shield=True):
             try:
@@ -465,6 +479,7 @@ class _ApiKeyUsageMixin:
                     await api_keys_service.release_usage_reservation(
                         api_key_reservation.reservation_id,
                     )
+                return True
             except Exception:
                 logger.warning(
                     "Failed to release stream API key reservation key_id=%s request_id=%s",
@@ -472,3 +487,4 @@ class _ApiKeyUsageMixin:
                     request_id,
                     exc_info=True,
                 )
+                return False

--- a/app/modules/proxy/_service/api_key_usage.py
+++ b/app/modules/proxy/_service/api_key_usage.py
@@ -331,7 +331,7 @@ class _ApiKeyUsageMixin:
                     cancellation_pending = True
             settled = fallback_task.result()
             if cancellation_pending:
-                raise asyncio.CancelledError
+                return False
             return settled
 
         async def _settle_once() -> bool:
@@ -357,6 +357,7 @@ class _ApiKeyUsageMixin:
             except asyncio.CancelledError:
                 if wait_for_settlement:
                     await _release_ordering_sensitive_fallback()
+                    return False
                 raise
             except Exception:
                 logger.warning(
@@ -372,8 +373,9 @@ class _ApiKeyUsageMixin:
         # Detach unconditionally instead of shield-awaiting: for ordinary
         # callers the tracking callback schedules a release when settlement
         # fails or is cancelled; an ordering-sensitive settlement task runs
-        # that fallback before the tracked task completes. The caller's
-        # finally-net skips via
+        # that fallback before the tracked task completes once started, while
+        # the tracker still owns cancellation before coroutine startup. The
+        # caller's finally-net skips via
         # usage_settlement_transferred, and reservations keep counting toward
         # limits until finalized/released, so a briefly-lagging settlement can
         # only over-restrict, never over-admit. Awaiting the ~5+2N-statement
@@ -437,12 +439,11 @@ class _ApiKeyUsageMixin:
                     api_key.id,
                     request_id,
                 )
-                if release_on_failure:
-                    self._schedule_cancel_safe_cleanup(
-                        _release_after_failed_settlement(),
-                        action="release_stream_api_key_reservation_after_cancelled_settlement",
-                        request_id=request_id,
-                    )
+                self._schedule_cancel_safe_cleanup(
+                    _release_after_failed_settlement(),
+                    action="release_stream_api_key_reservation_after_cancelled_settlement",
+                    request_id=request_id,
+                )
             except Exception as exc:
                 logger.warning(
                     "Stream API key settlement task failed key_id=%s request_id=%s",

--- a/app/modules/proxy/_service/api_key_usage.py
+++ b/app/modules/proxy/_service/api_key_usage.py
@@ -343,9 +343,10 @@ class _ApiKeyUsageMixin:
                 )
                 return False
 
-        # Detach unconditionally instead of shield-awaiting: the tracking
-        # callback already schedules a release when settlement fails or is
-        # cancelled, the caller's finally-net skips via
+        # Detach unconditionally instead of shield-awaiting: for ordinary
+        # callers the tracking callback schedules a release when settlement
+        # fails or is cancelled; ordering-sensitive waiters own that fallback
+        # inline. The caller's finally-net skips via
         # usage_settlement_transferred, and reservations keep counting toward
         # limits until finalized/released, so a briefly-lagging settlement can
         # only over-restrict, never over-admit. Awaiting the ~5+2N-statement

--- a/app/modules/proxy/_service/api_key_usage.py
+++ b/app/modules/proxy/_service/api_key_usage.py
@@ -314,6 +314,26 @@ class _ApiKeyUsageMixin:
         model_name = api_key_reservation.model or settlement.model or ""
         proxy = cast(_ApiKeyUsageServiceProtocol, self)
 
+        async def _release_ordering_sensitive_fallback() -> bool:
+            fallback_task = asyncio.create_task(
+                self._release_unsettled_stream_api_key_usage(
+                    api_key=api_key,
+                    api_key_reservation=api_key_reservation,
+                    request_id=request_id,
+                ),
+                name=f"proxy-stream-api-key-fallback-{request_id}",
+            )
+            cancellation_pending = False
+            while not fallback_task.done():
+                try:
+                    await asyncio.shield(fallback_task)
+                except asyncio.CancelledError:
+                    cancellation_pending = True
+            settled = fallback_task.result()
+            if cancellation_pending:
+                raise asyncio.CancelledError
+            return settled
+
         async def _settle_once() -> bool:
             try:
                 async with proxy._repo_factory() as repos:
@@ -334,6 +354,10 @@ class _ApiKeyUsageMixin:
                     else:
                         await api_keys_service.release_usage_reservation(reservation_id)
                 return True
+            except asyncio.CancelledError:
+                if wait_for_settlement:
+                    await _release_ordering_sensitive_fallback()
+                raise
             except Exception:
                 logger.warning(
                     "Failed to settle stream API key reservation key_id=%s request_id=%s",
@@ -341,12 +365,15 @@ class _ApiKeyUsageMixin:
                     request_id,
                     exc_info=True,
                 )
+                if wait_for_settlement:
+                    return await _release_ordering_sensitive_fallback()
                 return False
 
         # Detach unconditionally instead of shield-awaiting: for ordinary
         # callers the tracking callback schedules a release when settlement
-        # fails or is cancelled; ordering-sensitive waiters own that fallback
-        # inline. The caller's finally-net skips via
+        # fails or is cancelled; an ordering-sensitive settlement task runs
+        # that fallback before the tracked task completes. The caller's
+        # finally-net skips via
         # usage_settlement_transferred, and reservations keep counting toward
         # limits until finalized/released, so a briefly-lagging settlement can
         # only over-restrict, never over-admit. Awaiting the ~5+2N-statement
@@ -378,12 +405,7 @@ class _ApiKeyUsageMixin:
                             break
                     except Exception:
                         break
-                if not settlement_committed:
-                    return await self._release_unsettled_stream_api_key_usage(
-                        api_key=api_key,
-                        api_key_reservation=api_key_reservation,
-                        request_id=request_id,
-                    )
+            return settlement_committed
         return True
 
     def _track_stream_usage_settlement_task(

--- a/app/modules/proxy/_service/streaming/retry.py
+++ b/app/modules/proxy/_service/streaming/retry.py
@@ -405,6 +405,8 @@ class _StreamingRetryMixin:
                 )
                 pending_penalties = list(pending_post_refresh_transient_penalties)
                 pending_post_refresh_transient_penalties.clear()
+                if not settled_result:
+                    return False
                 for pending_penalty in pending_penalties:
                     (
                         failed_account,
@@ -421,7 +423,7 @@ class _StreamingRetryMixin:
                     )
                     if transient_retry_count > 1:
                         await proxy._load_balancer.record_errors(failed_account, transient_retry_count - 1)
-                return settled_result
+                return True
             return await proxy._settle_stream_api_key_usage(
                 api_key,
                 api_key_reservation,
@@ -431,7 +433,7 @@ class _StreamingRetryMixin:
 
         async def _drain_pending_post_refresh_penalty_on_terminal(
             current_settlement: _StreamSettlement,
-        ) -> None:
+        ) -> bool:
             nonlocal post_refresh_transient_replacement_selected, settled
             if pending_post_refresh_transient_penalties:
                 # A failed replacement selection still ends the request. Mark
@@ -439,6 +441,8 @@ class _StreamingRetryMixin:
                 # recorded before this path returns or re-raises.
                 post_refresh_transient_replacement_selected = True
                 settled = await _settle_stream_usage_before_pending_penalty(current_settlement)
+                return settled
+            return True
 
         async def _wait_for_process_network_recovery(
             account: Account,
@@ -1771,7 +1775,7 @@ class _StreamingRetryMixin:
                                     settlement.error = tex.error
                                 settlement.account_health_error = _facade()._should_penalize_stream_error(error_code)
                                 settled = await _settle_stream_usage_before_pending_penalty(settlement)
-                                if settlement.account_health_error:
+                                if settled and settlement.account_health_error:
                                     await proxy._handle_stream_error(
                                         account,
                                         _stream_settlement_error_payload(settlement),
@@ -1991,13 +1995,13 @@ class _StreamingRetryMixin:
                         finally:
                             pop_stream_timeout_overrides(stream_timeout_tokens)
                         settled = await _settle_stream_usage_before_pending_penalty(settlement)
-                        if settlement.account_health_error:
+                        if settled and settlement.account_health_error:
                             await proxy._handle_stream_error(
                                 account,
                                 _stream_settlement_error_payload(settlement),
                                 settlement.error_code or "upstream_error",
                             )
-                        elif settlement.record_success:
+                        elif settled and settlement.record_success:
                             await proxy._load_balancer.record_success(account)
                         network_recovery.log_recovered()
                         upstream_transport_metric_status = settlement.status
@@ -2051,8 +2055,8 @@ class _StreamingRetryMixin:
                     )
                     continue
                 except _TerminalStreamError as exc:
-                    await _drain_pending_post_refresh_penalty_on_terminal(settlement)
-                    if _facade()._should_penalize_stream_error(exc.code):
+                    health_write_allowed = await _drain_pending_post_refresh_penalty_on_terminal(settlement)
+                    if health_write_allowed and _facade()._should_penalize_stream_error(exc.code):
                         await proxy._handle_stream_error(account, exc.error, exc.code)
                     return
                 except ProxyResponseError as exc:
@@ -2349,7 +2353,7 @@ class _StreamingRetryMixin:
                                 settlement.error = _upstream_error_from_openai(error)
                                 settlement.account_health_error = _facade()._should_penalize_stream_error(error_code)
                                 settled = await _settle_stream_usage_before_pending_penalty(settlement)
-                                if settlement.account_health_error:
+                                if settled and settlement.account_health_error:
                                     await proxy._handle_stream_error(
                                         account,
                                         _stream_settlement_error_payload(settlement),
@@ -2451,13 +2455,14 @@ class _StreamingRetryMixin:
                                 )
                                 excluded_account_ids.add(account.id)
                                 continue
-                            await _drain_pending_post_refresh_penalty_on_terminal(settlement)
-                            await proxy._handle_stream_error(
-                                account,
-                                current_error_payload,
-                                current_error_code,
-                                http_status=retry_exc.status_code,
-                            )
+                            health_write_allowed = await _drain_pending_post_refresh_penalty_on_terminal(settlement)
+                            if health_write_allowed:
+                                await proxy._handle_stream_error(
+                                    account,
+                                    current_error_payload,
+                                    current_error_code,
+                                    http_status=retry_exc.status_code,
+                                )
                             if propagate_http_errors:
                                 raise
                             error_message = error.message if error else None
@@ -2475,17 +2480,20 @@ class _StreamingRetryMixin:
                             failed_account is account
                             for failed_account, *_rest in pending_post_refresh_transient_penalties
                         )
-                        if pending_post_refresh_transient_penalties:
-                            await _drain_pending_post_refresh_penalty_on_terminal(settlement)
-                        if settlement.account_health_error and not current_account_penalty_queued:
+                        health_write_allowed = await _drain_pending_post_refresh_penalty_on_terminal(settlement)
+                        if (
+                            health_write_allowed
+                            and settlement.account_health_error
+                            and not current_account_penalty_queued
+                        ):
                             await proxy._handle_stream_error(
                                 account,
                                 _stream_settlement_error_payload(settlement),
                                 settlement.error_code or "upstream_error",
                             )
-                        elif settlement.record_success:
+                        elif health_write_allowed and settlement.record_success:
                             await proxy._load_balancer.record_success(account)
-                        if not settled:
+                        if not settled and not settlement.usage_settlement_transferred:
                             settled = await _settle_stream_usage_before_pending_penalty(settlement)
                         upstream_transport_metric_status = settlement.status
                         _record_upstream_transport_metric_once(settlement.status)
@@ -2521,8 +2529,8 @@ class _StreamingRetryMixin:
                             excluded_account_ids.add(account.id)
                             require_security_work_authorized = True
                             continue
-                    await _drain_pending_post_refresh_penalty_on_terminal(settlement)
-                    if _facade()._should_penalize_stream_error(error_code):
+                    health_write_allowed = await _drain_pending_post_refresh_penalty_on_terminal(settlement)
+                    if health_write_allowed and _facade()._should_penalize_stream_error(error_code):
                         await proxy._handle_stream_error(
                             account,
                             _upstream_error_from_openai(error),

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -4432,6 +4432,11 @@ class _WebSocketMixin:
             settlement.account_health_error = False
         proxy._cancel_request_state_api_key_reservation_heartbeat(request_state)
         await _release_websocket_response_create_gate(request_state, response_create_gate)
+        if settlement.account_health_error:
+            # Connection safety must not wait on settlement or health
+            # persistence. The health write remains ordered below.
+            upstream_control.reconnect_requested = True
+            upstream_control.retire_after_drain = True
         settlement_confirmed = await proxy._settle_stream_api_key_usage(
             api_key,
             request_state.api_key_reservation,
@@ -4448,8 +4453,6 @@ class _WebSocketMixin:
                     _stream_settlement_error_payload(settlement),
                     settlement.error_code or "upstream_error",
                 )
-            upstream_control.reconnect_requested = True
-            upstream_control.retire_after_drain = True
         elif settlement.record_success:
             await proxy._load_balancer.record_success(account)
             for remembered_response_id in _websocket_continuity_response_ids(request_state, response_id):

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -4432,7 +4432,7 @@ class _WebSocketMixin:
             settlement.account_health_error = False
         proxy._cancel_request_state_api_key_reservation_heartbeat(request_state)
         await _release_websocket_response_create_gate(request_state, response_create_gate)
-        await proxy._settle_stream_api_key_usage(
+        settlement_confirmed = await proxy._settle_stream_api_key_usage(
             api_key,
             request_state.api_key_reservation,
             settlement,
@@ -4442,11 +4442,12 @@ class _WebSocketMixin:
             wait_for_settlement=settlement.account_health_error,
         )
         if settlement.account_health_error:
-            await proxy._handle_stream_error(
-                account,
-                _stream_settlement_error_payload(settlement),
-                settlement.error_code or "upstream_error",
-            )
+            if settlement_confirmed:
+                await proxy._handle_stream_error(
+                    account,
+                    _stream_settlement_error_payload(settlement),
+                    settlement.error_code or "upstream_error",
+                )
             upstream_control.reconnect_requested = True
             upstream_control.retire_after_drain = True
         elif settlement.record_success:

--- a/openspec/changes/sequence-websocket-health-after-settlement/.openspec.yaml
+++ b/openspec/changes/sequence-websocket-health-after-settlement/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/sequence-websocket-health-after-settlement/design.md
+++ b/openspec/changes/sequence-websocket-health-after-settlement/design.md
@@ -35,23 +35,28 @@ confirmed outcome.
 
 ## Decisions
 
-### Let the ordering-sensitive waiter own failed-settlement fallback
+### Let the tracked ordering-sensitive task own failed-settlement fallback
 
 The settlement task remains tracked in every mode. Detached callers keep the
-existing callback-owned fallback. An ordering-sensitive caller disables that
-callback fallback, observes the task's boolean result, and synchronously runs
-the existing fallback release helper after `False`.
+existing callback-owned fallback. For an ordering-sensitive caller, the tracked
+task runs the existing fallback release helper after primary failure and only
+then completes with the confirmed boolean outcome. Its fallback operation is
+shielded under that task, so cancellation before or during fallback propagates
+only after the release attempt completes. The caller disables callback fallback
+and awaits that same tracked task.
 
-This avoids racing two releases while reusing the established release path.
-Always leaving fallback with the callback was rejected because awaiting only
-the primary task cannot establish when the second-generation cleanup commits.
+This avoids racing two releases, keeps graceful-shutdown ownership across both
+settlement phases, and reuses the established release path. Always leaving
+fallback with the callback was rejected because awaiting only the primary task
+cannot establish when the second-generation cleanup commits.
 
 ### Return confirmed settlement state
 
 The fallback release helper reports `True` only after its repository operation
 returns successfully and `False` after its existing logged failure handling.
-The wait branch returns the primary or fallback result; the ordinary detached
-branch continues to return immediately after ownership transfer.
+The tracked ordering-sensitive task returns the primary or fallback result; the
+ordinary detached branch continues to return immediately after ownership
+transfer.
 
 ### Gate health persistence, not connection safety
 
@@ -86,8 +91,10 @@ attempt.
   Skipping the write is safer than reversing the settlement/health order;
   reconnect and retirement still protect the active connection.
 - **Cancellation can expose the primary task and fallback to concurrent
-  mutation.** The existing shielded wait and task tracker retain ownership,
-  and only one path is allowed to start fallback release.
+  mutation.** The existing shielded wait and task tracker retain ownership;
+  the ordering-sensitive task completes its shielded fallback before
+  propagating cancellation, and only one path is allowed to start fallback
+  release.
 
 ## Migration Plan
 

--- a/openspec/changes/sequence-websocket-health-after-settlement/design.md
+++ b/openspec/changes/sequence-websocket-health-after-settlement/design.md
@@ -41,14 +41,21 @@ The settlement task remains tracked in every mode. Detached callers keep the
 existing callback-owned fallback. For an ordering-sensitive caller, the tracked
 task runs the existing fallback release helper after primary failure and only
 then completes with the confirmed boolean outcome. Its fallback operation is
-shielded under that task, so cancellation before or during fallback propagates
-only after the release attempt completes. The caller disables callback fallback
-and awaits that same tracked task.
+shielded under that task, so cancellation during primary work or fallback is
+reported as unconfirmed only after the release attempt completes. If the task
+is cancelled before its coroutine starts, the tracking callback schedules the
+established tracked cleanup fallback instead. Any cancellation that still
+reaches the done callback likewise transfers release to that tracker. The caller
+disables callback fallback for ordinary failure results and awaits the
+settlement outcome.
 
-This avoids racing two releases, keeps graceful-shutdown ownership across both
-settlement phases, and reuses the established release path. Always leaving
-fallback with the callback was rejected because awaiting only the primary task
-cannot establish when the second-generation cleanup commits.
+This avoids racing two releases after coroutine startup, keeps
+graceful-shutdown ownership across both settlement phases, and reuses the
+established release path. The callback retains cancellation fallback for cases
+where no coroutine handler completes release, including pre-start cancellation.
+Always leaving ordinary failure fallback with the callback was rejected because
+awaiting only the primary task cannot establish when the second-generation
+cleanup commits.
 
 ### Return confirmed settlement state
 
@@ -92,9 +99,9 @@ attempt.
   reconnect and retirement still protect the active connection.
 - **Cancellation can expose the primary task and fallback to concurrent
   mutation.** The existing shielded wait and task tracker retain ownership;
-  the ordering-sensitive task completes its shielded fallback before
-  propagating cancellation, and only one path is allowed to start fallback
-  release.
+  a started ordering-sensitive task completes its shielded fallback before
+  reporting an unconfirmed result, while pre-start cancellation transfers
+  release to the tracker. Only one path starts fallback release.
 
 ## Migration Plan
 

--- a/openspec/changes/sequence-websocket-health-after-settlement/design.md
+++ b/openspec/changes/sequence-websocket-health-after-settlement/design.md
@@ -8,9 +8,10 @@ discards the task's `False` result, leaving the tracking callback to schedule
 fallback release later.
 
 This is a settlement-sensitive concurrency change across the shared stream
-settlement helper and the WebSocket finalizer. The design must preserve the
-ordinary detached path while giving the ordering-sensitive caller a confirmed
-outcome.
+settlement helper, the WebSocket finalizer, and the existing retry path that
+defers transient account-health penalties until settlement. The design must
+preserve the ordinary detached path while giving ordering-sensitive callers a
+confirmed outcome.
 
 ## Goals / Non-Goals
 
@@ -18,6 +19,8 @@ outcome.
 
 - Confirm primary settlement or fallback release before a WebSocket
   account-health write.
+- Apply retry-deferred account-health penalties only after the same confirmed
+  settlement outcome.
 - Prevent duplicate fallback release between the synchronous waiter and the
   detached task tracker.
 - Preserve cancellation shielding and tracked shutdown ownership.
@@ -57,6 +60,11 @@ confirmed. When neither primary settlement nor fallback release succeeds, the
 health write remains unapplied, while reconnect and retire-after-drain flags are
 still set so the failed upstream connection is not reused.
 
+The retry consumer uses the same wait mode before applying deferred transient
+penalties. A `False` result drops those pending penalties and gates any terminal
+health write that immediately follows the wait. Because the settlement helper
+has already transferred ownership, that path does not start another settlement.
+
 ### Test the real WebSocket finalizer seam
 
 The regression drives `_finalize_websocket_request_state` with a keyed,
@@ -65,11 +73,15 @@ blocks on an event, and assertions prove health remains blocked until fallback
 commit. A second outcome proves health remains unapplied when fallback also
 fails.
 
+The existing post-refresh retry regression also exercises an unconfirmed wait
+result and proves deferred penalties stay unapplied without another settlement
+attempt.
+
 ## Risks / Trade-offs
 
 - **An ordering-sensitive error path can wait on repository persistence.**
   This is the contract's deliberate exception and is limited to keyed
-  WebSocket account-health errors.
+  WebSocket account-health errors and the existing retry-deferred health path.
 - **A persistence outage can omit a legitimate account-health observation.**
   Skipping the write is safer than reversing the settlement/health order;
   reconnect and retirement still protect the active connection.

--- a/openspec/changes/sequence-websocket-health-after-settlement/design.md
+++ b/openspec/changes/sequence-websocket-health-after-settlement/design.md
@@ -1,0 +1,87 @@
+## Context
+
+Stream reservation settlement normally runs as a tracked background task so a
+response close does not wait on persistence. The existing WebSocket
+account-health path is the deliberate exception: health persistence must follow
+API-key settlement. Its wait branch currently awaits the primary task but
+discards the task's `False` result, leaving the tracking callback to schedule
+fallback release later.
+
+This is a settlement-sensitive concurrency change across the shared stream
+settlement helper and the WebSocket finalizer. The design must preserve the
+ordinary detached path while giving the ordering-sensitive caller a confirmed
+outcome.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Confirm primary settlement or fallback release before a WebSocket
+  account-health write.
+- Prevent duplicate fallback release between the synchronous waiter and the
+  detached task tracker.
+- Preserve cancellation shielding and tracked shutdown ownership.
+- Keep reconnect and connection retirement independent from database
+  persistence success.
+
+**Non-Goals:**
+
+- Changing detached settlement retry, drain, or cleanup policy.
+- Changing quota cleanup, reservation expiry, or compact settlement.
+- Changing which WebSocket errors affect account health.
+
+## Decisions
+
+### Let the ordering-sensitive waiter own failed-settlement fallback
+
+The settlement task remains tracked in every mode. Detached callers keep the
+existing callback-owned fallback. An ordering-sensitive caller disables that
+callback fallback, observes the task's boolean result, and synchronously runs
+the existing fallback release helper after `False`.
+
+This avoids racing two releases while reusing the established release path.
+Always leaving fallback with the callback was rejected because awaiting only
+the primary task cannot establish when the second-generation cleanup commits.
+
+### Return confirmed settlement state
+
+The fallback release helper reports `True` only after its repository operation
+returns successfully and `False` after its existing logged failure handling.
+The wait branch returns the primary or fallback result; the ordinary detached
+branch continues to return immediately after ownership transfer.
+
+### Gate health persistence, not connection safety
+
+The WebSocket finalizer records account health only when settlement is
+confirmed. When neither primary settlement nor fallback release succeeds, the
+health write remains unapplied, while reconnect and retire-after-drain flags are
+still set so the failed upstream connection is not reused.
+
+### Test the real WebSocket finalizer seam
+
+The regression drives `_finalize_websocket_request_state` with a keyed,
+health-penalizing terminal event. The primary release fails, the fallback
+blocks on an event, and assertions prove health remains blocked until fallback
+commit. A second outcome proves health remains unapplied when fallback also
+fails.
+
+## Risks / Trade-offs
+
+- **An ordering-sensitive error path can wait on repository persistence.**
+  This is the contract's deliberate exception and is limited to keyed
+  WebSocket account-health errors.
+- **A persistence outage can omit a legitimate account-health observation.**
+  Skipping the write is safer than reversing the settlement/health order;
+  reconnect and retirement still protect the active connection.
+- **Cancellation can expose the primary task and fallback to concurrent
+  mutation.** The existing shielded wait and task tracker retain ownership,
+  and only one path is allowed to start fallback release.
+
+## Migration Plan
+
+No data or configuration migration is required. Rollback restores the prior
+ordering behavior without changing stored schema.
+
+## Open Questions
+
+None.

--- a/openspec/changes/sequence-websocket-health-after-settlement/proposal.md
+++ b/openspec/changes/sequence-websocket-health-after-settlement/proposal.md
@@ -10,6 +10,8 @@ account health first, violating the existing settlement-ordering invariant.
 - Make ordering-sensitive stream settlement wait for a failed primary
   settlement's fallback release and report whether the reservation is actually
   settled.
+- Keep the tracked settlement task registered through ordering-sensitive
+  fallback release so graceful shutdown drains both phases.
 - Record WebSocket account health and existing retry-deferred health penalties
   only after settlement or fallback release is confirmed; keep reconnect and
   retirement safety independent of persistence.

--- a/openspec/changes/sequence-websocket-health-after-settlement/proposal.md
+++ b/openspec/changes/sequence-websocket-health-after-settlement/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The ordering-sensitive WebSocket finalizer waits for its API-key settlement
+task but ignores a `False` result. A failed primary settlement can therefore
+schedule fallback release in the background while the finalizer records
+account health first, violating the existing settlement-ordering invariant.
+
+## What Changes
+
+- Make ordering-sensitive stream settlement wait for a failed primary
+  settlement's fallback release and report whether the reservation is actually
+  settled.
+- Record WebSocket account health only after settlement or fallback release is
+  confirmed; keep reconnect and retirement safety independent of persistence.
+- Preserve the ordinary detached settlement path and its tracked fallback
+  behavior unchanged.
+- Add deterministic regression coverage for a failed primary settlement with a
+  blocked fallback and for an unconfirmed fallback.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `api-keys`: Clarify that an ordering-sensitive WebSocket health write waits
+  for fallback release after primary settlement failure and remains unapplied
+  when neither operation confirms settlement.
+
+## Impact
+
+The change is limited to stream API-key settlement coordination, WebSocket
+finalization, focused proxy tests, and the API-key settlement contract. It adds
+no setting, dependency, schema, migration, quota-cleanup behavior, or compact
+settlement behavior.

--- a/openspec/changes/sequence-websocket-health-after-settlement/proposal.md
+++ b/openspec/changes/sequence-websocket-health-after-settlement/proposal.md
@@ -10,8 +10,9 @@ account health first, violating the existing settlement-ordering invariant.
 - Make ordering-sensitive stream settlement wait for a failed primary
   settlement's fallback release and report whether the reservation is actually
   settled.
-- Keep the tracked settlement task registered through ordering-sensitive
-  fallback release so graceful shutdown drains both phases.
+- Keep tracked persistence ownership through ordering-sensitive fallback
+  release so graceful shutdown drains both phases, including pre-start task
+  cancellation.
 - Record WebSocket account health and existing retry-deferred health penalties
   only after settlement or fallback release is confirmed; keep reconnect and
   retirement safety independent of persistence.

--- a/openspec/changes/sequence-websocket-health-after-settlement/proposal.md
+++ b/openspec/changes/sequence-websocket-health-after-settlement/proposal.md
@@ -10,8 +10,9 @@ account health first, violating the existing settlement-ordering invariant.
 - Make ordering-sensitive stream settlement wait for a failed primary
   settlement's fallback release and report whether the reservation is actually
   settled.
-- Record WebSocket account health only after settlement or fallback release is
-  confirmed; keep reconnect and retirement safety independent of persistence.
+- Record WebSocket account health and existing retry-deferred health penalties
+  only after settlement or fallback release is confirmed; keep reconnect and
+  retirement safety independent of persistence.
 - Preserve the ordinary detached settlement path and its tracked fallback
   behavior unchanged.
 - Add deterministic regression coverage for a failed primary settlement with a
@@ -25,13 +26,13 @@ None.
 
 ### Modified Capabilities
 
-- `api-keys`: Clarify that an ordering-sensitive WebSocket health write waits
-  for fallback release after primary settlement failure and remains unapplied
-  when neither operation confirms settlement.
+- `api-keys`: Clarify that ordering-sensitive WebSocket and retry health writes
+  wait for fallback release after primary settlement failure and remain
+  unapplied when neither operation confirms settlement.
 
 ## Impact
 
 The change is limited to stream API-key settlement coordination, WebSocket
-finalization, focused proxy tests, and the API-key settlement contract. It adds
-no setting, dependency, schema, migration, quota-cleanup behavior, or compact
-settlement behavior.
+finalization, the existing retry-deferred health path, focused proxy tests, and
+the API-key settlement contract. It adds no setting, dependency, schema,
+migration, quota-cleanup behavior, or compact settlement behavior.

--- a/openspec/changes/sequence-websocket-health-after-settlement/specs/api-keys/spec.md
+++ b/openspec/changes/sequence-websocket-health-after-settlement/specs/api-keys/spec.md
@@ -9,12 +9,17 @@ before the load-balancer health write (the settlement-ordering invariant), so
 that error path intentionally blocks on settlement. If the primary settlement
 fails, the finalizer MUST wait for fallback release to commit before recording
 account health. If neither operation confirms settlement, the account-health
-write MUST remain unapplied. In all other cases the settlement MUST run as a
-tracked background task; when it fails or is cancelled, the reservation MUST
-still be released by the tracking fallback, and the request's finalization path
-MUST NOT double-release a transferred settlement. Reservations MUST continue to
-count toward key limits until finalized or released, so deferred settlement can
-never admit usage a synchronous settlement would have rejected.
+write MUST remain unapplied. When the existing stream-retry path deliberately
+defers an account-health penalty until the same ordering-sensitive settlement,
+it MUST likewise apply neither that penalty nor an immediately following
+terminal health write unless settlement is confirmed, and it MUST NOT start a
+second settlement for the transferred reservation. In all other cases the
+settlement MUST run as a tracked background task; when it fails or is cancelled,
+the reservation MUST still be released by the tracking fallback, and the
+request's finalization path MUST NOT double-release a transferred settlement.
+Reservations MUST continue to count toward key limits until finalized or
+released, so deferred settlement can never admit usage a synchronous settlement
+would have rejected.
 
 #### Scenario: Response close precedes settlement completion
 
@@ -49,6 +54,13 @@ never admit usage a synchronous settlement would have rejected.
 - **WHEN** both primary settlement and fallback release fail
 - **THEN** the finalizer does not record the account-health error
 - **AND** the upstream connection is still scheduled for reconnect and retirement
+
+#### Scenario: Unconfirmed retry settlement drops deferred health
+
+- **GIVEN** a keyed stream retry has deferred an account-health penalty until replacement selection
+- **WHEN** neither primary settlement nor fallback release confirms settlement
+- **THEN** the deferred penalty and any immediately following terminal health write remain unapplied
+- **AND** the retry path does not start a second settlement for the transferred reservation
 
 #### Scenario: Shutdown drains pending settlements
 

--- a/openspec/changes/sequence-websocket-health-after-settlement/specs/api-keys/spec.md
+++ b/openspec/changes/sequence-websocket-health-after-settlement/specs/api-keys/spec.md
@@ -9,17 +9,19 @@ before the load-balancer health write (the settlement-ordering invariant), so
 that error path intentionally blocks on settlement. If the primary settlement
 fails, the finalizer MUST wait for fallback release to commit before recording
 account health. If neither operation confirms settlement, the account-health
-write MUST remain unapplied. When the existing stream-retry path deliberately
-defers an account-health penalty until the same ordering-sensitive settlement,
-it MUST likewise apply neither that penalty nor an immediately following
-terminal health write unless settlement is confirmed, and it MUST NOT start a
-second settlement for the transferred reservation. In all other cases the
-settlement MUST run as a tracked background task; when it fails or is cancelled,
-the reservation MUST still be released by the tracking fallback, and the
-request's finalization path MUST NOT double-release a transferred settlement.
-Reservations MUST continue to count toward key limits until finalized or
-released, so deferred settlement can never admit usage a synchronous settlement
-would have rejected.
+write MUST remain unapplied. The tracked settlement task MUST remain registered
+through an ordering-sensitive fallback release, including cancellation before
+or during that release, so graceful shutdown drains both phases. When the
+existing stream-retry path deliberately defers an
+account-health penalty until the same ordering-sensitive settlement, it MUST
+likewise apply neither that penalty nor an immediately following terminal health
+write unless settlement is confirmed, and it MUST NOT start a second settlement
+for the transferred reservation. In all other cases the settlement MUST run as
+a tracked background task; when it fails or is cancelled, the reservation MUST
+still be released by the tracking fallback, and the request's finalization path
+MUST NOT double-release a transferred settlement. Reservations MUST continue to
+count toward key limits until finalized or released, so deferred settlement can
+never admit usage a synchronous settlement would have rejected.
 
 #### Scenario: Response close precedes settlement completion
 
@@ -66,3 +68,4 @@ would have rejected.
 
 - **WHEN** the service shuts down gracefully with settlements in flight
 - **THEN** shutdown waits for them up to the configured drain timeout
+- **AND** a pending ordering-sensitive fallback release remains part of that drain despite cancellation before or during fallback

--- a/openspec/changes/sequence-websocket-health-after-settlement/specs/api-keys/spec.md
+++ b/openspec/changes/sequence-websocket-health-after-settlement/specs/api-keys/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: Stream reservation settlement is detached from the response path
+
+Settling a stream API-key reservation MUST NOT block the response/stream close,
+with one deliberate exception: when a keyed websocket stream terminates with an
+account-health error, the finalizer MUST wait for the settlement to commit
+before the load-balancer health write (the settlement-ordering invariant), so
+that error path intentionally blocks on settlement. If the primary settlement
+fails, the finalizer MUST wait for fallback release to commit before recording
+account health. If neither operation confirms settlement, the account-health
+write MUST remain unapplied. In all other cases the settlement MUST run as a
+tracked background task; when it fails or is cancelled, the reservation MUST
+still be released by the tracking fallback, and the request's finalization path
+MUST NOT double-release a transferred settlement. Reservations MUST continue to
+count toward key limits until finalized or released, so deferred settlement can
+never admit usage a synchronous settlement would have rejected.
+
+#### Scenario: Response close precedes settlement completion
+
+- **GIVEN** a keyed stream whose settlement transaction is still running
+- **WHEN** the stream closes
+- **THEN** the close does not wait for the settlement
+- **AND** the settlement finalizes the reservation exactly once in the background
+
+#### Scenario: Failed detached settlement still releases the reservation
+
+- **GIVEN** a detached settlement whose finalize raises
+- **WHEN** the settlement task completes
+- **THEN** the tracking fallback releases the reservation
+
+#### Scenario: Websocket health-error settlement precedes the health write
+
+- **GIVEN** a keyed websocket stream that terminates with an account-health error
+- **WHEN** the finalizer settles the reservation
+- **THEN** it waits for the settlement to commit before recording the account-health error
+
+#### Scenario: Websocket health waits for fallback settlement
+
+- **GIVEN** a keyed websocket stream that terminates with an account-health error
+- **AND** its primary settlement fails
+- **WHEN** fallback release remains in progress
+- **THEN** the finalizer does not record the account-health error
+- **AND** it records the error only after fallback release commits
+
+#### Scenario: Unconfirmed websocket settlement leaves health unapplied
+
+- **GIVEN** a keyed websocket stream that terminates with an account-health error
+- **WHEN** both primary settlement and fallback release fail
+- **THEN** the finalizer does not record the account-health error
+- **AND** the upstream connection is still scheduled for reconnect and retirement
+
+#### Scenario: Shutdown drains pending settlements
+
+- **WHEN** the service shuts down gracefully with settlements in flight
+- **THEN** shutdown waits for them up to the configured drain timeout

--- a/openspec/changes/sequence-websocket-health-after-settlement/specs/api-keys/spec.md
+++ b/openspec/changes/sequence-websocket-health-after-settlement/specs/api-keys/spec.md
@@ -9,10 +9,11 @@ before the load-balancer health write (the settlement-ordering invariant), so
 that error path intentionally blocks on settlement. If the primary settlement
 fails, the finalizer MUST wait for fallback release to commit before recording
 account health. If neither operation confirms settlement, the account-health
-write MUST remain unapplied. The tracked settlement task MUST remain registered
-through an ordering-sensitive fallback release, including cancellation before
-or during that release, so graceful shutdown drains both phases. When the
-existing stream-retry path deliberately defers an
+write MUST remain unapplied. Tracked persistence ownership MUST remain
+registered through an ordering-sensitive fallback release, including
+cancellation before the primary coroutine starts or during that release, so
+graceful shutdown drains both phases. When the existing stream-retry path
+deliberately defers an
 account-health penalty until the same ordering-sensitive settlement, it MUST
 likewise apply neither that penalty nor an immediately following terminal health
 write unless settlement is confirmed, and it MUST NOT start a second settlement
@@ -68,4 +69,4 @@ never admit usage a synchronous settlement would have rejected.
 
 - **WHEN** the service shuts down gracefully with settlements in flight
 - **THEN** shutdown waits for them up to the configured drain timeout
-- **AND** a pending ordering-sensitive fallback release remains part of that drain despite cancellation before or during fallback
+- **AND** a pending ordering-sensitive fallback release remains part of that drain despite cancellation before primary startup or during fallback

--- a/openspec/changes/sequence-websocket-health-after-settlement/tasks.md
+++ b/openspec/changes/sequence-websocket-health-after-settlement/tasks.md
@@ -2,13 +2,16 @@
 
 - [x] 1.1 Add a deterministic real-WebSocket-finalizer regression proving a failed primary settlement blocks health until fallback release commits.
 - [x] 1.2 Prove an unconfirmed fallback leaves health unapplied while reconnect and retirement remain enabled.
+- [x] 1.3 Cover the existing retry consumer so an unconfirmed ordering-sensitive settlement drops deferred health penalties.
 
 ## 2. Settlement Ordering
 
 - [x] 2.1 Make ordering-sensitive stream settlement observe the primary task result and synchronously own fallback release without double release.
 - [x] 2.2 Return confirmed settlement state and gate WebSocket health persistence on that state without changing ordinary detached settlement.
+- [x] 2.3 Gate retry health persistence on confirmed settlement and avoid re-settling an already transferred reservation.
 
 ## 3. Verification
 
 - [x] 3.1 Run focused settlement and WebSocket-finalizer regression tests.
 - [x] 3.2 Run Sensitive persistence integration, affected lint/type checks, and strict scoped plus repository OpenSpec validation.
+- [x] 3.3 Re-run focused retry coverage, Sensitive verification, and independent review after the retry-consumer repair.

--- a/openspec/changes/sequence-websocket-health-after-settlement/tasks.md
+++ b/openspec/changes/sequence-websocket-health-after-settlement/tasks.md
@@ -3,7 +3,7 @@
 - [x] 1.1 Add a deterministic real-WebSocket-finalizer regression proving a failed primary settlement blocks health until fallback release commits.
 - [x] 1.2 Prove an unconfirmed fallback leaves health unapplied while reconnect and retirement remain enabled.
 - [x] 1.3 Cover the existing retry consumer so an unconfirmed ordering-sensitive settlement drops deferred health penalties.
-- [x] 1.4 Prove shutdown drain remains blocked while an ordering-sensitive fallback release is pending, including cancellation before or during fallback.
+- [x] 1.4 Prove shutdown drain remains blocked while an ordering-sensitive fallback release is pending, including cancellation before primary startup or during fallback.
 
 ## 2. Settlement Ordering
 

--- a/openspec/changes/sequence-websocket-health-after-settlement/tasks.md
+++ b/openspec/changes/sequence-websocket-health-after-settlement/tasks.md
@@ -1,0 +1,14 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add a deterministic real-WebSocket-finalizer regression proving a failed primary settlement blocks health until fallback release commits.
+- [x] 1.2 Prove an unconfirmed fallback leaves health unapplied while reconnect and retirement remain enabled.
+
+## 2. Settlement Ordering
+
+- [x] 2.1 Make ordering-sensitive stream settlement observe the primary task result and synchronously own fallback release without double release.
+- [x] 2.2 Return confirmed settlement state and gate WebSocket health persistence on that state without changing ordinary detached settlement.
+
+## 3. Verification
+
+- [x] 3.1 Run focused settlement and WebSocket-finalizer regression tests.
+- [x] 3.2 Run Sensitive persistence integration, affected lint/type checks, and strict scoped plus repository OpenSpec validation.

--- a/openspec/changes/sequence-websocket-health-after-settlement/tasks.md
+++ b/openspec/changes/sequence-websocket-health-after-settlement/tasks.md
@@ -3,15 +3,18 @@
 - [x] 1.1 Add a deterministic real-WebSocket-finalizer regression proving a failed primary settlement blocks health until fallback release commits.
 - [x] 1.2 Prove an unconfirmed fallback leaves health unapplied while reconnect and retirement remain enabled.
 - [x] 1.3 Cover the existing retry consumer so an unconfirmed ordering-sensitive settlement drops deferred health penalties.
+- [x] 1.4 Prove shutdown drain remains blocked while an ordering-sensitive fallback release is pending, including cancellation before or during fallback.
 
 ## 2. Settlement Ordering
 
 - [x] 2.1 Make ordering-sensitive stream settlement observe the primary task result and synchronously own fallback release without double release.
 - [x] 2.2 Return confirmed settlement state and gate WebSocket health persistence on that state without changing ordinary detached settlement.
 - [x] 2.3 Gate retry health persistence on confirmed settlement and avoid re-settling an already transferred reservation.
+- [x] 2.4 Keep primary settlement and ordering-sensitive fallback under one tracked persistence task.
 
 ## 3. Verification
 
 - [x] 3.1 Run focused settlement and WebSocket-finalizer regression tests.
 - [x] 3.2 Run Sensitive persistence integration, affected lint/type checks, and strict scoped plus repository OpenSpec validation.
 - [x] 3.3 Re-run focused retry coverage, Sensitive verification, and independent review after the retry-consumer repair.
+- [x] 3.4 Re-run focused shutdown ownership coverage and Sensitive verification after the current-head review repair.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -21352,13 +21352,20 @@ async def test_finalize_websocket_request_state_updates_balancer_state(monkeypat
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("fallback_fails", "health_fails"),
-    [(False, False), (True, False), (False, True)],
+    ("fallback_fails", "health_fails", "cancel_during"),
+    [
+        (False, False, None),
+        (True, False, None),
+        (False, True, None),
+        (False, False, "primary"),
+        (False, False, "fallback"),
+    ],
 )
 async def test_finalize_websocket_health_waits_for_confirmed_settlement_fallback(
     monkeypatch,
     fallback_fails: bool,
     health_fails: bool,
+    cancel_during: str | None,
 ):
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_ws_settlement_fallback")
@@ -21369,6 +21376,8 @@ async def test_finalize_websocket_health_waits_for_confirmed_settlement_fallback
         model="gpt-5.1",
     )
     fallback_started = asyncio.Event()
+    primary_started = asyncio.Event()
+    hold_primary = asyncio.Event()
     release_fallback = asyncio.Event()
     release_calls = 0
     order: list[str] = []
@@ -21382,6 +21391,10 @@ async def test_finalize_websocket_health_waits_for_confirmed_settlement_fallback
             assert reservation_id == reservation.reservation_id
             release_calls += 1
             if release_calls == 1:
+                if cancel_during == "primary":
+                    order.append("primary_started")
+                    primary_started.set()
+                    await hold_primary.wait()
                 order.append("primary_failed")
                 raise RuntimeError("primary settlement unavailable")
             order.append("fallback_started")
@@ -21434,9 +21447,28 @@ async def test_finalize_websocket_health_waits_for_confirmed_settlement_fallback
             response_create_gate=asyncio.Semaphore(1),
         )
     )
+    if cancel_during == "primary":
+        await asyncio.wait_for(primary_started.wait(), timeout=1)
+        settlement_task = next(
+            task
+            for task in service._background_cleanup_tasks
+            if task.get_name() == "proxy-stream-api-key-settle-resp_ws_settlement_fallback"
+        )
+        settlement_task.cancel()
     await asyncio.wait_for(fallback_started.wait(), timeout=1)
+    if cancel_during == "fallback":
+        settlement_task = next(
+            task
+            for task in service._background_cleanup_tasks
+            if task.get_name() == "proxy-stream-api-key-settle-resp_ws_settlement_fallback"
+        )
+        settlement_task.cancel()
     await asyncio.sleep(0)
+    drain = asyncio.create_task(service.drain_persistence_tasks(timeout_seconds=1))
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(asyncio.shield(drain), timeout=0.05)
     blocked_while_fallback_pending = not finalizer.done()
+    drain_blocked_while_fallback_pending = not drain.done()
     health_writes_while_fallback_pending = handle_stream_error.await_count
     reconnect_while_fallback_pending = upstream_control.reconnect_requested
     retire_while_fallback_pending = upstream_control.retire_after_drain
@@ -21446,16 +21478,23 @@ async def test_finalize_websocket_health_waits_for_confirmed_settlement_fallback
             await asyncio.wait_for(finalizer, timeout=1)
     else:
         await asyncio.wait_for(finalizer, timeout=1)
-    assert await service.drain_persistence_tasks(timeout_seconds=1)
+    assert await asyncio.wait_for(drain, timeout=1) is True
 
     assert blocked_while_fallback_pending is True
+    assert drain_blocked_while_fallback_pending is True
     assert health_writes_while_fallback_pending == 0
     assert reconnect_while_fallback_pending is True
     assert retire_while_fallback_pending is True
     assert release_calls == 2
     assert upstream_control.reconnect_requested is True
     assert upstream_control.retire_after_drain is True
-    if fallback_fails:
+    if cancel_during == "primary":
+        assert order == ["primary_started", "fallback_started", "fallback_committed"]
+        handle_stream_error.assert_not_awaited()
+    elif cancel_during == "fallback":
+        assert order == ["primary_failed", "fallback_started", "fallback_committed"]
+        handle_stream_error.assert_not_awaited()
+    elif fallback_fails:
         assert order == ["primary_failed", "fallback_started", "fallback_failed"]
         handle_stream_error.assert_not_awaited()
     else:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -21357,6 +21357,7 @@ async def test_finalize_websocket_request_state_updates_balancer_state(monkeypat
         (False, False, None),
         (True, False, None),
         (False, True, None),
+        (False, False, "pre_start"),
         (False, False, "primary"),
         (False, False, "fallback"),
     ],
@@ -21390,6 +21391,12 @@ async def test_finalize_websocket_health_waits_for_confirmed_settlement_fallback
             nonlocal release_calls
             assert reservation_id == reservation.reservation_id
             release_calls += 1
+            if cancel_during == "pre_start":
+                order.append("fallback_started")
+                fallback_started.set()
+                await release_fallback.wait()
+                order.append("fallback_committed")
+                return
             if release_calls == 1:
                 if cancel_during == "primary":
                     order.append("primary_started")
@@ -21413,6 +21420,27 @@ async def test_finalize_websocket_health_waits_for_confirmed_settlement_fallback
     handle_stream_error = AsyncMock(side_effect=record_health)
     monkeypatch.setattr(proxy_service, "ApiKeysService", FakeApiKeysService)
     monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+    if cancel_during == "pre_start":
+        original_track = service._track_stream_usage_settlement_task
+
+        def cancel_settlement_before_start(
+            task: asyncio.Task[bool],
+            *,
+            api_key: ApiKeyData,
+            api_key_reservation: proxy_service.ApiKeyUsageReservationData,
+            request_id: str,
+            release_on_failure: bool = True,
+        ) -> None:
+            original_track(
+                task,
+                api_key=api_key,
+                api_key_reservation=api_key_reservation,
+                request_id=request_id,
+                release_on_failure=release_on_failure,
+            )
+            task.cancel()
+
+        monkeypatch.setattr(service, "_track_stream_usage_settlement_task", cancel_settlement_before_start)
 
     failed_payload: dict[str, JsonValue] = {
         "type": "response.failed",
@@ -21480,15 +21508,18 @@ async def test_finalize_websocket_health_waits_for_confirmed_settlement_fallback
         await asyncio.wait_for(finalizer, timeout=1)
     assert await asyncio.wait_for(drain, timeout=1) is True
 
-    assert blocked_while_fallback_pending is True
+    assert blocked_while_fallback_pending is (cancel_during != "pre_start")
     assert drain_blocked_while_fallback_pending is True
     assert health_writes_while_fallback_pending == 0
     assert reconnect_while_fallback_pending is True
     assert retire_while_fallback_pending is True
-    assert release_calls == 2
+    assert release_calls == (1 if cancel_during == "pre_start" else 2)
     assert upstream_control.reconnect_requested is True
     assert upstream_control.retire_after_drain is True
-    if cancel_during == "primary":
+    if cancel_during == "pre_start":
+        assert order == ["fallback_started", "fallback_committed"]
+        handle_stream_error.assert_not_awaited()
+    elif cancel_during == "primary":
         assert order == ["primary_started", "fallback_started", "fallback_committed"]
         handle_stream_error.assert_not_awaited()
     elif cancel_during == "fallback":

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -12499,12 +12499,20 @@ async def test_stream_with_retry_post_refresh_transport_failure_retries_same_acc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "replacement_outcome",
-    ["success", "model_rejection", "surface", "visible_surface", "second_transient_exhaustion"],
+    ("replacement_outcome", "settlement_confirmed"),
+    [
+        ("success", True),
+        ("model_rejection", True),
+        ("surface", True),
+        ("visible_surface", True),
+        ("second_transient_exhaustion", True),
+        ("success", False),
+    ],
 )
 async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
     monkeypatch,
     replacement_outcome: str,
+    settlement_confirmed: bool,
 ):
     settings = _make_proxy_settings()
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
@@ -12526,10 +12534,12 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
         model="gpt-5.1",
     )
     release_unsettled = AsyncMock()
+    record_success = AsyncMock()
 
     async def settle_usage(
         settled_api_key: ApiKeyData | None,
         settled_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        stream_settlement: proxy_service._StreamSettlement,
         *_args: object,
         **_kwargs: object,
     ) -> bool:
@@ -12537,9 +12547,10 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
         assert settled_reservation is reservation
         expected_settlement_account = account_c if replacement_outcome == "second_transient_exhaustion" else account_b
         assert stream_account_ids[-1] == expected_settlement_account.id
+        stream_settlement.usage_settlement_transferred = True
         settlement_wait_flags.append(bool(_kwargs.get("wait_for_settlement")))
         settlement_order.append("settle")
-        return True
+        return settlement_confirmed
 
     async def record_health(
         account: Account,
@@ -12566,6 +12577,7 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
     monkeypatch.setattr(service, "_release_unsettled_stream_api_key_usage", release_unsettled)
     monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=lambda account, **_k: account))
     monkeypatch.setattr(service._load_balancer, "record_errors", record_errors)
+    monkeypatch.setattr(service._load_balancer, "record_success", record_success)
 
     async def select_account(_deadline: float, **kwargs: object) -> AccountSelection:
         excluded = set(cast(set[str], kwargs["exclude_account_ids"]))
@@ -12694,20 +12706,22 @@ async def test_stream_with_retry_post_refresh_transient_exhaustion_fails_over(
     transient_penalties = [
         call for call in handle_stream_error.await_args_list if call.args[2] == "invalid_request_error"
     ]
-    expected_penalty_accounts = [account_a]
-    if replacement_outcome == "second_transient_exhaustion":
+    expected_penalty_accounts = [account_a] if settlement_confirmed else []
+    if settlement_confirmed and replacement_outcome == "second_transient_exhaustion":
         expected_penalty_accounts.append(account_b)
     assert [call.args[0] for call in transient_penalties] == expected_penalty_accounts
     expected_health_codes = ["invalid_request_error"] * len(expected_penalty_accounts)
-    if replacement_outcome in ("surface", "visible_surface"):
+    if settlement_confirmed and replacement_outcome in ("surface", "visible_surface"):
         expected_health_codes.append("replacement_failed")
     ordered_terminal_effects = [entry for entry in settlement_order if entry != "health:invalid_api_key"]
     assert ordered_terminal_effects == ["settle"] + [f"health:{code}" for code in expected_health_codes]
     assert settlement_wait_flags == [True]
     assert stream_reservations == [reservation] * len(expected_account_ids)
     release_unsettled.assert_not_awaited()
-    expected_record_error_calls = [mock_call(account_a, 2)]
-    if replacement_outcome == "second_transient_exhaustion":
+    if not settlement_confirmed:
+        record_success.assert_not_awaited()
+    expected_record_error_calls = [mock_call(account_a, 2)] if settlement_confirmed else []
+    if settlement_confirmed and replacement_outcome == "second_transient_exhaustion":
         expected_record_error_calls.append(mock_call(account_b, 2))
     extra_retry_calls = [call for call in record_errors.await_args_list if call.args[1] == 2]
     assert extra_retry_calls == expected_record_error_calls

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -21337,10 +21337,14 @@ async def test_finalize_websocket_request_state_updates_balancer_state(monkeypat
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("fallback_fails", [False, True])
+@pytest.mark.parametrize(
+    ("fallback_fails", "health_fails"),
+    [(False, False), (True, False), (False, True)],
+)
 async def test_finalize_websocket_health_waits_for_confirmed_settlement_fallback(
     monkeypatch,
     fallback_fails: bool,
+    health_fails: bool,
 ):
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_ws_settlement_fallback")
@@ -21376,6 +21380,8 @@ async def test_finalize_websocket_health_waits_for_confirmed_settlement_fallback
 
     async def record_health(*_args: object, **_kwargs: object) -> None:
         order.append("health")
+        if health_fails:
+            raise RuntimeError("health persistence unavailable")
 
     handle_stream_error = AsyncMock(side_effect=record_health)
     monkeypatch.setattr(proxy_service, "ApiKeysService", FakeApiKeysService)
@@ -21418,12 +21424,20 @@ async def test_finalize_websocket_health_waits_for_confirmed_settlement_fallback
     await asyncio.sleep(0)
     blocked_while_fallback_pending = not finalizer.done()
     health_writes_while_fallback_pending = handle_stream_error.await_count
+    reconnect_while_fallback_pending = upstream_control.reconnect_requested
+    retire_while_fallback_pending = upstream_control.retire_after_drain
     release_fallback.set()
-    await asyncio.wait_for(finalizer, timeout=1)
+    if health_fails:
+        with pytest.raises(RuntimeError, match="health persistence unavailable"):
+            await asyncio.wait_for(finalizer, timeout=1)
+    else:
+        await asyncio.wait_for(finalizer, timeout=1)
     assert await service.drain_persistence_tasks(timeout_seconds=1)
 
     assert blocked_while_fallback_pending is True
     assert health_writes_while_fallback_pending == 0
+    assert reconnect_while_fallback_pending is True
+    assert retire_while_fallback_pending is True
     assert release_calls == 2
     assert upstream_control.reconnect_requested is True
     assert upstream_control.retire_after_drain is True

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -21337,6 +21337,105 @@ async def test_finalize_websocket_request_state_updates_balancer_state(monkeypat
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("fallback_fails", [False, True])
+async def test_finalize_websocket_health_waits_for_confirmed_settlement_fallback(
+    monkeypatch,
+    fallback_fails: bool,
+):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_ws_settlement_fallback")
+    api_key = _make_api_key_data("key_ws_settlement_fallback")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_ws_settlement_fallback",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+    fallback_started = asyncio.Event()
+    release_fallback = asyncio.Event()
+    release_calls = 0
+    order: list[str] = []
+
+    class FakeApiKeysService:
+        def __init__(self, api_keys_repository: object) -> None:
+            del api_keys_repository
+
+        async def release_usage_reservation(self, reservation_id: str) -> None:
+            nonlocal release_calls
+            assert reservation_id == reservation.reservation_id
+            release_calls += 1
+            if release_calls == 1:
+                order.append("primary_failed")
+                raise RuntimeError("primary settlement unavailable")
+            order.append("fallback_started")
+            fallback_started.set()
+            await release_fallback.wait()
+            if fallback_fails:
+                order.append("fallback_failed")
+                raise RuntimeError("fallback settlement unavailable")
+            order.append("fallback_committed")
+
+    async def record_health(*_args: object, **_kwargs: object) -> None:
+        order.append("health")
+
+    handle_stream_error = AsyncMock(side_effect=record_health)
+    monkeypatch.setattr(proxy_service, "ApiKeysService", FakeApiKeysService)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
+
+    failed_payload: dict[str, JsonValue] = {
+        "type": "response.failed",
+        "response": {
+            "id": "resp_ws_settlement_fallback",
+            "error": {"code": "rate_limit_exceeded", "message": "slow down"},
+        },
+    }
+    failed_event = parse_sse_event(f"data: {json.dumps(failed_payload)}\n\n")
+    assert failed_event is not None
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_settlement_fallback",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=reservation,
+        started_at=time.monotonic(),
+        skip_request_log=True,
+    )
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+
+    finalizer = asyncio.create_task(
+        service._finalize_websocket_request_state(
+            request_state,
+            account=account,
+            account_id_value=account.id,
+            event=failed_event,
+            event_type="response.failed",
+            payload=failed_payload,
+            api_key=api_key,
+            upstream_control=upstream_control,
+            response_create_gate=asyncio.Semaphore(1),
+        )
+    )
+    await asyncio.wait_for(fallback_started.wait(), timeout=1)
+    await asyncio.sleep(0)
+    blocked_while_fallback_pending = not finalizer.done()
+    health_writes_while_fallback_pending = handle_stream_error.await_count
+    release_fallback.set()
+    await asyncio.wait_for(finalizer, timeout=1)
+    assert await service.drain_persistence_tasks(timeout_seconds=1)
+
+    assert blocked_while_fallback_pending is True
+    assert health_writes_while_fallback_pending == 0
+    assert release_calls == 2
+    assert upstream_control.reconnect_requested is True
+    assert upstream_control.retire_after_drain is True
+    if fallback_fails:
+        assert order == ["primary_failed", "fallback_started", "fallback_failed"]
+        handle_stream_error.assert_not_awaited()
+    else:
+        assert order == ["primary_failed", "fallback_started", "fallback_committed", "health"]
+        handle_stream_error.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_finalize_websocket_empty_prewarm_does_not_store_continuity_anchor(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -24790,7 +24889,8 @@ async def test_stream_api_key_settlement_detaches_and_closes_repo(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_stream_api_key_settlement_wait_option_blocks_until_finalized(monkeypatch):
+@pytest.mark.parametrize("cancel_caller", [False, True])
+async def test_stream_api_key_settlement_wait_option_blocks_until_finalized(monkeypatch, cancel_caller: bool):
     """Ordering-sensitive callers (websocket error path) opt into waiting so
     the settlement commits before load-balancer health writes."""
     started = asyncio.Event()
@@ -24854,6 +24954,9 @@ async def test_stream_api_key_settlement_wait_option_blocks_until_finalized(monk
     )
     await asyncio.wait_for(started.wait(), timeout=1)
     await asyncio.sleep(0)
+    if cancel_caller:
+        caller.cancel()
+        await asyncio.sleep(0)
     # Still blocked on the in-flight settlement.
     assert not caller.done()
     release.set()


### PR DESCRIPTION
## Summary

Ensure ordering-sensitive stream callers observe whether API-key usage settlement actually committed before writing account health. A failed primary settlement now completes fallback release under the same tracked task once started; pre-start cancellation transfers release to the tracked callback instead. Cancellation during started work reports an unconfirmed outcome only after the release attempt completes. If neither operation confirms settlement, the related WebSocket or deferred retry health write remains unapplied.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Related to #1314

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent request/response behavior

Change directory: `openspec/changes/sequence-websocket-health-after-settlement/`

## Changes

- Propagate the real settlement/fallback result to ordering-sensitive callers while preserving the ordinary detached settlement path.
- Keep tracked persistence ownership through failed or cancelled ordering-sensitive settlement and fallback release so graceful shutdown drains every phase, including pre-start cancellation.
- Gate WebSocket and existing retry-deferred account-health writes on confirmed settlement, without coupling reconnect or retirement safety to persistence.
- Add deterministic coverage for blocked fallback, failed fallback, cancellation before startup and during fallback, health persistence failure, and an unconfirmed retry settlement.

## Related work

- #1546 contains an overlapping core fix among broader changes and is based on another topic branch; this PR isolates the settlement-ordering fix directly on current `main`.
- #1545 covers detached settlement retry and cleanup. That behavior is intentionally unchanged here.

## Test plan

```text
python -m pytest tests/unit/test_proxy_utils.py -q
# 912 passed

python -m pytest tests/integration/test_detached_persistence.py tests/integration/test_api_keys_api.py::test_stream_401_retry_success_finalizes_once -q
# 6 passed

ruff format --check app/modules/proxy/_service/api_key_usage.py app/modules/proxy/_service/streaming/retry.py tests/unit/test_proxy_utils.py
ruff check app/modules/proxy/_service/api_key_usage.py app/modules/proxy/_service/streaming/retry.py tests/unit/test_proxy_utils.py
ty check app/modules/proxy/_service/api_key_usage.py app/modules/proxy/_service/streaming/retry.py app/modules/proxy/_service/websocket/mixin.py tests/unit/test_proxy_utils.py
python scripts/check_proxy_architecture.py
openspec validate sequence-websocket-health-after-settlement --strict
openspec validate --specs --strict
# all passed; 48/48 main specs valid
```

Full local CI was not run; the focused Sensitive checks above cover the changed seam, and required GitHub CI remains the integration gate.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local test, lint, type, architecture, and spec subset.
- [x] If touching specs: `openspec validate --specs` passes and the change verification is clean.
- [x] Simplicity gates reviewed: no setting, setup step, README section, `.env.example`, dashboard navigation, or default changed.
- [x] CHANGELOG is not edited by hand.
