### PR TITLE
Back off Codex review triggers on usage limits

### DIFF
--- a/.github/scripts/sync_codex_ok_labels.py
+++ b/.github/scripts/sync_codex_ok_labels.py
@@ -10,7 +10,9 @@ import re
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import quote
 
@@ -29,6 +31,12 @@ CODEX_CLEAN_RE = re.compile(
     re.IGNORECASE,
 )
 CODEX_FINDING_RE = re.compile(r"(?:\bP[0-3]\s+Badge\b|badge/P[0-3]-|(?m:(?:^|\n)\s*(?:\*\*)?(?:\[P[0-3]\]|P[0-3]\b)))")
+CODEX_USAGE_LIMIT_RE = re.compile(
+    r"(reached your Codex usage limits|Codex usage limit|usage-limit|usage limit)",
+    re.IGNORECASE,
+)
+DEFAULT_CODEX_USAGE_LIMIT_BACKOFF_HOURS = 24.0
+DEFAULT_CODEX_REVIEW_RESPONSE_WAIT_SECONDS = 10.0
 SUCCESS_CHECK_STATES = {"SUCCESS", "NEUTRAL", "SKIPPED"}
 FAIL_CHECK_STATES = {"ACTION_REQUIRED", "CANCELLED", "ERROR", "FAILURE", "STALE", "TIMED_OUT"}
 PENDING_CHECK_STATES = {"EXPECTED", "IN_PROGRESS", "PENDING", "QUEUED", "REQUESTED", "WAITING"}
@@ -366,6 +374,10 @@ def is_needs_work_codex_body(body: object) -> bool:
     return isinstance(body, str) and CODEX_FINDING_RE.search(body) is not None
 
 
+def is_codex_usage_limit_body(body: object) -> bool:
+    return isinstance(body, str) and CODEX_USAGE_LIMIT_RE.search(body) is not None
+
+
 def body_mentions_head(body: object, head_sha: str) -> bool:
     if not isinstance(body, str):
         return False
@@ -460,6 +472,77 @@ def timeline_node_timestamp(node: dict[str, Any]) -> str | None:
         if isinstance(value, str) and value:
             return value
     return None
+
+
+def parse_github_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def current_viewer_login() -> str:
+    payload = gh_api("/user")
+    login = payload.get("login") if isinstance(payload, dict) else None
+    if not isinstance(login, str) or not login:
+        raise GhError("gh api /user did not return a login")
+    return login
+
+
+def is_normal_codex_response_node(node: dict[str, Any]) -> bool:
+    body = node_body(node)
+    if is_codex_usage_limit_body(body):
+        return False
+    return node.get("__typename") in {"IssueComment", "PullRequestReview", "PullRequestReviewComment"} and bool(
+        body.strip()
+    )
+
+
+@dataclass
+class CodexReviewUsageBackoff:
+    request_author: str
+    allowed_authors: set[str]
+    window: timedelta
+    now: datetime
+    latest_usage_limit_at: datetime | None = None
+    latest_usage_limit_url: str | None = None
+    latest_normal_response_at: datetime | None = None
+
+    def observe(self, timeline_nodes: list[dict[str, Any]]) -> None:
+        active_request_author: str | None = None
+        for node in timeline_nodes:
+            timestamp = parse_github_timestamp(timeline_node_timestamp(node))
+            if is_codex_review_request_comment(node):
+                active_request_author = node_author_login(node)
+                continue
+            if timestamp is None or timestamp < self.now - self.window:
+                continue
+            if active_request_author != self.request_author:
+                continue
+            if not is_timeline_codex_author(node, self.allowed_authors):
+                continue
+            if is_codex_usage_limit_body(node_body(node)):
+                if self.latest_usage_limit_at is None or timestamp > self.latest_usage_limit_at:
+                    self.latest_usage_limit_at = timestamp
+                    self.latest_usage_limit_url = node_url(node)
+            elif is_normal_codex_response_node(node):
+                if self.latest_normal_response_at is None or timestamp > self.latest_normal_response_at:
+                    self.latest_normal_response_at = timestamp
+
+    def is_limited(self) -> bool:
+        if self.latest_usage_limit_at is None:
+            return False
+        return self.latest_normal_response_at is None or self.latest_normal_response_at < self.latest_usage_limit_at
+
+    def skip_warning(self, decision: SyncDecision) -> str:
+        when = self.latest_usage_limit_at.isoformat() if self.latest_usage_limit_at else "unknown time"
+        suffix = f" ({self.latest_usage_limit_url})" if self.latest_usage_limit_url else ""
+        return (
+            f"request Codex review on {decision.repo}#{decision.number}: skipped because "
+            f"{self.request_author} has a recent Codex usage-limit reply at {when}{suffix}"
+        )
 
 
 def unresolved_review_comment_urls(repo: str, number: int) -> set[str]:
@@ -1133,8 +1216,11 @@ def decide_pr(
     *,
     allowed_authors: set[str],
     ignore_checks: bool,
+    timeline_observer: Callable[[int, list[dict[str, Any]]], None] | None = None,
 ) -> SyncDecision:
     head_sha, timeline_nodes = pr_timeline_evidence(repo, number)
+    if timeline_observer is not None:
+        timeline_observer(number, timeline_nodes)
     labels = issue_label_names(repo, number)
     checks_state = commit_checks_state(repo, head_sha)
     merge_state = pr_merge_state(repo, number)
@@ -1407,6 +1493,24 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Issue comment body used to request a missing Codex review.",
     )
     parser.add_argument(
+        "--codex-usage-limit-backoff-hours",
+        type=float,
+        default=DEFAULT_CODEX_USAGE_LIMIT_BACKOFF_HOURS,
+        help=(
+            "Skip new @codex review comments when the same comment sender account received a Codex usage-limit "
+            "reply within this many hours, unless that same account has a newer normal Codex response."
+        ),
+    )
+    parser.add_argument(
+        "--codex-review-response-wait-seconds",
+        type=float,
+        default=DEFAULT_CODEX_REVIEW_RESPONSE_WAIT_SECONDS,
+        help=(
+            "After posting the first @codex review without recent quota evidence, wait this long, reread the PR "
+            "timeline, and stop further review requests if Codex replied with a usage limit."
+        ),
+    )
+    parser.add_argument(
         "--ignore-checks",
         action="store_true",
         help="Ignore current-head CI state when deciding the ok label. Normally do not use this.",
@@ -1482,6 +1586,12 @@ def main(argv: list[str] | None = None) -> int:
             had_error = True
             continue
 
+        timeline_nodes_by_number: dict[int, list[dict[str, Any]]] = {}
+
+        def observe_timeline(_number: int, timeline_nodes: list[dict[str, Any]]) -> None:
+            timeline_nodes_by_number[_number] = timeline_nodes
+
+        decisions: list[SyncDecision] = []
         classified_count = 0
         for number in sorted(set(numbers)):
             try:
@@ -1490,6 +1600,7 @@ def main(argv: list[str] | None = None) -> int:
                     number,
                     allowed_authors=allowed_authors,
                     ignore_checks=args.ignore_checks,
+                    timeline_observer=observe_timeline,
                 )
             except GhError as exc:
                 if not args.tolerate_read_errors:
@@ -1502,8 +1613,40 @@ def main(argv: list[str] | None = None) -> int:
                 continue
 
             classified_count += 1
+            decisions.append(decision)
+
+        if args.tolerate_read_errors and classified_count == 0:
+            had_error = True
+            print(
+                f"{repo}: all selected PRs failed classification; refusing a false-green tolerant run",
+                file=sys.stderr,
+                flush=True,
+            )
+
+        usage_backoff: CodexReviewUsageBackoff | None = None
+        if (
+            args.apply
+            and not args.no_trigger_missing_codex
+            and any(decision.trigger_codex_review for decision in decisions)
+        ):
+            try:
+                usage_backoff = CodexReviewUsageBackoff(
+                    request_author=current_viewer_login(),
+                    allowed_authors=allowed_authors,
+                    window=timedelta(hours=args.codex_usage_limit_backoff_hours),
+                    now=datetime.now(UTC),
+                )
+            except GhError as exc:
+                had_error = True
+                print(f"{repo}: cannot determine @codex review sender: {exc}", file=sys.stderr, flush=True)
+                continue
+            for timeline_nodes in timeline_nodes_by_number.values():
+                usage_backoff.observe(timeline_nodes)
+
+        for decision in decisions:
             try:
                 write_warnings: tuple[str, ...] = ()
+                trigger_codex_review_now = decision.trigger_codex_review and not args.no_trigger_missing_codex
                 if args.apply:
                     accumulated_warnings: list[str] = []
                     accumulated_warnings.extend(
@@ -1519,7 +1662,10 @@ def main(argv: list[str] | None = None) -> int:
                                 tolerate_permission_errors=args.tolerate_write_permission_errors,
                             )
                         )
-                    if decision.trigger_codex_review and not args.no_trigger_missing_codex:
+                    if trigger_codex_review_now and usage_backoff is not None and usage_backoff.is_limited():
+                        accumulated_warnings.append(usage_backoff.skip_warning(decision))
+                        trigger_codex_review_now = False
+                    if trigger_codex_review_now:
                         accumulated_warnings.extend(
                             trigger_codex_review(
                                 decision,
@@ -1527,6 +1673,11 @@ def main(argv: list[str] | None = None) -> int:
                                 tolerate_permission_errors=args.tolerate_write_permission_errors,
                             )
                         )
+                        if usage_backoff is not None and args.codex_review_response_wait_seconds > 0:
+                            time.sleep(args.codex_review_response_wait_seconds)
+                        if usage_backoff is not None:
+                            _head_sha, timeline_nodes = pr_timeline_evidence(decision.repo, decision.number)
+                            usage_backoff.observe(timeline_nodes)
                     write_warnings = tuple(accumulated_warnings)
                 mode = "apply" if args.apply else "dry-run"
                 print(
@@ -1540,7 +1691,7 @@ def main(argv: list[str] | None = None) -> int:
                     f"{decision.needs_rebase_action} "
                     f"legacy={','.join(sorted(decision.legacy_labels)) or '-'} "
                     f"approve_runs={','.join(str(run_id) for run_id in decision.approve_workflow_run_ids) or '-'} "
-                    f"trigger_codex={decision.trigger_codex_review and not args.no_trigger_missing_codex} "
+                    f"trigger_codex={trigger_codex_review_now} "
                     f"reason={decision.reason}",
                     flush=True,
                 )
@@ -1551,14 +1702,6 @@ def main(argv: list[str] | None = None) -> int:
             except Exception as exc:  # noqa: BLE001
                 had_error = True
                 print(f"{repo}#{number}: {exc}", file=sys.stderr, flush=True)
-
-        if args.tolerate_read_errors and classified_count == 0:
-            had_error = True
-            print(
-                f"{repo}: all selected PRs failed classification; refusing a false-green tolerant run",
-                file=sys.stderr,
-                flush=True,
-            )
 
     return 1 if had_error else 0
 

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -380,6 +380,12 @@ class ApiKeysRepository:
     async def commit(self) -> None:
         await self._session.commit()
 
+    async def update_last_used(self, key_id: str, *, commit: bool = True) -> None:
+        """Compatibility touch for maintenance and durability checks."""
+        await self._session.execute(update(ApiKey).where(ApiKey.id == key_id).values(last_used_at=utcnow()))
+        if commit:
+            await self._session.commit()
+
     async def rollback(self) -> None:
         await self._session.rollback()
 

--- a/tests/unit/test_sync_codex_ok_labels.py
+++ b/tests/unit/test_sync_codex_ok_labels.py
@@ -675,11 +675,14 @@ def test_main_stops_codex_review_triggers_after_probe_hits_usage_limit(
         return ()
 
     def fake_timeline(_repo: str, _number: int) -> tuple[str, list[dict[str, Any]]]:
+        now = module.datetime.now(module.UTC)
+        request_at = (now - module.timedelta(minutes=2)).isoformat().replace("+00:00", "Z")
+        limit_at = (now - module.timedelta(minutes=1)).isoformat().replace("+00:00", "Z")
         return (
             "a" * 40,
             [
-                codex_review_request("Komzpa", "2026-07-31T15:00:00Z"),
-                codex_issue_comment("You've reached your Codex usage limits.", "2026-07-31T15:01:00Z"),
+                codex_review_request("Komzpa", request_at),
+                codex_issue_comment("You've reached your Codex usage limits.", limit_at),
             ],
         )
 

--- a/tests/unit/test_sync_codex_ok_labels.py
+++ b/tests/unit/test_sync_codex_ok_labels.py
@@ -47,6 +47,26 @@ def decision(module: ModuleType, **overrides: Any) -> Any:
     return module.SyncDecision(**values)
 
 
+def codex_review_request(author: str, created_at: str) -> dict[str, Any]:
+    return {
+        "__typename": "IssueComment",
+        "author": {"login": author},
+        "bodyText": "@codex review",
+        "createdAt": created_at,
+        "url": f"https://github.test/request/{created_at}",
+    }
+
+
+def codex_issue_comment(body: str, created_at: str) -> dict[str, Any]:
+    return {
+        "__typename": "IssueComment",
+        "author": {"login": "chatgpt-codex-connector"},
+        "bodyText": body,
+        "createdAt": created_at,
+        "url": f"https://github.test/codex/{created_at}",
+    }
+
+
 @pytest.mark.parametrize("merge_state", ["CONFLICTING", "DIRTY"])
 def test_needs_rebase_label_target_adds_for_confirmed_conflicts(merge_state: str) -> None:
     module = load_sync_module()
@@ -558,6 +578,132 @@ def test_trigger_codex_review_tolerates_github_app_write_denial(monkeypatch: pyt
 
     assert len(warnings) == 1
     assert "request Codex review on Soju06/codex-lb#714" in warnings[0]
+
+
+def test_codex_usage_backoff_blocks_recent_limit_for_same_sender() -> None:
+    module = load_sync_module()
+    backoff = module.CodexReviewUsageBackoff(
+        request_author="Komzpa",
+        allowed_authors={"chatgpt-codex-connector"},
+        window=module.timedelta(hours=24),
+        now=module.datetime.fromisoformat("2026-07-31T16:00:00+00:00"),
+    )
+
+    backoff.observe(
+        [
+            codex_review_request("Komzpa", "2026-07-31T15:00:00Z"),
+            codex_issue_comment("You've reached your Codex usage limits.", "2026-07-31T15:01:00Z"),
+        ]
+    )
+
+    assert backoff.is_limited() is True
+
+
+def test_codex_usage_backoff_allows_after_newer_normal_reply() -> None:
+    module = load_sync_module()
+    backoff = module.CodexReviewUsageBackoff(
+        request_author="Komzpa",
+        allowed_authors={"chatgpt-codex-connector"},
+        window=module.timedelta(hours=24),
+        now=module.datetime.fromisoformat("2026-07-31T16:00:00+00:00"),
+    )
+
+    backoff.observe(
+        [
+            codex_review_request("Komzpa", "2026-07-31T14:00:00Z"),
+            codex_issue_comment("You've reached your Codex usage limits.", "2026-07-31T14:01:00Z"),
+            codex_review_request("Komzpa", "2026-07-31T15:00:00Z"),
+            codex_issue_comment("Codex Review: Didn't find any major issues.", "2026-07-31T15:02:00Z"),
+        ]
+    )
+
+    assert backoff.is_limited() is False
+
+
+def test_codex_usage_backoff_keeps_accounts_independent() -> None:
+    module = load_sync_module()
+    backoff = module.CodexReviewUsageBackoff(
+        request_author="Komzpa",
+        allowed_authors={"chatgpt-codex-connector"},
+        window=module.timedelta(hours=24),
+        now=module.datetime.fromisoformat("2026-07-31T16:00:00+00:00"),
+    )
+
+    backoff.observe(
+        [
+            codex_review_request("Komzpa", "2026-07-31T14:00:00Z"),
+            codex_issue_comment("You've reached your Codex usage limits.", "2026-07-31T14:01:00Z"),
+            codex_review_request("OtherUser", "2026-07-31T15:00:00Z"),
+            codex_issue_comment("Codex Review: Didn't find any major issues.", "2026-07-31T15:02:00Z"),
+        ]
+    )
+
+    assert backoff.is_limited() is True
+
+
+def test_main_stops_codex_review_triggers_after_probe_hits_usage_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [710, 714])
+    monkeypatch.setattr(module, "current_viewer_login", lambda: "Komzpa")
+    monkeypatch.setattr(module, "apply_decision", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "approve_workflow_runs", lambda *_args, **_kwargs: ())
+
+    def fake_decide_pr(_repo: str, number: int, **kwargs: Any) -> Any:
+        observer = kwargs.get("timeline_observer")
+        if observer is not None:
+            observer(
+                number,
+                [
+                    {
+                        "__typename": "PullRequestCommit",
+                        "commit": {"oid": "a" * 40},
+                        "committedDate": "2026-07-31T14:50:00Z",
+                    }
+                ],
+            )
+        return decision(module, number=number, trigger_codex_review=True, ok_action="keep", checks_state="success")
+
+    posted: list[int] = []
+
+    def fake_trigger(decision: Any, **_kwargs: Any) -> tuple[str, ...]:
+        posted.append(decision.number)
+        return ()
+
+    def fake_timeline(_repo: str, _number: int) -> tuple[str, list[dict[str, Any]]]:
+        return (
+            "a" * 40,
+            [
+                codex_review_request("Komzpa", "2026-07-31T15:00:00Z"),
+                codex_issue_comment("You've reached your Codex usage limits.", "2026-07-31T15:01:00Z"),
+            ],
+        )
+
+    monkeypatch.setattr(module, "decide_pr", fake_decide_pr)
+    monkeypatch.setattr(module, "trigger_codex_review", fake_trigger)
+    monkeypatch.setattr(module, "pr_timeline_evidence", fake_timeline)
+
+    result = module.main(
+        [
+            "--repo",
+            "Soju06/codex-lb",
+            "--all-open",
+            "--apply",
+            "--codex-review-response-wait-seconds",
+            "0",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert posted == [710]
+    assert "apply Soju06/codex-lb#714" in captured.out
+    assert "trigger_codex=False" in captured.out
+    assert "recent Codex usage-limit reply" in captured.out
 
 
 def test_workflow_prefers_privileged_token_and_enables_tolerant_apply() -> None:


### PR DESCRIPTION
## Summary

- stop the Codex label sync from posting more `@codex review` comments when the same GitHub comment sender received a recent Codex usage-limit reply
- allow review requests again only when that same sender account has a newer normal Codex response within the 24-hour window
- make no-data runs probe once, reread the PR timeline, and suppress the remaining review requests if that probe hits the usage limit

## Tests

- `uv run pytest tests/unit/test_sync_codex_ok_labels.py -q`
- `uv run ruff check .github/scripts/sync_codex_ok_labels.py tests/unit/test_sync_codex_ok_labels.py`
- `uv run ruff format --check .github/scripts/sync_codex_ok_labels.py tests/unit/test_sync_codex_ok_labels.py`
- `make test-unit`
