### PR TITLE
fix(proxy): surface forwarded compact settlement failures

### DIFF
--- a/app/modules/proxy/_service/api_key_usage.py
+++ b/app/modules/proxy/_service/api_key_usage.py
@@ -9,6 +9,8 @@ from typing import Any, Protocol, cast
 
 import anyio
 
+from app.core.clients.proxy import ProxyResponseError
+from app.core.errors import openai_error
 from app.core.exceptions import ProxyAuthError, ProxyRateLimitError
 from app.core.openai.models import CompactResponsePayload
 from app.core.utils.request_id import get_request_id
@@ -289,13 +291,36 @@ class _ApiKeyUsageMixin:
                         )
                     else:
                         await api_keys_service.release_usage_reservation(reservation_id)
-            except Exception:
+            except Exception as exc:
                 logger.warning(
                     "Failed to settle compact API key reservation key_id=%s request_id=%s",
                     api_key.id,
                     get_request_id(),
                     exc_info=True,
                 )
+                try:
+                    async with proxy._repo_factory() as repos:
+                        api_keys_service = _service_api_keys_service()(repos.api_keys)
+                        await api_keys_service.release_usage_reservation(reservation_id)
+                except Exception:
+                    logger.warning(
+                        "Failed to release compact API key reservation after settlement failure "
+                        "key_id=%s request_id=%s",
+                        api_key.id,
+                        get_request_id(),
+                        exc_info=True,
+                    )
+                raise ProxyResponseError(
+                    502,
+                    openai_error(
+                        "usage_settlement_failed",
+                        "Compact API key usage could not be settled",
+                        error_type="server_error",
+                    ),
+                    failure_phase="usage_settlement",
+                    failure_detail="compact_api_key_usage_persistence_failed",
+                    failure_exception_type=type(exc).__name__,
+                ) from exc
 
     async def _settle_stream_api_key_usage(
         self,

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -1133,6 +1133,8 @@ class _CompactMixin:
                         log_status = "success"
                         return response
                     except ProxyResponseError as exc:
+                        if exc.failure_phase == "usage_settlement":
+                            raise
                         compact_continuity_error = _compact_previous_response_not_found_error(exc)
                         if compact_continuity_error is not None:
                             await proxy._settle_compact_api_key_usage(

--- a/openspec/changes/propagate-forwarded-compact-settlement-failure/.openspec.yaml
+++ b/openspec/changes/propagate-forwarded-compact-settlement-failure/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/propagate-forwarded-compact-settlement-failure/design.md
+++ b/openspec/changes/propagate-forwarded-compact-settlement-failure/design.md
@@ -1,0 +1,87 @@
+## Context
+
+The origin reserves API-key quota before forwarding an HTTP-bridge request and
+signs the reservation into the owner request. The owner restores that
+reservation as an override, making `owns_reservation` false at the route layer;
+`compact_responses` is therefore the only owner-side settlement path.
+
+`_settle_compact_api_key_usage` currently catches every repository,
+finalization, or release exception and returns normally. A successful upstream
+compact can consequently be reported as successful even though the reservation
+is still `reserved`. The source-adapter settlement path already establishes the
+local pattern: log the failed accounting write, attempt a release with a fresh
+repository, and fail the request explicitly.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make compact settlement persistence failure observable to the forwarded
+  caller.
+- Release the held reservation through a fresh repository when the fail-safe
+  write succeeds.
+- Prevent the compact retry loop from treating local usage persistence as an
+  upstream or account-health failure.
+- Prove the signed owner-forwarded route, failure response, single upstream
+  attempt, and final reservation state in one focused integration regression.
+
+**Non-Goals:**
+
+- Changing stale-reservation or quota-cleanup jobs.
+- Adding background retries, settings, migrations, or dependencies.
+- Changing WebSocket settlement or WebSocket account-health behavior.
+- Retrying the upstream compact after it may already have succeeded.
+
+## Decisions
+
+1. **Attempt fail-safe release from a fresh repository, then fail closed.**
+   When compact finalization or release raises, the helper logs the original
+   exception and attempts `release_usage_reservation` from a newly opened
+   repository context. It then raises a `502 usage_settlement_failed`
+   `ProxyResponseError` with trusted `failure_phase="usage_settlement"`
+   provenance regardless of the fail-safe outcome. A fresh repository avoids
+   reusing a transaction that the failed settlement may have rolled back or invalidated.
+   If the original commit actually completed before its outcome became
+   uncertain, the idempotent release observes a non-`reserved` row and is a
+   no-op.
+
+2. **Propagate trusted settlement provenance before retry classification.**
+   The compact `except ProxyResponseError` handler checks the internal
+   `failure_phase` before any upstream retry, failover, or account-health logic
+   and immediately propagates usage-settlement failures. This is stronger than
+   matching the externally supplied error code and prevents an upstream
+   response from bypassing normal health handling. Raising the public error from
+   the central helper also covers settlement calls made from terminal exception
+   handlers without duplicating conversion logic at every call site.
+
+3. **Reuse the existing public error convention.**
+   The response uses the existing `usage_settlement_failed` code and a generic
+   server-error message. Raw database details remain in structured server logs
+   and are not exposed to the client.
+
+Alternatives considered:
+
+- Merely re-raising the repository exception would make the failure visible but
+  would leave held quota behind even when an immediate fresh-session release
+  could recover it, and would expose only a generic owner-forward error.
+- An internal exception converted only at the outer request boundary would
+  structurally bypass the main retry handler, but settlement is also invoked
+  from terminal exception handlers; covering every such site would duplicate
+  conversion logic. A single trusted-phase guard keeps the central helper safe.
+- Swallowing the exception and relying on stale cleanup preserves the current
+  leak window and falsely reports success.
+- Retrying the upstream compact is unsafe because the upstream side effect may
+  already have completed.
+
+## Risks / Trade-offs
+
+- **Finalization fails but fail-safe release succeeds, so exact usage is not
+  charged** → The request fails closed instead of returning success, and the
+  held quota is released to avoid a quota deadlock; this matches the existing
+  source-settlement policy.
+- **Both settlement and fail-safe release fail** → The explicit 502 remains
+  visible and the reservation stays held for the existing cleanup policy; both
+  failures are logged without adding a new background mechanism.
+- **A settlement error is accidentally treated as upstream failure** → The
+  trusted `failure_phase` guard runs before the inner retry/health logic, and the
+  integration regression asserts a single upstream call and no health-error handling.

--- a/openspec/changes/propagate-forwarded-compact-settlement-failure/proposal.md
+++ b/openspec/changes/propagate-forwarded-compact-settlement-failure/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+An HTTP-bridge owner receives the origin's API-key usage reservation with
+`owns_reservation` false, so compact settlement on the owner is the reservation's
+only persistence path. `_settle_compact_api_key_usage` currently logs and
+swallows persistence exceptions, which can make the owner report the original
+compact result while the reservation remains held until stale cleanup.
+
+## What Changes
+
+- Propagate compact API-key settlement persistence failures after logging them,
+  so an owner-forwarded request cannot report a successfully handled terminal
+  when its sole settlement did not persist.
+- Attempt a fail-safe release through a fresh repository before surfacing the
+  failure, while preserving the origin's existing idempotent reservation cleanup
+  and adding no background retry or stale-cleanup mechanism.
+- Add a signed forwarded-route failure regression that injects a settlement
+  persistence error and verifies both the surfaced error and the reservation's
+  final status.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `usage-refresh-policy`: Require owner-forwarded compact settlement failures to
+  remain observable and fail closed instead of being swallowed.
+
+## Impact
+
+- Affected code: `app/modules/proxy/_service/api_key_usage.py` and
+  `app/modules/proxy/_service/compact.py`.
+- Affected tests: `tests/integration/test_proxy_compact.py`.
+- No API schema, setting, dependency, migration, quota-cleanup, or WebSocket
+  health behavior changes.

--- a/openspec/changes/propagate-forwarded-compact-settlement-failure/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/propagate-forwarded-compact-settlement-failure/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Owner-forwarded compact settlement failures fail closed
+
+An HTTP-bridge owner MUST treat any persistence exception while finalizing or
+releasing a forwarded compact API-key usage reservation as a failed settlement,
+and MUST NOT swallow it.
+The owner MUST log the persistence failure, MUST attempt to release the
+reservation through a fresh repository context, and MUST surface a `502`
+`usage_settlement_failed` server error regardless of whether that fail-safe
+release succeeds. The settlement failure MUST carry trusted internal provenance
+that is checked before compact upstream retry, failover, and account-health error
+handling, so the compact request is not sent upstream again and the selected
+account is not penalized for a local persistence failure. When the reservation
+is still `reserved` when the fail-safe release begins and that release succeeds,
+the reservation's final status MUST be `released`. This behavior MUST NOT add or
+alter stale-reservation cleanup or WebSocket health handling.
+
+#### Scenario: Forwarded compact finalization fails after upstream success
+
+- **GIVEN** a signed owner-forwarded compact request whose API-key reservation is `reserved`
+- **AND** the upstream compact succeeds but usage finalization raises a persistence exception
+- **WHEN** the owner handles the settlement failure
+- **THEN** the owner attempts a fail-safe reservation release through a fresh repository context
+- **AND** the request returns `502` with error code `usage_settlement_failed`
+- **AND** the upstream compact is called exactly once and no account-health error is recorded
+- **AND** when the reservation is still `reserved` at fail-safe release and that release succeeds, its status is `released`

--- a/openspec/changes/propagate-forwarded-compact-settlement-failure/tasks.md
+++ b/openspec/changes/propagate-forwarded-compact-settlement-failure/tasks.md
@@ -1,0 +1,14 @@
+## 1. Settlement Failure Handling
+
+- [x] 1.1 Add a fresh-repository fail-safe release and a trusted `502 usage_settlement_failed` error to `_settle_compact_api_key_usage`.
+- [x] 1.2 Propagate trusted usage-settlement failures before compact upstream retry and account-health handling.
+
+## 2. Forwarded Regression
+
+- [x] 2.1 Add a signed owner-forwarded compact integration regression that injects finalization failure and verifies one upstream call, no health-error handling, the 502 error, and a `released` reservation.
+
+## 3. Verification
+
+- [x] 3.1 Prove the regression fails without the behavior fix and passes with it.
+- [x] 3.2 Run the focused compact integration slice plus affected ruff, format, type, and proxy-architecture checks.
+- [x] 3.3 Validate the scoped OpenSpec change and all main specs strictly, run OpenSpec verification, and inspect the final diff/status.

--- a/openspec/changes/propagate-forwarded-compact-settlement-failure/tasks.md
+++ b/openspec/changes/propagate-forwarded-compact-settlement-failure/tasks.md
@@ -6,6 +6,7 @@
 ## 2. Forwarded Regression
 
 - [x] 2.1 Add a signed owner-forwarded compact integration regression that injects finalization failure and verifies one upstream call, no health-error handling, the 502 error, and a `released` reservation.
+- [x] 2.2 Add a unit regression that makes finalization and fail-safe release both fail and verifies the trusted `usage_settlement_failed` error provenance.
 
 ## 3. Verification
 

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -1259,6 +1259,145 @@ async def test_proxy_compact_forwarded_bridge_preflight_budget_exhausted_settles
 
 
 @pytest.mark.asyncio
+async def test_proxy_compact_forwarded_bridge_settlement_failure_surfaces_and_releases_reservation(
+    async_client,
+    monkeypatch,
+):
+    """A forwarded owner must not report compact success when its sole API-key
+    usage settlement fails. The failure is surfaced without another upstream or
+    account-health attempt, and a fresh repository releases the held quota."""
+    from app.core.config.settings import get_settings
+    from app.core.openai.requests import ResponsesCompactRequest, ResponsesRequest
+    from app.db.models import ApiKeyUsageReservation
+    from app.modules.api_keys.service import ApiKeyUsageReservationData
+    from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
+    from app.modules.proxy.http_bridge_forwarding import HTTPBridgeForwardContext, build_owner_forward_headers
+
+    email = "compact-forwarded-settlement-failure@example.com"
+    raw_account_id = "acc_compact_forwarded_settlement_failure"
+    auth_json = _make_auth_json(raw_account_id, email)
+    response = await async_client.post(
+        "/api/accounts/import",
+        files={"auth_json": ("auth.json", json.dumps(auth_json), "application/json")},
+    )
+    assert response.status_code == 200
+
+    settings_resp = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": False,
+            "preferEarlierResetAccounts": False,
+            "totpRequiredOnLogin": False,
+            "apiKeyAuthEnabled": True,
+        },
+    )
+    assert settings_resp.status_code == 200
+
+    create = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "compact-forwarded-settlement-failure-key",
+            "limits": [{"limitType": "total_tokens", "limitWindow": "weekly", "maxValue": 1_000_000}],
+        },
+    )
+    assert create.status_code == 200
+    key_id = create.json()["id"]
+    key = create.json()["key"]
+
+    compact_model = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    async with SessionLocal() as session:
+        api_keys_service = ApiKeysService(ApiKeysRepository(session))
+        reservation = await api_keys_service.enforce_limits_for_request(
+            key_id,
+            request_model=compact_model.model,
+            request_service_tier=None,
+            request_usage_budget=estimate_api_key_request_usage(compact_model),
+        )
+    async with SessionLocal() as session:
+        row = await session.get(ApiKeyUsageReservation, reservation.reservation_id)
+        assert row is not None
+        assert row.status == "reserved"
+
+    forwarded_payload = ResponsesRequest.model_validate(
+        {
+            "model": compact_model.model,
+            "instructions": "hi",
+            "input": [{"role": "user", "content": "hello"}, {"type": "compaction_trigger"}],
+            "stream": True,
+        }
+    )
+    context = HTTPBridgeForwardContext(
+        origin_instance="origin-instance",
+        target_instance=get_settings().http_responses_session_bridge_instance_id,
+        codex_session_affinity=True,
+        downstream_turn_state=None,
+        reservation=ApiKeyUsageReservationData(
+            reservation_id=reservation.reservation_id,
+            key_id=key_id,
+            model=compact_model.model,
+        ),
+    )
+    headers = build_owner_forward_headers(
+        headers={"authorization": f"Bearer {key}"},
+        payload=forwarded_payload,
+        context=context,
+    )
+
+    compact_calls: list[str | None] = []
+
+    async def fake_compact(payload, request_headers, access_token, account_id):
+        del payload, request_headers, access_token
+        compact_calls.append(account_id)
+        return CompactResponsePayload.model_validate(
+            {
+                "object": "response.compaction",
+                "model": compact_model.model,
+                "output": [
+                    {
+                        "id": "cmp_forwarded_settlement_failure",
+                        "type": "compaction",
+                        "encrypted_content": "enc_forwarded_settlement_failure",
+                    }
+                ],
+                "usage": {
+                    "input_tokens": 7,
+                    "output_tokens": 3,
+                    "total_tokens": 10,
+                },
+            }
+        )
+
+    finalize_attempts: list[str] = []
+
+    async def fail_finalize(self, reservation_id: str, **kwargs: object) -> None:
+        del self, kwargs
+        finalize_attempts.append(reservation_id)
+        raise RuntimeError("compact settlement persistence failed")
+
+    handle_stream_error = AsyncMock(return_value={"failure_class": "upstream"})
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+    monkeypatch.setattr(ApiKeysService, "finalize_usage_reservation", fail_finalize)
+    monkeypatch.setattr(proxy_module.ProxyService, "_handle_stream_error", handle_stream_error)
+
+    response = await async_client.post(
+        "/internal/bridge/responses",
+        json=forwarded_payload.model_dump_for_forwarding(),
+        headers=headers,
+    )
+
+    assert response.status_code == 502, response.text
+    assert response.json()["error"]["code"] == "usage_settlement_failed"
+    assert compact_calls == [raw_account_id]
+    assert finalize_attempts == [reservation.reservation_id]
+    handle_stream_error.assert_not_awaited()
+
+    async with SessionLocal() as session:
+        row = await session.get(ApiKeyUsageReservation, reservation.reservation_id)
+        assert row is not None
+        assert row.status == "released"
+
+
+@pytest.mark.asyncio
 async def test_proxy_compact_retryable_transport_failure_retries_same_contract_only(async_client, monkeypatch):
     email = "compact-safe-retry@example.com"
     raw_account_id = "acc_compact_safe_retry"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -30659,6 +30659,64 @@ async def test_compact_responses_budget_exhaustion_returns_request_timeout(monke
 
 
 @pytest.mark.asyncio
+async def test_compact_usage_settlement_surfaces_when_fail_safe_release_fails(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    api_key = _make_api_key_data("key_compact_double_settlement_failure")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_double_settlement_failure",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+    response = CompactResponsePayload.model_validate(
+        {
+            "object": "response.compaction",
+            "model": "gpt-5.1",
+            "output": [],
+            "usage": {"input_tokens": 7, "output_tokens": 3, "total_tokens": 10},
+        }
+    )
+    primary_service = SimpleNamespace(
+        finalize_usage_reservation=AsyncMock(side_effect=RuntimeError("compact finalize failed")),
+        release_usage_reservation=AsyncMock(),
+    )
+    fail_safe_service = SimpleNamespace(
+        finalize_usage_reservation=AsyncMock(),
+        release_usage_reservation=AsyncMock(side_effect=RuntimeError("compact fail-safe release failed")),
+    )
+    service_factory = MagicMock(side_effect=[primary_service, fail_safe_service])
+    monkeypatch.setattr(proxy_service, "ApiKeysService", service_factory)
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service._settle_compact_api_key_usage(
+            api_key=api_key,
+            api_key_reservation=reservation,
+            response=response,
+            request_service_tier=None,
+        )
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 502
+    assert _proxy_error_code(exc) == "usage_settlement_failed"
+    assert exc.failure_phase == "usage_settlement"
+    assert exc.failure_detail == "compact_api_key_usage_persistence_failed"
+    assert exc.failure_exception_type == "RuntimeError"
+    assert isinstance(exc.__cause__, RuntimeError)
+    assert str(exc.__cause__) == "compact finalize failed"
+    assert service_factory.call_count == 2
+    primary_service.finalize_usage_reservation.assert_awaited_once_with(
+        reservation.reservation_id,
+        model="gpt-5.1",
+        input_tokens=7,
+        output_tokens=3,
+        cached_input_tokens=0,
+        service_tier=None,
+    )
+    primary_service.release_usage_reservation.assert_not_awaited()
+    fail_safe_service.finalize_usage_reservation.assert_not_awaited()
+    fail_safe_service.release_usage_reservation.assert_awaited_once_with(reservation.reservation_id)
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "failure_path",
     ["body_read", "request_client_error", "request_os_error"],

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -30681,7 +30681,7 @@ async def test_compact_usage_settlement_surfaces_when_fail_safe_release_fails(mo
     )
     fail_safe_service = SimpleNamespace(
         finalize_usage_reservation=AsyncMock(),
-        release_usage_reservation=AsyncMock(side_effect=RuntimeError("compact fail-safe release failed")),
+        release_usage_reservation=AsyncMock(side_effect=OSError("compact fail-safe release failed")),
     )
     service_factory = MagicMock(side_effect=[primary_service, fail_safe_service])
     monkeypatch.setattr(proxy_service, "ApiKeysService", service_factory)


### PR DESCRIPTION
## Summary

Fail closed when an HTTP-bridge owner cannot persist the only settlement of a
forwarded compact API-key reservation. The owner now attempts a fresh-repository
release and returns `502 usage_settlement_failed` without retrying upstream or
penalizing the selected account.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: none found in the bounded related-work search.

Related work:

- #1332 settled forwarded compact reservations on budget-exhausted terminals;
  this PR covers persistence failure after an upstream compact succeeds.
- #1549 concerns bridge/session continuity and does not overlap this settlement
  path or the changed files.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path and preserves the existing compact
      request/response framing

Change directory:
`openspec/changes/propagate-forwarded-compact-settlement-failure/`

## Changes

- Attempt an idempotent fail-safe reservation release through a fresh repository
  after compact finalization or release persistence fails, then surface the
  existing `usage_settlement_failed` error contract.
- Propagate trusted settlement provenance before compact retry, failover, and
  account-health classification.
- Add a signed `/internal/bridge/responses` regression proving one upstream call,
  no health-error handling, a 502 response, and final `released` reservation state,
  plus a hermetic unit regression for finalization and fail-safe release both failing.

## Test plan

```text
pytest tests/integration/test_proxy_compact.py -q
# 26 passed

pytest tests/unit/test_proxy_utils.py::test_compact_usage_settlement_surfaces_when_fail_safe_release_fails -q
# 1 passed

ruff check app/modules/proxy/_service/api_key_usage.py app/modules/proxy/_service/compact.py tests/integration/test_proxy_compact.py tests/unit/test_proxy_utils.py
ruff format --check app/modules/proxy/_service/api_key_usage.py app/modules/proxy/_service/compact.py tests/integration/test_proxy_compact.py tests/unit/test_proxy_utils.py
ty check app/modules/proxy/_service/api_key_usage.py app/modules/proxy/_service/compact.py tests/integration/test_proxy_compact.py tests/unit/test_proxy_utils.py
make architecture-check
openspec validate propagate-forwarded-compact-settlement-failure --strict
openspec validate --specs --strict
# 48 main specs passed
```

The focused regression also failed against the unmodified baseline as expected:
the old path returned HTTP 200 after swallowing the injected settlement failure.

Full-project `ty check` was attempted with Python 3.13 and reported one diagnostic
in unchanged `tests/unit/test_settings_reference.py:36` for the Pydantic
`_env_file` constructor argument. The affected files pass targeted type checking;
required GitHub CI remains the authoritative full-project gate. Full local CI was
not run.

## Screenshots / output

No dashboard-visible change. The signed forwarded-route regression observes:

```text
HTTP 502
error.code = usage_settlement_failed
upstream compact calls = 1
account-health handlers = 0
reservation.status = released
```

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Bounded related work is documented; no matching issue was found.
- [x] Added integration coverage at the externally failing forwarded route.
- [x] Ran the relevant sensitive-change test, lint, format, type, architecture,
      and OpenSpec subset locally.
- [x] `openspec validate --specs --strict` passes and OpenSpec verification is clean.
- [x] Simplicity gates P1-P5 reviewed: no setting, setup step, README section,
      dashboard navigation, default, or dashboard pixels change.
- [x] `CHANGELOG.md` is not edited.
