### PR TITLE
feat(proxy): add durable capability lineage for reconnect

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -92,6 +92,7 @@ from app.core.utils.sse import format_sse_event, parse_sse_data_json
 
 CODEX_INSTALLATION_ID_HEADER = "x-codex-installation-id"
 CODEX_TURN_METADATA_HEADER = "x-codex-turn-metadata"
+CODEX_LB_REQUIRED_CAPABILITY_HEADER = "x-codex-lb-required-capability"
 CODEX_RESPONSES_LITE_HEADER = "x-openai-internal-codex-responses-lite"
 CODEX_RESPONSES_LITE_WEBSOCKET_METADATA_KEY = "ws_request_header_x_openai_internal_codex_responses_lite"
 
@@ -103,6 +104,7 @@ IGNORE_INBOUND_HEADERS = {
     "forwarded",
     "x-real-ip",
     CODEX_INSTALLATION_ID_HEADER,
+    CODEX_LB_REQUIRED_CAPABILITY_HEADER,
     "true-client-ip",
 }
 INTERNAL_OPENAI_UPSTREAM_HEADERS = frozenset(

--- a/app/db/alembic/versions/20260731_000000_add_capability_lineage_markers.py
+++ b/app/db/alembic/versions/20260731_000000_add_capability_lineage_markers.py
@@ -1,0 +1,38 @@
+"""add durable capability lineage markers
+
+Revision ID: 20260731_000000_add_capability_lineage_markers
+Revises: 20260725_000000_add_http_bridge_pending_tool_calls
+Create Date: 2026-07-31
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260731_000000_add_capability_lineage_markers"
+down_revision = "20260725_000000_add_http_bridge_pending_tool_calls"
+branch_labels = None
+depends_on = None
+
+_TABLE = "capability_lineage_markers"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if sa.inspect(bind).has_table(_TABLE):
+        return
+    op.create_table(
+        _TABLE,
+        sa.Column("marker_hash", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("marker_hash"),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if not sa.inspect(bind).has_table(_TABLE):
+        return
+    op.drop_table(_TABLE)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -719,6 +719,23 @@ class StickySession(Base):
     )
 
 
+class CapabilityLineageMarker(Base):
+    __tablename__ = "capability_lineage_markers"
+
+    marker_hash: Mapped[str] = mapped_column(String(64), primary_key=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    last_seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
 class DashboardSettings(Base):
     __tablename__ = "dashboard_settings"
 

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -32,6 +32,7 @@ from app.modules.limit_warmup.repository import LimitWarmupRepository
 from app.modules.model_sources.repository import ModelSourcesRepository
 from app.modules.model_sources.service import ModelSourcesService
 from app.modules.oauth.service import OauthService
+from app.modules.proxy.capability_lineage_repository import CapabilityLineageRepository
 from app.modules.proxy.repo_bundle import ProxyRepositories
 from app.modules.proxy.service import ProxyService
 from app.modules.proxy.sticky_repository import StickySessionsRepository
@@ -220,6 +221,7 @@ async def _proxy_repo_context() -> AsyncIterator[ProxyRepositories]:
             api_keys=ApiKeysRepository(session),
             additional_usage=AdditionalUsageRepository(session),
             quota_planner=QuotaPlannerRepository(session),
+            capability_lineage=CapabilityLineageRepository(session),
         )
 
 

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -820,6 +820,7 @@ class _WebSocketRequestState:
     request_stage: str = "first_turn"
     preferred_account_id: str | None = None
     require_security_work_authorized: bool = False
+    durable_capability_lineage_required: bool = False
     file_required_preferred_account: bool = False
     bridge_soft_capacity_reroute_allowed: bool = False
     error_code_override: str | None = None

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -14,8 +14,8 @@ import anyio
 from app.core.clients.files import create_file as core_create_file  # noqa: F401
 from app.core.clients.files import finalize_file as core_finalize_file  # noqa: F401
 from app.core.clients.http import lease_http_session as lease_http_session  # noqa: F401
-from app.core.clients.proxy import CodexControlResponse as CodexControlResponse
 from app.core.clients.proxy import (  # noqa: F401  # noqa: F401
+    CODEX_LB_REQUIRED_CAPABILITY_HEADER,
     ImageFetchSession,
     ProxyResponseError,
     UpstreamProxyRouteTrace,
@@ -31,6 +31,7 @@ from app.core.clients.proxy import (  # noqa: F401  # noqa: F401
     push_stream_timeout_overrides,
     push_transcribe_timeout_overrides,
 )
+from app.core.clients.proxy import CodexControlResponse as CodexControlResponse
 from app.core.clients.proxy import codex_control_request as core_codex_control_request  # noqa: F401
 from app.core.clients.proxy import compact_responses as core_compact_responses  # noqa: F401
 from app.core.clients.proxy import transcribe_audio as core_transcribe_audio  # noqa: F401
@@ -1696,14 +1697,38 @@ def _websocket_receive_timeout_for_pending_requests(
     )
 
 
+class _WebSocketJsonObject(dict[str, JsonValue]):
+    def __init__(self, pairs: list[tuple[str, JsonValue]]) -> None:
+        super().__init__(pairs)
+        self.raw_pairs = tuple(pairs)
+
+
 def _parse_websocket_payload(text: str) -> dict[str, JsonValue] | None:
     try:
-        payload = json.loads(text)
+        payload = json.loads(text, object_pairs_hook=_WebSocketJsonObject)
     except json.JSONDecodeError:
         return None
     if not isinstance(payload, dict):
         return None
     return payload
+
+
+def _websocket_capability_metadata_values(payload: dict[str, JsonValue]) -> tuple[JsonValue, ...] | None:
+    if not isinstance(payload, _WebSocketJsonObject):
+        return None
+    metadata_objects = [value for key, value in payload.raw_pairs if key == "client_metadata"]
+    values: list[JsonValue] = []
+    normalized_name = CODEX_LB_REQUIRED_CAPABILITY_HEADER.lower()
+    for metadata in metadata_objects:
+        if not isinstance(metadata, _WebSocketJsonObject):
+            continue
+        values.extend(value for key, value in metadata.raw_pairs if key.lower() == normalized_name)
+    if len(metadata_objects) > 1 and values:
+        # A duplicate top-level metadata container can otherwise erase the
+        # sole marker through last-key-wins JSON decoding. Treat the carrier
+        # as ambiguous so routing fails before selection.
+        values.append(values[0])
+    return tuple(values)
 
 
 def _is_websocket_response_create(payload: dict[str, JsonValue]) -> bool:

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -1714,11 +1714,18 @@ def _parse_websocket_payload(text: str) -> dict[str, JsonValue] | None:
 
 
 def _websocket_capability_metadata_values(payload: dict[str, JsonValue]) -> tuple[JsonValue, ...] | None:
+    normalized_name = CODEX_LB_REQUIRED_CAPABILITY_HEADER.lower()
+    payload_pairs = payload.raw_pairs if isinstance(payload, _WebSocketJsonObject) else tuple(payload.items())
+    misplaced_values = [value for key, value in payload_pairs if key.lower() == normalized_name]
+    if misplaced_values:
+        # The reserved per-frame carrier is valid only inside
+        # ``client_metadata``. Surface a deliberately ambiguous carrier set so
+        # the shared parser rejects any top-level placement before selection.
+        return (misplaced_values[0], misplaced_values[0])
     if not isinstance(payload, _WebSocketJsonObject):
         return None
     metadata_objects = [value for key, value in payload.raw_pairs if key == "client_metadata"]
     values: list[JsonValue] = []
-    normalized_name = CODEX_LB_REQUIRED_CAPABILITY_HEADER.lower()
     for metadata in metadata_objects:
         if not isinstance(metadata, _WebSocketJsonObject):
             continue

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -401,6 +401,7 @@ from app.modules.proxy._service.websocket.helpers import (
     _trim_websocket_previous_response_input_items,
     _upstream_websocket_disconnect_message,
     _websocket_auth_failure_requires_reauth,
+    _websocket_capability_metadata_values,
     _websocket_client_previous_response_full_resend_is_retry_safe,
     _websocket_connect_deadline,
     _websocket_continuity_anchor_for_payload,
@@ -433,6 +434,17 @@ from app.modules.proxy.affinity import (
     _sticky_key_from_turn_state_header,
 )
 from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
+from app.modules.proxy.capability_routing import (
+    CAPABILITY_ROUTING_UNAVAILABLE_CODE,
+    CAPABILITY_ROUTING_UNAVAILABLE_MESSAGE,
+    RoutingCapability,
+    RoutingIntent,
+    _capability_lineage_unavailable_error,
+    capability_lineage_aliases,
+    parse_routing_intent,
+    reject_capability_signal_outside_response_create,
+    strip_capability_metadata,
+)
 from app.modules.proxy.continuity import resolve_required_account_id
 from app.modules.proxy.durable_bridge_coordinator import (
     DurableBridgeLookup as DurableBridgeLookup,
@@ -475,10 +487,21 @@ def _facade() -> Any:
 logger = logging.getLogger(__name__)
 
 _WEBSOCKET_PINNED_REFRESH_UNAVAILABLE_MESSAGE = "Account refresh is temporarily unavailable; retry later."
+_CAPABILITY_REQUIRED_NO_AUTHORIZED_ACCOUNTS_MESSAGE = (
+    "This request requires Trusted Access for Cyber, but no eligible account is marked as "
+    "security-work-authorized. codex-lb did not fall back to an ordinary account."
+)
+_CAPABILITY_REQUIRED_NO_AUTHORIZED_ACCOUNTS_ACTION = "fail_closed_capability_routing"
 
 
 class _WebSocketReplaySequenceRegression(Exception):
     pass
+
+
+class _CapabilityLineagePropagationError(Exception):
+    def __init__(self, error: ProxyResponseError) -> None:
+        super().__init__("Capability lineage propagation failed")
+        self.error = error
 
 
 def _log_websocket_persist_conflict(context: str, exc: RefreshError, account_id: str) -> None:
@@ -523,6 +546,40 @@ async def _reject_websocket_owner_switch_blocked(
         client_send_lock=client_send_lock,
         request_state=request_state,
         error_code="previous_response_owner_unavailable",
+        error_message=error_message,
+        downstream_activity=downstream_activity,
+    )
+    await _release_websocket_response_create_gate(request_state, response_create_gate)
+
+
+async def _reject_websocket_capability_switch_blocked(
+    proxy: Any,
+    websocket: WebSocket,
+    *,
+    client_send_lock: anyio.Lock,
+    request_state: _WebSocketRequestState,
+    account: Account,
+    api_key: ApiKeyData | None,
+    response_create_gate: asyncio.Semaphore,
+    downstream_activity: _DownstreamWebSocketActivity,
+) -> None:
+    error_message = (
+        "Required capability cannot switch accounts while another response is still streaming; "
+        "retry after the terminal frame."
+    )
+    await proxy._release_websocket_request_state_reservation(request_state)
+    await proxy._write_websocket_connect_failure(
+        account_id=account.id,
+        api_key=api_key,
+        request_state=request_state,
+        error_code="continuity_owner_conflict",
+        error_message=error_message,
+    )
+    await proxy._emit_websocket_terminal_error(
+        websocket,
+        client_send_lock=client_send_lock,
+        request_state=request_state,
+        error_code="continuity_owner_conflict",
         error_message=error_message,
         downstream_activity=downstream_activity,
     )
@@ -748,6 +805,7 @@ class _WebSocketMixin:
         api_key: ApiKeyData | None,
         client_ip: str | None = None,
         synthesized_turn_state: str | None = None,
+        capability_header_values: tuple[str, ...] | None = None,
     ) -> None:
         proxy = cast(_WebSocketServiceProtocol, self)
         _ = proxy
@@ -775,6 +833,7 @@ class _WebSocketMixin:
         )
         account: Account | None = None
         account_lease: AccountLease | None = None
+        upstream_requires_security_work_authorized: bool | None = None
         upstream_turn_state: str | None = _sticky_key_from_turn_state_header(headers)
         client_turn_state_header: str | None = _sticky_key_from_turn_state_header(filtered_headers)
         upstream_account_id: str | None = None
@@ -788,6 +847,7 @@ class _WebSocketMixin:
 
         async def retire_current_upstream() -> None:
             nonlocal account, upstream, upstream_control, upstream_reader
+            nonlocal upstream_requires_security_work_authorized
             if upstream_control is not None:
                 upstream_control.reconnect_requested = True
             if upstream_reader is not None:
@@ -805,6 +865,7 @@ class _WebSocketMixin:
             upstream = None
             await release_current_account_lease()
             account = None
+            upstream_requires_security_work_authorized = None
 
         try:
             while True:
@@ -934,9 +995,26 @@ class _WebSocketMixin:
                     text_data = message.get("text")
                     bytes_data = message.get("bytes")
 
+                    if bytes_data is not None:
+                        async with client_send_lock:
+                            await websocket.send_text(
+                                _serialize_websocket_error_event(
+                                    _wrapped_websocket_error_event(400, openai_invalid_payload_error())
+                                )
+                            )
+                        continue
+
                     if text_data is not None:
                         payload = _parse_websocket_payload(text_data)
-                        if payload is not None and _is_websocket_response_create(payload):
+                        if payload is None:
+                            async with client_send_lock:
+                                await websocket.send_text(
+                                    _serialize_websocket_error_event(
+                                        _wrapped_websocket_error_event(400, openai_invalid_payload_error())
+                                    )
+                                )
+                            continue
+                        if _is_websocket_response_create(payload):
                             try:
                                 prepared_request = await proxy._prepare_websocket_response_create_request(
                                     payload,
@@ -953,6 +1031,7 @@ class _WebSocketMixin:
                                     conversation_id=conversation_id,
                                     client_ip=client_ip,
                                     synthesized_turn_state=synthesized_turn_state,
+                                    capability_header_values=capability_header_values,
                                 )
                                 if await _websocket_full_replay_should_wait_for_continuity(
                                     prepared_request.request_state,
@@ -991,6 +1070,7 @@ class _WebSocketMixin:
                                         conversation_id=conversation_id,
                                         client_ip=client_ip,
                                         synthesized_turn_state=synthesized_turn_state,
+                                        capability_header_values=capability_header_values,
                                     )
                                 request_state = prepared_request.request_state
                                 request_affinity = prepared_request.affinity_policy
@@ -1040,6 +1120,21 @@ class _WebSocketMixin:
                                     await websocket.send_text(
                                         _serialize_websocket_error_event(
                                             _wrapped_websocket_error_event(400, openai_validation_error(exc))
+                                        )
+                                    )
+                                continue
+                        elif payload is not None:
+                            try:
+                                reject_capability_signal_outside_response_create(
+                                    api_key=api_key,
+                                    client_metadata=payload.get("client_metadata"),
+                                    client_metadata_values=_websocket_capability_metadata_values(payload),
+                                )
+                            except ProxyResponseError as exc:
+                                async with client_send_lock:
+                                    await websocket.send_text(
+                                        _serialize_websocket_error_event(
+                                            _wrapped_websocket_error_event(exc.status_code, exc.payload)
                                         )
                                     )
                                 continue
@@ -1179,6 +1274,117 @@ class _WebSocketMixin:
                     request_state is not None
                     and upstream is not None
                     and account is not None
+                    and request_state.require_security_work_authorized
+                ):
+                    capability_account_reusable = False
+                    if upstream_requires_security_work_authorized:
+                        try:
+                            (
+                                revalidated_account,
+                                _error_code,
+                                _error_message,
+                            ) = await proxy._revalidate_open_websocket_account(
+                                account,
+                                request_state=request_state,
+                                api_key=request_state.api_key or api_key,
+                            )
+                        except ProxyResponseError as exc:
+                            error = _parse_openai_error(exc.payload)
+                            error_code = _normalize_error_code(
+                                error.code if error else None,
+                                error.type if error else None,
+                            )
+                            error_message = error.message if error and error.message else "Upstream error"
+                            await proxy._release_websocket_request_state_reservation(request_state)
+                            await proxy._write_websocket_connect_failure(
+                                account_id=account.id,
+                                api_key=api_key,
+                                request_state=request_state,
+                                error_code=error_code or "upstream_error",
+                                error_message=error_message,
+                            )
+                            await proxy._emit_websocket_terminal_error(
+                                websocket,
+                                client_send_lock=client_send_lock,
+                                request_state=request_state,
+                                error_code=error_code or "upstream_error",
+                                error_message=error_message,
+                                error_type=error.type if error and error.type else "server_error",
+                                error_param=error.param if error else None,
+                                downstream_activity=downstream_activity,
+                            )
+                            request_state = None
+                            text_data = None
+                            payload = None
+                            continue
+                        except BaseException as exc:
+                            await proxy._release_websocket_request_state_reservation(request_state)
+                            if not isinstance(exc, Exception):
+                                raise
+                            _facade().logger.exception(
+                                "Capability account revalidation failed request_id=%s account_id=%s",
+                                request_state.request_log_id or request_state.request_id,
+                                account.id,
+                            )
+                            await proxy._write_websocket_connect_failure(
+                                account_id=account.id,
+                                api_key=api_key,
+                                request_state=request_state,
+                                error_code=CAPABILITY_ROUTING_UNAVAILABLE_CODE,
+                                error_message=CAPABILITY_ROUTING_UNAVAILABLE_MESSAGE,
+                            )
+                            await proxy._emit_websocket_terminal_error(
+                                websocket,
+                                client_send_lock=client_send_lock,
+                                request_state=request_state,
+                                error_code=CAPABILITY_ROUTING_UNAVAILABLE_CODE,
+                                error_message=CAPABILITY_ROUTING_UNAVAILABLE_MESSAGE,
+                                error_type="server_error",
+                                downstream_activity=downstream_activity,
+                            )
+                            request_state = None
+                            text_data = None
+                            payload = None
+                            continue
+                        if revalidated_account is not None:
+                            account = revalidated_account
+                            capability_account_reusable = True
+
+                    if not capability_account_reusable:
+                        async with pending_lock:
+                            capability_switch_blocked = any(
+                                pending_request is not request_state for pending_request in pending_requests
+                            )
+                            if capability_switch_blocked and request_state in pending_requests:
+                                pending_requests.remove(request_state)
+                        if capability_switch_blocked:
+                            await _reject_websocket_capability_switch_blocked(
+                                proxy,
+                                websocket,
+                                client_send_lock=client_send_lock,
+                                request_state=request_state,
+                                account=account,
+                                api_key=api_key,
+                                response_create_gate=response_create_gate,
+                                downstream_activity=downstream_activity,
+                            )
+                            request_state = None
+                            text_data = None
+                            payload = None
+                            continue
+                        await retire_current_upstream()
+                        upstream_turn_state = None
+                        if synthesized_turn_state is not None:
+                            filtered_headers = {
+                                key: value
+                                for key, value in filtered_headers.items()
+                                if key.lower() != "x-codex-turn-state"
+                            }
+
+                if (
+                    request_state is not None
+                    and upstream is not None
+                    and account is not None
                     and request_state.affinity_policy.require_unambiguous_account
                 ):
                     # Socket reuse bypasses connect-time selection. Re-run the
@@ -1193,6 +1399,7 @@ class _WebSocketMixin:
                         affinity_policy=request_state.affinity_policy,
                         model=request_state.model,
                         preferred_account_id=account.id,
+                        require_security_work_authorized=request_state.require_security_work_authorized,
                         fallback_on_preferred_account_unavailable=False,
                     )
                     if ownership_selection.account is None:
@@ -1321,14 +1528,6 @@ class _WebSocketMixin:
                             }
 
                 if upstream is None:
-                    if text_data is not None and payload is None:
-                        async with client_send_lock:
-                            await websocket.send_text(
-                                _serialize_websocket_error_event(
-                                    _wrapped_websocket_error_event(400, openai_invalid_payload_error())
-                                )
-                            )
-                        continue
                     if request_state is None:
                         async with client_send_lock:
                             await websocket.send_text(
@@ -1402,6 +1601,7 @@ class _WebSocketMixin:
                         # owner when a transparent replay reconnects.
                         upstream_turn_state = None
                     upstream_account_id = account.id
+                    upstream_requires_security_work_authorized = request_state.require_security_work_authorized
                     upstream_turn_state = _facade()._upstream_turn_state_from_socket(upstream) or upstream_turn_state
                     upstream_control = _WebSocketUpstreamControl()
                     upstream_reader = asyncio.create_task(
@@ -1471,10 +1671,6 @@ class _WebSocketMixin:
                         archive_request_id = None if request_state is None else request_state.archive_request_id
                         with _websocket_archive_request_context(archive_request_id):
                             await upstream.send_text(text_data)
-                    elif bytes_data is not None:
-                        archive_request_id = None if request_state is None else request_state.archive_request_id
-                        with _websocket_archive_request_context(archive_request_id):
-                            await upstream.send_bytes(bytes_data)
                 except ProxyResponseError as exc:
                     error = _parse_openai_error(exc.payload)
                     error_code = _normalize_error_code(error.code if error else None, error.type if error else None)
@@ -1659,10 +1855,19 @@ class _WebSocketMixin:
         conversation_id: str | None = None,
         client_ip: str | None = None,
         synthesized_turn_state: str | None = None,
+        capability_header_values: tuple[str, ...] | None = None,
     ) -> _PreparedWebSocketRequest:
         proxy = cast(_WebSocketServiceProtocol, self)
         _ = proxy
         refreshed_api_key = await proxy._refresh_websocket_api_key_policy(api_key)
+        raw_client_metadata = payload.get("client_metadata")
+        capability_intent = parse_routing_intent(
+            headers,
+            api_key=refreshed_api_key,
+            client_metadata=raw_client_metadata,
+            header_values=capability_header_values,
+            client_metadata_values=_websocket_capability_metadata_values(payload),
+        )
         responses_payload = normalize_responses_request_payload(
             payload,
             openai_compat=openai_cache_affinity,
@@ -1677,6 +1882,10 @@ class _WebSocketMixin:
             service_tier_was_enforced=service_tier_was_enforced,
         )
         normalized_payload = responses_payload.to_payload()
+        stripped_client_metadata = strip_capability_metadata(normalized_payload.get("client_metadata"))
+        if stripped_client_metadata is not normalized_payload.get("client_metadata"):
+            responses_payload = responses_payload.model_copy(update={"client_metadata": stripped_client_metadata})
+            normalized_payload = responses_payload.to_payload()
         body_uses_responses_lite = _payload_uses_responses_lite(normalized_payload)
         trusted_incremental_responses_lite = bool(
             not body_uses_responses_lite
@@ -1785,6 +1994,21 @@ class _WebSocketMixin:
                     responses_payload.previous_response_id,
                     len(missing_call_ids),
                 )
+        session_id = _owner_lookup_session_id_from_headers(
+            headers,
+            synthesized_turn_state=synthesized_turn_state,
+        )
+        capability_route = await proxy._capability_router.route(
+            capability_intent,
+            api_key_id=refreshed_api_key.id if refreshed_api_key is not None else None,
+            aliases=capability_lineage_aliases(
+                headers,
+                session_id=_sticky_key_from_session_header(headers),
+                turn_state=_sticky_key_from_turn_state_header(headers) or synthesized_turn_state,
+                previous_response_ids=(responses_payload.previous_response_id,),
+                client_metadata=client_metadata,
+            ),
+        )
         reservation = await proxy._reserve_websocket_api_key_usage(
             refreshed_api_key,
             request_model=responses_payload.model,
@@ -1794,7 +2018,6 @@ class _WebSocketMixin:
             request_usage_budget=estimate_api_key_request_usage(responses_payload),
         )
         try:
-            session_id = _owner_lookup_session_id_from_headers(headers, synthesized_turn_state=synthesized_turn_state)
             request_state, text_data = proxy._prepare_response_bridge_request_state(
                 responses_payload,
                 api_key=refreshed_api_key,
@@ -1815,6 +2038,8 @@ class _WebSocketMixin:
         request_state.client_ip = client_ip
         request_state.responses_lite_model = next_responses_lite_model
         request_state.expose_stale_previous_response_classifier = codex_session_affinity
+        request_state.require_security_work_authorized = capability_route.require_security_work_authorized
+        request_state.durable_capability_lineage_required = capability_route.require_security_work_authorized
         original_full_resend_input: JsonValue | None = None
         if session_anchor is not None:
             request_state.proxy_injected_previous_response_id = True
@@ -2485,14 +2710,35 @@ class _WebSocketMixin:
     ) -> None:
         proxy = cast(_WebSocketServiceProtocol, self)
         _ = proxy
+        if request_state.durable_capability_lineage_required:
+            _clear_websocket_precreated_replay_fallback(request_state)
+            error_code = _facade()._NO_SECURITY_WORK_AUTHORIZED_ACCOUNTS_CODE
+            error_message = _CAPABILITY_REQUIRED_NO_AUTHORIZED_ACCOUNTS_MESSAGE
+            error_type = "server_error"
+            status_code = 503
+            advisory_message = _CAPABILITY_REQUIRED_NO_AUTHORIZED_ACCOUNTS_MESSAGE
+            advisory_action = _CAPABILITY_REQUIRED_NO_AUTHORIZED_ACCOUNTS_ACTION
+        else:
+            error_code = request_state.error_code_override or _facade()._NO_SECURITY_WORK_AUTHORIZED_ACCOUNTS_CODE
+            error_message = (
+                request_state.error_message_override or _facade()._SECURITY_WORK_NO_AUTHORIZED_ACCOUNTS_MESSAGE
+            )
+            error_type = request_state.error_type_override or (
+                "invalid_request_error" if request_state.error_code_override is not None else "server_error"
+            )
+            status_code = request_state.error_http_status_override or (
+                400 if request_state.error_code_override is not None else 503
+            )
+            advisory_message = _facade()._SECURITY_WORK_NO_AUTHORIZED_ACCOUNTS_MESSAGE
+            advisory_action = "forward_original_security_work_error"
         async with client_send_lock:
             await websocket.send_text(
                 json.dumps(
                     _facade()._security_work_advisory_event(
                         code=_facade()._NO_SECURITY_WORK_AUTHORIZED_ACCOUNTS_CODE,
-                        message=_facade()._SECURITY_WORK_NO_AUTHORIZED_ACCOUNTS_MESSAGE,
+                        message=advisory_message,
                         request_id=request_state.request_log_id or request_state.request_id,
-                        action="forward_original_security_work_error",
+                        action=advisory_action,
                     ),
                     ensure_ascii=True,
                     separators=(",", ":"),
@@ -2504,14 +2750,14 @@ class _WebSocketMixin:
             account_id=account_id,
             api_key=api_key,
             request_state=request_state,
-            status_code=400,
+            status_code=status_code,
             payload=openai_error(
-                request_state.error_code_override or _facade()._SECURITY_WORK_AUTHORIZATION_REQUIRED_CODE,
-                request_state.error_message_override or "Security work authorization is required",
-                error_type=request_state.error_type_override or "invalid_request_error",
+                error_code,
+                error_message,
+                error_type=error_type,
             ),
-            error_code=request_state.error_code_override or _facade()._SECURITY_WORK_AUTHORIZATION_REQUIRED_CODE,
-            error_message=request_state.error_message_override or "Security work authorization is required",
+            error_code=error_code,
+            error_message=error_message,
         )
 
     async def _try_open_websocket_connect_attempt(
@@ -3532,6 +3778,35 @@ class _WebSocketMixin:
                 break
         except asyncio.CancelledError:
             raise
+        except _CapabilityLineagePropagationError as exc:
+            error = _parse_openai_error(exc.error.payload)
+            error_code = _normalize_error_code(
+                error.code if error else None,
+                error.type if error else None,
+            )
+            error_message = error.message if error and error.message else "Required capability lineage is unavailable"
+            await proxy._fail_pending_websocket_requests(
+                account=account,
+                account_id_value=account_id_value,
+                pending_requests=pending_requests,
+                pending_lock=pending_lock,
+                error_code=error_code or "capability_lineage_unavailable",
+                error_message=error_message,
+                api_key=api_key,
+                websocket=websocket,
+                client_send_lock=client_send_lock,
+                response_create_gate=response_create_gate,
+                downstream_activity=downstream_activity,
+                penalize_account=False,
+            )
+            upstream_control.reconnect_requested = True
+            try:
+                await upstream.close()
+            except Exception:
+                _facade().logger.debug(
+                    "Failed to retire upstream websocket after capability lineage propagation failure",
+                    exc_info=True,
+                )
         except _WebSocketReplaySequenceRegression as exc:
             _facade().logger.warning(
                 "Refusing websocket replay after non-advancing sequence account_id=%s detail=%s",
@@ -3655,11 +3930,6 @@ class _WebSocketMixin:
                 request_state = _assign_websocket_response_id(pending_requests, response_id)
                 created_request_state = request_state
                 release_create_gate = request_state is not None
-                if request_state is not None and continuity_state is not None:
-                    _record_websocket_responses_lite_acceptance(
-                        continuity_state,
-                        request_state=request_state,
-                    )
             elif response_id is not None:
                 request_state = _find_websocket_request_state_by_response_id(pending_requests, response_id)
                 release_create_gate = False
@@ -3812,6 +4082,38 @@ class _WebSocketMixin:
                 has_other_pending_requests = bool(pending_requests)
             else:
                 request_state = None
+
+        if (
+            event_type == "response.created"
+            and response_id is not None
+            and created_request_state is not None
+            and created_request_state.durable_capability_lineage_required
+        ):
+            capability_api_key = created_request_state.api_key
+            try:
+                if capability_api_key is None:
+                    raise _capability_lineage_unavailable_error()
+                await proxy._capability_router.route(
+                    RoutingIntent.requiring(RoutingCapability.TRUSTED_CYBER),
+                    api_key_id=capability_api_key.id,
+                    aliases=capability_lineage_aliases(
+                        {},
+                        previous_response_ids=_websocket_continuity_response_ids(
+                            created_request_state,
+                            response_id,
+                        ),
+                    ),
+                )
+            except ProxyResponseError as exc:
+                async with pending_lock:
+                    created_request_state.response_id = None
+                raise _CapabilityLineagePropagationError(exc) from exc
+
+        if event_type == "response.created" and created_request_state is not None and continuity_state is not None:
+            _record_websocket_responses_lite_acceptance(
+                continuity_state,
+                request_state=created_request_state,
+            )
 
         if event_type == "response.created" and release_create_gate and created_request_state is not None:
             await _release_websocket_response_create_gate(created_request_state, response_create_gate)

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -2603,7 +2603,17 @@ class _WebSocketMixin:
         if account:
             request_state.websocket_stream_lease = selection.lease
             return account
-        if defer_no_account_error and not _facade()._is_local_account_cap_code(selection.error_code):
+        durable_capability_pool_missing = bool(
+            require_security_work_authorized
+            and request_state.durable_capability_lineage_required
+            and not require_preferred_account
+            and not _facade()._is_local_account_cap_code(selection.error_code)
+        )
+        if (
+            defer_no_account_error
+            and not durable_capability_pool_missing
+            and not _facade()._is_local_account_cap_code(selection.error_code)
+        ):
             _facade().logger.warning(
                 "Websocket account selection deferred no-account error request_id=%s model=%s "
                 "preferred_account_id=%s require_preferred=%s error_code=%s error=%s excluded_count=%s",
@@ -2618,7 +2628,9 @@ class _WebSocketMixin:
             return None
         error_code = selection.error_code or "no_accounts"
         error_message = selection.error_message or "No active accounts available"
-        if require_security_work_authorized and error_code == _facade()._NO_SECURITY_WORK_AUTHORIZED_ACCOUNTS_CODE:
+        if durable_capability_pool_missing or (
+            require_security_work_authorized and error_code == _facade()._NO_SECURITY_WORK_AUTHORIZED_ACCOUNTS_CODE
+        ):
             await proxy._emit_websocket_security_work_missing_pool(
                 websocket,
                 client_send_lock=client_send_lock,

--- a/app/modules/proxy/_service/websocket/protocol.py
+++ b/app/modules/proxy/_service/websocket/protocol.py
@@ -4,6 +4,7 @@ from typing import Any, Protocol
 
 
 class _WebSocketServiceProtocol(Protocol):
+    _capability_router: Any
     _acquire_account_response_create_lease_or_overload: Any
     _acquire_request_state_response_create_admission: Any
     _cancel_request_state_api_key_reservation_heartbeat: Any

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -44,6 +44,7 @@ from app.core.auth.refresh import RefreshError
 from app.core.cache.invalidation import NAMESPACE_RESET_CREDITS, bump_cache_invalidation_local
 from app.core.clients.files import FileProxyError
 from app.core.clients.proxy import (
+    CODEX_LB_REQUIRED_CAPABILITY_HEADER,
     CodexControlRequestPrivacyPolicy,
     CodexControlResponse,
     ProxyResponseError,
@@ -1106,6 +1107,7 @@ async def responses_websocket(
         api_key=api_key,
         client_ip=resolve_request_client_host(websocket),
         synthesized_turn_state=turn_state if client_turn_state is None else None,
+        capability_header_values=tuple(websocket.headers.getlist(CODEX_LB_REQUIRED_CAPABILITY_HEADER)),
     )
 
 
@@ -1410,6 +1412,7 @@ async def v1_responses_websocket(
         api_key=api_key,
         client_ip=resolve_request_client_host(websocket),
         synthesized_turn_state=turn_state if client_turn_state is None else None,
+        capability_header_values=tuple(websocket.headers.getlist(CODEX_LB_REQUIRED_CAPABILITY_HEADER)),
     )
 
 

--- a/app/modules/proxy/capability_lineage.py
+++ b/app/modules/proxy/capability_lineage.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from collections.abc import Collection
+from dataclasses import dataclass
+from hashlib import sha256
+
+_MARKER_DOMAIN = "capability-lineage/v1"
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityLineageAlias:
+    kind: str
+    value: str
+
+
+def normalize_capability_lineage_aliases(
+    aliases: Collection[CapabilityLineageAlias],
+) -> tuple[CapabilityLineageAlias, ...]:
+    normalized: dict[tuple[str, str], CapabilityLineageAlias] = {}
+    for alias in aliases:
+        kind = alias.kind.strip()
+        value = alias.value.strip()
+        if kind and value:
+            normalized[(kind, value)] = CapabilityLineageAlias(kind=kind, value=value)
+    return tuple(normalized.values())
+
+
+def capability_lineage_marker_hash(
+    *,
+    capability: str,
+    api_key_scope: str,
+    alias: CapabilityLineageAlias,
+) -> str:
+    normalized_capability = capability.strip()
+    normalized_scope = api_key_scope.strip()
+    normalized_aliases = normalize_capability_lineage_aliases((alias,))
+    if not normalized_capability or not normalized_scope or not normalized_aliases:
+        raise ValueError("capability, API-key scope, and lineage alias must be non-empty")
+    normalized_alias = normalized_aliases[0]
+    payload = "\0".join(
+        (
+            _MARKER_DOMAIN,
+            normalized_capability,
+            normalized_scope,
+            normalized_alias.kind,
+            normalized_alias.value,
+        )
+    )
+    return sha256(payload.encode("utf-8")).hexdigest()
+
+
+def capability_lineage_marker_hashes(
+    *,
+    capability: str,
+    api_key_scope: str,
+    aliases: Collection[CapabilityLineageAlias],
+) -> tuple[str, ...]:
+    return tuple(
+        capability_lineage_marker_hash(
+            capability=capability,
+            api_key_scope=api_key_scope,
+            alias=alias,
+        )
+        for alias in normalize_capability_lineage_aliases(aliases)
+    )

--- a/app/modules/proxy/capability_lineage_repository.py
+++ b/app/modules/proxy/capability_lineage_repository.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from collections.abc import Collection
+
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import Insert
+
+from app.db.models import CapabilityLineageMarker
+from app.db.session import sqlite_writer_section
+from app.modules.proxy.capability_lineage import (
+    CapabilityLineageAlias,
+    capability_lineage_marker_hashes,
+)
+
+
+class CapabilityLineageRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def is_required(
+        self,
+        *,
+        capability: str,
+        api_key_scope: str,
+        aliases: Collection[CapabilityLineageAlias],
+    ) -> bool:
+        marker_hashes = capability_lineage_marker_hashes(
+            capability=capability,
+            api_key_scope=api_key_scope,
+            aliases=aliases,
+        )
+        if not marker_hashes:
+            return False
+        statement = (
+            select(CapabilityLineageMarker.marker_hash)
+            .where(CapabilityLineageMarker.marker_hash.in_(marker_hashes))
+            .limit(1)
+        )
+        required = (await self._session.execute(statement)).scalar_one_or_none() is not None
+        # End SQLite's read snapshot before a caller upgrades this dedicated
+        # repository session into a writer while another connection commits.
+        await self._session.commit()
+        return required
+
+    async def require(
+        self,
+        *,
+        capability: str,
+        api_key_scope: str,
+        aliases: Collection[CapabilityLineageAlias],
+    ) -> tuple[str, ...]:
+        marker_hashes = capability_lineage_marker_hashes(
+            capability=capability,
+            api_key_scope=api_key_scope,
+            aliases=aliases,
+        )
+        if not marker_hashes:
+            return ()
+        async with sqlite_writer_section():
+            # Overlapping alias sets must lock rows in one global order on
+            # PostgreSQL so concurrent reconnects cannot deadlock A->B/B->A.
+            for marker_hash in sorted(marker_hashes):
+                await self._session.execute(self._upsert_statement(marker_hash))
+            await self._session.commit()
+        return marker_hashes
+
+    def _upsert_statement(self, marker_hash: str) -> Insert:
+        dialect = self._session.get_bind().dialect.name
+        if dialect == "postgresql":
+            insert_fn = pg_insert
+        elif dialect == "sqlite":
+            insert_fn = sqlite_insert
+        else:
+            raise RuntimeError(f"Capability lineage persistence unsupported for dialect={dialect!r}")
+        statement = insert_fn(CapabilityLineageMarker).values(marker_hash=marker_hash)
+        return statement.on_conflict_do_update(
+            index_elements=[CapabilityLineageMarker.marker_hash],
+            set_={"last_seen_at": func.now()},
+        )

--- a/app/modules/proxy/capability_routing.py
+++ b/app/modules/proxy/capability_routing.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Collection, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+
+from app.core.clients.proxy import CODEX_LB_REQUIRED_CAPABILITY_HEADER, ProxyResponseError
+from app.core.errors import openai_error
+from app.core.types import JsonValue
+from app.core.utils.json_guards import is_json_mapping
+from app.modules.api_keys.service import ApiKeyData
+from app.modules.proxy.capability_lineage import (
+    CapabilityLineageAlias,
+    normalize_capability_lineage_aliases,
+)
+from app.modules.proxy.repo_bundle import ProxyRepoFactory
+
+REQUIRED_CAPABILITY_HEADER = CODEX_LB_REQUIRED_CAPABILITY_HEADER
+CODEX_PARENT_THREAD_ID_HEADER = "x-codex-parent-thread-id"
+CODEX_WINDOW_ID_HEADER = "x-codex-window-id"
+CAPABILITY_SIGNAL_UNTRUSTED_CODE = "capability_signal_untrusted"
+UNSUPPORTED_REQUIRED_CAPABILITY_CODE = "unsupported_required_capability"
+CAPABILITY_LINEAGE_UNAVAILABLE_CODE = "capability_lineage_unavailable"
+CAPABILITY_ROUTING_UNAVAILABLE_CODE = "capability_routing_unavailable"
+CAPABILITY_ROUTING_UNAVAILABLE_MESSAGE = "Required capability routing is unavailable; retry later."
+
+_TERMINAL_WINDOW_SLOT_RE = re.compile(r":\d+$")
+
+
+class RoutingCapability(StrEnum):
+    TRUSTED_CYBER = "trusted_cyber"
+
+
+@dataclass(frozen=True, slots=True)
+class RoutingIntent:
+    required_capabilities: frozenset[RoutingCapability] = frozenset()
+
+    @classmethod
+    def empty(cls) -> RoutingIntent:
+        return cls()
+
+    @classmethod
+    def requiring(cls, capability: RoutingCapability) -> RoutingIntent:
+        return cls(required_capabilities=frozenset({capability}))
+
+    @property
+    def requires_trusted_cyber(self) -> bool:
+        return RoutingCapability.TRUSTED_CYBER in self.required_capabilities
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityRoute:
+    require_security_work_authorized: bool
+    aliases: tuple[CapabilityLineageAlias, ...]
+
+
+class CapabilityRouter:
+    def __init__(self, repo_factory: ProxyRepoFactory) -> None:
+        self._repo_factory = repo_factory
+
+    async def route(
+        self,
+        intent: RoutingIntent,
+        *,
+        api_key_id: str | None,
+        aliases: Collection[CapabilityLineageAlias],
+    ) -> CapabilityRoute:
+        normalized_aliases = normalize_capability_lineage_aliases(aliases)
+        explicitly_required = intent.requires_trusted_cyber
+        if api_key_id is None or not normalized_aliases:
+            return CapabilityRoute(
+                require_security_work_authorized=explicitly_required,
+                aliases=normalized_aliases,
+            )
+
+        try:
+            async with self._repo_factory() as repositories:
+                repository = repositories.capability_lineage
+                if repository is None:
+                    raise RuntimeError("capability lineage repository is unavailable")
+                inherited_requirement = False
+                if not explicitly_required:
+                    inherited_requirement = await repository.is_required(
+                        capability=RoutingCapability.TRUSTED_CYBER.value,
+                        api_key_scope=api_key_id,
+                        aliases=normalized_aliases,
+                    )
+                required = explicitly_required or inherited_requirement
+                if required:
+                    marker_hashes = await repository.require(
+                        capability=RoutingCapability.TRUSTED_CYBER.value,
+                        api_key_scope=api_key_id,
+                        aliases=normalized_aliases,
+                    )
+                    if not marker_hashes:
+                        raise RuntimeError("capability lineage marker was not persisted")
+        except Exception as exc:
+            raise _capability_lineage_unavailable_error() from exc
+
+        return CapabilityRoute(
+            require_security_work_authorized=required,
+            aliases=normalized_aliases,
+        )
+
+
+def capability_lineage_aliases(
+    headers: Mapping[str, str],
+    *,
+    session_id: str | None = None,
+    turn_state: str | None = None,
+    previous_response_ids: Collection[str | None] = (),
+    client_metadata: JsonValue | None = None,
+) -> tuple[CapabilityLineageAlias, ...]:
+    aliases: list[CapabilityLineageAlias] = []
+    _append_alias(aliases, "session_header", session_id)
+    _append_alias(aliases, "turn_state", turn_state)
+    for previous_response_id in previous_response_ids:
+        _append_alias(aliases, "previous_response", previous_response_id)
+
+    parent_thread_ids = (
+        *_header_values(headers, CODEX_PARENT_THREAD_ID_HEADER),
+        *_metadata_string_values(client_metadata, CODEX_PARENT_THREAD_ID_HEADER),
+    )
+    for parent_thread_id in parent_thread_ids:
+        _append_alias(aliases, "codex_task", parent_thread_id)
+
+    window_ids = (
+        *_header_values(headers, CODEX_WINDOW_ID_HEADER),
+        *_metadata_string_values(client_metadata, CODEX_WINDOW_ID_HEADER),
+    )
+    for window_id in window_ids:
+        _append_alias(aliases, "codex_window", window_id)
+        stable_task_id = _TERMINAL_WINDOW_SLOT_RE.sub("", window_id.strip())
+        _append_alias(aliases, "codex_task", stable_task_id)
+    return normalize_capability_lineage_aliases(aliases)
+
+
+def parse_routing_intent(
+    headers: Mapping[str, str],
+    *,
+    api_key: ApiKeyData | None,
+    client_metadata: JsonValue | None = None,
+    header_values: Collection[str] | None = None,
+    client_metadata_values: Collection[JsonValue] | None = None,
+) -> RoutingIntent:
+    values: tuple[JsonValue, ...] = (
+        *(tuple(header_values) if header_values is not None else _header_values(headers, REQUIRED_CAPABILITY_HEADER)),
+        *(
+            tuple(client_metadata_values)
+            if client_metadata_values is not None
+            else _metadata_values(client_metadata, REQUIRED_CAPABILITY_HEADER)
+        ),
+    )
+    if not values:
+        return RoutingIntent.empty()
+    if api_key is None:
+        raise ProxyResponseError(
+            403,
+            openai_error(
+                CAPABILITY_SIGNAL_UNTRUSTED_CODE,
+                "Required capability signal requires an authenticated proxy API key.",
+                error_type="permission_error",
+            ),
+        )
+    if len(values) != 1:
+        raise _unsupported_capability_error()
+    raw_capability = values[0]
+    if not isinstance(raw_capability, str):
+        raise _unsupported_capability_error()
+    try:
+        capability = RoutingCapability(raw_capability.strip())
+    except ValueError as exc:
+        raise _unsupported_capability_error() from exc
+    return RoutingIntent.requiring(capability)
+
+
+def reject_capability_signal_outside_response_create(
+    *,
+    api_key: ApiKeyData | None,
+    client_metadata: JsonValue | None,
+    client_metadata_values: Collection[JsonValue] | None = None,
+) -> None:
+    intent = parse_routing_intent(
+        {},
+        api_key=api_key,
+        client_metadata=client_metadata,
+        client_metadata_values=client_metadata_values,
+    )
+    if intent.required_capabilities:
+        raise _unsupported_capability_error()
+
+
+def strip_capability_metadata(client_metadata: JsonValue | None) -> JsonValue | None:
+    if not is_json_mapping(client_metadata):
+        return client_metadata
+    normalized_name = REQUIRED_CAPABILITY_HEADER.lower()
+    return {
+        key: value
+        for key, value in client_metadata.items()
+        if not isinstance(key, str) or key.lower() != normalized_name
+    }
+
+
+def _header_values(headers: Mapping[str, str], name: str) -> tuple[str, ...]:
+    normalized_name = name.lower()
+    return tuple(value for header_name, value in headers.items() if header_name.lower() == normalized_name)
+
+
+def _metadata_values(client_metadata: JsonValue | None, name: str) -> tuple[JsonValue, ...]:
+    if not is_json_mapping(client_metadata):
+        return ()
+    normalized_name = name.lower()
+    return tuple(
+        value for key, value in client_metadata.items() if isinstance(key, str) and key.lower() == normalized_name
+    )
+
+
+def _metadata_string_values(client_metadata: JsonValue | None, name: str) -> tuple[str, ...]:
+    return tuple(value for value in _metadata_values(client_metadata, name) if isinstance(value, str))
+
+
+def _append_alias(aliases: list[CapabilityLineageAlias], kind: str, value: str | None) -> None:
+    if value is not None:
+        aliases.append(CapabilityLineageAlias(kind=kind, value=value))
+
+
+def _unsupported_capability_error() -> ProxyResponseError:
+    return ProxyResponseError(
+        400,
+        openai_error(
+            UNSUPPORTED_REQUIRED_CAPABILITY_CODE,
+            "Required routing capability is unsupported.",
+            error_type="invalid_request_error",
+        ),
+    )
+
+
+def _capability_lineage_unavailable_error() -> ProxyResponseError:
+    return ProxyResponseError(
+        503,
+        openai_error(
+            CAPABILITY_LINEAGE_UNAVAILABLE_CODE,
+            "Required capability lineage is unavailable; retry later.",
+            error_type="server_error",
+        ),
+    )

--- a/app/modules/proxy/capability_routing.py
+++ b/app/modules/proxy/capability_routing.py
@@ -169,7 +169,7 @@ def parse_routing_intent(
     if not isinstance(raw_capability, str):
         raise _unsupported_capability_error()
     try:
-        capability = RoutingCapability(raw_capability.strip())
+        capability = RoutingCapability(raw_capability)
     except ValueError as exc:
         raise _unsupported_capability_error() from exc
     return RoutingIntent.requiring(capability)

--- a/app/modules/proxy/repo_bundle.py
+++ b/app/modules/proxy/repo_bundle.py
@@ -6,6 +6,7 @@ from typing import AsyncContextManager
 
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.repository import ApiKeysRepository
+from app.modules.proxy.capability_lineage_repository import CapabilityLineageRepository
 from app.modules.proxy.sticky_repository import StickySessionsRepository
 from app.modules.quota_planner.repository import QuotaPlannerRepository
 from app.modules.request_logs.repository import RequestLogsRepository
@@ -21,6 +22,7 @@ class ProxyRepositories:
     api_keys: ApiKeysRepository
     additional_usage: AdditionalUsageRepository
     quota_planner: QuotaPlannerRepository | None = None
+    capability_lineage: CapabilityLineageRepository | None = None
 
 
 ProxyRepoFactory = Callable[[], AsyncContextManager[ProxyRepositories]]

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -703,6 +703,7 @@ from app.modules.proxy.affinity import (
 from app.modules.proxy.affinity import (
     _sticky_key_for_responses_request as _sticky_key_for_responses_request,
 )
+from app.modules.proxy.capability_routing import CapabilityRouter
 from app.modules.proxy.durable_bridge_coordinator import (
     DurableBridgeLookup as DurableBridgeLookup,
 )
@@ -934,6 +935,7 @@ class ProxyService(
         self._repo_factory = repo_factory
         self._encryptor = TokenEncryptor()
         self._load_balancer = LoadBalancer(repo_factory)
+        self._capability_router = CapabilityRouter(repo_factory)
         self._live_websocket_connector = live_websocket_connector
         self._ring_membership = RingMembershipService(SessionLocal)
         self._durable_bridge = DurableBridgeSessionCoordinator(SessionLocal)
@@ -1407,10 +1409,16 @@ class ProxyService(
                 require_unambiguous_account=affinity_policy.require_unambiguous_account,
                 sticky_max_age_seconds=affinity_policy.max_age_seconds,
             )
+        required_capability_kwargs = {}
+        if kwargs.get("require_security_work_authorized") is True:
+            required_capability_kwargs["require_security_work_authorized"] = kwargs.pop(
+                "require_security_work_authorized"
+            )
         return await _call_with_supported_optional_kwargs(
             self._select_account_with_budget,
             deadline,
             optional_kwargs=kwargs,
+            **required_capability_kwargs,
         )
 
     @asynccontextmanager

--- a/openspec/changes/add-capability-aware-routing/.openspec.yaml
+++ b/openspec/changes/add-capability-aware-routing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-31

--- a/openspec/changes/add-capability-aware-routing/design.md
+++ b/openspec/changes/add-capability-aware-routing/design.md
@@ -1,0 +1,145 @@
+## Context
+
+Current `main` already exposes the operator-controlled
+`Account.security_work_authorized` grant, filters the canonical load balancer
+when `require_security_work_authorized=True`, propagates that flag through
+direct-WebSocket retry state, and reports the typed empty-pool error. It does
+not have a trusted proactive signal or durable state that can restore the flag
+after a new downstream connection omits the generated turn state.
+
+Existing persistence cannot safely stand in for that state. A sticky row means
+account ownership rather than capability; inferring from a capable owner would
+mark ordinary work and loses the requirement when ownership changes. Durable
+HTTP-bridge rows do not cover direct WebSockets and are retention-bound.
+Request logs are also retention-bound and contain no routing requirement.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish authenticated `trusted_cyber` intent before the first direct
+  Responses WebSocket account selection.
+- Persist a monotonic, API-key-scoped requirement before upstream dispatch and
+  restore it on reconnect with or without a client-echoed turn state.
+- Reuse the canonical account selector, retry, ownership, admission, and
+  `security_work_authorized` contracts already on `main`.
+- Keep raw lineage identifiers out of the new capability-marker persistence
+  and capability-specific observability, and keep the internal capability
+  carrier out of upstream traffic, archives, and logs.
+- Add only the schema needed for this durable requirement.
+
+**Non-Goals:**
+
+- A new account grant, routing strategy, prompt classifier, reservation policy,
+  reactive `cyber_policy` retry, or generic capability framework.
+- HTTP/compact/HTTP-bridge capability ingress in this first direct-WebSocket
+  slice.
+- Dashboard, settings, README, or production/deployment changes.
+- Historical backfill from draft-only lineage representations.
+
+## Decisions
+
+### Use one exact authenticated, narrowing-only signal
+
+The accepted value is `trusted_cyber` under the exact internal key
+`X-Codex-LB-Required-Capability`. A direct WebSocket may carry it on the
+handshake or in the current `response.create.client_metadata`, because the
+decision can be made after opening the downstream socket. The parser accepts
+exactly one carrier only after existing proxy API-key authentication. Unknown,
+malformed, duplicate, conflicting, or unauthenticated signals fail before
+selection. Capability-aware raw JSON parsing retains duplicate carrier keys
+long enough to reject them instead of accepting last-key-wins normalization;
+the reserved metadata key is also rejected on non-`response.create` frames.
+
+The signal grants nothing. It only turns on the existing
+`require_security_work_authorized` selector constraint inside the caller's
+already-authorized account/model/ownership pool.
+
+Alternative: infer cyber intent from prompts, user-agent, or multi-agent
+headers. Those values are not authenticated authorization inputs and are
+rejected.
+
+### Store opaque capability-lineage markers in a dedicated table
+
+`capability_lineage_markers` stores a single SHA-256 marker key plus creation
+and last-seen timestamps. The digest covers a versioned domain, capability,
+API-key scope, lineage kind, and normalized lineage value. No raw lineage,
+account identifier, or user payload is stored.
+
+Repository writes use an atomic insert/upsert and can only establish or refresh
+a marker; routing code never clears it. Lookup and write accept explicit typed
+lineage aliases. Reusing the existing proxy repository session keeps writes
+transactionally simple while the dedicated table avoids changing sticky
+ownership, nullable account foreign keys, account deletion, HTTP-bridge
+cleanup, or usage history.
+
+Alternative: encode detached marker rows in `sticky_sessions`. That requires a
+nullable account, different foreign-key deletion behavior, special purge rules,
+and account lifecycle changes. A dedicated table is smaller and less coupled.
+
+### Restore from stable direct-WebSocket lineage before selection
+
+The routing seam considers authenticated session identity, accepted or
+synthesized turn state, `previous_response_id`, and domain-separated Codex
+window/parent identifiers. Externally supplied identifiers cannot impersonate
+marker keys because the repository hashes their explicit lineage kind.
+
+An explicit trusted signal first persists every known alias, then requires the
+capable pool. A later request first checks its lookup aliases; inherited
+REQUIRED state is persisted onto any newly generated alias before selection.
+The accepted session identity remains a lookup alias when the proxy synthesizes
+a turn state, which is what makes no-echo reconnect safe.
+
+If a later frame establishes REQUIRED while an idle upstream socket belongs to
+an ordinary account, the proxy retires that socket and reselects before send.
+If a prior frame is still pending, it fails closed rather than mixing account
+requirements on one upstream connection.
+
+The socket contract is the constraint used when that socket was selected, not
+the selected account object's capability snapshot. A REQUIRED-selected socket
+is also revalidated through the canonical selector before each later REQUIRED
+frame so a revoked grant cannot be reused from stale in-memory state. Typed and
+unexpected revalidation failures settle the frame reservation and fail closed
+before send.
+
+When `response.created` first reveals an upstream response ID for a durably
+REQUIRED request, the proxy commits that previous-response alias before making
+the created frame visible downstream. A failed propagation emits the typed
+lineage-unavailable error, does not expose the unpersisted ID or penalize the
+upstream account, and retires the socket without replaying accepted work.
+
+### Fail closed on persistence uncertainty
+
+The table is required for authenticated lineage lookup. A read or write error
+produces a typed capability-lineage-unavailable response before ordinary
+dispatch. An explicit signal with no reusable alias still constrains the
+current in-memory request; it does not claim future inheritance.
+
+### Treat the carrier as private proxy metadata
+
+The handshake header is part of the proxy's internal-header denylist. The exact
+metadata key is removed from the copied `response.create` payload before
+upstream send and before request archival. Other client metadata is preserved.
+
+## Risks / Trade-offs
+
+- **Marker storage grows monotonically** -> rows are opaque and small; this
+  slice favors never downgrading security lineage over unsafe TTL expiry.
+- **A migration is required** -> the revision creates one empty table with no
+  data rewrite and descends from the current single head.
+- **An authenticated caller may self-select the narrow pool** -> it cannot add
+  account/model access and can only reduce candidates.
+- **A capable account later becomes unavailable** -> canonical selection fails
+  with the existing typed no-capable-account error; it never widens the pool.
+
+## Migration Plan
+
+Create `capability_lineage_markers` after
+`20260725_000000_add_http_bridge_pending_tool_calls`. Upgrade creates the empty
+table and its primary-key index without scanning existing rows. Downgrade drops
+only that table. Application rollback after upgrade is compatible because the
+older code ignores the additive table.
+
+## Open Questions
+
+None for this direct-WebSocket slice.

--- a/openspec/changes/add-capability-aware-routing/proposal.md
+++ b/openspec/changes/add-capability-aware-routing/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+Authenticated Codex orchestration can know that a Responses WebSocket turn
+requires Trusted Access for Cyber before codex-lb selects an account. Today
+that requirement can be discovered only after an ordinary upstream attempt,
+and it is not durable across a reconnect that omits the proxy-generated turn
+state.
+
+## What Changes
+
+- Accept one exact authenticated `trusted_cyber` routing signal on the direct
+  Responses WebSocket handshake or current `response.create` metadata.
+- Narrow the already-eligible account pool to existing
+  `security_work_authorized` accounts before the first upstream attempt and on
+  every retry; fail closed when none remain.
+- Persist the requirement before dispatch as API-key-scoped, domain-separated
+  hashes so a same-lineage reconnect remains required without repeating the
+  capability signal or generated turn state.
+- Strip the internal capability carrier before upstream dispatch, archives,
+  request diagnostics, and logging.
+- Add one additive, zero-backfill lineage table instead of importing the
+  broader migration and lifecycle changes from earlier draft work.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `account-routing`: Require `trusted_cyber` turns to use only already-eligible
+  accounts whose existing `security_work_authorized` grant is true.
+- `responses-api-compat`: Establish and restore the requirement before direct
+  WebSocket account selection while preserving ordinary Responses behavior.
+- `sticky-session-operations`: Preserve a monotonic capability requirement
+  across API-key-scoped session, turn-state, response, and task lineage.
+- `database-migrations`: Add the minimal durable hashed-lineage table on the
+  current single Alembic head without a historical-row backfill.
+
+## Impact
+
+- Direct Responses WebSocket ingress, account selection, reconnect request
+  state, and internal-header/privacy filtering.
+- Proxy lineage persistence and one additive database migration.
+- Focused parser, repository, migration, selection, privacy, and realistic
+  no-echo reconnect regression coverage.
+- No new setting, dependency, account field, dashboard surface, README
+  section, reactive retry algorithm, or required setup step.

--- a/openspec/changes/add-capability-aware-routing/specs/account-routing/spec.md
+++ b/openspec/changes/add-capability-aware-routing/specs/account-routing/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Trusted cyber intent narrows the existing account pool
+
+Account routing MUST constrain an authenticated direct Responses WebSocket
+turn requiring `trusted_cyber` by passing
+`require_security_work_authorized=True` to the canonical selector before the
+first upstream attempt and every later retry. The selector MUST apply the
+constraint only to accounts already permitted by API-key, account, model,
+service-tier, ownership, health, quota, affinity, concurrency, and failover
+rules. Routing MUST NOT add an account, change the configured strategy, rebind
+an owner, or fall back to an ordinary account.
+
+#### Scenario: First attempt uses the capable pool
+- **WHEN** an authenticated direct WebSocket turn establishes `trusted_cyber`
+- **THEN** its first account-selection call requires a
+  security-work-authorized account
+- **AND** no ordinary account receives an upstream attempt
+
+#### Scenario: Empty capable pool fails closed
+- **WHEN** a required turn has no eligible security-work-authorized account
+- **THEN** selection returns the existing typed
+  `no_security_work_authorized_accounts` error
+- **AND** its advisory states that no ordinary-account fallback occurred
+- **AND** an earlier reactive or account/model error cannot replace that typed
+  capability-routing result
+- **AND** ordinary routing is not attempted
+
+#### Scenario: Ordinary routing is unchanged
+- **WHEN** an authenticated direct WebSocket turn has neither a trusted signal
+  nor required lineage
+- **THEN** selection receives the same scope, strategy, ownership, admission,
+  and retry inputs as before this change

--- a/openspec/changes/add-capability-aware-routing/specs/database-migrations/spec.md
+++ b/openspec/changes/add-capability-aware-routing/specs/database-migrations/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Capability lineage uses one additive opaque-marker table
+
+The migration MUST descend from the current single Alembic head and create one
+`capability_lineage_markers` table containing only an opaque SHA-256 marker
+primary key plus creation and last-seen timestamps. It MUST NOT modify existing
+sticky-session, account, usage, quota, request-log, or durable-bridge columns or
+foreign keys, and MUST NOT backfill historical rows.
+
+#### Scenario: Upgrade creates an empty marker table
+- **WHEN** a database at the previous head upgrades to the new head
+- **THEN** the marker table exists with its primary-key uniqueness contract
+- **AND** no existing application table is scanned or rewritten for backfill
+
+#### Scenario: Downgrade removes only the marker table
+- **WHEN** the migration is downgraded to its parent revision
+- **THEN** only `capability_lineage_markers` is removed
+- **AND** existing application data remains unchanged
+
+#### Scenario: Migration graph remains single-head
+- **WHEN** the repository migration graph is inspected after this change
+- **THEN** it has exactly one head containing the marker-table revision

--- a/openspec/changes/add-capability-aware-routing/specs/responses-api-compat/spec.md
+++ b/openspec/changes/add-capability-aware-routing/specs/responses-api-compat/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Direct WebSocket capability intent is trusted and private
+
+A direct Responses WebSocket MUST recognize the exact internal marker
+`X-Codex-LB-Required-Capability: trusted_cyber` only after successful existing
+proxy API-key authentication. It MUST accept one marker from either the
+handshake headers or the current `response.create.client_metadata`. Duplicate,
+conflicting, non-string, unknown, malformed, or unauthenticated signals MUST
+fail before account selection. Raw duplicate JSON keys or duplicate
+`client_metadata` containers MUST NOT collapse into an ordinary request. The
+marker MUST be rejected on every downstream frame type other than
+`response.create`.
+
+The proxy MUST remove the capability header and the exact consumed metadata
+key before upstream dispatch, request archival, diagnostics, and logging.
+Unrelated client metadata MUST remain unchanged.
+
+#### Scenario: Per-frame intent routes before upstream open
+- **WHEN** an authenticated frame carries the exact metadata marker on a
+  downstream socket opened without the header
+- **THEN** the proxy establishes REQUIRED before opening or reusing an upstream
+  socket
+
+#### Scenario: Ambiguous or untrusted signal fails closed
+- **WHEN** a signal is duplicated, malformed, unknown, or lacks an authenticated
+  proxy API-key principal
+- **THEN** the proxy returns a typed error before account or model-source
+  dispatch
+
+#### Scenario: Duplicate JSON cannot erase intent
+- **WHEN** raw JSON repeats the capability key or repeats `client_metadata`
+  around a capability marker
+- **THEN** the proxy returns the typed unsupported-capability error before
+  selection
+
+#### Scenario: Capability metadata on another frame is rejected
+- **WHEN** a downstream frame other than `response.create` contains the
+  capability metadata key
+- **THEN** the proxy returns a typed error without forwarding or archiving that
+  frame upstream
+- **AND** malformed JSON text is rejected rather than passed through an already
+  open upstream socket
+- **AND** binary downstream frames are rejected before parsing, archiving, or
+  upstream forwarding
+
+#### Scenario: Internal metadata is not forwarded or archived
+- **WHEN** a valid capability-bearing frame is dispatched and archived
+- **THEN** neither capability carrier appears in upstream headers, upstream
+  payload, archive payload, diagnostics, or logs
+
+### Requirement: A late capability cannot reuse an ordinary upstream socket
+
+A later REQUIRED frame MUST NOT reuse an upstream socket selected for an
+ordinary request on the same downstream WebSocket. An idle ordinary socket
+MUST be retired before capable
+reselection. If another frame is still pending, the proxy MUST fail closed
+rather than change the account requirement beneath in-flight work. The socket's
+selection contract, not whether its account happened to have the capability
+grant, MUST determine whether it was selected as ordinary. Before reusing a
+REQUIRED-selected socket, the proxy MUST revalidate the pinned account and its
+current capability grant through the canonical selector.
+
+#### Scenario: Idle ordinary socket is replaced
+- **WHEN** an idle downstream session previously selected an ordinary account
+  and a later frame establishes REQUIRED
+- **THEN** the ordinary upstream is retired before the frame is sent
+- **AND** the replacement selection requires a security-work-authorized account
+
+#### Scenario: Pending ordinary work blocks a requirement change
+- **WHEN** ordinary work is still pending and a later frame establishes REQUIRED
+- **THEN** the later frame fails before upstream send
+- **AND** the pending frame's account and request state are not rewritten
+
+#### Scenario: Revoked capability grant prevents socket reuse
+- **WHEN** a socket was selected for REQUIRED but its pinned account's grant is
+  no longer valid at canonical revalidation
+- **THEN** the stale socket does not receive the next REQUIRED frame
+- **AND** an idle socket is retired before constrained reselection
+
+#### Scenario: Revalidation uncertainty fails closed
+- **WHEN** canonical account revalidation cannot complete for a REQUIRED socket
+- **THEN** the frame receives a typed capability-routing-unavailable error
+- **AND** its reservation is settled without forwarding the frame upstream

--- a/openspec/changes/add-capability-aware-routing/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/add-capability-aware-routing/specs/sticky-session-operations/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Trusted capability requirements are monotonic across lineage
+
+Before dispatch, the proxy MUST persist an authenticated `trusted_cyber`
+requirement as API-key-scoped, domain-separated opaque hashes for every known
+session, accepted or synthesized turn-state, previous-response, and Codex task
+lineage alias. Marker writes MUST be monotonic and MUST NOT store raw lineage
+or account identifiers.
+
+A later authenticated request MUST restore REQUIRED before account selection
+when any presented alias matches under the same API-key scope. It MUST persist
+that requirement onto newly generated aliases. A marker under one API key MUST
+NOT establish REQUIRED under another key. Read or write uncertainty MUST fail
+before ordinary dispatch.
+
+When `response.created` first reveals a response ID for a durably REQUIRED
+request, the proxy MUST persist the upstream and downstream-visible response
+aliases before forwarding that created event. If this propagation fails, the
+proxy MUST NOT expose the unpersisted response ID, replay the accepted request,
+or penalize the upstream account.
+
+#### Scenario: No-echo reconnect remains required
+- **WHEN** a capability-bearing direct WebSocket turn persists an accepted
+  session identity and a proxy-synthesized turn state
+- **AND** a new connection presents the same session identity without the
+  capability marker or generated turn state
+- **THEN** REQUIRED is restored before its first account selection
+
+#### Scenario: Echoed synthesized turn state remains required
+- **WHEN** the reconnect instead echoes the accepted synthesized turn state
+- **THEN** REQUIRED is restored before its first account selection
+
+#### Scenario: Response-only reconnect remains required
+- **WHEN** a capability-bearing turn exposes a response ID only after upstream
+  acceptance
+- **AND** a new connection presents only that `previous_response_id` under the
+  same API key, without a matching session or turn state
+- **THEN** REQUIRED is restored before its first account selection
+
+#### Scenario: Requirement survives a fresh service instance
+- **WHEN** a new repository and proxy service instance reads an alias marked by
+  an earlier instance
+- **THEN** the alias still restores REQUIRED
+
+#### Scenario: API-key scope is isolated
+- **WHEN** API key B presents the same visible lineage identifier previously
+  marked under API key A
+- **THEN** key A's marker does not establish REQUIRED for key B
+
+#### Scenario: Persistence uncertainty cannot downgrade
+- **WHEN** required lineage cannot be read or established durably
+- **THEN** the request fails before ordinary account selection or dispatch

--- a/openspec/changes/add-capability-aware-routing/tasks.md
+++ b/openspec/changes/add-capability-aware-routing/tasks.md
@@ -1,0 +1,29 @@
+## 1. Durable lineage
+
+- [x] 1.1 Add failing repository regressions for monotonic persistence,
+  API-key isolation, opaque storage, and fresh-instance recovery; then add the
+  marker model, focused migration, and repository contract.
+- [x] 1.2 Prove upgrade/downgrade behavior and a single Alembic head without
+  modifying existing table contracts or backfilling rows.
+
+## 2. Direct WebSocket capability routing
+
+- [x] 2.1 Add failing parser and privacy regressions; then implement strict
+  authenticated header/per-frame metadata parsing and carrier stripping.
+- [x] 2.2 Add failing first-selection and empty-pool regressions; then establish
+  the capability requirement before canonical account selection.
+- [x] 2.3 Add failing no-echo and echoed-turn-state reconnect regressions; then
+  restore and propagate the API-key-scoped requirement across accepted session,
+  synthesized turn-state, previous-response, and task aliases.
+- [x] 2.4 Add failing late-capability regressions; then retire an idle ordinary
+  upstream before capable reselection and fail closed while ordinary work is
+  pending.
+
+## 3. Verification and publication readiness
+
+- [x] 3.1 Run strict scoped and repository OpenSpec validation, focused unit and
+  direct-WebSocket integration tests, migration checks, architecture checks,
+  affected lint/format/type gates, `git diff --check`, and the repository local
+  CI gate.
+- [ ] 3.2 Inspect the final committed diff, run one independent Sensitive review,
+  and resolve every actionable in-scope finding before publication.

--- a/openspec/changes/add-capability-aware-routing/tasks.md
+++ b/openspec/changes/add-capability-aware-routing/tasks.md
@@ -25,5 +25,5 @@
   direct-WebSocket integration tests, migration checks, architecture checks,
   affected lint/format/type gates, `git diff --check`, and the repository local
   CI gate.
-- [ ] 3.2 Inspect the final committed diff, run one independent Sensitive review,
+- [x] 3.2 Inspect the final committed diff, run one independent Sensitive review,
   and resolve every actionable in-scope finding before publication.

--- a/tests/integration/test_capability_lineage_repository.py
+++ b/tests/integration/test_capability_lineage_repository.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import Insert
+
+from app.db.models import CapabilityLineageMarker
+from app.db.session import SessionLocal
+from app.modules.proxy.capability_lineage import (
+    CapabilityLineageAlias,
+    capability_lineage_marker_hash,
+)
+from app.modules.proxy.capability_lineage_repository import CapabilityLineageRepository
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_capability_lineage_is_durable_scope_isolated_and_opaque(db_setup) -> None:
+    aliases = (
+        CapabilityLineageAlias(kind="session_header", value="visible-session-id"),
+        CapabilityLineageAlias(kind="turn_state", value="visible-turn-state"),
+    )
+
+    async with SessionLocal() as session:
+        repository = CapabilityLineageRepository(session)
+        marker_hashes = await repository.require(
+            capability="trusted_cyber",
+            api_key_scope="api-key-a",
+            aliases=aliases,
+        )
+
+        assert len(marker_hashes) == 2
+        stored_markers = (await session.execute(select(CapabilityLineageMarker))).scalars().all()
+        assert {marker.marker_hash for marker in stored_markers} == set(marker_hashes)
+        assert all("visible-session-id" not in marker.marker_hash for marker in stored_markers)
+        assert all("visible-turn-state" not in marker.marker_hash for marker in stored_markers)
+        assert all("api-key-a" not in marker.marker_hash for marker in stored_markers)
+
+    async with SessionLocal() as fresh_session:
+        fresh_repository = CapabilityLineageRepository(fresh_session)
+
+        assert await fresh_repository.is_required(
+            capability="trusted_cyber",
+            api_key_scope="api-key-a",
+            aliases=aliases,
+        )
+        assert not await fresh_repository.is_required(
+            capability="trusted_cyber",
+            api_key_scope="api-key-b",
+            aliases=aliases,
+        )
+        assert (
+            await fresh_repository.require(
+                capability="trusted_cyber",
+                api_key_scope="api-key-a",
+                aliases=aliases,
+            )
+            == marker_hashes
+        )
+        stored_markers = (await fresh_session.execute(select(CapabilityLineageMarker))).scalars().all()
+        assert len(stored_markers) == 2
+
+
+@pytest.mark.asyncio
+async def test_capability_lineage_read_snapshot_can_upgrade_after_concurrent_writer(db_setup) -> None:
+    first_alias = CapabilityLineageAlias(kind="session_header", value="first-session")
+    concurrent_alias = CapabilityLineageAlias(kind="session_header", value="concurrent-session")
+
+    async with SessionLocal() as first_session, SessionLocal() as concurrent_session:
+        first_repository = CapabilityLineageRepository(first_session)
+        concurrent_repository = CapabilityLineageRepository(concurrent_session)
+
+        assert not await first_repository.is_required(
+            capability="trusted_cyber",
+            api_key_scope="api-key-a",
+            aliases=(first_alias,),
+        )
+        await concurrent_repository.require(
+            capability="trusted_cyber",
+            api_key_scope="api-key-a",
+            aliases=(concurrent_alias,),
+        )
+
+        assert await first_repository.require(
+            capability="trusted_cyber",
+            api_key_scope="api-key-a",
+            aliases=(first_alias,),
+        )
+
+
+@pytest.mark.asyncio
+async def test_capability_lineage_writes_markers_in_global_hash_order(monkeypatch) -> None:
+    class _RecordingSession:
+        def __init__(self) -> None:
+            self.statements: list[str] = []
+
+        async def execute(self, statement: Insert) -> None:
+            self.statements.append(cast(str, statement))
+
+        async def commit(self) -> None:
+            return None
+
+    aliases = tuple(
+        sorted(
+            (
+                CapabilityLineageAlias(kind="session_header", value="session-a"),
+                CapabilityLineageAlias(kind="turn_state", value="turn-a"),
+                CapabilityLineageAlias(kind="previous_response", value="response-a"),
+            ),
+            key=lambda alias: capability_lineage_marker_hash(
+                capability="trusted_cyber",
+                api_key_scope="api-key-a",
+                alias=alias,
+            ),
+            reverse=True,
+        )
+    )
+    session = _RecordingSession()
+    repository = CapabilityLineageRepository(cast(AsyncSession, session))
+    monkeypatch.setattr(
+        repository,
+        "_upsert_statement",
+        lambda marker_hash: cast(Insert, marker_hash),
+    )
+
+    marker_hashes = await repository.require(
+        capability="trusted_cyber",
+        api_key_scope="api-key-a",
+        aliases=aliases,
+    )
+
+    assert marker_hashes == tuple(sorted(marker_hashes, reverse=True))
+    assert session.statements == sorted(marker_hashes)

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -10695,8 +10695,8 @@ def test_backend_responses_websocket_trusted_capability_empty_pool_fails_closed_
         selection_requirements.append(bool(kwargs["require_security_work_authorized"]))
         return proxy_module.AccountSelection(
             account=None,
-            error_message="No accounts marked as authorized for security work",
-            error_code="no_security_work_authorized_accounts",
+            error_message="No available accounts. Service is operating in degraded mode",
+            error_code=None,
         )
 
     async def reject_upstream_open(*_args, **_kwargs):
@@ -10892,13 +10892,13 @@ def test_backend_responses_websocket_durable_capability_model_rejection_keeps_ty
 
 @pytest.mark.parametrize("websocket_path", ["/backend-api/codex/responses", "/v1/responses"])
 @pytest.mark.parametrize(
-    "duplicate_kind",
-    ["header_and_metadata", "raw_headers", "raw_metadata_containers", "raw_metadata_keys"],
+    "invalid_carrier_kind",
+    ["header_and_metadata", "raw_headers", "raw_metadata_containers", "raw_metadata_keys", "top_level"],
 )
-def test_direct_responses_websocket_duplicate_capability_carriers_fail_before_selection(
+def test_direct_responses_websocket_ambiguous_or_misplaced_capability_carriers_fail_before_selection(
     app_instance,
     monkeypatch,
-    duplicate_kind,
+    invalid_carrier_kind,
     websocket_path,
 ):
     api_key = _capability_test_api_key("key_ws_capability_duplicate")
@@ -10922,6 +10922,11 @@ def test_direct_responses_websocket_duplicate_capability_carriers_fail_before_se
         assert current_api_key == api_key
         return current_api_key
 
+    async def bypass_api_key_usage_reservation(self, current_api_key, **_kwargs):
+        del self, _kwargs
+        assert current_api_key == api_key
+        return None
+
     async def reject_selection(*_args, **_kwargs):
         nonlocal selection_attempted
         selection_attempted = True
@@ -10942,6 +10947,11 @@ def test_direct_responses_websocket_duplicate_capability_carriers_fail_before_se
     )
     monkeypatch.setattr(
         proxy_module.ProxyService,
+        "_reserve_websocket_api_key_usage",
+        bypass_api_key_usage_reservation,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
         "_select_websocket_connect_account",
         reject_selection,
     )
@@ -10954,14 +10964,14 @@ def test_direct_responses_websocket_duplicate_capability_carriers_fail_before_se
     response_create = _websocket_response_create("security task")
     websocket_headers: dict[str, str] | Headers
     request_text = json.dumps(response_create, separators=(",", ":"))
-    if duplicate_kind == "header_and_metadata":
+    if invalid_carrier_kind == "header_and_metadata":
         response_create["client_metadata"] = {REQUIRED_CAPABILITY_HEADER: "trusted_cyber"}
         request_text = json.dumps(response_create, separators=(",", ":"))
         websocket_headers = {
             "Authorization": "Bearer capability-duplicate",
             REQUIRED_CAPABILITY_HEADER: "trusted_cyber",
         }
-    elif duplicate_kind == "raw_headers":
+    elif invalid_carrier_kind == "raw_headers":
         websocket_headers = Headers(
             [
                 ("Authorization", "Bearer capability-duplicate"),
@@ -10975,13 +10985,16 @@ def test_direct_responses_websocket_duplicate_capability_carriers_fail_before_se
             {REQUIRED_CAPABILITY_HEADER: "trusted_cyber"},
             separators=(",", ":"),
         )
-        if duplicate_kind == "raw_metadata_containers":
+        if invalid_carrier_kind == "raw_metadata_containers":
             request_text = request_text[:-1] + ',"client_metadata":' + marker_json + ',"client_metadata":{}}'
-        else:
+        elif invalid_carrier_kind == "raw_metadata_keys":
             capability_key = json.dumps(REQUIRED_CAPABILITY_HEADER)
             lowercase_key = json.dumps(REQUIRED_CAPABILITY_HEADER.lower())
             metadata_json = "{" + capability_key + ':"trusted_cyber",' + lowercase_key + ':"trusted_cyber"}'
             request_text = request_text[:-1] + ',"client_metadata":' + metadata_json + "}"
+        else:
+            response_create[REQUIRED_CAPABILITY_HEADER] = "trusted_cyber"
+            request_text = json.dumps(response_create, separators=(",", ":"))
 
     with TestClient(app_instance) as client:
         with client.websocket_connect(

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -4,20 +4,26 @@ import asyncio
 import json
 import logging
 from collections import deque
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
 from fastapi.testclient import TestClient
+from httpx import Headers
 from starlette.websockets import WebSocketDisconnect
 
 import app.modules.proxy.api as proxy_api_module
 import app.modules.proxy.service as proxy_module
 from app.core.auth.refresh import RefreshError
 from app.core.utils.request_id import get_request_id
+from app.modules.api_keys.service import ApiKeyData
 from app.modules.proxy._service.websocket import mixin as websocket_mixin_module
 from app.modules.proxy.affinity import _codex_session_selection_key
+from app.modules.proxy.capability_routing import (
+    REQUIRED_CAPABILITY_HEADER,
+    _capability_lineage_unavailable_error,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -168,6 +174,64 @@ def _websocket_settings(**overrides):
     }
     values.update(overrides)
     return SimpleNamespace(**values)
+
+
+def _capability_test_api_key(key_id: str) -> ApiKeyData:
+    return ApiKeyData(
+        id=key_id,
+        name="Capability routing test",
+        key_prefix="sk-capability",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=datetime(2026, 7, 29, tzinfo=timezone.utc),
+        last_used_at=None,
+    )
+
+
+def _websocket_response_batch(
+    response_id: str,
+    *,
+    completed: bool = True,
+) -> list[_FakeUpstreamMessage]:
+    messages = [
+        _FakeUpstreamMessage(
+            "text",
+            text=json.dumps(
+                {
+                    "type": "response.created",
+                    "response": {"id": response_id, "status": "in_progress"},
+                },
+                separators=(",", ":"),
+            ),
+        )
+    ]
+    if completed:
+        messages.append(
+            _FakeUpstreamMessage(
+                "text",
+                text=json.dumps(
+                    {
+                        "type": "response.completed",
+                        "response": {"id": response_id, "status": "completed"},
+                    },
+                    separators=(",", ":"),
+                ),
+            )
+        )
+    return messages
+
+
+def _websocket_response_create(text: str) -> dict[str, object]:
+    return {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "input": text,
+        "stream": True,
+    }
 
 
 def test_backend_responses_websocket_session_ended_auth_failure_fails_over_before_visible_output(
@@ -10099,3 +10163,1534 @@ def test_backend_responses_websocket_grouped_anonymous_stale_anchor_persists_dia
         assert "surface=websocket_stream" in message
         assert "previous_response_source=client_supplied" in message or "diagnostics=" in message
         assert "resp_ws_grouped_anchor" not in message
+
+
+@pytest.mark.parametrize("capability_carrier", ["handshake", "response_create"])
+def test_backend_responses_websocket_trusted_capability_routes_before_first_account_attempt(
+    app_instance,
+    monkeypatch,
+    capability_carrier,
+):
+    api_key = _capability_test_api_key("key_ws_capability_upfront")
+    cyber_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[_websocket_response_batch("resp_ws_capability_upfront")],
+    )
+    selection_requirements: list[bool] = []
+    opened_account_ids: list[str] = []
+    forwarded_capability_headers: list[bool] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        del request
+        assert authorization == "Bearer capability-upfront"
+        return api_key
+
+    async def keep_authenticated_api_key_policy(self, current_api_key):
+        del self
+        assert current_api_key == api_key
+        return current_api_key
+
+    async def bypass_api_key_usage_reservation(self, current_api_key, **_kwargs):
+        del self, _kwargs
+        assert current_api_key == api_key
+        return None
+
+    async def fake_select_websocket_connect_account(
+        self,
+        deadline,
+        *,
+        request_state,
+        require_security_work_authorized,
+        **_kwargs,
+    ):
+        del self, deadline, request_state, _kwargs
+        selection_requirements.append(require_security_work_authorized)
+        account_kind = "cyber" if require_security_work_authorized else "ordinary"
+        return SimpleNamespace(
+            id=f"acct_ws_capability_{account_kind}",
+            security_work_authorized=require_security_work_authorized,
+        )
+
+    async def fake_try_open_websocket_connect_attempt(self, account, headers, **_kwargs):
+        del self, _kwargs
+        opened_account_ids.append(account.id)
+        forwarded_capability_headers.append(any(name.lower() == REQUIRED_CAPABILITY_HEADER for name in headers))
+        return account, cyber_upstream
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_refresh_websocket_api_key_policy",
+        keep_authenticated_api_key_policy,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_reserve_websocket_api_key_usage",
+        bypass_api_key_usage_reservation,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_websocket_connect_account",
+        fake_select_websocket_connect_account,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_try_open_websocket_connect_attempt",
+        fake_try_open_websocket_connect_attempt,
+    )
+
+    websocket_headers = {
+        "Authorization": "Bearer capability-upfront",
+    }
+    response_create = _websocket_response_create("security task")
+    if capability_carrier == "handshake":
+        websocket_headers.update(
+            {
+                "x-codex-window-id": "task-ws-capability-upfront:1",
+                REQUIRED_CAPABILITY_HEADER: "trusted_cyber",
+            }
+        )
+    else:
+        response_create["client_metadata"] = {
+            "x-codex-window-id": "task-ws-capability-upfront:1",
+            REQUIRED_CAPABILITY_HEADER: "trusted_cyber",
+        }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers=websocket_headers,
+        ) as websocket:
+            websocket.send_text(json.dumps(response_create))
+            created = json.loads(websocket.receive_text())
+            completed = json.loads(websocket.receive_text())
+
+    assert created["response"]["id"] == "resp_ws_capability_upfront"
+    assert completed["type"] == "response.completed"
+    assert selection_requirements == [True]
+    assert opened_account_ids == ["acct_ws_capability_cyber"]
+    assert forwarded_capability_headers == [False]
+    forwarded_payload = json.loads(cyber_upstream.sent_text[0])
+    assert REQUIRED_CAPABILITY_HEADER not in {key.lower() for key in forwarded_payload.get("client_metadata", {})}
+
+
+@pytest.mark.parametrize(
+    "echo_turn_state",
+    [False, True],
+    ids=["same-session-no-echo", "echoed-turn-state"],
+)
+def test_backend_responses_websocket_trusted_capability_survives_session_reconnect_before_selection(
+    app_instance,
+    monkeypatch,
+    echo_turn_state,
+):
+    api_key = _capability_test_api_key(
+        f"key_ws_capability_session_reconnect_{'echo' if echo_turn_state else 'no_echo'}"
+    )
+    upstreams = deque(
+        [
+            _SequencedUpstreamWebSocket(
+                [],
+                deferred_message_batches=[_websocket_response_batch("resp_ws_capability_session_first")],
+            ),
+            _SequencedUpstreamWebSocket(
+                [],
+                deferred_message_batches=[_websocket_response_batch("resp_ws_capability_session_reconnect")],
+            ),
+        ]
+    )
+    selection_requirements: list[bool] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        del request
+        assert authorization == "Bearer capability-session-reconnect"
+        return api_key
+
+    async def keep_authenticated_api_key_policy(self, current_api_key):
+        del self
+        assert current_api_key == api_key
+        return current_api_key
+
+    async def bypass_api_key_usage_reservation(self, current_api_key, **_kwargs):
+        del self, _kwargs
+        assert current_api_key == api_key
+        return None
+
+    async def fake_select_websocket_connect_account(
+        self,
+        deadline,
+        *,
+        request_state,
+        require_security_work_authorized,
+        **_kwargs,
+    ):
+        del self, deadline, request_state, _kwargs
+        selection_requirements.append(require_security_work_authorized)
+        return SimpleNamespace(
+            id=f"acct_ws_capability_session_{len(selection_requirements)}",
+            security_work_authorized=require_security_work_authorized,
+        )
+
+    async def fake_try_open_websocket_connect_attempt(self, account, headers, **_kwargs):
+        del self, _kwargs
+        assert not any(name.lower() == REQUIRED_CAPABILITY_HEADER for name in headers)
+        return account, upstreams.popleft()
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_refresh_websocket_api_key_policy",
+        keep_authenticated_api_key_policy,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_reserve_websocket_api_key_usage",
+        bypass_api_key_usage_reservation,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_websocket_connect_account",
+        fake_select_websocket_connect_account,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_try_open_websocket_connect_attempt",
+        fake_try_open_websocket_connect_attempt,
+    )
+
+    session_headers = {
+        "Authorization": "Bearer capability-session-reconnect",
+        "session_id": "session-capability-reconnect",
+    }
+    marker_request = _websocket_response_create("establish session capability")
+    marker_request["client_metadata"] = {REQUIRED_CAPABILITY_HEADER: "trusted_cyber"}
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers=session_headers,
+        ) as marker_websocket:
+            accepted_headers = {
+                key.decode(): value.decode()
+                for key, value in cast(list[tuple[bytes, bytes]], marker_websocket.extra_headers)
+            }
+            first_turn_state = accepted_headers["x-codex-turn-state"]
+            marker_websocket.send_text(json.dumps(marker_request))
+            first_created = json.loads(marker_websocket.receive_text())
+            first_completed = json.loads(marker_websocket.receive_text())
+
+        reconnect_headers = dict(session_headers)
+        if echo_turn_state:
+            reconnect_headers["x-codex-turn-state"] = first_turn_state
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers=reconnect_headers,
+        ) as reconnect_websocket:
+            accepted_headers = {
+                key.decode(): value.decode()
+                for key, value in cast(list[tuple[bytes, bytes]], reconnect_websocket.extra_headers)
+            }
+            reconnect_turn_state = accepted_headers["x-codex-turn-state"]
+            reconnect_websocket.send_text(json.dumps(_websocket_response_create("continue session capability")))
+            reconnect_created = json.loads(reconnect_websocket.receive_text())
+            reconnect_completed = json.loads(reconnect_websocket.receive_text())
+
+    assert first_created["response"]["id"] == "resp_ws_capability_session_first"
+    assert first_completed["type"] == "response.completed"
+    assert reconnect_created["response"]["id"] == "resp_ws_capability_session_reconnect"
+    assert reconnect_completed["type"] == "response.completed"
+    assert selection_requirements == [True, True]
+    assert (reconnect_turn_state == first_turn_state) is echo_turn_state
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    ["/backend-api/codex/responses", "/v1/responses"],
+    ids=["backend-responses", "v1-responses"],
+)
+def test_backend_responses_websocket_trusted_capability_survives_response_only_reconnect(
+    app_instance,
+    monkeypatch,
+    endpoint,
+):
+    api_key = _capability_test_api_key("key_ws_capability_response_reconnect")
+    upstreams = deque(
+        [
+            _SequencedUpstreamWebSocket(
+                [],
+                deferred_message_batches=[_websocket_response_batch("resp_ws_capability_response_first")],
+            ),
+            _SequencedUpstreamWebSocket(
+                [],
+                deferred_message_batches=[_websocket_response_batch("resp_ws_capability_response_reconnect")],
+            ),
+        ]
+    )
+    selection_requirements: list[bool] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        del request
+        assert authorization == "Bearer capability-response-reconnect"
+        return api_key
+
+    async def keep_authenticated_api_key_policy(self, current_api_key):
+        del self
+        assert current_api_key == api_key
+        return current_api_key
+
+    async def bypass_api_key_usage_reservation(self, current_api_key, **_kwargs):
+        del self, _kwargs
+        assert current_api_key == api_key
+        return None
+
+    async def fake_select_websocket_connect_account(
+        self,
+        deadline,
+        *,
+        request_state,
+        require_security_work_authorized,
+        **_kwargs,
+    ):
+        del self, deadline, request_state, _kwargs
+        selection_requirements.append(require_security_work_authorized)
+        return SimpleNamespace(
+            id="acct_ws_capability_response",
+            security_work_authorized=require_security_work_authorized,
+        )
+
+    async def fake_try_open_websocket_connect_attempt(self, account, headers, **_kwargs):
+        del self, _kwargs
+        assert not any(name.lower() == REQUIRED_CAPABILITY_HEADER for name in headers)
+        return account, upstreams.popleft()
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_refresh_websocket_api_key_policy",
+        keep_authenticated_api_key_policy,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_reserve_websocket_api_key_usage",
+        bypass_api_key_usage_reservation,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_websocket_connect_account",
+        fake_select_websocket_connect_account,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_try_open_websocket_connect_attempt",
+        fake_try_open_websocket_connect_attempt,
+    )
+
+    marker_request = _websocket_response_create("establish response lineage")
+    marker_request["client_metadata"] = {REQUIRED_CAPABILITY_HEADER: "trusted_cyber"}
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            endpoint,
+            headers={"Authorization": "Bearer capability-response-reconnect"},
+        ) as marker_websocket:
+            marker_websocket.send_text(json.dumps(marker_request))
+            first_created = json.loads(marker_websocket.receive_text())
+            first_completed = json.loads(marker_websocket.receive_text())
+
+        reconnect_request = _websocket_response_create("continue from response only")
+        reconnect_request["previous_response_id"] = first_created["response"]["id"]
+        with client.websocket_connect(
+            endpoint,
+            headers={"Authorization": "Bearer capability-response-reconnect"},
+        ) as reconnect_websocket:
+            reconnect_websocket.send_text(json.dumps(reconnect_request))
+            reconnect_created = json.loads(reconnect_websocket.receive_text())
+            reconnect_completed = json.loads(reconnect_websocket.receive_text())
+
+    assert first_created["response"]["id"] == "resp_ws_capability_response_first"
+    assert first_completed["type"] == "response.completed"
+    assert reconnect_created["response"]["id"] == "resp_ws_capability_response_reconnect"
+    assert reconnect_completed["type"] == "response.completed"
+    assert selection_requirements == [True, True]
+
+
+def test_backend_responses_websocket_capability_response_lineage_write_failure_fails_before_created_is_visible(
+    app_instance,
+    monkeypatch,
+):
+    api_key = _capability_test_api_key("key_ws_capability_response_write_failure")
+    upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[_websocket_response_batch("resp_ws_capability_must_not_leak")],
+    )
+    selection_requirements: list[bool] = []
+    health_penalties: list[str] = []
+    original_route = proxy_module.CapabilityRouter.route
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        del request
+        assert authorization == "Bearer capability-response-write-failure"
+        return api_key
+
+    async def keep_authenticated_api_key_policy(self, current_api_key):
+        del self
+        assert current_api_key == api_key
+        return current_api_key
+
+    async def bypass_api_key_usage_reservation(self, current_api_key, **_kwargs):
+        del self, _kwargs
+        assert current_api_key == api_key
+        return None
+
+    async def fail_response_lineage_write(self, intent, *, api_key_id, aliases):
+        if any(alias.kind == "previous_response" for alias in aliases):
+            raise _capability_lineage_unavailable_error()
+        return await original_route(
+            self,
+            intent,
+            api_key_id=api_key_id,
+            aliases=aliases,
+        )
+
+    async def fake_select_websocket_connect_account(
+        self,
+        deadline,
+        *,
+        request_state,
+        require_security_work_authorized,
+        **_kwargs,
+    ):
+        del self, deadline, request_state, _kwargs
+        selection_requirements.append(require_security_work_authorized)
+        return SimpleNamespace(
+            id="acct_ws_capability_response_write_failure",
+            security_work_authorized=True,
+        )
+
+    async def fake_try_open_websocket_connect_attempt(self, account, headers, **_kwargs):
+        del self, _kwargs
+        assert not any(name.lower() == REQUIRED_CAPABILITY_HEADER for name in headers)
+        return account, upstream
+
+    async def reject_account_health_penalty(self, account, error, error_code, **_kwargs):
+        del self, account, error, _kwargs
+        health_penalties.append(error_code)
+        raise AssertionError("capability lineage persistence must not penalize the upstream account")
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.CapabilityRouter, "route", fail_response_lineage_write)
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_refresh_websocket_api_key_policy",
+        keep_authenticated_api_key_policy,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_reserve_websocket_api_key_usage",
+        bypass_api_key_usage_reservation,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_websocket_connect_account",
+        fake_select_websocket_connect_account,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_try_open_websocket_connect_attempt",
+        fake_try_open_websocket_connect_attempt,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_handle_stream_error",
+        reject_account_health_penalty,
+    )
+
+    marker_request = _websocket_response_create("establish response lineage")
+    marker_request["client_metadata"] = {REQUIRED_CAPABILITY_HEADER: "trusted_cyber"}
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers={"Authorization": "Bearer capability-response-write-failure"},
+        ) as websocket:
+            websocket.send_text(json.dumps(marker_request))
+            terminal = json.loads(websocket.receive_text())
+
+    assert terminal["type"] == "response.failed"
+    assert terminal["response"]["error"]["code"] == "capability_lineage_unavailable"
+    assert "resp_ws_capability_must_not_leak" not in json.dumps(terminal)
+    assert selection_requirements == [True]
+    assert health_penalties == []
+    assert upstream.closed is True
+
+
+def test_backend_responses_websocket_trusted_capability_empty_pool_fails_closed_before_upstream(
+    app_instance,
+    monkeypatch,
+):
+    api_key = _capability_test_api_key("key_ws_capability_empty_pool")
+    selection_requirements: list[bool] = []
+    upstream_opened = False
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        del request
+        assert authorization == "Bearer capability-empty-pool"
+        return api_key
+
+    async def keep_authenticated_api_key_policy(self, current_api_key):
+        del self
+        assert current_api_key == api_key
+        return current_api_key
+
+    async def bypass_api_key_usage_reservation(self, current_api_key, **_kwargs):
+        del self, _kwargs
+        assert current_api_key == api_key
+        return None
+
+    async def empty_capability_pool(self, deadline, **kwargs):
+        del self, deadline
+        selection_requirements.append(bool(kwargs["require_security_work_authorized"]))
+        return proxy_module.AccountSelection(
+            account=None,
+            error_message="No accounts marked as authorized for security work",
+            error_code="no_security_work_authorized_accounts",
+        )
+
+    async def reject_upstream_open(*_args, **_kwargs):
+        nonlocal upstream_opened
+        upstream_opened = True
+        raise AssertionError("empty trusted-cyber pool must fail before upstream open")
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_refresh_websocket_api_key_policy",
+        keep_authenticated_api_key_policy,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_reserve_websocket_api_key_usage",
+        bypass_api_key_usage_reservation,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_account_with_budget_compatible",
+        empty_capability_pool,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_try_open_websocket_connect_attempt",
+        reject_upstream_open,
+    )
+
+    response_create = _websocket_response_create("security task")
+    response_create["client_metadata"] = {
+        "x-codex-window-id": "task-ws-capability-empty-pool:1",
+        REQUIRED_CAPABILITY_HEADER: "trusted_cyber",
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers={"Authorization": "Bearer capability-empty-pool"},
+        ) as websocket:
+            websocket.send_text(json.dumps(response_create))
+            warning = json.loads(websocket.receive_text())
+            terminal = json.loads(websocket.receive_text())
+
+    assert warning["type"] == "codex_lb.warning"
+    assert warning["warning"]["code"] == "no_security_work_authorized_accounts"
+    assert warning["warning"]["action"] == "fail_closed_capability_routing"
+    assert "did not fall back to an ordinary account" in warning["warning"]["message"]
+    assert terminal["type"] == "error"
+    assert terminal["status"] == 503
+    assert terminal["error"]["code"] == "no_security_work_authorized_accounts"
+    assert terminal["error"]["message"] == warning["warning"]["message"]
+    assert selection_requirements == [True]
+    assert upstream_opened is False
+
+
+def test_backend_responses_websocket_durable_capability_model_rejection_keeps_typed_empty_pool(
+    app_instance,
+    monkeypatch,
+):
+    api_key = _capability_test_api_key("key_ws_capability_model_rejection")
+    model_rejecting_account = proxy_module.Account(
+        id="acct_ws_capability_model_rejection",
+        chatgpt_account_id="acct_ws_capability_model_rejection",
+        email="capability-model-rejection@example.com",
+        plan_type="plus",
+        access_token_encrypted=b"access",
+        refresh_token_encrypted=b"refresh",
+        id_token_encrypted=b"id",
+        last_refresh=proxy_module.utcnow(),
+        status=proxy_module.AccountStatus.ACTIVE,
+        security_work_authorized=True,
+    )
+    model_rejection_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[
+            [
+                _FakeUpstreamMessage(
+                    "text",
+                    text=json.dumps(
+                        {
+                            "type": "error",
+                            "status": 400,
+                            "error": {
+                                "type": "invalid_request_error",
+                                "code": "invalid_request_error",
+                                "message": (
+                                    "The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account."
+                                ),
+                            },
+                        },
+                        separators=(",", ":"),
+                    ),
+                )
+            ]
+        ],
+    )
+    selection_requirements: list[bool] = []
+    selection_exclusions: list[set[str]] = []
+    opened_account_ids: list[str] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        del request
+        assert authorization == "Bearer capability-model-rejection"
+        return api_key
+
+    async def keep_authenticated_api_key_policy(self, current_api_key):
+        del self
+        assert current_api_key == api_key
+        return current_api_key
+
+    async def bypass_api_key_usage_reservation(self, current_api_key, **_kwargs):
+        del self, _kwargs
+        assert current_api_key == api_key
+        return None
+
+    async def select_capability_pool(self, deadline, **kwargs):
+        del self, deadline
+        selection_requirements.append(bool(kwargs["require_security_work_authorized"]))
+        selection_exclusions.append(set(kwargs["exclude_account_ids"]))
+        if len(selection_requirements) == 1:
+            return proxy_module.AccountSelection(
+                account=model_rejecting_account,
+                error_message=None,
+            )
+        return proxy_module.AccountSelection(
+            account=None,
+            error_message="No accounts marked as authorized for security work",
+            error_code="no_security_work_authorized_accounts",
+        )
+
+    async def open_model_rejecting_upstream(self, account, headers, **_kwargs):
+        del self, headers, _kwargs
+        opened_account_ids.append(account.id)
+        return account, model_rejection_upstream
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_refresh_websocket_api_key_policy",
+        keep_authenticated_api_key_policy,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_reserve_websocket_api_key_usage",
+        bypass_api_key_usage_reservation,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_account_with_budget_compatible",
+        select_capability_pool,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_try_open_websocket_connect_attempt",
+        open_model_rejecting_upstream,
+    )
+
+    request = _websocket_response_create("security task on a model-capable account")
+    request["client_metadata"] = {REQUIRED_CAPABILITY_HEADER: "trusted_cyber"}
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers={"Authorization": "Bearer capability-model-rejection"},
+        ) as websocket:
+            websocket.send_text(json.dumps(request))
+            warning = json.loads(websocket.receive_text())
+            terminal = json.loads(websocket.receive_text())
+
+    assert warning["warning"]["code"] == "no_security_work_authorized_accounts"
+    assert warning["warning"]["action"] == "fail_closed_capability_routing"
+    assert "did not fall back to an ordinary account" in warning["warning"]["message"]
+    assert terminal["type"] == "error"
+    assert terminal["status"] == 503
+    assert terminal["error"]["code"] == "no_security_work_authorized_accounts"
+    assert selection_requirements == [True, True]
+    assert selection_exclusions == [set(), {"acct_ws_capability_model_rejection"}]
+    assert opened_account_ids == ["acct_ws_capability_model_rejection"]
+    assert len(model_rejection_upstream.sent_text) == 1
+
+
+@pytest.mark.parametrize("websocket_path", ["/backend-api/codex/responses", "/v1/responses"])
+@pytest.mark.parametrize(
+    "duplicate_kind",
+    ["header_and_metadata", "raw_headers", "raw_metadata_containers", "raw_metadata_keys"],
+)
+def test_direct_responses_websocket_duplicate_capability_carriers_fail_before_selection(
+    app_instance,
+    monkeypatch,
+    duplicate_kind,
+    websocket_path,
+):
+    api_key = _capability_test_api_key("key_ws_capability_duplicate")
+    selection_attempted = False
+    upstream_opened = False
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        del request
+        assert authorization == "Bearer capability-duplicate"
+        return api_key
+
+    async def keep_authenticated_api_key_policy(self, current_api_key):
+        del self
+        assert current_api_key == api_key
+        return current_api_key
+
+    async def reject_selection(*_args, **_kwargs):
+        nonlocal selection_attempted
+        selection_attempted = True
+        raise AssertionError("ambiguous capability carriers must fail before account selection")
+
+    async def reject_upstream_open(*_args, **_kwargs):
+        nonlocal upstream_opened
+        upstream_opened = True
+        raise AssertionError("ambiguous capability carriers must fail before upstream open")
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_refresh_websocket_api_key_policy",
+        keep_authenticated_api_key_policy,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_websocket_connect_account",
+        reject_selection,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_try_open_websocket_connect_attempt",
+        reject_upstream_open,
+    )
+
+    response_create = _websocket_response_create("security task")
+    websocket_headers: dict[str, str] | Headers
+    request_text = json.dumps(response_create, separators=(",", ":"))
+    if duplicate_kind == "header_and_metadata":
+        response_create["client_metadata"] = {REQUIRED_CAPABILITY_HEADER: "trusted_cyber"}
+        request_text = json.dumps(response_create, separators=(",", ":"))
+        websocket_headers = {
+            "Authorization": "Bearer capability-duplicate",
+            REQUIRED_CAPABILITY_HEADER: "trusted_cyber",
+        }
+    elif duplicate_kind == "raw_headers":
+        websocket_headers = Headers(
+            [
+                ("Authorization", "Bearer capability-duplicate"),
+                (REQUIRED_CAPABILITY_HEADER, "trusted_cyber"),
+                (REQUIRED_CAPABILITY_HEADER, "trusted_cyber"),
+            ]
+        )
+    else:
+        websocket_headers = {"Authorization": "Bearer capability-duplicate"}
+        marker_json = json.dumps(
+            {REQUIRED_CAPABILITY_HEADER: "trusted_cyber"},
+            separators=(",", ":"),
+        )
+        if duplicate_kind == "raw_metadata_containers":
+            request_text = request_text[:-1] + ',"client_metadata":' + marker_json + ',"client_metadata":{}}'
+        else:
+            capability_key = json.dumps(REQUIRED_CAPABILITY_HEADER)
+            lowercase_key = json.dumps(REQUIRED_CAPABILITY_HEADER.lower())
+            metadata_json = "{" + capability_key + ':"trusted_cyber",' + lowercase_key + ':"trusted_cyber"}'
+            request_text = request_text[:-1] + ',"client_metadata":' + metadata_json + "}"
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            websocket_path,
+            headers=websocket_headers,
+        ) as websocket:
+            websocket.send_text(request_text)
+            error = json.loads(websocket.receive_text())
+
+    assert error["type"] == "error"
+    assert error["status"] == 400
+    assert error["error"]["code"] == "unsupported_required_capability"
+    assert selection_attempted is False
+    assert upstream_opened is False
+
+
+@pytest.mark.parametrize("websocket_path", ["/backend-api/codex/responses", "/v1/responses"])
+@pytest.mark.parametrize(
+    ("frame_kind", "expected_error_code"),
+    [
+        ("valid_wrong_frame", "unsupported_required_capability"),
+        ("malformed_wrong_frame", "invalid_request_error"),
+        ("binary_response_create", "invalid_request_error"),
+    ],
+)
+def test_direct_responses_websocket_rejects_capability_carrier_on_unsupported_frame(
+    app_instance,
+    monkeypatch,
+    websocket_path,
+    frame_kind,
+    expected_error_code,
+):
+    api_key = _capability_test_api_key("key_ws_capability_wrong_frame")
+    upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[_websocket_response_batch("resp_ws_capability_wrong_frame")],
+    )
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        del request
+        assert authorization == "Bearer capability-wrong-frame"
+        return api_key
+
+    async def keep_authenticated_api_key_policy(self, current_api_key):
+        del self
+        assert current_api_key == api_key
+        return current_api_key
+
+    async def bypass_api_key_usage_reservation(self, current_api_key, **_kwargs):
+        del self, _kwargs
+        assert current_api_key == api_key
+        return None
+
+    async def select_ordinary_account(self, deadline, *, require_security_work_authorized, **_kwargs):
+        del self, deadline, _kwargs
+        assert require_security_work_authorized is False
+        return SimpleNamespace(
+            id="acct_ws_capability_wrong_frame",
+            security_work_authorized=False,
+        )
+
+    async def open_upstream(self, account, headers, **_kwargs):
+        del self, headers, _kwargs
+        return account, upstream
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_refresh_websocket_api_key_policy",
+        keep_authenticated_api_key_policy,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_reserve_websocket_api_key_usage",
+        bypass_api_key_usage_reservation,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_websocket_connect_account",
+        select_ordinary_account,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_try_open_websocket_connect_attempt",
+        open_upstream,
+    )
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            websocket_path,
+            headers={"Authorization": "Bearer capability-wrong-frame"},
+        ) as websocket:
+            websocket.send_text(json.dumps(_websocket_response_create("open ordinary socket")))
+            created = json.loads(websocket.receive_text())
+            completed = json.loads(websocket.receive_text())
+
+            if frame_kind == "valid_wrong_frame":
+                wrong_frame_text = json.dumps(
+                    {
+                        "type": "session.update",
+                        "client_metadata": {REQUIRED_CAPABILITY_HEADER: "trusted_cyber"},
+                    }
+                )
+                websocket.send_text(wrong_frame_text)
+            elif frame_kind == "malformed_wrong_frame":
+                wrong_frame_text = (
+                    '{"type":"session.update","client_metadata":{'
+                    + json.dumps(REQUIRED_CAPABILITY_HEADER)
+                    + ':"trusted_cyber"},}'
+                )
+                websocket.send_text(wrong_frame_text)
+            else:
+                binary_request = _websocket_response_create("must not bypass capability routing")
+                binary_request["client_metadata"] = {REQUIRED_CAPABILITY_HEADER: "trusted_cyber"}
+                websocket.send_bytes(json.dumps(binary_request).encode())
+            error = json.loads(websocket.receive_text())
+
+    assert created["response"]["id"] == "resp_ws_capability_wrong_frame"
+    assert completed["type"] == "response.completed"
+    assert error["type"] == "error"
+    assert error["status"] == 400
+    assert error["error"]["code"] == expected_error_code
+    assert len(upstream.sent_text) == 1
+
+
+def test_backend_responses_websocket_trusted_capability_inheritance_retires_idle_ordinary_socket(
+    app_instance,
+    monkeypatch,
+):
+    api_key = _capability_test_api_key("key_ws_capability_inheritance")
+
+    class _TurnStateUpstreamWebSocket(_SequencedUpstreamWebSocket):
+        def response_header(self, name: str) -> str | None:
+            return "ordinary-account-turn-state" if name.lower() == "x-codex-turn-state" else None
+
+    ordinary_upstream = _TurnStateUpstreamWebSocket(
+        [],
+        deferred_message_batches=[
+            _websocket_response_batch("resp_ws_capability_ordinary"),
+            _websocket_response_batch("resp_ws_capability_leaked_ordinary"),
+        ],
+    )
+    marker_cyber_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[_websocket_response_batch("resp_ws_capability_marker")],
+    )
+    inherited_cyber_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[_websocket_response_batch("resp_ws_capability_inherited")],
+    )
+    ordinary_upstreams = deque([ordinary_upstream])
+    cyber_upstreams = deque([marker_cyber_upstream, inherited_cyber_upstream])
+    selection_requirements: list[bool] = []
+    opened_account_ids: list[str] = []
+    opened_headers: list[dict[str, str]] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        del request
+        assert authorization == "Bearer capability-inheritance"
+        return api_key
+
+    async def keep_authenticated_api_key_policy(self, current_api_key):
+        del self
+        assert current_api_key == api_key
+        return current_api_key
+
+    async def bypass_api_key_usage_reservation(self, current_api_key, **_kwargs):
+        del self, _kwargs
+        assert current_api_key == api_key
+        return None
+
+    async def resolve_marker_owner(self, payload, _headers):
+        del self
+        return "acct_ws_capability_cyber_1" if getattr(payload, "input", None) == "establish requirement" else None
+
+    async def fake_select_websocket_connect_account(
+        self,
+        deadline,
+        *,
+        request_state,
+        require_security_work_authorized,
+        **_kwargs,
+    ):
+        del self, deadline, request_state, _kwargs
+        selection_requirements.append(require_security_work_authorized)
+        account_kind = "cyber" if require_security_work_authorized else "ordinary"
+        account_index = selection_requirements.count(require_security_work_authorized)
+        return SimpleNamespace(
+            id=f"acct_ws_capability_{account_kind}_{account_index}",
+            # An ordinary selection may happen to land on a capable account.
+            # Socket reuse must follow the selection contract, not this flag.
+            security_work_authorized=True,
+        )
+
+    async def fake_try_open_websocket_connect_attempt(self, account, headers, **_kwargs):
+        del self, _kwargs
+        assert not any(name.lower() == REQUIRED_CAPABILITY_HEADER for name in headers)
+        opened_account_ids.append(account.id)
+        opened_headers.append(dict(headers))
+        upstreams = cyber_upstreams if "_cyber_" in account.id else ordinary_upstreams
+        return account, upstreams.popleft()
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_refresh_websocket_api_key_policy",
+        keep_authenticated_api_key_policy,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_reserve_websocket_api_key_usage",
+        bypass_api_key_usage_reservation,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_resolve_file_account_for_responses",
+        resolve_marker_owner,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_websocket_connect_account",
+        fake_select_websocket_connect_account,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_try_open_websocket_connect_attempt",
+        fake_try_open_websocket_connect_attempt,
+    )
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers={
+                "Authorization": "Bearer capability-inheritance",
+                "x-codex-window-id": "task-ws-capability-inheritance:1",
+            },
+        ) as ordinary_websocket:
+            ordinary_websocket.send_text(json.dumps(_websocket_response_create("ordinary first frame")))
+            ordinary_created = json.loads(ordinary_websocket.receive_text())
+            ordinary_completed = json.loads(ordinary_websocket.receive_text())
+
+            marker_request = _websocket_response_create("establish requirement")
+            marker_request["client_metadata"] = {
+                "x-codex-window-id": "task-ws-capability-inheritance:2",
+                REQUIRED_CAPABILITY_HEADER: "trusted_cyber",
+            }
+            ordinary_websocket.send_text(json.dumps(marker_request))
+            marker_created = json.loads(ordinary_websocket.receive_text())
+            marker_completed = json.loads(ordinary_websocket.receive_text())
+
+            assert ordinary_upstream.closed is True
+            assert len(ordinary_upstream.sent_text) == 1
+            assert not any(name.lower() == "x-codex-turn-state" for name in opened_headers[1])
+
+            with client.websocket_connect(
+                "/backend-api/codex/responses",
+                headers={
+                    "Authorization": "Bearer capability-inheritance",
+                    "x-codex-window-id": "task-ws-capability-inheritance:3",
+                },
+            ) as inherited_websocket:
+                inherited_websocket.send_text(json.dumps(_websocket_response_create("inherited requirement")))
+                inherited_created = json.loads(inherited_websocket.receive_text())
+                inherited_completed = json.loads(inherited_websocket.receive_text())
+
+    assert ordinary_created["response"]["id"] == "resp_ws_capability_ordinary"
+    assert ordinary_completed["type"] == "response.completed"
+    assert marker_created["response"]["id"] == "resp_ws_capability_marker"
+    assert marker_completed["type"] == "response.completed"
+    assert inherited_created["response"]["id"] == "resp_ws_capability_inherited"
+    assert inherited_completed["type"] == "response.completed"
+    assert selection_requirements == [False, True, True]
+    assert opened_account_ids == [
+        "acct_ws_capability_ordinary_1",
+        "acct_ws_capability_cyber_1",
+        "acct_ws_capability_cyber_2",
+    ]
+    assert len(inherited_cyber_upstream.sent_text) == 1
+
+
+def test_backend_responses_websocket_revalidates_required_socket_after_grant_revocation(
+    app_instance,
+    monkeypatch,
+):
+    api_key = _capability_test_api_key("key_ws_capability_revoked_socket")
+    revoked_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[
+            _websocket_response_batch("resp_ws_capability_before_revocation"),
+            _websocket_response_batch("resp_ws_capability_revoked_leak"),
+        ],
+    )
+    replacement_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[_websocket_response_batch("resp_ws_capability_after_revocation")],
+    )
+    upstreams = deque([revoked_upstream, replacement_upstream])
+    selection_requirements: list[bool] = []
+    revalidation_requirements: list[bool] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        del request
+        assert authorization == "Bearer capability-revoked-socket"
+        return api_key
+
+    async def keep_authenticated_api_key_policy(self, current_api_key):
+        del self
+        assert current_api_key == api_key
+        return current_api_key
+
+    async def bypass_api_key_usage_reservation(self, current_api_key, **_kwargs):
+        del self, _kwargs
+        assert current_api_key == api_key
+        return None
+
+    async def fake_select_websocket_connect_account(
+        self,
+        deadline,
+        *,
+        request_state,
+        require_security_work_authorized,
+        **_kwargs,
+    ):
+        del self, deadline, request_state, _kwargs
+        selection_requirements.append(require_security_work_authorized)
+        return SimpleNamespace(
+            id=f"acct_ws_capability_revocation_{len(selection_requirements)}",
+            security_work_authorized=True,
+        )
+
+    async def revoked_preferred_account(self, deadline, **kwargs):
+        del self, deadline
+        revalidation_requirements.append(bool(kwargs["require_security_work_authorized"]))
+        assert kwargs["api_key"] == api_key
+        assert kwargs["model"] == "gpt-5.4"
+        assert kwargs["service_tier"] is None
+        assert kwargs["preferred_account_id"] == "acct_ws_capability_revocation_1"
+        assert kwargs["fallback_on_preferred_account_unavailable"] is False
+        return proxy_module.AccountSelection(
+            account=None,
+            error_message="Preferred account capability grant was revoked",
+            error_code="no_security_work_authorized_accounts",
+        )
+
+    async def fake_try_open_websocket_connect_attempt(self, account, headers, **_kwargs):
+        del self, _kwargs
+        assert not any(name.lower() == REQUIRED_CAPABILITY_HEADER for name in headers)
+        return account, upstreams.popleft()
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_refresh_websocket_api_key_policy",
+        keep_authenticated_api_key_policy,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_reserve_websocket_api_key_usage",
+        bypass_api_key_usage_reservation,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_websocket_connect_account",
+        fake_select_websocket_connect_account,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_account_with_budget_compatible",
+        revoked_preferred_account,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_try_open_websocket_connect_attempt",
+        fake_try_open_websocket_connect_attempt,
+    )
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers={
+                "Authorization": "Bearer capability-revoked-socket",
+                "x-codex-window-id": "task-ws-capability-revoked:1",
+            },
+        ) as websocket:
+            marker_request = _websocket_response_create("establish required socket")
+            marker_request["client_metadata"] = {REQUIRED_CAPABILITY_HEADER: "trusted_cyber"}
+            websocket.send_text(json.dumps(marker_request))
+            first_created = json.loads(websocket.receive_text())
+            first_completed = json.loads(websocket.receive_text())
+
+            websocket.send_text(json.dumps(_websocket_response_create("continue after grant revocation")))
+            second_created = json.loads(websocket.receive_text())
+            second_completed = json.loads(websocket.receive_text())
+
+    assert first_created["response"]["id"] == "resp_ws_capability_before_revocation"
+    assert first_completed["type"] == "response.completed"
+    assert second_created["response"]["id"] == "resp_ws_capability_after_revocation"
+    assert second_completed["type"] == "response.completed"
+    assert revalidation_requirements == [True]
+    assert selection_requirements == [True, True]
+    assert revoked_upstream.closed is True
+    assert len(revoked_upstream.sent_text) == 1
+
+
+@pytest.mark.parametrize(
+    ("failure_kind", "expected_error_code"),
+    [
+        ("typed", "capability_lineage_unavailable"),
+        ("unexpected", "capability_routing_unavailable"),
+    ],
+)
+def test_backend_responses_websocket_capability_revalidation_error_releases_frame_reservation(
+    app_instance,
+    monkeypatch,
+    failure_kind,
+    expected_error_code,
+):
+    api_key = _capability_test_api_key("key_ws_capability_revalidation_error")
+    upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[
+            _websocket_response_batch("resp_ws_capability_before_revalidation_error"),
+            _websocket_response_batch("resp_ws_capability_revalidation_error_leak"),
+        ],
+    )
+    selection_requirements: list[bool] = []
+    released_request_ids: list[str] = []
+    original_release = proxy_module.ProxyService._release_websocket_request_state_reservation
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        del request
+        assert authorization == "Bearer capability-revalidation-error"
+        return api_key
+
+    async def keep_authenticated_api_key_policy(self, current_api_key):
+        del self
+        assert current_api_key == api_key
+        return current_api_key
+
+    async def bypass_api_key_usage_reservation(self, current_api_key, **_kwargs):
+        del self, _kwargs
+        assert current_api_key == api_key
+        return None
+
+    async def fake_select_websocket_connect_account(
+        self,
+        deadline,
+        *,
+        request_state,
+        require_security_work_authorized,
+        **_kwargs,
+    ):
+        del self, deadline, request_state, _kwargs
+        selection_requirements.append(require_security_work_authorized)
+        return SimpleNamespace(
+            id="acct_ws_capability_revalidation_error",
+            security_work_authorized=True,
+        )
+
+    async def fail_capability_revalidation(self, deadline, **kwargs):
+        del self, deadline
+        assert kwargs["api_key"] == api_key
+        assert kwargs["require_security_work_authorized"] is True
+        assert kwargs["preferred_account_id"] == "acct_ws_capability_revalidation_error"
+        if failure_kind == "typed":
+            raise _capability_lineage_unavailable_error()
+        raise RuntimeError("capability selector boundary failed")
+
+    async def fake_try_open_websocket_connect_attempt(self, account, headers, **_kwargs):
+        del self, _kwargs
+        assert not any(name.lower() == REQUIRED_CAPABILITY_HEADER for name in headers)
+        return account, upstream
+
+    async def track_reservation_release(self, request_state):
+        released_request_ids.append(request_state.request_id)
+        await original_release(self, request_state)
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_refresh_websocket_api_key_policy",
+        keep_authenticated_api_key_policy,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_reserve_websocket_api_key_usage",
+        bypass_api_key_usage_reservation,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_websocket_connect_account",
+        fake_select_websocket_connect_account,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_account_with_budget_compatible",
+        fail_capability_revalidation,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_try_open_websocket_connect_attempt",
+        fake_try_open_websocket_connect_attempt,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_release_websocket_request_state_reservation",
+        track_reservation_release,
+    )
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers={
+                "Authorization": "Bearer capability-revalidation-error",
+                "x-codex-window-id": "task-ws-capability-revalidation-error:1",
+            },
+        ) as websocket:
+            marker_request = _websocket_response_create("establish required socket")
+            marker_request["client_metadata"] = {REQUIRED_CAPABILITY_HEADER: "trusted_cyber"}
+            websocket.send_text(json.dumps(marker_request))
+            first_created = json.loads(websocket.receive_text())
+            first_completed = json.loads(websocket.receive_text())
+            releases_after_first_turn = len(released_request_ids)
+
+            websocket.send_text(json.dumps(_websocket_response_create("trigger typed revalidation failure")))
+            terminal = json.loads(websocket.receive_text())
+
+    assert first_created["response"]["id"] == "resp_ws_capability_before_revalidation_error"
+    assert first_completed["type"] == "response.completed"
+    assert terminal["type"] == "response.failed"
+    assert terminal["response"]["error"]["code"] == expected_error_code
+    assert len(released_request_ids) == releases_after_first_turn + 1
+    assert selection_requirements == [True]
+    assert len(upstream.sent_text) == 1
+
+
+def test_backend_responses_websocket_trusted_capability_pending_conflict_keeps_ordinary_socket(
+    app_instance,
+    monkeypatch,
+):
+    api_key = _capability_test_api_key("key_ws_capability_pending_conflict")
+    ordinary_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[
+            _websocket_response_batch("resp_ws_capability_pending", completed=False),
+            _websocket_response_batch("resp_ws_capability_conflict_leak", completed=False),
+        ],
+    )
+    reopened_ordinary_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[_websocket_response_batch("resp_ws_capability_conflict_reopened")],
+    )
+    marker_cyber_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[_websocket_response_batch("resp_ws_capability_conflict_marker")],
+    )
+    unexpected_cyber_upstream = _SequencedUpstreamWebSocket(
+        [],
+        deferred_message_batches=[_websocket_response_batch("resp_ws_capability_conflict_reconnected")],
+    )
+    ordinary_upstreams = deque([ordinary_upstream, reopened_ordinary_upstream])
+    cyber_upstreams = deque([marker_cyber_upstream, unexpected_cyber_upstream])
+    selection_requirements: list[bool] = []
+    opened_account_ids: list[str] = []
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        del request
+        assert authorization == "Bearer capability-pending-conflict"
+        return api_key
+
+    async def keep_authenticated_api_key_policy(self, current_api_key):
+        del self
+        assert current_api_key == api_key
+        return current_api_key
+
+    async def bypass_api_key_usage_reservation(self, current_api_key, **_kwargs):
+        del self, _kwargs
+        assert current_api_key == api_key
+        return None
+
+    async def fake_select_websocket_connect_account(
+        self,
+        deadline,
+        *,
+        request_state,
+        require_security_work_authorized,
+        **_kwargs,
+    ):
+        del self, deadline, request_state, _kwargs
+        selection_requirements.append(require_security_work_authorized)
+        account_kind = "cyber" if require_security_work_authorized else "ordinary"
+        account_index = selection_requirements.count(require_security_work_authorized)
+        return SimpleNamespace(
+            id=f"acct_ws_capability_conflict_{account_kind}_{account_index}",
+            # This socket was selected under the ordinary contract even though
+            # the selected account itself currently has the capability grant.
+            security_work_authorized=True,
+        )
+
+    async def fake_try_open_websocket_connect_attempt(self, account, headers, **_kwargs):
+        del self, _kwargs
+        assert not any(name.lower() == REQUIRED_CAPABILITY_HEADER for name in headers)
+        opened_account_ids.append(account.id)
+        upstreams = cyber_upstreams if "_cyber_" in account.id else ordinary_upstreams
+        return account, upstreams.popleft()
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_refresh_websocket_api_key_policy",
+        keep_authenticated_api_key_policy,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_reserve_websocket_api_key_usage",
+        bypass_api_key_usage_reservation,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_websocket_connect_account",
+        fake_select_websocket_connect_account,
+    )
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_try_open_websocket_connect_attempt",
+        fake_try_open_websocket_connect_attempt,
+    )
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect(
+            "/backend-api/codex/responses",
+            headers={
+                "Authorization": "Bearer capability-pending-conflict",
+                "x-codex-window-id": "task-ws-capability-pending-conflict:1",
+            },
+        ) as ordinary_websocket:
+            ordinary_websocket.send_text(json.dumps(_websocket_response_create("long ordinary response")))
+            pending_created = json.loads(ordinary_websocket.receive_text())
+
+            with client.websocket_connect(
+                "/backend-api/codex/responses",
+                headers={
+                    "Authorization": "Bearer capability-pending-conflict",
+                    "x-codex-window-id": "task-ws-capability-pending-conflict:2",
+                    REQUIRED_CAPABILITY_HEADER: "trusted_cyber",
+                },
+            ) as marker_websocket:
+                marker_websocket.send_text(json.dumps(_websocket_response_create("establish requirement")))
+                marker_created = json.loads(marker_websocket.receive_text())
+                marker_completed = json.loads(marker_websocket.receive_text())
+
+            ordinary_websocket.send_text(json.dumps(_websocket_response_create("must not cross accounts")))
+            conflict = json.loads(ordinary_websocket.receive_text())
+
+            assert conflict["type"] == "response.failed"
+            assert conflict["response"]["error"]["code"] == "continuity_owner_conflict"
+            assert ordinary_upstream.closed is False
+            assert len(ordinary_upstream.sent_text) == 1
+            assert selection_requirements == [False, True]
+
+    assert pending_created["response"]["id"] == "resp_ws_capability_pending"
+    assert marker_created["response"]["id"] == "resp_ws_capability_conflict_marker"
+    assert marker_completed["type"] == "response.completed"
+    assert opened_account_ids == [
+        "acct_ws_capability_conflict_ordinary_1",
+        "acct_ws_capability_conflict_cyber_1",
+    ]

--- a/tests/unit/test_capability_routing.py
+++ b/tests/unit/test_capability_routing.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core.clients.proxy import ProxyResponseError
+from app.core.types import JsonValue
+from app.modules.api_keys.service import ApiKeyData
+from app.modules.proxy.capability_lineage import CapabilityLineageAlias
+from app.modules.proxy.capability_routing import (
+    CAPABILITY_LINEAGE_UNAVAILABLE_CODE,
+    CAPABILITY_SIGNAL_UNTRUSTED_CODE,
+    REQUIRED_CAPABILITY_HEADER,
+    UNSUPPORTED_REQUIRED_CAPABILITY_CODE,
+    CapabilityRoute,
+    CapabilityRouter,
+    RoutingCapability,
+    RoutingIntent,
+    capability_lineage_aliases,
+    parse_routing_intent,
+    strip_capability_metadata,
+)
+from app.modules.proxy.repo_bundle import ProxyRepoFactory, ProxyRepositories
+
+pytestmark = pytest.mark.unit
+
+
+def _api_key() -> ApiKeyData:
+    return ApiKeyData(
+        id="api-key-a",
+        name="test",
+        key_prefix="sk-test",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=datetime(2026, 7, 31, tzinfo=timezone.utc),
+        last_used_at=None,
+    )
+
+
+def _error_code(error: ProxyResponseError) -> str | None:
+    return error.payload["error"].get("code")
+
+
+def _repo_factory(repository: object) -> ProxyRepoFactory:
+    @asynccontextmanager
+    async def factory() -> AsyncIterator[ProxyRepositories]:
+        yield cast(ProxyRepositories, SimpleNamespace(capability_lineage=repository))
+
+    return factory
+
+
+def test_parse_routing_intent_accepts_one_authenticated_carrier() -> None:
+    assert parse_routing_intent(
+        {"X-CoDeX-LB-ReQuIrEd-CaPaBiLiTy": " trusted_cyber "},
+        api_key=_api_key(),
+    ) == RoutingIntent.requiring(RoutingCapability.TRUSTED_CYBER)
+    assert parse_routing_intent(
+        {},
+        api_key=_api_key(),
+        client_metadata={"x-codex-lb-required-capability": "trusted_cyber"},
+    ) == RoutingIntent.requiring(RoutingCapability.TRUSTED_CYBER)
+
+
+def test_parse_routing_intent_rejects_ambiguous_carriers() -> None:
+    with pytest.raises(ProxyResponseError) as exc_info:
+        parse_routing_intent(
+            {REQUIRED_CAPABILITY_HEADER: "trusted_cyber"},
+            api_key=_api_key(),
+            client_metadata={REQUIRED_CAPABILITY_HEADER: "trusted_cyber"},
+        )
+
+    assert exc_info.value.status_code == 400
+    assert _error_code(exc_info.value) == UNSUPPORTED_REQUIRED_CAPABILITY_CODE
+
+
+def test_parse_routing_intent_rejects_duplicate_raw_header_values() -> None:
+    with pytest.raises(ProxyResponseError) as exc_info:
+        parse_routing_intent(
+            {REQUIRED_CAPABILITY_HEADER: "trusted_cyber"},
+            api_key=_api_key(),
+            header_values=("trusted_cyber", "trusted_cyber"),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert _error_code(exc_info.value) == UNSUPPORTED_REQUIRED_CAPABILITY_CODE
+
+
+@pytest.mark.parametrize("value", ["other", "TRUSTED_CYBER", True, ["trusted_cyber"]])
+def test_parse_routing_intent_rejects_unknown_or_malformed_values(value: JsonValue) -> None:
+    with pytest.raises(ProxyResponseError) as exc_info:
+        parse_routing_intent(
+            {},
+            api_key=_api_key(),
+            client_metadata={REQUIRED_CAPABILITY_HEADER: value},
+        )
+
+    assert exc_info.value.status_code == 400
+    assert _error_code(exc_info.value) == UNSUPPORTED_REQUIRED_CAPABILITY_CODE
+
+
+def test_parse_routing_intent_rejects_unauthenticated_signal() -> None:
+    with pytest.raises(ProxyResponseError) as exc_info:
+        parse_routing_intent(
+            {REQUIRED_CAPABILITY_HEADER: "trusted_cyber"},
+            api_key=None,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert _error_code(exc_info.value) == CAPABILITY_SIGNAL_UNTRUSTED_CODE
+
+
+def test_strip_capability_metadata_removes_only_internal_key() -> None:
+    metadata = {
+        "X-Codex-LB-Required-Capability": "trusted_cyber",
+        "x-codex-window-id": "window-1",
+        "custom": {"nested": True},
+    }
+
+    assert strip_capability_metadata(metadata) == {
+        "x-codex-window-id": "window-1",
+        "custom": {"nested": True},
+    }
+    assert metadata["X-Codex-LB-Required-Capability"] == "trusted_cyber"
+
+
+def test_capability_lineage_aliases_preserve_domains_and_stable_task_root() -> None:
+    aliases = capability_lineage_aliases(
+        {
+            "x-codex-parent-thread-id": "task-parent",
+            "x-codex-window-id": "task-root:2",
+        },
+        session_id="same-visible-id",
+        turn_state="same-visible-id",
+        previous_response_ids=("resp-1",),
+        client_metadata={
+            "x-codex-parent-thread-id": "task-root",
+            "x-codex-window-id": "task-metadata:3",
+        },
+    )
+
+    assert aliases == (
+        CapabilityLineageAlias(kind="session_header", value="same-visible-id"),
+        CapabilityLineageAlias(kind="turn_state", value="same-visible-id"),
+        CapabilityLineageAlias(kind="previous_response", value="resp-1"),
+        CapabilityLineageAlias(kind="codex_task", value="task-parent"),
+        CapabilityLineageAlias(kind="codex_task", value="task-root"),
+        CapabilityLineageAlias(kind="codex_window", value="task-root:2"),
+        CapabilityLineageAlias(kind="codex_window", value="task-metadata:3"),
+        CapabilityLineageAlias(kind="codex_task", value="task-metadata"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_capability_router_persists_explicit_intent_before_returning_required() -> None:
+    repository = SimpleNamespace(is_required=AsyncMock(return_value=False), require=AsyncMock(return_value=("hash",)))
+    router = CapabilityRouter(_repo_factory(repository))
+    aliases = (CapabilityLineageAlias(kind="session_header", value="session-a"),)
+
+    route = await router.route(
+        RoutingIntent.requiring(RoutingCapability.TRUSTED_CYBER),
+        api_key_id="api-key-a",
+        aliases=aliases,
+    )
+
+    assert route == CapabilityRoute(require_security_work_authorized=True, aliases=aliases)
+    repository.require.assert_awaited_once_with(
+        capability="trusted_cyber",
+        api_key_scope="api-key-a",
+        aliases=aliases,
+    )
+
+
+@pytest.mark.asyncio
+async def test_capability_router_restores_inherited_requirement_and_fails_closed_on_lookup_error() -> None:
+    aliases = (CapabilityLineageAlias(kind="session_header", value="session-a"),)
+    repository = SimpleNamespace(is_required=AsyncMock(return_value=True), require=AsyncMock(return_value=("hash",)))
+    router = CapabilityRouter(_repo_factory(repository))
+
+    route = await router.route(RoutingIntent.empty(), api_key_id="api-key-a", aliases=aliases)
+
+    assert route.require_security_work_authorized is True
+    repository.require.assert_awaited_once()
+
+    repository.is_required.side_effect = RuntimeError("database unavailable")
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await router.route(RoutingIntent.empty(), api_key_id="api-key-a", aliases=aliases)
+
+    assert exc_info.value.status_code == 503
+    assert _error_code(exc_info.value) == CAPABILITY_LINEAGE_UNAVAILABLE_CODE

--- a/tests/unit/test_capability_routing.py
+++ b/tests/unit/test_capability_routing.py
@@ -61,7 +61,7 @@ def _repo_factory(repository: object) -> ProxyRepoFactory:
 
 def test_parse_routing_intent_accepts_one_authenticated_carrier() -> None:
     assert parse_routing_intent(
-        {"X-CoDeX-LB-ReQuIrEd-CaPaBiLiTy": " trusted_cyber "},
+        {"X-CoDeX-LB-ReQuIrEd-CaPaBiLiTy": "trusted_cyber"},
         api_key=_api_key(),
     ) == RoutingIntent.requiring(RoutingCapability.TRUSTED_CYBER)
     assert parse_routing_intent(
@@ -95,7 +95,10 @@ def test_parse_routing_intent_rejects_duplicate_raw_header_values() -> None:
     assert _error_code(exc_info.value) == UNSUPPORTED_REQUIRED_CAPABILITY_CODE
 
 
-@pytest.mark.parametrize("value", ["other", "TRUSTED_CYBER", True, ["trusted_cyber"]])
+@pytest.mark.parametrize(
+    "value",
+    ["other", "TRUSTED_CYBER", " trusted_cyber ", True, ["trusted_cyber"]],
+)
 def test_parse_routing_intent_rejects_unknown_or_malformed_values(value: JsonValue) -> None:
     with pytest.raises(ProxyResponseError) as exc_info:
         parse_routing_intent(

--- a/tests/unit/test_db_migrate.py
+++ b/tests/unit/test_db_migrate.py
@@ -2019,6 +2019,53 @@ def test_replica_guardrails_migration_round_trips_with_version_backfill(tmp_path
         engine.dispose()
 
 
+def test_capability_lineage_migration_is_additive_reversible_and_single_head(tmp_path: Path) -> None:
+    from alembic.script import ScriptDirectory
+
+    db_path = tmp_path / "capability-lineage.db"
+    url = _db_url(db_path)
+    parent_revision = "20260725_000000_add_http_bridge_pending_tool_calls"
+    target_revision = "20260731_000000_add_capability_lineage_markers"
+
+    run_upgrade(url, parent_revision, bootstrap_legacy=False)
+    config = _build_alembic_config(url)
+    script_directory = ScriptDirectory.from_config(config)
+    assert script_directory.get_heads() == [target_revision]
+
+    engine = create_engine(to_sync_database_url(url))
+    try:
+        with engine.connect() as connection:
+            inspector = inspect(connection)
+            existing_columns = {
+                table: tuple(column["name"] for column in inspector.get_columns(table))
+                for table in ("accounts", "sticky_sessions", "usage_history", "http_bridge_sessions")
+            }
+
+        command.upgrade(config, target_revision)
+        with engine.connect() as connection:
+            inspector = inspect(connection)
+            assert inspector.has_table("capability_lineage_markers")
+            assert {column["name"] for column in inspector.get_columns("capability_lineage_markers")} == {
+                "marker_hash",
+                "created_at",
+                "last_seen_at",
+            }
+            assert connection.execute(text("SELECT COUNT(*) FROM capability_lineage_markers")).scalar_one() == 0
+            assert {
+                table: tuple(column["name"] for column in inspector.get_columns(table)) for table in existing_columns
+            } == existing_columns
+
+        command.downgrade(config, parent_revision)
+        with engine.connect() as connection:
+            inspector = inspect(connection)
+            assert not inspector.has_table("capability_lineage_markers")
+            assert {
+                table: tuple(column["name"] for column in inspector.get_columns(table)) for table in existing_columns
+            } == existing_columns
+    finally:
+        engine.dispose()
+
+
 def test_check_schema_drift_detects_missing_dashboard_hot_path_indexes(tmp_path: Path) -> None:
     db_path = tmp_path / "missing-hot-path-indexes.db"
     url = _db_url(db_path)

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -79,6 +79,7 @@ from app.modules.proxy._service.support import (
 from app.modules.proxy._service.websocket import helpers as websocket_helpers_module
 from app.modules.proxy._service.websocket import mixin as websocket_mixin
 from app.modules.proxy._service.websocket import mixin as websocket_mixin_module
+from app.modules.proxy.capability_lineage_repository import CapabilityLineageRepository
 from app.modules.proxy.continuity import make_http_bridge_account_neutral_replay_key
 from app.modules.proxy.load_balancer import (
     AccountLease,
@@ -189,6 +190,38 @@ async def test_stream_selector_compatibility_drops_unsupported_continuity_owner_
 
     assert result.error_message == "unavailable"
     assert calls == [(42.0, "acc-owner")]
+
+
+@pytest.mark.asyncio
+async def test_budget_compatibility_requires_security_flag_support() -> None:
+    calls: list[float] = []
+
+    async def narrow_selector(deadline: float) -> AccountSelection:
+        calls.append(deadline)
+        return AccountSelection(account=None, error_message="unavailable")
+
+    service = cast(
+        proxy_service.ProxyService,
+        SimpleNamespace(_select_account_with_budget=narrow_selector),
+    )
+
+    ordinary_result = await proxy_service.ProxyService._select_account_with_budget_compatible(
+        service,
+        41.0,
+        require_security_work_authorized=False,
+    )
+
+    assert ordinary_result.error_message == "unavailable"
+    assert calls == [41.0]
+
+    with pytest.raises(TypeError, match="require_security_work_authorized"):
+        await proxy_service.ProxyService._select_account_with_budget_compatible(
+            service,
+            42.0,
+            require_security_work_authorized=True,
+        )
+
+    assert calls == [41.0]
 
 
 @pytest.mark.asyncio
@@ -1289,6 +1322,18 @@ def test_filter_inbound_headers_strips_internal_responses_lite_header():
     assert "x-openai-internal-codex-responses-lite" not in lowered
     assert filtered["x-openai-client-version"] == "2.24.0"
     assert filtered["User-Agent"] == "codex-test"
+
+
+def test_filter_inbound_headers_strips_internal_capability_header():
+    filtered = filter_inbound_headers(
+        {
+            "X-Codex-LB-Required-Capability": "trusted_cyber",
+            "X-Custom": "preserved",
+        }
+    )
+
+    assert "X-Codex-LB-Required-Capability" not in filtered
+    assert filtered["X-Custom"] == "preserved"
 
 
 def test_request_log_useragent_fields_extract_full_value_and_group() -> None:
@@ -4462,6 +4507,9 @@ class _RequestLogsRecorder:
 
 class _RepoContext:
     def __init__(self, request_logs: _RequestLogsRecorder) -> None:
+        capability_lineage = AsyncMock(spec=CapabilityLineageRepository)
+        capability_lineage.is_required.return_value = False
+        capability_lineage.require.return_value = ("test-marker",)
         self._repos = ProxyRepositories(
             accounts=cast(AccountsRepository, AsyncMock()),
             usage=cast(UsageRepository, AsyncMock()),
@@ -4469,6 +4517,7 @@ class _RepoContext:
             sticky_sessions=cast(StickySessionsRepository, AsyncMock()),
             api_keys=cast(ApiKeysRepository, AsyncMock()),
             additional_usage=cast(AdditionalUsageRepository, AsyncMock()),
+            capability_lineage=capability_lineage,
         )
 
     async def __aenter__(self) -> ProxyRepositories:


### PR DESCRIPTION
## Summary

Security-approved CyberTrusted work now routes to an eligible `security_work_authorized` account from the first selection and remains constrained after reconnect without a capability echo. Once `trusted_cyber` is established, the request never falls back to an ordinary account.

The new lineage layer is the durable evidence for that decision. It stores API-key-scoped, domain-separated opaque markers across session, turn-state, previous-response, and Codex task aliases, then restores the existing security routing constraint before selection and every retry.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: none.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/add-capability-aware-routing/`

## Changes

- Parse one exact authenticated `trusted_cyber` carrier and reject duplicate, misplaced, malformed, or unauthenticated signals before selection.
- Persist monotonic, opaque capability-lineage markers in one additive zero-backfill table.
- Restore the requirement for no-echo, echoed-turn-state, and response-only reconnects before account selection.
- Reuse canonical account scope, ownership, health, quota, retry, reservation, and grant-revalidation paths while failing closed on empty capable pools or persistence uncertainty.
- Strip the private carrier before upstream dispatch, archival, diagnostics, and logging.

## Simplicity

- [x] New feature works with zero config
- [x] No new required setup step
- New setting(s): none
- [x] README sections / `.env.example` / dashboard nav remain unchanged

## Test plan

```text
make ci-fast
# frontend: 947 passed; production build passed
# backend: 5087 passed, 67 skipped
# sdist, wheel, and wheel asset verification passed

uv run pytest tests/unit/test_capability_routing.py tests/integration/test_capability_lineage_repository.py tests/integration/test_proxy_websocket_responses.py -k "capability or routing_intent" -q
# 45 passed

uv run pytest tests/unit/test_load_balancer_contract.py tests/unit/test_load_balancer_concurrency.py -q
# 117 passed

uv run pytest tests/unit/test_db_migrate.py::test_capability_lineage_migration_is_additive_reversible_and_single_head -q
# 1 passed

openspec validate add-capability-aware-routing --type change --strict --no-interactive
openspec validate --specs --strict --no-interactive
# scoped change valid; 48 specs passed
```

The full container, Helm, and PostgreSQL local-CI jobs were not run because their required runtimes are not available in the local environment. Required GitHub CI remains the integration authority.

Behavioral provenance: the underlying selection and reconnect contract was previously exercised end-to-end against a mixed eligible pool. Initial selection and a no-echo reconnect both remained on security-authorized accounts, with zero ordinary-account attempts. This PR independently reimplements and regression-tests that behavior on current `main`.

## Related work and attribution

The durable security-lineage contract was originally developed by @Komzpa in #1183. This PR is an independent current-main implementation limited to capability routing and no-echo reconnect behavior.

## Screenshots / output

No dashboard-visible surface.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Related work is linked above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local CI subset.
- [x] Strict OpenSpec validation passes and independent Sensitive review is clean.
- [x] Simplicity gates reviewed.
- [x] CHANGELOG is not edited by hand.