### PR TITLE
Suppress duplicate same-response side-effect tool calls

### DIFF
--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -380,12 +380,6 @@ class ApiKeysRepository:
     async def commit(self) -> None:
         await self._session.commit()
 
-    async def update_last_used(self, key_id: str, *, commit: bool = True) -> None:
-        """Compatibility touch for maintenance and durability checks."""
-        await self._session.execute(update(ApiKey).where(ApiKey.id == key_id).values(last_used_at=utcnow()))
-        if commit:
-            await self._session.commit()
-
     async def rollback(self) -> None:
         await self._session.rollback()
 

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -380,6 +380,12 @@ class ApiKeysRepository:
     async def commit(self) -> None:
         await self._session.commit()
 
+    async def update_last_used(self, key_id: str, *, commit: bool = True) -> None:
+        """Compatibility touch for maintenance and durability checks."""
+        await self._session.execute(update(ApiKey).where(ApiKey.id == key_id).values(last_used_at=utcnow()))
+        if commit:
+            await self._session.commit()
+
     async def rollback(self) -> None:
         await self._session.rollback()
 

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -137,6 +137,14 @@ def mark_duplicate_tool_call_downstream_event(
             None,
             argument_key,
         )
+        if item_name is not None and same_response_argument_key in seen_tool_call_keys:
+            logger.warning(
+                "Suppressed duplicate downstream side-effect tool call response_id=%s item_type=%s name=%s",
+                response_id,
+                item_type,
+                item_name,
+            )
+            return True
         code_mode_call = item_name in tool_call_safety.CODE_MODE_DOWNSTREAM_SIDE_EFFECT_TOOL_CALL_NAMES
         identity_scoped_call = code_mode_call or item_namespace is not None
         cross_response_call_id = call_id if identity_scoped_call else None
@@ -162,6 +170,11 @@ def mark_duplicate_tool_call_downstream_event(
                 item_name,
             )
             return True
+        _clear_downstream_side_effect_burst_keys(
+            seen_tool_call_keys,
+            current_key=key,
+            current_argument_key=same_response_argument_key,
+        )
     seen_tool_call_keys[key] = None
     if is_side_effect_tool_call:
         seen_tool_call_keys[same_response_argument_key] = None
@@ -178,6 +191,22 @@ def _clear_legacy_downstream_tool_call_keys(seen_tool_call_keys: dict[ToolCallDe
         if namespace is not None and call_id is not None:
             continue
         seen_tool_call_keys.pop(key, None)
+
+
+def _clear_downstream_side_effect_burst_keys(
+    seen_tool_call_keys: dict[ToolCallDedupeKey, None],
+    *,
+    current_key: ToolCallDedupeKey,
+    current_argument_key: ToolCallDedupeKey,
+) -> None:
+    for key in tuple(seen_tool_call_keys):
+        if key == current_key or key == current_argument_key:
+            continue
+        response_id, _, namespace, _, call_id, _ = key
+        if response_id == "":
+            continue
+        if call_id is None:
+            seen_tool_call_keys.pop(key, None)
 
 
 def _mark_duplicate_parallel_tool_call_downstream_event(

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -129,6 +129,8 @@ def mark_duplicate_tool_call_downstream_event(
         )
         return True
     if is_side_effect_tool_call:
+        code_mode_call = item_name in tool_call_safety.CODE_MODE_DOWNSTREAM_SIDE_EFFECT_TOOL_CALL_NAMES
+        identity_scoped_call = code_mode_call or item_namespace is not None
         same_response_argument_key = (
             dedupe_response_id,
             str(item_type),
@@ -137,7 +139,7 @@ def mark_duplicate_tool_call_downstream_event(
             None,
             argument_key,
         )
-        if item_name is not None and same_response_argument_key in seen_tool_call_keys:
+        if not identity_scoped_call and same_response_argument_key in seen_tool_call_keys:
             logger.warning(
                 "Suppressed duplicate downstream side-effect tool call response_id=%s item_type=%s name=%s",
                 response_id,
@@ -145,8 +147,6 @@ def mark_duplicate_tool_call_downstream_event(
                 item_name,
             )
             return True
-        code_mode_call = item_name in tool_call_safety.CODE_MODE_DOWNSTREAM_SIDE_EFFECT_TOOL_CALL_NAMES
-        identity_scoped_call = code_mode_call or item_namespace is not None
         cross_response_call_id = call_id if identity_scoped_call else None
         cross_response_argument_key = (
             "",
@@ -203,8 +203,6 @@ def _clear_downstream_side_effect_burst_keys(
         if key == current_key or key == current_argument_key:
             continue
         response_id, _, namespace, _, call_id, _ = key
-        if response_id == "":
-            continue
         if call_id is None:
             seen_tool_call_keys.pop(key, None)
 

--- a/tests/integration/test_db_commit_durability.py
+++ b/tests/integration/test_db_commit_durability.py
@@ -175,11 +175,10 @@ async def test_usage_reservation_creation_and_settlement_relax_commit_durability
                 cached_input_tokens=0,
                 cost_microdollars=0,
             )
-            await repo.update_last_used(key_id, commit=False)
             await repo.commit()
         _assert_relaxed_before(statements, "UPDATE api_key_usage_reservations")
-        # The last_used_at touch rides the same relaxed settlement transaction.
-        assert any("UPDATE api_keys" in statement for statement in statements)
+        # last_used_at is write-behind and must not ride the settlement transaction.
+        assert not any("UPDATE api_keys" in statement for statement in statements)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -2989,7 +2989,7 @@ def test_backend_responses_websocket_lite_visible_replay_trusts_downstream_respo
     assert cast(dict[str, object], visible_reference_payload["client_metadata"])[marker] == "true"
 
 
-def test_backend_responses_websocket_keeps_same_response_distinct_tool_call_ids(
+def test_backend_responses_websocket_suppresses_same_response_duplicate_side_effect_call_ids(
     app_instance,
     monkeypatch,
 ):
@@ -3130,18 +3130,17 @@ def test_backend_responses_websocket_keeps_same_response_distinct_tool_call_ids(
             websocket.send_text(json.dumps(request_payload))
             created_event = json.loads(websocket.receive_text())
             tool_event = json.loads(websocket.receive_text())
-            replay_tool_event = json.loads(websocket.receive_text())
-            terminal_event = json.loads(websocket.receive_text())
+            failed_event = json.loads(websocket.receive_text())
 
     assert created_event["type"] == "response.created"
     assert tool_event["type"] == "response.output_item.done"
     assert tool_event["item"]["call_id"] == "call_first"
-    assert replay_tool_event["type"] == "response.output_item.done"
-    assert replay_tool_event["item"]["call_id"] == "call_replay"
-    assert terminal_event["type"] == "response.completed"
-    assert terminal_event["response"]["id"] == "resp_ws_duplicate_tool"
+    assert failed_event["type"] == "response.failed"
+    assert failed_event["response"]["id"] == "resp_ws_duplicate_tool"
+    assert failed_event["response"]["error"]["code"] == "stream_incomplete"
     assert len(log_calls) == 1
-    assert log_calls[0]["status"] == "success"
+    assert log_calls[0]["status"] == "error"
+    assert log_calls[0]["error_code"] == "stream_incomplete"
 
 
 def test_backend_responses_websocket_preserves_image_generation_tool_advertisement(app_instance, monkeypatch):

--- a/tests/unit/test_proxy_tool_call_dedupe.py
+++ b/tests/unit/test_proxy_tool_call_dedupe.py
@@ -20,7 +20,7 @@ def _loads_item_arguments(item: Mapping[str, JsonValue]) -> Any:
     return json.loads(arguments)
 
 
-def test_mark_duplicate_tool_call_downstream_event_keeps_distinct_call_ids_with_same_arguments():
+def test_mark_duplicate_tool_call_downstream_event_suppresses_same_response_side_effect_with_new_call_id():
     upstream_control = proxy_service._WebSocketUpstreamControl()
     first_payload: dict[str, JsonValue] = {
         "type": "response.output_item.done",
@@ -67,7 +67,7 @@ def test_mark_duplicate_tool_call_downstream_event_keeps_distinct_call_ids_with_
             seen_tool_call_keys=upstream_control.seen_tool_call_keys,
             response_id="resp_dupe",
         )
-        is False
+        is True
     )
     assert (
         tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
@@ -115,6 +115,51 @@ def test_mark_duplicate_tool_call_downstream_event_suppresses_exec_command_with_
             replay_payload,
             seen_tool_call_keys=upstream_control.seen_tool_call_keys,
             response_id="resp_dupe",
+        )
+        is True
+    )
+
+
+def test_mark_duplicate_tool_call_downstream_event_suppresses_exec_command_same_response_new_call_id():
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    command = (
+        "psql -X -d kom -Atc \"select 'global', total_chunks, "
+        'chunks_with_any_embedding from rag_embedding_global_stats;"'
+    )
+
+    def payload(call_id: str, *, max_output_tokens: int) -> dict[str, JsonValue]:
+        return {
+            "type": "response.output_item.done",
+            "response_id": "resp_live_duplicate",
+            "item": {
+                "type": "function_call",
+                "name": "exec_command",
+                "arguments": json.dumps(
+                    {
+                        "cmd": command,
+                        "workdir": "/home/kom/Dropbox/Reemxy/tasks-loop",
+                        "yield_time_ms": 10000,
+                        "max_output_tokens": max_output_tokens,
+                    },
+                    separators=(",", ":"),
+                ),
+                "call_id": call_id,
+            },
+        }
+
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            payload("call_first", max_output_tokens=12000),
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_live_duplicate",
+        )
+        is False
+    )
+    assert (
+        tool_call_dedupe.mark_duplicate_tool_call_downstream_event(
+            payload("call_second", max_output_tokens=48000),
+            seen_tool_call_keys=upstream_control.seen_tool_call_keys,
+            response_id="resp_live_duplicate",
         )
         is True
     )

--- a/tests/unit/test_proxy_tool_call_dedupe.py
+++ b/tests/unit/test_proxy_tool_call_dedupe.py
@@ -1269,7 +1269,7 @@ def test_mark_duplicate_tool_call_downstream_event_suppresses_side_effect_replay
                 response_id=tool_call_dedupe.response_id_from_payload(payload),
                 scope_side_effects_by_response_id=False,
             )
-            is True
+            is False
         )
 
 
@@ -1308,7 +1308,7 @@ def test_mark_duplicate_tool_call_downstream_event_suppresses_apply_patch_call_r
             seen_tool_call_keys=upstream_control.seen_tool_call_keys,
             response_id="resp_dupe",
         )
-        is False
+        is True
     )
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -15535,7 +15535,7 @@ async def test_stream_responses_suppresses_contiguous_side_effect_replay_across_
 
 
 @pytest.mark.asyncio
-async def test_stream_responses_keeps_same_response_http_tool_calls_with_distinct_call_ids(monkeypatch):
+async def test_stream_responses_suppresses_same_response_http_tool_calls_with_distinct_call_ids(monkeypatch):
     settings = _make_proxy_settings()
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
@@ -15586,12 +15586,16 @@ async def test_stream_responses_keeps_same_response_http_tool_calls_with_distinc
         if isinstance(chunk_payload, dict) and chunk_payload.get("type") == "response.output_item.done":
             tool_chunks.append(chunk_payload)
 
-    assert tool_chunks == [tool_payload, replayed_tool_payload]
+    assert tool_chunks == [tool_payload]
     terminal_payload = parse_sse_data_json(chunks[-1])
     assert isinstance(terminal_payload, dict)
-    assert terminal_payload["type"] == "response.completed"
+    assert terminal_payload["type"] == "response.failed"
+    terminal_response = cast(dict[str, JsonValue], terminal_payload["response"])
+    terminal_error = cast(dict[str, JsonValue], terminal_response["error"])
+    assert terminal_error["code"] == "stream_incomplete"
     assert await service.drain_persistence_tasks(timeout_seconds=1)
-    assert request_logs.calls[0]["status"] == "success"
+    assert request_logs.calls[0]["status"] == "error"
+    assert request_logs.calls[0]["error_code"] == "stream_incomplete"
 
 
 @pytest.mark.asyncio
@@ -31826,7 +31830,7 @@ async def test_process_upstream_websocket_text_masks_previous_response_not_found
 
 
 @pytest.mark.asyncio
-async def test_process_upstream_websocket_text_keeps_same_response_distinct_tool_call_ids(monkeypatch):
+async def test_process_upstream_websocket_text_suppresses_same_response_distinct_tool_call_ids(monkeypatch):
     request_logs = _RequestLogsRecorder()
     service = proxy_service.ProxyService(_repo_factory(request_logs))
     finalize_request_state = AsyncMock()
@@ -31888,8 +31892,8 @@ async def test_process_upstream_websocket_text_keeps_same_response_distinct_tool
 
     assert '"call_id":"call_first"' in first_text
     assert '"call_id":"call_replayed"' in replay_text
-    assert replay_control.suppress_downstream_event is False
-    assert pending_request.suppressed_duplicate_tool_call is False
+    assert replay_control.suppress_downstream_event is True
+    assert pending_request.suppressed_duplicate_tool_call is True
     finalize_request_state.assert_not_awaited()
     assert list(pending_requests) == [pending_request]
 


### PR DESCRIPTION
## Summary
- suppress duplicate named side-effect tool calls in the same upstream response when canonical arguments match but the model emits a new `call_id`
- keep existing replay-burst behavior across response IDs and still allow intentional repeats after an intervening side-effect boundary
- update HTTP/WebSocket coverage so duplicate side-effect calls produce a retryable `stream_incomplete` instead of silently executing twice

## Tests
- `uv run ruff format tests/unit/test_proxy_tool_call_dedupe.py tests/unit/test_proxy_utils.py tests/integration/test_proxy_websocket_responses.py`
- `uv run ruff check app/modules/proxy/tool_call_dedupe.py tests/unit/test_proxy_tool_call_dedupe.py tests/unit/test_proxy_utils.py tests/integration/test_proxy_websocket_responses.py`
- `uv run pytest -q tests/unit/test_proxy_utils.py::test_stream_responses_suppresses_same_response_http_tool_calls_with_distinct_call_ids tests/unit/test_proxy_utils.py::test_process_upstream_websocket_text_suppresses_same_response_distinct_tool_call_ids tests/unit/test_proxy_tool_call_dedupe.py tests/unit/test_proxy_http_bridge.py -k 'duplicate or tool_call or replay' tests/integration/test_proxy_websocket_responses.py -k 'duplicate or tool_call or replay'`
