### PR TITLE
Penalize eventless HTTP bridge accounts

### DIFF
--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -661,7 +661,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                                 session,
                                 error_code="upstream_request_timeout",
                                 error_message=receive_timeout.error_message,
-                                penalize_account=False,
+                                penalize_account=True,
                                 retire_detail=_HTTP_BRIDGE_MISSING_RESPONSE_CREATED_TIMEOUT_DETAIL,
                                 force_retire=True,
                             )

--- a/openspec/changes/recover-codex-desktop-idle-bridge/design.md
+++ b/openspec/changes/recover-codex-desktop-idle-bridge/design.md
@@ -53,7 +53,7 @@ Leading non-response telemetry such as `codex.rate_limits` does not change those
 
 When the deadline expires, reuse the reader-owned terminal failure and whole-session retirement path. Emit a stable `missing_response_created_timeout` detail, increment the existing stuck-retirement metric, settle every pending request exactly once, and close the bridge session.
 
-Do not transparently replay the timed-out request, submit it on another account, or mark the selected account unhealthy. Upstream acceptance is unknown, so duplicate submission and account movement are less safe than an explicit terminal failure. A later client request creates a fresh session through existing behavior.
+Do not transparently replay the timed-out request or submit that same request on another account. Upstream acceptance is unknown, so duplicate submission is less safe than an explicit terminal failure. Record a transient health failure for the selected account so a later client request creates a fresh session through existing selection and can avoid repeating an account that accepted `response.create` but emitted no `response.created`.
 
 Example: a request sends at monotonic time 1,000 with the default 300-second stuck threshold. With no matched response lifecycle event, it becomes eligible at 1,240 and receives an explicit terminal failure; it does not wait for a second request or the 300-second Desktop idle timeout.
 
@@ -66,7 +66,7 @@ Explicit `x-stainless-*` headers or an OpenAI User-Agent retain comment liveness
 ## Risks / Trade-offs
 
 - **A send fails after the timestamp is set.** Existing send-error cleanup retires or settles the request before the watchdog can act; tests cover that the timestamp alone is not sufficient eligibility.
-- **A quiet upstream accepted the request but emitted no event.** The proxy returns an explicit failure rather than risking a duplicate replay. The selected account remains healthy because silence is not proof of account failure.
+- **A quiet upstream accepted the request but emitted no event.** The proxy returns an explicit failure rather than risking a duplicate replay. The selected account receives a transient health failure because repeated missing-created timeouts on the same account are a live availability fault.
 - **A matched lifecycle event arrives just before timeout.** Eligibility is rechecked under the existing request/session synchronization before retirement, and any matched `response.*` event suppresses this watchdog.
 - **Whole-session retirement interrupts a healthy sibling.** This narrow design chooses fail-closed session cleanup rather than attempting unsafe sibling isolation on current `main`. Existing terminal settlement must cover every pending sibling exactly once.
 - **A client spoofs native identity.** The only benefit is an ignored vendor liveness event on the authenticated Codex backend route; explicit SDK markers still take precedence.

--- a/openspec/changes/recover-codex-desktop-idle-bridge/proposal.md
+++ b/openspec/changes/recover-codex-desktop-idle-bridge/proposal.md
@@ -6,9 +6,9 @@ A production Codex Desktop request on the HTTP-to-WebSocket bridge remained pend
 
 - Record the monotonic time of the current upstream `response.create` send.
 - Proactively expire an eventless request that remains pre-`response.created` for the smaller of the existing stuck-gate threshold and 240 seconds, even when no second gate waiter exists and periodic keepalives are disabled.
-- Fail the affected bridge session closed through existing terminal settlement and retirement paths, without transparent replay, account movement, or account-health penalties.
+- Fail the affected bridge session closed through existing terminal settlement and retirement paths, without transparent replay or moving the timed-out request to another account, while recording a transient account-health failure so later requests can avoid the eventless account.
 - Give verified native Codex identity parser-visible `codex.keepalive` frames even when payload-shape heuristics still require OpenAI-compatible event normalization; explicit SDK markers and public `/v1/responses` retain comment liveness.
-- Add regressions for the no-waiter deadline, protected created/eventful requests, account-neutral retirement, and contrasting Desktop/SDK/public heartbeat contracts.
+- Add regressions for the no-waiter deadline, protected created/eventful requests, health-accounted retirement without replay, and contrasting Desktop/SDK/public heartbeat contracts.
 
 ## Capabilities
 

--- a/openspec/changes/recover-codex-desktop-idle-bridge/specs/proxy-admission-control/spec.md
+++ b/openspec/changes/recover-codex-desktop-idle-bridge/specs/proxy-admission-control/spec.md
@@ -6,7 +6,7 @@ The proxy MUST retain the existing waiter-triggered retirement behavior for stal
 
 The owner-side watchdog MUST apply only while the request owns the response-create gate, awaits `response.created`, has neither a response id nor recorded `response.created` latency, has received no matched `response.*` lifecycle event, and has produced no downstream-visible output or sequence evidence. Non-response telemetry such as `codex.rate_limits` MUST NOT suppress this watchdog. Any matched `response.*` lifecycle event, response-created milestone, or downstream-visible evidence MUST suppress the owner-side watchdog and leave existing timeout behavior unchanged.
 
-When the owner-side deadline expires, the proxy MUST recheck eligibility, emit a structured low-cardinality log and the existing stuck-retirement Prometheus counter, terminally fail and settle every pending request exactly once, and retire the whole bridge session. It MUST NOT transparently replay the timed-out request, move it to another account, or write an account-health failure for the missing-created timeout.
+When the owner-side deadline expires, the proxy MUST recheck eligibility, emit a structured low-cardinality log and the existing stuck-retirement Prometheus counter, terminally fail and settle every pending request exactly once, write the selected account's transient health failure, and retire the whole bridge session. It MUST NOT transparently replay the timed-out request or move that timed-out request to another account.
 
 #### Scenario: Lone eventless gate owner is retired before the client timeout
 
@@ -38,10 +38,10 @@ When the owner-side deadline expires, the proxy MUST recheck eligibility, emit a
 - **THEN** this watchdog does not retire the session
 - **AND** existing stream, request-budget, and waiter-triggered timeout behavior remains authoritative
 
-#### Scenario: Timeout is fail-closed and account-neutral
+#### Scenario: Timeout is fail-closed and health-accounted
 
 - **GIVEN** an eventless pre-created owner reaches the owner-side deadline
 - **WHEN** terminal cleanup runs
 - **THEN** every pending request is settled exactly once and the whole session is retired
 - **AND** the proxy does not replay the timed-out request or submit it on another account
-- **AND** the selected account is not marked unhealthy solely because `response.created` was missing
+- **AND** the selected account records a transient health failure so later requests can avoid repeating the eventless account

--- a/openspec/changes/recover-codex-desktop-idle-bridge/tasks.md
+++ b/openspec/changes/recover-codex-desktop-idle-bridge/tasks.md
@@ -3,8 +3,8 @@
 - [x] 1.1 Record the current monotonic `response.create` send timestamp in HTTP bridge request state and replace it on every real send.
 - [x] 1.2 Add a pure client-safe deadline helper that uses the smaller of the existing stuck-gate threshold and 240 seconds.
 - [x] 1.3 Enforce the deadline from the upstream reader without requiring a second gate waiter or SSE keepalives; recheck narrow eventless eligibility before acting.
-- [x] 1.4 Fail and retire the whole bridge session through existing settlement, logging, and Prometheus paths without replay, account movement, or account-health writes.
-- [x] 1.5 Add focused regressions for no-waiter expiry, send-time anchoring, leading telemetry, created/eventful/downstream protection, terminal settlement, and account neutrality.
+- [x] 1.4 Fail and retire the whole bridge session through existing settlement, logging, Prometheus, and transient account-health paths without replaying or moving the timed-out request.
+- [x] 1.5 Add focused regressions for no-waiter expiry, send-time anchoring, leading telemetry, created/eventful/downstream protection, terminal settlement, and health-accounted retirement.
 
 ## 2. Native Codex SSE liveness
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -32,7 +32,7 @@ from app.core.clients.proxy_websocket import (
 from app.core.config.settings import Settings
 from app.core.errors import openai_error
 from app.core.utils.request_id import get_request_id, reset_request_scope_id, set_request_scope_id
-from app.db.models import AccountStatus, HttpBridgeSessionState
+from app.db.models import Account, AccountStatus, HttpBridgeSessionState
 from app.modules.proxy import http_bridge_forwarding as http_bridge_forwarding_module
 from app.modules.proxy import service as proxy_service
 from app.modules.proxy._service import support as proxy_support_module
@@ -18356,6 +18356,16 @@ async def test_http_bridge_reader_wakes_and_retires_lone_eventless_owner_without
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     upstream = _TrackingUpstream()
     session = _make_bridge_session(key_value=f"eventless-{leading_telemetry}")
+    session.account = Account(
+        id="acc-bridge",
+        email="bridge@example.com",
+        plan_type="plus",
+        access_token_encrypted=b"",
+        refresh_token_encrypted=b"",
+        id_token_encrypted=b"",
+        last_refresh=datetime.now(timezone.utc),
+        status=AccountStatus.ACTIVE,
+    )
     session.upstream = cast(UpstreamWebSocket, upstream)
     service._http_bridge_sessions[session.key] = session
     settings = _make_app_settings(
@@ -18367,7 +18377,8 @@ async def test_http_bridge_reader_wakes_and_retires_lone_eventless_owner_without
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
     retry_precreated = AsyncMock(return_value=False)
     monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
-    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    handle_stream_error = AsyncMock()
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error)
     write_request_log = AsyncMock()
     monkeypatch.setattr(service, "_write_request_log", write_request_log)
     record_stuck_retire = Mock()
@@ -18448,8 +18459,13 @@ async def test_http_bridge_reader_wakes_and_retires_lone_eventless_owner_without
     assert write_request_log.await_count == 2
     assert {call.kwargs["error_code"] for call in write_request_log.await_args_list} == {"upstream_request_timeout"}
     fail_reader.assert_awaited_once()
-    assert fail_reader.await_args.kwargs["penalize_account"] is False
+    assert fail_reader.await_args.kwargs["penalize_account"] is True
     assert fail_reader.await_args.kwargs["force_retire"] is True
+    handle_stream_error.assert_awaited_once()
+    handle_stream_error_args = handle_stream_error.await_args
+    assert handle_stream_error_args is not None
+    assert handle_stream_error_args.args[0] is session.account
+    assert handle_stream_error_args.args[2] == "upstream_request_timeout"
     record_stuck_retire.assert_called_once_with(
         reason="missing_response_created_timeout",
         session=session,
@@ -19134,7 +19150,6 @@ async def test_http_bridge_eventless_timeout_force_retires_with_admission_waiter
         session,
         error_code="upstream_request_timeout",
         error_message="missing response.created",
-        penalize_account=False,
         retire_detail="missing_response_created_timeout",
         force_retire=True,
     )
@@ -19144,7 +19159,7 @@ async def test_http_bridge_eventless_timeout_force_retires_with_admission_waiter
     retire.assert_awaited_once_with(session, detail="missing_response_created_timeout")
     fail_pending_await_args = fail_pending.await_args
     assert fail_pending_await_args is not None
-    assert fail_pending_await_args.kwargs["penalize_account"] is False
+    assert fail_pending_await_args.kwargs["penalize_account"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes an HTTP bridge recovery gap where a `response.create` send that never
receives `response.created` retires the stale bridge session but leaves the
selected account fully healthy.

That made later requests eligible to select the same eventless account again,
turning a single missing-created timeout into repeated
`upstream_request_timeout` failures. The request itself is still failed closed
without replaying or moving it to another account, but the selected account now
records the normal transient health failure so subsequent selection can avoid
the unhealthy route.

## Changes

- Record a transient account-health penalty when the HTTP bridge owner-side
  missing-`response.created` deadline expires.
- Keep the existing fail-closed behavior: no transparent replay and no
  submission of the timed-out request on another account.
- Update the active OpenSpec change so the spec matches the health-accounted
  recovery behavior.
- Extend HTTP bridge regression coverage to verify the penalty reaches
  `_handle_stream_error` for a real `Account`.

## Tests

- `uv run pytest -q tests/unit/test_proxy_http_bridge.py`
- `uv run ruff check app/modules/proxy/_service/http_bridge/upstream_events.py tests/unit/test_proxy_http_bridge.py`
- `git diff --check`
- `openspec validate recover-codex-desktop-idle-bridge --strict`

Full `openspec validate --specs` still reports existing normative-keyword
issues in `api-keys` and `conversations-api`, outside this change.
