### PR TITLE
fix(proxy): strip replayed tool call namespaces

### DIFF
--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -804,6 +804,7 @@ def _strip_unsupported_fields(payload: MutableJsonObject) -> MutableJsonObject:
     _strip_subscription_prompt_cache_controls(payload)
     _sanitize_interleaved_reasoning_input(payload)
     _strip_poisoned_local_compact_fallback_items(payload)
+    _strip_replayed_function_call_namespaces(payload)
     # ``tools`` is deliberately NOT canonicalized here: the wire payload must
     # forward client tool entries byte-preserved (array order, key order, and
     # unknown keys untouched) so reserved model tools survive upstream
@@ -861,6 +862,26 @@ def _strip_subscription_prompt_cache_breakpoints(value: JsonValue | None) -> Non
         value.pop("prompt_cache_breakpoint", None)
     for child in value.values():
         _strip_subscription_prompt_cache_breakpoints(child)
+
+
+def _strip_replayed_function_call_namespaces(payload: MutableJsonObject) -> None:
+    input_value = payload.get("input")
+    if not is_json_list(input_value):
+        return
+
+    normalized_items: list[JsonValue] = []
+    changed = False
+    for item in input_value:
+        if is_json_mapping(item) and item.get("type") == "function_call" and "namespace" in item:
+            normalized_item = dict(item)
+            normalized_item.pop("namespace")
+            normalized_items.append(normalized_item)
+            changed = True
+            continue
+        normalized_items.append(item)
+
+    if changed:
+        payload["input"] = normalized_items
 
 
 def _strip_poisoned_local_compact_fallback_items(payload: MutableJsonObject) -> None:

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -42,7 +42,7 @@ _INTERLEAVED_REASONING_PART_TYPES = frozenset({"reasoning", "reasoning_content",
 _ASSISTANT_TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
 _TOOL_TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text", "refusal"})
 _COMPACT_STATE_TOOL_NAMES = frozenset({"create_goal", "get_goal", "update_goal", "update_plan"})
-_COMPACT_TOOL_CALL_ITEM_TYPES = frozenset({"function_call", "custom_tool_call", "apply_patch_call"})
+_TOOL_CALL_ITEM_TYPES = frozenset({"function_call", "custom_tool_call", "apply_patch_call"})
 _COMPACT_TOOL_CALL_OUTPUT_ITEM_TYPES = frozenset(
     {"function_call_output", "custom_tool_call_output", "apply_patch_call_output"}
 )
@@ -804,7 +804,7 @@ def _strip_unsupported_fields(payload: MutableJsonObject) -> MutableJsonObject:
     _strip_subscription_prompt_cache_controls(payload)
     _sanitize_interleaved_reasoning_input(payload)
     _strip_poisoned_local_compact_fallback_items(payload)
-    _strip_replayed_function_call_namespaces(payload)
+    _strip_replayed_tool_call_namespaces(payload)
     # ``tools`` is deliberately NOT canonicalized here: the wire payload must
     # forward client tool entries byte-preserved (array order, key order, and
     # unknown keys untouched) so reserved model tools survive upstream
@@ -864,7 +864,7 @@ def _strip_subscription_prompt_cache_breakpoints(value: JsonValue | None) -> Non
         _strip_subscription_prompt_cache_breakpoints(child)
 
 
-def _strip_replayed_function_call_namespaces(payload: MutableJsonObject) -> None:
+def _strip_replayed_tool_call_namespaces(payload: MutableJsonObject) -> None:
     input_value = payload.get("input")
     if not is_json_list(input_value):
         return
@@ -872,7 +872,7 @@ def _strip_replayed_function_call_namespaces(payload: MutableJsonObject) -> None
     normalized_items: list[JsonValue] = []
     changed = False
     for item in input_value:
-        if is_json_mapping(item) and item.get("type") == "function_call" and "namespace" in item:
+        if is_json_mapping(item) and item.get("type") in _TOOL_CALL_ITEM_TYPES and "namespace" in item:
             normalized_item = dict(item)
             normalized_item.pop("namespace")
             normalized_items.append(normalized_item)
@@ -1311,7 +1311,7 @@ def _compact_reconciled_tool_call_indices(
         if not isinstance(call_id, str) or not call_id:
             continue
         item_type = item.get("type")
-        if item_type in _COMPACT_TOOL_CALL_ITEM_TYPES:
+        if item_type in _TOOL_CALL_ITEM_TYPES:
             call_indices_by_id.setdefault(call_id, []).append(index)
         elif item_type in _COMPACT_TOOL_CALL_OUTPUT_ITEM_TYPES:
             output_indices_by_id.setdefault(call_id, []).append(index)

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -725,6 +725,12 @@ class ResponsesRequest(BaseModel):
     def to_payload(self) -> JsonObject:
         return _strip_unsupported_fields(self.model_dump_for_forwarding())
 
+    def to_replay_safety_payload(self) -> JsonObject:
+        return _strip_unsupported_fields(
+            self.model_dump_for_forwarding(),
+            strip_replayed_tool_call_namespaces=False,
+        )
+
 
 class ResponsesCompactRequest(BaseModel):
     model_config = ConfigDict(extra="allow")
@@ -798,13 +804,18 @@ _COMPACT_OMITTED_INLINE_IMAGE_TEXT = (
 _COMPACT_INLINE_IMAGE_DATA_URL_RE = re.compile(r"""data:image/[^,\s]+,[^\s"'<>]+""")
 
 
-def _strip_unsupported_fields(payload: MutableJsonObject) -> MutableJsonObject:
+def _strip_unsupported_fields(
+    payload: MutableJsonObject,
+    *,
+    strip_replayed_tool_call_namespaces: bool = True,
+) -> MutableJsonObject:
     _normalize_openai_compatible_aliases(payload)
     _normalize_service_tier_aliases(payload)
     _strip_subscription_prompt_cache_controls(payload)
     _sanitize_interleaved_reasoning_input(payload)
     _strip_poisoned_local_compact_fallback_items(payload)
-    _strip_replayed_tool_call_namespaces(payload)
+    if strip_replayed_tool_call_namespaces:
+        strip_replayed_tool_call_namespaces_from_payload(payload)
     # ``tools`` is deliberately NOT canonicalized here: the wire payload must
     # forward client tool entries byte-preserved (array order, key order, and
     # unknown keys untouched) so reserved model tools survive upstream
@@ -864,7 +875,7 @@ def _strip_subscription_prompt_cache_breakpoints(value: JsonValue | None) -> Non
         _strip_subscription_prompt_cache_breakpoints(child)
 
 
-def _strip_replayed_tool_call_namespaces(payload: MutableJsonObject) -> None:
+def strip_replayed_tool_call_namespaces_from_payload(payload: MutableJsonObject) -> None:
     input_value = payload.get("input")
     if not is_json_list(input_value):
         return
@@ -872,8 +883,13 @@ def _strip_replayed_tool_call_namespaces(payload: MutableJsonObject) -> None:
     normalized_items: list[JsonValue] = []
     changed = False
     for item in input_value:
-        if is_json_mapping(item) and item.get("type") in _TOOL_CALL_ITEM_TYPES and "namespace" in item:
-            normalized_item = dict(item)
+        if not is_json_mapping(item):
+            normalized_items.append(item)
+            continue
+        item_mapping = item
+        item_type = item_mapping.get("type")
+        if isinstance(item_type, str) and item_type in _TOOL_CALL_ITEM_TYPES and "namespace" in item_mapping:
+            normalized_item = dict(item_mapping)
             normalized_item.pop("namespace")
             normalized_items.append(normalized_item)
             changed = True

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -238,7 +238,7 @@ def _http_bridge_continuity_bound_without_safe_replay(request_state: _WebSocketR
 
 
 def _http_bridge_payload_is_account_neutral_fresh_replay(payload: ResponsesRequest) -> bool:
-    return responses_payload_is_account_neutral_fresh_replay(payload.to_payload())
+    return responses_payload_is_account_neutral_fresh_replay(payload.to_replay_safety_payload())
 
 
 def _apply_http_bridge_downstream_turn_state(

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -132,6 +132,7 @@ from app.core.openai.requests import (
     extract_input_file_ids,
     normalize_tool_type,
     responses_request_has_explicit_prompt_cache_controls,
+    strip_replayed_tool_call_namespaces_from_payload,
 )
 from app.core.openai.v1_requests import V1ResponsesCompactRequest, V1ResponsesRequest
 from app.core.request_locality import (
@@ -4176,6 +4177,7 @@ async def _source_responses_response(
         request_usage_budget=estimate_api_key_request_usage(payload),
     )
     source_payload = payload.model_dump_for_forwarding()
+    strip_replayed_tool_call_namespaces_from_payload(source_payload)
     source_payload["stream"] = bool(payload.stream)
     _apply_source_response_request_overrides(source_payload, source_model_request_overrides(source, payload.model))
     _drop_unsupported_source_response_tools(

--- a/openspec/changes/fix-replayed-namespaced-function-call/.openspec.yaml
+++ b/openspec/changes/fix-replayed-namespaced-function-call/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/fix-replayed-namespaced-function-call/context.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/context.md
@@ -1,0 +1,19 @@
+# Replayed namespaced function-call compatibility
+
+## Purpose
+
+Newer Codex clients can replay historical side-effect calls with a local `namespace` such as `collaboration`. The proxy uses that namespace to distinguish same-named calls during deduplication, while the OpenAI upstream input schema accepts the historical call fields but rejects `namespace`.
+
+## Decision and constraints
+
+Treat the namespace as local metadata: retain it on the parsed request and remove it only from the copied wire payload. The rule applies only to `input` items of type `function_call`; top-level `tools` entries, other input-item types, and cross-account replay policy remain unchanged.
+
+## Failure modes
+
+- Forwarding the field causes an upstream `invalid_request_error` naming `input[*].namespace`.
+- Removing it during parsing collapses local namespaced dedupe identity.
+- Recursively removing every `namespace` key corrupts reserved top-level namespace tool definitions.
+
+## Example
+
+An input item `{ "type": "function_call", "namespace": "collaboration", "name": "spawn_agent", "arguments": "{}", "call_id": "call_123" }` remains intact for local processing. Its upstream copy is identical except that `namespace` is absent.

--- a/openspec/changes/fix-replayed-namespaced-function-call/context.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/context.md
@@ -1,12 +1,12 @@
-# Replayed namespaced function-call compatibility
+# Replayed namespaced tool-call compatibility
 
 ## Purpose
 
-Newer Codex clients can replay historical side-effect calls with a local `namespace` such as `collaboration`. The proxy uses that namespace to distinguish same-named calls during deduplication, while the OpenAI upstream input schema accepts the historical call fields but rejects `namespace`.
+Newer Codex clients can replay historical `function_call`, `custom_tool_call`, and `apply_patch_call` items with a local `namespace` such as `collaboration` or `exec`. The proxy uses that namespace to distinguish same-named calls during deduplication, while the OpenAI upstream input schema accepts the historical call fields but rejects `namespace`.
 
 ## Decision and constraints
 
-Treat the namespace as local metadata: retain it on the parsed request and remove it only from the copied wire payload. The rule applies only to `input` items of type `function_call`; top-level `tools` entries, other input-item types, and cross-account replay policy remain unchanged.
+Treat the namespace as local metadata: retain it on the parsed request and remove it only from the copied wire payload. The rule applies only to replayed tool-call `input` items; top-level `tools` entries, other input-item types, and cross-account replay policy remain unchanged.
 
 ## Failure modes
 
@@ -16,4 +16,4 @@ Treat the namespace as local metadata: retain it on the parsed request and remov
 
 ## Example
 
-An input item `{ "type": "function_call", "namespace": "collaboration", "name": "spawn_agent", "arguments": "{}", "call_id": "call_123" }` remains intact for local processing. Its upstream copy is identical except that `namespace` is absent.
+An input item `{ "type": "custom_tool_call", "namespace": "exec", "name": "exec", "input": "git status", "call_id": "call_123" }` remains intact for local processing. Its upstream copy is identical except that `namespace` is absent.

--- a/openspec/changes/fix-replayed-namespaced-function-call/context.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/context.md
@@ -6,7 +6,7 @@ Newer Codex clients can replay historical `function_call`, `custom_tool_call`, a
 
 ## Decision and constraints
 
-Treat the namespace as local metadata: retain it on the parsed request and remove it only from the copied wire payload. The rule applies only to replayed tool-call `input` items; top-level `tools` entries, other input-item types, and cross-account replay policy remain unchanged.
+Treat the namespace as local metadata: retain it on the parsed request and replay-safety classifier input, then remove it only from copied wire payloads. The rule applies only to replayed tool-call `input` items; top-level `tools` entries, other input-item types, and cross-account replay policy remain unchanged. Configured model-source requests receive only this namespace normalization so their otherwise supported OpenAI-compatible fields are preserved.
 
 ## Failure modes
 

--- a/openspec/changes/fix-replayed-namespaced-function-call/design.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/design.md
@@ -32,7 +32,7 @@ Compact serialization already delegates to the standard unsupported-field saniti
 
 ### Prove behavior at serialization and public route boundaries
 
-Unit tests will assert wire normalization and request-model preservation for normal and compact requests. An integration test will capture the payload forwarded by `/v1/responses`, establishing regression coverage at the externally failing path.
+Unit tests will assert wire normalization and request-model preservation for normal and compact requests. Integration tests will capture the payload forwarded by `/v1/responses` and the actual upstream WebSocket `response.create` frame, establishing regression coverage for both transport paths including the externally observed failure.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/fix-replayed-namespaced-function-call/design.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/design.md
@@ -30,9 +30,15 @@ Stripping during model validation was rejected because it would erase local dedu
 
 Compact serialization already delegates to the standard unsupported-field sanitizer before compact-specific trimming. Adding the compatibility normalization there keeps both wire paths consistent without duplicating behavior.
 
+### Preserve local metadata during replay-safety classification
+
+Account-neutral replay classification uses the same general request normalization but must retain namespace metadata so unknown owner-scoped call identity continues to fail closed. A dedicated replay-safety payload method skips only namespace removal; actual HTTP, WebSocket, compact, and model-source egress still removes it.
+
+Configured OpenAI-compatible model sources preserve request fields that the Codex upstream path strips, so source egress reuses only the namespace sanitizer rather than the full Codex unsupported-field sanitizer.
+
 ### Prove behavior at serialization and public route boundaries
 
-Unit tests will assert wire normalization and request-model preservation for normal and compact requests. Integration tests will capture the payload forwarded by `/v1/responses` and the actual upstream WebSocket `response.create` frame, establishing regression coverage for both transport paths including the externally observed failure.
+Unit tests will assert wire normalization, malformed-item handling, request-model preservation, and fail-closed replay classification. Integration tests will capture payloads forwarded by `/v1/responses`, a configured Responses model source, and the actual upstream WebSocket `response.create` frame.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/fix-replayed-namespaced-function-call/design.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/design.md
@@ -1,12 +1,12 @@
 ## Context
 
-Responses request models intentionally retain unknown input-item fields so local proxy features can inspect metadata added by newer clients. Namespaced side-effect calls use `namespace` together with `call_id` for replay deduplication, but OpenAI's Responses request schema does not accept `namespace` on historical `input` function calls. The same outbound field-stripping path is shared by normal and compact Responses requests.
+Responses request models intentionally retain unknown input-item fields so local proxy features can inspect metadata added by newer clients. Namespaced side-effect calls use `namespace` together with `call_id` for replay deduplication, but OpenAI's Responses request schema does not accept `namespace` on historical `input` tool calls. The same outbound field-stripping path is shared by normal and compact Responses requests.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
-- Produce an upstream-compatible wire payload for replayed namespaced `function_call` items.
+- Produce an upstream-compatible wire payload for replayed namespaced `function_call`, `custom_tool_call`, and `apply_patch_call` items.
 - Keep namespace metadata available on the request model for local replay deduplication.
 - Cover both normal and compact Responses serialization and the public proxy path.
 - Leave client-provided top-level tool entries untouched.
@@ -22,7 +22,7 @@ Responses request models intentionally retain unknown input-item fields so local
 
 ### Normalize only the copied outbound payload
 
-The shared unsupported-field sanitizer will copy only affected input items and remove `namespace` when `type == "function_call"`. Request model input remains unchanged, so internal consumers retain the namespace.
+The shared unsupported-field sanitizer will copy only affected input items and remove `namespace` when the item type is one of the recognized replayed tool-call types. Request model input remains unchanged, so internal consumers retain the namespace.
 
 Stripping during model validation was rejected because it would erase local dedupe identity. Broad unknown-field filtering was rejected because it could silently remove future-compatible client data and expand the scope beyond issue #1450.
 
@@ -36,7 +36,7 @@ Unit tests will assert wire normalization and request-model preservation for nor
 
 ## Risks / Trade-offs
 
-- [Future upstream support for input-item namespace] The proxy will continue omitting the field → Scope the rewrite narrowly to historical `function_call` input items and preserve it internally.
+- [Future upstream support for input-item namespace] The proxy will continue omitting the field → Scope the rewrite narrowly to historical tool-call input items and preserve it internally.
 - [Accidental mutation of local request state] In-place item mutation could erase dedupe identity → Copy each changed item and replace only the outbound payload list.
 - [Top-level namespace tool regression] A broad namespace scrub could alter tool definitions → Do not traverse `tools`; retain existing byte-preservation coverage.
 

--- a/openspec/changes/fix-replayed-namespaced-function-call/design.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/design.md
@@ -1,0 +1,49 @@
+## Context
+
+Responses request models intentionally retain unknown input-item fields so local proxy features can inspect metadata added by newer clients. Namespaced side-effect calls use `namespace` together with `call_id` for replay deduplication, but OpenAI's Responses request schema does not accept `namespace` on historical `input` function calls. The same outbound field-stripping path is shared by normal and compact Responses requests.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Produce an upstream-compatible wire payload for replayed namespaced `function_call` items.
+- Keep namespace metadata available on the request model for local replay deduplication.
+- Cover both normal and compact Responses serialization and the public proxy path.
+- Leave client-provided top-level tool entries untouched.
+
+**Non-Goals:**
+
+- Changing namespaced dedupe identity or settlement behavior.
+- Removing unknown fields from other input-item types.
+- Canonicalizing or rewriting top-level tool definitions.
+- Relaxing cross-account replay safety.
+
+## Decisions
+
+### Normalize only the copied outbound payload
+
+The shared unsupported-field sanitizer will copy only affected input items and remove `namespace` when `type == "function_call"`. Request model input remains unchanged, so internal consumers retain the namespace.
+
+Stripping during model validation was rejected because it would erase local dedupe identity. Broad unknown-field filtering was rejected because it could silently remove future-compatible client data and expand the scope beyond issue #1450.
+
+### Reuse the standard outbound sanitizer for compact requests
+
+Compact serialization already delegates to the standard unsupported-field sanitizer before compact-specific trimming. Adding the compatibility normalization there keeps both wire paths consistent without duplicating behavior.
+
+### Prove behavior at serialization and public route boundaries
+
+Unit tests will assert wire normalization and request-model preservation for normal and compact requests. An integration test will capture the payload forwarded by `/v1/responses`, establishing regression coverage at the externally failing path.
+
+## Risks / Trade-offs
+
+- [Future upstream support for input-item namespace] The proxy will continue omitting the field → Scope the rewrite narrowly to historical `function_call` input items and preserve it internally.
+- [Accidental mutation of local request state] In-place item mutation could erase dedupe identity → Copy each changed item and replace only the outbound payload list.
+- [Top-level namespace tool regression] A broad namespace scrub could alter tool definitions → Do not traverse `tools`; retain existing byte-preservation coverage.
+
+## Migration Plan
+
+No data migration or configuration change is required. Deploy the serialization fix normally; rollback restores the prior request serialization behavior.
+
+## Open Questions
+
+None.

--- a/openspec/changes/fix-replayed-namespaced-function-call/proposal.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/proposal.md
@@ -8,7 +8,7 @@ Replaying a namespaced Responses API `function_call` currently forwards its loca
 - Preserve the validated request input, including namespace metadata, for local deduplication and continuity processing.
 - Preserve client-provided top-level namespace tool definitions byte-identically.
 - Apply the same outbound normalization to standard and compact Responses requests.
-- Add regression coverage at request serialization and the public Responses proxy path.
+- Add regression coverage at request serialization and the public HTTP and WebSocket Responses proxy paths.
 
 ## Capabilities
 
@@ -23,5 +23,5 @@ None.
 ## Impact
 
 - Affects Responses request serialization in `app/core/openai/requests.py`.
-- Adds unit and `/v1/responses` integration regression tests.
+- Adds unit, `/v1/responses`, and WebSocket `response.create` integration regression tests.
 - Does not change dependencies, settings, schemas, or user-facing documentation.

--- a/openspec/changes/fix-replayed-namespaced-function-call/proposal.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/proposal.md
@@ -1,10 +1,10 @@
 ## Why
 
-Replaying a namespaced Responses API `function_call` currently forwards its local-only `namespace` field to OpenAI, which rejects the request with `Unknown parameter: input[*].namespace`. The proxy must restore upstream compatibility without losing the namespace identity used for local side-effect replay deduplication.
+Replaying a namespaced Responses API tool call currently forwards its local-only `namespace` field to OpenAI, which rejects the request with `Unknown parameter: input[*].namespace`. Codex 0.146 emits this shape for both namespaced `function_call` and `custom_tool_call` history. The proxy must restore upstream compatibility without losing the namespace identity used for local side-effect replay deduplication.
 
 ## What Changes
 
-- Remove `namespace` only from replayed `input` items whose type is `function_call` when building the upstream wire payload.
+- Remove `namespace` only from recognized replayed tool-call `input` items when building the upstream wire payload.
 - Preserve the validated request input, including namespace metadata, for local deduplication and continuity processing.
 - Preserve client-provided top-level namespace tool definitions byte-identically.
 - Apply the same outbound normalization to standard and compact Responses requests.
@@ -18,7 +18,7 @@ None.
 
 ### Modified Capabilities
 
-- `responses-api-compat`: Define upstream wire compatibility for replayed namespaced function calls while preserving local call identity and top-level tool definitions.
+- `responses-api-compat`: Define upstream wire compatibility for replayed namespaced tool calls while preserving local call identity and top-level tool definitions.
 
 ## Impact
 

--- a/openspec/changes/fix-replayed-namespaced-function-call/proposal.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/proposal.md
@@ -8,7 +8,9 @@ Replaying a namespaced Responses API tool call currently forwards its local-only
 - Preserve the validated request input, including namespace metadata, for local deduplication and continuity processing.
 - Preserve client-provided top-level namespace tool definitions byte-identically.
 - Apply the same outbound normalization to standard and compact Responses requests.
-- Add regression coverage at request serialization and the public HTTP and WebSocket Responses proxy paths.
+- Apply namespace-only normalization to configured OpenAI-compatible Responses model-source egress.
+- Preserve namespace metadata while classifying HTTP bridge requests for cross-account replay safety.
+- Add regression coverage at request serialization and the public HTTP, model-source, and WebSocket Responses proxy paths.
 
 ## Capabilities
 
@@ -23,5 +25,5 @@ None.
 ## Impact
 
 - Affects Responses request serialization in `app/core/openai/requests.py`.
-- Adds unit, `/v1/responses`, and WebSocket `response.create` integration regression tests.
+- Adds unit, `/v1/responses`, model-source, and WebSocket `response.create` integration regression tests.
 - Does not change dependencies, settings, schemas, or user-facing documentation.

--- a/openspec/changes/fix-replayed-namespaced-function-call/proposal.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Replaying a namespaced Responses API `function_call` currently forwards its local-only `namespace` field to OpenAI, which rejects the request with `Unknown parameter: input[*].namespace`. The proxy must restore upstream compatibility without losing the namespace identity used for local side-effect replay deduplication.
+
+## What Changes
+
+- Remove `namespace` only from replayed `input` items whose type is `function_call` when building the upstream wire payload.
+- Preserve the validated request input, including namespace metadata, for local deduplication and continuity processing.
+- Preserve client-provided top-level namespace tool definitions byte-identically.
+- Apply the same outbound normalization to standard and compact Responses requests.
+- Add regression coverage at request serialization and the public Responses proxy path.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: Define upstream wire compatibility for replayed namespaced function calls while preserving local call identity and top-level tool definitions.
+
+## Impact
+
+- Affects Responses request serialization in `app/core/openai/requests.py`.
+- Adds unit and `/v1/responses` integration regression tests.
+- Does not change dependencies, settings, schemas, or user-facing documentation.

--- a/openspec/changes/fix-replayed-namespaced-function-call/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/specs/responses-api-compat/spec.md
@@ -23,6 +23,24 @@ For standard and compact Responses requests, the proxy MUST omit `namespace` fro
 - **THEN** the upstream `response.create` frame omits only those items' `namespace`
 - **AND** preserves their remaining call fields
 
+#### Scenario: Configured Responses model source omits tool-call namespaces upstream
+
+- **WHEN** `/v1/responses` routes a replayed namespaced tool call to a configured OpenAI-compatible Responses model source
+- **THEN** the source payload omits only the call item's `namespace`
+- **AND** preserves source-compatible request fields that the Codex upstream path does not support
+
+#### Scenario: Account-neutral replay classification retains namespace identity
+
+- **WHEN** an HTTP bridge evaluates a namespaced tool-call history for cross-account replay safety
+- **THEN** the classifier input retains the namespace metadata
+- **AND** the request fails closed rather than becoming account-neutral because of wire normalization
+
+#### Scenario: Malformed replay item type does not fail serialization
+
+- **WHEN** a permissively parsed input item has a non-string `type` and a `namespace`
+- **THEN** outbound serialization does not raise an internal type error
+- **AND** does not treat the item as a recognized replayed tool call
+
 #### Scenario: Top-level namespace tool remains byte-preserved
 
 - **WHEN** the client includes a top-level tool entry whose `type` is `namespace`

--- a/openspec/changes/fix-replayed-namespaced-function-call/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/specs/responses-api-compat/spec.md
@@ -17,6 +17,12 @@ For standard and compact Responses requests, the proxy MUST omit `namespace` fro
 - **THEN** its upstream payload omits the input item's `namespace`
 - **AND** preserves the remaining function-call fields
 
+#### Scenario: WebSocket response.create omits function-call namespace upstream
+
+- **WHEN** a Responses WebSocket request replays a namespaced `function_call` input item
+- **THEN** the upstream `response.create` frame omits only that item's `namespace`
+- **AND** preserves its `call_id`, `name`, and `arguments`
+
 #### Scenario: Top-level namespace tool remains byte-preserved
 
 - **WHEN** the client includes a top-level tool entry whose `type` is `namespace`

--- a/openspec/changes/fix-replayed-namespaced-function-call/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/specs/responses-api-compat/spec.md
@@ -1,27 +1,27 @@
 ## ADDED Requirements
 
-### Requirement: Replayed function-call namespace metadata is local-only on upstream input
+### Requirement: Replayed tool-call namespace metadata is local-only on upstream input
 
-For standard and compact Responses requests, the proxy MUST omit `namespace` from every replayed `input` item whose `type` is `function_call` before forwarding the request upstream. The proxy MUST preserve all other fields on that item, MUST retain the original namespace metadata for local call-identity and replay-deduplication processing, and MUST NOT alter client-provided top-level tool entries as part of this normalization.
+For standard and compact Responses requests, the proxy MUST omit `namespace` from every replayed `input` item whose `type` is `function_call`, `custom_tool_call`, or `apply_patch_call` before forwarding the request upstream. The proxy MUST preserve all other fields on that item, MUST retain the original namespace metadata for local call-identity and replay-deduplication processing, and MUST NOT alter client-provided top-level tool entries as part of this normalization.
 
-#### Scenario: Standard Responses replay omits function-call namespace upstream
+#### Scenario: Standard Responses replay omits tool-call namespaces upstream
 
-- **WHEN** a standard Responses request replays a `function_call` input item with `namespace`, `call_id`, `name`, and `arguments`
-- **THEN** the upstream payload omits only that item's `namespace`
-- **AND** preserves its `call_id`, `name`, and `arguments`
+- **WHEN** a standard Responses request replays `function_call` and `custom_tool_call` input items with `namespace`
+- **THEN** the upstream payload omits only those items' `namespace`
+- **AND** preserves their remaining call fields
 - **AND** the local request input retains the namespace metadata
 
-#### Scenario: Compact Responses replay omits function-call namespace upstream
+#### Scenario: Compact Responses replay omits tool-call namespace upstream
 
-- **WHEN** a compact Responses request replays a `function_call` input item with a namespace
+- **WHEN** a compact Responses request replays a recognized tool-call input item with a namespace
 - **THEN** its upstream payload omits the input item's `namespace`
-- **AND** preserves the remaining function-call fields
+- **AND** preserves the remaining tool-call fields
 
-#### Scenario: WebSocket response.create omits function-call namespace upstream
+#### Scenario: WebSocket response.create omits tool-call namespaces upstream
 
-- **WHEN** a Responses WebSocket request replays a namespaced `function_call` input item
-- **THEN** the upstream `response.create` frame omits only that item's `namespace`
-- **AND** preserves its `call_id`, `name`, and `arguments`
+- **WHEN** a Responses WebSocket request replays namespaced `function_call` and `custom_tool_call` input items
+- **THEN** the upstream `response.create` frame omits only those items' `namespace`
+- **AND** preserves their remaining call fields
 
 #### Scenario: Top-level namespace tool remains byte-preserved
 

--- a/openspec/changes/fix-replayed-namespaced-function-call/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/specs/responses-api-compat/spec.md
@@ -13,7 +13,7 @@ For standard and compact Responses requests, the proxy MUST omit `namespace` fro
 
 #### Scenario: Compact Responses replay omits tool-call namespace upstream
 
-- **WHEN** a compact Responses request replays a recognized tool-call input item with a namespace
+- **WHEN** `/v1/responses/compact` replays a recognized tool-call input item with a namespace
 - **THEN** its upstream payload omits the input item's `namespace`
 - **AND** preserves the remaining tool-call fields
 

--- a/openspec/changes/fix-replayed-namespaced-function-call/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/specs/responses-api-compat/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Replayed function-call namespace metadata is local-only on upstream input
+
+For standard and compact Responses requests, the proxy MUST omit `namespace` from every replayed `input` item whose `type` is `function_call` before forwarding the request upstream. The proxy MUST preserve all other fields on that item, MUST retain the original namespace metadata for local call-identity and replay-deduplication processing, and MUST NOT alter client-provided top-level tool entries as part of this normalization.
+
+#### Scenario: Standard Responses replay omits function-call namespace upstream
+
+- **WHEN** a standard Responses request replays a `function_call` input item with `namespace`, `call_id`, `name`, and `arguments`
+- **THEN** the upstream payload omits only that item's `namespace`
+- **AND** preserves its `call_id`, `name`, and `arguments`
+- **AND** the local request input retains the namespace metadata
+
+#### Scenario: Compact Responses replay omits function-call namespace upstream
+
+- **WHEN** a compact Responses request replays a `function_call` input item with a namespace
+- **THEN** its upstream payload omits the input item's `namespace`
+- **AND** preserves the remaining function-call fields
+
+#### Scenario: Top-level namespace tool remains byte-preserved
+
+- **WHEN** the client includes a top-level tool entry whose `type` is `namespace`
+- **THEN** standard Responses serialization forwards that tool entry byte-identically

--- a/openspec/changes/fix-replayed-namespaced-function-call/tasks.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Regression coverage
 
 - [x] 1.1 Add unit tests proving standard and compact wire payloads omit replayed function-call namespaces while request input retains local metadata.
-- [x] 1.2 Add public `/v1/responses` integration coverage for the forwarded replay payload and confirm top-level namespace tools remain preserved by existing coverage.
+- [x] 1.2 Add public `/v1/responses` and WebSocket `response.create` integration coverage for the forwarded replay payload and confirm top-level namespace tools remain preserved by existing coverage.
 - [x] 1.3 Run the focused regression tests before implementation and confirm they fail for the missing normalization.
 
 ## 2. Implementation

--- a/openspec/changes/fix-replayed-namespaced-function-call/tasks.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/tasks.md
@@ -13,3 +13,9 @@
 
 - [x] 3.1 Run formatter, linter, focused tests, and relevant broader request/proxy tests.
 - [x] 3.2 Run strict change validation, repository spec validation, OpenSpec verification, and inspect the final diff.
+
+## 4. Review findings
+
+- [x] 4.1 Preserve namespaced call identity in HTTP bridge account-neutral replay classification and add fail-closed coverage.
+- [x] 4.2 Apply namespace-only normalization to configured Responses model-source egress without stripping source-compatible fields.
+- [x] 4.3 Guard recognized tool-call membership against malformed non-string item types and add regression coverage.

--- a/openspec/changes/fix-replayed-namespaced-function-call/tasks.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/tasks.md
@@ -1,0 +1,15 @@
+## 1. Regression coverage
+
+- [x] 1.1 Add unit tests proving standard and compact wire payloads omit replayed function-call namespaces while request input retains local metadata.
+- [x] 1.2 Add public `/v1/responses` integration coverage for the forwarded replay payload and confirm top-level namespace tools remain preserved by existing coverage.
+- [x] 1.3 Run the focused regression tests before implementation and confirm they fail for the missing normalization.
+
+## 2. Implementation
+
+- [x] 2.1 Normalize replayed `function_call` input items in the shared outbound sanitizer by copying affected items and removing only `namespace`.
+- [x] 2.2 Run focused unit and integration tests and complete the regression assertions.
+
+## 3. Validation
+
+- [x] 3.1 Run formatter, linter, focused tests, and relevant broader request/proxy tests.
+- [x] 3.2 Run strict change validation, repository spec validation, OpenSpec verification, and inspect the final diff.

--- a/openspec/changes/fix-replayed-namespaced-function-call/tasks.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/tasks.md
@@ -19,3 +19,4 @@
 - [x] 4.1 Preserve namespaced call identity in HTTP bridge account-neutral replay classification and add fail-closed coverage.
 - [x] 4.2 Apply namespace-only normalization to configured Responses model-source egress without stripping source-compatible fields.
 - [x] 4.3 Guard recognized tool-call membership against malformed non-string item types and add regression coverage.
+- [x] 4.4 Cover namespace stripping through the public compact route and actual upstream compact payload.

--- a/openspec/changes/fix-replayed-namespaced-function-call/tasks.md
+++ b/openspec/changes/fix-replayed-namespaced-function-call/tasks.md
@@ -1,12 +1,12 @@
 ## 1. Regression coverage
 
-- [x] 1.1 Add unit tests proving standard and compact wire payloads omit replayed function-call namespaces while request input retains local metadata.
-- [x] 1.2 Add public `/v1/responses` and WebSocket `response.create` integration coverage for the forwarded replay payload and confirm top-level namespace tools remain preserved by existing coverage.
+- [x] 1.1 Add unit tests proving standard and compact wire payloads omit replayed tool-call namespaces while request input retains local metadata.
+- [x] 1.2 Add public `/v1/responses` and WebSocket `response.create` integration coverage for namespaced `function_call` and `custom_tool_call` replay payloads, and confirm top-level namespace tools remain preserved by existing coverage.
 - [x] 1.3 Run the focused regression tests before implementation and confirm they fail for the missing normalization.
 
 ## 2. Implementation
 
-- [x] 2.1 Normalize replayed `function_call` input items in the shared outbound sanitizer by copying affected items and removing only `namespace`.
+- [x] 2.1 Normalize recognized replayed tool-call input items in the shared outbound sanitizer by copying affected items and removing only `namespace`.
 - [x] 2.2 Run focused unit and integration tests and complete the regression assertions.
 
 ## 3. Validation

--- a/tests/integration/test_api_keys_api.py
+++ b/tests/integration/test_api_keys_api.py
@@ -1365,6 +1365,78 @@ async def test_backend_codex_responses_routes_responses_capable_model_source(asy
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_strips_replayed_tool_call_namespaces_for_model_source(async_client, monkeypatch):
+    model = "external-v1-namespaced-replay"
+    await _create_model_source(
+        async_client,
+        name="v1-namespaced-replay",
+        model=model,
+        supports_responses=True,
+    )
+    observed: dict[str, object] = {}
+
+    async def fake_stream(source, payload):
+        observed["payload"] = dict(payload)
+        usage_holder = SourceUsageHolder()
+
+        async def body():
+            usage_holder.usage = SourceUsage(input_tokens=2, output_tokens=1, cached_input_tokens=0)
+            yield (
+                b'data: {"type":"response.completed","response":{"id":"resp_source_namespaced_replay",'
+                b'"usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}\n\n'
+            )
+
+        return SourceResponsesStream(body=body(), usage_holder=usage_holder, upstream_status_code=200)
+
+    monkeypatch.setattr(proxy_api, "stream_source_responses", fake_stream)
+
+    response = await async_client.post(
+        "/v1/responses",
+        json={
+            "model": model,
+            "input": [
+                {
+                    "type": "function_call",
+                    "namespace": "collaboration",
+                    "call_id": "call_1",
+                    "name": "spawn_agent",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "custom_tool_call",
+                    "namespace": "exec",
+                    "call_id": "call_2",
+                    "name": "exec",
+                    "input": "pwd",
+                },
+            ],
+            "stream": True,
+            "temperature": 0.2,
+            "metadata": {"client": "source-compatible"},
+        },
+    )
+    assert response.status_code == 200
+
+    forwarded_payload = cast("dict[str, object]", observed["payload"])
+    assert forwarded_payload["input"] == [
+        {
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "spawn_agent",
+            "arguments": "{}",
+        },
+        {
+            "type": "custom_tool_call",
+            "call_id": "call_2",
+            "name": "exec",
+            "input": "pwd",
+        },
+    ]
+    assert forwarded_payload["temperature"] == 0.2
+    assert forwarded_payload["metadata"] == {"client": "source-compatible"}
+
+
+@pytest.mark.asyncio
 async def test_backend_codex_responses_filters_unsupported_model_source_tools(async_client, monkeypatch):
     model = "external-codex-responses-tools"
     await _create_model_source(

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -2691,6 +2691,72 @@ async def test_v1_responses_compact_invalid_messages_returns_openai_400(async_cl
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_compact_strips_replayed_tool_call_namespaces_upstream(async_client, monkeypatch):
+    raw_account_id = "acc_v1_compact_namespaced_replay"
+    auth_json = _make_auth_json(raw_account_id, "v1-compact-namespaced-replay@example.com")
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payload: dict[str, object] = {}
+
+    async def fake_compact(payload, headers, access_token, account_id, **kwargs):
+        del headers, access_token, account_id, kwargs
+        seen_payload.update(payload.to_payload())
+        return CompactResponsePayload.model_validate(
+            {
+                "object": "response.compaction",
+                "compaction_summary": {
+                    "encrypted_content": "ENCRYPTED_CONTEXT_COMPACTION_SUMMARY",
+                    "summary_text": "condensed thread state",
+                },
+            }
+        )
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    response = await async_client.post(
+        "/v1/responses/compact",
+        json={
+            "model": "gpt-5.6-sol",
+            "instructions": "compact",
+            "input": [
+                {
+                    "type": "function_call",
+                    "namespace": "collaboration",
+                    "call_id": "call_1",
+                    "name": "spawn_agent",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "custom_tool_call",
+                    "namespace": "exec",
+                    "call_id": "call_2",
+                    "name": "exec",
+                    "input": "pwd",
+                },
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert seen_payload["input"] == [
+        {
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "spawn_agent",
+            "arguments": "{}",
+        },
+        {
+            "type": "custom_tool_call",
+            "call_id": "call_2",
+            "name": "exec",
+            "input": "pwd",
+        },
+    ]
+
+
+@pytest.mark.asyncio
 async def test_v1_chat_completions_invalid_tool_calls_returns_openai_400(async_client):
     payload = {
         "model": "gpt-5.2",

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -428,7 +428,7 @@ async def test_backend_responses_forwards_explicit_empty_tools(async_client, mon
 
 
 @pytest.mark.asyncio
-async def test_v1_responses_strips_replayed_function_call_namespace_upstream(async_client, monkeypatch):
+async def test_v1_responses_strips_replayed_tool_call_namespaces_upstream(async_client, monkeypatch):
     raw_account_id = "acc_replayed_namespaced_function_call"
     auth_json = _make_auth_json(raw_account_id, "replayed-namespaced-call@example.com")
     files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
@@ -448,20 +448,29 @@ async def test_v1_responses_strips_replayed_function_call_namespace_upstream(asy
 
     monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
 
-    replayed_call = {
-        "type": "function_call",
-        "namespace": "collaboration",
-        "name": "spawn_agent",
-        "arguments": '{"message":"same task"}',
-        "call_id": "call_123",
-    }
+    replayed_calls = [
+        {
+            "type": "function_call",
+            "namespace": "collaboration",
+            "name": "spawn_agent",
+            "arguments": '{"message":"same task"}',
+            "call_id": "call_123",
+        },
+        {
+            "type": "custom_tool_call",
+            "namespace": "exec",
+            "name": "exec",
+            "input": "git status --short",
+            "call_id": "call_456",
+        },
+    ]
     async with async_client.stream(
         "POST",
         "/v1/responses",
         json={
             "model": "gpt-5.6-sol",
             "instructions": "continue",
-            "input": [replayed_call],
+            "input": replayed_calls,
             "stream": True,
         },
     ) as resp:
@@ -475,7 +484,13 @@ async def test_v1_responses_strips_replayed_function_call_namespace_upstream(asy
             "name": "spawn_agent",
             "arguments": '{"message":"same task"}',
             "call_id": "call_123",
-        }
+        },
+        {
+            "type": "custom_tool_call",
+            "name": "exec",
+            "input": "git status --short",
+            "call_id": "call_456",
+        },
     ]
 
 

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -428,6 +428,58 @@ async def test_backend_responses_forwards_explicit_empty_tools(async_client, mon
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_strips_replayed_function_call_namespace_upstream(async_client, monkeypatch):
+    raw_account_id = "acc_replayed_namespaced_function_call"
+    auth_json = _make_auth_json(raw_account_id, "replayed-namespaced-call@example.com")
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payload: dict[str, object] = {}
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del headers, access_token, account_id, base_url, raise_for_status, kwargs
+        seen_payload.update(payload.to_payload())
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_replayed_namespaced_call",'
+            '"object":"response","status":"completed","output":[],"usage":{"input_tokens":2,'
+            '"output_tokens":1}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    replayed_call = {
+        "type": "function_call",
+        "namespace": "collaboration",
+        "name": "spawn_agent",
+        "arguments": '{"message":"same task"}',
+        "call_id": "call_123",
+    }
+    async with async_client.stream(
+        "POST",
+        "/v1/responses",
+        json={
+            "model": "gpt-5.6-sol",
+            "instructions": "continue",
+            "input": [replayed_call],
+            "stream": True,
+        },
+    ) as resp:
+        assert resp.status_code == 200
+        lines = [line async for line in resp.aiter_lines() if line]
+
+    assert _extract_first_event(lines)["type"] == "response.completed"
+    assert seen_payload["input"] == [
+        {
+            "type": "function_call",
+            "name": "spawn_agent",
+            "arguments": '{"message":"same task"}',
+            "call_id": "call_123",
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_backend_responses_preserves_non_message_developer_directive(async_client, monkeypatch):
     raw_account_id = "acc_future_directive"
     auth_json = _make_auth_json(raw_account_id, "future-directive@example.com")

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -1701,6 +1701,95 @@ def test_backend_responses_websocket_forwards_client_tools_byte_identical(app_in
     assert expected_tools_bytes in frame
 
 
+def test_backend_responses_websocket_strips_replayed_function_call_namespace(app_instance, monkeypatch):
+    upstream_messages = [
+        _FakeUpstreamMessage(
+            "text",
+            text=json.dumps(
+                {
+                    "type": "response.created",
+                    "response": {
+                        "id": "resp_ws_replayed_namespaced_call",
+                        "object": "response",
+                        "status": "in_progress",
+                    },
+                },
+                separators=(",", ":"),
+            ),
+        ),
+        _FakeUpstreamMessage(
+            "text",
+            text=json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_ws_replayed_namespaced_call",
+                        "object": "response",
+                        "status": "completed",
+                        "usage": {"input_tokens": 3, "output_tokens": 1, "total_tokens": 4},
+                    },
+                },
+                separators=(",", ":"),
+            ),
+        ),
+    ]
+    fake_upstream = _FakeUpstreamWebSocket(upstream_messages)
+
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(authorization: str | None, *, request: object | None = None):
+        del authorization, request
+        return None
+
+    async def fake_connect_proxy_websocket(self, headers, **kwargs):
+        del self, headers, kwargs
+        return SimpleNamespace(id="acct_ws_namespaced_call", codex_installation_id=None), fake_upstream
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fake_connect_proxy_websocket)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.6-sol",
+        "instructions": "continue",
+        "input": [
+            {
+                "type": "function_call",
+                "namespace": "collaboration",
+                "name": "spawn_agent",
+                "arguments": '{"message":"same task"}',
+                "call_id": "call_123",
+            }
+        ],
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            assert json.loads(websocket.receive_text())["type"] == "response.created"
+            assert json.loads(websocket.receive_text())["type"] == "response.completed"
+
+    assert len(fake_upstream.sent_text) == 1
+    upstream_frame = json.loads(fake_upstream.sent_text[0])
+    assert upstream_frame["type"] == "response.create"
+    assert upstream_frame["input"] == [
+        {
+            "type": "function_call",
+            "name": "spawn_agent",
+            "arguments": '{"message":"same task"}',
+            "call_id": "call_123",
+        }
+    ]
+
+
 def test_backend_responses_websocket_lite_marker_requires_previous_response_linkage(app_instance, monkeypatch):
     def _response_batch(response_id: str) -> list[_FakeUpstreamMessage]:
         return [

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -1701,7 +1701,7 @@ def test_backend_responses_websocket_forwards_client_tools_byte_identical(app_in
     assert expected_tools_bytes in frame
 
 
-def test_backend_responses_websocket_strips_replayed_function_call_namespace(app_instance, monkeypatch):
+def test_backend_responses_websocket_strips_replayed_tool_call_namespaces(app_instance, monkeypatch):
     upstream_messages = [
         _FakeUpstreamMessage(
             "text",
@@ -1766,7 +1766,14 @@ def test_backend_responses_websocket_strips_replayed_function_call_namespace(app
                 "name": "spawn_agent",
                 "arguments": '{"message":"same task"}',
                 "call_id": "call_123",
-            }
+            },
+            {
+                "type": "custom_tool_call",
+                "namespace": "exec",
+                "name": "exec",
+                "input": "git status --short",
+                "call_id": "call_456",
+            },
         ],
         "stream": True,
     }
@@ -1786,7 +1793,13 @@ def test_backend_responses_websocket_strips_replayed_function_call_namespace(app
             "name": "spawn_agent",
             "arguments": '{"message":"same task"}',
             "call_id": "call_123",
-        }
+        },
+        {
+            "type": "custom_tool_call",
+            "name": "exec",
+            "input": "git status --short",
+            "call_id": "call_456",
+        },
     ]
 
 

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -115,60 +115,90 @@ def test_known_unsupported_upstream_fields_are_stripped():
     assert dumped["custom_field"] == "kept"
 
 
-def test_responses_to_payload_strips_replayed_function_call_namespace_only_on_wire():
-    replayed_call = {
-        "type": "function_call",
-        "namespace": "collaboration",
-        "name": "spawn_agent",
-        "arguments": '{"message":"same task"}',
-        "call_id": "call_123",
-    }
+def test_responses_to_payload_strips_replayed_tool_call_namespaces_only_on_wire():
+    replayed_calls = [
+        {
+            "type": "function_call",
+            "namespace": "collaboration",
+            "name": "spawn_agent",
+            "arguments": '{"message":"same task"}',
+            "call_id": "call_123",
+        },
+        {
+            "type": "custom_tool_call",
+            "namespace": "exec",
+            "name": "exec",
+            "input": "git status --short",
+            "call_id": "call_456",
+        },
+    ]
     request = ResponsesRequest.model_validate(
         {
             "model": "gpt-5.6-sol",
             "instructions": "continue",
-            "input": [replayed_call],
+            "input": replayed_calls,
         }
     )
 
-    assert request.input == [replayed_call]
+    assert request.input == replayed_calls
     assert request.to_payload()["input"] == [
         {
             "type": "function_call",
             "name": "spawn_agent",
             "arguments": '{"message":"same task"}',
             "call_id": "call_123",
-        }
+        },
+        {
+            "type": "custom_tool_call",
+            "name": "exec",
+            "input": "git status --short",
+            "call_id": "call_456",
+        },
     ]
-    assert request.input == [replayed_call]
+    assert request.input == replayed_calls
 
 
-def test_compact_to_payload_strips_replayed_function_call_namespace_only_on_wire():
-    replayed_call = {
-        "type": "function_call",
-        "namespace": "collaboration",
-        "name": "spawn_agent",
-        "arguments": '{"message":"same task"}',
-        "call_id": "call_123",
-    }
+def test_compact_to_payload_strips_replayed_tool_call_namespaces_only_on_wire():
+    replayed_calls = [
+        {
+            "type": "function_call",
+            "namespace": "collaboration",
+            "name": "spawn_agent",
+            "arguments": '{"message":"same task"}',
+            "call_id": "call_123",
+        },
+        {
+            "type": "custom_tool_call",
+            "namespace": "exec",
+            "name": "exec",
+            "input": "git status --short",
+            "call_id": "call_456",
+        },
+    ]
     request = ResponsesCompactRequest.model_validate(
         {
             "model": "gpt-5.6-sol",
             "instructions": "continue",
-            "input": [replayed_call],
+            "input": replayed_calls,
         }
     )
 
-    assert request.input == [replayed_call]
+    assert request.input == replayed_calls
     assert request.to_payload()["input"] == [
         {
             "type": "function_call",
             "name": "spawn_agent",
             "arguments": '{"message":"same task"}',
             "call_id": "call_123",
-        }
+        },
+        {
+            "type": "custom_tool_call",
+            "name": "exec",
+            "input": "git status --short",
+            "call_id": "call_456",
+        },
     ]
-    assert request.input == [replayed_call]
+    assert request.input == replayed_calls
 
 
 def test_responses_preserves_service_tier():

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -201,6 +201,20 @@ def test_compact_to_payload_strips_replayed_tool_call_namespaces_only_on_wire():
     assert request.input == replayed_calls
 
 
+@pytest.mark.parametrize("invalid_type", [[], {}])
+def test_responses_to_payload_ignores_unhashable_replayed_item_types(invalid_type: JsonValue):
+    malformed_item = {"type": invalid_type, "namespace": "client-metadata", "value": "kept"}
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "continue",
+            "input": [malformed_item],
+        }
+    )
+
+    assert request.to_payload()["input"] == [malformed_item]
+
+
 def test_responses_preserves_service_tier():
     payload = {
         "model": "gpt-5.1",

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -115,6 +115,62 @@ def test_known_unsupported_upstream_fields_are_stripped():
     assert dumped["custom_field"] == "kept"
 
 
+def test_responses_to_payload_strips_replayed_function_call_namespace_only_on_wire():
+    replayed_call = {
+        "type": "function_call",
+        "namespace": "collaboration",
+        "name": "spawn_agent",
+        "arguments": '{"message":"same task"}',
+        "call_id": "call_123",
+    }
+    request = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "continue",
+            "input": [replayed_call],
+        }
+    )
+
+    assert request.input == [replayed_call]
+    assert request.to_payload()["input"] == [
+        {
+            "type": "function_call",
+            "name": "spawn_agent",
+            "arguments": '{"message":"same task"}',
+            "call_id": "call_123",
+        }
+    ]
+    assert request.input == [replayed_call]
+
+
+def test_compact_to_payload_strips_replayed_function_call_namespace_only_on_wire():
+    replayed_call = {
+        "type": "function_call",
+        "namespace": "collaboration",
+        "name": "spawn_agent",
+        "arguments": '{"message":"same task"}',
+        "call_id": "call_123",
+    }
+    request = ResponsesCompactRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "continue",
+            "input": [replayed_call],
+        }
+    )
+
+    assert request.input == [replayed_call]
+    assert request.to_payload()["input"] == [
+        {
+            "type": "function_call",
+            "name": "spawn_agent",
+            "arguments": '{"message":"same task"}',
+            "call_id": "call_123",
+        }
+    ]
+    assert request.input == [replayed_call]
+
+
 def test_responses_preserves_service_tier():
     payload = {
         "model": "gpt-5.1",

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -120,6 +120,29 @@ def _make_bridge_session(
     )
 
 
+def test_http_bridge_account_neutral_replay_rejects_namespaced_tool_call_history() -> None:
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "",
+            "input": [
+                {"role": "user", "content": "old request"},
+                {
+                    "type": "function_call",
+                    "namespace": "collaboration",
+                    "call_id": "call_1",
+                    "name": "spawn_agent",
+                    "arguments": "{}",
+                },
+                {"type": "function_call_output", "call_id": "call_1", "output": "ok"},
+                {"role": "user", "content": "next request"},
+            ],
+        }
+    )
+
+    assert http_bridge_streaming_module._http_bridge_payload_is_account_neutral_fresh_replay(payload) is False
+
+
 def _make_eventless_http_bridge_owner(
     *,
     request_id: str = "req-eventless-owner",


### PR DESCRIPTION
## Summary

Strip local-only `namespace` metadata from replayed Responses tool-call items at the final upstream wire boundary while retaining the original namespaced items for local replay deduplication. This prevents Codex histories from repeatedly failing with `Unknown parameter: input[*].namespace` over both HTTP and WebSocket transports.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Refs #1450 — partial fix for the replayed `input[*].namespace` failure family. The separate replayed local `item_*` ID validation failures reported in #1450 remain out of scope, so this PR intentionally does not auto-close the issue.

## Root cause and scope

Responses request parsing intentionally preserves unknown fields for forward compatibility and local proxy behavior. Current Codex histories can replay namespaced `function_call` and `custom_tool_call` items, but the upstream Responses input schema rejects `namespace` on historical call items. Once such an item is retained in history, forwarding it unchanged makes every retry fail at the same input index.

The fix is deliberately type-aware and copy-on-write:

- Strip `namespace` only from recognized replayed call items: `function_call`, `custom_tool_call`, and `apply_patch_call`.
- Normalize only the copied outbound payload; keep the validated request input unchanged so local dedupe and continuity logic retain namespaced call identity.
- Do not recursively remove `namespace`, which would corrupt reserved top-level `type: "namespace"` tool definitions.
- Do not alter replayed `item_*` IDs in this PR.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [x] This PR touches a codex-faithful path (request/response shape and `response.create` framing) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/fix-replayed-namespaced-function-call/`

The change records the wire-compatibility requirement, local-identity invariant, HTTP/compact/WebSocket scenarios, design trade-offs, and completed implementation tasks.

## Changes

- Add a shared outbound sanitizer for namespaced replayed tool-call input items.
- Preserve every field except the unsupported per-item `namespace` on the upstream copy.
- Cover standard and compact request serialization.
- Cover public HTTP `/v1/responses` forwarding.
- Cover configured OpenAI-compatible Responses model-source forwarding without removing source-supported fields.
- Cover the actual backend Codex WebSocket `response.create` frame.
- Preserve namespace identity during HTTP bridge account-neutral replay classification so cross-account movement remains fail-closed.
- Retain existing byte-preservation coverage for top-level namespace tools.

## Simplicity

- [x] Works with zero configuration
- [x] No new required setup step
- New setting(s) and why each can't be a default: None.
- [x] No dependency, migration, schema, README, `.env.example`, dashboard, or navigation changes

## Test plan

```text
PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest -p no:cacheprovider \
  tests/unit/test_openai_requests.py \
  tests/integration/test_proxy_responses.py \
  tests/integration/test_proxy_websocket_responses.py -q
# 312 passed, 1 warning

UV_CACHE_DIR=/tmp/codex-lb-uv-cache uv run pytest tests/unit/test_proxy_http_bridge.py -q
# 389 passed

UV_CACHE_DIR=/tmp/codex-lb-uv-cache uv run pytest tests/integration/test_api_keys_api.py -q
# 82 passed

PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -B -m pytest -p no:cacheprovider \
  tests/unit/test_openai_requests.py::test_responses_to_payload_strips_replayed_tool_call_namespaces_only_on_wire \
  tests/unit/test_openai_requests.py::test_compact_to_payload_strips_replayed_tool_call_namespaces_only_on_wire \
  tests/integration/test_proxy_responses.py::test_v1_responses_strips_replayed_tool_call_namespaces_upstream \
  tests/integration/test_proxy_websocket_responses.py::test_backend_responses_websocket_strips_replayed_tool_call_namespaces \
  tests/integration/test_proxy_websocket_responses.py::test_backend_responses_websocket_forwards_client_tools_byte_identical -q
# 5 passed, 1 warning

.venv/bin/ruff format --check app/core/openai/requests.py tests/unit/test_openai_requests.py tests/integration/test_proxy_responses.py tests/integration/test_proxy_websocket_responses.py
# 4 files already formatted

.venv/bin/ruff check --no-cache app/core/openai/requests.py tests/unit/test_openai_requests.py tests/integration/test_proxy_responses.py tests/integration/test_proxy_websocket_responses.py
# All checks passed!

.venv/bin/ty check app/core/openai/requests.py
# All checks passed!

openspec validate fix-replayed-namespaced-function-call --strict
# Change 'fix-replayed-namespaced-function-call' is valid

openspec status --change fix-replayed-namespaced-function-call --json
openspec instructions apply --change fix-replayed-namespaced-function-call --json
# artifacts complete; tasks 11/11; state=all_done

git diff --check
# passed
```

`openspec validate --specs` reports 47 passing specs and two pre-existing failures in unchanged main specs:

- `api-keys` requirement 45 lacks a SHALL/MUST keyword.
- `conversations-api` requirements 4 and 5 lack SHALL/MUST keywords.

This PR does not modify either capability.

## Live verification

The originally failing path was exercised against the local `codex-lb` WebSocket route with `model=codex-auto-review`:

```text
before:
{"type":"error","error":{"type":"invalid_request_error","message":"Unknown parameter: 'input[1].namespace'."}}

after restart with this patch:
{"type":"response.completed","error":null,"status":"completed"}
```

An actual escalated `git fetch upstream main` then passed automatic approval and executed successfully. Subsequent `codex-auto-review` request-log rows were recorded with `transport=websocket` and `status=success`.

## Screenshots / output

Not applicable — backend-only proxy wire-compatibility fix with no dashboard-visible changes. The before/after live output is included above.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked #1450 and explicitly documented that this is a partial fix.
- [x] Added regression coverage at the externally failing HTTP and WebSocket product paths.
- [x] Ran the relevant lint, format, type-check, unit, integration, and strict OpenSpec validation.
- [ ] `openspec validate --specs` passes and `/opsx:verify` is clean — blocked only by the two unchanged baseline spec errors documented above; strict change validation and task verification pass.
- [x] Simplicity gates reviewed: PRINCIPLES.md P1-P5.
- [x] `CHANGELOG.md` is not edited by hand.
