### PR TITLE
docs(contributors): add lkraider, ret2basic, and yeongjun-cigro

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1101,6 +1101,37 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "lkraider",
+      "name": "Paul Eipper",
+      "avatar_url": "https://avatars.githubusercontent.com/u/52256?v=4",
+      "profile": "https://github.com/lkraider",
+      "contributions": [
+        "code",
+        "test",
+        "doc"
+      ]
+    },
+    {
+      "login": "ret2basic",
+      "name": "ret2basic.eth",
+      "avatar_url": "https://avatars.githubusercontent.com/u/59381775?v=4",
+      "profile": "https://github.com/ret2basic",
+      "contributions": [
+        "code",
+        "test"
+      ]
+    },
+    {
+      "login": "yeongjun-cigro",
+      "name": "유영준",
+      "avatar_url": "https://avatars.githubusercontent.com/u/260819931?v=4",
+      "profile": "https://github.com/yeongjun-cigro",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -267,6 +267,11 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/e
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/crowscc"><img src="https://avatars.githubusercontent.com/u/17800561?v=4?s=100" width="100px;" alt="crowscc"/><br /><sub><b>crowscc</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=crowscc" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://expressthisout.com/"><img src="https://avatars.githubusercontent.com/u/1113851?v=4?s=100" width="100px;" alt="Syakur Rahman"/><br /><sub><b>Syakur Rahman</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=shaqman" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=shaqman" title="Tests">⚠️</a></td>
     </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/lkraider"><img src="https://avatars.githubusercontent.com/u/52256?v=4?s=100" width="100px;" alt="Paul Eipper"/><br /><sub><b>Paul Eipper</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=lkraider" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=lkraider" title="Tests">⚠️</a> <a href="https://github.com/Soju06/codex-lb/commits?author=lkraider" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ret2basic"><img src="https://avatars.githubusercontent.com/u/59381775?v=4?s=100" width="100px;" alt="ret2basic.eth"/><br /><sub><b>ret2basic.eth</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=ret2basic" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=ret2basic" title="Tests">⚠️</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/yeongjun-cigro"><img src="https://avatars.githubusercontent.com/u/260819931?v=4?s=100" width="100px;" alt="유영준"/><br /><sub><b>유영준</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=yeongjun-cigro" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=yeongjun-cigro" title="Tests">⚠️</a></td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Adds missing all-contributors entries for recent PR authors (lkraider #1550/#1563, ret2basic #1517/#1549, yeongjun-cigro #1531/#1532) so their attribution checks can pass. Docs-only.