### PR TITLE
fix(db): handle percent-encoded SQLite URLs on Windows (takeover of #1295)

### DIFF
--- a/app/db/migrate.py
+++ b/app/db/migrate.py
@@ -144,7 +144,16 @@ def _script_location() -> str:
 def _build_alembic_config(database_url: str) -> Config:
     config = Config()
     config.set_main_option("script_location", _script_location())
-    config.set_main_option("sqlalchemy.url", to_sync_database_url(database_url))
+    sync_database_url = to_sync_database_url(database_url)
+    # `to_sync_database_url` routes the URL through `make_url().render_as_string()`,
+    # which percent-encodes the path on Windows (e.g.
+    # `sqlite:///C%3A%5CUsers%5C...%5Cstore.db`). Alembic stores option values in
+    # a `configparser` using `BasicInterpolation`, which treats a bare `%` as
+    # interpolation syntax and raises `ValueError: invalid interpolation syntax`
+    # from `set_main_option`. Escape `%` -> `%%` so ConfigParser keeps the value
+    # verbatim; `get_main_option` decodes `%%` back to `%`, so the URL handed to
+    # SQLAlchemy is unchanged.
+    config.set_main_option("sqlalchemy.url", sync_database_url.replace("%", "%%"))
     config.attributes["configure_logger"] = False
     return config
 

--- a/app/db/migration_url.py
+++ b/app/db/migration_url.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from sqlalchemy.engine import make_url
 
+from app.db.sqlite_utils import normalize_sqlite_url
+
 
 def to_sync_database_url(database_url: str) -> str:
+    database_url = normalize_sqlite_url(database_url)
     parsed = make_url(database_url)
     driver = parsed.drivername
 

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -17,7 +17,12 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.pool import NullPool
 
 from app.core.config.settings import get_settings
-from app.db.sqlite_utils import SqliteIntegrityCheckMode, check_sqlite_integrity, sqlite_db_path_from_url
+from app.db.sqlite_utils import (
+    SqliteIntegrityCheckMode,
+    check_sqlite_integrity,
+    normalize_sqlite_url,
+    sqlite_db_path_from_url,
+)
 
 if TYPE_CHECKING:
     from app.db.migrate import MigrationRunResult, MigrationState
@@ -36,6 +41,7 @@ _SQLITE_BUSY_TIMEOUT_SECONDS = _SQLITE_BUSY_TIMEOUT_MS / 1000
 # ``database_pool_size`` / ``database_max_overflow``.
 _POSTGRES_POOL_TIMEOUT_SECONDS = 30.0
 _POSTGRES_POOL_RECYCLE_SECONDS = 1800
+_database_url = normalize_sqlite_url(_settings.database_url)
 
 
 class _PostgresPooledEngineRole(StrEnum):
@@ -155,7 +161,7 @@ def _create_main_engine(url: str) -> AsyncEngine:
     return main_engine
 
 
-engine = _create_main_engine(_settings.database_url)
+engine = _create_main_engine(_database_url)
 
 SessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
@@ -171,24 +177,11 @@ class _SqliteBackupCreator(Protocol):
 
 
 def _ensure_sqlite_dir(url: str) -> None:
-    if not (url.startswith("sqlite+aiosqlite:") or url.startswith("sqlite:")):
+    sqlite_path = sqlite_db_path_from_url(url)
+    if sqlite_path is None:
         return
 
-    marker = ":///"
-    marker_index = url.find(marker)
-    if marker_index < 0:
-        return
-
-    # Works for both relative (sqlite+aiosqlite:///./db.sqlite) and absolute
-    # paths (sqlite+aiosqlite:////var/lib/app/db.sqlite).
-    path = url[marker_index + len(marker) :]
-    path = path.partition("?")[0]
-    path = path.partition("#")[0]
-
-    if not path or path == ":memory:":
-        return
-
-    Path(path).expanduser().parent.mkdir(parents=True, exist_ok=True)
+    sqlite_path.parent.mkdir(parents=True, exist_ok=True)
 
 
 def _startup_sqlite_check_mode(raw_mode: str) -> SqliteIntegrityCheckMode | None:
@@ -260,7 +253,7 @@ def init_background_db(url: str | None = None) -> None:
         url: Database URL. If None, uses settings.database_url.
     """
     global _background_engine, _background_session_factory
-    db_url = url or _settings.database_url
+    db_url = normalize_sqlite_url(url or _settings.database_url)
 
     if _is_sqlite_url(db_url):
         is_sqlite_memory = _is_sqlite_memory_url(db_url)
@@ -307,7 +300,8 @@ async def get_background_session() -> AsyncIterator[AsyncSession]:
 async def sqlite_writer_section() -> AsyncIterator[None]:
     """Serialize local SQLite write transactions without throttling upstream work."""
     global _sqlite_writer_lock
-    if not _is_sqlite_url(_settings.database_url) or _is_sqlite_memory_url(_settings.database_url):
+    database_url = normalize_sqlite_url(_settings.database_url)
+    if not _is_sqlite_url(database_url) or _is_sqlite_memory_url(database_url):
         yield
         return
     if _sqlite_writer_lock is None:
@@ -328,8 +322,9 @@ async def get_session() -> AsyncIterator[AsyncSession]:
 
 
 async def init_db() -> None:
-    _ensure_sqlite_dir(_settings.database_url)
-    sqlite_path = sqlite_db_path_from_url(_settings.database_url)
+    database_url = normalize_sqlite_url(_settings.database_url)
+    _ensure_sqlite_dir(database_url)
+    sqlite_path = sqlite_db_path_from_url(database_url)
     if sqlite_path is not None:
         check_mode = _startup_sqlite_check_mode(_settings.database_sqlite_startup_check_mode)
         if check_mode is not None:
@@ -371,7 +366,7 @@ async def init_db() -> None:
 
     if not _settings.database_migrate_on_startup:
         migration_state = await to_thread.run_sync(
-            lambda: inspect_migration_state(_settings.database_url),
+            lambda: inspect_migration_state(database_url),
         )
         if migration_state.needs_upgrade:
             current_revision = migration_state.current_revision or "none"
@@ -397,7 +392,7 @@ async def init_db() -> None:
 
     if sqlite_path is not None and _settings.database_sqlite_pre_migrate_backup_enabled and sqlite_path.exists():
         migration_state = await to_thread.run_sync(
-            lambda: inspect_migration_state(_settings.database_url),
+            lambda: inspect_migration_state(database_url),
         )
         if migration_state.needs_upgrade:
             try:
@@ -421,7 +416,7 @@ async def init_db() -> None:
             )
 
     try:
-        result = await run_startup_migrations(_settings.database_url)
+        result = await run_startup_migrations(database_url)
         if result.bootstrap.stamped_revision is not None:
             logger.info(
                 "Bootstrapped legacy migrations stamped_revision=%s legacy_rows=%s",
@@ -430,7 +425,7 @@ async def init_db() -> None:
             )
         if result.current_revision is not None:
             logger.info("Database migration complete revision=%s", result.current_revision)
-        drift = await to_thread.run_sync(lambda: check_schema_drift(_settings.database_url))
+        drift = await to_thread.run_sync(lambda: check_schema_drift(database_url))
         if drift:
             drift_details = "; ".join(drift)
             raise RuntimeError(f"Schema drift detected after startup migrations: {drift_details}")

--- a/app/db/sqlite_utils.py
+++ b/app/db/sqlite_utils.py
@@ -32,7 +32,14 @@ def sqlite_connection(path: str | Path) -> Iterator[sqlite3.Connection]:
 
 def _sqlite_path_uses_sqlalchemy_windows_escapes(path: str) -> bool:
     lower_path = path.lower()
-    if len(lower_path) >= 5 and lower_path[1:4] == "%3a" and lower_path[0].isalpha():
+    if len(path) >= 3 and path[1] == ":" and path[0].isalpha() and path[2] in ("\\", "/"):
+        return True
+    if (
+        len(lower_path) >= 7
+        and lower_path[1:4] == "%3a"
+        and lower_path[0].isalpha()
+        and lower_path[4:7] in ("%5c", "%2f")
+    ):
         return True
     return lower_path.startswith("%5c%5c")
 
@@ -41,6 +48,10 @@ def _decode_sqlalchemy_windows_sqlite_path(path: str) -> str:
     if not _sqlite_path_uses_sqlalchemy_windows_escapes(path):
         return path
     return urllib.parse.unquote(path)
+
+
+def _escape_sqlite_url_path_separators(path: str) -> str:
+    return path.replace("%", "%25").replace("?", "%3F").replace("#", "%23")
 
 
 def sqlite_db_path_from_url(url: str) -> Path | None:
@@ -91,6 +102,8 @@ def normalize_sqlite_url(url: str) -> str:
         return url
 
     decoded_path = _decode_sqlalchemy_windows_sqlite_path(path)
+    if decoded_path != path:
+        decoded_path = _escape_sqlite_url_path_separators(decoded_path)
     return f"{url[:path_start]}{decoded_path}{url[suffix_index:]}"
 
 

--- a/app/db/sqlite_utils.py
+++ b/app/db/sqlite_utils.py
@@ -46,6 +46,10 @@ def _sqlite_path_is_raw_windows_drive(path: str) -> bool:
     return len(path) >= 3 and path[1] == ":" and path[0].isalpha() and path[2] in ("\\", "/")
 
 
+def _sqlite_path_is_raw_windows_unc(path: str) -> bool:
+    return path.startswith("\\\\")
+
+
 def _decode_sqlalchemy_windows_sqlite_path(path: str) -> str:
     if not _sqlite_path_uses_sqlalchemy_windows_escapes(path):
         return path
@@ -62,7 +66,11 @@ def sqlite_db_path_from_url(url: str) -> Path | None:
         return None
 
     path = url[marker_index + len(marker) :]
-    if _sqlite_path_is_raw_windows_drive(path):
+    if _sqlite_path_is_raw_windows_drive(path) or _sqlite_path_is_raw_windows_unc(path):
+        # Raw Windows drive and UNC paths are filesystem paths, not URL-encoded
+        # forms: a `#` is a legal path character there (e.g. the decoded output
+        # of `normalize_sqlite_url()`), so it must not be stripped as a URL
+        # fragment separator.
         path = path.partition("?")[0]
     else:
         path = path.partition("?")[0]

--- a/app/db/sqlite_utils.py
+++ b/app/db/sqlite_utils.py
@@ -30,6 +30,19 @@ def sqlite_connection(path: str | Path) -> Iterator[sqlite3.Connection]:
         connection.close()
 
 
+def _sqlite_path_uses_sqlalchemy_windows_escapes(path: str) -> bool:
+    lower_path = path.lower()
+    if len(lower_path) >= 5 and lower_path[1:4] == "%3a" and lower_path[0].isalpha():
+        return True
+    return lower_path.startswith("%5c%5c")
+
+
+def _decode_sqlalchemy_windows_sqlite_path(path: str) -> str:
+    if not _sqlite_path_uses_sqlalchemy_windows_escapes(path):
+        return path
+    return urllib.parse.unquote(path)
+
+
 def sqlite_db_path_from_url(url: str) -> Path | None:
     if not (url.startswith("sqlite+aiosqlite:") or url.startswith("sqlite:")):
         return None
@@ -43,18 +56,42 @@ def sqlite_db_path_from_url(url: str) -> Path | None:
     path = path.partition("?")[0]
     path = path.partition("#")[0]
 
-    # SQLAlchemy`s `URL.render_as_string()` percent-encodes the database path on
-    # Windows (e.g. `sqlite:///C%3A%5CUsers%5C...%5Cstore.db`). Without decoding
-    # it here, the literal percent-escaped string reaches `sqlite3.connect()`,
-    # which either fails with "unable to open database file" or creates a stray
-    # 0-byte database next to the working directory. Decode the path before
-    # turning it into a `Path` so the real file is opened.
-    path = urllib.parse.unquote(path)
+    # SQLAlchemy's `URL.render_as_string()` percent-encodes Windows drive and
+    # UNC SQLite paths (e.g. `sqlite:///C%3A%5CUsers%5C...%5Cstore.db`). Decode
+    # those recognizable rendered Windows forms before opening the filesystem
+    # path. Do not unquote arbitrary `%xx` sequences here: settings builds the
+    # default SQLite URL directly from `data_dir`, so a valid literal path such
+    # as `/var/lib/codex%20lb/store.db` must remain literal.
+    path = _decode_sqlalchemy_windows_sqlite_path(path)
 
     if not path or path == ":memory:":
         return None
 
     return Path(path).expanduser()
+
+
+def normalize_sqlite_url(url: str) -> str:
+    if not (url.startswith("sqlite+aiosqlite:") or url.startswith("sqlite:")):
+        return url
+
+    marker = ":///"
+    marker_index = url.find(marker)
+    if marker_index < 0:
+        return url
+
+    path_start = marker_index + len(marker)
+    suffix_index = len(url)
+    for separator in ("?", "#"):
+        separator_index = url.find(separator, path_start)
+        if separator_index >= 0:
+            suffix_index = min(suffix_index, separator_index)
+
+    path = url[path_start:suffix_index]
+    if not path or path == ":memory:":
+        return url
+
+    decoded_path = _decode_sqlalchemy_windows_sqlite_path(path)
+    return f"{url[:path_start]}{decoded_path}{url[suffix_index:]}"
 
 
 def _integrity_check_pragma(mode: SqliteIntegrityCheckMode) -> str:

--- a/app/db/sqlite_utils.py
+++ b/app/db/sqlite_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+import urllib.parse
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -41,6 +42,14 @@ def sqlite_db_path_from_url(url: str) -> Path | None:
     path = url[marker_index + len(marker) :]
     path = path.partition("?")[0]
     path = path.partition("#")[0]
+
+    # SQLAlchemy`s `URL.render_as_string()` percent-encodes the database path on
+    # Windows (e.g. `sqlite:///C%3A%5CUsers%5C...%5Cstore.db`). Without decoding
+    # it here, the literal percent-escaped string reaches `sqlite3.connect()`,
+    # which either fails with "unable to open database file" or creates a stray
+    # 0-byte database next to the working directory. Decode the path before
+    # turning it into a `Path` so the real file is opened.
+    path = urllib.parse.unquote(path)
 
     if not path or path == ":memory:":
         return None

--- a/app/db/sqlite_utils.py
+++ b/app/db/sqlite_utils.py
@@ -33,10 +33,10 @@ def sqlite_connection(path: str | Path) -> Iterator[sqlite3.Connection]:
 def _sqlite_path_uses_sqlalchemy_windows_escapes(path: str) -> bool:
     lower_path = path.lower()
     if (
-        len(lower_path) >= 7
+        len(lower_path) >= 5
         and lower_path[1:4] == "%3a"
         and lower_path[0].isalpha()
-        and lower_path[4:7] in ("%5c", "%2f")
+        and (lower_path[4:7] in ("%5c", "%2f") or (path[0].isupper() and lower_path[4] in ("\\", "/")))
     ):
         return True
     return lower_path.startswith("%5c%5c")
@@ -52,6 +52,14 @@ def _decode_sqlalchemy_windows_sqlite_path(path: str) -> str:
     return urllib.parse.unquote(path)
 
 
+def _decode_sqlite_url_reserved_separators(path: str) -> str:
+    return path.replace("%23", "#").replace("%3f", "?").replace("%3F", "?")
+
+
+def _quote_sqlite_url_path_separators(path: str) -> str:
+    return urllib.parse.quote(path, safe=":/\\")
+
+
 def sqlite_db_path_from_url(url: str) -> Path | None:
     if not (url.startswith("sqlite+aiosqlite:") or url.startswith("sqlite:")):
         return None
@@ -64,6 +72,7 @@ def sqlite_db_path_from_url(url: str) -> Path | None:
     path = url[marker_index + len(marker) :]
     if _sqlite_path_is_raw_windows_drive(path):
         path = path.partition("?")[0]
+        path = _decode_sqlite_url_reserved_separators(path)
     else:
         path = path.partition("?")[0]
         path = path.partition("#")[0]
@@ -103,6 +112,8 @@ def normalize_sqlite_url(url: str) -> str:
         return url
 
     decoded_path = _decode_sqlalchemy_windows_sqlite_path(path)
+    if decoded_path != path:
+        decoded_path = _quote_sqlite_url_path_separators(decoded_path)
     return f"{url[:path_start]}{decoded_path}{url[suffix_index:]}"
 
 

--- a/app/db/sqlite_utils.py
+++ b/app/db/sqlite_utils.py
@@ -36,7 +36,7 @@ def _sqlite_path_uses_sqlalchemy_windows_escapes(path: str) -> bool:
         len(lower_path) >= 5
         and lower_path[1:4] == "%3a"
         and lower_path[0].isalpha()
-        and (lower_path[4:7] in ("%5c", "%2f") or (path[0].isupper() and lower_path[4] in ("\\", "/")))
+        and (lower_path[4:7] in ("%5c", "%2f") or lower_path[4] in ("\\", "/"))
     ):
         return True
     return lower_path.startswith("%5c%5c")
@@ -52,14 +52,6 @@ def _decode_sqlalchemy_windows_sqlite_path(path: str) -> str:
     return urllib.parse.unquote(path)
 
 
-def _decode_sqlite_url_reserved_separators(path: str) -> str:
-    return path.replace("%23", "#").replace("%3f", "?").replace("%3F", "?")
-
-
-def _quote_sqlite_url_path_separators(path: str) -> str:
-    return urllib.parse.quote(path, safe=":/\\")
-
-
 def sqlite_db_path_from_url(url: str) -> Path | None:
     if not (url.startswith("sqlite+aiosqlite:") or url.startswith("sqlite:")):
         return None
@@ -72,7 +64,6 @@ def sqlite_db_path_from_url(url: str) -> Path | None:
     path = url[marker_index + len(marker) :]
     if _sqlite_path_is_raw_windows_drive(path):
         path = path.partition("?")[0]
-        path = _decode_sqlite_url_reserved_separators(path)
     else:
         path = path.partition("?")[0]
         path = path.partition("#")[0]
@@ -112,8 +103,6 @@ def normalize_sqlite_url(url: str) -> str:
         return url
 
     decoded_path = _decode_sqlalchemy_windows_sqlite_path(path)
-    if decoded_path != path:
-        decoded_path = _quote_sqlite_url_path_separators(decoded_path)
     return f"{url[:path_start]}{decoded_path}{url[suffix_index:]}"
 
 

--- a/app/db/sqlite_utils.py
+++ b/app/db/sqlite_utils.py
@@ -32,8 +32,6 @@ def sqlite_connection(path: str | Path) -> Iterator[sqlite3.Connection]:
 
 def _sqlite_path_uses_sqlalchemy_windows_escapes(path: str) -> bool:
     lower_path = path.lower()
-    if len(path) >= 3 and path[1] == ":" and path[0].isalpha() and path[2] in ("\\", "/"):
-        return True
     if (
         len(lower_path) >= 7
         and lower_path[1:4] == "%3a"
@@ -44,14 +42,14 @@ def _sqlite_path_uses_sqlalchemy_windows_escapes(path: str) -> bool:
     return lower_path.startswith("%5c%5c")
 
 
+def _sqlite_path_is_raw_windows_drive(path: str) -> bool:
+    return len(path) >= 3 and path[1] == ":" and path[0].isalpha() and path[2] in ("\\", "/")
+
+
 def _decode_sqlalchemy_windows_sqlite_path(path: str) -> str:
     if not _sqlite_path_uses_sqlalchemy_windows_escapes(path):
         return path
     return urllib.parse.unquote(path)
-
-
-def _escape_sqlite_url_path_separators(path: str) -> str:
-    return path.replace("%", "%25").replace("?", "%3F").replace("#", "%23")
 
 
 def sqlite_db_path_from_url(url: str) -> Path | None:
@@ -64,8 +62,11 @@ def sqlite_db_path_from_url(url: str) -> Path | None:
         return None
 
     path = url[marker_index + len(marker) :]
-    path = path.partition("?")[0]
-    path = path.partition("#")[0]
+    if _sqlite_path_is_raw_windows_drive(path):
+        path = path.partition("?")[0]
+    else:
+        path = path.partition("?")[0]
+        path = path.partition("#")[0]
 
     # SQLAlchemy's `URL.render_as_string()` percent-encodes Windows drive and
     # UNC SQLite paths (e.g. `sqlite:///C%3A%5CUsers%5C...%5Cstore.db`). Decode
@@ -102,8 +103,6 @@ def normalize_sqlite_url(url: str) -> str:
         return url
 
     decoded_path = _decode_sqlalchemy_windows_sqlite_path(path)
-    if decoded_path != path:
-        decoded_path = _escape_sqlite_url_path_separators(decoded_path)
     return f"{url[:path_start]}{decoded_path}{url[suffix_index:]}"
 
 

--- a/openspec/changes/windows-sqlite-url-encoding/.openspec.yaml
+++ b/openspec/changes/windows-sqlite-url-encoding/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/windows-sqlite-url-encoding/proposal.md
+++ b/openspec/changes/windows-sqlite-url-encoding/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+On Windows the default SQLite database URL is built from `Path.home() / ".codex-lb" / "store.db"`, an absolute path with a drive letter and backslashes (e.g. `sqlite+aiosqlite:///C:\Users\...\store.db`). SQLAlchemy's `URL.render_as_string()` percent-encodes that path into `sqlite:///C%3A%5CUsers%5C...%5Cstore.db`, and two code paths break on the resulting bare `%` characters:
+
+- `app/db/migrate.py::_build_alembic_config` hands the encoded URL to Alembic's `ConfigParser` (`BasicInterpolation`), which treats `%` as interpolation syntax and raises `ValueError: invalid interpolation syntax` during startup (`inspect_migration_state`). The server never reaches "Application startup complete".
+- `app/db/sqlite_utils.py::sqlite_db_path_from_url` returns the literal percent-escaped string, so `sqlite3.connect()` either fails with "unable to open database file" or silently creates a stray 0-byte database next to the CWD, breaking `/api/accounts` and `/api/dashboard/overview` with `no such table: accounts` while `/health` and `/v1/models` still return 200.
+
+Non-Windows SQLite installs and PostgreSQL installs are unaffected (their paths contain no `%`).
+
+## What Changes
+
+- `sqlite_db_path_from_url` now `urllib.parse.unquote()`s the path before turning it into a `Path`, so `sqlite3.connect()` receives the real filesystem path on every platform. No-op on already-decoded paths.
+- `_build_alembic_config` now escapes `%` -> `%%` before storing the URL in the Alembic `Config`. `get_main_option()` decodes `%%` back to `%`, so the URL SQLAlchemy receives is unchanged; the escape is transparent to every consumer of the config.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `database-backends`: SQLite file paths extracted from a SQLAlchemy URL MUST be percent-decoded before being handed to `sqlite3.connect()` so a Windows-style default database path resolves to the real file.
+- `database-migrations`: The Alembic `Config` built for inspection/upgrade MUST escape `%` in the SQLAlchemy URL so `configparser` `BasicInterpolation` does not treat a percent-encoded Windows path as interpolation syntax.
+
+## Impact
+
+`app/db/sqlite_utils.py`, `app/db/migrate.py`. New regression tests in `tests/unit/test_sqlite_url_windows.py`. No schema, API, or settings change.

--- a/openspec/changes/windows-sqlite-url-encoding/proposal.md
+++ b/openspec/changes/windows-sqlite-url-encoding/proposal.md
@@ -10,6 +10,7 @@ Non-Windows SQLite installs and PostgreSQL installs are unaffected (their paths 
 ## What Changes
 
 - `sqlite_db_path_from_url` now `urllib.parse.unquote()`s the path before turning it into a `Path`, so `sqlite3.connect()` receives the real filesystem path on every platform. No-op on already-decoded paths.
+- Startup directory creation now reuses the same decoded SQLite path helper, so `init_db()` creates/checks the real database parent instead of a percent-literal sibling.
 - `_build_alembic_config` now escapes `%` -> `%%` before storing the URL in the Alembic `Config`. `get_main_option()` decodes `%%` back to `%`, so the URL SQLAlchemy receives is unchanged; the escape is transparent to every consumer of the config.
 
 ## Capabilities
@@ -25,4 +26,4 @@ Non-Windows SQLite installs and PostgreSQL installs are unaffected (their paths 
 
 ## Impact
 
-`app/db/sqlite_utils.py`, `app/db/migrate.py`. New regression tests in `tests/unit/test_sqlite_url_windows.py`. No schema, API, or settings change.
+`app/db/sqlite_utils.py`, `app/db/session.py`, `app/db/migrate.py`. New regression tests in `tests/unit/test_sqlite_url_windows.py`. No schema, API, or settings change.

--- a/openspec/changes/windows-sqlite-url-encoding/specs/database-backends/spec.md
+++ b/openspec/changes/windows-sqlite-url-encoding/specs/database-backends/spec.md
@@ -1,0 +1,26 @@
+# database-backends Delta
+
+## ADDED Requirements
+
+### Requirement: SQLite file paths are percent-decoded before opening
+
+When a SQLite database URL is converted to a filesystem path for direct `sqlite3.connect()` use (e.g. the usage repository's read-only helper), the path MUST be percent-decoded before being handed to the filesystem. SQLAlchemy's `URL.render_as_string()` percent-encodes a Windows-style default path (`C:\Users\...` -> `C%3A%5CUsers%5C...`); without decoding, the literal escaped string either fails to open with "unable to open database file" or creates a stray 0-byte database next to the current working directory, which breaks account/usage reads with `no such table`.
+
+#### Scenario: Windows default path resolves to the real file
+
+- **GIVEN** the default SQLite URL on Windows (`sqlite+aiosqlite:///C:\Users\...\store.db`)
+- **WHEN** `URL.render_as_string()` percent-encodes it into `sqlite:///C%3A%5CUsers%5C...%5Cstore.db`
+- **AND** the path is extracted and decoded
+- **THEN** `sqlite3.connect()` receives `C:\Users\...\store.db` (the real file), not the percent-escaped literal
+
+#### Scenario: POSIX paths are unchanged
+
+- **GIVEN** a POSIX-style SQLite URL (`sqlite+aiosqlite:///var/lib/codex-lb/store.db`)
+- **WHEN** the path is extracted and decoded
+- **THEN** the result is identical to the input path (no `%` to decode; behavior is a no-op)
+
+#### Scenario: In-memory databases are not treated as file paths
+
+- **GIVEN** a `:memory:` SQLite URL
+- **WHEN** the path is extracted
+- **THEN** no filesystem path is returned and no file is created

--- a/openspec/changes/windows-sqlite-url-encoding/specs/database-backends/spec.md
+++ b/openspec/changes/windows-sqlite-url-encoding/specs/database-backends/spec.md
@@ -13,12 +13,25 @@ When a SQLite database URL is converted to a filesystem path for direct filesyst
 - **AND** the path is extracted and decoded
 - **THEN** `sqlite3.connect()` receives `C:\Users\...\store.db` (the real file), not the percent-escaped literal
 
+#### Scenario: Encoded drive with URL slash separators resolves to the real file
+
+- **GIVEN** a Windows SQLite URL with an encoded drive colon and normal URL path separators (`sqlite:///C%3A/Users/me/.codex-lb/store.db`)
+- **WHEN** the path is extracted and decoded
+- **THEN** the filesystem path is `C:/Users/me/.codex-lb/store.db`, not the literal `C%3A/Users/me/.codex-lb/store.db`
+
 #### Scenario: Startup uses the decoded SQLite path
 
 - **GIVEN** a percent-encoded SQLite file URL whose decoded parent directory differs from the percent-literal parent
 - **WHEN** `init_db()` prepares the SQLite directory and runs the startup integrity check
 - **THEN** the decoded parent directory is created
 - **AND** the integrity check receives the decoded database path
+
+#### Scenario: URL normalization preserves encoded path separators
+
+- **GIVEN** an encoded Windows SQLite URL whose decoded database path contains a URL separator such as `#`
+- **WHEN** the URL is normalized for SQLAlchemy consumers
+- **THEN** the returned URL keeps that separator percent-encoded in the URL path
+- **AND** filesystem extraction still decodes it to the real path segment
 
 #### Scenario: POSIX paths are unchanged
 

--- a/openspec/changes/windows-sqlite-url-encoding/specs/database-backends/spec.md
+++ b/openspec/changes/windows-sqlite-url-encoding/specs/database-backends/spec.md
@@ -26,12 +26,13 @@ When a SQLite database URL is converted to a filesystem path for direct filesyst
 - **THEN** the decoded parent directory is created
 - **AND** the integrity check receives the decoded database path
 
-#### Scenario: URL normalization preserves encoded path separators
+#### Scenario: URL normalization preserves decoded Windows path characters
 
-- **GIVEN** an encoded Windows SQLite URL whose decoded database path contains a URL separator such as `#`
+- **GIVEN** an encoded Windows SQLite URL whose decoded database path contains spaces, literal `%`, or `#`
 - **WHEN** the URL is normalized for SQLAlchemy consumers
-- **THEN** the returned URL keeps that separator percent-encoded in the URL path
-- **AND** filesystem extraction still decodes it to the real path segment
+- **THEN** the returned URL contains the real decoded Windows filesystem path
+- **AND** filesystem extraction from that normalized URL returns the same decoded path
+- **AND** a raw Windows URL containing a literal percent sequence such as `%23` is not decoded unless it first matched a SQLAlchemy-rendered encoded Windows form
 
 #### Scenario: POSIX paths are unchanged
 

--- a/openspec/changes/windows-sqlite-url-encoding/specs/database-backends/spec.md
+++ b/openspec/changes/windows-sqlite-url-encoding/specs/database-backends/spec.md
@@ -4,7 +4,7 @@
 
 ### Requirement: SQLite file paths are percent-decoded before opening
 
-When a SQLite database URL is converted to a filesystem path for direct `sqlite3.connect()` use (e.g. the usage repository's read-only helper), the path MUST be percent-decoded before being handed to the filesystem. SQLAlchemy's `URL.render_as_string()` percent-encodes a Windows-style default path (`C:\Users\...` -> `C%3A%5CUsers%5C...`); without decoding, the literal escaped string either fails to open with "unable to open database file" or creates a stray 0-byte database next to the current working directory, which breaks account/usage reads with `no such table`.
+When a SQLite database URL is converted to a filesystem path for direct filesystem use (e.g. startup directory creation, startup integrity checks, migration locks, or the usage repository's read-only helper), the path MUST be percent-decoded before being handed to the filesystem. SQLAlchemy's `URL.render_as_string()` percent-encodes a Windows-style default path (`C:\Users\...` -> `C%3A%5CUsers%5C...`); without decoding, the literal escaped string either fails to open with "unable to open database file" or creates a stray 0-byte database next to the current working directory, which breaks account/usage reads with `no such table`.
 
 #### Scenario: Windows default path resolves to the real file
 
@@ -12,6 +12,13 @@ When a SQLite database URL is converted to a filesystem path for direct `sqlite3
 - **WHEN** `URL.render_as_string()` percent-encodes it into `sqlite:///C%3A%5CUsers%5C...%5Cstore.db`
 - **AND** the path is extracted and decoded
 - **THEN** `sqlite3.connect()` receives `C:\Users\...\store.db` (the real file), not the percent-escaped literal
+
+#### Scenario: Startup uses the decoded SQLite path
+
+- **GIVEN** a percent-encoded SQLite file URL whose decoded parent directory differs from the percent-literal parent
+- **WHEN** `init_db()` prepares the SQLite directory and runs the startup integrity check
+- **THEN** the decoded parent directory is created
+- **AND** the integrity check receives the decoded database path
 
 #### Scenario: POSIX paths are unchanged
 

--- a/openspec/changes/windows-sqlite-url-encoding/specs/database-backends/spec.md
+++ b/openspec/changes/windows-sqlite-url-encoding/specs/database-backends/spec.md
@@ -2,9 +2,11 @@
 
 ## ADDED Requirements
 
-### Requirement: SQLite file paths are percent-decoded before opening
+### Requirement: SQLAlchemy-rendered Windows SQLite paths are percent-decoded before opening
 
-When a SQLite database URL is converted to a filesystem path for direct filesystem use (e.g. startup directory creation, startup integrity checks, migration locks, or the usage repository's read-only helper), the path MUST be percent-decoded before being handed to the filesystem. SQLAlchemy's `URL.render_as_string()` percent-encodes a Windows-style default path (`C:\Users\...` -> `C%3A%5CUsers%5C...`); without decoding, the literal escaped string either fails to open with "unable to open database file" or creates a stray 0-byte database next to the current working directory, which breaks account/usage reads with `no such table`.
+When a SQLite database URL is converted to a filesystem path for direct filesystem use (e.g. startup directory creation, startup integrity checks, migration locks, or the usage repository's read-only helper), a path that matches a recognizable SQLAlchemy-rendered Windows form — an encoded drive marker (`<letter>%3A` followed by an encoded or raw path separator) or an encoded UNC prefix (`%5C%5C`) — MUST be percent-decoded before being handed to the filesystem. SQLAlchemy's `URL.render_as_string()` percent-encodes a Windows-style default path (`C:\Users\...` -> `C%3A%5CUsers%5C...`); without decoding, the literal escaped string either fails to open with "unable to open database file" or creates a stray 0-byte database next to the current working directory, which breaks account/usage reads with `no such table`.
+
+Paths that do NOT match those rendered Windows forms MUST be preserved literally. Settings builds the default SQLite URL directly from the configured data directory without URL-encoding it, so a percent sequence in a POSIX or raw Windows path (e.g. `/var/lib/codex%20lb/store.db`) names a real directory and MUST NOT be rewritten by decoding.
 
 #### Scenario: Windows default path resolves to the real file
 
@@ -33,6 +35,19 @@ When a SQLite database URL is converted to a filesystem path for direct filesyst
 - **THEN** the returned URL contains the real decoded Windows filesystem path
 - **AND** filesystem extraction from that normalized URL returns the same decoded path
 - **AND** a raw Windows URL containing a literal percent sequence such as `%23` is not decoded unless it first matched a SQLAlchemy-rendered encoded Windows form
+
+#### Scenario: Literal percent sequences in POSIX paths are preserved
+
+- **GIVEN** a POSIX SQLite URL whose path contains a literal percent sequence (`sqlite+aiosqlite:////var/lib/codex%20lb/store.db`) built directly from the configured data directory
+- **WHEN** the path is extracted for filesystem use or the URL is normalized
+- **THEN** the filesystem path remains `/var/lib/codex%20lb/store.db` and the URL is unchanged (the sequence is not decoded to a space)
+
+#### Scenario: Normalized UNC paths keep fragment characters
+
+- **GIVEN** an encoded UNC SQLite URL whose decoded share path contains a legal `#` character (`sqlite:///%5C%5Cserver%5Cshare%23x%5Cstore.db`)
+- **WHEN** the URL is normalized and the filesystem path is then extracted from the normalized URL
+- **THEN** the extracted path is `\\server\share#x\store.db`
+- **AND** the path is not truncated at the `#` as if it were a URL fragment separator
 
 #### Scenario: POSIX paths are unchanged
 

--- a/openspec/changes/windows-sqlite-url-encoding/specs/database-migrations/spec.md
+++ b/openspec/changes/windows-sqlite-url-encoding/specs/database-migrations/spec.md
@@ -1,0 +1,26 @@
+# database-migrations Delta
+
+## ADDED Requirements
+
+### Requirement: Alembic Config escapes percent characters in the SQLAlchemy URL
+
+When the application builds an Alembic `Config` for migration inspection or upgrade (`_build_alembic_config`), any `%` in the SQLAlchemy URL MUST be escaped to `%%` before being stored via `set_main_option`. Alembic stores option values in a `configparser` using `BasicInterpolation`, which treats a bare `%` as interpolation syntax; a percent-encoded Windows path (`C%3A%5CUsers%5C...`) otherwise raises `ValueError: invalid interpolation syntax` during startup. `get_main_option` decodes `%%` back to `%`, so the URL handed to SQLAlchemy is unchanged.
+
+#### Scenario: Windows path does not crash migration inspection
+
+- **GIVEN** the default SQLite URL on Windows, percent-encoded by `URL.render_as_string()` into `sqlite:///C%3A%5CUsers%5C...%5Cstore.db`
+- **WHEN** the Alembic `Config` is built for migration inspection
+- **THEN** no `ValueError: invalid interpolation syntax` is raised
+- **AND** `get_main_option("sqlalchemy.url")` returns the original percent-encoded URL unchanged
+
+#### Scenario: Round-trip preserves an already-encoded percent
+
+- **GIVEN** a path that already contains a percent-encoded `%` (rendered as `%25`)
+- **WHEN** the escape turns it into `%%25` and `get_main_option` decodes it
+- **THEN** the value SQLAlchemy receives decodes back to `%25`, i.e. the original URL is preserved exactly
+
+#### Scenario: Non-Windows URLs are unaffected
+
+- **GIVEN** a SQLite or PostgreSQL URL whose path contains no `%`
+- **WHEN** the escape and decode round-trip is applied
+- **THEN** the URL is unchanged and migration behavior is identical to before

--- a/openspec/changes/windows-sqlite-url-encoding/specs/database-migrations/spec.md
+++ b/openspec/changes/windows-sqlite-url-encoding/specs/database-migrations/spec.md
@@ -11,7 +11,7 @@ When the application builds an Alembic `Config` for migration inspection or upgr
 - **GIVEN** the default SQLite URL on Windows, percent-encoded by `URL.render_as_string()` into `sqlite:///C%3A%5CUsers%5C...%5Cstore.db`
 - **WHEN** the Alembic `Config` is built for migration inspection
 - **THEN** no `ValueError: invalid interpolation syntax` is raised
-- **AND** `get_main_option("sqlalchemy.url")` returns the original percent-encoded URL unchanged
+- **AND** `get_main_option("sqlalchemy.url")` returns the normalized sync URL whose path is the decoded Windows filesystem path (`sqlite:///C:\Users\...\store.db`), because `to_sync_database_url` normalizes recognizable SQLAlchemy-rendered Windows SQLite URLs before the value is stored in the Alembic `Config`
 
 #### Scenario: Round-trip preserves an already-encoded percent
 

--- a/openspec/changes/windows-sqlite-url-encoding/tasks.md
+++ b/openspec/changes/windows-sqlite-url-encoding/tasks.md
@@ -2,9 +2,10 @@
 
 - [x] 1.1 `sqlite_db_path_from_url` percent-decodes the path before `Path(path)` so Windows-style encoded URLs resolve to the real file (`app/db/sqlite_utils.py`)
 - [x] 1.2 `_build_alembic_config` escapes `%` -> `%%` before `set_main_option` so Alembic `BasicInterpolation` does not raise on a percent-encoded Windows path (`app/db/migrate.py`)
+- [x] 1.3 Startup SQLite directory creation reuses the decoded helper so `init_db()` does not create/check a percent-literal database path (`app/db/session.py`)
 
 ## 2. Validation
 
-- [x] 2.1 Regression tests at the failing surface: a Windows-style `sqlite+aiosqlite:///C:\Users\...` URL exercises both `sqlite_db_path_from_url` (decoded path returned) and `_build_alembic_config` (no `ValueError`; URL round-trips through `get_main_option`); both fail without the fix (`tests/unit/test_sqlite_url_windows.py`)
+- [x] 2.1 Regression tests at the failing surface: a Windows-style `sqlite+aiosqlite:///C:\Users\...` URL exercises both `sqlite_db_path_from_url` (decoded path returned) and `_build_alembic_config` (no `ValueError`; URL round-trips through `get_main_option`); startup `init_db()` and the dashboard/account usage SQLite fast path also prove the real decoded DB path is used instead of a percent-literal sibling (`tests/unit/test_sqlite_url_windows.py`)
 - [x] 2.2 POSIX-style and `:memory:` SQLite URLs are unchanged (no behavior change off Windows)
 - [x] 2.3 `ruff` / `ty`; `openspec validate --specs`

--- a/openspec/changes/windows-sqlite-url-encoding/tasks.md
+++ b/openspec/changes/windows-sqlite-url-encoding/tasks.md
@@ -1,0 +1,10 @@
+## 1. Implementation
+
+- [x] 1.1 `sqlite_db_path_from_url` percent-decodes the path before `Path(path)` so Windows-style encoded URLs resolve to the real file (`app/db/sqlite_utils.py`)
+- [x] 1.2 `_build_alembic_config` escapes `%` -> `%%` before `set_main_option` so Alembic `BasicInterpolation` does not raise on a percent-encoded Windows path (`app/db/migrate.py`)
+
+## 2. Validation
+
+- [x] 2.1 Regression tests at the failing surface: a Windows-style `sqlite+aiosqlite:///C:\Users\...` URL exercises both `sqlite_db_path_from_url` (decoded path returned) and `_build_alembic_config` (no `ValueError`; URL round-trips through `get_main_option`); both fail without the fix (`tests/unit/test_sqlite_url_windows.py`)
+- [x] 2.2 POSIX-style and `:memory:` SQLite URLs are unchanged (no behavior change off Windows)
+- [x] 2.3 `ruff` / `ty`; `openspec validate --specs`

--- a/openspec/changes/windows-sqlite-url-encoding/tasks.md
+++ b/openspec/changes/windows-sqlite-url-encoding/tasks.md
@@ -3,9 +3,11 @@
 - [x] 1.1 `sqlite_db_path_from_url` percent-decodes the path before `Path(path)` so Windows-style encoded URLs resolve to the real file (`app/db/sqlite_utils.py`)
 - [x] 1.2 `_build_alembic_config` escapes `%` -> `%%` before `set_main_option` so Alembic `BasicInterpolation` does not raise on a percent-encoded Windows path (`app/db/migrate.py`)
 - [x] 1.3 Startup SQLite directory creation reuses the decoded helper so `init_db()` does not create/check a percent-literal database path (`app/db/session.py`)
+- [x] 1.4 Mixed Windows URL forms with `C%3A/Users/...` decode the drive colon, while normalized URLs keep reserved path separators such as `#` escaped until filesystem extraction
 
 ## 2. Validation
 
 - [x] 2.1 Regression tests at the failing surface: a Windows-style `sqlite+aiosqlite:///C:\Users\...` URL exercises both `sqlite_db_path_from_url` (decoded path returned) and `_build_alembic_config` (no `ValueError`; URL round-trips through `get_main_option`); startup `init_db()` and the dashboard/account usage SQLite fast path also prove the real decoded DB path is used instead of a percent-literal sibling (`tests/unit/test_sqlite_url_windows.py`)
 - [x] 2.2 POSIX-style and `:memory:` SQLite URLs are unchanged (no behavior change off Windows)
-- [x] 2.3 `ruff` / `ty`; `openspec validate --specs`
+- [x] 2.3 Encoded reserved separators and mixed drive-slash forms are covered by `tests/unit/test_sqlite_url_windows.py`
+- [x] 2.4 `ruff` / `ty`; `openspec validate --specs`

--- a/openspec/changes/windows-sqlite-url-encoding/tasks.md
+++ b/openspec/changes/windows-sqlite-url-encoding/tasks.md
@@ -3,11 +3,11 @@
 - [x] 1.1 `sqlite_db_path_from_url` percent-decodes the path before `Path(path)` so Windows-style encoded URLs resolve to the real file (`app/db/sqlite_utils.py`)
 - [x] 1.2 `_build_alembic_config` escapes `%` -> `%%` before `set_main_option` so Alembic `BasicInterpolation` does not raise on a percent-encoded Windows path (`app/db/migrate.py`)
 - [x] 1.3 Startup SQLite directory creation reuses the decoded helper so `init_db()` does not create/check a percent-literal database path (`app/db/session.py`)
-- [x] 1.4 Mixed Windows URL forms with `C%3A/Users/...` decode the drive colon, while normalized URLs keep reserved path separators such as `#` escaped until filesystem extraction
+- [x] 1.4 Mixed Windows URL forms with `C%3A/Users/...` or `c%3A/Users/...` decode the drive colon, while normalized Windows URLs preserve real decoded filesystem characters and raw Windows percent sequences stay literal
 
 ## 2. Validation
 
 - [x] 2.1 Regression tests at the failing surface: a Windows-style `sqlite+aiosqlite:///C:\Users\...` URL exercises both `sqlite_db_path_from_url` (decoded path returned) and `_build_alembic_config` (no `ValueError`; URL round-trips through `get_main_option`); startup `init_db()` and the dashboard/account usage SQLite fast path also prove the real decoded DB path is used instead of a percent-literal sibling (`tests/unit/test_sqlite_url_windows.py`)
 - [x] 2.2 POSIX-style and `:memory:` SQLite URLs are unchanged (no behavior change off Windows)
-- [x] 2.3 Encoded reserved separators and mixed drive-slash forms are covered by `tests/unit/test_sqlite_url_windows.py`
+- [x] 2.3 Encoded reserved separators, decoded spaces/percent signs, raw Windows percent sequences, and mixed drive-slash forms are covered by `tests/unit/test_sqlite_url_windows.py`
 - [x] 2.4 `ruff` / `ty`; `openspec validate --specs`

--- a/openspec/changes/windows-sqlite-url-encoding/tasks.md
+++ b/openspec/changes/windows-sqlite-url-encoding/tasks.md
@@ -4,10 +4,11 @@
 - [x] 1.2 `_build_alembic_config` escapes `%` -> `%%` before `set_main_option` so Alembic `BasicInterpolation` does not raise on a percent-encoded Windows path (`app/db/migrate.py`)
 - [x] 1.3 Startup SQLite directory creation reuses the decoded helper so `init_db()` does not create/check a percent-literal database path (`app/db/session.py`)
 - [x] 1.4 Mixed Windows URL forms with `C%3A/Users/...` or `c%3A/Users/...` decode the drive colon, while normalized Windows URLs preserve real decoded filesystem characters and raw Windows percent sequences stay literal
+- [x] 1.5 Raw Windows UNC paths (including normalized/decoded output of `normalize_sqlite_url`) keep legal `#` characters at the filesystem boundary instead of being truncated as URL fragments (`app/db/sqlite_utils.py`)
 
 ## 2. Validation
 
 - [x] 2.1 Regression tests at the failing surface: a Windows-style `sqlite+aiosqlite:///C:\Users\...` URL exercises both `sqlite_db_path_from_url` (decoded path returned) and `_build_alembic_config` (no `ValueError`; URL round-trips through `get_main_option`); startup `init_db()` and the dashboard/account usage SQLite fast path also prove the real decoded DB path is used instead of a percent-literal sibling (`tests/unit/test_sqlite_url_windows.py`)
 - [x] 2.2 POSIX-style and `:memory:` SQLite URLs are unchanged (no behavior change off Windows)
-- [x] 2.3 Encoded reserved separators, decoded spaces/percent signs, raw Windows percent sequences, and mixed drive-slash forms are covered by `tests/unit/test_sqlite_url_windows.py`
+- [x] 2.3 Encoded reserved separators, decoded spaces/percent signs, raw Windows percent sequences, mixed drive-slash forms, and UNC share paths containing `#` are covered by `tests/unit/test_sqlite_url_windows.py`
 - [x] 2.4 `ruff` / `ty`; `openspec validate --specs`

--- a/tests/unit/test_sqlite_url_windows.py
+++ b/tests/unit/test_sqlite_url_windows.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
 from alembic.config import Config
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.migrate import _build_alembic_config
 from app.db.migration_url import to_sync_database_url
-from app.db.sqlite_utils import sqlite_db_path_from_url
+from app.db.sqlite_utils import normalize_sqlite_url, sqlite_db_path_from_url
+from app.modules.usage.repository import UsageRepository
 
 # The shape SQLAlchemy's `URL.render_as_string()` produces for the Windows
 # default SQLite path `C:\Users\me\.codex-lb\store.db` on a platform that
@@ -13,6 +22,7 @@ from app.db.sqlite_utils import sqlite_db_path_from_url
 # and the shape CI reproduces on Linux). Using the encoded form directly keeps
 # the regression test platform-independent.
 ENCODED_WINDOWS_URL = "sqlite:///C%3A%5CUsers%5Cme%5C.codex-lb%5Cstore.db"
+DECODED_WINDOWS_PATH = r"C:\Users\me\.codex-lb\store.db"
 
 
 class TestSqlitePathFromUrlWindows:
@@ -29,10 +39,27 @@ class TestSqlitePathFromUrlWindows:
         path = sqlite_db_path_from_url(ENCODED_WINDOWS_URL)
         assert path is not None
         # the real filesystem path is returned, not the percent-escaped literal
-        assert str(path) == r"C:\Users\me\.codex-lb\store.db"
+        assert str(path) == DECODED_WINDOWS_PATH
 
     def test_memory_database_returns_none(self) -> None:
         assert sqlite_db_path_from_url("sqlite+aiosqlite:///:memory:") is None
+
+    def test_normalize_decodes_percent_encoded_file_path(self) -> None:
+        assert normalize_sqlite_url(ENCODED_WINDOWS_URL) == f"sqlite:///{DECODED_WINDOWS_PATH}"
+
+    def test_preserves_literal_percent_sequences_from_data_dir_defaults(self) -> None:
+        url = "sqlite+aiosqlite:////var/lib/codex%20lb/store.db"
+
+        path = sqlite_db_path_from_url(url)
+
+        assert path is not None
+        assert str(path) == "/var/lib/codex%20lb/store.db"
+        assert normalize_sqlite_url(url) == url
+
+    def test_normalize_preserves_query_and_fragment(self) -> None:
+        assert (
+            normalize_sqlite_url(f"{ENCODED_WINDOWS_URL}?mode=ro#db") == f"sqlite:///{DECODED_WINDOWS_PATH}?mode=ro#db"
+        )
 
 
 class TestBuildAlembicConfigWindowsUrl:
@@ -55,6 +82,221 @@ class TestBuildAlembicConfigWindowsUrl:
         config = _build_alembic_config(ENCODED_WINDOWS_URL)
         # get_main_option decodes '%%' back to '%', so SQLAlchemy sees the
         # original encoded URL unchanged.
-        assert config.get_main_option("sqlalchemy.url") == to_sync_database_url(
-            ENCODED_WINDOWS_URL
+        sqlalchemy_url = config.get_main_option("sqlalchemy.url")
+        assert sqlalchemy_url is not None
+        assert sqlalchemy_url == to_sync_database_url(ENCODED_WINDOWS_URL)
+        assert r"C:\Users\me\.codex-lb\store.db" in sqlalchemy_url
+
+
+def test_to_sync_database_url_decodes_percent_encoded_sqlite_path() -> None:
+    assert to_sync_database_url(ENCODED_WINDOWS_URL) == f"sqlite:///{DECODED_WINDOWS_PATH}"
+
+
+def test_to_sync_database_url_preserves_literal_percent_path() -> None:
+    literal_percent_url = "sqlite+aiosqlite:////var/lib/codex%20lb/store.db"
+
+    assert to_sync_database_url(literal_percent_url) == "sqlite:////var/lib/codex%20lb/store.db"
+
+
+def test_background_engine_creation_decodes_percent_encoded_sqlite_url(tmp_path, monkeypatch) -> None:
+    from app.db import session as session_module
+
+    decoded_db_path = DECODED_WINDOWS_PATH
+    encoded_url = ENCODED_WINDOWS_URL.replace("sqlite:///", "sqlite+aiosqlite:///")
+    created_urls: list[str] = []
+
+    class FakeEngine:
+        sync_engine = object()
+
+    def fake_create_async_engine(url: str, **kwargs):
+        del kwargs
+        created_urls.append(url)
+        return FakeEngine()
+
+    monkeypatch.setattr(session_module, "create_async_engine", fake_create_async_engine)
+    monkeypatch.setattr(session_module, "_configure_sqlite_engine", lambda *args, **kwargs: None)
+    monkeypatch.setattr(session_module, "async_sessionmaker", lambda *args, **kwargs: object())
+
+    try:
+        session_module.init_background_db(encoded_url)
+
+        assert created_urls == [f"sqlite+aiosqlite:///{decoded_db_path}"]
+    finally:
+        session_module._background_engine = None
+        session_module._background_session_factory = None
+
+
+@pytest.mark.asyncio
+async def test_startup_init_db_decodes_percent_encoded_sqlite_path(tmp_path, monkeypatch) -> None:
+    """Regression: startup must not create/check the percent-literal DB path.
+
+    The production failure happens before serving requests when startup walks
+    through ``init_db()``. This exercises that product path instead of only the
+    helper that decodes URLs.
+    """
+
+    from app.db import session as session_module
+    from app.db.sqlite_utils import IntegrityCheck
+
+    monkeypatch.chdir(tmp_path)
+    decoded_db_path = Path(DECODED_WINDOWS_PATH)
+    encoded_url = ENCODED_WINDOWS_URL.replace("sqlite:///", "sqlite+aiosqlite:///")
+    checked_paths: list[str] = []
+
+    monkeypatch.setattr(
+        session_module,
+        "_settings",
+        SimpleNamespace(
+            database_url=encoded_url,
+            database_sqlite_startup_check_mode="quick",
+            database_migrate_on_startup=True,
+            database_sqlite_pre_migrate_backup_enabled=False,
+            database_migrations_fail_fast=True,
+        ),
+    )
+
+    def fake_check_sqlite_integrity(path, *, mode):
+        del mode
+        checked_paths.append(str(path))
+        return IntegrityCheck(ok=True, details=None)
+
+    async def fake_run_startup_migrations(database_url: str):
+        assert database_url == f"sqlite+aiosqlite:///{DECODED_WINDOWS_PATH}"
+        return SimpleNamespace(
+            current_revision="head",
+            bootstrap=SimpleNamespace(stamped_revision=None, legacy_row_count=0),
         )
+
+    monkeypatch.setattr(session_module, "check_sqlite_integrity", fake_check_sqlite_integrity)
+    monkeypatch.setattr(
+        session_module,
+        "_load_migration_entrypoints",
+        lambda: (
+            lambda database_url: SimpleNamespace(needs_upgrade=False),
+            fake_run_startup_migrations,
+            lambda database_url: (),
+        ),
+    )
+
+    await session_module.init_db()
+
+    assert checked_paths == [str(decoded_db_path)]
+    assert not Path("C%3A%5CUsers%5Cme%5C.codex-lb%5Cstore.db").exists()
+
+
+@pytest.mark.asyncio
+async def test_startup_init_db_preserves_literal_percent_data_dir_path(tmp_path, monkeypatch) -> None:
+    """Regression: a raw data_dir path containing ``%20`` is not URL-decoded."""
+
+    from app.db import session as session_module
+    from app.db.sqlite_utils import IntegrityCheck
+
+    literal_percent_db_path = tmp_path / "codex%20lb" / "store.db"
+    literal_percent_url = f"sqlite+aiosqlite:///{literal_percent_db_path}"
+    checked_paths: list[str] = []
+
+    monkeypatch.setattr(
+        session_module,
+        "_settings",
+        SimpleNamespace(
+            database_url=literal_percent_url,
+            database_sqlite_startup_check_mode="quick",
+            database_migrate_on_startup=True,
+            database_sqlite_pre_migrate_backup_enabled=False,
+            database_migrations_fail_fast=True,
+        ),
+    )
+
+    def fake_check_sqlite_integrity(path, *, mode):
+        del mode
+        checked_paths.append(str(path))
+        return IntegrityCheck(ok=True, details=None)
+
+    async def fake_run_startup_migrations(database_url: str):
+        assert database_url == literal_percent_url
+        return SimpleNamespace(
+            current_revision="head",
+            bootstrap=SimpleNamespace(stamped_revision=None, legacy_row_count=0),
+        )
+
+    monkeypatch.setattr(session_module, "check_sqlite_integrity", fake_check_sqlite_integrity)
+    monkeypatch.setattr(
+        session_module,
+        "_load_migration_entrypoints",
+        lambda: (
+            lambda database_url: SimpleNamespace(needs_upgrade=False),
+            fake_run_startup_migrations,
+            lambda database_url: (),
+        ),
+    )
+
+    await session_module.init_db()
+
+    assert checked_paths == [str(literal_percent_db_path)]
+    assert literal_percent_db_path.parent.is_dir()
+    assert not (tmp_path / "codex lb").exists()
+
+
+@pytest.mark.asyncio
+async def test_dashboard_usage_sqlite_fast_path_decodes_percent_encoded_bind_url(tmp_path, monkeypatch) -> None:
+    """Regression: dashboard/account usage reads open the real decoded DB file.
+
+    ``/api/accounts`` and ``/api/dashboard/overview`` reach usage data through
+    ``DashboardRepository.latest_usage_by_account`` /
+    ``UsageRepository.latest_by_account``. On SQLite that path intentionally
+    uses direct read-only ``sqlite3.connect`` calls, so it must decode an
+    encoded SQLAlchemy bind URL before opening the file.
+    """
+
+    monkeypatch.chdir(tmp_path)
+    decoded_db_path = Path(DECODED_WINDOWS_PATH)
+    encoded_url = ENCODED_WINDOWS_URL
+
+    with sqlite3.connect(decoded_db_path) as conn:
+        conn.execute("create table accounts (id text primary key)")
+        conn.execute(
+            """
+            create table usage_history (
+                id integer primary key,
+                account_id text not null,
+                recorded_at text not null,
+                window text,
+                used_percent real not null,
+                input_tokens integer,
+                output_tokens integer,
+                reset_at integer,
+                window_minutes integer,
+                credits_has integer,
+                credits_unlimited integer,
+                credits_balance real
+            )
+            """
+        )
+        conn.execute("insert into accounts (id) values (?)", ("acc_dash",))
+        conn.execute(
+            """
+            insert into usage_history (
+                id, account_id, recorded_at, window, used_percent, window_minutes
+            )
+            values (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                1,
+                "acc_dash",
+                datetime(2026, 7, 18, 0, 0, tzinfo=UTC).isoformat(),
+                "primary",
+                42.0,
+                300,
+            ),
+        )
+
+    bind = SimpleNamespace(
+        dialect=SimpleNamespace(name="sqlite"),
+        url=encoded_url,
+    )
+    repository = UsageRepository(cast(AsyncSession, SimpleNamespace(get_bind=lambda: bind)))
+
+    latest = await repository.latest_by_account("primary")
+
+    assert latest["acc_dash"].used_percent == pytest.approx(42.0)
+    assert not Path("C%3A%5CUsers%5Cme%5C.codex-lb%5Cstore.db").exists()

--- a/tests/unit/test_sqlite_url_windows.py
+++ b/tests/unit/test_sqlite_url_windows.py
@@ -60,6 +60,15 @@ class TestSqlitePathFromUrlWindows:
     def test_normalize_decodes_percent_encoded_file_path(self) -> None:
         assert normalize_sqlite_url(ENCODED_WINDOWS_URL) == f"sqlite:///{DECODED_WINDOWS_PATH}"
 
+    def test_decodes_encoded_drive_with_unescaped_separators(self) -> None:
+        url = "sqlite:///C%3A/Users/me/.codex-lb/store.db"
+
+        path = sqlite_db_path_from_url(url)
+
+        assert path is not None
+        assert str(path) == "C:/Users/me/.codex-lb/store.db"
+        assert normalize_sqlite_url(url) == "sqlite:///C:/Users/me/.codex-lb/store.db"
+
     def test_preserves_literal_percent_sequences_from_data_dir_defaults(self) -> None:
         url = "sqlite+aiosqlite:////var/lib/codex%20lb/store.db"
 
@@ -87,7 +96,7 @@ class TestSqlitePathFromUrlWindows:
 
         normalized = normalize_sqlite_url(url)
 
-        assert normalized == r"sqlite:///C:\Users\me\foo#bar\store.db"
+        assert normalized == r"sqlite:///C:\Users\me\foo%23bar\store.db"
         assert sqlite_db_path_from_url(normalized) == Path(r"C:\Users\me\foo#bar\store.db")
 
     def test_raw_windows_literal_percent_path_is_not_decoded(self) -> None:
@@ -194,7 +203,7 @@ def test_background_engine_creation_decodes_encoded_hash_for_sqlalchemy(monkeypa
     try:
         session_module.init_background_db(encoded_url)
 
-        assert created_urls == [r"sqlite+aiosqlite:///C:\data#set\store.db"]
+        assert created_urls == [r"sqlite+aiosqlite:///C:\data%23set\store.db"]
     finally:
         session_module._background_engine = None
         session_module._background_session_factory = None

--- a/tests/unit/test_sqlite_url_windows.py
+++ b/tests/unit/test_sqlite_url_windows.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from alembic.config import Config
+
+from app.db.migrate import _build_alembic_config
+from app.db.migration_url import to_sync_database_url
+from app.db.sqlite_utils import sqlite_db_path_from_url
+
+# The shape SQLAlchemy's `URL.render_as_string()` produces for the Windows
+# default SQLite path `C:\Users\me\.codex-lb\store.db` on a platform that
+# percent-encodes backslashes (the exact string that reaches
+# `sqlite_db_path_from_url` and `_build_alembic_config` at runtime on Windows,
+# and the shape CI reproduces on Linux). Using the encoded form directly keeps
+# the regression test platform-independent.
+ENCODED_WINDOWS_URL = "sqlite:///C%3A%5CUsers%5Cme%5C.codex-lb%5Cstore.db"
+
+
+class TestSqlitePathFromUrlWindows:
+    """Regression: ``sqlite_db_path_from_url`` must percent-decode the path.
+
+    Before the fix, the literal ``C%3A%5CUsers%5C...`` reached
+    ``sqlite3.connect()``, which either failed with "unable to open database
+    file" or created a stray 0-byte database next to the CWD, breaking
+    ``/api/accounts`` and ``/api/dashboard/overview`` with
+    ``no such table: accounts`` while ``/health`` stayed 200.
+    """
+
+    def test_decodes_percent_encoded_windows_path(self) -> None:
+        path = sqlite_db_path_from_url(ENCODED_WINDOWS_URL)
+        assert path is not None
+        # the real filesystem path is returned, not the percent-escaped literal
+        assert str(path) == r"C:\Users\me\.codex-lb\store.db"
+
+    def test_memory_database_returns_none(self) -> None:
+        assert sqlite_db_path_from_url("sqlite+aiosqlite:///:memory:") is None
+
+
+class TestBuildAlembicConfigWindowsUrl:
+    """Regression: ``_build_alembic_config`` must escape ``%`` before ConfigParser.
+
+    Before the fix, ``set_main_option`` raised ``ValueError: invalid
+    interpolation syntax`` because Alembic's ``configparser`` uses
+    ``BasicInterpolation``, which treats a bare ``%`` as interpolation syntax.
+    On CI (Linux) the encoded URL above keeps its ``%`` so this test fails
+    without the ``%%`` escape; on Windows the encoded form round-trips without
+    ``%`` so the assertion is trivially satisfied there.
+    """
+
+    def test_does_not_raise_on_percent_encoded_url(self) -> None:
+        # Must not raise ValueError: invalid interpolation syntax
+        config = _build_alembic_config(ENCODED_WINDOWS_URL)
+        assert isinstance(config, Config)
+
+    def test_url_round_trips_through_configparser(self) -> None:
+        config = _build_alembic_config(ENCODED_WINDOWS_URL)
+        # get_main_option decodes '%%' back to '%', so SQLAlchemy sees the
+        # original encoded URL unchanged.
+        assert config.get_main_option("sqlalchemy.url") == to_sync_database_url(
+            ENCODED_WINDOWS_URL
+        )

--- a/tests/unit/test_sqlite_url_windows.py
+++ b/tests/unit/test_sqlite_url_windows.py
@@ -69,6 +69,15 @@ class TestSqlitePathFromUrlWindows:
         assert str(path) == "C:/Users/me/.codex-lb/store.db"
         assert normalize_sqlite_url(url) == "sqlite:///C:/Users/me/.codex-lb/store.db"
 
+    def test_decodes_lowercase_encoded_drive_with_unescaped_separators(self) -> None:
+        url = "sqlite:///c%3A/Users/me/.codex-lb/store.db"
+
+        path = sqlite_db_path_from_url(url)
+
+        assert path is not None
+        assert str(path) == "c:/Users/me/.codex-lb/store.db"
+        assert normalize_sqlite_url(url) == "sqlite:///c:/Users/me/.codex-lb/store.db"
+
     def test_preserves_literal_percent_sequences_from_data_dir_defaults(self) -> None:
         url = "sqlite+aiosqlite:////var/lib/codex%20lb/store.db"
 
@@ -96,8 +105,16 @@ class TestSqlitePathFromUrlWindows:
 
         normalized = normalize_sqlite_url(url)
 
-        assert normalized == r"sqlite:///C:\Users\me\foo%23bar\store.db"
+        assert normalized == r"sqlite:///C:\Users\me\foo#bar\store.db"
         assert sqlite_db_path_from_url(normalized) == Path(r"C:\Users\me\foo#bar\store.db")
+
+    def test_normalize_preserves_decoded_windows_space_and_percent_characters(self) -> None:
+        url = "sqlite:///C%3A%5CUsers%5CFirst%20Last%5C100%25%5Cstore.db"
+
+        normalized = normalize_sqlite_url(url)
+
+        assert normalized == r"sqlite:///C:\Users\First Last\100%\store.db"
+        assert sqlite_db_path_from_url(normalized) == Path(r"C:\Users\First Last\100%\store.db")
 
     def test_raw_windows_literal_percent_path_is_not_decoded(self) -> None:
         url = r"sqlite:///C:\codex%20lb\store.db"
@@ -108,14 +125,23 @@ class TestSqlitePathFromUrlWindows:
         assert str(path) == r"C:\codex%20lb\store.db"
         assert normalize_sqlite_url(url) == url
 
-    def test_posix_literal_encoded_drive_segment_is_not_decoded(self) -> None:
+    def test_raw_windows_literal_encoded_hash_path_is_not_decoded(self) -> None:
+        url = r"sqlite:///C:\data%23set\store.db"
+
+        path = sqlite_db_path_from_url(url)
+
+        assert path is not None
+        assert str(path) == r"C:\data%23set\store.db"
+        assert normalize_sqlite_url(url) == url
+
+    def test_lowercase_windows_encoded_drive_segment_is_decoded(self) -> None:
         url = "sqlite+aiosqlite:///c%3A/cache.db"
 
         path = sqlite_db_path_from_url(url)
 
         assert path is not None
-        assert str(path) == "c%3A/cache.db"
-        assert normalize_sqlite_url(url) == url
+        assert str(path) == "c:/cache.db"
+        assert normalize_sqlite_url(url) == "sqlite+aiosqlite:///c:/cache.db"
 
 
 class TestBuildAlembicConfigWindowsUrl:
@@ -203,7 +229,7 @@ def test_background_engine_creation_decodes_encoded_hash_for_sqlalchemy(monkeypa
     try:
         session_module.init_background_db(encoded_url)
 
-        assert created_urls == [r"sqlite+aiosqlite:///C:\data%23set\store.db"]
+        assert created_urls == [r"sqlite+aiosqlite:///C:\data#set\store.db"]
     finally:
         session_module._background_engine = None
         session_module._background_session_factory = None

--- a/tests/unit/test_sqlite_url_windows.py
+++ b/tests/unit/test_sqlite_url_windows.py
@@ -87,8 +87,17 @@ class TestSqlitePathFromUrlWindows:
 
         normalized = normalize_sqlite_url(url)
 
-        assert normalized == r"sqlite:///C:\Users\me\foo%23bar\store.db"
+        assert normalized == r"sqlite:///C:\Users\me\foo#bar\store.db"
         assert sqlite_db_path_from_url(normalized) == Path(r"C:\Users\me\foo#bar\store.db")
+
+    def test_raw_windows_literal_percent_path_is_not_decoded(self) -> None:
+        url = r"sqlite:///C:\codex%20lb\store.db"
+
+        path = sqlite_db_path_from_url(url)
+
+        assert path is not None
+        assert str(path) == r"C:\codex%20lb\store.db"
+        assert normalize_sqlite_url(url) == url
 
     def test_posix_literal_encoded_drive_segment_is_not_decoded(self) -> None:
         url = "sqlite+aiosqlite:///c%3A/cache.db"
@@ -164,6 +173,33 @@ def test_background_engine_creation_decodes_percent_encoded_sqlite_url(tmp_path,
         session_module._background_session_factory = None
 
 
+def test_background_engine_creation_decodes_encoded_hash_for_sqlalchemy(monkeypatch) -> None:
+    from app.db import session as session_module
+
+    encoded_url = "sqlite+aiosqlite:///C%3A%5Cdata%23set%5Cstore.db"
+    created_urls: list[str] = []
+
+    class FakeEngine:
+        sync_engine = object()
+
+    def fake_create_async_engine(url: str, **kwargs):
+        del kwargs
+        created_urls.append(url)
+        return FakeEngine()
+
+    monkeypatch.setattr(session_module, "create_async_engine", fake_create_async_engine)
+    monkeypatch.setattr(session_module, "_configure_sqlite_engine", lambda *args, **kwargs: None)
+    monkeypatch.setattr(session_module, "async_sessionmaker", lambda *args, **kwargs: object())
+
+    try:
+        session_module.init_background_db(encoded_url)
+
+        assert created_urls == [r"sqlite+aiosqlite:///C:\data#set\store.db"]
+    finally:
+        session_module._background_engine = None
+        session_module._background_session_factory = None
+
+
 @pytest.mark.asyncio
 async def test_startup_init_db_decodes_percent_encoded_sqlite_path(tmp_path, monkeypatch) -> None:
     """Regression: startup must not create/check the percent-literal DB path.
@@ -177,8 +213,8 @@ async def test_startup_init_db_decodes_percent_encoded_sqlite_path(tmp_path, mon
     from app.db.sqlite_utils import IntegrityCheck
 
     monkeypatch.chdir(tmp_path)
-    decoded_db_path = Path(DECODED_WINDOWS_PATH)
-    encoded_url = ENCODED_WINDOWS_URL.replace("sqlite:///", "sqlite+aiosqlite:///")
+    decoded_db_path, encoded_url = _dashboard_fixture_path_and_url(tmp_path)
+    encoded_url = encoded_url.replace("sqlite:///", "sqlite+aiosqlite:///")
     checked_paths: list[str] = []
 
     monkeypatch.setattr(
@@ -199,7 +235,7 @@ async def test_startup_init_db_decodes_percent_encoded_sqlite_path(tmp_path, mon
         return IntegrityCheck(ok=True, details=None)
 
     async def fake_run_startup_migrations(database_url: str):
-        assert database_url == f"sqlite+aiosqlite:///{DECODED_WINDOWS_PATH}"
+        assert database_url == f"sqlite+aiosqlite:///{decoded_db_path}"
         return SimpleNamespace(
             current_revision="head",
             bootstrap=SimpleNamespace(stamped_revision=None, legacy_row_count=0),
@@ -219,7 +255,7 @@ async def test_startup_init_db_decodes_percent_encoded_sqlite_path(tmp_path, mon
     await session_module.init_db()
 
     assert checked_paths == [str(decoded_db_path)]
-    assert not Path("C%3A%5CUsers%5Cme%5C.codex-lb%5Cstore.db").exists()
+    assert not (tmp_path / "C%3A%5CUsers%5Cme%5C.codex-lb%5Cstore.db").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_sqlite_url_windows.py
+++ b/tests/unit/test_sqlite_url_windows.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import sqlite3
+import urllib.parse
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -23,6 +25,17 @@ from app.modules.usage.repository import UsageRepository
 # the regression test platform-independent.
 ENCODED_WINDOWS_URL = "sqlite:///C%3A%5CUsers%5Cme%5C.codex-lb%5Cstore.db"
 DECODED_WINDOWS_PATH = r"C:\Users\me\.codex-lb\store.db"
+
+
+def _encoded_windows_sqlite_url_for_path(path: Path) -> str:
+    return "sqlite:///" + urllib.parse.quote(str(path), safe="")
+
+
+def _dashboard_fixture_path_and_url(tmp_path: Path) -> tuple[Path, str]:
+    if os.name == "nt":
+        decoded_db_path = tmp_path / "store.db"
+        return decoded_db_path, _encoded_windows_sqlite_url_for_path(decoded_db_path)
+    return Path(DECODED_WINDOWS_PATH), ENCODED_WINDOWS_URL
 
 
 class TestSqlitePathFromUrlWindows:
@@ -60,6 +73,31 @@ class TestSqlitePathFromUrlWindows:
         assert (
             normalize_sqlite_url(f"{ENCODED_WINDOWS_URL}?mode=ro#db") == f"sqlite:///{DECODED_WINDOWS_PATH}?mode=ro#db"
         )
+
+    def test_decodes_encoded_hash_at_filesystem_boundary(self) -> None:
+        url = "sqlite:///C%3A%5CUsers%5Cme%5Cfoo%23bar%5Cstore.db"
+
+        path = sqlite_db_path_from_url(url)
+
+        assert path is not None
+        assert str(path) == r"C:\Users\me\foo#bar\store.db"
+
+    def test_normalize_keeps_encoded_hash_in_url_path(self) -> None:
+        url = "sqlite:///C%3A%5CUsers%5Cme%5Cfoo%23bar%5Cstore.db"
+
+        normalized = normalize_sqlite_url(url)
+
+        assert normalized == r"sqlite:///C:\Users\me\foo%23bar\store.db"
+        assert sqlite_db_path_from_url(normalized) == Path(r"C:\Users\me\foo#bar\store.db")
+
+    def test_posix_literal_encoded_drive_segment_is_not_decoded(self) -> None:
+        url = "sqlite+aiosqlite:///c%3A/cache.db"
+
+        path = sqlite_db_path_from_url(url)
+
+        assert path is not None
+        assert str(path) == "c%3A/cache.db"
+        assert normalize_sqlite_url(url) == url
 
 
 class TestBuildAlembicConfigWindowsUrl:
@@ -249,8 +287,7 @@ async def test_dashboard_usage_sqlite_fast_path_decodes_percent_encoded_bind_url
     """
 
     monkeypatch.chdir(tmp_path)
-    decoded_db_path = Path(DECODED_WINDOWS_PATH)
-    encoded_url = ENCODED_WINDOWS_URL
+    decoded_db_path, encoded_url = _dashboard_fixture_path_and_url(tmp_path)
 
     with sqlite3.connect(decoded_db_path) as conn:
         conn.execute("create table accounts (id text primary key)")

--- a/tests/unit/test_sqlite_url_windows.py
+++ b/tests/unit/test_sqlite_url_windows.py
@@ -134,6 +134,35 @@ class TestSqlitePathFromUrlWindows:
         assert str(path) == r"C:\data%23set\store.db"
         assert normalize_sqlite_url(url) == url
 
+    def test_normalized_unc_path_keeps_hash_at_filesystem_boundary(self) -> None:
+        # Regression: after normalize_sqlite_url() decodes an encoded UNC URL,
+        # a legal '#' in the share path must not be stripped as a URL fragment
+        # when the normalized URL is fed back into sqlite_db_path_from_url()
+        # (init_db(), migration locks); previously the path was truncated to
+        # '\\\\server\\share'.
+        url = "sqlite:///%5C%5Cserver%5Cshare%23x%5Cstore.db"
+
+        normalized = normalize_sqlite_url(url)
+
+        assert normalized == r"sqlite:///\\server\share#x\store.db"
+        assert sqlite_db_path_from_url(normalized) == Path(r"\\server\share#x\store.db")
+
+    def test_encoded_unc_path_decodes_hash_directly(self) -> None:
+        url = "sqlite:///%5C%5Cserver%5Cshare%23x%5Cstore.db"
+
+        path = sqlite_db_path_from_url(url)
+
+        assert path is not None
+        assert str(path) == r"\\server\share#x\store.db"
+
+    def test_raw_unc_path_preserves_query_suffix_only(self) -> None:
+        url = r"sqlite:///\\server\share#x\store.db?mode=ro"
+
+        path = sqlite_db_path_from_url(url)
+
+        assert path is not None
+        assert str(path) == r"\\server\share#x\store.db"
+
     def test_lowercase_windows_encoded_drive_segment_is_decoded(self) -> None:
         url = "sqlite+aiosqlite:///c%3A/cache.db"
 


### PR DESCRIPTION
Supersedes #1295, original implementation by @alchemistkiv, taken over per maintainer decision (author inactive since 07-17).

## Summary

On Windows the default SQLite database URL (`sqlite+aiosqlite:///C:\Users\...\store.db`) is percent-encoded by SQLAlchemy's `URL.render_as_string()` into `sqlite:///C%3A%5CUsers%5C...%5Cstore.db`. Two code paths break on the bare `%` characters:

1. **Alembic startup crash** — `_build_alembic_config()` stores the encoded URL in a `configparser`-backed `Config` with `BasicInterpolation`, raising `ValueError: invalid interpolation syntax` and preventing startup.
2. **Runtime usage queries hit a stray database** — `sqlite_db_path_from_url()` returned the percent-escaped literal, so `sqlite3.connect()` silently created a 0-byte database next to the CWD, and every dashboard endpoint joining account data returned 500 (`no such table: accounts`) while `/health` stayed 200.

The fix escapes `%` -> `%%` before handing the URL to the Alembic `Config`, and adds `normalize_sqlite_url()` / recognizable-Windows-form decoding in `app/db/sqlite_utils.py` so engines, migrations, startup checks, and the usage fast path all target the same real filesystem path. Literal percent sequences in paths built directly from the configured data directory are preserved.

All commits from #1295 are carried over with original authorship, rebased onto current `main` (one conflict: `main` refactored `app/db/session.py` engine creation into `_create_main_engine()`; resolved by feeding it the normalized URL).

## Open review threads from #1295, addressed here

1. **`database-migrations` spec scenario contradicted the implementation** (`openspec/.../database-migrations/spec.md`) — the scenario asserted `get_main_option("sqlalchemy.url")` returns the *original percent-encoded* URL, but `to_sync_database_url()` normalizes encoded Windows URLs before the value is stored, so it actually returns the decoded sync URL (verified empirically). **Fixed**: the scenario now requires the normalized/decoded round-trip.
2. **UNC paths truncated at `#` after normalization** (`app/db/sqlite_utils.py`) — `sqlite_db_path_from_url()` only skipped URL-fragment stripping for raw drive paths, so a normalized UNC URL like `sqlite:///\\server\share#x\store.db` (decoded from `%5C%5Cserver%5Cshare%23x%5Cstore.db` by `init_db()` or the migration lock) was truncated to `\\server\share`. **Fixed with code**: raw UNC paths (`\\` prefix) are now treated like raw drive paths, plus regression tests and an OpenSpec scenario.
3. **`database-backends` requirement was too broad** — it promised percent-decoding for *every* SQLite URL converted for filesystem use, while the implementation intentionally preserves literal percent sequences (e.g. `/var/lib/codex%20lb/store.db` from a configured data dir). **Fixed**: the requirement is narrowed to recognizable SQLAlchemy-rendered Windows forms (encoded drive marker or encoded UNC prefix) and documents the literal-percent exception, with a matching scenario.

## Validation

- `openspec validate windows-sqlite-url-encoding --strict` — valid
- `tests/unit/test_sqlite_url_windows.py` — 25 passed (incl. 3 new UNC `#` regressions)
- db/sqlite/migrate unit slice — 118 passed
- `make test-unit` — 5306 passed, 3 skipped (pre-existing)
- `make architecture-check` — passed, no ratchet changes
- `ruff check` + `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
