### PR TITLE
fix(compact): preserve tool search pairs

### DIFF
--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -48,6 +48,7 @@ _COMPACT_TOOL_CALL_TYPE_BY_OUTPUT_TYPE: dict[str, str] = {
     "function_call_output": "function_call",
     "custom_tool_call_output": "custom_tool_call",
     "apply_patch_call_output": "apply_patch_call",
+    "tool_search_output": "tool_search_call",
 }
 _COMPACT_TOOL_CALL_ITEM_TYPES = frozenset(_COMPACT_TOOL_CALL_TYPE_BY_OUTPUT_TYPE.values())
 _COMPACT_TOOL_CALL_OUTPUT_ITEM_TYPES = frozenset(_COMPACT_TOOL_CALL_TYPE_BY_OUTPUT_TYPE)

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -530,7 +530,7 @@ def _trim_http_bridge_previous_response_input_items(input_items: list[JsonValue]
             index
             for index, item in enumerate(input_items)
             if _http_bridge_input_item_type(item)
-            in {"function_call_output", "custom_tool_call_output", "apply_patch_call_output"}
+            in {"function_call_output", "custom_tool_call_output", "apply_patch_call_output", "tool_search_output"}
         ),
         None,
     )
@@ -544,7 +544,7 @@ def _trim_http_bridge_previous_response_input_items(input_items: list[JsonValue]
 
 def _is_http_bridge_previous_response_output_item(item: JsonValue) -> bool:
     item_type = _http_bridge_input_item_type(item)
-    if item_type in {"reasoning", "function_call", "custom_tool_call", "apply_patch_call"}:
+    if item_type in {"reasoning", "function_call", "custom_tool_call", "apply_patch_call", "tool_search_call"}:
         return _has_http_bridge_response_output_marker(item)
     if item_type != "message" or not isinstance(item, dict):
         return False

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -3020,12 +3020,13 @@ class _HTTPBridgeRequestSubmitMixin:
                 # Account-scoped uploaded files cannot be replayed on a
                 # different owner. Keep the preferred account mandatory for
                 # both silent recovery and clean-close recovery.
-                require_preferred_reconnect = account_neutral_recovery or request_state.file_required_preferred_account
+                require_preferred_reconnect = request_state.file_required_preferred_account
                 request_text = _prepare_websocket_request_state_for_visible_output_replay(request_state)
                 if request_text is None:
                     return False
                 if account_neutral_recovery:
-                    request_state.preferred_account_id = session.account.id
+                    request_state.preferred_account_id = None
+                    request_state.excluded_account_ids.add(session.account.id)
                 elif not request_state.file_required_preferred_account:
                     if hard_owner_bound and not model_fallback_replay and not fresh_hard_request_account_switch_allowed:
                         request_state.preferred_account_id = session.account.id

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -522,6 +522,7 @@ _WEBSOCKET_TOOL_CALL_ITEM_TYPES_BY_OUTPUT_TYPE = {
     "function_call_output": "function_call",
     "custom_tool_call_output": "custom_tool_call",
     "apply_patch_call_output": "apply_patch_call",
+    "tool_search_output": "tool_search_call",
 }
 _WEBSOCKET_TOOL_CALL_ITEM_TYPES = frozenset(_WEBSOCKET_TOOL_CALL_ITEM_TYPES_BY_OUTPUT_TYPE.values())
 
@@ -1881,7 +1882,7 @@ def _trim_websocket_previous_response_input_items(input_items: list[JsonValue]) 
             index
             for index, item in enumerate(input_items)
             if _websocket_input_item_type(item)
-            in {"function_call_output", "custom_tool_call_output", "apply_patch_call_output"}
+            in {"function_call_output", "custom_tool_call_output", "apply_patch_call_output", "tool_search_output"}
         ),
         None,
     )
@@ -1897,7 +1898,7 @@ def _is_websocket_previous_response_output_item(item: JsonValue) -> bool:
     if isinstance(item, dict) and _websocket_input_item_type(item) is None and item.get("role") == "assistant":
         return True
     item_type = _websocket_input_item_type(item)
-    if item_type in {"reasoning", "function_call", "custom_tool_call", "apply_patch_call"}:
+    if item_type in {"reasoning", "function_call", "custom_tool_call", "apply_patch_call", "tool_search_call"}:
         return True
     if item_type != "message" or not isinstance(item, dict):
         return False

--- a/app/modules/proxy/replay_safety.py
+++ b/app/modules/proxy/replay_safety.py
@@ -15,6 +15,7 @@ _TOOL_CALL_TYPE_BY_OUTPUT_TYPE = {
     "function_call_output": "function_call",
     "custom_tool_call_output": "custom_tool_call",
     "apply_patch_call_output": "apply_patch_call",
+    "tool_search_output": "tool_search_call",
 }
 _TOOL_CALL_TYPES = frozenset(_TOOL_CALL_TYPE_BY_OUTPUT_TYPE.values())
 _ACCOUNT_NEUTRAL_REPLAY_OMITTED_ITEM_TYPES = frozenset(
@@ -39,6 +40,7 @@ _ACCOUNT_NEUTRAL_INPUT_ITEM_TYPES = frozenset(
         "additional_tools",
         "apply_patch_call",
         "apply_patch_call_output",
+        "compaction",
         "custom_tool_call",
         "custom_tool_call_output",
         "function_call",
@@ -47,6 +49,8 @@ _ACCOUNT_NEUTRAL_INPUT_ITEM_TYPES = frozenset(
         "input_image",
         "input_text",
         "message",
+        "tool_search_call",
+        "tool_search_output",
     }
 )
 _ACCOUNT_NEUTRAL_MESSAGE_CONTENT_TYPES = frozenset(
@@ -65,6 +69,7 @@ _ACCOUNT_NEUTRAL_CONTENT_FIELDS = {
 }
 _ACCOUNT_NEUTRAL_INPUT_ITEM_FIELDS = {
     "additional_tools": frozenset({"role", "tools", "type"}),
+    "compaction": frozenset({"encrypted_content", "id", "status", "type"}),
     "apply_patch_call": frozenset(
         {
             "call_id",
@@ -92,6 +97,22 @@ _ACCOUNT_NEUTRAL_INPUT_ITEM_FIELDS = {
     ),
     "function_call_output": frozenset(
         {"call_id", "caller", "id", _INTERNAL_CHAT_MESSAGE_METADATA_FIELD, "output", "status", "type"}
+    ),
+    "tool_search_call": frozenset(
+        {"arguments", "call_id", "caller", "execution", "id", _INTERNAL_CHAT_MESSAGE_METADATA_FIELD, "status", "type"}
+    ),
+    "tool_search_output": frozenset(
+        {
+            "call_id",
+            "caller",
+            "execution",
+            "id",
+            _INTERNAL_CHAT_MESSAGE_METADATA_FIELD,
+            "output",
+            "status",
+            "tools",
+            "type",
+        }
     ),
 }
 _ACCOUNT_NEUTRAL_ITEM_STATUSES = frozenset({"completed", "failed"})
@@ -269,6 +290,10 @@ def responses_input_items_are_self_contained_fresh_replay(input_items: list[Json
         item_type = item_type_value if isinstance(item_type_value, str) else None
         if not _input_item_has_only_known_fields(item, item_type):
             return False
+        if item_type == "compaction":
+            if not _compaction_item_is_self_contained(item):
+                return False
+            continue
         call_id_value = item.get("call_id")
         call_id = call_id_value if isinstance(call_id_value, str) and call_id_value else None
         if item_type in _TOOL_CALL_TYPES:
@@ -628,6 +653,9 @@ def _tool_call_is_self_contained(item_type: str, item: Mapping[str, JsonValue]) 
         return _is_nonblank_string(item.get("name")) and isinstance(item.get("arguments"), str)
     if item_type == "custom_tool_call":
         return _is_nonblank_string(item.get("name")) and isinstance(item.get("input"), str)
+    if item_type == "tool_search_call":
+        arguments = item.get("arguments")
+        return isinstance(arguments, dict) and item.get("execution") in (None, "client")
     operation = item.get("operation")
     patch = item.get("patch")
     input_value = item.get("input")
@@ -638,6 +666,10 @@ def _tool_call_is_self_contained(item_type: str, item: Mapping[str, JsonValue]) 
     if "patch" in item:
         return _is_nonblank_string(patch)
     return _is_nonblank_string(input_value)
+
+
+def _compaction_item_is_self_contained(item: Mapping[str, JsonValue]) -> bool:
+    return item.get("status") in (None, "completed") and _is_nonblank_string(item.get("encrypted_content"))
 
 
 def _caller_is_self_contained(item: Mapping[str, JsonValue]) -> bool:
@@ -1017,6 +1049,8 @@ def _contains_account_scoped_input_state(value: JsonValue) -> bool:
                 return True
             if item_type == "additional_tools" and not _tools_are_account_neutral(current.get("tools")):
                 return True
+            if item_type == "compaction" and _compaction_item_is_self_contained(current):
+                continue
             if (
                 isinstance(item_type, str)
                 and (item_type.endswith("_call") or item_type.endswith("_call_output"))

--- a/openspec/changes/archive/2026-08-13-classify-tool-search-missing-tool-output/proposal.md
+++ b/openspec/changes/archive/2026-08-13-classify-tool-search-missing-tool-output/proposal.md
@@ -37,6 +37,10 @@ item type is real, only the classifier list is stale.
   there is nothing for the continuity recovery paths to do with it.
 - Add regression coverage for the classifier and for the HTTP-bridge masking
   surface.
+- Treat `tool_search_call` / `tool_search_output` like the other client-side
+  tool pairs when trimming already-stored previous-response replay prefixes, so
+  compaction-preserved tool-search pairs do not get resent in full on top of a
+  `previous_response_id` anchor.
 
 ## Non-goals
 

--- a/openspec/changes/archive/2026-08-13-classify-tool-search-missing-tool-output/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-08-13-classify-tool-search-missing-tool-output/specs/responses-api-compat/spec.md
@@ -18,3 +18,18 @@ The service MUST classify an upstream `invalid_request_error` with `param=input`
 #### Scenario: hosted web search wording stays unclassified
 - **WHEN** upstream emits `invalid_request_error` with `param=input` and a message starting `No tool output found for web search call`
 - **THEN** the service does not treat it as a missing-tool-output continuity error
+
+### Requirement: Previous-response replay trimming handles tool-search output pairs
+When a Responses HTTP bridge or WebSocket continuation carries `previous_response_id` and replays already-stored response output items before a fresh `tool_search_output`, the service MUST trim the replayed `tool_search_call` prefix and preserve the `tool_search_output` plus the fresh turn. The service MUST NOT forward both the replayed `tool_search_call` and its `tool_search_output` on top of the `previous_response_id` anchor.
+
+#### Scenario: HTTP bridge trims replayed tool-search call prefix
+- **GIVEN** an HTTP bridge session has a completed previous response
+- **WHEN** the next request carries `previous_response_id` and input `[tool_search_call, tool_search_output, user_message]`
+- **THEN** the upstream request keeps the same `previous_response_id`
+- **AND** its input is `[tool_search_output, user_message]`
+
+#### Scenario: WebSocket bridge trims replayed tool-search call prefix
+- **GIVEN** a WebSocket Responses session has a completed previous response
+- **WHEN** the next request carries `previous_response_id` and input `[tool_search_call, tool_search_output, user_message]`
+- **THEN** the upstream request keeps the same `previous_response_id`
+- **AND** its input is `[tool_search_output, user_message]`

--- a/openspec/changes/archive/2026-08-13-classify-tool-search-missing-tool-output/tasks.md
+++ b/openspec/changes/archive/2026-08-13-classify-tool-search-missing-tool-output/tasks.md
@@ -3,4 +3,5 @@
 - [x] Extend the missing-tool-output message classifier with the tool-search wording.
 - [x] Keep the hosted `web search call` wording unclassified.
 - [x] Add classifier and HTTP-bridge masking regression coverage.
+- [x] Trim replayed tool-search call prefixes on previous-response HTTP bridge and WebSocket continuations.
 - [x] Run focused unit tests, lint/format, type check, architecture check, diff check, and strict OpenSpec validation.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -5662,6 +5662,121 @@ async def test_v1_responses_http_bridge_trims_replayed_apply_patch_previous_resp
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_http_bridge_trims_replayed_tool_search_previous_response_prefix(
+    async_client,
+    monkeypatch,
+):
+    _install_bridge_settings(monkeypatch, enabled=True)
+    account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_tool_search_trim",
+        "http-bridge-tool-search-trim@example.com",
+    )
+    account = await _get_account(account_id)
+    fake_upstream = _FakeBridgeUpstreamWebSocket()
+
+    async def fake_select_account_with_budget(
+        self,
+        deadline,
+        *,
+        request_id,
+        kind,
+        request_stage="first_turn",
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset_accounts,
+        routing_strategy,
+        model,
+        exclude_account_ids=None,
+        additional_limit_name=None,
+        api_key=None,
+        preferred_account_id=None,
+    ):
+        del preferred_account_id
+        del (
+            self,
+            deadline,
+            request_id,
+            kind,
+            request_stage,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset_accounts,
+            routing_strategy,
+            model,
+            exclude_account_ids,
+            additional_limit_name,
+        )
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        return fake_upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    first = await async_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "Search the tools.",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "find context"}]}],
+            "prompt_cache_key": "http-bridge-tool-search-trim-1",
+        },
+    )
+    assert first.status_code == 200
+    first_body = first.json()
+    assert first_body["id"] == "resp_bridge_1"
+
+    replayed_tool_search_call = {
+        "id": "tsc_replay",
+        "type": "tool_search_call",
+        "status": "completed",
+        "call_id": "call_search_1",
+    }
+    replayed_tool_search_output = {
+        "type": "tool_search_output",
+        "call_id": "call_search_1",
+        "output": [{"title": "context result"}],
+    }
+    next_user_message = {"role": "user", "content": [{"type": "input_text", "text": "continue"}]}
+    second = await async_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "Search the tools.",
+            "previous_response_id": first_body["id"],
+            "input": [replayed_tool_search_call, replayed_tool_search_output, next_user_message],
+            "prompt_cache_key": "http-bridge-tool-search-trim-1",
+        },
+    )
+    assert second.status_code == 200
+    assert second.json()["id"] == "resp_bridge_2"
+
+    assert len(fake_upstream.sent_text) == 2
+    second_upstream_payload = json.loads(fake_upstream.sent_text[1])
+    assert second_upstream_payload["previous_response_id"] == "resp_bridge_1"
+    assert second_upstream_payload["input"] == [replayed_tool_search_output, next_user_message]
+
+
+@pytest.mark.asyncio
 async def test_backend_responses_http_bridge_lite_request_omits_synthesized_tools(
     async_client,
     monkeypatch,

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -13007,6 +13007,86 @@ async def test_retry_http_bridge_precreated_request_ignores_existing_response_id
 
 
 @pytest.mark.asyncio
+async def test_retry_account_neutral_precreated_request_switches_from_silent_account(app_instance, monkeypatch):
+    from app.modules.proxy.continuity import make_http_bridge_account_neutral_replay_key
+
+    service = get_proxy_service_for_app(app_instance)
+    recovery_kind, recovery_key = make_http_bridge_account_neutral_replay_key("retry-silent-account")
+    first_account = cast(Account, SimpleNamespace(id="acct-silent", status=AccountStatus.ACTIVE, plan_type="plus"))
+    replacement_account = cast(
+        Account,
+        SimpleNamespace(id="acct-replacement", status=AccountStatus.ACTIVE, plan_type="plus"),
+    )
+    replacement_upstream = _RecordingUpstreamWebSocket()
+    session = proxy_module._HTTPBridgeSession(
+        key=proxy_module._HTTPBridgeSessionKey(recovery_kind, recovery_key, None),
+        headers={"x-codex-turn-state": "stale-turn-state"},
+        affinity=proxy_module._AffinityPolicy(),
+        request_model="gpt-5.5",
+        account=first_account,
+        upstream=cast(proxy_module.UpstreamWebSocket, _SilentUpstreamWebSocket()),
+        upstream_control=proxy_module._WebSocketUpstreamControl(),
+        pending_lock=anyio.Lock(),
+        pending_requests=deque(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+    )
+    request_state = proxy_module._WebSocketRequestState(
+        request_id="req-account-neutral-precreated-retry",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        transport="http",
+        response_create_gate_acquired=True,
+        request_text=json.dumps({"type": "response.create", "model": "gpt-5.5", "input": []}),
+    )
+    session.pending_requests.append(request_state)
+    reconnect_calls: list[dict[str, object]] = []
+
+    async def fake_reconnect(
+        self,
+        target_session,
+        *,
+        request_state,
+        restart_reader=False,
+        require_same_account=False,
+        require_preferred_account=False,
+    ):
+        del self, restart_reader
+        reconnect_calls.append(
+            {
+                "require_same_account": require_same_account,
+                "require_preferred_account": require_preferred_account,
+                "preferred_account_id": target_session.account.id,
+                "excluded_account_ids": set(request_state.excluded_account_ids),
+            }
+        )
+        target_session.account = replacement_account
+        target_session.upstream = replacement_upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_reconnect_http_bridge_session", fake_reconnect)
+
+    assert await service._retry_http_bridge_precreated_request(session) is True
+
+    assert reconnect_calls == [
+        {
+            "require_same_account": False,
+            "require_preferred_account": False,
+            "preferred_account_id": "acct-silent",
+            "excluded_account_ids": {"acct-silent"},
+        }
+    ]
+    assert request_state.preferred_account_id is None
+    assert session.account.id == "acct-replacement"
+    assert replacement_upstream.sent_text == [request_state.request_text]
+
+
+@pytest.mark.asyncio
 async def test_v1_responses_http_bridge_send_failure_returns_upstream_unavailable(
     async_client,
     app_instance,

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -5662,121 +5662,6 @@ async def test_v1_responses_http_bridge_trims_replayed_apply_patch_previous_resp
 
 
 @pytest.mark.asyncio
-async def test_v1_responses_http_bridge_trims_replayed_tool_search_previous_response_prefix(
-    async_client,
-    monkeypatch,
-):
-    _install_bridge_settings(monkeypatch, enabled=True)
-    account_id = await _import_account(
-        async_client,
-        "acc_http_bridge_tool_search_trim",
-        "http-bridge-tool-search-trim@example.com",
-    )
-    account = await _get_account(account_id)
-    fake_upstream = _FakeBridgeUpstreamWebSocket()
-
-    async def fake_select_account_with_budget(
-        self,
-        deadline,
-        *,
-        request_id,
-        kind,
-        request_stage="first_turn",
-        sticky_key,
-        sticky_kind,
-        reallocate_sticky,
-        sticky_max_age_seconds,
-        prefer_earlier_reset_accounts,
-        routing_strategy,
-        model,
-        exclude_account_ids=None,
-        additional_limit_name=None,
-        api_key=None,
-        preferred_account_id=None,
-    ):
-        del preferred_account_id
-        del (
-            self,
-            deadline,
-            request_id,
-            kind,
-            request_stage,
-            sticky_key,
-            sticky_kind,
-            reallocate_sticky,
-            sticky_max_age_seconds,
-            prefer_earlier_reset_accounts,
-            routing_strategy,
-            model,
-            exclude_account_ids,
-            additional_limit_name,
-        )
-        return AccountSelection(account=account, error_message=None, error_code=None)
-
-    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
-        del self, force, timeout_seconds
-        return target
-
-    async def fake_connect_responses_websocket(
-        headers,
-        access_token,
-        account_id_header,
-        *,
-        base_url=None,
-        session=None,
-    ):
-        del headers, access_token, account_id_header, base_url, session
-        return fake_upstream
-
-    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
-    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
-    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
-
-    first = await async_client.post(
-        "/v1/responses",
-        json={
-            "model": "gpt-5.1",
-            "instructions": "Search the tools.",
-            "input": [{"role": "user", "content": [{"type": "input_text", "text": "find context"}]}],
-            "prompt_cache_key": "http-bridge-tool-search-trim-1",
-        },
-    )
-    assert first.status_code == 200
-    first_body = first.json()
-    assert first_body["id"] == "resp_bridge_1"
-
-    replayed_tool_search_call = {
-        "id": "tsc_replay",
-        "type": "tool_search_call",
-        "status": "completed",
-        "call_id": "call_search_1",
-    }
-    replayed_tool_search_output = {
-        "type": "tool_search_output",
-        "call_id": "call_search_1",
-        "output": [{"title": "context result"}],
-    }
-    next_user_message = {"role": "user", "content": [{"type": "input_text", "text": "continue"}]}
-    second = await async_client.post(
-        "/v1/responses",
-        json={
-            "model": "gpt-5.1",
-            "instructions": "Search the tools.",
-            "previous_response_id": first_body["id"],
-            "input": [replayed_tool_search_call, replayed_tool_search_output, next_user_message],
-            "prompt_cache_key": "http-bridge-tool-search-trim-1",
-        },
-    )
-    assert second.status_code == 200
-    assert second.json()["id"] == "resp_bridge_2"
-
-    assert len(fake_upstream.sent_text) == 2
-    second_upstream_payload = json.loads(fake_upstream.sent_text[1])
-    assert second_upstream_payload["previous_response_id"] == "resp_bridge_1"
-    assert second_upstream_payload["input"] == [replayed_tool_search_output, next_user_message]
-
-
-@pytest.mark.asyncio
 async def test_backend_responses_http_bridge_lite_request_omits_synthesized_tools(
     async_client,
     monkeypatch,
@@ -6986,6 +6871,201 @@ async def test_v1_responses_http_bridge_refresh_failure_returns_proxy_error(asyn
     assert response.status_code == 401
     assert response.json()["error"]["code"] == "invalid_api_key"
     assert "x-codex-turn-state" not in response.headers
+
+
+@pytest.mark.asyncio
+async def test_v1_responses_http_bridge_trims_replayed_tool_search_previous_response_prefix(
+    async_client,
+    monkeypatch,
+):
+    _install_bridge_settings(monkeypatch, enabled=True)
+    account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_tool_search_trim",
+        "http-bridge-tool-search-trim@example.com",
+    )
+    account = await _get_account(account_id)
+    fake_upstream = _FakeBridgeUpstreamWebSocket()
+
+    async def fake_select_account_with_budget(
+        self,
+        deadline,
+        *,
+        request_id,
+        kind,
+        request_stage="first_turn",
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset_accounts,
+        routing_strategy,
+        model,
+        exclude_account_ids=None,
+        additional_limit_name=None,
+        api_key=None,
+        preferred_account_id=None,
+    ):
+        del preferred_account_id
+        del (
+            self,
+            deadline,
+            request_id,
+            kind,
+            request_stage,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset_accounts,
+            routing_strategy,
+            model,
+            exclude_account_ids,
+            additional_limit_name,
+        )
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        return fake_upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    first = await async_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "Search the tools.",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "find context"}]}],
+            "prompt_cache_key": "http-bridge-tool-search-trim-1",
+        },
+    )
+    assert first.status_code == 200
+    first_body = first.json()
+    assert first_body["id"] == "resp_bridge_1"
+
+    replayed_tool_search_call = {
+        "id": "tsc_replay",
+        "type": "tool_search_call",
+        "status": "completed",
+        "call_id": "call_search_1",
+    }
+    replayed_tool_search_output = {
+        "type": "tool_search_output",
+        "call_id": "call_search_1",
+        "output": [{"title": "context result"}],
+    }
+    next_user_message = {"role": "user", "content": [{"type": "input_text", "text": "continue"}]}
+    second = await async_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "Search the tools.",
+            "previous_response_id": first_body["id"],
+            "input": [replayed_tool_search_call, replayed_tool_search_output, next_user_message],
+            "prompt_cache_key": "http-bridge-tool-search-trim-1",
+        },
+    )
+    assert second.status_code == 200
+    assert second.json()["id"] == "resp_bridge_2"
+
+    assert len(fake_upstream.sent_text) == 2
+    second_upstream_payload = json.loads(fake_upstream.sent_text[1])
+    assert second_upstream_payload["previous_response_id"] == "resp_bridge_1"
+    assert second_upstream_payload["input"] == [replayed_tool_search_output, next_user_message]
+
+
+@pytest.mark.asyncio
+async def test_retry_account_neutral_precreated_request_switches_from_silent_account(app_instance, monkeypatch):
+    from app.modules.proxy.continuity import make_http_bridge_account_neutral_replay_key
+
+    service = get_proxy_service_for_app(app_instance)
+    recovery_kind, recovery_key = make_http_bridge_account_neutral_replay_key("retry-silent-account")
+    first_account = cast(Account, SimpleNamespace(id="acct-silent", status=AccountStatus.ACTIVE, plan_type="plus"))
+    replacement_account = cast(
+        Account,
+        SimpleNamespace(id="acct-replacement", status=AccountStatus.ACTIVE, plan_type="plus"),
+    )
+    replacement_upstream = _RecordingUpstreamWebSocket()
+    session = proxy_module._HTTPBridgeSession(
+        key=proxy_module._HTTPBridgeSessionKey(recovery_kind, recovery_key, None),
+        headers={"x-codex-turn-state": "stale-turn-state"},
+        affinity=proxy_module._AffinityPolicy(),
+        request_model="gpt-5.5",
+        account=first_account,
+        upstream=cast(proxy_module.UpstreamWebSocket, _SilentUpstreamWebSocket()),
+        upstream_control=proxy_module._WebSocketUpstreamControl(),
+        pending_lock=anyio.Lock(),
+        pending_requests=deque(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+    )
+    request_state = proxy_module._WebSocketRequestState(
+        request_id="req-account-neutral-precreated-retry",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        transport="http",
+        response_create_gate_acquired=True,
+        request_text=json.dumps({"type": "response.create", "model": "gpt-5.5", "input": []}),
+    )
+    session.pending_requests.append(request_state)
+    reconnect_calls: list[dict[str, object]] = []
+
+    async def fake_reconnect(
+        self,
+        target_session,
+        *,
+        request_state,
+        restart_reader=False,
+        require_same_account=False,
+        require_preferred_account=False,
+    ):
+        del self, restart_reader
+        reconnect_calls.append(
+            {
+                "require_same_account": require_same_account,
+                "require_preferred_account": require_preferred_account,
+                "preferred_account_id": target_session.account.id,
+                "excluded_account_ids": set(request_state.excluded_account_ids),
+            }
+        )
+        target_session.account = replacement_account
+        target_session.upstream = replacement_upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_reconnect_http_bridge_session", fake_reconnect)
+
+    assert await service._retry_http_bridge_precreated_request(session) is True
+
+    assert reconnect_calls == [
+        {
+            "require_same_account": False,
+            "require_preferred_account": False,
+            "preferred_account_id": "acct-silent",
+            "excluded_account_ids": {"acct-silent"},
+        }
+    ]
+    assert request_state.preferred_account_id is None
+    assert session.account.id == "acct-replacement"
+    assert replacement_upstream.sent_text == [request_state.request_text]
 
 
 @pytest.mark.asyncio
@@ -13004,86 +13084,6 @@ async def test_retry_http_bridge_precreated_request_ignores_existing_response_id
 
     assert await service._retry_http_bridge_precreated_request(session) is True
     assert replacement_upstream.sent_text == [retry_request.request_text]
-
-
-@pytest.mark.asyncio
-async def test_retry_account_neutral_precreated_request_switches_from_silent_account(app_instance, monkeypatch):
-    from app.modules.proxy.continuity import make_http_bridge_account_neutral_replay_key
-
-    service = get_proxy_service_for_app(app_instance)
-    recovery_kind, recovery_key = make_http_bridge_account_neutral_replay_key("retry-silent-account")
-    first_account = cast(Account, SimpleNamespace(id="acct-silent", status=AccountStatus.ACTIVE, plan_type="plus"))
-    replacement_account = cast(
-        Account,
-        SimpleNamespace(id="acct-replacement", status=AccountStatus.ACTIVE, plan_type="plus"),
-    )
-    replacement_upstream = _RecordingUpstreamWebSocket()
-    session = proxy_module._HTTPBridgeSession(
-        key=proxy_module._HTTPBridgeSessionKey(recovery_kind, recovery_key, None),
-        headers={"x-codex-turn-state": "stale-turn-state"},
-        affinity=proxy_module._AffinityPolicy(),
-        request_model="gpt-5.5",
-        account=first_account,
-        upstream=cast(proxy_module.UpstreamWebSocket, _SilentUpstreamWebSocket()),
-        upstream_control=proxy_module._WebSocketUpstreamControl(),
-        pending_lock=anyio.Lock(),
-        pending_requests=deque(),
-        response_create_gate=asyncio.Semaphore(1),
-        queued_request_count=1,
-        last_used_at=time.monotonic(),
-        idle_ttl_seconds=120.0,
-    )
-    request_state = proxy_module._WebSocketRequestState(
-        request_id="req-account-neutral-precreated-retry",
-        model="gpt-5.5",
-        service_tier=None,
-        reasoning_effort=None,
-        api_key_reservation=None,
-        started_at=time.monotonic(),
-        awaiting_response_created=True,
-        transport="http",
-        response_create_gate_acquired=True,
-        request_text=json.dumps({"type": "response.create", "model": "gpt-5.5", "input": []}),
-    )
-    session.pending_requests.append(request_state)
-    reconnect_calls: list[dict[str, object]] = []
-
-    async def fake_reconnect(
-        self,
-        target_session,
-        *,
-        request_state,
-        restart_reader=False,
-        require_same_account=False,
-        require_preferred_account=False,
-    ):
-        del self, restart_reader
-        reconnect_calls.append(
-            {
-                "require_same_account": require_same_account,
-                "require_preferred_account": require_preferred_account,
-                "preferred_account_id": target_session.account.id,
-                "excluded_account_ids": set(request_state.excluded_account_ids),
-            }
-        )
-        target_session.account = replacement_account
-        target_session.upstream = replacement_upstream
-
-    monkeypatch.setattr(proxy_module.ProxyService, "_reconnect_http_bridge_session", fake_reconnect)
-
-    assert await service._retry_http_bridge_precreated_request(session) is True
-
-    assert reconnect_calls == [
-        {
-            "require_same_account": False,
-            "require_preferred_account": False,
-            "preferred_account_id": "acct-silent",
-            "excluded_account_ids": {"acct-silent"},
-        }
-    ]
-    assert request_state.preferred_account_id is None
-    assert session.account.id == "acct-replacement"
-    assert replacement_upstream.sent_text == [request_state.request_text]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -398,68 +398,6 @@ async def test_proxy_compact_preserves_historical_code_mode_side_effect_pair_bef
 
 
 @pytest.mark.asyncio
-async def test_proxy_compact_preserves_tool_search_pair_before_ordinary_tail(async_client, monkeypatch):
-    email = "compact-tool-search@example.com"
-    raw_account_id = "acc_compact_tool_search"
-    files = {"auth_json": ("auth.json", json.dumps(_make_auth_json(raw_account_id, email)), "application/json")}
-    response = await async_client.post("/api/accounts/import", files=files)
-    assert response.status_code == 200
-
-    seen_payloads: list[dict[str, object]] = []
-
-    async def fake_compact(payload, headers, access_token, account_id):
-        del headers, access_token, account_id
-        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
-        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
-
-    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
-    tool_call = {
-        "type": "tool_search_call",
-        "call_id": "call-search-tail",
-        "status": "completed",
-        "execution": "client",
-        "arguments": {"query": "codex-lb compaction tool search"},
-    }
-    tool_output = {
-        "type": "tool_search_output",
-        "call_id": "call-search-tail",
-        "output": [{"title": "codex-lb compaction result"}],
-    }
-    ordinary_tail = {"role": "assistant", "content": "ordinary tail " + "x" * 500_000}
-    latest_request = {"role": "user", "content": "latest request"}
-    payload = {
-        "model": "gpt-5.6-sol",
-        "instructions": "hi",
-        "input": [
-            {"role": "user", "content": "initial request"},
-            {"role": "assistant", "content": "older answer " + "y" * 500_000},
-            tool_call,
-            ordinary_tail,
-            tool_output,
-            latest_request,
-        ],
-    }
-
-    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
-
-    assert response.status_code == 200
-    assert len(seen_payloads) == 1
-    upstream_input = seen_payloads[0]["input"]
-    assert isinstance(upstream_input, list)
-    assert tool_call in upstream_input
-    assert tool_output in upstream_input
-    assert latest_request in upstream_input
-    assert all(
-        not (
-            isinstance(item, dict)
-            and item.get("role") == "assistant"
-            and item.get("content") == [{"type": "output_text", "text": ordinary_tail["content"]}]
-        )
-        for item in upstream_input
-    )
-
-
-@pytest.mark.asyncio
 async def test_proxy_compact_omits_oversized_optional_tool_tail_before_upstream(async_client, monkeypatch):
     email = "compact-optional-tail@example.com"
     raw_account_id = "acc_compact_optional_tail"
@@ -888,6 +826,68 @@ async def test_proxy_compact_masks_previous_response_not_found(async_client, mon
     assert body["error"]["code"] == "stream_incomplete"
     assert body["error"]["message"] == "Upstream websocket closed before response.completed"
     assert "resp_compact_missing" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_preserves_tool_search_pair_before_ordinary_tail(async_client, monkeypatch):
+    email = "compact-tool-search@example.com"
+    raw_account_id = "acc_compact_tool_search"
+    files = {"auth_json": ("auth.json", json.dumps(_make_auth_json(raw_account_id, email)), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payloads: list[dict[str, object]] = []
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del headers, access_token, account_id
+        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+    tool_call = {
+        "type": "tool_search_call",
+        "call_id": "call-search-tail",
+        "status": "completed",
+        "execution": "client",
+        "arguments": {"query": "codex-lb compaction tool search"},
+    }
+    tool_output = {
+        "type": "tool_search_output",
+        "call_id": "call-search-tail",
+        "output": [{"title": "codex-lb compaction result"}],
+    }
+    ordinary_tail = {"role": "assistant", "content": "ordinary tail " + "x" * 500_000}
+    latest_request = {"role": "user", "content": "latest request"}
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "hi",
+        "input": [
+            {"role": "user", "content": "initial request"},
+            {"role": "assistant", "content": "older answer " + "y" * 500_000},
+            tool_call,
+            ordinary_tail,
+            tool_output,
+            latest_request,
+        ],
+    }
+
+    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
+
+    assert response.status_code == 200
+    assert len(seen_payloads) == 1
+    upstream_input = seen_payloads[0]["input"]
+    assert isinstance(upstream_input, list)
+    assert tool_call in upstream_input
+    assert tool_output in upstream_input
+    assert latest_request in upstream_input
+    assert all(
+        not (
+            isinstance(item, dict)
+            and item.get("role") == "assistant"
+            and item.get("content") == [{"type": "output_text", "text": ordinary_tail["content"]}]
+        )
+        for item in upstream_input
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -398,6 +398,68 @@ async def test_proxy_compact_preserves_historical_code_mode_side_effect_pair_bef
 
 
 @pytest.mark.asyncio
+async def test_proxy_compact_preserves_tool_search_pair_before_ordinary_tail(async_client, monkeypatch):
+    email = "compact-tool-search@example.com"
+    raw_account_id = "acc_compact_tool_search"
+    files = {"auth_json": ("auth.json", json.dumps(_make_auth_json(raw_account_id, email)), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payloads: list[dict[str, object]] = []
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del headers, access_token, account_id
+        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+    tool_call = {
+        "type": "tool_search_call",
+        "call_id": "call-search-tail",
+        "status": "completed",
+        "execution": "client",
+        "arguments": {"query": "codex-lb compaction tool search"},
+    }
+    tool_output = {
+        "type": "tool_search_output",
+        "call_id": "call-search-tail",
+        "output": [{"title": "codex-lb compaction result"}],
+    }
+    ordinary_tail = {"role": "assistant", "content": "ordinary tail " + "x" * 500_000}
+    latest_request = {"role": "user", "content": "latest request"}
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "hi",
+        "input": [
+            {"role": "user", "content": "initial request"},
+            {"role": "assistant", "content": "older answer " + "y" * 500_000},
+            tool_call,
+            ordinary_tail,
+            tool_output,
+            latest_request,
+        ],
+    }
+
+    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
+
+    assert response.status_code == 200
+    assert len(seen_payloads) == 1
+    upstream_input = seen_payloads[0]["input"]
+    assert isinstance(upstream_input, list)
+    assert tool_call in upstream_input
+    assert tool_output in upstream_input
+    assert latest_request in upstream_input
+    assert all(
+        not (
+            isinstance(item, dict)
+            and item.get("role") == "assistant"
+            and item.get("content") == [{"type": "output_text", "text": ordinary_tail["content"]}]
+        )
+        for item in upstream_input
+    )
+
+
+@pytest.mark.asyncio
 async def test_proxy_compact_omits_oversized_optional_tool_tail_before_upstream(async_client, monkeypatch):
     email = "compact-optional-tail@example.com"
     raw_account_id = "acc_compact_optional_tail"

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -1074,6 +1074,42 @@ def test_compact_strips_tool_fields():
     assert "text" not in dumped
 
 
+def test_compact_trimming_keeps_tool_search_outputs_with_matching_calls():
+    tool_call = {
+        "type": "tool_search_call",
+        "call_id": "call_search_tail",
+        "status": "completed",
+        "execution": "client",
+        "arguments": {"query": "spawn_agent multi-agent schema", "limit": 8},
+    }
+    tool_output = {
+        "type": "tool_search_output",
+        "call_id": "call_search_tail",
+        "output": "Found matching tools",
+    }
+    input_items = [
+        {"role": "user", "content": "initial instructions"},
+        {"role": "assistant", "content": "x" * 500_000},
+        tool_call,
+        {"role": "assistant", "content": "y" * 500_000},
+        tool_output,
+        {"role": "user", "content": "latest request"},
+    ]
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": input_items,
+    }
+
+    request = ResponsesCompactRequest.model_validate(payload)
+    dumped = request.to_payload()
+    dumped_input = dumped["input"]
+
+    assert isinstance(dumped_input, list)
+    assert tool_call in dumped_input
+    assert tool_output in dumped_input
+
+
 def test_responses_strips_poisoned_local_compact_fallback_items():
     poisoned_message = {
         "type": "message",
@@ -2636,42 +2672,6 @@ def test_compact_trimming_keeps_selected_tool_calls_with_matching_outputs():
         {"role": "assistant", "content": "x" * 500_000},
         tool_output,
         {"role": "assistant", "content": "y" * 500_000},
-        {"role": "user", "content": "latest request"},
-    ]
-    payload = {
-        "model": "gpt-5.1",
-        "instructions": "hi",
-        "input": input_items,
-    }
-
-    request = ResponsesCompactRequest.model_validate(payload)
-    dumped = request.to_payload()
-    dumped_input = dumped["input"]
-
-    assert isinstance(dumped_input, list)
-    assert tool_call in dumped_input
-    assert tool_output in dumped_input
-
-
-def test_compact_trimming_keeps_tool_search_outputs_with_matching_calls():
-    tool_call = {
-        "type": "tool_search_call",
-        "call_id": "call_search_tail",
-        "status": "completed",
-        "execution": "client",
-        "arguments": {"query": "spawn_agent multi-agent schema", "limit": 8},
-    }
-    tool_output = {
-        "type": "tool_search_output",
-        "call_id": "call_search_tail",
-        "output": "Found matching tools",
-    }
-    input_items = [
-        {"role": "user", "content": "initial instructions"},
-        {"role": "assistant", "content": "x" * 500_000},
-        tool_call,
-        {"role": "assistant", "content": "y" * 500_000},
-        tool_output,
         {"role": "user", "content": "latest request"},
     ]
     payload = {

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -2653,6 +2653,42 @@ def test_compact_trimming_keeps_selected_tool_calls_with_matching_outputs():
     assert tool_output in dumped_input
 
 
+def test_compact_trimming_keeps_tool_search_outputs_with_matching_calls():
+    tool_call = {
+        "type": "tool_search_call",
+        "call_id": "call_search_tail",
+        "status": "completed",
+        "execution": "client",
+        "arguments": {"query": "spawn_agent multi-agent schema", "limit": 8},
+    }
+    tool_output = {
+        "type": "tool_search_output",
+        "call_id": "call_search_tail",
+        "output": "Found matching tools",
+    }
+    input_items = [
+        {"role": "user", "content": "initial instructions"},
+        {"role": "assistant", "content": "x" * 500_000},
+        tool_call,
+        {"role": "assistant", "content": "y" * 500_000},
+        tool_output,
+        {"role": "user", "content": "latest request"},
+    ]
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": input_items,
+    }
+
+    request = ResponsesCompactRequest.model_validate(payload)
+    dumped = request.to_payload()
+    dumped_input = dumped["input"]
+
+    assert isinstance(dumped_input, list)
+    assert tool_call in dumped_input
+    assert tool_output in dumped_input
+
+
 def test_compact_trimming_reconciles_duplicate_tool_call_ids_by_occurrence():
     first_tool_call = {
         "type": "function_call",

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -19415,6 +19415,76 @@ async def test_select_websocket_connect_account_stream_cap_is_local_overload(mon
     assert sent_payload["error"]["type"] == "rate_limit_error"
 
 
+def test_websocket_client_previous_response_full_resend_retry_allows_tool_search_history() -> None:
+    self_contained_tool_search_history: list[JsonValue] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "search tools"}]},
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "mcp tools"},
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "output": [{"title": "tool_search"}],
+            "status": "completed",
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert (
+        proxy_service._websocket_client_previous_response_full_resend_is_retry_safe(
+            previous_response_id="resp_client_anchor",
+            input_value=self_contained_tool_search_history,
+            continuity_state=None,
+        )
+        is True
+    )
+
+
+def test_trim_http_bridge_previous_response_input_items_handles_tool_search_replay():
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "id": "tsc_replay",
+            "call_id": "call_search_1",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search_1",
+            "output": [{"title": "result"}],
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    trimmed = proxy_service._trim_http_bridge_previous_response_input_items(input_items)
+
+    assert trimmed == input_items[1:]
+
+
+def test_trim_websocket_previous_response_input_items_handles_tool_search_replay():
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "id": "tsc_replay",
+            "call_id": "call_search_1",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search_1",
+            "output": [{"title": "result"}],
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    trimmed = proxy_service._trim_websocket_previous_response_input_items(input_items)
+
+    assert trimmed == input_items[1:]
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("error_code", "error_message"),
@@ -21149,34 +21219,6 @@ def test_websocket_client_previous_response_full_resend_retry_allows_self_contai
         proxy_service._websocket_client_previous_response_full_resend_is_retry_safe(
             previous_response_id="resp_client_anchor",
             input_value=self_contained_tool_history,
-            continuity_state=None,
-        )
-        is True
-    )
-
-
-def test_websocket_client_previous_response_full_resend_retry_allows_tool_search_history() -> None:
-    self_contained_tool_search_history: list[JsonValue] = [
-        {"role": "user", "content": [{"type": "input_text", "text": "search tools"}]},
-        {
-            "type": "tool_search_call",
-            "call_id": "call_search",
-            "arguments": {"query": "mcp tools"},
-            "status": "completed",
-        },
-        {
-            "type": "tool_search_output",
-            "call_id": "call_search",
-            "output": [{"title": "tool_search"}],
-            "status": "completed",
-        },
-        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
-    ]
-
-    assert (
-        proxy_service._websocket_client_previous_response_full_resend_is_retry_safe(
-            previous_response_id="resp_client_anchor",
-            input_value=self_contained_tool_search_history,
             continuity_state=None,
         )
         is True
@@ -40327,48 +40369,6 @@ def test_trim_websocket_previous_response_input_items_handles_apply_patch_replay
     trimmed = proxy_service._trim_websocket_previous_response_input_items(input_items)
 
     assert trimmed == input_items[2:]
-
-
-def test_trim_http_bridge_previous_response_input_items_handles_tool_search_replay():
-    input_items: list[JsonValue] = [
-        {
-            "type": "tool_search_call",
-            "id": "tsc_replay",
-            "call_id": "call_search_1",
-            "status": "completed",
-        },
-        {
-            "type": "tool_search_output",
-            "call_id": "call_search_1",
-            "output": [{"title": "result"}],
-        },
-        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
-    ]
-
-    trimmed = proxy_service._trim_http_bridge_previous_response_input_items(input_items)
-
-    assert trimmed == input_items[1:]
-
-
-def test_trim_websocket_previous_response_input_items_handles_tool_search_replay():
-    input_items: list[JsonValue] = [
-        {
-            "type": "tool_search_call",
-            "id": "tsc_replay",
-            "call_id": "call_search_1",
-            "status": "completed",
-        },
-        {
-            "type": "tool_search_output",
-            "call_id": "call_search_1",
-            "output": [{"title": "result"}],
-        },
-        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
-    ]
-
-    trimmed = proxy_service._trim_websocket_previous_response_input_items(input_items)
-
-    assert trimmed == input_items[1:]
 
 
 def test_prepare_response_bridge_request_state_keeps_unconfirmed_missing_tool_output_history():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -21155,6 +21155,34 @@ def test_websocket_client_previous_response_full_resend_retry_allows_self_contai
     )
 
 
+def test_websocket_client_previous_response_full_resend_retry_allows_tool_search_history() -> None:
+    self_contained_tool_search_history: list[JsonValue] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "search tools"}]},
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "mcp tools"},
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "output": [{"title": "tool_search"}],
+            "status": "completed",
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert (
+        proxy_service._websocket_client_previous_response_full_resend_is_retry_safe(
+            previous_response_id="resp_client_anchor",
+            input_value=self_contained_tool_search_history,
+            continuity_state=None,
+        )
+        is True
+    )
+
+
 @pytest.mark.asyncio
 async def test_prepare_websocket_response_create_request_fills_interrupted_pending_tool_outputs(monkeypatch):
     request_logs = _RequestLogsRecorder()
@@ -40299,6 +40327,48 @@ def test_trim_websocket_previous_response_input_items_handles_apply_patch_replay
     trimmed = proxy_service._trim_websocket_previous_response_input_items(input_items)
 
     assert trimmed == input_items[2:]
+
+
+def test_trim_http_bridge_previous_response_input_items_handles_tool_search_replay():
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "id": "tsc_replay",
+            "call_id": "call_search_1",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search_1",
+            "output": [{"title": "result"}],
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    trimmed = proxy_service._trim_http_bridge_previous_response_input_items(input_items)
+
+    assert trimmed == input_items[1:]
+
+
+def test_trim_websocket_previous_response_input_items_handles_tool_search_replay():
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "id": "tsc_replay",
+            "call_id": "call_search_1",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search_1",
+            "output": [{"title": "result"}],
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    trimmed = proxy_service._trim_websocket_previous_response_input_items(input_items)
+
+    assert trimmed == input_items[1:]
 
 
 def test_prepare_response_bridge_request_state_keeps_unconfirmed_missing_tool_output_history():

--- a/tests/unit/test_replay_safety.py
+++ b/tests/unit/test_replay_safety.py
@@ -152,51 +152,6 @@ def test_account_neutral_fresh_replay_accepts_self_contained_payloads(
     assert responses_payload_is_account_neutral_fresh_replay(payload) is True
 
 
-def test_account_neutral_fresh_replay_accepts_compaction_context_item() -> None:
-    payload: dict[str, JsonValue] = {
-        "input": [
-            {
-                "type": "compaction",
-                "status": "completed",
-                "encrypted_content": "encrypted-compact-context",
-            },
-            {
-                "type": "message",
-                "role": "user",
-                "content": [{"type": "input_text", "text": "continue"}],
-            },
-        ],
-    }
-
-    assert responses_payload_is_account_neutral_fresh_replay(payload) is True
-
-
-def test_account_neutral_replay_projection_preserves_compaction_without_response_id() -> None:
-    input_items: list[JsonValue] = [
-        {
-            "type": "compaction",
-            "id": "cmp_owner_a",
-            "status": "completed",
-            "encrypted_content": "encrypted-compact-context",
-        },
-        {
-            "type": "message",
-            "role": "user",
-            "content": [{"type": "input_text", "text": "continue"}],
-        },
-    ]
-
-    projection = project_responses_input_for_account_neutral_fresh_replay(input_items, stored_count=1)
-
-    assert projection is not None
-    assert projection.input_items[0] == {
-        "type": "compaction",
-        "status": "completed",
-        "encrypted_content": "encrypted-compact-context",
-    }
-    assert responses_payload_is_account_neutral_fresh_replay({"input": projection.input_items}) is True
-
-
 def test_account_neutral_replay_projection_removes_response_owned_bookkeeping() -> None:
     metadata = {"turn_id": "turn_owner_a"}
     input_items: list[JsonValue] = [
@@ -372,27 +327,6 @@ def test_account_neutral_replay_projection_preserves_noncompleted_search_state_t
     assert projection is not None
     assert any(isinstance(item, dict) and item.get("type") == search_item["type"] for item in projection.input_items)
     assert responses_payload_is_account_neutral_fresh_replay({"input": projection.input_items}) is False
-
-
-def test_account_neutral_fresh_replay_accepts_self_contained_tool_search_pair() -> None:
-    input_items: list[JsonValue] = [
-        {
-            "type": "tool_search_call",
-            "call_id": "call_search",
-            "arguments": {"query": "codex-lb"},
-            "status": "completed",
-        },
-        {
-            "type": "tool_search_output",
-            "call_id": "call_search",
-            "output": "Found codex-lb",
-            "status": "completed",
-        },
-        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
-    ]
-
-    assert responses_input_items_are_self_contained_fresh_replay(input_items) is True
-    assert responses_payload_is_account_neutral_fresh_replay({"input": input_items}) is True
 
 
 @pytest.mark.parametrize(
@@ -780,6 +714,46 @@ def test_full_resend_suffix_accepts_only_self_contained_tool_loops(
         )
         is expected
     )
+
+
+def test_account_neutral_fresh_replay_accepts_compaction_context_item() -> None:
+    payload: dict[str, JsonValue] = {
+        "input": [
+            {
+                "type": "compaction",
+                "status": "completed",
+                "encrypted_content": "encrypted-compact-context",
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "continue"}],
+            },
+        ],
+    }
+
+    assert responses_payload_is_account_neutral_fresh_replay(payload) is True
+
+
+def test_account_neutral_fresh_replay_accepts_self_contained_tool_search_pair() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb"},
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "output": "Found codex-lb",
+            "status": "completed",
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert responses_input_items_are_self_contained_fresh_replay(input_items) is True
+    assert responses_payload_is_account_neutral_fresh_replay({"input": input_items}) is True
 
 
 def test_full_resend_tool_loop_manifest_tolerates_fresh_developer_interleave_after_historical_one() -> None:

--- a/tests/unit/test_replay_safety.py
+++ b/tests/unit/test_replay_safety.py
@@ -10,6 +10,7 @@ from app.modules.proxy.continuity import (
 )
 from app.modules.proxy.replay_safety import (
     project_responses_input_for_account_neutral_fresh_replay,
+    responses_input_items_are_self_contained_fresh_replay,
     responses_input_suffix_matches_pending_tool_calls,
     responses_input_suffix_retains_prior_output,
     responses_payload_is_account_neutral_fresh_replay,
@@ -149,6 +150,51 @@ def test_account_neutral_fresh_replay_accepts_self_contained_payloads(
     payload: dict[str, JsonValue],
 ) -> None:
     assert responses_payload_is_account_neutral_fresh_replay(payload) is True
+
+
+def test_account_neutral_fresh_replay_accepts_compaction_context_item() -> None:
+    payload: dict[str, JsonValue] = {
+        "input": [
+            {
+                "type": "compaction",
+                "status": "completed",
+                "encrypted_content": "encrypted-compact-context",
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "continue"}],
+            },
+        ],
+    }
+
+    assert responses_payload_is_account_neutral_fresh_replay(payload) is True
+
+
+def test_account_neutral_replay_projection_preserves_compaction_without_response_id() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "compaction",
+            "id": "cmp_owner_a",
+            "status": "completed",
+            "encrypted_content": "encrypted-compact-context",
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "continue"}],
+        },
+    ]
+
+    projection = project_responses_input_for_account_neutral_fresh_replay(input_items, stored_count=1)
+
+    assert projection is not None
+    assert projection.input_items[0] == {
+        "type": "compaction",
+        "status": "completed",
+        "encrypted_content": "encrypted-compact-context",
+    }
+    assert responses_payload_is_account_neutral_fresh_replay({"input": projection.input_items}) is True
 
 
 def test_account_neutral_replay_projection_removes_response_owned_bookkeeping() -> None:
@@ -326,6 +372,27 @@ def test_account_neutral_replay_projection_preserves_noncompleted_search_state_t
     assert projection is not None
     assert any(isinstance(item, dict) and item.get("type") == search_item["type"] for item in projection.input_items)
     assert responses_payload_is_account_neutral_fresh_replay({"input": projection.input_items}) is False
+
+
+def test_account_neutral_fresh_replay_accepts_self_contained_tool_search_pair() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb"},
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "output": "Found codex-lb",
+            "status": "completed",
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert responses_input_items_are_self_contained_fresh_replay(input_items) is True
+    assert responses_payload_is_account_neutral_fresh_replay({"input": input_items}) is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Preserve Codex `tool_search_call` / `tool_search_output` pairs during compact input trimming so oversized sessions do not forward an orphan `tool_search_output` upstream. This fixes a live compact failure where OpenAI rejected session `019fcc77-8e08-7f02-b5d2-3388c5122004` with `No tool call found for tool search output with call_id call_d2chifMNZfXqfFWin5jz0dQf.`

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: none

## OpenSpec

- [x] Not applicable — bug fix that matches the existing spec
- [x] This PR touches a codex-faithful path (image pipeline, request/response shape, SSE framing, OAuth flow) and preserves upstream-equivalent behavior

Change directory: n/a

## Changes

- Adds `tool_search_call` and `tool_search_output` to the compact tool pair reconciliation sets.
- Adds a regression test using the live-shaped `tool_search_call` / `tool_search_output` history item pair.

## Test plan

```sh
.venv/bin/python -m pytest tests/unit/test_openai_requests.py -k 'tool_search_outputs or compact_trimming_keeps_selected_tool_outputs_with_matching_calls or compact_trimming_drops_selected_tool_outputs_without_matching_calls or compact_trimming_reconciles_duplicate_tool_call_ids_by_occurrence' -q\n# 4 passed, 146 deselected\n\n.venv/bin/python -m pytest tests/integration/test_proxy_compact.py -k 'compact_strips_tool_fields or side_effect_pair' -q\n# 2 passed, 25 deselected\n\ngit diff --check\n```\n\n## Screenshots / output\n\nLive replay from `/home/kom/.codex/sessions/2026/08/04/rollout-2026-08-04T15-10-15-019fcc77-8e08-7f02-b5d2-3388c5122004.jsonl` through `ResponsesCompactRequest.to_payload()` now keeps both `tool_search_call` and `tool_search_output` for `call_d2chifMNZfXqfFWin5jz0dQf`; `has_orphan_tool_search_output` is `False`.\n\n## Checklist\n\n- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).\n- [ ] Linked the related issue / discussion above.\n- [x] Added or updated tests covering the change.\n- [ ] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` or the relevant `make <target>` subset locally.\n- [ ] If touching specs: `openspec validate --specs` passes and `/opsx:verify` is clean.\n- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).\n- [x] CHANGELOG is **not** edited by hand (release-please handles it).\n