### PR TITLE
fix(proxy): bound upstream streams that never send response headers

### DIFF
--- a/app/core/clients/http.py
+++ b/app/core/clients/http.py
@@ -4,6 +4,7 @@ import asyncio
 import contextlib
 import logging
 import os
+import socket
 import ssl
 import time
 from collections.abc import AsyncIterator, Mapping
@@ -12,6 +13,7 @@ from types import TracebackType
 
 import aiohttp
 import certifi
+from aiohappyeyeballs.types import AddrInfoType
 from aiohttp_retry import RetryClient
 from aiohttp_socks import ProxyConnector
 
@@ -48,6 +50,16 @@ _retired_http_clients: list[_ManagedHttpClient] = []
 _closing_http_clients: list[_ManagedHttpClient] = []
 _last_generationless_network_rotation_at: float | None = None
 _GENERATIONLESS_NETWORK_ROTATION_COOLDOWN_SECONDS = 1.0
+
+# Pooled upstream connections outlive the request that opened them, so a socket
+# dropped by an intermediary (NAT rebind, tunnel reconnect, route change) is
+# otherwise only discovered when an application-level timeout fires. Probes turn
+# that silent black hole into a transport error the failover paths already
+# handle. Idle/interval/count are chosen to declare a dead peer in ~90s, which
+# matches the pooled keepalive window below.
+_TCP_KEEPALIVE_IDLE_SECONDS = 30
+_TCP_KEEPALIVE_INTERVAL_SECONDS = 10
+_TCP_KEEPALIVE_PROBE_COUNT = 6
 
 
 def _socks_proxy_config(environ: Mapping[str, str | None] = os.environ) -> _SocksProxyConfig | None:
@@ -95,6 +107,46 @@ def _build_ssl_context() -> ssl.SSLContext:
     return context
 
 
+def _apply_tcp_keepalive(sock: socket.socket) -> None:
+    """Enable OS keepalive probes on an upstream socket.
+
+    Probe tuning is best-effort by design: ``TCP_KEEPIDLE`` is Linux-only,
+    macOS spells the same knob ``TCP_KEEPALIVE``, and other platforms may
+    expose neither. Failing client construction over a missing socket option
+    would trade a rare hang for a certain outage, so unsupported knobs are
+    skipped and only the enable step is required.
+    """
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+    except OSError:
+        logger.debug("Upstream socket rejected SO_KEEPALIVE", exc_info=True)
+        return
+    for option_name, option_value in (
+        ("TCP_KEEPIDLE", _TCP_KEEPALIVE_IDLE_SECONDS),
+        ("TCP_KEEPALIVE", _TCP_KEEPALIVE_IDLE_SECONDS),
+        ("TCP_KEEPINTVL", _TCP_KEEPALIVE_INTERVAL_SECONDS),
+        ("TCP_KEEPCNT", _TCP_KEEPALIVE_PROBE_COUNT),
+    ):
+        option = getattr(socket, option_name, None)
+        if option is None:
+            continue
+        try:
+            sock.setsockopt(socket.IPPROTO_TCP, option, option_value)
+        except OSError:
+            logger.debug("Upstream socket rejected %s", option_name, exc_info=True)
+
+
+def _keepalive_socket_factory(addr_info: AddrInfoType) -> socket.socket:
+    family, socket_type, proto = addr_info[0], addr_info[1], addr_info[2]
+    sock = socket.socket(family=family, type=socket_type, proto=proto)
+    try:
+        _apply_tcp_keepalive(sock)
+    except BaseException:
+        sock.close()
+        raise
+    return sock
+
+
 class HttpClientLease:
     def __init__(self, managed_client: _ManagedHttpClient) -> None:
         self.client = managed_client.client
@@ -133,6 +185,7 @@ async def _build_http_client() -> HttpClient:
             limit_per_host=settings.http_connector_limit_per_host,
             ssl=ssl_context,
             rdns=socks_config.rdns,
+            socket_factory=_keepalive_socket_factory,
         )
     else:
         connector = aiohttp.TCPConnector(
@@ -146,6 +199,7 @@ async def _build_http_client() -> HttpClient:
             # around across turns instead.
             keepalive_timeout=90,
             ttl_dns_cache=300,
+            socket_factory=_keepalive_socket_factory,
         )
     session = aiohttp.ClientSession(
         connector=connector,
@@ -158,10 +212,16 @@ async def _build_http_client() -> HttpClient:
                 socks_config.connector_url,
                 ssl=ssl_context,
                 rdns=socks_config.rdns,
+                socket_factory=_keepalive_socket_factory,
             )
             ws_trust_env = False
         else:
-            ws_connector = aiohttp.TCPConnector(ssl=ssl_context, keepalive_timeout=90, ttl_dns_cache=300)
+            ws_connector = aiohttp.TCPConnector(
+                ssl=ssl_context,
+                keepalive_timeout=90,
+                ttl_dns_cache=300,
+                socket_factory=_keepalive_socket_factory,
+            )
             ws_trust_env = settings.upstream_websocket_trust_env
         try:
             websocket_session = aiohttp.ClientSession(

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -2780,14 +2780,32 @@ async def _stream_responses_with_session(
         pre_request_started_at,
         time.monotonic(),
     )
+    # sock_read carries the idle budget into the phase before response headers
+    # exist. Without it, a connection that is established but never answered is
+    # bounded only by the request budget, which is hours long, while it holds a
+    # per-session response-create gate that later turns queue behind.
     timeout = aiohttp.ClientTimeout(
         total=remaining_request_timeout,
         sock_connect=effective_connect_timeout,
-        sock_read=None,
+        sock_read=effective_idle_timeout,
     )
     started_at = time.monotonic()
 
     async def _stream_via_http(
+        current_headers: Mapping[str, str],
+        current_timeout: aiohttp.ClientTimeout,
+    ) -> AsyncIterator[str]:
+        try:
+            async for event_block in _stream_via_http_attempt(current_headers, current_timeout):
+                yield event_block
+        except aiohttp.SocketTimeoutError as exc:
+            # A socket read timeout means the connection was established and
+            # then produced nothing. That is an idle stream, not a transport
+            # failure, so it joins the idle-timeout path instead of being
+            # reported as an unavailable upstream.
+            raise StreamIdleTimeoutError() from exc
+
+    async def _stream_via_http_attempt(
         current_headers: Mapping[str, str],
         current_timeout: aiohttp.ClientTimeout,
     ) -> AsyncIterator[str]:
@@ -3051,7 +3069,7 @@ async def _stream_responses_with_session(
         timeout = aiohttp.ClientTimeout(
             total=remaining_request_timeout,
             sock_connect=effective_connect_timeout,
-            sock_read=None,
+            sock_read=effective_idle_timeout,
         )
         started_at = time.monotonic()
         _maybe_log_upstream_request_start(

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -1123,6 +1123,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                 release_create_gate = False
 
             _archive_http_bridge_upstream_text(session, original_text, matched_request_state)
+            pending_request_count = len(session.pending_requests)
 
             if matched_request_state is not None:
                 now = _service_time().monotonic()
@@ -1345,6 +1346,22 @@ class _HTTPBridgeUpstreamEventsMixin:
         if status_request_state is None and is_previous_response_not_found_event:
             session.upstream_control.reconnect_requested = True
             return
+
+        if status_request_state is None and pending_request_count:
+            # The bridge multiplexes one upstream connection across pending
+            # requests. An event that reaches none of them is dropped here, and
+            # whatever was waiting for it waits until a timeout fires, so the
+            # drop needs to be visible rather than inferred from a missing
+            # downstream response.
+            logger.warning(
+                "HTTP bridge upstream event matched no pending request account_id=%s bridge_kind=%s "
+                "event_type=%s has_response_id=%s pending_count=%d",
+                session.account.id,
+                session.key.affinity_kind,
+                event_type or "unknown",
+                response_id is not None,
+                pending_request_count,
+            )
 
         if status_request_state is not None and event_type not in {
             "response.completed",

--- a/openspec/changes/bound-stalled-upstream-streams/context.md
+++ b/openspec/changes/bound-stalled-upstream-streams/context.md
@@ -1,0 +1,74 @@
+# Context
+
+## The incident this change is built from
+
+2026-08-05, single-tenant deployment behind a Cloudflare tunnel. Codex CLI reported
+`stream disconnected before completion: idle timeout waiting for SSE` repeatedly, while
+the proxy's own error rate over the preceding three days was 13 failures in 1976
+requests.
+
+Log evidence at the time of the failure:
+
+```
+http_bridge_startup_wait_timeout stage=response_create_gate
+  bridge_key=sha256:8721fd39e627 available=0 pending_count=1 queued_count=5
+  pending_request_ids=d27c4984-… pending_request_ages_seconds=1548.9
+```
+
+`d27c4984` was submitted at 16:29:18Z. It logged `session_anchor_injected` and
+`store_context_input_trimmed`, then nothing: no `response.created`, no terminal event,
+no `request_logs` row (rows are written on completion). Meanwhile the same account
+served `gpt-5.6-terra` and `claude-opus-5` traffic with 4–13s latencies throughout,
+which rules out quota exhaustion, account health, and the network path to the proxy.
+
+The five queued requests behind it were retrying gate acquisition every 10 seconds and
+would have kept doing so until the 7200s request budget expired.
+
+## Why the idle timeout did not help
+
+`stream_idle_timeout_seconds` guards `_iter_sse_events`, which only runs once response
+headers exist. The failing request never got that far, so the only applicable bound was
+`http_responses_stream_request_budget_seconds` — also 7200s by default. Between the
+`upstream_connect_timeout_seconds` handshake bound (8s) and the request budget (2h)
+there was no bound at all.
+
+Carrying the idle timeout into `sock_read` closes that hole without introducing a
+fourth timeout for operators to reason about: the socket read that waits for response
+headers is bounded by the same number that bounds every later read.
+
+The resulting `aiohttp.SocketTimeoutError` is mapped to `StreamIdleTimeoutError` at the
+stream boundary rather than being classified further down, because the generic
+`aiohttp.ClientError` handler runs first and would otherwise report a silent
+established connection as an unavailable upstream. The classifier's existing tie-break
+between idle and request-budget expiry is deliberately left untouched.
+
+## Why keepalive probes matter here
+
+`keepalive_timeout=90` on the connector governs how long an *idle pooled* connection is
+retained; it says nothing about whether that connection is still alive. Without
+`SO_KEEPALIVE`, a socket dropped by a NAT or tunnel is only discovered when the
+application writes and eventually times out. Enabling probes turns a silent black hole
+into a transport error the existing failover already handles.
+
+Probe tuning is deliberately best-effort. `TCP_KEEPIDLE` is Linux-only; macOS exposes
+`TCP_KEEPALIVE` with different semantics; other platforms may expose neither. Failing
+client construction over a missing socket option would trade a rare hang for a certain
+outage.
+
+## What this change deliberately leaves alone
+
+The incident has a second half: the silent request held the per-session
+`response_create_gate` while it waited. `main` already covers that through
+`_http_bridge_pending_state_is_stale`, which uses `last_upstream_activity_at` as the
+silence clock and retires a holder that stopped progressing. The deployment where this
+was observed runs an older build without it.
+
+Retirement is a cleanup of the symptom; this change removes the condition that produces
+the symptom, so the two are complementary and stay in separate changes.
+
+## Scope note
+
+The unroutable-event logging is observability only. It was added because the incident
+could not distinguish "upstream went silent" from "event arrived and was not routed to
+its waiting request" — the bridge drops unmatched events without a trace today. If that
+log ever fires in practice, the routing gap it exposes is a separate change.

--- a/openspec/changes/bound-stalled-upstream-streams/proposal.md
+++ b/openspec/changes/bound-stalled-upstream-streams/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+Nothing bounds an upstream streaming request between the TCP handshake and the first
+response byte.
+
+The shared session is built with `ClientTimeout(total=None)`, streaming requests pass
+`sock_read=None`, and `upstream_connect_timeout_seconds` covers only the handshake. Once
+a connection is established, a peer that never sends response headers is bounded solely
+by `http_responses_stream_request_budget_seconds`, which defaults to 7200s. The stream
+idle timeout does not apply, because it guards `_iter_sse_events`, which only runs after
+headers exist.
+
+That gap is expensive because the waiting request holds its session's
+`response_create_gate` (an `asyncio.Semaphore(1)`). Observed in a single-tenant
+deployment on 2026-08-05: one bridged request submitted at 16:29:18Z produced no
+upstream event and no request-log row, while five later turns on the same session
+retried gate acquisition every 10 seconds for 26 minutes and the Codex client gave up
+with `stream disconnected before completion: idle timeout waiting for SSE`. Unrelated
+traffic on the same account completed normally throughout.
+
+Two conditions make the silent case likely and hard to see:
+
+1. **A dead pooled socket is indistinguishable from a slow model.** Connectors retain
+   idle connections for 90 seconds and enable no TCP keepalive probes, so a connection
+   dropped by an intermediary (NAT rebind, tunnel reconnect, route change) is only
+   discovered when the application layer eventually gives up.
+2. **A dropped event leaves no trace.** A bridge session multiplexes one upstream
+   connection across its pending requests; an event that matches none of them is
+   discarded silently, so "upstream went quiet" and "the event arrived and was not
+   routed" look identical in operations.
+
+## What Changes
+
+- The configured stream idle timeout MUST also bound the phase before response headers
+  arrive, so "connected but silent" is treated the same as "streaming then silent". No
+  new setting: `sock_read` carries the timeout that already exists.
+- A socket read timeout MUST be reported as `stream_idle_timeout` rather than as an
+  unavailable upstream, so the existing idle retry and failover paths apply.
+- Upstream TCP connectors MUST enable OS-level keepalive probes, so a connection killed
+  by an intermediary surfaces as a transport error instead of an indefinite wait. The
+  existing pooled-reuse guarantees (`keepalive_timeout >= 90`, `ttl_dns_cache >= 300`)
+  are unchanged.
+- Upstream events that match no pending request MUST be logged with a stable
+  low-cardinality reason while work is still waiting on the session.
+
+## Impact
+
+- Affected specs: `outbound-http-clients`, `proxy-runtime-observability`
+- Affected code: `app/core/clients/http.py`, `app/core/clients/proxy.py`,
+  `app/modules/proxy/_service/http_bridge/upstream_events.py`
+- No new settings, no migration, no dashboard surface. Behavior changes only in failure
+  paths that previously had no bound.
+- A deployment that relies on upstream taking longer than `stream_idle_timeout_seconds`
+  to send response headers would now see those attempts fail fast. That window is
+  operator-configurable and defaults to two hours, so the practical blast radius is
+  limited to genuinely dead connections.
+- The stuck-gate retirement side of this failure is already handled on `main` by
+  `_http_bridge_pending_state_is_stale`, which uses `last_upstream_activity_at` as the
+  silence clock. This change is deliberately limited to the transport gap that lets a
+  request go silent in the first place.

--- a/openspec/changes/bound-stalled-upstream-streams/specs/outbound-http-clients/spec.md
+++ b/openspec/changes/bound-stalled-upstream-streams/specs/outbound-http-clients/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Upstream streaming requests are bounded before the first response byte
+
+A streaming upstream request MUST reach response headers within the effective stream
+idle timeout. The bound applies from the moment the request is issued, so a connection
+that is established but never answered fails on the same budget as a stream that stops
+mid-flight.
+
+Exceeding the bound MUST be reported with the existing `stream_idle_timeout` error code
+and failure detail, MUST release every resource the attempt holds — including the
+per-session response-create gate and any account lease — and MUST be eligible for the
+same retry and failover handling as an idle timeout observed after the first byte.
+
+Non-streaming control calls (token refresh, usage fetch, compaction) keep their own
+timeouts and are unaffected.
+
+#### Scenario: Established connection never returns response headers
+
+- **GIVEN** an upstream connection that completes its TCP and TLS handshake
+- **AND** the peer sends no response headers
+- **WHEN** the effective stream idle timeout elapses
+- **THEN** the attempt fails with `stream_idle_timeout`
+- **AND** the failure is recorded before the request budget would have expired
+
+#### Scenario: Response headers inside the bound stream normally
+
+- **GIVEN** an upstream request whose response headers arrive before the idle timeout
+- **WHEN** the stream then produces events with gaps shorter than the idle timeout
+- **THEN** the request completes normally
+- **AND** the pre-header bound does not truncate the stream
+
+## MODIFIED Requirements
+
+### Requirement: Upstream connectors persist across interactive turn gaps
+
+The shared upstream TCP connectors MUST configure connection keepalive of at least 90 seconds and a DNS cache TTL of at least 300 seconds, so consecutive interactive requests reuse pooled connections and resolved names instead of re-handshaking per turn.
+
+Because pooled connections outlive the requests that opened them, the connectors MUST
+also enable OS-level TCP keepalive probes on upstream sockets, so a connection dropped
+by an intermediary is reported as a transport error rather than waiting for an
+application-level timeout. Probe tuning beyond enabling keepalive is best-effort:
+platforms that do not expose the per-socket knobs MUST still enable keepalive and MUST
+NOT fail client construction.
+
+#### Scenario: Connector construction pins reuse settings
+
+- **WHEN** the shared HTTP client initializes its direct TCP connectors
+- **THEN** they are constructed with `keepalive_timeout >= 90` and `ttl_dns_cache >= 300`
+
+#### Scenario: Pooled sockets carry keepalive probes
+
+- **WHEN** the shared HTTP client creates an upstream socket
+- **THEN** `SO_KEEPALIVE` is enabled on that socket
+- **AND** client construction succeeds even when per-socket probe tuning is unavailable

--- a/openspec/changes/bound-stalled-upstream-streams/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/bound-stalled-upstream-streams/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Unroutable upstream bridge events are logged
+
+An HTTP bridge session multiplexes one upstream connection across its pending requests.
+When an upstream event cannot be attributed to any pending request, the service MUST log
+it once with the event type, whether the event carried a response id, and the count of
+pending requests on that session. The log MUST NOT include raw prompt-cache keys,
+session ids, response ids, or payload content.
+
+Terminal bookkeeping events that are expected to arrive with no pending request — the
+drain and retirement paths that already run after a session's requests have been
+settled — MUST NOT be logged as unroutable, so the signal stays specific to events that
+were dropped while work was still waiting.
+
+#### Scenario: Event arrives with no pending request to receive it
+
+- **GIVEN** an HTTP bridge session with at least one pending request
+- **WHEN** an upstream event matches none of those pending requests
+- **THEN** the service logs the event type and the pending-request count
+- **AND** the log contains no response id, prompt-cache key, or payload content
+
+#### Scenario: Routed events stay silent
+
+- **WHEN** an upstream event is attributed to a pending request
+- **THEN** no unroutable-event log is emitted for it

--- a/openspec/changes/bound-stalled-upstream-streams/tasks.md
+++ b/openspec/changes/bound-stalled-upstream-streams/tasks.md
@@ -1,0 +1,37 @@
+# Tasks
+
+## 1. Transport keepalive
+
+- [x] 1.1 Enable `SO_KEEPALIVE` on upstream sockets via the connector `socket_factory`
+      in `app/core/clients/http.py`, wired into the direct, SOCKS, and websocket
+      connectors
+- [x] 1.2 Best-effort probe tuning (`TCP_KEEPIDLE` / `TCP_KEEPALIVE`, `TCP_KEEPINTVL`,
+      `TCP_KEEPCNT`) guarded so platforms without a knob still construct a client
+
+## 2. Pre-first-byte bound
+
+- [x] 2.1 Carry the effective stream idle timeout into `sock_read` for both streaming
+      request paths in `app/core/clients/proxy.py`, replacing `sock_read=None`
+- [x] 2.2 Map `aiohttp.SocketTimeoutError` to `StreamIdleTimeoutError` at the stream
+      boundary so the existing `stream_idle_timeout` reporting, retry, and failover
+      paths apply unchanged. The generic `ClientError` handler runs first, so the
+      mapping has to happen before it, and the idle-vs-budget tie-break stays as it was.
+
+## 3. Unroutable event observability
+
+- [x] 3.1 Log unattributed upstream bridge events with event type, response-id presence,
+      and pending count; no raw ids or payload content
+- [x] 3.2 Stay silent when no pending request is waiting, so drain and retirement paths
+      do not produce noise
+
+## 4. Verification
+
+- [x] 4.1 Regression tests: keepalive on constructed sockets, tolerated unsupported
+      probe options, pre-header silence reported as `stream_idle_timeout` with
+      `sock_read` set to the idle budget, and the unroutable-event log
+- [x] 4.2 `uv run pytest tests/unit/test_http_client.py tests/unit/test_proxy_utils.py`,
+      `uv run ruff check`, `uv run ruff format --check`
+- [ ] 4.3 `openspec validate bound-stalled-upstream-streams --strict` — the OpenSpec CLI
+      was not available in the authoring environment; the deltas follow the repository's
+      existing `## ADDED/MODIFIED Requirements` + `### Requirement:` + `#### Scenario:`
+      structure and still need a CLI run before merge

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import socket
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -90,11 +91,13 @@ async def test_init_http_client_creates_tcp_connector_with_limits() -> None:
         "ssl": ssl_context,
         "keepalive_timeout": 90,
         "ttl_dns_cache": 300,
+        "socket_factory": http_module._keepalive_socket_factory,
     }
     assert tcp_connector_cls.call_args_list[1].kwargs == {
         "ssl": ssl_context,
         "keepalive_timeout": 90,
         "ttl_dns_cache": 300,
+        "socket_factory": http_module._keepalive_socket_factory,
     }
     assert client_session_cls.call_args_list[0].kwargs["connector"] is connector
     assert client_session_cls.call_args_list[1].kwargs["connector"] is websocket_connector
@@ -282,6 +285,43 @@ async def test_init_http_client_preserves_socks4a_remote_dns_for_proxy_connector
     assert [call.kwargs["rdns"] for call in proxy_connector_cls.from_url.call_args_list] == [True, True]
 
     await http_module.close_http_client()
+
+
+def test_keepalive_socket_factory_enables_keepalive_probes() -> None:
+    addr_info = (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("127.0.0.1", 0))
+
+    sock = http_module._keepalive_socket_factory(addr_info)
+    try:
+        assert sock.family == socket.AF_INET
+        assert sock.type == socket.SOCK_STREAM
+        # Linux reports the flag as 1, macOS as the option's bit value, so the
+        # portable assertion is "enabled" rather than a specific integer.
+        assert sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE) != 0
+    finally:
+        sock.close()
+
+
+def test_apply_tcp_keepalive_survives_unsupported_probe_options() -> None:
+    sock = MagicMock()
+    sock.setsockopt.side_effect = lambda level, *_: None if level == socket.SOL_SOCKET else _raise_os_error()
+
+    http_module._apply_tcp_keepalive(sock)
+
+    assert sock.setsockopt.call_args_list[0].args[:2] == (socket.SOL_SOCKET, socket.SO_KEEPALIVE)
+    assert sock.setsockopt.call_count > 1
+
+
+def test_apply_tcp_keepalive_stops_when_keepalive_is_rejected() -> None:
+    sock = MagicMock()
+    sock.setsockopt.side_effect = OSError("unsupported")
+
+    http_module._apply_tcp_keepalive(sock)
+
+    assert sock.setsockopt.call_count == 1
+
+
+def _raise_os_error() -> None:
+    raise OSError("unsupported")
 
 
 def test_build_ssl_context_preserves_default_roots_and_adds_certifi_bundle() -> None:

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5775,7 +5775,7 @@ class _SilentBeforeHeadersSseSession:
     def __init__(self, clock: dict[str, float], *, silence_seconds: float) -> None:
         self._clock = clock
         self._silence_seconds = silence_seconds
-        self.timeouts: list[aiohttp.ClientTimeout] = []
+        self.timeouts: list[aiohttp.ClientTimeout | None] = []
 
     def post(
         self,
@@ -6766,7 +6766,9 @@ async def test_stream_responses_reports_idle_timeout_when_headers_never_arrive(m
     ]
 
     # The idle budget, not the two-hour request budget, decides the outcome.
-    assert session.timeouts[0].sock_read == 180.0
+    recorded_timeout = session.timeouts[0]
+    assert recorded_timeout is not None
+    assert recorded_timeout.sock_read == 180.0
     event = json.loads(events[0].split("data: ", 1)[1])
     assert event["response"]["error"]["code"] == "stream_idle_timeout"
     assert event["response"]["error"]["message"] == "Upstream stream idle timeout"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -5769,6 +5769,27 @@ class _TimeoutAfterHeadersSseSession:
         return _TimeoutAfterHeadersSseResponse()
 
 
+class _SilentBeforeHeadersSseSession:
+    """Upstream that accepts the connection and never sends response headers."""
+
+    def __init__(self, clock: dict[str, float], *, silence_seconds: float) -> None:
+        self._clock = clock
+        self._silence_seconds = silence_seconds
+        self.timeouts: list[aiohttp.ClientTimeout] = []
+
+    def post(
+        self,
+        url: str,
+        *,
+        json=None,
+        headers: dict[str, str] | None = None,
+        timeout=None,
+    ):
+        self.timeouts.append(timeout)
+        self._clock["now"] += self._silence_seconds
+        raise aiohttp.SocketTimeoutError("Timeout on reading data from socket")
+
+
 class _ActiveThenTotalTimeoutChunkIterator:
     def __init__(self, clock: dict[str, float]) -> None:
         self._clock = clock
@@ -6703,6 +6724,49 @@ async def test_stream_responses_prefers_idle_timeout_when_total_deadline_ties_af
         )
     ]
 
+    event = json.loads(events[0].split("data: ", 1)[1])
+    assert event["response"]["error"]["code"] == "stream_idle_timeout"
+    assert event["response"]["error"]["message"] == "Upstream stream idle timeout"
+
+
+@pytest.mark.asyncio
+async def test_stream_responses_reports_idle_timeout_when_headers_never_arrive(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 8.0
+        stream_idle_timeout_seconds = 180.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        trace_channels = frozenset()
+        proxy_request_budget_seconds = 7200.0
+        http_responses_stream_request_budget_seconds = 7200.0
+        upstream_stream_transport = "http"
+
+    clock = {"now": 100.0}
+    session = _SilentBeforeHeadersSseSession(clock, silence_seconds=180.5)
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+
+    payload = ResponsesRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, session),
+        )
+    ]
+
+    # The idle budget, not the two-hour request budget, decides the outcome.
+    assert session.timeouts[0].sock_read == 180.0
     event = json.loads(events[0].split("data: ", 1)[1])
     assert event["response"]["error"]["code"] == "stream_idle_timeout"
     assert event["response"]["error"]["message"] == "Upstream stream idle timeout"
@@ -11003,6 +11067,55 @@ async def test_service_stream_responses_records_typeless_raw_codex_error_after_c
     assert handle_args is not None
     assert handle_args.args[0] == account
     assert handle_args.args[2] == "rate_limit_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_logs_upstream_event_that_matches_no_pending_request(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_owner",
+        model="gpt-5.4",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        transport="http",
+        response_id="resp_owned",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-unroutable", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.4",
+        account=_make_account("acc_bridge_unroutable"),
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    cast(Any, session.upstream).archive_received = MagicMock()
+    stray_event = {"type": "response.in_progress", "response": {"id": "resp_from_another_turn"}}
+
+    with caplog.at_level(logging.WARNING, logger="app.modules.proxy.service"):
+        await service._process_http_bridge_upstream_text(session, json.dumps(stray_event, separators=(",", ":")))
+
+    unroutable_logs = [record for record in caplog.records if "matched no pending request" in record.getMessage()]
+    assert len(unroutable_logs) == 1
+    message = unroutable_logs[0].getMessage()
+    assert "event_type=response.in_progress" in message
+    assert "pending_count=1" in message
+    # The drop is reported without leaking the identifiers it carried.
+    assert "resp_from_another_turn" not in message
+    assert "bridge-unroutable" not in message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

An established upstream connection that never sends response headers has no short bound.
The shared session is built with `ClientTimeout(total=None)`, streaming requests pass
`sock_read=None`, and `upstream_connect_timeout_seconds` covers only the handshake, so the
only applicable limit is `http_responses_stream_request_budget_seconds` (7200s by default).
`stream_idle_timeout_seconds` does not apply, because it guards `_iter_sse_events`, which
only runs once headers exist.

That matters because the waiting request holds its session's `response_create_gate`
(`asyncio.Semaphore(1)`) for the entire window.

Observed on a single-tenant deployment (older build) on 2026-08-05:

```
http_bridge_startup_wait_timeout stage=response_create_gate
  bridge_key=sha256:… available=0 pending_count=1 queued_count=5
  pending_request_ids=d27c4984-… pending_request_ages_seconds=1548.9
```

The holder produced no upstream event and no `request_logs` row; five later turns on the
same session retried gate acquisition every 10s for 26 minutes, and the Codex client gave
up with `stream disconnected before completion: idle timeout waiting for SSE`. Other
traffic on the same account completed normally throughout, so quota, account health, and
the client-side network path were not involved.

## What changes

- **Pre-first-byte bound.** `sock_read` carries the effective stream idle timeout on both
  streaming request paths. `aiohttp.SocketTimeoutError` is mapped to
  `StreamIdleTimeoutError` at the stream boundary so the existing `stream_idle_timeout`
  reporting, retry, and failover paths apply unchanged — the generic `aiohttp.ClientError`
  handler runs first and would otherwise report a silent established connection as an
  unavailable upstream. The idle-vs-budget tie-break in the timeout classifier is
  untouched.
- **TCP keepalive probes** on upstream sockets via the connector `socket_factory`, so a
  connection dropped by an intermediary (NAT rebind, tunnel reconnect, route change)
  surfaces as a transport error instead of an indefinite wait. `keepalive_timeout=90` and
  `ttl_dns_cache=300` are unchanged; probe tuning is best-effort because `TCP_KEEPIDLE` is
  Linux-only and macOS spells it `TCP_KEEPALIVE`.
- **Unroutable-event logging.** A bridge session multiplexes one upstream connection
  across its pending requests; an event matching none of them is dropped without a trace
  today, which makes "upstream went quiet" and "the event was not routed" look identical.
  The log is low-cardinality and carries no response ids, cache keys, or payload content,
  and stays silent when nothing is pending so drain and retirement paths do not add noise.

No new settings, no migration, no dashboard surface.

## Scope note

The retirement side of this failure is already handled on `main` by
`_http_bridge_pending_state_is_stale`, which uses `last_upstream_activity_at` as the
silence clock. That is cleanup of the symptom; this PR removes the condition that
produces it. Kept as separate concerns.

## Tests

- `tests/unit/test_http_client.py` — keepalive enabled on constructed sockets, connector
  wiring, and tolerated unsupported probe options
- `tests/unit/test_proxy_utils.py` — silence before response headers reports
  `stream_idle_timeout` with `sock_read` set to the idle budget; unroutable event is
  logged without leaking identifiers

`uv run pytest tests/unit/test_http_client.py tests/unit/test_proxy_utils.py` → 962 passed.
`uv run ruff check` / `ruff format --check` clean.

## OpenSpec

`openspec/changes/bound-stalled-upstream-streams/` covers `outbound-http-clients` (added
pre-first-byte bound, modified connector requirement) and `proxy-runtime-observability`
(added unroutable-event logging). The OpenSpec CLI was not available in my environment, so
`openspec validate --strict` still needs a run here — task 4.3 is left unchecked for that
reason.