### PR TITLE
test: deflake WS masks-anonymous inflight teardown synchronization

### DIFF
--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import threading
+import time
 from collections import deque
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
@@ -6028,6 +6029,20 @@ def test_backend_responses_websocket_masks_anonymous_previous_response_not_found
             websocket.send_text(json.dumps(followup_request))
             failed_event = json.loads(websocket.receive_text())
             completed_event = json.loads(websocket.receive_text())
+
+            # Deliver the client disconnect explicitly and wait for the
+            # session teardown to retire the upstream socket before leaving
+            # the context. Relying on ``WebSocketTestSession.__exit__`` is
+            # racy: it cancels the application's cancel scope right after
+            # queueing the disconnect, so the session cleanup can be
+            # cancelled between the reader-task shutdown and
+            # ``upstream.close()``, leaving ``fake_upstream.closed`` unset.
+            # Real servers deliver client disconnects without cancelling the
+            # handler mid-cleanup.
+            websocket.close(1000)
+            deadline = time.monotonic() + 5.0
+            while not fake_upstream.closed and time.monotonic() < deadline:
+                time.sleep(0.01)
 
     assert created_event["type"] == "response.created"
     assert created_event["response"]["id"] == "resp_ws_inflight"


### PR DESCRIPTION
## Summary

Fixes the known main flake `test_backend_responses_websocket_masks_anonymous_previous_response_not_found_with_inflight_request` (integration-bridge), which has been failing intermittently on main itself and polluting fork-PR CI (#1563, #1504, and the 08-04 rounds).

**Root cause — test-synchronization bug, not a product race.** The test asserts `fake_upstream.closed is True` after exiting the TestClient websocket context, but starlette's `WebSocketTestSession.__exit__` cancels the ASGI app's cancel scope while the proxy session cleanup `finally` (websocket/mixin.py:1820-1831) is still awaiting the upstream-reader shutdown. `_await_cancelled_task` deliberately re-raises `CancelledError` when the caller task is being cancelled (handing the reader to `_background_cleanup_tasks`), so `await upstream.close()` is skipped and the fake's `closed` flag never flips. Real ASGI servers deliver client disconnects without cancelling the handler mid-cleanup, so the product close path is sound; only the harness cancels this hostilely.

**Fix (test-only, 15 lines):** deliver the client disconnect explicitly via `websocket.close(1000)` inside the session context after the completed event, then poll `fake_upstream.closed` with a bounded 5s deadline before the context-manager exit can cancel the app scope.

## Evidence

- Pre-fix: 4/60 iterations failed locally on origin/main (identical assertion to CI).
- Post-fix: 120/120 consecutive single-test runs passed, with a concurrent full-module pytest run adding CPU load.
- Full module `tests/integration/test_proxy_websocket_responses.py`: 105 passed; ruff + architecture-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)