### PR TITLE
perf(dashboard): bound projection history fetch per account

### DIFF
--- a/app/modules/dashboard/repository.py
+++ b/app/modules/dashboard/repository.py
@@ -49,8 +49,10 @@ class DashboardRepository:
         account_ids: list[str],
         window: str,
         since: datetime,
+        *,
+        cutoffs: dict[str, datetime] | None = None,
     ) -> dict[str, list[UsageHistorySnapshot]]:
-        return await self._usage_repo.bulk_history_since(account_ids, window, since)
+        return await self._usage_repo.bulk_history_since(account_ids, window, since, cutoffs=cutoffs)
 
     async def latest_window_minutes(self, window: str) -> int | None:
         return await self._usage_repo.latest_window_minutes(window)

--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -279,8 +279,16 @@ async def _load_projection_histories(
             if acct_since < sec_since:
                 sec_since = acct_since
 
-    all_pri_rows = await repo.bulk_usage_history_since(pri_fetch_ids, "primary", pri_since) if pri_fetch_ids else {}
-    all_sec_rows = await repo.bulk_usage_history_since(sec_fetch_ids, "secondary", sec_since) if sec_fetch_ids else {}
+    all_pri_rows = (
+        await repo.bulk_usage_history_since(pri_fetch_ids, "primary", pri_since, cutoffs=pri_cutoffs)
+        if pri_fetch_ids
+        else {}
+    )
+    all_sec_rows = (
+        await repo.bulk_usage_history_since(sec_fetch_ids, "secondary", sec_since, cutoffs=sec_cutoffs)
+        if sec_fetch_ids
+        else {}
+    )
 
     primary_history: dict[str, list[UsageHistory]] = {}
     secondary_history: dict[str, list[UsageHistory]] = {}

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -783,8 +783,19 @@ class UsageRepository:
         account_ids: list[str],
         window: str,
         since: datetime,
+        *,
+        cutoffs: dict[str, datetime] | None = None,
     ) -> dict[str, list[UsageHistorySnapshot]]:
-        """Fetch minimal usage history fields for multiple accounts in a single query."""
+        """Fetch minimal usage history fields for multiple accounts in a single query.
+
+        ``since`` is the global floor. ``cutoffs`` optionally tightens the
+        lookback per account: callers whose accounts have different window
+        lengths would otherwise widen the fetch to the longest window for
+        every account and discard the surplus in Python. The SQLite path
+        ignores ``cutoffs`` (its snapshot cache is keyed on the shared
+        floor); callers keep their own per-account trimming, so honoring the
+        bound here only changes how many rows are read, never the result.
+        """
         if not account_ids:
             return {}
         bind = self._session.get_bind()
@@ -799,6 +810,21 @@ class UsageRepository:
                 since,
             )
 
+        if cutoffs:
+            recency_clause = or_(
+                *(
+                    and_(
+                        UsageHistory.account_id == account_id,
+                        UsageHistory.recorded_at >= max(cutoffs.get(account_id, since), since),
+                    )
+                    for account_id in account_ids
+                )
+            )
+        else:
+            recency_clause = and_(
+                UsageHistory.account_id.in_(account_ids),
+                UsageHistory.recorded_at >= since,
+            )
         stmt = (
             select(
                 UsageHistory.id,
@@ -809,9 +835,8 @@ class UsageRepository:
                 UsageHistory.window_minutes,
             )
             .where(
-                UsageHistory.account_id.in_(account_ids),
+                recency_clause,
                 _window_clause(window),
-                UsageHistory.recorded_at >= since,
             )
             .order_by(UsageHistory.account_id, UsageHistory.recorded_at.asc())
         )

--- a/openspec/changes/bound-projection-history-fetch/.openspec.yaml
+++ b/openspec/changes/bound-projection-history-fetch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/bound-projection-history-fetch/proposal.md
+++ b/openspec/changes/bound-projection-history-fetch/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+`GET /api/dashboard/projections` fetches usage history for all accounts with
+a single shared lookback equal to the *widest* account window
+(`_load_projection_histories` takes the min `since` across accounts). One
+weekly-window (or window-less fallback) account therefore widens the
+PostgreSQL fetch to 7 days for every account, even though most accounts use
+5-hour primary windows; the surplus rows are discarded in Python immediately
+after the fetch. On the reference deployment this read returns ~165k rows
+per window per poll (25 s under contention) where the per-account bounds
+would keep it in the low thousands.
+
+## What Changes
+
+- `UsageRepository.bulk_history_since` accepts optional per-account
+  `cutoffs`; on PostgreSQL the recency predicate becomes an OR of
+  per-account `(account_id, recorded_at >= cutoff)` ranges (each range is a
+  btree range scan over the existing window/account/recorded_at indexes)
+  instead of one shared `recorded_at >= min(cutoffs)` bound.
+- `_load_projection_histories` passes the per-account cutoff maps it already
+  computes.
+- The SQLite path is unchanged (its snapshot cache is keyed on the shared
+  floor) and callers keep their existing per-account Python trimming, so
+  results are byte-identical on every backend — only the number of rows
+  read changes.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `query-caching`: projection history reads MUST bound the fetched rows per
+  account by that account's own window lookback on PostgreSQL.
+
+## Impact
+
+`app/modules/usage/repository.py`, `app/modules/dashboard/repository.py`,
+`app/modules/dashboard/service.py`. No schema or API change.

--- a/openspec/changes/bound-projection-history-fetch/specs/query-caching/spec.md
+++ b/openspec/changes/bound-projection-history-fetch/specs/query-caching/spec.md
@@ -1,0 +1,22 @@
+# query-caching Delta
+
+## ADDED Requirements
+
+### Requirement: Projection history reads are bounded per account
+The dashboard projections history fetch MUST NOT widen every account's
+lookback to the widest account window. On PostgreSQL the bulk usage-history
+read MUST bound rows per account by that account's own window cutoff; the
+returned per-account histories MUST equal the previous shared-floor fetch
+after the existing per-account trimming.
+
+#### Scenario: One weekly account does not widen the fetch for short-window accounts
+- **GIVEN** one account with a 7-day window and several accounts with 5-hour windows
+- **WHEN** the projections history fetch runs on PostgreSQL
+- **THEN** rows for the 5-hour accounts MUST be bounded by their own cutoff in SQL
+- **AND** each account's resulting history slice MUST equal the slice the shared-floor fetch produced after per-account trimming
+
+#### Scenario: SQLite snapshot cache keeps the shared floor
+- **GIVEN** the SQLite backend serves the projections history fetch through its snapshot cache
+- **WHEN** per-account cutoffs are supplied
+- **THEN** the SQLite read MAY keep the shared floor
+- **AND** per-account trimming in the caller MUST still bound each account's slice

--- a/openspec/changes/bound-projection-history-fetch/tasks.md
+++ b/openspec/changes/bound-projection-history-fetch/tasks.md
@@ -1,0 +1,15 @@
+## 1. Implementation
+
+- [x] 1.1 `UsageRepository.bulk_history_since`: optional per-account
+      `cutoffs`; PostgreSQL recency predicate becomes an OR of per-account
+      `(account_id, recorded_at >= cutoff)` ranges. SQLite path unchanged.
+- [x] 1.2 `DashboardRepository.bulk_usage_history_since` passes `cutoffs`
+      through; `_load_projection_histories` supplies the cutoff maps it
+      already computes.
+
+## 2. Validation
+
+- [x] 2.1 Integration coverage: per-account bounding excludes rows older
+      than an account's own cutoff while a wider account still gets its
+      full window; results match the shared-floor fetch after trimming.
+- [x] 2.2 Existing suites pass (`uv run pytest`), `ruff`, `ty`.

--- a/tests/integration/test_usage_repository.py
+++ b/tests/integration/test_usage_repository.py
@@ -1034,3 +1034,47 @@ async def test_trends_by_bucket_sqlite_avoids_window_function_for_latest_metadat
     ]
     assert len(trend_queries) == 1
     assert "row_number()" not in trend_queries[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_bulk_history_since_per_account_cutoffs_parity(db_setup):
+    """Per-account cutoffs bound the PostgreSQL fetch without changing what
+    callers keep after their own trimming; SQLite keeps the shared floor."""
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        repo = UsageRepository(session)
+        await accounts_repo.upsert(_make_account("acc-short"))
+        await accounts_repo.upsert(_make_account("acc-wide"))
+
+        # acc-short: rows inside and outside its 5h cutoff.
+        await repo.add_entry("acc-short", 10.0, window="primary", recorded_at=now - timedelta(hours=20))
+        await repo.add_entry("acc-short", 20.0, window="primary", recorded_at=now - timedelta(hours=1))
+        # acc-wide: an old row that only its wide cutoff keeps.
+        await repo.add_entry("acc-wide", 30.0, window="primary", recorded_at=now - timedelta(hours=20))
+        await repo.add_entry("acc-wide", 40.0, window="primary", recorded_at=now - timedelta(hours=1))
+
+        shared_floor = now - timedelta(days=7)
+        cutoffs = {
+            "acc-short": now - timedelta(hours=5),
+            "acc-wide": now - timedelta(days=7),
+        }
+        bounded = await repo.bulk_history_since(
+            ["acc-short", "acc-wide"],
+            "primary",
+            shared_floor,
+            cutoffs=cutoffs,
+        )
+        unbounded = await repo.bulk_history_since(["acc-short", "acc-wide"], "primary", shared_floor)
+
+    dialect = "postgresql" if str(engine.url).startswith("postgresql") else "sqlite"
+    if dialect == "postgresql":
+        assert [snapshot.used_percent for snapshot in bounded["acc-short"]] == [20.0]
+    else:
+        # SQLite keeps the shared floor; callers trim per account.
+        assert [snapshot.used_percent for snapshot in bounded["acc-short"]] == [10.0, 20.0]
+    assert [snapshot.used_percent for snapshot in bounded["acc-wide"]] == [30.0, 40.0]
+
+    # Parity with the shared-floor fetch after per-account trimming.
+    trimmed = [snapshot for snapshot in unbounded["acc-short"] if snapshot.recorded_at >= cutoffs["acc-short"]]
+    assert [snapshot.used_percent for snapshot in trimmed] == [20.0]


### PR DESCRIPTION
## Why

`GET /api/dashboard/projections` fetches usage history with a single shared lookback equal to the **widest** account window: `_load_projection_histories` takes the min `since` across accounts, so one weekly-window (or window-less fallback) account widens the PostgreSQL fetch to 7 days for every 5-hour-window account, and the surplus is discarded in Python right after the fetch. On the reference deployment this read returns ~165k rows per window per 30 s poll (25.5 s observed under contention).

## What

- `UsageRepository.bulk_history_since` accepts optional per-account `cutoffs`; on PostgreSQL the recency predicate becomes an OR of per-account `(account_id, recorded_at >= cutoff)` ranges — each one a btree range scan over the existing window/account/recorded_at indexes.
- `_load_projection_histories` passes the per-account cutoff maps it already computes.
- SQLite path unchanged (its snapshot cache is keyed on the shared floor); callers keep their existing per-account trimming, so results are byte-identical on every backend — only the number of rows read changes.

## Validation

- New integration test: per-account bounding excludes rows older than an account's own cutoff while a wider account keeps its full window; parity with the shared-floor fetch after trimming (run on SQLite and PostgreSQL).
- `uv run pytest tests/unit -k "dashboard or projection or depletion"` (148 passed), usage-repository integration suite green on both backends, `ruff`, `ty` clean.
- Local `codex review --base origin/main`: no findings.

OpenSpec: `openspec/changes/bound-projection-history-fetch/` (query-caching delta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)