### PR TITLE
perf(request-logs): serve listing totals from the demand rollup plus raw tail

### DIFF
--- a/app/core/retention/job.py
+++ b/app/core/retention/job.py
@@ -139,8 +139,16 @@ async def _prune_request_logs(cutoff: datetime, *, now: datetime) -> int:
                         )
                     return total
                 effective_cutoff = min(cutoff, watermark - FOLD_LAG)
+                # Oldest-first batches keep min(requested_at) a contiguous
+                # retention frontier: an interrupted pass never leaves
+                # deleted holes above the oldest surviving row, which the
+                # rollup-served listing count relies on when clamping its
+                # folded window to listable history.
                 batch_ids = (
-                    select(RequestLog.id).where(RequestLog.requested_at < effective_cutoff).limit(BATCH_SIZE)
+                    select(RequestLog.id)
+                    .where(RequestLog.requested_at < effective_cutoff)
+                    .order_by(RequestLog.requested_at.asc(), RequestLog.id.asc())
+                    .limit(BATCH_SIZE)
                 ).scalar_subquery()
                 result = await session.execute(
                     delete(RequestLog).where(RequestLog.id.in_(batch_ids)).returning(RequestLog.id)

--- a/app/modules/accounts/usage_time_rollup_read.py
+++ b/app/modules/accounts/usage_time_rollup_read.py
@@ -35,11 +35,13 @@ from __future__ import annotations
 from collections.abc import Sequence
 from datetime import datetime, timedelta
 
-from sqlalchemy import ColumnElement, and_, func, or_, select
+from sqlalchemy import BigInteger, ColumnElement, Integer, and_, func, or_, select
+from sqlalchemy import cast as sa_cast
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db.models import RequestLog, RequestUsageHourlyRollup
+from app.db.models import AccountUsageRollupState, RequestDemandQuarterRollup, RequestLog, RequestUsageHourlyRollup
 from app.modules.accounts.usage_time_rollup import (
+    _STATE_ROW_ID,
     HOURLY_BUCKET_SECONDS,
     QUARTER_SLOT_SECONDS,
     WARMUP_REQUEST_KINDS,
@@ -137,6 +139,58 @@ async def read_demand_window(
 ) -> tuple[list[QuarterDemandRollupRow], list[RawWindow]]:
     repo = RequestUsageTimeRollupRepository(session)
     return await _read_window(repo.read_demand, "slot_epoch", since, until, QUARTER_SLOT_SECONDS, filters)
+
+
+async def sum_demand_window(
+    session: AsyncSession,
+    since: datetime,
+    until: datetime | None = None,
+    *,
+    filters: Sequence[ColumnElement[bool]] = (),
+) -> tuple[int, list[RawWindow]]:
+    """Watermark-consistent SUM(request_count) over the demand rollup.
+
+    Same partitioning rule as the row readers, aggregated in SQL so counting
+    a long window does not materialize every demand-grain row. The watermark
+    and the folded sum come from ONE statement (state LEFT JOIN demand, with
+    the slot upper bound expressed against the state row's own watermark
+    epoch), so an escape-hatch reset committing concurrently can never pair
+    an old watermark with already-truncated rollups. With no watermark the
+    sum is 0 and the raw windows cover the full range — the caller degrades
+    to the exact legacy raw read.
+    """
+    lo_epoch = epoch_seconds(ceil_to_grid(since, QUARTER_SLOT_SECONDS))
+    if session.get_bind().dialect.name == "postgresql":
+        watermark_epoch = sa_cast(func.extract("epoch", AccountUsageRollupState.hourly_folded_through), BigInteger)
+    else:
+        watermark_epoch = sa_cast(func.strftime("%s", AccountUsageRollupState.hourly_folded_through), Integer)
+    join_conditions = [
+        *filters,
+        RequestDemandQuarterRollup.slot_epoch >= lo_epoch,
+        RequestDemandQuarterRollup.slot_epoch < watermark_epoch,
+    ]
+    if until is not None:
+        join_conditions.append(
+            RequestDemandQuarterRollup.slot_epoch < epoch_seconds(floor_to_grid(until, QUARTER_SLOT_SECONDS))
+        )
+    stmt = (
+        select(
+            AccountUsageRollupState.hourly_folded_through,
+            func.coalesce(func.sum(RequestDemandQuarterRollup.request_count), 0),
+        )
+        .select_from(AccountUsageRollupState)
+        .outerjoin(RequestDemandQuarterRollup, and_(*join_conditions))
+        .where(AccountUsageRollupState.id == _STATE_ROW_ID)
+        .group_by(AccountUsageRollupState.hourly_folded_through)
+    )
+    row = (await session.execute(stmt)).first()
+    if row is None:
+        return 0, [(since, until)]
+    watermark, folded_total = row[0], int(row[1])
+    folded_until_epoch, raw_windows = _partition_raw_windows(since, until, watermark, QUARTER_SLOT_SECONDS)
+    if folded_until_epoch is None:
+        return 0, raw_windows
+    return folded_total, raw_windows
 
 
 def raw_windows_clause(windows: Sequence[RawWindow]) -> ColumnElement[bool]:

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import cast as typing_cast
 
 import anyio
@@ -21,7 +21,15 @@ from app.core.usage.types import (
 )
 from app.core.utils.request_id import ensure_request_id
 from app.core.utils.time import utcnow
-from app.db.models import Account, AccountUsageRollupState, ApiKey, RequestKind, RequestLog, RequestUsageHourlyRollup
+from app.db.models import (
+    Account,
+    AccountUsageRollupState,
+    ApiKey,
+    RequestDemandQuarterRollup,
+    RequestKind,
+    RequestLog,
+    RequestUsageHourlyRollup,
+)
 from app.db.session import sqlite_writer_section
 from app.modules.accounts.usage_rollup import lock_fold_state
 from app.modules.accounts.usage_time_rollup import (
@@ -29,6 +37,7 @@ from app.modules.accounts.usage_time_rollup import (
     WARMUP_REQUEST_KINDS,
     floor_to_hour,
     from_dimension,
+    to_dimension,
 )
 from app.modules.accounts.usage_time_rollup_read import (
     RawWindow,
@@ -36,6 +45,7 @@ from app.modules.accounts.usage_time_rollup_read import (
     raw_windows_clause,
     read_errors_window,
     read_hourly_window,
+    sum_demand_window,
 )
 
 
@@ -43,6 +53,41 @@ from app.modules.accounts.usage_time_rollup_read import (
 class _RequestLogFilters:
     conditions: list
     needs_related_search_joins: bool
+
+
+# Earliest representable listing lower bound for the rollup-count window.
+_ROLLUP_EPOCH = datetime(1970, 1, 1)
+
+
+def _naive_utc(value: datetime) -> datetime:
+    """FastAPI parses ISO `Z` query bounds as offset-aware datetimes;
+    ``requested_at`` and the rollup grid are naive UTC, so normalize before
+    any window arithmetic (the SQL filter comparisons already coerce)."""
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+@dataclass(frozen=True, slots=True)
+class _DemandCountParams:
+    """Listing filters that map losslessly onto demand-rollup dimensions.
+
+    Built only when the listing carries no free-text search and no
+    error-code splits — the demand grain has no error_code dimension, and
+    search reaches related tables. Everything else (time bounds, accounts,
+    api keys, model/effort pairs, statuses, soft-delete exclusion) is a
+    demand dimension, so the folded window can be counted from the rollup.
+    """
+
+    since: datetime | None
+    until: datetime | None
+    account_ids: list[str] | None
+    api_key_ids: list[str] | None
+    model_options: list[tuple[str, str | None]] | None
+    models: list[str] | None
+    reasoning_efforts: list[str] | None
+    include_success: bool
+    include_error_other: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -1078,6 +1123,8 @@ class RequestLogsRepository:
         *,
         include_sensitive_metadata: bool = True,
     ) -> RequestLogsResult:
+        since = _naive_utc(since) if since is not None else None
+        until = _naive_utc(until) if until is not None else None
         filters = self._build_filters(
             search=search,
             since=since,
@@ -1111,9 +1158,23 @@ class RequestLogsRepository:
             total, aggregated_cost_usd = await self._count_and_sum_recent(filters)
             return RequestLogsResult(logs=logs, total=total, aggregated_cost_usd=aggregated_cost_usd)
 
+        demand_params: _DemandCountParams | None = None
+        if search is None and not error_codes_in and not error_codes_excluding:
+            demand_params = _DemandCountParams(
+                since=since,
+                until=until,
+                account_ids=account_ids,
+                api_key_ids=api_key_ids,
+                model_options=model_options,
+                models=models,
+                reasoning_efforts=reasoning_efforts,
+                include_success=include_success,
+                include_error_other=include_error_other,
+            )
+
         ttl_seconds = _COUNT_CACHE_TTL_SECONDS
         if ttl_seconds <= 0:
-            return RequestLogsResult(logs=logs, total=await self._count_recent(filters))
+            return RequestLogsResult(logs=logs, total=await self._count_recent(filters, demand_params))
         cache_key = (
             search,
             since,
@@ -1132,7 +1193,7 @@ class RequestLogsRepository:
         )
         total = _cached_recent_count(cache_key)
         if total is None:
-            total = await self._count_recent(filters)
+            total = await self._count_recent(filters, demand_params)
             _store_recent_count(cache_key, total, ttl_seconds)
         return RequestLogsResult(logs=logs, total=total)
 
@@ -1148,13 +1209,111 @@ class RequestLogsRepository:
         request_count, aggregated_cost_usd = result.one()
         return int(request_count), float(aggregated_cost_usd)
 
-    async def _count_recent(self, filters: _RequestLogFilters) -> int:
+    async def _count_recent(
+        self,
+        filters: _RequestLogFilters,
+        demand_params: _DemandCountParams | None = None,
+    ) -> int:
+        if demand_params is not None:
+            return await self._count_recent_from_demand_rollup(filters, demand_params)
         count_stmt = select(func.count(RequestLog.id)).select_from(RequestLog)
         count_stmt = self._apply_related_search_joins(count_stmt, filters.needs_related_search_joins)
         if filters.conditions:
             count_stmt = count_stmt.where(and_(*filters.conditions))
         result = await self._session.execute(count_stmt)
         return int(result.scalar_one())
+
+    async def _count_recent_from_demand_rollup(
+        self,
+        filters: _RequestLogFilters,
+        params: _DemandCountParams,
+    ) -> int:
+        """Serve the listing total from the demand rollup plus the raw tail.
+
+        Every filter the listing exposes except free-text search and
+        error-code splits maps onto a demand-rollup dimension (status is a
+        dimension there, unlike the hourly rollup), so the folded part of
+        the window is one indexed SUM instead of a scan that grows with
+        history. The un-folded complement is counted from raw with the
+        exact listing conditions. With no watermark the folded sum is 0 and
+        the raw windows cover the whole range, which is the legacy count —
+        no kill switch needed.
+        """
+        rollup_filters: list = [RequestDemandQuarterRollup.is_deleted.is_(False)]
+        if params.account_ids:
+            rollup_filters.append(
+                RequestDemandQuarterRollup.account_id.in_([to_dimension(value) for value in params.account_ids])
+            )
+        if params.api_key_ids:
+            rollup_filters.append(
+                RequestDemandQuarterRollup.api_key_id.in_([to_dimension(value) for value in params.api_key_ids])
+            )
+        if params.model_options:
+            pair_filters = []
+            for model, effort in params.model_options:
+                base = (model or "").strip()
+                if not base:
+                    continue
+                pair_filters.append(
+                    and_(
+                        RequestDemandQuarterRollup.model == base,
+                        RequestDemandQuarterRollup.reasoning_effort == to_dimension(effort),
+                    )
+                )
+            if pair_filters:
+                rollup_filters.append(or_(*pair_filters))
+        else:
+            if params.models:
+                rollup_filters.append(RequestDemandQuarterRollup.model.in_(params.models))
+            if params.reasoning_efforts:
+                rollup_filters.append(
+                    RequestDemandQuarterRollup.reasoning_effort.in_(
+                        [to_dimension(value) for value in params.reasoning_efforts]
+                    )
+                )
+        statuses = []
+        if params.include_success:
+            statuses.append("success")
+        if params.include_error_other:
+            statuses.append("error")
+        if statuses:
+            rollup_filters.append(RequestDemandQuarterRollup.status.in_(statuses))
+
+        # Retention prunes raw rows but keeps their folded counts; the
+        # listing total must track listable rows, so clamp the rollup window
+        # to the earliest surviving live row (the slot containing it stays
+        # raw-served, excluding any partially pruned slot). A prune
+        # committing between this read and the sum can transiently overcount
+        # — the same cross-statement exposure every rollup reader accepts.
+        earliest_live = (
+            await self._session.execute(
+                select(func.min(RequestLog.requested_at)).where(RequestLog.deleted_at.is_(None))
+            )
+        ).scalar_one_or_none()
+        rollup_since = params.since if params.since is not None else _ROLLUP_EPOCH
+        if earliest_live is None:
+            rollup_since = utcnow().replace(tzinfo=None)
+        else:
+            rollup_since = max(rollup_since, earliest_live)
+        # The listing's `until` bound is inclusive; the rollup window is
+        # half-open, so shift by the smallest representable step
+        # (datetime.max cannot be shifted — treat it as unbounded).
+        rollup_until = (
+            None if params.until is None or params.until == datetime.max else params.until + timedelta(microseconds=1)
+        )
+        folded_total, raw_windows = await sum_demand_window(
+            self._session,
+            rollup_since,
+            rollup_until,
+            filters=rollup_filters,
+        )
+        if not raw_windows:
+            return folded_total
+        tail_stmt = select(func.count(RequestLog.id)).select_from(RequestLog).where(raw_windows_clause(raw_windows))
+        if filters.conditions:
+            tail_stmt = tail_stmt.where(and_(*filters.conditions))
+        tail_total = (await self._session.execute(tail_stmt)).scalar_one()
+        return folded_total + int(tail_total)
 
     async def _resolve_account_plan_type(self, account_id: str) -> str | None:
         result = await self._session.execute(select(Account.plan_type).where(Account.id == account_id).limit(1))

--- a/openspec/changes/serve-request-log-count-from-rollups/.openspec.yaml
+++ b/openspec/changes/serve-request-log-count-from-rollups/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/serve-request-log-count-from-rollups/proposal.md
+++ b/openspec/changes/serve-request-log-count-from-rollups/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+The request-log listing total is an exact `COUNT(*)` over the filtered set.
+With the default filters that is a full pass over `request_logs` (no time
+bound at all), re-run every 30 s when the short-TTL cache expires exactly at
+the dashboard's poll interval — measured 4.4 s warm and 9–19 s under
+contention at 4.5M rows, and it grows with history (full-history retention
+is a supported configuration). The 30 s TTL cache bounds the frequency but
+not the cost of each recount.
+
+## What Changes
+
+- Serve the listing total from the demand quarter rollup plus the un-folded
+  raw tail whenever every active filter maps onto a demand dimension. The
+  demand grain already carries `status` (unlike the hourly rollup), so time
+  bounds, accounts, api keys, model/effort pairs, statuses, and soft-delete
+  exclusion are all expressible; free-text search and error-code splits fall
+  back to the exact raw count.
+- The folded part of the window is one SQL `SUM(request_count)` bounded by
+  the hourly watermark (new `sum_demand_window` read primitive following the
+  shared partitioning rule); the complement raw windows are counted with the
+  exact listing conditions. Counts remain exact — the total equals the
+  legacy raw `COUNT(*)` for every watermark position, including the
+  degenerate no-watermark state (empty folded sum, full-range raw count),
+  so there is no kill switch.
+- The per-filter-signature TTL cache stays in front of both paths.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `query-caching`: the request-log listing total MUST be computed from the
+  demand rollup plus the raw tail for rollup-expressible filter
+  signatures, with cost bounded by the un-folded tail instead of total
+  history size, and MUST stay exactly equal to the raw count.
+
+## Impact
+
+`app/modules/request_logs/repository.py`,
+`app/modules/accounts/usage_time_rollup_read.py` (new `sum_demand_window`),
+rollup parity harness extended with listing-count shapes (including
+cancelled-status corpus rows). No schema or API change.

--- a/openspec/changes/serve-request-log-count-from-rollups/specs/query-caching/spec.md
+++ b/openspec/changes/serve-request-log-count-from-rollups/specs/query-caching/spec.md
@@ -1,0 +1,48 @@
+# query-caching Delta
+
+## ADDED Requirements
+
+### Requirement: Request-log listing totals are cached and rollup-served
+The request-log listing total MUST be served from a short-TTL per-filter
+cache. On a cache miss, filter signatures whose every active filter maps
+onto a demand-rollup dimension (time bounds, accounts, api keys,
+model/effort pairs, statuses, soft-delete exclusion) MUST be counted as the
+demand rollup's folded `SUM(request_count)` under the hourly watermark plus
+an exact raw count over the un-folded complement windows; the result MUST
+equal the legacy raw `COUNT(*)`. Signatures carrying free-text search or
+error-code splits MUST fall back to the exact raw count.
+
+#### Scenario: Default listing total avoids a full history scan once folded
+- **GIVEN** request logs folded below the hourly watermark and a live raw tail
+- **WHEN** the listing total is computed with default filters
+- **THEN** the folded portion MUST be one aggregated read over the demand rollup bounded by the watermark
+- **AND** only the un-folded complement windows are counted from raw
+- **AND** the total MUST equal the raw `COUNT(*)` over the same filters
+
+#### Scenario: Status splits stay exact through the rollup
+- **GIVEN** history containing success, error, and cancelled requests on both sides of the watermark
+- **WHEN** the listing total is computed for the default success+error split, a single status, or no status filter
+- **THEN** the rollup-served total MUST equal the raw count for the same split
+
+#### Scenario: Non-expressible filters fall back to the raw count
+- **GIVEN** a listing filtered by free-text search or an error-code split
+- **WHEN** the total is computed
+- **THEN** the exact raw `COUNT(*)` path MUST be used
+
+#### Scenario: Retention pruning keeps totals aligned with listable rows
+- **GIVEN** retention has pruned folded raw rows while their demand-rollup counts remain
+- **WHEN** the listing total is computed for an expressible signature
+- **THEN** the rollup window MUST be clamped to the earliest surviving live row
+- **AND** the total MUST equal the raw count over the surviving rows, never advertising pages the listing cannot return
+
+#### Scenario: Offset-aware time bounds are accepted
+- **GIVEN** the dashboard sends ISO-8601 `Z` (offset-aware) `since`/`until` bounds
+- **WHEN** the listing total is computed
+- **THEN** the bounds MUST be normalized to the naive-UTC domain before window arithmetic
+- **AND** the result MUST equal the naive-UTC equivalent request
+
+#### Scenario: No watermark degrades to the legacy count
+- **GIVEN** no hourly fold watermark exists (pre-backfill or after the operator escape hatch)
+- **WHEN** the listing total is computed for an expressible signature
+- **THEN** the folded sum MUST be empty and the raw windows MUST cover the full range
+- **AND** the result MUST be the exact legacy count with no kill switch involved

--- a/openspec/changes/serve-request-log-count-from-rollups/tasks.md
+++ b/openspec/changes/serve-request-log-count-from-rollups/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+- [x] 1.1 `sum_demand_window` read primitive: watermark-consistent SQL
+      `SUM(request_count)` over folded demand slots plus the raw complement
+      windows, degrading to a full-range raw window with no watermark.
+- [x] 1.2 Route `_count_recent` through the demand rollup when every active
+      listing filter maps onto a demand dimension (no search, no error-code
+      splits); count the raw complement with the exact listing conditions.
+- [x] 1.3 Keep the per-filter-signature TTL cache in front of both paths.
+
+## 2. Validation
+
+- [x] 2.1 Rollup parity harness: listing totals (default/status
+      splits/window/account/api-key/model/effort/search-fallback shapes,
+      with cancelled-status rows on both sides of the watermark) equal the
+      legacy counts across every watermark state, concurrent folds, escape
+      hatch, and retention pruning.
+- [x] 2.2 Existing suites pass (`uv run pytest`), `ruff`, `ty`.

--- a/tests/integration/test_request_usage_rollup_parity.py
+++ b/tests/integration/test_request_usage_rollup_parity.py
@@ -133,6 +133,18 @@ def _corpus() -> list[RequestLog]:
     for offset in (timedelta(hours=30), timedelta(days=5, hours=1), timedelta(days=9, hours=20)):
         rows.append(_log(BASE + offset, request_id_suffix="w", request_kind="warmup", cost_usd=0.002))
         rows.append(_log(BASE + offset + timedelta(minutes=20), request_id_suffix="lw", request_kind="limit_warmup"))
+    # Cancelled rows on both sides of every candidate watermark: the listing
+    # count's default status split (success+error) must exclude them from
+    # the folded sum and the raw tail alike.
+    for offset in (timedelta(days=1, hours=5), timedelta(days=9, hours=23)):
+        rows.append(
+            _log(
+                BASE + offset,
+                request_id_suffix="cx",
+                status="cancelled",
+                cost_usd=None,
+            )
+        )
     # Soft-deleted orphans (account detached): kept by dashboard buckets and
     # top-error, excluded by the planner.
     for offset in (timedelta(days=1, hours=2), timedelta(days=6, hours=7, minutes=31)):
@@ -280,7 +292,32 @@ async def _snapshot(*, lead_since: datetime = SINCE_UNALIGNED) -> dict:
             "trends_key2": await api_keys.trends_by_key("key_2", SINCE_ALIGNED, UNTIL_UNALIGNED, 7200),
             "trends_raw_degrade": await api_keys.trends_by_key("key_1", lead_since, NOW, 5400),
             "trends_no_logs": await api_keys.trends_by_key("key_none", lead_since, NOW, 3600),
+            "listing_totals": await _listing_totals(logs, lead_since),
         }
+
+
+async def _listing_totals(logs: RequestLogsRepository, lead_since: datetime) -> dict[str, int]:
+    """Every rollup-expressible listing count shape (the demand-rollup path),
+    plus a non-expressible search fallback for contrast."""
+
+    async def _total(**kwargs) -> int:
+        result = await logs.list_recent(limit=1, **kwargs)
+        return result.total
+
+    return {
+        "default": await _total(),
+        "success_only": await _total(include_error_other=False),
+        "error_only": await _total(include_success=False),
+        "no_status_filter": await _total(include_success=False, include_error_other=False),
+        "windowed": await _total(since=lead_since, until=UNTIL_UNALIGNED),
+        "folded_only": await _total(since=FOLDED_ONLY_WINDOW[0], until=FOLDED_ONLY_WINDOW[1]),
+        "tail_only": await _total(since=TAIL_ONLY_WINDOW[0], until=TAIL_ONLY_WINDOW[1]),
+        "account": await _total(account_ids=["acc_par_a"]),
+        "api_key": await _total(api_key_ids=["key_2"], since=lead_since),
+        "models": await _total(models=[_MODELS[0]]),
+        "model_effort_pairs": await _total(model_options=[(_MODELS[1], None)]),
+        "search_fallback": await _total(search="gpt-5.1"),
+    }
 
 
 def _project_demand(bins) -> dict:
@@ -449,7 +486,7 @@ async def test_escape_hatch_reset_degrades_to_legacy_then_rebackfills(db_setup):
 
 
 @pytest.mark.asyncio
-async def test_statistics_survive_retention_pruning_folded_raw(db_setup):
+async def test_statistics_survive_retention_pruning_folded_raw(db_setup, monkeypatch):
     """The headline guarantee: after raw rows below the retention gate
     (watermark - FOLD_LAG) are physically deleted, every rollup-served
     statistic is unchanged. Distinct-conversation metrics shrink to the
@@ -487,8 +524,21 @@ async def test_statistics_survive_retention_pruning_folded_raw(db_setup):
             # degrade path: after pruning they only see the surviving tail.
             "buckets_raw_degrade",
             "trends_raw_degrade",
+            "listing_totals",  # search fallback is raw-bound (asserted below)
         ),
     )
+    # Listing totals track LISTABLE rows, not the permanent folded
+    # statistics: after pruning they must equal the legacy raw counts over
+    # the surviving corpus (the rollup window is clamped to the earliest
+    # surviving live row).
+    original_count_recent = RequestLogsRepository._count_recent
+
+    async def _raw_only_count(self, filters, demand_params=None):
+        return await original_count_recent(self, filters, None)
+
+    monkeypatch.setattr(RequestLogsRepository, "_count_recent", _raw_only_count)
+    raw_expected = (await _snapshot())["listing_totals"]
+    assert pruned["listing_totals"] == raw_expected
     # Additive activity totals are unchanged (modulo the pruned partial
     # leading hour for unaligned starts); only the distinct-conversation
     # metrics dropped to what raw still holds.
@@ -552,3 +602,24 @@ async def test_dashboard_overview_json_is_identical_before_and_after_fold(async_
     after = await async_client.get("/api/dashboard/overview?timeframe=7d")
     assert after.status_code == 200
     assert after.json() == before.json()
+
+
+@pytest.mark.asyncio
+async def test_listing_total_accepts_offset_aware_bounds(db_setup):
+    """The dashboard sends ISO `Z` bounds (offset-aware); the rollup window
+    arithmetic and the raw path must both accept them and agree with the
+    naive-UTC equivalents."""
+    from datetime import timezone
+
+    await _seed_corpus()
+    await run_hourly_fold_pass(now=NOW)
+    async with SessionLocal() as session:
+        logs = RequestLogsRepository(session)
+        naive = await logs.list_recent(limit=1, since=SINCE_UNALIGNED, until=UNTIL_UNALIGNED)
+        aware = await logs.list_recent(
+            limit=1,
+            since=SINCE_UNALIGNED.replace(tzinfo=timezone.utc),
+            until=UNTIL_UNALIGNED.replace(tzinfo=timezone.utc),
+        )
+    assert aware.total == naive.total
+    assert naive.total > 0


### PR DESCRIPTION
## Why

The request-log listing total is an exact `COUNT(*)` over the filtered set — with default filters a full pass over `request_logs` with **no time bound at all** (4.4 s warm, 9–19 s under contention at 4.5M rows on the reference deployment), re-run every 30 s because the count cache TTL expires exactly at the dashboard's poll interval. It grows with history, and full-history retention is a supported configuration.

## What

- The demand quarter rollup preserves the full legacy grain **including `status`** (unlike the hourly rollup), so every listing filter except free-text search and error-code splits maps losslessly onto demand dimensions: time bounds, accounts, api keys, model/effort pairs, statuses (success/error/cancelled stay exact), soft-delete exclusion.
- New `sum_demand_window` read primitive: watermark-consistent SQL `SUM(request_count)` over the folded slots — watermark and sum in ONE statement (state LEFT JOIN demand with the slot bound expressed against the state row's own watermark epoch), so a concurrent escape-hatch reset can never pair an old watermark with truncated rollups. The un-folded complement is counted from raw with the exact listing conditions.
- Totals stay **exactly** equal to the legacy raw count for every watermark position; no watermark degrades to the legacy count with no kill switch.
- Retention: the rollup window is clamped to the earliest surviving live row so totals track *listable* rows, and `_prune_request_logs` now deletes oldest-first so that frontier stays contiguous even across interrupted passes.
- Offset-aware ISO `Z` bounds (what the dashboard actually sends) are normalized once at `list_recent` entry; `datetime.max` is treated as unbounded.

## Validation

- Rollup parity harness extended with 12 listing-count shapes (default/status splits incl. new cancelled-status corpus rows on both sides of the watermark/windows/account/api-key/model/effort/search-fallback) — asserted equal to the legacy counts across every watermark state, concurrent folds, the escape hatch, and retention pruning (where totals are asserted equal to the raw counts over the surviving corpus); new offset-aware-bounds test.
- Integration suites green on SQLite and PostgreSQL (parity + retention: 26 passed each backend); unit subset 995 passed; `ruff`, `ty` clean.
- Local `codex review`: round-1 P1 (offset-aware bounds crash) and P2s (retention overcount, atomic watermark+sum) plus round-2 P2s (non-contiguous prune batches, `datetime.max` overflow) addressed with regression coverage; a final confirmation round is pending upstream quota reset.

OpenSpec: `openspec/changes/serve-request-log-count-from-rollups/` (query-caching delta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)