### PR TITLE
perf(dashboard): serve conversation metrics from an hourly presence rollup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ POSTGRES_PYTEST_TARGETS := \
 	tests/integration/test_request_usage_time_rollup.py \
 	tests/integration/test_request_usage_rollup_parity.py \
 	tests/integration/test_migrations.py::test_request_usage_time_rollups_migration_upgrade_and_downgrade \
+	tests/integration/test_migrations.py::test_conversation_presence_rollup_migration_upgrade_and_downgrade \
 	tests/integration/test_data_retention.py \
 	tests/integration/test_plan_downgrade_observation_store.py \
 	tests/integration/test_accounts_api_probe.py::test_force_probe_confirms_paid_to_free_plan_downgrade \

--- a/app/core/retention/job.py
+++ b/app/core/retention/job.py
@@ -85,11 +85,12 @@ async def _prune_request_logs(cutoff: datetime, *, now: datetime) -> int:
     lifetime account totals. No watermark (fold never ran) means skip.
 
     The effective watermark is the MIN of the lifetime fold watermark and the
-    hourly time-axis watermark: a raw row is only prunable once EVERY rollup
-    that must outlive it has folded it. While the hourly backfill is catching
-    up (its watermark starts at the epoch), the min fails the currency check
-    below and pruning pauses entirely — the pre-existing "never delete what
-    is not folded" invariant extended to the time-axis rollups.
+    hourly and conversation time-axis watermarks: a raw row is only prunable
+    once EVERY rollup that must outlive it has folded it. While either
+    time-axis backfill is catching up (each watermark starts at the epoch),
+    the min fails the currency check below and pruning pauses entirely — the
+    pre-existing "never delete what is not folded" invariant extended to the
+    time-axis rollups.
 
     Pruning also requires the fold to be CURRENT (watermark within two fold
     lags of now) and stays a full fold lag below it. Summary reads load the
@@ -121,6 +122,7 @@ async def _prune_request_logs(cutoff: datetime, *, now: datetime) -> int:
                         select(
                             AccountUsageRollupState.folded_through,
                             AccountUsageRollupState.hourly_folded_through,
+                            AccountUsageRollupState.conversation_folded_through,
                         )
                         .where(AccountUsageRollupState.id == 1)
                         .with_for_update()

--- a/app/db/alembic/versions/20260806_010000_add_conversation_presence_rollup.py
+++ b/app/db/alembic/versions/20260806_010000_add_conversation_presence_rollup.py
@@ -1,0 +1,72 @@
+"""add conversation presence rollup table and fold watermark
+
+DDL only — the satellite is created empty and backfill is owned entirely by
+the runtime conversation fold pass, so this revision never blocks startup.
+The watermark column backfills existing state rows to the epoch, so the new
+satellite starts its own paced backfill from zero without touching the
+lifetime or hourly watermarks.
+
+Revision ID: 20260806_010000_add_conversation_presence_rollup
+Revises: 20260806_000000_add_additional_usage_alias_probe_indexes
+Create Date: 2026-08-06
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Connection
+
+revision = "20260806_010000_add_conversation_presence_rollup"
+down_revision = "20260806_000000_add_additional_usage_alias_probe_indexes"
+branch_labels = None
+depends_on = None
+
+_TABLE = "request_conversation_hourly_rollups"
+_STATE_TABLE = "account_usage_rollup_state"
+_WATERMARK_COLUMN = "conversation_folded_through"
+
+
+def _columns(connection: Connection, table_name: str) -> set[str]:
+    inspector = sa.inspect(connection)
+    if not inspector.has_table(table_name):
+        return set()
+    return {str(column["name"]) for column in inspector.get_columns(table_name) if column.get("name") is not None}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    if not sa.inspect(bind).has_table(_TABLE):
+        op.create_table(
+            _TABLE,
+            sa.Column("bucket_epoch", sa.BigInteger(), nullable=False),
+            sa.Column("conversation_id", sa.String(), nullable=False),
+            sa.Column("account_id", sa.String(), nullable=False),
+            sa.Column("is_deleted", sa.Boolean(), server_default=sa.false(), nullable=False),
+            sa.Column("request_count", sa.BigInteger(), server_default=sa.text("0"), nullable=False),
+            sa.PrimaryKeyConstraint("bucket_epoch", "conversation_id", "account_id", "is_deleted"),
+        )
+
+    state_columns = _columns(bind, _STATE_TABLE)
+    if state_columns and _WATERMARK_COLUMN not in state_columns:
+        with op.batch_alter_table(_STATE_TABLE) as batch_op:
+            batch_op.add_column(
+                sa.Column(
+                    _WATERMARK_COLUMN,
+                    sa.DateTime(),
+                    server_default=sa.text("'1970-01-01 00:00:00'"),
+                    nullable=False,
+                )
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    if _WATERMARK_COLUMN in _columns(bind, _STATE_TABLE):
+        with op.batch_alter_table(_STATE_TABLE) as batch_op:
+            batch_op.drop_column(_WATERMARK_COLUMN)
+
+    if sa.inspect(bind).has_table(_TABLE):
+        op.drop_table(_TABLE)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -232,6 +232,15 @@ class AccountUsageRollupState(Base):
         nullable=False,
         server_default=text("'1970-01-01 00:00:00'"),
     )
+    # Watermark for the conversation presence satellite. Separate from
+    # `hourly_folded_through` (same alignment invariant, same state row and
+    # row lock) so the satellite added later backfills from epoch without
+    # rewinding — and without being gated on — the other time-axis rollups.
+    conversation_folded_through: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        server_default=text("'1970-01-01 00:00:00'"),
+    )
 
 
 class RequestUsageHourlyRollup(Base):
@@ -337,6 +346,34 @@ class RequestDemandQuarterRollup(Base):
     )
     cached_input_tokens: Mapped[int] = mapped_column(BigInteger, default=0, server_default=text("0"), nullable=False)
     cost_usd: Mapped[float] = mapped_column(Float, default=0.0, server_default=text("0"), nullable=False)
+
+
+class RequestConversationHourlyRollup(Base):
+    """Hour-bucketed conversation presence (distinct-conversation satellite).
+
+    One row means "this conversation had ``request_count`` countable requests
+    in this UTC hour under this (account, is_deleted) attribution". Distinct
+    conversation counts are not additive across buckets, so the reads UNION
+    the folded ``conversation_id`` values with the raw live tail and count
+    distinct over the merge; ``request_count`` stays additive for the
+    conversation-request totals.
+
+    ``conversation_id`` is the normalized value (whitespace-trimmed,
+    non-empty — NULL/blank rows are excluded by the fold filter, matching
+    every reader). ``is_deleted`` is a dimension because the dashboard
+    conversation reads exclude soft-deleted rows while the reports reads
+    include them; ``account_id`` (NULL-sentinel encoded) is carried only so
+    the account lifecycle mirrors can re-attribute or remove folded presence
+    exactly as the raw mutation does. No FKs: rows must outlive accounts.
+    """
+
+    __tablename__ = "request_conversation_hourly_rollups"
+
+    bucket_epoch: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    conversation_id: Mapped[str] = mapped_column(String, primary_key=True)
+    account_id: Mapped[str] = mapped_column(String, primary_key=True)
+    is_deleted: Mapped[bool] = mapped_column(Boolean, primary_key=True, default=False, server_default=false())
+    request_count: Mapped[int] = mapped_column(BigInteger, default=0, server_default=text("0"), nullable=False)
 
 
 class AdditionalUsageHistory(Base):

--- a/app/modules/accounts/usage_rollup_scheduler.py
+++ b/app/modules/accounts/usage_rollup_scheduler.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from typing import Protocol, TypeVar, cast
 
 from app.modules.accounts.usage_rollup import run_fold_pass
-from app.modules.accounts.usage_time_rollup import run_hourly_fold_pass
+from app.modules.accounts.usage_time_rollup import run_conversation_fold_pass, run_hourly_fold_pass
 
 logger = logging.getLogger(__name__)
 
@@ -67,14 +67,17 @@ class AccountUsageRollupScheduler:
                 await run_fold_pass()
             except Exception:
                 logger.exception("Account usage rollup fold pass failed")
-            # Separate try-block on purpose: an hourly-aggregation bug must
-            # not stop the lifetime fold (and vice versa) — retention only
-            # ever pauses, because its prune gate takes the MIN of the two
-            # watermarks.
+            # Separate try-blocks on purpose: a bug in any one fold must not
+            # stop the others — retention only ever pauses, because its prune
+            # gate takes the MIN of every watermark.
             try:
                 await run_hourly_fold_pass()
             except Exception:
                 logger.exception("Hourly usage rollup fold pass failed")
+            try:
+                await run_conversation_fold_pass()
+            except Exception:
+                logger.exception("Conversation rollup fold pass failed")
 
 
 def build_account_usage_rollup_scheduler() -> AccountUsageRollupScheduler:

--- a/app/modules/accounts/usage_time_rollup.py
+++ b/app/modules/accounts/usage_time_rollup.py
@@ -1,6 +1,6 @@
 """Time-axis request-usage rollups: schema primitives and repository.
 
-Three permanent aggregate tables serve the dashboard/statistics read paths
+Four permanent aggregate tables serve the dashboard/statistics read paths
 without scanning raw ``request_logs``:
 
 - ``request_usage_hourly_rollups`` — UTC hour buckets x (account_id,
@@ -12,12 +12,21 @@ without scanning raw ``request_logs``:
   planner. The full legacy demand grain is preserved on purpose: the
   planner's ``_bin_demand_units`` applies ``max()`` PER BIN before summing
   (nonlinear), so folding to a coarser grain would change forecasts.
+- ``request_conversation_hourly_rollups`` — UTC hour buckets x (normalized
+  conversation_id, account_id, is_deleted); the distinct-conversation
+  presence satellite. Folded on its OWN watermark and fold pass with the
+  shared read-side filter (normalized conversation id present, warmup kinds
+  excluded); the deleted split stays a dimension because the dashboard
+  conversation reads exclude soft-deleted rows while the reports reads
+  include them.
 
-Watermark contract: ``account_usage_rollup_state.hourly_folded_through`` (the
-same single state row as the lifetime fold, so one ``FOR UPDATE`` row lock
-serializes every fold and lifecycle mutation) is ALWAYS aligned to a whole
-UTC hour. Raw rows with ``requested_at < watermark`` are fully folded; rows
-at or above it are the live tail. Buckets are half-open ``[start, end)``.
+Watermark contract: ``account_usage_rollup_state.hourly_folded_through`` and
+``conversation_folded_through`` (the same single state row as the lifetime
+fold, so one ``FOR UPDATE`` row lock serializes every fold and lifecycle
+mutation) are ALWAYS aligned to a whole UTC hour. Raw rows with
+``requested_at < watermark`` are fully folded by that watermark's tables;
+rows at or above it are the live tail. Buckets are half-open ``[start,
+end)``.
 
 NULL-dimension sentinel: nullable raw dimensions (account_id, api_key_id,
 service_tier, reasoning_effort) are stored as ``'\\x1f'`` so they can
@@ -34,12 +43,14 @@ rollups from raw.
 History-rewrite discipline (MUST): any code path that mutates a folded
 dimension (``requested_at``, ``deleted_at``, ``account_id``, ``api_key_id``,
 ``model``, ``service_tier``, ``reasoning_effort``, ``request_kind``,
-``status``, ``error_code``) or an aggregated measure column of
-``request_logs`` rows BELOW the hourly watermark must take
+``status``, ``error_code``, ``conversation_id``) or an aggregated measure
+column of ``request_logs`` rows BELOW the relevant watermark must take
 ``lock_fold_state()`` in the same transaction and either mirror the mutation
-into all three rollup tables or skip the pre-watermark rows (folded buckets
-are never recomputed from raw — raw may already be pruned by retention).
-``RequestLogsRepository.update_model_for_request`` takes the skip route.
+into every rollup table that folded it or skip the pre-watermark rows
+(folded buckets are never recomputed from raw — raw may already be pruned by
+retention). ``RequestLogsRepository.update_model_for_request`` takes the
+skip route (and needs no conversation-satellite bound at all: neither
+``model`` nor ``cost_usd`` is folded there).
 """
 
 from __future__ import annotations
@@ -55,6 +66,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.utils.time import utcnow
 from app.db.models import (
     AccountUsageRollupState,
+    RequestConversationHourlyRollup,
     RequestDemandQuarterRollup,
     RequestLog,
     RequestUsageHourlyErrorRollup,
@@ -89,6 +101,22 @@ _EPOCH = datetime(1970, 1, 1)
 # legacy raw queries do row-side.
 WARMUP_REQUEST_KINDS = ("warmup", "limit_warmup")
 _EXCLUDED_REQUEST_KINDS = WARMUP_REQUEST_KINDS
+
+# The whitespace set the conversation readers strip before comparing/counting
+# conversation ids (str.strip()'s ASCII whitespace).
+CONVERSATION_WHITESPACE = " \t\n\v\f\r"
+
+
+def conversation_id_expr() -> ColumnElement:
+    """Normalized conversation id: trimmed, with blank collapsed to NULL.
+
+    The single SQL definition shared by the conversation fold and every
+    conversation reader (dashboard and reports repositories) — a drifted
+    variant would silently split one conversation into two.
+    """
+    trimmed = func.ltrim(func.rtrim(RequestLog.conversation_id, CONVERSATION_WHITESPACE), CONVERSATION_WHITESPACE)
+    return func.nullif(trimmed, "")
+
 
 # Stored stand-in for NULL account_id / api_key_id / service_tier /
 # reasoning_effort (PK columns cannot be NULL, and NULLs would be distinct
@@ -173,6 +201,15 @@ class QuarterDemandRollupRow:
     cost_usd: float = 0.0
 
 
+@dataclass(frozen=True, slots=True)
+class ConversationHourlyRollupRow:
+    bucket_epoch: int
+    conversation_id: str
+    account_id: str
+    is_deleted: bool
+    request_count: int = 0
+
+
 _HOURLY_KEY_COLUMNS = (
     "bucket_epoch",
     "account_id",
@@ -213,6 +250,8 @@ _QUARTER_MEASURE_COLUMNS = (
     "cached_input_tokens",
     "cost_usd",
 )
+_CONVERSATION_KEY_COLUMNS = ("bucket_epoch", "conversation_id", "account_id", "is_deleted")
+_CONVERSATION_MEASURE_COLUMNS = ("request_count",)
 
 
 def _merge_rows(rows: Iterable, key_width: int, columns: tuple[str, ...], row_type):
@@ -306,6 +345,16 @@ class RequestUsageTimeRollupRepository:
             _QUARTER_KEY_COLUMNS,
             _QUARTER_KEY_COLUMNS + _QUARTER_MEASURE_COLUMNS,
             QuarterDemandRollupRow,
+        )
+
+    async def add_conversations(self, rows: Sequence[ConversationHourlyRollupRow]) -> None:
+        await _merge_add(
+            self._session,
+            RequestConversationHourlyRollup,
+            rows,
+            _CONVERSATION_KEY_COLUMNS,
+            _CONVERSATION_KEY_COLUMNS + _CONVERSATION_MEASURE_COLUMNS,
+            ConversationHourlyRollupRow,
         )
 
     async def read_hourly(
@@ -514,6 +563,34 @@ def _demand_fold_insert(session: AsyncSession, window: tuple[ColumnElement, ...]
     return insert(RequestDemandQuarterRollup).from_select(list(_QUARTER_KEY_COLUMNS + _QUARTER_MEASURE_COLUMNS), stmt)
 
 
+# Shared fold filter of the conversation satellite: exactly the row set every
+# conversation reader counts. The dashboard readers additionally require
+# `deleted_at IS NULL` and the reports readers additionally exclude
+# `source = 'limit_warmup'`; the former is the `is_deleted` dimension, the
+# latter is subsumed by the request_kind filter for every row the system
+# writes (limit-warmup traffic always carries a warmup request_kind).
+def _conversation_fold_conditions() -> tuple[ColumnElement[bool], ...]:
+    return (
+        conversation_id_expr().is_not(None),
+        RequestLog.request_kind.not_in(_EXCLUDED_REQUEST_KINDS),
+    )
+
+
+def _conversation_fold_insert(session: AsyncSession, window: tuple[ColumnElement, ...]):
+    bucket = _requested_at_epoch_bucket_expr(session, HOURLY_BUCKET_SECONDS).label("bucket_epoch")
+    conversation_id = conversation_id_expr().label("conversation_id")
+    account_id = _dimension_expr(RequestLog.account_id).label("account_id")
+    is_deleted = RequestLog.deleted_at.is_not(None).label("is_deleted")
+    stmt = (
+        select(bucket, conversation_id, account_id, is_deleted, func.count(RequestLog.id))
+        .where(*window, *_conversation_fold_conditions())
+        .group_by(bucket, conversation_id, account_id, is_deleted)
+    )
+    return insert(RequestConversationHourlyRollup).from_select(
+        list(_CONVERSATION_KEY_COLUMNS + _CONVERSATION_MEASURE_COLUMNS), stmt
+    )
+
+
 async def run_hourly_fold_pass(*, now: datetime | None = None) -> int:
     """Advance the hourly watermark toward `floor_hour(now - FOLD_LAG)`.
 
@@ -636,6 +713,88 @@ async def _advance_hourly_watermark(session: AsyncSession, value: datetime) -> N
     )
 
 
+async def run_conversation_fold_pass(*, now: datetime | None = None) -> int:
+    """Advance the conversation watermark toward `floor_hour(now - FOLD_LAG)`.
+
+    Same slice/transaction/crash-safety contract as `run_hourly_fold_pass`
+    (DELETE-then-INSERT slices, bounded per pass, watermark advance committed
+    atomically with the slice), on the satellite's own watermark so its
+    from-epoch backfill neither rewinds nor stalls the other rollups.
+    """
+    target = floor_to_hour((now or utcnow()) - FOLD_LAG)
+    committed = 0
+    while committed < TS_MAX_SLICES_PER_PASS:
+        async with get_background_session() as session:
+            status, wrote = await _fold_next_conversation_slice(session, target)
+        if wrote:
+            committed += 1
+        if status is _FoldStatus.DONE:
+            break
+    return committed
+
+
+async def _fold_next_conversation_slice(session: AsyncSession, target: datetime) -> tuple[_FoldStatus, bool]:
+    async with sqlite_writer_section():
+        # Same state row lock as every other fold and lifecycle mirror.
+        state = await _locked_state(session)
+        if state is None:
+            await session.execute(_state_bootstrap_stmt(session))
+            await session.commit()
+            state = await _locked_state(session)
+        if state is None:
+            logger.warning("account_usage_rollup_state row missing; skipping conversation fold pass")
+            return _FoldStatus.DONE, False
+        watermark = state.conversation_folded_through
+        if watermark >= target:
+            return _FoldStatus.DONE, False
+
+        # Unlike the hourly fold (which folds every row), only rows matching
+        # the fold filter contribute here, so the empty-prefix/gap jump scans
+        # for the next COUNTABLE row — hours holding only conversation-less
+        # rows are skipped exactly like empty ones.
+        next_populated = (
+            await session.execute(
+                select(func.min(RequestLog.requested_at)).where(
+                    RequestLog.requested_at >= watermark,
+                    RequestLog.requested_at < target,
+                    *_conversation_fold_conditions(),
+                )
+            )
+        ).scalar_one_or_none()
+        if next_populated is None:
+            await _advance_conversation_watermark(session, target)
+            await session.commit()
+            logger.info("Folded conversation rollups through %s (no rows below target)", target.isoformat())
+            return _FoldStatus.DONE, True
+
+        start = max(watermark, floor_to_hour(next_populated))
+        slice_end = min(start + TS_FOLD_SLICE, target)
+        start_epoch, end_epoch = epoch_seconds(start), epoch_seconds(slice_end)
+
+        # Defensive DELETE with the same convergence/preservation trade-off
+        # as the hourly slice: skipped hours are deliberately NOT cleared.
+        await session.execute(
+            delete(RequestConversationHourlyRollup).where(
+                RequestConversationHourlyRollup.bucket_epoch >= start_epoch,
+                RequestConversationHourlyRollup.bucket_epoch < end_epoch,
+            )
+        )
+        window = (RequestLog.requested_at >= start, RequestLog.requested_at < slice_end)
+        await session.execute(_conversation_fold_insert(session, window))
+        await _advance_conversation_watermark(session, slice_end)
+        await session.commit()
+        logger.info("Folded conversation rollups through %s", slice_end.isoformat())
+        return (_FoldStatus.DONE if slice_end >= target else _FoldStatus.CONTINUE), True
+
+
+async def _advance_conversation_watermark(session: AsyncSession, value: datetime) -> None:
+    await session.execute(
+        update(AccountUsageRollupState)
+        .where(AccountUsageRollupState.id == _STATE_ROW_ID)
+        .values(conversation_folded_through=value)
+    )
+
+
 # --- Account lifecycle mirrors -------------------------------------------
 #
 # The ONLY code paths allowed to touch folded buckets after the watermark
@@ -648,6 +807,12 @@ _ROLLUP_TABLES = (
     (RequestUsageHourlyRollup, _HOURLY_KEY_COLUMNS + _HOURLY_MEASURE_COLUMNS, HourlyUsageRollupRow, "add_hourly"),
     (RequestUsageHourlyErrorRollup, _ERROR_KEY_COLUMNS + _ERROR_MEASURE_COLUMNS, HourlyErrorRollupRow, "add_errors"),
     (RequestDemandQuarterRollup, _QUARTER_KEY_COLUMNS + _QUARTER_MEASURE_COLUMNS, QuarterDemandRollupRow, "add_demand"),
+    (
+        RequestConversationHourlyRollup,
+        _CONVERSATION_KEY_COLUMNS + _CONVERSATION_MEASURE_COLUMNS,
+        ConversationHourlyRollupRow,
+        "add_conversations",
+    ),
 )
 
 
@@ -670,7 +835,11 @@ async def mirror_account_soft_delete_into_time_rollups(session: AsyncSession, ac
     is_deleted=true)` dimension (merge-added — an orphaned-deleted bucket
     may already exist).
     The error satellite has no `is_deleted` dimension (its read includes
-    soft-deleted rows), so only `account_id` is re-keyed there.
+    soft-deleted rows), so only `account_id` is re-keyed there. The
+    conversation satellite carries `account_id` precisely so this mirror can
+    re-attribute presence the way the raw UPDATE does — the dashboard
+    conversation reads (which exclude soft-deleted rows) then stop counting
+    it while the reports reads (which include them) keep it.
     """
 
     def _rekey(row):

--- a/app/modules/accounts/usage_time_rollup_read.py
+++ b/app/modules/accounts/usage_time_rollup_read.py
@@ -28,6 +28,16 @@ apart across consumers:
   operator escape hatch reset) the rollup segment is empty and the raw
   windows collapse to the full ``[since, until)`` — the readers degrade to
   the exact legacy behaviour with no kill switch.
+
+The conversation-presence primitives at the bottom follow the same
+partitioning rule but resolve it INSIDE one statement (the watermark joined
+into both UNION branches) instead of returning raw windows: distinct
+conversation counts must merge folded ids and raw-tail ids in a single
+snapshot, and the raw complement can be phrased watermark-relative as
+``requested_at < ceil_grid(since) OR requested_at >= least(W,
+floor_grid(until))`` — an exact complement of the folded buckets for any
+watermark position, degrading to the full window when the watermark is at
+the epoch (or the state row is missing, via the raw branch's OUTER join).
 """
 
 from __future__ import annotations
@@ -35,11 +45,18 @@ from __future__ import annotations
 from collections.abc import Sequence
 from datetime import datetime, timedelta
 
-from sqlalchemy import BigInteger, ColumnElement, Integer, and_, func, or_, select
+from sqlalchemy import BigInteger, ColumnElement, Integer, Select, and_, cast, func, literal, or_, select, union_all
 from sqlalchemy import cast as sa_cast
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.selectable import CompoundSelect
 
-from app.db.models import AccountUsageRollupState, RequestDemandQuarterRollup, RequestLog, RequestUsageHourlyRollup
+from app.db.models import (
+    AccountUsageRollupState,
+    RequestConversationHourlyRollup,
+    RequestDemandQuarterRollup,
+    RequestLog,
+    RequestUsageHourlyRollup,
+)
 from app.modules.accounts.usage_time_rollup import (
     _STATE_ROW_ID,
     HOURLY_BUCKET_SECONDS,
@@ -49,6 +66,8 @@ from app.modules.accounts.usage_time_rollup import (
     HourlyUsageRollupRow,
     QuarterDemandRollupRow,
     RequestUsageTimeRollupRepository,
+    _requested_at_epoch_bucket_expr,
+    conversation_id_expr,
     epoch_seconds,
 )
 
@@ -205,6 +224,202 @@ def raw_windows_clause(windows: Sequence[RawWindow]) -> ColumnElement[bool]:
     if not clauses:
         raise ValueError("raw_windows_clause requires at least one window")
     return or_(*clauses)
+
+
+# --- Conversation presence primitives -------------------------------------
+#
+# Distinct conversation counts are not additive across the fold boundary, so
+# the conversation readers merge the folded ids and the raw-tail ids inside
+# ONE statement: the state row is joined into both UNION branches, giving the
+# whole read a single snapshot (a concurrent fold slice or an operator
+# escape-hatch reset can never split the watermark generation between the
+# folded segment and the raw complement). `request_count` rides along for the
+# additive conversation-request totals (each raw row contributes 1).
+
+
+def _conversation_watermark_epoch_expr(session: AsyncSession) -> ColumnElement:
+    """Epoch seconds of the conversation watermark (whole hours, so the
+    conversion is exact), dialect-split like the bucket expressions."""
+    column = AccountUsageRollupState.conversation_folded_through
+    if session.get_bind().dialect.name == "postgresql":
+        return cast(func.floor(func.extract("epoch", column)), BigInteger)
+    return cast(func.strftime("%s", column), Integer)
+
+
+def _least_fn(session: AsyncSession):
+    # SQLite's two-argument min() scalar function is its least().
+    return func.least if session.get_bind().dialect.name == "postgresql" else func.min
+
+
+def _conversation_folded_select(
+    session: AsyncSession,
+    since: datetime,
+    until: datetime | None,
+    *,
+    include_deleted: bool,
+    display_bucket_seconds: int | None,
+) -> Select:
+    rollup = RequestConversationHourlyRollup
+    conditions: list[ColumnElement[bool]] = [
+        rollup.bucket_epoch >= epoch_seconds(ceil_to_grid(since, HOURLY_BUCKET_SECONDS)),
+        rollup.bucket_epoch < _conversation_watermark_epoch_expr(session),
+    ]
+    if until is not None:
+        conditions.append(rollup.bucket_epoch < epoch_seconds(floor_to_grid(until, HOURLY_BUCKET_SECONDS)))
+    if not include_deleted:
+        conditions.append(rollup.is_deleted.is_(False))
+    columns: list = [rollup.conversation_id.label("cid"), rollup.request_count.label("request_count")]
+    if display_bucket_seconds is not None:
+        # Dialect-split integer flooring: SQLAlchemy renders `/` as true
+        # division (NUMERIC on PostgreSQL, where a bigint cast then ROUNDS),
+        # so mirror the raw readers' bucket arithmetic instead.
+        if session.get_bind().dialect.name == "postgresql":
+            display = cast(
+                func.floor(rollup.bucket_epoch / display_bucket_seconds) * display_bucket_seconds, BigInteger
+            )
+        else:
+            display = cast(rollup.bucket_epoch / display_bucket_seconds, Integer) * display_bucket_seconds
+        columns.insert(0, display.label("bucket_epoch"))
+    return (
+        select(*columns)
+        .select_from(AccountUsageRollupState)
+        .join(rollup, and_(*conditions))
+        .where(AccountUsageRollupState.id == _STATE_ROW_ID)
+    )
+
+
+def _conversation_raw_complement_clause(
+    session: AsyncSession, lo: datetime, hi: datetime | None
+) -> ColumnElement[bool]:
+    """Rows NOT covered by the folded segment ``[lo, min(W, hi))``: below the
+    ceil-grid start, or at/above the watermark-clamped end. A NULL watermark
+    (state row missing — the callers OUTER-join it) or an epoch watermark
+    degrades to the caller's full window."""
+    watermark = AccountUsageRollupState.conversation_folded_through
+    tail_start = watermark if hi is None else _least_fn(session)(watermark, hi)
+    return or_(watermark.is_(None), RequestLog.requested_at < lo, RequestLog.requested_at >= tail_start)
+
+
+def _conversation_raw_select(
+    session: AsyncSession,
+    since: datetime,
+    until: datetime | None,
+    *,
+    raw_conditions: Sequence[ColumnElement[bool]],
+    display_bucket_seconds: int | None,
+) -> Select:
+    lo = ceil_to_grid(since, HOURLY_BUCKET_SECONDS)
+    hi = None if until is None else floor_to_grid(until, HOURLY_BUCKET_SECONDS)
+    conditions: list[ColumnElement[bool]] = [
+        RequestLog.requested_at >= since,
+        _conversation_raw_complement_clause(session, lo, hi),
+        conversation_id_expr().is_not(None),
+        *raw_conditions,
+    ]
+    if until is not None:
+        conditions.append(RequestLog.requested_at < until)
+    columns: list = [conversation_id_expr().label("cid"), literal(1).label("request_count")]
+    if display_bucket_seconds is not None:
+        columns.insert(0, _requested_at_epoch_bucket_expr(session, display_bucket_seconds).label("bucket_epoch"))
+    return (
+        select(*columns)
+        .select_from(RequestLog)
+        .outerjoin(AccountUsageRollupState, AccountUsageRollupState.id == _STATE_ROW_ID)
+        .where(and_(*conditions))
+    )
+
+
+def conversation_presence_union(
+    session: AsyncSession,
+    since: datetime,
+    until: datetime | None = None,
+    *,
+    include_deleted: bool,
+    raw_conditions: Sequence[ColumnElement[bool]] = (),
+    display_bucket_seconds: int | None = None,
+) -> CompoundSelect:
+    """UNION ALL of ``(bucket_epoch?, cid, request_count)`` rows: the folded
+    presence inside ``[since, until)`` plus its exact raw complement.
+
+    ``raw_conditions`` MUST be the caller's legacy row filter minus the
+    window and the non-empty-conversation predicate (both owned here);
+    ``include_deleted`` mirrors whether that filter keeps soft-deleted rows.
+    Callers count ``DISTINCT cid`` (dedup across the fold boundary) and/or
+    ``SUM(request_count)`` over the union. ``display_bucket_seconds`` (a
+    whole multiple of the rollup hour) adds the display-bucket column for
+    per-bucket grouping.
+    """
+    return union_all(
+        _conversation_folded_select(
+            session, since, until, include_deleted=include_deleted, display_bucket_seconds=display_bucket_seconds
+        ),
+        _conversation_raw_select(
+            session, since, until, raw_conditions=raw_conditions, display_bucket_seconds=display_bucket_seconds
+        ),
+    )
+
+
+def conversation_labeled_presence_union(
+    session: AsyncSession,
+    windows: Sequence[tuple[str, datetime, datetime]],
+    *,
+    raw_conditions: Sequence[ColumnElement[bool]] = (),
+) -> CompoundSelect:
+    """``(label, cid)`` UNION ALL rows over labeled half-open windows (the
+    reports per-local-day ranges, whose bounds need not be hour-aligned).
+
+    Soft-deleted rows are included on both sides — the reports conversation
+    reads carry no ``deleted_at`` filter. Callers group by label and count
+    ``DISTINCT cid``; windows are expected pre-batched below the SQLite
+    compound-select limit (the reports repository already batches at 500).
+    """
+    window_rows = [
+        select(
+            literal(label).label("label"),
+            literal(start).label("window_start"),
+            literal(end).label("window_end"),
+            literal(ceil_to_grid(start, HOURLY_BUCKET_SECONDS)).label("fold_lo_at"),
+            literal(floor_to_grid(end, HOURLY_BUCKET_SECONDS)).label("fold_hi_at"),
+            literal(epoch_seconds(ceil_to_grid(start, HOURLY_BUCKET_SECONDS))).label("fold_lo_epoch"),
+            literal(epoch_seconds(floor_to_grid(end, HOURLY_BUCKET_SECONDS))).label("fold_hi_epoch"),
+        )
+        for label, start, end in windows
+    ]
+    windows_cte = (window_rows[0] if len(window_rows) == 1 else union_all(*window_rows)).cte("conversation_windows")
+    rollup = RequestConversationHourlyRollup
+    folded = select(windows_cte.c.label, rollup.conversation_id.label("cid")).select_from(
+        windows_cte.join(AccountUsageRollupState, AccountUsageRollupState.id == _STATE_ROW_ID).join(
+            rollup,
+            and_(
+                rollup.bucket_epoch >= windows_cte.c.fold_lo_epoch,
+                rollup.bucket_epoch < windows_cte.c.fold_hi_epoch,
+                rollup.bucket_epoch < _conversation_watermark_epoch_expr(session),
+            ),
+        )
+    )
+    watermark = AccountUsageRollupState.conversation_folded_through
+    raw = (
+        select(windows_cte.c.label, conversation_id_expr().label("cid"))
+        .select_from(
+            windows_cte.join(
+                RequestLog,
+                and_(
+                    RequestLog.requested_at >= windows_cte.c.window_start,
+                    RequestLog.requested_at < windows_cte.c.window_end,
+                    conversation_id_expr().is_not(None),
+                    *raw_conditions,
+                ),
+            ).outerjoin(AccountUsageRollupState, AccountUsageRollupState.id == _STATE_ROW_ID)
+        )
+        .where(
+            or_(
+                watermark.is_(None),
+                RequestLog.requested_at < windows_cte.c.fold_lo_at,
+                RequestLog.requested_at >= _least_fn(session)(watermark, windows_cte.c.fold_hi_at),
+            )
+        )
+    )
+    return union_all(folded, raw)
 
 
 async def earliest_hourly_bucket_at(session: AsyncSession) -> datetime | None:

--- a/app/modules/reports/repository.py
+++ b/app/modules/reports/repository.py
@@ -9,6 +9,11 @@ from sqlalchemy import and_, case, func, literal, or_, select, union_all
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.models import Account, RequestLog
+from app.modules.accounts.usage_time_rollup import conversation_id_expr
+from app.modules.accounts.usage_time_rollup_read import (
+    conversation_labeled_presence_union,
+    conversation_presence_union,
+)
 
 _INTERNAL_LIMIT_WARMUP_SOURCE = "limit_warmup"
 _INTERNAL_WARMUP_REQUEST_KINDS = ("warmup", "limit_warmup")
@@ -16,7 +21,6 @@ _SQLITE_COMPOUND_SELECT_LIMIT = 500
 MAX_DAILY_REPORT_DAYS = 730
 UNKNOWN_USERAGENT_GROUP = "Unknown"
 MISSING_USERAGENT_GROUP = "Missing User-Agent"
-_CONVERSATION_WHITESPACE = " \t\n\v\f\r"
 
 
 class DailyReportRangeTooLargeError(ValueError):
@@ -79,11 +83,7 @@ class ReportsRepository:
 
     @staticmethod
     def _conversation_id_expr():
-        trimmed = func.ltrim(
-            func.rtrim(RequestLog.conversation_id, _CONVERSATION_WHITESPACE),
-            _CONVERSATION_WHITESPACE,
-        )
-        return func.nullif(trimmed, "")
+        return conversation_id_expr()
 
     async def aggregate_daily_rows(
         self,
@@ -101,6 +101,11 @@ class ReportsRepository:
         if not day_ranges:
             return []
 
+        # Same filtered-vs-unfiltered split as `aggregate_summary`: only the
+        # unfiltered per-day conversation counts are served from the
+        # conversation satellite (one extra statement per batch, replacing
+        # the raw COUNT(DISTINCT ...) column in the main statement).
+        use_rollup = not (account_ids or model or useragent_group)
         rows: list[DailyReportAggregateRow] = []
         # SQLite caps compound SELECTs at 500 terms, so long report ranges are
         # executed in chunks instead of building a single oversized UNION ALL.
@@ -117,8 +122,23 @@ class ReportsRepository:
                 )
                 for speed_row in speed_result.all()
             }
+            conversation_values: dict[str, int] = {}
+            if use_rollup:
+                union = conversation_labeled_presence_union(
+                    self._session,
+                    day_ranges_list,
+                    raw_conditions=(_normal_traffic_clause(),),
+                ).subquery()
+                conversation_result = await self._session.execute(
+                    select(union.c.label, func.count(func.distinct(union.c.cid))).group_by(union.c.label)
+                )
+                conversation_values = {label: int(count) for label, count in conversation_result.all()}
 
-            result = await self._session.execute(_daily_rows_stmt(day_ranges_list, account_ids, model, useragent_group))
+            result = await self._session.execute(
+                _daily_rows_stmt(
+                    day_ranges_list, account_ids, model, useragent_group, include_conversations=not use_rollup
+                )
+            )
             rows.extend(
                 DailyReportAggregateRow(
                     date=row.report_date,
@@ -132,7 +152,9 @@ class ReportsRepository:
                     median_ttft_ms=speed_values.get(row.report_date, (0.0, 0.0, 0.0))[0],
                     median_tps=speed_values.get(row.report_date, (0.0, 0.0, 0.0))[1],
                     median_queue_ms=speed_values.get(row.report_date, (0.0, 0.0, 0.0))[2],
-                    conversation_count=int(row.conversation_count or 0),
+                    conversation_count=(
+                        conversation_values.get(row.report_date, 0) if use_rollup else int(row.conversation_count or 0)
+                    ),
                 )
                 for row in result.all()
             )
@@ -148,22 +170,40 @@ class ReportsRepository:
     ) -> SummaryAggregateRow:
         conditions = _report_conditions(start_date, end_date, account_ids, model, useragent_group)
 
-        result = await self._session.execute(
-            select(
-                func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("total_cost_usd"),
-                func.coalesce(func.sum(RequestLog.input_tokens), 0).label("total_input_tokens"),
-                func.coalesce(func.sum(RequestLog.output_tokens), 0).label("total_output_tokens"),
-                func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("total_cached_tokens"),
-                func.count().label("total_requests"),
-                func.coalesce(
-                    func.sum(case((RequestLog.status != "success", 1), else_=0)),
-                    0,
-                ).label("total_errors"),
-                func.count(func.distinct(RequestLog.account_id)).label("active_accounts"),
-                func.count(func.distinct(self._conversation_id_expr())).label("conversation_count"),
-            ).where(and_(*conditions))
-        )
-        row = result.one()
+        # The conversation satellite carries no model/useragent dimensions
+        # and pre-merges accounts, so only the unfiltered read is served from
+        # it (rollup + raw tail, split out of the single statement the same
+        # way the dashboard activity read splits its conversation metrics);
+        # filtered summaries keep the legacy raw single statement.
+        use_rollup = not (account_ids or model or useragent_group)
+        columns = [
+            func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("total_cost_usd"),
+            func.coalesce(func.sum(RequestLog.input_tokens), 0).label("total_input_tokens"),
+            func.coalesce(func.sum(RequestLog.output_tokens), 0).label("total_output_tokens"),
+            func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("total_cached_tokens"),
+            func.count().label("total_requests"),
+            func.coalesce(
+                func.sum(case((RequestLog.status != "success", 1), else_=0)),
+                0,
+            ).label("total_errors"),
+            func.count(func.distinct(RequestLog.account_id)).label("active_accounts"),
+        ]
+        if not use_rollup:
+            columns.append(func.count(func.distinct(self._conversation_id_expr())).label("conversation_count"))
+        row = (await self._session.execute(select(*columns).where(and_(*conditions)))).one()
+        if use_rollup:
+            union = conversation_presence_union(
+                self._session,
+                start_date,
+                end_date,
+                include_deleted=True,
+                raw_conditions=(_normal_traffic_clause(),),
+            ).subquery()
+            conversation_count = (
+                await self._session.execute(select(func.count(func.distinct(union.c.cid))))
+            ).scalar_one()
+        else:
+            conversation_count = row.conversation_count
         return SummaryAggregateRow(
             total_cost_usd=float(row.total_cost_usd),
             total_input_tokens=int(row.total_input_tokens),
@@ -172,7 +212,7 @@ class ReportsRepository:
             total_requests=int(row.total_requests),
             total_errors=int(row.total_errors),
             active_accounts=int(row.active_accounts),
-            conversation_count=int(row.conversation_count or 0),
+            conversation_count=int(conversation_count or 0),
         )
 
     async def aggregate_by_model(
@@ -530,24 +570,28 @@ def _daily_rows_stmt(
     account_ids: list[str] | None,
     model: str | None,
     useragent_group: str | None,
+    *,
+    include_conversations: bool = True,
 ):
     useragent_group_clause = _useragent_group_filter_clause(useragent_group)
     day_ranges_cte = _day_ranges_cte(day_ranges)
+    columns = [
+        day_ranges_cte.c.report_date,
+        func.count(RequestLog.id).label("requests"),
+        func.coalesce(func.sum(RequestLog.input_tokens), 0).label("input_tokens"),
+        func.coalesce(func.sum(RequestLog.output_tokens), 0).label("output_tokens"),
+        func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("cached_input_tokens"),
+        func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("cost_usd"),
+        func.count(func.distinct(RequestLog.account_id)).label("active_accounts"),
+        func.coalesce(
+            func.sum(case((RequestLog.status != "success", 1), else_=0)),
+            0,
+        ).label("error_count"),
+    ]
+    if include_conversations:
+        columns.append(func.count(func.distinct(ReportsRepository._conversation_id_expr())).label("conversation_count"))
     return (
-        select(
-            day_ranges_cte.c.report_date,
-            func.count(RequestLog.id).label("requests"),
-            func.coalesce(func.sum(RequestLog.input_tokens), 0).label("input_tokens"),
-            func.coalesce(func.sum(RequestLog.output_tokens), 0).label("output_tokens"),
-            func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("cached_input_tokens"),
-            func.coalesce(func.sum(RequestLog.cost_usd), 0.0).label("cost_usd"),
-            func.count(func.distinct(RequestLog.account_id)).label("active_accounts"),
-            func.count(func.distinct(ReportsRepository._conversation_id_expr())).label("conversation_count"),
-            func.coalesce(
-                func.sum(case((RequestLog.status != "success", 1), else_=0)),
-                0,
-            ).label("error_count"),
-        )
+        select(*columns)
         .select_from(
             day_ranges_cte.join(
                 RequestLog,

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -35,12 +35,14 @@ from app.modules.accounts.usage_rollup import lock_fold_state
 from app.modules.accounts.usage_time_rollup import (
     HOURLY_BUCKET_SECONDS,
     WARMUP_REQUEST_KINDS,
+    conversation_id_expr,
     floor_to_hour,
     from_dimension,
     to_dimension,
 )
 from app.modules.accounts.usage_time_rollup_read import (
     RawWindow,
+    conversation_presence_union,
     earliest_hourly_bucket_at,
     raw_windows_clause,
     read_errors_window,
@@ -210,11 +212,7 @@ class RequestLogsRepository:
 
     @staticmethod
     def _conversation_id_expr() -> ColumnElement:
-        trimmed = func.ltrim(
-            func.rtrim(RequestLog.conversation_id, _CONVERSATION_WHITESPACE),
-            _CONVERSATION_WHITESPACE,
-        )
-        return func.nullif(trimmed, "")
+        return conversation_id_expr()
 
     def _conversation_output_expr(self) -> ColumnElement:
         return func.coalesce(RequestLog.output_tokens, RequestLog.reasoning_tokens, 0)
@@ -663,22 +661,40 @@ class RequestLogsRepository:
         since: datetime,
         bucket_seconds: int = 21600,
     ) -> list[BucketConversationAggregate]:
-        bucket_expr = self._bucket_epoch_expr(bucket_seconds)
-        bucket_col = bucket_expr.label("bucket_epoch")
-        conversation_id = self._conversation_id_expr()
-        stmt = (
-            select(
-                bucket_col,
-                func.count(func.distinct(conversation_id)).label("conversation_count"),
+        # Hour-multiple display buckets merge the conversation satellite with
+        # the raw tail in one UNION statement: COUNT(DISTINCT) over the merge
+        # dedups a conversation present on both sides of the fold boundary
+        # within one display bucket. Any other granularity degrades to the
+        # legacy full-raw scan (a display bucket would split a folded hour).
+        if bucket_seconds > 0 and bucket_seconds % HOURLY_BUCKET_SECONDS == 0:
+            union = conversation_presence_union(
+                self._session,
+                since,
+                include_deleted=False,
+                raw_conditions=self._eligible_conversation_row_conditions(),
+                display_bucket_seconds=bucket_seconds,
+            ).subquery()
+            stmt = (
+                select(union.c.bucket_epoch, func.count(func.distinct(union.c.cid)).label("conversation_count"))
+                .group_by(union.c.bucket_epoch)
+                .order_by(union.c.bucket_epoch)
             )
-            .where(
-                RequestLog.requested_at >= since,
-                *self._eligible_conversation_row_conditions(),
-                conversation_id.is_not(None),
+        else:
+            bucket_col = self._bucket_epoch_expr(bucket_seconds).label("bucket_epoch")
+            conversation_id = self._conversation_id_expr()
+            stmt = (
+                select(
+                    bucket_col,
+                    func.count(func.distinct(conversation_id)).label("conversation_count"),
+                )
+                .where(
+                    RequestLog.requested_at >= since,
+                    *self._eligible_conversation_row_conditions(),
+                    conversation_id.is_not(None),
+                )
+                .group_by(bucket_col)
+                .order_by(bucket_col)
             )
-            .group_by(bucket_col)
-            .order_by(bucket_col)
-        )
         result = await self._session.execute(stmt)
         return [
             BucketConversationAggregate(
@@ -734,20 +750,23 @@ class RequestLogsRepository:
             cost_usd += float(row.cost_usd or 0.0)
 
         # Distinct conversation counts are not additive across the fold
-        # boundary, so they always come from raw over the FULL window (a
-        # documented non-goal: they only reach as far back as retention keeps
-        # raw rows). This splits the legacy single-statement read in two —
+        # boundary, so they merge the conversation satellite with the raw
+        # tail via UNION ALL in one statement: COUNT(DISTINCT) dedups a
+        # conversation straddling the boundary, SUM(request_count) stays
+        # additive. This keeps the legacy read split in two statements —
         # totals and conversation metrics can straddle a concurrent insert,
         # which the periodically-polled dashboard tolerates.
+        union = conversation_presence_union(
+            self._session,
+            since,
+            until,
+            include_deleted=False,
+            raw_conditions=self._eligible_conversation_row_conditions(),
+        ).subquery()
         conversation_stmt = select(
-            func.count(func.distinct(self._conversation_id_expr())).label("conversation_count"),
-            func.count(self._conversation_id_expr()).label("conversation_request_count"),
-        ).where(
-            RequestLog.requested_at >= since,
-            *self._eligible_conversation_row_conditions(),
+            func.count(func.distinct(union.c.cid)).label("conversation_count"),
+            func.coalesce(func.sum(union.c.request_count), 0).label("conversation_request_count"),
         )
-        if until is not None:
-            conversation_stmt = conversation_stmt.where(RequestLog.requested_at < until)
         conversation_row = (await self._session.execute(conversation_stmt)).one()
 
         return RequestActivityAggregate(
@@ -1054,7 +1073,9 @@ class RequestLogsRepository:
         A matching row below the watermarks can only be a client-reused
         request id colliding with unrelated old traffic — the rewrite's
         target is the row the caller inserted moments ago. The fold-state
-        lock serializes this against an in-flight fold slice.
+        lock serializes this against an in-flight fold slice. The
+        conversation satellite needs no bound here: neither ``model`` nor
+        ``cost_usd`` is folded into it.
 
         Returns the number of rows that were updated.
         """

--- a/openspec/changes/add-conversation-presence-rollup/.openspec.yaml
+++ b/openspec/changes/add-conversation-presence-rollup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/add-conversation-presence-rollup/design.md
+++ b/openspec/changes/add-conversation-presence-rollup/design.md
@@ -1,0 +1,52 @@
+# Design — conversation presence rollup
+
+## Context
+
+Reference: `origin/main` 201281b5, mirroring the prior art in `add-request-log-usage-rollups` (hourly/error/demand rollups, `usage_time_rollup.py` + `usage_time_rollup_read.py`). Verified read-site filters as implemented today:
+
+- Dashboard (`request_logs/repository.py`, `aggregate_conversations_by_bucket` + `_aggregate_activity`): `deleted_at IS NULL`, `request_kind NOT IN ('warmup','limit_warmup')`, normalized `conversation_id` non-blank (`nullif(ltrim(rtrim(...)), '')`).
+- Reports (`reports/repository.py`, `aggregate_summary` + `_daily_rows_stmt`): `_normal_traffic_clause()` — same warmup-kind exclusion plus a belt-and-braces `source != 'limit_warmup'` — and NO `deleted_at` filter; optional account/model/useragent filters.
+
+The two reader families disagree on soft-deleted rows, which forces `is_deleted` to be a dimension, not a fold filter.
+
+## Decisions
+
+### D1: Key = (bucket_epoch, conversation_id, account_id, is_deleted); measure = request_count
+
+Distinct counts are not additive, so the satellite stores per-hour *presence* and the readers count `DISTINCT conversation_id` over folded ∪ raw. `request_count` stays additive for `conversation_request_count`. `is_deleted` reconciles the dashboard/reports filter split at read time. `account_id` (NULL-sentinel encoded, never read by the aggregates) is carried so ALL THREE lifecycle mirrors stay exact — the satellite simply joins the shared `_ROLLUP_TABLES` mirror registry:
+
+- soft delete → re-key to `(sentinel, is_deleted=true)`, exactly mirroring the raw `account_id=NULL, deleted_at=now` UPDATE;
+- hard history delete → `DELETE WHERE account_id = X`, exactly mirroring the raw row deletion (a conversation shared with a surviving account keeps the survivor's presence);
+- duplicate consolidation → re-key to the canonical account.
+
+This deliberately deviates from the sketched "no account dimension + watermark reset on hard delete" design: a reset would re-backfill the whole satellite from raw on every account deletion and permanently lose all conversation history older than the raw retention window each time. One extra key column buys exact O(account-history) mirrors and no reset machinery. The cost is one satellite row per (hour × conversation × account × deleted-split) instead of per (hour × conversation) — in practice a conversation rarely spans accounts within an hour.
+
+### D2: Separate `conversation_folded_through` watermark, same state row
+
+Same reasoning as `hourly_folded_through`: the satellite backfills from the epoch without rewinding the other rollups, and the single state row keeps one `FOR UPDATE` lock serializing every fold and mirror. The fold pass reuses the slice contract verbatim (DELETE-then-INSERT, 48 h slices, ≤20 per pass, hour-aligned half-open windows, FOLD_LAG target); the empty-prefix jump uses the fold-filtered `min(requested_at)` because only conversation-bearing non-warmup rows contribute.
+
+### D3: Reads are ONE statement — the state row joined into both UNION branches
+
+Distinct-dedup across the fold boundary needs folded ids and raw-tail ids in the same query. Rather than pre-reading the watermark (a torn read against the operator escape hatch), both UNION ALL branches join the state row: the folded branch takes buckets in `[ceil_hour(since), min(W, floor_hour(until)))`, the raw branch takes the exact complement `t < ceil_hour(since) OR t >= least(W, floor_hour(until))` (windows-bounded), OUTER-joining state so a missing row degrades to the full window. One statement = one snapshot, preserving the established consistency argument. The reports per-local-day variant (`conversation_labeled_presence_union`) carries per-day fold bounds as CTE literals, so half-hour-offset timezones and DST days partition exactly with no hour-alignment assumption.
+
+### D4: Fold filter = normalized cid present AND non-warmup kind; `source` clause not folded
+
+The reports readers' `source != 'limit_warmup'` clause cannot be a fold filter (the dashboard readers don't apply it) and is not worth a dimension: every writer couples `source='limit_warmup'` with `request_kind='warmup'` (`limit_warmup/service.py`), so the folded kind filter subsumes it for every row the system writes. The raw-tail side still applies the full `_normal_traffic_clause`. Documented residual: a hand-crafted row with a limit-warmup source but normal kind would be counted by the folded segment and excluded by a pure raw scan.
+
+### D5: Reports rollup path only when unfiltered
+
+`aggregate_summary`/`aggregate_daily_rows` accept account/model/useragent filters the satellite cannot express; filtered calls keep the legacy raw statement (including its inline conversation count). The unfiltered calls (the hot dashboard-shaped ones) split the conversation count out, like `_aggregate_activity` did in the prior change. Daily-report day-row membership stays raw-driven (the day CTE INNER-joins `request_logs`): a day whose raw rows are fully pruned drops out of the report exactly as before.
+
+### D6: Retention gate includes the conversation watermark
+
+`_prune_request_logs` takes `min(folded_through, hourly_folded_through, conversation_folded_through)` under the same `FOR UPDATE` read; the currency check is unchanged. Consequence (accepted, same as the hourly introduction): pruning pauses entirely until the conversation backfill catches up after deploy.
+
+## Risks / Trade-offs
+
+- Satellite cardinality is unbounded in `conversation_id`. Presence rows are bounded by request rows ever folded and are far smaller than `request_logs`; the error satellite already accepted the unbounded-dimension pattern.
+- Escape hatch now spans four tables + two watermark columns (truncate + reset in one transaction). The parity harness pins the degrade-and-rebackfill behaviour.
+- Mixed-version rolling deploys: an old replica neither folds nor reads the satellite (degrades to raw); the retention gate change rides the same release as the satellite, so no pruning can outrun it.
+
+## Migration Plan
+
+One guarded DDL-only revision (`20260806_010000_add_conversation_presence_rollup`, parent = the 20260803 merge head): create the empty satellite, add `conversation_folded_through` with an epoch server default (existing state rows backfill to epoch → paced runtime backfill). Downgrade drops both. No data migration ever.

--- a/openspec/changes/add-conversation-presence-rollup/proposal.md
+++ b/openspec/changes/add-conversation-presence-rollup/proposal.md
@@ -1,0 +1,30 @@
+# Add conversation presence rollup
+
+## Why
+
+The dashboard overview's conversation metrics are the last rollup-uncovered aggregates on the 30 s poll path: `aggregate_conversations_by_bucket`, the conversation half of `_aggregate_activity`, and the reports `aggregate_summary`/per-day conversation counts all run `COUNT(DISTINCT normalized conversation_id)` over the FULL raw `request_logs` window on every read (7–13 s observed in production). The `add-request-log-usage-rollups` change deliberately left them raw-bound ("distinct counts are not additive" was a documented non-goal); this change reverses that non-goal with a presence satellite whose reads dedup across the fold boundary, and as a consequence the conversation statistics now also survive request-log retention pruning.
+
+## What Changes
+
+- Add a permanent conversation presence satellite `request_conversation_hourly_rollups` keyed by `(bucket_epoch, conversation_id, account_id, is_deleted)` with an additive `request_count` measure. `conversation_id` is the normalized (trimmed, non-blank) value; `is_deleted` is a dimension because the dashboard conversation reads exclude soft-deleted rows while the reports reads include them; `account_id` (NULL-sentinel encoded) exists only so the account lifecycle mirrors stay exact.
+- Add a dedicated `conversation_folded_through` watermark on `account_usage_rollup_state` (same single row and `FOR UPDATE` lock; existing rows backfilled to the epoch) and a `run_conversation_fold_pass` with the established slice contract (DELETE-then-INSERT, hour-aligned half-open windows, paced backfill), run as a third leg of the existing scheduler tick.
+- Switch four conversation read sites (dashboard buckets + activity, reports summary + per-day) to a single-statement UNION of the folded presence and its exact raw complement, with `COUNT(DISTINCT)` deduplicating conversations that straddle the fold boundary. Reports reads take the rollup path only when unfiltered (the satellite has no model/useragent dimensions and pre-merges accounts). Epoch/missing watermark degrades to the exact legacy raw query — no kill switch.
+- Extend the account lifecycle mirrors (soft delete, hard history delete, duplicate consolidation) to the satellite via the shared mirror table registry, and extend the retention prune gate's min-watermark to include the conversation watermark.
+- One guarded DDL-only migration (one table, one state column); backfill is owned by the runtime fold pass.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `query-caching`: add the conversation presence satellite, its fold pass and watermark, and the rollup-plus-raw-tail switch for the distinct-conversation read paths (reversing the previous "conversation distinct counts stay raw-only" non-goal). This capability owns the rollup + live-tail pattern and the conversation aggregate query shapes.
+- `data-retention`: request-log pruning gates on the minimum of ALL fold watermarks, now including `conversation_folded_through`, so conversation statistics are never destroyed before the satellite has folded them.
+
+## Impact
+
+- Affected code: `app/db/models.py` (one model, one state column), one Alembic revision, `app/modules/accounts/usage_time_rollup.py` (fold pass + mirror registry), `usage_time_rollup_read.py` (presence-union read primitives), `usage_rollup_scheduler.py` (third fold leg), `app/core/retention/job.py` (min gate), read paths in `app/modules/request_logs/repository.py` and `app/modules/reports/repository.py`.
+- Affected tests: parity harness extended with conversation bucket series and reports snapshots plus conversation folds at every watermark state; retention-survival expectations for conversation metrics REVERSED (they now survive); new fold/dedup/lifecycle-mirror tests; a migration round-trip test; retention min-gate test for the conversation watermark.
+- No API request/response schema change, no frontend change, no new settings.

--- a/openspec/changes/add-conversation-presence-rollup/specs/data-retention/spec.md
+++ b/openspec/changes/add-conversation-presence-rollup/specs/data-retention/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Request-log pruning never deletes unfolded rows
+
+Request-log pruning MUST gate on every usage-rollup watermark — the lifetime `folded_through`, the time-axis `hourly_folded_through`, and the conversation satellite's `conversation_folded_through` — combined as their minimum. Pruning MUST run only while the combined fold is current (the minimum watermark within two fold lags of now) and MUST delete only rows with `requested_at` older than the retention cutoff AND at least one fold lag below the minimum watermark, so concurrent summary readers holding a slightly older watermark can never lose rows from a just-folded window and no rollup is ever robbed of raw it has not folded. When no rollup watermark exists, or any fold is catching up (initial backfill, stalled scheduler), request-log pruning MUST be skipped.
+
+#### Scenario: Unfolded rows survive pruning
+
+- **GIVEN** a request-log row older than the retention cutoff whose `requested_at` is above any fold watermark
+- **WHEN** the retention job runs
+- **THEN** the row MUST NOT be deleted
+
+#### Scenario: Stalled fold suspends pruning
+
+- **GIVEN** any fold watermark older than two fold lags
+- **WHEN** the retention job runs with request-log retention enabled
+- **THEN** no `request_logs` rows are deleted
+
+#### Scenario: Conversation backfill suspends pruning
+
+- **GIVEN** a deployment upgraded with existing history, where the lifetime and hourly watermarks are current but `conversation_folded_through` is still at or near the epoch
+- **WHEN** the retention job runs with request-log retention enabled
+- **THEN** no `request_logs` rows are deleted until the conversation backfill watermark becomes current
+
+#### Scenario: Lifetime totals are unchanged by pruning
+
+- **GIVEN** folded request-log rows older than the retention cutoff
+- **WHEN** the retention job deletes them and account usage summaries are read afterwards
+- **THEN** per-account lifetime totals MUST equal their pre-pruning values
+
+#### Scenario: Conversation statistics are unchanged by pruning
+
+- **GIVEN** request-log rows folded into the conversation presence satellite and older than the retention cutoff
+- **WHEN** the retention job deletes them
+- **THEN** the switched distinct-conversation reads over the pruned period MUST equal their pre-pruning values
+
+#### Scenario: Pruning is skipped before the first fold
+
+- **GIVEN** no `account_usage_rollup_state` row exists
+- **WHEN** the retention job runs with request-log retention enabled
+- **THEN** no `request_logs` rows are deleted

--- a/openspec/changes/add-conversation-presence-rollup/specs/query-caching/spec.md
+++ b/openspec/changes/add-conversation-presence-rollup/specs/query-caching/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: A conversation presence rollup serves distinct-conversation reads
+
+The system SHALL maintain a permanent conversation presence satellite `request_conversation_hourly_rollups` dimensioned by `(bucket_epoch, conversation_id, account_id, is_deleted)` with an additive `request_count` measure, folded from `request_logs` rows whose normalized conversation id (`NULLIF(TRIM(conversation_id), '')`) is non-null and whose `request_kind` is not a warmup kind. `conversation_id` MUST be stored as the normalized value; `is_deleted` MUST be a dimension (not a fold filter) because dashboard conversation reads exclude soft-deleted rows while reports conversation reads include them; `account_id` MUST be carried (NULL-sentinel encoded) solely so account lifecycle mirrors can re-attribute or remove folded presence exactly as the corresponding raw mutation does. The fold SHALL advance a dedicated hour-aligned `conversation_folded_through` watermark on `account_usage_rollup_state` under the shared fold-state row lock, with the established slice contract (DELETE-then-INSERT over half-open hour-aligned windows committed atomically with the watermark advance, bounded paced backfill, fold lag). Rollup rows MUST NOT be deleted by data retention.
+
+#### Scenario: Conversation straddling the fold boundary counts once
+
+- **GIVEN** one conversation with request rows both below and above `conversation_folded_through`
+- **WHEN** a switched distinct-conversation read spans both sides
+- **THEN** the conversation counts exactly once
+- **AND** the additive conversation-request total equals the folded `request_count` sum plus the raw-tail row count
+
+#### Scenario: Soft delete moves presence to the orphaned-deleted dimension
+
+- **GIVEN** folded conversation presence attributed to an account
+- **WHEN** the account is soft-deleted (raw history detached with `account_id=NULL, deleted_at=now`)
+- **THEN** the folded presence moves to the NULL-sentinel, `is_deleted=true` dimension in the same transaction
+- **AND** dashboard conversation reads stop counting it while reports conversation reads keep counting it
+
+#### Scenario: Hard history delete removes only that account's presence
+
+- **GIVEN** a conversation with folded presence from two accounts
+- **WHEN** one account is deleted with history removal
+- **THEN** only that account's presence rows are removed
+- **AND** the conversation still counts through the surviving account's presence, matching a raw scan of the surviving rows
+
+#### Scenario: Fold is idempotent
+
+- **GIVEN** a completed conversation fold pass
+- **WHEN** the pass re-runs with the same clock
+- **THEN** it commits no slices and the satellite contents are unchanged
+
+### Requirement: Distinct-conversation reads combine the presence rollup with a raw live tail in one statement
+
+The dashboard conversation activity metrics (`conversation_count`, `conversation_request_count`), the dashboard conversation trend buckets, and the UNFILTERED reports summary and per-day conversation counts MUST serve folded history from the presence satellite and the remainder from raw `request_logs`, merged in a single statement per read: the fold watermark joined into both branches of a UNION so the folded segment, its exact raw complement, and the watermark come from one database snapshot, and `COUNT(DISTINCT ...)` deduplicates across the fold boundary. Merged results MUST equal the legacy full-raw aggregation whenever the underlying raw rows still exist. With an epoch or missing watermark the reads MUST degrade to exactly the legacy raw queries (no kill switch). Reports reads carrying account, model, or useragent filters MUST keep the legacy raw statement (the satellite has no such dimensions), and non-hour-multiple dashboard display buckets MUST keep the full-raw path. This reverses the `add-request-log-usage-rollups` non-goal that kept distinct conversation counts raw-bound: conversation statistics over folded history now survive request-log retention pruning, except the documented raw-bound residues (sub-hour window edges, filtered reports reads, and daily-report day-row membership, which stays raw-driven).
+
+#### Scenario: Switched conversation reads equal legacy reads while raw exists
+
+- **GIVEN** a corpus with conversations spanning hours, blank and NULL conversation ids, warmup kinds, and soft-deleted rows
+- **WHEN** each switched conversation read runs with the conversation watermark at epoch, mid-history on an hour boundary, and at the fold target — including states where the hourly and conversation watermarks differ
+- **THEN** every result equals the legacy raw-only implementation exactly
+
+#### Scenario: Conversation statistics survive raw pruning
+
+- **GIVEN** folded conversation presence whose source raw rows have been pruned by retention
+- **WHEN** the dashboard conversation activity metrics, hour-multiple conversation trend buckets, or the unfiltered reports summary conversation count are read over that period
+- **THEN** the distinct-conversation values equal those reported before the pruning (modulo the documented sub-bucket window edges)
+
+#### Scenario: Filtered reports reads stay raw-bound
+
+- **GIVEN** a reports summary or daily read filtered by account, model, or useragent group
+- **WHEN** the read executes
+- **THEN** it uses the legacy raw statement and reaches only as far back as raw retention keeps rows
+
+#### Scenario: Non-hour-multiple conversation buckets degrade to full raw
+
+- **GIVEN** a conversation trend request with a display bucket that is not a whole multiple of the rollup hour
+- **WHEN** the aggregate is calculated
+- **THEN** the legacy full-raw query is used unchanged
+
+## MODIFIED Requirements
+
+### Requirement: Dashboard conversation trends aggregate by bucket
+
+The dashboard conversation trend query MUST group by the configured time bucket
+and count distinct non-empty normalized conversation IDs within each bucket. It
+MUST exclude warmup traffic and MUST NOT use model or service-tier grouping that
+could cause one conversation to be counted more than once in a bucket. For
+hour-multiple display buckets the count MUST merge the conversation presence
+rollup with the raw live tail through a UNION before the distinct count, so a
+conversation appearing in both the folded segment and the raw tail of one
+display bucket still counts once.
+
+#### Scenario: One conversation across model groups counts once per bucket
+
+- **GIVEN** a bucket contains two non-warmup request logs for `conv-a` under
+  different models and one log for `conv-b`
+- **WHEN** the dashboard conversation trend aggregate is calculated
+- **THEN** that bucket's conversation count is `2`
+
+#### Scenario: One conversation across the fold boundary counts once per bucket
+
+- **GIVEN** a display bucket containing rows for `conv-a` below the
+  conversation watermark (rollup-served) and above it (raw-served)
+- **WHEN** the dashboard conversation trend aggregate is calculated
+- **THEN** that bucket's conversation count counts `conv-a` once

--- a/openspec/changes/add-conversation-presence-rollup/tasks.md
+++ b/openspec/changes/add-conversation-presence-rollup/tasks.md
@@ -1,0 +1,27 @@
+# Tasks
+
+## 1. Schema and migration
+
+- [x] 1.1 Declare `RequestConversationHourlyRollup` and the `conversation_folded_through` state column in `app/db/models.py`.
+- [x] 1.2 Guarded DDL-only revision `20260806_010000_add_conversation_presence_rollup` (create table, add state column with epoch server default, guarded downgrade).
+- [x] 1.3 Migration round-trip test (upgrade → schema/PK/epoch-backfill assertions → downgrade → re-upgrade), registered in `POSTGRES_PYTEST_TARGETS`.
+
+## 2. Fold pass and lifecycle
+
+- [x] 2.1 `run_conversation_fold_pass` in `usage_time_rollup.py`: own watermark, shared state-row lock, DELETE-then-INSERT slices, fold-filtered empty-prefix jump, shared `conversation_id_expr` (also adopted by both repositories' `_conversation_id_expr`).
+- [x] 2.2 Third leg in `AccountUsageRollupScheduler._fold_as_leader` (own try-block).
+- [x] 2.3 Satellite registered in `_ROLLUP_TABLES`: soft-delete re-key, hard-delete removal, and consolidation re-key mirrors work unchanged; `update_model_for_request` needs no conversation bound (documented).
+- [x] 2.4 Retention prune gate takes the min over all three watermarks.
+
+## 3. Read switch
+
+- [x] 3.1 Single-statement presence-union primitives in `usage_time_rollup_read.py` (`conversation_presence_union`, `conversation_labeled_presence_union`), state row joined into both branches, exact complement clause, full-raw degrade on epoch/missing watermark.
+- [x] 3.2 Switch `aggregate_conversations_by_bucket` (hour-multiple buckets; others degrade full-raw) and `_aggregate_activity`'s conversation metrics.
+- [x] 3.3 Switch reports `aggregate_summary` and `aggregate_daily_rows` per-day conversation counts (unfiltered calls only; filtered calls keep the legacy statement).
+
+## 4. Verification
+
+- [x] 4.1 Parity harness: conversation bucket series (1h/6h/non-multiple degrade) and reports summary/daily (UTC and +05:30 local days) snapshotted; conversation folds run at every watermark state, in the concurrent-fold injection, the concurrent-pass gather, and the escape hatch (satellite truncated + watermark reset).
+- [x] 4.2 Retention parity expectations reversed: conversation activity metrics and hour-aligned conversation buckets now SURVIVE raw pruning; reports summary conversation count survives; daily day-row membership stays raw-driven (documented).
+- [x] 4.3 New tests: fold-boundary dedup + idempotent fixed point, bucket-series parity and non-hour-multiple degrade, soft-delete mirror (dashboard drops / reports keep), hard-delete mirror (shared conversation keeps the survivor), retention gate paused until the conversation backfill catches up.
+- [x] 4.4 SQLite + PostgreSQL runs of the rollup/parity/retention/migration suites; ruff, ruff format, ty.

--- a/tests/integration/test_data_retention.py
+++ b/tests/integration/test_data_retention.py
@@ -15,7 +15,7 @@ from app.db.models import Account, AccountStatus, AdditionalUsageHistory, Reques
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.accounts.usage_rollup import run_fold_pass
-from app.modules.accounts.usage_time_rollup import run_hourly_fold_pass
+from app.modules.accounts.usage_time_rollup import run_conversation_fold_pass, run_hourly_fold_pass
 from app.modules.request_logs.repository import RequestLogsRepository
 
 pytestmark = pytest.mark.integration
@@ -36,7 +36,9 @@ def _make_account(account_id: str, email: str) -> Account:
     )
 
 
-async def _add_log(logs_repo: RequestLogsRepository, *, account_id: str, request_id: str, requested_at):
+async def _add_log(
+    logs_repo: RequestLogsRepository, *, account_id: str, request_id: str, requested_at, conversation_id=None
+):
     return await logs_repo.add_log(
         account_id=account_id,
         request_id=request_id,
@@ -48,6 +50,7 @@ async def _add_log(logs_repo: RequestLogsRepository, *, account_id: str, request
         error_code=None,
         requested_at=requested_at,
         cost_usd=0.01,
+        conversation_id=conversation_id,
     )
 
 
@@ -95,6 +98,7 @@ async def test_request_log_pruning_respects_watermark_and_preserves_totals(async
 
     await run_fold_pass(now=now)
     await run_hourly_fold_pass(now=now)
+    await run_conversation_fold_pass(now=now)
 
     async def _request_usage():
         response = await async_client.get("/api/accounts")
@@ -191,6 +195,7 @@ async def test_pruning_drains_backlog_across_batches(db_setup, monkeypatch):
 
     await run_fold_pass(now=now)
     await run_hourly_fold_pass(now=now)
+    await run_conversation_fold_pass(now=now)
     _set_retention(monkeypatch, request_logs=30)
     monkeypatch.setattr(retention_job, "BATCH_SIZE", 2)
     deleted = await run_retention_pass(now=now)
@@ -216,6 +221,7 @@ async def test_request_log_pruning_skipped_while_fold_is_not_current(async_clien
     # Fold stalled 50 days ago: watermark = (now - 50d) - FOLD_LAG.
     await run_fold_pass(now=now - timedelta(days=50))
     await run_hourly_fold_pass(now=now - timedelta(days=50))
+    await run_conversation_fold_pass(now=now - timedelta(days=50))
 
     async def _request_usage():
         response = await async_client.get("/api/accounts")
@@ -264,6 +270,7 @@ async def test_request_log_pruning_skipped_while_hourly_backfill_behind(db_setup
 
     # Hourly fold catches up -> min watermark is current -> pruning resumes.
     await run_hourly_fold_pass(now=now)
+    await run_conversation_fold_pass(now=now)
     async with SessionLocal() as session:
         hourly_before = sorted(
             (await session.execute(sa_select(RequestUsageHourlyRollup))).scalars().all(),
@@ -303,6 +310,7 @@ async def test_request_log_pruning_skipped_while_hourly_fold_stalled(db_setup, m
         await _add_log(logs_repo, account_id="acc_hstall", request_id="req_1d", requested_at=now - timedelta(days=1))
 
     await run_hourly_fold_pass(now=now - timedelta(days=50))
+    await run_conversation_fold_pass(now=now - timedelta(days=50))
     await run_fold_pass(now=now)
 
     _set_retention(monkeypatch, request_logs=30)
@@ -311,6 +319,43 @@ async def test_request_log_pruning_skipped_while_hourly_fold_stalled(db_setup, m
     async with SessionLocal() as session:
         remaining = (await session.execute(select(RequestLog.request_id))).scalars().all()
     assert sorted(remaining) == ["req_1d", "req_60d"]
+
+
+@pytest.mark.asyncio
+async def test_request_log_pruning_skipped_while_conversation_backfill_behind(db_setup, monkeypatch):
+    """min-gate: the conversation satellite participates in the prune gate —
+    lifetime and hourly currency alone must not enable pruning while the
+    conversation backfill is still at the epoch, or raw the satellite never
+    folded would be lost. Once it catches up, pruning resumes and the folded
+    presence survives the prune."""
+    from sqlalchemy import select as sa_select
+
+    from app.db.models import RequestConversationHourlyRollup
+
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_cgate", "cgate@example.com"))
+        await _add_log(
+            logs_repo,
+            account_id="acc_cgate",
+            request_id="req_60d",
+            requested_at=now - timedelta(days=60),
+            conversation_id="conv_gate",
+        )
+        await _add_log(logs_repo, account_id="acc_cgate", request_id="req_1d", requested_at=now - timedelta(days=1))
+
+    await run_fold_pass(now=now)
+    await run_hourly_fold_pass(now=now)
+    _set_retention(monkeypatch, request_logs=30)
+    assert (await run_retention_pass(now=now))["request_logs"] == 0
+
+    await run_conversation_fold_pass(now=now)
+    assert (await run_retention_pass(now=now))["request_logs"] == 1
+    async with SessionLocal() as session:
+        presence = (await session.execute(sa_select(RequestConversationHourlyRollup))).scalars().all()
+    assert [(row.conversation_id, row.request_count) for row in presence] == [("conv_gate", 1)]
 
 
 @pytest.mark.asyncio
@@ -476,6 +521,7 @@ async def test_api_key_totals_survive_pruning_and_match_pre_fold(db_setup, monke
 
     await run_fold_pass(now=now)
     await run_hourly_fold_pass(now=now)
+    await run_conversation_fold_pass(now=now)
     assert await _key_summary() == before
 
     _set_retention(monkeypatch, request_logs=30)
@@ -612,6 +658,7 @@ async def test_dashboard_retention_overrides_env_alias(async_client, db_setup, m
 
     await run_fold_pass(now=now)
     await run_hourly_fold_pass(now=now)
+    await run_conversation_fold_pass(now=now)
 
     # Env alias alone (90 days) would keep the 40-day-old row...
     _set_retention(monkeypatch, request_logs=90)

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -1551,3 +1551,69 @@ async def test_stamped_merge_rollup_repair_downgrade_preserves_schema(tmp_path):
         assert rollup_tables <= tables_after_downgrade
     finally:
         await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_conversation_presence_rollup_migration_upgrade_and_downgrade(tmp_path):
+    from alembic import command
+    from sqlalchemy import inspect as sa_inspect
+
+    from app.db.migrate import _build_alembic_config
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'conversation-presence-rollup.sqlite'}"
+    parent_revision = "20260806_000000_add_additional_usage_alias_probe_indexes"
+    rollup_revision = "20260806_010000_add_conversation_presence_rollup"
+    table = "request_conversation_hourly_rollups"
+
+    def _schema_state(sync_conn):
+        inspector = sa_inspect(sync_conn)
+        return {
+            "has_table": inspector.has_table(table),
+            "state_columns": {column["name"] for column in inspector.get_columns("account_usage_rollup_state")},
+            "pk": (inspector.get_pk_constraint(table)["constrained_columns"] if inspector.has_table(table) else None),
+        }
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, parent_revision, bootstrap_legacy=False))
+    engine = create_async_engine(db_url, future=True)
+    try:
+        async with engine.connect() as conn:
+            state = await conn.run_sync(_schema_state)
+        assert not state["has_table"]
+        assert "conversation_folded_through" not in state["state_columns"]
+
+        await to_thread.run_sync(lambda: run_upgrade(db_url, rollup_revision, bootstrap_legacy=False))
+        async with engine.connect() as conn:
+            state = await conn.run_sync(_schema_state)
+        assert state["has_table"]
+        assert "conversation_folded_through" in state["state_columns"]
+        assert state["pk"] == ["bucket_epoch", "conversation_id", "account_id", "is_deleted"]
+
+        # The migration-seeded fold-state row (older revision) must have been
+        # backfilled to the epoch by the new column's server default — the
+        # satellite starts its own from-zero backfill — without touching the
+        # lifetime or hourly watermarks.
+        async with engine.connect() as conn:
+            row = (
+                await conn.execute(
+                    text(
+                        "SELECT hourly_folded_through, conversation_folded_through "
+                        "FROM account_usage_rollup_state WHERE id = 1"
+                    )
+                )
+            ).one()
+        assert str(row[1]).startswith("1970-01-01")
+
+        await to_thread.run_sync(lambda: command.downgrade(_build_alembic_config(db_url), parent_revision))
+        async with engine.connect() as conn:
+            state = await conn.run_sync(_schema_state)
+        assert not state["has_table"]
+        assert "conversation_folded_through" not in state["state_columns"]
+
+        # Idempotent re-upgrade.
+        await to_thread.run_sync(lambda: run_upgrade(db_url, rollup_revision, bootstrap_legacy=False))
+        async with engine.connect() as conn:
+            state = await conn.run_sync(_schema_state)
+        assert state["has_table"]
+        assert "conversation_folded_through" in state["state_columns"]
+    finally:
+        await engine.dispose()

--- a/tests/integration/test_request_usage_rollup_parity.py
+++ b/tests/integration/test_request_usage_rollup_parity.py
@@ -6,15 +6,16 @@ at watermark = epoch — in that state the switched code paths degrade to the
 identical single raw query the legacy readers ran — and re-asserted after
 folding to a mid-history hour and to the full target, plus under a
 concurrently-advancing fold, after the operator escape hatch, and after
-retention physically pruned the folded raw rows (the headline: statistics
-survive raw deletion; conversation metrics are expectedly raw-bound).
+retention physically pruned the folded raw rows (the headline: statistics —
+including the satellite-served distinct-conversation metrics — survive raw
+deletion).
 """
 
 from __future__ import annotations
 
 import asyncio
 from dataclasses import replace
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import delete, select, update
@@ -26,6 +27,7 @@ from app.db.models import (
     Account,
     AccountStatus,
     AccountUsageRollupState,
+    RequestConversationHourlyRollup,
     RequestDemandQuarterRollup,
     RequestLog,
     RequestUsageHourlyErrorRollup,
@@ -34,9 +36,14 @@ from app.db.models import (
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.accounts.usage_rollup import FOLD_LAG
-from app.modules.accounts.usage_time_rollup import floor_to_hour, run_hourly_fold_pass
+from app.modules.accounts.usage_time_rollup import (
+    floor_to_hour,
+    run_conversation_fold_pass,
+    run_hourly_fold_pass,
+)
 from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.quota_planner.repository import QuotaPlannerRepository
+from app.modules.reports.repository import ReportsRepository
 from app.modules.request_logs.repository import RequestLogsRepository
 
 pytestmark = pytest.mark.integration
@@ -273,11 +280,28 @@ async def _snapshot(*, lead_since: datetime = SINCE_UNALIGNED) -> dict:
         logs = RequestLogsRepository(session)
         planner = QuotaPlannerRepository(session)
         api_keys = ApiKeysRepository(session)
+        reports = ReportsRepository(session)
         return {
             "buckets_1h": await logs.aggregate_by_bucket(lead_since, 3600),
             "buckets_6h": await logs.aggregate_by_bucket(lead_since, 21600),
             "buckets_1d": await logs.aggregate_by_bucket(SINCE_ALIGNED, 86400),
             "buckets_raw_degrade": await logs.aggregate_by_bucket(lead_since, 5400),
+            "conv_buckets_1h": await logs.aggregate_conversations_by_bucket(lead_since, 3600),
+            "conv_buckets_6h": await logs.aggregate_conversations_by_bucket(lead_since, 21600),
+            "conv_buckets_raw_degrade": await logs.aggregate_conversations_by_bucket(lead_since, 5400),
+            "reports_summary": await reports.aggregate_summary(SINCE_ALIGNED, UNTIL_UNALIGNED),
+            "reports_summary_filtered": await reports.aggregate_summary(
+                SINCE_ALIGNED, UNTIL_UNALIGNED, account_ids=["acc_par_a"]
+            ),
+            "reports_daily_utc": await reports.aggregate_daily_rows(
+                BASE.date(), (BASE + timedelta(days=9)).date(), timezone.utc
+            ),
+            # A half-hour-offset local day: per-day windows are NOT
+            # hour-aligned, so every day carries partial raw edges around the
+            # satellite-served whole hours.
+            "reports_daily_offset": await reports.aggregate_daily_rows(
+                BASE.date(), (BASE + timedelta(days=9)).date(), timezone(timedelta(hours=5, minutes=30))
+            ),
             "activity_since": await logs.aggregate_activity_since(lead_since),
             "activity_between": await logs.aggregate_activity_between(lead_since, UNTIL_UNALIGNED),
             "activity_folded_only": await logs.aggregate_activity_between(*FOLDED_ONLY_WINDOW),
@@ -362,6 +386,18 @@ def _assert_snapshots_equal(actual: dict, expected: dict, *, skip_keys: tuple[st
                 actual_entry = actual_value[demand_key]
                 assert actual_entry[:4] == expected_entry[:4], (key, demand_key)
                 assert actual_entry[4] == pytest.approx(expected_entry[4], rel=1e-9, abs=1e-12), (key, demand_key)
+        elif key.startswith("reports_summary"):
+            assert replace(actual_value, total_cost_usd=0.0) == replace(expected_value, total_cost_usd=0.0), key
+            assert actual_value.total_cost_usd == pytest.approx(expected_value.total_cost_usd, rel=1e-9, abs=1e-12), key
+        elif key.startswith("reports_daily"):
+            float_zeroes = {"cost_usd": 0.0, "median_ttft_ms": 0.0, "median_tps": 0.0, "median_queue_ms": 0.0}
+            assert [replace(row, **float_zeroes) for row in actual_value] == [
+                replace(row, **float_zeroes) for row in expected_value
+            ], key
+            for field in float_zeroes:
+                assert [getattr(row, field) for row in actual_value] == pytest.approx(
+                    [getattr(row, field) for row in expected_value], rel=1e-9, abs=1e-9
+                ), (key, field)
         elif key.startswith("trends"):
             assert [(row.bucket_epoch, row.total_tokens) for row in actual_value] == [
                 (row.bucket_epoch, row.total_tokens) for row in expected_value
@@ -395,6 +431,14 @@ async def _watermark() -> datetime | None:
         return None if state is None else state.hourly_folded_through
 
 
+async def _conversation_watermark() -> datetime | None:
+    async with SessionLocal() as session:
+        state = (
+            await session.execute(select(AccountUsageRollupState).where(AccountUsageRollupState.id == 1))
+        ).scalar_one_or_none()
+        return None if state is None else state.conversation_folded_through
+
+
 @pytest.mark.asyncio
 async def test_switched_readers_match_legacy_across_watermark_states(db_setup):
     await _seed_corpus()
@@ -406,14 +450,22 @@ async def test_switched_readers_match_legacy_across_watermark_states(db_setup):
     assert reference["top_error_empty"] is None
     assert reference["trends_no_logs"] == []
 
-    # Watermark state 2 — mid-history whole hour.
+    # Watermark state 2 — mid-history whole hour. The hourly and conversation
+    # folds advance separately (mixed-watermark states in between must hold
+    # parity too: each satellite degrades on its own watermark).
     await run_hourly_fold_pass(now=MID_W + FOLD_LAG)
     assert await _watermark() == MID_W
+    _assert_snapshots_equal(await _snapshot(), reference)
+    await run_conversation_fold_pass(now=MID_W + FOLD_LAG)
+    assert await _conversation_watermark() == MID_W
     _assert_snapshots_equal(await _snapshot(), reference)
 
     # Watermark state 3 — full target: everything older than FOLD_LAG folded.
     await run_hourly_fold_pass(now=NOW)
+    _assert_snapshots_equal(await _snapshot(), reference)
+    await run_conversation_fold_pass(now=NOW)
     assert await _watermark() == TARGET_W
+    assert await _conversation_watermark() == TARGET_W
     _assert_snapshots_equal(await _snapshot(), reference)
 
 
@@ -426,6 +478,7 @@ async def test_reader_is_consistent_under_concurrent_fold_commit(db_setup, monke
     await _seed_corpus()
     reference = await _snapshot()
     await run_hourly_fold_pass(now=MID_W + FOLD_LAG)
+    await run_conversation_fold_pass(now=MID_W + FOLD_LAG)
 
     real_read_hourly_window = request_logs_repository_module.read_hourly_window
     fold_injections = {"count": 0}
@@ -435,6 +488,10 @@ async def test_reader_is_consistent_under_concurrent_fold_commit(db_setup, monke
         if fold_injections["count"] == 0:
             fold_injections["count"] += 1
             await run_hourly_fold_pass(now=NOW)  # advances MID_W -> TARGET_W
+            # The conversation metrics read comes AFTER this hook in the same
+            # reader; its single-statement UNION must see one consistent
+            # watermark generation even though the fold just advanced.
+            await run_conversation_fold_pass(now=NOW)
         return result
 
     monkeypatch.setattr(request_logs_repository_module, "read_hourly_window", _read_then_fold)
@@ -452,9 +509,16 @@ async def test_two_concurrent_fold_passes_serialize_without_double_count(db_setu
     await _seed_corpus()
     reference = await _snapshot()
 
-    await asyncio.gather(run_hourly_fold_pass(now=NOW), run_hourly_fold_pass(now=NOW))
+    await asyncio.gather(
+        run_hourly_fold_pass(now=NOW),
+        run_hourly_fold_pass(now=NOW),
+        run_conversation_fold_pass(now=NOW),
+        run_conversation_fold_pass(now=NOW),
+    )
     assert await _watermark() == TARGET_W
+    assert await _conversation_watermark() == TARGET_W
     assert await run_hourly_fold_pass(now=NOW) == 0  # fixed point
+    assert await run_conversation_fold_pass(now=NOW) == 0
     _assert_snapshots_equal(await _snapshot(), reference)
 
 
@@ -466,22 +530,29 @@ async def test_escape_hatch_reset_degrades_to_legacy_then_rebackfills(db_setup):
     await _seed_corpus()
     reference = await _snapshot()
     await run_hourly_fold_pass(now=NOW)
+    await run_conversation_fold_pass(now=NOW)
     _assert_snapshots_equal(await _snapshot(), reference)
 
     async with SessionLocal() as session:
         await session.execute(delete(RequestUsageHourlyRollup))
         await session.execute(delete(RequestUsageHourlyErrorRollup))
         await session.execute(delete(RequestDemandQuarterRollup))
+        await session.execute(delete(RequestConversationHourlyRollup))
         await session.execute(
-            update(AccountUsageRollupState).where(AccountUsageRollupState.id == 1).values(hourly_folded_through=_EPOCH)
+            update(AccountUsageRollupState)
+            .where(AccountUsageRollupState.id == 1)
+            .values(hourly_folded_through=_EPOCH, conversation_folded_through=_EPOCH)
         )
         await session.commit()
 
     assert await _watermark() == _EPOCH
+    assert await _conversation_watermark() == _EPOCH
     _assert_snapshots_equal(await _snapshot(), reference)  # pure-raw degrade
 
     await run_hourly_fold_pass(now=NOW)
+    await run_conversation_fold_pass(now=NOW)
     assert await _watermark() == TARGET_W
+    assert await _conversation_watermark() == TARGET_W
     _assert_snapshots_equal(await _snapshot(), reference)  # re-backfill converged
 
 
@@ -489,12 +560,14 @@ async def test_escape_hatch_reset_degrades_to_legacy_then_rebackfills(db_setup):
 async def test_statistics_survive_retention_pruning_folded_raw(db_setup, monkeypatch):
     """The headline guarantee: after raw rows below the retention gate
     (watermark - FOLD_LAG) are physically deleted, every rollup-served
-    statistic is unchanged. Distinct-conversation metrics shrink to the
-    surviving raw rows (documented non-goal), and earliest_activity_at falls
+    statistic is unchanged — INCLUDING the distinct-conversation metrics,
+    which the conversation presence satellite now serves for folded history
+    (they used to be raw-bound and shrink here). earliest_activity_at falls
     back to the earliest folded bucket at whole-hour precision."""
     await _seed_corpus()
     reference = await _snapshot()
     await run_hourly_fold_pass(now=NOW)
+    await run_conversation_fold_pass(now=NOW)
     # The reference for unaligned window starts once their partial leading
     # hour is un-servable: identical to starting at the ceil hour (that
     # partial slice is ALWAYS raw-served, by design). Captured pre-prune;
@@ -509,22 +582,37 @@ async def test_statistics_survive_retention_pruning_folded_raw(db_setup, monkeyp
 
     pruned = await _snapshot()
     expected = dict(reference)
-    for key in ("buckets_1h", "buckets_6h", "top_error_since", "top_error_between", "trends_key1"):
+    for key in (
+        "buckets_1h",
+        "buckets_6h",
+        "top_error_since",
+        "top_error_between",
+        "trends_key1",
+        "conv_buckets_1h",
+        "conv_buckets_6h",
+        "activity_since",
+        "activity_between",
+    ):
         expected[key] = leadless[key]
     _assert_snapshots_equal(
         pruned,
         expected,
         skip_keys=(
-            # Raw-bound by design after pruning:
-            "activity_since",  # conversation fields shrink (asserted below)
-            "activity_between",
-            "activity_folded_only",
             "earliest",  # hour-precision fallback (asserted below)
             # Non-hour-multiple display buckets are the documented full-raw
             # degrade path: after pruning they only see the surviving tail.
             "buckets_raw_degrade",
             "trends_raw_degrade",
-            "listing_totals",  # search fallback is raw-bound (asserted below)
+            "conv_buckets_raw_degrade",
+            # Reports measures other than conversation_count are raw-bound
+            # (documented non-goal); the satellite-served conversation counts
+            # are asserted to survive below. The half-hour-offset local days
+            # additionally lose their pruned partial leading half hours.
+            "reports_summary",
+            "reports_summary_filtered",
+            "reports_daily_utc",
+            "reports_daily_offset",
+            "listing_totals",  # tracks listable rows (asserted below)
         ),
     )
     # Listing totals track LISTABLE rows, not the permanent folded
@@ -539,22 +627,24 @@ async def test_statistics_survive_retention_pruning_folded_raw(db_setup, monkeyp
     monkeypatch.setattr(RequestLogsRepository, "_count_recent", _raw_only_count)
     raw_expected = (await _snapshot())["listing_totals"]
     assert pruned["listing_totals"] == raw_expected
-    # Additive activity totals are unchanged (modulo the pruned partial
-    # leading hour for unaligned starts); only the distinct-conversation
-    # metrics dropped to what raw still holds.
-    for key, baseline in (
-        ("activity_since", leadless),
-        ("activity_between", leadless),
-        ("activity_folded_only", reference),
-    ):
-        actual, wanted = pruned[key], baseline[key]
-        assert replace(actual, cost_usd=0.0, conversation_count=0, conversation_request_count=0) == replace(
-            wanted, cost_usd=0.0, conversation_count=0, conversation_request_count=0
-        ), key
-        assert actual.cost_usd == pytest.approx(wanted.cost_usd, rel=1e-9), key
-        assert actual.conversation_count <= wanted.conversation_count, key
-        assert actual.conversation_request_count <= wanted.conversation_request_count, key
-    assert pruned["activity_folded_only"].conversation_count == 0  # fully pruned window
+    monkeypatch.undo()
+    # Satellite-served conversation counts survive pruning exactly: the
+    # summary window is hour-aligned at the start and its unaligned tail is
+    # served from surviving raw; UTC local days are hour-aligned throughout.
+    assert pruned["reports_summary"].conversation_count == reference["reports_summary"].conversation_count
+    # Daily-report day-row membership stays raw-driven (the day CTE INNER
+    # joins request_logs, exactly as before the satellite): a fully pruned
+    # day drops out of the report; days that still have raw rows keep their
+    # satellite-served conversation counts unchanged.
+    pruned_daily = {row.date: row.conversation_count for row in pruned["reports_daily_utc"]}
+    reference_daily = {row.date: row.conversation_count for row in reference["reports_daily_utc"]}
+    assert pruned_daily
+    assert pruned_daily == {date: reference_daily[date] for date in pruned_daily}
+    # The filtered summary path stays fully raw-bound by design.
+    assert (
+        pruned["reports_summary_filtered"].conversation_count
+        <= reference["reports_summary_filtered"].conversation_count
+    )
     # earliest_activity_at: raw min is gone; the rollup fallback reports the
     # first countable bucket at hour precision.
     assert pruned["earliest"] == floor_to_hour(reference["earliest"])
@@ -562,6 +652,7 @@ async def test_statistics_survive_retention_pruning_folded_raw(db_setup, monkeyp
     prune_cutoff_epoch = int((prune_cutoff - _EPOCH).total_seconds())
     assert all(row.bucket_epoch >= prune_cutoff_epoch // 5400 * 5400 for row in pruned["buckets_raw_degrade"])
     assert all(row.bucket_epoch >= prune_cutoff_epoch // 5400 * 5400 for row in pruned["trends_raw_degrade"])
+    assert all(row.bucket_epoch >= prune_cutoff_epoch // 5400 * 5400 for row in pruned["conv_buckets_raw_degrade"])
     assert pruned["buckets_raw_degrade"]  # the tail is still served
 
 
@@ -595,9 +686,12 @@ async def test_dashboard_overview_json_is_identical_before_and_after_fold(async_
 
     folded_slices = await run_hourly_fold_pass()  # real now: rows are > FOLD_LAG old
     assert folded_slices > 0
+    assert await run_conversation_fold_pass() > 0
     async with SessionLocal() as session:
         folded = (await session.execute(select(RequestUsageHourlyRollup))).scalars().all()
+        folded_conversations = (await session.execute(select(RequestConversationHourlyRollup))).scalars().all()
     assert folded  # the window flipped to rollup-served
+    assert folded_conversations  # conversation series flipped as well
 
     after = await async_client.get("/api/dashboard/overview?timeframe=7d")
     assert after.status_code == 200

--- a/tests/integration/test_request_usage_time_rollup.py
+++ b/tests/integration/test_request_usage_time_rollup.py
@@ -13,6 +13,7 @@ from app.db.models import (
     Account,
     AccountStatus,
     AccountUsageRollupState,
+    RequestConversationHourlyRollup,
     RequestLog,
     RequestUsageHourlyRollup,
 )
@@ -31,9 +32,11 @@ from app.modules.accounts.usage_time_rollup import (
     floor_to_hour,
     from_dimension,
     mirror_account_soft_delete_into_time_rollups,
+    run_conversation_fold_pass,
     run_hourly_fold_pass,
     to_dimension,
 )
+from app.modules.reports.repository import ReportsRepository
 from app.modules.request_logs.repository import RequestLogsRepository
 
 pytestmark = pytest.mark.integration
@@ -114,6 +117,7 @@ async def test_bootstrap_state_defaults_hourly_watermark_to_epoch(db_setup):
             await session.execute(select(AccountUsageRollupState).where(AccountUsageRollupState.id == 1))
         ).scalar_one()
         assert state.hourly_folded_through == _EPOCH
+        assert state.conversation_folded_through == _EPOCH
 
         repo = RequestUsageTimeRollupRepository(session)
         rows, watermark = await repo.read_hourly()
@@ -377,6 +381,7 @@ async def _add_log(
     service_tier: str | None = None,
     api_key_id: str | None = None,
     model: str = "gpt-5.1-codex",
+    conversation_id: str | None = None,
 ):
     return await logs_repo.add_log(
         account_id=account_id,
@@ -394,6 +399,7 @@ async def _add_log(
         request_kind=request_kind,
         service_tier=service_tier,
         api_key_id=api_key_id,
+        conversation_id=conversation_id,
     )
 
 
@@ -1159,3 +1165,213 @@ async def test_rewound_watermark_refold_converges(db_setup):
 
     assert await run_hourly_fold_pass(now=now) >= 1
     assert await _dump_all_rollups() == baseline
+
+
+# --- Conversation presence satellite ---------------------------------------
+
+
+async def _dump_conversation_rollups() -> list[tuple[int, str, str, bool, int]]:
+    async with SessionLocal() as session:
+        rows = (await session.execute(select(RequestConversationHourlyRollup))).scalars().all()
+        return sorted(
+            (row.bucket_epoch, row.conversation_id, row.account_id, row.is_deleted, row.request_count) for row in rows
+        )
+
+
+async def _conversation_activity(since: datetime, until: datetime) -> tuple[int, int]:
+    async with SessionLocal() as session:
+        activity = await RequestLogsRepository(session).aggregate_activity_between(since, until)
+        return activity.conversation_count, activity.conversation_request_count
+
+
+@pytest.mark.asyncio
+async def test_conversation_fold_dedups_across_the_fold_boundary(db_setup):
+    """A conversation with rows on both sides of the conversation watermark
+    counts ONCE: the folded id and the raw-tail id merge through the UNION
+    before COUNT(DISTINCT), while the request total stays additive. Warmup
+    kinds and blank ids never enter the satellite."""
+    now = utcnow()
+    mid = floor_to_hour(now - timedelta(days=2))
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(_make_account("acc_conv", "conv-ts@example.com"))
+        logs = RequestLogsRepository(session)
+        await _add_log(
+            logs,
+            account_id="acc_conv",
+            request_id="r_cv_folded",
+            requested_at=mid - timedelta(days=1),
+            conversation_id="conv_x",
+        )
+        await _add_log(
+            logs,
+            account_id="acc_conv",
+            request_id="r_cv_tail",
+            requested_at=mid + timedelta(hours=1),
+            conversation_id="conv_x",
+        )
+        await _add_log(
+            logs,
+            account_id="acc_conv",
+            request_id="r_cv_warm",
+            requested_at=mid - timedelta(days=1, hours=1),
+            request_kind="warmup",
+            conversation_id="conv_x",
+        )
+        await _add_log(
+            logs,
+            account_id="acc_conv",
+            request_id="r_cv_blank",
+            requested_at=mid - timedelta(days=1, hours=2),
+            conversation_id=" \t",
+        )
+
+    window = (mid - timedelta(days=2), now)
+    reference = await _conversation_activity(*window)
+    assert reference == (1, 2)
+
+    # Watermark lands exactly at `mid`: the first row folds, the second stays
+    # in the live tail, and the metrics must not change.
+    assert await run_conversation_fold_pass(now=mid + FOLD_LAG) >= 1
+    async with SessionLocal() as session:
+        state = (
+            await session.execute(select(AccountUsageRollupState).where(AccountUsageRollupState.id == 1))
+        ).scalar_one()
+        assert state.conversation_folded_through == mid
+    folded = await _dump_conversation_rollups()
+    assert [(row[1], row[2], row[3], row[4]) for row in folded] == [("conv_x", "acc_conv", False, 1)]
+    assert await _conversation_activity(*window) == reference
+
+    # Idempotent fixed point at the same clock.
+    assert await run_conversation_fold_pass(now=mid + FOLD_LAG) == 0
+    assert await _dump_conversation_rollups() == folded
+
+
+@pytest.mark.asyncio
+async def test_conversation_bucket_series_rollup_matches_and_degrades(db_setup):
+    """Hour-multiple display buckets are served rollup+tail and must equal
+    the pre-fold (pure raw) series; non-hour-multiple buckets take the
+    documented full-raw degrade path and must also be unchanged."""
+    now = utcnow()
+    hour = floor_to_hour(now - timedelta(days=2))
+    since = hour - timedelta(days=1)
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(_make_account("acc_cser", "cser-ts@example.com"))
+        logs = RequestLogsRepository(session)
+        for index, (offset, conversation_id) in enumerate(
+            [
+                (timedelta(minutes=1), "conv_a"),
+                (timedelta(minutes=2), "conv_a"),
+                (timedelta(hours=1, minutes=1), "conv_a"),
+                (timedelta(hours=1, minutes=2), "conv_b"),
+            ]
+        ):
+            await _add_log(
+                logs,
+                account_id="acc_cser",
+                request_id=f"r_cs_{index}",
+                requested_at=hour + offset,
+                conversation_id=conversation_id,
+            )
+
+    async def _series(bucket_seconds: int):
+        async with SessionLocal() as session:
+            rows = await RequestLogsRepository(session).aggregate_conversations_by_bucket(since, bucket_seconds)
+            return [(row.bucket_epoch, row.conversation_count) for row in rows]
+
+    hour_epoch = epoch_seconds(hour)
+    before_hourly, before_odd = await _series(3600), await _series(5400)
+    assert before_hourly == [(hour_epoch, 1), (hour_epoch + 3600, 2)]
+
+    await run_conversation_fold_pass(now=now)
+    assert await _series(3600) == before_hourly
+    assert await _series(5400) == before_odd
+
+
+@pytest.mark.asyncio
+async def test_account_soft_delete_mirrors_conversation_presence(db_setup):
+    """Soft deletion retroactively detaches the account's raw history
+    (account_id=NULL, deleted_at=now); the folded presence must move to the
+    orphaned-deleted dimension so the dashboard reads (deleted_at IS NULL)
+    stop counting it while the reports reads (no deleted_at filter) keep it —
+    exactly what the raw scan reports after the UPDATE."""
+    now = utcnow()
+    hour = floor_to_hour(now - timedelta(days=2))
+    window = (hour - timedelta(hours=1), now)
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(_make_account("acc_csoft", "csoft-ts@example.com"))
+        await AccountsRepository(session).upsert(_make_account("acc_ckeep", "ckeep-ts@example.com"))
+        logs = RequestLogsRepository(session)
+        for index in range(2):
+            await _add_log(
+                logs,
+                account_id="acc_csoft",
+                request_id=f"r_cd_{index}",
+                requested_at=hour + timedelta(minutes=index),
+                conversation_id="conv_del",
+            )
+        await _add_log(
+            logs,
+            account_id="acc_ckeep",
+            request_id="r_ck",
+            requested_at=hour + timedelta(minutes=5),
+            conversation_id="conv_keep",
+        )
+    await run_conversation_fold_pass(now=now)
+
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).delete("acc_csoft")
+
+    assert await _conversation_activity(*window) == (1, 1)  # conv_keep only
+    async with SessionLocal() as session:
+        summary = await ReportsRepository(session).aggregate_summary(*window)
+    assert summary.conversation_count == 2  # reports include soft-deleted rows
+    assert await _dump_conversation_rollups() == [
+        (epoch_seconds(hour), "conv_del", _S, True, 2),
+        (epoch_seconds(hour), "conv_keep", "acc_ckeep", False, 1),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_account_hard_delete_removes_conversation_presence(db_setup):
+    """History deletion physically removes the account's raw rows; the mirror
+    must remove exactly that account's folded presence — a conversation
+    shared with a surviving account keeps the survivor's contribution, so
+    the switched reads still equal a raw scan of what remains."""
+    now = utcnow()
+    hour = floor_to_hour(now - timedelta(days=2))
+    window = (hour - timedelta(hours=1), now)
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(_make_account("acc_chard", "chard-ts@example.com"))
+        await AccountsRepository(session).upsert(_make_account("acc_cother", "cother-ts@example.com"))
+        logs = RequestLogsRepository(session)
+        await _add_log(
+            logs,
+            account_id="acc_chard",
+            request_id="r_ch_shared",
+            requested_at=hour + timedelta(minutes=1),
+            conversation_id="conv_shared",
+        )
+        await _add_log(
+            logs,
+            account_id="acc_cother",
+            request_id="r_co_shared",
+            requested_at=hour + timedelta(minutes=2),
+            conversation_id="conv_shared",
+        )
+        await _add_log(
+            logs,
+            account_id="acc_chard",
+            request_id="r_ch_only",
+            requested_at=hour + timedelta(minutes=3),
+            conversation_id="conv_only",
+        )
+    await run_conversation_fold_pass(now=now)
+    assert await _conversation_activity(*window) == (2, 3)
+
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).delete("acc_chard", delete_history=True)
+
+    assert await _conversation_activity(*window) == (1, 1)  # conv_shared via the survivor
+    assert await _dump_conversation_rollups() == [
+        (epoch_seconds(hour), "conv_shared", "acc_cother", False, 1),
+    ]


### PR DESCRIPTION
## Why

Distinct-conversation metrics are the last raw-bound reads on the dashboard hot path: `GET /api/dashboard/overview` runs three full-window `COUNT(DISTINCT trim(conversation_id))` scans over `request_logs` per 30 s poll (7–13 s each observed under contention at 4.5M rows / ~450k rows per 7-day window), and `GET /api/reports` repeats the shape twice plus per-day. `add-request-log-usage-rollups` documented this as a non-goal ("distinct counts are not additive across the fold boundary"); presence rows make them mergeable.

## What

- New satellite `request_conversation_hourly_rollups` — `(bucket_epoch, conversation_id, account_id, is_deleted)` dimensions with an additive `request_count`, folded from rows with a non-empty normalized conversation id excluding warmup kinds. `is_deleted` is a dimension because the dashboard conversation reads exclude soft-deleted rows while reports include them; `account_id` is carried so the existing `_ROLLUP_TABLES` lifecycle mirrors (soft delete, hard history delete, account consolidation) stay exact O(account) row moves — no reset machinery.
- Dedicated hour-aligned `conversation_folded_through` watermark on the shared fold-state row: existing deployments backfill incrementally from epoch under the same slice contract (DELETE-then-INSERT, paced, idempotent); the retention prune gate becomes the min over all three watermarks, so pruning pauses until the conversation backfill catches up (same rollout behavior the hourly rollup had).
- Switched reads (single statement each, watermark joined into both UNION branches so segment + raw complement + watermark come from one snapshot; `COUNT(DISTINCT …)` dedups conversations straddling the fold boundary): overview activity conversation metrics, hour-multiple conversation trend buckets, unfiltered reports summary and per-day counts. Non-hour-multiple buckets and filtered reports reads keep the legacy raw path; epoch/missing watermark degrades to exactly the legacy queries, no kill switch.
- Conversation statistics over folded history now **survive request-log retention pruning** (spec deltas for query-caching and data-retention; parity harness assertions flipped from "shrinks" to exact equality).

## Validation

- Parity harness extended: switched conversation reads equal the legacy raw implementation across watermark states (epoch/mid/full, hourly and conversation watermarks diverging), concurrent folds, escape hatch, and retention pruning; fold-boundary dedup and lifecycle-mirror coverage added (4 new time-rollup tests, 1 new retention test, migration upgrade test).
- SQLite and PostgreSQL integration suites green (parity 6, time-rollup 29, retention 21, dashboard/reports/conversations API 94; PG adds drift/contract/upgrade-head — 106); full unit suite **5,472 passed**; `ruff`, `ty` clean.
- Found & fixed during PG testing: SQLAlchemy `/` renders true division and PG's numeric→bigint cast rounds — bucket arithmetic uses the same dialect-split floor as the raw readers.
- Local `codex review` pending upstream quota reset (all reference-deployment accounts rate-limited); will re-run before merge.

Note: shares an Alembic parent with #1614 — whichever merges second needs a trivial merge revision (planned).

OpenSpec: `openspec/changes/add-conversation-presence-rollup/` (query-caching + data-retention deltas, design.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)