### PR TITLE
docs(contributors): add joschi655

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1162,6 +1162,16 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "joschi655",
+      "name": "joschi655",
+      "avatar_url": "https://avatars.githubusercontent.com/u/183807437?v=4",
+      "profile": "https://github.com/joschi655",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/e
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/mrnaturalmonopoly-prog"><img src="https://avatars.githubusercontent.com/u/309156020?v=4?s=100" width="100px;" alt="mrnaturalmonopoly-prog"/><br /><sub><b>mrnaturalmonopoly-prog</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=mrnaturalmonopoly-prog" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=mrnaturalmonopoly-prog" title="Tests">⚠️</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/mrunnaturalmonopoly-svg"><img src="https://avatars.githubusercontent.com/u/308138851?v=4?s=100" width="100px;" alt="mrunnaturalmonopoly-svg"/><br /><sub><b>mrunnaturalmonopoly-svg</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=mrunnaturalmonopoly-svg" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=mrunnaturalmonopoly-svg" title="Tests">⚠️</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/joschi655"><img src="https://avatars.githubusercontent.com/u/183807437?v=4?s=100" width="100px;" alt="joschi655"/><br /><sub><b>joschi655</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=joschi655" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=joschi655" title="Tests">⚠️</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
#1611 was admin-merged past the attribution gate (substantive CI was green; only attribution was red), which left every subsequent PR failing the Contributors attribution check because joschi655 is a commit contributor missing from .all-contributorsrc. Adds the entry + README cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)