### PR TITLE
fix(proxy): guard model-transition owner-conflict fork

### DIFF
--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -2067,10 +2067,20 @@ class _HTTPBridgeStreamingMixin:
             account_neutral_recovery = True
             force_local_recovery_creation = True
             model_transition_owner_conflict_fork_attempted = True
+            # request_state was prepared for the parent lane before the
+            # creation loop, and `continue` re-enters the loop without
+            # rebuilding it. Reset the parent-derived continuity fields so the
+            # submit, retry, and clean-close paths classify the child as the
+            # account-neutral fresh request it is: a stale hard anchor here
+            # would block a later fresh account switch and let a clean close
+            # treat the parent turn alias as this lane's continuation.
+            request_state.affinity_policy = affinity
+            request_state.hard_continuity_anchor = False
             request_state.preferred_account_id = None
             request_state.excluded_account_ids.update(fresh_replay_excluded_account_ids)
             preferred_account_has_continuity_provenance = False
             if reused_parent_turn_state:
+                request_state.session_id = None
                 downstream_turn_state = None
             return True
 

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -2006,6 +2006,53 @@ class _HTTPBridgeStreamingMixin:
                 )
             return durable_full_resend_is_account_neutral
 
+        def switch_model_transition_to_account_neutral_fork(exc: ProxyResponseError) -> bool:
+            nonlocal account_neutral_recovery
+            nonlocal affinity
+            nonlocal bridge_session_key
+            nonlocal force_local_recovery_creation
+            nonlocal incoming_turn_state_header
+            nonlocal preferred_account_has_continuity_provenance
+            nonlocal request_state
+            nonlocal session_creation_headers
+            nonlocal session_header_fallback_key
+
+            error_code, _error_message = _proxy_error_code_message(exc)
+            if (
+                durable_model_transition_lookup is None
+                or error_code != "continuity_owner_conflict"
+                or forwarded_request
+                or not _http_bridge_payload_is_account_neutral_fresh_replay(effective_payload)
+                or request_state.previous_response_id is not None
+                or rewritten_file_account_id is not None
+            ):
+                return False
+            failed_owner_id = request_state.preferred_account_id
+            _log_http_bridge_event(
+                "model_transition_owner_conflict_fork",
+                bridge_session_key,
+                account_id=failed_owner_id,
+                model=effective_payload.model,
+                detail="outcome=retry_without_previous_model_owner",
+                cache_key_family=bridge_session_key.affinity_kind,
+                model_class=_extract_model_class(effective_payload.model) if effective_payload.model else None,
+                owner_check_applied=True,
+            )
+            if failed_owner_id is not None:
+                fresh_replay_excluded_account_ids.add(failed_owner_id)
+            session_creation_headers = without_http_bridge_session_affinity_headers(session_creation_headers)
+            incoming_turn_state_header = None
+            session_header_fallback_key = None
+            affinity = _AffinityPolicy()
+            replay_kind, replay_key = make_http_bridge_account_neutral_replay_key(uuid4().hex)
+            bridge_session_key = _HTTPBridgeSessionKey(replay_kind, replay_key, bridge_session_key.api_key_id)
+            account_neutral_recovery = True
+            force_local_recovery_creation = True
+            request_state.preferred_account_id = None
+            request_state.excluded_account_ids.update(fresh_replay_excluded_account_ids)
+            preferred_account_has_continuity_provenance = False
+            return True
+
         def owner_unavailable_allows_account_neutral_replay(exc: ProxyResponseError) -> bool:
             return (
                 _http_bridge_is_previous_response_owner_unavailable(exc)
@@ -2205,6 +2252,8 @@ class _HTTPBridgeStreamingMixin:
                     defer_account_health_writes=request_state.api_key_reservation is not None,
                 )
             except ProxyResponseError as exc:
+                if switch_model_transition_to_account_neutral_fork(exc):
+                    continue
                 if not owner_unavailable_allows_account_neutral_replay(exc):
                     exc_code, _exc_message = _proxy_error_code_message(exc)
                     if not unanchored_fork_spill_attempted and _http_bridge_unanchored_fork_can_spill_on_cap(

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -1947,6 +1947,7 @@ class _HTTPBridgeStreamingMixin:
             else dict(headers)
         )
         fresh_replay_excluded_account_ids: set[str] = set()
+        model_transition_owner_conflict_fork_attempted = False
         unanchored_fork_spill_attempted = False
 
         def durable_full_resend_allows_account_neutral_replay() -> bool:
@@ -2010,8 +2011,10 @@ class _HTTPBridgeStreamingMixin:
             nonlocal account_neutral_recovery
             nonlocal affinity
             nonlocal bridge_session_key
+            nonlocal downstream_turn_state
             nonlocal force_local_recovery_creation
             nonlocal incoming_turn_state_header
+            nonlocal model_transition_owner_conflict_fork_attempted
             nonlocal preferred_account_has_continuity_provenance
             nonlocal request_state
             nonlocal session_creation_headers
@@ -2021,12 +2024,16 @@ class _HTTPBridgeStreamingMixin:
             if (
                 durable_model_transition_lookup is None
                 or error_code != "continuity_owner_conflict"
+                or model_transition_owner_conflict_fork_attempted
                 or forwarded_request
                 or not _http_bridge_payload_is_account_neutral_fresh_replay(effective_payload)
                 or request_state.previous_response_id is not None
                 or rewritten_file_account_id is not None
             ):
                 return False
+            reused_parent_turn_state = (
+                incoming_turn_state_header is not None and downstream_turn_state == incoming_turn_state_header
+            )
             failed_owner_id = request_state.preferred_account_id
             _log_http_bridge_event(
                 "model_transition_owner_conflict_fork",
@@ -2048,9 +2055,12 @@ class _HTTPBridgeStreamingMixin:
             bridge_session_key = _HTTPBridgeSessionKey(replay_kind, replay_key, bridge_session_key.api_key_id)
             account_neutral_recovery = True
             force_local_recovery_creation = True
+            model_transition_owner_conflict_fork_attempted = True
             request_state.preferred_account_id = None
             request_state.excluded_account_ids.update(fresh_replay_excluded_account_ids)
             preferred_account_has_continuity_provenance = False
+            if reused_parent_turn_state:
+                downstream_turn_state = None
             return True
 
         def owner_unavailable_allows_account_neutral_replay(exc: ProxyResponseError) -> bool:

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -2052,7 +2052,18 @@ class _HTTPBridgeStreamingMixin:
             session_header_fallback_key = None
             affinity = _AffinityPolicy()
             replay_kind, replay_key = make_http_bridge_account_neutral_replay_key(uuid4().hex)
-            bridge_session_key = _HTTPBridgeSessionKey(replay_kind, replay_key, bridge_session_key.api_key_id)
+            # Pin the child lane hard instead of inheriting the implicit
+            # default: this fork keeps the client's own payload rather than a
+            # proved full-resend projection like the model-transition fresh
+            # resend above, so once the lane owns upstream turn state there is
+            # no verified replay text that would make a later soft reroute to a
+            # third account safe.
+            bridge_session_key = _HTTPBridgeSessionKey(
+                replay_kind,
+                replay_key,
+                bridge_session_key.api_key_id,
+                strength="hard",
+            )
             account_neutral_recovery = True
             force_local_recovery_creation = True
             model_transition_owner_conflict_fork_attempted = True

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/.openspec.yaml
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/design.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/design.md
@@ -1,0 +1,31 @@
+## Context
+
+The durable full-resend reconciliation in the sibling change handles a
+verified complete replay. A model transition is a separate path: the request
+has no previous-response anchor to replay, but the durable lookup still binds
+the old model's owner. When a stale hard alias disagrees, blindly selecting a
+new account would be unsafe, while retrying the same alias produces a stable
+503 loop.
+
+## Decision
+
+Keep the recovery gate inside the HTTP bridge creation loop. Inspect the typed
+error code and continue only when it is `continuity_owner_conflict`; do not
+reuse the broader owner-unavailable predicate. Reject forwarded requests so a
+replica cannot create a local lane after an origin forwarding failure. Validate
+the effective Responses payload with the existing account-neutral replay
+classifier, which rejects `previous_response_id`, conversation state, opaque
+hosted inputs, and other account-bound fields. File-owner resolution and
+previous-response checks remain explicit defensive gates.
+
+On success, strip session/turn aliases, replace the request key with a
+server-namespaced account-neutral key, exclude the failed owner, clear the
+preferred owner/provenance, and force local creation. Persisted hard aliases
+are not rewritten.
+
+## Negative Controls
+
+- A forwarded request with the same owner conflict must return the original
+  `continuity_owner_conflict` without a second creation attempt.
+- A fresh payload containing an unpinned `input_file.file_id` must also return
+  the original conflict without account-neutral forking.

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/design.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/design.md
@@ -5,7 +5,7 @@ verified complete replay. A model transition is a separate path: the request
 has no previous-response anchor to replay, but the durable lookup still binds
 the old model's owner. When a stale hard alias disagrees, blindly selecting a
 new account would be unsafe, while retrying the same alias produces a stable
-503 loop.
+502 `continuity_owner_conflict` loop.
 
 ## Decision
 
@@ -14,14 +14,26 @@ error code and continue only when it is `continuity_owner_conflict`; do not
 reuse the broader owner-unavailable predicate. Reject forwarded requests so a
 replica cannot create a local lane after an origin forwarding failure. Validate
 the effective Responses payload with the existing account-neutral replay
-classifier, which rejects `previous_response_id`, conversation state, opaque
-hosted inputs, and other account-bound fields. File-owner resolution and
-previous-response checks remain explicit defensive gates.
+classifier, which rejects `previous_response_id`, conversation state,
+account-scoped hosted references such as `input_file.file_id`, hosted/MCP call
+items, and any input item that is not self-contained. That classifier is shared
+with the post-compaction recovery work, so its admitted shapes can widen over
+time: a completed `compaction` item carrying its own encrypted content and
+client-executed `tool_search_*` items are now accepted as self-contained, while
+a compaction placeholder without that content still fails closed. File-owner
+resolution and previous-response checks remain explicit defensive gates.
 
 On success, strip session/turn aliases, replace the request key with a
 server-namespaced account-neutral key, exclude the failed owner, clear the
 preferred owner/provenance, and force local creation. Persisted hard aliases
 are not rewritten.
+
+The child lane key is pinned `hard` rather than inheriting the implicit
+strength default. The sibling model-transition fresh-resend path may use a
+`soft` key because it substitutes a proved full-resend projection that any
+account can serve at any point. This fork forwards the client's own payload
+unchanged, so once the child lane owns upstream turn state there is no verified
+replay text that would make a later soft reroute to a third account safe.
 
 ## Negative Controls
 
@@ -29,3 +41,9 @@ are not rewritten.
   `continuity_owner_conflict` without a second creation attempt.
 - A fresh payload containing an unpinned `input_file.file_id` must also return
   the original conflict without account-neutral forking.
+- A post-compaction payload whose `compaction` item only references the owner's
+  compacted context — no encrypted content of its own, or still in progress —
+  must return the original conflict instead of forking, because the prior turns
+  exist only behind the previous owner.
+- A second conflict on the child lane must surface the original error instead of
+  forking again.

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/design.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/design.md
@@ -28,6 +28,15 @@ server-namespaced account-neutral key, exclude the failed owner, clear the
 preferred owner/provenance, and force local creation. Persisted hard aliases
 are not rewritten.
 
+The request state itself is reset to the child's own identity. It was prepared
+for the parent lane before the creation loop, and the retry re-enters that loop
+without rebuilding it, so the fork clears the parent affinity policy, the hard
+continuity anchor, and a reused parent turn state. Leaving those set would let
+the submit and clean-close paths treat the account-neutral child as the old
+owner-bound turn: a stale anchor blocks the pre-output account switch that the
+neutrality proof already permits, and a clean close would recover it as a
+continuation of the parent turn alias.
+
 The child lane key is pinned `hard` rather than inheriting the implicit
 strength default. The sibling model-transition fresh-resend path may use a
 `soft` key because it substitutes a proved full-resend projection that any
@@ -47,3 +56,5 @@ replay text that would make a later soft reroute to a third account safe.
   exist only behind the previous owner.
 - A second conflict on the child lane must surface the original error instead of
   forking again.
+- The forked child request must not keep the parent's affinity policy, hard
+  continuity anchor, or reused parent turn state.

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/proposal.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+An HTTP bridge model transition can resolve a durable model owner while a
+legacy hard alias resolves to a different account. The bridge then returns
+`continuity_owner_conflict` before dispatch even when the request is a fresh,
+account-neutral payload that can safely start a model-transition child lane.
+Forwarded requests and payloads containing opaque account-scoped inputs must
+remain fail-closed.
+
+## What Changes
+
+- Permit a model-transition child lane only for the exact
+  `continuity_owner_conflict` error.
+- Require a local request, no `previous_response_id`, no resolved file owner,
+  and a payload proven account-neutral by the existing replay-safety validator.
+- Clear session/turn aliases, exclude the conflicting owner, and create a
+  server-namespaced account-neutral lane without changing persisted aliases.
+- Keep forwarded requests, unpinned hosted files, and other owner failures
+  fail-closed.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: model-transition owner conflicts may use a
+  proof-gated account-neutral child lane.
+- `sticky-session-operations`: the hard-owner conflict exception is limited to
+  that exact fresh model-transition case.
+
+## Impact
+
+- Affected code: HTTP bridge model-transition recovery and unit coverage.
+- No schema, setting, dependency, or live deployment change.
+- Rollback is a source revert; the existing fail-closed path remains the
+  fallback for every request that does not satisfy the proof.

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/proposal.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/proposal.md
@@ -4,7 +4,7 @@ An HTTP bridge model transition can resolve a durable model owner while a
 legacy hard alias resolves to a different account. The bridge then returns
 `continuity_owner_conflict` before dispatch even when the request is a fresh,
 account-neutral payload that can safely start a model-transition child lane.
-Forwarded requests and payloads containing opaque account-scoped inputs must
+Forwarded requests and payloads that still depend on account-scoped state must
 remain fail-closed.
 
 ## What Changes
@@ -14,8 +14,10 @@ remain fail-closed.
 - Require a local request, no `previous_response_id`, no resolved file owner,
   and a payload proven account-neutral by the existing replay-safety validator.
 - Clear session/turn aliases, exclude the conflicting owner, and create a
-  server-namespaced account-neutral lane without changing persisted aliases.
-- Keep forwarded requests, unpinned hosted files, and other owner failures
+  server-namespaced account-neutral lane, pinned `hard`, without changing
+  persisted aliases.
+- Keep forwarded requests, unpinned hosted files, post-compaction payloads whose
+  compacted context is not carried in the request, and other owner failures
   fail-closed.
 
 ## Capabilities

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/specs/responses-api-compat/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: HTTP bridge model-transition owner conflicts use a guarded child lane
+
+The service MUST use a guarded account-neutral child lane when a hard
+continuity lookup identifies a durable owner for an incompatible model and
+bridge creation returns `continuity_owner_conflict`; it may retry on that new
+server-namespaced lane only when the
+request is local (not forwarded), has no `previous_response_id`, has no
+resolved file owner, and the effective payload passes the existing
+account-neutral fresh-replay validator. The child lane MUST clear session and
+turn aliases, exclude the conflicting owner, and force local creation. The
+service MUST preserve the original conflict for every other owner error or
+payload shape.
+
+#### Scenario: Neutral model transition conflict forks locally
+
+- **GIVEN** a durable hard continuity key belongs to account A for the old model
+- **AND** the requested model is incompatible with that durable session
+- **AND** the effective payload is account-neutral and has no previous-response
+  or resolved file owner
+- **AND** bridge creation returns `continuity_owner_conflict`
+- **WHEN** the request is local to the current replica
+- **THEN** the service creates one server-namespaced account-neutral child lane
+- **AND** it excludes account A and does not forward the request
+- **AND** it leaves the original hard aliases unchanged
+
+#### Scenario: Forwarded model transition conflict remains fail-closed
+
+- **GIVEN** the same durable model-transition conflict occurs for a forwarded
+  request
+- **THEN** the service returns `continuity_owner_conflict`
+- **AND** it does not create an account-neutral child lane
+
+#### Scenario: Account-bound payload remains fail-closed
+
+- **GIVEN** the effective model-transition payload contains an opaque or
+  account-scoped hosted input such as an unpinned `input_file.file_id`
+- **WHEN** bridge creation returns `continuity_owner_conflict`
+- **THEN** the service returns `continuity_owner_conflict`
+- **AND** it does not retry on another account

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/specs/responses-api-compat/spec.md
@@ -9,9 +9,10 @@ server-namespaced lane only when the
 request is local (not forwarded), has no `previous_response_id`, has no
 resolved file owner, and the effective payload passes the existing
 account-neutral fresh-replay validator. The child lane MUST clear session and
-turn aliases, exclude the conflicting owner, force local creation, and remain
-owner-bound (`hard`) once created so a later capacity failure cannot reroute the
-same request to a third account. The service MUST attempt this child lane at
+turn aliases, reset the request's parent-derived affinity policy, hard
+continuity anchor, and reused parent turn state, exclude the conflicting owner,
+force local creation, and remain owner-bound (`hard`) once created so a later
+capacity failure cannot reroute the same request to a third account. The service MUST attempt this child lane at
 most once per request and MUST preserve the original conflict for every other
 owner error or payload shape.
 
@@ -26,6 +27,8 @@ owner error or payload shape.
 - **THEN** the service creates one server-namespaced account-neutral child lane
 - **AND** that child lane key is owner-bound (`hard`)
 - **AND** it excludes account A and does not forward the request
+- **AND** the child request carries no parent affinity policy, hard continuity
+  anchor, or reused parent turn state
 - **AND** it leaves the original hard aliases unchanged
 
 #### Scenario: Forwarded model transition conflict remains fail-closed

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/specs/responses-api-compat/spec.md
@@ -9,9 +9,11 @@ server-namespaced lane only when the
 request is local (not forwarded), has no `previous_response_id`, has no
 resolved file owner, and the effective payload passes the existing
 account-neutral fresh-replay validator. The child lane MUST clear session and
-turn aliases, exclude the conflicting owner, and force local creation. The
-service MUST preserve the original conflict for every other owner error or
-payload shape.
+turn aliases, exclude the conflicting owner, force local creation, and remain
+owner-bound (`hard`) once created so a later capacity failure cannot reroute the
+same request to a third account. The service MUST attempt this child lane at
+most once per request and MUST preserve the original conflict for every other
+owner error or payload shape.
 
 #### Scenario: Neutral model transition conflict forks locally
 
@@ -22,6 +24,7 @@ payload shape.
 - **AND** bridge creation returns `continuity_owner_conflict`
 - **WHEN** the request is local to the current replica
 - **THEN** the service creates one server-namespaced account-neutral child lane
+- **AND** that child lane key is owner-bound (`hard`)
 - **AND** it excludes account A and does not forward the request
 - **AND** it leaves the original hard aliases unchanged
 
@@ -34,8 +37,25 @@ payload shape.
 
 #### Scenario: Account-bound payload remains fail-closed
 
-- **GIVEN** the effective model-transition payload contains an opaque or
-  account-scoped hosted input such as an unpinned `input_file.file_id`
+- **GIVEN** the effective model-transition payload contains an account-scoped
+  hosted reference such as an unpinned `input_file.file_id`
 - **WHEN** bridge creation returns `continuity_owner_conflict`
 - **THEN** the service returns `continuity_owner_conflict`
 - **AND** it does not retry on another account
+
+#### Scenario: Post-compaction payload without carried compact context stays fail-closed
+
+- **GIVEN** the effective model-transition payload contains a `compaction` item
+  that is not self-contained, such as a placeholder with no encrypted content or
+  a compaction still in progress
+- **WHEN** bridge creation returns `continuity_owner_conflict`
+- **THEN** the service returns `continuity_owner_conflict`
+- **AND** it does not fork the request onto an account that never held the
+  compacted context
+
+#### Scenario: Child lane conflict is not forked again
+
+- **GIVEN** the guarded child lane was already created for this request
+- **WHEN** creation on that lane also returns `continuity_owner_conflict`
+- **THEN** the service returns that error to the caller
+- **AND** it does not create a further account-neutral lane

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/specs/sticky-session-operations/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Hard continuity remains owner-bound and bounded
+
+Requests that depend on hard continuity MUST remain owner-bound and fail closed
+when independently resolved owners conflict. The sole model-transition
+exception is the proof-gated HTTP bridge child lane defined by
+`responses-api-compat`: it is limited to a local request with the exact
+`continuity_owner_conflict` error, no previous-response or resolved file owner,
+and an account-neutral effective payload. That child lane MUST clear aliases,
+exclude the failed owner, and leave persisted hard mappings unchanged.
+
+#### Scenario: Non-model-transition hard owner conflict fails closed
+
+- **GIVEN** independently resolved hard sources identify different accounts
+- **AND** the request is not the guarded model-transition case
+- **WHEN** the request is routed
+- **THEN** the service fails with `continuity_owner_conflict` before upstream
+  dispatch
+- **AND** source ordering does not choose either owner
+
+#### Scenario: Guarded model-transition exception does not rewrite hard mappings
+
+- **GIVEN** a request satisfies the account-neutral model-transition child-lane
+  proof
+- **WHEN** the child lane is created
+- **THEN** persisted hard aliases remain unchanged
+- **AND** the failed owner is excluded only for that request

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/specs/sticky-session-operations/spec.md
@@ -2,22 +2,165 @@
 
 ### Requirement: Hard continuity remains owner-bound and bounded
 
-Requests that depend on hard continuity MUST remain owner-bound and fail closed
-when independently resolved owners conflict. The sole model-transition
-exception is the proof-gated HTTP bridge child lane defined by
-`responses-api-compat`: it is limited to a local request with the exact
-`continuity_owner_conflict` error, no previous-response or resolved file owner,
-and an account-neutral effective payload. That child lane MUST clear aliases,
-exclude the failed owner, and leave persisted hard mappings unchanged.
+Requests that depend on `previous_response_id`, hard turn-state, nonblank `conversation`, account-scoped `input_file.file_id` pins, live or durable bridge ownership, replay/reattach state, or another required owner continuity source MUST NOT silently reroute to an account that cannot preserve continuity. A resolved required owner MUST override bare process-session locality and MUST be selected without consulting or rewriting that soft mapping. A `previous_response_id` is a stored-object continuation reference and remains owner-bound even when the same request also carries a session header, `prompt_cache_key`, or another soft locality key. If independently resolved hard sources identify different accounts, if live durable referenced-file pins identify different accounts, or if a request has partial live durable file-pin coverage, the service MUST fail closed before upstream dispatch. A request for which no referenced file has a live durable pin MUST preserve opaque `file_id` compatibility and proceed without inventing ownership evidence. If the owner account/session is unavailable or saturated, the service MUST fail closed with an explicit retryable continuity/local overload reason instead of flooding the owner queue indefinitely.
 
-#### Scenario: Non-model-transition hard owner conflict fails closed
+Every HTTP, compact, direct WebSocket, and HTTP-bridge transport MUST resolve explicit turn state against both live and durable bridge aliases. Live, durable, previous-response, file, and explicit turn-state evidence MUST be compared independently; source ordering MUST NOT choose the first match when distinct sessions or accounts resolve. A reused direct WebSocket MUST repeat nonblank `conversation` ownership validation for each response-create frame because the existing socket account proves only the current route. Single-account routing MUST constrain effective routing without narrowing the ownership-candidate pool used by that validation.
 
-- **GIVEN** independently resolved hard sources identify different accounts
-- **AND** the request is not the guarded model-transition case
+When an HTTP-bridge owner is on another replica, the origin MUST forward its resolved durable file owner in authenticated full-context metadata. The receiving owner MUST perform its own fresh shared-database lookup and MUST require that durable result to match the forwarded owner. A missing or conflicting receiver-side durable owner MUST fail closed before account selection or upstream invocation. A retired direct WebSocket's upstream turn-state token MUST NOT be sent to a different account selected for a later movable bare-session request.
+
+A nonblank `conversation` without a dedicated resolved owner MUST proceed only when an explicit hard Codex mapping proves ownership or exactly one account remains in the model/API-key/security-scoped selection pool before transient additional-quota availability, retry exclusions, runtime health, budget, or account-cap filtering. A temporarily quota-filtered, excluded, unhealthy, or capped candidate MUST remain part of this ambiguity check because it may be the actual owner. A bare process-session mapping MUST NOT prove conversation ownership.
+
+The sole exception to the hard-owner conflict rule is the proof-gated HTTP
+bridge model-transition child lane defined by `responses-api-compat`. It
+applies only to a local request that fails with the exact
+`continuity_owner_conflict` error, carries no `previous_response_id` and no
+resolved file owner, and whose effective payload passes the account-neutral
+fresh-replay validator. That child lane MUST clear session and turn aliases,
+exclude the failed owner for that request only, and leave persisted hard
+mappings unchanged. Every other hard-owner conflict MUST still fail closed.
+
+#### Scenario: Previous-response owner queue is saturated
+
+- **WHEN** a `/v1/responses` follow-up requires a previous-response owner
+- **AND** the owner session queue or account cap is saturated
+- **THEN** the service fails closed with `hard_affinity_saturated`, `previous_response_owner_unavailable`, or the applicable stable `account_stream_cap` / `account_response_create_cap` code
+- **AND** it does not route to an unrelated account that lacks continuity state
+
+#### Scenario: File-pinned request owner is capped
+
+- **WHEN** a `/v1/responses` request references an `input_file.file_id` pinned to an owner account
+- **AND** the owner account is at its account stream or response-create cap
+- **THEN** the service returns a local account-cap overload for the owner
+- **AND** it does not route the file reference to another account
+
+#### Scenario: File-pinned request owner overrides process-session locality
+
+- **GIVEN** a request carries a bare process-session header mapped to account A
+- **AND** its `input_file.file_id` is durably pinned to account B
 - **WHEN** the request is routed
-- **THEN** the service fails with `continuity_owner_conflict` before upstream
-  dispatch
+- **THEN** account B is treated as the required owner
+- **AND** the process-session mapping is neither consulted as an owner nor rewritten
+
+#### Scenario: File-pinned request owner overrides thread locality
+
+- **GIVEN** a request carries a `thread-id` whose bounded mapping points to account A
+- **AND** its `input_file.file_id` is durably pinned to account B
+- **WHEN** the request is routed
+- **THEN** account B is treated as the required owner
+- **AND** the thread mapping is neither consulted as an owner nor rewritten
+
+#### Scenario: Conflicting hard owners fail closed
+
+- **GIVEN** a turn state, previous response, bridge, or input file resolves to account A
+- **AND** another hard source on the same request resolves to account B
+- **AND** the request is not the guarded model-transition child-lane case
+- **WHEN** the request is routed
+- **THEN** the service fails with `continuity_owner_conflict` before upstream dispatch
 - **AND** source ordering does not choose either owner
+
+#### Scenario: Partial or cross-account file pins fail closed
+
+- **GIVEN** a request references multiple account-scoped input files
+- **AND** at least one file has a live durable owner pin
+- **AND** another file has no live durable owner pin or the live pins resolve to different accounts
+- **WHEN** the request is routed
+- **THEN** the service fails with `file_owner_unavailable` or `continuity_owner_conflict`
+- **AND** it does not route the files using a soft affinity account
+
+#### Scenario: Opaque file IDs with no live durable pins preserve compatibility
+
+- **GIVEN** a request references one or more `input_file.file_id` values
+- **AND** none of those IDs has a live durable owner pin
+- **WHEN** the request is routed
+- **THEN** the service forwards the opaque file references under ordinary unpinned routing
+- **AND** it does not invent a hard owner or fail solely because durable pin metadata is absent
+
+#### Scenario: Ambiguous conversation fails closed
+
+- **GIVEN** a request carries nonblank `conversation` continuity and only bare process-session affinity
+- **AND** more than one account is eligible
+- **WHEN** no dedicated or hard-mapping owner can be resolved
+- **THEN** the request fails with a stable owner-unavailable error before upstream dispatch
+
+#### Scenario: Account-cap pressure does not manufacture a conversation owner
+
+- **GIVEN** two accounts remain in the model/API-key/security-scoped selection pool
+- **AND** one account is temporarily at its local account cap
+- **WHEN** a request carries nonblank `conversation` continuity without a dedicated or hard-mapping owner
+- **THEN** the request still fails with a stable owner-unavailable error
+- **AND** the uncapped account is not treated as the unique owner
+
+#### Scenario: Retry or additional-quota filtering does not manufacture a conversation owner
+
+- **GIVEN** two accounts remain in the model/API-key/security-scoped selection pool
+- **AND** retry exclusion or transient additional-quota availability removes one from the effective routing pool
+- **WHEN** a request carries nonblank `conversation` continuity without a dedicated or hard-mapping owner
+- **THEN** the request still fails with a stable owner-unavailable error
+- **AND** the remaining effective account is not treated as the unique owner
+
+#### Scenario: Account status does not manufacture a conversation owner
+
+- **GIVEN** two accounts are in the model/API-key/security ownership pool
+- **AND** one account is paused, requires reauthentication, deactivated, or otherwise unavailable for routing
+- **WHEN** a request carries nonblank `conversation` continuity without a dedicated or hard-mapping owner
+- **THEN** the request still fails with a stable owner-unavailable error
+- **AND** the active account is not treated as the unique owner
+
+#### Scenario: Preferred file owner does not manufacture a conversation owner
+
+- **GIVEN** a request carries nonblank `conversation` continuity and a file durably pinned to account B
+- **AND** another account remains in the model/API-key/security ownership pool
+- **WHEN** no dedicated conversation owner can be resolved
+- **THEN** file ownership does not narrow the conversation ambiguity check to account B
+- **AND** the request fails closed before upstream dispatch
+
+#### Scenario: Bridge turn state is owner-bound across transports
+
+- **GIVEN** an HTTP bridge registered a turn-state alias for account A
+- **WHEN** the alias is reused through compact, plain HTTP streaming, or direct WebSocket transport
+- **THEN** each transport treats account A as the required owner
+- **AND** it does not fall back to unrelated sticky affinity
+
+#### Scenario: Independent bridge aliases conflict
+
+- **GIVEN** a live or durable turn-state alias resolves to one bridge session
+- **AND** a previous-response alias on the same request resolves to a distinct session or account
+- **WHEN** the request is routed
+- **THEN** the service fails with `continuity_owner_conflict`
+- **AND** alias lookup order does not select either session
+
+#### Scenario: Reused WebSocket revalidates conversation ownership
+
+- **GIVEN** a direct upstream WebSocket is already open on account A
+- **AND** a later response-create frame carries nonblank `conversation`
+- **WHEN** more than one account remains in the ownership-candidate pool
+- **THEN** the later frame fails with a stable owner-unavailable error before upstream send
+- **AND** the existing socket account is not treated as ownership proof
+
+#### Scenario: Single-account routing does not manufacture conversation ownership
+
+- **GIVEN** single-account routing selects account A
+- **AND** multiple accounts remain in the model/API-key/security ownership pool
+- **WHEN** a request carries nonblank `conversation` without dedicated owner evidence
+- **THEN** the request remains ambiguous and fails closed
+- **AND** only the effective routing states are constrained to account A
+
+#### Scenario: Remote bridge owner revalidates forwarded file ownership
+
+- **GIVEN** origin replica A durably resolves an input file to account A
+- **AND** the request's HTTP bridge owner runs on replica B
+- **WHEN** replica A forwards the request to replica B with authenticated file-owner metadata
+- **THEN** replica B MUST freshly resolve the shared durable pin
+- **AND** it MUST accept the forwarded owner only when both owner values match
+- **AND** a missing, conflicting, tampered, or legacy-unbound proof MUST be rejected before upstream invocation
+
+#### Scenario: Retired WebSocket turn state does not cross accounts
+
+- **GIVEN** a closed upstream WebSocket on account A supplied an account-scoped turn-state token
+- **AND** a later movable bare-session frame or marked self-contained goal restart selects account B
+- **WHEN** the proxy opens the replacement WebSocket
+- **THEN** it removes account A's stale turn-state token before connect
+- **AND** account B never receives that token
 
 #### Scenario: Guarded model-transition exception does not rewrite hard mappings
 

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/tasks.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/tasks.md
@@ -1,0 +1,16 @@
+## 1. Contract
+
+- [x] 1.1 Define the exact conflict, local-request, payload-neutrality, and
+  owner-preservation gates.
+- [x] 1.2 Add the sticky-session exception without weakening unrelated hard
+  owner conflicts.
+
+## 2. Implementation
+
+- [x] 2.1 Add the guarded account-neutral model-transition child-lane path.
+- [x] 2.2 Add positive and forwarded/unpinned-file negative regressions.
+
+## 3. Verification
+
+- [x] 3.1 Run model-transition unit and existing HTTP bridge integration tests.
+- [x] 3.2 Run Ruff, diff checks, and strict OpenSpec validation.

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/tasks.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/tasks.md
@@ -10,7 +10,9 @@
 - [x] 2.1 Add the guarded account-neutral model-transition child-lane path.
 - [x] 2.2 Pin the child lane key strength explicitly instead of relying on the
   implicit default.
-- [x] 2.3 Add positive and forwarded/unpinned-file/post-compaction negative
+- [x] 2.3 Reset the child request state's parent-derived affinity policy,
+  continuity anchor, and reused parent turn state.
+- [x] 2.4 Add positive and forwarded/unpinned-file/post-compaction negative
   regressions plus the single-retry bound.
 
 ## 3. Verification

--- a/openspec/changes/fork-safe-model-transition-owner-conflict/tasks.md
+++ b/openspec/changes/fork-safe-model-transition-owner-conflict/tasks.md
@@ -8,9 +8,12 @@
 ## 2. Implementation
 
 - [x] 2.1 Add the guarded account-neutral model-transition child-lane path.
-- [x] 2.2 Add positive and forwarded/unpinned-file negative regressions.
+- [x] 2.2 Pin the child lane key strength explicitly instead of relying on the
+  implicit default.
+- [x] 2.3 Add positive and forwarded/unpinned-file/post-compaction negative
+  regressions plus the single-retry bound.
 
 ## 3. Verification
 
 - [x] 3.1 Run model-transition unit and existing HTTP bridge integration tests.
-- [x] 3.2 Run Ruff, diff checks, and strict OpenSpec validation.
+- [x] 3.2 Run Ruff, type checks, and strict OpenSpec validation.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -25261,6 +25261,445 @@ async def test_durable_model_transition_full_resend_pending_tool_context_uses_ac
 
 
 @pytest.mark.asyncio
+async def test_stream_via_http_bridge_forks_account_neutral_model_transition_after_owner_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-terra",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": "continue on the new model"}],
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-model-conflict-parent",
+        canonical_kind="session_header",
+        canonical_key="shared-root",
+        api_key_scope="__anonymous__",
+        account_id="acc-model-owner",
+        owner_instance_id=None,
+        owner_epoch=1,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state="http_turn_model_parent",
+        latest_response_id="resp_model_parent",
+        model="gpt-5.6-sol",
+    )
+    owner_conflict = ProxyResponseError(
+        502,
+        openai_error(
+            "continuity_owner_conflict",
+            "Durable continuity aliases resolve to conflicting upstream owners.",
+        ),
+    )
+    creation_keys: list[proxy_service._HTTPBridgeSessionKey] = []
+    creation_calls: list[dict[str, Any]] = []
+
+    async def fake_get_or_create(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        creation_keys.append(key)
+        creation_calls.append(kwargs)
+        if len(creation_calls) == 1:
+            raise owner_conflict
+        session = _make_bridge_session(key=key)
+        session.account = cast(
+            Any,
+            SimpleNamespace(id="acc-model-alternate", status=AccountStatus.ACTIVE),
+        )
+        session.request_model = payload.model
+        return session
+
+    async def fake_stream_events(
+        _session: proxy_service._HTTPBridgeSession,
+        **_kwargs: Any,
+    ):
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={
+                "x-codex-turn-state": "http_turn_model_parent",
+                "x-codex-session-id": "shared-root",
+            },
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+            downstream_turn_state="http_turn_model_child",
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert len(creation_calls) == 2
+    assert creation_keys[0].affinity_kind in {"session_header", "turn_state_header"}
+    assert is_http_bridge_account_neutral_replay(
+        kind=creation_keys[1].affinity_kind,
+        key=creation_keys[1].affinity_key,
+    )
+    assert creation_calls[0]["preferred_account_id"] == "acc-model-owner"
+    assert creation_calls[0]["preferred_account_has_continuity_provenance"] is True
+    assert creation_calls[1]["preferred_account_id"] is None
+    assert creation_calls[1]["preferred_account_has_continuity_provenance"] is False
+    assert creation_calls[1]["exclude_account_ids"] == {"acc-model-owner"}
+    assert creation_calls[1]["allow_forward_to_owner"] is False
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_limits_model_transition_owner_conflict_fork_to_one_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-terra",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": "continue on the new model"}],
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-model-conflict-parent",
+        canonical_kind="session_header",
+        canonical_key="shared-root",
+        api_key_scope="__anonymous__",
+        account_id="acc-model-owner",
+        owner_instance_id=None,
+        owner_epoch=1,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state="http_turn_model_parent",
+        latest_response_id="resp_model_parent",
+        model="gpt-5.6-sol",
+    )
+    owner_conflict = ProxyResponseError(
+        502,
+        openai_error(
+            "continuity_owner_conflict",
+            "Durable continuity aliases resolve to conflicting upstream owners.",
+        ),
+    )
+    creation_calls: list[dict[str, Any]] = []
+
+    async def fake_get_or_create(
+        _key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        creation_calls.append(kwargs)
+        raise owner_conflict
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        async for _ in service._stream_via_http_bridge(
+            payload,
+            headers={
+                "x-codex-turn-state": "http_turn_model_parent",
+                "x-codex-session-id": "shared-root",
+            },
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+            downstream_turn_state="http_turn_model_child",
+        ):
+            pass
+
+    assert exc_info.value is owner_conflict
+    assert len(creation_calls) == 2
+    assert creation_calls[0]["preferred_account_id"] == "acc-model-owner"
+    assert creation_calls[1]["preferred_account_id"] is None
+    assert creation_calls[1]["exclude_account_ids"] == {"acc-model-owner"}
+    assert creation_calls[1]["allow_forward_to_owner"] is False
+
+
+@pytest.mark.asyncio
+async def test_stream_via_http_bridge_model_transition_owner_conflict_fork_does_not_rebind_parent_turn_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-terra",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": "continue on the new model"}],
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-model-conflict-parent",
+        canonical_kind="session_header",
+        canonical_key="shared-root",
+        api_key_scope="__anonymous__",
+        account_id="acc-model-owner",
+        owner_instance_id=None,
+        owner_epoch=1,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state="http_turn_model_parent",
+        latest_response_id="resp_model_parent",
+        model="gpt-5.6-sol",
+    )
+    owner_conflict = ProxyResponseError(
+        502,
+        openai_error(
+            "continuity_owner_conflict",
+            "Durable continuity aliases resolve to conflicting upstream owners.",
+        ),
+    )
+    stream_downstream_turn_states: list[str | None] = []
+
+    async def fake_get_or_create(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        if kwargs["preferred_account_id"] == "acc-model-owner":
+            raise owner_conflict
+        session = _make_bridge_session(key=key)
+        session.account = cast(
+            Any,
+            SimpleNamespace(id="acc-model-alternate", status=AccountStatus.ACTIVE),
+        )
+        session.request_model = payload.model
+        return session
+
+    async def fake_stream_events(
+        _session: proxy_service._HTTPBridgeSession,
+        **kwargs: Any,
+    ):
+        stream_downstream_turn_states.append(kwargs["downstream_turn_state"])
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={
+                "x-codex-turn-state": "http_turn_model_parent",
+                "x-codex-session-id": "shared-root",
+            },
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+            downstream_turn_state="http_turn_model_parent",
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert stream_downstream_turn_states == [None]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("forwarded_request", "input_items"),
+    [
+        (
+            True,
+            [{"role": "user", "content": "continue on the new model"}],
+        ),
+        (
+            False,
+            [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "continue on the new model"},
+                        {"type": "input_file", "file_id": "file-unpinned"},
+                    ],
+                }
+            ],
+        ),
+    ],
+    ids=["forwarded-request", "unpinned-input-file"],
+)
+async def test_stream_via_http_bridge_keeps_model_transition_owner_conflict_fail_closed_for_unsafe_fork(
+    monkeypatch: pytest.MonkeyPatch,
+    forwarded_request: bool,
+    input_items: list[dict[str, Any]],
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-terra",
+            "instructions": "hi",
+            "input": input_items,
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-model-unsafe-fork",
+        canonical_kind="session_header",
+        canonical_key="shared-root",
+        api_key_scope="__anonymous__",
+        account_id="acc-model-owner",
+        owner_instance_id=None,
+        owner_epoch=1,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state="http_turn_model_parent",
+        latest_response_id="resp_model_parent",
+        model="gpt-5.6-sol",
+    )
+    owner_conflict = ProxyResponseError(
+        502,
+        openai_error(
+            "continuity_owner_conflict",
+            "Durable continuity aliases resolve to conflicting upstream owners.",
+        ),
+    )
+    creation_keys: list[proxy_service._HTTPBridgeSessionKey] = []
+    creation_calls: list[dict[str, Any]] = []
+
+    async def fake_get_or_create(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        creation_keys.append(key)
+        creation_calls.append(kwargs)
+        raise owner_conflict
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        async for _ in service._stream_via_http_bridge(
+            payload,
+            headers={
+                "x-codex-turn-state": "http_turn_model_parent",
+                "x-codex-session-id": "shared-root",
+            },
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+            downstream_turn_state="http_turn_model_child",
+            forwarded_request=forwarded_request,
+        ):
+            pass
+
+    assert exc_info.value is owner_conflict
+    assert len(creation_calls) == 1
+    assert creation_calls[0]["preferred_account_id"] == "acc-model-owner"
+    assert creation_calls[0]["preferred_account_has_continuity_provenance"] is True
+    assert not is_http_bridge_account_neutral_replay(
+        kind=creation_keys[0].affinity_kind,
+        key=creation_keys[0].affinity_key,
+    )
+
+
+@pytest.mark.asyncio
 async def test_stream_via_http_bridge_preserves_verified_replay_kind_for_durable_model_transition(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -25370,6 +25370,9 @@ async def test_stream_via_http_bridge_forks_account_neutral_model_transition_aft
         kind=creation_keys[1].affinity_kind,
         key=creation_keys[1].affinity_key,
     )
+    # The child lane stays owner-bound so a later capacity failure cannot soft
+    # reroute this request onto a third account.
+    assert creation_keys[1].strength == "hard"
     assert creation_calls[0]["preferred_account_id"] == "acc-model-owner"
     assert creation_calls[0]["preferred_account_has_continuity_provenance"] is True
     assert creation_calls[1]["preferred_account_id"] is None
@@ -25597,8 +25600,45 @@ async def test_stream_via_http_bridge_model_transition_owner_conflict_fork_does_
                 }
             ],
         ),
+        # Negative controls for the widened account-neutral classifier (#1849):
+        # a `compaction` item is admitted only when it carries its own
+        # completed encrypted content. A placeholder that merely references the
+        # owner's compacted context, or one still being produced, keeps the
+        # prior turns behind the old owner, so forking would silently drop
+        # them.
+        (
+            False,
+            [
+                {"type": "compaction", "id": "cmpct_model_parent"},
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "continue on the new model"}],
+                },
+            ],
+        ),
+        (
+            False,
+            [
+                {
+                    "type": "compaction",
+                    "status": "in_progress",
+                    "encrypted_content": "gAAAAABopaque",
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "continue on the new model"}],
+                },
+            ],
+        ),
     ],
-    ids=["forwarded-request", "unpinned-input-file"],
+    ids=[
+        "forwarded-request",
+        "unpinned-input-file",
+        "post-compaction-placeholder",
+        "post-compaction-in-progress",
+    ],
 )
 async def test_stream_via_http_bridge_keeps_model_transition_owner_conflict_fail_closed_for_unsafe_fork(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -25525,6 +25525,7 @@ async def test_stream_via_http_bridge_model_transition_owner_conflict_fork_does_
         ),
     )
     stream_downstream_turn_states: list[str | None] = []
+    stream_request_states: list[Any] = []
 
     async def fake_get_or_create(
         key: proxy_service._HTTPBridgeSessionKey,
@@ -25545,6 +25546,7 @@ async def test_stream_via_http_bridge_model_transition_owner_conflict_fork_does_
         **kwargs: Any,
     ):
         stream_downstream_turn_states.append(kwargs["downstream_turn_state"])
+        stream_request_states.append(kwargs["request_state"])
         yield 'data: {"type":"response.completed"}\n\n'
 
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
@@ -25577,6 +25579,15 @@ async def test_stream_via_http_bridge_model_transition_owner_conflict_fork_does_
 
     assert chunks == ['data: {"type":"response.completed"}\n\n']
     assert stream_downstream_turn_states == [None]
+    # The child lane must not inherit the parent's continuity identity: a stale
+    # hard anchor or parent affinity policy would make the submit and
+    # clean-close paths treat this account-neutral fork as the old owner-bound
+    # turn.
+    (child_request_state,) = stream_request_states
+    assert child_request_state.session_id is None
+    assert child_request_state.hard_continuity_anchor is False
+    assert child_request_state.affinity_policy.key is None
+    assert child_request_state.affinity_policy.codex_session_source is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

An HTTP bridge model transition could return `continuity_owner_conflict`
indefinitely when a durable model owner and a stale hard alias pointed at
different accounts, even though the request itself was safe to start on a
fresh child bridge.

This change adds a narrowly gated account-neutral model-transition
fork. It runs only for the exact `continuity_owner_conflict` error, local
requests, and an account-neutral effective Responses payload. Forwarded
requests, previous-response continuations, resolved file owners,
account-scoped hosted references, and post-compaction payloads whose
compacted context is not carried in the request remain fail-closed.

This is the focused remainder requested on
[Soju06/codex-lb#1557](https://github.com/Soju06/codex-lb/pull/1557). The
durable full-resend/OpenSpec owner reconciliation it used to stack on has since
landed on `main` through
[Soju06/codex-lb#1599](https://github.com/Soju06/codex-lb/pull/1599) and
[Soju06/codex-lb#1849](https://github.com/Soju06/codex-lb/pull/1849), so this
branch is now rebased directly on `main`.

## Changes

- Fork only on `continuity_owner_conflict` after the existing model-transition
  owner lookup has established the conflicting durable owner.
- Reject forwarded requests and non-neutral payloads before changing affinity.
- Clear session/turn aliases, exclude the failed owner, and force local
  creation under a server-namespaced account-neutral key.
- Pin the forked child key to `hard` strength. The fork replays the client's own
  payload rather than a proved full-resend projection, so once the child lane
  owns upstream turn state there is no verified replay text that would make a
  later soft reroute to a third account safe.
- Reset the child request's parent-derived affinity policy, hard continuity
  anchor and reused parent turn state. The request state is prepared for the
  parent lane before the creation loop and the retry re-enters that loop without
  rebuilding it, so leaving those set made the submit and clean-close paths
  classify the account-neutral child as the parent's owner-bound turn.
- Add OpenSpec deltas for the model-transition exception and its hard-owner
  boundary.
- Add positive coverage plus single-retry and parent-turn-alias assertions, and
  forwarded-request, unpinned-`input_file`, post-compaction-placeholder and
  post-compaction-in-progress negative controls.

## Validation

```
uv run pytest tests/unit/test_proxy_http_bridge.py -k "model_transition and owner_conflict"
uv run ruff check app/modules/proxy/_service/http_bridge/streaming.py tests/unit/test_proxy_http_bridge.py
uv run ruff format --check app/modules/proxy/_service/http_bridge/streaming.py tests/unit/test_proxy_http_bridge.py
uv run ty check app/modules/proxy/_service/http_bridge/streaming.py
git diff --check
openspec validate fork-safe-model-transition-owner-conflict --strict --no-interactive
```

All listed checks pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guarded recovery for eligible model-transition requests affected by session ownership conflicts.
  * Account-neutral requests can retry once through an alternate, owner-isolated session lane.
  * Added safer quarantine recovery with stale-session protection and continuity metadata updates.

* **Bug Fixes**
  * Improved continuity handling while preserving ownership and session bindings.
  * Unsafe, forwarded, or repeated conflicts continue to fail safely without rerouting.

* **Tests**
  * Expanded coverage for recovery, retry limits, owner exclusion, state cleanup, quarantine handling, and fail-closed scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->