### PR TITLE
fix(quota-planner): compare warmup reset epochs in UTC

### DIFF
--- a/app/modules/quota_planner/warmup.py
+++ b/app/modules/quota_planner/warmup.py
@@ -14,7 +14,7 @@ from app.core.clients.proxy import stream_responses
 from app.core.crypto import TokenEncryptor
 from app.core.openai.parsing import parse_sse_event
 from app.core.openai.requests import ResponsesRequest
-from app.core.utils.time import utcnow
+from app.core.utils.time import naive_utc_to_epoch, utcnow
 from app.db.models import Account, AccountStatus, QuotaPlannerDecision
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.api_keys.repository import ApiKeysRepository
@@ -420,7 +420,7 @@ class QuotaWarmupService:
             return False, "no_short_window"
         if await self._short_window_superseded(account, latest):
             return False, "no_short_window"
-        if latest is not None and latest.reset_at is not None and latest.reset_at > int(utcnow().timestamp()):
+        if latest is not None and latest.reset_at is not None and latest.reset_at > naive_utc_to_epoch(utcnow()):
             return False, "account_window_already_active"
 
         # Advisory pre-check only: the authoritative budget enforcement happens

--- a/openspec/changes/fix-warm-now-reset-utc-gate/.openspec.yaml
+++ b/openspec/changes/fix-warm-now-reset-utc-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/fix-warm-now-reset-utc-gate/proposal.md
+++ b/openspec/changes/fix-warm-now-reset-utc-gate/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Warm-now compares quota reset epochs from usage history against the current
+server time before deciding whether a short-window account is already active.
+On non-UTC hosts, converting the planner's naive UTC `utcnow()` value with
+`datetime.timestamp()` interprets that naive value as local time and can make a
+past reset look future-dated. Operators then see a due manual warm-now request
+skip as `account_window_already_active` instead of executing.
+
+## What Changes
+
+- Compare warmup reset epochs against a current epoch derived from naive UTC,
+  independent of the process local timezone.
+- Strengthen the route-level warm-now regression by running the due-reset path
+  under a simulated UTC+ process timezone with cleanup.
+- Document the observable behavior under the quota phase planner contract.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `quota-phase-planner`: Warm-now reset gates must treat persisted reset epochs
+  as UTC instants regardless of the process timezone.
+
+## Impact
+
+- Backend: `app/modules/quota_planner/warmup.py`
+- Tests: `tests/integration/test_quota_planner_api.py`
+- Contract: Manual warm-now execution eligibility on non-UTC hosts
+- No API schema, database migration, dependency, setting, dashboard, or
+  successful-response shape change

--- a/openspec/changes/fix-warm-now-reset-utc-gate/specs/quota-phase-planner/spec.md
+++ b/openspec/changes/fix-warm-now-reset-utc-gate/specs/quota-phase-planner/spec.md
@@ -1,0 +1,35 @@
+# Delta Specification: quota-phase-planner
+
+## MODIFIED Requirements
+
+### Requirement: Quota planner API and dashboard expose auditable controls
+
+The quota planner SHALL expose authenticated dashboard APIs and UI controls for
+settings, forecast, decisions, warm-now, and cancellation. Settings changes and
+scheduler decisions MUST remain auditable, and decision responses SHOULD expose
+parsed decision details when stored audit JSON is available. Warm-now reset
+eligibility gates MUST compare persisted quota reset epochs against the current
+UTC instant regardless of the server process timezone.
+
+#### Scenario: Operators can inspect planner decisions
+
+- **WHEN** a dashboard user requests quota planner decisions
+- **THEN** the API returns recent decisions with status, action, account,
+  scheduled time, reason, and parsed details when present
+
+#### Scenario: Warm-now uses server-side gates
+
+- **WHEN** a dashboard user requests a manual warm-now probe
+- **THEN** the server evaluates the same safety gates used by scheduler
+  execution
+- **AND** it records a skipped, failed, or executed decision outcome
+
+#### Scenario: Warm-now reset gate is timezone-independent
+
+- **GIVEN** a short-window usage reset epoch is already due in UTC
+- **AND** the server process local timezone is UTC+
+- **WHEN** a dashboard user requests a manual warm-now probe for that account
+- **THEN** the reset gate MUST NOT skip with `account_window_already_active`
+  because of process-local timestamp conversion
+- **AND** the warm-now request remains eligible for execution when the other
+  server-side gates allow it

--- a/openspec/changes/fix-warm-now-reset-utc-gate/tasks.md
+++ b/openspec/changes/fix-warm-now-reset-utc-gate/tasks.md
@@ -1,0 +1,18 @@
+## 1. Warm-now reset gate
+
+- [x] 1.1 Compare warm-now usage reset epochs against a current epoch computed
+  from naive UTC rather than process-local time.
+- [x] 1.2 Preserve existing no-short-window and budget safety gates.
+
+## 2. Regression coverage
+
+- [x] 2.1 Simulate a UTC+ process timezone in the route-level warm-now test
+  with `TZ`, `time.tzset()`, and cleanup.
+- [x] 2.2 Verify the strengthened test fails when the warm-now epoch comparison
+  is temporarily reverted to process-local timestamp conversion.
+
+## 3. Validation
+
+- [x] 3.1 Validate the OpenSpec change artifacts.
+- [x] 3.2 Re-run the target integration test file and one broader integration
+  slice after restoring the production fix.

--- a/tests/integration/test_quota_planner_api.py
+++ b/tests/integration/test_quota_planner_api.py
@@ -383,7 +383,7 @@ async def test_quota_planner_warm_now_keeps_bootstrap_for_metadata_less_primary_
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["status"] == "executed"
+    assert payload["status"] == "executed", payload
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_quota_planner_api.py
+++ b/tests/integration/test_quota_planner_api.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import time
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
@@ -302,84 +304,97 @@ async def test_quota_planner_warm_now_refuses_weekly_only_account(async_client, 
 async def test_quota_planner_warm_now_keeps_bootstrap_for_metadata_less_primary_rows(
     monkeypatch, async_client, db_setup
 ):
+    if not hasattr(time, "tzset"):
+        pytest.skip("tzset is required to simulate non-UTC local time")
+
     del db_setup
+    original_tz = os.environ.get("TZ")
+    os.environ["TZ"] = "Asia/Seoul"
+    time.tzset()
     encryptor = TokenEncryptor()
-    now_epoch = int(utcnow().replace(tzinfo=timezone.utc).timestamp())
-    async with SessionLocal() as session:
-        account = Account(
-            id="acc-metadata-less",
-            email="metadata-less@example.test",
-            plan_type="plus",
-            access_token_encrypted=encryptor.encrypt("access"),
-            refresh_token_encrypted=encryptor.encrypt("refresh"),
-            id_token_encrypted=encryptor.encrypt("id"),
-            last_refresh=utcnow(),
-            status=AccountStatus.ACTIVE,
-        )
-        session.add(account)
-        # A legacy primary row without duration metadata plus a newer weekly
-        # row: the metadata-less sample keeps the legacy bootstrap path and
-        # must not be rejected as a superseded short window.
-        session.add(
-            UsageHistory(
+    try:
+        now_epoch = int(utcnow().replace(tzinfo=timezone.utc).timestamp())
+        async with SessionLocal() as session:
+            account = Account(
+                id="acc-metadata-less",
+                email="metadata-less@example.test",
+                plan_type="plus",
+                access_token_encrypted=encryptor.encrypt("access"),
+                refresh_token_encrypted=encryptor.encrypt("refresh"),
+                id_token_encrypted=encryptor.encrypt("id"),
+                last_refresh=utcnow(),
+                status=AccountStatus.ACTIVE,
+            )
+            session.add(account)
+            # A legacy primary row without duration metadata plus a newer weekly
+            # row: the metadata-less sample keeps the legacy bootstrap path and
+            # must not be rejected as a superseded short window.
+            session.add(
+                UsageHistory(
+                    account_id="acc-metadata-less",
+                    used_percent=0.0,
+                    recorded_at=utcnow() - timedelta(hours=3),
+                    window="primary",
+                    reset_at=now_epoch - 7200,
+                    window_minutes=None,
+                )
+            )
+            session.add(
+                UsageHistory(
+                    account_id="acc-metadata-less",
+                    used_percent=40.0,
+                    recorded_at=utcnow(),
+                    window="secondary",
+                    reset_at=now_epoch + 5 * 24 * 3600,
+                    window_minutes=10080,
+                )
+            )
+            repo = QuotaPlannerRepository(session)
+            await repo.upsert_settings(
+                PlannerSettings(
+                    mode="auto",
+                    timezone="UTC",
+                    working_days=(0, 1, 2, 3, 4),
+                    working_hours_start="09:00",
+                    working_hours_end="18:00",
+                    prewarm_enabled=True,
+                    prewarm_lead_minutes=300,
+                    max_warmups_per_day=3,
+                    max_warmup_credits_per_day=1.0,
+                    min_expected_gain=1.0,
+                    forecast_quantile="p75",
+                    allow_synthetic_traffic=True,
+                    warmup_model_preference="gpt-5.4-mini",
+                    dry_run=False,
+                )
+            )
+            await repo.add_window_observation(
                 account_id="acc-metadata-less",
-                used_percent=0.0,
-                recorded_at=utcnow() - timedelta(hours=3),
-                window="primary",
-                reset_at=now_epoch - 7200,
-                window_minutes=None,
+                model="gpt-5.4-mini",
+                source="warmup_probe",
+                confidence="observed",
             )
-        )
-        session.add(
-            UsageHistory(
-                account_id="acc-metadata-less",
-                used_percent=40.0,
-                recorded_at=utcnow(),
-                window="secondary",
-                reset_at=now_epoch + 5 * 24 * 3600,
-                window_minutes=10080,
-            )
-        )
-        repo = QuotaPlannerRepository(session)
-        await repo.upsert_settings(
-            PlannerSettings(
-                mode="auto",
-                timezone="UTC",
-                working_days=(0, 1, 2, 3, 4),
-                working_hours_start="09:00",
-                working_hours_end="18:00",
-                prewarm_enabled=True,
-                prewarm_lead_minutes=300,
-                max_warmups_per_day=3,
-                max_warmup_credits_per_day=1.0,
-                min_expected_gain=1.0,
-                forecast_quantile="p75",
-                allow_synthetic_traffic=True,
-                warmup_model_preference="gpt-5.4-mini",
-                dry_run=False,
-            )
-        )
-        await repo.add_window_observation(
-            account_id="acc-metadata-less",
-            model="gpt-5.4-mini",
-            source="warmup_probe",
-            confidence="observed",
-        )
 
-    async def fake_send(self, *, account, model, request_id):
-        del self, account, model, request_id
-        return WarmupUsage(input_tokens=3, output_tokens=1, cached_input_tokens=0, reasoning_tokens=None)
+        async def fake_send(self, *, account, model, request_id):
+            del self, account, model, request_id
+            return WarmupUsage(input_tokens=3, output_tokens=1, cached_input_tokens=0, reasoning_tokens=None)
 
-    async def noop_record_effect(self, account, model, *, source, confidence):
-        del self, account, model, source, confidence
+        async def noop_record_effect(self, account, model, *, source, confidence):
+            del self, account, model, source, confidence
 
-    monkeypatch.setattr(QuotaWarmupService, "_send_warmup_probe", fake_send)
-    monkeypatch.setattr(QuotaWarmupService, "_record_warmup_effect", noop_record_effect)
+        monkeypatch.setattr(QuotaWarmupService, "_send_warmup_probe", fake_send)
+        monkeypatch.setattr(QuotaWarmupService, "_record_warmup_effect", noop_record_effect)
 
-    response = await async_client.post(
-        "/api/quota-planner/warm-now",
-        json={"accountId": "acc-metadata-less", "model": "gpt-5.4-mini"},
-    )
+        response = await async_client.post(
+            "/api/quota-planner/warm-now",
+            json={"accountId": "acc-metadata-less", "model": "gpt-5.4-mini"},
+        )
+    finally:
+        if original_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original_tz
+        time.tzset()
 
     assert response.status_code == 200
     payload = response.json()


### PR DESCRIPTION
`test_quota_planner_warm_now_keeps_bootstrap_for_metadata_less_primary_rows` failed on clean main (`status=skipped`, expected `executed`) when the host timezone is ahead of UTC.

**Root cause**: `app/modules/quota_planner/warmup.py` compared `latest.reset_at` epoch seconds against `int(utcnow().timestamp())`. `utcnow()` returns a naive datetime, and `.timestamp()` interprets naive values as *local* time — on a UTC+4 host "now" lands 4 hours early, so a primary reset 2 hours in the past still looked active and the warm-now gate returned `skipped/account_window_already_active`.

**Fix**: use the existing `naive_utc_to_epoch()` helper for the active-window gate. The test still asserts `executed` (assertion not weakened; failure payload context added).

**Evidence**: target test pre-fix fails alone (reason `account_window_already_active`), post-fix passes; `tests/integration/test_quota_planner_api.py` 20/20 consecutive green runs; full suite `7485 passed, 12 skipped` — the pre-existing baseline failure is gone.
