### PR TITLE
chore: release v1.23.0-beta.4

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.23.0-beta.3"  # x-release-please-version
+__version__ = "1.23.0-beta.4"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.23.0-beta.3
-appVersion: 1.23.0-beta.3
+version: 1.23.0-beta.4
+appVersion: 1.23.0-beta.4
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.23.0-beta.3",
+  "version": "1.23.0-beta.4",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.23.0-beta.3"
+version = "1.23.0-beta.4"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.23.0-beta.3"
+version = "1.23.0-beta.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.23.0-beta.4 for the 1.23.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.23.0-beta.4 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1472; no manual beta workflow dispatch is required.

## Changes since v1.23.0-beta.3
- fix(db): handle percent-encoded SQLite URLs on Windows (takeover of #1295) (#1597) (e5dbd9a)
- fix(proxy): reconcile durable full resend owner (#1599) (
e95932)
- fix(proxy): settle reservations when terminal bookkeeping aborts (#1600) (
ce7b58)
- fix(proxy): fail over dead account proxy routes before upstream dispatch (#1542) (
e9a9e8)
- fix(proxy): report eligible pool usage exhaustion as 429 (#1541) (
897ae1)
- feat(proxy): congestion-aware per-API-key fair-share stream admission (#1536) (
0518b9)
- perf(api-keys): coalesce last_used_at writes behind a periodic flush (#1627) (
846670)
- perf(db): relax commit durability for telemetry writes on PostgreSQL (#1628) (
7c799c)
- perf(usage): cover the projections bulk history fetch with an index-only path (#1629) (
410bfa)
- fix(api-keys): restore last-used compatibility touch (#1656) (
3fffc0)
- fix(proxy): quarantine silent HTTP bridge sessions (takeover of #1405) (#1630) (
3aabe9)
- fix(ci): back off Codex review triggers on usage limits (takeover of #1560) (#1631) (
c33bc4)

## Release-candidate validation
Validated candidate: b3a7132582bfde17698d6ef49fa7064cf9bfcaec

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates — CI green at b3a71325 (unit, e2e, integration-core 1-3, integration-bridge, PostgreSQL suite, alembic migration checks sqlite+postgres, ruff, ty; only the pre-evidence Beta release guard was red)
- [x] Frontend tests/build — CI green at b3a71325 (vitest + production build + Playwright dashboard smoke)
- [x] Wheel/package validation — CI green at b3a71325 (package build/validation job)
- [x] Docker/container smoke — image built locally from b3a71325 (sha256:4a2b643a78dd818ddacba698daa01366dccecb82e843d44e93c214b7ad601d9b); booted against scratch postgres:18-alpine (PG 18.4): alembic migrated to single head 20260806_020000_add_usage_history_bulk_covering_indexes, / 200, /api/runtime/version 401 bootstrap_required (auth enforced), logs clean; default-sqlite boot also migrated to the same head with / 200
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required — this beta deploys to the production pool immediately after publish for the soak window (incl. the #1630 quarantine and #1536 fair-share behavior changes that motivated the cut); rollback runbook staged (image tag pin to 1.23.0-beta.3)

## Install after publish
```bash
uvx --from "codex-lb==1.23.0b4" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.23.0-beta.4
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.23.0-beta.4 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.23.0.

