### PR TITLE
perf(db): relax commit durability for telemetry writes on PostgreSQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ POSTGRES_PYTEST_TARGETS := \
 	tests/integration/test_proxy_compact.py::test_proxy_compact_headers_include_monthly_only_credits \
 	tests/integration/test_repositories.py::test_accounts_upsert_with_merge_disabled_uses_identity_lock_on_postgresql \
 	tests/integration/test_db_session_timezone.py \
+	tests/integration/test_db_commit_durability.py \
 	tests/test_request_logs_options_api.py \
 	tests/integration/test_account_usage_rollup.py \
 	tests/integration/test_request_usage_time_rollup.py \

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, AsyncIterator, Awaitable, Callable, Protocol, 
 
 import anyio
 from anyio import to_thread
-from sqlalchemy import event
+from sqlalchemy import event, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
@@ -294,6 +294,36 @@ async def get_background_session() -> AsyncIterator[AsyncSession]:
         raise
     finally:
         await close_session(session)
+
+
+async def relax_commit_durability(session: AsyncSession) -> None:
+    """Relax commit durability for the current telemetry write transaction.
+
+    High-frequency append-only accounting/telemetry writes (request logs,
+    API-key usage reservations, usage history entries) dominate the slow-query
+    profile on PostgreSQL because every commit waits for a WAL fsync. Those
+    rows describe in-flight requests: if the server crashes, the in-flight
+    requests are lost anyway, so losing the final unflushed WAL window (bounded
+    by three times ``wal_writer_delay`` — up to ~600 ms at the default 200 ms
+    setting) keeps accounting semantics identical. For such transactions
+    this helper emits ``SET LOCAL synchronous_commit = off`` so the commit
+    returns without waiting for the WAL flush.
+
+    ``SET LOCAL`` is transaction-scoped: PostgreSQL reverts it automatically
+    at COMMIT/ROLLBACK, so nothing leaks onto the pooled connection. Executed
+    outside a transaction, PostgreSQL merely emits a WARNING and the setting
+    never applies — calling this through an ``AsyncSession`` is what makes it
+    safe, because session autobegin opens the write transaction at this very
+    statement when none is open yet.
+
+    No-op on SQLite (durability there is governed by ``PRAGMA synchronous``).
+    MUST NOT be used for configuration writes (accounts, API keys, settings,
+    limits management): those keep full durability.
+    """
+    bind = session.get_bind()
+    if bind is None or bind.dialect.name != "postgresql":
+        return
+    await session.execute(text("SET LOCAL synchronous_commit = off"))
 
 
 @asynccontextmanager

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -27,7 +27,7 @@ from app.db.models import (
     RequestLog,
     RequestUsageHourlyRollup,
 )
-from app.db.session import sqlite_writer_section
+from app.db.session import relax_commit_durability, sqlite_writer_section
 from app.modules.accounts.usage_rollup import api_key_usage_aggregate_stmt, read_api_key_rollup_state
 from app.modules.accounts.usage_time_rollup import HOURLY_BUCKET_SECONDS, WARMUP_REQUEST_KINDS, to_dimension
 from app.modules.accounts.usage_time_rollup_read import RawWindow, raw_windows_clause, read_hourly_window
@@ -601,6 +601,10 @@ class ApiKeysRepository:
         model: str,
         items: list[UsageReservationItemData],
     ) -> None:
+        # Telemetry write: reservation creation (and the limit counters it
+        # rides with) is per-request usage accounting, so the enclosing
+        # transaction's commit may skip the synchronous WAL flush.
+        await relax_commit_durability(self._session)
         reservation = ApiKeyUsageReservation(
             id=reservation_id,
             api_key_id=key_id,
@@ -733,6 +737,11 @@ class ApiKeysRepository:
         cached_input_tokens: int | None,
         cost_microdollars: int | None,
     ) -> None:
+        # Telemetry write: reservation settlement (finalize/fail/release,
+        # including the last_used_at touch that rides the same transaction)
+        # is per-request usage accounting, so the enclosing transaction's
+        # commit may skip the synchronous WAL flush.
+        await relax_commit_durability(self._session)
         await self._session.execute(
             update(ApiKeyUsageReservation)
             .where(ApiKeyUsageReservation.id == reservation_id)
@@ -788,6 +797,14 @@ class ApiKeysRepository:
                     reservation_ids = list(result.scalars().all())
                     if not reservation_ids:
                         break
+
+                    # Telemetry write: stale-reservation release settles the
+                    # same per-request accounting rows as the request-path
+                    # settlement (reservation status flip plus limit-counter
+                    # adjustments), and a crash-lost batch is simply reclaimed
+                    # by the next scheduler run. Each batch commits its own
+                    # transaction, so relax every batch individually.
+                    await relax_commit_durability(self._session)
 
                     item_result = await self._session.execute(
                         select(

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -30,7 +30,7 @@ from app.db.models import (
     RequestLog,
     RequestUsageHourlyRollup,
 )
-from app.db.session import sqlite_writer_section
+from app.db.session import relax_commit_durability, sqlite_writer_section
 from app.modules.accounts.usage_rollup import lock_fold_state
 from app.modules.accounts.usage_time_rollup import (
     HOURLY_BUCKET_SECONDS,
@@ -969,6 +969,9 @@ class RequestLogsRepository:
         archive_request_id: str | None = None,
     ) -> RequestLog:
         async with sqlite_writer_section():
+            # Telemetry write: this transaction only appends one request-log
+            # row, so its commit may skip the synchronous WAL flush.
+            await relax_commit_durability(self._session)
             resolved_request_id = ensure_request_id(request_id)
             resolved_archive_request_id = (archive_request_id or "").strip() or resolved_request_id
             resolved_plan_type = plan_type

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -18,7 +18,7 @@ from app.core.config.settings import get_settings
 from app.core.usage.types import UsageAggregateRow, UsageTrendBucket
 from app.core.utils.time import utcnow
 from app.db.models import Account, AdditionalUsageHistory, UsageHistory
-from app.db.session import sqlite_writer_section
+from app.db.session import relax_commit_durability, sqlite_writer_section
 from app.db.sqlite_utils import sqlite_db_path_from_url
 from app.modules.usage.additional_quota_keys import (
     AdditionalQuotaQueryScope,
@@ -616,8 +616,11 @@ class UsageRepository:
             credits_balance=credits_balance,
             recorded_at=recorded_at or utcnow(),
         )
-        self._session.add(entry)
         async with sqlite_writer_section():
+            # Telemetry write: this transaction only appends usage-history
+            # rows, so its commit may skip the synchronous WAL flush.
+            await relax_commit_durability(self._session)
+            self._session.add(entry)
             await self._session.commit()
             await self._session.refresh(entry)
         return entry
@@ -649,9 +652,12 @@ class UsageRepository:
             )
             for window in windows
         ]
-        self._session.add_all(entries)
         try:
             async with sqlite_writer_section():
+                # Telemetry write: this transaction only appends usage-history
+                # rows, so its commit may skip the synchronous WAL flush.
+                await relax_commit_durability(self._session)
+                self._session.add_all(entries)
                 await self._session.commit()
         except BaseException:
             await self._session.rollback()
@@ -1080,8 +1086,12 @@ class AdditionalUsageRepository:
             window_minutes=window_minutes,
             recorded_at=recorded_at or utcnow(),
         )
-        self._session.add(entry)
         async with sqlite_writer_section():
+            # Telemetry write: this transaction only appends one
+            # additional-usage-history row, so its commit may skip the
+            # synchronous WAL flush.
+            await relax_commit_durability(self._session)
+            self._session.add(entry)
             await self._session.commit()
 
     async def delete_for_account(self, account_id: str) -> None:

--- a/openspec/changes/async-commit-telemetry-writes/.openspec.yaml
+++ b/openspec/changes/async-commit-telemetry-writes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/async-commit-telemetry-writes/proposal.md
+++ b/openspec/changes/async-commit-telemetry-writes/proposal.md
@@ -1,0 +1,32 @@
+# Relax commit durability for telemetry writes on PostgreSQL
+
+## Why
+
+On the production PostgreSQL deployment (15 accounts, 4.5M request logs), 93% of slow queries over 500 ms are write-path fsync waits: `INSERT request_logs` (667 calls / 30.8 s per 10 min), `INSERT api_key_usage_reservations` (1,612 calls / 25.7 s), and the settlement `UPDATE api_keys SET last_used_at` (616 calls / 44.6 s). Every one of these commits pays a synchronous WAL flush for rows that are pure per-request accounting/telemetry. If the database server crashes, the in-flight requests those rows describe are lost anyway, so losing the final few hundred milliseconds of unflushed WAL changes nothing about accounting semantics — full durability buys these transactions nothing.
+
+## What Changes
+
+- Add a shared helper `relax_commit_durability(session)` in `app/db/session.py` that emits `SET LOCAL synchronous_commit = off` inside the current write transaction when the session's dialect is PostgreSQL, and is a no-op otherwise (SQLite durability stays governed by `PRAGMA synchronous`). `SET LOCAL` is transaction-scoped, so PostgreSQL reverts it automatically at COMMIT/ROLLBACK and nothing leaks onto pooled connections.
+- Invoke the helper inside the high-frequency append-only telemetry write transactions:
+  - `RequestLogsRepository.add_log` (request-log insert),
+  - `ApiKeysRepository.create_usage_reservation` and `ApiKeysRepository.settle_usage_reservation` (usage-reservation creation and finalize/fail/release settlement, including the `last_used_at` touch and limit-counter adjustments that ride the same transactions),
+  - `ApiKeysRepository.release_stale_usage_reservations` (the scheduler's stale-reservation release settles the same accounting rows batch by batch; a crash-lost batch is reclaimed by the next scheduler run),
+  - `UsageRepository.add_entry`, `UsageRepository.add_account_snapshot`, and `AdditionalUsageRepository.add_entry` (usage-history appends).
+- Configuration writes (account/key/limit/setting mutations, migrations, schedulers' state) are explicitly NOT relaxed and keep full durability.
+- No new settings (reduce-settings-surface policy): the behavior is an unconditional application constant of the telemetry write paths.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `database-backends`: add the telemetry-write durability contract — which write transactions qualify as telemetry, the bounded-loss semantics they accept, the requirement that the relaxation is transaction-scoped (`SET LOCAL`) and PostgreSQL-only, and the requirement that configuration writes keep full durability.
+
+## Impact
+
+- Affected code: `app/db/session.py` (helper), `app/modules/request_logs/repository.py`, `app/modules/api_keys/repository.py`, `app/modules/usage/repository.py`.
+- Affected tests: new unit test for the helper's dialect guard; new PostgreSQL integration tests proving in-transaction application, automatic revert after COMMIT/ROLLBACK, the outside-transaction WARNING trap, telemetry paths emitting the relaxation, and configuration writes not emitting it.
+- Crash-loss contract: on a PostgreSQL server crash, committed telemetry rows within the final unflushed WAL window — bounded by three times `wal_writer_delay`, up to ~600 ms at the default 200 ms setting — may be lost; replication/failover semantics of `synchronous_commit = off` are identical to local-crash semantics for these rows. No API change, no frontend change, no migration, no new settings.

--- a/openspec/changes/async-commit-telemetry-writes/specs/database-backends/spec.md
+++ b/openspec/changes/async-commit-telemetry-writes/specs/database-backends/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Telemetry write transactions relax commit durability on PostgreSQL
+
+A write transaction is classified as a **telemetry write** when it only appends or settles per-request accounting rows whose loss on a database-server crash is semantically equivalent to losing the in-flight request they describe: request-log inserts (`request_logs`), API-key usage-reservation creation and settlement (`api_key_usage_reservations` and the limit-counter / `last_used_at` statements riding the same transaction) — including the scheduler's stale-reservation release, whose batches settle the same rows and are re-derived by the next scheduler run if a crash loses them — and usage-history appends (`usage_history`, `additional_usage_history`).
+
+On PostgreSQL, every telemetry write transaction MUST execute `SET LOCAL synchronous_commit = off` within the transaction itself, so its commit does not wait for the synchronous WAL flush. The relaxation MUST be transaction-scoped (`SET LOCAL`, never `SET`): it reverts automatically at COMMIT or ROLLBACK and MUST NOT leak onto the pooled connection. Because PostgreSQL only emits a WARNING — and applies nothing — when `SET LOCAL` runs outside a transaction, the relaxation MUST be issued through the transaction's own session (SQLAlchemy autobegin opens the transaction at that statement when none is open yet). On SQLite and any other non-PostgreSQL dialect the relaxation MUST be a no-op.
+
+The accepted loss contract is: after a PostgreSQL server crash, telemetry rows committed within the final unflushed WAL window (bounded by three times `wal_writer_delay` — up to ~600 ms at the default 200 ms setting) may be lost. Because such a crash also destroys every in-flight request, accounting semantics are unchanged. Configuration writes — account, API-key, limit, and settings mutations, schema migrations, scheduler coordination state — MUST NOT relax commit durability.
+
+#### Scenario: Relaxation applies inside the telemetry write transaction
+
+- **GIVEN** a PostgreSQL backend and a telemetry write transaction that has issued the relaxation
+- **WHEN** `SHOW synchronous_commit` is executed within the same transaction
+- **THEN** it reports `off`
+
+#### Scenario: Session durability is restored after commit or rollback
+
+- **GIVEN** a PostgreSQL session whose current transaction relaxed commit durability
+- **WHEN** that transaction commits or rolls back and a subsequent statement runs `SHOW synchronous_commit`
+- **THEN** it reports the session default (`on`)
+
+#### Scenario: Relaxation outside a transaction has no effect
+
+- **GIVEN** a PostgreSQL connection in autocommit mode (no open transaction)
+- **WHEN** `SET LOCAL synchronous_commit = off` is executed followed by `SHOW synchronous_commit`
+- **THEN** the setting does not stick (`on` is reported), which is why the relaxation is issued through the transaction-owning session
+
+#### Scenario: Telemetry write paths emit the relaxation on PostgreSQL
+
+- **GIVEN** a PostgreSQL backend
+- **WHEN** a request log is inserted, a usage reservation is created or settled, or a usage-history entry is appended
+- **THEN** the statements executed by that transaction include `SET LOCAL synchronous_commit = off` before the commit
+
+#### Scenario: Scheduler stale-reservation release relaxes commit durability
+
+- **GIVEN** a PostgreSQL backend holding a stale usage reservation (heartbeat stopped or past the maximum age)
+- **WHEN** the stale-reservation release settles a batch (status flip to `released` plus its limit-counter adjustments)
+- **THEN** each batch transaction executes `SET LOCAL synchronous_commit = off` before its commit, matching the request-path settlement of the same rows
+
+#### Scenario: Configuration writes keep full durability
+
+- **GIVEN** a PostgreSQL backend
+- **WHEN** a configuration write runs (for example creating or updating an API key or account)
+- **THEN** its transaction never executes `SET LOCAL synchronous_commit = off`
+
+#### Scenario: SQLite backends are unaffected
+
+- **GIVEN** a SQLite backend (file or `:memory:`)
+- **WHEN** any telemetry write path invokes the durability relaxation helper
+- **THEN** no statement is emitted and SQLite durability remains governed by its existing PRAGMA configuration

--- a/openspec/changes/async-commit-telemetry-writes/tasks.md
+++ b/openspec/changes/async-commit-telemetry-writes/tasks.md
@@ -1,0 +1,19 @@
+# Tasks
+
+## 1. Shared helper
+
+- [x] 1.1 Add `relax_commit_durability(session)` to `app/db/session.py`: PostgreSQL-only `SET LOCAL synchronous_commit = off` executed through the session (autobegin guarantees an open transaction), no-op for every other dialect.
+
+## 2. Telemetry write call sites
+
+- [x] 2.1 `RequestLogsRepository.add_log`: relax as the first statement of the insert transaction.
+- [x] 2.2 `ApiKeysRepository.create_usage_reservation` and `ApiKeysRepository.settle_usage_reservation`: relax the reservation-creation and settlement transactions (covers finalize/fail/release plus the `last_used_at` touch riding the settlement commit).
+- [x] 2.2b `ApiKeysRepository.release_stale_usage_reservations`: relax each stale-release batch transaction (scheduler path settles the same accounting rows as the request-path release).
+- [x] 2.3 `UsageRepository.add_entry`, `UsageRepository.add_account_snapshot`, `AdditionalUsageRepository.add_entry`: relax the usage-history append transactions.
+- [x] 2.4 Confirm no configuration write path (account/key/limit management, schedulers, migrations) calls the helper.
+
+## 3. Verification
+
+- [x] 3.1 Unit test: helper executes `SET LOCAL` only for PostgreSQL sessions and is a no-op for SQLite.
+- [x] 3.2 PostgreSQL integration tests: `SHOW synchronous_commit` inside the relaxed transaction reports `off`; after COMMIT and after ROLLBACK the session default (`on`) is restored; `SET LOCAL` outside a transaction (autocommit) does not stick (the WARNING trap); telemetry write paths (including the scheduler's stale-reservation release) emit the relaxation and a configuration write does not.
+- [x] 3.3 Register the integration test module in `POSTGRES_PYTEST_TARGETS`; run ruff check, ruff format, ty, and the unit suite (SQLite) plus the new integration module against PostgreSQL.

--- a/tests/integration/test_db_commit_durability.py
+++ b/tests/integration/test_db_commit_durability.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import timedelta
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import event, text
+
+from app.core.crypto import TokenEncryptor
+from app.core.utils.time import utcnow
+from app.db.models import Account, AccountStatus, ApiKey
+from app.db.session import SessionLocal, engine, relax_commit_durability
+from app.modules.accounts.repository import AccountsRepository
+from app.modules.api_keys.repository import ApiKeysRepository
+from app.modules.request_logs.repository import RequestLogsRepository
+from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository, UsageWindowWrite
+
+pytestmark = pytest.mark.integration
+
+_SET_LOCAL_FRAGMENT = "SET LOCAL synchronous_commit"
+
+
+def _require_postgres() -> None:
+    url = os.environ.get("CODEX_LB_TEST_DATABASE_URL", "")
+    if not url.startswith("postgresql+asyncpg://"):
+        pytest.skip("requires CODEX_LB_TEST_DATABASE_URL=postgresql+asyncpg://...")
+
+
+@contextmanager
+def _captured_statements() -> Iterator[list[str]]:
+    statements: list[str] = []
+
+    def _record(conn, cursor, statement, parameters, context, executemany) -> None:  # type: ignore[no-untyped-def]
+        del conn, cursor, parameters, context, executemany
+        statements.append(statement)
+
+    event.listen(engine.sync_engine, "before_cursor_execute", _record)
+    try:
+        yield statements
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _record)
+
+
+def _assert_relaxed_before(statements: list[str], statement_fragment: str) -> None:
+    relax_indexes = [index for index, statement in enumerate(statements) if _SET_LOCAL_FRAGMENT in statement]
+    target_indexes = [index for index, statement in enumerate(statements) if statement_fragment in statement]
+    assert relax_indexes, f"no durability relaxation captured in {statements!r}"
+    assert target_indexes, f"no {statement_fragment!r} captured in {statements!r}"
+    assert relax_indexes[0] < target_indexes[0], (
+        f"durability relaxation must precede {statement_fragment!r} within the transaction: {statements!r}"
+    )
+
+
+def _assert_not_relaxed(statements: list[str]) -> None:
+    assert all(_SET_LOCAL_FRAGMENT not in statement for statement in statements), statements
+
+
+def _make_account(account_id: str) -> Account:
+    encryptor = TokenEncryptor()
+    return Account(
+        id=account_id,
+        email=f"{account_id}@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access"),
+        refresh_token_encrypted=encryptor.encrypt("refresh"),
+        id_token_encrypted=encryptor.encrypt("id"),
+        last_refresh=utcnow(),
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+
+
+def _make_api_key(key_id: str) -> ApiKey:
+    return ApiKey(
+        id=key_id,
+        name=f"key-{key_id}",
+        key_hash=f"hash-{key_id}",
+        key_prefix="sk-test",
+    )
+
+
+@pytest.mark.asyncio
+async def test_relax_commit_durability_applies_within_the_write_transaction() -> None:
+    _require_postgres()
+    async with SessionLocal() as session:
+        await relax_commit_durability(session)
+        # Session autobegin opened the transaction at the SET LOCAL statement
+        # itself — the in-transaction guarantee that makes SET LOCAL apply at
+        # all (outside a transaction PostgreSQL only emits a WARNING).
+        assert session.in_transaction()
+        value = (await session.execute(text("SHOW synchronous_commit"))).scalar_one()
+        assert value == "off"
+        await session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_relaxed_durability_reverts_to_session_default_after_commit_and_rollback() -> None:
+    _require_postgres()
+    async with engine.connect() as conn:
+        transaction = await conn.begin()
+        await conn.execute(text("SET LOCAL synchronous_commit = off"))
+        assert (await conn.execute(text("SHOW synchronous_commit"))).scalar_one() == "off"
+        await transaction.commit()
+        # Same physical connection: COMMIT reverted the transaction-local
+        # override back to the session default.
+        assert (await conn.execute(text("SHOW synchronous_commit"))).scalar_one() == "on"
+        await conn.rollback()
+
+        transaction = await conn.begin()
+        await conn.execute(text("SET LOCAL synchronous_commit = off"))
+        assert (await conn.execute(text("SHOW synchronous_commit"))).scalar_one() == "off"
+        await transaction.rollback()
+        assert (await conn.execute(text("SHOW synchronous_commit"))).scalar_one() == "on"
+        await conn.rollback()
+
+
+@pytest.mark.asyncio
+async def test_set_local_outside_a_transaction_does_not_stick() -> None:
+    """The trap the helper exists to avoid: SET LOCAL without a transaction.
+
+    PostgreSQL only emits ``WARNING: SET LOCAL can only be used in transaction
+    blocks`` and applies nothing. The helper always runs through the write
+    transaction's session, where autobegin guarantees an open transaction.
+    """
+    _require_postgres()
+    async with engine.connect() as conn:
+        autocommit_conn = await conn.execution_options(isolation_level="AUTOCOMMIT")
+        await autocommit_conn.execute(text("SET LOCAL synchronous_commit = off"))
+        value = (await autocommit_conn.execute(text("SHOW synchronous_commit"))).scalar_one()
+        assert value == "on"
+
+
+@pytest.mark.asyncio
+async def test_request_log_insert_transaction_relaxes_commit_durability(db_setup) -> None:
+    _require_postgres()
+    async with SessionLocal() as session:
+        repo = RequestLogsRepository(session)
+        with _captured_statements() as statements:
+            await repo.add_log(
+                account_id=None,
+                request_id=f"req-{uuid4().hex}",
+                model="gpt-5",
+                input_tokens=10,
+                output_tokens=5,
+                latency_ms=42,
+                status="success",
+                error_code=None,
+            )
+        _assert_relaxed_before(statements, "INSERT INTO request_logs")
+
+
+@pytest.mark.asyncio
+async def test_usage_reservation_creation_and_settlement_relax_commit_durability(db_setup) -> None:
+    _require_postgres()
+    async with SessionLocal() as session:
+        repo = ApiKeysRepository(session)
+        key_id = f"key-{uuid4().hex[:8]}"
+        await repo.create(_make_api_key(key_id))
+
+        reservation_id = f"res-{uuid4().hex[:8]}"
+        with _captured_statements() as statements:
+            await repo.create_usage_reservation(reservation_id, key_id=key_id, model="gpt-5", items=[])
+            await repo.commit()
+        _assert_relaxed_before(statements, "INSERT INTO api_key_usage_reservations")
+
+        with _captured_statements() as statements:
+            await repo.settle_usage_reservation(
+                reservation_id,
+                status="finalized",
+                input_tokens=10,
+                output_tokens=5,
+                cached_input_tokens=0,
+                cost_microdollars=0,
+            )
+            await repo.update_last_used(key_id, commit=False)
+            await repo.commit()
+        _assert_relaxed_before(statements, "UPDATE api_key_usage_reservations")
+        # The last_used_at touch rides the same relaxed settlement transaction.
+        assert any("UPDATE api_keys" in statement for statement in statements)
+
+
+@pytest.mark.asyncio
+async def test_stale_usage_reservation_release_relaxes_commit_durability(db_setup) -> None:
+    """Regression: the scheduler's stale-reservation release settles the same
+    per-request accounting rows as the request-path settlement, so each batch
+    transaction must relax commit durability too — durability of a release
+    must not depend on which path fires (adversarial review P2).
+    """
+    _require_postgres()
+    async with SessionLocal() as session:
+        repo = ApiKeysRepository(session)
+        key_id = f"key-{uuid4().hex[:8]}"
+        await repo.create(_make_api_key(key_id))
+
+        reservation_id = f"res-{uuid4().hex[:8]}"
+        await repo.create_usage_reservation(reservation_id, key_id=key_id, model="gpt-5", items=[])
+        await repo.commit()
+
+        # A cutoff in the future makes the freshly created reservation stale.
+        with _captured_statements() as statements:
+            released_count = await repo.release_stale_usage_reservations(cutoff=utcnow() + timedelta(hours=1))
+
+        assert released_count == 1
+        _assert_relaxed_before(statements, "UPDATE api_key_usage_reservations")
+
+
+@pytest.mark.asyncio
+async def test_usage_history_appends_relax_commit_durability(db_setup) -> None:
+    _require_postgres()
+    async with SessionLocal() as session:
+        account_id = f"acc-{uuid4().hex[:8]}"
+        await AccountsRepository(session).upsert(_make_account(account_id))
+
+        usage_repo = UsageRepository(session)
+        with _captured_statements() as statements:
+            await usage_repo.add_entry(account_id, 12.5)
+        _assert_relaxed_before(statements, "INSERT INTO usage_history")
+
+        with _captured_statements() as statements:
+            await usage_repo.add_account_snapshot(
+                account_id,
+                [UsageWindowWrite(window="primary", used_percent=20.0)],
+            )
+        _assert_relaxed_before(statements, "INSERT INTO usage_history")
+
+        additional_repo = AdditionalUsageRepository(session)
+        with _captured_statements() as statements:
+            await additional_repo.add_entry(
+                account_id,
+                limit_name="requests_per_minute",
+                metered_feature="api_calls",
+                window="1m",
+                used_percent=3.0,
+            )
+        _assert_relaxed_before(statements, "INSERT INTO additional_usage_history")
+
+
+@pytest.mark.asyncio
+async def test_configuration_writes_keep_full_commit_durability(db_setup) -> None:
+    _require_postgres()
+    async with SessionLocal() as session:
+        with _captured_statements() as statements:
+            await ApiKeysRepository(session).create(_make_api_key(f"key-{uuid4().hex[:8]}"))
+        _assert_not_relaxed(statements)
+
+        with _captured_statements() as statements:
+            await AccountsRepository(session).upsert(_make_account(f"acc-{uuid4().hex[:8]}"))
+        _assert_not_relaxed(statements)

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import pytest
+from sqlalchemy import event as sa_event
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
@@ -831,3 +832,48 @@ async def test_safe_rollback_outlives_caller_cancellation() -> None:
 
     assert rolled_back.is_set()
     assert cleanup_done.is_set()
+
+
+@pytest.mark.asyncio
+async def test_relax_commit_durability_is_noop_for_sqlite_sessions() -> None:
+    statements: list[str] = []
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", poolclass=NullPool)
+
+    @sa_event.listens_for(engine.sync_engine, "before_cursor_execute")
+    def _record(conn, cursor, statement, parameters, context, executemany) -> None:  # type: ignore[no-untyped-def]
+        del conn, cursor, parameters, context, executemany
+        statements.append(statement)
+
+    try:
+        session_factory = async_sessionmaker(engine, expire_on_commit=False)
+        async with session_factory() as session:
+            await session_module.relax_commit_durability(session)
+            # The no-op must not even open a transaction: on SQLite the helper
+            # returns before touching the connection.
+            assert not session.in_transaction()
+    finally:
+        await engine.dispose()
+
+    assert all("synchronous_commit" not in statement for statement in statements)
+
+
+@pytest.mark.asyncio
+async def test_relax_commit_durability_emits_set_local_for_postgresql_sessions() -> None:
+    executed: list[str] = []
+
+    class _FakeDialect:
+        name = "postgresql"
+
+    class _FakeBind:
+        dialect = _FakeDialect()
+
+    class _FakeSession:
+        def get_bind(self) -> _FakeBind:
+            return _FakeBind()
+
+        async def execute(self, statement: object) -> None:
+            executed.append(str(statement))
+
+    await session_module.relax_commit_durability(cast(session_module.AsyncSession, _FakeSession()))
+
+    assert executed == ["SET LOCAL synchronous_commit = off"]


### PR DESCRIPTION
## Why

Every proxied request pays 3-4 synchronous commits (request log insert, reservation create/settle, usage snapshots) — each one waits for a WAL fsync. On the reference deployment these write commits are now 93% of all >500 ms statements; the data they protect is per-request accounting whose sub-second loss on a crash is semantically indistinguishable from the crash itself (in-flight requests are lost either way).

## What

- New session helper `relax_commit_durability(session)`: executes `SET LOCAL synchronous_commit = off` inside the current transaction on PostgreSQL, no-op elsewhere. `SET LOCAL` scopes to the transaction, so durability reverts automatically at commit/rollback — nothing leaks to pooled sessions.
- Applied to the enumerated telemetry transactions only: request-log inserts, api-key usage reservation create/settle (both the request path and the scheduler's stale-reservation release — the same accounting rows, fully re-derivable), usage-history and additional-usage snapshot writes. Account/key/config writes keep full durability; the spec defines the classification normatively.
- Loss window stated precisely: bounded by 3× `wal_writer_delay` (~600 ms at the default 200 ms), per PostgreSQL docs.
- Known trap covered by tests: `SET LOCAL` outside a transaction is a silent no-op warning — integration tests assert the setting is captured before the write statement inside the same transaction and reverts after commit.

## Validation

- PG integration suite `test_db_commit_durability`: 8 passed (applies inside transaction, reverts after commit, non-telemetry paths unaffected, scheduler stale-release regression); targeted repo suites 104 passed on PG, 137 on SQLite; full unit suite 5,681 passed; `ruff`, `ty`, openspec validate clean.
- Adversarial review round: P2 (scheduler stale-reservation release settled at full durability, violating the spec's MUST) fixed with a statement-capture regression test; loss-window wording corrected to the documented 3× bound.

OpenSpec: `openspec/changes/async-commit-telemetry-writes/` (database-backends delta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)