### PR TITLE
fix(ci): back off Codex review triggers on usage limits (takeover of #1560)

### DIFF
--- a/.github/scripts/sync_codex_ok_labels.py
+++ b/.github/scripts/sync_codex_ok_labels.py
@@ -31,10 +31,14 @@ CODEX_CLEAN_RE = re.compile(
     re.IGNORECASE,
 )
 CODEX_FINDING_RE = re.compile(r"(?:\bP[0-3]\s+Badge\b|badge/P[0-3]-|(?m:(?:^|\n)\s*(?:\*\*)?(?:\[P[0-3]\]|P[0-3]\b)))")
+# Anchored to the real quota envelope ("You have reached your Codex usage limits
+# for code reviews. ...") so ordinary reviews that merely discuss usage limits do
+# not latch the backoff.
 CODEX_USAGE_LIMIT_RE = re.compile(
-    r"(reached your Codex usage limits|Codex usage limit|usage-limit|usage limit)",
+    r"^\s*You(?: have|['’]ve) reached your Codex usage limits",
     re.IGNORECASE,
 )
+CLEAN_REACTION_CONTENTS = frozenset({"THUMBS_UP", "+1"})
 DEFAULT_CODEX_USAGE_LIMIT_BACKOFF_HOURS = 24.0
 DEFAULT_CODEX_REVIEW_RESPONSE_WAIT_SECONDS = 10.0
 SUCCESS_CHECK_STATES = {"SUCCESS", "NEUTRAL", "SKIPPED"}
@@ -253,7 +257,13 @@ class SyncDecision:
     approve_workflow_run_ids: tuple[int, ...]
 
 
-def run_gh(args: list[str], *, input_json: Any | None = None, timeout_seconds: int = 30) -> Any:
+def run_gh(
+    args: list[str],
+    *,
+    input_json: Any | None = None,
+    timeout_seconds: int = 30,
+    fallback_retry: bool = True,
+) -> Any:
     command = ["gh", *args]
     input_text = json.dumps(input_json) if input_json is not None else None
     safe_to_retry = _gh_args_safe_to_retry(args)
@@ -280,6 +290,14 @@ def run_gh(args: list[str], *, input_json: Any | None = None, timeout_seconds: i
 
         detail = proc.stderr.strip() or proc.stdout.strip()
         if _RATE_LIMIT_MARKER in detail and _activate_fallback_token():
+            if not fallback_retry:
+                # Identity-sensitive commands (e.g. the @codex review comment)
+                # must not silently retry under the fallback token's identity;
+                # later calls still benefit from the activated fallback.
+                raise GhError(
+                    f"{' '.join(command)}: rate-limited; switched to GH_FALLBACK_TOKEN "
+                    f"without retrying this identity-sensitive command ({detail})"
+                )
             print(
                 "warning: active token rate-limited; retrying with GH_FALLBACK_TOKEN",
                 file=sys.stderr,
@@ -447,7 +465,7 @@ def codex_request_reaction_state(node: dict[str, Any], *, allowed_authors: set[s
         if reaction_user_login(reaction) not in allowed_authors:
             continue
         content = str(reaction.get("content") or "").upper()
-        if content in {"THUMBS_UP", "+1"}:
+        if content in CLEAN_REACTION_CONTENTS:
             state = "clean"
         elif content == "EYES" and state == "none":
             state = "pending"
@@ -491,6 +509,27 @@ def current_viewer_login() -> str:
     return login
 
 
+def resolve_codex_request_sender() -> str | None:
+    """Resolve the login GitHub records as the author of our `@codex review` comments.
+
+    GitHub App installation tokens cannot call ``GET /user``, so prefer the app
+    slug the workflow exports (installation comments are authored as
+    ``<slug>[bot]``) and fall back to ``GET /user`` for PAT-backed runs.
+    The slug describes the primary token only, so it is ignored once the run
+    has switched to ``GH_FALLBACK_TOKEN``. Returns ``None`` when no path can
+    resolve a login.
+    """
+
+    slug = os.environ.get("GH_APP_SLUG", "").strip()
+    if slug and not _fallback_token_active:
+        return slug if slug.endswith("[bot]") else f"{slug}[bot]"
+    try:
+        return current_viewer_login()
+    except GhError as exc:
+        print(f"warning: cannot resolve @codex review sender via GET /user: {exc}", file=sys.stderr, flush=True)
+        return None
+
+
 def is_normal_codex_response_node(node: dict[str, Any]) -> bool:
     body = node_body(node)
     if is_codex_usage_limit_body(body):
@@ -516,6 +555,8 @@ class CodexReviewUsageBackoff:
             timestamp = parse_github_timestamp(timeline_node_timestamp(node))
             if is_codex_review_request_comment(node):
                 active_request_author = node_author_login(node)
+                if active_request_author == self.request_author:
+                    self._observe_clean_request_reactions(node)
                 continue
             if timestamp is None or timestamp < self.now - self.window:
                 continue
@@ -531,6 +572,26 @@ class CodexReviewUsageBackoff:
                 if self.latest_normal_response_at is None or timestamp > self.latest_normal_response_at:
                     self.latest_normal_response_at = timestamp
 
+    def _observe_clean_request_reactions(self, node: dict[str, Any]) -> None:
+        """Count clean THUMBS_UP reactions on the sender's requests as normal responses."""
+
+        reactions = node.get("reactions")
+        reaction_nodes = reactions.get("nodes") if isinstance(reactions, dict) else None
+        if not isinstance(reaction_nodes, list):
+            return
+        for reaction in reaction_nodes:
+            if not isinstance(reaction, dict):
+                continue
+            if reaction_user_login(reaction) not in self.allowed_authors:
+                continue
+            if str(reaction.get("content") or "").upper() not in CLEAN_REACTION_CONTENTS:
+                continue
+            timestamp = parse_github_timestamp(reaction.get("createdAt"))
+            if timestamp is None or timestamp < self.now - self.window:
+                continue
+            if self.latest_normal_response_at is None or timestamp > self.latest_normal_response_at:
+                self.latest_normal_response_at = timestamp
+
     def is_limited(self) -> bool:
         if self.latest_usage_limit_at is None:
             return False
@@ -543,6 +604,42 @@ class CodexReviewUsageBackoff:
             f"request Codex review on {decision.repo}#{decision.number}: skipped because "
             f"{self.request_author} has a recent Codex usage-limit reply at {when}{suffix}"
         )
+
+
+def recent_issue_comment_timelines(repo: str, *, since: datetime) -> list[list[dict[str, Any]]]:
+    """Return repo-wide recent issue comments grouped per issue as timeline nodes.
+
+    Sender quota evidence can live on pull requests outside the current
+    selection (single --pr runs, closed PRs), so the backoff also observes
+    every issue comment in the window, grouped per issue to keep request ->
+    reply attribution intact.
+    """
+
+    since_text = since.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    comments = paged_api(f"/repos/{repo}/issues/comments?since={quote(since_text, safe='')}")
+    nodes_by_issue: dict[str, list[dict[str, Any]]] = {}
+    for comment in comments:
+        body = comment.get("body")
+        if not isinstance(body, str):
+            continue
+        issue_url = str(comment.get("issue_url") or "")
+        nodes_by_issue.setdefault(issue_url, []).append(
+            {
+                "__typename": "IssueComment",
+                "author": {"login": author_login(comment)},
+                "bodyText": body,
+                "createdAt": comment.get("created_at"),
+                "url": comment.get("html_url"),
+            }
+        )
+    return [sorted(nodes, key=lambda node: str(node.get("createdAt") or "")) for nodes in nodes_by_issue.values()]
+
+
+def backoff_timeline_observer(backoff: CodexReviewUsageBackoff) -> Callable[[int, list[dict[str, Any]]], None]:
+    def observe(_number: int, timeline_nodes: list[dict[str, Any]]) -> None:
+        backoff.observe(timeline_nodes)
+
+    return observe
 
 
 def unresolved_review_comment_urls(repo: str, number: int) -> set[str]:
@@ -1008,6 +1105,18 @@ def commit_checks_state(repo: str, head_sha: str) -> str:
     )
 
 
+def decision_requires_writes(decision: SyncDecision) -> bool:
+    """Return whether applying this decision would mutate GitHub state."""
+
+    return (
+        decision.ok_action != "keep"
+        or decision.needs_work_action != "keep"
+        or decision.needs_rebase_action != "keep"
+        or bool(decision.legacy_labels)
+        or bool(decision.approve_workflow_run_ids)
+    )
+
+
 def pr_merge_state(repo: str, number: int) -> str:
     payload = run_gh(
         ["pr", "view", str(number), "--repo", repo, "--json", "mergeStateStatus,mergeable"],
@@ -1163,9 +1272,10 @@ def run_gh_write(
     timeout_seconds: int,
     tolerate_permission_errors: bool,
     action: str,
+    fallback_retry: bool = True,
 ) -> str | None:
     try:
-        run_gh(args, timeout_seconds=timeout_seconds)
+        run_gh(args, timeout_seconds=timeout_seconds, fallback_retry=fallback_retry)
     except GhError as exc:
         if tolerate_permission_errors and is_github_app_write_denial(exc):
             return write_warning(action, exc)
@@ -1444,6 +1554,7 @@ def trigger_codex_review(
         timeout_seconds=30,
         tolerate_permission_errors=tolerate_permission_errors,
         action=f"request Codex review on {decision.repo}#{decision.number}",
+        fallback_retry=False,
     )
     return (warning,) if warning else ()
 
@@ -1545,6 +1656,13 @@ def main(argv: list[str] | None = None) -> int:
     repos = [repo_path(repo) for repo in args.repo]
     allowed_authors = CODEX_REVIEW_AUTHORS | set(args.reviewer_login)
     had_error = False
+    # Per-sender quota state is shared across every --repo in the run: a usage
+    # limit observed in one repository suppresses review requests in the rest.
+    # Timelines classified before the backoff exists are retained so evidence
+    # from repositories without their own triggers still counts.
+    usage_backoff: CodexReviewUsageBackoff | None = None
+    unobserved_timelines: list[list[dict[str, Any]]] = []
+    codex_sender_unresolved = False
 
     for repo in repos:
         setup_warnings: list[str] = []
@@ -1623,30 +1741,92 @@ def main(argv: list[str] | None = None) -> int:
                 flush=True,
             )
 
-        usage_backoff: CodexReviewUsageBackoff | None = None
-        if (
-            args.apply
-            and not args.no_trigger_missing_codex
-            and any(decision.trigger_codex_review for decision in decisions)
-        ):
-            try:
-                usage_backoff = CodexReviewUsageBackoff(
-                    request_author=current_viewer_login(),
-                    allowed_authors=allowed_authors,
-                    window=timedelta(hours=args.codex_usage_limit_backoff_hours),
-                    now=datetime.now(UTC),
-                )
-            except GhError as exc:
-                had_error = True
-                print(f"{repo}: cannot determine @codex review sender: {exc}", file=sys.stderr, flush=True)
-                continue
-            for timeline_nodes in timeline_nodes_by_number.values():
-                usage_backoff.observe(timeline_nodes)
+        if args.apply and not args.no_trigger_missing_codex:
+            unobserved_timelines.extend(timeline_nodes_by_number.values())
+            repo_has_triggers = any(decision.trigger_codex_review for decision in decisions)
+            if repo_has_triggers:
+                # Quota evidence may live outside the selected PRs (single
+                # --pr runs, closed PRs), so also observe the repo's recent
+                # issue comments before posting anything here.
+                try:
+                    unobserved_timelines.extend(
+                        recent_issue_comment_timelines(
+                            repo,
+                            since=datetime.now(UTC) - timedelta(hours=args.codex_usage_limit_backoff_hours),
+                        )
+                    )
+                except GhError as exc:
+                    print(
+                        f"warning: {repo}: could not gather repo-wide Codex quota evidence: {exc}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+            if usage_backoff is None and not codex_sender_unresolved and repo_has_triggers:
+                sender = resolve_codex_request_sender()
+                if sender is None:
+                    # Only the trigger/backoff path depends on the sender;
+                    # label sync and workflow approvals proceed regardless.
+                    codex_sender_unresolved = True
+                    print(
+                        f"{repo}: cannot determine @codex review sender; "
+                        "skipping review triggers but continuing label sync",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                else:
+                    usage_backoff = CodexReviewUsageBackoff(
+                        request_author=sender,
+                        allowed_authors=allowed_authors,
+                        window=timedelta(hours=args.codex_usage_limit_backoff_hours),
+                        now=datetime.now(UTC),
+                    )
+            if usage_backoff is not None:
+                for timeline_nodes in unobserved_timelines:
+                    usage_backoff.observe(timeline_nodes)
+                unobserved_timelines.clear()
 
         for decision in decisions:
             try:
                 write_warnings: tuple[str, ...] = ()
                 trigger_codex_review_now = decision.trigger_codex_review and not args.no_trigger_missing_codex
+                if args.apply and (decision_requires_writes(decision) or trigger_codex_review_now):
+                    # Under --all-open every PR is classified before any is
+                    # applied; evidence (head, checks, reviews, mergeability)
+                    # may have moved meanwhile. Reclassify immediately before
+                    # writing and act on the fresh decision only. The fresh
+                    # timeline also feeds the shared backoff so a quota reply
+                    # that arrived after bulk classification suppresses the
+                    # remaining review requests.
+                    try:
+                        fresh_decision = decide_pr(
+                            decision.repo,
+                            decision.number,
+                            allowed_authors=allowed_authors,
+                            ignore_checks=args.ignore_checks,
+                            timeline_observer=(
+                                backoff_timeline_observer(usage_backoff) if usage_backoff is not None else None
+                            ),
+                        )
+                    except GhError as exc:
+                        if not args.tolerate_read_errors:
+                            had_error = True
+                        print(
+                            f"{decision.repo}#{decision.number}: apply-time reclassification failed: {exc}",
+                            file=sys.stderr,
+                            flush=True,
+                        )
+                        continue
+                    if fresh_decision.head_sha != decision.head_sha:
+                        print(
+                            f"warning: {decision.repo}#{decision.number}: head moved from "
+                            f"{decision.head_sha[:12]} to {fresh_decision.head_sha[:12]} after classification; "
+                            "skipping stale decision",
+                            file=sys.stderr,
+                            flush=True,
+                        )
+                        continue
+                    trigger_codex_review_now = trigger_codex_review_now and fresh_decision.trigger_codex_review
+                    decision = fresh_decision
                 if args.apply:
                     accumulated_warnings: list[str] = []
                     accumulated_warnings.extend(
@@ -1662,18 +1842,38 @@ def main(argv: list[str] | None = None) -> int:
                                 tolerate_permission_errors=args.tolerate_write_permission_errors,
                             )
                         )
+                    if trigger_codex_review_now and _fallback_token_active:
+                        # Comments would now be authored by the fallback token's
+                        # identity, not the resolved sender, so quota replies
+                        # could no longer be attributed. Stop posting.
+                        accumulated_warnings.append(
+                            f"request Codex review on {decision.repo}#{decision.number}: skipped because "
+                            "the run switched to GH_FALLBACK_TOKEN and the resolved sender no longer "
+                            "matches the active token"
+                        )
+                        trigger_codex_review_now = False
+                    if trigger_codex_review_now and codex_sender_unresolved:
+                        accumulated_warnings.append(
+                            f"request Codex review on {decision.repo}#{decision.number}: skipped because "
+                            "the @codex review sender could not be resolved"
+                        )
+                        trigger_codex_review_now = False
                     if trigger_codex_review_now and usage_backoff is not None and usage_backoff.is_limited():
                         accumulated_warnings.append(usage_backoff.skip_warning(decision))
                         trigger_codex_review_now = False
                     if trigger_codex_review_now:
-                        accumulated_warnings.extend(
-                            trigger_codex_review(
-                                decision,
-                                body=args.codex_review_command,
-                                tolerate_permission_errors=args.tolerate_write_permission_errors,
-                            )
+                        trigger_warnings = trigger_codex_review(
+                            decision,
+                            body=args.codex_review_command,
+                            tolerate_permission_errors=args.tolerate_write_permission_errors,
                         )
-                        if usage_backoff is not None and usage_backoff.latest_normal_response_at is None:
+                        accumulated_warnings.extend(trigger_warnings)
+                        review_request_posted = not trigger_warnings
+                        if (
+                            review_request_posted
+                            and usage_backoff is not None
+                            and usage_backoff.latest_normal_response_at is None
+                        ):
                             if args.codex_review_response_wait_seconds > 0:
                                 time.sleep(args.codex_review_response_wait_seconds)
                             _head_sha, timeline_nodes = pr_timeline_evidence(decision.repo, decision.number)

--- a/.github/scripts/sync_codex_ok_labels.py
+++ b/.github/scripts/sync_codex_ok_labels.py
@@ -1673,15 +1673,15 @@ def main(argv: list[str] | None = None) -> int:
                                 tolerate_permission_errors=args.tolerate_write_permission_errors,
                             )
                         )
-                        if usage_backoff is not None and args.codex_review_response_wait_seconds > 0:
-                            time.sleep(args.codex_review_response_wait_seconds)
-                        if usage_backoff is not None:
+                        if usage_backoff is not None and usage_backoff.latest_normal_response_at is None:
+                            if args.codex_review_response_wait_seconds > 0:
+                                time.sleep(args.codex_review_response_wait_seconds)
                             _head_sha, timeline_nodes = pr_timeline_evidence(decision.repo, decision.number)
                             usage_backoff.observe(timeline_nodes)
                     write_warnings = tuple(accumulated_warnings)
                 mode = "apply" if args.apply else "dry-run"
                 print(
-                    f"{mode} {repo}#{number}: "
+                    f"{mode} {decision.repo}#{decision.number}: "
                     f"head={decision.head_sha[:12]} checks={decision.checks_state} "
                     f"merge={decision.merge_state} review={decision.review_state} "
                     f"ok={decision.has_ok_label}->{decision.wants_ok_label}/{decision.ok_action} "
@@ -1701,7 +1701,7 @@ def main(argv: list[str] | None = None) -> int:
                     print(f"  write_warning={warning}", flush=True)
             except Exception as exc:  # noqa: BLE001
                 had_error = True
-                print(f"{repo}#{number}: {exc}", file=sys.stderr, flush=True)
+                print(f"{decision.repo}#{decision.number}: {exc}", file=sys.stderr, flush=True)
 
     return 1 if had_error else 0
 

--- a/.github/scripts/sync_codex_ok_labels.py
+++ b/.github/scripts/sync_codex_ok_labels.py
@@ -10,7 +10,9 @@ import re
 import subprocess
 import sys
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import quote
 
@@ -29,6 +31,12 @@ CODEX_CLEAN_RE = re.compile(
     re.IGNORECASE,
 )
 CODEX_FINDING_RE = re.compile(r"(?:\bP[0-3]\s+Badge\b|badge/P[0-3]-|(?m:(?:^|\n)\s*(?:\*\*)?(?:\[P[0-3]\]|P[0-3]\b)))")
+CODEX_USAGE_LIMIT_RE = re.compile(
+    r"(reached your Codex usage limits|Codex usage limit|usage-limit|usage limit)",
+    re.IGNORECASE,
+)
+DEFAULT_CODEX_USAGE_LIMIT_BACKOFF_HOURS = 24.0
+DEFAULT_CODEX_REVIEW_RESPONSE_WAIT_SECONDS = 10.0
 SUCCESS_CHECK_STATES = {"SUCCESS", "NEUTRAL", "SKIPPED"}
 FAIL_CHECK_STATES = {"ACTION_REQUIRED", "CANCELLED", "ERROR", "FAILURE", "STALE", "TIMED_OUT"}
 PENDING_CHECK_STATES = {"EXPECTED", "IN_PROGRESS", "PENDING", "QUEUED", "REQUESTED", "WAITING"}
@@ -366,6 +374,10 @@ def is_needs_work_codex_body(body: object) -> bool:
     return isinstance(body, str) and CODEX_FINDING_RE.search(body) is not None
 
 
+def is_codex_usage_limit_body(body: object) -> bool:
+    return isinstance(body, str) and CODEX_USAGE_LIMIT_RE.search(body) is not None
+
+
 def body_mentions_head(body: object, head_sha: str) -> bool:
     if not isinstance(body, str):
         return False
@@ -460,6 +472,77 @@ def timeline_node_timestamp(node: dict[str, Any]) -> str | None:
         if isinstance(value, str) and value:
             return value
     return None
+
+
+def parse_github_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def current_viewer_login() -> str:
+    payload = gh_api("/user")
+    login = payload.get("login") if isinstance(payload, dict) else None
+    if not isinstance(login, str) or not login:
+        raise GhError("gh api /user did not return a login")
+    return login
+
+
+def is_normal_codex_response_node(node: dict[str, Any]) -> bool:
+    body = node_body(node)
+    if is_codex_usage_limit_body(body):
+        return False
+    return node.get("__typename") in {"IssueComment", "PullRequestReview", "PullRequestReviewComment"} and bool(
+        body.strip()
+    )
+
+
+@dataclass
+class CodexReviewUsageBackoff:
+    request_author: str
+    allowed_authors: set[str]
+    window: timedelta
+    now: datetime
+    latest_usage_limit_at: datetime | None = None
+    latest_usage_limit_url: str | None = None
+    latest_normal_response_at: datetime | None = None
+
+    def observe(self, timeline_nodes: list[dict[str, Any]]) -> None:
+        active_request_author: str | None = None
+        for node in timeline_nodes:
+            timestamp = parse_github_timestamp(timeline_node_timestamp(node))
+            if is_codex_review_request_comment(node):
+                active_request_author = node_author_login(node)
+                continue
+            if timestamp is None or timestamp < self.now - self.window:
+                continue
+            if active_request_author != self.request_author:
+                continue
+            if not is_timeline_codex_author(node, self.allowed_authors):
+                continue
+            if is_codex_usage_limit_body(node_body(node)):
+                if self.latest_usage_limit_at is None or timestamp > self.latest_usage_limit_at:
+                    self.latest_usage_limit_at = timestamp
+                    self.latest_usage_limit_url = node_url(node)
+            elif is_normal_codex_response_node(node):
+                if self.latest_normal_response_at is None or timestamp > self.latest_normal_response_at:
+                    self.latest_normal_response_at = timestamp
+
+    def is_limited(self) -> bool:
+        if self.latest_usage_limit_at is None:
+            return False
+        return self.latest_normal_response_at is None or self.latest_normal_response_at < self.latest_usage_limit_at
+
+    def skip_warning(self, decision: SyncDecision) -> str:
+        when = self.latest_usage_limit_at.isoformat() if self.latest_usage_limit_at else "unknown time"
+        suffix = f" ({self.latest_usage_limit_url})" if self.latest_usage_limit_url else ""
+        return (
+            f"request Codex review on {decision.repo}#{decision.number}: skipped because "
+            f"{self.request_author} has a recent Codex usage-limit reply at {when}{suffix}"
+        )
 
 
 def unresolved_review_comment_urls(repo: str, number: int) -> set[str]:
@@ -1133,8 +1216,11 @@ def decide_pr(
     *,
     allowed_authors: set[str],
     ignore_checks: bool,
+    timeline_observer: Callable[[int, list[dict[str, Any]]], None] | None = None,
 ) -> SyncDecision:
     head_sha, timeline_nodes = pr_timeline_evidence(repo, number)
+    if timeline_observer is not None:
+        timeline_observer(number, timeline_nodes)
     labels = issue_label_names(repo, number)
     checks_state = commit_checks_state(repo, head_sha)
     merge_state = pr_merge_state(repo, number)
@@ -1407,6 +1493,24 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Issue comment body used to request a missing Codex review.",
     )
     parser.add_argument(
+        "--codex-usage-limit-backoff-hours",
+        type=float,
+        default=DEFAULT_CODEX_USAGE_LIMIT_BACKOFF_HOURS,
+        help=(
+            "Skip new @codex review comments when the same comment sender account received a Codex usage-limit "
+            "reply within this many hours, unless that same account has a newer normal Codex response."
+        ),
+    )
+    parser.add_argument(
+        "--codex-review-response-wait-seconds",
+        type=float,
+        default=DEFAULT_CODEX_REVIEW_RESPONSE_WAIT_SECONDS,
+        help=(
+            "After posting the first @codex review without recent quota evidence, wait this long, reread the PR "
+            "timeline, and stop further review requests if Codex replied with a usage limit."
+        ),
+    )
+    parser.add_argument(
         "--ignore-checks",
         action="store_true",
         help="Ignore current-head CI state when deciding the ok label. Normally do not use this.",
@@ -1482,6 +1586,12 @@ def main(argv: list[str] | None = None) -> int:
             had_error = True
             continue
 
+        timeline_nodes_by_number: dict[int, list[dict[str, Any]]] = {}
+
+        def observe_timeline(_number: int, timeline_nodes: list[dict[str, Any]]) -> None:
+            timeline_nodes_by_number[_number] = timeline_nodes
+
+        decisions: list[SyncDecision] = []
         classified_count = 0
         for number in sorted(set(numbers)):
             try:
@@ -1490,6 +1600,7 @@ def main(argv: list[str] | None = None) -> int:
                     number,
                     allowed_authors=allowed_authors,
                     ignore_checks=args.ignore_checks,
+                    timeline_observer=observe_timeline,
                 )
             except GhError as exc:
                 if not args.tolerate_read_errors:
@@ -1502,8 +1613,40 @@ def main(argv: list[str] | None = None) -> int:
                 continue
 
             classified_count += 1
+            decisions.append(decision)
+
+        if args.tolerate_read_errors and classified_count == 0:
+            had_error = True
+            print(
+                f"{repo}: all selected PRs failed classification; refusing a false-green tolerant run",
+                file=sys.stderr,
+                flush=True,
+            )
+
+        usage_backoff: CodexReviewUsageBackoff | None = None
+        if (
+            args.apply
+            and not args.no_trigger_missing_codex
+            and any(decision.trigger_codex_review for decision in decisions)
+        ):
+            try:
+                usage_backoff = CodexReviewUsageBackoff(
+                    request_author=current_viewer_login(),
+                    allowed_authors=allowed_authors,
+                    window=timedelta(hours=args.codex_usage_limit_backoff_hours),
+                    now=datetime.now(UTC),
+                )
+            except GhError as exc:
+                had_error = True
+                print(f"{repo}: cannot determine @codex review sender: {exc}", file=sys.stderr, flush=True)
+                continue
+            for timeline_nodes in timeline_nodes_by_number.values():
+                usage_backoff.observe(timeline_nodes)
+
+        for decision in decisions:
             try:
                 write_warnings: tuple[str, ...] = ()
+                trigger_codex_review_now = decision.trigger_codex_review and not args.no_trigger_missing_codex
                 if args.apply:
                     accumulated_warnings: list[str] = []
                     accumulated_warnings.extend(
@@ -1519,7 +1662,10 @@ def main(argv: list[str] | None = None) -> int:
                                 tolerate_permission_errors=args.tolerate_write_permission_errors,
                             )
                         )
-                    if decision.trigger_codex_review and not args.no_trigger_missing_codex:
+                    if trigger_codex_review_now and usage_backoff is not None and usage_backoff.is_limited():
+                        accumulated_warnings.append(usage_backoff.skip_warning(decision))
+                        trigger_codex_review_now = False
+                    if trigger_codex_review_now:
                         accumulated_warnings.extend(
                             trigger_codex_review(
                                 decision,
@@ -1527,6 +1673,11 @@ def main(argv: list[str] | None = None) -> int:
                                 tolerate_permission_errors=args.tolerate_write_permission_errors,
                             )
                         )
+                        if usage_backoff is not None and args.codex_review_response_wait_seconds > 0:
+                            time.sleep(args.codex_review_response_wait_seconds)
+                        if usage_backoff is not None:
+                            _head_sha, timeline_nodes = pr_timeline_evidence(decision.repo, decision.number)
+                            usage_backoff.observe(timeline_nodes)
                     write_warnings = tuple(accumulated_warnings)
                 mode = "apply" if args.apply else "dry-run"
                 print(
@@ -1540,7 +1691,7 @@ def main(argv: list[str] | None = None) -> int:
                     f"{decision.needs_rebase_action} "
                     f"legacy={','.join(sorted(decision.legacy_labels)) or '-'} "
                     f"approve_runs={','.join(str(run_id) for run_id in decision.approve_workflow_run_ids) or '-'} "
-                    f"trigger_codex={decision.trigger_codex_review and not args.no_trigger_missing_codex} "
+                    f"trigger_codex={trigger_codex_review_now} "
                     f"reason={decision.reason}",
                     flush=True,
                 )
@@ -1551,14 +1702,6 @@ def main(argv: list[str] | None = None) -> int:
             except Exception as exc:  # noqa: BLE001
                 had_error = True
                 print(f"{repo}#{number}: {exc}", file=sys.stderr, flush=True)
-
-        if args.tolerate_read_errors and classified_count == 0:
-            had_error = True
-            print(
-                f"{repo}: all selected PRs failed classification; refusing a false-green tolerant run",
-                file=sys.stderr,
-                flush=True,
-            )
 
     return 1 if had_error else 0
 

--- a/.github/workflows/codex-review-labels.yml
+++ b/.github/workflows/codex-review-labels.yml
@@ -62,6 +62,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.CODEX_LABEL_SYNC_TOKEN || secrets.RELEASE_PLEASE_TOKEN || github.token }}
           GH_FALLBACK_TOKEN: ${{ github.token }}
+          # App installation tokens cannot call GET /user; the script derives the
+          # @codex review sender login from this slug as "<slug>[bot]" instead.
+          GH_APP_SLUG: ${{ steps.app-token.outputs.token && steps.app-token.outputs.app-slug || '' }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
@@ -109,6 +112,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.CODEX_LABEL_SYNC_TOKEN || secrets.RELEASE_PLEASE_TOKEN || github.token }}
           GH_FALLBACK_TOKEN: ${{ github.token }}
+          # App installation tokens cannot call GET /user; the script derives the
+          # @codex review sender login from this slug as "<slug>[bot]" instead.
+          GH_APP_SLUG: ${{ steps.app-token.outputs.token && steps.app-token.outputs.app-slug || '' }}
           REPO: ${{ github.repository }}
         run: |
           if [ ! -f .github/scripts/sync_codex_ok_labels.py ]; then

--- a/openspec/changes/backoff-codex-review-usage-limits/proposal.md
+++ b/openspec/changes/backoff-codex-review-usage-limits/proposal.md
@@ -4,9 +4,11 @@ The Codex label sync posts `@codex review` for every merge-ready PR missing a cu
 
 ## What Changes
 
-- The sync script attributes Codex usage-limit replies to the comment sender that triggered them and skips further `@codex review` posts for that sender while a usage-limit reply is the sender's latest Codex response within a backoff window (default 24h, `--codex-usage-limit-backoff-hours`).
-- A newer normal Codex response for the same sender unlatches the backoff; other senders' limits and responses are independent.
-- When no quota evidence exists, the script posts the first `@codex review`, waits briefly (`--codex-review-response-wait-seconds`, default 10s), rereads that PR's timeline, and suppresses the remaining review requests if the probe hit the usage limit. Probing stops after the first normal Codex response is observed.
+- The sync script attributes Codex usage-limit replies to the comment sender that triggered them and skips further `@codex review` posts for that sender while a usage-limit reply is the sender's latest Codex response within a backoff window (default 24h, `--codex-usage-limit-backoff-hours`). Usage-limit detection is anchored to the real quota envelope (body starts with "You have reached your Codex usage limits"), so reviews that merely discuss usage limits do not latch the backoff.
+- A newer normal Codex response for the same sender unlatches the backoff; a clean THUMBS_UP reaction by a Codex reviewer on the sender's request comment counts as a normal response. Other senders' limits and responses are independent. Backoff state is shared across all `--repo` arguments in one run, classified timelines from repositories without their own triggers still contribute evidence, and before posting in a repository the script also gathers the repository's recent issue comments (grouped per issue) so quota replies outside the selected PRs — single `--pr` runs, closed PRs — still latch.
+- When no quota evidence exists, the script posts the first `@codex review`, waits briefly (`--codex-review-response-wait-seconds`, default 10s), rereads that PR's timeline, and suppresses the remaining review requests if the probe hit the usage limit. Probing stops after the first normal Codex response is observed and is skipped when the request was not actually posted (tolerated write denial).
+- The sender identity is resolved installation-token-compatibly: the workflow exports the App slug (`GH_APP_SLUG`, sender `<slug>[bot]`) and the script only falls back to `GET /user` for PAT-backed runs. A sender-resolution failure disables only the review-trigger path (warning per decision); label sync proceeds. Once the run switches to `GH_FALLBACK_TOKEN`, the slug is ignored and review triggers are suppressed because the comment author would no longer match the resolved sender; the review-request POST itself is never silently retried under the fallback token.
+- Immediately before performing writes for a decision, the script reclassifies the PR and acts on the fresh evidence: head moves skip the decision with a warning, same-head evidence changes are applied fresh, a trigger fires only when both classifications want it, the fresh timeline feeds the shared backoff, and reclassification read failures honor `--tolerate-read-errors`.
 
 ## Capabilities
 
@@ -20,6 +22,6 @@ None.
 
 ## Impact
 
-- Code: `.github/scripts/sync_codex_ok_labels.py`
+- Code: `.github/scripts/sync_codex_ok_labels.py`, `.github/workflows/codex-review-labels.yml`
 - Tests: `tests/unit/test_sync_codex_ok_labels.py`
 - Specs: `openspec/specs/github-automation/spec.md`

--- a/openspec/changes/backoff-codex-review-usage-limits/proposal.md
+++ b/openspec/changes/backoff-codex-review-usage-limits/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The Codex label sync posts `@codex review` for every merge-ready PR missing a current-head review. When the Codex account behind the sender has exhausted its usage limits, Codex replies "You have reached your Codex usage limits" — and the next sync run re-fires `@codex review` anyway, burning the shared quota further and spamming PR timelines. Observed on 6+ PRs during the week of 2026-08-03 (including #1599). Takeover of #1560 (Komzpa), whose author is unresponsive since 2026-07-31.
+
+## What Changes
+
+- The sync script attributes Codex usage-limit replies to the comment sender that triggered them and skips further `@codex review` posts for that sender while a usage-limit reply is the sender's latest Codex response within a backoff window (default 24h, `--codex-usage-limit-backoff-hours`).
+- A newer normal Codex response for the same sender unlatches the backoff; other senders' limits and responses are independent.
+- When no quota evidence exists, the script posts the first `@codex review`, waits briefly (`--codex-review-response-wait-seconds`, default 10s), rereads that PR's timeline, and suppresses the remaining review requests if the probe hit the usage limit. Probing stops after the first normal Codex response is observed.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `github-automation`: label sync gains a usage-limit backoff for `@codex review` triggers.
+
+## Impact
+
+- Code: `.github/scripts/sync_codex_ok_labels.py`
+- Tests: `tests/unit/test_sync_codex_ok_labels.py`
+- Specs: `openspec/specs/github-automation/spec.md`

--- a/openspec/changes/backoff-codex-review-usage-limits/specs/github-automation/spec.md
+++ b/openspec/changes/backoff-codex-review-usage-limits/specs/github-automation/spec.md
@@ -2,7 +2,9 @@
 
 ### Requirement: Codex review trigger usage-limit backoff
 
-The Codex label synchronization script MUST NOT post a new `@codex review` comment while the comment sender's latest Codex response within the configured backoff window is a usage-limit reply. Usage-limit evidence MUST be attributed to the sender whose request comment preceded the reply, and a newer normal Codex response for that same sender MUST lift the backoff. When no quota evidence exists for the sender, the script MUST post the first `@codex review`, wait briefly, reread that pull request's timeline, and suppress the remaining review requests in the run if that probe observed a usage-limit reply; probing MUST stop once a normal Codex response has been observed. Apply-loop status lines and error reports MUST reference the pull request of the decision being applied.
+The Codex label synchronization script MUST NOT post a new `@codex review` comment while the comment sender's latest Codex response within the configured backoff window is a usage-limit reply. A usage-limit reply is a Codex response whose body starts (after optional leading whitespace) with the quota envelope "You have reached your Codex usage limits"; Codex reviews that merely discuss usage limits MUST NOT latch the backoff. Usage-limit evidence MUST be attributed to the sender whose request comment preceded the reply, and a newer normal Codex response for that same sender MUST lift the backoff; a clean THUMBS_UP reaction by a Codex reviewer on the sender's request comment counts as a normal response. Backoff state MUST be shared across all repositories processed in one run, so a usage limit observed in one repository suppresses the remaining review requests in the run; classified timelines from repositories without their own triggers MUST still contribute evidence. Before posting review requests in a repository, the script MUST also gather the repository's recent issue comments (within the backoff window, grouped per issue) as evidence, so quota replies on pull requests outside the current selection — including single `--pr` runs and closed pull requests — still latch the backoff; a failure to gather this evidence degrades to the classified-timeline evidence with a warning. When no quota evidence exists for the sender, the script MUST post the first `@codex review`, wait briefly, reread that pull request's timeline, and suppress the remaining review requests in the run if that probe observed a usage-limit reply; probing MUST stop once a normal Codex response has been observed, and MUST NOT run when the review request was not actually posted (for example after a tolerated write denial). Apply-loop status lines and error reports MUST reference the pull request of the decision being applied.
+
+The script MUST resolve the sender identity in a way that works with GitHub App installation tokens (which cannot call `GET /user`): it prefers the app slug exported by the workflow (`GH_APP_SLUG`, yielding `<slug>[bot]`) and falls back to `GET /user` for PAT-backed runs. Once the run has switched to the fallback token, the app slug no longer describes the active identity: sender resolution MUST ignore it, and review triggers MUST be suppressed with a warning because posted comments would no longer be authored by the resolved sender. The review-request POST itself MUST NOT be silently retried under the fallback token after a rate-limit response: the fallback activates for subsequent calls, but the identity-sensitive comment fails instead of posting under the wrong author. If the sender cannot be resolved, only the review-trigger path is disabled (with a warning per affected decision); label synchronization and workflow-run approvals MUST proceed.
 
 #### Scenario: Recent usage-limit reply latches the backoff
 
@@ -11,10 +13,23 @@ The Codex label synchronization script MUST NOT post a new `@codex review` comme
 - **WHEN** the script would trigger a missing Codex review
 - **THEN** it skips the `@codex review` post and surfaces a write warning naming the usage-limit evidence
 
+#### Scenario: Reviews that merely discuss usage limits do not latch
+
+- **GIVEN** a Codex review whose body discusses usage limits but does not start with the quota envelope
+- **WHEN** the script classifies Codex responses for the backoff
+- **THEN** the response is treated as a normal Codex response, not a usage-limit reply
+
 #### Scenario: Newer normal response lifts the backoff
 
 - **GIVEN** the sender received a Codex usage-limit reply within the backoff window
 - **AND** the same sender has a newer normal Codex response
+- **WHEN** the script would trigger a missing Codex review
+- **THEN** it posts the `@codex review` comment
+
+#### Scenario: Newer clean reaction lifts the backoff
+
+- **GIVEN** the sender received a Codex usage-limit reply within the backoff window
+- **AND** a Codex reviewer later reacted with THUMBS_UP to the sender's `@codex review` comment
 - **WHEN** the script would trigger a missing Codex review
 - **THEN** it posts the `@codex review` comment
 
@@ -24,6 +39,31 @@ The Codex label synchronization script MUST NOT post a new `@codex review` comme
 - **AND** only a different account has a newer normal Codex response
 - **WHEN** the script would trigger a missing Codex review
 - **THEN** it still skips the `@codex review` post for the sender
+
+#### Scenario: Backoff persists across repositories in one run
+
+- **GIVEN** a run selecting multiple repositories
+- **AND** the sender's usage limit was observed while processing an earlier repository
+- **WHEN** the script would trigger a missing Codex review in a later repository
+- **THEN** it skips the `@codex review` post there as well
+
+#### Scenario: Evidence from a non-triggering repository still counts
+
+- **GIVEN** an earlier repository whose classified timelines contain the sender's usage-limit reply but whose decisions need no review trigger
+- **WHEN** a later repository in the same run would trigger a missing Codex review
+- **THEN** the earlier repository's evidence latches the backoff and the post is skipped
+
+#### Scenario: Quota evidence outside the selected pull requests still counts
+
+- **GIVEN** a single `--pr` run where the sender's usage-limit reply lives on a different (possibly closed) pull request of the repository
+- **WHEN** the script would trigger a missing Codex review
+- **THEN** the repository's recent issue comments provide the evidence and the post is skipped
+
+#### Scenario: Probe requires an actual post
+
+- **GIVEN** the review-request comment was not posted because the write was denied and tolerated
+- **WHEN** the script would otherwise probe for a quota reply
+- **THEN** it neither waits nor rereads the pull request timeline for that decision
 
 #### Scenario: No-data probe latches off remaining triggers
 
@@ -37,7 +77,59 @@ The Codex label synchronization script MUST NOT post a new `@codex review` comme
 - **WHEN** the script posts further `@codex review` comments in the run
 - **THEN** it does not wait or reread pull request timelines for those posts
 
+#### Scenario: Installation tokens resolve the sender from the app slug
+
+- **GIVEN** the run authenticates with a GitHub App installation token and the workflow exports the app slug
+- **WHEN** the script resolves the `@codex review` sender
+- **THEN** it derives `<slug>[bot]` without calling `GET /user`
+
+#### Scenario: Sender resolution failure only disables review triggers
+
+- **GIVEN** the sender cannot be resolved from either the app slug or `GET /user`
+- **WHEN** the script applies decisions
+- **THEN** label synchronization proceeds and each suppressed review trigger surfaces a warning naming the unresolved sender
+
+#### Scenario: Fallback token activation suppresses review triggers
+
+- **GIVEN** the run has switched to `GH_FALLBACK_TOKEN` after rate-limit exhaustion
+- **WHEN** the script would trigger a missing Codex review
+- **THEN** it skips the `@codex review` post with a warning, because the comment author would no longer match the resolved sender
+
+#### Scenario: The review-request POST is not retried under the fallback identity
+
+- **GIVEN** the review-request comment POST itself hits the primary token's rate limit
+- **WHEN** the fallback token activates
+- **THEN** the POST fails instead of being silently retried under the fallback identity, while later calls use the fallback token
+
 #### Scenario: Apply status is attributed to the applied pull request
 
 - **WHEN** the script applies decisions for multiple pull requests in one run
 - **THEN** each status line and error report references the pull request of the decision being applied
+
+### Requirement: Apply-time reclassification
+
+Before performing writes for a classified decision (label changes, legacy label removal, workflow-run approvals, or review triggers), the Codex label synchronization script MUST reclassify the pull request and act on the fresh evidence only. If the head SHA no longer matches the SHA the decision was classified against, the decision MUST be skipped with a warning. If the head is unchanged but the evidence changed (checks, reviews, mergeability), the writes MUST follow the fresh decision, and a review trigger MUST only fire when both the original and the fresh classification want it. The freshly read timeline MUST feed the shared usage-limit backoff so quota replies that arrived after bulk classification suppress the remaining review requests. Reclassification read failures MUST honor `--tolerate-read-errors` (log and skip the decision without failing the run). Decisions without pending writes need not be reclassified.
+
+#### Scenario: Stale decision is skipped after a head move
+
+- **GIVEN** a pull request whose head changed between classification and apply
+- **WHEN** the script reaches that decision in the apply loop
+- **THEN** it skips all writes for the decision and warns that the head moved
+
+#### Scenario: Same-head evidence changes are applied fresh
+
+- **GIVEN** a pull request whose head is unchanged but where Codex raised a new finding after classification
+- **WHEN** the script reaches that decision in the apply loop
+- **THEN** the writes reflect the fresh classification instead of the superseded one
+
+#### Scenario: Fresh quota evidence suppresses later triggers
+
+- **GIVEN** a quota reply that arrived between bulk classification and apply-time reclassification of one pull request
+- **WHEN** later decisions in the run would trigger missing Codex reviews
+- **THEN** the reclassified timeline has latched the backoff and those posts are skipped
+
+#### Scenario: Reclassification honors tolerant reads
+
+- **GIVEN** a run with `--tolerate-read-errors`
+- **WHEN** apply-time reclassification of one pull request fails with a GitHub read error
+- **THEN** the decision is logged and skipped without failing the run

--- a/openspec/changes/backoff-codex-review-usage-limits/specs/github-automation/spec.md
+++ b/openspec/changes/backoff-codex-review-usage-limits/specs/github-automation/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Codex review trigger usage-limit backoff
+
+The Codex label synchronization script MUST NOT post a new `@codex review` comment while the comment sender's latest Codex response within the configured backoff window is a usage-limit reply. Usage-limit evidence MUST be attributed to the sender whose request comment preceded the reply, and a newer normal Codex response for that same sender MUST lift the backoff. When no quota evidence exists for the sender, the script MUST post the first `@codex review`, wait briefly, reread that pull request's timeline, and suppress the remaining review requests in the run if that probe observed a usage-limit reply; probing MUST stop once a normal Codex response has been observed. Apply-loop status lines and error reports MUST reference the pull request of the decision being applied.
+
+#### Scenario: Recent usage-limit reply latches the backoff
+
+- **GIVEN** the sender's `@codex review` comment was answered by a Codex usage-limit reply within the backoff window
+- **AND** the sender has no newer normal Codex response
+- **WHEN** the script would trigger a missing Codex review
+- **THEN** it skips the `@codex review` post and surfaces a write warning naming the usage-limit evidence
+
+#### Scenario: Newer normal response lifts the backoff
+
+- **GIVEN** the sender received a Codex usage-limit reply within the backoff window
+- **AND** the same sender has a newer normal Codex response
+- **WHEN** the script would trigger a missing Codex review
+- **THEN** it posts the `@codex review` comment
+
+#### Scenario: Senders are attributed independently
+
+- **GIVEN** the sender received a Codex usage-limit reply within the backoff window
+- **AND** only a different account has a newer normal Codex response
+- **WHEN** the script would trigger a missing Codex review
+- **THEN** it still skips the `@codex review` post for the sender
+
+#### Scenario: No-data probe latches off remaining triggers
+
+- **GIVEN** no Codex quota evidence exists for the sender in the classified timelines
+- **WHEN** the script posts the first `@codex review` of the run
+- **THEN** it waits the configured probe interval, rereads that pull request's timeline, and skips the remaining review requests if the probe observed a usage-limit reply
+
+#### Scenario: Probing stops after a normal response
+
+- **GIVEN** a normal Codex response for the sender has already been observed
+- **WHEN** the script posts further `@codex review` comments in the run
+- **THEN** it does not wait or reread pull request timelines for those posts
+
+#### Scenario: Apply status is attributed to the applied pull request
+
+- **WHEN** the script applies decisions for multiple pull requests in one run
+- **THEN** each status line and error report references the pull request of the decision being applied

--- a/openspec/changes/backoff-codex-review-usage-limits/tasks.md
+++ b/openspec/changes/backoff-codex-review-usage-limits/tasks.md
@@ -1,0 +1,12 @@
+## 1. Usage-limit backoff
+
+- [x] 1.1 Track per-sender Codex usage-limit and normal-response timestamps from classified PR timelines (`CodexReviewUsageBackoff`).
+- [x] 1.2 Skip `@codex review` posts while the sender's latest Codex response within the backoff window is a usage-limit reply; surface a write warning naming the evidence.
+- [x] 1.3 Probe after posting when no quota evidence exists: wait, reread the PR timeline, and latch off remaining triggers on a usage-limit reply; stop probing after the first observed normal response.
+- [x] 1.4 Report apply-loop status and errors per decision (`decision.repo`/`decision.number`), not the stale classification-loop variables.
+
+## 2. Validation
+
+- [x] 2.1 Unit coverage: latch on recent limit, unlatch on newer normal reply, per-sender independence, probe latch across PRs (asserting per-PR apply lines), probe suppression after a normal response.
+- [x] 2.2 Run the sync-script unit suite.
+- [x] 2.3 Validate with `openspec validate backoff-codex-review-usage-limits --strict`.

--- a/openspec/changes/backoff-codex-review-usage-limits/tasks.md
+++ b/openspec/changes/backoff-codex-review-usage-limits/tasks.md
@@ -4,9 +4,18 @@
 - [x] 1.2 Skip `@codex review` posts while the sender's latest Codex response within the backoff window is a usage-limit reply; surface a write warning naming the evidence.
 - [x] 1.3 Probe after posting when no quota evidence exists: wait, reread the PR timeline, and latch off remaining triggers on a usage-limit reply; stop probing after the first observed normal response.
 - [x] 1.4 Report apply-loop status and errors per decision (`decision.repo`/`decision.number`), not the stale classification-loop variables.
+- [x] 1.5 Anchor usage-limit detection to the real quota envelope ("You have reached your Codex usage limits" at start of body) so reviews discussing usage limits do not latch.
+- [x] 1.6 Count clean THUMBS_UP reactions by Codex reviewers on the sender's request comments as normal responses for unlatching.
+- [x] 1.7 Share backoff state across all `--repo` arguments in one run, retaining classified timelines from repositories without their own triggers as evidence.
+- [x] 1.7b Gather the repository's recent issue comments (within the window, grouped per issue) as additional quota evidence before posting, covering single `--pr` runs and closed PRs; degrade with a warning if the gather fails.
+- [x] 1.8 Resolve the sender installation-token-compatibly (workflow-exported `GH_APP_SLUG` -> `<slug>[bot]`, `GET /user` fallback); on failure, disable only the trigger path with per-decision warnings while label sync proceeds.
+- [x] 1.9 Reclassify each PR immediately before performing its writes: skip superseded heads with a warning, apply same-head evidence changes fresh, and trigger only when both classifications agree. Feed the fresh timeline into the shared backoff and honor `--tolerate-read-errors` for reclassification failures.
+- [x] 1.10 Suppress review triggers (and ignore the app slug) once the run has switched to `GH_FALLBACK_TOKEN`, since posted comments would no longer be authored by the resolved sender; never silently retry the review-request POST itself under the fallback token.
+- [x] 1.11 Probe for quota replies only when the review request was actually posted (skip the wait/reread after tolerated write denials).
 
 ## 2. Validation
 
 - [x] 2.1 Unit coverage: latch on recent limit, unlatch on newer normal reply, per-sender independence, probe latch across PRs (asserting per-PR apply lines), probe suppression after a normal response.
+- [x] 2.1b Unit coverage for the review-fix hardening: anchored quota envelope matching, clean-reaction unlatch, cross-repo backoff persistence (including non-triggering repos), app-slug sender resolution and degraded trigger-only skip, fallback-token trigger suppression, apply-time reclassification (head move and same-head evidence change).
 - [x] 2.2 Run the sync-script unit suite.
 - [x] 2.3 Validate with `openspec validate backoff-codex-review-usage-limits --strict`.

--- a/tests/unit/test_sync_codex_ok_labels.py
+++ b/tests/unit/test_sync_codex_ok_labels.py
@@ -641,6 +641,179 @@ def test_codex_usage_backoff_keeps_accounts_independent() -> None:
     assert backoff.is_limited() is True
 
 
+@pytest.mark.parametrize(
+    "body",
+    [
+        "You have reached your Codex usage limits for code reviews. "
+        "You can see your limits in the [Codex usage dashboard](https://chatgpt.com/codex/settings/usage).",
+        "  \nYou have reached your Codex usage limits for code reviews.",
+        "You've reached your Codex usage limits.",
+    ],
+)
+def test_usage_limit_body_matches_real_quota_envelope(body: str) -> None:
+    module = load_sync_module()
+
+    assert module.is_codex_usage_limit_body(body) is True
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "**[P1]** The unanchored `usage limit` pattern also matches reviews discussing usage limits.",
+        "Codex Review: the backoff should latch on a Codex usage limit reply. Didn't find any major issues.",
+        "This PR adds a usage-limit backoff. You have reached your Codex usage limits is the trigger phrase.",
+        None,
+        "",
+    ],
+)
+def test_usage_limit_body_ignores_reviews_discussing_usage_limits(body: object) -> None:
+    module = load_sync_module()
+
+    assert module.is_codex_usage_limit_body(body) is False
+
+
+def codex_review_request_with_reaction(
+    author: str,
+    created_at: str,
+    *,
+    reaction_user: str,
+    reaction_content: str,
+    reaction_created_at: str,
+) -> dict[str, Any]:
+    request = codex_review_request(author, created_at)
+    request["reactions"] = {
+        "nodes": [
+            {
+                "content": reaction_content,
+                "createdAt": reaction_created_at,
+                "user": {"login": reaction_user},
+            }
+        ]
+    }
+    return request
+
+
+def test_codex_usage_backoff_unlatches_on_newer_clean_reaction() -> None:
+    module = load_sync_module()
+    backoff = module.CodexReviewUsageBackoff(
+        request_author="Komzpa",
+        allowed_authors={"chatgpt-codex-connector"},
+        window=module.timedelta(hours=24),
+        now=module.datetime.fromisoformat("2026-07-31T16:00:00+00:00"),
+    )
+
+    backoff.observe(
+        [
+            codex_review_request("Komzpa", "2026-07-31T14:00:00Z"),
+            codex_issue_comment("You've reached your Codex usage limits.", "2026-07-31T14:01:00Z"),
+            codex_review_request_with_reaction(
+                "Komzpa",
+                "2026-07-31T15:00:00Z",
+                reaction_user="chatgpt-codex-connector",
+                reaction_content="THUMBS_UP",
+                reaction_created_at="2026-07-31T15:05:00Z",
+            ),
+        ]
+    )
+
+    assert backoff.is_limited() is False
+
+
+def test_codex_usage_backoff_ignores_reactions_from_non_codex_users() -> None:
+    module = load_sync_module()
+    backoff = module.CodexReviewUsageBackoff(
+        request_author="Komzpa",
+        allowed_authors={"chatgpt-codex-connector"},
+        window=module.timedelta(hours=24),
+        now=module.datetime.fromisoformat("2026-07-31T16:00:00+00:00"),
+    )
+
+    backoff.observe(
+        [
+            codex_review_request("Komzpa", "2026-07-31T14:00:00Z"),
+            codex_issue_comment("You've reached your Codex usage limits.", "2026-07-31T14:01:00Z"),
+            codex_review_request_with_reaction(
+                "Komzpa",
+                "2026-07-31T15:00:00Z",
+                reaction_user="SomeoneElse",
+                reaction_content="THUMBS_UP",
+                reaction_created_at="2026-07-31T15:05:00Z",
+            ),
+        ]
+    )
+
+    assert backoff.is_limited() is True
+
+
+def test_codex_usage_backoff_ignores_clean_reaction_older_than_limit() -> None:
+    module = load_sync_module()
+    backoff = module.CodexReviewUsageBackoff(
+        request_author="Komzpa",
+        allowed_authors={"chatgpt-codex-connector"},
+        window=module.timedelta(hours=24),
+        now=module.datetime.fromisoformat("2026-07-31T16:00:00+00:00"),
+    )
+
+    backoff.observe(
+        [
+            codex_review_request_with_reaction(
+                "Komzpa",
+                "2026-07-31T13:00:00Z",
+                reaction_user="chatgpt-codex-connector",
+                reaction_content="THUMBS_UP",
+                reaction_created_at="2026-07-31T13:05:00Z",
+            ),
+            codex_review_request("Komzpa", "2026-07-31T14:00:00Z"),
+            codex_issue_comment("You've reached your Codex usage limits.", "2026-07-31T14:01:00Z"),
+        ]
+    )
+
+    assert backoff.is_limited() is True
+
+
+def test_resolve_codex_request_sender_prefers_app_slug(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_sync_module()
+    monkeypatch.setenv("GH_APP_SLUG", "codex-label-sync")
+
+    def fail_viewer_login() -> str:
+        raise AssertionError("GET /user must not be called when GH_APP_SLUG is set")
+
+    monkeypatch.setattr(module, "current_viewer_login", fail_viewer_login)
+
+    assert module.resolve_codex_request_sender() == "codex-label-sync[bot]"
+
+
+def test_resolve_codex_request_sender_keeps_explicit_bot_suffix(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_sync_module()
+    monkeypatch.setenv("GH_APP_SLUG", "codex-label-sync[bot]")
+
+    assert module.resolve_codex_request_sender() == "codex-label-sync[bot]"
+
+
+def test_resolve_codex_request_sender_falls_back_to_viewer_login(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_sync_module()
+    monkeypatch.delenv("GH_APP_SLUG", raising=False)
+    monkeypatch.setattr(module, "current_viewer_login", lambda: "Komzpa")
+
+    assert module.resolve_codex_request_sender() == "Komzpa"
+
+
+def test_resolve_codex_request_sender_returns_none_when_unresolvable(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+    monkeypatch.delenv("GH_APP_SLUG", raising=False)
+
+    def fail_viewer_login() -> str:
+        raise module.GhError("gh api /user: HTTP 403 (installation token)")
+
+    monkeypatch.setattr(module, "current_viewer_login", fail_viewer_login)
+
+    assert module.resolve_codex_request_sender() is None
+    assert "cannot resolve @codex review sender" in capsys.readouterr().err
+
+
 def recent_timestamp(module: ModuleType, *, minutes_ago: int) -> str:
     moment = module.datetime.now(module.UTC) - module.timedelta(minutes=minutes_ago)
     return moment.strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -652,9 +825,11 @@ def test_main_stops_codex_review_triggers_after_probe_hits_usage_limit(
 ) -> None:
     module = load_sync_module()
 
+    monkeypatch.delenv("GH_APP_SLUG", raising=False)
     monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
     monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [710, 714])
     monkeypatch.setattr(module, "current_viewer_login", lambda: "Komzpa")
+    monkeypatch.setattr(module, "recent_issue_comment_timelines", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(module, "apply_decision", lambda *_args, **_kwargs: ())
     monkeypatch.setattr(module, "approve_workflow_runs", lambda *_args, **_kwargs: ())
 
@@ -724,9 +899,11 @@ def test_main_skips_probe_after_normal_codex_response_observed(
 ) -> None:
     module = load_sync_module()
 
+    monkeypatch.delenv("GH_APP_SLUG", raising=False)
     monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
     monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [710, 714])
     monkeypatch.setattr(module, "current_viewer_login", lambda: "Komzpa")
+    monkeypatch.setattr(module, "recent_issue_comment_timelines", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(module, "apply_decision", lambda *_args, **_kwargs: ())
     monkeypatch.setattr(module, "approve_workflow_runs", lambda *_args, **_kwargs: ())
 
@@ -780,10 +957,637 @@ def test_main_skips_probe_after_normal_codex_response_observed(
     assert "apply Soju06/codex-lb#714: " in captured.out
 
 
+def test_main_continues_label_sync_when_sender_is_unresolvable(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.delenv("GH_APP_SLUG", raising=False)
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [710, 714])
+    monkeypatch.setattr(module, "approve_workflow_runs", lambda *_args, **_kwargs: ())
+
+    def fail_viewer_login() -> str:
+        raise module.GhError("gh api /user: HTTP 403 (installation token)")
+
+    monkeypatch.setattr(module, "current_viewer_login", fail_viewer_login)
+    monkeypatch.setattr(module, "recent_issue_comment_timelines", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        module,
+        "decide_pr",
+        lambda _repo, number, **_kwargs: decision(
+            module, number=number, trigger_codex_review=True, checks_state="success"
+        ),
+    )
+
+    applied: list[int] = []
+    monkeypatch.setattr(
+        module,
+        "apply_decision",
+        lambda applied_decision, **_kwargs: (applied.append(applied_decision.number), ())[1],
+    )
+    posted: list[int] = []
+    monkeypatch.setattr(
+        module,
+        "trigger_codex_review",
+        lambda request_decision, **_kwargs: (posted.append(request_decision.number), ())[1],
+    )
+
+    result = module.main(["--repo", "Soju06/codex-lb", "--all-open", "--apply"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert applied == [710, 714]
+    assert posted == []
+    assert "cannot determine @codex review sender; skipping review triggers" in captured.err
+    assert captured.out.count("sender could not be resolved") == 2
+    assert captured.out.count("trigger_codex=False") == 2
+
+
+def test_main_skips_apply_when_head_moved_after_classification(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [710, 714])
+    monkeypatch.setattr(module, "approve_workflow_runs", lambda *_args, **_kwargs: ())
+
+    calls_by_number: dict[int, int] = {}
+
+    def fake_decide_pr(_repo: str, number: int, **_kwargs: Any) -> Any:
+        calls_by_number[number] = calls_by_number.get(number, 0) + 1
+        # The classification pass sees head a...a; by the time #710 is
+        # re-classified in the apply loop its head has moved to b...b.
+        if number == 710 and calls_by_number[number] > 1:
+            return decision(module, number=number, head_sha="b" * 40)
+        return decision(module, number=number)
+
+    monkeypatch.setattr(module, "decide_pr", fake_decide_pr)
+
+    applied: list[int] = []
+    monkeypatch.setattr(
+        module,
+        "apply_decision",
+        lambda applied_decision, **_kwargs: (applied.append(applied_decision.number), ())[1],
+    )
+
+    result = module.main(["--repo", "Soju06/codex-lb", "--all-open", "--apply"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert applied == [714]
+    assert calls_by_number == {710: 2, 714: 2}
+    assert "Soju06/codex-lb#710: head moved from" in captured.err
+    assert "skipping stale decision" in captured.err
+    assert "apply Soju06/codex-lb#710" not in captured.out
+    assert "apply Soju06/codex-lb#714" in captured.out
+
+
+def test_main_applies_freshly_reclassified_decision_for_same_head(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [714])
+    monkeypatch.setattr(module, "approve_workflow_runs", lambda *_args, **_kwargs: ())
+
+    calls: list[int] = []
+
+    def fake_decide_pr(_repo: str, number: int, **_kwargs: Any) -> Any:
+        calls.append(number)
+        if len(calls) == 1:
+            return decision(
+                module,
+                number=number,
+                has_ok_label=False,
+                wants_ok_label=True,
+                ok_action="add",
+                checks_state="success",
+            )
+        # Same head, but by apply time Codex raised a new finding.
+        return decision(
+            module,
+            number=number,
+            has_ok_label=False,
+            wants_ok_label=False,
+            ok_action="keep",
+            wants_needs_work_label=True,
+            needs_work_action="add",
+            review_state="needs_work",
+        )
+
+    monkeypatch.setattr(module, "decide_pr", fake_decide_pr)
+
+    applied_actions: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        module,
+        "apply_decision",
+        lambda applied_decision, **_kwargs: (
+            applied_actions.append((applied_decision.ok_action, applied_decision.needs_work_action)),
+            (),
+        )[1],
+    )
+
+    result = module.main(["--repo", "Soju06/codex-lb", "--all-open", "--apply"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert applied_actions == [("keep", "add")]
+    assert "review=needs_work" in captured.out
+
+
+def test_main_usage_backoff_state_persists_across_repos(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.delenv("GH_APP_SLUG", raising=False)
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [710])
+    monkeypatch.setattr(module, "current_viewer_login", lambda: "Komzpa")
+    monkeypatch.setattr(module, "recent_issue_comment_timelines", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(module, "apply_decision", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "approve_workflow_runs", lambda *_args, **_kwargs: ())
+
+    def fake_decide_pr(repo: str, number: int, **kwargs: Any) -> Any:
+        observer = kwargs.get("timeline_observer")
+        if observer is not None:
+            timeline: list[dict[str, Any]] = [
+                {
+                    "__typename": "PullRequestCommit",
+                    "commit": {"oid": "a" * 40},
+                    "committedDate": recent_timestamp(module, minutes_ago=70),
+                }
+            ]
+            if repo == "Soju06/codex-lb":
+                timeline.extend(
+                    [
+                        codex_review_request("Komzpa", recent_timestamp(module, minutes_ago=30)),
+                        codex_issue_comment(
+                            "You have reached your Codex usage limits for code reviews.",
+                            recent_timestamp(module, minutes_ago=29),
+                        ),
+                    ]
+                )
+            observer(number, timeline)
+        return decision(module, repo=repo, number=number, trigger_codex_review=True, checks_state="success")
+
+    posted: list[str] = []
+    monkeypatch.setattr(
+        module,
+        "trigger_codex_review",
+        lambda request_decision, **_kwargs: (posted.append(request_decision.repo), ())[1],
+    )
+    monkeypatch.setattr(module, "decide_pr", fake_decide_pr)
+
+    result = module.main(
+        [
+            "--repo",
+            "Soju06/codex-lb",
+            "--repo",
+            "Soju06/other-repo",
+            "--all-open",
+            "--apply",
+            "--codex-review-response-wait-seconds",
+            "0",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert posted == []
+    assert "apply Soju06/codex-lb#710" in captured.out
+    assert "apply Soju06/other-repo#710" in captured.out
+    assert "request Codex review on Soju06/other-repo#710: skipped" in captured.out
+    assert "recent Codex usage-limit reply" in captured.out
+
+
+def test_main_usage_backoff_counts_evidence_from_non_triggering_repo(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.delenv("GH_APP_SLUG", raising=False)
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [710])
+    monkeypatch.setattr(module, "current_viewer_login", lambda: "Komzpa")
+    monkeypatch.setattr(module, "recent_issue_comment_timelines", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(module, "apply_decision", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "approve_workflow_runs", lambda *_args, **_kwargs: ())
+
+    def fake_decide_pr(repo: str, number: int, **kwargs: Any) -> Any:
+        observer = kwargs.get("timeline_observer")
+        if observer is not None and repo == "Soju06/codex-lb":
+            # The first repo has quota evidence but no trigger of its own.
+            observer(
+                number,
+                [
+                    codex_review_request("Komzpa", recent_timestamp(module, minutes_ago=30)),
+                    codex_issue_comment(
+                        "You have reached your Codex usage limits for code reviews.",
+                        recent_timestamp(module, minutes_ago=29),
+                    ),
+                ],
+            )
+        elif observer is not None:
+            observer(number, [])
+        trigger = repo == "Soju06/other-repo"
+        return decision(
+            module,
+            repo=repo,
+            number=number,
+            ok_action="keep",
+            has_ok_label=False,
+            trigger_codex_review=trigger,
+            checks_state="success",
+        )
+
+    posted: list[str] = []
+    monkeypatch.setattr(
+        module,
+        "trigger_codex_review",
+        lambda request_decision, **_kwargs: (posted.append(request_decision.repo), ())[1],
+    )
+    monkeypatch.setattr(module, "decide_pr", fake_decide_pr)
+
+    result = module.main(
+        [
+            "--repo",
+            "Soju06/codex-lb",
+            "--repo",
+            "Soju06/other-repo",
+            "--all-open",
+            "--apply",
+            "--codex-review-response-wait-seconds",
+            "0",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert posted == []
+    assert "request Codex review on Soju06/other-repo#710: skipped" in captured.out
+    assert "recent Codex usage-limit reply" in captured.out
+
+
+def test_main_stops_codex_review_triggers_after_fallback_token_activates(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.setenv("GH_APP_SLUG", "codex-label-sync")
+    monkeypatch.setattr(module, "_fallback_token_active", True)
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [714])
+    monkeypatch.setattr(module, "current_viewer_login", lambda: "fallback-user")
+    monkeypatch.setattr(module, "recent_issue_comment_timelines", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(module, "apply_decision", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "approve_workflow_runs", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(
+        module,
+        "decide_pr",
+        lambda _repo, number, **_kwargs: decision(
+            module,
+            number=number,
+            ok_action="keep",
+            has_ok_label=False,
+            trigger_codex_review=True,
+            checks_state="success",
+        ),
+    )
+
+    posted: list[int] = []
+    monkeypatch.setattr(
+        module,
+        "trigger_codex_review",
+        lambda request_decision, **_kwargs: (posted.append(request_decision.number), ())[1],
+    )
+
+    result = module.main(["--repo", "Soju06/codex-lb", "--all-open", "--apply"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert posted == []
+    assert "switched to GH_FALLBACK_TOKEN" in captured.out
+    assert "trigger_codex=False" in captured.out
+
+
+def test_resolve_codex_request_sender_ignores_app_slug_after_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_sync_module()
+    monkeypatch.setenv("GH_APP_SLUG", "codex-label-sync")
+    monkeypatch.setattr(module, "_fallback_token_active", True)
+    monkeypatch.setattr(module, "current_viewer_login", lambda: "fallback-user")
+
+    assert module.resolve_codex_request_sender() == "fallback-user"
+
+
+def test_recent_issue_comment_timelines_groups_by_issue(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_sync_module()
+
+    comments = [
+        {
+            "body": "@codex review",
+            "issue_url": "https://api.github.test/repos/Soju06/codex-lb/issues/700",
+            "created_at": "2026-07-31T14:00:00Z",
+            "html_url": "https://github.test/pull/700#issuecomment-1",
+            "user": {"login": "Komzpa"},
+        },
+        {
+            "body": "unrelated comment on another issue",
+            "issue_url": "https://api.github.test/repos/Soju06/codex-lb/issues/701",
+            "created_at": "2026-07-31T14:00:30Z",
+            "html_url": "https://github.test/pull/701#issuecomment-2",
+            "user": {"login": "someone"},
+        },
+        {
+            "body": "You have reached your Codex usage limits for code reviews.",
+            "issue_url": "https://api.github.test/repos/Soju06/codex-lb/issues/700",
+            "created_at": "2026-07-31T14:01:00Z",
+            "html_url": "https://github.test/pull/700#issuecomment-3",
+            "user": {"login": "chatgpt-codex-connector"},
+        },
+    ]
+    paths: list[str] = []
+
+    def fake_paged_api(path: str) -> list[dict[str, Any]]:
+        paths.append(path)
+        return comments
+
+    monkeypatch.setattr(module, "paged_api", fake_paged_api)
+
+    timelines = module.recent_issue_comment_timelines(
+        "Soju06/codex-lb",
+        since=module.datetime.fromisoformat("2026-07-30T16:00:00+00:00"),
+    )
+
+    assert len(paths) == 1
+    assert paths[0].startswith("/repos/Soju06/codex-lb/issues/comments?since=2026-07-30T16")
+    assert len(timelines) == 2
+    grouped = {timeline[0]["url"].split("#")[0]: timeline for timeline in timelines}
+    pr_700 = grouped["https://github.test/pull/700"]
+    assert [node["bodyText"] for node in pr_700] == [
+        "@codex review",
+        "You have reached your Codex usage limits for code reviews.",
+    ]
+    assert all(node["__typename"] == "IssueComment" for node in pr_700)
+
+    backoff = module.CodexReviewUsageBackoff(
+        request_author="Komzpa",
+        allowed_authors={"chatgpt-codex-connector"},
+        window=module.timedelta(hours=24),
+        now=module.datetime.fromisoformat("2026-07-31T16:00:00+00:00"),
+    )
+    for timeline in timelines:
+        backoff.observe(timeline)
+    assert backoff.is_limited() is True
+
+
+def test_main_gathers_repo_wide_quota_evidence_for_single_pr_run(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.delenv("GH_APP_SLUG", raising=False)
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "current_viewer_login", lambda: "Komzpa")
+    monkeypatch.setattr(module, "apply_decision", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "approve_workflow_runs", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(
+        module,
+        "decide_pr",
+        lambda _repo, number, **_kwargs: decision(
+            module,
+            number=number,
+            ok_action="keep",
+            has_ok_label=False,
+            trigger_codex_review=True,
+            checks_state="success",
+        ),
+    )
+    # Quota evidence lives on another (already closed) PR of the repo.
+    monkeypatch.setattr(
+        module,
+        "recent_issue_comment_timelines",
+        lambda _repo, **_kwargs: [
+            [
+                codex_review_request("Komzpa", recent_timestamp(module, minutes_ago=30)),
+                codex_issue_comment(
+                    "You have reached your Codex usage limits for code reviews.",
+                    recent_timestamp(module, minutes_ago=29),
+                ),
+            ]
+        ],
+    )
+
+    posted: list[int] = []
+    monkeypatch.setattr(
+        module,
+        "trigger_codex_review",
+        lambda request_decision, **_kwargs: (posted.append(request_decision.number), ())[1],
+    )
+
+    result = module.main(["--repo", "Soju06/codex-lb", "--pr", "714", "--apply"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert posted == []
+    assert "request Codex review on Soju06/codex-lb#714: skipped" in captured.out
+    assert "recent Codex usage-limit reply" in captured.out
+
+
+def test_main_observes_quota_evidence_from_apply_time_reclassification(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.delenv("GH_APP_SLUG", raising=False)
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [710, 714])
+    monkeypatch.setattr(module, "current_viewer_login", lambda: "Komzpa")
+    monkeypatch.setattr(module, "recent_issue_comment_timelines", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(module, "apply_decision", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "approve_workflow_runs", lambda *_args, **_kwargs: ())
+
+    calls_by_number: dict[int, int] = {}
+
+    def fake_decide_pr(_repo: str, number: int, **kwargs: Any) -> Any:
+        calls_by_number[number] = calls_by_number.get(number, 0) + 1
+        reclassification = calls_by_number[number] > 1
+        observer = kwargs.get("timeline_observer")
+        if observer is not None:
+            timeline: list[dict[str, Any]] = [
+                {
+                    "__typename": "PullRequestCommit",
+                    "commit": {"oid": "a" * 40},
+                    "committedDate": recent_timestamp(module, minutes_ago=70),
+                }
+            ]
+            if reclassification and number == 710:
+                # A quota reply arrived between bulk classification and apply.
+                timeline.extend(
+                    [
+                        codex_review_request("Komzpa", recent_timestamp(module, minutes_ago=3)),
+                        codex_issue_comment(
+                            "You have reached your Codex usage limits for code reviews.",
+                            recent_timestamp(module, minutes_ago=2),
+                        ),
+                    ]
+                )
+            observer(number, timeline)
+        trigger = not (reclassification and number == 710)
+        return decision(
+            module,
+            number=number,
+            ok_action="keep",
+            has_ok_label=False,
+            trigger_codex_review=trigger,
+            checks_state="success",
+        )
+
+    monkeypatch.setattr(module, "decide_pr", fake_decide_pr)
+
+    posted: list[int] = []
+    monkeypatch.setattr(
+        module,
+        "trigger_codex_review",
+        lambda request_decision, **_kwargs: (posted.append(request_decision.number), ())[1],
+    )
+
+    result = module.main(["--repo", "Soju06/codex-lb", "--all-open", "--apply"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert posted == []
+    assert "request Codex review on Soju06/codex-lb#714: skipped" in captured.out
+    assert "recent Codex usage-limit reply" in captured.out
+
+
+def test_main_tolerates_apply_time_reclassification_read_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [714])
+    monkeypatch.setattr(module, "approve_workflow_runs", lambda *_args, **_kwargs: ())
+
+    calls: list[int] = []
+
+    def fake_decide_pr(_repo: str, number: int, **_kwargs: Any) -> Any:
+        calls.append(number)
+        if len(calls) > 1:
+            raise module.GhError("gh: HTTP 502")
+        return decision(module, number=number)
+
+    monkeypatch.setattr(module, "decide_pr", fake_decide_pr)
+
+    applied: list[int] = []
+    monkeypatch.setattr(
+        module,
+        "apply_decision",
+        lambda applied_decision, **_kwargs: (applied.append(applied_decision.number), ())[1],
+    )
+
+    result = module.main(["--repo", "Soju06/codex-lb", "--all-open", "--apply", "--tolerate-read-errors"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert applied == []
+    assert "Soju06/codex-lb#714: apply-time reclassification failed" in captured.err
+
+
+def test_main_fails_apply_time_reclassification_read_errors_without_tolerance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [714])
+    monkeypatch.setattr(module, "approve_workflow_runs", lambda *_args, **_kwargs: ())
+
+    calls: list[int] = []
+
+    def fake_decide_pr(_repo: str, number: int, **_kwargs: Any) -> Any:
+        calls.append(number)
+        if len(calls) > 1:
+            raise module.GhError("gh: HTTP 502")
+        return decision(module, number=number)
+
+    monkeypatch.setattr(module, "decide_pr", fake_decide_pr)
+    monkeypatch.setattr(module, "apply_decision", lambda *_args, **_kwargs: ())
+
+    assert module.main(["--repo", "Soju06/codex-lb", "--all-open", "--apply"]) == 1
+
+
+def test_main_skips_probe_when_trigger_post_was_denied(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.delenv("GH_APP_SLUG", raising=False)
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [714])
+    monkeypatch.setattr(module, "current_viewer_login", lambda: "Komzpa")
+    monkeypatch.setattr(module, "recent_issue_comment_timelines", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(module, "apply_decision", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "approve_workflow_runs", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(
+        module,
+        "decide_pr",
+        lambda _repo, number, **_kwargs: decision(
+            module,
+            number=number,
+            ok_action="keep",
+            has_ok_label=False,
+            trigger_codex_review=True,
+            checks_state="success",
+        ),
+    )
+    monkeypatch.setattr(
+        module,
+        "trigger_codex_review",
+        lambda request_decision, **_kwargs: (
+            f"request Codex review on {request_decision.repo}#{request_decision.number}: "
+            "skipped because the GitHub token cannot write this resource",
+        ),
+    )
+
+    probe_calls: list[int] = []
+    monkeypatch.setattr(
+        module,
+        "pr_timeline_evidence",
+        lambda _repo, number: (probe_calls.append(number), ("a" * 40, []))[1],
+    )
+    sleeps: list[float] = []
+    monkeypatch.setattr(module.time, "sleep", sleeps.append)
+
+    result = module.main(["--repo", "Soju06/codex-lb", "--all-open", "--apply"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert probe_calls == []
+    assert sleeps == []
+    assert "write_warning=request Codex review on Soju06/codex-lb#714" in captured.out
+
+
 def test_workflow_prefers_privileged_token_and_enables_tolerant_apply() -> None:
     workflow = Path(".github/workflows/codex-review-labels.yml").read_text(encoding="utf-8")
 
     assert "secrets.CODEX_LABEL_SYNC_TOKEN || secrets.RELEASE_PLEASE_TOKEN || github.token" in workflow
+    app_slug_env = "GH_APP_SLUG: ${{ steps.app-token.outputs.token && steps.app-token.outputs.app-slug || '' }}"
+    assert workflow.count(app_slug_env) == 2
     assert "pull_request_review_thread:" not in workflow
     assert "github.event_name == 'pull_request_review_thread'" not in workflow
     assert 'cron: "*/15 * * * *"' in workflow
@@ -1229,6 +2033,55 @@ def test_run_gh_does_not_retry_mutating_pr_comment(monkeypatch: pytest.MonkeyPat
     with pytest.raises(module.GhError):
         module.run_gh(["pr", "comment", "1344", "--body", "@codex review"])
     assert len(calls) == 1
+
+
+def test_run_gh_activates_fallback_without_retrying_identity_sensitive_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = load_sync_module()
+    monkeypatch.setenv("GH_TOKEN", "primary-token")
+    monkeypatch.setenv("GH_FALLBACK_TOKEN", "fallback-token")
+
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: Any) -> Any:
+        del kwargs
+        calls.append(command)
+        return _rate_limited_proc()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    with pytest.raises(module.GhError, match="without retrying this identity-sensitive command"):
+        module.run_gh(
+            ["api", "--method", "POST", "/repos/example/project/issues/1/comments"],
+            fallback_retry=False,
+        )
+
+    assert len(calls) == 1
+    # The fallback still activates so the rest of the run stays alive.
+    assert module._fallback_token_active is True
+    import os
+
+    assert os.environ["GH_TOKEN"] == "fallback-token"
+
+
+def test_trigger_codex_review_posts_without_fallback_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = load_sync_module()
+    captured_kwargs: list[dict[str, Any]] = []
+
+    def capture_run_gh(_args: list[str], **kwargs: Any) -> None:
+        captured_kwargs.append(kwargs)
+
+    monkeypatch.setattr(module, "run_gh", capture_run_gh)
+
+    warnings = module.trigger_codex_review(
+        decision(module, trigger_codex_review=True, ok_action="keep"),
+        body="@codex review",
+    )
+
+    assert warnings == ()
+    assert len(captured_kwargs) == 1
+    assert captured_kwargs[0]["fallback_retry"] is False
 
 
 def test_run_gh_fails_without_distinct_fallback_token(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_sync_codex_ok_labels.py
+++ b/tests/unit/test_sync_codex_ok_labels.py
@@ -47,6 +47,26 @@ def decision(module: ModuleType, **overrides: Any) -> Any:
     return module.SyncDecision(**values)
 
 
+def codex_review_request(author: str, created_at: str) -> dict[str, Any]:
+    return {
+        "__typename": "IssueComment",
+        "author": {"login": author},
+        "bodyText": "@codex review",
+        "createdAt": created_at,
+        "url": f"https://github.test/request/{created_at}",
+    }
+
+
+def codex_issue_comment(body: str, created_at: str) -> dict[str, Any]:
+    return {
+        "__typename": "IssueComment",
+        "author": {"login": "chatgpt-codex-connector"},
+        "bodyText": body,
+        "createdAt": created_at,
+        "url": f"https://github.test/codex/{created_at}",
+    }
+
+
 @pytest.mark.parametrize("merge_state", ["CONFLICTING", "DIRTY"])
 def test_needs_rebase_label_target_adds_for_confirmed_conflicts(merge_state: str) -> None:
     module = load_sync_module()
@@ -558,6 +578,132 @@ def test_trigger_codex_review_tolerates_github_app_write_denial(monkeypatch: pyt
 
     assert len(warnings) == 1
     assert "request Codex review on Soju06/codex-lb#714" in warnings[0]
+
+
+def test_codex_usage_backoff_blocks_recent_limit_for_same_sender() -> None:
+    module = load_sync_module()
+    backoff = module.CodexReviewUsageBackoff(
+        request_author="Komzpa",
+        allowed_authors={"chatgpt-codex-connector"},
+        window=module.timedelta(hours=24),
+        now=module.datetime.fromisoformat("2026-07-31T16:00:00+00:00"),
+    )
+
+    backoff.observe(
+        [
+            codex_review_request("Komzpa", "2026-07-31T15:00:00Z"),
+            codex_issue_comment("You've reached your Codex usage limits.", "2026-07-31T15:01:00Z"),
+        ]
+    )
+
+    assert backoff.is_limited() is True
+
+
+def test_codex_usage_backoff_allows_after_newer_normal_reply() -> None:
+    module = load_sync_module()
+    backoff = module.CodexReviewUsageBackoff(
+        request_author="Komzpa",
+        allowed_authors={"chatgpt-codex-connector"},
+        window=module.timedelta(hours=24),
+        now=module.datetime.fromisoformat("2026-07-31T16:00:00+00:00"),
+    )
+
+    backoff.observe(
+        [
+            codex_review_request("Komzpa", "2026-07-31T14:00:00Z"),
+            codex_issue_comment("You've reached your Codex usage limits.", "2026-07-31T14:01:00Z"),
+            codex_review_request("Komzpa", "2026-07-31T15:00:00Z"),
+            codex_issue_comment("Codex Review: Didn't find any major issues.", "2026-07-31T15:02:00Z"),
+        ]
+    )
+
+    assert backoff.is_limited() is False
+
+
+def test_codex_usage_backoff_keeps_accounts_independent() -> None:
+    module = load_sync_module()
+    backoff = module.CodexReviewUsageBackoff(
+        request_author="Komzpa",
+        allowed_authors={"chatgpt-codex-connector"},
+        window=module.timedelta(hours=24),
+        now=module.datetime.fromisoformat("2026-07-31T16:00:00+00:00"),
+    )
+
+    backoff.observe(
+        [
+            codex_review_request("Komzpa", "2026-07-31T14:00:00Z"),
+            codex_issue_comment("You've reached your Codex usage limits.", "2026-07-31T14:01:00Z"),
+            codex_review_request("OtherUser", "2026-07-31T15:00:00Z"),
+            codex_issue_comment("Codex Review: Didn't find any major issues.", "2026-07-31T15:02:00Z"),
+        ]
+    )
+
+    assert backoff.is_limited() is True
+
+
+def test_main_stops_codex_review_triggers_after_probe_hits_usage_limit(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [710, 714])
+    monkeypatch.setattr(module, "current_viewer_login", lambda: "Komzpa")
+    monkeypatch.setattr(module, "apply_decision", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "approve_workflow_runs", lambda *_args, **_kwargs: ())
+
+    def fake_decide_pr(_repo: str, number: int, **kwargs: Any) -> Any:
+        observer = kwargs.get("timeline_observer")
+        if observer is not None:
+            observer(
+                number,
+                [
+                    {
+                        "__typename": "PullRequestCommit",
+                        "commit": {"oid": "a" * 40},
+                        "committedDate": "2026-07-31T14:50:00Z",
+                    }
+                ],
+            )
+        return decision(module, number=number, trigger_codex_review=True, ok_action="keep", checks_state="success")
+
+    posted: list[int] = []
+
+    def fake_trigger(decision: Any, **_kwargs: Any) -> tuple[str, ...]:
+        posted.append(decision.number)
+        return ()
+
+    def fake_timeline(_repo: str, _number: int) -> tuple[str, list[dict[str, Any]]]:
+        return (
+            "a" * 40,
+            [
+                codex_review_request("Komzpa", "2026-07-31T15:00:00Z"),
+                codex_issue_comment("You've reached your Codex usage limits.", "2026-07-31T15:01:00Z"),
+            ],
+        )
+
+    monkeypatch.setattr(module, "decide_pr", fake_decide_pr)
+    monkeypatch.setattr(module, "trigger_codex_review", fake_trigger)
+    monkeypatch.setattr(module, "pr_timeline_evidence", fake_timeline)
+
+    result = module.main(
+        [
+            "--repo",
+            "Soju06/codex-lb",
+            "--all-open",
+            "--apply",
+            "--codex-review-response-wait-seconds",
+            "0",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert posted == [710]
+    assert "apply Soju06/codex-lb#714" in captured.out
+    assert "trigger_codex=False" in captured.out
+    assert "recent Codex usage-limit reply" in captured.out
 
 
 def test_workflow_prefers_privileged_token_and_enables_tolerant_apply() -> None:

--- a/tests/unit/test_sync_codex_ok_labels.py
+++ b/tests/unit/test_sync_codex_ok_labels.py
@@ -641,6 +641,11 @@ def test_codex_usage_backoff_keeps_accounts_independent() -> None:
     assert backoff.is_limited() is True
 
 
+def recent_timestamp(module: ModuleType, *, minutes_ago: int) -> str:
+    moment = module.datetime.now(module.UTC) - module.timedelta(minutes=minutes_ago)
+    return moment.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def test_main_stops_codex_review_triggers_after_probe_hits_usage_limit(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -662,7 +667,7 @@ def test_main_stops_codex_review_triggers_after_probe_hits_usage_limit(
                     {
                         "__typename": "PullRequestCommit",
                         "commit": {"oid": "a" * 40},
-                        "committedDate": "2026-07-31T14:50:00Z",
+                        "committedDate": recent_timestamp(module, minutes_ago=70),
                     }
                 ],
             )
@@ -678,8 +683,11 @@ def test_main_stops_codex_review_triggers_after_probe_hits_usage_limit(
         return (
             "a" * 40,
             [
-                codex_review_request("Komzpa", "2026-07-31T15:00:00Z"),
-                codex_issue_comment("You've reached your Codex usage limits.", "2026-07-31T15:01:00Z"),
+                codex_review_request("Komzpa", recent_timestamp(module, minutes_ago=2)),
+                codex_issue_comment(
+                    "You've reached your Codex usage limits.",
+                    recent_timestamp(module, minutes_ago=1),
+                ),
             ],
         )
 
@@ -701,9 +709,75 @@ def test_main_stops_codex_review_triggers_after_probe_hits_usage_limit(
     captured = capsys.readouterr()
     assert result == 0
     assert posted == [710]
-    assert "apply Soju06/codex-lb#714" in captured.out
-    assert "trigger_codex=False" in captured.out
+    apply_lines = [line for line in captured.out.splitlines() if line.startswith("apply ")]
+    assert len(apply_lines) == 2
+    assert apply_lines[0].startswith("apply Soju06/codex-lb#710: ")
+    assert "trigger_codex=True" in apply_lines[0]
+    assert apply_lines[1].startswith("apply Soju06/codex-lb#714: ")
+    assert "trigger_codex=False" in apply_lines[1]
     assert "recent Codex usage-limit reply" in captured.out
+
+
+def test_main_skips_probe_after_normal_codex_response_observed(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = load_sync_module()
+
+    monkeypatch.setattr(module, "ensure_label", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "list_open_pr_numbers", lambda _repo: [710, 714])
+    monkeypatch.setattr(module, "current_viewer_login", lambda: "Komzpa")
+    monkeypatch.setattr(module, "apply_decision", lambda *_args, **_kwargs: ())
+    monkeypatch.setattr(module, "approve_workflow_runs", lambda *_args, **_kwargs: ())
+
+    def fake_decide_pr(_repo: str, number: int, **kwargs: Any) -> Any:
+        observer = kwargs.get("timeline_observer")
+        if observer is not None:
+            observer(
+                number,
+                [
+                    codex_review_request("Komzpa", recent_timestamp(module, minutes_ago=30)),
+                    codex_issue_comment(
+                        "Codex Review: Didn't find any major issues.",
+                        recent_timestamp(module, minutes_ago=29),
+                    ),
+                ],
+            )
+        return decision(module, number=number, trigger_codex_review=True, ok_action="keep", checks_state="success")
+
+    posted: list[int] = []
+
+    def fake_trigger(decision: Any, **_kwargs: Any) -> tuple[str, ...]:
+        posted.append(decision.number)
+        return ()
+
+    probe_calls: list[int] = []
+
+    def fake_timeline(_repo: str, number: int) -> tuple[str, list[dict[str, Any]]]:
+        probe_calls.append(number)
+        return ("a" * 40, [])
+
+    monkeypatch.setattr(module, "decide_pr", fake_decide_pr)
+    monkeypatch.setattr(module, "trigger_codex_review", fake_trigger)
+    monkeypatch.setattr(module, "pr_timeline_evidence", fake_timeline)
+
+    result = module.main(
+        [
+            "--repo",
+            "Soju06/codex-lb",
+            "--all-open",
+            "--apply",
+            "--codex-review-response-wait-seconds",
+            "0",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert posted == [710, 714]
+    assert probe_calls == []
+    assert "apply Soju06/codex-lb#710: " in captured.out
+    assert "apply Soju06/codex-lb#714: " in captured.out
 
 
 def test_workflow_prefers_privileged_token_and_enables_tolerant_apply() -> None:


### PR DESCRIPTION
Supersedes #1560 — first-party takeover of @Komzpa's work (author unresponsive since 07-31; the problem is live: 6+ PRs this week, including #1599, hit "You have reached your Codex usage limits" and repeated `@codex review` re-fires keep burning the shared quota). Komzpa's commit is cherry-picked with original authorship preserved; full credit for the backoff design to them.

## What #1560 brought (unchanged)

- Stop the label sync from posting more `@codex review` comments when the same comment sender received a recent Codex usage-limit reply (default 24h window, `--codex-usage-limit-backoff-hours`)
- Unlatch only when that same sender has a newer normal Codex response — per-sender attribution
- No-data runs probe: post once, wait (`--codex-review-response-wait-seconds`, default 10s), reread the PR timeline, and suppress remaining review requests if the probe hit the usage limit

## Review-fix delta (second commit, addresses the 08-04 review on #1560)

- **Apply-loop log misattribution**: the split of classification from apply left the status line and the except handler formatting `f"{repo}#{number}"` with the stale classification-loop `number` (always the last classified PR) — with `--all-open` over #710 and #714, both lines printed `#714`, and apply exceptions were attributed to the wrong PR. Now `decision.repo`/`decision.number`.
- **Bounded probing**: the sleep+reread ran after every posted `@codex review` (N x 10s + N timeline fetches per run); it now probes only until the first normal Codex response is observed.
- **Strengthened the weak test assertion**: the probe test asserted only on `#714` (the last PR), which is exactly why it couldn't catch the misattribution; it now pins both per-PR apply lines (`#710 ... trigger_codex=True`, `#714 ... trigger_codex=False`).
- **Fixed latent test rot** (found during takeover): that test used hardcoded `2026-07-31` timestamps against `datetime.now(UTC)`, so it fell out of the 24h window and failed on any run after 08-01 — verified failing on today's main + cherry-pick. Timestamps are now generated relative to now.
- **New test**: probe fully suppressed once a normal Codex response is observed (zero extra timeline fetches).
- **OpenSpec**: added `backoff-codex-review-usage-limits` delta for `github-automation` (this script is spec-governed; `label-sync-rate-limit-fallback` precedent), validated `--strict`.

## Tests

- `uv run pytest tests/unit/test_sync_codex_ok_labels.py -q` — 47 passed
- `uv run ruff check` / `ruff format --check` on script + tests; `uv run ruff check app tests`; `uv run ty check`; `uv run python scripts/check_proxy_architecture.py`; `uv run openspec validate backoff-codex-review-usage-limits --strict` — all green

Co-authored-by: Darafei Praliaskouski <me@komzpa.net>

🤖 Generated with [Claude Code](https://claude.com/claude-code)