### PR TITLE
fix(proxy): complete Codex compaction SSE lifecycle

### DIFF
--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -5405,6 +5405,9 @@ def _normalize_compaction_output_item(item: Mapping[str, JsonValue]) -> dict[str
     item_id = item.get("id")
     if isinstance(item_id, str) and item_id.strip():
         normalized["id"] = item_id
+    status = item.get("status")
+    if isinstance(status, str) and status.strip():
+        normalized["status"] = status
     return normalized
 
 
@@ -5433,25 +5436,52 @@ async def _synthetic_compaction_response_stream(
     response_id: str,
     usage: object | None,
 ) -> AsyncIterator[str]:
+    item = dict(compact_item)
+    item.setdefault("status", "completed")
     completed_response: dict[str, JsonValue] = {
         "id": response_id,
         "object": "response",
         "status": "completed",
-        "output": [dict(compact_item)],
+        "output": [item],
     }
     usage_mapping = _json_mapping_from_model_or_mapping(usage)
     if usage_mapping is not None:
         completed_response["usage"] = dict(usage_mapping)
     yield format_sse_event(
         {
-            "type": "response.output_item.done",
+            "type": "response.created",
+            "sequence_number": 0,
+            "response": {
+                "id": response_id,
+                "object": "response",
+                "status": "in_progress",
+                "output": [],
+            },
+        }
+    )
+    yield format_sse_event(
+        {
+            "type": "response.output_item.added",
+            "sequence_number": 1,
             "output_index": 0,
-            "item": dict(compact_item),
+            "item": {
+                **item,
+                "status": "in_progress",
+            },
+        }
+    )
+    yield format_sse_event(
+        {
+            "type": "response.output_item.done",
+            "sequence_number": 2,
+            "output_index": 0,
+            "item": item,
         }
     )
     yield format_sse_event(
         {
             "type": "response.completed",
+            "sequence_number": 3,
             "response": completed_response,
         }
     )

--- a/openspec/changes/archive/2026-08-06-complete-codex-compaction-sse-lifecycle/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-06-complete-codex-compaction-sse-lifecycle/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/archive/2026-08-06-complete-codex-compaction-sse-lifecycle/design.md
+++ b/openspec/changes/archive/2026-08-06-complete-codex-compaction-sse-lifecycle/design.md
@@ -1,0 +1,59 @@
+## Context
+
+The compaction-trigger bridge converts a terminal `compaction_trigger` into a
+short synthetic Responses stream. The current source emits the terminal item
+and response events but omits the lifecycle events that normally establish the
+response and output item first. A locally proven runtime patch fills that gap.
+
+This change builds on the existing encrypted-item fidelity work: the
+authoritative upstream `cmp_*` ID remains paired with its encrypted content.
+The bridge does not invent an ID when upstream omits one because a generated ID
+cannot prove the ciphertext was bound to it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Emit a complete, deterministic Responses lifecycle for synthetic Codex
+  compaction streams.
+- Preserve the selected compaction item's ID, encrypted content, and terminal
+  status across all terminal representations.
+- Keep the implementation isolated to the existing synthetic stream helper.
+
+**Non-Goals:**
+
+- Change compact account selection, retries, affinity, or persistence.
+- Generate replacement compaction item IDs.
+- Change OpenAI-style `/v1/responses/compact`.
+- Rework HTTP bridge stale-session cleanup, which current `main` already
+  handles through the bounded session close path.
+
+## Decisions
+
+1. The synthetic stream emits the canonical order:
+   `response.created`, `response.output_item.added`,
+   `response.output_item.done`, `response.completed`, then `[DONE]`.
+   Sequence numbers are `0` through `3`.
+
+2. The added event presents the selected item with `status="in_progress"`.
+   The done event and completed response reuse one terminal item mapping with
+   `status="completed"` unless upstream supplied another non-empty terminal
+   status.
+
+3. Normalization preserves a non-empty upstream status alongside the existing
+   ID and encrypted-content fidelity. Unknown fields remain excluded so the
+   Codex-facing compact item contract stays narrow.
+
+4. No replacement ID is generated. Remote compaction ciphertext can be bound to
+   its upstream item ID, so synthesizing a different ID would recreate the
+   replay failure this path is intended to prevent.
+
+## Risks / Trade-offs
+
+- [Risk] Older consumers see two additional non-terminal events.
+  - Mitigation: both events are standard Responses lifecycle events, while the
+    existing done and completed events remain unchanged in meaning.
+- [Risk] An upstream item without a status gains `completed` in the synthetic
+  stream.
+  - Mitigation: the helper is building a terminal compact result, and the added
+    event still overrides that view to `in_progress`.

--- a/openspec/changes/archive/2026-08-06-complete-codex-compaction-sse-lifecycle/proposal.md
+++ b/openspec/changes/archive/2026-08-06-complete-codex-compaction-sse-lifecycle/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+The Codex compaction-trigger bridge currently emits only
+`response.output_item.done` and `response.completed`. That abbreviated stream
+worked with the first remote-compaction-v2 collector, but it is not a complete
+Responses lifecycle and leaves stricter Codex clients, SDKs, and intermediaries
+without the response and output-item creation events they use to initialize
+stream state.
+
+The live codex-lb runtime has already been operating with the complete event
+sequence. Keeping that fix only in `site-packages` means a reinstall or upgrade
+silently restores the abbreviated stream.
+
+## What Changes
+
+- Emit `response.created`, `response.output_item.added`,
+  `response.output_item.done`, and `response.completed` in that order for a
+  synthetic Codex compaction response.
+- Number those events monotonically from zero.
+- Preserve the authoritative compaction item ID, encrypted content, and
+  terminal status across the done event and completed response, while exposing
+  the same item as `in_progress` in the added event.
+- Preserve a non-empty upstream compaction item status during normalization.
+- Add focused regression coverage for the complete wire lifecycle and item
+  fidelity.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: Synthetic Codex compaction streams use a complete,
+  ordered Responses lifecycle without changing standalone compact routing or
+  public `/v1/responses/compact`.
+
+## Impact
+
+- Affected code: `app/modules/proxy/api.py`.
+- Affected API surface: terminal compaction-trigger responses on
+  `POST /backend-api/codex/responses`.
+- No schema, dependency, configuration, dashboard, account-routing, or public
+  OpenAI compact behavior changes.

--- a/openspec/changes/archive/2026-08-06-complete-codex-compaction-sse-lifecycle/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-08-06-complete-codex-compaction-sse-lifecycle/specs/responses-api-compat/spec.md
@@ -1,0 +1,65 @@
+## MODIFIED Requirements
+
+### Requirement: Codex compaction triggers are bridged into compact output
+
+When `POST /backend-api/codex/responses` receives a request whose top-level
+`input` array contains exactly one `{"type":"compaction_trigger"}` item as its
+final element, the proxy SHALL remove that trigger before calling upstream
+compaction handling and SHALL emit a raw SSE stream that contains exactly one
+compaction output item.
+
+The stream MUST emit `response.created`, `response.output_item.added`,
+`response.output_item.done`, and `response.completed` in that order with
+monotonically increasing sequence numbers. The added event MUST expose the
+selected compaction item as in progress. The done event and terminal completed
+response MUST carry the same terminal `compaction` item. When the selected
+encrypted upstream compaction item carries a non-empty `id` or `status`, the
+synthetic stream MUST preserve those values with its `encrypted_content`; it
+MUST NOT generate a replacement item ID.
+
+For Codex-affinity standalone compact requests,
+`POST /backend-api/codex/responses/compact` SHALL normalize an upstream
+remote-compaction-v2 response that includes historical message output plus a
+compaction summary into the single compact output item required by Codex
+clients. A non-empty upstream compaction item `id` or `status` MUST be preserved
+in that normalized output item.
+
+OpenAI-style `/v1/responses/compact` is unchanged by this requirement.
+
+#### Scenario: terminal trigger emits a complete compact lifecycle
+
+- **WHEN** a `POST /backend-api/codex/responses` request ends with exactly one
+  top-level `compaction_trigger`
+- **THEN** the proxy strips the trigger and invokes compact handling
+- **AND** it emits created, added, done, and completed events in that order
+- **AND** their sequence numbers increase monotonically from zero
+- **AND** the done event and completed response contain the same single
+  terminal compaction item
+
+#### Scenario: encrypted compaction item identity survives trigger streaming
+
+- **WHEN** compaction handling for a terminal trigger returns encrypted content
+  with a non-empty upstream `cmp_*` ID and terminal status
+- **THEN** the added event exposes that ID with in-progress status
+- **AND** the done event and completed response preserve the exact upstream ID,
+  terminal status, and encrypted content
+- **AND** the proxy does not synthesize a replacement item ID
+
+#### Scenario: malformed trigger placement is rejected
+
+- **WHEN** a `POST /backend-api/codex/responses` request contains a duplicated
+  or non-terminal top-level `compaction_trigger` item
+- **THEN** the proxy returns HTTP 400 with `invalid_request_error`
+- **AND** it does not attempt upstream compaction handling
+
+#### Scenario: Codex-affinity standalone compact normalizes remote v2 output
+
+- **WHEN** a Codex-affinity `POST /backend-api/codex/responses/compact` request
+  receives upstream output that contains historical message items and one
+  compaction summary item
+- **THEN** the JSON response body contains exactly one `output` item for that
+  compaction summary
+- **AND** the normalized item preserves the compaction summary's non-empty
+  upstream ID and status
+- **AND** it does not expose historical message items as standalone compact
+  output

--- a/openspec/changes/archive/2026-08-06-complete-codex-compaction-sse-lifecycle/tasks.md
+++ b/openspec/changes/archive/2026-08-06-complete-codex-compaction-sse-lifecycle/tasks.md
@@ -1,0 +1,22 @@
+## 1. Contract
+
+- [x] 1.1 Record the complete synthetic Codex compaction SSE lifecycle in the
+  `responses-api-compat` delta.
+- [x] 1.2 Preserve the existing encrypted-item ID constraint and explicitly
+  reject generated replacement IDs.
+
+## 2. Implementation
+
+- [x] 2.1 Preserve non-empty upstream compaction item status during
+  normalization.
+- [x] 2.2 Emit created, added, done, and completed events with monotonic
+  sequence numbers.
+- [x] 2.3 Reuse one terminal compaction item across the done event and completed
+  response.
+
+## 3. Verification
+
+- [x] 3.1 Add focused unit coverage for event order, sequence numbers, status,
+  ID, encrypted-content, usage, and `[DONE]`.
+- [x] 3.2 Run focused tests, lint/type checks, OpenSpec validation, and diff
+  hygiene checks.

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -1610,21 +1610,24 @@ requests MUST NOT wait on an orphaned creation future that can never complete.
 
 When `POST /backend-api/codex/responses` receives a request whose top-level `input` array contains exactly one `{"type":"compaction_trigger"}` item as its final element, the proxy SHALL remove that trigger before calling upstream compaction handling and SHALL emit a raw SSE stream that contains exactly one compaction output item.
 
-The stream MUST include a `response.output_item.done` event whose `item` is a `compaction` record, and the terminal `response.completed` event MUST carry the same single compaction item in `response.output`. When the selected encrypted upstream compaction item carries a non-empty `id`, both events MUST preserve that exact ID with its `encrypted_content` so a later replay retains the ciphertext's item binding.
+The stream MUST emit `response.created`, `response.output_item.added`, `response.output_item.done`, and `response.completed` in that order with monotonically increasing sequence numbers. The added event MUST expose the selected compaction item as in progress. The done event and terminal completed response MUST carry the same terminal `compaction` item. When the selected encrypted upstream compaction item carries a non-empty `id` or `status`, the synthetic stream MUST preserve those values with its `encrypted_content`; it MUST NOT generate a replacement item ID.
 
-For Codex-affinity standalone compact requests, `POST /backend-api/codex/responses/compact` SHALL normalize an upstream remote-compaction-v2 response that includes historical message output plus a compaction summary into the single compact output item required by Codex clients. A non-empty upstream compaction item `id` MUST be preserved in that normalized output item.
+For Codex-affinity standalone compact requests, `POST /backend-api/codex/responses/compact` SHALL normalize an upstream remote-compaction-v2 response that includes historical message output plus a compaction summary into the single compact output item required by Codex clients. A non-empty upstream compaction item `id` or `status` MUST be preserved in that normalized output item.
 
 OpenAI-style `/v1/responses/compact` is unchanged by this requirement.
 
-#### Scenario: terminal trigger is converted into a compact stream
+#### Scenario: terminal trigger emits a complete compact lifecycle
 - **WHEN** a `POST /backend-api/codex/responses` request ends with exactly one top-level `compaction_trigger`
-- **THEN** the proxy strips the trigger, invokes compact handling, and streams one `response.output_item.done` event containing a `compaction` item
-- **AND** the terminal `response.completed` event carries that same item in `response.output`
+- **THEN** the proxy strips the trigger and invokes compact handling
+- **AND** it emits created, added, done, and completed events in that order
+- **AND** their sequence numbers increase monotonically from zero
+- **AND** the done event and completed response contain the same single terminal compaction item
 
-#### Scenario: encrypted compaction item ID survives trigger streaming
-- **WHEN** compaction handling for a terminal trigger returns encrypted content in an item with a non-empty `cmp_*` ID
-- **THEN** the `response.output_item.done` item preserves that exact ID
-- **AND** the `response.completed` output item preserves the same ID with the same encrypted content
+#### Scenario: encrypted compaction item identity survives trigger streaming
+- **WHEN** compaction handling for a terminal trigger returns encrypted content with a non-empty upstream `cmp_*` ID and terminal status
+- **THEN** the added event exposes that ID with in-progress status
+- **AND** the done event and completed response preserve the exact upstream ID, terminal status, and encrypted content
+- **AND** the proxy does not synthesize a replacement item ID
 
 #### Scenario: malformed trigger placement is rejected
 - **WHEN** a `POST /backend-api/codex/responses` request contains a duplicated or non-terminal top-level `compaction_trigger` item
@@ -1634,7 +1637,7 @@ OpenAI-style `/v1/responses/compact` is unchanged by this requirement.
 #### Scenario: Codex-affinity standalone compact normalizes remote v2 output
 - **WHEN** a Codex-affinity `POST /backend-api/codex/responses/compact` request receives upstream output that contains historical message items and one compaction summary item
 - **THEN** the JSON response body contains exactly one `output` item for that compaction summary
-- **AND** the normalized item preserves the compaction summary's non-empty upstream ID
+- **AND** the normalized item preserves the compaction summary's non-empty upstream ID and status
 - **AND** it does not expose historical message items as standalone compact output
 
 ### Requirement: Request logs expose upstream Responses transport

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -858,7 +858,13 @@ async def test_proxy_responses_compaction_trigger_elides_required_tool_image_and
         lines = [line async for line in resp.aiter_lines() if line]
 
     events = list(_iter_sse_events(lines))
-    assert [event["type"] for event in events] == ["response.output_item.done", "response.completed"]
+    assert [event["type"] for event in events] == [
+        "response.created",
+        "response.output_item.added",
+        "response.output_item.done",
+        "response.completed",
+    ]
+    assert [event["sequence_number"] for event in events] == [0, 1, 2, 3]
     assert selection_preferred_ids == [owner_account.id]
     assert seen_payload["model"] == "gpt-5.1"
     compact_input = cast(list[Mapping[str, object]], seen_payload["input"])
@@ -875,19 +881,21 @@ async def test_proxy_responses_compaction_trigger_elides_required_tool_image_and
     assert compact_payload["prompt_cache_key"] == "compact-cache-affinity"
     assert "include" not in compact_payload
     assert "stream" not in compact_payload
-    assert events[0]["item"] == {
+    assert events[1]["item"] == {
         "id": "cmp_trigger_summary",
         "type": "compaction",
+        "status": "in_progress",
         "encrypted_content": "ENCRYPTED_CONTEXT_COMPACTION_SUMMARY",
     }
-    assert events[1]["response"]["output"] == [
-        {
-            "id": "cmp_trigger_summary",
-            "type": "compaction",
-            "encrypted_content": "ENCRYPTED_CONTEXT_COMPACTION_SUMMARY",
-        }
-    ]
-    assert events[1]["response"]["usage"] == {"input_tokens": 12, "output_tokens": 3, "total_tokens": 15}
+    terminal_item = {
+        "id": "cmp_trigger_summary",
+        "type": "compaction",
+        "status": "completed",
+        "encrypted_content": "ENCRYPTED_CONTEXT_COMPACTION_SUMMARY",
+    }
+    assert events[2]["item"] == terminal_item
+    assert events[3]["response"]["output"] == [terminal_item]
+    assert events[3]["response"]["usage"] == {"input_tokens": 12, "output_tokens": 3, "total_tokens": 15}
     assert lines[-1] == "data: [DONE]"
 
 
@@ -949,7 +957,13 @@ async def test_proxy_responses_compaction_trigger_preserves_conversation(async_c
         lines = [line async for line in resp.aiter_lines() if line]
 
     events = list(_iter_sse_events(lines))
-    assert [event["type"] for event in events] == ["response.output_item.done", "response.completed"]
+    assert [event["type"] for event in events] == [
+        "response.created",
+        "response.output_item.added",
+        "response.output_item.done",
+        "response.completed",
+    ]
+    assert [event["sequence_number"] for event in events] == [0, 1, 2, 3]
     assert seen_payload["conversation"] == "conv_compact_anchor"
     assert seen_payload["account_id"] == raw_account_id
     compact_payload = cast(Mapping[str, object], seen_payload["payload"])

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -367,6 +367,7 @@ def test_compact_response_output_item_preserves_summary_item_id() -> None:
             "object": "response.compaction",
             "compaction_summary": {
                 "id": "cmp_summary_context",
+                "status": "completed",
                 "encrypted_content": "SUMMARY_CONTEXT",
             },
         }
@@ -375,6 +376,7 @@ def test_compact_response_output_item_preserves_summary_item_id() -> None:
     assert proxy_api_module._compact_response_output_item(payload) == {
         "id": "cmp_summary_context",
         "type": "compaction",
+        "status": "completed",
         "encrypted_content": "SUMMARY_CONTEXT",
     }
 
@@ -402,11 +404,67 @@ async def test_synthetic_compaction_stream_preserves_mapping_usage() -> None:
         )
     ]
 
-    completed = proxy_api_module._parse_sse_payload(blocks[1])
+    completed = proxy_api_module._parse_sse_payload(blocks[3])
     assert completed is not None
     response = completed["response"]
     assert isinstance(response, dict)
     assert response["usage"] == {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+
+
+@pytest.mark.asyncio
+async def test_synthetic_compaction_stream_emits_complete_lifecycle() -> None:
+    blocks = [
+        block
+        async for block in proxy_api_module._synthetic_compaction_response_stream(
+            {
+                "id": "cmp_authoritative",
+                "type": "compaction",
+                "status": "completed",
+                "encrypted_content": "SUMMARY",
+            },
+            response_id="resp_compaction",
+            usage=None,
+        )
+    ]
+
+    payloads = [proxy_api_module._parse_sse_payload(block) for block in blocks[:-1]]
+    assert all(payload is not None for payload in payloads)
+    assert [payload["type"] for payload in payloads if payload is not None] == [
+        "response.created",
+        "response.output_item.added",
+        "response.output_item.done",
+        "response.completed",
+    ]
+    assert [payload["sequence_number"] for payload in payloads if payload is not None] == [0, 1, 2, 3]
+
+    created, added, done, completed = payloads
+    assert created is not None
+    assert added is not None
+    assert done is not None
+    assert completed is not None
+    assert created["response"] == {
+        "id": "resp_compaction",
+        "object": "response",
+        "status": "in_progress",
+        "output": [],
+    }
+    assert added["item"] == {
+        "id": "cmp_authoritative",
+        "type": "compaction",
+        "status": "in_progress",
+        "encrypted_content": "SUMMARY",
+    }
+    terminal_item = {
+        "id": "cmp_authoritative",
+        "type": "compaction",
+        "status": "completed",
+        "encrypted_content": "SUMMARY",
+    }
+    assert done["item"] == terminal_item
+    completed_response = completed["response"]
+    assert isinstance(completed_response, dict)
+    assert completed_response["output"] == [terminal_item]
+    assert blocks[-1] == "data: [DONE]\n\n"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Merge priority: high

This moves a proven live-runtime Codex compatibility patch into source control.
Without it, reinstalling or upgrading codex-lb silently restores an abbreviated
synthetic compaction stream on a thread-recovery path.

## Summary

Complete the synthetic SSE lifecycle emitted when a Codex
`compaction_trigger` is bridged into remote compaction. The stream now creates
the response and output item before completing them, while preserving the
authoritative encrypted compaction item identity.

## Type of change

- [x] `fix:` — bug fix / compatibility hardening
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor
- [ ] **Breaking change**

References #998. Related to #1316.

## Root cause

`_synthetic_compaction_response_stream` currently emits only:

1. `response.output_item.done`
2. `response.completed`

That is enough for the original narrow collector, but it is not a complete
Responses lifecycle. Stateful Codex clients, SDKs, or intermediaries can see a
completed output item that was never added to a response that was never
created.

The live codex-lb runtime already carries the missing lifecycle patch. This PR
removes that source/runtime drift.

## OpenSpec

- [x] This PR includes an archived OpenSpec change.
- [x] This PR touches a Codex-faithful request/response shape and preserves
      upstream-compatible behavior.

Change directory:
`openspec/changes/archive/2026-08-06-complete-codex-compaction-sse-lifecycle/`

## Changes

- Emit the canonical synthetic sequence:
  `response.created` → `response.output_item.added` →
  `response.output_item.done` → `response.completed` → `[DONE]`.
- Add monotonically increasing sequence numbers `0..3`.
- Expose the added compaction item as `in_progress`, then reuse one terminal
  item in the done event and completed response.
- Preserve non-empty upstream `id` and `status` with `encrypted_content`.
- Never invent a replacement compaction item ID, preserving the encrypted item
  binding fixed by #1316.
- Align the PostgreSQL commit-durability regression with the coalesced
  `last_used_at` write-behind path introduced by #1627; the removed repository
  method is no longer called by tests.
- Add unit and route-level regressions for event ordering, sequence numbers,
  item fidelity, usage, and terminal framing.

## Simplicity

- [x] Zero configuration; no new setting or setup step.
- [x] No README, `.env.example`, dashboard navigation, dependency, schema, or
      migration change.
- [x] Public `/v1/responses/compact` behavior is unchanged.

## Test plan

```text
uv run pytest \
  tests/unit/test_proxy_api_responses_contract.py \
  tests/integration/test_proxy_responses.py \
  tests/integration/test_proxy_compact.py -q
# 157 passed

PATH="$HOME/Library/Python/3.13/bin:$PWD/.venv/bin:$PATH" make lint
# proxy architecture checks passed
# ruff check passed
# 897 files already formatted

PATH="$HOME/Library/Python/3.13/bin:$PWD/.venv/bin:$PATH" make typecheck
# All checks passed

uv run ty check \
  app/modules/proxy/api.py \
  tests/unit/test_proxy_api_responses_contract.py \
  tests/integration/test_proxy_responses.py
# All checks passed

npx -y @fission-ai/openspec@1.8.0 validate --specs
# 49 passed, 0 failed

npx -y @fission-ai/openspec@1.8.0 \
  validate complete-codex-compaction-sse-lifecycle --strict
# Change is valid (before archival)

git diff --check
# Passed
```

The PostgreSQL durability test requires
`CODEX_LB_TEST_DATABASE_URL=postgresql+asyncpg://...`; without that local
service it skips locally. GitHub CI runs the full PostgreSQL job.

## Wire output

```text
response.created                 sequence_number=0
response.output_item.added       sequence_number=1 status=in_progress
response.output_item.done        sequence_number=2 status=completed
response.completed               sequence_number=3
[DONE]
```

## Checklist

- [x] Conventional Commit PR title.
- [x] One concern wide.
- [x] Product-path regression coverage added.
- [x] OpenSpec synced, strictly validated, and archived.
- [x] Simplicity gates reviewed.
- [x] `CHANGELOG.md` was not edited.
- [x] Branch is based on current `upstream/main` (`410bfaea`).
