### PR TITLE
docs(openspec): fix strict requirement line formatting

### DIFF
--- a/openspec/specs/api-keys/spec.md
+++ b/openspec/specs/api-keys/spec.md
@@ -1166,8 +1166,7 @@ When API-key authentication and proxy-header trust are disabled, a loopback sock
 
 ### Requirement: GPT-5.6 usage cost pricing matches the current published rates
 
-When computing API-key usage, request-log, reservation, or aggregate cost for
-the canonical GPT-5.6 models, the system MUST use these USD-per-1M-token rates
+When computing API-key usage, request-log, reservation, or aggregate cost for the canonical GPT-5.6 models, the system MUST use these USD-per-1M-token rates
 for input, cached input, and output:
 
 | Model | Standard | Fast/priority | Flex | Standard long context |

--- a/openspec/specs/conversations-api/spec.md
+++ b/openspec/specs/conversations-api/spec.md
@@ -71,8 +71,7 @@ The membership rule used by `/api/conversations` (any in-window request qualifie
 
 ### Requirement: Conversation membership candidate discovery is bounded
 
-When the conversations list has an effective `since` value, the repository
-MUST discover qualifying conversation IDs from eligible rows with
+When the conversations list has an effective `since` value, the repository MUST discover qualifying conversation IDs from eligible rows with
 `requested_at >= since` before aggregating the list page. The candidate query
 MUST select distinct IDs and MUST include the active search predicate when a
 search term is supplied. The summary and facet aggregates MUST constrain their
@@ -99,8 +98,7 @@ all eligible rows for that conversation, including rows older than `since`.
 
 ### Requirement: Conversation list and detail routes require an admin principal
 
-The `/api/conversations` collection aliases and
-`/api/conversations/{id}` detail route MUST require an `admin` dashboard
+The `/api/conversations` collection aliases and `/api/conversations/{id}` detail route MUST require an `admin` dashboard
 principal before reading conversation data. A non-admin principal MUST receive
 HTTP 403 with error code `admin_access_required`; the route MUST NOT return a
 conversation payload. Admin requests SHALL retain all existing membership,


### PR DESCRIPTION
## Summary

Fix three OpenSpec requirement headings so strict validation recognizes their existing normative `MUST` language. This is a strict-validator formatting fix only: it changes no wording, behavior, API, or schema.

## Type of change

- [x] `docs:` — documentation only

Linked issue: None; bounded related-work search found no existing issue or PR for this formatting fix.

## OpenSpec

- [x] Not applicable — docs / CI / chore only

Change directory: Not applicable. No contract or behavior changes; this only moves existing normative text onto each requirement's first physical line.

## Changes

- Move the existing API-key requirement's `MUST` sentence onto the requirement heading line.
- Move the existing `MUST` sentences for two conversations API requirements onto their requirement heading lines.

## Test plan

- `openspec validate --specs --strict` — 49 passed, 0 failed
- `git diff --check` — passed
- Final word diff — no wording changes

The broader beta.3 local readiness evidence was reused; only the focused checks affected by integrating this formatting-only patch onto current `main` were rerun.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] No related issue applies.
- [x] Tests are not applicable because code and behavior are unchanged.
- [x] Ran the relevant strict OpenSpec and diff checks locally.
- [x] Strict OpenSpec validation passes; no OpenSpec change folder is applicable for this formatting-only correction.
- [x] Simplicity gates reviewed; no settings, defaults, README sections, dashboard navigation, or setup steps change.
- [x] CHANGELOG is not edited.