### PR TITLE
feat(cli): add targeted Codex session metadata repair

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import sqlite3
 import sys
@@ -8,7 +9,13 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from app.codex_sessions_retag import RetagResult, default_codex_home, retag_codex_sessions
+from app.codex_sessions_retag import (
+    RetagResult,
+    default_codex_home,
+    preview_session_metadata_mismatches,
+    repair_session_metadata_mismatches,
+    retag_codex_sessions,
+)
 
 if TYPE_CHECKING:
     from app.core.runtime_logging import LogConfig
@@ -54,6 +61,29 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Confirm that Codex/Codex CLI is closed and allow a non-interactive write.",
     )
+    mismatches = codex_sessions_subparsers.add_parser(
+        "metadata-mismatches",
+        help="Preview individual openai/codex-lb session metadata disagreements without writing files.",
+        formatter_class=_CliHelpFormatter,
+    )
+    _add_targeted_metadata_arguments(mismatches, include_session_ids=False)
+    mismatches.add_argument("--json", action="store_true", help="Write the preview as JSON for ProviderSwitcher.")
+    repair_metadata = codex_sessions_subparsers.add_parser(
+        "repair-metadata",
+        help="Repair only explicitly supplied metadata mismatch session IDs.",
+        formatter_class=_CliHelpFormatter,
+    )
+    _add_targeted_metadata_arguments(repair_metadata, include_session_ids=True)
+    repair_metadata.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm Codex/Codex CLI is closed before writing metadata.",
+    )
+    repair_metadata.add_argument(
+        "--json",
+        action="store_true",
+        help="Write the repair result as JSON for ProviderSwitcher.",
+    )
 
     parser.add_argument("--host", default=os.getenv("HOST", "127.0.0.1"))
     parser.add_argument("--port", default=os.getenv("PORT", "2455"))
@@ -89,6 +119,12 @@ def main(argv: Sequence[str] | None = None) -> None:
     if args.command == "codex-sessions":
         if args.codex_sessions_command == "retag":
             _run_codex_sessions_retag(args)
+            return
+        if args.codex_sessions_command == "metadata-mismatches":
+            _run_session_metadata_mismatch_preview(args)
+            return
+        if args.codex_sessions_command == "repair-metadata":
+            _run_session_metadata_repair(args)
             return
         raise SystemExit("codex-sessions requires a subcommand")
 
@@ -220,6 +256,92 @@ def _run_codex_sessions_retag(args: argparse.Namespace) -> None:
         raise SystemExit(f"Unable to read or write Codex session files: {exc}") from exc
 
     _print_retag_summary(result)
+
+
+def _add_targeted_metadata_arguments(parser: argparse.ArgumentParser, *, include_session_ids: bool) -> None:
+    parser.add_argument("--provider", required=True, metavar="PROVIDER", help="Currently active provider tag.")
+    parser.add_argument(
+        "--codex-home",
+        type=Path,
+        metavar="PATH",
+        default=None,
+        help="Codex data directory. Defaults to CODEX_HOME, /codex-home in Docker, or ~/.codex.",
+    )
+    if include_session_ids:
+        parser.add_argument(
+            "--session-id",
+            dest="session_ids",
+            metavar="ID",
+            action="append",
+            required=True,
+            help="Session ID returned from metadata-mismatches. Repeat for each session.",
+        )
+
+
+def _run_session_metadata_mismatch_preview(args: argparse.Namespace) -> None:
+    try:
+        preview = preview_session_metadata_mismatches(
+            codex_home=args.codex_home or default_codex_home(),
+            active_provider=args.provider,
+        )
+    except (OSError, ValueError, sqlite3.Error) as exc:
+        raise SystemExit(str(exc)) from exc
+    payload = {
+        "codex_home": str(preview.codex_home),
+        "active_provider": preview.active_provider,
+        "jsonl_files_scanned": preview.jsonl_files_scanned,
+        "sqlite_dbs_scanned": preview.sqlite_dbs_scanned,
+        "mismatches": [
+            {
+                "session_id": item.session_id,
+                "active_provider": item.active_provider,
+                "opposite_provider": item.opposite_provider,
+                "jsonl_paths": [str(path) for path in item.jsonl_paths],
+                "sqlite_db_paths": [str(path) for path in item.sqlite_db_paths],
+            }
+            for item in preview.mismatches
+        ],
+    }
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+        return
+    print(f"Found {len(preview.mismatches)} targeted session metadata mismatch(es).")
+    for item in preview.mismatches:
+        components = []
+        if item.jsonl_paths:
+            components.append(f"JSONL {len(item.jsonl_paths)}")
+        if item.sqlite_db_paths:
+            components.append(f"SQLite {len(item.sqlite_db_paths)}")
+        print(f"- {item.session_id}: {item.opposite_provider} -> {item.active_provider} ({', '.join(components)})")
+
+
+def _run_session_metadata_repair(args: argparse.Namespace) -> None:
+    _confirm_retag_write(args.yes)
+    try:
+        result = repair_session_metadata_mismatches(
+            codex_home=args.codex_home or default_codex_home(),
+            active_provider=args.provider,
+            session_ids=args.session_ids,
+        )
+    except (OSError, RuntimeError, ValueError, sqlite3.Error) as exc:
+        raise SystemExit(str(exc)) from exc
+    payload = {
+        "codex_home": str(result.codex_home),
+        "active_provider": result.active_provider,
+        "session_ids": list(result.session_ids),
+        "backup_path": str(result.backup_path) if result.backup_path is not None else None,
+        "jsonl_files_updated": result.jsonl_files_updated,
+        "sqlite_rows_updated": result.sqlite_rows_updated,
+    }
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+        return
+    print("Targeted session metadata repair completed.")
+    print(f"- Session IDs: {', '.join(result.session_ids)}")
+    print(f"- Updated JSONL files: {result.jsonl_files_updated}")
+    print(f"- Updated SQLite rows: {result.sqlite_rows_updated}")
+    if result.backup_path is not None:
+        print(f"- Backup: {result.backup_path}")
 
 
 def _confirm_retag_write(yes: bool) -> None:

--- a/app/cli.py
+++ b/app/cli.py
@@ -250,7 +250,7 @@ def _run_codex_sessions_retag(args: argparse.Namespace) -> None:
                 "Close Codex/Codex CLI and retry. The state_*.sqlite database can be locked while Codex is running."
             )
         raise SystemExit(message) from exc
-    except ValueError as exc:
+    except (RuntimeError, ValueError) as exc:
         raise SystemExit(str(exc)) from exc
     except OSError as exc:
         raise SystemExit(f"Unable to read or write Codex session files: {exc}") from exc

--- a/app/cli.py
+++ b/app/cli.py
@@ -67,7 +67,7 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         formatter_class=_CliHelpFormatter,
     )
     _add_targeted_metadata_arguments(mismatches, include_session_ids=False)
-    mismatches.add_argument("--json", action="store_true", help="Write the preview as JSON for ProviderSwitcher.")
+    mismatches.add_argument("--json", action="store_true", help="Write the preview as JSON for automation.")
     repair_metadata = codex_sessions_subparsers.add_parser(
         "repair-metadata",
         help="Repair only explicitly supplied metadata mismatch session IDs.",
@@ -82,7 +82,7 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     repair_metadata.add_argument(
         "--json",
         action="store_true",
-        help="Write the repair result as JSON for ProviderSwitcher.",
+        help="Write the repair result as JSON for automation.",
     )
 
     parser.add_argument("--host", default=os.getenv("HOST", "127.0.0.1"))

--- a/app/cli.py
+++ b/app/cli.py
@@ -317,11 +317,13 @@ def _run_session_metadata_mismatch_preview(args: argparse.Namespace) -> None:
 
 def _run_session_metadata_repair(args: argparse.Namespace) -> None:
     _confirm_retag_write(args.yes)
+    progress_stream = sys.stderr if args.json else sys.stdout
     try:
         result = repair_session_metadata_mismatches(
             codex_home=args.codex_home or default_codex_home(),
             active_provider=args.provider,
             session_ids=args.session_ids,
+            progress_logger=lambda message: print(message, file=progress_stream, flush=True),
         )
     except (OSError, RuntimeError, ValueError, sqlite3.Error) as exc:
         raise SystemExit(str(exc)) from exc

--- a/app/codex_sessions_retag.py
+++ b/app/codex_sessions_retag.py
@@ -148,16 +148,7 @@ def retag_codex_sessions(
             progress_logger(message)
 
     def emit_progress(phase: str, completed: int, total: int, unit: str, message: str) -> None:
-        if progress_logger is None:
-            return
-        payload = {
-            "phase": phase,
-            "completed": max(0, completed),
-            "total": max(0, total),
-            "unit": unit,
-            "message": message,
-        }
-        progress_logger(PROGRESS_PREFIX + json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+        _emit_structured_progress(progress_logger, phase, completed, total, unit, message)
 
     source_provider = _normalize_provider(source_provider)
     target_provider = _normalize_provider(target_provider)
@@ -371,8 +362,13 @@ def repair_session_metadata_mismatches(
     active_provider: str,
     session_ids: Sequence[str],
     dry_run: bool = False,
+    progress_logger: ProgressLogger | None = None,
 ) -> SessionMetadataRepairResult:
     """Repair only explicitly supplied, currently eligible mismatch session IDs."""
+
+    def emit_progress(phase: str, completed: int, total: int, unit: str, message: str) -> None:
+        _emit_structured_progress(progress_logger, phase, completed, total, unit, message)
+
     normalized_ids = tuple(dict.fromkeys(session_id.strip() for session_id in session_ids if session_id.strip()))
     if not normalized_ids:
         raise ValueError("at least one session ID is required for targeted metadata repair")
@@ -423,31 +419,75 @@ def repair_session_metadata_mismatches(
         preview.codex_home,
         tuple(target.path for target in jsonl_targets),
         tuple(dict.fromkeys(target.db_path for target in sqlite_targets)),
+        progress_callback=lambda completed, total, message: emit_progress(
+            "backup",
+            completed,
+            total,
+            "bytes",
+            message,
+        ),
     )
     try:
+        jsonl_total_bytes = sum(target.size_bytes for target in jsonl_targets)
+        jsonl_completed_bytes = 0
+        if jsonl_targets:
+            emit_progress("jsonl_rewrite", 0, jsonl_total_bytes, "bytes", "Starting targeted JSONL rewrite")
         for target in jsonl_targets:
             assert target.metadata_line_index is not None
+            base_completed = jsonl_completed_bytes
             _retag_jsonl_file(
                 target.path,
                 opposite_provider,
                 preview.active_provider,
                 target.metadata_line_index,
+                progress_callback=lambda completed, _total, message, base=base_completed: emit_progress(
+                    "jsonl_rewrite",
+                    min(base + completed, jsonl_total_bytes),
+                    jsonl_total_bytes,
+                    "bytes",
+                    message,
+                ),
             )
-        sqlite_rows_updated = sum(
-            _update_sqlite_thread_provider(
+            jsonl_completed_bytes += target.size_bytes
+            emit_progress(
+                "jsonl_rewrite",
+                jsonl_completed_bytes,
+                jsonl_total_bytes,
+                "bytes",
+                f"Rewrote {target.path.name}",
+            )
+        sqlite_rows_updated = 0
+        if sqlite_targets:
+            emit_progress("sqlite_update", 0, len(sqlite_targets), "rows", "Starting targeted SQLite update")
+        for target in sqlite_targets:
+            sqlite_rows_updated += _update_sqlite_thread_provider(
                 target.db_path,
                 target.session_id,
                 opposite_provider,
                 preview.active_provider,
             )
-            for target in sqlite_targets
-        )
+            emit_progress(
+                "sqlite_update",
+                sqlite_rows_updated,
+                len(sqlite_targets),
+                "rows",
+                f"Updated {target.db_path.name}",
+            )
+        verification_items = len(jsonl_targets) + len(sqlite_targets)
+        emit_progress("verification", 0, verification_items, "items", "Verifying targeted metadata repair")
         _verify_targeted_metadata_repair(
             preview.codex_home,
             preview.active_provider,
             normalized_ids,
             jsonl_targets,
             sqlite_targets,
+        )
+        emit_progress(
+            "verification",
+            verification_items,
+            verification_items,
+            "items",
+            "Verified targeted metadata repair",
         )
     except Exception:
         _restore_backup(preview.codex_home, backup_path)
@@ -1107,6 +1147,26 @@ def _report_progress(
 ) -> None:
     if progress_callback is not None:
         progress_callback(completed, total, message)
+
+
+def _emit_structured_progress(
+    progress_logger: ProgressLogger | None,
+    phase: str,
+    completed: int,
+    total: int,
+    unit: str,
+    message: str,
+) -> None:
+    if progress_logger is None:
+        return
+    payload = {
+        "phase": phase,
+        "completed": max(0, completed),
+        "total": max(0, total),
+        "unit": unit,
+        "message": message,
+    }
+    progress_logger(PROGRESS_PREFIX + json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
 
 
 def _methods_used(jsonl_files: Sequence[Path], state_dbs: Sequence[Path]) -> tuple[str, ...]:

--- a/app/codex_sessions_retag.py
+++ b/app/codex_sessions_retag.py
@@ -316,6 +316,7 @@ def preview_session_metadata_mismatches(
     it does not inspect transcript records or make any filesystem changes.
     """
     active_provider = _normalize_provider(active_provider)
+    _validate_active_provider(active_provider)
     codex_home = codex_home.expanduser().resolve()
     jsonl_sessions = tuple(_discover_jsonl_session(path) for path in _find_jsonl_session_files(codex_home / "sessions"))
     sqlite_dbs = _find_state_dbs(codex_home)
@@ -515,6 +516,12 @@ def _validate_providers(source_provider: str, target_provider: str) -> None:
     if unknown:
         supported = ", ".join(sorted(_SUPPORTED_PROVIDERS))
         raise ValueError(f"unsupported provider {', '.join(sorted(unknown))}; expected one of: {supported}")
+
+
+def _validate_active_provider(active_provider: str) -> None:
+    if active_provider not in _SUPPORTED_PROVIDERS:
+        supported = ", ".join(sorted(_SUPPORTED_PROVIDERS))
+        raise ValueError(f"unsupported active provider {active_provider}; expected one of: {supported}")
 
 
 def _running_in_container() -> bool:

--- a/app/codex_sessions_retag.py
+++ b/app/codex_sessions_retag.py
@@ -5,7 +5,8 @@ import os
 import re
 import shutil
 import sqlite3
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Sequence
+from contextlib import closing
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -15,16 +16,54 @@ from urllib.parse import quote
 
 JsonObject = dict[str, object]
 ProgressLogger = Callable[[str], None]
+ByteProgress = Callable[[int, int, str], None]
 
 PROVIDER_RETAG_BACKUP_DIR = "provider-retag"
+PROGRESS_PREFIX = "CODEX_LB_RETAG_PROGRESS "
 _SUPPORTED_PROVIDERS = {"openai", "codex-lb"}
 _STATE_DB_PATTERN = "state_*.sqlite"
+_STATE_DB_NAME_PATTERN = re.compile(r"state_(\d+)\.sqlite")
+_COPY_CHUNK_SIZE = 4 * 1024 * 1024
+_MAX_SESSION_METADATA_BYTES = 1024 * 1024
+_UTF8_BOM = b"\xef\xbb\xbf"
 
 
 @dataclass(frozen=True)
 class ProviderCount:
     provider: str
     count: int
+
+
+@dataclass(frozen=True)
+class _JsonlSessionPlan:
+    path: Path
+    session_id: str | None
+    provider: str | None
+    metadata_line_index: int | None
+    size_bytes: int
+
+
+@dataclass(frozen=True)
+class _SqliteDbPlan:
+    path: Path
+    provider_counts: tuple[ProviderCount, ...]
+
+
+@dataclass(frozen=True)
+class _SqliteThreadPlan:
+    db_path: Path
+    session_id: str
+    provider: str
+
+
+@dataclass(frozen=True)
+class _RetagPlan:
+    jsonl_sessions: tuple[_JsonlSessionPlan, ...]
+    jsonl_targets: tuple[_JsonlSessionPlan, ...]
+    sqlite_dbs: tuple[_SqliteDbPlan, ...]
+    sqlite_targets: tuple[_SqliteDbPlan, ...]
+    provider_counts_before: tuple[ProviderCount, ...]
+    sqlite_rows_matched: int
 
 
 @dataclass(frozen=True)
@@ -45,6 +84,37 @@ class RetagResult:
     provider_counts_before: tuple[ProviderCount, ...]
     provider_counts_after: tuple[ProviderCount, ...]
     logs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SessionMetadataMismatch:
+    """A partial provider-tag disagreement for one logical Codex session."""
+
+    session_id: str
+    active_provider: str
+    opposite_provider: str
+    jsonl_paths: tuple[Path, ...]
+    sqlite_db_paths: tuple[Path, ...]
+
+
+@dataclass(frozen=True)
+class SessionMetadataRepairPreview:
+    codex_home: Path
+    active_provider: str
+    mismatches: tuple[SessionMetadataMismatch, ...]
+    jsonl_files_scanned: int
+    sqlite_dbs_scanned: int
+
+
+@dataclass(frozen=True)
+class SessionMetadataRepairResult:
+    codex_home: Path
+    active_provider: str
+    session_ids: tuple[str, ...]
+    dry_run: bool
+    backup_path: Path | None
+    jsonl_files_updated: int
+    sqlite_rows_updated: int
 
 
 def default_codex_home() -> Path:
@@ -76,6 +146,18 @@ def retag_codex_sessions(
         if progress_logger is not None:
             progress_logger(message)
 
+    def emit_progress(phase: str, completed: int, total: int, unit: str, message: str) -> None:
+        if progress_logger is None:
+            return
+        payload = {
+            "phase": phase,
+            "completed": max(0, completed),
+            "total": max(0, total),
+            "unit": unit,
+            "message": message,
+        }
+        progress_logger(PROGRESS_PREFIX + json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+
     source_provider = _normalize_provider(source_provider)
     target_provider = _normalize_provider(target_provider)
     _validate_providers(source_provider, target_provider)
@@ -85,18 +167,24 @@ def retag_codex_sessions(
     log(f"Using Codex home {codex_home}")
     log(f"Retagging Codex sessions from {source_provider} to {target_provider}")
 
-    # Build the full write set before taking a backup so dry-runs and real
-    # retags report the same targets.
-    jsonl_files = tuple(_find_jsonl_session_files(sessions_dir))
-    state_dbs = tuple(_find_state_dbs(codex_home))
-    provider_counts_before = _provider_counts(codex_home)
-    jsonl_files_to_update = tuple(path for path in jsonl_files if _jsonl_contains_provider(path, source_provider))
-    sqlite_dbs_to_update = tuple(db for db in state_dbs if _sqlite_count_provider_rows(db, source_provider) > 0)
-    sqlite_rows_matched = sum(_sqlite_count_provider_rows(db, source_provider) for db in sqlite_dbs_to_update)
+    plan = _build_retag_plan(
+        codex_home,
+        source_provider,
+        lambda completed, total, message: emit_progress("discovery", completed, total, "items", message),
+    )
 
-    methods_used = _methods_used(jsonl_files_to_update, sqlite_dbs_to_update)
-    log(f"JSONL sessions method scanned {len(jsonl_files)} files under {sessions_dir}")
-    log(f"SQLite state DB method scanned {len(state_dbs)} state database file(s)")
+    methods_used = _methods_used(
+        tuple(target.path for target in plan.jsonl_targets),
+        tuple(target.path for target in plan.sqlite_targets),
+    )
+    log(f"JSONL sessions method scanned {len(plan.jsonl_sessions)} files under {sessions_dir}")
+    unknown_jsonl_sessions = sum(session.provider is None for session in plan.jsonl_sessions)
+    if unknown_jsonl_sessions:
+        log(
+            f"JSONL session metadata was unavailable in {unknown_jsonl_sessions} file(s); "
+            "transcript content was not scanned"
+        )
+    log(f"SQLite state DB method scanned {len(plan.sqlite_dbs)} state database file(s)")
 
     backup_path: Path | None = None
     jsonl_files_updated = 0
@@ -104,24 +192,92 @@ def retag_codex_sessions(
 
     if dry_run:
         log("Dry run enabled; no files will be changed")
-    elif jsonl_files_to_update or sqlite_dbs_to_update:
-        backup_path = _create_backup(codex_home, jsonl_files_to_update, sqlite_dbs_to_update)
+    elif plan.jsonl_targets or plan.sqlite_targets:
+        backup_path = _create_backup(
+            codex_home,
+            tuple(target.path for target in plan.jsonl_targets),
+            tuple(target.path for target in plan.sqlite_targets),
+            progress_callback=lambda completed, total, message: emit_progress(
+                "backup",
+                completed,
+                total,
+                "bytes",
+                message,
+            ),
+        )
         log(f"Created backup at {backup_path}")
 
-        for path in jsonl_files_to_update:
-            if _retag_jsonl_file(path, source_provider, target_provider):
+        jsonl_total_bytes = sum(target.size_bytes for target in plan.jsonl_targets)
+        jsonl_completed_bytes = 0
+        if plan.jsonl_targets:
+            emit_progress("jsonl_rewrite", 0, jsonl_total_bytes, "bytes", "Starting JSONL rewrite")
+        for target in plan.jsonl_targets:
+            assert target.metadata_line_index is not None
+            base_completed = jsonl_completed_bytes
+            if _retag_jsonl_file(
+                target.path,
+                source_provider,
+                target_provider,
+                target.metadata_line_index,
+                progress_callback=lambda completed, _total, message, base=base_completed: emit_progress(
+                    "jsonl_rewrite",
+                    min(base + completed, jsonl_total_bytes),
+                    jsonl_total_bytes,
+                    "bytes",
+                    message,
+                ),
+            ):
                 jsonl_files_updated += 1
-        if jsonl_files_to_update:
+            jsonl_completed_bytes += target.size_bytes
+            emit_progress(
+                "jsonl_rewrite",
+                jsonl_completed_bytes,
+                jsonl_total_bytes,
+                "bytes",
+                f"Rewrote {target.path.name}",
+            )
+        if plan.jsonl_targets:
             log(f"Updated {jsonl_files_updated} JSONL session file(s)")
 
-        for db_path in sqlite_dbs_to_update:
-            sqlite_rows_updated += _update_sqlite_provider(db_path, source_provider, target_provider)
-        if sqlite_dbs_to_update:
+        if plan.sqlite_targets:
+            emit_progress("sqlite_update", 0, plan.sqlite_rows_matched, "rows", "Starting SQLite update")
+        for target in plan.sqlite_targets:
+            sqlite_rows_updated += _update_sqlite_provider(target.path, source_provider, target_provider)
+            emit_progress(
+                "sqlite_update",
+                sqlite_rows_updated,
+                plan.sqlite_rows_matched,
+                "rows",
+                f"Updated {target.path.name}",
+            )
+        if plan.sqlite_targets:
             log(f"Updated {sqlite_rows_updated} SQLite thread row(s)")
+
+        _verify_retag_plan(
+            plan,
+            source_provider,
+            target_provider,
+            lambda completed, total, message: emit_progress(
+                "verification",
+                completed,
+                total,
+                "items",
+                message,
+            ),
+        )
     else:
         log(f"No {source_provider} Codex session tags were found")
 
-    provider_counts_after = provider_counts_before if dry_run else _provider_counts(codex_home)
+    provider_counts_after = (
+        plan.provider_counts_before
+        if dry_run
+        else _derive_provider_counts_after(
+            plan.provider_counts_before,
+            source_provider,
+            target_provider,
+            len(plan.jsonl_targets) + plan.sqlite_rows_matched,
+        )
+    )
 
     return RetagResult(
         codex_home=codex_home,
@@ -130,16 +286,167 @@ def retag_codex_sessions(
         dry_run=dry_run,
         methods_used=methods_used,
         backup_path=backup_path,
-        jsonl_files_scanned=len(jsonl_files),
-        jsonl_files_matched=len(jsonl_files_to_update),
+        jsonl_files_scanned=len(plan.jsonl_sessions),
+        jsonl_files_matched=len(plan.jsonl_targets),
         jsonl_files_updated=jsonl_files_updated,
-        sqlite_dbs_scanned=len(state_dbs),
-        sqlite_dbs_matched=len(sqlite_dbs_to_update),
-        sqlite_rows_matched=sqlite_rows_matched,
+        sqlite_dbs_scanned=len(plan.sqlite_dbs),
+        sqlite_dbs_matched=len(plan.sqlite_targets),
+        sqlite_rows_matched=plan.sqlite_rows_matched,
         sqlite_rows_updated=sqlite_rows_updated,
-        provider_counts_before=provider_counts_before,
+        provider_counts_before=plan.provider_counts_before,
         provider_counts_after=provider_counts_after,
         logs=tuple(logs),
+    )
+
+
+def preview_session_metadata_mismatches(
+    *,
+    codex_home: Path,
+    active_provider: str,
+) -> SessionMetadataRepairPreview:
+    """Return only sessions with conflicting supported provider tags.
+
+    This deliberately reads bounded JSONL metadata and SQLite thread rows only;
+    it does not inspect transcript records or make any filesystem changes.
+    """
+    active_provider = _normalize_provider(active_provider)
+    codex_home = codex_home.expanduser().resolve()
+    jsonl_sessions = tuple(_discover_jsonl_session(path) for path in _find_jsonl_session_files(codex_home / "sessions"))
+    sqlite_dbs = _find_state_dbs(codex_home)
+    sqlite_threads = tuple(thread for db_path in sqlite_dbs for thread in _sqlite_thread_plans(db_path))
+    opposite_provider = _opposite_provider(active_provider)
+
+    jsonl_by_session: dict[str, list[_JsonlSessionPlan]] = {}
+    for session in jsonl_sessions:
+        if session.session_id is not None and session.provider in _SUPPORTED_PROVIDERS:
+            jsonl_by_session.setdefault(session.session_id, []).append(session)
+    sqlite_by_session: dict[str, list[_SqliteThreadPlan]] = {}
+    for thread in sqlite_threads:
+        if thread.provider in _SUPPORTED_PROVIDERS:
+            sqlite_by_session.setdefault(thread.session_id, []).append(thread)
+
+    mismatches: list[SessionMetadataMismatch] = []
+    for session_id in sorted(set(jsonl_by_session) | set(sqlite_by_session)):
+        jsonl_entries = tuple(jsonl_by_session.get(session_id, ()))
+        sqlite_entries = tuple(sqlite_by_session.get(session_id, ()))
+        providers = {entry.provider for entry in jsonl_entries} | {entry.provider for entry in sqlite_entries}
+        if providers != {active_provider, opposite_provider}:
+            continue
+        mismatches.append(
+            SessionMetadataMismatch(
+                session_id=session_id,
+                active_provider=active_provider,
+                opposite_provider=opposite_provider,
+                jsonl_paths=tuple(entry.path for entry in jsonl_entries if entry.provider == opposite_provider),
+                sqlite_db_paths=tuple(entry.db_path for entry in sqlite_entries if entry.provider == opposite_provider),
+            )
+        )
+
+    return SessionMetadataRepairPreview(
+        codex_home=codex_home,
+        active_provider=active_provider,
+        mismatches=tuple(mismatches),
+        jsonl_files_scanned=len(jsonl_sessions),
+        sqlite_dbs_scanned=len(sqlite_dbs),
+    )
+
+
+def repair_session_metadata_mismatches(
+    *,
+    codex_home: Path,
+    active_provider: str,
+    session_ids: Sequence[str],
+    dry_run: bool = False,
+) -> SessionMetadataRepairResult:
+    """Repair only explicitly supplied, currently eligible mismatch session IDs."""
+    normalized_ids = tuple(dict.fromkeys(session_id.strip() for session_id in session_ids if session_id.strip()))
+    if not normalized_ids:
+        raise ValueError("at least one session ID is required for targeted metadata repair")
+    preview = preview_session_metadata_mismatches(codex_home=codex_home, active_provider=active_provider)
+    candidates = {mismatch.session_id: mismatch for mismatch in preview.mismatches}
+    unknown_ids = tuple(session_id for session_id in normalized_ids if session_id not in candidates)
+    if unknown_ids:
+        raise ValueError("session metadata mismatch preview changed or is ineligible: " + ", ".join(unknown_ids))
+
+    opposite_provider = _opposite_provider(preview.active_provider)
+    jsonl_sessions = tuple(
+        _discover_jsonl_session(path) for path in _find_jsonl_session_files(preview.codex_home / "sessions")
+    )
+    sqlite_threads = tuple(
+        thread for db_path in _find_state_dbs(preview.codex_home) for thread in _sqlite_thread_plans(db_path)
+    )
+    jsonl_targets = tuple(
+        session
+        for session in jsonl_sessions
+        if session.session_id in normalized_ids
+        and session.provider == opposite_provider
+        and session.metadata_line_index is not None
+    )
+    sqlite_targets = tuple(
+        thread
+        for thread in sqlite_threads
+        if thread.session_id in normalized_ids and thread.provider == opposite_provider
+    )
+    expected_components = sum(
+        len(candidates[session_id].jsonl_paths) + len(candidates[session_id].sqlite_db_paths)
+        for session_id in normalized_ids
+    )
+    if len(jsonl_targets) + len(sqlite_targets) != expected_components:
+        raise RuntimeError("session metadata changed after preview; no files were modified")
+
+    if dry_run:
+        return SessionMetadataRepairResult(
+            codex_home=preview.codex_home,
+            active_provider=preview.active_provider,
+            session_ids=normalized_ids,
+            dry_run=True,
+            backup_path=None,
+            jsonl_files_updated=0,
+            sqlite_rows_updated=0,
+        )
+
+    backup_path = _create_backup(
+        preview.codex_home,
+        tuple(target.path for target in jsonl_targets),
+        tuple(dict.fromkeys(target.db_path for target in sqlite_targets)),
+    )
+    try:
+        for target in jsonl_targets:
+            assert target.metadata_line_index is not None
+            _retag_jsonl_file(
+                target.path,
+                opposite_provider,
+                preview.active_provider,
+                target.metadata_line_index,
+            )
+        sqlite_rows_updated = sum(
+            _update_sqlite_thread_provider(
+                target.db_path,
+                target.session_id,
+                opposite_provider,
+                preview.active_provider,
+            )
+            for target in sqlite_targets
+        )
+        _verify_targeted_metadata_repair(
+            preview.codex_home,
+            preview.active_provider,
+            normalized_ids,
+            jsonl_targets,
+            sqlite_targets,
+        )
+    except Exception:
+        _restore_backup(preview.codex_home, backup_path)
+        raise
+
+    return SessionMetadataRepairResult(
+        codex_home=preview.codex_home,
+        active_provider=preview.active_provider,
+        session_ids=normalized_ids,
+        dry_run=False,
+        backup_path=backup_path,
+        jsonl_files_updated=len(jsonl_targets),
+        sqlite_rows_updated=sqlite_rows_updated,
     )
 
 
@@ -209,68 +516,178 @@ def _find_jsonl_session_files(sessions_dir: Path) -> tuple[Path, ...]:
 
 
 def _find_state_dbs(codex_home: Path) -> tuple[Path, ...]:
-    state_dbs = (path for path in codex_home.glob(_STATE_DB_PATTERN) if path.is_file())
+    state_dbs = (
+        path
+        for path in codex_home.glob(_STATE_DB_PATTERN)
+        if path.is_file() and _STATE_DB_NAME_PATTERN.fullmatch(path.name)
+    )
     return tuple(sorted(state_dbs, key=_state_db_sort_key))
 
 
 def _state_db_sort_key(path: Path) -> tuple[int, str]:
-    match = re.fullmatch(r"state_(\d+)\.sqlite", path.name)
+    match = _STATE_DB_NAME_PATTERN.fullmatch(path.name)
     version = int(match.group(1)) if match else -1
     return version, path.name
 
 
-def _jsonl_contains_provider(path: Path, provider: str) -> bool:
-    return any(_jsonl_record_provider(record) == provider for record in _read_jsonl_records(path))
+def _build_retag_plan(
+    codex_home: Path,
+    source_provider: str,
+    progress_callback: ByteProgress | None = None,
+) -> _RetagPlan:
+    jsonl_files = _find_jsonl_session_files(codex_home / "sessions")
+    state_dbs = _find_state_dbs(codex_home)
+    total_items = len(jsonl_files) + len(state_dbs)
+    completed_items = 0
+    _report_progress(progress_callback, completed_items, total_items, "Discovering session metadata")
+
+    aggregate_counts: dict[str, int] = {}
+    jsonl_sessions: list[_JsonlSessionPlan] = []
+    for path in jsonl_files:
+        session = _discover_jsonl_session(path)
+        jsonl_sessions.append(session)
+        if session.provider is not None:
+            aggregate_counts[session.provider] = aggregate_counts.get(session.provider, 0) + 1
+        completed_items += 1
+        _report_progress(progress_callback, completed_items, total_items, f"Discovered {path.name}")
+
+    sqlite_dbs: list[_SqliteDbPlan] = []
+    for path in state_dbs:
+        provider_counts = _sqlite_provider_counts(path)
+        sqlite_dbs.append(_SqliteDbPlan(path=path, provider_counts=provider_counts))
+        for provider_count in provider_counts:
+            aggregate_counts[provider_count.provider] = (
+                aggregate_counts.get(provider_count.provider, 0) + provider_count.count
+            )
+        completed_items += 1
+        _report_progress(progress_callback, completed_items, total_items, f"Inspected {path.name}")
+
+    jsonl_sessions_tuple = tuple(jsonl_sessions)
+    sqlite_dbs_tuple = tuple(sqlite_dbs)
+    jsonl_targets = tuple(session for session in jsonl_sessions_tuple if session.provider == source_provider)
+    sqlite_targets = tuple(db for db in sqlite_dbs_tuple if _provider_count(db.provider_counts, source_provider) > 0)
+    sqlite_rows_matched = sum(_provider_count(db.provider_counts, source_provider) for db in sqlite_targets)
+    return _RetagPlan(
+        jsonl_sessions=jsonl_sessions_tuple,
+        jsonl_targets=jsonl_targets,
+        sqlite_dbs=sqlite_dbs_tuple,
+        sqlite_targets=sqlite_targets,
+        provider_counts_before=_provider_counts_tuple(aggregate_counts),
+        sqlite_rows_matched=sqlite_rows_matched,
+    )
 
 
-def _retag_jsonl_file(path: Path, source_provider: str, target_provider: str) -> bool:
-    changed = False
+def _discover_jsonl_session(path: Path) -> _JsonlSessionPlan:
+    size_bytes = path.stat().st_size
+    with path.open("rb") as handle:
+        raw_line = handle.readline(_MAX_SESSION_METADATA_BYTES + 1)
+    if not raw_line or len(raw_line) > _MAX_SESSION_METADATA_BYTES:
+        return _JsonlSessionPlan(
+            path=path,
+            session_id=None,
+            provider=None,
+            metadata_line_index=None,
+            size_bytes=size_bytes,
+        )
+    try:
+        record = json.loads(raw_line.decode("utf-8-sig"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return _JsonlSessionPlan(
+            path=path,
+            session_id=None,
+            provider=None,
+            metadata_line_index=None,
+            size_bytes=size_bytes,
+        )
+    if isinstance(record, dict):
+        provider = _jsonl_record_provider(record)
+        if provider is not None:
+            return _JsonlSessionPlan(
+                path=path,
+                session_id=_jsonl_record_session_id(record),
+                provider=provider,
+                metadata_line_index=0,
+                size_bytes=size_bytes,
+            )
+    return _JsonlSessionPlan(path=path, session_id=None, provider=None, metadata_line_index=None, size_bytes=size_bytes)
+
+
+def _retag_jsonl_file(
+    path: Path,
+    source_provider: str,
+    target_provider: str,
+    metadata_line_index: int,
+    *,
+    progress_callback: ByteProgress | None = None,
+) -> bool:
+    total_bytes = path.stat().st_size
+    completed_bytes = 0
     temp_path: Path | None = None
     try:
         with (
-            path.open("r", encoding="utf-8") as input_handle,
-            NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as output_handle,
+            path.open("rb") as input_handle,
+            NamedTemporaryFile("wb", dir=path.parent, delete=False) as output_handle,
         ):
             temp_path = Path(output_handle.name)
-            for raw_line in input_handle:
-                line = raw_line.rstrip("\n")
-                if not line:
-                    output_handle.write(raw_line)
-                    continue
-                try:
-                    record = json.loads(line)
-                except json.JSONDecodeError:
-                    output_handle.write(raw_line)
-                    continue
-                if isinstance(record, dict) and _retag_jsonl_record_provider(record, source_provider, target_provider):
-                    # Preserve invalid or unrelated JSONL lines verbatim; only
-                    # matched session records are normalized through json.dumps.
-                    changed = True
-                    output_handle.write(json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n")
+            for line_index in range(metadata_line_index + 1):
+                raw_line = input_handle.readline()
+                if not raw_line:
+                    raise RuntimeError(f"session metadata disappeared from {path}")
+                completed_bytes += len(raw_line)
+                if line_index == metadata_line_index:
+                    output_handle.write(_retag_jsonl_metadata_line(raw_line, source_provider, target_provider, path))
                 else:
                     output_handle.write(raw_line)
+                _report_progress(progress_callback, completed_bytes, total_bytes, f"Rewriting {path.name}")
+
+            while chunk := input_handle.read(_COPY_CHUNK_SIZE):
+                output_handle.write(chunk)
+                completed_bytes += len(chunk)
+                _report_progress(progress_callback, completed_bytes, total_bytes, f"Rewriting {path.name}")
+            output_handle.flush()
+            os.fsync(output_handle.fileno())
     except Exception:
         if temp_path is not None:
             temp_path.unlink(missing_ok=True)
         raise
-    if not changed:
-        if temp_path is not None:
-            temp_path.unlink(missing_ok=True)
-        return False
     assert temp_path is not None
-    temp_path.replace(path)
+    try:
+        shutil.copystat(path, temp_path)
+        os.replace(temp_path, path)
+    except Exception:
+        temp_path.unlink(missing_ok=True)
+        raise
+    _report_progress(progress_callback, total_bytes, total_bytes, f"Rewrote {path.name}")
     return True
 
 
-def _read_jsonl_records(path: Path) -> Iterable[JsonObject]:
-    with path.open("r", encoding="utf-8") as handle:
-        for line in handle:
-            try:
-                record = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if isinstance(record, dict):
-                yield record
+def _retag_jsonl_metadata_line(
+    raw_line: bytes,
+    source_provider: str,
+    target_provider: str,
+    path: Path,
+) -> bytes:
+    if raw_line.endswith(b"\r\n"):
+        body, newline = raw_line[:-2], b"\r\n"
+    elif raw_line.endswith(b"\n"):
+        body, newline = raw_line[:-1], b"\n"
+    else:
+        body, newline = raw_line, b""
+    has_bom = body.startswith(_UTF8_BOM)
+    try:
+        record = json.loads(body.decode("utf-8-sig"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"planned session metadata is no longer readable in {path}") from exc
+    if not isinstance(record, dict) or not _retag_jsonl_record_provider(
+        record,
+        source_provider,
+        target_provider,
+    ):
+        raise RuntimeError(f"planned {source_provider} session metadata changed in {path}")
+    encoded = json.dumps(record, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    if has_bom:
+        encoded = _UTF8_BOM + encoded
+    return encoded + newline
 
 
 def _jsonl_record_provider(record: JsonObject) -> str | None:
@@ -285,6 +702,17 @@ def _jsonl_record_provider(record: JsonObject) -> str | None:
     payload = cast(JsonObject, payload)
     payload_provider = payload.get("model_provider")
     return payload_provider if isinstance(payload_provider, str) else None
+
+
+def _jsonl_record_session_id(record: JsonObject) -> str | None:
+    record_id = record.get("id")
+    if isinstance(record_id, str) and record_id:
+        return record_id
+    payload = record.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    payload_id = payload.get("id")
+    return payload_id if isinstance(payload_id, str) and payload_id else None
 
 
 def _retag_jsonl_record_provider(record: JsonObject, source_provider: str, target_provider: str) -> bool:
@@ -303,19 +731,51 @@ def _retag_jsonl_record_provider(record: JsonObject, source_provider: str, targe
     return True
 
 
-def _sqlite_count_provider_rows(db_path: Path, provider: str) -> int:
+def _sqlite_provider_counts(db_path: Path) -> tuple[ProviderCount, ...]:
     try:
-        with _connect_sqlite(db_path, read_only=True) as conn:
+        with closing(_connect_sqlite(db_path, read_only=True)) as conn:
             if not _sqlite_has_threads_table(conn):
-                return 0
+                return ()
             if not _sqlite_has_model_provider_column(conn):
-                return 0
-            row = conn.execute("SELECT COUNT(*) FROM threads WHERE model_provider = ?", (provider,)).fetchone()
-            return int(row[0]) if row is not None else 0
+                return ()
+            rows = conn.execute(
+                "SELECT model_provider, COUNT(*) FROM threads GROUP BY model_provider",
+            ).fetchall()
+            return tuple(ProviderCount(provider, int(count)) for provider, count in rows if isinstance(provider, str))
     except sqlite3.OperationalError as exc:
         if "unable to open database file" not in str(exc).casefold():
             raise
-        return _sqlite_count_provider_rows_via_copy(db_path, provider)
+        return _sqlite_provider_counts_via_copy(db_path)
+
+
+def _sqlite_count_provider_rows(db_path: Path, provider: str) -> int:
+    return _provider_count(_sqlite_provider_counts(db_path), provider)
+
+
+def _sqlite_thread_plans(db_path: Path) -> tuple[_SqliteThreadPlan, ...]:
+    try:
+        with closing(_connect_sqlite(db_path, read_only=True)) as conn:
+            if not _sqlite_has_threads_table(conn) or not _sqlite_has_model_provider_column(conn):
+                return ()
+            rows = conn.execute(
+                "SELECT id, model_provider FROM threads WHERE model_provider IN ('openai', 'codex-lb')",
+            ).fetchall()
+            return tuple(
+                _SqliteThreadPlan(db_path=db_path, session_id=session_id, provider=provider)
+                for session_id, provider in rows
+                if isinstance(session_id, str) and session_id and isinstance(provider, str)
+            )
+    except sqlite3.OperationalError as exc:
+        if "unable to open database file" not in str(exc).casefold():
+            raise
+        temp_path = _copy_sqlite_to_temp(db_path)
+        try:
+            return tuple(
+                _SqliteThreadPlan(db_path=db_path, session_id=item.session_id, provider=item.provider)
+                for item in _sqlite_thread_plans(temp_path)
+            )
+        finally:
+            temp_path.unlink(missing_ok=True)
 
 
 def _update_sqlite_provider(db_path: Path, source_provider: str, target_provider: str) -> int:
@@ -330,8 +790,46 @@ def _update_sqlite_provider(db_path: Path, source_provider: str, target_provider
         return _update_sqlite_provider_via_copy(db_path, source_provider, target_provider)
 
 
+def _update_sqlite_thread_provider(
+    db_path: Path,
+    session_id: str,
+    source_provider: str,
+    target_provider: str,
+) -> int:
+    try:
+        return _update_sqlite_thread_provider_in_place(db_path, session_id, source_provider, target_provider)
+    except sqlite3.OperationalError as exc:
+        if "unable to open database file" not in str(exc).casefold():
+            raise
+        temp_path = _copy_sqlite_to_temp(db_path)
+        try:
+            updated = _update_sqlite_thread_provider_in_place(temp_path, session_id, source_provider, target_provider)
+            if updated:
+                _replace_sqlite_db(temp_path, db_path)
+            return updated
+        finally:
+            temp_path.unlink(missing_ok=True)
+
+
+def _update_sqlite_thread_provider_in_place(
+    db_path: Path,
+    session_id: str,
+    source_provider: str,
+    target_provider: str,
+) -> int:
+    with closing(_connect_sqlite(db_path)) as conn:
+        if not _sqlite_has_threads_table(conn) or not _sqlite_has_model_provider_column(conn):
+            return 0
+        cursor = conn.execute(
+            "UPDATE threads SET model_provider = ? WHERE id = ? AND model_provider = ?",
+            (target_provider, session_id, source_provider),
+        )
+        conn.commit()
+        return int(cursor.rowcount if cursor.rowcount != -1 else 0)
+
+
 def _update_sqlite_provider_in_place(db_path: Path, source_provider: str, target_provider: str) -> int:
-    with _connect_sqlite(db_path) as conn:
+    with closing(_connect_sqlite(db_path)) as conn:
         if not _sqlite_has_threads_table(conn):
             return 0
         cursor = conn.execute(
@@ -353,10 +851,10 @@ def _update_sqlite_provider_via_copy(db_path: Path, source_provider: str, target
         temp_path.unlink(missing_ok=True)
 
 
-def _sqlite_count_provider_rows_via_copy(db_path: Path, provider: str) -> int:
+def _sqlite_provider_counts_via_copy(db_path: Path) -> tuple[ProviderCount, ...]:
     temp_path = _copy_sqlite_to_temp(db_path)
     try:
-        return _sqlite_count_provider_rows(temp_path, provider)
+        return _sqlite_provider_counts(temp_path)
     finally:
         temp_path.unlink(missing_ok=True)
 
@@ -371,7 +869,11 @@ def _copy_sqlite_to_temp(db_path: Path) -> Path:
 
 def _replace_sqlite_db(source: Path, destination: Path) -> None:
     _consolidate_sqlite_db(source)
-    shutil.copy2(source, destination)
+    if destination.exists():
+        shutil.copymode(destination, source)
+    with source.open("r+b") as source_handle:
+        os.fsync(source_handle.fileno())
+    os.replace(source, destination)
     for sidecar in _sqlite_sidecar_paths(destination):
         sidecar.unlink(missing_ok=True)
 
@@ -383,7 +885,11 @@ def _connect_sqlite(db_path: Path, *, read_only: bool = False, immutable: bool =
         immutable_flag = "&immutable=1" if immutable else ""
         target = f"file:{quoted_path}?mode=ro{immutable_flag}"
     conn = sqlite3.connect(target, timeout=5, uri=read_only)
-    conn.execute("PRAGMA busy_timeout=5000")
+    try:
+        conn.execute("PRAGMA busy_timeout=5000")
+    except Exception:
+        conn.close()
+        raise
     return conn
 
 
@@ -403,30 +909,139 @@ def _sqlite_has_model_provider_column(conn: sqlite3.Connection) -> bool:
     return any(row[1] == "model_provider" for row in rows)
 
 
-def _provider_counts(codex_home: Path) -> tuple[ProviderCount, ...]:
-    counts: dict[str, int] = {}
-    for path in _find_jsonl_session_files(codex_home / "sessions"):
-        for record in _read_jsonl_records(path):
-            provider = _jsonl_record_provider(record)
-            if isinstance(provider, str):
-                counts[provider] = counts.get(provider, 0) + 1
-    for db_path in _find_state_dbs(codex_home):
+def _verify_retag_plan(
+    plan: _RetagPlan,
+    source_provider: str,
+    target_provider: str,
+    progress_callback: ByteProgress | None = None,
+) -> None:
+    total_items = len(plan.jsonl_targets) + len(plan.sqlite_targets)
+    completed_items = 0
+    _report_progress(progress_callback, completed_items, total_items, "Verifying changed metadata")
+    for target in plan.jsonl_targets:
+        observed = _discover_jsonl_session(target.path)
+        if observed.provider != target_provider:
+            raise RuntimeError(
+                f"JSONL verification failed for {target.path}: expected {target_provider}, "
+                f"found {observed.provider or 'no provider'}"
+            )
+        completed_items += 1
+        _report_progress(progress_callback, completed_items, total_items, f"Verified {target.path.name}")
+
+    for target in plan.sqlite_targets:
+        observed_counts = _sqlite_provider_counts(target.path)
+        expected_moved = _provider_count(target.provider_counts, source_provider)
+        expected_target = _provider_count(target.provider_counts, target_provider) + expected_moved
+        observed_source = _provider_count(observed_counts, source_provider)
+        observed_target = _provider_count(observed_counts, target_provider)
+        if observed_source != 0 or observed_target != expected_target:
+            raise RuntimeError(
+                f"SQLite verification failed for {target.path}: source={observed_source}, "
+                f"target={observed_target}, expected_target={expected_target}"
+            )
+        completed_items += 1
+        _report_progress(progress_callback, completed_items, total_items, f"Verified {target.path.name}")
+
+
+def _verify_targeted_metadata_repair(
+    codex_home: Path,
+    active_provider: str,
+    session_ids: Sequence[str],
+    jsonl_targets: Sequence[_JsonlSessionPlan],
+    sqlite_targets: Sequence[_SqliteThreadPlan],
+) -> None:
+    for target in jsonl_targets:
+        observed = _discover_jsonl_session(target.path)
+        if observed.session_id != target.session_id or observed.provider != active_provider:
+            raise RuntimeError(f"JSONL verification failed for targeted session {target.session_id} in {target.path}")
+    for target in sqlite_targets:
+        observed = tuple(item for item in _sqlite_thread_plans(target.db_path) if item.session_id == target.session_id)
+        if len(observed) != 1 or observed[0].provider != active_provider:
+            raise RuntimeError(
+                f"SQLite verification failed for targeted session {target.session_id} in {target.db_path}"
+            )
+    remaining = preview_session_metadata_mismatches(codex_home=codex_home, active_provider=active_provider)
+    remaining_ids = {item.session_id for item in remaining.mismatches}
+    unexpected = sorted(set(session_ids) & remaining_ids)
+    if unexpected:
+        raise RuntimeError("targeted metadata verification found remaining mismatches: " + ", ".join(unexpected))
+
+
+def _restore_backup(codex_home: Path, backup_path: Path) -> None:
+    for source in backup_path.rglob("*"):
+        if not source.is_file():
+            continue
+        relative = source.relative_to(backup_path)
+        if relative.parts and relative.parts[0] == "sessions":
+            destination = codex_home / relative
+        elif len(relative.parts) == 1 and relative.name.startswith("state_") and relative.suffix == ".sqlite":
+            destination = codex_home / relative
+        else:
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        _copy_file_atomically(source, destination)
+        if destination.suffix == ".sqlite":
+            for sidecar in _sqlite_sidecar_paths(destination):
+                sidecar.unlink(missing_ok=True)
+
+
+def _copy_file_atomically(source: Path, destination: Path) -> None:
+    with NamedTemporaryFile("wb", dir=destination.parent, delete=False) as output_handle:
+        temporary = Path(output_handle.name)
         try:
-            with _connect_sqlite(db_path, read_only=True) as conn:
-                if not _sqlite_has_threads_table(conn):
-                    continue
-                if not _sqlite_has_model_provider_column(conn):
-                    continue
-                rows = conn.execute(
-                    "SELECT model_provider, COUNT(*) FROM threads GROUP BY model_provider",
-                ).fetchall()
-                for provider, count in rows:
-                    if isinstance(provider, str):
-                        counts[provider] = counts.get(provider, 0) + int(count)
-        except sqlite3.OperationalError as exc:
-            if "unable to open database file" not in str(exc).casefold():
-                raise
-    return tuple(ProviderCount(provider, count) for provider, count in sorted(counts.items()))
+            with source.open("rb") as input_handle:
+                while chunk := input_handle.read(_COPY_CHUNK_SIZE):
+                    output_handle.write(chunk)
+            output_handle.flush()
+            os.fsync(output_handle.fileno())
+        except Exception:
+            temporary.unlink(missing_ok=True)
+            raise
+    shutil.copystat(source, temporary)
+    os.replace(temporary, destination)
+
+
+def _derive_provider_counts_after(
+    before: tuple[ProviderCount, ...],
+    source_provider: str,
+    target_provider: str,
+    moved_count: int,
+) -> tuple[ProviderCount, ...]:
+    counts = {provider_count.provider: provider_count.count for provider_count in before}
+    source_count = counts.get(source_provider, 0)
+    if moved_count > source_count:
+        raise RuntimeError(
+            f"retag plan moves {moved_count} records but only {source_count} source records were discovered"
+        )
+    remaining_source = source_count - moved_count
+    if remaining_source:
+        counts[source_provider] = remaining_source
+    else:
+        counts.pop(source_provider, None)
+    counts[target_provider] = counts.get(target_provider, 0) + moved_count
+    return _provider_counts_tuple(counts)
+
+
+def _opposite_provider(provider: str) -> str:
+    return "codex-lb" if provider == "openai" else "openai"
+
+
+def _provider_count(provider_counts: Sequence[ProviderCount], provider: str) -> int:
+    return next((item.count for item in provider_counts if item.provider == provider), 0)
+
+
+def _provider_counts_tuple(counts: dict[str, int]) -> tuple[ProviderCount, ...]:
+    return tuple(ProviderCount(provider, count) for provider, count in sorted(counts.items()) if count > 0)
+
+
+def _report_progress(
+    progress_callback: ByteProgress | None,
+    completed: int,
+    total: int,
+    message: str,
+) -> None:
+    if progress_callback is not None:
+        progress_callback(completed, total, message)
 
 
 def _methods_used(jsonl_files: Sequence[Path], state_dbs: Sequence[Path]) -> tuple[str, ...]:
@@ -438,39 +1053,165 @@ def _methods_used(jsonl_files: Sequence[Path], state_dbs: Sequence[Path]) -> tup
     return tuple(methods)
 
 
-def _create_backup(codex_home: Path, jsonl_files: Sequence[Path], state_dbs: Sequence[Path]) -> Path:
+def _create_backup(
+    codex_home: Path,
+    jsonl_files: Sequence[Path],
+    state_dbs: Sequence[Path],
+    *,
+    progress_callback: ByteProgress | None = None,
+) -> Path:
     backup_dir = _next_backup_dir(codex_home / "backups" / PROVIDER_RETAG_BACKUP_DIR)
     backup_dir.mkdir(parents=True)
 
-    for db_path in state_dbs:
-        _backup_sqlite_db(db_path, backup_dir / db_path.name)
-
     session_index = codex_home / "session_index.jsonl"
+    backup_sources = tuple(state_dbs) + ((session_index,) if session_index.is_file() else ()) + tuple(jsonl_files)
+    total_bytes = sum(path.stat().st_size for path in backup_sources)
+    completed_bytes = 0
+    _report_progress(progress_callback, completed_bytes, total_bytes, "Starting metadata backup")
+
+    for db_path in state_dbs:
+        source_size = db_path.stat().st_size
+        base_completed = completed_bytes
+        _backup_sqlite_db(
+            db_path,
+            backup_dir / db_path.name,
+            progress_callback=lambda copied, total, name=db_path.name, base=base_completed, size=source_size: (
+                _report_progress(
+                    progress_callback,
+                    min(base + _scale_progress(copied, total, size), base + size),
+                    total_bytes,
+                    f"Backing up {name}",
+                )
+            ),
+        )
+        completed_bytes += source_size
+        _report_progress(progress_callback, completed_bytes, total_bytes, f"Backed up {db_path.name}")
+
     if session_index.is_file():
-        shutil.copy2(session_index, backup_dir / session_index.name)
+        source_size = session_index.stat().st_size
+        base_completed = completed_bytes
+        _copy_file_safely(
+            session_index,
+            backup_dir / session_index.name,
+            progress_callback=lambda copied, _total, message, base=base_completed: _report_progress(
+                progress_callback,
+                base + copied,
+                total_bytes,
+                message,
+            ),
+        )
+        completed_bytes += source_size
 
     for path in jsonl_files:
         destination = backup_dir / path.relative_to(codex_home)
         destination.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(path, destination)
+        source_size = path.stat().st_size
+        base_completed = completed_bytes
+        _backup_jsonl_file(
+            path,
+            destination,
+            progress_callback=lambda copied, _total, message, base=base_completed: _report_progress(
+                progress_callback,
+                base + copied,
+                total_bytes,
+                message,
+            ),
+        )
+        completed_bytes += source_size
+        _report_progress(progress_callback, completed_bytes, total_bytes, f"Backed up {path.name}")
 
+    _report_progress(progress_callback, total_bytes, total_bytes, "Metadata backup complete")
     return backup_dir
 
 
-def _backup_sqlite_db(source: Path, destination: Path) -> None:
+def _backup_jsonl_file(
+    source: Path,
+    destination: Path,
+    *,
+    progress_callback: ByteProgress | None = None,
+) -> None:
+    source_size = source.stat().st_size
+    try:
+        os.link(source, destination)
+    except OSError:
+        destination.unlink(missing_ok=True)
+        _copy_file_safely(source, destination, progress_callback=progress_callback)
+        return
+    if destination.stat().st_size != source_size:
+        destination.unlink(missing_ok=True)
+        raise OSError(f"hard-link backup size mismatch for {source}")
+    _report_progress(progress_callback, source_size, source_size, f"Hard-linked {source.name}")
+
+
+def _copy_file_safely(
+    source: Path,
+    destination: Path,
+    *,
+    progress_callback: ByteProgress | None = None,
+) -> None:
+    source_size = source.stat().st_size
+    copied = 0
     destination.parent.mkdir(parents=True, exist_ok=True)
-    with _connect_sqlite(source, read_only=True) as source_conn, sqlite3.connect(str(destination)) as backup_conn:
-        source_conn.backup(backup_conn)
+    try:
+        with source.open("rb") as input_handle, destination.open("xb") as output_handle:
+            while chunk := input_handle.read(_COPY_CHUNK_SIZE):
+                output_handle.write(chunk)
+                copied += len(chunk)
+                _report_progress(progress_callback, copied, source_size, f"Copying {source.name}")
+            output_handle.flush()
+            os.fsync(output_handle.fileno())
+        shutil.copystat(source, destination)
+        if destination.stat().st_size != source_size:
+            raise OSError(f"copy backup size mismatch for {source}")
+    except Exception:
+        destination.unlink(missing_ok=True)
+        raise
+    _report_progress(progress_callback, source_size, source_size, f"Copied {source.name}")
+
+
+def _backup_sqlite_db(
+    source: Path,
+    destination: Path,
+    *,
+    progress_callback: ByteProgress | None = None,
+) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with (
+        closing(_connect_sqlite(source, read_only=True)) as source_conn,
+        closing(sqlite3.connect(str(destination))) as backup_conn,
+    ):
+        page_size_row = source_conn.execute("PRAGMA page_size").fetchone()
+        page_size = int(page_size_row[0]) if page_size_row is not None else 4096
+
+        def report_backup(_status: int, remaining: int, total: int) -> None:
+            _report_progress(
+                progress_callback,
+                max(0, total - remaining) * page_size,
+                max(0, total) * page_size,
+                f"Backing up {source.name}",
+            )
+
+        source_conn.backup(backup_conn, pages=256, progress=report_backup)
         backup_conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
         backup_conn.execute("PRAGMA journal_mode=DELETE")
+        backup_conn.commit()
     for sidecar in _sqlite_sidecar_paths(destination):
         sidecar.unlink(missing_ok=True)
+    destination_size = destination.stat().st_size
+    _report_progress(progress_callback, destination_size, destination_size, f"Backed up {source.name}")
+
+
+def _scale_progress(completed: int, total: int, output_total: int) -> int:
+    if total <= 0:
+        return output_total
+    return min(output_total, int(output_total * completed / total))
 
 
 def _consolidate_sqlite_db(db_path: Path) -> None:
-    with _connect_sqlite(db_path) as conn:
+    with closing(_connect_sqlite(db_path)) as conn:
         conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
         conn.execute("PRAGMA journal_mode=DELETE")
+        conn.commit()
 
 
 def _sqlite_sidecar_paths(db_path: Path) -> tuple[Path, Path]:

--- a/app/codex_sessions_retag.py
+++ b/app/codex_sessions_retag.py
@@ -24,6 +24,7 @@ _SUPPORTED_PROVIDERS = {"openai", "codex-lb"}
 _STATE_DB_PATTERN = "state_*.sqlite"
 _STATE_DB_NAME_PATTERN = re.compile(r"state_(\d+)\.sqlite")
 _COPY_CHUNK_SIZE = 4 * 1024 * 1024
+_SQLITE_UPDATE_BATCH_SIZE = 1_000
 _MAX_SESSION_METADATA_BYTES = 1024 * 1024
 _UTF8_BOM = b"\xef\xbb\xbf"
 
@@ -242,7 +243,21 @@ def retag_codex_sessions(
         if plan.sqlite_targets:
             emit_progress("sqlite_update", 0, plan.sqlite_rows_matched, "rows", "Starting SQLite update")
         for target in plan.sqlite_targets:
-            sqlite_rows_updated += _update_sqlite_provider(target.path, source_provider, target_provider)
+            expected_rows = _provider_count(target.provider_counts, source_provider)
+            base_updated = sqlite_rows_updated
+            sqlite_rows_updated += _update_sqlite_provider(
+                target.path,
+                source_provider,
+                target_provider,
+                expected_rows=expected_rows,
+                progress_callback=lambda completed, _total, message, base=base_updated: emit_progress(
+                    "sqlite_update",
+                    min(base + completed, plan.sqlite_rows_matched),
+                    plan.sqlite_rows_matched,
+                    "rows",
+                    message,
+                ),
+            )
             emit_progress(
                 "sqlite_update",
                 sqlite_rows_updated,
@@ -775,16 +790,35 @@ def _sqlite_thread_plans(db_path: Path) -> tuple[_SqliteThreadPlan, ...]:
             temp_path.unlink(missing_ok=True)
 
 
-def _update_sqlite_provider(db_path: Path, source_provider: str, target_provider: str) -> int:
+def _update_sqlite_provider(
+    db_path: Path,
+    source_provider: str,
+    target_provider: str,
+    *,
+    expected_rows: int,
+    progress_callback: ByteProgress | None = None,
+) -> int:
     try:
-        return _update_sqlite_provider_in_place(db_path, source_provider, target_provider)
+        return _update_sqlite_provider_in_place(
+            db_path,
+            source_provider,
+            target_provider,
+            expected_rows=expected_rows,
+            progress_callback=progress_callback,
+        )
     except sqlite3.OperationalError as exc:
         if "unable to open database file" not in str(exc).casefold():
             raise
         # Some bind mounts reject direct SQLite writes from inside a container.
         # Updating a sibling copy and moving it back keeps the operation scoped
         # to the mounted Codex home.
-        return _update_sqlite_provider_via_copy(db_path, source_provider, target_provider)
+        return _update_sqlite_provider_via_copy(
+            db_path,
+            source_provider,
+            target_provider,
+            expected_rows=expected_rows,
+            progress_callback=progress_callback,
+        )
 
 
 def _update_sqlite_thread_provider(
@@ -825,22 +859,56 @@ def _update_sqlite_thread_provider_in_place(
         return int(cursor.rowcount if cursor.rowcount != -1 else 0)
 
 
-def _update_sqlite_provider_in_place(db_path: Path, source_provider: str, target_provider: str) -> int:
+def _update_sqlite_provider_in_place(
+    db_path: Path,
+    source_provider: str,
+    target_provider: str,
+    *,
+    expected_rows: int,
+    progress_callback: ByteProgress | None = None,
+) -> int:
     with closing(_connect_sqlite(db_path)) as conn:
-        if not _sqlite_has_threads_table(conn):
+        if not _sqlite_has_threads_table(conn) or not _sqlite_has_model_provider_column(conn):
             return 0
-        cursor = conn.execute(
-            "UPDATE threads SET model_provider = ? WHERE model_provider = ?",
-            (target_provider, source_provider),
-        )
+        updated = 0
+        while updated < expected_rows:
+            batch_size = min(_SQLITE_UPDATE_BATCH_SIZE, expected_rows - updated)
+            cursor = conn.execute(
+                """
+                UPDATE threads
+                SET model_provider = ?
+                WHERE id IN (
+                    SELECT id FROM threads WHERE model_provider = ? LIMIT ?
+                )
+                """,
+                (target_provider, source_provider, batch_size),
+            )
+            batch_updated = int(cursor.rowcount if cursor.rowcount != -1 else 0)
+            if batch_updated <= 0:
+                break
+            updated += batch_updated
+            _report_progress(progress_callback, updated, expected_rows, f"Updating {db_path.name}")
         conn.commit()
-        return int(cursor.rowcount if cursor.rowcount != -1 else 0)
+        return updated
 
 
-def _update_sqlite_provider_via_copy(db_path: Path, source_provider: str, target_provider: str) -> int:
+def _update_sqlite_provider_via_copy(
+    db_path: Path,
+    source_provider: str,
+    target_provider: str,
+    *,
+    expected_rows: int,
+    progress_callback: ByteProgress | None = None,
+) -> int:
     temp_path = _copy_sqlite_to_temp(db_path)
     try:
-        updated = _update_sqlite_provider_in_place(temp_path, source_provider, target_provider)
+        updated = _update_sqlite_provider_in_place(
+            temp_path,
+            source_provider,
+            target_provider,
+            expected_rows=expected_rows,
+            progress_callback=progress_callback,
+        )
         if updated:
             _replace_sqlite_db(temp_path, db_path)
         return updated

--- a/app/codex_sessions_retag.py
+++ b/app/codex_sessions_retag.py
@@ -318,12 +318,11 @@ def preview_session_metadata_mismatches(
 
     jsonl_by_session: dict[str, list[_JsonlSessionPlan]] = {}
     for session in jsonl_sessions:
-        if session.session_id is not None and session.provider in _SUPPORTED_PROVIDERS:
+        if session.session_id is not None and session.provider is not None:
             jsonl_by_session.setdefault(session.session_id, []).append(session)
     sqlite_by_session: dict[str, list[_SqliteThreadPlan]] = {}
     for thread in sqlite_threads:
-        if thread.provider in _SUPPORTED_PROVIDERS:
-            sqlite_by_session.setdefault(thread.session_id, []).append(thread)
+        sqlite_by_session.setdefault(thread.session_id, []).append(thread)
 
     mismatches: list[SessionMetadataMismatch] = []
     for session_id in sorted(set(jsonl_by_session) | set(sqlite_by_session)):
@@ -757,9 +756,7 @@ def _sqlite_thread_plans(db_path: Path) -> tuple[_SqliteThreadPlan, ...]:
         with closing(_connect_sqlite(db_path, read_only=True)) as conn:
             if not _sqlite_has_threads_table(conn) or not _sqlite_has_model_provider_column(conn):
                 return ()
-            rows = conn.execute(
-                "SELECT id, model_provider FROM threads WHERE model_provider IN ('openai', 'codex-lb')",
-            ).fetchall()
+            rows = conn.execute("SELECT id, model_provider FROM threads").fetchall()
             return tuple(
                 _SqliteThreadPlan(db_path=db_path, session_id=session_id, provider=provider)
                 for session_id, provider in rows

--- a/openspec/changes/add-targeted-session-metadata-repair/.openspec.yaml
+++ b/openspec/changes/add-targeted-session-metadata-repair/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/add-targeted-session-metadata-repair/design.md
+++ b/openspec/changes/add-targeted-session-metadata-repair/design.md
@@ -25,7 +25,9 @@ Codex stores a session provider tag both in the first `session_meta` record of i
 
 3. **Preview and apply use one frozen candidate list.** The preview returns session IDs, source provider, affected JSONL segment count, and affected SQLite row count. Apply accepts only those IDs, revalidates their eligibility, and writes no non-candidate session.
 
-4. **The CLI exposes a consumer-neutral workflow.** Preview and repair are separate subcommands with optional JSON results. The repair command requires explicit session IDs and confirmation. External supervisors remain responsible for process quiescence, presentation, and deciding whether to invoke repair.
+4. **Targeted repair reuses the retag progress protocol.** Backup and JSONL rewrite byte progress plus SQLite update and verification item progress use the existing `CODEX_LB_RETAG_PROGRESS` stream. JSON result mode sends progress to stderr so stdout remains one parseable result document.
+
+5. **The CLI exposes a consumer-neutral workflow.** Preview and repair are separate subcommands with optional JSON results. The repair command requires explicit session IDs and confirmation. External supervisors remain responsible for process quiescence, presentation, and deciding whether to invoke repair.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/add-targeted-session-metadata-repair/design.md
+++ b/openspec/changes/add-targeted-session-metadata-repair/design.md
@@ -1,0 +1,40 @@
+## Context
+
+Codex stores a session provider tag both in the first `session_meta` record of its JSONL segments and in `state_*.sqlite` thread rows. A provider transition interrupted by a Codex update can leave only one of those stores retagged. The existing retag command is deliberately whole-home and is therefore inappropriate for repairing a single inconsistent session.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detect only session IDs whose JSONL and SQLite provider tags disagree with the currently active `openai` or `codex-lb` provider.
+- Preview the exact IDs and metadata components that would change.
+- Apply a confirmed repair through the existing targeted backup, quiescence, atomic replacement, and verification mechanisms.
+
+**Non-Goals:**
+
+- Do not infer that a session consistently tagged for another provider is missing.
+- Do not change `config.toml`, switch profiles, create SQLite rows, or run a global retag.
+- Do not expose raw transcript contents in the UI.
+
+## Decisions
+
+1. **The Python metadata module owns detection and mutation.** It already owns the bounded JSONL metadata reader, SQLite access, backup, and verification behavior. A new session-ID-scoped command prevents the Windows UI from duplicating file-format logic.
+
+2. **The active provider is the repair target.** A session is eligible only when its discovered JSONL/SQLite provider set contains the active provider and exactly one opposite supported provider. This repairs partial transitions while excluding sessions that are consistently owned by another profile or have unsupported metadata.
+
+3. **Preview and apply use one frozen candidate list.** The preview returns session IDs, source provider, affected JSONL segment count, and affected SQLite row count. Apply accepts only those IDs, revalidates their eligibility, and writes no non-candidate session.
+
+4. **ProviderSwitcher exposes a separate compact action.** The action first runs preview, displays the count and IDs in the activity panel, then asks for an explicit confirmation before apply. It reuses the existing quiescence probe and progress display without entering the profile transition transaction.
+
+## Risks / Trade-offs
+
+- [Codex writes while repair is running] → The existing quiescence check blocks apply; preview remains read-only.
+- [Stale preview] → Apply revalidates every candidate and refuses a changed or no-longer-eligible ID.
+- [Consistently old session is misclassified] → Eligibility requires disagreement, not merely a provider different from the active profile.
+- [Large session homes] → Detection reads only bounded first metadata records and queries SQLite once per state DB.
+
+## Migration Plan
+
+1. Ship the session-ID-scoped CLI preview/apply interface with targeted unit coverage.
+2. Ship the ProviderSwitcher action with its existing build/self-test package.
+3. Existing configuration, session data, and profile-transition behavior require no migration. A failed apply retains its targeted backup for restoration.

--- a/openspec/changes/add-targeted-session-metadata-repair/design.md
+++ b/openspec/changes/add-targeted-session-metadata-repair/design.md
@@ -9,6 +9,7 @@ Codex stores a session provider tag both in the first `session_meta` record of i
 - Detect only session IDs whose JSONL and SQLite provider tags disagree with the currently active `openai` or `codex-lb` provider.
 - Preview the exact IDs and metadata components that would change.
 - Apply a confirmed repair through the existing targeted backup, quiescence, atomic replacement, and verification mechanisms.
+- Expose machine-readable CLI results for external supervisors without promising a specific UI integration.
 
 **Non-Goals:**
 
@@ -24,17 +25,17 @@ Codex stores a session provider tag both in the first `session_meta` record of i
 
 3. **Preview and apply use one frozen candidate list.** The preview returns session IDs, source provider, affected JSONL segment count, and affected SQLite row count. Apply accepts only those IDs, revalidates their eligibility, and writes no non-candidate session.
 
-4. **ProviderSwitcher exposes a separate compact action.** The action first runs preview, displays the count and IDs in the activity panel, then asks for an explicit confirmation before apply. It reuses the existing quiescence probe and progress display without entering the profile transition transaction.
+4. **The CLI exposes a consumer-neutral workflow.** Preview and repair are separate subcommands with optional JSON results. The repair command requires explicit session IDs and confirmation. External supervisors remain responsible for process quiescence, presentation, and deciding whether to invoke repair.
 
 ## Risks / Trade-offs
 
-- [Codex writes while repair is running] → The existing quiescence check blocks apply; preview remains read-only.
+- [Codex writes while repair is running] → The CLI warns that Codex must be closed and requires explicit confirmation; external supervisors that automate the command must enforce process quiescence.
 - [Stale preview] → Apply revalidates every candidate and refuses a changed or no-longer-eligible ID.
 - [Consistently old session is misclassified] → Eligibility requires disagreement, not merely a provider different from the active profile.
 - [Large session homes] → Detection reads only bounded first metadata records and queries SQLite once per state DB.
 
 ## Migration Plan
 
-1. Ship the session-ID-scoped CLI preview/apply interface with targeted unit coverage.
-2. Ship the ProviderSwitcher action with its existing build/self-test package.
+1. Ship the session-ID-scoped CLI preview/apply interface with targeted unit and CLI coverage.
+2. Document the JSON and explicit-confirmation contract for external supervisors.
 3. Existing configuration, session data, and profile-transition behavior require no migration. A failed apply retains its targeted backup for restoration.

--- a/openspec/changes/add-targeted-session-metadata-repair/proposal.md
+++ b/openspec/changes/add-targeted-session-metadata-repair/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+After a provider change and a Codex update, a session can retain conflicting `openai` and `codex-lb` tags between its JSONL metadata and SQLite thread index. The session is then absent from the active provider's list even though its conversation data is intact.
+
+## What Changes
+
+- Add a ProviderSwitcher action that previews session metadata tag mismatches for the currently active provider.
+- Allow an explicitly confirmed repair to retag only the identified mismatched session metadata; do not run a whole-home retag or change the selected provider.
+- Preserve the existing backup, quiescence, and targeted verification guarantees for any repaired metadata.
+
+## Capabilities
+
+### New Capabilities
+
+- `targeted-session-metadata-repair`: Detect and reconcile provider-tag mismatches between Codex session JSONL metadata and its SQLite thread index for individual sessions.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `app/codex_sessions_retag.py` and `app/cli.py` gain a session-ID-scoped metadata repair interface.
+- ProviderSwitcher gains a compact preview-and-confirm action and its process adapter gains typed mismatch results.
+- Targeted Python and ProviderSwitcher regression coverage verifies that normal sessions and unrelated sessions are unchanged.

--- a/openspec/changes/add-targeted-session-metadata-repair/proposal.md
+++ b/openspec/changes/add-targeted-session-metadata-repair/proposal.md
@@ -7,6 +7,7 @@ After a provider change and a Codex update, a session can retain conflicting `op
 - Add a CLI preview that reports session metadata tag mismatches for a supplied active provider.
 - Allow an explicitly confirmed, session-ID-scoped repair to retag only the identified mismatched session metadata; do not run a whole-home retag or change the selected provider.
 - Provide machine-readable JSON so an external supervisor can build its own preview-and-confirm flow without duplicating metadata logic.
+- Stream the existing structured backup, rewrite, SQLite update, and verification progress protocol during targeted repair.
 - Preserve the existing backup, quiescence, and targeted verification guarantees for any repaired metadata.
 
 ## Capabilities

--- a/openspec/changes/add-targeted-session-metadata-repair/proposal.md
+++ b/openspec/changes/add-targeted-session-metadata-repair/proposal.md
@@ -4,8 +4,9 @@ After a provider change and a Codex update, a session can retain conflicting `op
 
 ## What Changes
 
-- Add a ProviderSwitcher action that previews session metadata tag mismatches for the currently active provider.
-- Allow an explicitly confirmed repair to retag only the identified mismatched session metadata; do not run a whole-home retag or change the selected provider.
+- Add a CLI preview that reports session metadata tag mismatches for a supplied active provider.
+- Allow an explicitly confirmed, session-ID-scoped repair to retag only the identified mismatched session metadata; do not run a whole-home retag or change the selected provider.
+- Provide machine-readable JSON so an external supervisor can build its own preview-and-confirm flow without duplicating metadata logic.
 - Preserve the existing backup, quiescence, and targeted verification guarantees for any repaired metadata.
 
 ## Capabilities
@@ -21,5 +22,5 @@ After a provider change and a Codex update, a session can retain conflicting `op
 ## Impact
 
 - `app/codex_sessions_retag.py` and `app/cli.py` gain a session-ID-scoped metadata repair interface.
-- ProviderSwitcher gains a compact preview-and-confirm action and its process adapter gains typed mismatch results.
-- Targeted Python and ProviderSwitcher regression coverage verifies that normal sessions and unrelated sessions are unchanged.
+- External UI, process-quiescence orchestration, and profile-selection integration remain consumer responsibilities.
+- Targeted Python and CLI regression coverage verifies that normal sessions and unrelated sessions are unchanged.

--- a/openspec/changes/add-targeted-session-metadata-repair/specs/targeted-session-metadata-repair/spec.md
+++ b/openspec/changes/add-targeted-session-metadata-repair/specs/targeted-session-metadata-repair/spec.md
@@ -28,6 +28,12 @@ The system SHALL require an explicit confirmation before changing metadata and S
 - **WHEN** the preview finds no eligible mismatched session IDs
 - **THEN** the system SHALL perform no write and SHALL report that no targeted repair is required
 
+#### Scenario: Long targeted repair reports forward progress
+
+- **WHEN** a confirmed repair backs up or rewrites a large targeted JSONL segment
+- **THEN** the CLI SHALL emit structured progress during backup, JSONL rewrite, SQLite update, and verification phases
+- **AND** JSON result mode SHALL keep the final JSON document separate from the progress stream
+
 ### Requirement: CLI offers an independent targeted-repair workflow
 
 The CLI SHALL expose metadata mismatch preview and session-ID-scoped repair independently of provider selection. The preview SHALL support machine-readable JSON, and the repair SHALL require explicit confirmation and explicit previewed session IDs. Neither command SHALL invoke a profile transition, a whole-home retag, or a config rewrite.

--- a/openspec/changes/add-targeted-session-metadata-repair/specs/targeted-session-metadata-repair/spec.md
+++ b/openspec/changes/add-targeted-session-metadata-repair/specs/targeted-session-metadata-repair/spec.md
@@ -28,11 +28,16 @@ The system SHALL require an explicit confirmation before changing metadata and S
 - **WHEN** the preview finds no eligible mismatched session IDs
 - **THEN** the system SHALL perform no write and SHALL report that no targeted repair is required
 
-### Requirement: ProviderSwitcher offers an independent targeted-repair action
+### Requirement: CLI offers an independent targeted-repair workflow
 
-ProviderSwitcher SHALL offer a metadata consistency action independent of provider selection. It SHALL present the preview result and SHALL not invoke a profile transition, a whole-home retag, or a config rewrite.
+The CLI SHALL expose metadata mismatch preview and session-ID-scoped repair independently of provider selection. The preview SHALL support machine-readable JSON, and the repair SHALL require explicit confirmation and explicit previewed session IDs. Neither command SHALL invoke a profile transition, a whole-home retag, or a config rewrite.
 
-#### Scenario: User declines the repair confirmation
+#### Scenario: Automation requests a machine-readable preview
 
-- **WHEN** ProviderSwitcher displays a non-empty mismatch preview and the user declines confirmation
-- **THEN** the system SHALL leave all session metadata and provider configuration unchanged
+- **WHEN** an operator runs `codex-lb codex-sessions metadata-mismatches --provider codex-lb --json`
+- **THEN** the CLI SHALL emit the scanned counts and eligible mismatch IDs as JSON without changing metadata
+
+#### Scenario: Non-interactive repair lacks confirmation
+
+- **WHEN** a non-interactive caller invokes `repair-metadata` without `--yes`
+- **THEN** the CLI SHALL refuse the write and leave all session metadata and provider configuration unchanged

--- a/openspec/changes/add-targeted-session-metadata-repair/specs/targeted-session-metadata-repair/spec.md
+++ b/openspec/changes/add-targeted-session-metadata-repair/specs/targeted-session-metadata-repair/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Detect partial provider-tag mismatches
+
+The system SHALL inspect bounded JSONL session metadata and SQLite thread provider tags for the active `openai` or `codex-lb` provider and SHALL report only session IDs whose metadata contains both the active provider and exactly one opposite supported provider.
+
+#### Scenario: JSONL and SQLite disagree for the active provider
+
+- **WHEN** a session's JSONL metadata is tagged `codex-lb` and its SQLite thread row is tagged `openai` while `codex-lb` is active
+- **THEN** the preview SHALL report that session ID and identify the SQLite row as a repair target
+
+#### Scenario: Session is consistently owned by another provider
+
+- **WHEN** both the JSONL metadata and SQLite thread row are tagged `openai` while `codex-lb` is active
+- **THEN** the preview SHALL exclude the session
+
+### Requirement: Repair only previewed mismatched session metadata
+
+The system SHALL require an explicit confirmation before changing metadata and SHALL retag only the previewed eligible session IDs to the active provider. The system SHALL preserve unrelated JSONL segments, SQLite rows, and `config.toml`.
+
+#### Scenario: Confirmed repair updates a SQLite-only mismatch
+
+- **WHEN** the user confirms a preview containing one session whose SQLite tag is `openai` and JSONL tag is `codex-lb`
+- **THEN** the system SHALL back up and update only that SQLite row to `codex-lb` and SHALL verify the row after the update
+
+#### Scenario: No eligible mismatch exists
+
+- **WHEN** the preview finds no eligible mismatched session IDs
+- **THEN** the system SHALL perform no write and SHALL report that no targeted repair is required
+
+### Requirement: ProviderSwitcher offers an independent targeted-repair action
+
+ProviderSwitcher SHALL offer a metadata consistency action independent of provider selection. It SHALL present the preview result and SHALL not invoke a profile transition, a whole-home retag, or a config rewrite.
+
+#### Scenario: User declines the repair confirmation
+
+- **WHEN** ProviderSwitcher displays a non-empty mismatch preview and the user declines confirmation
+- **THEN** the system SHALL leave all session metadata and provider configuration unchanged

--- a/openspec/changes/add-targeted-session-metadata-repair/specs/targeted-session-metadata-repair/spec.md
+++ b/openspec/changes/add-targeted-session-metadata-repair/specs/targeted-session-metadata-repair/spec.md
@@ -14,6 +14,11 @@ The system SHALL inspect bounded JSONL session metadata and SQLite thread provid
 - **WHEN** both the JSONL metadata and SQLite thread row are tagged `openai` while `codex-lb` is active
 - **THEN** the preview SHALL exclude the session
 
+#### Scenario: Active provider is unsupported
+
+- **WHEN** preview is requested with an active provider other than `openai` or `codex-lb`
+- **THEN** the CLI SHALL reject the request instead of reporting an empty successful preview
+
 ### Requirement: Repair only previewed mismatched session metadata
 
 The system SHALL require an explicit confirmation before changing metadata and SHALL retag only the previewed eligible session IDs to the active provider. The system SHALL preserve unrelated JSONL segments, SQLite rows, and `config.toml`.

--- a/openspec/changes/add-targeted-session-metadata-repair/tasks.md
+++ b/openspec/changes/add-targeted-session-metadata-repair/tasks.md
@@ -3,6 +3,7 @@
 - [x] 1.1 Add typed mismatch preview and session-ID-scoped retag support to the Codex session metadata module.
 - [x] 1.2 Expose read-only preview and confirmed repair subcommands without altering existing whole-home retag behavior.
 - [x] 1.3 Thread structured progress through targeted backup, rewrite, SQLite update, and verification work.
+- [x] 1.4 Reject unsupported active providers before mismatch discovery.
 
 ## 2. Machine-readable CLI workflow
 

--- a/openspec/changes/add-targeted-session-metadata-repair/tasks.md
+++ b/openspec/changes/add-targeted-session-metadata-repair/tasks.md
@@ -1,0 +1,14 @@
+## 1. Targeted metadata interface
+
+- [x] 1.1 Add typed mismatch preview and session-ID-scoped retag support to the Codex session metadata module.
+- [x] 1.2 Expose read-only preview and confirmed repair subcommands without altering existing whole-home retag behavior.
+
+## 2. ProviderSwitcher action
+
+- [x] 2.1 Add typed process results and a quiescence-guarded preview/apply adapter for targeted metadata repair.
+- [x] 2.2 Add a compact UI action that displays candidate IDs and requires confirmation before repair.
+
+## 3. Focused verification and package
+
+- [x] 3.1 Add focused Python and ProviderSwitcher regression cases for a SQLite-only mismatch and unrelated-session preservation.
+- [x] 3.2 Run targeted tests, strict OpenSpec validation, publish the local beta artifact, and run its isolated self-test.

--- a/openspec/changes/add-targeted-session-metadata-repair/tasks.md
+++ b/openspec/changes/add-targeted-session-metadata-repair/tasks.md
@@ -3,12 +3,12 @@
 - [x] 1.1 Add typed mismatch preview and session-ID-scoped retag support to the Codex session metadata module.
 - [x] 1.2 Expose read-only preview and confirmed repair subcommands without altering existing whole-home retag behavior.
 
-## 2. ProviderSwitcher action
+## 2. Machine-readable CLI workflow
 
-- [x] 2.1 Add typed process results and a quiescence-guarded preview/apply adapter for targeted metadata repair.
-- [x] 2.2 Add a compact UI action that displays candidate IDs and requires confirmation before repair.
+- [x] 2.1 Add JSON preview and repair results suitable for an external supervisor.
+- [x] 2.2 Require explicit session IDs and confirmation without entering provider-selection behavior.
 
 ## 3. Focused verification and package
 
-- [x] 3.1 Add focused Python and ProviderSwitcher regression cases for a SQLite-only mismatch and unrelated-session preservation.
-- [x] 3.2 Run targeted tests, strict OpenSpec validation, publish the local beta artifact, and run its isolated self-test.
+- [x] 3.1 Add focused Python and CLI regression cases for a SQLite-only mismatch and unrelated-session preservation.
+- [x] 3.2 Run targeted tests and strict OpenSpec validation.

--- a/openspec/changes/add-targeted-session-metadata-repair/tasks.md
+++ b/openspec/changes/add-targeted-session-metadata-repair/tasks.md
@@ -2,6 +2,7 @@
 
 - [x] 1.1 Add typed mismatch preview and session-ID-scoped retag support to the Codex session metadata module.
 - [x] 1.2 Expose read-only preview and confirmed repair subcommands without altering existing whole-home retag behavior.
+- [x] 1.3 Thread structured progress through targeted backup, rewrite, SQLite update, and verification work.
 
 ## 2. Machine-readable CLI workflow
 
@@ -12,3 +13,4 @@
 
 - [x] 3.1 Add focused Python and CLI regression cases for a SQLite-only mismatch and unrelated-session preservation.
 - [x] 3.2 Run targeted tests and strict OpenSpec validation.
+- [x] 3.3 Verify long JSONL repair progress and JSON result stream separation.

--- a/openspec/changes/optimize-large-session-retag/.openspec.yaml
+++ b/openspec/changes/optimize-large-session-retag/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/optimize-large-session-retag/design.md
+++ b/openspec/changes/optimize-large-session-retag/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-The current retag implementation enumerates the same JSONL set repeatedly, parses every record to build provider counts, scans again to select targets, copies every target, rewrites every target, and parses the full home again after mutation. ProviderSwitcher supervises that work with a fixed 300-second process timeout and only reads the completed output. A 9.5 GiB Codex home therefore reached the timeout after creating its backup and partially rewriting files; the supervisor discarded the already-emitted backup path and could not prove rollback.
+The current retag implementation enumerates the same JSONL set repeatedly, parses every record to build provider counts, scans again to select targets, copies every target, rewrites every target, and parses the full home again after mutation. A supervisor that uses a fixed total timeout and reads only completed output can terminate the command after backup creation and partial rewriting while losing already-emitted rollback evidence.
 
 The CLI already requires Codex process quiescence for writes. That invariant makes same-volume hard-link backups safe when each target is replaced with a newly written file rather than modified in place.
 
@@ -12,8 +12,8 @@ The CLI already requires Codex process quiescence for writes. That invariant mak
 - Preserve byte-exact rollback evidence before any target is replaced.
 - Read and rewrite each selected JSONL once, leaving unrelated bytes unchanged.
 - Eliminate duplicate SQLite planning queries and full-home post-scans.
-- Emit structured progress frequently enough for ProviderSwitcher to distinguish long work from a stall.
-- Let ProviderSwitcher stop a process only after progress has been idle, while retaining all output and backup identities for rollback.
+- Emit structured progress frequently enough for a subprocess supervisor to distinguish long work from a stall.
+- Define enough output semantics for a supervisor to use progress-idle detection while retaining output and backup identities for rollback.
 
 **Non-Goals:**
 
@@ -47,7 +47,7 @@ After mutation, verification reads only the provider-bearing metadata record fro
 
 The CLI emits newline-delimited events prefixed with `CODEX_LB_RETAG_PROGRESS `. The JSON payload contains `phase`, `completed`, `total`, `unit`, and `message`. Phases cover discovery, backup, JSONL rewrite, SQLite update, and verification. Copy fallback and long rewrites emit chunk-level progress; other loops emit periodic item-level progress. Human-readable summary output remains compatible.
 
-ProviderSwitcher parses these events into a typed 64-bit progress record, updates a phase label and progress bar, and resets an idle timer only when completed work increases or the operation makes a valid phase/total transition. Repeated identical events do not mask a stall. There is no total-duration deadline. If progress does not advance for the configured idle interval, the process tree is terminated, accumulated stdout/stderr is retained, both the immediate `Created backup at ...` identity and final `- Backup: ...` identity are accepted only after path validation, and rollback is attempted. A timeout without valid backup evidence is reported as unproven rather than as a successful restore.
+A supervising consumer can parse these events into a 64-bit progress record and reset an idle timer only when completed work increases or the operation makes a valid phase/total transition. Repeated identical events must not mask a stall. Consumer-specific process-tree termination, UI display, output retention, backup-path validation, and rollback orchestration are outside this CLI change.
 
 ## Risks / Trade-offs
 
@@ -55,13 +55,13 @@ ProviderSwitcher parses these events into a typed 64-bit progress record, update
 - [A first metadata record is missing, oversized, or malformed] → Discovery reports the file as metadata-unavailable and does not inspect transcript content or select the file for mutation.
 - [Progress event loss could trigger an idle timeout during healthy work] → Long byte-copy and rewrite loops emit chunk-level events, and the idle interval is comfortably above the maximum expected gap.
 - [Derived after-counts could hide a failed mutation] → Results are returned only after targeted JSONL and SQLite verification confirms the plan.
-- [Rollback after an unreported timeout cannot be proven] → ProviderSwitcher preserves the target config and marks metadata repair pending instead of claiming a safe rollback.
+- [Rollback after an unreported timeout cannot be proven] → The supervisor must retain validated backup evidence and report an unproven restore rather than claiming success.
 
 ## Migration Plan
 
 1. Add regression and performance-shape tests for one-pass planning, hard-link/copy fallback, atomic replacement, targeted verification, and progress emission.
-2. Release the optimized CLI code and the progress-aware ProviderSwitcher together.
-3. Validate both components against synthetic large files and isolated copied metadata; do not run the user's live retag.
+2. Publish the structured progress contract for integrating subprocess supervisors.
+3. Validate the CLI against synthetic large files and isolated copied metadata; do not run the user's live retag.
 4. Keep existing backups. After final user approval and Codex shutdown, use the exact failed-run backup to repair the current partial metadata before retrying the provider switch.
 
 ## Open Questions

--- a/openspec/changes/optimize-large-session-retag/design.md
+++ b/openspec/changes/optimize-large-session-retag/design.md
@@ -41,7 +41,7 @@ A selected JSONL is opened once in binary mode and streamed to a temporary sibli
 
 ### Targeted verification
 
-After mutation, verification reads only the provider-bearing metadata record from JSONL files actually replaced and queries only SQLite databases selected by the plan. It asserts that no planned source-provider metadata remains and that the expected number of rows moved. It does not rescan unrelated JSONL transcript content, unrelated files, or unselected databases.
+After mutation, verification reads only the provider-bearing metadata record from JSONL files actually replaced and queries only SQLite databases selected by the plan. It asserts that no planned source-provider metadata remains and that the expected number of rows moved. It does not rescan unrelated JSONL transcript content, unrelated files, or unselected databases. Verification failures cross the CLI boundary as a controlled non-zero exit; the backup identity emitted before mutation remains available to the operator or supervisor.
 
 ### Structured progress protocol
 

--- a/openspec/changes/optimize-large-session-retag/design.md
+++ b/openspec/changes/optimize-large-session-retag/design.md
@@ -1,0 +1,69 @@
+## Context
+
+The current retag implementation enumerates the same JSONL set repeatedly, parses every record to build provider counts, scans again to select targets, copies every target, rewrites every target, and parses the full home again after mutation. ProviderSwitcher supervises that work with a fixed 300-second process timeout and only reads the completed output. A 9.5 GiB Codex home therefore reached the timeout after creating its backup and partially rewriting files; the supervisor discarded the already-emitted backup path and could not prove rollback.
+
+The CLI already requires Codex process quiescence for writes. That invariant makes same-volume hard-link backups safe when each target is replaced with a newly written file rather than modified in place.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make discovery proportional to the number of sessions rather than total transcript content by reading only each file's first provider-bearing session metadata record.
+- Preserve byte-exact rollback evidence before any target is replaced.
+- Read and rewrite each selected JSONL once, leaving unrelated bytes unchanged.
+- Eliminate duplicate SQLite planning queries and full-home post-scans.
+- Emit structured progress frequently enough for ProviderSwitcher to distinguish long work from a stall.
+- Let ProviderSwitcher stop a process only after progress has been idle, while retaining all output and backup identities for rollback.
+
+**Non-Goals:**
+
+- Running a real provider switch or repairing the user's current session metadata during implementation validation.
+- Changing supported provider names or command-line confirmation semantics.
+- Using hard links for live SQLite databases, which require SQLite-aware backups.
+
+## Decisions
+
+### One immutable execution plan
+
+Discovery creates a typed plan containing every JSONL path, its single session provider, selected JSONL targets, each SQLite database's grouped provider counts, selected SQLite targets, and aggregate before counts. JSONL discovery reads only the bounded first JSONL record, accepting an optional UTF-8 BOM, and treats a missing, oversized, or malformed first metadata record as unavailable instead of parsing transcript records. Each SQLite database is queried once with a grouped provider count query.
+
+The plan is reused for backup, mutation, result counts, and targeted verification. Provider counts after mutation are derived by moving the planned match counts from source to target and are accepted only after targeted verification succeeds.
+
+### Hard-link JSONL backups with copy fallback
+
+For each selected JSONL, the backup destination is created before mutation. The implementation first calls the platform hard-link operation. Because the backup directory is under the same Codex home and write mode requires quiescence, the link points at an immutable original inode. The live path is then replaced with a separately written temporary file, so the backup continues to reference the original bytes.
+
+If link creation is unsupported, crosses a volume, or is denied by the filesystem, the implementation copies the original to a new backup file, flushes the copy, preserves metadata, and verifies its size before allowing replacement. Unexpected backup errors abort the operation before that target is replaced. SQLite databases continue to use SQLite's backup API.
+
+### Single-pass atomic JSONL rewrite
+
+A selected JSONL is opened once in binary mode and streamed to a temporary sibling. Only the planned provider-bearing metadata record is decoded and normalized; an existing UTF-8 BOM is preserved, and all other lines are copied byte-for-byte. The temporary file is flushed and atomically replaces the live path. A failed write removes the temporary file and leaves the original path intact. The SQLite copy fallback likewise consolidates and flushes its sibling temporary database before atomically replacing the live database rather than copying over the live path.
+
+### Targeted verification
+
+After mutation, verification reads only the provider-bearing metadata record from JSONL files actually replaced and queries only SQLite databases selected by the plan. It asserts that no planned source-provider metadata remains and that the expected number of rows moved. It does not rescan unrelated JSONL transcript content, unrelated files, or unselected databases.
+
+### Structured progress protocol
+
+The CLI emits newline-delimited events prefixed with `CODEX_LB_RETAG_PROGRESS `. The JSON payload contains `phase`, `completed`, `total`, `unit`, and `message`. Phases cover discovery, backup, JSONL rewrite, SQLite update, and verification. Copy fallback and long rewrites emit chunk-level progress; other loops emit periodic item-level progress. Human-readable summary output remains compatible.
+
+ProviderSwitcher parses these events into a typed 64-bit progress record, updates a phase label and progress bar, and resets an idle timer only when completed work increases or the operation makes a valid phase/total transition. Repeated identical events do not mask a stall. There is no total-duration deadline. If progress does not advance for the configured idle interval, the process tree is terminated, accumulated stdout/stderr is retained, both the immediate `Created backup at ...` identity and final `- Backup: ...` identity are accepted only after path validation, and rollback is attempted. A timeout without valid backup evidence is reported as unproven rather than as a successful restore.
+
+## Risks / Trade-offs
+
+- [Hard links share the original inode] → Writes remain copy-on-replace only, write mode retains the Codex quiescence gate, and fallback copy is used whenever link creation fails.
+- [A first metadata record is missing, oversized, or malformed] → Discovery reports the file as metadata-unavailable and does not inspect transcript content or select the file for mutation.
+- [Progress event loss could trigger an idle timeout during healthy work] → Long byte-copy and rewrite loops emit chunk-level events, and the idle interval is comfortably above the maximum expected gap.
+- [Derived after-counts could hide a failed mutation] → Results are returned only after targeted JSONL and SQLite verification confirms the plan.
+- [Rollback after an unreported timeout cannot be proven] → ProviderSwitcher preserves the target config and marks metadata repair pending instead of claiming a safe rollback.
+
+## Migration Plan
+
+1. Add regression and performance-shape tests for one-pass planning, hard-link/copy fallback, atomic replacement, targeted verification, and progress emission.
+2. Release the optimized CLI code and the progress-aware ProviderSwitcher together.
+3. Validate both components against synthetic large files and isolated copied metadata; do not run the user's live retag.
+4. Keep existing backups. After final user approval and Codex shutdown, use the exact failed-run backup to repair the current partial metadata before retrying the provider switch.
+
+## Open Questions
+
+None. The user has explicitly selected single-pass planning, hard-link-first backup, targeted verification, idle timeout, and UI progress as the required behavior.

--- a/openspec/changes/optimize-large-session-retag/proposal.md
+++ b/openspec/changes/optimize-large-session-retag/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Provider switching can leave large Codex homes partially retagged when repeated full JSONL scans, full-copy backups, rewrites, and verification exceed the ProviderSwitcher process limit. The retag path must scale with session volume while preserving exact rollback evidence and observable forward progress.
+
+## What Changes
+
+- Build the JSONL target set and provider counts from one metadata-only discovery pass.
+- Back up matched JSONL files with same-volume hard links when safe, with a verified copy fallback when links are unavailable.
+- Rewrite each matched JSONL once through an atomic replacement and verify only the metadata that was changed.
+- Query each SQLite database once for planning, then verify only databases and rows selected by that plan.
+- Emit machine-readable progress events that distinguish discovery, backup, JSONL rewrite, SQLite update, and verification work.
+- Define progress-aware execution so an integrating UI can stop a genuinely stalled retag without imposing a fixed total-duration limit.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `runtime-portability`: Strengthen the Codex session retag contract for large homes, exact rollback, bounded passes, progress reporting, and targeted verification.
+
+## Impact
+
+- Affected code: `app/codex_sessions_retag.py`, `app/cli.py`, and retag unit/CLI tests.
+- Affected consumer: ProviderSwitcher subprocess supervision and progress UI.
+- Storage behavior: backup creation prefers same-volume hard links but retains a safe copy fallback and atomic destination replacement.
+- No CLI command-line compatibility break is intended.

--- a/openspec/changes/optimize-large-session-retag/proposal.md
+++ b/openspec/changes/optimize-large-session-retag/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-Provider switching can leave large Codex homes partially retagged when repeated full JSONL scans, full-copy backups, rewrites, and verification exceed the ProviderSwitcher process limit. The retag path must scale with session volume while preserving exact rollback evidence and observable forward progress.
+Provider switching can leave large Codex homes partially retagged when repeated full JSONL scans, full-copy backups, rewrites, and verification exceed an integrating supervisor's process limit. The retag path must scale with session volume while preserving exact rollback evidence and observable forward progress.
 
 ## What Changes
 
@@ -24,6 +24,6 @@ None.
 ## Impact
 
 - Affected code: `app/codex_sessions_retag.py`, `app/cli.py`, and retag unit/CLI tests.
-- Affected consumer: ProviderSwitcher subprocess supervision and progress UI.
+- Affected consumer contract: any subprocess supervisor that parses the structured progress stream.
 - Storage behavior: backup creation prefers same-volume hard links but retains a safe copy fallback and atomic destination replacement.
 - No CLI command-line compatibility break is intended.

--- a/openspec/changes/optimize-large-session-retag/specs/runtime-portability/spec.md
+++ b/openspec/changes/optimize-large-session-retag/specs/runtime-portability/spec.md
@@ -1,0 +1,55 @@
+## MODIFIED Requirements
+
+### Requirement: Codex session provider retag CLI
+
+The `codex-lb` CLI SHALL provide a `codex-sessions retag` subcommand that rewrites local Codex session metadata from one supported model provider tag to another supported model provider tag. The command MUST support `openai` and `codex-lb` provider tags, MUST reject unknown providers, and MUST reject retag requests where `--from` and `--to` are the same provider. The command MUST preserve session continuity and exact rollback evidence while avoiding duplicate full-session scans.
+
+#### Scenario: Dry run plans JSONL and SQLite changes without writing
+
+- **WHEN** an operator runs `codex-lb codex-sessions retag --from openai --to codex-lb --dry-run`
+- **THEN** the command reads only the provider-bearing session metadata needed from each JSONL session file
+- **AND** it does not scan transcript records when the bounded first metadata record is missing or malformed
+- **AND** the same discovery pass determines JSONL targets and JSONL provider counts
+- **AND** each `state_*.sqlite` database with a `threads.model_provider` column is queried once for planning
+- **AND** the command reports the matching files and rows
+- **AND** it does not create backups or mutate session metadata
+
+#### Scenario: Confirmed retag uses exact backup and atomic JSONL replacement
+
+- **WHEN** an operator runs `codex-lb codex-sessions retag --from openai --to codex-lb --yes`
+- **THEN** each matched JSONL original is backed up before replacement
+- **AND** the command MUST prefer a same-volume hard link for the JSONL backup
+- **AND** it MUST fall back to a completed safe copy when a hard link cannot be created
+- **AND** each matched JSONL is read once for transformation and atomically replaced with the converted file
+- **AND** matched SQLite `threads.model_provider` rows are backed up through a SQLite-safe mechanism and rewritten to `codex-lb`
+- **AND** a SQLite copy fallback flushes a sibling temporary database and atomically replaces the live database
+- **AND** the command reports a summary of scanned and updated JSONL files and SQLite rows
+
+#### Scenario: Retag verifies only planned mutation targets
+
+- **WHEN** the confirmed retag finishes writing its planned targets
+- **THEN** the command verifies the provider-bearing metadata of each changed JSONL file
+- **AND** it verifies only SQLite databases selected by the plan
+- **AND** it MUST NOT perform a second full-home JSONL transcript scan or re-query unselected SQLite databases
+- **AND** it fails without reporting success if any planned source-provider metadata remains
+
+#### Scenario: Retag emits structured progress throughout long work
+
+- **WHEN** discovery, fallback copying, JSONL rewriting, SQLite updating, or verification is in progress
+- **THEN** the CLI emits newline-delimited structured progress containing phase, completed work, total work, unit, and a human-readable message
+- **AND** long byte-processing operations emit progress often enough for a supervising process to distinguish active work from a stall
+- **AND** byte counters support totals larger than 2 GiB
+- **AND** a supervising process treats repeated unchanged progress as stalled rather than extending the operation indefinitely
+- **AND** existing human-readable summary fields remain available after completion
+
+#### Scenario: Non-interactive writes require explicit confirmation
+
+- **WHEN** the command is run in a non-interactive shell without `--dry-run` and without `--yes`
+- **THEN** it refuses to write session metadata
+- **AND** it exits with an error explaining that `--yes` is required
+
+#### Scenario: Codex home resolves across host runtimes
+
+- **WHEN** `--codex-home` is provided
+- **THEN** the command uses that path as the Codex data directory
+- **AND** otherwise it falls back to `CODEX_HOME`, `/codex-home` in containers, a discoverable WSL Windows profile Codex directory, or `~/.codex`

--- a/openspec/changes/optimize-large-session-retag/specs/runtime-portability/spec.md
+++ b/openspec/changes/optimize-large-session-retag/specs/runtime-portability/spec.md
@@ -32,6 +32,7 @@ The `codex-lb` CLI SHALL provide a `codex-sessions retag` subcommand that rewrit
 - **AND** it verifies only SQLite databases selected by the plan
 - **AND** it MUST NOT perform a second full-home JSONL transcript scan or re-query unselected SQLite databases
 - **AND** it fails without reporting success if any planned source-provider metadata remains
+- **AND** the CLI reports verification failure as a controlled non-zero exit while retaining the already-emitted backup identity
 
 #### Scenario: Retag emits structured progress throughout long work
 

--- a/openspec/changes/optimize-large-session-retag/tasks.md
+++ b/openspec/changes/optimize-large-session-retag/tasks.md
@@ -11,15 +11,15 @@
 - [x] 2.3 Implement single-pass atomic JSONL conversion and targeted post-verification.
 - [x] 2.4 Emit structured phase and byte/item progress events while preserving the human-readable CLI summary.
 
-## 3. ProviderSwitcher Supervision and UX
+## 3. Subprocess supervision contract
 
-- [x] 3.1 Add a subprocess regression test for timeout after a reported backup and for missing rollback evidence.
-- [x] 3.2 Replace the fixed total timeout with progress-event-based idle detection while retaining partial stdout and backup paths.
-- [x] 3.3 Add typed retag progress propagation and display phase/progress in the ProviderSwitcher UI.
+- [x] 3.1 Emit a backup identity before long mutation phases and preserve the final backup identity in the summary.
+- [x] 3.2 Define progress-event semantics that allow an external supervisor to implement idle detection.
+- [x] 3.3 Keep process termination, UI display, and rollback orchestration outside the CLI implementation contract.
 
 ## 4. Verification and Packaging
 
 - [x] 4.1 Run focused and full codex-lb retag/CLI tests plus lint and strict OpenSpec validation.
-- [x] 4.2 Run ProviderSwitcher recovery tests, build, isolated self-test, and publish checks.
+- [x] 4.2 Run strict OpenSpec validation for the CLI contract.
 - [x] 4.3 Benchmark an isolated large-session fixture and verify no live provider switch or user-session retag is performed.
-- [x] 4.4 Produce the updated local EXE and approval-safe handoff with the existing 2455 and 2456 containers unchanged.
+- [x] 4.4 Produce an approval-safe CLI handoff without changing live provider configuration or containers.

--- a/openspec/changes/optimize-large-session-retag/tasks.md
+++ b/openspec/changes/optimize-large-session-retag/tasks.md
@@ -1,0 +1,25 @@
+## 1. Retag Planning and Backup Tests
+
+- [x] 1.1 Add a regression test proving JSONL target selection and provider counts share one metadata-only discovery pass.
+- [x] 1.2 Add tests for hard-link backup success and safe copy fallback before atomic replacement.
+- [x] 1.3 Add tests proving SQLite planning removes duplicate count queries and verification is target-only.
+
+## 2. Retag Core Implementation
+
+- [x] 2.1 Implement the immutable JSONL and SQLite retag plan.
+- [x] 2.2 Implement hard-link-first JSONL backup with flushed copy fallback.
+- [x] 2.3 Implement single-pass atomic JSONL conversion and targeted post-verification.
+- [x] 2.4 Emit structured phase and byte/item progress events while preserving the human-readable CLI summary.
+
+## 3. ProviderSwitcher Supervision and UX
+
+- [x] 3.1 Add a subprocess regression test for timeout after a reported backup and for missing rollback evidence.
+- [x] 3.2 Replace the fixed total timeout with progress-event-based idle detection while retaining partial stdout and backup paths.
+- [x] 3.3 Add typed retag progress propagation and display phase/progress in the ProviderSwitcher UI.
+
+## 4. Verification and Packaging
+
+- [x] 4.1 Run focused and full codex-lb retag/CLI tests plus lint and strict OpenSpec validation.
+- [x] 4.2 Run ProviderSwitcher recovery tests, build, isolated self-test, and publish checks.
+- [x] 4.3 Benchmark an isolated large-session fixture and verify no live provider switch or user-session retag is performed.
+- [x] 4.4 Produce the updated local EXE and approval-safe handoff with the existing 2455 and 2456 containers unchanged.

--- a/openspec/changes/optimize-large-session-retag/tasks.md
+++ b/openspec/changes/optimize-large-session-retag/tasks.md
@@ -10,6 +10,7 @@
 - [x] 2.2 Implement hard-link-first JSONL backup with flushed copy fallback.
 - [x] 2.3 Implement single-pass atomic JSONL conversion and targeted post-verification.
 - [x] 2.4 Emit structured phase and byte/item progress events while preserving the human-readable CLI summary.
+- [x] 2.5 Translate verification failures into a controlled CLI error while retaining backup evidence.
 
 ## 3. Subprocess supervision contract
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -486,6 +486,40 @@ def test_codex_sessions_retag_reports_file_access_errors(monkeypatch, tmp_path):
         )
 
 
+def test_codex_sessions_retag_reports_verification_failure_without_traceback(capsys, tmp_path):
+    state_db = tmp_path / "state_5.sqlite"
+    with sqlite3.connect(state_db) as conn:
+        conn.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT)")
+        conn.execute("INSERT INTO threads (id, model_provider) VALUES ('thread-1', 'openai')")
+        conn.execute(
+            """
+            CREATE TRIGGER preserve_provider
+            AFTER UPDATE OF model_provider ON threads
+            BEGIN
+                UPDATE threads SET model_provider = 'openai' WHERE id = NEW.id;
+            END
+            """
+        )
+
+    with pytest.raises(SystemExit, match="SQLite verification failed"):
+        cli.main(
+            [
+                "codex-sessions",
+                "retag",
+                "--from",
+                "openai",
+                "--to",
+                "codex-lb",
+                "--codex-home",
+                str(tmp_path),
+                "--yes",
+            ]
+        )
+
+    captured = capsys.readouterr()
+    assert "Created backup at " in captured.out
+
+
 def test_codex_sessions_retag_yes_updates_jsonl_and_sqlite(capsys, tmp_path):
     session_file = tmp_path / "sessions" / "session.jsonl"
     session_file.parent.mkdir(parents=True)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -517,6 +517,44 @@ def test_codex_sessions_retag_yes_updates_jsonl_and_sqlite(capsys, tmp_path):
         assert conn.execute("SELECT model_provider FROM threads").fetchone()[0] == "codex-lb"
 
 
+def test_codex_sessions_metadata_mismatches_returns_only_conflicting_session_as_json(capsys, tmp_path):
+    target_id = "019f7249-90ee-74c0-a0e6-42117e80bc7f"
+    unrelated_id = "019f7249-90ee-74c0-a0e6-42117e80bc70"
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir(parents=True)
+    (sessions_dir / "target.jsonl").write_text(
+        json.dumps({"type": "session_meta", "payload": {"id": target_id, "model_provider": "codex-lb"}}) + "\n",
+        encoding="utf-8",
+    )
+    (sessions_dir / "unrelated.jsonl").write_text(
+        json.dumps({"type": "session_meta", "payload": {"id": unrelated_id, "model_provider": "openai"}}) + "\n",
+        encoding="utf-8",
+    )
+    with sqlite3.connect(tmp_path / "state_5.sqlite") as conn:
+        conn.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT)")
+        conn.executemany(
+            "INSERT INTO threads (id, model_provider) VALUES (?, ?)",
+            [(target_id, "openai"), (unrelated_id, "openai")],
+        )
+
+    cli.main(
+        [
+            "codex-sessions",
+            "metadata-mismatches",
+            "--provider",
+            "codex-lb",
+            "--codex-home",
+            str(tmp_path),
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert [item["session_id"] for item in payload["mismatches"]] == [target_id]
+    assert payload["mismatches"][0]["jsonl_paths"] == []
+    assert payload["mismatches"][0]["sqlite_db_paths"] == [str(tmp_path / "state_5.sqlite")]
+
+
 def test_utc_default_formatter_formats_without_converter_binding_error():
     formatter = UtcDefaultFormatter(
         fmt="%(asctime)s %(message)s",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -10,6 +10,7 @@ from typing import Any
 import pytest
 
 from app import cli
+from app.codex_sessions_retag import PROGRESS_PREFIX
 from app.core.runtime_logging import UtcDefaultFormatter
 
 pytestmark = pytest.mark.unit
@@ -553,6 +554,43 @@ def test_codex_sessions_metadata_mismatches_returns_only_conflicting_session_as_
     assert [item["session_id"] for item in payload["mismatches"]] == [target_id]
     assert payload["mismatches"][0]["jsonl_paths"] == []
     assert payload["mismatches"][0]["sqlite_db_paths"] == [str(tmp_path / "state_5.sqlite")]
+
+
+def test_codex_sessions_repair_metadata_streams_progress_to_stderr_with_json(capsys, tmp_path):
+    session_id = "019f7249-90ee-74c0-a0e6-42117e80bc7f"
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir(parents=True)
+    (sessions_dir / "target.jsonl").write_text(
+        json.dumps({"type": "session_meta", "payload": {"id": session_id, "model_provider": "codex-lb"}}) + "\n",
+        encoding="utf-8",
+    )
+    with sqlite3.connect(tmp_path / "state_5.sqlite") as conn:
+        conn.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT)")
+        conn.execute(
+            "INSERT INTO threads (id, model_provider) VALUES (?, ?)",
+            (session_id, "openai"),
+        )
+
+    cli.main(
+        [
+            "codex-sessions",
+            "repair-metadata",
+            "--provider",
+            "codex-lb",
+            "--session-id",
+            session_id,
+            "--codex-home",
+            str(tmp_path),
+            "--yes",
+            "--json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["session_ids"] == [session_id]
+    assert payload["sqlite_rows_updated"] == 1
+    assert PROGRESS_PREFIX in captured.err
 
 
 def test_utc_default_formatter_formats_without_converter_binding_error():

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -590,6 +590,21 @@ def test_codex_sessions_metadata_mismatches_returns_only_conflicting_session_as_
     assert payload["mismatches"][0]["sqlite_db_paths"] == [str(tmp_path / "state_5.sqlite")]
 
 
+def test_codex_sessions_metadata_mismatches_rejects_unsupported_active_provider(tmp_path):
+    with pytest.raises(SystemExit, match="unsupported active provider bogus"):
+        cli.main(
+            [
+                "codex-sessions",
+                "metadata-mismatches",
+                "--provider",
+                "bogus",
+                "--codex-home",
+                str(tmp_path),
+                "--json",
+            ]
+        )
+
+
 def test_codex_sessions_repair_metadata_streams_progress_to_stderr_with_json(capsys, tmp_path):
     session_id = "019f7249-90ee-74c0-a0e6-42117e80bc7f"
     sessions_dir = tmp_path / "sessions"

--- a/tests/unit/test_codex_sessions_retag.py
+++ b/tests/unit/test_codex_sessions_retag.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
+import errno
 import json
+import os
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 
 import pytest
 
 from app import codex_sessions_retag
-from app.codex_sessions_retag import ProviderCount, retag_codex_sessions
+from app.codex_sessions_retag import (
+    ProviderCount,
+    preview_session_metadata_mismatches,
+    repair_session_metadata_mismatches,
+    retag_codex_sessions,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -18,17 +26,60 @@ def _write_jsonl(path: Path, records: list[dict[str, object]]) -> None:
 
 
 def _create_state_db(path: Path, providers: list[str]) -> None:
-    with sqlite3.connect(path) as conn:
+    with closing(sqlite3.connect(path)) as conn:
         conn.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT)")
         conn.executemany(
             "INSERT INTO threads (id, model_provider) VALUES (?, ?)",
             [(f"thread-{index}", provider) for index, provider in enumerate(providers)],
         )
+        conn.commit()
 
 
 def _read_state_providers(path: Path) -> list[str]:
-    with sqlite3.connect(path) as conn:
+    with closing(sqlite3.connect(path)) as conn:
         return [row[0] for row in conn.execute("SELECT model_provider FROM threads ORDER BY id").fetchall()]
+
+
+def test_targeted_metadata_repair_updates_only_sqlite_mismatch_and_preserves_unrelated_session(tmp_path: Path) -> None:
+    codex_home = tmp_path / ".codex"
+    target_id = "019f7249-90ee-74c0-a0e6-42117e80bc7f"
+    unrelated_id = "019f7249-90ee-74c0-a0e6-42117e80bc70"
+    target_jsonl = codex_home / "sessions" / "2026" / f"{target_id}.jsonl"
+    unrelated_jsonl = codex_home / "sessions" / "2026" / f"{unrelated_id}.jsonl"
+    state_db = codex_home / "state_5.sqlite"
+    _write_jsonl(target_jsonl, [{"type": "session_meta", "payload": {"id": target_id, "model_provider": "codex-lb"}}])
+    _write_jsonl(
+        unrelated_jsonl,
+        [{"type": "session_meta", "payload": {"id": unrelated_id, "model_provider": "openai"}}],
+    )
+    with closing(sqlite3.connect(state_db)) as conn:
+        conn.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT)")
+        conn.executemany(
+            "INSERT INTO threads (id, model_provider) VALUES (?, ?)",
+            [(target_id, "openai"), (unrelated_id, "openai")],
+        )
+        conn.commit()
+
+    preview = preview_session_metadata_mismatches(codex_home=codex_home, active_provider="codex-lb")
+
+    assert [item.session_id for item in preview.mismatches] == [target_id]
+    assert preview.mismatches[0].jsonl_paths == ()
+    assert preview.mismatches[0].sqlite_db_paths == (state_db,)
+
+    result = repair_session_metadata_mismatches(
+        codex_home=codex_home,
+        active_provider="codex-lb",
+        session_ids=[target_id],
+    )
+
+    assert result.sqlite_rows_updated == 1
+    assert result.jsonl_files_updated == 0
+    assert result.backup_path is not None
+    with closing(sqlite3.connect(state_db)) as conn:
+        rows = dict(conn.execute("SELECT id, model_provider FROM threads").fetchall())
+    assert rows == {target_id: "codex-lb", unrelated_id: "openai"}
+    assert json.loads(target_jsonl.read_text(encoding="utf-8"))["payload"]["model_provider"] == "codex-lb"
+    assert json.loads(unrelated_jsonl.read_text(encoding="utf-8"))["payload"]["model_provider"] == "openai"
 
 
 def test_dry_run_reports_jsonl_and_sqlite_without_writing(tmp_path: Path) -> None:
@@ -60,6 +111,229 @@ def test_dry_run_reports_jsonl_and_sqlite_without_writing(tmp_path: Path) -> Non
     assert not (codex_home / "backups").exists()
 
 
+def test_discovery_stops_after_first_session_metadata_record(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    codex_home = tmp_path / ".codex"
+    session_file = codex_home / "sessions" / "2026" / "session.jsonl"
+    _write_jsonl(
+        session_file,
+        [
+            {"type": "session_meta", "payload": {"model_provider": "openai", "id": "meta"}},
+            {"type": "turn_context", "payload": {"model_provider": "openai"}},
+        ],
+    )
+    original_loads = json.loads
+
+    def reject_turn_payload(value: str, *args, **kwargs):
+        if '"type": "turn_context"' in value:
+            raise AssertionError("discovery parsed beyond session metadata")
+        return original_loads(value, *args, **kwargs)
+
+    monkeypatch.setattr(codex_sessions_retag.json, "loads", reject_turn_payload)
+
+    result = retag_codex_sessions(
+        codex_home=codex_home,
+        source_provider="openai",
+        target_provider="codex-lb",
+        dry_run=True,
+    )
+
+    assert result.jsonl_files_scanned == 1
+    assert result.jsonl_files_matched == 1
+    assert result.provider_counts_before == (ProviderCount("openai", 1),)
+
+
+def test_discovery_does_not_scan_transcript_after_malformed_first_record(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    codex_home = tmp_path / ".codex"
+    session_file = codex_home / "sessions" / "2026" / "session.jsonl"
+    session_file.parent.mkdir(parents=True)
+    session_file.write_text(
+        "{malformed-session-meta}\n"
+        + json.dumps({"type": "turn_context", "payload": {"model_provider": "openai"}})
+        + "\n",
+        encoding="utf-8",
+    )
+    original_loads = json.loads
+
+    def reject_turn_payload(value: str, *args, **kwargs):
+        if '"type": "turn_context"' in value:
+            raise AssertionError("discovery parsed transcript content after malformed metadata")
+        return original_loads(value, *args, **kwargs)
+
+    monkeypatch.setattr(codex_sessions_retag.json, "loads", reject_turn_payload)
+
+    result = retag_codex_sessions(
+        codex_home=codex_home,
+        source_provider="openai",
+        target_provider="codex-lb",
+        dry_run=True,
+    )
+
+    assert result.jsonl_files_scanned == 1
+    assert result.jsonl_files_matched == 0
+    assert result.provider_counts_before == ()
+    assert any("metadata was unavailable in 1 file" in line for line in result.logs)
+
+
+def test_retag_accepts_and_preserves_utf8_bom_on_session_metadata(tmp_path: Path) -> None:
+    codex_home = tmp_path / ".codex"
+    session_file = codex_home / "sessions" / "2026" / "session.jsonl"
+    session_file.parent.mkdir(parents=True)
+    metadata = json.dumps(
+        {"type": "session_meta", "payload": {"model_provider": "openai", "id": "bom"}},
+        separators=(",", ":"),
+    ).encode("utf-8")
+    session_file.write_bytes(b"\xef\xbb\xbf" + metadata + b"\ntranscript bytes are not parsed\n")
+
+    result = retag_codex_sessions(
+        codex_home=codex_home,
+        source_provider="openai",
+        target_provider="codex-lb",
+    )
+
+    assert result.jsonl_files_matched == 1
+    assert result.provider_counts_before == (ProviderCount("openai", 1),)
+    rewritten = session_file.read_bytes()
+    assert rewritten.startswith(b"\xef\xbb\xbf")
+    assert (
+        json.loads(rewritten.removeprefix(b"\xef\xbb\xbf").splitlines()[0])["payload"]["model_provider"] == "codex-lb"
+    )
+
+
+def test_jsonl_backup_prefers_hardlink_before_atomic_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    codex_home = tmp_path / ".codex"
+    session_file = codex_home / "sessions" / "2026" / "session.jsonl"
+    original_bytes = (
+        b'{"type":"session_meta","payload":{"model_provider":"openai","id":"meta"}}\r\n'
+        b'{"type":"turn_context","payload":{"note":"preserve this byte-for-byte"}}\r\n'
+    )
+    session_file.parent.mkdir(parents=True)
+    session_file.write_bytes(original_bytes)
+    original_inode = session_file.stat().st_ino
+    link_calls: list[tuple[Path, Path]] = []
+    original_link = os.link
+
+    def capture_link(source: Path, destination: Path) -> None:
+        link_calls.append((Path(source), Path(destination)))
+        original_link(source, destination)
+
+    monkeypatch.setattr(codex_sessions_retag.os, "link", capture_link)
+
+    result = retag_codex_sessions(
+        codex_home=codex_home,
+        source_provider="openai",
+        target_provider="codex-lb",
+    )
+
+    assert result.backup_path is not None
+    backup_file = result.backup_path / "sessions" / "2026" / "session.jsonl"
+    assert link_calls == [(session_file, backup_file)]
+    assert backup_file.read_bytes() == original_bytes
+    assert backup_file.stat().st_ino == original_inode
+    assert session_file.stat().st_ino != original_inode
+    assert session_file.read_bytes().splitlines(keepends=True)[1] == original_bytes.splitlines(keepends=True)[1]
+
+
+def test_jsonl_backup_falls_back_to_flushed_copy(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    codex_home = tmp_path / ".codex"
+    session_file = codex_home / "sessions" / "2026" / "session.jsonl"
+    original_bytes = b'{"model_provider":"openai","id":"meta"}\ntrailing bytes stay unchanged\n'
+    session_file.parent.mkdir(parents=True)
+    session_file.write_bytes(original_bytes)
+
+    def reject_link(_source: Path, _destination: Path) -> None:
+        raise OSError(errno.EXDEV, "cross-device link")
+
+    monkeypatch.setattr(codex_sessions_retag.os, "link", reject_link)
+
+    result = retag_codex_sessions(
+        codex_home=codex_home,
+        source_provider="openai",
+        target_provider="codex-lb",
+    )
+
+    assert result.backup_path is not None
+    backup_file = result.backup_path / "sessions" / "2026" / "session.jsonl"
+    assert backup_file.read_bytes() == original_bytes
+    assert session_file.read_bytes().endswith(b"trailing bytes stay unchanged\n")
+
+
+def test_sqlite_planning_queries_each_db_once_and_verifies_only_selected_db(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    codex_home = tmp_path / ".codex"
+    selected_db = codex_home / "state_5.sqlite"
+    unselected_db = codex_home / "state_6.sqlite"
+    codex_home.mkdir()
+    _create_state_db(selected_db, ["openai", "codex-lb"])
+    _create_state_db(unselected_db, ["codex-lb"])
+    calls: dict[Path, int] = {}
+    original_provider_counts = codex_sessions_retag._sqlite_provider_counts
+
+    def capture_provider_counts(path: Path):
+        calls[path] = calls.get(path, 0) + 1
+        return original_provider_counts(path)
+
+    monkeypatch.setattr(codex_sessions_retag, "_sqlite_provider_counts", capture_provider_counts)
+
+    result = retag_codex_sessions(
+        codex_home=codex_home,
+        source_provider="openai",
+        target_provider="codex-lb",
+    )
+
+    assert result.sqlite_rows_matched == 1
+    assert calls == {selected_db: 2, unselected_db: 1}
+
+
+def test_retag_emits_structured_progress_for_each_work_phase(tmp_path: Path) -> None:
+    codex_home = tmp_path / ".codex"
+    session_file = codex_home / "sessions" / "2026" / "session.jsonl"
+    state_db = codex_home / "state_5.sqlite"
+    codex_home.mkdir()
+    _write_jsonl(session_file, [{"model_provider": "openai", "id": "meta"}])
+    _create_state_db(state_db, ["openai"])
+    output: list[str] = []
+
+    retag_codex_sessions(
+        codex_home=codex_home,
+        source_provider="openai",
+        target_provider="codex-lb",
+        progress_logger=output.append,
+    )
+
+    progress = [
+        json.loads(line.removeprefix(codex_sessions_retag.PROGRESS_PREFIX))
+        for line in output
+        if line.startswith(codex_sessions_retag.PROGRESS_PREFIX)
+    ]
+    phases = {event["phase"] for event in progress}
+    assert {"discovery", "backup", "jsonl_rewrite", "sqlite_update", "verification"} <= phases
+    backup_identity_index = next(index for index, line in enumerate(output) if line.startswith("Created backup at "))
+    first_rewrite_index = next(
+        index
+        for index, line in enumerate(output)
+        if line.startswith(codex_sessions_retag.PROGRESS_PREFIX)
+        and json.loads(line.removeprefix(codex_sessions_retag.PROGRESS_PREFIX))["phase"] == "jsonl_rewrite"
+    )
+    assert backup_identity_index < first_rewrite_index
+    for phase in phases:
+        final = [event for event in progress if event["phase"] == phase][-1]
+        assert final["completed"] == final["total"]
+
+
 def test_retag_updates_jsonl_and_sqlite_with_backup(tmp_path: Path) -> None:
     codex_home = tmp_path / ".codex"
     session_file = codex_home / "sessions" / "2026" / "session.jsonl"
@@ -68,8 +342,8 @@ def test_retag_updates_jsonl_and_sqlite_with_backup(tmp_path: Path) -> None:
     _write_jsonl(
         session_file,
         [
-            {"model_provider": "openai", "id": "a"},
-            {"model_provider": "codex-lb", "id": "b"},
+            {"type": "session_meta", "payload": {"model_provider": "openai", "id": "a"}},
+            {"type": "turn_context", "payload": {"model_provider": "codex-lb", "id": "b"}},
         ],
     )
     _create_state_db(state_db, ["openai", "openai", "codex-lb"])
@@ -81,7 +355,8 @@ def test_retag_updates_jsonl_and_sqlite_with_backup(tmp_path: Path) -> None:
     )
 
     records = [json.loads(line) for line in session_file.read_text(encoding="utf-8").splitlines()]
-    assert [record["model_provider"] for record in records] == ["codex-lb", "codex-lb"]
+    assert records[0]["payload"]["model_provider"] == "codex-lb"
+    assert records[1]["payload"]["model_provider"] == "codex-lb"
     assert _read_state_providers(state_db) == ["codex-lb", "codex-lb", "codex-lb"]
     assert result.methods_used == ("jsonl", "sqlite")
     assert result.jsonl_files_updated == 1
@@ -90,7 +365,7 @@ def test_retag_updates_jsonl_and_sqlite_with_backup(tmp_path: Path) -> None:
     assert (result.backup_path / "state_5.sqlite").is_file()
     assert (result.backup_path / "sessions" / "2026" / "session.jsonl").is_file()
     assert ProviderCount("openai", 3) in result.provider_counts_before
-    assert ProviderCount("codex-lb", 5) in result.provider_counts_after
+    assert ProviderCount("codex-lb", 4) in result.provider_counts_after
 
 
 def test_retag_updates_nested_session_meta_provider(tmp_path: Path) -> None:
@@ -118,29 +393,18 @@ def test_retag_updates_nested_session_meta_provider(tmp_path: Path) -> None:
     assert ProviderCount("codex-lb", 1) in result.provider_counts_after
 
 
-def test_retag_streams_jsonl_rewrite_to_temp_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_retag_rewrites_only_planned_metadata_line(tmp_path: Path) -> None:
     codex_home = tmp_path / ".codex"
     session_file = codex_home / "sessions" / "2026" / "session.jsonl"
-    _write_jsonl(session_file, [{"model_provider": "openai", "id": "a"}])
-    writes: list[str] = []
-    original_named_temporary_file = codex_sessions_retag.NamedTemporaryFile
-
-    def capture_named_temporary_file(*args, **kwargs):
-        handle = original_named_temporary_file(*args, **kwargs)
-        original_write = handle.write
-
-        def capture_write(text: str) -> int:
-            writes.append(text)
-            return original_write(text)
-
-        handle.write = capture_write
-        return handle
-
-    monkeypatch.setattr(codex_sessions_retag, "NamedTemporaryFile", capture_named_temporary_file)
+    session_file.parent.mkdir(parents=True)
+    tail = b"{not-json}\n\xff\x00transcript bytes\r\n"
+    session_file.write_bytes(b'{"model_provider": "openai", "id": "a"}\n' + tail)
 
     retag_codex_sessions(codex_home=codex_home, source_provider="openai", target_provider="codex-lb")
 
-    assert writes == ['{"model_provider":"codex-lb","id":"a"}\n']
+    rewritten = session_file.read_bytes()
+    assert rewritten.startswith(b'{"model_provider":"codex-lb","id":"a"}\n')
+    assert rewritten.endswith(tail)
 
 
 def test_retag_surfaces_unreadable_jsonl_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -211,7 +475,6 @@ def test_retag_uses_copy_fallback_when_live_sqlite_cannot_open(monkeypatch: pyte
         return original_connect(path, read_only=read_only, immutable=immutable)
 
     monkeypatch.setattr(codex_sessions_retag, "_connect_sqlite", flaky_connect)
-    monkeypatch.setattr(codex_sessions_retag, "_sqlite_count_provider_rows", lambda _path, _provider: 1)
 
     result = retag_codex_sessions(
         codex_home=codex_home,
@@ -242,15 +505,57 @@ def test_read_only_sqlite_count_uses_non_immutable_uri(monkeypatch: pytest.Monke
     assert "immutable=1" not in calls[0][0]
 
 
+def test_sqlite_provider_count_closes_connection_explicitly(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    state_db = tmp_path / "state_5.sqlite"
+    _create_state_db(state_db, ["openai"])
+    original_connect = codex_sessions_retag._connect_sqlite
+
+    class TrackingConnection:
+        def __init__(self, connection: sqlite3.Connection) -> None:
+            self.connection = connection
+            self.closed = False
+
+        def __getattr__(self, name: str):
+            return getattr(self.connection, name)
+
+        def __enter__(self):
+            self.connection.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self.connection.__exit__(*args)
+
+        def close(self) -> None:
+            self.closed = True
+            self.connection.close()
+
+    tracked: list[TrackingConnection] = []
+
+    def tracking_connect(path: Path, *, read_only: bool = False, immutable: bool = False):
+        connection = TrackingConnection(original_connect(path, read_only=read_only, immutable=immutable))
+        tracked.append(connection)
+        return connection
+
+    monkeypatch.setattr(codex_sessions_retag, "_connect_sqlite", tracking_connect)
+
+    assert codex_sessions_retag._sqlite_provider_counts(state_db) == (ProviderCount("openai", 1),)
+    assert tracked
+    assert all(connection.closed for connection in tracked)
+
+
 def test_retag_skips_legacy_sqlite_without_model_provider_column(tmp_path: Path) -> None:
     codex_home = tmp_path / ".codex"
     state_db = codex_home / "state_4.sqlite"
     session_file = codex_home / "sessions" / "2026" / "session.jsonl"
     codex_home.mkdir()
     _write_jsonl(session_file, [{"model_provider": "openai", "id": "a"}])
-    with sqlite3.connect(state_db) as conn:
+    with closing(sqlite3.connect(state_db)) as conn:
         conn.execute("CREATE TABLE threads (id TEXT PRIMARY KEY)")
         conn.execute("INSERT INTO threads (id) VALUES ('thread-legacy')")
+        conn.commit()
 
     result = retag_codex_sessions(
         codex_home=codex_home,
@@ -261,6 +566,24 @@ def test_retag_skips_legacy_sqlite_without_model_provider_column(tmp_path: Path)
     assert result.sqlite_dbs_scanned == 1
     assert result.sqlite_rows_matched == 0
     assert result.jsonl_files_updated == 1
+
+
+def test_retag_ignores_noncanonical_state_database_backups(tmp_path: Path) -> None:
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    _create_state_db(codex_home / "state_5.sqlite", ["openai"])
+    _create_state_db(codex_home / "state_5.sqlite.xml-cwd-backup.sqlite", ["openai"])
+
+    result = retag_codex_sessions(
+        codex_home=codex_home,
+        source_provider="openai",
+        target_provider="codex-lb",
+        dry_run=True,
+    )
+
+    assert result.sqlite_dbs_scanned == 1
+    assert result.sqlite_dbs_matched == 1
+    assert result.sqlite_rows_matched == 1
 
 
 def test_sqlite_uri_path_normalizes_windows_separators() -> None:
@@ -274,7 +597,7 @@ def test_sqlite_backup_consolidates_wal_rows(tmp_path: Path) -> None:
     codex_home = tmp_path / ".codex"
     state_db = codex_home / "state_5.sqlite"
     codex_home.mkdir()
-    with sqlite3.connect(state_db) as conn:
+    with closing(sqlite3.connect(state_db)) as conn:
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA wal_autocheckpoint=0")
         conn.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT)")
@@ -289,11 +612,14 @@ def test_sqlite_backup_consolidates_wal_rows(tmp_path: Path) -> None:
     assert not Path(f"{backup_db}-wal").exists()
 
 
-def test_sqlite_copy_fallback_uses_consolidated_backup_and_removes_sidecars(tmp_path: Path) -> None:
+def test_sqlite_copy_fallback_uses_atomic_consolidated_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     codex_home = tmp_path / ".codex"
     state_db = codex_home / "state_5.sqlite"
     codex_home.mkdir()
-    with sqlite3.connect(state_db) as conn:
+    with closing(sqlite3.connect(state_db)) as conn:
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA wal_autocheckpoint=0")
         conn.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT)")
@@ -308,9 +634,22 @@ def test_sqlite_copy_fallback_uses_consolidated_backup_and_removes_sidecars(tmp_
         codex_sessions_retag._update_sqlite_provider_in_place(temp_path, "openai", "codex-lb")
         Path(f"{state_db}-wal").write_bytes(b"stale wal")
         Path(f"{state_db}-shm").write_bytes(b"stale shm")
+        replacements: list[tuple[Path, Path]] = []
+        original_replace = codex_sessions_retag.os.replace
+
+        def capture_replace(source: Path, destination: Path) -> None:
+            replacements.append((Path(source), Path(destination)))
+            original_replace(source, destination)
+
+        def reject_non_atomic_copy(*_args, **_kwargs):
+            raise AssertionError("SQLite fallback copied directly over the live database")
+
+        monkeypatch.setattr(codex_sessions_retag.os, "replace", capture_replace)
+        monkeypatch.setattr(codex_sessions_retag.shutil, "copy2", reject_non_atomic_copy)
         codex_sessions_retag._replace_sqlite_db(temp_path, state_db)
 
         assert _read_state_providers(state_db) == ["codex-lb"]
+        assert replacements == [(temp_path, state_db)]
         assert not Path(f"{state_db}-wal").exists()
         assert not Path(f"{state_db}-shm").exists()
     finally:

--- a/tests/unit/test_codex_sessions_retag.py
+++ b/tests/unit/test_codex_sessions_retag.py
@@ -123,6 +123,39 @@ def test_targeted_metadata_preview_rejects_unsupported_sqlite_provider_tag(tmp_p
     assert preview.mismatches == ()
 
 
+def test_targeted_metadata_repair_reports_progress_while_rewriting_large_jsonl(tmp_path: Path) -> None:
+    codex_home = tmp_path / ".codex"
+    session_id = "019f7249-90ee-74c0-a0e6-42117e80bc7f"
+    session_file = codex_home / "sessions" / "2026" / "session.jsonl"
+    session_file.parent.mkdir(parents=True)
+    metadata = json.dumps({"type": "session_meta", "payload": {"id": session_id, "model_provider": "openai"}}).encode()
+    session_file.write_bytes(metadata + b"\n" + b"x" * (8 * 1024 * 1024))
+    original_size = session_file.stat().st_size
+    state_db = codex_home / "state_5.sqlite"
+    _create_state_db(state_db, ["codex-lb"])
+    with closing(sqlite3.connect(state_db)) as conn:
+        conn.execute("UPDATE threads SET id = ?", (session_id,))
+        conn.commit()
+    output: list[str] = []
+
+    result = repair_session_metadata_mismatches(
+        codex_home=codex_home,
+        active_provider="codex-lb",
+        session_ids=[session_id],
+        progress_logger=output.append,
+    )
+
+    progress = [
+        json.loads(line.removeprefix(codex_sessions_retag.PROGRESS_PREFIX))
+        for line in output
+        if line.startswith(codex_sessions_retag.PROGRESS_PREFIX)
+    ]
+    rewrite_progress = [event for event in progress if event["phase"] == "jsonl_rewrite"]
+    assert result.jsonl_files_updated == 1
+    assert any(0 < event["completed"] < event["total"] for event in rewrite_progress)
+    assert rewrite_progress[-1]["completed"] == rewrite_progress[-1]["total"] == original_size
+
+
 def test_dry_run_reports_jsonl_and_sqlite_without_writing(tmp_path: Path) -> None:
     codex_home = tmp_path / ".codex"
     session_file = codex_home / "sessions" / "2026" / "session.jsonl"

--- a/tests/unit/test_codex_sessions_retag.py
+++ b/tests/unit/test_codex_sessions_retag.py
@@ -82,6 +82,47 @@ def test_targeted_metadata_repair_updates_only_sqlite_mismatch_and_preserves_unr
     assert json.loads(unrelated_jsonl.read_text(encoding="utf-8"))["payload"]["model_provider"] == "openai"
 
 
+def test_targeted_metadata_preview_rejects_unsupported_jsonl_provider_tag(tmp_path: Path) -> None:
+    codex_home = tmp_path / ".codex"
+    session_id = "019f7249-90ee-74c0-a0e6-42117e80bc7f"
+    _write_jsonl(
+        codex_home / "sessions" / "2026" / "active.jsonl",
+        [{"type": "session_meta", "payload": {"id": session_id, "model_provider": "codex-lb"}}],
+    )
+    _write_jsonl(
+        codex_home / "sessions" / "2026" / "unsupported.jsonl",
+        [{"type": "session_meta", "payload": {"id": session_id, "model_provider": "codex-lb-ws"}}],
+    )
+    state_db = codex_home / "state_5.sqlite"
+    _create_state_db(state_db, ["openai"])
+    with closing(sqlite3.connect(state_db)) as conn:
+        conn.execute("UPDATE threads SET id = ?", (session_id,))
+        conn.commit()
+
+    preview = preview_session_metadata_mismatches(codex_home=codex_home, active_provider="codex-lb")
+
+    assert preview.mismatches == ()
+
+
+def test_targeted_metadata_preview_rejects_unsupported_sqlite_provider_tag(tmp_path: Path) -> None:
+    codex_home = tmp_path / ".codex"
+    session_id = "019f7249-90ee-74c0-a0e6-42117e80bc7f"
+    _write_jsonl(
+        codex_home / "sessions" / "2026" / "active.jsonl",
+        [{"type": "session_meta", "payload": {"id": session_id, "model_provider": "codex-lb"}}],
+    )
+    for db_name, provider in (("state_5.sqlite", "openai"), ("state_6.sqlite", "codex-lb-ws")):
+        state_db = codex_home / db_name
+        _create_state_db(state_db, [provider])
+        with closing(sqlite3.connect(state_db)) as conn:
+            conn.execute("UPDATE threads SET id = ?", (session_id,))
+            conn.commit()
+
+    preview = preview_session_metadata_mismatches(codex_home=codex_home, active_provider="codex-lb")
+
+    assert preview.mismatches == ()
+
+
 def test_dry_run_reports_jsonl_and_sqlite_without_writing(tmp_path: Path) -> None:
     codex_home = tmp_path / ".codex"
     session_file = codex_home / "sessions" / "2026" / "session.jsonl"

--- a/tests/unit/test_codex_sessions_retag.py
+++ b/tests/unit/test_codex_sessions_retag.py
@@ -375,6 +375,31 @@ def test_retag_emits_structured_progress_for_each_work_phase(tmp_path: Path) -> 
         assert final["completed"] == final["total"]
 
 
+def test_retag_emits_intermediate_progress_while_updating_large_sqlite_database(tmp_path: Path) -> None:
+    codex_home = tmp_path / ".codex"
+    state_db = codex_home / "state_5.sqlite"
+    codex_home.mkdir()
+    _create_state_db(state_db, ["openai"] * 2_501)
+    output: list[str] = []
+
+    result = retag_codex_sessions(
+        codex_home=codex_home,
+        source_provider="openai",
+        target_provider="codex-lb",
+        progress_logger=output.append,
+    )
+
+    progress = [
+        json.loads(line.removeprefix(codex_sessions_retag.PROGRESS_PREFIX))
+        for line in output
+        if line.startswith(codex_sessions_retag.PROGRESS_PREFIX)
+    ]
+    sqlite_progress = [event for event in progress if event["phase"] == "sqlite_update"]
+    assert result.sqlite_rows_updated == 2_501
+    assert any(0 < event["completed"] < event["total"] for event in sqlite_progress)
+    assert sqlite_progress[-1]["completed"] == sqlite_progress[-1]["total"] == 2_501
+
+
 def test_retag_updates_jsonl_and_sqlite_with_backup(tmp_path: Path) -> None:
     codex_home = tmp_path / ".codex"
     session_file = codex_home / "sessions" / "2026" / "session.jsonl"
@@ -672,7 +697,12 @@ def test_sqlite_copy_fallback_uses_atomic_consolidated_replacement(
 
     try:
         assert _read_state_providers(temp_path) == ["openai"]
-        codex_sessions_retag._update_sqlite_provider_in_place(temp_path, "openai", "codex-lb")
+        codex_sessions_retag._update_sqlite_provider_in_place(
+            temp_path,
+            "openai",
+            "codex-lb",
+            expected_rows=1,
+        )
         Path(f"{state_db}-wal").write_bytes(b"stale wal")
         Path(f"{state_db}-shm").write_bytes(b"stale shm")
         replacements: list[tuple[Path, Path]] = []


### PR DESCRIPTION
## Summary

Add a consumer-neutral CLI workflow for detecting and repairing individual Codex session provider-tag mismatches, while making whole-home retagging bounded, atomic, verifiable, and observable on large homes.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [x] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Fixes #1636

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directories:

- `openspec/changes/optimize-large-session-retag/`
- `openspec/changes/add-targeted-session-metadata-repair/`

## Changes

- Build one immutable metadata-only retag plan, prefer same-volume hard-link JSONL backups, rewrite through atomic replacement, batch SQLite updates, and verify only planned targets.
- Emit structured progress across discovery, backup, JSONL rewrite, SQLite update, and verification while retaining human-readable summaries and controlled CLI failures.
- Add `metadata-mismatches` and explicitly confirmed `repair-metadata` subcommands scoped to supplied session IDs; neither command changes provider selection or `config.toml`.
- Add regression coverage for unsupported providers, stale previews, unrelated-session preservation, backup fallbacks, large-file progress, JSON stream separation, and verification failures.

## Simplicity

- [x] New feature works with **zero config**
- [x] No new required setup step
- New setting(s): none
- [x] README sections / `.env.example` / dashboard nav unchanged and within budget

## Test plan

```text
python -m pytest tests/unit/test_codex_sessions_retag.py tests/unit/test_cli.py -q
70 passed

ruff check app/cli.py app/codex_sessions_retag.py tests/unit/test_cli.py tests/unit/test_codex_sessions_retag.py
All checks passed!

ruff format --check app/cli.py app/codex_sessions_retag.py tests/unit/test_cli.py tests/unit/test_codex_sessions_retag.py
4 files already formatted

ty check app/cli.py app/codex_sessions_retag.py tests/unit/test_cli.py tests/unit/test_codex_sessions_retag.py
All checks passed!

openspec validate optimize-large-session-retag --strict
openspec validate add-targeted-session-metadata-repair --strict
openspec validate --specs --strict
2 changes valid; 49 canonical specs passed
```

Full Windows unit run: `5,602 passed / 71 skipped / 25 failed`. The same 25 nodes fail on a clean `main` checkout, so they are environment baseline failures rather than PR regressions.

Isolated large fixture: 256 JSONL files / 134,664,450 bytes plus 256 SQLite rows; dry-run 1.412s, confirmed fixture-only retag 2.325s, all targets verified, `config.toml` untouched, fixture removed.

Local adversarial review found six issues; commits `ce035a49` through `94a62bd1` address all six. A second local review was stopped after 70 minutes while stalled in the codebase-memory `detect_changes` tool call, before producing findings; the independent gates above were rerun afterward.

## Screenshots / output

No dashboard-visible change. New CLI entry points:

```text
codex-lb codex-sessions metadata-mismatches --provider codex-lb --json
codex-lb codex-sessions repair-metadata --provider codex-lb --session-id <ID> --yes --json
```

## Checklist

- [x] Title is in Conventional Commits format.
- [x] Linked the related issue.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local lint, type, test, and spec subsets.
- [x] OpenSpec strict validation passes and verification found no critical, warning, or coherence issues.
- [x] Simplicity gates reviewed.
- [x] CHANGELOG is not edited by hand.