### PR TITLE
fix(tests): align settlement durability test with coalesced last_used writes

### DIFF
--- a/tests/integration/test_db_commit_durability.py
+++ b/tests/integration/test_db_commit_durability.py
@@ -175,11 +175,12 @@ async def test_usage_reservation_creation_and_settlement_relax_commit_durability
                 cached_input_tokens=0,
                 cost_microdollars=0,
             )
-            await repo.update_last_used(key_id, commit=False)
             await repo.commit()
         _assert_relaxed_before(statements, "UPDATE api_key_usage_reservations")
-        # The last_used_at touch rides the same relaxed settlement transaction.
-        assert any("UPDATE api_keys" in statement for statement in statements)
+        # The last_used_at touch no longer rides the settlement transaction:
+        # since #1627 it is coalesced in memory and flushed periodically by
+        # ApiKeyLastUsedCoalescer, so settlement must not update api_keys.
+        assert not any("UPDATE api_keys " in statement for statement in statements)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Repairs `main`, which is currently red on every PR: **ty** (`unresolved-attribute`) and the **PostgreSQL pytest slice** (`AttributeError`) both fail in `tests/integration/test_db_commit_durability.py`.

## Root cause: #1627 x #1628 merge race

- #1627 (merged 10:25 UTC) removed `ApiKeysRepository.update_last_used` in favor of the in-memory `ApiKeyLastUsedCoalescer` with a periodic flush.
- #1628 (merged minutes later) added `test_usage_reservation_creation_and_settlement_relax_commit_durability`, which calls `await repo.update_last_used(key_id, commit=False)` and asserts the `last_used_at` touch rides the settlement transaction.

Each PR was green against its own merge base; their union broke `main` (first red: ty run on `410bfaea`).

## Fix

Drop the stale call and invert the assertion to pin the post-#1627 contract: settlement must **not** update `api_keys` inline, because `last_used_at` is coalesced and flushed out-of-band. The reservation-settlement relaxed-durability assertions are unchanged.

## Testing

- `uv run ty check` → All checks passed! (was: 1 diagnostic)
- `tests/integration/test_db_commit_durability.py` against PostgreSQL 16 → 8 passed

No behavior change; test-only. No OpenSpec change needed (no requirement altered — the test is realigned to the contract #1627 already specified in `openspec/changes/coalesce-api-key-last-used-writes/`).