### PR TITLE
fix(ops,config,quota): compose stop grace, refresh timeout bounds, expirable warmup claim

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -496,7 +496,7 @@ class Settings(BaseSettings):
     otel_exporter_endpoint: str = ""
 
     # Shutdown drain
-    shutdown_drain_timeout_seconds: int = 30
+    shutdown_drain_timeout_seconds: int = Field(default=30, gt=0, le=300)
 
     # HTTP connector limits
     http_connector_limit: int = 100

--- a/app/core/server.py
+++ b/app/core/server.py
@@ -75,6 +75,7 @@ class GracefulDrainServer(uvicorn.Server):
         super().handle_exit(sig, frame)
 
     async def shutdown(self, sockets: list[socket.socket] | None = None) -> None:
+        shutdown_state.set_post_drain_cleanup_timeout_seconds(self._post_drain_cleanup_timeout_seconds)
         shutdown_state.commit_shutdown(timeout_seconds=self._drain_timeout_seconds)
         remaining = shutdown_state.remaining_drain_timeout_seconds() or 0.0
         drained = await shutdown_state.wait_for_in_flight_drain(

--- a/app/core/shutdown.py
+++ b/app/core/shutdown.py
@@ -20,6 +20,7 @@ _lifespan_completed: bool = False
 _bridge_drain_active: bool = False
 _in_flight: int = 0
 _control_plane_task_admission_open: bool = True
+_post_drain_cleanup_timeout_seconds: float | None = None
 
 
 def _effective_drain_deadline() -> float | None:
@@ -38,6 +39,7 @@ def reset() -> None:
     global _shutdown_deadline_candidates
     global _server_start_pending, _lifespan_completed
     global _bridge_drain_active, _in_flight, _control_plane_task_admission_open
+    global _post_drain_cleanup_timeout_seconds
     _draining = False
     _drain_deadline = None
     _drain_started = False
@@ -48,6 +50,7 @@ def reset() -> None:
     _bridge_drain_active = False
     _in_flight = 0
     _control_plane_task_admission_open = True
+    _post_drain_cleanup_timeout_seconds = None
 
 
 def prepare_server_start() -> None:
@@ -226,6 +229,23 @@ def remaining_drain_timeout_seconds() -> float | None:
     if deadline is None:
         return None
     return max(deadline - time.monotonic(), 0.0)
+
+
+def set_post_drain_cleanup_timeout_seconds(timeout_seconds: float) -> None:
+    """Publish the fixed cleanup reserve belonging to the server shutdown."""
+
+    global _post_drain_cleanup_timeout_seconds
+    _post_drain_cleanup_timeout_seconds = max(float(timeout_seconds), 0.0)
+
+
+def remaining_post_drain_cleanup_timeout_seconds() -> float | None:
+    """Return the unused portion of the shared drain-plus-reserve deadline."""
+
+    deadline = _effective_drain_deadline()
+    reserve = _post_drain_cleanup_timeout_seconds
+    if deadline is None or reserve is None:
+        return None
+    return max(deadline + reserve - time.monotonic(), 0.0)
 
 
 def is_draining() -> bool:

--- a/app/db/alembic/versions/20260806_030000_add_quota_warmup_claim_expiry.py
+++ b/app/db/alembic/versions/20260806_030000_add_quota_warmup_claim_expiry.py
@@ -1,0 +1,48 @@
+"""Add expiry metadata for quota warmup execution claims."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260806_030000_add_quota_warmup_claim_expiry"
+down_revision = "20260820_000000_repair_retired_identity_and_warmup_stamp"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    columns = {column["name"] for column in sa.inspect(bind).get_columns("quota_planner_decisions")}
+    if "lease_expires_at" not in columns:
+        with op.batch_alter_table("quota_planner_decisions") as batch_op:
+            batch_op.add_column(sa.Column("lease_expires_at", sa.DateTime(), nullable=True))
+    # Claims created before lease metadata existed must not remain permanently
+    # active. Expire legacy executing rows so a subsequent scheduler cycle can
+    # reclaim them safely.
+    #
+    # Outside the column guard: the IS NULL predicate already makes this
+    # idempotent, and a re-run that finds the column but no backfill (an
+    # earlier attempt that added the column and then failed) would otherwise
+    # leave those rows unexpirable forever.
+    #
+    # A fixed past instant, not CURRENT_TIMESTAMP: on PostgreSQL that is a
+    # timestamptz rendered into this naive column with the session TimeZone,
+    # so a session ahead of UTC would backfill a lease that is still in the
+    # future for the UTC-naive comparisons the planner makes.
+    op.execute(
+        sa.text(
+            "UPDATE quota_planner_decisions "
+            "SET lease_expires_at = '1970-01-01 00:00:00.000000' "
+            "WHERE action = 'warmup' AND status = 'executing' "
+            "AND lease_expires_at IS NULL"
+        )
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    columns = {column["name"] for column in sa.inspect(bind).get_columns("quota_planner_decisions")}
+    if "lease_expires_at" in columns:
+        with op.batch_alter_table("quota_planner_decisions") as batch_op:
+            batch_op.drop_column("lease_expires_at")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1713,6 +1713,7 @@ class QuotaPlannerDecision(Base):
     action: Mapped[str] = mapped_column(String, nullable=False)
     scheduled_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     executed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    lease_expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     score: Mapped[float] = mapped_column(Float, default=0.0, server_default=text("0.0"), nullable=False)
     reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     forecast_snapshot_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)

--- a/app/main.py
+++ b/app/main.py
@@ -634,10 +634,9 @@ async def lifespan(app: FastAPI):
         recovery_settlements_drained = True
         # Settle detached recovery journals while their origin leases are
         # still held; bridge teardown below may release those owner fences.
-        remaining_drain_seconds = shutdown_state.remaining_drain_timeout_seconds() or 0.0
         recovery_settlements_drained = await _drain_proxy_persistence_tasks(
             proxy_service,
-            remaining_drain_seconds,
+            shutdown_state.remaining_post_drain_cleanup_timeout_seconds() or 0.0,
             task_name_prefixes=("http-bridge-recovery-settlement-",),
             failure_message="Failed to pre-drain proxy settlement tasks during shutdown",
         )

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -2738,15 +2738,15 @@ class _WebSocketMixin:
             scope_cancelled = True
             raise
         finally:
-            remaining_drain_timeout = shutdown_state.remaining_drain_timeout_seconds()
-            cleanup_timeout = (
-                _WEBSOCKET_SCOPE_CLEANUP_TIMEOUT_SECONDS
-                if remaining_drain_timeout is None
-                else max(float(remaining_drain_timeout), 0.0)
-            )
-            task_cleanup_timeout = (
-                _facade()._TASK_CANCEL_TIMEOUT_SECONDS if remaining_drain_timeout is None else cleanup_timeout
-            )
+
+            def current_scope_cleanup_timeout() -> float:
+                remaining = shutdown_state.remaining_drain_timeout_seconds()
+                return _WEBSOCKET_SCOPE_CLEANUP_TIMEOUT_SECONDS if remaining is None else max(float(remaining), 0.0)
+
+            def current_cleanup_timeout() -> float:
+                remaining = shutdown_state.remaining_drain_timeout_seconds()
+                return _facade()._TASK_CANCEL_TIMEOUT_SECONDS if remaining is None else max(float(remaining), 0.0)
+
             cleanup_phase = "not_started"
 
             async def finalize_websocket_scope() -> None:
@@ -2767,7 +2767,7 @@ class _WebSocketMixin:
                     await _close_websocket_upstream_for_cleanup(
                         proxy,
                         upstream,
-                        timeout_seconds=task_cleanup_timeout,
+                        timeout_seconds=current_cleanup_timeout(),
                     )
                 if reader_to_await is not None:
                     try:
@@ -2791,7 +2791,7 @@ class _WebSocketMixin:
                         cleanup_phase = "retired_create_lease"
                         await _facade()._await_cancelled_task(
                             retired_create_lease_release_task,
-                            timeout_seconds=task_cleanup_timeout,
+                            timeout_seconds=current_cleanup_timeout(),
                             label="proxy websocket retired create lease release",
                             cancel=False,
                         )
@@ -2806,7 +2806,7 @@ class _WebSocketMixin:
                         cleanup_phase = "unsent_request"
                         await _facade()._await_cancelled_task(
                             request_state_failure_task,
-                            timeout_seconds=task_cleanup_timeout,
+                            timeout_seconds=current_cleanup_timeout(),
                             label="proxy websocket unsent request finalization",
                             cancel=False,
                         )
@@ -2908,15 +2908,16 @@ class _WebSocketMixin:
                     )
 
             cleanup_task.add_done_callback(log_scope_cleanup_failure)
+            scope_cleanup_timeout = current_scope_cleanup_timeout()
             done, _ = await asyncio.wait(
                 {cleanup_task},
-                timeout=max(float(cleanup_timeout), 0.0),
+                timeout=scope_cleanup_timeout,
             )
             if not done:
                 _facade().logger.warning(
                     "Websocket scope cleanup exceeded its cleanup budget "
                     "timeout_seconds=%.3f cleanup_phase=%s background_cleanup_tasks=%d",
-                    max(float(cleanup_timeout), 0.0),
+                    scope_cleanup_timeout,
                     cleanup_phase,
                     sum(1 for task in proxy._background_cleanup_tasks if not task.done()),
                 )
@@ -6376,7 +6377,7 @@ class _WebSocketMixin:
         try:
             settlement_succeeded = await asyncio.shield(finalization_task)
         except asyncio.CancelledError:
-            remaining_timeout = shutdown_state.remaining_drain_timeout_seconds()
+            remaining_timeout = shutdown_state.remaining_post_drain_cleanup_timeout_seconds()
             timeout_seconds = (
                 _facade()._TASK_CANCEL_TIMEOUT_SECONDS
                 if remaining_timeout is None

--- a/app/modules/quota_planner/repository.py
+++ b/app/modules/quota_planner/repository.py
@@ -3,8 +3,22 @@ from __future__ import annotations
 from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import cast as typing_cast
 
-from sqlalchemy import ColumnElement, Integer, and_, cast, false, func, literal, or_, select, text, update
+from sqlalchemy import (
+    ColumnElement,
+    Integer,
+    and_,
+    cast,
+    false,
+    func,
+    literal,
+    literal_column,
+    or_,
+    select,
+    text,
+    update,
+)
 from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -63,9 +77,45 @@ class DemandBin:
 
 
 _WARMUP_BUDGET_LOCK_KEY = "quota_planner:warmup_budget"
+WARMUP_EXECUTION_CLAIM_TTL_SECONDS = 300.0
+_SQLITE_NOW = "(strftime('%Y-%m-%d %H:%M:%f', 'now') || '000')"
 
 
-def _active_warmup_budget_clause(since: datetime) -> ColumnElement[bool]:
+def _db_now_expr(dialect_name: str) -> ColumnElement[datetime]:
+    if dialect_name == "postgresql":
+        return typing_cast(ColumnElement[datetime], func.clock_timestamp())
+    return typing_cast(ColumnElement[datetime], literal_column(_SQLITE_NOW))
+
+
+def _db_now_plus_seconds_expr(dialect_name: str, *, ttl_seconds: float) -> ColumnElement[datetime]:
+    ttl_seconds = max(1.0, float(ttl_seconds))
+    if dialect_name == "postgresql":
+        return typing_cast(
+            ColumnElement[datetime],
+            literal_column(f"(clock_timestamp() + make_interval(secs => {ttl_seconds:.3f}))"),
+        )
+    return typing_cast(
+        ColumnElement[datetime],
+        literal_column(f"(strftime('%Y-%m-%d %H:%M:%f', 'now', '+{ttl_seconds:.3f} seconds') || '000')"),
+    )
+
+
+def _expired_warmup_claim_clause(*, dialect_name: str) -> ColumnElement[bool]:
+    now = _db_now_expr(dialect_name)
+    return and_(
+        QuotaPlannerDecision.lease_expires_at.is_not(None),
+        QuotaPlannerDecision.lease_expires_at <= now,
+    )
+
+
+def warmup_claim_is_expired(decision: QuotaPlannerDecision, *, now: datetime | None = None) -> bool:
+    if decision.status != "executing" or decision.action != "warmup" or decision.lease_expires_at is None:
+        return False
+    current = to_utc_naive(now or utcnow())
+    return to_utc_naive(decision.lease_expires_at) <= current
+
+
+def _active_warmup_budget_clause(since: datetime, *, dialect_name: str) -> ColumnElement[bool]:
     """Filter warmup decisions consuming the daily count budget since ``since``.
 
     ``executed`` decisions count by ``executed_at`` (completion time).
@@ -87,6 +137,10 @@ def _active_warmup_budget_clause(since: datetime) -> ColumnElement[bool]:
             ),
             and_(
                 QuotaPlannerDecision.status == "executing",
+                or_(
+                    QuotaPlannerDecision.lease_expires_at.is_(None),
+                    QuotaPlannerDecision.lease_expires_at > _db_now_expr(dialect_name),
+                ),
                 or_(
                     QuotaPlannerDecision.executed_at >= since,
                     and_(
@@ -212,6 +266,7 @@ class QuotaPlannerRepository:
         since: datetime,
         max_warmups: int,
         max_credits: float,
+        claim_ttl_seconds: float = WARMUP_EXECUTION_CLAIM_TTL_SECONDS,
     ) -> QuotaPlannerDecision | None:
         """Atomically claim a planned warmup decision within the daily budgets.
 
@@ -238,8 +293,11 @@ class QuotaPlannerRepository:
         (already claimed elsewhere, or a budget guard failed).
         """
         since = to_utc_naive(since)
+        dialect_name = self._dialect_name()
         active_warmups = (
-            select(func.count(QuotaPlannerDecision.id)).where(_active_warmup_budget_clause(since)).scalar_subquery()
+            select(func.count(QuotaPlannerDecision.id))
+            .where(_active_warmup_budget_clause(since, dialect_name=dialect_name))
+            .scalar_subquery()
         )
         warmup_cost = (
             select(func.coalesce(func.sum(RequestLog.cost_usd), 0.0))
@@ -252,15 +310,29 @@ class QuotaPlannerRepository:
             )
             .scalar_subquery()
         )
+        claim_now = _db_now_expr(dialect_name)
+        claim_expires_at = _db_now_plus_seconds_expr(dialect_name, ttl_seconds=claim_ttl_seconds)
         stmt = (
             update(QuotaPlannerDecision)
             .where(
                 QuotaPlannerDecision.id == decision_id,
-                QuotaPlannerDecision.status == "planned",
+                QuotaPlannerDecision.action == "warmup",
+                or_(
+                    QuotaPlannerDecision.status == "planned",
+                    and_(
+                        QuotaPlannerDecision.status == "executing",
+                        _expired_warmup_claim_clause(dialect_name=dialect_name),
+                    ),
+                ),
                 active_warmups < max_warmups,
                 warmup_cost < max_credits,
             )
-            .values(status="executing", reason="warmup_executing", executed_at=to_utc_naive(utcnow()))
+            .values(
+                status="executing",
+                reason="warmup_executing",
+                executed_at=claim_now,
+                lease_expires_at=claim_expires_at,
+            )
             .returning(QuotaPlannerDecision.id)
         )
         async with sqlite_writer_section():
@@ -268,7 +340,7 @@ class QuotaPlannerRepository:
             # statement snapshot (and, on PostgreSQL, the advisory lock scope)
             # is not tied to earlier reads on this session.
             await self._session.commit()
-            if self._dialect_name() == "postgresql":
+            if dialect_name == "postgresql":
                 await self._session.execute(
                     text("SELECT pg_advisory_xact_lock(hashtext(:key))"),
                     {"key": _WARMUP_BUDGET_LOCK_KEY},
@@ -279,6 +351,21 @@ class QuotaPlannerRepository:
             return None
         return await self._session.get(QuotaPlannerDecision, claimed_id, populate_existing=True)
 
+    async def list_expired_warmup_claims(self, *, limit: int = 100) -> list[QuotaPlannerDecision]:
+        dialect_name = self._dialect_name()
+        stmt = (
+            select(QuotaPlannerDecision)
+            .where(
+                QuotaPlannerDecision.action == "warmup",
+                QuotaPlannerDecision.status == "executing",
+                _expired_warmup_claim_clause(dialect_name=dialect_name),
+            )
+            .order_by(QuotaPlannerDecision.lease_expires_at.asc(), QuotaPlannerDecision.created_at.asc())
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
     async def update_decision_status(
         self,
         decision_id: str,
@@ -288,12 +375,16 @@ class QuotaPlannerRepository:
         executed_at: datetime | None = None,
         state_after_json: str | None = None,
         expected_status: str | Collection[str] | None = None,
+        expected_executed_at: datetime | None = None,
+        expected_lease_expires_at: datetime | None = None,
     ) -> QuotaPlannerDecision | None:
         values: dict[str, object] = {"status": status}
         if reason is not None:
             values["reason"] = reason
         if executed_at is not None:
             values["executed_at"] = _to_db_naive_utc(executed_at)
+        if status != "executing":
+            values["lease_expires_at"] = None
         if state_after_json is not None:
             values["state_after_json"] = state_after_json
         stmt = update(QuotaPlannerDecision).where(QuotaPlannerDecision.id == decision_id).values(**values)
@@ -302,7 +393,48 @@ class QuotaPlannerRepository:
                 stmt = stmt.where(QuotaPlannerDecision.status == expected_status)
             else:
                 stmt = stmt.where(QuotaPlannerDecision.status.in_(tuple(expected_status)))
+        if expected_executed_at is not None:
+            stmt = stmt.where(QuotaPlannerDecision.executed_at == _to_db_naive_utc(expected_executed_at))
+        if expected_lease_expires_at is not None:
+            stmt = stmt.where(QuotaPlannerDecision.lease_expires_at == _to_db_naive_utc(expected_lease_expires_at))
         stmt = stmt.returning(QuotaPlannerDecision.id)
+        async with sqlite_writer_section():
+            updated_id = await self._session.scalar(stmt)
+            await self._session.commit()
+        if updated_id is None:
+            return None
+        row = await self._session.get(QuotaPlannerDecision, updated_id)
+        if row is None:
+            return None
+        await self._session.refresh(row)
+        return row
+
+    async def skip_stale_warmup_claim(
+        self,
+        decision_id: str,
+        *,
+        reason: str,
+        executed_at: datetime | None = None,
+    ) -> QuotaPlannerDecision | None:
+        dialect_name = self._dialect_name()
+        values: dict[str, object] = {
+            "status": "skipped",
+            "reason": reason,
+            "lease_expires_at": None,
+        }
+        if executed_at is not None:
+            values["executed_at"] = _to_db_naive_utc(executed_at)
+        stmt = (
+            update(QuotaPlannerDecision)
+            .where(
+                QuotaPlannerDecision.id == decision_id,
+                QuotaPlannerDecision.action == "warmup",
+                QuotaPlannerDecision.status == "executing",
+                _expired_warmup_claim_clause(dialect_name=dialect_name),
+            )
+            .values(**values)
+            .returning(QuotaPlannerDecision.id)
+        )
         async with sqlite_writer_section():
             updated_id = await self._session.scalar(stmt)
             await self._session.commit()
@@ -323,7 +455,9 @@ class QuotaPlannerRepository:
         ``_active_warmup_budget_clause``).
         """
         since = to_utc_naive(since)
-        stmt = select(func.count(QuotaPlannerDecision.id)).where(_active_warmup_budget_clause(since))
+        stmt = select(func.count(QuotaPlannerDecision.id)).where(
+            _active_warmup_budget_clause(since, dialect_name=self._dialect_name())
+        )
         return int(await self._session.scalar(stmt) or 0)
 
     async def count_executed_warmups_since(self, since: datetime) -> int:

--- a/app/modules/quota_planner/scheduler.py
+++ b/app/modules/quota_planner/scheduler.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from typing import Protocol, TypeVar, cast
 
 from app.core.config.settings import get_settings
+from app.core.utils.time import to_utc_naive
 from app.db.session import get_background_session
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.proxy.load_balancer import _build_states
@@ -81,6 +82,8 @@ class QuotaPlannerScheduler:
             settings = await planner_repo.get_settings()
             if settings.mode == "off":
                 return
+            warmup_service = QuotaWarmupService(session)
+            await self._reconcile_expired_warmup_claims(planner_repo=planner_repo, warmup_service=warmup_service)
             accounts_repo = AccountsRepository(session)
             usage_repo = UsageRepository(session)
             accounts = await accounts_repo.list_accounts()
@@ -133,7 +136,6 @@ class QuotaPlannerScheduler:
                 now=now,
             )
             expected_gain = max(0.0, base_simulation.loss - scenario.loss)
-            warmup_service = QuotaWarmupService(session)
             for action in actions:
                 cycle_key = action.warmup_cycle_key or f"{now:%Y%m%d%H%M}"
                 key = f"{cycle_key}:{settings.mode}:{action.account_id}:{action.action}"
@@ -163,9 +165,29 @@ class QuotaPlannerScheduler:
                         separators=(",", ":"),
                     ),
                 )
-                due = action.scheduled_at is None or action.scheduled_at <= now
-                if settings.mode == "auto" and action.action == "warmup" and due and decision.status == "planned":
+                # Decision timestamps come back from the timezone-naive DB
+                # columns while planner output is timezone-aware. Compare
+                # normalized UTC-naive instants at this boundary.
+                due = action.scheduled_at is None or to_utc_naive(action.scheduled_at) <= to_utc_naive(now)
+                if (
+                    settings.mode == "auto"
+                    and action.action == "warmup"
+                    and due
+                    and decision.status in {"planned", "executing"}
+                ):
+                    # An expired executing row is reclaimed inside warm_now;
+                    # a still-live executing row is read back and left alone.
                     await warmup_service.warm_now(account_id=action.account_id, decision_id=decision.id)
+
+    async def _reconcile_expired_warmup_claims(
+        self,
+        *,
+        planner_repo: QuotaPlannerRepository,
+        warmup_service: QuotaWarmupService,
+    ) -> None:
+        expired_claims = await planner_repo.list_expired_warmup_claims()
+        for decision in expired_claims:
+            await warmup_service.warm_now(account_id=decision.account_id or "", decision_id=decision.id)
 
 
 def build_quota_planner_scheduler() -> QuotaPlannerScheduler:

--- a/app/modules/quota_planner/warmup.py
+++ b/app/modules/quota_planner/warmup.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core import usage as usage_core
 from app.core.clients.proxy import stream_responses
+from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
 from app.core.openai.parsing import parse_sse_event
 from app.core.openai.requests import ResponsesRequest
@@ -30,7 +31,11 @@ from app.modules.usage.repository import UsageRepository
 from app.modules.usage.updater import UsageUpdater
 
 from .logic import SHORT_WINDOW_MAX_MINUTES, PlannerSettings
-from .repository import QuotaPlannerRepository
+from .repository import (
+    WARMUP_EXECUTION_CLAIM_TTL_SECONDS,
+    QuotaPlannerRepository,
+    warmup_claim_is_expired,
+)
 
 WARMUP_REQUEST_KIND = "warmup"
 # Rows written by the same upstream fetch land within milliseconds of each
@@ -41,6 +46,16 @@ WARMUP_DEFAULT_INPUT_BUDGET = 32
 WARMUP_DEFAULT_OUTPUT_BUDGET = 8
 
 logger = logging.getLogger(__name__)
+
+
+def _warmup_request_id(decision_id: str) -> str:
+    return f"quota-warmup-{decision_id}"
+
+
+def _warmup_claim_ttl_seconds() -> float:
+    settings = get_settings()
+    budget_seconds = float(getattr(settings, "http_responses_stream_request_budget_seconds", 0.0) or 0.0)
+    return max(WARMUP_EXECUTION_CLAIM_TTL_SECONDS, budget_seconds)
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,11 +94,19 @@ class QuotaWarmupService:
         force_probe: bool = False,
         decision_id: str | None = None,
     ) -> WarmupExecutionResult:
+        decision = await self._planner.get_decision(decision_id) if decision_id is not None else None
+        if decision is not None and decision.status not in {"planned", "executing"}:
+            return WarmupExecutionResult(
+                decision_id=decision.id,
+                status=decision.status,
+                reason=decision.reason or f"decision_{decision.status}",
+                executed_at=decision.executed_at,
+            )
+
         settings = await self._planner.get_settings()
         account = await self._accounts.get_by_id(account_id)
         resolved_model = (model or settings.warmup_model_preference or "gpt-5.4-mini").strip()
         scheduled_at = utcnow()
-        decision = await self._planner.get_decision(decision_id) if decision_id is not None else None
         if decision is None:
             decision = await self._planner.log_decision(
                 mode=settings.mode,
@@ -95,7 +118,7 @@ class QuotaWarmupService:
                 status="planned",
                 idempotency_key=f"manual:{scheduled_at:%Y%m%d%H%M%S}:{account_id}:{uuid4().hex}",
             )
-        elif decision.status != "planned":
+        elif decision.status == "executing" and not warmup_claim_is_expired(decision):
             return WarmupExecutionResult(
                 decision_id=decision.id,
                 status=decision.status,
@@ -109,12 +132,15 @@ class QuotaWarmupService:
             force_probe=force_probe,
         )
         if not allowed:
-            row = await self._planner.update_decision_status(
-                decision.id,
-                status="skipped",
-                reason=reason,
-                expected_status="planned",
-            )
+            if decision.status == "executing" and warmup_claim_is_expired(decision):
+                row = await self._planner.skip_stale_warmup_claim(decision.id, reason=reason)
+            else:
+                row = await self._planner.update_decision_status(
+                    decision.id,
+                    status="skipped",
+                    reason=reason,
+                    expected_status="planned",
+                )
             if row is None:
                 current = await self._planner.get_decision(decision.id)
                 if current is not None:
@@ -136,9 +162,24 @@ class QuotaWarmupService:
             since=_local_midnight(),
             max_warmups=settings.max_warmups_per_day,
             max_credits=settings.max_warmup_credits_per_day,
+            claim_ttl_seconds=_warmup_claim_ttl_seconds(),
         )
         if claimed is None:
             return await self._resolve_refused_claim(decision_id=decision.id, settings=settings)
+        claim_executed_at = claimed.executed_at
+        claim_lease_expires_at = claimed.lease_expires_at
+        assert claim_executed_at is not None
+        assert claim_lease_expires_at is not None
+
+        request_id = _warmup_request_id(decision.id)
+        replay_result = await self._reconcile_existing_warmup_request(
+            decision_id=decision.id,
+            request_id=request_id,
+            claim_executed_at=claim_executed_at,
+            claim_lease_expires_at=claim_lease_expires_at,
+        )
+        if replay_result is not None:
+            return replay_result
 
         reservation_id: str | None = None
         if api_key_id is not None:
@@ -159,7 +200,10 @@ class QuotaWarmupService:
                     decision.id,
                     status="skipped",
                     reason="api_key_not_found",
+                    executed_at=utcnow(),
                     expected_status="executing",
+                    expected_executed_at=claim_executed_at,
+                    expected_lease_expires_at=claim_lease_expires_at,
                 )
                 return await self._result_from_update_or_current(
                     decision_id=decision.id,
@@ -172,7 +216,10 @@ class QuotaWarmupService:
                     decision.id,
                     status="skipped",
                     reason="api_key_invalid",
+                    executed_at=utcnow(),
                     expected_status="executing",
+                    expected_executed_at=claim_executed_at,
+                    expected_lease_expires_at=claim_lease_expires_at,
                 )
                 return await self._result_from_update_or_current(
                     decision_id=decision.id,
@@ -186,7 +233,10 @@ class QuotaWarmupService:
                     decision.id,
                     status="skipped",
                     reason=reason,
+                    executed_at=utcnow(),
                     expected_status="executing",
+                    expected_executed_at=claim_executed_at,
+                    expected_lease_expires_at=claim_lease_expires_at,
                 )
                 return await self._result_from_update_or_current(
                     decision_id=decision.id,
@@ -195,7 +245,6 @@ class QuotaWarmupService:
                     fallback_reason=reason,
                 )
 
-        request_id = f"quota-warmup-{uuid4().hex}"
         started = time.monotonic()
         try:
             usage = await self._send_warmup_probe(
@@ -238,6 +287,8 @@ class QuotaWarmupService:
                 reason="warmup_executed",
                 executed_at=utcnow(),
                 expected_status="executing",
+                expected_executed_at=claim_executed_at,
+                expected_lease_expires_at=claim_lease_expires_at,
             )
             return await self._result_from_update_or_current(
                 decision_id=decision.id,
@@ -291,6 +342,8 @@ class QuotaWarmupService:
                 reason=f"warmup_failed:{type(exc).__name__}",
                 executed_at=utcnow(),
                 expected_status="executing",
+                expected_executed_at=claim_executed_at,
+                expected_lease_expires_at=claim_lease_expires_at,
             )
             return await self._result_from_update_or_current(
                 decision_id=decision.id,
@@ -330,7 +383,7 @@ class QuotaWarmupService:
         current = await self._planner.get_decision_fresh(decision_id)
         if current is None:
             return WarmupExecutionResult(decision_id=decision_id, status="skipped", reason="decision_missing")
-        if current.status != "planned":
+        if current.status not in {"planned", "executing"}:
             return WarmupExecutionResult(
                 decision_id=current.id,
                 status=current.status,
@@ -343,12 +396,21 @@ class QuotaWarmupService:
             reason = "daily_warmup_count_budget_exhausted"
         else:
             reason = "daily_warmup_credit_budget_exhausted"
-        row = await self._planner.update_decision_status(
-            decision_id,
-            status="skipped",
-            reason=reason,
-            expected_status="planned",
-        )
+        if current.status == "planned":
+            row = await self._planner.update_decision_status(
+                decision_id,
+                status="skipped",
+                reason=reason,
+                expected_status="planned",
+            )
+        elif warmup_claim_is_expired(current):
+            row = await self._planner.skip_stale_warmup_claim(
+                decision_id,
+                reason=reason,
+                executed_at=utcnow(),
+            )
+        else:
+            row = current
         return await self._result_from_update_or_current(
             decision_id=decision_id,
             row=row,
@@ -376,6 +438,37 @@ class QuotaWarmupService:
             request_id=request_id,
             executed_at=row.executed_at,
         )
+
+    async def _reconcile_existing_warmup_request(
+        self,
+        *,
+        decision_id: str,
+        request_id: str,
+        claim_executed_at: datetime,
+        claim_lease_expires_at: datetime,
+    ) -> WarmupExecutionResult | None:
+        existing = await self._request_logs.latest_successful_log_for_request_id(
+            request_id,
+            request_kind=WARMUP_REQUEST_KIND,
+        )
+        if existing is not None:
+            row = await self._planner.update_decision_status(
+                decision_id,
+                status="executed",
+                reason="warmup_executed",
+                executed_at=existing.requested_at,
+                expected_status="executing",
+                expected_executed_at=claim_executed_at,
+                expected_lease_expires_at=claim_lease_expires_at,
+            )
+            return await self._result_from_update_or_current(
+                decision_id=decision_id,
+                row=row,
+                fallback_status="executed",
+                fallback_reason="warmup_executed",
+                request_id=request_id,
+            )
+        return None
 
     async def cancel_decision(self, decision_id: str) -> WarmupExecutionResult | None:
         row = await self._planner.get_decision(decision_id)

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -1147,6 +1147,28 @@ class RequestLogsRepository:
                 await _safe_rollback(self._session)
                 raise
 
+    async def latest_successful_log_for_request_id(self, request_id: str, *, request_kind: str) -> RequestLog | None:
+        """Return the newest *successful* ``request_kind`` log for ``request_id``.
+
+        A stable request id can carry more than one row. A warmup probe that
+        succeeded upstream and then failed while recording its effect writes a
+        success row followed by an error row under the same id, so a caller
+        reconciling "did this request already happen upstream" must not read
+        only the newest row: the status and kind belong in the query.
+        """
+
+        stmt = (
+            select(RequestLog)
+            .where(
+                RequestLog.request_id == ensure_request_id(request_id),
+                RequestLog.request_kind == request_kind,
+                RequestLog.status == "success",
+            )
+            .order_by(RequestLog.requested_at.desc(), RequestLog.id.desc())
+            .limit(1)
+        )
+        return await self._session.scalar(stmt)
+
     async def update_model_for_request(self, request_id: str, model: str) -> int:
         """Override the ``model`` field of any logs matching ``request_id``.
 

--- a/deploy/helm/codex-lb/templates/deployment.yaml
+++ b/deploy/helm/codex-lb/templates/deployment.yaml
@@ -10,6 +10,9 @@ launch headroom above the enforced arithmetic minimum.
 {{- if lt $shutdownDrainTimeoutSeconds $preStopSleepSeconds }}
 {{- fail "config.shutdownDrainTimeoutSeconds must be greater than or equal to preStopSleepSeconds so routing dwell fits inside the shared drain deadline." }}
 {{- end }}
+{{- if gt $shutdownDrainTimeoutSeconds 300 }}
+{{- fail "config.shutdownDrainTimeoutSeconds must be less than or equal to 300 seconds, matching the application shutdown limit." }}
+{{- end }}
 {{- $preStopStartFailureBudgetSeconds := 2 }}
 {{- $postDrainCleanupBufferSeconds := 30 }}
 {{- $minimumTerminationGraceSeconds := add (add $shutdownDrainTimeoutSeconds $preStopStartFailureBudgetSeconds) $postDrainCleanupBufferSeconds }}

--- a/deploy/helm/codex-lb/values.schema.json
+++ b/deploy/helm/codex-lb/values.schema.json
@@ -209,7 +209,8 @@
       "properties": {
         "shutdownDrainTimeoutSeconds": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 1,
+          "maximum": 300
         }
       }
     },

--- a/openspec/changes/fix-shutdown-grace-and-nested-budget/.openspec.yaml
+++ b/openspec/changes/fix-shutdown-grace-and-nested-budget/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/fix-shutdown-grace-and-nested-budget/proposal.md
+++ b/openspec/changes/fix-shutdown-grace-and-nested-budget/proposal.md
@@ -1,0 +1,5 @@
+# Fix shutdown settlement grace and nested cleanup bounds
+
+Graceful shutdown must reserve the existing post-drain cleanup window for the work that runs after the drain barrier: terminal websocket settlement and the recovery-settlement pre-drain both draw on that shared remainder, so an exhausted drain still leaves them a budget. Lifespan cleanup must use a live remainder throughout instead of nesting the full configured drain timeout inside the server cleanup window.
+
+This change also validates the configured drain timeout as a positive, bounded integer.

--- a/openspec/changes/fix-shutdown-grace-and-nested-budget/spec.md
+++ b/openspec/changes/fix-shutdown-grace-and-nested-budget/spec.md
@@ -1,0 +1,11 @@
+## Shutdown settlement grace
+
+Terminal websocket settlement MUST use the unused post-drain cleanup reserve after the shared drain deadline expires. The settlement wait MUST be bounded by the remaining combined drain-plus-reserve deadline.
+
+## Nested cleanup budget
+
+Lifespan cleanup MUST bound every nested persistence cleanup by a live remaining deadline, never by the full configured drain timeout. Recovery-settlement cleanup runs after the drain barrier and MUST use the remaining combined drain-plus-reserve deadline, so an exhausted drain does not leave it a zero budget; persistence cleanup after bridge teardown MUST use the remaining drain timeout. No nested timeout MUST exceed the containing shutdown budget.
+
+## Drain timeout validation
+
+`shutdown_drain_timeout_seconds` MUST be greater than zero and MUST NOT exceed 300 seconds.

--- a/openspec/changes/fix-shutdown-grace-and-nested-budget/specs/replica-operations/spec.md
+++ b/openspec/changes/fix-shutdown-grace-and-nested-budget/specs/replica-operations/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Shutdown settlement uses the post-drain reserve
+
+Terminal websocket settlement MUST use the unused post-drain cleanup reserve after the shared drain deadline expires, and MUST remain bounded by the combined drain-plus-reserve deadline.
+
+#### Scenario: Exhausted drain retains settlement grace
+
+- **WHEN** shutdown cancellation occurs after the drain deadline has expired
+- **THEN** terminal settlement receives the remaining post-drain reserve rather than a zero timeout
+
+### Requirement: Nested shutdown cleanup stays inside its containing window
+
+Lifespan persistence cleanup MUST receive a live remaining deadline and MUST NOT receive the full configured drain timeout, which would nest a fresh copy of the whole budget inside the containing shutdown window.
+
+Recovery-settlement cleanup runs after the drain barrier, so it MUST be bounded by the remaining combined drain-plus-reserve deadline — the same budget terminal settlement draws on. Persistence cleanup that runs after bridge teardown MUST be bounded by the remaining drain timeout.
+
+#### Scenario: Recovery settlement cleanup keeps a budget after an exhausted drain
+
+- **WHEN** lifespan shutdown drains recovery settlements after the drain deadline has expired
+- **THEN** its timeout is the remaining drain-plus-reserve deadline rather than a zero drain remainder, and cannot exceed the containing shutdown window
+
+#### Scenario: Post-teardown cleanup is bounded by the drain remainder
+
+- **WHEN** lifespan shutdown drains persistence tasks after HTTP bridge teardown
+- **THEN** its timeout is the live drain remainder and cannot exceed the containing shutdown window
+
+### Requirement: Shutdown drain timeout is bounded
+
+`shutdown_drain_timeout_seconds` MUST be greater than zero and no greater than 300 seconds.
+
+#### Scenario: Invalid drain timeout is rejected
+
+- **WHEN** configuration supplies zero, a negative value, or a value above 300
+- **THEN** settings validation fails

--- a/openspec/changes/fix-shutdown-grace-and-nested-budget/tasks.md
+++ b/openspec/changes/fix-shutdown-grace-and-nested-budget/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] Carry the post-drain reserve through shutdown state and use it for terminal websocket settlement.
+- [x] Bound the lifespan recovery-settlement cleanup by the live drain remainder.
+- [x] Validate `shutdown_drain_timeout_seconds` as `1..300`.
+- [x] Add fail-pre/pass-post regression coverage for settlement grace, nested budget, and invalid settings.
+- [x] Run focused shutdown, websocket, proxy bridge, and OpenSpec validation suites.

--- a/openspec/changes/recover-expired-quota-warmup-claims/proposal.md
+++ b/openspec/changes/recover-expired-quota-warmup-claims/proposal.md
@@ -1,0 +1,34 @@
+# Proposal: recover expired quota warmup claims
+
+## Why
+
+PR #1646 introduced expiring quota-warmup claims, but current-head review still
+found four contract gaps:
+
+- the claim TTL can expire long before the warmup probe's HTTP stream budget;
+- the scheduler only revisits expired claims when a fresh planner action points
+  back at the same decision;
+- a reclaimed decision cannot tell whether a prior attempt already committed a
+  successful warmup request log; and
+- the lease-expiry Alembic revision lacked its own migration-path coverage.
+
+These are all part of the same quota-phase-planner claim-recovery contract.
+
+## What Changes
+
+- Keep warmup execution claims alive for at least the full configured Responses
+  stream budget.
+- Give each warmup decision a stable warmup request id so a reclaimed claim can
+  reconcile from an already-committed request log instead of sending a duplicate
+  probe.
+- Add a scheduler reconciliation sweep for expired `executing` warmup claims
+  that is independent of the current planner output.
+- Add migration coverage for the `lease_expires_at` Alembic revision.
+
+## Impact
+
+- Prevents duplicate synthetic warmup traffic after a process dies between the
+  durable request-log commit and the final decision-status update.
+- Lets manual and no-longer-planned stale claims self-heal on the next scheduler
+  tick instead of waiting for a matching future planner action.
+- Documents the new recovery contract in OpenSpec.

--- a/openspec/changes/recover-expired-quota-warmup-claims/specs/quota-phase-planner/spec.md
+++ b/openspec/changes/recover-expired-quota-warmup-claims/specs/quota-phase-planner/spec.md
@@ -1,0 +1,68 @@
+# Delta Specification: quota-phase-planner
+
+## MODIFIED Requirements
+
+### Requirement: Warmup decisions are claimed before synthetic traffic
+
+Warmup execution SHALL atomically transition a planned decision to `executing`
+before reserving API-key budget or sending synthetic probe traffic, and that
+transition SHALL be the single authoritative enforcement point for the daily
+warmup count and credit budgets: the claim statement MUST evaluate either the
+`planned` precondition or an expired `executing` warmup claim plus both budget
+guards atomically, so concurrent claimants on other replicas or processes
+cannot exceed either budget. The count-budget guard MUST include in-flight
+`executing` warmup decisions in addition to `executed` ones, so a probe
+reserves budget when it is claimed rather than after it completes. The claim
+MUST record its own timestamp on the decision, and in-flight `executing`
+decisions MUST count against the budget day in which they were claimed — not
+the day the decision row was created — so a decision planned before the daily
+boundary but claimed after it consumes the claim day's budget. The claim lease
+TTL MUST be at least the configured Responses stream request budget so a healthy
+warmup probe cannot lose its claim mid-flight. On PostgreSQL, concurrent claims
+MUST be serialized (a transaction-scoped advisory lock on a fixed
+warmup-budget key) so two claims cannot both evaluate the budget against a
+stale snapshot; on SQLite the claim MUST execute as a single statement under
+the database-level writer lock. When a claim is refused because a budget guard
+failed, the decision MUST be skipped with a reason that distinguishes the
+exhausted count budget from the exhausted credit budget. Final outcomes such as
+`executed`, `failed`, or API-key skip reasons MUST only update decisions that
+are still `executing`. Cancellation MUST only update decisions that are still
+`planned` or `skipped` and MUST NOT cancel an in-flight `executing` decision.
+Every warmup decision MUST reuse one deterministic warmup request identity
+across retries so a reclaimed claim can reconcile from an already-committed
+request log instead of sending a duplicate probe.
+
+#### Scenario: Warmup claim lease covers the probe budget
+
+- **GIVEN** the configured Responses stream request budget exceeds five minutes
+- **WHEN** warm-now claims a warmup decision
+- **THEN** the persisted `lease_expires_at` is at least one full stream budget
+  after the claim timestamp
+
+#### Scenario: Reclaimed decision settles from a committed success log
+
+- **GIVEN** a warmup decision's prior attempt already committed a successful
+  warmup request log
+- **AND** the process died before the final decision-status update committed
+- **WHEN** a later replica reclaims the expired `executing` decision
+- **THEN** it marks the decision `executed` from the durable request-log
+  evidence
+- **AND** it MUST NOT send a second synthetic probe
+
+## ADDED Requirements
+
+### Requirement: Scheduler reconciles expired warmup claims independently of current actions
+
+The quota planner scheduler SHALL reconcile expired `executing` warmup claims
+even when the current planner output contains no matching warmup action. This
+reconciliation sweep MUST run before the scheduler decides that a tick is a
+pure no-op, and it MUST reuse the same warm-now recovery contract so manual
+warm-now decisions and no-longer-planned scheduled decisions can self-heal.
+
+#### Scenario: Expired manual warmup claim is reconciled without a new planner action
+
+- **GIVEN** an expired `executing` warmup decision created by a manual warm-now
+- **AND** the current planner output contains no action for that decision
+- **WHEN** the scheduler runs its next leader tick
+- **THEN** the expired claim is still reconciled
+- **AND** the decision no longer remains stuck in `executing`

--- a/openspec/changes/recover-expired-quota-warmup-claims/tasks.md
+++ b/openspec/changes/recover-expired-quota-warmup-claims/tasks.md
@@ -1,0 +1,23 @@
+## 1. OpenSpec
+
+- [x] 1.1 Add a quota-phase-planner delta for long-lived claim TTLs, scheduler
+      stale-claim sweeps, and request-log-based stale-claim reconciliation.
+- [x] 1.2 Sync the same contract into `openspec/specs/quota-phase-planner/spec.md`.
+
+## 2. Implementation
+
+- [x] 2.1 Keep warmup claim TTL at least as long as the configured Responses
+      stream request budget.
+- [x] 2.2 Use a decision-stable warmup request id and reconcile reclaimed claims
+      from a previously committed success log before sending a new probe.
+- [x] 2.3 Add a scheduler sweep for expired `executing` warmup claims that does
+      not depend on the current planner output.
+
+## 3. Validation
+
+- [x] 3.1 Add focused regression coverage for long TTL claims, stale-claim
+      scheduler sweeps, request-log-based reconciliation, and the
+      `20260806_030000_add_quota_warmup_claim_expiry` migration.
+- [x] 3.2 Run focused pytest, `uv run ruff check`, `uv run ruff format --check`,
+      `openspec validate recover-expired-quota-warmup-claims --strict`, and
+      `openspec validate --specs` so the normative specs are checked too.

--- a/openspec/specs/quota-phase-planner/spec.md
+++ b/openspec/specs/quota-phase-planner/spec.md
@@ -143,25 +143,30 @@ persisted planner observation timestamps.
 Warmup execution SHALL atomically transition a planned decision to `executing`
 before reserving API-key budget or sending synthetic probe traffic, and that
 transition SHALL be the single authoritative enforcement point for the daily
-warmup count and credit budgets: the claim statement MUST evaluate the
-`planned` status precondition and both budget guards atomically, so concurrent
-claimants on other replicas or processes cannot exceed either budget. The
-count-budget guard MUST include in-flight `executing` warmup decisions in
-addition to `executed` ones, so a probe reserves budget when it is claimed
-rather than after it completes. The claim MUST record its own timestamp on the
-decision, and in-flight `executing` decisions MUST count against the budget
-day in which they were claimed — not the day the decision row was created —
-so a decision planned before the daily boundary but claimed after it consumes
-the claim day's budget. On PostgreSQL, concurrent claims MUST be
-serialized (a transaction-scoped advisory lock on a fixed warmup-budget key)
-so two claims cannot both evaluate the budget against a stale snapshot; on
-SQLite the claim MUST execute as a single statement under the database-level
-writer lock. When a claim is refused because a budget guard failed, the
-decision MUST be skipped with a reason that distinguishes the exhausted count
-budget from the exhausted credit budget. Final outcomes such as `executed`,
-`failed`, or API-key skip reasons MUST only update decisions that are still
-`executing`. Cancellation MUST only update decisions that are still `planned`
-or `skipped` and MUST NOT cancel an in-flight `executing` decision.
+warmup count and credit budgets: the claim statement MUST evaluate either the
+`planned` precondition or an expired `executing` warmup claim plus both budget
+guards atomically, so concurrent claimants on other replicas or processes
+cannot exceed either budget. The count-budget guard MUST include in-flight
+`executing` warmup decisions in addition to `executed` ones, so a probe
+reserves budget when it is claimed rather than after it completes. The claim
+MUST record its own timestamp on the decision, and in-flight `executing`
+decisions MUST count against the budget day in which they were claimed — not
+the day the decision row was created — so a decision planned before the daily
+boundary but claimed after it consumes the claim day's budget. The claim lease
+TTL MUST be at least the configured Responses stream request budget so a
+healthy warmup probe cannot lose its claim mid-flight. On PostgreSQL,
+concurrent claims MUST be serialized (a transaction-scoped advisory lock on a
+fixed warmup-budget key) so two claims cannot both evaluate the budget against
+a stale snapshot; on SQLite the claim MUST execute as a single statement under
+the database-level writer lock. When a claim is refused because a budget guard
+failed, the decision MUST be skipped with a reason that distinguishes the
+exhausted count budget from the exhausted credit budget. Final outcomes such as
+`executed`, `failed`, or API-key skip reasons MUST only update decisions that
+are still `executing`. Cancellation MUST only update decisions that are still
+`planned` or `skipped` and MUST NOT cancel an in-flight `executing` decision.
+Every warmup decision MUST reuse one deterministic warmup request identity
+across retries so a reclaimed claim can reconcile from an already-committed
+request log instead of sending a duplicate probe.
 
 #### Scenario: Planned warmup is claimed before probe send
 
@@ -207,12 +212,45 @@ or `skipped` and MUST NOT cancel an in-flight `executing` decision.
 - **AND** the decision is skipped with reason
   `daily_warmup_credit_budget_exhausted`
 
+#### Scenario: Warmup claim lease covers the probe budget
+
+- **GIVEN** the configured Responses stream request budget exceeds five minutes
+- **WHEN** warm-now claims a warmup decision
+- **THEN** the persisted `lease_expires_at` is at least one full stream budget
+  after the claim timestamp
+
+#### Scenario: Reclaimed decision settles from a committed success log
+
+- **GIVEN** a warmup decision's prior attempt already committed a successful
+  warmup request log
+- **AND** the process died before the final decision-status update committed
+- **WHEN** a later replica reclaims the expired `executing` decision
+- **THEN** it marks the decision `executed` from the durable request-log
+  evidence
+- **AND** it MUST NOT send a second synthetic probe
+
 #### Scenario: Executing warmup cannot be canceled
 
 - **GIVEN** a warmup decision is already `executing`
 - **WHEN** an operator requests cancellation
 - **THEN** the decision remains `executing`
 - **AND** the response reports that the decision is not cancelable
+
+### Requirement: Scheduler reconciles expired warmup claims independently of current actions
+
+The quota planner scheduler SHALL reconcile expired `executing` warmup claims
+even when the current planner output contains no matching warmup action. This
+reconciliation sweep MUST run before the scheduler decides that a tick is a
+pure no-op, and it MUST reuse the same warm-now recovery contract so manual
+warm-now decisions and no-longer-planned scheduled decisions can self-heal.
+
+#### Scenario: Expired manual warmup claim is reconciled without a new planner action
+
+- **GIVEN** an expired `executing` warmup decision created by a manual warm-now
+- **AND** the current planner output contains no action for that decision
+- **WHEN** the scheduler runs its next leader tick
+- **THEN** the expired claim is still reconciled
+- **AND** the decision no longer remains stuck in `executing`
 
 ### Requirement: Phase planning is scoped to short rolling windows
 
@@ -288,4 +326,3 @@ integrity error that aborts the remainder of a planning tick.
 - **WHEN** one decision's idempotency key was concurrently inserted by another
   writer
 - **THEN** the tick continues logging the remaining accounts' decisions
-

--- a/tests/integration/test_atomic_quota_warmup_claims.py
+++ b/tests/integration/test_atomic_quota_warmup_claims.py
@@ -16,6 +16,7 @@ from datetime import timedelta
 import pytest
 from sqlalchemy import func, select, update
 
+from app.core.config.settings import get_settings
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountLimitWarmup, AccountStatus, QuotaPlannerDecision, RequestLog
@@ -25,7 +26,9 @@ from app.modules.limit_warmup.repository import LimitWarmupRepository
 from app.modules.quota_planner import repository as quota_planner_repository_module
 from app.modules.quota_planner.logic import PlannerSettings
 from app.modules.quota_planner.repository import QuotaPlannerRepository
-from app.modules.quota_planner.warmup import QuotaWarmupService, WarmupUsage
+from app.modules.quota_planner.scheduler import QuotaPlannerScheduler
+from app.modules.quota_planner.warmup import QuotaWarmupService, WarmupUsage, _warmup_request_id
+from app.modules.request_logs.repository import RequestLogsRepository
 
 pytestmark = pytest.mark.integration
 
@@ -294,6 +297,267 @@ async def test_claim_refuses_spent_credit_budget_after_stale_gate_read(monkeypat
     async with SessionLocal() as session:
         status = await session.scalar(select(QuotaPlannerDecision.status).where(QuotaPlannerDecision.id == decision.id))
     assert status == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_warm_now_claim_ttl_covers_stream_budget(monkeypatch, db_setup):
+    del db_setup
+    await _seed_planner(_account("acc-long-ttl"), max_warmups_per_day=5)
+    settings = get_settings()
+    original_budget = settings.http_responses_stream_request_budget_seconds
+    settings.http_responses_stream_request_budget_seconds = 1234.0
+    decision_id: str | None = None
+
+    async def fake_send(self, *, account, model, request_id):
+        del self, account, model, request_id
+        assert decision_id is not None
+        async with SessionLocal() as verification_session:
+            claimed = await verification_session.get(QuotaPlannerDecision, decision_id)
+            assert claimed is not None
+            assert claimed.executed_at is not None
+            assert claimed.lease_expires_at is not None
+            ttl_seconds = (claimed.lease_expires_at - claimed.executed_at).total_seconds()
+            assert ttl_seconds >= 1234.0
+        return WarmupUsage(input_tokens=1, output_tokens=1, cached_input_tokens=0, reasoning_tokens=None)
+
+    async def noop_record_effect(self, account, model, *, source, confidence):
+        del self, account, model, source, confidence
+
+    monkeypatch.setattr(QuotaWarmupService, "_send_warmup_probe", fake_send)
+    monkeypatch.setattr(QuotaWarmupService, "_record_warmup_effect", noop_record_effect)
+
+    try:
+        async with SessionLocal() as session:
+            repo = QuotaPlannerRepository(session)
+            await repo.add_window_observation(
+                account_id="acc-long-ttl",
+                model="gpt-5.4-mini",
+                source="warmup_probe",
+                confidence="observed",
+            )
+            decision = await repo.log_decision(
+                mode="auto",
+                action="warmup",
+                idempotency_key="long-ttl",
+                account_id="acc-long-ttl",
+                status="planned",
+            )
+            decision_id = decision.id
+            result = await QuotaWarmupService(session).warm_now(
+                account_id="acc-long-ttl",
+                model="gpt-5.4-mini",
+                force_probe=True,
+                decision_id=decision.id,
+            )
+        assert result.status == "executed"
+    finally:
+        settings.http_responses_stream_request_budget_seconds = original_budget
+
+
+@pytest.mark.asyncio
+async def test_scheduler_reconciles_expired_warmup_claim_without_current_action(monkeypatch, db_setup):
+    del db_setup
+    await _seed_planner(_account("acc-expired-claim"), max_warmups_per_day=3)
+    now = utcnow()
+
+    async with SessionLocal() as session:
+        repo = QuotaPlannerRepository(session)
+        await repo.add_window_observation(
+            account_id="acc-expired-claim",
+            model="gpt-5.4-mini",
+            source="warmup_probe",
+            confidence="observed",
+        )
+        decision = await repo.log_decision(
+            mode="auto",
+            action="warmup",
+            idempotency_key="expired-claim-sweep",
+            account_id="acc-expired-claim",
+            status="executing",
+            executed_at=now - timedelta(hours=2),
+            reason="warmup_executing",
+        )
+        decision.executed_at = now - timedelta(hours=2)
+        decision.lease_expires_at = now - timedelta(hours=1)
+        await session.commit()
+
+    forecast = type("Forecast", (), {"peak_slot_start": None, "peak_demand_units": 0.0})()
+    simulation = type("Simulation", (), {"loss": 0.0, "unmet_demand": 0.0})()
+    calls: list[str] = []
+
+    async def fake_send(self, *, account, model, request_id):
+        del self, model, request_id
+        calls.append(account.id)
+        return WarmupUsage(input_tokens=2, output_tokens=1, cached_input_tokens=0, reasoning_tokens=None)
+
+    async def noop_record_effect(self, account, model, *, source, confidence):
+        del self, account, model, source, confidence
+
+    monkeypatch.setattr("app.modules.quota_planner.scheduler._build_states", lambda **kwargs: ([], {}))
+    monkeypatch.setattr("app.modules.quota_planner.scheduler.build_demand_forecast", lambda **kwargs: forecast)
+    monkeypatch.setattr("app.modules.quota_planner.scheduler.simulate_pool", lambda **kwargs: simulation)
+    monkeypatch.setattr("app.modules.quota_planner.scheduler.plan_shadow_actions", lambda **kwargs: [])
+    monkeypatch.setattr(QuotaWarmupService, "_send_warmup_probe", fake_send)
+    monkeypatch.setattr(QuotaWarmupService, "_record_warmup_effect", noop_record_effect)
+
+    await QuotaPlannerScheduler()._run_once_as_leader()
+
+    assert calls == ["acc-expired-claim"]
+    async with SessionLocal() as session:
+        refreshed = await session.get(QuotaPlannerDecision, decision.id)
+        assert refreshed is not None
+        assert refreshed.status == "executed"
+        assert refreshed.reason == "warmup_executed"
+
+
+@pytest.mark.asyncio
+async def test_scheduler_reconciles_existing_success_log_without_resending_probe(monkeypatch, db_setup):
+    del db_setup
+    await _seed_planner(_account("acc-replay-claim"), max_warmups_per_day=3)
+    now = utcnow()
+
+    async with SessionLocal() as session:
+        repo = QuotaPlannerRepository(session)
+        await repo.add_window_observation(
+            account_id="acc-replay-claim",
+            model="gpt-5.4-mini",
+            source="warmup_probe",
+            confidence="observed",
+        )
+        decision = await repo.log_decision(
+            mode="auto",
+            action="warmup",
+            idempotency_key="expired-claim-replay",
+            account_id="acc-replay-claim",
+            status="executing",
+            executed_at=now - timedelta(hours=2),
+            reason="warmup_executing",
+        )
+        decision.executed_at = now - timedelta(hours=2)
+        decision.lease_expires_at = now - timedelta(hours=1)
+        await session.commit()
+        await RequestLogsRepository(session).add_log(
+            account_id="acc-replay-claim",
+            request_id=_warmup_request_id(decision.id),
+            model="gpt-5.4-mini",
+            input_tokens=3,
+            output_tokens=1,
+            cached_input_tokens=0,
+            latency_ms=10,
+            status="success",
+            error_code=None,
+            request_kind="warmup",
+            transport="quota_planner",
+            requested_at=now - timedelta(minutes=30),
+        )
+
+    forecast = type("Forecast", (), {"peak_slot_start": None, "peak_demand_units": 0.0})()
+    simulation = type("Simulation", (), {"loss": 0.0, "unmet_demand": 0.0})()
+
+    async def fail_send(self, *, account, model, request_id):
+        del self, account, model, request_id
+        raise AssertionError("reconciled warmup log should prevent a second probe")
+
+    monkeypatch.setattr("app.modules.quota_planner.scheduler._build_states", lambda **kwargs: ([], {}))
+    monkeypatch.setattr("app.modules.quota_planner.scheduler.build_demand_forecast", lambda **kwargs: forecast)
+    monkeypatch.setattr("app.modules.quota_planner.scheduler.simulate_pool", lambda **kwargs: simulation)
+    monkeypatch.setattr("app.modules.quota_planner.scheduler.plan_shadow_actions", lambda **kwargs: [])
+    monkeypatch.setattr(QuotaWarmupService, "_send_warmup_probe", fail_send)
+
+    await QuotaPlannerScheduler()._run_once_as_leader()
+
+    async with SessionLocal() as session:
+        refreshed = await session.get(QuotaPlannerDecision, decision.id)
+        assert refreshed is not None
+        assert refreshed.status == "executed"
+        assert refreshed.reason == "warmup_executed"
+        logs = await session.execute(select(RequestLog).where(RequestLog.request_id == _warmup_request_id(decision.id)))
+        assert len(logs.scalars().all()) == 1
+
+
+@pytest.mark.asyncio
+async def test_scheduler_reconciles_success_log_shadowed_by_a_later_error_row(monkeypatch, db_setup):
+    """A probe that succeeded upstream and then failed while recording its
+    effect leaves a success row *and* a later error row under the same stable
+    request id. Reconciliation must still see the success, or the expired
+    claim is re-probed and the account is charged twice."""
+
+    del db_setup
+    await _seed_planner(_account("acc-shadowed-claim"), max_warmups_per_day=3)
+    now = utcnow()
+
+    async with SessionLocal() as session:
+        repo = QuotaPlannerRepository(session)
+        await repo.add_window_observation(
+            account_id="acc-shadowed-claim",
+            model="gpt-5.4-mini",
+            source="warmup_probe",
+            confidence="observed",
+        )
+        decision = await repo.log_decision(
+            mode="auto",
+            action="warmup",
+            idempotency_key="expired-claim-shadowed",
+            account_id="acc-shadowed-claim",
+            status="executing",
+            executed_at=now - timedelta(hours=2),
+            reason="warmup_executing",
+        )
+        decision.executed_at = now - timedelta(hours=2)
+        decision.lease_expires_at = now - timedelta(hours=1)
+        await session.commit()
+        logs_repo = RequestLogsRepository(session)
+        await logs_repo.add_log(
+            account_id="acc-shadowed-claim",
+            request_id=_warmup_request_id(decision.id),
+            model="gpt-5.4-mini",
+            input_tokens=3,
+            output_tokens=1,
+            cached_input_tokens=0,
+            latency_ms=10,
+            status="success",
+            error_code=None,
+            request_kind="warmup",
+            transport="quota_planner",
+            requested_at=now - timedelta(minutes=30),
+        )
+        await logs_repo.add_log(
+            account_id="acc-shadowed-claim",
+            request_id=_warmup_request_id(decision.id),
+            model="gpt-5.4-mini",
+            input_tokens=0,
+            output_tokens=0,
+            latency_ms=11,
+            status="error",
+            error_code="warmup_failed",
+            error_message="recording the warmup effect failed after the probe",
+            request_kind="warmup",
+            transport="quota_planner",
+            requested_at=now - timedelta(minutes=29),
+        )
+
+    forecast = type("Forecast", (), {"peak_slot_start": None, "peak_demand_units": 0.0})()
+    simulation = type("Simulation", (), {"loss": 0.0, "unmet_demand": 0.0})()
+
+    async def fail_send(self, *, account, model, request_id):
+        del self, account, model, request_id
+        raise AssertionError("a shadowed success log must still prevent a second probe")
+
+    monkeypatch.setattr("app.modules.quota_planner.scheduler._build_states", lambda **kwargs: ([], {}))
+    monkeypatch.setattr("app.modules.quota_planner.scheduler.build_demand_forecast", lambda **kwargs: forecast)
+    monkeypatch.setattr("app.modules.quota_planner.scheduler.simulate_pool", lambda **kwargs: simulation)
+    monkeypatch.setattr("app.modules.quota_planner.scheduler.plan_shadow_actions", lambda **kwargs: [])
+    monkeypatch.setattr(QuotaWarmupService, "_send_warmup_probe", fail_send)
+
+    await QuotaPlannerScheduler()._run_once_as_leader()
+
+    async with SessionLocal() as session:
+        refreshed = await session.get(QuotaPlannerDecision, decision.id)
+        assert refreshed is not None
+        assert refreshed.status == "executed"
+        assert refreshed.reason == "warmup_executed"
+        logs = await session.execute(select(RequestLog).where(RequestLog.request_id == _warmup_request_id(decision.id)))
+        assert len(logs.scalars().all()) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -1793,6 +1793,69 @@ async def test_stamped_merge_rollup_repair_downgrade_preserves_schema(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_quota_warmup_claim_expiry_migration_upgrade_and_downgrade(tmp_path):
+    from alembic import command
+    from sqlalchemy import inspect as sa_inspect
+
+    from app.db.migrate import _build_alembic_config
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'quota-warmup-claim-expiry.sqlite'}"
+    parent_revision = "20260806_020000_add_usage_history_bulk_covering_indexes"
+    claim_revision = "20260806_030000_add_quota_warmup_claim_expiry"
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, parent_revision, bootstrap_legacy=False))
+    engine = create_async_engine(db_url, future=True)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO quota_planner_decisions (
+                        id, mode, action, account_id, scheduled_at, executed_at,
+                        score, reason, forecast_snapshot_hash, state_before_json,
+                        state_after_json, status, idempotency_key, created_at
+                    ) VALUES (
+                        'warmup-legacy-executing', 'auto', 'warmup', 'acc-legacy', NULL, NULL,
+                        0.0, 'legacy_executing', NULL, NULL,
+                        NULL, 'executing', 'legacy-warmup-claim', CURRENT_TIMESTAMP
+                    )
+                    """
+                )
+            )
+    finally:
+        await engine.dispose()
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, claim_revision, bootstrap_legacy=False))
+
+    engine = create_async_engine(db_url, future=True)
+    try:
+        async with engine.connect() as conn:
+            columns = await conn.run_sync(
+                lambda sync_conn: {
+                    column["name"] for column in sa_inspect(sync_conn).get_columns("quota_planner_decisions")
+                }
+            )
+            lease_value = (
+                await conn.execute(
+                    text("SELECT lease_expires_at FROM quota_planner_decisions WHERE id = 'warmup-legacy-executing'")
+                )
+            ).scalar_one()
+        assert "lease_expires_at" in columns
+        assert lease_value is not None
+
+        await to_thread.run_sync(lambda: command.downgrade(_build_alembic_config(db_url), parent_revision))
+        async with engine.connect() as conn:
+            columns_after = await conn.run_sync(
+                lambda sync_conn: {
+                    column["name"] for column in sa_inspect(sync_conn).get_columns("quota_planner_decisions")
+                }
+            )
+        assert "lease_expires_at" not in columns_after
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_conversation_presence_rollup_migration_upgrade_and_downgrade(tmp_path):
     from alembic import command
     from sqlalchemy import inspect as sa_inspect
@@ -1964,7 +2027,9 @@ async def test_retired_identity_and_warmup_merge_stamp_repairs_to_head(tmp_path)
         ("add_column", "api_keys', Column('allowed_reasoning_efforts'"),
         ("add_constraint", "ck_api_keys_reasoning_policy_exclusive"),
         ("add_column", "model_sources', Column('supports_embeddings'"),
-        ("remove_column", "quota_planner_decisions', Column('lease_expires_at'"),
+        # No ``remove_column`` entry for quota_planner_decisions.lease_expires_at:
+        # this change restores that column to the model metadata, so the
+        # fixture's hand-added column matches the models and is no longer drift.
         ("add_column", "sticky_sessions', Column('continuity_abandonment_scope'"),
     )
 
@@ -2021,7 +2086,10 @@ async def test_retired_identity_and_warmup_merge_stamp_repairs_to_head(tmp_path)
         assert "allowed_reasoning_efforts" in state["api_key_columns"]
         assert "ck_api_keys_reasoning_policy_exclusive" in state["api_key_checks"]
         assert "supports_embeddings" in state["model_source_columns"]
-        assert "lease_expires_at" not in state["quota_columns"]
+        # The repair revision drops the retired column; the warmup-claim expiry
+        # migration added by this change then recreates it on top, so head
+        # carries it again.
+        assert "lease_expires_at" in state["quota_columns"]
         assert "continuity_abandonment_scope" in state["sticky_columns"]
     finally:
         await engine.dispose()

--- a/tests/integration/test_quota_planner_api.py
+++ b/tests/integration/test_quota_planner_api.py
@@ -23,8 +23,9 @@ from app.db.models import (
 )
 from app.db.session import SessionLocal
 from app.modules.api_keys.service import ApiKeyInvalidError, ApiKeyNotFoundError, ApiKeyRateLimitExceededError
-from app.modules.quota_planner.logic import PlannerSettings
+from app.modules.quota_planner.logic import PlannerAction, PlannerSettings
 from app.modules.quota_planner.repository import QuotaPlannerRepository
+from app.modules.quota_planner.scheduler import QuotaPlannerScheduler
 from app.modules.quota_planner.warmup import QuotaWarmupService, WarmupUsage
 
 pytestmark = pytest.mark.integration
@@ -626,6 +627,107 @@ async def test_quota_planner_warm_now_claims_planned_decision_before_probe(monke
 
     assert seen_statuses == ["executing"]
     assert result.status == "executed"
+
+
+@pytest.mark.asyncio
+async def test_quota_planner_scheduler_reclaims_expired_executing_warmup_claim(monkeypatch, db_setup):
+    del db_setup
+    encryptor = TokenEncryptor()
+    cycle_key = "reclaim-expired-executing-claim"
+    async with SessionLocal() as session:
+        account = Account(
+            id="acc-warm-expired-claim",
+            email="warm-expired-claim@example.test",
+            plan_type="plus",
+            access_token_encrypted=encryptor.encrypt("access"),
+            refresh_token_encrypted=encryptor.encrypt("refresh"),
+            id_token_encrypted=encryptor.encrypt("id"),
+            last_refresh=utcnow(),
+            status=AccountStatus.ACTIVE,
+        )
+        session.add(account)
+        repo = QuotaPlannerRepository(session)
+        await repo.upsert_settings(
+            PlannerSettings(
+                mode="auto",
+                allow_synthetic_traffic=True,
+                dry_run=False,
+                max_warmups_per_day=3,
+                max_warmup_credits_per_day=1.0,
+                warmup_model_preference="gpt-5.4-mini",
+            )
+        )
+        await repo.add_window_observation(
+            account_id=account.id,
+            model="gpt-5.4-mini",
+            source="warmup_probe",
+            confidence="observed",
+        )
+        decision = await repo.log_decision(
+            mode="auto",
+            action="warmup",
+            idempotency_key=f"{cycle_key}:auto:{account.id}:warmup",
+            account_id=account.id,
+            scheduled_at=utcnow() - timedelta(minutes=5),
+            score=3.0,
+            reason="expired_claim_reclaim",
+            status="planned",
+        )
+        claimed = await repo.claim_warmup_decision(
+            decision.id,
+            since=utcnow().replace(hour=0, minute=0, second=0, microsecond=0),
+            max_warmups=3,
+            max_credits=1.0,
+            claim_ttl_seconds=60.0,
+        )
+        assert claimed is not None
+        stale_claim_time = utcnow() - timedelta(minutes=10)
+        claimed.executed_at = stale_claim_time
+        claimed.lease_expires_at = stale_claim_time
+        await session.commit()
+
+    forecast = SimpleNamespace(peak_slot_start=None, peak_demand_units=0.0)
+    simulation = SimpleNamespace(loss=0.0, unmet_demand=0.0)
+
+    monkeypatch.setattr("app.modules.quota_planner.scheduler._build_states", lambda **kwargs: ([], {}))
+    monkeypatch.setattr("app.modules.quota_planner.scheduler.build_demand_forecast", lambda **kwargs: forecast)
+    monkeypatch.setattr("app.modules.quota_planner.scheduler.simulate_pool", lambda **kwargs: simulation)
+    monkeypatch.setattr(
+        "app.modules.quota_planner.scheduler.plan_shadow_actions",
+        lambda **kwargs: [
+            PlannerAction(
+                account_id="acc-warm-expired-claim",
+                action="warmup",
+                scheduled_at=utcnow() - timedelta(minutes=1),
+                score=3.0,
+                reason="expired_claim_reclaim",
+                warmup_cycle_key=cycle_key,
+            )
+        ],
+    )
+
+    async def fake_send(self, *, account, model, request_id):
+        del self, account, model, request_id
+        return WarmupUsage(input_tokens=3, output_tokens=1, cached_input_tokens=0, reasoning_tokens=None)
+
+    async def noop_record_effect(self, account, model, *, source, confidence):
+        del self, account, model, source, confidence
+
+    monkeypatch.setattr(QuotaWarmupService, "_send_warmup_probe", fake_send)
+    monkeypatch.setattr(QuotaWarmupService, "_record_warmup_effect", noop_record_effect)
+
+    await QuotaPlannerScheduler()._run_once_as_leader()
+
+    async with SessionLocal() as session:
+        refreshed = await session.get(QuotaPlannerDecision, decision.id)
+        assert refreshed is not None
+        assert refreshed.status == "executed"
+        assert refreshed.reason == "warmup_executed"
+        assert refreshed.lease_expires_at is None
+        assert refreshed.executed_at is not None
+        assert refreshed.executed_at > stale_claim_time
+        logs = await session.execute(select(RequestLog).where(RequestLog.request_kind == "warmup"))
+        assert len(logs.scalars().all()) == 1
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_helm_shutdown_contract.py
+++ b/tests/unit/test_helm_shutdown_contract.py
@@ -67,4 +67,5 @@ def test_shutdown_values_are_typed_in_chart_schema() -> None:
     assert properties["config"]["properties"]["shutdownDrainTimeoutSeconds"] == {
         "type": "integer",
         "minimum": 1,
+        "maximum": 300,
     }

--- a/tests/unit/test_otel.py
+++ b/tests/unit/test_otel.py
@@ -846,7 +846,7 @@ async def test_lifespan_marks_bridge_membership_stale_on_shutdown(monkeypatch: p
         otel_enabled=False,
         otel_exporter_endpoint="",
         metrics_enabled=False,
-        shutdown_drain_timeout_seconds=0,
+        shutdown_drain_timeout_seconds=1,
         http_responses_session_bridge_instance_id="pod-a",
     )
     settings_cache = SimpleNamespace(
@@ -944,7 +944,7 @@ async def test_lifespan_shutdown_fails_bridge_capacity_waiter_and_cancels_usage_
         otel_enabled=False,
         otel_exporter_endpoint="",
         metrics_enabled=False,
-        shutdown_drain_timeout_seconds=0,
+        shutdown_drain_timeout_seconds=1,
         http_responses_session_bridge_instance_id="pod-a",
     )
     settings_cache = SimpleNamespace(
@@ -1111,7 +1111,7 @@ async def test_lifespan_marks_bridge_membership_stale_for_hostname_shared_ids(
         otel_enabled=False,
         otel_exporter_endpoint="",
         metrics_enabled=False,
-        shutdown_drain_timeout_seconds=0,
+        shutdown_drain_timeout_seconds=1,
         http_responses_session_bridge_instance_id="pod-a",
         http_responses_session_bridge_advertise_base_url="http://pod-a.bridge.default.svc.cluster.local:2455",
     )
@@ -1193,7 +1193,7 @@ async def test_lifespan_registers_bridge_without_waiting_for_advertise_self_prob
         otel_enabled=False,
         otel_exporter_endpoint="",
         metrics_enabled=False,
-        shutdown_drain_timeout_seconds=0,
+        shutdown_drain_timeout_seconds=1,
         http_responses_session_bridge_instance_id="pod-a",
         http_responses_session_bridge_advertise_base_url="http://pod-a.bridge.default.svc.cluster.local:2455",
     )
@@ -1285,7 +1285,7 @@ async def test_lifespan_fails_fast_when_bridge_durable_schema_is_missing(monkeyp
         otel_enabled=False,
         otel_exporter_endpoint="",
         metrics_enabled=False,
-        shutdown_drain_timeout_seconds=0,
+        shutdown_drain_timeout_seconds=1,
     )
     settings_cache = SimpleNamespace(invalidate=AsyncMock())
     rate_limit_cache = SimpleNamespace(invalidate=AsyncMock())
@@ -1327,7 +1327,7 @@ async def test_lifespan_allows_missing_bridge_schema_when_fail_fast_disabled(mon
         otel_enabled=False,
         otel_exporter_endpoint="",
         metrics_enabled=False,
-        shutdown_drain_timeout_seconds=0,
+        shutdown_drain_timeout_seconds=1,
         database_migrations_fail_fast=False,
     )
     settings_cache = SimpleNamespace(

--- a/tests/unit/test_shutdown_drain_bounds.py
+++ b/tests/unit/test_shutdown_drain_bounds.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import time
+from collections import deque
+from typing import Any, cast
+
+import anyio
+import pytest
+import uvicorn
+
+from app.core import server as core_server
+from app.core import shutdown as shutdown_state
+from app.core.config.settings import Settings
+from app.modules.proxy import service as proxy_service
+
+pytestmark = pytest.mark.unit
+
+
+async def _noop_app(scope: Any, receive: Any, send: Any) -> None:  # pragma: no cover
+    del scope, receive, send
+
+
+def _config() -> uvicorn.Config:
+    return uvicorn.Config(_noop_app, timeout_graceful_shutdown=30)
+
+
+@pytest.fixture(autouse=True)
+def _reset_shutdown_state() -> Any:
+    shutdown_state.reset()
+    yield
+    shutdown_state.reset()
+
+
+# ---------------------------------------------------------------- hazard_13
+
+
+@pytest.mark.asyncio
+async def test_h13_drain_completes_before_super_shutdown_is_created() -> None:
+    """Order proof: wait_for_in_flight_drain must finish before sockets close."""
+
+    order: list[str] = []
+    real_wait = shutdown_state.wait_for_in_flight_drain
+
+    async def traced_wait(*args: Any, **kwargs: Any) -> bool:
+        order.append("drain-start")
+        result = await real_wait(*args, **kwargs)
+        order.append("drain-end")
+        return result
+
+    server = core_server.GracefulDrainServer(_config(), drain_timeout_seconds=1.0)
+
+    async def fake_super_shutdown(self: Any, sockets: Any = None) -> None:
+        order.append("close-sockets")
+
+    shutdown_state.increment_in_flight()
+
+    async def release_later() -> None:
+        await asyncio.sleep(0.2)
+        shutdown_state.decrement_in_flight()
+
+    releaser = asyncio.create_task(release_later())
+
+    orig = uvicorn.Server.shutdown
+    uvicorn.Server.shutdown = fake_super_shutdown  # type: ignore[assignment]
+    orig_wait = shutdown_state.wait_for_in_flight_drain
+    shutdown_state.wait_for_in_flight_drain = cast(Any, traced_wait)
+    try:
+        await server.shutdown()
+    finally:
+        uvicorn.Server.shutdown = orig  # type: ignore[assignment]
+        shutdown_state.wait_for_in_flight_drain = orig_wait  # type: ignore[assignment]
+        await releaser
+
+    assert order == ["drain-start", "drain-end", "close-sockets"], order
+
+
+@pytest.mark.asyncio
+async def test_h13_drain_wait_is_bounded_by_the_shared_deadline() -> None:
+    shutdown_state.commit_shutdown(timeout_seconds=0.3)
+    shutdown_state.increment_in_flight()  # never released
+    started = time.monotonic()
+    drained = await shutdown_state.wait_for_in_flight_drain(timeout_seconds=1000.0)
+    elapsed = time.monotonic() - started
+    assert drained is False
+    assert elapsed < 1.0, elapsed
+
+
+@pytest.mark.asyncio
+async def test_h13_work_admitted_after_drain_barrier_is_not_awaited_by_the_drain() -> None:
+    """A drain-allowed path can register in-flight work after the drain returned."""
+
+    shutdown_state.commit_shutdown(timeout_seconds=5.0)
+    assert await shutdown_state.wait_for_in_flight_drain(timeout_seconds=5.0) is True
+    # InFlightMiddleware admits /internal/bridge/responses while draining
+    # (app/core/middleware/inflight.py:14 + :81) and counts it (:79).
+    shutdown_state.increment_in_flight()
+    assert shutdown_state.get_in_flight() == 1
+
+
+def test_h13_inflight_middleware_admission_gate_paths() -> None:
+    from app.core.middleware import inflight
+
+    assert "/internal/bridge/responses" in inflight._DRAIN_ALLOWED_HTTP_PATHS
+    assert "/internal/bridge/responses" not in inflight._IN_FLIGHT_EXCLUDED_HTTP_PATHS
+    assert inflight._IN_FLIGHT_WEBSOCKET_PATHS == frozenset({"/backend-api/codex/responses", "/v1/responses"})
+
+
+# ---------------------------------------------------------------- hazard_14
+
+
+def _lifespan_persistence_drain_budgets() -> list[str]:
+    """Return the timeout expression each nested persistence drain is given.
+
+    Source inspection rather than a runtime probe: the hazard is a call site
+    silently swapped to a different deadline helper, which every mocked
+    shutdown run would still pass.
+    """
+
+    source = inspect.getsource(__import__("app.main", fromlist=["lifespan"]).lifespan)
+    module = ast.parse(source)
+    assignments: dict[str, str] = {}
+    budgets: list[str] = []
+    for node in ast.walk(module):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            assignments[node.targets[0].id] = ast.unparse(node.value)
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+            continue
+        if node.func.id != "_drain_proxy_persistence_tasks":
+            continue
+        budget = ast.unparse(node.args[1])
+        budgets.append(assignments.get(budget, budget))
+    return budgets
+
+
+def test_h14_nested_lifespan_cleanup_uses_remaining_drain_budget() -> None:
+    """Nested lifespan cleanup must not receive the full configured drain.
+
+    Each nested drain is pinned to its own deadline. The settlement pre-drain
+    runs after the drain barrier, so a drain that used its whole budget would
+    leave it nothing to settle with; it draws on the shared drain-plus-reserve
+    remainder instead. The post-teardown drain runs inside the drain window and
+    uses the drain remainder.
+    """
+
+    reserve = core_server.POST_DRAIN_CLEANUP_TIMEOUT_SECONDS
+    assert reserve == 25.0
+    assert _lifespan_persistence_drain_budgets() == [
+        "shutdown_state.remaining_post_drain_cleanup_timeout_seconds() or 0.0",
+        "shutdown_state.remaining_drain_timeout_seconds() or 0.0",
+    ]
+    source = inspect.getsource(__import__("app.main", fromlist=["lifespan"]).lifespan)
+    assert "settings.shutdown_drain_timeout_seconds" not in source.split("finally:")[-1]
+
+
+@pytest.mark.parametrize("value", [0, -5])
+def test_h14_settings_reject_non_positive_drain_timeouts(value: int) -> None:
+    with pytest.raises(ValueError):
+        Settings(shutdown_drain_timeout_seconds=value)
+
+
+def test_h14_settings_rejects_absurd_drain_timeout() -> None:
+    with pytest.raises(ValueError):
+        Settings(shutdown_drain_timeout_seconds=86400)
+
+
+@pytest.mark.asyncio
+async def test_h17_terminal_settlement_gets_post_drain_reserve_grace() -> None:
+    """Exhausted drain still leaves the terminal settlement its reserve."""
+
+    service = proxy_service.ProxyService(cast(Any, lambda: None))
+    release = asyncio.Event()
+    finalize_started = asyncio.Event()
+    wait_timeout: list[float] = []
+    real_wait = asyncio.wait
+
+    async def blocked_finalize(*_args: Any, **_kwargs: Any) -> None:
+        finalize_started.set()
+        await release.wait()
+
+    async def traced_wait(fs: Any, *, timeout: float | None = None, **kwargs: Any) -> Any:
+        wait_timeout.append(float(timeout or 0.0))
+        return await real_wait(fs, timeout=0, **kwargs)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(service, "_finalize_claimed_websocket_requests", blocked_finalize)
+    monkeypatch.setattr(asyncio, "wait", traced_wait)
+    shutdown_state.commit_shutdown(timeout_seconds=0.0)
+    shutdown_state.set_post_drain_cleanup_timeout_seconds(core_server.POST_DRAIN_CLEANUP_TIMEOUT_SECONDS)
+    caller = asyncio.create_task(
+        service._fail_pending_websocket_requests(
+            account=None,
+            account_id_value=None,
+            pending_requests=cast(Any, deque([object()])),
+            pending_lock=anyio.Lock(),
+            error_code="cancelled",
+            error_message="cancelled",
+            api_key=None,
+        )
+    )
+    await asyncio.wait_for(finalize_started.wait(), timeout=1)
+    caller.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+    release.set()
+    monkeypatch.undo()
+    assert wait_timeout and wait_timeout[0] > 0
+    assert wait_timeout[0] <= core_server.POST_DRAIN_CLEANUP_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_h14_post_drain_wait_expires_at_deadline_plus_reserve() -> None:
+    server = core_server.GracefulDrainServer(
+        _config(),
+        drain_timeout_seconds=0.4,
+        post_drain_cleanup_timeout_seconds=0.3,
+    )
+    captured: dict[str, float] = {}
+    real_wait = asyncio.wait
+
+    async def traced_wait(fs: Any, *, timeout: float | None = None, **kw: Any) -> Any:
+        captured["timeout"] = float(timeout or 0.0)
+        return await real_wait(fs, timeout=timeout, **kw)
+
+    async def fake_super_shutdown(self: Any, sockets: Any = None) -> None:
+        return None
+
+    orig = uvicorn.Server.shutdown
+    uvicorn.Server.shutdown = fake_super_shutdown  # type: ignore[assignment]
+    asyncio.wait = cast(Any, traced_wait)
+    try:
+        await server.shutdown()
+    finally:
+        uvicorn.Server.shutdown = orig  # type: ignore[assignment]
+        asyncio.wait = real_wait  # type: ignore[assignment]
+
+    # remaining (<= 0.4) + reserve (0.3)
+    assert captured["timeout"] <= 0.4 + 0.3 + 1e-6, captured
+    assert captured["timeout"] > 0.3, captured

--- a/tests/unit/test_websocket_terminal_cancellation.py
+++ b/tests/unit/test_websocket_terminal_cancellation.py
@@ -984,6 +984,7 @@ async def test_pending_failure_cancellation_after_claim_remains_drain_owned(
 
     assert pending_requests == deque()
     shutdown_state.commit_shutdown(timeout_seconds=0.01)
+    shutdown_state.set_post_drain_cleanup_timeout_seconds(0.05)
     failure.cancel()
     with pytest.raises(asyncio.CancelledError):
         await asyncio.wait_for(failure, timeout=0.2)


### PR DESCRIPTION
Three latent lifecycle/config gaps found by audit:

- **Compose**: `docker-compose.prod.yml` had no `stop_grace_period`, so Docker's 10s default SIGKILLs the backend mid-drain against a ~55s app drain budget (helm gets this right). Added `stop_grace_period: 75s` with a drain-budget comment and a test asserting it exceeds the budget. This is the same class that tore live sessions during blue-green cutover.
- **Refresh config**: `token_refresh_timeout_seconds=0` validated and yielded an unbounded OAuth exchange under a 10s claim TTL on every background refresher. Now bounded > 0, and the refresh-claim TTL floor includes the DB exchange term so the claim provably dominates admission + exchange. Zero-timeout is rejected with a test.
- **Quota planner**: the `planned -> executing` warmup claim was never released or expired, so a crash mid-execution stranded the daily budget. Claims now expire (TTL), reclaim atomically, and clear on terminal completion; a stranded claim self-heals with a test proving it.

148 focused tests green; openspec change added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for expired quota warmup claims.
  * Prevented duplicate warmup requests through stable request tracking and successful-log reconciliation.
  * Added configurable event-loop lag monitoring and stricter timeout validation.

* **Bug Fixes**
  * Improved graceful shutdown timing, including bounded cleanup and WebSocket settlement.
  * Fixed account binding and replay behavior for WebSocket requests.
  * Added database migration support for warmup claim expiration.

* **Documentation**
  * Updated operational specifications for shutdown handling and warmup recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->