### PR TITLE
test(sim): deterministic proxy turn-lifecycle simulation harness

### DIFF
--- a/app/core/clock.py
+++ b/app/core/clock.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Coroutine
+from datetime import datetime, timezone
+from typing import Any, Protocol, TypeVar
+
+T = TypeVar("T")
+
+
+class Clock(Protocol):
+    def monotonic(self) -> float: ...
+
+    def time(self) -> float: ...
+
+    def now(self) -> datetime: ...
+
+
+class Scheduler(Protocol):
+    async def sleep(self, delay: float, result: T | None = None) -> T | None: ...
+
+    async def wait_for(self, awaitable: Awaitable[T], timeout: float | None) -> T: ...
+
+    def create_task(self, coroutine: Coroutine[Any, Any, T], *, name: str | None = None) -> asyncio.Task[T]: ...
+
+    async def drain(self) -> None: ...
+
+    async def cancel_owned_tasks(self) -> None: ...
+
+
+class RealClock:
+    def monotonic(self) -> float:
+        return time.monotonic()
+
+    def time(self) -> float:
+        return time.time()
+
+    def now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+
+class RealScheduler:
+    def __init__(self) -> None:
+        self._tasks: set[asyncio.Task[Any]] = set()
+
+    async def sleep(self, delay: float, result: T | None = None) -> T | None:
+        return await asyncio.sleep(delay, result=result)
+
+    async def wait_for(self, awaitable: Awaitable[T], timeout: float | None) -> T:
+        return await asyncio.wait_for(awaitable, timeout=timeout)
+
+    def create_task(self, coroutine: Coroutine[Any, Any, T], *, name: str | None = None) -> asyncio.Task[T]:
+        task = asyncio.create_task(coroutine, name=name)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task
+
+    async def drain(self) -> None:
+        if not self._tasks:
+            await asyncio.sleep(0)
+            return
+        done = [task for task in self._tasks if task.done()]
+        if done:
+            await asyncio.gather(*done, return_exceptions=True)
+        await asyncio.sleep(0)
+
+    async def cancel_owned_tasks(self) -> None:
+        tasks = list(self._tasks)
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._tasks.clear()
+
+
+REAL_CLOCK = RealClock()
+REAL_SCHEDULER = RealScheduler()
+
+
+def scheduler_for(owner: object) -> Scheduler:
+    """Return the scheduler collaborator of ``owner``.
+
+    Proxy lifecycle behavior is spread over mixins that are also reached through
+    partial collaborators, so the seam reads the collaborator instead of
+    requiring every holder to carry one. Anything without an explicit scheduler
+    gets the real ``asyncio`` one, which keeps the production default intact.
+    """
+
+    return getattr(owner, "_scheduler", REAL_SCHEDULER)
+
+
+def clock_for(owner: object) -> Clock:
+    """Return the clock collaborator of ``owner``, defaulting to real time."""
+
+    return getattr(owner, "_clock", REAL_CLOCK)

--- a/app/core/usage/quota.py
+++ b/app/core/usage/quota.py
@@ -68,7 +68,7 @@ def apply_usage_quota(
                 if primary_reset is not None:
                     reset_at = primary_reset
                 else:
-                    reset_at = _fallback_primary_reset(primary_window_minutes) or reset_at
+                    reset_at = _fallback_primary_reset(primary_window_minutes, now=now) or reset_at
                 status = AccountStatus.RATE_LIMITED
                 return status, used_percent, reset_at
         if status == AccountStatus.RATE_LIMITED:
@@ -93,11 +93,11 @@ def apply_usage_quota(
     return status, used_percent, reset_at
 
 
-def _fallback_primary_reset(primary_window_minutes: int | None) -> float | None:
+def _fallback_primary_reset(primary_window_minutes: int | None, *, now: float) -> float | None:
     window_minutes = primary_window_minutes or usage_core.default_window_minutes("primary")
     if not window_minutes:
         return None
-    return time.time() + float(window_minutes) * 60.0
+    return now + float(window_minutes) * 60.0
 
 
 def _has_credit_override(

--- a/app/core/usage/quota.py
+++ b/app/core/usage/quota.py
@@ -19,7 +19,9 @@ def apply_usage_quota(
     credits_unlimited: bool | None = None,
     credits_balance: float | None = None,
     infer_status_from_usage: bool = True,
+    now: float | None = None,
 ) -> tuple[AccountStatus, float | None, float | None]:
+    now = time.time() if now is None else now
     used_percent = primary_used
     reset_at = runtime_reset
 
@@ -45,7 +47,7 @@ def apply_usage_quota(
                     status = AccountStatus.QUOTA_EXCEEDED
                     return status, used_percent, reset_at
         if status == AccountStatus.QUOTA_EXCEEDED:
-            if runtime_reset and runtime_reset > time.time():
+            if runtime_reset and runtime_reset > now:
                 reset_at = runtime_reset
             else:
                 status = AccountStatus.ACTIVE
@@ -70,7 +72,7 @@ def apply_usage_quota(
                 status = AccountStatus.RATE_LIMITED
                 return status, used_percent, reset_at
         if status == AccountStatus.RATE_LIMITED:
-            if runtime_reset and runtime_reset > time.time():
+            if runtime_reset and runtime_reset > now:
                 reset_at = runtime_reset
             else:
                 status = AccountStatus.ACTIVE
@@ -82,7 +84,7 @@ def apply_usage_quota(
         # account rate-limited indefinitely. Callers that cannot tie the
         # sample to a reset deadline or post-block evidence must preserve
         # the block themselves.
-        if runtime_reset and runtime_reset > time.time():
+        if runtime_reset and runtime_reset > now:
             reset_at = runtime_reset
         else:
             status = AccountStatus.ACTIVE

--- a/app/modules/proxy/_load_balancer/sticky_selection.py
+++ b/app/modules/proxy/_load_balancer/sticky_selection.py
@@ -23,6 +23,7 @@ from app.core.balancer import (
     TrafficClass,
     select_account,
 )
+from app.core.clock import Clock
 from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, AdditionalUsageHistory, StickySessionKind, UsageHistory
 from app.modules.accounts.repository import AccountsRepository
@@ -86,6 +87,7 @@ SelectionInputsT = TypeVar("SelectionInputsT", bound=SelectionInputsProtocol)
 
 
 class StickySelectionOwner(Protocol):
+    _clock: Clock
     _runtime_lock: asyncio.Lock
     _repo_factory: ProxyRepoFactory
 
@@ -437,7 +439,7 @@ async def run_sticky_selection_path(
                 else build_routing_costs(
                     settings=selection_inputs.quota_planner_settings,
                     states=states,
-                    now=datetime.now(timezone.utc),
+                    now=datetime.fromtimestamp(owner._clock.time(), timezone.utc),
                 )
             )
             # Key shape is deliberately irrelevant here. Only typed
@@ -1169,6 +1171,7 @@ async def _select_with_stickiness(
     allow_usage_exhaustion_error: bool = True,
     usage_exhaustion_states: Iterable[AccountState] | None = None,
     sticky_refresh_skip_deadline: datetime | None = None,
+    now: float,
 ) -> _StickySelectionOutcome:
     if not sticky_key or not sticky_repo:
         return _StickySelectionOutcome(
@@ -1273,7 +1276,6 @@ async def _select_with_stickiness(
             # budget threshold. That preserves continuity below the
             # threshold while avoiding obvious short-window failures once
             # the session is skating on the edge of exhaustion.
-            now = time.time()
             budget_pressured = (
                 sticky_kind
                 in (
@@ -1398,7 +1400,7 @@ async def _select_with_stickiness(
                 grace_copy = replace(pinned)
                 grace_result = select_account(
                     [grace_copy],
-                    now=time.time() + _STICKY_GRACE_PERIOD_SECONDS,
+                    now=now + _STICKY_GRACE_PERIOD_SECONDS,
                     prefer_earlier_reset=prefer_earlier_reset_accounts,
                     prefer_earlier_reset_window=prefer_earlier_reset_window,
                     routing_strategy=routing_strategy,

--- a/app/modules/proxy/_load_balancer/sticky_selection.py
+++ b/app/modules/proxy/_load_balancer/sticky_selection.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import time
 from collections.abc import Awaitable, Callable, Collection, Iterable
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
@@ -198,6 +197,7 @@ class StickySelectionOwner(Protocol):
         allow_usage_exhaustion_error: bool = True,
         usage_exhaustion_states: Iterable[AccountState] | None = None,
         sticky_refresh_skip_deadline: datetime | None = None,
+        now: float,
     ) -> _StickySelectionOutcome: ...
 
     async def release_account_lease(self, lease: AccountLease | None) -> None: ...
@@ -417,6 +417,7 @@ async def run_sticky_selection_path(
                 # not the raw legacy owner that now shadows it.
                 sticky_refresh_skip_deadline = None
         async with owner._runtime_lock:
+            selection_now = owner._clock.time()
             states, account_map = owner._prepare_sticky_selection_states(
                 selection_inputs,
                 required_account_id=required_account_id,
@@ -439,7 +440,7 @@ async def run_sticky_selection_path(
                 else build_routing_costs(
                     settings=selection_inputs.quota_planner_settings,
                     states=states,
-                    now=datetime.fromtimestamp(owner._clock.time(), timezone.utc),
+                    now=datetime.fromtimestamp(selection_now, timezone.utc),
                 )
             )
             # Key shape is deliberately irrelevant here. Only typed
@@ -543,6 +544,7 @@ async def run_sticky_selection_path(
                 selection_states = _filter_recovery_probe_candidates(
                     selection_states,
                     traffic_class=traffic_class,
+                    now=selection_now,
                 )
             probe_reservation: ProbeReservation | None = None
         # Raw sticky rows are global, while account-assigned API keys and
@@ -690,6 +692,7 @@ async def run_sticky_selection_path(
                         allow_usage_exhaustion_error=allow_usage_exhaustion_error,
                         usage_exhaustion_states=states,
                         sticky_refresh_skip_deadline=sticky_refresh_skip_deadline,
+                        now=selection_now,
                     )
                     result = sticky_outcome.selection
                     if (
@@ -732,6 +735,7 @@ async def run_sticky_selection_path(
                 result.account,
                 routing_strategy=routing_strategy,
                 traffic_class=traffic_class,
+                now=selection_now,
             )
             if should_reserve_probe and probing_result_requires_reservation:
                 # Sticky persistence happens outside the runtime lock.
@@ -1570,20 +1574,22 @@ def _probing_result_requires_recovery_reservation(
     *,
     routing_strategy: str,
     traffic_class: TrafficClass,
+    now: float,
 ) -> bool:
     if routing_strategy in ("sequential_drain", "reset_drain", "single_account"):
         return False
     if result_account is None or result_account.health_tier != HEALTH_TIER_PROBING:
         return False
-    return _pool_has_available_healthy_account_without_backoff(states, traffic_class=traffic_class)
+    return _pool_has_available_healthy_account_without_backoff(states, traffic_class=traffic_class, now=now)
 
 
 def _filter_recovery_probe_candidates(
     states: list[AccountState],
     *,
     traffic_class: TrafficClass,
+    now: float,
 ) -> list[AccountState]:
-    if not _pool_has_available_healthy_account_without_backoff(states, traffic_class=traffic_class):
+    if not _pool_has_available_healthy_account_without_backoff(states, traffic_class=traffic_class, now=now):
         return states
     return [state for state in states if state.health_tier != HEALTH_TIER_PROBING]
 
@@ -1592,10 +1598,12 @@ def _pool_has_available_healthy_account_without_backoff(
     states: Iterable[AccountState],
     *,
     traffic_class: TrafficClass,
+    now: float,
 ) -> bool:
     return _pool_has_available_account_without_backoff(
         (state for state in states if state.health_tier == HEALTH_TIER_HEALTHY),
         traffic_class=traffic_class,
+        now=now,
     )
 
 
@@ -1603,6 +1611,7 @@ def _pool_has_available_account_without_backoff(
     states: Iterable[AccountState],
     *,
     traffic_class: TrafficClass,
+    now: float,
 ) -> bool:
     """Return whether the complete pool passes non-cap routing eligibility."""
     # ``select_account`` normalizes expired quota/cooldown fields in place;
@@ -1611,7 +1620,7 @@ def _pool_has_available_account_without_backoff(
     # opportunistic admission compares candidates with one another.
     result = select_account(
         [replace(state) for state in states],
-        now=time.time(),
+        now=now,
         routing_strategy="single_account",
         allow_backoff_fallback=False,
         traffic_class=traffic_class,

--- a/app/modules/proxy/_load_balancer/unbound_selection.py
+++ b/app/modules/proxy/_load_balancer/unbound_selection.py
@@ -157,7 +157,7 @@ async def run_unbound_selection_path(
                 else build_routing_costs(
                     settings=selection_inputs.quota_planner_settings,
                     states=states,
-                    now=datetime.now(timezone.utc),
+                    now=datetime.fromtimestamp(owner._clock.time(), timezone.utc),
                 )
             )
             fair_share_denial = owner._api_key_stream_fair_share_denial_locked(

--- a/app/modules/proxy/_load_balancer/unbound_selection.py
+++ b/app/modules/proxy/_load_balancer/unbound_selection.py
@@ -146,6 +146,7 @@ async def run_unbound_selection_path(
         probe_reservation: ProbeReservation | None = None
         probe_reservation_invalidated = False
         async with owner._runtime_lock:
+            selection_now = owner._clock.time()
             states, account_map = owner._prepare_sticky_selection_states(
                 selection_inputs,
                 required_account_id=required_account_id,
@@ -157,7 +158,7 @@ async def run_unbound_selection_path(
                 else build_routing_costs(
                     settings=selection_inputs.quota_planner_settings,
                     states=states,
-                    now=datetime.fromtimestamp(owner._clock.time(), timezone.utc),
+                    now=datetime.fromtimestamp(selection_now, timezone.utc),
                 )
             )
             fair_share_denial = owner._api_key_stream_fair_share_denial_locked(
@@ -179,6 +180,7 @@ async def run_unbound_selection_path(
                 selection_states = _filter_recovery_probe_candidates(
                     selection_states,
                     traffic_class=traffic_class,
+                    now=selection_now,
                 )
             if fair_share_denial is not None:
                 # Gate and acquire share this lock section, so the denial is
@@ -234,6 +236,7 @@ async def run_unbound_selection_path(
                     result.account,
                     routing_strategy=routing_strategy,
                     traffic_class=traffic_class,
+                    now=selection_now,
                 )
                 if probing_result_requires_reservation and result.account is not None:
                     # Unbound recovery admissions have the same

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -1008,6 +1008,7 @@ async def _close_http_bridge_session_resources(
                 upstream_reader,
                 label="http bridge upstream reader",
                 cleanup_tasks=service._background_cleanup_tasks,
+                scheduler=scheduler_for(service),
             )
             if session.upstream_reader is upstream_reader:
                 session.upstream_reader = None

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -1059,7 +1059,7 @@ async def _close_http_bridge_session(
             not existing.done() or (not existing.cancelled() and existing.exception() is None)
         ):
             return existing
-        created = asyncio.create_task(
+        created = scheduler_for(service).create_task(
             _close_http_bridge_session_resources(
                 service,
                 session,

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -2102,7 +2102,17 @@ async def _await_cancelled_task(
     if cancel:
         task.cancel()
     try:
-        done, _ = await asyncio.wait({task}, timeout=effective_timeout)
+        await scheduler.wait_for(asyncio.wait({task}), timeout=effective_timeout)
+    except TimeoutError:
+        logger.warning("Timed out waiting for %s cancellation", label)
+        _cancel_and_track_cancelled_task(
+            task,
+            label=label,
+            cleanup_tasks=cleanup_tasks,
+            cancel_task=False,
+            scheduler=scheduler,
+        )
+        return False
     except asyncio.CancelledError:
         if not task.done():
             _cancel_and_track_cancelled_task(
@@ -2113,16 +2123,6 @@ async def _await_cancelled_task(
                 scheduler=scheduler,
             )
         raise
-    if task not in done:
-        logger.warning("Timed out waiting for %s cancellation", label)
-        _cancel_and_track_cancelled_task(
-            task,
-            label=label,
-            cleanup_tasks=cleanup_tasks,
-            cancel_task=False,
-            scheduler=scheduler,
-        )
-        return False
     try:
         task.result()
     except asyncio.CancelledError:

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -36,6 +36,7 @@ from app.core.clients.proxy import (  # noqa: F401  # noqa: F401
 from app.core.clients.proxy import codex_control_request as core_codex_control_request  # noqa: F401
 from app.core.clients.proxy import compact_responses as core_compact_responses  # noqa: F401
 from app.core.clients.proxy import transcribe_audio as core_transcribe_audio  # noqa: F401
+from app.core.clock import REAL_SCHEDULER, Scheduler, scheduler_for
 from app.core.config.settings import Settings, get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.errors import (
@@ -1102,7 +1103,7 @@ async def _close_http_bridge_session_bounded(
     if session.upstream_reader is asyncio.current_task():
         session.upstream_reader = None
 
-    close_task = asyncio.create_task(
+    close_task = scheduler_for(service).create_task(
         service._close_http_bridge_session(session),
         name=f"http-bridge-close-{_hash_identifier(session.key.affinity_key)}",
     )
@@ -2065,10 +2066,11 @@ def _cancel_and_track_cancelled_task(
     label: str,
     cleanup_tasks: set[asyncio.Task[None]] | None,
     cancel_task: bool = True,
+    scheduler: Scheduler = REAL_SCHEDULER,
 ) -> None:
     if cancel_task:
         task.cancel()
-    cleanup_task = asyncio.create_task(_drain_cancelled_task(task), name=f"cancelled-task-cleanup-{label}")
+    cleanup_task = scheduler.create_task(_drain_cancelled_task(task), name=f"cancelled-task-cleanup-{label}")
     if cleanup_tasks is not None:
         cleanup_tasks.add(cleanup_task)
         cleanup_task.add_done_callback(cleanup_tasks.discard)
@@ -2081,6 +2083,7 @@ async def _await_cancelled_task(
     label: str,
     cancel: bool = True,
     cleanup_tasks: set[asyncio.Task[None]] | None = None,
+    scheduler: Scheduler = REAL_SCHEDULER,
 ) -> bool:
     effective_timeout = max(float(timeout_seconds), 0.0)
     remaining_drain_timeout = shutdown_state.remaining_drain_timeout_seconds()
@@ -2093,7 +2096,7 @@ async def _await_cancelled_task(
         try:
             await asyncio.sleep(0)
         except asyncio.CancelledError:
-            _cancel_and_track_cancelled_task(task, label=label, cleanup_tasks=cleanup_tasks)
+            _cancel_and_track_cancelled_task(task, label=label, cleanup_tasks=cleanup_tasks, scheduler=scheduler)
             raise
     if cancel:
         task.cancel()
@@ -2101,11 +2104,23 @@ async def _await_cancelled_task(
         done, _ = await asyncio.wait({task}, timeout=effective_timeout)
     except asyncio.CancelledError:
         if not task.done():
-            _cancel_and_track_cancelled_task(task, label=label, cleanup_tasks=cleanup_tasks, cancel_task=False)
+            _cancel_and_track_cancelled_task(
+                task,
+                label=label,
+                cleanup_tasks=cleanup_tasks,
+                cancel_task=False,
+                scheduler=scheduler,
+            )
         raise
     if task not in done:
         logger.warning("Timed out waiting for %s cancellation", label)
-        _cancel_and_track_cancelled_task(task, label=label, cleanup_tasks=cleanup_tasks, cancel_task=False)
+        _cancel_and_track_cancelled_task(
+            task,
+            label=label,
+            cleanup_tasks=cleanup_tasks,
+            cancel_task=False,
+            scheduler=scheduler,
+        )
         return False
     try:
         task.result()

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -36,6 +36,7 @@ from app.core.clients.proxy import (  # noqa: F401  # noqa: F401
 from app.core.clients.proxy import codex_control_request as core_codex_control_request  # noqa: F401
 from app.core.clients.proxy import compact_responses as core_compact_responses  # noqa: F401
 from app.core.clients.proxy import transcribe_audio as core_transcribe_audio  # noqa: F401
+from app.core.clock import REAL_SCHEDULER, Scheduler, scheduler_for
 from app.core.config.settings import Settings, get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.errors import (
@@ -1101,7 +1102,7 @@ async def _close_http_bridge_session_bounded(
     if session.upstream_reader is asyncio.current_task():
         session.upstream_reader = None
 
-    close_task = asyncio.create_task(
+    close_task = scheduler_for(service).create_task(
         service._close_http_bridge_session(session),
         name=f"http-bridge-close-{_hash_identifier(session.key.affinity_key)}",
     )
@@ -2064,10 +2065,11 @@ def _cancel_and_track_cancelled_task(
     label: str,
     cleanup_tasks: set[asyncio.Task[None]] | None,
     cancel_task: bool = True,
+    scheduler: Scheduler = REAL_SCHEDULER,
 ) -> None:
     if cancel_task:
         task.cancel()
-    cleanup_task = asyncio.create_task(_drain_cancelled_task(task), name=f"cancelled-task-cleanup-{label}")
+    cleanup_task = scheduler.create_task(_drain_cancelled_task(task), name=f"cancelled-task-cleanup-{label}")
     if cleanup_tasks is not None:
         cleanup_tasks.add(cleanup_task)
         cleanup_task.add_done_callback(cleanup_tasks.discard)
@@ -2080,6 +2082,7 @@ async def _await_cancelled_task(
     label: str,
     cancel: bool = True,
     cleanup_tasks: set[asyncio.Task[None]] | None = None,
+    scheduler: Scheduler = REAL_SCHEDULER,
 ) -> bool:
     effective_timeout = max(float(timeout_seconds), 0.0)
     remaining_drain_timeout = shutdown_state.remaining_drain_timeout_seconds()
@@ -2092,7 +2095,7 @@ async def _await_cancelled_task(
         try:
             await asyncio.sleep(0)
         except asyncio.CancelledError:
-            _cancel_and_track_cancelled_task(task, label=label, cleanup_tasks=cleanup_tasks)
+            _cancel_and_track_cancelled_task(task, label=label, cleanup_tasks=cleanup_tasks, scheduler=scheduler)
             raise
     if cancel:
         task.cancel()
@@ -2100,11 +2103,23 @@ async def _await_cancelled_task(
         done, _ = await asyncio.wait({task}, timeout=effective_timeout)
     except asyncio.CancelledError:
         if not task.done():
-            _cancel_and_track_cancelled_task(task, label=label, cleanup_tasks=cleanup_tasks, cancel_task=False)
+            _cancel_and_track_cancelled_task(
+                task,
+                label=label,
+                cleanup_tasks=cleanup_tasks,
+                cancel_task=False,
+                scheduler=scheduler,
+            )
         raise
     if task not in done:
         logger.warning("Timed out waiting for %s cancellation", label)
-        _cancel_and_track_cancelled_task(task, label=label, cleanup_tasks=cleanup_tasks, cancel_task=False)
+        _cancel_and_track_cancelled_task(
+            task,
+            label=label,
+            cleanup_tasks=cleanup_tasks,
+            cancel_task=False,
+            scheduler=scheduler,
+        )
         return False
     try:
         task.result()

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -2016,6 +2016,7 @@ class _HTTPBridgeMixin(
                         old_reader,
                         label="http bridge upstream reader",
                         cleanup_tasks=self._background_cleanup_tasks,
+                        scheduler=scheduler_for(self),
                     )
                 except BaseException:
                     session.closed = True

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -1527,9 +1527,6 @@ class _HTTPBridgeMixin(
                     "deferred_account_backoff_lifecycle": deferred_account_backoff_lifecycle,
                     "defer_account_health_writes": defer_account_health_writes,
                 }
-                durable_owner = getattr(durable_lookup, "owner_instance_id", None)
-                if existing is None and durable_owner == settings.http_responses_session_bridge_instance_id:
-                    force_durable_takeover = True  # Fence late writes from the prior local owner.
                 try:
                     create_signature = inspect.signature(create_session)
                 except (TypeError, ValueError):

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -1527,13 +1527,9 @@ class _HTTPBridgeMixin(
                     "deferred_account_backoff_lifecycle": deferred_account_backoff_lifecycle,
                     "defer_account_health_writes": defer_account_health_writes,
                 }
-                if (
-                    existing is None
-                    and durable_lookup is not None
-                    and durable_lookup.owner_instance_id == settings.http_responses_session_bridge_instance_id
-                ):
-                    # Fence late close/release writes from the prior local owner.
-                    force_durable_takeover = True
+                durable_owner = getattr(durable_lookup, "owner_instance_id", None)
+                if existing is None and durable_owner == settings.http_responses_session_bridge_instance_id:
+                    force_durable_takeover = True  # Fence late writes from the prior local owner.
                 try:
                     create_signature = inspect.signature(create_session)
                 except (TypeError, ValueError):

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -36,6 +36,7 @@ from app.core.clients.proxy import (  # noqa: F401  # noqa: F401
 from app.core.clients.proxy import codex_control_request as core_codex_control_request  # noqa: F401
 from app.core.clients.proxy import compact_responses as core_compact_responses  # noqa: F401
 from app.core.clients.proxy import transcribe_audio as core_transcribe_audio  # noqa: F401
+from app.core.clock import scheduler_for
 from app.core.errors import openai_error
 from app.core.metrics.prometheus import (
     PROMETHEUS_AVAILABLE,
@@ -1526,6 +1527,13 @@ class _HTTPBridgeMixin(
                     "deferred_account_backoff_lifecycle": deferred_account_backoff_lifecycle,
                     "defer_account_health_writes": defer_account_health_writes,
                 }
+                if (
+                    existing is None
+                    and durable_lookup is not None
+                    and durable_lookup.owner_instance_id == settings.http_responses_session_bridge_instance_id
+                ):
+                    # Fence late close/release writes from the prior local owner.
+                    force_durable_takeover = True
                 try:
                     create_signature = inspect.signature(create_session)
                 except (TypeError, ValueError):
@@ -1975,7 +1983,7 @@ class _HTTPBridgeMixin(
             catalog_omission_quota_admission=selection.catalog_omission_quota_admission,
         )
         _copy_websocket_route_metadata_to_session(session, request_state)
-        session.upstream_reader = asyncio.create_task(self._relay_http_bridge_upstream_messages(session))
+        session.upstream_reader = scheduler_for(self).create_task(self._relay_http_bridge_upstream_messages(session))
         return session
 
     async def _reconnect_http_bridge_session(
@@ -2418,7 +2426,9 @@ class _HTTPBridgeMixin(
             await abort_selected_handoff()
             raise
         if restart_reader:
-            session.upstream_reader = asyncio.create_task(self._relay_http_bridge_upstream_messages(session))
+            session.upstream_reader = scheduler_for(self).create_task(
+                self._relay_http_bridge_upstream_messages(session)
+            )
         _log_http_bridge_event(
             "reconnect",
             session.key,

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -36,6 +36,7 @@ from app.core.clients.proxy import (  # noqa: F401  # noqa: F401
 from app.core.clients.proxy import codex_control_request as core_codex_control_request  # noqa: F401
 from app.core.clients.proxy import compact_responses as core_compact_responses  # noqa: F401
 from app.core.clients.proxy import transcribe_audio as core_transcribe_audio  # noqa: F401
+from app.core.clock import scheduler_for
 from app.core.errors import openai_error
 from app.core.metrics.prometheus import (
     PROMETHEUS_AVAILABLE,
@@ -1518,6 +1519,13 @@ class _HTTPBridgeMixin(
                     "deferred_account_backoff_lifecycle": deferred_account_backoff_lifecycle,
                     "defer_account_health_writes": defer_account_health_writes,
                 }
+                if (
+                    existing is None
+                    and durable_lookup is not None
+                    and durable_lookup.owner_instance_id == settings.http_responses_session_bridge_instance_id
+                ):
+                    # Fence late close/release writes from the prior local owner.
+                    force_durable_takeover = True
                 try:
                     create_signature = inspect.signature(create_session)
                 except (TypeError, ValueError):
@@ -1967,7 +1975,7 @@ class _HTTPBridgeMixin(
             catalog_omission_quota_admission=selection.catalog_omission_quota_admission,
         )
         _copy_websocket_route_metadata_to_session(session, request_state)
-        session.upstream_reader = asyncio.create_task(self._relay_http_bridge_upstream_messages(session))
+        session.upstream_reader = scheduler_for(self).create_task(self._relay_http_bridge_upstream_messages(session))
         return session
 
     async def _reconnect_http_bridge_session(
@@ -2410,7 +2418,9 @@ class _HTTPBridgeMixin(
             await abort_selected_handoff()
             raise
         if restart_reader:
-            session.upstream_reader = asyncio.create_task(self._relay_http_bridge_upstream_messages(session))
+            session.upstream_reader = scheduler_for(self).create_task(
+                self._relay_http_bridge_upstream_messages(session)
+            )
         _log_http_bridge_event(
             "reconnect",
             session.key,

--- a/app/modules/proxy/_service/http_bridge/protocol.py
+++ b/app/modules/proxy/_service/http_bridge/protocol.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from typing import Any, Protocol
 
 from app.core.clients.proxy import ProxyResponseError
+from app.core.clock import Clock, Scheduler
 from app.core.openai.requests import ResponsesRequest
 from app.db.models import Account
 from app.modules.proxy._service.support import _HTTPBridgeSession, _HTTPBridgeSessionKey
@@ -15,6 +16,8 @@ from app.modules.proxy.load_balancer import AccountSelection
 class _HTTPBridgeServiceProtocol(Protocol):
     _repo_factory: Any
     _encryptor: Any
+    _clock: Clock
+    _scheduler: Scheduler
     _load_balancer: Any
     _http_client: Any
     _ring_membership: Any

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -356,7 +356,7 @@ async def _rollback_http_bridge_recovery_turn_state_registration(
     service: Any,
     receipt: DurableBridgeAliasRegistrationReceipt,
 ) -> tuple[bool, asyncio.CancelledError | None]:
-    rollback_task = asyncio.create_task(
+    rollback_task = scheduler_for(service).create_task(
         service._durable_bridge.rollback_recovery_turn_state_registration(receipt=receipt)
     )
     return await _await_task_deferring_cancellation(rollback_task)
@@ -1567,7 +1567,7 @@ class _HTTPBridgeRequestSubmitMixin:
             # error so a later reconnect is not fenced as already dispatched.
             if getattr(session, "unanchored_reservation_id", None) == request_scope_id:
                 session.unanchored_reservation_id = None
-            cleanup_task = asyncio.create_task(
+            cleanup_task = scheduler_for(self).create_task(
                 self._cleanup_http_bridge_submit_interruption(
                     session,
                     request_state=request_state,
@@ -2074,7 +2074,7 @@ class _HTTPBridgeRequestSubmitMixin:
                 # Publish the cleanup task before the first await after the
                 # claim. Shielding it makes cancellation wait for settlement,
                 # so the claim can never outlive its exactly-once owner.
-                settlement_task = asyncio.create_task(
+                settlement_task = scheduler_for(self).create_task(
                     _settle_claimed_http_bridge_liveness_failure(
                         self,
                         session,

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -46,6 +46,7 @@ from app.core.clients.proxy_websocket import (
     UpstreamWebSocketTransportError,
     is_account_neutral_websocket_error_code,
 )
+from app.core.clock import scheduler_for
 from app.core.errors import OpenAIErrorEnvelope, openai_error
 from app.core.openai.parsing import parse_sse_event
 from app.core.openai.requests import (
@@ -1587,7 +1588,7 @@ class _HTTPBridgeRequestSubmitMixin:
         except BaseException:
             if getattr(session, "unanchored_reservation_id", None) == request_scope_id:
                 session.unanchored_reservation_id = None
-            cleanup_task = asyncio.create_task(
+            cleanup_task = scheduler_for(self).create_task(
                 self._cleanup_http_bridge_submit_interruption(
                     session,
                     request_state=request_state,
@@ -1626,7 +1627,7 @@ class _HTTPBridgeRequestSubmitMixin:
         except BaseException:
             if getattr(session, "unanchored_reservation_id", None) == request_scope_id:
                 session.unanchored_reservation_id = None
-            cleanup_task = asyncio.create_task(
+            cleanup_task = scheduler_for(self).create_task(
                 self._cleanup_http_bridge_submit_interruption(
                     session,
                     request_state=request_state,
@@ -1721,7 +1722,7 @@ class _HTTPBridgeRequestSubmitMixin:
                         registration_cancellation: asyncio.CancelledError | None = None
                         try:
                             async with session.recovery_alias_lock:
-                                registration_task = asyncio.create_task(
+                                registration_task = scheduler_for(self).create_task(
                                     self._register_http_bridge_recovery_turn_state_locked(
                                         session,
                                         recovery_turn_state,
@@ -2025,7 +2026,7 @@ class _HTTPBridgeRequestSubmitMixin:
                 await self._retire_http_bridge_after_drain_if_ready(session)
             raise
         except asyncio.CancelledError as cancellation:
-            cleanup_task = asyncio.create_task(
+            cleanup_task = scheduler_for(self).create_task(
                 self._cleanup_http_bridge_submit_interruption(
                     session,
                     request_state=request_state,
@@ -2040,7 +2041,7 @@ class _HTTPBridgeRequestSubmitMixin:
             except Exception:
                 logger.warning("Failed to clean up cancelled HTTP bridge submit", exc_info=True)
             if session.upstream_control.retire_after_drain and not session.upstream_close_attempted:
-                retire_task = asyncio.create_task(self._retire_http_bridge_after_drain_if_ready(session))
+                retire_task = scheduler_for(self).create_task(self._retire_http_bridge_after_drain_if_ready(session))
                 try:
                     await _await_task_deferring_cancellation(retire_task)
                 except Exception:
@@ -2269,7 +2270,7 @@ class _HTTPBridgeRequestSubmitMixin:
                     await _send_http_bridge_request_text_with_archive_id(session, warmup_state, warmup_text)
                 while True:
                     try:
-                        event_block = await asyncio.wait_for(
+                        event_block = await scheduler_for(self).wait_for(
                             event_queue.get(),
                             timeout=_prewarm_response_timeout_seconds(),
                         )
@@ -2365,7 +2366,7 @@ class _HTTPBridgeRequestSubmitMixin:
                 )
                 request_state.prewarm_status = "error"
                 _record_http_bridge_prewarm_outcome(outcome="error")
-                cleanup_task = asyncio.create_task(
+                cleanup_task = scheduler_for(self).create_task(
                     self._cleanup_http_bridge_submit_interruption(
                         session,
                         request_state=warmup_state,
@@ -2380,7 +2381,9 @@ class _HTTPBridgeRequestSubmitMixin:
                     and session.upstream_control.retire_after_drain
                     and not session.upstream_close_attempted
                 ):
-                    retire_task = asyncio.create_task(self._retire_http_bridge_after_drain_if_ready(session))
+                    retire_task = scheduler_for(self).create_task(
+                        self._retire_http_bridge_after_drain_if_ready(session)
+                    )
                     await _await_task_deferring_cancellation(retire_task)
                 raise
 
@@ -2618,7 +2621,7 @@ class _HTTPBridgeRequestSubmitMixin:
                         exc_info=True,
                     )
 
-            release_task = asyncio.create_task(release_detached_lease())
+            release_task = scheduler_for(self).create_task(release_detached_lease())
             _, cancellation = await _await_task_deferring_cancellation(release_task)
             if cancellation is not None:
                 raise cancellation
@@ -2663,7 +2666,7 @@ class _HTTPBridgeRequestSubmitMixin:
             except Exception:
                 logger.warning("Failed to release idle HTTP bridge account lease", exc_info=True)
 
-        release_task = asyncio.create_task(release_idle_lease())
+        release_task = scheduler_for(self).create_task(release_idle_lease())
         _, cancellation = await _await_task_deferring_cancellation(release_task)
         if cancellation is not None:
             raise cancellation
@@ -3302,7 +3305,7 @@ class _HTTPBridgeRequestSubmitMixin:
                     request_state.request_id,
                     retry_jitter_seconds,
                 )
-                await asyncio.sleep(retry_jitter_seconds)
+                await scheduler_for(self).sleep(retry_jitter_seconds)
                 request_deadline = request_state.bridge_request_deadline
                 if request_deadline is None:
                     request_deadline = request_state.started_at + _http_bridge_request_budget_seconds(
@@ -3384,7 +3387,7 @@ class _HTTPBridgeRequestSubmitMixin:
                     await self._release_request_state_account_response_create_lease(request_state)
                     return False
                 try:
-                    request_state.response_create_admission = await asyncio.wait_for(
+                    request_state.response_create_admission = await scheduler_for(self).wait_for(
                         self._get_work_admission().acquire_response_create(),
                         timeout=remaining_retry_budget_seconds,
                     )

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -46,6 +46,7 @@ from app.core.clients.proxy_websocket import (
     UpstreamWebSocketTransportError,
     is_account_neutral_websocket_error_code,
 )
+from app.core.clock import scheduler_for
 from app.core.errors import OpenAIErrorEnvelope, openai_error
 from app.core.openai.parsing import parse_sse_event
 from app.core.openai.requests import (
@@ -1571,7 +1572,7 @@ class _HTTPBridgeRequestSubmitMixin:
         except BaseException:
             if getattr(session, "unanchored_reservation_id", None) == request_scope_id:
                 session.unanchored_reservation_id = None
-            cleanup_task = asyncio.create_task(
+            cleanup_task = scheduler_for(self).create_task(
                 self._cleanup_http_bridge_submit_interruption(
                     session,
                     request_state=request_state,
@@ -1610,7 +1611,7 @@ class _HTTPBridgeRequestSubmitMixin:
         except BaseException:
             if getattr(session, "unanchored_reservation_id", None) == request_scope_id:
                 session.unanchored_reservation_id = None
-            cleanup_task = asyncio.create_task(
+            cleanup_task = scheduler_for(self).create_task(
                 self._cleanup_http_bridge_submit_interruption(
                     session,
                     request_state=request_state,
@@ -1705,7 +1706,7 @@ class _HTTPBridgeRequestSubmitMixin:
                         registration_cancellation: asyncio.CancelledError | None = None
                         try:
                             async with session.recovery_alias_lock:
-                                registration_task = asyncio.create_task(
+                                registration_task = scheduler_for(self).create_task(
                                     self._register_http_bridge_recovery_turn_state_locked(
                                         session,
                                         recovery_turn_state,
@@ -1967,7 +1968,7 @@ class _HTTPBridgeRequestSubmitMixin:
                 await self._retire_http_bridge_after_drain_if_ready(session)
             raise
         except asyncio.CancelledError as cancellation:
-            cleanup_task = asyncio.create_task(
+            cleanup_task = scheduler_for(self).create_task(
                 self._cleanup_http_bridge_submit_interruption(
                     session,
                     request_state=request_state,
@@ -1982,7 +1983,7 @@ class _HTTPBridgeRequestSubmitMixin:
             except Exception:
                 logger.warning("Failed to clean up cancelled HTTP bridge submit", exc_info=True)
             if session.upstream_control.retire_after_drain and not session.upstream_close_attempted:
-                retire_task = asyncio.create_task(self._retire_http_bridge_after_drain_if_ready(session))
+                retire_task = scheduler_for(self).create_task(self._retire_http_bridge_after_drain_if_ready(session))
                 try:
                     await _await_task_deferring_cancellation(retire_task)
                 except Exception:
@@ -2211,7 +2212,7 @@ class _HTTPBridgeRequestSubmitMixin:
                     await _send_http_bridge_request_text_with_archive_id(session, warmup_state, warmup_text)
                 while True:
                     try:
-                        event_block = await asyncio.wait_for(
+                        event_block = await scheduler_for(self).wait_for(
                             event_queue.get(),
                             timeout=_prewarm_response_timeout_seconds(),
                         )
@@ -2307,7 +2308,7 @@ class _HTTPBridgeRequestSubmitMixin:
                 )
                 request_state.prewarm_status = "error"
                 _record_http_bridge_prewarm_outcome(outcome="error")
-                cleanup_task = asyncio.create_task(
+                cleanup_task = scheduler_for(self).create_task(
                     self._cleanup_http_bridge_submit_interruption(
                         session,
                         request_state=warmup_state,
@@ -2322,7 +2323,9 @@ class _HTTPBridgeRequestSubmitMixin:
                     and session.upstream_control.retire_after_drain
                     and not session.upstream_close_attempted
                 ):
-                    retire_task = asyncio.create_task(self._retire_http_bridge_after_drain_if_ready(session))
+                    retire_task = scheduler_for(self).create_task(
+                        self._retire_http_bridge_after_drain_if_ready(session)
+                    )
                     await _await_task_deferring_cancellation(retire_task)
                 raise
 
@@ -2545,7 +2548,7 @@ class _HTTPBridgeRequestSubmitMixin:
                         exc_info=True,
                     )
 
-            release_task = asyncio.create_task(release_detached_lease())
+            release_task = scheduler_for(self).create_task(release_detached_lease())
             _, cancellation = await _await_task_deferring_cancellation(release_task)
             if cancellation is not None:
                 raise cancellation
@@ -2590,7 +2593,7 @@ class _HTTPBridgeRequestSubmitMixin:
             except Exception:
                 logger.warning("Failed to release idle HTTP bridge account lease", exc_info=True)
 
-        release_task = asyncio.create_task(release_idle_lease())
+        release_task = scheduler_for(self).create_task(release_idle_lease())
         _, cancellation = await _await_task_deferring_cancellation(release_task)
         if cancellation is not None:
             raise cancellation
@@ -3172,7 +3175,7 @@ class _HTTPBridgeRequestSubmitMixin:
                     request_state.request_id,
                     retry_jitter_seconds,
                 )
-                await asyncio.sleep(retry_jitter_seconds)
+                await scheduler_for(self).sleep(retry_jitter_seconds)
                 request_deadline = request_state.bridge_request_deadline
                 if request_deadline is None:
                     request_deadline = request_state.started_at + _http_bridge_request_budget_seconds(
@@ -3254,7 +3257,7 @@ class _HTTPBridgeRequestSubmitMixin:
                     await self._release_request_state_account_response_create_lease(request_state)
                     return False
                 try:
-                    request_state.response_create_admission = await asyncio.wait_for(
+                    request_state.response_create_admission = await scheduler_for(self).wait_for(
                         self._get_work_admission().acquire_response_create(),
                         timeout=remaining_retry_budget_seconds,
                     )

--- a/app/modules/proxy/_service/http_bridge/retry_circuit.py
+++ b/app/modules/proxy/_service/http_bridge/retry_circuit.py
@@ -606,8 +606,8 @@ class _HTTPBridgeRetryCircuitMixin:
             return 0.0
         return max(
             0.0,
-            generation[3] - time.time(),
-            generation[6] - time.monotonic(),
+            generation[3] - self._http_bridge_retry_circuit_clock.time(),
+            generation[6] - self._http_bridge_retry_circuit_clock.monotonic(),
         )
 
     async def _record_http_bridge_retry_circuit_failure(

--- a/app/modules/proxy/_service/http_bridge/retry_circuit.py
+++ b/app/modules/proxy/_service/http_bridge/retry_circuit.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import time
 from dataclasses import dataclass
 from typing import Any
 
 import anyio
 
+from app.core.clock import REAL_CLOCK, Clock
 from app.core.metrics.prometheus import PROMETHEUS_AVAILABLE, http_bridge_retry_circuit_total
 from app.modules.proxy._service.observability import _hash_identifier
 from app.modules.proxy._service.support import (
@@ -73,9 +73,15 @@ class _HTTPBridgeRetryCircuitState:
     half_open_until: float = 0.0
 
 
-def _initialize_http_bridge_retry_circuit(service: Any, reset_transient_cache: Any = None) -> None:
+def _initialize_http_bridge_retry_circuit(
+    service: Any,
+    reset_transient_cache: Any = None,
+    *,
+    clock: Clock = REAL_CLOCK,
+) -> None:
     if reset_transient_cache is not None:
         reset_transient_cache()
+    service._http_bridge_retry_circuit_clock = clock
     service._http_bridge_retry_circuits = {}
     service._http_bridge_retry_circuit_loaded_keys = set()
     service._http_bridge_retry_circuit_persisted_keys = set()
@@ -312,7 +318,7 @@ class _HTTPBridgeRetryCircuitMixin:
         if session.key.strength != "hard":
             return True
 
-        now_monotonic = time.monotonic()
+        now_monotonic = self._http_bridge_retry_circuit_clock.monotonic()
         async with self._http_bridge_retry_circuit_lock:
             self._prune_http_bridge_retry_circuit_state(now_monotonic)
             local_state = self._http_bridge_retry_circuits.get(session.key)
@@ -352,7 +358,7 @@ class _HTTPBridgeRetryCircuitMixin:
                     self._http_bridge_retry_circuit_persisted_keys.discard(session.key)
             return True
 
-        now_epoch = time.time()
+        now_epoch = self._http_bridge_retry_circuit_clock.time()
         if now_epoch - persisted.updated_at_epoch > DURABLE_BRIDGE_RETRY_CIRCUIT_STATE_TTL_SECONDS:
             async with self._http_bridge_retry_circuit_lock:
                 stale_local_state = self._http_bridge_retry_circuits.get(session.key)
@@ -419,8 +425,8 @@ class _HTTPBridgeRetryCircuitMixin:
         session: _HTTPBridgeSession,
         state: _HTTPBridgeRetryCircuitState,
     ) -> None:
-        now_monotonic = time.monotonic()
-        now_wall = time.time()
+        now_monotonic = self._http_bridge_retry_circuit_clock.monotonic()
+        now_wall = self._http_bridge_retry_circuit_clock.time()
         threshold = max(1, _HTTP_BRIDGE_RETRY_CIRCUIT_FAILURE_THRESHOLD)
         async with self._http_bridge_retry_circuit_lock:
             if self._http_bridge_retry_circuits.get(session.key) is not state:
@@ -509,7 +515,7 @@ class _HTTPBridgeRetryCircuitMixin:
             return True
 
         await self._load_http_bridge_retry_circuit(session)
-        now = time.monotonic()
+        now = self._http_bridge_retry_circuit_clock.monotonic()
         async with self._http_bridge_retry_circuit_lock:
             state = self._http_bridge_retry_circuits.get(session.key)
             if state is None or state.cooldown_until <= now:
@@ -583,7 +589,7 @@ class _HTTPBridgeRetryCircuitMixin:
             return 0.0
 
         await self._load_http_bridge_retry_circuit(session)
-        now = time.monotonic()
+        now = self._http_bridge_retry_circuit_clock.monotonic()
         async with self._http_bridge_retry_circuit_lock:
             state = self._http_bridge_retry_circuits.get(session.key)
             if state is None:
@@ -631,7 +637,7 @@ class _HTTPBridgeRetryCircuitMixin:
         base_backoff = max(0.001, _HTTP_BRIDGE_RETRY_CIRCUIT_BASE_BACKOFF_SECONDS)
         max_backoff = max(base_backoff, _HTTP_BRIDGE_RETRY_CIRCUIT_MAX_BACKOFF_SECONDS)
         clean_close_max_backoff = max(0.001, _HTTP_BRIDGE_RETRY_CIRCUIT_CLEAN_CLOSE_MAX_BACKOFF_SECONDS)
-        now = time.monotonic()
+        now = self._http_bridge_retry_circuit_clock.monotonic()
         duplicate_attempt: _HTTPBridgeResponseCreateAttempt | None = None
         state: _HTTPBridgeRetryCircuitState | None = None
         async with self._http_bridge_retry_circuit_lock:

--- a/app/modules/proxy/_service/http_bridge/retry_circuit.py
+++ b/app/modules/proxy/_service/http_bridge/retry_circuit.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import logging
-import time
 from dataclasses import dataclass
 from typing import Any
 
 import anyio
 
+from app.core.clock import REAL_CLOCK, Clock
 from app.core.metrics.prometheus import PROMETHEUS_AVAILABLE, http_bridge_retry_circuit_total
 from app.modules.proxy._service.observability import _hash_identifier
 from app.modules.proxy._service.support import (
@@ -52,9 +52,15 @@ class _HTTPBridgeRetryCircuitState:
     half_open_until: float = 0.0
 
 
-def _initialize_http_bridge_retry_circuit(service: Any, reset_transient_cache: Any = None) -> None:
+def _initialize_http_bridge_retry_circuit(
+    service: Any,
+    reset_transient_cache: Any = None,
+    *,
+    clock: Clock = REAL_CLOCK,
+) -> None:
     if reset_transient_cache is not None:
         reset_transient_cache()
+    service._http_bridge_retry_circuit_clock = clock
     service._http_bridge_retry_circuits = {}
     service._http_bridge_retry_circuit_loaded_keys = set()
     service._http_bridge_retry_circuit_persisted_keys = set()
@@ -163,7 +169,7 @@ class _HTTPBridgeRetryCircuitMixin:
         if session.key.strength != "hard":
             return True
 
-        now_monotonic = time.monotonic()
+        now_monotonic = self._http_bridge_retry_circuit_clock.monotonic()
         async with self._http_bridge_retry_circuit_lock:
             self._prune_http_bridge_retry_circuit_state(now_monotonic)
             local_state = self._http_bridge_retry_circuits.get(session.key)
@@ -203,7 +209,7 @@ class _HTTPBridgeRetryCircuitMixin:
                     self._http_bridge_retry_circuit_persisted_keys.discard(session.key)
             return True
 
-        now_epoch = time.time()
+        now_epoch = self._http_bridge_retry_circuit_clock.time()
         if now_epoch - persisted.updated_at_epoch > DURABLE_BRIDGE_RETRY_CIRCUIT_STATE_TTL_SECONDS:
             async with self._http_bridge_retry_circuit_lock:
                 stale_local_state = self._http_bridge_retry_circuits.get(session.key)
@@ -270,8 +276,8 @@ class _HTTPBridgeRetryCircuitMixin:
         session: _HTTPBridgeSession,
         state: _HTTPBridgeRetryCircuitState,
     ) -> None:
-        now_monotonic = time.monotonic()
-        now_wall = time.time()
+        now_monotonic = self._http_bridge_retry_circuit_clock.monotonic()
+        now_wall = self._http_bridge_retry_circuit_clock.time()
         threshold = max(1, _HTTP_BRIDGE_RETRY_CIRCUIT_FAILURE_THRESHOLD)
         async with self._http_bridge_retry_circuit_lock:
             if self._http_bridge_retry_circuits.get(session.key) is not state:
@@ -360,7 +366,7 @@ class _HTTPBridgeRetryCircuitMixin:
             return True
 
         await self._load_http_bridge_retry_circuit(session)
-        now = time.monotonic()
+        now = self._http_bridge_retry_circuit_clock.monotonic()
         async with self._http_bridge_retry_circuit_lock:
             state = self._http_bridge_retry_circuits.get(session.key)
             if state is None or state.cooldown_until <= now:
@@ -434,7 +440,7 @@ class _HTTPBridgeRetryCircuitMixin:
             return 0.0
 
         await self._load_http_bridge_retry_circuit(session)
-        now = time.monotonic()
+        now = self._http_bridge_retry_circuit_clock.monotonic()
         async with self._http_bridge_retry_circuit_lock:
             state = self._http_bridge_retry_circuits.get(session.key)
             if state is None:
@@ -468,7 +474,7 @@ class _HTTPBridgeRetryCircuitMixin:
         base_backoff = max(0.001, _HTTP_BRIDGE_RETRY_CIRCUIT_BASE_BACKOFF_SECONDS)
         max_backoff = max(base_backoff, _HTTP_BRIDGE_RETRY_CIRCUIT_MAX_BACKOFF_SECONDS)
         clean_close_max_backoff = max(0.001, _HTTP_BRIDGE_RETRY_CIRCUIT_CLEAN_CLOSE_MAX_BACKOFF_SECONDS)
-        now = time.monotonic()
+        now = self._http_bridge_retry_circuit_clock.monotonic()
         duplicate_attempt: _HTTPBridgeResponseCreateAttempt | None = None
         state: _HTTPBridgeRetryCircuitState | None = None
         async with self._http_bridge_retry_circuit_lock:

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -35,6 +35,7 @@ from app.core.clients.proxy import codex_control_request as core_codex_control_r
 from app.core.clients.proxy import compact_responses as core_compact_responses  # noqa: F401
 from app.core.clients.proxy import transcribe_audio as core_transcribe_audio  # noqa: F401
 from app.core.clients.proxy_websocket import UpstreamWebSocketTransportError
+from app.core.clock import scheduler_for
 from app.core.errors import (
     OpenAIErrorEnvelope,
     openai_error,
@@ -4180,7 +4181,7 @@ class _HTTPBridgeStreamingMixin:
                     if not yielded_any and not keepalive_sent:
                         wait_timeout = max(wait_timeout, _http_bridge_startup_keepalive_grace_seconds())
                     try:
-                        event_block = await asyncio.wait_for(event_queue.get(), timeout=wait_timeout)
+                        event_block = await scheduler_for(self).wait_for(event_queue.get(), timeout=wait_timeout)
                     except asyncio.TimeoutError:
                         if request_state.account_capacity_waiting:
                             keepalive_count = 0

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -35,6 +35,7 @@ from app.core.clients.proxy import codex_control_request as core_codex_control_r
 from app.core.clients.proxy import compact_responses as core_compact_responses  # noqa: F401
 from app.core.clients.proxy import transcribe_audio as core_transcribe_audio  # noqa: F401
 from app.core.clients.proxy_websocket import UpstreamWebSocketTransportError
+from app.core.clock import scheduler_for
 from app.core.errors import (
     OpenAIErrorEnvelope,
     openai_error,
@@ -4128,7 +4129,7 @@ class _HTTPBridgeStreamingMixin:
                     if not yielded_any and not keepalive_sent:
                         wait_timeout = max(wait_timeout, _http_bridge_startup_keepalive_grace_seconds())
                     try:
-                        event_block = await asyncio.wait_for(event_queue.get(), timeout=wait_timeout)
+                        event_block = await scheduler_for(self).wait_for(event_queue.get(), timeout=wait_timeout)
                     except asyncio.TimeoutError:
                         if request_state.account_capacity_waiting:
                             keepalive_count = 0

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -38,6 +38,7 @@ from app.core.clients.proxy_websocket import (
     UpstreamWebSocketTransportError,
     is_account_neutral_websocket_error_code,
 )
+from app.core.clock import scheduler_for
 from app.core.errors import response_failed_event
 from app.core.openai.models import OpenAIEvent
 from app.core.openai.parsing import (
@@ -939,6 +940,7 @@ async def _cancel_http_bridge_reader_child(
     *,
     label: str,
     cleanup_tasks: set[asyncio.Task[None]] | None = None,
+    scheduler_owner: Any | None = None,
 ) -> bool:
     if task is None:
         return True
@@ -956,6 +958,7 @@ async def _cancel_http_bridge_reader_child(
                 task,
                 label=label,
                 cleanup_tasks=cleanup_tasks,
+                scheduler=scheduler_for(scheduler_owner) if scheduler_owner is not None else scheduler_for(task),
             )
         )
     except Exception:
@@ -1326,7 +1329,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                     stuck_gate_retire_after_seconds=stuck_gate_retire_after_seconds,
                 )
                 if receive_task is None:
-                    receive_task = asyncio.create_task(session.upstream.receive())
+                    receive_task = scheduler_for(self).create_task(session.upstream.receive())
 
                 message: UpstreamWebSocketMessage | None = None
                 timed_out = False
@@ -1336,7 +1339,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                 elif receive_timeout is not None and receive_timeout.timeout_seconds <= 0:
                     timed_out = True
                 else:
-                    wakeup_task = asyncio.create_task(session.upstream_reader_wakeup.wait())
+                    wakeup_task = scheduler_for(self).create_task(session.upstream_reader_wakeup.wait())
                     done, _pending = await asyncio.wait(
                         (receive_task, wakeup_task),
                         timeout=receive_timeout.timeout_seconds if receive_timeout is not None else None,
@@ -1356,6 +1359,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                             wakeup_task,
                             label="HTTP bridge reader wakeup wait",
                             cleanup_tasks=self._background_cleanup_tasks,
+                            scheduler_owner=self,
                         )
                         wakeup_task = None
 

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -1349,7 +1349,12 @@ class _HTTPBridgeUpstreamEventsMixin:
                             timeout=receive_timeout.timeout_seconds if receive_timeout is not None else None,
                         )
                     except asyncio.TimeoutError:
-                        done = set()
+                        # The scheduler deadline can fire while either child
+                        # finishes. Recheck before classifying the race as a
+                        # transport timeout: ``asyncio.wait`` itself was
+                        # cancelled by the wrapper, not these persistent
+                        # reader children.
+                        done = {task for task in (receive_task, wakeup_task) if task is not None and task.done()}
                     if receive_task in done:
                         message = receive_task.result()
                         receive_task = None

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -1340,11 +1340,16 @@ class _HTTPBridgeUpstreamEventsMixin:
                     timed_out = True
                 else:
                     wakeup_task = scheduler_for(self).create_task(session.upstream_reader_wakeup.wait())
-                    done, _pending = await asyncio.wait(
-                        (receive_task, wakeup_task),
-                        timeout=receive_timeout.timeout_seconds if receive_timeout is not None else None,
-                        return_when=asyncio.FIRST_COMPLETED,
-                    )
+                    try:
+                        done, _pending = await scheduler_for(self).wait_for(
+                            asyncio.wait(
+                                (receive_task, wakeup_task),
+                                return_when=asyncio.FIRST_COMPLETED,
+                            ),
+                            timeout=receive_timeout.timeout_seconds if receive_timeout is not None else None,
+                        )
+                    except asyncio.TimeoutError:
+                        done = set()
                     if receive_task in done:
                         message = receive_task.result()
                         receive_task = None

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -939,8 +939,8 @@ async def _cancel_http_bridge_reader_child(
     task: asyncio.Task[Any] | None,
     *,
     label: str,
+    scheduler_owner: Any,
     cleanup_tasks: set[asyncio.Task[None]] | None = None,
-    scheduler_owner: Any | None = None,
 ) -> bool:
     if task is None:
         return True
@@ -958,7 +958,7 @@ async def _cancel_http_bridge_reader_child(
                 task,
                 label=label,
                 cleanup_tasks=cleanup_tasks,
-                scheduler=scheduler_for(scheduler_owner) if scheduler_owner is not None else scheduler_for(task),
+                scheduler=scheduler_for(scheduler_owner),
             )
         )
     except Exception:
@@ -1431,6 +1431,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                                     receive_task,
                                     label="HTTP bridge upstream receive after missing response.created",
                                     cleanup_tasks=self._background_cleanup_tasks,
+                                    scheduler_owner=self,
                                 )
                                 if receive_task.done() and not receive_task.cancelled():
                                     # A response (or a typed receive failure)
@@ -1528,6 +1529,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                             receive_task,
                             label="HTTP bridge upstream receive after timeout",
                             cleanup_tasks=self._background_cleanup_tasks,
+                            scheduler_owner=self,
                         )
                         if not receive_cancelled:
                             raise RuntimeError("HTTP bridge upstream receive did not cancel after timeout")
@@ -1699,11 +1701,13 @@ class _HTTPBridgeUpstreamEventsMixin:
                 wakeup_task,
                 label="HTTP bridge reader wakeup wait",
                 cleanup_tasks=self._background_cleanup_tasks,
+                scheduler_owner=self,
             )
             await _cancel_http_bridge_reader_child(
                 receive_task,
                 label="HTTP bridge upstream receive",
                 cleanup_tasks=self._background_cleanup_tasks,
+                scheduler_owner=self,
             )
             if session.upstream is relay_upstream:
                 session.closed = True

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -37,6 +37,7 @@ from app.core.clients.proxy_websocket import (
     UpstreamWebSocketTransportError,
     is_account_neutral_websocket_error_code,
 )
+from app.core.clock import scheduler_for
 from app.core.errors import response_failed_event
 from app.core.openai.models import OpenAIEvent
 from app.core.openai.parsing import (
@@ -897,6 +898,7 @@ async def _cancel_http_bridge_reader_child(
     *,
     label: str,
     cleanup_tasks: set[asyncio.Task[None]] | None = None,
+    scheduler_owner: Any | None = None,
 ) -> bool:
     if task is None:
         return True
@@ -914,6 +916,7 @@ async def _cancel_http_bridge_reader_child(
                 task,
                 label=label,
                 cleanup_tasks=cleanup_tasks,
+                scheduler=scheduler_for(scheduler_owner) if scheduler_owner is not None else scheduler_for(task),
             )
         )
     except Exception:
@@ -1280,7 +1283,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                     stuck_gate_retire_after_seconds=stuck_gate_retire_after_seconds,
                 )
                 if receive_task is None:
-                    receive_task = asyncio.create_task(session.upstream.receive())
+                    receive_task = scheduler_for(self).create_task(session.upstream.receive())
 
                 message: UpstreamWebSocketMessage | None = None
                 timed_out = False
@@ -1290,7 +1293,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                 elif receive_timeout is not None and receive_timeout.timeout_seconds <= 0:
                     timed_out = True
                 else:
-                    wakeup_task = asyncio.create_task(session.upstream_reader_wakeup.wait())
+                    wakeup_task = scheduler_for(self).create_task(session.upstream_reader_wakeup.wait())
                     done, _pending = await asyncio.wait(
                         (receive_task, wakeup_task),
                         timeout=receive_timeout.timeout_seconds if receive_timeout is not None else None,
@@ -1310,6 +1313,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                             wakeup_task,
                             label="HTTP bridge reader wakeup wait",
                             cleanup_tasks=self._background_cleanup_tasks,
+                            scheduler_owner=self,
                         )
                         wakeup_task = None
 

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -1429,6 +1429,7 @@ class _WebSocketMixin:
                     upstream_reader,
                     label="proxy websocket upstream reader",
                     cleanup_tasks=proxy._background_cleanup_tasks,
+                    scheduler=scheduler_for(proxy),
                 )
                 upstream_reader = None
             upstream_control = None
@@ -1472,6 +1473,7 @@ class _WebSocketMixin:
                     reader_to_await,
                     label="proxy websocket upstream reader",
                     cancel=False,
+                    scheduler=scheduler_for(proxy),
                 )
             except Exception:
                 # A completed reader failure must not hide an ownership
@@ -2842,6 +2844,7 @@ class _WebSocketMixin:
                             label="proxy websocket upstream reader",
                             cancel=False,
                             cleanup_tasks=proxy._background_cleanup_tasks,
+                            scheduler=scheduler_for(proxy),
                         )
                     except Exception:
                         # Reader failure must not skip lease release or the
@@ -2859,6 +2862,7 @@ class _WebSocketMixin:
                             timeout_seconds=task_cleanup_timeout,
                             label="proxy websocket retired create lease release",
                             cancel=False,
+                            scheduler=scheduler_for(proxy),
                         )
                     except Exception:
                         _facade().logger.warning(
@@ -2874,6 +2878,7 @@ class _WebSocketMixin:
                             timeout_seconds=task_cleanup_timeout,
                             label="proxy websocket unsent request finalization",
                             cancel=False,
+                            scheduler=scheduler_for(proxy),
                         )
                     except Exception:
                         _facade().logger.warning(

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -858,6 +858,7 @@ async def _close_websocket_upstream_for_cleanup(
                 timeout_seconds=effective_timeout,
                 label="proxy websocket upstream close",
                 cleanup_tasks=proxy._background_cleanup_tasks,
+                scheduler=scheduler,
             )
         except Exception:
             _facade().logger.debug("Failed to cancel upstream websocket close task", exc_info=True)

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -63,7 +63,7 @@ from app.core.clients.proxy_websocket import (
     filter_inbound_websocket_headers,
     is_account_neutral_websocket_error_code,
 )
-from app.core.clock import scheduler_for
+from app.core.clock import Scheduler, scheduler_for
 from app.core.errors import (
     OpenAIErrorEnvelope,
     openai_error,
@@ -882,6 +882,7 @@ async def _await_owned_websocket_task_after_reader_cancellation(
     task: asyncio.Task[Any],
     *,
     failure_message: str,
+    scheduler: Scheduler,
 ) -> None:
     """Observe owned child completion without replacing reader cancellation."""
 
@@ -889,10 +890,12 @@ async def _await_owned_websocket_task_after_reader_cancellation(
     timeout_seconds = _facade()._TASK_CANCEL_TIMEOUT_SECONDS if remaining is None else max(float(remaining), 0.0)
 
     try:
-        done, _ = await asyncio.wait(
-            {task},
+        done, _ = await scheduler.wait_for(
+            asyncio.wait({task}),
             timeout=timeout_seconds,
         )
+    except TimeoutError:
+        return
     except asyncio.CancelledError:
         raise
     if not done:
@@ -2961,7 +2964,8 @@ class _WebSocketMixin:
                     )
                 cleanup_phase = "complete"
 
-            cleanup_task = scheduler_for(proxy).create_task(
+            scheduler = scheduler_for(proxy)
+            cleanup_task = scheduler.create_task(
                 finalize_websocket_scope(),
                 name="proxy-websocket-finalization-scope-cleanup",
             )
@@ -2978,10 +2982,13 @@ class _WebSocketMixin:
                     )
 
             cleanup_task.add_done_callback(log_scope_cleanup_failure)
-            done, _ = await asyncio.wait(
-                {cleanup_task},
-                timeout=max(float(cleanup_timeout), 0.0),
-            )
+            try:
+                done, _ = await scheduler.wait_for(
+                    asyncio.wait({cleanup_task}),
+                    timeout=max(float(cleanup_timeout), 0.0),
+                )
+            except TimeoutError:
+                done = set()
             if not done:
                 _facade().logger.warning(
                     "Websocket scope cleanup exceeded its cleanup budget "
@@ -4985,6 +4992,7 @@ class _WebSocketMixin:
                             await _await_owned_websocket_task_after_reader_cancellation(
                                 terminal_task,
                                 failure_message="Websocket terminal task failed during reader cancellation",
+                                scheduler=scheduler_for(proxy),
                             )
                             raise
                     finally:
@@ -5059,6 +5067,7 @@ class _WebSocketMixin:
                         await _await_owned_websocket_task_after_reader_cancellation(
                             terminal_task,
                             failure_message="Websocket transport-end task failed during reader cancellation",
+                            scheduler=scheduler_for(proxy),
                         )
                         raise
                 finally:
@@ -6426,7 +6435,8 @@ class _WebSocketMixin:
             remaining = list(pending_requests)
             pending_requests.clear()
             if remaining:
-                finalization_task = scheduler_for(proxy).create_task(
+                scheduler = scheduler_for(proxy)
+                finalization_task = scheduler.create_task(
                     self._finalize_claimed_websocket_requests(
                         account=account,
                         account_id_value=account_id_value,
@@ -6466,7 +6476,10 @@ class _WebSocketMixin:
             if not finalization_task.done() and timeout_seconds > 0:
                 # Do not cancel the child at the bound: it is the sole owner of
                 # the claimed states and remains visible to lifespan draining.
-                await asyncio.wait({finalization_task}, timeout=timeout_seconds)
+                try:
+                    await scheduler.wait_for(asyncio.wait({finalization_task}), timeout=timeout_seconds)
+                except TimeoutError:
+                    pass
             raise
         return settlement_succeeded
 

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -840,7 +840,8 @@ async def _close_websocket_upstream_for_cleanup(
     request ownership and leases within its bounded cleanup budget.
     """
 
-    close_task = asyncio.create_task(
+    scheduler = scheduler_for(proxy)
+    close_task = scheduler.create_task(
         upstream.close(),
         name="proxy-websocket-upstream-close",
     )
@@ -865,7 +866,7 @@ async def _close_websocket_upstream_for_cleanup(
         await cancel_close_task()
         return
     try:
-        await asyncio.wait_for(asyncio.shield(close_task), timeout=effective_timeout)
+        await scheduler.wait_for(asyncio.shield(close_task), timeout=effective_timeout)
     except TimeoutError:
         _facade().logger.debug(
             "Upstream websocket close continued after cleanup budget timeout_seconds=%.3f",

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -63,6 +63,7 @@ from app.core.clients.proxy_websocket import (
     filter_inbound_websocket_headers,
     is_account_neutral_websocket_error_code,
 )
+from app.core.clock import scheduler_for
 from app.core.errors import (
     OpenAIErrorEnvelope,
     openai_error,
@@ -1404,7 +1405,7 @@ class _WebSocketMixin:
                 account_lease = None
                 if lease_to_release is None:
                     return
-                account_lease_release_task = asyncio.create_task(
+                account_lease_release_task = scheduler_for(proxy).create_task(
                     proxy._load_balancer.release_account_lease(lease_to_release),
                     name="proxy-websocket-finalization-connection-lease",
                 )
@@ -1595,7 +1596,7 @@ class _WebSocketMixin:
                                 break
                     message: Any | None = None
                     try:
-                        message = await asyncio.wait_for(
+                        message = await scheduler_for(proxy).wait_for(
                             websocket.receive(),
                             timeout=min(
                                 downstream_idle_timeout_seconds, _facade()._DOWNSTREAM_WEBSOCKET_RECEIVE_POLL_SECONDS
@@ -2492,7 +2493,7 @@ class _WebSocketMixin:
                     upstream_requires_security_work_authorized = request_state.require_security_work_authorized
                     upstream_turn_state = _facade()._upstream_turn_state_from_socket(upstream) or upstream_turn_state
                     upstream_control = _WebSocketUpstreamControl()
-                    upstream_reader = asyncio.create_task(
+                    upstream_reader = scheduler_for(proxy).create_task(
                         proxy._relay_upstream_websocket_messages(
                             websocket,
                             upstream,
@@ -2592,7 +2593,7 @@ class _WebSocketMixin:
                         # transport owner. A fresh connection re-acquires it
                         # for its selected account; the global turn admission
                         # remains attached to a claimed request state.
-                        retired_create_lease_release_task = asyncio.create_task(
+                        retired_create_lease_release_task = scheduler_for(proxy).create_task(
                             proxy._release_request_state_account_response_create_lease(request_state),
                             name="proxy-websocket-finalization-retired-create-lease",
                         )
@@ -2601,7 +2602,7 @@ class _WebSocketMixin:
                         retired_create_lease_release_task = None
                         if request_state_to_fail is not None:
                             owned_request_state = request_state_to_fail
-                            request_state_failure_task = asyncio.create_task(
+                            request_state_failure_task = scheduler_for(proxy).create_task(
                                 proxy._fail_pending_websocket_requests(
                                     account=None,
                                     account_id_value=account.id if account is not None else upstream_account_id,
@@ -2691,7 +2692,7 @@ class _WebSocketMixin:
                         # find either this slot or the registered child task.
                         request_state_to_fail = reader_replay
                         owned_request_state = request_state_to_fail
-                        request_state_failure_task = asyncio.create_task(
+                        request_state_failure_task = scheduler_for(proxy).create_task(
                             proxy._fail_pending_websocket_requests(
                                 account=account,
                                 account_id_value=account.id if account else None,
@@ -2759,7 +2760,7 @@ class _WebSocketMixin:
                             "Transparent websocket replay after upstream send failure request_id=%s",
                             replay_candidate.request_log_id or replay_candidate.request_id,
                         )
-                        retired_create_lease_release_task = asyncio.create_task(
+                        retired_create_lease_release_task = scheduler_for(proxy).create_task(
                             proxy._release_request_state_account_response_create_lease(replay_candidate),
                             name="proxy-websocket-finalization-retired-create-lease",
                         )
@@ -2953,7 +2954,7 @@ class _WebSocketMixin:
                     )
                 cleanup_phase = "complete"
 
-            cleanup_task = asyncio.create_task(
+            cleanup_task = scheduler_for(proxy).create_task(
                 finalize_websocket_scope(),
                 name="proxy-websocket-finalization-scope-cleanup",
             )
@@ -4943,7 +4944,7 @@ class _WebSocketMixin:
                     continue
                 if message.kind == "text" and message.text is not None:
                     downstream_activity.mark()
-                    terminal_task = asyncio.create_task(
+                    terminal_task = scheduler_for(proxy).create_task(
                         _process_and_forward_upstream_websocket_text(
                             proxy,
                             websocket,
@@ -5020,7 +5021,7 @@ class _WebSocketMixin:
                             )
                         break
                     continue
-                terminal_task = asyncio.create_task(
+                terminal_task = scheduler_for(proxy).create_task(
                     _process_upstream_websocket_transport_end(
                         proxy,
                         websocket,
@@ -6418,7 +6419,7 @@ class _WebSocketMixin:
             remaining = list(pending_requests)
             pending_requests.clear()
             if remaining:
-                finalization_task = asyncio.create_task(
+                finalization_task = scheduler_for(proxy).create_task(
                     self._finalize_claimed_websocket_requests(
                         account=account,
                         account_id_value=account_id_value,

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -63,6 +63,7 @@ from app.core.clients.proxy_websocket import (
     filter_inbound_websocket_headers,
     is_account_neutral_websocket_error_code,
 )
+from app.core.clock import scheduler_for
 from app.core.errors import (
     OpenAIErrorEnvelope,
     openai_error,
@@ -1402,7 +1403,7 @@ class _WebSocketMixin:
                 account_lease = None
                 if lease_to_release is None:
                     return
-                account_lease_release_task = asyncio.create_task(
+                account_lease_release_task = scheduler_for(proxy).create_task(
                     proxy._load_balancer.release_account_lease(lease_to_release),
                     name="proxy-websocket-finalization-connection-lease",
                 )
@@ -1593,7 +1594,7 @@ class _WebSocketMixin:
                                 break
                     message: Any | None = None
                     try:
-                        message = await asyncio.wait_for(
+                        message = await scheduler_for(proxy).wait_for(
                             websocket.receive(),
                             timeout=min(
                                 downstream_idle_timeout_seconds, _facade()._DOWNSTREAM_WEBSOCKET_RECEIVE_POLL_SECONDS
@@ -2428,7 +2429,7 @@ class _WebSocketMixin:
                     upstream_requires_security_work_authorized = request_state.require_security_work_authorized
                     upstream_turn_state = _facade()._upstream_turn_state_from_socket(upstream) or upstream_turn_state
                     upstream_control = _WebSocketUpstreamControl()
-                    upstream_reader = asyncio.create_task(
+                    upstream_reader = scheduler_for(proxy).create_task(
                         proxy._relay_upstream_websocket_messages(
                             websocket,
                             upstream,
@@ -2528,7 +2529,7 @@ class _WebSocketMixin:
                         # transport owner. A fresh connection re-acquires it
                         # for its selected account; the global turn admission
                         # remains attached to a claimed request state.
-                        retired_create_lease_release_task = asyncio.create_task(
+                        retired_create_lease_release_task = scheduler_for(proxy).create_task(
                             proxy._release_request_state_account_response_create_lease(request_state),
                             name="proxy-websocket-finalization-retired-create-lease",
                         )
@@ -2537,7 +2538,7 @@ class _WebSocketMixin:
                         retired_create_lease_release_task = None
                         if request_state_to_fail is not None:
                             owned_request_state = request_state_to_fail
-                            request_state_failure_task = asyncio.create_task(
+                            request_state_failure_task = scheduler_for(proxy).create_task(
                                 proxy._fail_pending_websocket_requests(
                                     account=None,
                                     account_id_value=account.id if account is not None else upstream_account_id,
@@ -2614,7 +2615,7 @@ class _WebSocketMixin:
                         # find either this slot or the registered child task.
                         request_state_to_fail = reader_replay
                         owned_request_state = request_state_to_fail
-                        request_state_failure_task = asyncio.create_task(
+                        request_state_failure_task = scheduler_for(proxy).create_task(
                             proxy._fail_pending_websocket_requests(
                                 account=account,
                                 account_id_value=account.id if account else None,
@@ -2682,7 +2683,7 @@ class _WebSocketMixin:
                             "Transparent websocket replay after upstream send failure request_id=%s",
                             replay_candidate.request_log_id or replay_candidate.request_id,
                         )
-                        retired_create_lease_release_task = asyncio.create_task(
+                        retired_create_lease_release_task = scheduler_for(proxy).create_task(
                             proxy._release_request_state_account_response_create_lease(replay_candidate),
                             name="proxy-websocket-finalization-retired-create-lease",
                         )
@@ -2876,7 +2877,7 @@ class _WebSocketMixin:
                     )
                 cleanup_phase = "complete"
 
-            cleanup_task = asyncio.create_task(
+            cleanup_task = scheduler_for(proxy).create_task(
                 finalize_websocket_scope(),
                 name="proxy-websocket-finalization-scope-cleanup",
             )
@@ -4850,7 +4851,7 @@ class _WebSocketMixin:
                     continue
                 if message.kind == "text" and message.text is not None:
                     downstream_activity.mark()
-                    terminal_task = asyncio.create_task(
+                    terminal_task = scheduler_for(proxy).create_task(
                         _process_and_forward_upstream_websocket_text(
                             proxy,
                             websocket,
@@ -4927,7 +4928,7 @@ class _WebSocketMixin:
                             )
                         break
                     continue
-                terminal_task = asyncio.create_task(
+                terminal_task = scheduler_for(proxy).create_task(
                     _process_upstream_websocket_transport_end(
                         proxy,
                         websocket,
@@ -6293,7 +6294,7 @@ class _WebSocketMixin:
             remaining = list(pending_requests)
             pending_requests.clear()
             if remaining:
-                finalization_task = asyncio.create_task(
+                finalization_task = scheduler_for(proxy).create_task(
                     self._finalize_claimed_websocket_requests(
                         account=account,
                         account_id_value=account_id_value,

--- a/app/modules/proxy/_service/websocket/protocol.py
+++ b/app/modules/proxy/_service/websocket/protocol.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 from typing import Any, Protocol
 
+from app.core.clock import Clock, Scheduler
+
 
 class _WebSocketServiceProtocol(Protocol):
     _capability_router: Any
     _background_cleanup_tasks: Any
+    _clock: Clock
     _acquire_account_response_create_lease_or_overload: Any
     _acquire_request_state_response_create_admission: Any
     _cancel_request_state_api_key_reservation_heartbeat: Any
@@ -53,6 +56,7 @@ class _WebSocketServiceProtocol(Protocol):
     _resolve_upstream_route_for_account: Any
     _resolve_websocket_previous_response_owner: Any
     _retry_websocket_connect_after_401: Any
+    _scheduler: Scheduler
     _select_account_with_budget_compatible: Any
     _select_websocket_connect_account: Any
     _send_downstream_websocket_bytes: Any

--- a/app/modules/proxy/_service/websocket/protocol.py
+++ b/app/modules/proxy/_service/websocket/protocol.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 from typing import Any, Protocol
 
+from app.core.clock import Clock, Scheduler
+
 
 class _WebSocketServiceProtocol(Protocol):
     _capability_router: Any
     _background_cleanup_tasks: Any
+    _clock: Clock
     _acquire_account_response_create_lease_or_overload: Any
     _acquire_request_state_response_create_admission: Any
     _cancel_request_state_api_key_reservation_heartbeat: Any
@@ -52,6 +55,7 @@ class _WebSocketServiceProtocol(Protocol):
     _resolve_upstream_route_for_account: Any
     _resolve_websocket_previous_response_owner: Any
     _retry_websocket_connect_after_401: Any
+    _scheduler: Scheduler
     _select_account_with_budget_compatible: Any
     _select_websocket_connect_account: Any
     _send_downstream_websocket_bytes: Any

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -72,6 +72,7 @@ from app.core.clients.usage import (
     ConsumeRateLimitResetCreditResponse as UpstreamConsumeRateLimitResetCreditResponse,
 )
 from app.core.clients.usage import UsageFetchError, consume_rate_limit_reset_credit
+from app.core.clock import REAL_SCHEDULER, Scheduler
 from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
@@ -6902,7 +6903,11 @@ def _retrieve_first_stream_task_exception(task: asyncio.Task[str]) -> None:
         task.exception()
 
 
-def _create_first_stream_probe_task(stream: AsyncIterator[str]) -> asyncio.Task[str]:
+def _create_first_stream_probe_task(
+    stream: AsyncIterator[str],
+    *,
+    scheduler: Scheduler = REAL_SCHEDULER,
+) -> asyncio.Task[str]:
     """Create the first-stream-item probe task.
 
     ``_probe_stream_startup_error`` / ``_probe_chat_stream_startup_error`` race
@@ -6914,21 +6919,28 @@ def _create_first_stream_probe_task(stream: AsyncIterator[str]) -> asyncio.Task[
     would log it. The done-callback retrieves the result in that abandoned case
     without hiding the error from consumers that do await the task.
     """
-    task = asyncio.create_task(_read_first_stream_item(stream))
+    task = scheduler.create_task(_read_first_stream_item(stream))
     task.add_done_callback(_retrieve_first_stream_task_exception)
     return task
 
 
 async def _wait_for_first_stream_probe(
-    first_task: asyncio.Task[str],
+    first_task: asyncio.Task[str | None],
     *,
     timeout_seconds: float,
     capacity_wait_event: asyncio.Event | None,
     capacity_ready_event: asyncio.Event | None = None,
+    scheduler: Scheduler = REAL_SCHEDULER,
 ) -> bool:
     try:
-        done, _pending = await asyncio.wait({first_task}, timeout=timeout_seconds)
-        if done:
+        timeout_task = scheduler.create_task(scheduler.sleep(timeout_seconds))
+        try:
+            done, _pending = await asyncio.wait({first_task, timeout_task}, return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            if not timeout_task.done():
+                timeout_task.cancel()
+                await asyncio.gather(timeout_task, return_exceptions=True)
+        if first_task in done:
             if capacity_wait_event is not None and capacity_wait_event.is_set():
                 capacity_wait_event.clear()
             return True
@@ -6945,85 +6957,84 @@ async def _wait_for_first_stream_probe(
             if capacity_ready_event is not None
             else _CAPACITY_WAIT_MARKER_GRACE_SECONDS
         )
-        signal_discovery_deadline = asyncio.get_running_loop().time() + signal_discovery_seconds
-        while True:
-            if first_task.done():
+        signal_timeout_task = scheduler.create_task(scheduler.sleep(signal_discovery_seconds))
+        try:
+            while True:
+                if first_task.done():
+                    if capacity_wait_event.is_set():
+                        capacity_wait_event.clear()
+                    return True
                 if capacity_wait_event.is_set():
-                    capacity_wait_event.clear()
-                return True
-            if capacity_wait_event.is_set():
-                recovery_ready_task = (
-                    asyncio.create_task(capacity_ready_event.wait()) if capacity_ready_event is not None else None
+                    recovery_ready_task = (
+                        scheduler.create_task(capacity_ready_event.wait()) if capacity_ready_event is not None else None
+                    )
+                    try:
+                        recovery_waiters = {first_task}
+                        if recovery_ready_task is not None:
+                            recovery_waiters.add(recovery_ready_task)
+                        recovery_done, _pending = await asyncio.wait(
+                            recovery_waiters,
+                            return_when=asyncio.FIRST_COMPLETED,
+                        )
+                        if first_task not in recovery_done:
+                            continue
+                    finally:
+                        if recovery_ready_task is not None and not recovery_ready_task.done():
+                            recovery_ready_task.cancel()
+                        if recovery_ready_task is not None:
+                            await asyncio.gather(recovery_ready_task, return_exceptions=True)
+                    continue
+                if capacity_ready_event is not None and capacity_ready_event.is_set():
+                    # Admission recovery only proves that local capacity is ready;
+                    # the resumed upstream can still fail before its first item.
+                    # Preserve the route's normal bounded startup-error window so
+                    # an immediate 4xx / response.failed remains an HTTP startup
+                    # error, while a slow healthy upstream is still handed off.
+                    post_ready_timeout = timeout_seconds
+                    if isinstance(capacity_ready_event, _CapacityStartupReadyEvent):
+                        ready_set_at = capacity_ready_event.set_at
+                        if ready_set_at is not None:
+                            post_ready_timeout = max(0.0, timeout_seconds - (time.monotonic() - ready_set_at))
+                    if post_ready_timeout <= 0:
+                        return False
+                    post_ready_timeout_task = scheduler.create_task(scheduler.sleep(post_ready_timeout))
+                    try:
+                        post_ready_done, _pending = await asyncio.wait(
+                            {first_task, post_ready_timeout_task},
+                            return_when=asyncio.FIRST_COMPLETED,
+                        )
+                    finally:
+                        if not post_ready_timeout_task.done():
+                            post_ready_timeout_task.cancel()
+                            await asyncio.gather(post_ready_timeout_task, return_exceptions=True)
+                    return first_task in post_ready_done
+
+                marker_task = scheduler.create_task(capacity_wait_event.wait())
+                ready_task = (
+                    scheduler.create_task(capacity_ready_event.wait()) if capacity_ready_event is not None else None
                 )
                 try:
-                    recovery_waiters = {first_task}
-                    if recovery_ready_task is not None:
-                        recovery_waiters.add(recovery_ready_task)
-                    recovery_done, _pending = await asyncio.wait(
-                        recovery_waiters,
-                        return_when=asyncio.FIRST_COMPLETED,
-                    )
-                    if first_task not in recovery_done:
-                        # Re-read the paired level state. The ready signal has
-                        # cleared the wait that recovered, but a newer wait may
-                        # already have superseded that ready before this task
-                        # resumes.
-                        continue
+                    signal_waiters = {first_task, marker_task, signal_timeout_task}
+                    if ready_task is not None:
+                        signal_waiters.add(ready_task)
+                    signal_done, _pending = await asyncio.wait(signal_waiters, return_when=asyncio.FIRST_COMPLETED)
+                    if signal_timeout_task in signal_done:
+                        return False
                 finally:
-                    if recovery_ready_task is not None and not recovery_ready_task.done():
-                        recovery_ready_task.cancel()
-                    if recovery_ready_task is not None:
-                        await asyncio.gather(recovery_ready_task, return_exceptions=True)
-                continue
-            if capacity_ready_event is not None and capacity_ready_event.is_set():
-                # Admission recovery only proves that local capacity is ready;
-                # the resumed upstream can still fail before its first item.
-                # Preserve the route's normal bounded startup-error window so
-                # an immediate 4xx / response.failed remains an HTTP startup
-                # error, while a slow healthy upstream is still handed off.
-                post_ready_timeout = timeout_seconds
-                if isinstance(capacity_ready_event, _CapacityStartupReadyEvent):
-                    ready_set_at = capacity_ready_event.set_at
-                    if ready_set_at is not None:
-                        post_ready_timeout = max(0.0, timeout_seconds - (time.monotonic() - ready_set_at))
-                if post_ready_timeout <= 0:
-                    return False
-                post_ready_done, _pending = await asyncio.wait(
-                    {first_task},
-                    timeout=post_ready_timeout,
-                )
-                return bool(post_ready_done)
-
-            marker_task = asyncio.create_task(capacity_wait_event.wait())
-            ready_task = asyncio.create_task(capacity_ready_event.wait()) if capacity_ready_event is not None else None
-            try:
-                signal_discovery_remaining = max(
-                    0.0,
-                    signal_discovery_deadline - asyncio.get_running_loop().time(),
-                )
-                if signal_discovery_remaining <= 0:
-                    return False
-                signal_waiters = {first_task, marker_task}
-                if ready_task is not None:
-                    signal_waiters.add(ready_task)
-                signal_done, _pending = await asyncio.wait(
-                    signal_waiters,
-                    timeout=signal_discovery_remaining,
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-                if not signal_done:
-                    return False
-            finally:
-                pending_signal_tasks = [
-                    task for task in (marker_task, ready_task) if task is not None and not task.done()
-                ]
-                for task in pending_signal_tasks:
-                    task.cancel()
-                await asyncio.gather(
-                    marker_task,
-                    *(task for task in (ready_task,) if task is not None),
-                    return_exceptions=True,
-                )
+                    pending_signal_tasks = [
+                        task for task in (marker_task, ready_task) if task is not None and not task.done()
+                    ]
+                    for task in pending_signal_tasks:
+                        task.cancel()
+                    await asyncio.gather(
+                        marker_task,
+                        *(task for task in (ready_task,) if task is not None),
+                        return_exceptions=True,
+                    )
+        finally:
+            if not signal_timeout_task.done():
+                signal_timeout_task.cancel()
+                await asyncio.gather(signal_timeout_task, return_exceptions=True)
     except asyncio.CancelledError:
         with anyio.CancelScope(shield=True):
             first_task.cancel()
@@ -7040,15 +7051,17 @@ async def _probe_stream_startup_error(
     capacity_ready_event: asyncio.Event | None = None,
     handoff_task_sink: list[asyncio.Task[str]] | None = None,
     service_cleanup_ready_event: asyncio.Event | None = None,
+    scheduler: Scheduler = REAL_SCHEDULER,
 ) -> tuple[AsyncIterator[str], ProxyResponseError | OpenAIErrorEnvelopeModel | None]:
     if timeout_seconds is None:
         timeout_seconds = _STREAM_STARTUP_ERROR_PROBE_SECONDS
-    first_task = _create_first_stream_probe_task(stream)
+    first_task = _create_first_stream_probe_task(stream, scheduler=scheduler)
     probe_done = await _wait_for_first_stream_probe(
         first_task,
         timeout_seconds=timeout_seconds,
         capacity_wait_event=capacity_wait_event,
         capacity_ready_event=capacity_ready_event,
+        scheduler=scheduler,
     )
     if service_cleanup_ready_event is not None:
         buffered_before_cleanup_ready: list[str] = []

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -6980,6 +6980,8 @@ async def _wait_for_first_stream_probe(
                         )
                         if first_task not in recovery_done and signal_timeout_task in recovery_done:
                             return False
+                        if recovery_ready_task is not None and recovery_ready_task in recovery_done:
+                            capacity_wait_event.clear()
                     finally:
                         if recovery_ready_task is not None and not recovery_ready_task.done():
                             recovery_ready_task.cancel()

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -72,7 +72,7 @@ from app.core.clients.usage import (
     ConsumeRateLimitResetCreditResponse as UpstreamConsumeRateLimitResetCreditResponse,
 )
 from app.core.clients.usage import UsageFetchError, consume_rate_limit_reset_credit
-from app.core.clock import REAL_SCHEDULER, Scheduler
+from app.core.clock import REAL_CLOCK, REAL_SCHEDULER, Clock, Scheduler
 from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
@@ -621,13 +621,14 @@ _V1_MAX_OUTPUT_TOKEN_OVERRIDES: Final[dict[str, int]] = {
 class _CapacityStartupReadyEvent(asyncio.Event):
     """Track when admission became ready so its startup probe cannot reset."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, clock: Clock = REAL_CLOCK) -> None:
         super().__init__()
+        self._clock = clock
         self.set_at: float | None = None
 
     def set(self) -> None:
         if not self.is_set():
-            self.set_at = time.monotonic()
+            self.set_at = self._clock.monotonic()
         super().set()
 
     def clear(self) -> None:
@@ -6931,6 +6932,7 @@ async def _wait_for_first_stream_probe(
     capacity_wait_event: asyncio.Event | None,
     capacity_ready_event: asyncio.Event | None = None,
     scheduler: Scheduler = REAL_SCHEDULER,
+    clock: Clock = REAL_CLOCK,
 ) -> bool:
     try:
         timeout_task = scheduler.create_task(scheduler.sleep(timeout_seconds))
@@ -6969,15 +6971,15 @@ async def _wait_for_first_stream_probe(
                         scheduler.create_task(capacity_ready_event.wait()) if capacity_ready_event is not None else None
                     )
                     try:
-                        recovery_waiters = {first_task}
+                        recovery_waiters = {first_task, signal_timeout_task}
                         if recovery_ready_task is not None:
                             recovery_waiters.add(recovery_ready_task)
                         recovery_done, _pending = await asyncio.wait(
                             recovery_waiters,
                             return_when=asyncio.FIRST_COMPLETED,
                         )
-                        if first_task not in recovery_done:
-                            continue
+                        if first_task not in recovery_done and signal_timeout_task in recovery_done:
+                            return False
                     finally:
                         if recovery_ready_task is not None and not recovery_ready_task.done():
                             recovery_ready_task.cancel()
@@ -6994,7 +6996,7 @@ async def _wait_for_first_stream_probe(
                     if isinstance(capacity_ready_event, _CapacityStartupReadyEvent):
                         ready_set_at = capacity_ready_event.set_at
                         if ready_set_at is not None:
-                            post_ready_timeout = max(0.0, timeout_seconds - (time.monotonic() - ready_set_at))
+                            post_ready_timeout = max(0.0, timeout_seconds - (clock.monotonic() - ready_set_at))
                     if post_ready_timeout <= 0:
                         return False
                     post_ready_timeout_task = scheduler.create_task(scheduler.sleep(post_ready_timeout))

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -69,6 +69,7 @@ from app.core.clients.usage import (
     ConsumeRateLimitResetCreditResponse as UpstreamConsumeRateLimitResetCreditResponse,
 )
 from app.core.clients.usage import UsageFetchError, consume_rate_limit_reset_credit
+from app.core.clock import REAL_SCHEDULER, Scheduler
 from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
@@ -6475,7 +6476,11 @@ def _retrieve_first_stream_task_exception(task: asyncio.Task[str]) -> None:
         task.exception()
 
 
-def _create_first_stream_probe_task(stream: AsyncIterator[str]) -> asyncio.Task[str]:
+def _create_first_stream_probe_task(
+    stream: AsyncIterator[str],
+    *,
+    scheduler: Scheduler = REAL_SCHEDULER,
+) -> asyncio.Task[str]:
     """Create the first-stream-item probe task.
 
     ``_probe_stream_startup_error`` / ``_probe_chat_stream_startup_error`` race
@@ -6487,21 +6492,28 @@ def _create_first_stream_probe_task(stream: AsyncIterator[str]) -> asyncio.Task[
     would log it. The done-callback retrieves the result in that abandoned case
     without hiding the error from consumers that do await the task.
     """
-    task = asyncio.create_task(_read_first_stream_item(stream))
+    task = scheduler.create_task(_read_first_stream_item(stream))
     task.add_done_callback(_retrieve_first_stream_task_exception)
     return task
 
 
 async def _wait_for_first_stream_probe(
-    first_task: asyncio.Task[str],
+    first_task: asyncio.Task[str | None],
     *,
     timeout_seconds: float,
     capacity_wait_event: asyncio.Event | None,
     capacity_ready_event: asyncio.Event | None = None,
+    scheduler: Scheduler = REAL_SCHEDULER,
 ) -> bool:
     try:
-        done, _pending = await asyncio.wait({first_task}, timeout=timeout_seconds)
-        if done:
+        timeout_task = scheduler.create_task(scheduler.sleep(timeout_seconds))
+        try:
+            done, _pending = await asyncio.wait({first_task, timeout_task}, return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            if not timeout_task.done():
+                timeout_task.cancel()
+                await asyncio.gather(timeout_task, return_exceptions=True)
+        if first_task in done:
             if capacity_wait_event is not None and capacity_wait_event.is_set():
                 capacity_wait_event.clear()
             return True
@@ -6518,85 +6530,84 @@ async def _wait_for_first_stream_probe(
             if capacity_ready_event is not None
             else _CAPACITY_WAIT_MARKER_GRACE_SECONDS
         )
-        signal_discovery_deadline = asyncio.get_running_loop().time() + signal_discovery_seconds
-        while True:
-            if first_task.done():
+        signal_timeout_task = scheduler.create_task(scheduler.sleep(signal_discovery_seconds))
+        try:
+            while True:
+                if first_task.done():
+                    if capacity_wait_event.is_set():
+                        capacity_wait_event.clear()
+                    return True
                 if capacity_wait_event.is_set():
-                    capacity_wait_event.clear()
-                return True
-            if capacity_wait_event.is_set():
-                recovery_ready_task = (
-                    asyncio.create_task(capacity_ready_event.wait()) if capacity_ready_event is not None else None
+                    recovery_ready_task = (
+                        scheduler.create_task(capacity_ready_event.wait()) if capacity_ready_event is not None else None
+                    )
+                    try:
+                        recovery_waiters = {first_task}
+                        if recovery_ready_task is not None:
+                            recovery_waiters.add(recovery_ready_task)
+                        recovery_done, _pending = await asyncio.wait(
+                            recovery_waiters,
+                            return_when=asyncio.FIRST_COMPLETED,
+                        )
+                        if first_task not in recovery_done:
+                            continue
+                    finally:
+                        if recovery_ready_task is not None and not recovery_ready_task.done():
+                            recovery_ready_task.cancel()
+                        if recovery_ready_task is not None:
+                            await asyncio.gather(recovery_ready_task, return_exceptions=True)
+                    continue
+                if capacity_ready_event is not None and capacity_ready_event.is_set():
+                    # Admission recovery only proves that local capacity is ready;
+                    # the resumed upstream can still fail before its first item.
+                    # Preserve the route's normal bounded startup-error window so
+                    # an immediate 4xx / response.failed remains an HTTP startup
+                    # error, while a slow healthy upstream is still handed off.
+                    post_ready_timeout = timeout_seconds
+                    if isinstance(capacity_ready_event, _CapacityStartupReadyEvent):
+                        ready_set_at = capacity_ready_event.set_at
+                        if ready_set_at is not None:
+                            post_ready_timeout = max(0.0, timeout_seconds - (time.monotonic() - ready_set_at))
+                    if post_ready_timeout <= 0:
+                        return False
+                    post_ready_timeout_task = scheduler.create_task(scheduler.sleep(post_ready_timeout))
+                    try:
+                        post_ready_done, _pending = await asyncio.wait(
+                            {first_task, post_ready_timeout_task},
+                            return_when=asyncio.FIRST_COMPLETED,
+                        )
+                    finally:
+                        if not post_ready_timeout_task.done():
+                            post_ready_timeout_task.cancel()
+                            await asyncio.gather(post_ready_timeout_task, return_exceptions=True)
+                    return first_task in post_ready_done
+
+                marker_task = scheduler.create_task(capacity_wait_event.wait())
+                ready_task = (
+                    scheduler.create_task(capacity_ready_event.wait()) if capacity_ready_event is not None else None
                 )
                 try:
-                    recovery_waiters = {first_task}
-                    if recovery_ready_task is not None:
-                        recovery_waiters.add(recovery_ready_task)
-                    recovery_done, _pending = await asyncio.wait(
-                        recovery_waiters,
-                        return_when=asyncio.FIRST_COMPLETED,
-                    )
-                    if first_task not in recovery_done:
-                        # Re-read the paired level state. The ready signal has
-                        # cleared the wait that recovered, but a newer wait may
-                        # already have superseded that ready before this task
-                        # resumes.
-                        continue
+                    signal_waiters = {first_task, marker_task, signal_timeout_task}
+                    if ready_task is not None:
+                        signal_waiters.add(ready_task)
+                    signal_done, _pending = await asyncio.wait(signal_waiters, return_when=asyncio.FIRST_COMPLETED)
+                    if signal_timeout_task in signal_done:
+                        return False
                 finally:
-                    if recovery_ready_task is not None and not recovery_ready_task.done():
-                        recovery_ready_task.cancel()
-                    if recovery_ready_task is not None:
-                        await asyncio.gather(recovery_ready_task, return_exceptions=True)
-                continue
-            if capacity_ready_event is not None and capacity_ready_event.is_set():
-                # Admission recovery only proves that local capacity is ready;
-                # the resumed upstream can still fail before its first item.
-                # Preserve the route's normal bounded startup-error window so
-                # an immediate 4xx / response.failed remains an HTTP startup
-                # error, while a slow healthy upstream is still handed off.
-                post_ready_timeout = timeout_seconds
-                if isinstance(capacity_ready_event, _CapacityStartupReadyEvent):
-                    ready_set_at = capacity_ready_event.set_at
-                    if ready_set_at is not None:
-                        post_ready_timeout = max(0.0, timeout_seconds - (time.monotonic() - ready_set_at))
-                if post_ready_timeout <= 0:
-                    return False
-                post_ready_done, _pending = await asyncio.wait(
-                    {first_task},
-                    timeout=post_ready_timeout,
-                )
-                return bool(post_ready_done)
-
-            marker_task = asyncio.create_task(capacity_wait_event.wait())
-            ready_task = asyncio.create_task(capacity_ready_event.wait()) if capacity_ready_event is not None else None
-            try:
-                signal_discovery_remaining = max(
-                    0.0,
-                    signal_discovery_deadline - asyncio.get_running_loop().time(),
-                )
-                if signal_discovery_remaining <= 0:
-                    return False
-                signal_waiters = {first_task, marker_task}
-                if ready_task is not None:
-                    signal_waiters.add(ready_task)
-                signal_done, _pending = await asyncio.wait(
-                    signal_waiters,
-                    timeout=signal_discovery_remaining,
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-                if not signal_done:
-                    return False
-            finally:
-                pending_signal_tasks = [
-                    task for task in (marker_task, ready_task) if task is not None and not task.done()
-                ]
-                for task in pending_signal_tasks:
-                    task.cancel()
-                await asyncio.gather(
-                    marker_task,
-                    *(task for task in (ready_task,) if task is not None),
-                    return_exceptions=True,
-                )
+                    pending_signal_tasks = [
+                        task for task in (marker_task, ready_task) if task is not None and not task.done()
+                    ]
+                    for task in pending_signal_tasks:
+                        task.cancel()
+                    await asyncio.gather(
+                        marker_task,
+                        *(task for task in (ready_task,) if task is not None),
+                        return_exceptions=True,
+                    )
+        finally:
+            if not signal_timeout_task.done():
+                signal_timeout_task.cancel()
+                await asyncio.gather(signal_timeout_task, return_exceptions=True)
     except asyncio.CancelledError:
         with anyio.CancelScope(shield=True):
             first_task.cancel()
@@ -6613,15 +6624,17 @@ async def _probe_stream_startup_error(
     capacity_ready_event: asyncio.Event | None = None,
     handoff_task_sink: list[asyncio.Task[str]] | None = None,
     service_cleanup_ready_event: asyncio.Event | None = None,
+    scheduler: Scheduler = REAL_SCHEDULER,
 ) -> tuple[AsyncIterator[str], ProxyResponseError | OpenAIErrorEnvelopeModel | None]:
     if timeout_seconds is None:
         timeout_seconds = _STREAM_STARTUP_ERROR_PROBE_SECONDS
-    first_task = _create_first_stream_probe_task(stream)
+    first_task = _create_first_stream_probe_task(stream, scheduler=scheduler)
     probe_done = await _wait_for_first_stream_probe(
         first_task,
         timeout_seconds=timeout_seconds,
         capacity_wait_event=capacity_wait_event,
         capacity_ready_event=capacity_ready_event,
+        scheduler=scheduler,
     )
     if service_cleanup_ready_event is not None:
         buffered_before_cleanup_ready: list[str] = []

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -39,6 +39,7 @@ from app.core.balancer import (
     select_account as select_account,
 )
 from app.core.balancer.types import UpstreamError
+from app.core.clock import REAL_CLOCK, Clock
 from app.core.config import settings as config_settings
 from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
@@ -280,8 +281,9 @@ SelectionInputs = _SelectionInputs
 
 
 class LoadBalancer:
-    def __init__(self, repo_factory: ProxyRepoFactory) -> None:
+    def __init__(self, repo_factory: ProxyRepoFactory, *, clock: Clock = REAL_CLOCK) -> None:
         self._repo_factory = repo_factory
+        self._clock = clock
         self._runtime: dict[str, RuntimeState] = {}
         self._runtime_lock = asyncio.Lock()
         self._account_locks: dict[str, asyncio.Lock] = {}
@@ -366,7 +368,7 @@ class LoadBalancer:
             lease_id=uuid4().hex,
             account_id=account_id,
             kind=kind,
-            acquired_at=time.monotonic(),
+            acquired_at=self._clock.monotonic(),
             estimated_tokens=max(0.0, estimated_tokens),
             api_key_id=api_key_id,
         )
@@ -383,7 +385,7 @@ class LoadBalancer:
                 runtime.stream_key_inflight[api_key_id] = runtime.stream_key_inflight.get(api_key_id, 0) + 1
         runtime.leased_tokens += lease.estimated_tokens
         if record_selection:
-            runtime.last_selected_at = time.time()
+            runtime.last_selected_at = self._clock.time()
             runtime.version += 1
         _record_account_lease_acquired(kind)
         _record_account_inflight_leases(account_id, runtime)
@@ -498,7 +500,7 @@ class LoadBalancer:
                 "Reclaimed stale account lease account_id=%s kind=%s age_seconds=%.3f",
                 "<redacted>" if redact_sensitive_details else current.account_id,
                 current.kind,
-                time.monotonic() - current.acquired_at,
+                self._clock.monotonic() - current.acquired_at,
             )
         return True
 
@@ -508,7 +510,7 @@ class LoadBalancer:
         redact_sensitive_details: bool = False,
     ) -> None:
         settings = get_settings()
-        now = time.monotonic()
+        now = self._clock.monotonic()
         for runtime in self._runtime.values():
             if not runtime.leases:
                 continue

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -4,7 +4,7 @@ import asyncio
 import inspect
 import json
 import logging
-import time
+import time  # noqa: F401 - preserve the module-local seam used by legacy clock tests.
 from collections.abc import Collection, Mapping
 from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
@@ -1404,6 +1404,7 @@ class LoadBalancer:
                 latest_secondary=selection_inputs.latest_secondary,
                 latest_monthly=selection_inputs.latest_monthly,
                 runtime=self._runtime,
+                now=self._clock.time(),
                 routing_policy_override=selection_inputs.routing_policy_override,
                 ignore_standard_quota_account_ids=selection_inputs.ignore_standard_quota_account_ids,
             )
@@ -1607,6 +1608,7 @@ class LoadBalancer:
             latest_secondary=selection_inputs.latest_secondary,
             latest_monthly=selection_inputs.latest_monthly,
             runtime=self._runtime,
+            now=self._clock.time(),
             routing_policy_override=selection_inputs.routing_policy_override,
             ignore_standard_quota_account_ids=selection_inputs.ignore_standard_quota_account_ids,
         )
@@ -1794,7 +1796,7 @@ class LoadBalancer:
             account_snapshot = _clone_account(account)
             state = self._state_for(account)
             state.error_count = max(state.error_count + count, minimum_error_count)
-            state.last_error_at = time.time()
+            state.last_error_at = self._clock.time()
             self._sync_runtime_state(account, state)
             runtime = self._runtime.get(account.id)
             if runtime and runtime.health_tier == HEALTH_TIER_PROBING:
@@ -1855,11 +1857,12 @@ class LoadBalancer:
                 monthly_entry=monthly_entry,
                 secondary_entry=secondary_entry,
             )
+            now = self._clock.time()
             normalized_usage = _normalize_usage_inputs(
                 account=account,
                 primary_entry=primary_entry,
                 secondary_entry=effective_secondary_entry,
-                now_epoch=int(time.time()),
+                now_epoch=int(now),
             )
             health_primary_used = _health_tier_primary_used(
                 plan_type=account.plan_type,
@@ -1880,13 +1883,13 @@ class LoadBalancer:
                 primary_entry=primary_entry,
                 secondary_entry=effective_secondary_entry,
                 runtime=replace(runtime),
+                now=now,
             )
             account_status = normalized_state.status
             if account_status != AccountStatus.ACTIVE:
                 return
 
             settings = get_settings()
-            now = time.time()
             was_probe_eligible = runtime.health_tier == HEALTH_TIER_PROBING
             if was_probe_eligible and (runtime.error_count > 0 or runtime.last_error_at is not None):
                 runtime.error_count = 0
@@ -2090,9 +2093,11 @@ def _build_states(
     latest_secondary: Mapping[str, UsageHistory | AdditionalUsageHistory],
     latest_monthly: Mapping[str, UsageHistory],
     runtime: dict[str, RuntimeState],
+    now: float | None = None,
     routing_policy_override: str | None = None,
     ignore_standard_quota_account_ids: frozenset[str] = frozenset(),
 ) -> tuple[list[AccountState], dict[str, Account]]:
+    now = REAL_CLOCK.time() if now is None else now
     states: list[AccountState] = []
     account_map: dict[str, Account] = {}
 
@@ -2109,6 +2114,7 @@ def _build_states(
             primary_entry=latest_primary.get(account.id),
             secondary_entry=secondary_entry,
             runtime=runtime.setdefault(account.id, RuntimeState()),
+            now=now,
         )
         if routing_policy_override is not None and account.id in ignore_standard_quota_account_ids:
             state.routing_policy = routing_policy_override
@@ -2252,13 +2258,15 @@ def _state_from_account(
     primary_entry: UsageHistory | AdditionalUsageHistory | None,
     secondary_entry: UsageHistory | AdditionalUsageHistory | None,
     runtime: RuntimeState,
+    now: float | None = None,
 ) -> AccountState:
+    now = REAL_CLOCK.time() if now is None else now
     routing_policy = _normalize_account_routing_policy(getattr(account, "routing_policy", None))
     normalized_usage = _normalize_usage_inputs(
         account=account,
         primary_entry=primary_entry,
         secondary_entry=secondary_entry,
-        now_epoch=int(time.time()),
+        now_epoch=int(now),
     )
     primary_used = normalized_usage.primary_used
     primary_reset = normalized_usage.primary_reset
@@ -2282,7 +2290,6 @@ def _state_from_account(
     # while waiting for the next usage refresh. Expired samples map to 0.0
     # rather than None because usage-derived status recovery only evaluates
     # non-None percentages.
-    now = time.time()
     now_epoch = int(now)
     if primary_used is not None and primary_reset is not None and primary_reset <= now_epoch:
         primary_used = 0.0
@@ -2344,6 +2351,7 @@ def _state_from_account(
                 account=account,
                 primary_entry=primary_entry,
                 long_window_entry=effective_secondary_entry,
+                now=now,
             )
             if early_freshness_entry is not None and early_freshness_entry.recorded_at is not None:
                 recorded_epoch = early_freshness_entry.recorded_at.replace(tzinfo=timezone.utc).timestamp()
@@ -2416,7 +2424,7 @@ def _state_from_account(
     if (
         account.status == AccountStatus.QUOTA_EXCEEDED
         and effective_runtime_reset is not None
-        and effective_runtime_reset > time.time()
+        and effective_runtime_reset > now
         and effective_blocked_at is None
         and effective_secondary_entry is not None
         and _usage_entry_is_recent_enough(effective_secondary_entry.recorded_at)
@@ -2441,11 +2449,11 @@ def _state_from_account(
     cooldown_ready = False
     if account.status == AccountStatus.QUOTA_EXCEEDED:
         cooldown_ready = (
-            effective_blocked_at is not None and time.time() >= effective_blocked_at + QUOTA_EXCEEDED_COOLDOWN_SECONDS
+            effective_blocked_at is not None and now >= effective_blocked_at + QUOTA_EXCEEDED_COOLDOWN_SECONDS
         )
     elif (
         runtime.cooldown_until is not None
-        and runtime.cooldown_until <= time.time()
+        and runtime.cooldown_until <= now
         and runtime.blocked_at is not None
         and effective_blocked_at is not None
         and runtime.blocked_at >= effective_blocked_at
@@ -2460,6 +2468,7 @@ def _state_from_account(
                 account=account,
                 primary_entry=primary_entry,
                 long_window_entry=effective_secondary_entry,
+                now=now,
             )
         else:
             freshness_entry = None
@@ -2474,6 +2483,7 @@ def _state_from_account(
             account=account,
             primary_entry=primary_entry,
             long_window_entry=effective_secondary_entry,
+            now=now,
         )
         # One healthy window must not conceal exhaustion in another applicable
         # window; at least one window must also have supplied actual evidence.
@@ -2536,7 +2546,7 @@ def _state_from_account(
         secondary_used_percent=secondary_used,
         routing_policy=routing_policy,
         runtime=runtime,
-        now=time.time(),
+        now=now,
         soft_drain_enabled=getattr(settings, "soft_drain_enabled", True),
     )
 
@@ -2718,6 +2728,7 @@ def background_recovery_state_from_account(
     account: Account,
     primary_entry: UsageHistory | None,
     secondary_entry: UsageHistory | None,
+    now: float | None = None,
 ) -> AccountState:
     """Evaluate recovery for a persisted blocked account without live runtime state.
 
@@ -2729,7 +2740,7 @@ def background_recovery_state_from_account(
 
     runtime = RuntimeState()
     blocked_at = float(account.blocked_at) if account.blocked_at is not None else None
-    now = time.time()
+    now = REAL_CLOCK.time() if now is None else now
     reset_at = float(account.reset_at) if account.reset_at is not None else None
     valid_reset_at = plausible_rate_limit_reset_at(reset_at, now=now)
 
@@ -2744,12 +2755,14 @@ def background_recovery_state_from_account(
         primary_entry=primary_entry,
         secondary_entry=secondary_entry,
         runtime=runtime,
+        now=now,
     )
     if account.status == AccountStatus.RATE_LIMITED:
         freshness_entry = _rate_limited_freshness_entry(
             account=account,
             primary_entry=primary_entry,
             long_window_entry=secondary_entry,
+            now=now,
         )
         # Keep elapsed resets intact until _state_from_account evaluates the
         # selector's normal expiry path; only freshness gates the final repair.
@@ -2801,6 +2814,7 @@ def _rate_limited_freshness_entry(
     account: Account,
     primary_entry: _UsageWindowEntry | None,
     long_window_entry: _UsageWindowEntry | None,
+    now: float,
 ) -> _UsageWindowEntry | None:
     if (
         long_window_entry is not None
@@ -2820,7 +2834,7 @@ def _rate_limited_freshness_entry(
     # block: recovery would route traffic to an account whose long quota is
     # still at 100%. While the primary sample still claims an active window,
     # or omits reset metadata entirely, its freshness keeps gating recovery.
-    primary_window_expired = primary_entry.reset_at is not None and float(primary_entry.reset_at) <= time.time()
+    primary_window_expired = primary_entry.reset_at is not None and float(primary_entry.reset_at) <= now
     long_window_available = long_window_entry.used_percent is not None and float(long_window_entry.used_percent) < 100.0
     if primary_window_expired and long_window_available and long_window_entry.recorded_at > primary_entry.recorded_at:
         return long_window_entry

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -39,6 +39,7 @@ from app.core.balancer import (
     select_account as select_account,
 )
 from app.core.balancer.types import UpstreamError
+from app.core.clock import REAL_CLOCK, Clock
 from app.core.config import settings as config_settings
 from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
@@ -276,8 +277,9 @@ SelectionInputs = _SelectionInputs
 
 
 class LoadBalancer:
-    def __init__(self, repo_factory: ProxyRepoFactory) -> None:
+    def __init__(self, repo_factory: ProxyRepoFactory, *, clock: Clock = REAL_CLOCK) -> None:
         self._repo_factory = repo_factory
+        self._clock = clock
         self._runtime: dict[str, RuntimeState] = {}
         self._runtime_lock = asyncio.Lock()
         self._account_locks: dict[str, asyncio.Lock] = {}
@@ -362,7 +364,7 @@ class LoadBalancer:
             lease_id=uuid4().hex,
             account_id=account_id,
             kind=kind,
-            acquired_at=time.monotonic(),
+            acquired_at=self._clock.monotonic(),
             estimated_tokens=max(0.0, estimated_tokens),
             api_key_id=api_key_id,
         )
@@ -379,7 +381,7 @@ class LoadBalancer:
                 runtime.stream_key_inflight[api_key_id] = runtime.stream_key_inflight.get(api_key_id, 0) + 1
         runtime.leased_tokens += lease.estimated_tokens
         if record_selection:
-            runtime.last_selected_at = time.time()
+            runtime.last_selected_at = self._clock.time()
             runtime.version += 1
         _record_account_lease_acquired(kind)
         _record_account_inflight_leases(account_id, runtime)
@@ -494,7 +496,7 @@ class LoadBalancer:
                 "Reclaimed stale account lease account_id=%s kind=%s age_seconds=%.3f",
                 "<redacted>" if redact_sensitive_details else current.account_id,
                 current.kind,
-                time.monotonic() - current.acquired_at,
+                self._clock.monotonic() - current.acquired_at,
             )
         return True
 
@@ -504,7 +506,7 @@ class LoadBalancer:
         redact_sensitive_details: bool = False,
     ) -> None:
         settings = get_settings()
-        now = time.monotonic()
+        now = self._clock.monotonic()
         for runtime in self._runtime.values():
             if not runtime.leases:
                 continue

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1017,6 +1017,7 @@ class LoadBalancer:
             return None
         result = select_account(
             states,
+            now=self._clock.time(),
             prefer_earlier_reset=prefer_earlier_reset,
             prefer_earlier_reset_window=prefer_earlier_reset_window,
             routing_strategy=routing_strategy,
@@ -1040,7 +1041,7 @@ class LoadBalancer:
         # This is not a health observation, so it must not advance ``version``
         # and invalidate an operator Force Probe that is loading usage.
         previous_last_selected_at = runtime.last_selected_at
-        reserved_at = time.time()
+        reserved_at = self._clock.time()
         runtime.last_selected_at = reserved_at
         return ProbeReservation(
             account_id=result.account.account_id,
@@ -1079,7 +1080,7 @@ class LoadBalancer:
         # Only a selection that survived sticky persistence and final local
         # admission consumes the quiet interval. Unlike reserve/release, this
         # committed observation must invalidate older Force Probe settlement.
-        runtime.last_selected_at = time.time()
+        runtime.last_selected_at = self._clock.time()
         runtime.version += 1
         runtime.health_version += 1
         return True
@@ -1959,7 +1960,7 @@ class LoadBalancer:
         runtime = self._runtime.setdefault(account.id, RuntimeState())
         if expected_version is not None and runtime.version != expected_version:
             if selected:
-                runtime.last_selected_at = time.time()
+                runtime.last_selected_at = self._clock.time()
                 runtime.version += 1
             return False
 
@@ -1985,7 +1986,7 @@ class LoadBalancer:
             dirty = True
         health_dirty = dirty
         if selected:
-            runtime.last_selected_at = time.time()
+            runtime.last_selected_at = self._clock.time()
             dirty = True
         if dirty:
             runtime.version += 1

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -2290,8 +2290,7 @@ def _state_from_account(
     # while waiting for the next usage refresh. Expired samples map to 0.0
     # rather than None because usage-derived status recovery only evaluates
     # non-None percentages.
-    now_epoch = int(now)
-    if primary_used is not None and primary_reset is not None and primary_reset <= now_epoch:
+    if primary_used is not None and primary_reset is not None and primary_reset <= int(now):
         primary_used = 0.0
         primary_reset = None
     # A strictly newer long-window row proves a later fetch no longer
@@ -2307,7 +2306,7 @@ def _state_from_account(
         > _SIBLING_FETCH_MARGIN_SECONDS
     ):
         primary_window_minutes = None
-    if secondary_used is not None and secondary_reset is not None and secondary_reset <= now_epoch:
+    if secondary_used is not None and secondary_reset is not None and secondary_reset <= int(now):
         secondary_used = 0.0
         secondary_reset = None
     ignore_zero_capacity_primary_runtime_reset = False
@@ -2524,6 +2523,7 @@ def _state_from_account(
         credits_unlimited=credits_unlimited,
         credits_balance=credits_balance,
         infer_status_from_usage=False,
+        now=now,
     )
     if resetless_rate_limit_without_evidence and primary_used is None and status == AccountStatus.ACTIVE:
         status = AccountStatus.RATE_LIMITED

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1698,6 +1698,7 @@ class LoadBalancer:
             allow_usage_exhaustion_error=allow_usage_exhaustion_error,
             usage_exhaustion_states=usage_exhaustion_states,
             sticky_refresh_skip_deadline=sticky_refresh_skip_deadline,
+            now=self._clock.time(),
         )
 
     _persist_sticky_mutation = staticmethod(_persist_sticky_mutation)

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -2313,7 +2313,7 @@ def _state_from_account(
     status_seed = account.status
     long_window_quota_available = (
         effective_secondary_entry is not None
-        and _usage_entry_is_recent_enough(effective_secondary_entry.recorded_at)
+        and _usage_entry_is_recent_enough(effective_secondary_entry.recorded_at, now=now)
         and effective_secondary_entry.used_percent is not None
         and float(effective_secondary_entry.used_percent) < 100.0
     )
@@ -2426,7 +2426,7 @@ def _state_from_account(
         and effective_runtime_reset > now
         and effective_blocked_at is None
         and effective_secondary_entry is not None
-        and _usage_entry_is_recent_enough(effective_secondary_entry.recorded_at)
+        and _usage_entry_is_recent_enough(effective_secondary_entry.recorded_at, now=now)
         and effective_secondary_entry.used_percent is not None
         and float(effective_secondary_entry.used_percent) < 100.0
         and effective_secondary_entry.reset_at is not None
@@ -2492,7 +2492,7 @@ def _state_from_account(
             and (primary_used is not None or secondary_used is not None)
         )
         rejected_reset_recovery_evidence = all_quota_windows_available and _usage_entry_is_recent_available(
-            rejected_reset_freshness_entry
+            rejected_reset_freshness_entry, now=now
         )
         if effective_blocked_at is not None:
             # A sample predating the 429 cannot disprove the persisted block.
@@ -2775,7 +2775,7 @@ def background_recovery_state_from_account(
                     cooldown_until=max(reset_at, minimum_floor_deadline),
                 )
         elif blocked_at is None and reset_at is not None and reset_at <= now:
-            if not _usage_entry_is_recent_available(freshness_entry):
+            if not _usage_entry_is_recent_available(freshness_entry, now=now):
                 return replace(
                     state,
                     status=AccountStatus.RATE_LIMITED,
@@ -2837,10 +2837,10 @@ def _rate_limited_freshness_entry(
     return primary_entry
 
 
-def _usage_entry_is_recent_available(entry: _UsageWindowEntry | None) -> bool:
+def _usage_entry_is_recent_available(entry: _UsageWindowEntry | None, *, now: float) -> bool:
     return (
         entry is not None
-        and _usage_entry_is_recent_enough(entry.recorded_at)
+        and _usage_entry_is_recent_enough(entry.recorded_at, now=now)
         and entry.used_percent is not None
         and float(entry.used_percent) < 100.0
     )
@@ -2875,12 +2875,10 @@ def _extract_credit_status(
     return None, None, None
 
 
-def _usage_entry_is_recent_enough(recorded_at: datetime | None) -> bool:
+def _usage_entry_is_recent_enough(recorded_at: datetime | None, *, now: float) -> bool:
     if recorded_at is None:
         return False
-    current_time = utcnow()
-    if current_time.tzinfo is None:
-        current_time = current_time.replace(tzinfo=timezone.utc)
+    current_time = datetime.fromtimestamp(now, tz=timezone.utc)
     interval_seconds = max(_usage_refresh_interval_seconds() * 2, 180)
     recorded_time = recorded_at if recorded_at.tzinfo is not None else recorded_at.replace(tzinfo=timezone.utc)
     return recorded_time >= current_time - timedelta(seconds=interval_seconds)

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1673,6 +1673,7 @@ class LoadBalancer:
         allow_usage_exhaustion_error: bool = True,
         usage_exhaustion_states: Iterable[AccountState] | None = None,
         sticky_refresh_skip_deadline: datetime | None = None,
+        now: float | None = None,
     ) -> _StickySelectionOutcome:
         return await _run_select_with_stickiness(
             states=states,
@@ -1698,7 +1699,7 @@ class LoadBalancer:
             allow_usage_exhaustion_error=allow_usage_exhaustion_error,
             usage_exhaustion_states=usage_exhaustion_states,
             sticky_refresh_skip_deadline=sticky_refresh_skip_deadline,
-            now=self._clock.time(),
+            now=self._clock.time() if now is None else now,
         )
 
     _persist_sticky_mutation = staticmethod(_persist_sticky_mutation)

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -2531,12 +2531,12 @@ def _state_from_account(
         status = AccountStatus.RATE_LIMITED
         reset_at = float(account.reset_at)
 
-    if status == AccountStatus.QUOTA_EXCEEDED:
-        next_blocked_at = effective_blocked_at
-    elif status == AccountStatus.RATE_LIMITED and account.status != AccountStatus.QUOTA_EXCEEDED:
-        next_blocked_at = effective_blocked_at
-    else:
-        next_blocked_at = None
+    next_blocked_at = (
+        effective_blocked_at
+        if status == AccountStatus.QUOTA_EXCEEDED
+        or (status == AccountStatus.RATE_LIMITED and account.status != AccountStatus.QUOTA_EXCEEDED)
+        else None
+    )
 
     settings = get_settings()
     new_tier = _sync_runtime_health_tier(
@@ -2728,28 +2728,24 @@ def background_recovery_state_from_account(
     account: Account,
     primary_entry: UsageHistory | None,
     secondary_entry: UsageHistory | None,
-    now: float | None = None,
 ) -> AccountState:
-    """Evaluate recovery for a persisted blocked account without live runtime state.
+    """Evaluate recovery without live runtime state.
 
-    The usage refresh scheduler only needs to know whether a persisted blocked
-    account can safely return to `active`. Seed a throwaway runtime snapshot
-    from the persisted block marker so fresh post-block usage rows can clear a
-    stale reset guard even when the original balancer process is gone.
+    Seed a throwaway runtime from the persisted block marker so post-block usage
+    can clear stale reset guards after a balancer restart.
     """
 
     runtime = RuntimeState()
     blocked_at = float(account.blocked_at) if account.blocked_at is not None else None
-    now = REAL_CLOCK.time() if now is None else now
+    now = REAL_CLOCK.time()
     reset_at = float(account.reset_at) if account.reset_at is not None else None
     valid_reset_at = plausible_rate_limit_reset_at(reset_at, now=now)
 
     if blocked_at is not None:
         runtime.blocked_at = blocked_at
 
-    if account.status == AccountStatus.RATE_LIMITED and blocked_at is not None:
-        if valid_reset_at is not None:
-            runtime.cooldown_until = valid_reset_at
+    if account.status == AccountStatus.RATE_LIMITED and blocked_at is not None and valid_reset_at is not None:
+        runtime.cooldown_until = valid_reset_at
     state = _state_from_account(
         account=account,
         primary_entry=primary_entry,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -60,6 +60,7 @@ from app.core.clients.proxy_websocket import (
 from app.core.clients.proxy_websocket import (
     connect_responses_websocket as connect_responses_websocket,
 )
+from app.core.clock import REAL_CLOCK, REAL_SCHEDULER, Clock, Scheduler
 from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
@@ -915,11 +916,14 @@ class ProxyService(
         self,
         repo_factory: ProxyRepoFactory,
         *,
+        clock: Clock = REAL_CLOCK,
+        scheduler: Scheduler = REAL_SCHEDULER,
         live_websocket_connector: LiveWebSocketConnector = connect_live_websocket,
     ) -> None:
         self._repo_factory = repo_factory
+        self._clock, self._scheduler = clock, scheduler
         self._encryptor = TokenEncryptor()
-        self._load_balancer = LoadBalancer(repo_factory)
+        self._load_balancer = LoadBalancer(repo_factory, clock=clock)
         self._capability_router = CapabilityRouter(repo_factory)
         self._live_websocket_connector = live_websocket_connector
         self._ring_membership = RingMembershipService(SessionLocal)
@@ -927,7 +931,7 @@ class ProxyService(
         self._http_bridge_operation_event_batcher = HttpBridgeOperationEventBatcher.from_settings(self._durable_bridge)
         self._http_bridge_owner_client = HTTPBridgeOwnerClient()
         self._initialize_http_bridge_session_registry()
-        _initialize_http_bridge_retry_circuit(self, _clear_websocket_stale_previous_response_cache)
+        _initialize_http_bridge_retry_circuit(self, _clear_websocket_stale_previous_response_cache, clock=clock)
         self._http_bridge_account_timeout_failures, self._http_bridge_account_timeout_lock = {}, asyncio.Lock()
         self._http_bridge_inflight_sessions: dict[_HTTPBridgeSessionKey, asyncio.Future[_HTTPBridgeSession]] = {}
         self._http_bridge_turn_state_index: dict[tuple[str, str | None], _HTTPBridgeSessionKey] = {}
@@ -949,11 +953,8 @@ class ProxyService(
                 websocket_connect_limit=settings.proxy_upstream_websocket_connect_limit,
                 response_create_limit=settings.proxy_response_create_limit,
                 compact_response_create_limit=settings.proxy_compact_response_create_limit,
-                admission_wait_timeout_seconds=getattr(
-                    settings,
-                    "proxy_admission_wait_timeout_seconds",
-                    10.0,
-                ),
+                admission_wait_timeout_seconds=getattr(settings, "proxy_admission_wait_timeout_seconds", 10.0),
+                scheduler=self._scheduler,
             )
         return self._work_admission
 
@@ -970,7 +971,7 @@ class ProxyService(
         filtered = filter_inbound_headers(headers)
         useragent, useragent_group, conversation_id = _request_log_client_fields(headers)
         request_id = get_request_id() or ensure_request_id(None)
-        start = time.monotonic()
+        start = self._clock.monotonic()
         base_settings = get_settings()
         deadline = start + base_settings.proxy_request_budget_seconds
         settings = await get_settings_cache().get()
@@ -1232,7 +1233,7 @@ class ProxyService(
                 api_key=api_key,
                 request_id=request_id,
                 model=None,
-                latency_ms=int((time.monotonic() - start) * 1000),
+                latency_ms=int((self._clock.monotonic() - start) * 1000),
                 status=log_status,
                 error_code=log_error_code,
                 error_message=log_error_message,
@@ -1267,7 +1268,7 @@ class ProxyService(
         if bridge_session is not None:
             timeout_seconds = _http_bridge_admission_timeout_seconds(request_state, timeout_seconds, get_settings())
         request_state.response_create_gate = response_create_gate
-        request_state.response_create_gate_wait_started_at = time.monotonic()
+        request_state.response_create_gate_wait_started_at = self._clock.monotonic()
         if account_id is not None:
             settings = await get_settings_cache().get()
             request_state.account_response_create_lease = await self._acquire_account_response_create_lease_or_overload(
@@ -1278,7 +1279,7 @@ class ProxyService(
             )
             request_state.account_response_create_release = self._load_balancer.release_account_lease
         try:
-            await asyncio.wait_for(response_create_gate.acquire(), timeout=timeout_seconds)
+            await self._scheduler.wait_for(response_create_gate.acquire(), timeout=timeout_seconds)
         except TimeoutError as exc:
             await self._release_request_state_account_response_create_lease(request_state)
             request_state.response_create_gate = None
@@ -1292,7 +1293,7 @@ class ProxyService(
             stale_pending_requests_to_fail: list[_WebSocketRequestState] = []
             retry_circuit_attempt_selection = None
             if bridge_session is not None:
-                now = time.monotonic()
+                now = self._clock.monotonic()
                 stale_gate_snapshot = await self._snapshot_http_bridge_stale_gate_state(bridge_session, now=now)
                 pending_states = stale_gate_snapshot.pending_states
                 pending_count = len(pending_states)
@@ -1376,7 +1377,7 @@ class ProxyService(
         request_state.awaiting_response_created = True
         if request_state.response_create_gate_wait_started_at is not None:
             request_state.latency_response_create_gate_wait_ms = int(
-                max(0.0, time.monotonic() - request_state.response_create_gate_wait_started_at) * 1000
+                max(0.0, self._clock.monotonic() - request_state.response_create_gate_wait_started_at) * 1000
             )
         try:
             request_state.response_create_admission = await self._get_work_admission().acquire_response_create(
@@ -1440,7 +1441,7 @@ class ProxyService(
                 refresh = auth_manager.ensure_fresh(account, force=force)
                 if timeout_seconds is None:
                     return await refresh
-                return await asyncio.wait_for(refresh, timeout=max(0.001, timeout_seconds))
+                return await self._scheduler.wait_for(refresh, timeout=max(0.001, timeout_seconds))
         finally:
             pop_token_refresh_timeout_override(token)
 
@@ -1452,7 +1453,7 @@ class ProxyService(
         timeout_seconds: float | None = None,
         privacy_policy: CodexControlRequestPrivacyPolicy = CodexControlRequestPrivacyPolicy.STANDARD,
     ) -> Account:
-        deadline = None if timeout_seconds is None else time.monotonic() + timeout_seconds
+        deadline = None if timeout_seconds is None else self._clock.monotonic() + timeout_seconds
         return await _recover_fresh_account(
             self,
             account,

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1844,7 +1844,7 @@ class ProxyService(
                         sticky_source,
                         legacy_sticky_key,
                     )
-                    preferred_selection = await self._load_balancer.select_account(
+                    preferred_selection = await self._scheduler.wait_for(self._load_balancer.select_account(
                         sticky_key=preferred_sticky_inputs[0],
                         sticky_kind=preferred_sticky_inputs[1],
                         reallocate_sticky=preferred_sticky_inputs[2],
@@ -1886,7 +1886,7 @@ class ProxyService(
                         allow_usage_exhaustion_error=not required_preferred_account,
                         api_key_id=api_key_id,
                         api_key_stream_fair_share_threshold_pct=api_key_fair_share_threshold_pct,
-                    )
+                    ), timeout=self._remaining_budget_seconds(deadline))  # fmt: skip
                     if preferred_selection.account is not None:
                         logger.info(
                             "Selected preferred account request_id=%s kind=%s request_stage=%s account_id=%s",
@@ -1908,7 +1908,7 @@ class ProxyService(
                             preferred_selection.error_message,
                         )
                         return preferred_selection
-                selection = await self._load_balancer.select_account(
+                selection = await self._scheduler.wait_for(self._load_balancer.select_account(
                     sticky_key=sticky_key,
                     sticky_kind=sticky_kind,
                     reallocate_sticky=reallocate_sticky,
@@ -1947,7 +1947,7 @@ class ProxyService(
                     redact_sensitive_details=redact_sensitive_details,
                     api_key_id=api_key_id,
                     api_key_stream_fair_share_threshold_pct=api_key_fair_share_threshold_pct,
-                )
+                ), timeout=self._remaining_budget_seconds(deadline))  # fmt: skip
                 if selection.account is not None and selection.account.id in excluded_account_ids_set:
                     logger.warning(
                         "Proxy account selection returned excluded account request_id=%s kind=%s request_stage=%s "

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -945,6 +945,9 @@ class ProxyService(
         self._work_admission: WorkAdmissionController | None = None
         self._request_log_tasks: set[asyncio.Task[None]] = set()
 
+    def _remaining_budget_seconds(self, deadline: float) -> float:
+        return max(0.0, deadline - self._clock.monotonic())
+
     def _get_work_admission(self) -> WorkAdmissionController:
         if self._work_admission is None:
             settings = get_settings()
@@ -1025,7 +1028,7 @@ class ProxyService(
                 nonlocal route_fallback_used, route_mode, route_pool_id, route_endpoint_id
                 access_token = self._encryptor.decrypt(target.access_token_encrypted)
                 upstream_account_id = _header_account_id(target.chatgpt_account_id)
-                remaining_budget = _remaining_budget_seconds(deadline)
+                remaining_budget = self._remaining_budget_seconds(deadline)
                 if remaining_budget <= 0:
                     logger.warning(
                         "Thread goal request budget exhausted before upstream call request_id=%s operation=%s "
@@ -1124,7 +1127,7 @@ class ProxyService(
                         return response
                 if exc.status_code == 401:
                     try:
-                        remaining_budget = _remaining_budget_seconds(deadline)
+                        remaining_budget = self._remaining_budget_seconds(deadline)
                         if remaining_budget <= 0:
                             logger.warning(
                                 "Thread goal request budget exhausted before forced refresh retry request_id=%s "
@@ -1174,7 +1177,7 @@ class ProxyService(
                                     account_id_value = account.id
                                     account = await self._ensure_fresh_with_budget_or_auth_error(
                                         account,
-                                        timeout_seconds=_remaining_budget_seconds(deadline),
+                                        timeout_seconds=self._remaining_budget_seconds(deadline),
                                     )
                                     try:
                                         response = await _call_goal(account)
@@ -1459,7 +1462,7 @@ class ProxyService(
             account,
             force=force,
             deadline=deadline,
-            remaining_budget_seconds=_remaining_budget_seconds,
+            remaining_budget_seconds=self._remaining_budget_seconds,
             request_id=get_request_id(),
             privacy_policy=privacy_policy,
         )
@@ -1483,7 +1486,7 @@ class ProxyService(
         force_current = force
         while True:
             attempt += 1
-            remaining_budget = _remaining_budget_seconds(deadline)
+            remaining_budget = self._remaining_budget_seconds(deadline)
             if remaining_budget <= 0:
                 logger.warning(
                     "%s request budget exhausted before freshness check request_id=%s account_id=%s",
@@ -1568,7 +1571,7 @@ class ProxyService(
                 self,
                 account,
                 force=force,
-                timeout_seconds=_remaining_budget_seconds(deadline),
+                timeout_seconds=self._remaining_budget_seconds(deadline),
                 privacy_policy=privacy_policy,
             )
 
@@ -1597,7 +1600,7 @@ class ProxyService(
             failover_failed_account = _proxy_response_failed_account(failover_exc, next_account)
             setattr(failover_exc, _FAILED_ACCOUNT_ATTR, failover_failed_account)
             if failover_exc.status_code == 401:
-                remaining_budget = _remaining_budget_seconds(deadline)
+                remaining_budget = self._remaining_budget_seconds(deadline)
                 if remaining_budget <= 0:
                     _raise_proxy_budget_exhausted()
                 try:
@@ -1710,7 +1713,7 @@ class ProxyService(
         traffic_class: TrafficClass = TRAFFIC_CLASS_FOREGROUND,
         redact_sensitive_details: bool = False,
     ) -> AccountSelection:
-        remaining_budget = _remaining_budget_seconds(deadline)
+        remaining_budget = self._remaining_budget_seconds(deadline)
         if remaining_budget <= 0:
             logger.warning(
                 "%s request budget exhausted before account selection request_id=%s", kind.title(), request_id

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -60,6 +60,7 @@ from app.core.clients.proxy_websocket import (
 from app.core.clients.proxy_websocket import (
     connect_responses_websocket as connect_responses_websocket,
 )
+from app.core.clock import REAL_CLOCK, REAL_SCHEDULER, Clock, Scheduler
 from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
@@ -931,11 +932,14 @@ class ProxyService(
         self,
         repo_factory: ProxyRepoFactory,
         *,
+        clock: Clock = REAL_CLOCK,
+        scheduler: Scheduler = REAL_SCHEDULER,
         live_websocket_connector: LiveWebSocketConnector = connect_live_websocket,
     ) -> None:
         self._repo_factory = repo_factory
+        self._clock, self._scheduler = clock, scheduler
         self._encryptor = TokenEncryptor()
-        self._load_balancer = LoadBalancer(repo_factory)
+        self._load_balancer = LoadBalancer(repo_factory, clock=clock)
         self._capability_router = CapabilityRouter(repo_factory)
         self._live_websocket_connector = live_websocket_connector
         self._ring_membership = RingMembershipService(SessionLocal)
@@ -943,7 +947,7 @@ class ProxyService(
         self._http_bridge_operation_event_batcher = HttpBridgeOperationEventBatcher.from_settings(self._durable_bridge)
         self._http_bridge_owner_client = HTTPBridgeOwnerClient()
         self._initialize_http_bridge_session_registry()
-        _initialize_http_bridge_retry_circuit(self, _clear_websocket_stale_previous_response_cache)
+        _initialize_http_bridge_retry_circuit(self, _clear_websocket_stale_previous_response_cache, clock=clock)
         self._http_bridge_account_timeout_failures, self._http_bridge_account_timeout_lock = {}, asyncio.Lock()
         self._http_bridge_inflight_sessions: dict[_HTTPBridgeSessionKey, asyncio.Future[_HTTPBridgeSession]] = {}
         self._http_bridge_turn_state_index: dict[tuple[str, str | None], _HTTPBridgeSessionKey] = {}
@@ -965,11 +969,8 @@ class ProxyService(
                 websocket_connect_limit=settings.proxy_upstream_websocket_connect_limit,
                 response_create_limit=settings.proxy_response_create_limit,
                 compact_response_create_limit=settings.proxy_compact_response_create_limit,
-                admission_wait_timeout_seconds=getattr(
-                    settings,
-                    "proxy_admission_wait_timeout_seconds",
-                    10.0,
-                ),
+                admission_wait_timeout_seconds=getattr(settings, "proxy_admission_wait_timeout_seconds", 10.0),
+                scheduler=self._scheduler,
             )
         return self._work_admission
 
@@ -986,7 +987,7 @@ class ProxyService(
         filtered = filter_inbound_headers(headers)
         useragent, useragent_group, conversation_id = _request_log_client_fields(headers)
         request_id = get_request_id() or ensure_request_id(None)
-        start = time.monotonic()
+        start = self._clock.monotonic()
         base_settings = get_settings()
         deadline = start + base_settings.proxy_request_budget_seconds
         settings = await get_settings_cache().get()
@@ -1248,7 +1249,7 @@ class ProxyService(
                 api_key=api_key,
                 request_id=request_id,
                 model=None,
-                latency_ms=int((time.monotonic() - start) * 1000),
+                latency_ms=int((self._clock.monotonic() - start) * 1000),
                 status=log_status,
                 error_code=log_error_code,
                 error_message=log_error_message,
@@ -1283,7 +1284,7 @@ class ProxyService(
         if bridge_session is not None:
             timeout_seconds = _http_bridge_admission_timeout_seconds(request_state, timeout_seconds, get_settings())
         request_state.response_create_gate = response_create_gate
-        request_state.response_create_gate_wait_started_at = time.monotonic()
+        request_state.response_create_gate_wait_started_at = self._clock.monotonic()
         if account_id is not None:
             settings = await get_settings_cache().get()
             request_state.account_response_create_lease = await self._acquire_account_response_create_lease_or_overload(
@@ -1294,7 +1295,7 @@ class ProxyService(
             )
             request_state.account_response_create_release = self._load_balancer.release_account_lease
         try:
-            await asyncio.wait_for(response_create_gate.acquire(), timeout=timeout_seconds)
+            await self._scheduler.wait_for(response_create_gate.acquire(), timeout=timeout_seconds)
         except TimeoutError as exc:
             await self._release_request_state_account_response_create_lease(request_state)
             request_state.response_create_gate = None
@@ -1308,7 +1309,7 @@ class ProxyService(
             stale_pending_requests_to_fail: list[_WebSocketRequestState] = []
             retry_circuit_attempt_selection = None
             if bridge_session is not None:
-                now = time.monotonic()
+                now = self._clock.monotonic()
                 stale_gate_snapshot = await self._snapshot_http_bridge_stale_gate_state(bridge_session, now=now)
                 pending_states = stale_gate_snapshot.pending_states
                 pending_count = len(pending_states)
@@ -1392,7 +1393,7 @@ class ProxyService(
         request_state.awaiting_response_created = True
         if request_state.response_create_gate_wait_started_at is not None:
             request_state.latency_response_create_gate_wait_ms = int(
-                max(0.0, time.monotonic() - request_state.response_create_gate_wait_started_at) * 1000
+                max(0.0, self._clock.monotonic() - request_state.response_create_gate_wait_started_at) * 1000
             )
         try:
             request_state.response_create_admission = await self._get_work_admission().acquire_response_create(
@@ -1456,7 +1457,7 @@ class ProxyService(
                 refresh = auth_manager.ensure_fresh(account, force=force)
                 if timeout_seconds is None:
                     return await refresh
-                return await asyncio.wait_for(refresh, timeout=max(0.001, timeout_seconds))
+                return await self._scheduler.wait_for(refresh, timeout=max(0.001, timeout_seconds))
         finally:
             pop_token_refresh_timeout_override(token)
 
@@ -1468,7 +1469,7 @@ class ProxyService(
         timeout_seconds: float | None = None,
         privacy_policy: CodexControlRequestPrivacyPolicy = CodexControlRequestPrivacyPolicy.STANDARD,
     ) -> Account:
-        deadline = None if timeout_seconds is None else time.monotonic() + timeout_seconds
+        deadline = None if timeout_seconds is None else self._clock.monotonic() + timeout_seconds
         return await _recover_fresh_account(
             self,
             account,

--- a/app/modules/proxy/work_admission.py
+++ b/app/modules/proxy/work_admission.py
@@ -5,6 +5,7 @@ import logging
 from dataclasses import dataclass
 
 from app.core.clients.proxy import ProxyResponseError
+from app.core.clock import REAL_SCHEDULER, Scheduler
 from app.core.resilience.overload import local_overload_error
 from app.core.utils.request_id import get_request_id
 
@@ -60,7 +61,9 @@ class WorkAdmissionController:
         response_create_limit: int,
         compact_response_create_limit: int,
         admission_wait_timeout_seconds: float = _DEFAULT_ADMISSION_WAIT_TIMEOUT_SECONDS,
+        scheduler: Scheduler = REAL_SCHEDULER,
     ) -> None:
+        self._scheduler = scheduler
         self._token_refresh = _make_gate(token_refresh_limit, admission_wait_timeout_seconds)
         self._websocket_connect = _make_gate(websocket_connect_limit, admission_wait_timeout_seconds)
         self._response_create = _make_gate(response_create_limit, admission_wait_timeout_seconds)
@@ -81,7 +84,7 @@ class WorkAdmissionController:
         if gate is None:
             return AdmissionLease(None, stage=stage, request_id=get_request_id())
         try:
-            await asyncio.wait_for(gate.semaphore.acquire(), timeout=gate.wait_timeout_seconds)
+            await self._scheduler.wait_for(gate.semaphore.acquire(), timeout=gate.wait_timeout_seconds)
         except asyncio.TimeoutError:
             available = gate.semaphore._value  # noqa: SLF001
             message = f"codex-lb is temporarily overloaded during {stage}"

--- a/openspec/changes/add-deterministic-proxy-simulation/context.md
+++ b/openspec/changes/add-deterministic-proxy-simulation/context.md
@@ -1,0 +1,45 @@
+# Context
+
+This change is deliberately a first harness, not a complete conversion of every
+proxy timing seam. The seam audit found hundreds of direct time reads and more
+than one hundred sleeps or waits. Rewriting all of them at once would make the
+review about incidental plumbing instead of proving one deterministic lifecycle
+slice.
+
+The production adapters default to real `asyncio` and real time. Tests opt into
+virtual time by constructing services or controllers with explicit clock and
+scheduler objects. The virtual scheduler runs on the pytest loop but owns its
+timers and task registry, so tests can advance deadlines without wall-clock
+sleep and can cancel owned tasks at the reset boundary.
+
+Inside the proxy mixins the seam is read through `scheduler_for` and `clock_for`
+rather than a bare attribute. Bridge and websocket lifecycle methods are also
+called with partial service doubles, so requiring every caller to carry a
+collaborator would turn a test-only construction detail into a runtime failure.
+The accessors fall back to the real scheduler and real clock, which is the same
+production default the constructors use.
+
+The audit's third injection item, an upstream transport factory, is deliberately
+left out. The converted tests reach their upstream through the existing fake SSE
+and fake websocket doubles, so a transport factory would be new production
+surface with no consumer yet. It stays available for the next slice.
+
+The first schedule checker models the recurring lease and terminal-state bug
+class from the taxonomy: a bridge turn must reach exactly one terminal outcome
+and release response-create, API-key, and account leases exactly once even when
+admission, upstream terminal delivery, downstream cancellation, and retry
+attachment interleave.
+
+The checker drives production code rather than a model of it. Release runs
+through `_release_websocket_response_create_ownership_for_cleanup` and
+`ProxyService._release_websocket_request_state_reservation`, and the admission
+wait contends for a permit on a real `WorkAdmissionController`. Every event in a
+schedule is a concurrent task with its own seeded virtual deadline, so equal
+deadlines produce real interleaving at the await points inside those helpers.
+
+Its planted-bug canary releases the create ownership on the cancel path before
+the shared cleanup takes ownership of it, so a cancel racing an upstream
+terminal double-releases. That proves the checker fails a known bad state
+machine. The same checker also rejects a lost terminal claim, a dropped API-key
+reservation release, and a permit that is never handed back to the admission
+gate.

--- a/openspec/changes/add-deterministic-proxy-simulation/proposal.md
+++ b/openspec/changes/add-deterministic-proxy-simulation/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Proxy turn lifecycle regressions repeatedly come from timing-dependent
+interleavings: admission waits, upstream terminal events, downstream
+cancellation, retries, and lease release ownership. Existing tests cover many
+of these paths, but several rely on short real sleeps and scheduler jitter.
+
+## What Changes
+
+- Add production clock and scheduler adapters with real defaults.
+- Thread those adapters through the first audited proxy lifecycle seams.
+- Add a virtual-clock test harness that can drive selected proxy tests without
+  wall-clock sleeps.
+- Add a seeded schedule checker for bridge-turn terminal and lease-release
+  invariants, plus a canary that proves the checker catches a planted
+  double-release bug.
+
+## Impact
+
+- Affected specs: `deterministic-proxy-simulation`
+- Affected code: proxy clock/scheduler injection seams and deterministic tests.
+- No new dependency, setting, migration, dashboard surface, or production
+  behavior change.

--- a/openspec/changes/add-deterministic-proxy-simulation/specs/deterministic-proxy-simulation/spec.md
+++ b/openspec/changes/add-deterministic-proxy-simulation/specs/deterministic-proxy-simulation/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Proxy lifecycle tests can run under virtual time
+
+Proxy lifecycle code that participates in deterministic simulation MUST accept
+clock and scheduler collaborators while preserving real-time production defaults.
+The scheduler MUST provide sleep, timeout wait, task creation, drain, and
+owned-task cancellation operations. Tests MAY supply a virtual implementation
+that advances time explicitly instead of sleeping on the wall clock.
+
+#### Scenario: Production uses real time by default
+
+- **WHEN** proxy services and admission controllers are constructed without test
+  collaborators
+- **THEN** they use real clock and `asyncio` scheduler behavior
+- **AND** no operator setting or runtime configuration is required
+
+#### Scenario: Test harness advances admission timeout deterministically
+
+- **WHEN** an admission gate is saturated under a virtual scheduler
+- **THEN** the test can advance the virtual clock to the configured admission
+  timeout
+- **AND** the request observes the same local overload behavior without a real
+  sleep
+
+### Requirement: Bridge turn lifecycle schedule checking proves exactly-once settlement
+
+The deterministic simulation test suite MUST include a seeded schedule checker
+that executes at least 200 schedules by default. Each schedule MUST dispatch its
+lifecycle events as concurrent scheduler tasks with seeded virtual wake-up
+deadlines, so events sharing a deadline interleave at their await points. For
+every schedule interleaving admission wait, upstream terminal event, downstream
+cancellation, and retry request, the checker MUST assert that the bridge request
+reaches exactly one terminal outcome and releases its response-create, API-key,
+and account leases exactly once. The checker MUST also assert that the released
+response-create permit is observable by a waiting admission request, so the
+release counters cannot be satisfied by never releasing. Failure output MUST
+include the seed needed to reproduce the schedule.
+
+The checker MUST also be run against a deliberately buggy implementation and the
+test MUST assert that the checker fails that implementation.
+
+#### Scenario: Seeded schedules preserve terminal and release invariants
+
+- **WHEN** the bridge lifecycle checker runs its default schedule set
+- **THEN** at least 200 deterministic schedules are exercised
+- **AND** every schedule contains all four lifecycle events
+- **AND** every accepted schedule reaches one terminal outcome
+- **AND** every lease category is released exactly once
+- **AND** every queued admission waiter is admitted
+
+#### Scenario: Canary double release is caught
+
+- **WHEN** the same checker runs against a toy implementation whose cancel path
+  releases the response-create admission and account create lease before the
+  shared terminal cleanup takes ownership of them
+- **THEN** the checker fails the toy implementation

--- a/openspec/changes/add-deterministic-proxy-simulation/tasks.md
+++ b/openspec/changes/add-deterministic-proxy-simulation/tasks.md
@@ -1,0 +1,36 @@
+# Tasks
+
+## 1. Clock and scheduler seams
+
+- [x] 1.1 Add narrow clock and scheduler adapters with real production defaults.
+- [x] 1.2 Thread the clock through the proxy service, load balancer, and HTTP
+      bridge retry circuit seams needed by the first harness.
+- [x] 1.3 Thread scheduler waits through the selected admission, startup probe,
+      HTTP bridge, and WebSocket lifecycle seams.
+- [x] 1.4 Thread scheduler task creation through the HTTP bridge and WebSocket
+      lifecycle owners so a simulation owns every task a turn spawns.
+- [x] 1.5 Declare the clock and scheduler collaborators on the HTTP bridge and
+      WebSocket service protocols.
+- [x] 1.6 Read the collaborators through `scheduler_for`/`clock_for` inside the
+      mixins so partial service objects keep the real production default.
+
+## 2. Deterministic tests
+
+- [x] 2.1 Add a virtual-clock scheduler harness under `tests/simulation/`.
+- [x] 2.2 Convert selected admission and startup probe tests from real sleeps
+      to virtual time.
+- [x] 2.3 Convert the HTTP bridge cancel-drain idle-timeout and recovery-wait
+      tests to virtual time.
+- [x] 2.4 Add a seeded schedule-exploring bridge lifecycle property test that
+      dispatches events as concurrent scheduler tasks.
+- [x] 2.5 Add a canary proving the property checker catches a planted
+      double-release bug.
+
+## 3. Verification
+
+- [x] 3.1 Run the new and converted deterministic tests three consecutive times.
+- [x] 3.2 Run strict OpenSpec validation.
+- [x] 3.3 Run the full pytest suite and confirm no new failures beyond the
+      documented baseline.
+- [x] 3.4 Run `ruff check`, `ruff format --check`, the proxy architecture
+      ratchet, and `ty check`.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -15552,7 +15552,12 @@ async def test_v1_responses_http_bridge_stream_cancel_retires_session(
 
     first_event = await stream.__anext__()
     assert "response.created" in first_event
-    await stream.aclose()
+    # Let the upstream reader observe its queued terminal close while the
+    # downstream cancellation is scheduled.  This is the production
+    # terminal-vs-cancel interleaving that the deterministic harness models.
+    close_task = asyncio.create_task(stream.aclose())
+    await asyncio.sleep(0)
+    await close_task
 
     session_key = proxy_module._HTTPBridgeSessionKey(
         affinity_kind="prompt_cache",

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -4079,8 +4079,9 @@ async def test_v1_responses_http_bridge_reconnect_fails_when_reader_cancel_times
     blocking_reader = asyncio.create_task(blocking_reader_task())
     bridge_session.upstream_reader = blocking_reader
 
-    async def fake_await_cancelled_task(task, *, timeout_seconds=1.0, label, cleanup_tasks=None):
+    async def fake_await_cancelled_task(task, *, timeout_seconds=1.0, label, cleanup_tasks=None, scheduler):
         del task, timeout_seconds, label, cleanup_tasks
+        assert scheduler is service._scheduler
         return False
 
     monkeypatch.setattr(proxy_module, "_await_cancelled_task", fake_await_cancelled_task)

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -15051,7 +15051,12 @@ async def test_v1_responses_http_bridge_stream_cancel_retires_session(
 
     first_event = await stream.__anext__()
     assert "response.created" in first_event
-    await stream.aclose()
+    # Let the upstream reader observe its queued terminal close while the
+    # downstream cancellation is scheduled.  This is the production
+    # terminal-vs-cancel interleaving that the deterministic harness models.
+    close_task = asyncio.create_task(stream.aclose())
+    await asyncio.sleep(0)
+    await close_task
 
     session_key = proxy_module._HTTPBridgeSessionKey(
         affinity_kind="prompt_cache",

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -1318,10 +1318,10 @@ async def test_codex_realtime_call_failure_logs_redact_account_identifiers(
         fake_fresh_with_failover,
     )
     if failure_branch == "before-upstream":
-        remaining = iter((1.0, 0.0))
+        remaining = iter((0.0,))
         monkeypatch.setattr(proxy_module, "_remaining_budget_seconds", lambda _deadline: next(remaining))
     elif failure_branch == "before-forced-refresh":
-        remaining = iter((1.0, 1.0, 0.0))
+        remaining = iter((1.0, 0.0))
         monkeypatch.setattr(proxy_module, "_remaining_budget_seconds", lambda _deadline: next(remaining))
     else:
         monkeypatch.setattr(proxy_module, "_remaining_budget_seconds", lambda _deadline: 1.0)
@@ -1389,7 +1389,11 @@ async def test_codex_realtime_call_shared_freshness_budget_log_redacts_account_i
 
     remaining_budget = iter((1.0, 0.0))
     monkeypatch.setattr(proxy_module, "core_codex_control_request", unexpected_codex_control_request)
-    monkeypatch.setattr(proxy_module, "_remaining_budget_seconds", lambda _deadline: next(remaining_budget))
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_remaining_budget_seconds",
+        lambda _self, _deadline: next(remaining_budget),
+    )
 
     caplog.clear()
     with caplog.at_level(logging.WARNING):

--- a/tests/integration/test_proxy_api_extended.py
+++ b/tests/integration/test_proxy_api_extended.py
@@ -1387,7 +1387,9 @@ async def test_codex_realtime_call_shared_freshness_budget_log_redacts_account_i
     async def unexpected_codex_control_request(*_args, **_kwargs):
         raise AssertionError("freshness budget exhaustion must prevent the upstream call")
 
-    remaining_budget = iter((1.0, 0.0))
+    # Account selection now consumes its own scheduler-owned timeout budget;
+    # keep that stage live, then exhaust the shared deadline at freshness.
+    remaining_budget = iter((1.0, 1.0, 0.0))
     monkeypatch.setattr(proxy_module, "core_codex_control_request", unexpected_codex_control_request)
     monkeypatch.setattr(
         proxy_module.ProxyService,

--- a/tests/simulation/__init__.py
+++ b/tests/simulation/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic simulation helpers for proxy lifecycle tests."""

--- a/tests/simulation/test_proxy_turn_lifecycle_property.py
+++ b/tests/simulation/test_proxy_turn_lifecycle_property.py
@@ -1,0 +1,351 @@
+"""Seeded schedule exploration for the proxy bridge turn lifecycle.
+
+`TEST_AUDIT.md` names this as the first property worth checking: for any
+interleaving of an admission wait, an upstream terminal event, a downstream
+cancellation and a retry request, a bridge request must reach exactly one
+terminal outcome and must release its response-create, API-key and account
+leases exactly once.
+
+Every schedule runs on the deterministic ``VirtualScheduler``. Each lifecycle
+event is a concurrent task that wakes at a seeded virtual deadline, so events
+sharing a deadline genuinely interleave at their ``await`` points instead of
+running in a fixed order. Lease release is performed by the production helpers
+(``_release_websocket_response_create_ownership_for_cleanup`` and
+``ProxyService._release_websocket_request_state_reservation``) against a real
+``WorkAdmissionController`` gate, so the checker observes product behavior
+rather than a re-implementation of it.
+
+The canary at the bottom runs the same checker against a toy turn with a
+planted double-release-on-cancel bug and asserts that the checker rejects it.
+A checker that cannot catch a planted bug proves nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, Literal, Protocol, cast
+
+import pytest
+
+from app.modules.api_keys.service import ApiKeyUsageReservationData
+from app.modules.proxy import service as proxy_service
+from app.modules.proxy._service.websocket.mixin import _release_websocket_response_create_ownership_for_cleanup
+from app.modules.proxy.work_admission import AdmissionLease, WorkAdmissionController
+from tests.simulation.virtual_time import VirtualClock, VirtualScheduler
+
+pytestmark = pytest.mark.unit
+
+ScheduleEvent = Literal["admission_wait", "upstream_terminal", "downstream_cancel", "retry_request"]
+Terminal = Literal["upstream_terminal", "downstream_cancel"]
+
+_EVENTS: tuple[ScheduleEvent, ...] = (
+    "admission_wait",
+    "upstream_terminal",
+    "downstream_cancel",
+    "retry_request",
+)
+# Repeated zero delays make simultaneous wakeups - and therefore true
+# interleaving at the await points inside the production release helpers - the
+# common case rather than a rare one.
+_STEP_DELAYS: tuple[float, ...] = (0.0, 0.0, 0.05, 0.1)
+_SCHEDULE_COUNT = 200
+_MAX_EXTRA_EVENTS = 3
+_ADVANCE_SECONDS = 0.05
+_ADVANCE_STEPS = 8
+_ADMISSION_TIMEOUT_SECONDS = 10.0
+
+ScheduleStep = tuple[ScheduleEvent, float]
+Schedule = tuple[ScheduleStep, ...]
+
+
+class _BridgeTurn(Protocol):
+    async def start(self) -> None: ...
+
+    async def dispatch(self, event: ScheduleEvent, delay: float) -> None: ...
+
+    def snapshot(self) -> "_TurnSnapshot": ...
+
+    async def aclose(self) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class _TurnSnapshot:
+    terminal_outcomes: tuple[Terminal, ...]
+    response_create_releases: int
+    api_key_releases: int
+    account_releases: int
+    retry_terminal_events: tuple[Terminal, ...]
+    admission_waiters: int
+    admission_waiters_admitted: int
+
+
+class _CountingAdmissionLease:
+    """Counts release calls while delegating to a real ``AdmissionLease``.
+
+    ``AdmissionLease.release`` is idempotent on purpose, so the semaphore alone
+    cannot tell a single release apart from a double release. Counting the
+    calls is what the "released exactly once" invariant is actually about.
+    """
+
+    def __init__(self, lease: AdmissionLease) -> None:
+        self.lease = lease
+        self.release_count = 0
+
+    def release(self) -> None:
+        self.release_count += 1
+        self.lease.release()
+
+
+class _RecordingProxyService(proxy_service.ProxyService):
+    """Proxy service that counts API-key reservation releases.
+
+    Subclassing keeps the production call graph intact instead of patching a
+    bound method onto an instance.
+    """
+
+    def __init__(self, repo_factory: Any, *, clock: VirtualClock, scheduler: VirtualScheduler) -> None:
+        super().__init__(repo_factory, clock=clock, scheduler=scheduler)
+        self.api_key_releases = 0
+
+    async def _release_websocket_reservation(self, reservation: ApiKeyUsageReservationData | None) -> None:
+        if reservation is not None:
+            self.api_key_releases += 1
+
+
+class _ProductionBridgeTurn:
+    """One bridge turn driven through the production lease-release helpers."""
+
+    def __init__(self, scheduler: VirtualScheduler) -> None:
+        self.scheduler = scheduler
+        self.terminal_outcomes: list[Terminal] = []
+        self.retry_terminal_events: list[Terminal] = []
+        self.account_releases = 0
+        self.admission_waiters = 0
+        self.admission_waiters_admitted = 0
+        self._retry_attached = False
+        self.service = _RecordingProxyService(
+            cast(Any, SimpleNamespace()),
+            clock=scheduler.clock,
+            scheduler=scheduler,
+        )
+        # A single response-create permit: this turn holds it, so an admission
+        # wait can only be admitted once the terminal path hands it back.
+        self.admission = WorkAdmissionController(
+            token_refresh_limit=0,
+            websocket_connect_limit=0,
+            response_create_limit=1,
+            compact_response_create_limit=0,
+            admission_wait_timeout_seconds=_ADMISSION_TIMEOUT_SECONDS,
+            scheduler=scheduler,
+        )
+        self.response_create_gate = asyncio.Semaphore(0)
+        self.admission_lease: _CountingAdmissionLease | None = None
+        self.request_state = proxy_service._WebSocketRequestState(
+            request_id="req-property",
+            model="gpt-5.5",
+            service_tier=None,
+            reasoning_effort=None,
+            api_key_reservation=ApiKeyUsageReservationData(
+                reservation_id="reservation-property",
+                key_id="key-property",
+                model="gpt-5.5",
+            ),
+            started_at=0.0,
+            response_id=None,
+            awaiting_response_created=True,
+            event_queue=asyncio.Queue(),
+            transport="http",
+            skip_request_log=True,
+        )
+
+    async def start(self) -> None:
+        """Arm the turn with the three leases a live bridge request owns."""
+
+        lease = _CountingAdmissionLease(await self.admission.acquire_response_create())
+        self.admission_lease = lease
+        self.request_state.response_create_admission = cast(Any, lease)
+        self.request_state.response_create_gate = self.response_create_gate
+        self.request_state.response_create_gate_acquired = True
+        self.request_state.account_response_create_lease = cast(Any, "account-create-lease")
+        self.request_state.account_response_create_release = self._release_account_create_lease
+
+    async def aclose(self) -> None:
+        lease = self.admission_lease
+        if lease is not None:
+            # Idempotent, and deliberately untracked: this only hands the
+            # permit back when a schedule left the turn unsettled.
+            lease.lease.release()
+
+    async def _release_account_create_lease(self, lease: object) -> None:
+        assert lease == "account-create-lease"
+        self.account_releases += 1
+
+    async def dispatch(self, event: ScheduleEvent, delay: float) -> None:
+        await self.scheduler.sleep(delay)
+        await self.handle(event)
+
+    async def handle(self, event: ScheduleEvent) -> None:
+        if event == "admission_wait":
+            await self._wait_for_admission()
+            return
+        if event == "retry_request":
+            self._retry_attached = True
+            return
+        await self._settle(event)
+
+    async def _wait_for_admission(self) -> None:
+        """A queued request contending for the permit this turn still holds.
+
+        It can only be admitted once the terminal path hands the response-create
+        permit back to the real gate, then it releases the permit again so a
+        later waiter in the same schedule can be admitted too.
+        """
+
+        self.admission_waiters += 1
+        lease = await self.admission.acquire_response_create()
+        self.admission_waiters_admitted += 1
+        lease.release()
+
+    async def _settle(self, terminal: Terminal) -> None:
+        if not self._claim_terminal(terminal):
+            return
+        await _release_websocket_response_create_ownership_for_cleanup(
+            self.request_state,
+            self.response_create_gate,
+        )
+        await self.service._release_websocket_request_state_reservation(self.request_state)
+
+    def _claim_terminal(self, terminal: Terminal) -> bool:
+        if self.request_state.terminal_settlement_phase is not None or self.terminal_outcomes:
+            return False
+        self.request_state.terminal_settlement_phase = "claimed"
+        self._record_settled(terminal)
+        return True
+
+    def _record_settled(self, terminal: Terminal) -> None:
+        if self.terminal_outcomes and self._retry_attached:
+            # A retry attached and a later terminal still settled the request a
+            # second time - the exact shape the invariant forbids.
+            self.retry_terminal_events.append(terminal)
+        self.terminal_outcomes.append(terminal)
+
+    def snapshot(self) -> _TurnSnapshot:
+        lease = self.admission_lease
+        return _TurnSnapshot(
+            terminal_outcomes=tuple(self.terminal_outcomes),
+            response_create_releases=0 if lease is None else lease.release_count,
+            api_key_releases=self.service.api_key_releases,
+            account_releases=self.account_releases,
+            retry_terminal_events=tuple(self.retry_terminal_events),
+            admission_waiters=self.admission_waiters,
+            admission_waiters_admitted=self.admission_waiters_admitted,
+        )
+
+
+class _DoubleReleaseOnCancelBridgeTurn(_ProductionBridgeTurn):
+    """Toy turn carrying the planted bug the checker must reject.
+
+    The cancel path gives back the create ownership it observes *before* the
+    shared cleanup helper takes ownership of it, so a downstream cancel
+    releases the response-create admission and the account create lease a
+    second time. That is the "release what you no longer own" shape from
+    `TAXONOMY.md`.
+    """
+
+    async def _settle(self, terminal: Terminal) -> None:
+        if terminal == "downstream_cancel":
+            admission = self.request_state.response_create_admission
+            if admission is not None:
+                admission.release()
+            lease = self.request_state.account_response_create_lease
+            release = self.request_state.account_response_create_release
+            if lease is not None and release is not None:
+                await release(lease)
+        await super()._settle(terminal)
+
+
+def _schedule_for_seed(seed: int) -> Schedule:
+    """Build one deterministic schedule.
+
+    Every schedule contains all four lifecycle events at least once (so a
+    terminal always arrives), plus up to three repeats, each with its own
+    virtual wake-up delay.
+    """
+
+    rng = random.Random(seed)
+    events: list[ScheduleEvent] = list(_EVENTS)
+    rng.shuffle(events)
+    for _ in range(rng.randint(0, _MAX_EXTRA_EVENTS)):
+        events.insert(rng.randrange(len(events) + 1), rng.choice(_EVENTS))
+    return tuple((event, rng.choice(_STEP_DELAYS)) for event in events)
+
+
+def _assert_bridge_turn_invariants(turn: _BridgeTurn, *, seed: int, schedule: Schedule) -> None:
+    snapshot = turn.snapshot()
+    context = f"seed={seed} schedule={schedule} snapshot={snapshot}"
+    assert len(snapshot.terminal_outcomes) == 1, context
+    assert snapshot.response_create_releases == 1, context
+    assert snapshot.api_key_releases == 1, context
+    assert snapshot.account_releases == 1, context
+    assert not snapshot.retry_terminal_events, context
+    # Liveness: the permit really went back to the real admission gate, so the
+    # release counters above cannot be satisfied by never releasing at all.
+    assert snapshot.admission_waiters_admitted == snapshot.admission_waiters, context
+
+
+async def _run_schedule(turn: _BridgeTurn, schedule: Schedule, scheduler: VirtualScheduler) -> None:
+    await turn.start()
+    tasks = [scheduler.create_task(turn.dispatch(event, delay)) for event, delay in schedule]
+    await scheduler.drain()
+    for _ in range(_ADVANCE_STEPS):
+        if all(task.done() for task in tasks):
+            break
+        await scheduler.advance(_ADVANCE_SECONDS)
+    assert all(task.done() for task in tasks), f"schedule did not quiesce schedule={schedule}"
+    await asyncio.gather(*tasks)
+
+
+async def _check_schedules(
+    turn_factory: type[_ProductionBridgeTurn],
+    *,
+    schedule_count: int = _SCHEDULE_COUNT,
+) -> None:
+    for seed in range(schedule_count):
+        schedule = _schedule_for_seed(seed)
+        scheduler = VirtualScheduler(VirtualClock())
+        turn = turn_factory(scheduler)
+        try:
+            await _run_schedule(turn, schedule, scheduler)
+            _assert_bridge_turn_invariants(turn, seed=seed, schedule=schedule)
+        except BaseException:
+            # Reproduce this exact interleaving with _schedule_for_seed(<seed>).
+            print(f"bridge turn schedule check failed seed={seed} schedule={schedule}")
+            raise
+        finally:
+            await turn.aclose()
+            await scheduler.cancel_owned_tasks()
+
+
+@pytest.mark.asyncio
+async def test_bridge_turn_lifecycle_seeded_schedules_settle_exactly_once() -> None:
+    await _check_schedules(_ProductionBridgeTurn)
+
+
+@pytest.mark.asyncio
+async def test_bridge_turn_lifecycle_schedule_set_is_large_and_varied() -> None:
+    schedules = [_schedule_for_seed(seed) for seed in range(_SCHEDULE_COUNT)]
+
+    assert len(schedules) >= 200
+    assert len(set(schedules)) >= 150, "the seeded schedules collapse onto too few interleavings"
+    for schedule in schedules:
+        events = [event for event, _delay in schedule]
+        assert set(_EVENTS).issubset(events)
+
+
+@pytest.mark.asyncio
+async def test_bridge_turn_lifecycle_checker_catches_double_release_canary() -> None:
+    with pytest.raises(AssertionError, match="response_create_releases"):
+        await _check_schedules(_DoubleReleaseOnCancelBridgeTurn)

--- a/tests/simulation/test_proxy_turn_lifecycle_property.py
+++ b/tests/simulation/test_proxy_turn_lifecycle_property.py
@@ -15,15 +15,18 @@ running in a fixed order. Lease release is performed by the production helpers
 ``WorkAdmissionController`` gate, so the checker observes product behavior
 rather than a re-implementation of it.
 
-The canary at the bottom runs the same checker against a toy turn with a
-planted double-release-on-cancel bug and asserts that the checker rejects it.
-A checker that cannot catch a planted bug proves nothing.
+After settlement, retry requests run through the production pre-created retry
+operation against the same pending-owner deque. The canaries at the bottom
+plant double-release-on-cancel and post-settlement retry-reacquisition bugs and
+assert that the checker rejects both. A checker that cannot catch a planted bug
+proves nothing.
 """
 
 from __future__ import annotations
 
 import asyncio
 import random
+from collections import deque
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, Literal, Protocol, cast
@@ -74,10 +77,11 @@ class _BridgeTurn(Protocol):
 @dataclass(frozen=True, slots=True)
 class _TurnSnapshot:
     terminal_outcomes: tuple[Terminal, ...]
+    terminal_attempts: tuple[Terminal, ...]
     response_create_releases: int
     api_key_releases: int
     account_releases: int
-    retry_terminal_events: tuple[Terminal, ...]
+    retry_results: tuple[bool, ...]
     admission_waiters: int
     admission_waiters_admitted: int
 
@@ -106,13 +110,39 @@ class _RecordingProxyService(proxy_service.ProxyService):
     bound method onto an instance.
     """
 
-    def __init__(self, repo_factory: Any, *, clock: VirtualClock, scheduler: VirtualScheduler) -> None:
+    def __init__(
+        self,
+        repo_factory: Any,
+        *,
+        clock: VirtualClock,
+        scheduler: VirtualScheduler,
+        work_admission: WorkAdmissionController,
+    ) -> None:
         super().__init__(repo_factory, clock=clock, scheduler=scheduler)
         self.api_key_releases = 0
+        self._retry_work_admission = work_admission
 
     async def _release_websocket_reservation(self, reservation: ApiKeyUsageReservationData | None) -> None:
         if reservation is not None:
             self.api_key_releases += 1
+
+    async def _reconnect_http_bridge_session(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    async def _release_retry_account_lease(self, _lease: object) -> None:
+        return None
+
+    def _get_work_admission(self) -> WorkAdmissionController:
+        return self._retry_work_admission
+
+    def _http_bridge_text_with_account_installation_id(
+        self,
+        session: Any,
+        request_state: Any,
+        text_data: str,
+    ) -> str:
+        del session, request_state
+        return text_data
 
 
 class _ProductionBridgeTurn:
@@ -121,16 +151,12 @@ class _ProductionBridgeTurn:
     def __init__(self, scheduler: VirtualScheduler) -> None:
         self.scheduler = scheduler
         self.terminal_outcomes: list[Terminal] = []
-        self.retry_terminal_events: list[Terminal] = []
+        self.terminal_attempts: list[Terminal] = []
+        self.retry_results: list[bool] = []
         self.account_releases = 0
         self.admission_waiters = 0
         self.admission_waiters_admitted = 0
-        self._retry_attached = False
-        self.service = _RecordingProxyService(
-            cast(Any, SimpleNamespace()),
-            clock=scheduler.clock,
-            scheduler=scheduler,
-        )
+        self._settled = asyncio.Event()
         # A single response-create permit: this turn holds it, so an admission
         # wait can only be admitted once the terminal path hands it back.
         self.admission = WorkAdmissionController(
@@ -141,8 +167,15 @@ class _ProductionBridgeTurn:
             admission_wait_timeout_seconds=_ADMISSION_TIMEOUT_SECONDS,
             scheduler=scheduler,
         )
+        self.service = _RecordingProxyService(
+            cast(Any, SimpleNamespace()),
+            clock=scheduler.clock,
+            scheduler=scheduler,
+            work_admission=self.admission,
+        )
         self.response_create_gate = asyncio.Semaphore(0)
         self.admission_lease: _CountingAdmissionLease | None = None
+        self.retry_sends = 0
         self.request_state = proxy_service._WebSocketRequestState(
             request_id="req-property",
             model="gpt-5.5",
@@ -159,6 +192,25 @@ class _ProductionBridgeTurn:
             event_queue=asyncio.Queue(),
             transport="http",
             skip_request_log=True,
+            request_text='{"type":"response.create","model":"gpt-5.5","input":[]}',
+            bridge_request_deadline=1_000_000_000_000.0,
+        )
+        # Terminal bookkeeping owns a request by removing it from the pending
+        # deque under this lock. The production pre-created retry path checks
+        # the same ownership before it can reconnect or reacquire admission.
+        self.session = SimpleNamespace(
+            key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "property-retry", None),
+            pending_requests=deque([self.request_state]),
+            pending_lock=asyncio.Lock(),
+            account=SimpleNamespace(id="account-property-retry"),
+            headers={},
+            request_model="gpt-5.5",
+            upstream_turn_state=None,
+            downstream_turn_state=None,
+            last_upstream_close_code=None,
+            last_upstream_close_generation=0,
+            upstream_reader_wakeup=asyncio.Event(),
+            upstream=SimpleNamespace(send_text=self._record_retry_send),
         )
 
     async def start(self) -> None:
@@ -183,6 +235,9 @@ class _ProductionBridgeTurn:
         assert lease == "account-create-lease"
         self.account_releases += 1
 
+    async def _record_retry_send(self, _text: str) -> None:
+        self.retry_sends += 1
+
     async def dispatch(self, event: ScheduleEvent, delay: float) -> None:
         await self.scheduler.sleep(delay)
         await self.handle(event)
@@ -192,9 +247,26 @@ class _ProductionBridgeTurn:
             await self._wait_for_admission()
             return
         if event == "retry_request":
-            self._retry_attached = True
+            await self._retry_after_settlement()
             return
         await self._settle(event)
+
+    async def _retry_after_settlement(self) -> None:
+        """Drive the real retry owner check after terminal cleanup.
+
+        A retry may be requested before or during terminal bookkeeping, so it
+        waits for that bookkeeping to finish. The production retry operation
+        must then reject the request because terminal ownership removed it from
+        ``pending_requests``; reaching reconnect or admission reacquisition
+        would return ``True`` and violate the property.
+        """
+
+        await self._settled.wait()
+        retried = await self.service._retry_http_bridge_precreated_request(
+            cast(Any, self.session),
+            request_state=self.request_state,
+        )
+        self.retry_results.append(retried)
 
     async def _wait_for_admission(self) -> None:
         """A queued request contending for the permit this turn still holds.
@@ -210,36 +282,41 @@ class _ProductionBridgeTurn:
         lease.release()
 
     async def _settle(self, terminal: Terminal) -> None:
-        if not self._claim_terminal(terminal):
+        if not await self._claim_terminal(terminal):
             return
-        await _release_websocket_response_create_ownership_for_cleanup(
-            self.request_state,
-            self.response_create_gate,
-        )
-        await self.service._release_websocket_request_state_reservation(self.request_state)
+        try:
+            await _release_websocket_response_create_ownership_for_cleanup(
+                self.request_state,
+                self.response_create_gate,
+            )
+            await self.service._release_websocket_request_state_reservation(self.request_state)
+        finally:
+            self._settled.set()
 
-    def _claim_terminal(self, terminal: Terminal) -> bool:
-        if self.request_state.terminal_settlement_phase is not None or self.terminal_outcomes:
-            return False
-        self.request_state.terminal_settlement_phase = "claimed"
-        self._record_settled(terminal)
-        return True
-
-    def _record_settled(self, terminal: Terminal) -> None:
-        if self.terminal_outcomes and self._retry_attached:
-            # A retry attached and a later terminal still settled the request a
-            # second time - the exact shape the invariant forbids.
-            self.retry_terminal_events.append(terminal)
-        self.terminal_outcomes.append(terminal)
+    async def _claim_terminal(self, terminal: Terminal) -> bool:
+        # Record attempts before the claim guard so losing terminal tasks stay
+        # visible to the schedule oracle instead of disappearing as no-ops.
+        self.terminal_attempts.append(terminal)
+        async with self.session.pending_lock:
+            if (
+                self.request_state.terminal_settlement_phase is not None
+                or self.request_state not in self.session.pending_requests
+            ):
+                return False
+            self.session.pending_requests.remove(self.request_state)
+            self.request_state.terminal_settlement_phase = "claimed"
+            self.terminal_outcomes.append(terminal)
+            return True
 
     def snapshot(self) -> _TurnSnapshot:
         lease = self.admission_lease
         return _TurnSnapshot(
             terminal_outcomes=tuple(self.terminal_outcomes),
+            terminal_attempts=tuple(self.terminal_attempts),
             response_create_releases=0 if lease is None else lease.release_count,
             api_key_releases=self.service.api_key_releases,
             account_releases=self.account_releases,
-            retry_terminal_events=tuple(self.retry_terminal_events),
+            retry_results=tuple(self.retry_results),
             admission_waiters=self.admission_waiters,
             admission_waiters_admitted=self.admission_waiters_admitted,
         )
@@ -267,6 +344,41 @@ class _DoubleReleaseOnCancelBridgeTurn(_ProductionBridgeTurn):
         await super()._settle(terminal)
 
 
+class _RetryReacquiresAfterSettlementBridgeTurn(_ProductionBridgeTurn):
+    """Toy turn carrying a post-settlement retry ownership bug.
+
+    It plants stale pending ownership after terminal cleanup, then drives the
+    production retry operation through reconnect, admission reacquisition,
+    upstream send and cleanup. The old checker missed this exact behavior
+    because ``retry_request`` only toggled a flag.
+    """
+
+    def __init__(self, scheduler: VirtualScheduler) -> None:
+        super().__init__(scheduler)
+        self._retry_canary_lock = asyncio.Lock()
+
+    async def _retry_after_settlement(self) -> None:
+        async with self._retry_canary_lock:
+            await self._settled.wait()
+            if any(self.retry_results):
+                self.retry_results.append(False)
+                return
+            self.session.pending_requests.append(self.request_state)
+            self.request_state.awaiting_response_created = True
+            self.request_state.event_queue = asyncio.Queue()
+            self.request_state.replay_count = 0
+            self.request_state.response_create_admission_reacquire_required = True
+            self.request_state.account_response_create_lease = cast(Any, "retry-account-create-lease")
+            self.request_state.account_response_create_release = self.service._release_retry_account_lease
+            await super()._retry_after_settlement()
+            if self.retry_results[-1]:
+                assert self.retry_sends > 0
+                await _release_websocket_response_create_ownership_for_cleanup(
+                    self.request_state,
+                    self.response_create_gate,
+                )
+
+
 def _schedule_for_seed(seed: int) -> Schedule:
     """Build one deterministic schedule.
 
@@ -286,11 +398,15 @@ def _schedule_for_seed(seed: int) -> Schedule:
 def _assert_bridge_turn_invariants(turn: _BridgeTurn, *, seed: int, schedule: Schedule) -> None:
     snapshot = turn.snapshot()
     context = f"seed={seed} schedule={schedule} snapshot={snapshot}"
+    expected_terminal_attempts = sum(event in {"upstream_terminal", "downstream_cancel"} for event, _delay in schedule)
+    expected_retry_attempts = sum(event == "retry_request" for event, _delay in schedule)
     assert len(snapshot.terminal_outcomes) == 1, context
+    assert len(snapshot.terminal_attempts) == expected_terminal_attempts, context
     assert snapshot.response_create_releases == 1, context
     assert snapshot.api_key_releases == 1, context
     assert snapshot.account_releases == 1, context
-    assert not snapshot.retry_terminal_events, context
+    assert len(snapshot.retry_results) == expected_retry_attempts, context
+    assert not any(snapshot.retry_results), context
     # Liveness: the permit really went back to the real admission gate, so the
     # release counters above cannot be satisfied by never releasing at all.
     assert snapshot.admission_waiters_admitted == snapshot.admission_waiters, context
@@ -349,3 +465,9 @@ async def test_bridge_turn_lifecycle_schedule_set_is_large_and_varied() -> None:
 async def test_bridge_turn_lifecycle_checker_catches_double_release_canary() -> None:
     with pytest.raises(AssertionError, match="response_create_releases"):
         await _check_schedules(_DoubleReleaseOnCancelBridgeTurn)
+
+
+@pytest.mark.asyncio
+async def test_bridge_turn_lifecycle_checker_catches_retry_reacquisition_canary() -> None:
+    with pytest.raises(AssertionError, match="retry_results"):
+        await _check_schedules(_RetryReacquiresAfterSettlementBridgeTurn)

--- a/tests/simulation/virtual_time.py
+++ b/tests/simulation/virtual_time.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Coroutine
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+
+
+@dataclass(slots=True)
+class VirtualClock:
+    monotonic_value: float = 0.0
+    epoch_value: float = 1_700_000_000.0
+
+    def monotonic(self) -> float:
+        return self.monotonic_value
+
+    def time(self) -> float:
+        return self.epoch_value
+
+    def now(self) -> datetime:
+        return datetime.fromtimestamp(self.epoch_value, tz=timezone.utc)
+
+    def advance(self, seconds: float) -> None:
+        if seconds < 0:
+            raise ValueError("virtual time cannot move backwards")
+        self.monotonic_value += seconds
+        self.epoch_value += seconds
+
+
+@dataclass(order=True, slots=True)
+class _Timer:
+    deadline: float
+    sequence: int
+    future: asyncio.Future[Any] = field(compare=False)
+    result: Any = field(compare=False)
+
+
+class VirtualScheduler:
+    def __init__(self, clock: VirtualClock) -> None:
+        self.clock = clock
+        self._timers: list[_Timer] = []
+        self._tasks: set[asyncio.Task[Any]] = set()
+        self._sequence = 0
+
+    async def sleep(self, delay: float, result: T | None = None) -> T | None:
+        if delay <= 0:
+            await asyncio.sleep(0)
+            return result
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[T | None] = loop.create_future()
+        self._sequence += 1
+        self._timers.append(_Timer(self.clock.monotonic() + delay, self._sequence, future, result))
+        self._timers.sort()
+        return await future
+
+    async def wait_for(self, awaitable: Awaitable[T], timeout: float | None) -> T:
+        task = asyncio.ensure_future(awaitable)
+        if timeout is None:
+            return await task
+        timeout_task = self.create_task(self.sleep(timeout))
+        try:
+            done, pending = await asyncio.wait({task, timeout_task}, return_when=asyncio.FIRST_COMPLETED)
+            if timeout_task in done:
+                task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+                raise asyncio.TimeoutError
+            timeout_task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            return task.result()
+        except asyncio.CancelledError:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            timeout_task.cancel()
+            await asyncio.gather(timeout_task, return_exceptions=True)
+            raise
+
+    def create_task(self, coroutine: Coroutine[Any, Any, T], *, name: str | None = None) -> asyncio.Task[T]:
+        task = asyncio.create_task(coroutine, name=name)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task
+
+    async def advance(self, seconds: float) -> None:
+        self.clock.advance(seconds)
+        due = [timer for timer in self._timers if timer.deadline <= self.clock.monotonic()]
+        self._timers = [timer for timer in self._timers if timer.deadline > self.clock.monotonic()]
+        for timer in due:
+            if not timer.future.done():
+                timer.future.set_result(timer.result)
+        await self.drain()
+
+    async def drain(self) -> None:
+        for _ in range(8):
+            await asyncio.sleep(0)
+
+    async def cancel_owned_tasks(self) -> None:
+        tasks = list(self._tasks)
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._tasks.clear()
+        for timer in self._timers:
+            if not timer.future.done():
+                timer.future.cancel()
+        self._timers.clear()

--- a/tests/simulation/virtual_time.py
+++ b/tests/simulation/virtual_time.py
@@ -63,13 +63,13 @@ class VirtualScheduler:
         timeout_task = self.create_task(self.sleep(timeout))
         try:
             done, pending = await asyncio.wait({task, timeout_task}, return_when=asyncio.FIRST_COMPLETED)
-            if timeout_task in done:
-                task.cancel()
-                await asyncio.gather(task, return_exceptions=True)
-                raise asyncio.TimeoutError
-            timeout_task.cancel()
-            await asyncio.gather(*pending, return_exceptions=True)
-            return task.result()
+            if task in done:
+                timeout_task.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
+                return task.result()
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            raise asyncio.TimeoutError
         except asyncio.CancelledError:
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)

--- a/tests/unit/test_http_bridge_cancel_drain.py
+++ b/tests/unit/test_http_bridge_cancel_drain.py
@@ -16,8 +16,10 @@ from app.core.clients.proxy_websocket import UpstreamWebSocket
 from app.db.models import AccountStatus, Base
 from app.modules.api_keys.service import ApiKeyData, ApiKeyUsageReservationData
 from app.modules.proxy import service as proxy_service
+from app.modules.proxy._service.http_bridge import helpers as http_bridge_helpers
 from app.modules.proxy._service.http_bridge import upstream_events as http_bridge_upstream_events
 from app.modules.proxy.durable_bridge_coordinator import DurableBridgeSessionCoordinator
+from tests.simulation.virtual_time import VirtualClock, VirtualScheduler
 
 pytestmark = pytest.mark.unit
 
@@ -138,6 +140,29 @@ async def test_cancelled_stream_settlement_task_releases_reservation(
     assert ("release_stream_api_key_reservation_after_cancelled_settlement", "req-cancel-settle") in scheduled
     assert ("key-cancel-settle", "res-cancel-settle") in scheduled
     assert release_retry_flags == [True]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_task_cleanup_is_scheduler_owned() -> None:
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    cleanup_tasks: set[asyncio.Task[None]] = set()
+    blocked = asyncio.Event()
+    task = scheduler.create_task(blocked.wait())
+
+    await scheduler.drain()
+    http_bridge_helpers._cancel_and_track_cancelled_task(
+        task,
+        label="owned-cleanup",
+        cleanup_tasks=cleanup_tasks,
+        scheduler=scheduler,
+    )
+
+    assert cleanup_tasks
+    await scheduler.cancel_owned_tasks()
+
+    assert task.done() is True
+    assert all(cleanup_task.done() for cleanup_task in cleanup_tasks)
 
 
 @pytest.mark.asyncio
@@ -535,7 +560,9 @@ async def test_http_bridge_detach_reclaims_abandoned_terminal_settlement(
 async def test_http_bridge_stream_idle_timeout_revokes_queue_before_completed_claim(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    service = proxy_service.ProxyService(cast(Any, SimpleNamespace()))
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    service = proxy_service.ProxyService(cast(Any, SimpleNamespace()), clock=clock, scheduler=scheduler)
     queue_waiting = asyncio.Event()
 
     class ObservedQueue(asyncio.Queue[str | None]):
@@ -591,6 +618,10 @@ async def test_http_bridge_stream_idle_timeout_revokes_queue_before_completed_cl
     finalize_request = AsyncMock()
     monkeypatch.setattr(service, "_submit_http_bridge_request", fake_submit_http_bridge_request)
     monkeypatch.setattr(service, "_detach_http_bridge_request", fake_detach_http_bridge_request)
+    # The retry circuit lookup loads durable state over the real DB session,
+    # which the virtual clock cannot advance; this scenario is about the idle
+    # timeout, so the cooldown is stubbed out rather than simulated.
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_cooldown_seconds", AsyncMock(return_value=0.0))
     monkeypatch.setattr(service, "_register_http_bridge_previous_response_id", AsyncMock(return_value=True))
     monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request)
     monkeypatch.setattr(
@@ -617,9 +648,11 @@ async def test_http_bridge_stream_idle_timeout_revokes_queue_before_completed_cl
             )
         ]
 
-    stream_task = asyncio.create_task(consume_stream())
-    await asyncio.wait_for(queue_waiting.wait(), timeout=1.0)
-    event_blocks = await asyncio.wait_for(stream_task, timeout=1.0)
+    stream_task = scheduler.create_task(consume_stream())
+    await scheduler.drain()
+    await scheduler.advance(0.001)
+    assert queue_waiting.is_set()
+    event_blocks = await stream_task
 
     assert queue_revoked_before_lock_release is True
     assert request_state.event_queue is None
@@ -638,7 +671,9 @@ async def test_http_bridge_stream_idle_timeout_revokes_queue_before_completed_cl
 async def test_http_bridge_completed_delivery_stays_dominant_after_recovery_wait(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    service = proxy_service.ProxyService(cast(Any, SimpleNamespace()))
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    service = proxy_service.ProxyService(cast(Any, SimpleNamespace()), clock=clock, scheduler=scheduler)
     recovery_started = asyncio.Event()
     release_recovery = asyncio.Event()
     event_queue: asyncio.Queue[str | None] = asyncio.Queue()
@@ -699,8 +734,10 @@ async def test_http_bridge_completed_delivery_stays_dominant_after_recovery_wait
             )
         ]
 
-    stream_task = asyncio.create_task(consume_stream())
-    await asyncio.wait_for(recovery_started.wait(), timeout=1.0)
+    stream_task = scheduler.create_task(consume_stream())
+    await scheduler.drain()
+    await scheduler.advance(0.001)
+    assert recovery_started.is_set()
 
     terminal_text = (
         '{"type":"response.completed","response":{"id":"resp-completed-during-recovery","status":"completed"}}'
@@ -711,7 +748,8 @@ async def test_http_bridge_completed_delivery_stays_dominant_after_recovery_wait
     assert request_state.completed_delivery_scope.active is False
     assert request_state.completed_delivery_scope.terminal_enqueued is True
     release_recovery.set()
-    event_blocks = await asyncio.wait_for(stream_task, timeout=1.0)
+    await scheduler.drain()
+    event_blocks = await stream_task
 
     event_types = [
         payload["type"]

--- a/tests/unit/test_http_bridge_cancel_drain.py
+++ b/tests/unit/test_http_bridge_cancel_drain.py
@@ -166,6 +166,36 @@ async def test_cancelled_task_cleanup_is_scheduler_owned() -> None:
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_reader_child_uses_owner_scheduler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+
+    async def blocked_reader() -> None:
+        await asyncio.Event().wait()
+
+    reader = scheduler.create_task(blocked_reader())
+    await scheduler.drain()
+    captured_schedulers: list[Any] = []
+
+    async def await_cancelled_task(task: asyncio.Task[Any], **kwargs: Any) -> bool:
+        captured_schedulers.append(kwargs["scheduler"])
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        return True
+
+    monkeypatch.setattr(http_bridge_upstream_events, "_await_cancelled_task", await_cancelled_task)
+
+    assert await http_bridge_upstream_events._cancel_http_bridge_reader_child(
+        reader,
+        label="owned-reader",
+        scheduler_owner=SimpleNamespace(_scheduler=scheduler),
+    )
+    assert captured_schedulers == [scheduler]
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_resource_close_uses_service_scheduler_for_reader_drain(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_http_bridge_cancel_drain.py
+++ b/tests/unit/test_http_bridge_cancel_drain.py
@@ -166,6 +166,46 @@ async def test_cancelled_task_cleanup_is_scheduler_owned() -> None:
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_resource_close_uses_service_scheduler_for_reader_drain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    session = _make_http_bridge_session(deque(), queued_request_count=0)
+
+    async def blocked_reader() -> None:
+        await asyncio.Event().wait()
+
+    reader = scheduler.create_task(blocked_reader())
+    session.upstream_reader = reader
+    await scheduler.drain()
+
+    captured_schedulers: list[Any] = []
+
+    async def await_cancelled_task(task: asyncio.Task[Any], **kwargs: Any) -> bool:
+        captured_schedulers.append(kwargs["scheduler"])
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        return True
+
+    monkeypatch.setattr(http_bridge_helpers, "_await_cancelled_task", await_cancelled_task)
+    service = SimpleNamespace(
+        _scheduler=scheduler,
+        _background_cleanup_tasks=set(),
+        _unregister_http_bridge_turn_states=AsyncMock(),
+        _unregister_http_bridge_previous_response_ids=AsyncMock(),
+        _load_balancer=SimpleNamespace(release_account_lease=AsyncMock()),
+        _fail_pending_websocket_requests=AsyncMock(),
+    )
+
+    await http_bridge_helpers._close_http_bridge_session_resources(service, session)
+
+    assert captured_schedulers == [scheduler]
+    assert reader.cancelled()
+    assert session.upstream_reader is None
+
+
+@pytest.mark.asyncio
 async def test_cancelled_http_bridge_request_retires_session_before_retry_overlap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_http_bridge_idle_leases.py
+++ b/tests/unit/test_http_bridge_idle_leases.py
@@ -21,8 +21,21 @@ from app.modules.api_keys.service import ApiKeyRequestUsageBudget
 from app.modules.proxy import service as proxy_service
 from app.modules.proxy._service.http_bridge import request_submit as http_bridge_request_submit_module
 from app.modules.proxy.load_balancer import LoadBalancer
+from tests.simulation.virtual_time import VirtualClock, VirtualScheduler
 
 pytestmark = pytest.mark.unit
+
+
+class _RecordingVirtualScheduler(VirtualScheduler):
+    def __init__(self, clock: VirtualClock) -> None:
+        super().__init__(clock)
+        self.task_names: list[str | None] = []
+        self.task_coroutines: list[str] = []
+
+    def create_task(self, coroutine: Any, *, name: str | None = None) -> asyncio.Task[Any]:
+        self.task_names.append(name)
+        self.task_coroutines.append(coroutine.cr_code.co_name)
+        return super().create_task(coroutine, name=name)
 
 
 def _make_bridge_session(
@@ -424,7 +437,8 @@ async def test_response_create_admission_failure_releases_reacquired_stream_leas
 async def test_final_lease_check_failure_removes_admission_waiter(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    scheduler = _RecordingVirtualScheduler(VirtualClock())
+    service = proxy_service.ProxyService(cast(Any, nullcontext()), scheduler=scheduler)
     session = _make_bridge_session()
     lease = _make_lease("l-final-check")
     release_account_lease = AsyncMock()
@@ -476,6 +490,7 @@ async def test_final_lease_check_failure_removes_admission_waiter(
     assert session.queued_request_count == 0
     assert session.account_lease is None
     release_account_lease.assert_awaited_once_with(lease)
+    assert "_cleanup_http_bridge_submit_interruption" in scheduler.task_coroutines
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -40,6 +40,7 @@ from app.modules.proxy.load_balancer import (
     _state_from_account,
     background_recovery_state_from_account,
 )
+from tests.simulation.virtual_time import VirtualClock
 
 pytestmark = pytest.mark.unit
 
@@ -1792,6 +1793,64 @@ def test_apply_usage_quota_respects_runtime_reset_for_quota_exceeded(monkeypatch
     assert status == AccountStatus.QUOTA_EXCEEDED
     assert used_percent == 50.0
     assert reset_at == future
+
+
+@pytest.mark.parametrize(
+    ("status", "primary_used", "secondary_used"),
+    [
+        (AccountStatus.QUOTA_EXCEEDED, None, 50.0),
+        (AccountStatus.RATE_LIMITED, 50.0, None),
+        (AccountStatus.RATE_LIMITED, None, 50.0),
+    ],
+)
+def test_apply_usage_quota_uses_explicit_evaluation_time_for_runtime_recovery(
+    status: AccountStatus,
+    primary_used: float | None,
+    secondary_used: float | None,
+) -> None:
+    clock = VirtualClock(epoch_value=2_000_000_000.0)
+
+    recovered, _, reset_at = apply_usage_quota(
+        status=status,
+        primary_used=primary_used,
+        primary_reset=None,
+        primary_window_minutes=None,
+        runtime_reset=clock.time() - 1.0,
+        secondary_used=secondary_used,
+        secondary_reset=None,
+        now=clock.time(),
+    )
+    blocked, _, blocked_reset_at = apply_usage_quota(
+        status=status,
+        primary_used=primary_used,
+        primary_reset=None,
+        primary_window_minutes=None,
+        runtime_reset=clock.time() + 1.0,
+        secondary_used=secondary_used,
+        secondary_reset=None,
+        now=clock.time(),
+    )
+
+    assert recovered == AccountStatus.ACTIVE
+    assert reset_at is None
+    assert blocked == status
+    assert blocked_reset_at == clock.time() + 1.0
+
+
+def test_state_from_account_passes_injected_time_to_runtime_recovery() -> None:
+    clock = VirtualClock(epoch_value=2_000_000_000.0)
+    account = _make_test_account(status=AccountStatus.RATE_LIMITED, reset_at=int(clock.time() - 1.0))
+
+    state = _state_from_account(
+        account=account,
+        primary_entry=_make_test_usage(window="primary", used_percent=50.0),
+        secondary_entry=None,
+        runtime=RuntimeState(reset_at=clock.time() - 1.0),
+        now=clock.time(),
+    )
+
+    assert state.status == AccountStatus.ACTIVE
+    assert state.reset_at is None
 
 
 def test_apply_usage_quota_respects_runtime_reset_for_rate_limited(monkeypatch):

--- a/tests/unit/test_load_balancer.py
+++ b/tests/unit/test_load_balancer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import random
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -38,6 +38,7 @@ from app.modules.proxy.load_balancer import (
     _select_long_window_entry,
     _state_above_sticky_budget_threshold,
     _state_from_account,
+    _usage_entry_is_recent_enough,
     background_recovery_state_from_account,
 )
 from tests.simulation.virtual_time import VirtualClock
@@ -1679,9 +1680,8 @@ def test_select_account_caps_cooldown_retry_hint():
     assert states[0].cooldown_until == now + 86_400
 
 
-def test_apply_usage_quota_sets_fallback_reset_for_primary_window(monkeypatch):
+def test_apply_usage_quota_sets_fallback_reset_from_evaluation_time():
     now = 1_700_000_000.0
-    monkeypatch.setattr("app.core.usage.quota.time.time", lambda: now)
     status, used_percent, reset_at = apply_usage_quota(
         status=AccountStatus.ACTIVE,
         primary_used=100.0,
@@ -1690,11 +1690,21 @@ def test_apply_usage_quota_sets_fallback_reset_for_primary_window(monkeypatch):
         runtime_reset=None,
         secondary_used=None,
         secondary_reset=None,
+        now=now,
     )
     assert status == AccountStatus.RATE_LIMITED
     assert used_percent == 100.0
     assert reset_at is not None
     assert reset_at == pytest.approx(now + 60.0)
+
+
+def test_usage_recency_uses_injected_evaluation_time() -> None:
+    clock = VirtualClock(epoch_value=2_000_000_000.0)
+    recent = datetime.fromtimestamp(clock.time() - 179.0, tz=timezone.utc)
+    stale = datetime.fromtimestamp(clock.time() - 181.0, tz=timezone.utc)
+
+    assert _usage_entry_is_recent_enough(recent, now=clock.time())
+    assert not _usage_entry_is_recent_enough(stale, now=clock.time())
 
 
 def test_apply_usage_quota_secondary_exhausted_without_credits_sets_quota_exceeded():

--- a/tests/unit/test_load_balancer_concurrency.py
+++ b/tests/unit/test_load_balancer_concurrency.py
@@ -108,6 +108,59 @@ def test_probe_selection_uses_injected_clock() -> None:
     assert reservation is None
 
 
+@pytest.mark.asyncio
+async def test_record_errors_uses_injected_clock() -> None:
+    clock = VirtualClock(epoch_value=2_000_000_000.0)
+    account = _make_account("acc-virtual-clock-error")
+    balancer = LoadBalancer(
+        lambda: _repo_factory(_StubAccountsRepository([account]), _StubUsageRepository({}, {})),
+        clock=clock,
+    )
+
+    await balancer.record_errors(account, 2)
+
+    runtime = balancer._runtime[account.id]
+    assert runtime.error_count == 2
+    assert runtime.last_error_at == clock.time()
+
+
+@pytest.mark.asyncio
+async def test_record_errors_uses_real_clock_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_epoch = 2_000_000_001.0
+    monkeypatch.setattr("app.core.clock.time.time", lambda: real_epoch)
+    account = _make_account("acc-real-clock-error")
+    balancer = LoadBalancer(lambda: _repo_factory(_StubAccountsRepository([account]), _StubUsageRepository({}, {})))
+
+    await balancer.record_error(account)
+
+    assert balancer._runtime[account.id].last_error_at == real_epoch
+
+
+@pytest.mark.asyncio
+async def test_virtual_clock_controls_state_and_probe_health_transitions() -> None:
+    clock = VirtualClock(epoch_value=2_000_000_000.0)
+    account = _make_account("acc-virtual-clock-state")
+    primary = _usage_row_with_percent(
+        900,
+        account.id,
+        used_percent=DRAIN_PRIMARY_THRESHOLD_PCT,
+        reset_at=int(clock.time() + 300),
+    )
+    usage_repo = _StubUsageRepository({account.id: primary}, {})
+    balancer = LoadBalancer(lambda: _repo_factory(_StubAccountsRepository([account]), usage_repo), clock=clock)
+    balancer._runtime[account.id] = RuntimeState(health_tier=HEALTH_TIER_PROBING, probe_success_streak=2)
+
+    await balancer.select_account()
+    runtime = balancer._runtime[account.id]
+    assert runtime.health_tier == HEALTH_TIER_DRAINING
+    assert runtime.drain_entered_at == clock.time()
+
+    await balancer.record_probe_result(account_id=account.id, http_status=200)
+
+    assert runtime.health_tier == HEALTH_TIER_DRAINING
+    assert runtime.drain_entered_at == clock.time()
+
+
 @pytest.fixture(autouse=True)
 def _use_dashboard_caps_from_test_settings(monkeypatch: pytest.MonkeyPatch) -> None:
     class _SettingsCache:

--- a/tests/unit/test_load_balancer_concurrency.py
+++ b/tests/unit/test_load_balancer_concurrency.py
@@ -40,8 +40,72 @@ from app.modules.proxy.repo_bundle import ProxyRepositories
 from app.modules.proxy.sticky_repository import StickyOwnerLookup
 from app.modules.request_logs.repository import RequestLogsRepository
 from app.modules.usage.repository import AdditionalUsageRepository
+from tests.simulation.virtual_time import VirtualClock
 
 pytestmark = pytest.mark.unit
+
+
+def test_selected_probe_timestamps_use_injected_clock() -> None:
+    clock = VirtualClock(epoch_value=1_700_000_123.0)
+    balancer = LoadBalancer(cast(Any, None), clock=clock)
+    account = _make_account("acc-virtual-clock")
+    balancer._runtime[account.id] = RuntimeState(last_selected_at=10.0)
+    reservation = load_balancer_module.ProbeReservation(
+        account_id=account.id,
+        previous_last_selected_at=None,
+        reserved_at=10.0,
+        expected_runtime_version=0,
+    )
+
+    assert balancer._commit_due_probe_reservation_locked(reservation)
+    assert balancer._runtime[account.id].last_selected_at == clock.time()
+
+    state = balancer._state_for(account)
+    clock.advance(1.0)
+    assert balancer._sync_runtime_state(
+        account,
+        state,
+        selected=True,
+        expected_version=balancer._runtime[account.id].version,
+    )
+    assert balancer._runtime[account.id].last_selected_at == clock.time()
+
+
+def test_probe_selection_uses_injected_clock() -> None:
+    clock = VirtualClock(epoch_value=1_700_000_123.0)
+    balancer = LoadBalancer(cast(Any, None), clock=clock)
+    healthy = _make_account("acc-virtual-clock-healthy")
+    probing = _make_account("acc-virtual-clock-probing")
+    recent_selection = clock.time() - 1.0
+    balancer._runtime[probing.id] = RuntimeState(
+        health_tier=HEALTH_TIER_PROBING,
+        last_selected_at=recent_selection,
+    )
+
+    reservation = balancer._reserve_due_probe_locked(
+        [
+            AccountState(
+                account_id=healthy.id,
+                status=AccountStatus.ACTIVE,
+                health_tier=HEALTH_TIER_HEALTHY,
+            ),
+            AccountState(
+                account_id=probing.id,
+                status=AccountStatus.ACTIVE,
+                last_selected_at=recent_selection,
+                health_tier=HEALTH_TIER_PROBING,
+            ),
+        ],
+        prefer_earlier_reset=False,
+        prefer_earlier_reset_window="secondary",
+        routing_strategy="usage_weighted",
+        relative_availability_power=2.0,
+        relative_availability_top_k=5,
+        traffic_class=load_balancer_module.TRAFFIC_CLASS_FOREGROUND,
+        routing_costs_by_account_id=None,
+    )
+
+    assert reservation is None
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_load_balancer_concurrency.py
+++ b/tests/unit/test_load_balancer_concurrency.py
@@ -1530,6 +1530,7 @@ def test_bypass_routing_strategies_do_not_require_probe_reservations(routing_str
         states[1],
         routing_strategy=routing_strategy,
         traffic_class=load_balancer_module.TRAFFIC_CLASS_FOREGROUND,
+        now=0.0,
     )
 
 
@@ -1556,6 +1557,7 @@ def test_blocked_healthy_tier_peer_does_not_suppress_recovery_probe() -> None:
         load_balancer_module._filter_recovery_probe_candidates(
             states,
             traffic_class=load_balancer_module.TRAFFIC_CLASS_FOREGROUND,
+            now=float(now_epoch),
         )
         == states
     )
@@ -1564,7 +1566,31 @@ def test_blocked_healthy_tier_peer_does_not_suppress_recovery_probe() -> None:
         due_probe,
         routing_strategy="usage_weighted",
         traffic_class=load_balancer_module.TRAFFIC_CLASS_FOREGROUND,
+        now=float(now_epoch),
     )
+
+
+def test_recovery_probe_filter_uses_injected_selection_time() -> None:
+    clock = VirtualClock(epoch_value=2_000_000_000.0)
+    recovered_healthy = AccountState(
+        "recovered-healthy",
+        AccountStatus.RATE_LIMITED,
+        used_percent=100.0,
+        reset_at=clock.time() - 1.0,
+        health_tier=HEALTH_TIER_HEALTHY,
+    )
+    due_probe = AccountState(
+        "due-probe",
+        AccountStatus.ACTIVE,
+        used_percent=10.0,
+        health_tier=HEALTH_TIER_PROBING,
+    )
+
+    assert load_balancer_module._filter_recovery_probe_candidates(
+        [recovered_healthy, due_probe],
+        traffic_class=load_balancer_module.TRAFFIC_CLASS_FOREGROUND,
+        now=clock.time(),
+    ) == [recovered_healthy]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -13532,6 +13532,46 @@ async def test_await_cancelled_task_defers_stubborn_child_cleanup() -> None:
 
 
 @pytest.mark.asyncio
+async def test_await_cancelled_task_timeout_uses_injected_scheduler() -> None:
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    child_cancelled = asyncio.Event()
+    release_child = asyncio.Event()
+
+    async def stubborn_child() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            child_cancelled.set()
+            await release_child.wait()
+
+    child = scheduler.create_task(stubborn_child())
+    cleanup_tasks: set[asyncio.Task[None]] = set()
+    waiter = scheduler.create_task(
+        proxy_service._await_cancelled_task(
+            child,
+            timeout_seconds=0.25,
+            label="virtual stubborn cleanup",
+            cleanup_tasks=cleanup_tasks,
+            scheduler=scheduler,
+        )
+    )
+    await scheduler.drain()
+
+    assert child_cancelled.is_set()
+    assert not waiter.done()
+
+    await scheduler.advance(0.25)
+
+    assert await waiter is False
+    assert cleanup_tasks
+    release_child.set()
+    await child
+    await scheduler.drain()
+    assert cleanup_tasks == set()
+
+
+@pytest.mark.asyncio
 async def test_close_http_bridge_session_bounded_cancellation_keeps_close_task_tracked(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -25802,6 +25802,7 @@ async def test_http_bridge_eventless_timeout_clears_durable_anchor_only_for_expi
             *,
             label: str,
             cleanup_tasks: set[asyncio.Task[None]] | None = None,
+            scheduler_owner: Any | None = None,
         ) -> bool:
             if label == "HTTP bridge upstream receive after missing response.created":
                 return False
@@ -25809,6 +25810,7 @@ async def test_http_bridge_eventless_timeout_clears_durable_anchor_only_for_expi
                 task,
                 label=label,
                 cleanup_tasks=cleanup_tasks,
+                scheduler_owner=scheduler_owner,
             )
 
         monkeypatch.setattr(
@@ -25933,6 +25935,7 @@ async def test_http_bridge_eventless_timeout_does_not_mark_or_clear_after_late_r
         *,
         label: str,
         cleanup_tasks: set[asyncio.Task[None]] | None = None,
+        scheduler_owner: Any | None = None,
     ) -> bool:
         if label == "HTTP bridge upstream receive after missing response.created":
             upstream.release_receive.set()
@@ -25940,7 +25943,12 @@ async def test_http_bridge_eventless_timeout_does_not_mark_or_clear_after_late_r
             await asyncio.sleep(0)
             assert task is not None and task.done() and not task.cancelled()
             return True
-        return await original_cancel_reader_child(task, label=label, cleanup_tasks=cleanup_tasks)
+        return await original_cancel_reader_child(
+            task,
+            label=label,
+            cleanup_tasks=cleanup_tasks,
+            scheduler_owner=scheduler_owner,
+        )
 
     monkeypatch.setattr(
         http_bridge_upstream_events_module,

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -65,8 +65,21 @@ from app.modules.proxy.durable_bridge_runtime import http_bridge_owner_process_e
 from app.modules.proxy.http_bridge_event_batcher import TerminalOperationEventAppendResult
 from app.modules.proxy.http_bridge_forwarding import OwnerForwardRelayFailure
 from app.modules.proxy.load_balancer import CONTINUITY_OWNER_UNAVAILABLE, CatalogOmissionQuotaAdmission
+from tests.simulation.virtual_time import VirtualClock, VirtualScheduler
 
 pytestmark = pytest.mark.unit
+
+
+class _RecordingVirtualScheduler(VirtualScheduler):
+    def __init__(self, clock: VirtualClock) -> None:
+        super().__init__(clock)
+        self.task_names: list[str | None] = []
+        self.task_coroutines: list[str] = []
+
+    def create_task(self, coroutine: Any, *, name: str | None = None) -> asyncio.Task[Any]:
+        self.task_names.append(name)
+        self.task_coroutines.append(coroutine.cr_code.co_name)
+        return super().create_task(coroutine, name=name)
 
 
 def _durable_owner_lookup(*, process_epoch: str, lease_expires_at: datetime) -> DurableBridgeLookup:
@@ -13086,7 +13099,8 @@ async def test_close_http_bridge_session_fails_pending_downstream_requests() -> 
 async def test_close_http_bridge_session_uses_one_resource_owner_for_concurrent_callers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    scheduler = _RecordingVirtualScheduler(VirtualClock())
+    service = proxy_service.ProxyService(cast(Any, nullcontext()), scheduler=scheduler)
     session = _make_bridge_session(key_value="close-single-flight")
     close_started = asyncio.Event()
     release_close = asyncio.Event()
@@ -13113,6 +13127,7 @@ async def test_close_http_bridge_session_uses_one_resource_owner_for_concurrent_
     assert upstream_close_calls == 1
     release_account_lease.assert_awaited_once()
     assert service._http_bridge_detached_sessions == {}
+    assert any(name and name.startswith("http-bridge-resource-close-") for name in scheduler.task_names)
 
 
 @pytest.mark.asyncio
@@ -22311,7 +22326,8 @@ async def test_recovery_submit_owner_fence_rejection_retires_before_send() -> No
 
 @pytest.mark.asyncio
 async def test_recovery_submit_cancellation_after_alias_commit_restores_previous_owner() -> None:
-    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    scheduler = _RecordingVirtualScheduler(VirtualClock())
+    service = proxy_service.ProxyService(cast(Any, nullcontext()), scheduler=scheduler)
     key = _make_account_neutral_replay_session_key("alias-commit-cancel")
     send_text = AsyncMock()
     close = AsyncMock()
@@ -22402,6 +22418,9 @@ async def test_recovery_submit_cancellation_after_alias_commit_restores_previous
     assert session.closed is True
     assert session.queued_request_count == 0
     assert session.pending_requests == deque()
+    # Registration and its cancellation rollback are both scheduler-owned.
+    assert scheduler.task_coroutines.count("_register_http_bridge_recovery_turn_state_locked") == 1
+    assert scheduler.task_coroutines.count("rollback_recovery_turn_state_registration") == 1
 
 
 @pytest.mark.asyncio
@@ -26629,7 +26648,8 @@ async def test_http_bridge_liveness_send_receive_race_settles_request_once(
                 error_code=UPSTREAM_WEBSOCKET_LIVENESS_TIMEOUT_CODE,
             )
 
-    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    scheduler = _RecordingVirtualScheduler(VirtualClock())
+    service = proxy_service.ProxyService(cast(Any, nullcontext()), scheduler=scheduler)
     sibling_queue: asyncio.Queue[str | None] = asyncio.Queue()
     sibling_state = proxy_service._WebSocketRequestState(
         request_id="req-bridge-liveness-race-sibling",
@@ -26745,6 +26765,8 @@ async def test_http_bridge_liveness_send_receive_race_settles_request_once(
     retry_circuit_attempt_selection = retire_call.kwargs["retry_circuit_attempt_selection"]
     assert retry_circuit_attempt_selection.attempt is request_state.response_create_attempt
     assert request_state.response_create_attempt.disarmed is True
+    assert "http-bridge-liveness-send-settlement" in scheduler.task_names
+    assert "_settle_claimed_http_bridge_liveness_failure" in scheduler.task_coroutines
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -1166,6 +1166,81 @@ class _SilentEventlessUpstream:
         self.closed = True
 
 
+@pytest.mark.asyncio
+async def test_http_bridge_reader_receive_deadline_uses_injected_scheduler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blocked receive must time out on virtual, not wall-clock, time.
+
+    The reader keeps its receive task alive while it races the wakeup event.
+    The deadline wrapper must therefore use the service scheduler without
+    taking ownership of either child task; normal reader cleanup still owns
+    their cancellation.
+    """
+
+    class _BlockedUpstream:
+        def __init__(self) -> None:
+            self.receive_started = asyncio.Event()
+            self.receive_cancelled = asyncio.Event()
+            self.active_receives = 0
+
+        async def receive(self) -> UpstreamWebSocketMessage:
+            self.active_receives += 1
+            self.receive_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.receive_cancelled.set()
+                raise
+            finally:
+                self.active_receives -= 1
+            raise AssertionError("blocked upstream receive returned")
+
+        async def close(self) -> None:
+            return None
+
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    service = proxy_service.ProxyService(cast(Any, nullcontext()), clock=clock, scheduler=scheduler)
+    upstream = _BlockedUpstream()
+    session = _make_bridge_session(key_value="virtual-reader-deadline")
+    session.upstream = cast(UpstreamWebSocket, upstream)
+    receive_timeout = SimpleNamespace(
+        timeout_seconds=5.0,
+        error_code="stream_idle_timeout",
+        error_message="Upstream stream idle timeout",
+    )
+    fail_reader = AsyncMock()
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service, "_next_websocket_receive_timeout", AsyncMock(return_value=receive_timeout))
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_fail_http_bridge_reader_and_maybe_retire", fail_reader)
+
+    reader_task = scheduler.create_task(service._relay_http_bridge_upstream_messages(session))
+    await scheduler.drain()
+    assert upstream.receive_started.is_set()
+    assert reader_task.done() is False
+
+    await scheduler.advance(4.999)
+    assert reader_task.done() is False
+    assert upstream.active_receives == 1
+
+    await scheduler.advance(0.001)
+    await reader_task
+
+    assert clock.monotonic() == pytest.approx(5.0)
+    assert upstream.receive_cancelled.is_set()
+    assert upstream.active_receives == 0
+    fail_reader.assert_awaited_once()
+    assert fail_reader.await_args.args == (session,)
+    assert fail_reader.await_args.kwargs["error_code"] == "stream_idle_timeout"
+    assert fail_reader.await_args.kwargs["error_message"] == "Upstream stream idle timeout"
+    assert fail_reader.await_args.kwargs["retry_circuit_attempt_selection"].kind == "absent"
+    assert session.closed is True
+    await scheduler.drain()
+    assert scheduler._tasks == set()
+
+
 def test_http_bridge_eventless_precreated_deadline_uses_current_send_and_client_safe_cap() -> None:
     request_state = _make_eventless_http_bridge_owner()
 

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -1210,10 +1210,25 @@ async def test_http_bridge_reader_receive_deadline_uses_injected_scheduler(
         error_code="stream_idle_timeout",
         error_message="Upstream stream idle timeout",
     )
-    fail_reader = AsyncMock()
+
+    async def settle_pending_after_reader_closes(*args: Any, **kwargs: Any) -> bool:
+        del args, kwargs
+        assert session.closed is True
+        return True
+
+    async def retire_closed_session(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        assert session.closed is True
+
+    fail_pending = AsyncMock(side_effect=settle_pending_after_reader_closes)
+    retire_session = AsyncMock(side_effect=retire_closed_session)
+    original_fail_reader = service._fail_http_bridge_reader_and_maybe_retire
+    fail_reader = AsyncMock(wraps=original_fail_reader)
     monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
     monkeypatch.setattr(service, "_next_websocket_receive_timeout", AsyncMock(return_value=receive_timeout))
     monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_fail_pending_websocket_requests", fail_pending)
+    monkeypatch.setattr(service, "_retire_stale_pending_http_bridge_session", retire_session)
     monkeypatch.setattr(service, "_fail_http_bridge_reader_and_maybe_retire", fail_reader)
 
     reader_task = scheduler.create_task(service._relay_http_bridge_upstream_messages(session))
@@ -1236,6 +1251,89 @@ async def test_http_bridge_reader_receive_deadline_uses_injected_scheduler(
     assert fail_reader.await_args.kwargs["error_code"] == "stream_idle_timeout"
     assert fail_reader.await_args.kwargs["error_message"] == "Upstream stream idle timeout"
     assert fail_reader.await_args.kwargs["retry_circuit_attempt_selection"].kind == "absent"
+    fail_pending.assert_awaited_once()
+    retire_session.assert_awaited_once()
+    assert session.closed is True
+    await scheduler.drain()
+    assert scheduler._tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_reader_timeout_rechecks_receive_completed_during_timeout_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A receive that finishes with the scheduler timeout stays a receive.
+
+    ``Scheduler.wait_for`` can raise just as the transport receive completes.
+    In that case the reader must consume the completed message rather than
+    classifying it as an idle timeout and settling the live session as failed.
+    """
+
+    class _ReceiveAtTimeoutUpstream:
+        def __init__(self, release_receive: asyncio.Event) -> None:
+            self.receive_started = asyncio.Event()
+            self.release_receive = release_receive
+            self.receive_cancelled = False
+
+        async def receive(self) -> UpstreamWebSocketMessage:
+            self.receive_started.set()
+            try:
+                await self.release_receive.wait()
+            except asyncio.CancelledError:
+                self.receive_cancelled = True
+                raise
+            return UpstreamWebSocketMessage(kind="text", text='{"type":"response.completed"}')
+
+        async def close(self) -> None:
+            return None
+
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    release_receive = asyncio.Event()
+    original_wait_for = scheduler.wait_for
+
+    async def finish_receive_while_timeout_unwinds(awaitable: Any, timeout: float | None) -> Any:
+        try:
+            return await original_wait_for(awaitable, timeout)
+        except asyncio.TimeoutError:
+            release_receive.set()
+            await scheduler.drain()
+            raise
+
+    monkeypatch.setattr(scheduler, "wait_for", finish_receive_while_timeout_unwinds)
+    service = proxy_service.ProxyService(cast(Any, nullcontext()), clock=clock, scheduler=scheduler)
+    upstream = _ReceiveAtTimeoutUpstream(release_receive)
+    session = _make_bridge_session(key_value="virtual-reader-timeout-recheck")
+    session.upstream = cast(UpstreamWebSocket, upstream)
+    receive_timeout = SimpleNamespace(
+        timeout_seconds=5.0,
+        error_code="stream_idle_timeout",
+        error_message="Upstream stream idle timeout",
+    )
+    process_text = AsyncMock()
+    retire_after_drain = AsyncMock(return_value=True)
+    fail_reader = AsyncMock()
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service, "_next_websocket_receive_timeout", AsyncMock(return_value=receive_timeout))
+    monkeypatch.setattr(service, "_process_http_bridge_upstream_text", process_text)
+    monkeypatch.setattr(service, "_retire_http_bridge_after_drain_if_ready", retire_after_drain)
+    retry_precreated = AsyncMock(return_value=False)
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+    monkeypatch.setattr(service, "_fail_http_bridge_reader_and_maybe_retire", fail_reader)
+
+    reader_task = scheduler.create_task(service._relay_http_bridge_upstream_messages(session))
+    await scheduler.drain()
+    assert upstream.receive_started.is_set()
+
+    await scheduler.advance(5.0)
+    await reader_task
+
+    assert clock.monotonic() == pytest.approx(5.0)
+    process_text.assert_awaited_once_with(session, '{"type":"response.completed"}')
+    retire_after_drain.assert_awaited_once_with(session)
+    retry_precreated.assert_not_awaited()
+    fail_reader.assert_not_awaited()
+    assert upstream.receive_cancelled is False
     assert session.closed is True
     await scheduler.drain()
     assert scheduler._tasks == set()

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -25449,6 +25449,7 @@ async def test_http_bridge_eventless_timeout_clears_durable_anchor_only_for_expi
             *,
             label: str,
             cleanup_tasks: set[asyncio.Task[None]] | None = None,
+            scheduler_owner: Any | None = None,
         ) -> bool:
             if label == "HTTP bridge upstream receive after missing response.created":
                 return False
@@ -25456,6 +25457,7 @@ async def test_http_bridge_eventless_timeout_clears_durable_anchor_only_for_expi
                 task,
                 label=label,
                 cleanup_tasks=cleanup_tasks,
+                scheduler_owner=scheduler_owner,
             )
 
         monkeypatch.setattr(
@@ -25580,6 +25582,7 @@ async def test_http_bridge_eventless_timeout_does_not_mark_or_clear_after_late_r
         *,
         label: str,
         cleanup_tasks: set[asyncio.Task[None]] | None = None,
+        scheduler_owner: Any | None = None,
     ) -> bool:
         if label == "HTTP bridge upstream receive after missing response.created":
             upstream.release_receive.set()
@@ -25587,7 +25590,12 @@ async def test_http_bridge_eventless_timeout_does_not_mark_or_clear_after_late_r
             await asyncio.sleep(0)
             assert task is not None and task.done() and not task.cancelled()
             return True
-        return await original_cancel_reader_child(task, label=label, cleanup_tasks=cleanup_tasks)
+        return await original_cancel_reader_child(
+            task,
+            label=label,
+            cleanup_tasks=cleanup_tasks,
+            scheduler_owner=scheduler_owner,
+        )
 
     monkeypatch.setattr(
         http_bridge_upstream_events_module,

--- a/tests/unit/test_proxy_service_clock.py
+++ b/tests/unit/test_proxy_service_clock.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.modules.proxy import service as proxy_service
+from tests.simulation.virtual_time import VirtualClock, VirtualScheduler
+
+pytestmark = pytest.mark.unit
+
+
+def _service(clock: VirtualClock | None = None) -> proxy_service.ProxyService:
+    if clock is None:
+        return proxy_service.ProxyService(cast(Any, SimpleNamespace()))
+    return proxy_service.ProxyService(
+        cast(Any, SimpleNamespace()),
+        clock=clock,
+        scheduler=VirtualScheduler(clock),
+    )
+
+
+def test_remaining_budget_uses_injected_virtual_clock() -> None:
+    clock = VirtualClock(monotonic_value=10.0)
+    service = _service(clock)
+
+    assert service._remaining_budget_seconds(15.0) == 5.0
+
+    clock.advance(2.0)
+
+    assert service._remaining_budget_seconds(15.0) == 3.0
+
+
+def test_remaining_budget_keeps_real_clock_behavior(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = 100.0
+    monkeypatch.setattr(proxy_service.time, "monotonic", lambda: now)
+    service = _service()
+
+    assert service._remaining_budget_seconds(107.5) == 7.5
+
+
+@pytest.mark.asyncio
+async def test_thread_goal_refresh_and_upstream_budget_use_virtual_clock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = VirtualClock()
+    service = _service(clock)
+    account = SimpleNamespace(
+        id="account-virtual-clock",
+        access_token_encrypted=b"encrypted",
+        chatgpt_account_id="upstream-account",
+    )
+    settings = SimpleNamespace(
+        openai_cache_affinity_max_age_seconds=3600,
+        prefer_earlier_reset_accounts=False,
+    )
+    refresh = AsyncMock(return_value=account)
+    select = AsyncMock(return_value=proxy_service.AccountSelection(cast(Any, account), None))
+    upstream = AsyncMock(return_value={"goal": {"id": "goal-virtual-clock"}})
+
+    class SettingsCache:
+        async def get(self) -> object:
+            return settings
+
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: SimpleNamespace(proxy_request_budget_seconds=30.0))
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: SettingsCache())
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select)
+    monkeypatch.setattr(service, "_ensure_fresh", refresh)
+    monkeypatch.setattr(service, "_resolve_upstream_route_for_account", AsyncMock(return_value=None))
+    monkeypatch.setattr(service._encryptor, "decrypt", lambda _encrypted: "access-token")
+    monkeypatch.setattr(service._load_balancer, "record_success", AsyncMock())
+    monkeypatch.setattr(service, "_write_request_log", AsyncMock())
+    monkeypatch.setattr(proxy_service, "core_thread_goal_request", upstream)
+
+    response = await service.thread_goal_request("get", {}, {})
+
+    refresh_call = refresh.await_args
+    upstream_call = upstream.await_args
+
+    assert response == {"goal": {"id": "goal-virtual-clock"}}
+    assert refresh_call is not None
+    assert refresh_call.kwargs["timeout_seconds"] == 30.0
+    assert upstream_call is not None
+    assert upstream_call.kwargs["timeout_seconds"] == 30.0

--- a/tests/unit/test_proxy_service_clock.py
+++ b/tests/unit/test_proxy_service_clock.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock
@@ -12,13 +13,16 @@ from tests.simulation.virtual_time import VirtualClock, VirtualScheduler
 pytestmark = pytest.mark.unit
 
 
-def _service(clock: VirtualClock | None = None) -> proxy_service.ProxyService:
+def _service(
+    clock: VirtualClock | None = None,
+    scheduler: VirtualScheduler | None = None,
+) -> proxy_service.ProxyService:
     if clock is None:
         return proxy_service.ProxyService(cast(Any, SimpleNamespace()))
     return proxy_service.ProxyService(
         cast(Any, SimpleNamespace()),
         clock=clock,
-        scheduler=VirtualScheduler(clock),
+        scheduler=scheduler or VirtualScheduler(clock),
     )
 
 
@@ -84,3 +88,68 @@ async def test_thread_goal_refresh_and_upstream_budget_use_virtual_clock(
     assert refresh_call.kwargs["timeout_seconds"] == 30.0
     assert upstream_call is not None
     assert upstream_call.kwargs["timeout_seconds"] == 30.0
+
+
+@pytest.mark.asyncio
+async def test_account_selection_timeout_uses_virtual_scheduler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    service = _service(clock, scheduler)
+    selection_started = asyncio.Event()
+    selection_never_finishes = asyncio.Event()
+
+    class SettingsCache:
+        async def get(self) -> object:
+            return proxy_service.get_settings()
+
+    async def blocked_select_account(**_kwargs: object) -> object:
+        selection_started.set()
+        await selection_never_finishes.wait()
+        raise AssertionError("blocked selection unexpectedly resumed")
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: SettingsCache())
+    monkeypatch.setattr(service._load_balancer, "select_account", blocked_select_account)
+
+    selection_task = scheduler.create_task(
+        service._select_account_with_budget(
+            deadline=clock.monotonic() + 30.0,
+            request_id="req-virtual-selection-timeout",
+            kind="thread_goal_get",
+        )
+    )
+    await scheduler.drain()
+    assert selection_started.is_set()
+
+    await scheduler.advance(30.0)
+
+    assert selection_task.done()
+    with pytest.raises(proxy_service.ProxyResponseError) as exc_info:
+        await selection_task
+    assert exc_info.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_account_selection_keeps_real_scheduler_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = _service()
+    expected_selection = proxy_service.AccountSelection(None, "No active accounts available")
+    select_account = AsyncMock(return_value=expected_selection)
+
+    class SettingsCache:
+        async def get(self) -> object:
+            return proxy_service.get_settings()
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: SettingsCache())
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+
+    selection = await service._select_account_with_budget(
+        deadline=service._clock.monotonic() + 30.0,
+        request_id="req-real-selection-timeout",
+        kind="thread_goal_get",
+    )
+
+    assert selection is expected_selection
+    select_account.assert_awaited_once()

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -41236,7 +41236,7 @@ async def test_select_account_with_budget_times_out_during_settings_fetch(monkey
             return settings
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SlowSettingsCache())
-    monkeypatch.setattr(proxy_service, "_remaining_budget_seconds", lambda _deadline: 0.01)
+    monkeypatch.setattr(service, "_remaining_budget_seconds", lambda _deadline: 0.01)
     monkeypatch.setattr(service._load_balancer, "select_account", select_account)
 
     with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
@@ -41264,7 +41264,7 @@ async def test_select_account_with_budget_forwards_estimated_lease_tokens(monkey
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(service._load_balancer, "select_account", select_account)
-    monkeypatch.setattr(proxy_service, "_remaining_budget_seconds", lambda _deadline: 10.0)
+    monkeypatch.setattr(service, "_remaining_budget_seconds", lambda _deadline: 10.0)
 
     selection = await service._select_account_with_budget(
         deadline=123.0,
@@ -41307,7 +41307,7 @@ async def test_select_account_with_budget_intersects_cap_spillover_with_request_
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(service._load_balancer, "select_account", select_account)
-    monkeypatch.setattr(proxy_service, "_remaining_budget_seconds", lambda _deadline: 10.0)
+    monkeypatch.setattr(service, "_remaining_budget_seconds", lambda _deadline: 10.0)
 
     await service._select_account_with_budget(
         deadline=123.0,
@@ -41351,7 +41351,7 @@ async def test_select_account_with_budget_reconciles_sticky_mapping_for_preferre
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(service._load_balancer, "select_account", select_account)
-    monkeypatch.setattr(proxy_service, "_remaining_budget_seconds", lambda _deadline: 10.0)
+    monkeypatch.setattr(service, "_remaining_budget_seconds", lambda _deadline: 10.0)
 
     await service._select_account_with_budget(
         deadline=123.0,
@@ -41403,7 +41403,7 @@ async def test_select_account_with_budget_keeps_thread_seed_for_first_exact_owne
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(service._load_balancer, "select_account", select_account)
-    monkeypatch.setattr(proxy_service, "_remaining_budget_seconds", lambda _deadline: 10.0)
+    monkeypatch.setattr(service, "_remaining_budget_seconds", lambda _deadline: 10.0)
 
     await service._select_account_with_budget(
         deadline=123.0,
@@ -41444,7 +41444,7 @@ async def test_select_account_with_budget_preserves_conversation_check_for_prefe
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(service._load_balancer, "select_account", select_account)
-    monkeypatch.setattr(proxy_service, "_remaining_budget_seconds", lambda _deadline: 10.0)
+    monkeypatch.setattr(service, "_remaining_budget_seconds", lambda _deadline: 10.0)
 
     selection = await service._select_account_with_budget(
         deadline=123.0,
@@ -41482,7 +41482,7 @@ async def test_single_account_routing_does_not_narrow_conversation_ownership_sco
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(service._load_balancer, "select_account", select_account)
-    monkeypatch.setattr(proxy_service, "_remaining_budget_seconds", lambda _deadline: 10.0)
+    monkeypatch.setattr(service, "_remaining_budget_seconds", lambda _deadline: 10.0)
 
     selection = await service._select_account_with_budget(
         deadline=123.0,
@@ -41514,7 +41514,7 @@ async def test_single_account_routing_skips_soft_preferred_account_outside_singl
 
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(service._load_balancer, "select_account", select_account)
-    monkeypatch.setattr(proxy_service, "_remaining_budget_seconds", lambda _deadline: 10.0)
+    monkeypatch.setattr(service, "_remaining_budget_seconds", lambda _deadline: 10.0)
 
     selection = await service._select_account_with_budget(
         deadline=123.0,
@@ -41551,7 +41551,7 @@ async def test_select_account_with_budget_reserves_stream_slot_for_reattach(
     settings.proxy_account_stream_recovery_reserve = 3
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
     monkeypatch.setattr(service._load_balancer, "select_account", select_account)
-    monkeypatch.setattr(proxy_service, "_remaining_budget_seconds", lambda _deadline: 10.0)
+    monkeypatch.setattr(service, "_remaining_budget_seconds", lambda _deadline: 10.0)
 
     await service._select_account_with_budget(
         deadline=123.0,

--- a/tests/unit/test_responses_streaming_timeout_hardening.py
+++ b/tests/unit/test_responses_streaming_timeout_hardening.py
@@ -10,6 +10,7 @@ from app.core.clients.proxy import ProxyResponseError
 from app.core.resilience.overload import local_overload_error
 from app.core.utils.sse import SSE_KEEPALIVE_FRAME
 from app.modules.proxy import api as proxy_api
+from tests.simulation.virtual_time import VirtualClock, VirtualScheduler
 
 pytestmark = pytest.mark.unit
 
@@ -18,11 +19,11 @@ async def _one_event_stream() -> AsyncIterator[str]:
     yield 'event: response.created\ndata: {"type":"response.created"}\n\n'
 
 
-async def _delayed_429_stream() -> AsyncIterator[str]:
+async def _delayed_429_stream(scheduler: VirtualScheduler) -> AsyncIterator[str]:
     # The first item only resolves after the startup probe has already timed
     # out, then the upstream raises a 429 -- mirroring the response-create
     # admission gate denying admission after the probe window elapsed.
-    await asyncio.sleep(0.05)
+    await scheduler.sleep(0.05)
     raise ProxyResponseError(429, local_overload_error("admission gate timed out", code="global_admission_timeout"))
     yield ""  # pragma: no cover - present only so this is an async generator
 
@@ -45,28 +46,37 @@ async def test_initial_sse_heartbeat_precedes_openai_contract_event() -> None:
 
 @pytest.mark.asyncio
 async def test_startup_probe_timeout_then_upstream_error_is_not_logged() -> None:
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
     loop = asyncio.get_running_loop()
     captured: list[str] = []
     loop.set_exception_handler(lambda _loop, context: captured.append(str(context.get("message", ""))))
     try:
         # The probe times out before the first item arrives, so it hands the
         # still-running task to the streamed response.
-        stream, startup_error = await proxy_api._probe_stream_startup_error(
-            _delayed_429_stream(),
-            timeout_seconds=0.01,
+        probe_task = scheduler.create_task(
+            proxy_api._probe_stream_startup_error(
+                _delayed_429_stream(scheduler),
+                timeout_seconds=0.01,
+                scheduler=scheduler,
+            )
         )
+        await scheduler.drain()
+        await scheduler.advance(0.01)
+        stream, startup_error = await probe_task
         assert startup_error is None
 
         # Consuming the handed-off stream surfaces the upstream 429 to the
         # caller -- and must not also emit an "exception in shielded future"
         # diagnostic from the timed-out probe task.
         with pytest.raises(ProxyResponseError):
+            await scheduler.advance(0.04)
             async for _ in stream:
                 pass
 
-        await asyncio.sleep(0)
+        await scheduler.drain()
         gc.collect()
-        await asyncio.sleep(0)
+        await scheduler.drain()
     finally:
         loop.set_exception_handler(None)
 
@@ -75,14 +85,22 @@ async def test_startup_probe_timeout_then_upstream_error_is_not_logged() -> None
 
 @pytest.mark.asyncio
 async def test_abandoned_startup_probe_task_does_not_warn() -> None:
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
     loop = asyncio.get_running_loop()
     captured: list[str] = []
     loop.set_exception_handler(lambda _loop, context: captured.append(str(context.get("message", ""))))
     try:
-        stream, startup_error = await proxy_api._probe_stream_startup_error(
-            _delayed_429_stream(),
-            timeout_seconds=0.01,
+        probe_task = scheduler.create_task(
+            proxy_api._probe_stream_startup_error(
+                _delayed_429_stream(scheduler),
+                timeout_seconds=0.01,
+                scheduler=scheduler,
+            )
         )
+        await scheduler.drain()
+        await scheduler.advance(0.01)
+        stream, startup_error = await probe_task
         assert startup_error is None
 
         # Drop the wrapping generator without iterating it, as happens when the
@@ -90,11 +108,62 @@ async def test_abandoned_startup_probe_task_does_not_warn() -> None:
         # detached probe task then finishes with its 429 and must not log an
         # "exception was never retrieved" warning when it is collected.
         del stream
-        await asyncio.sleep(0.1)
+        await scheduler.advance(0.1)
         gc.collect()
-        await asyncio.sleep(0)
+        await scheduler.drain()
     finally:
         loop.set_exception_handler(None)
 
     leaked = [m for m in captured if "never retrieved" in m.lower() or "shielded future" in m]
     assert not leaked, f"probe task leaked an unretrieved exception: {captured}"
+
+
+@pytest.mark.asyncio
+async def test_capacity_ready_probe_timeout_uses_virtual_scheduler() -> None:
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    first_task = scheduler.create_task(scheduler.sleep(1.0, result="response.created"))
+    capacity_ready_event = proxy_api._CapacityStartupReadyEvent()
+    capacity_ready_event.set()
+    probe_task = scheduler.create_task(
+        proxy_api._wait_for_first_stream_probe(
+            first_task,
+            timeout_seconds=0.05,
+            capacity_wait_event=asyncio.Event(),
+            capacity_ready_event=capacity_ready_event,
+            scheduler=scheduler,
+        )
+    )
+
+    await scheduler.drain()
+    assert probe_task.done() is False
+    await scheduler.advance(0.05)
+    assert probe_task.done() is False
+    await scheduler.advance(0.05)
+
+    assert await probe_task is False
+    await scheduler.cancel_owned_tasks()
+
+
+@pytest.mark.asyncio
+async def test_capacity_signal_discovery_timeout_uses_virtual_scheduler(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    first_task = scheduler.create_task(scheduler.sleep(1.0, result="response.created"))
+    monkeypatch.setattr(proxy_api, "_CAPACITY_WAIT_MARKER_GRACE_SECONDS", 0.05)
+    probe_task = scheduler.create_task(
+        proxy_api._wait_for_first_stream_probe(
+            first_task,
+            timeout_seconds=0.01,
+            capacity_wait_event=asyncio.Event(),
+            scheduler=scheduler,
+        )
+    )
+
+    await scheduler.drain()
+    await scheduler.advance(0.01)
+    assert probe_task.done() is False
+    await scheduler.advance(0.05)
+
+    assert await probe_task is False
+    await scheduler.cancel_owned_tasks()

--- a/tests/unit/test_responses_streaming_timeout_hardening.py
+++ b/tests/unit/test_responses_streaming_timeout_hardening.py
@@ -226,7 +226,6 @@ async def test_capacity_recovery_ready_preserves_first_item_probe() -> None:
 
     async def mark_capacity_ready() -> None:
         await scheduler.sleep(0.02)
-        capacity_wait_event.clear()
         capacity_ready_event.set()
 
     scheduler.create_task(mark_capacity_ready())
@@ -246,9 +245,45 @@ async def test_capacity_recovery_ready_preserves_first_item_probe() -> None:
     assert probe_task.done() is False
     await scheduler.advance(0.01)
     assert capacity_ready_event.set_at == clock.monotonic()
+    assert capacity_wait_event.is_set() is False
     await scheduler.advance(0.01)
 
     assert await probe_task is True
+    await scheduler.cancel_owned_tasks()
+
+
+@pytest.mark.asyncio
+async def test_capacity_recovery_ready_starts_post_ready_timeout() -> None:
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    first_task = scheduler.create_task(scheduler.sleep(3.0, result="response.created"))
+    capacity_wait_event = asyncio.Event()
+    capacity_wait_event.set()
+    capacity_ready_event = proxy_api._CapacityStartupReadyEvent(clock=clock)
+
+    async def mark_capacity_ready() -> None:
+        await scheduler.sleep(0.02)
+        capacity_ready_event.set()
+
+    scheduler.create_task(mark_capacity_ready())
+    probe_task = scheduler.create_task(
+        proxy_api._wait_for_first_stream_probe(
+            first_task,
+            timeout_seconds=0.01,
+            capacity_wait_event=capacity_wait_event,
+            capacity_ready_event=capacity_ready_event,
+            scheduler=scheduler,
+            clock=clock,
+        )
+    )
+
+    await scheduler.drain()
+    await scheduler.advance(0.01)
+    await scheduler.advance(0.01)
+    assert capacity_wait_event.is_set() is False
+    await scheduler.advance(0.01)
+
+    assert await probe_task is False
     await scheduler.cancel_owned_tasks()
 
 

--- a/tests/unit/test_responses_streaming_timeout_hardening.py
+++ b/tests/unit/test_responses_streaming_timeout_hardening.py
@@ -15,6 +15,27 @@ from tests.simulation.virtual_time import VirtualClock, VirtualScheduler
 pytestmark = pytest.mark.unit
 
 
+@pytest.mark.asyncio
+async def test_virtual_wait_for_prefers_result_when_timeout_completes_same_tick() -> None:
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    semaphore = asyncio.Semaphore(0)
+
+    waiter = scheduler.create_task(scheduler.wait_for(semaphore.acquire(), timeout=0.1))
+
+    async def release_at_deadline() -> None:
+        await scheduler.sleep(0.1)
+        semaphore.release()
+
+    scheduler.create_task(release_at_deadline())
+    await scheduler.drain()
+    await scheduler.advance(0.1)
+
+    assert await waiter is True
+    assert semaphore.locked()
+    await scheduler.cancel_owned_tasks()
+
+
 async def _one_event_stream() -> AsyncIterator[str]:
     yield 'event: response.created\ndata: {"type":"response.created"}\n\n'
 

--- a/tests/unit/test_responses_streaming_timeout_hardening.py
+++ b/tests/unit/test_responses_streaming_timeout_hardening.py
@@ -144,8 +144,9 @@ async def test_capacity_ready_probe_timeout_uses_virtual_scheduler() -> None:
     clock = VirtualClock()
     scheduler = VirtualScheduler(clock)
     first_task = scheduler.create_task(scheduler.sleep(1.0, result="response.created"))
-    capacity_ready_event = proxy_api._CapacityStartupReadyEvent()
+    capacity_ready_event = proxy_api._CapacityStartupReadyEvent(clock=clock)
     capacity_ready_event.set()
+    assert capacity_ready_event.set_at == clock.monotonic()
     probe_task = scheduler.create_task(
         proxy_api._wait_for_first_stream_probe(
             first_task,
@@ -153,12 +154,11 @@ async def test_capacity_ready_probe_timeout_uses_virtual_scheduler() -> None:
             capacity_wait_event=asyncio.Event(),
             capacity_ready_event=capacity_ready_event,
             scheduler=scheduler,
+            clock=clock,
         )
     )
 
     await scheduler.drain()
-    assert probe_task.done() is False
-    await scheduler.advance(0.05)
     assert probe_task.done() is False
     await scheduler.advance(0.05)
 
@@ -167,11 +167,10 @@ async def test_capacity_ready_probe_timeout_uses_virtual_scheduler() -> None:
 
 
 @pytest.mark.asyncio
-async def test_capacity_signal_discovery_timeout_uses_virtual_scheduler(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_capacity_signal_discovery_timeout_uses_virtual_scheduler() -> None:
     clock = VirtualClock()
     scheduler = VirtualScheduler(clock)
     first_task = scheduler.create_task(scheduler.sleep(1.0, result="response.created"))
-    monkeypatch.setattr(proxy_api, "_CAPACITY_WAIT_MARKER_GRACE_SECONDS", 0.05)
     probe_task = scheduler.create_task(
         proxy_api._wait_for_first_stream_probe(
             first_task,
@@ -188,3 +187,83 @@ async def test_capacity_signal_discovery_timeout_uses_virtual_scheduler(monkeypa
 
     assert await probe_task is False
     await scheduler.cancel_owned_tasks()
+
+
+@pytest.mark.asyncio
+async def test_capacity_recovery_wait_ends_at_signal_timeout() -> None:
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    first_task = scheduler.create_task(scheduler.sleep(1.0, result="response.created"))
+    capacity_wait_event = asyncio.Event()
+    capacity_wait_event.set()
+    probe_task = scheduler.create_task(
+        proxy_api._wait_for_first_stream_probe(
+            first_task,
+            timeout_seconds=0.01,
+            capacity_wait_event=capacity_wait_event,
+            scheduler=scheduler,
+            clock=clock,
+        )
+    )
+
+    await scheduler.drain()
+    await scheduler.advance(0.01)
+    assert probe_task.done() is False
+    await scheduler.advance(proxy_api._CAPACITY_WAIT_MARKER_GRACE_SECONDS)
+
+    assert await probe_task is False
+    await scheduler.cancel_owned_tasks()
+
+
+@pytest.mark.asyncio
+async def test_capacity_recovery_ready_preserves_first_item_probe() -> None:
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    first_task = scheduler.create_task(scheduler.sleep(0.03, result="response.created"))
+    capacity_wait_event = asyncio.Event()
+    capacity_wait_event.set()
+    capacity_ready_event = proxy_api._CapacityStartupReadyEvent(clock=clock)
+
+    async def mark_capacity_ready() -> None:
+        await scheduler.sleep(0.02)
+        capacity_wait_event.clear()
+        capacity_ready_event.set()
+
+    scheduler.create_task(mark_capacity_ready())
+    probe_task = scheduler.create_task(
+        proxy_api._wait_for_first_stream_probe(
+            first_task,
+            timeout_seconds=0.01,
+            capacity_wait_event=capacity_wait_event,
+            capacity_ready_event=capacity_ready_event,
+            scheduler=scheduler,
+            clock=clock,
+        )
+    )
+
+    await scheduler.drain()
+    await scheduler.advance(0.01)
+    assert probe_task.done() is False
+    await scheduler.advance(0.01)
+    assert capacity_ready_event.set_at == clock.monotonic()
+    await scheduler.advance(0.01)
+
+    assert await probe_task is True
+    await scheduler.cancel_owned_tasks()
+
+
+@pytest.mark.asyncio
+async def test_capacity_probe_immediate_completion_keeps_real_scheduler_default() -> None:
+    async def first_item() -> str:
+        return "response.created"
+
+    first_task = asyncio.create_task(first_item())
+
+    assert (
+        await proxy_api._wait_for_first_stream_probe(
+            first_task,
+            timeout_seconds=0.05,
+            capacity_wait_event=asyncio.Event(),
+        )
+        is True
+    )

--- a/tests/unit/test_select_with_stickiness.py
+++ b/tests/unit/test_select_with_stickiness.py
@@ -16,12 +16,14 @@ from unittest.mock import AsyncMock
 import pytest
 
 from app.core.balancer import AccountState, RoutingCost, RoutingCostsByAccount, RoutingStrategy
+from app.core.clock import REAL_CLOCK, Clock
 from app.db.models import Account, AccountStatus, StickySessionKind
 from app.modules.proxy._load_balancer.sticky_selection import (
     _STICKY_EXISTING_UNSET,
     _sticky_refresh_write_skippable,
 )
 from app.modules.proxy.load_balancer import LoadBalancer
+from tests.simulation.virtual_time import VirtualClock
 
 pytestmark = pytest.mark.unit
 
@@ -84,6 +86,7 @@ async def _invoke_stickiness(
     routing_costs_by_account_id: RoutingCostsByAccount | None = None,
     sticky_refresh_skip_deadline: datetime | None = None,
     sticky_existing_account_id: str | None | object = _STICKY_EXISTING_UNSET,
+    clock: Clock = REAL_CLOCK,
 ):
     """Wrapper that calls production LoadBalancer._select_with_stickiness.
 
@@ -95,7 +98,7 @@ async def _invoke_stickiness(
     async def mock_repo_factory():
         yield AsyncMock()
 
-    lb = LoadBalancer(mock_repo_factory)
+    lb = LoadBalancer(mock_repo_factory, clock=clock)
     account_map = {s.account_id: cast(Account, AsyncMock()) for s in states}
 
     outcome = await lb._select_with_stickiness(
@@ -549,6 +552,24 @@ async def test_grace_period_returns_pinned_when_reset_imminent():
     assert result.account is not None
     assert result.account.account_id == "a"
     repo.upsert.assert_called_once_with("key1", "a", kind=StickySessionKind.PROMPT_CACHE)
+
+
+@pytest.mark.asyncio
+async def test_grace_period_uses_injected_selection_clock():
+    clock = VirtualClock(epoch_value=time.time() + 1_000_000.0)
+    acc_a = _rate_limited("a", reset_at=clock.time() + 5.0)
+    acc_b = _active("b")
+    repo = _make_sticky_repo(existing_account_id="a")
+
+    result = await _invoke_stickiness(
+        [acc_a, acc_b],
+        "key-injected-clock",
+        repo,
+        clock=clock,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "a"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_websocket_terminal_cancellation.py
+++ b/tests/unit/test_websocket_terminal_cancellation.py
@@ -20,6 +20,7 @@ from app.db.models import Account
 from app.modules.api_keys.service import ApiKeyData, ApiKeyUsageReservationData
 from app.modules.proxy import service as proxy_service
 from app.modules.proxy._service.websocket import mixin as websocket_mixin
+from tests.simulation.virtual_time import VirtualClock, VirtualScheduler
 
 pytestmark = pytest.mark.unit
 
@@ -1434,6 +1435,51 @@ async def test_stuck_upstream_close_is_cancelled_after_scope_cleanup_timeout() -
     assert close_cancelled is True
     assert service._background_cleanup_tasks == set()
     release_close.set()
+
+
+@pytest.mark.asyncio
+async def test_upstream_close_cleanup_uses_injected_scheduler_timeout() -> None:
+    @asynccontextmanager
+    async def repo_factory() -> AsyncIterator[SimpleNamespace]:
+        yield SimpleNamespace(request_logs=_RequestLogsRecorder(), api_keys=object())
+
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    service = proxy_service.ProxyService(
+        cast(proxy_service.ProxyRepoFactory, repo_factory),
+        clock=clock,
+        scheduler=scheduler,
+    )
+    close_started = asyncio.Event()
+    close_cancelled = False
+
+    async def close() -> None:
+        nonlocal close_cancelled
+        close_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            close_cancelled = True
+            raise
+
+    upstream = cast(UpstreamWebSocket, SimpleNamespace(close=close))
+    cleanup = scheduler.create_task(
+        websocket_mixin._close_websocket_upstream_for_cleanup(
+            service,
+            upstream,
+            timeout_seconds=1.0,
+        )
+    )
+
+    await scheduler.drain()
+    assert close_started.is_set()
+    assert not cleanup.done()
+
+    await scheduler.advance(0.25)
+    await cleanup
+
+    assert close_cancelled is True
+    assert service._background_cleanup_tasks == set()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_websocket_terminal_cancellation.py
+++ b/tests/unit/test_websocket_terminal_cancellation.py
@@ -1438,7 +1438,9 @@ async def test_stuck_upstream_close_is_cancelled_after_scope_cleanup_timeout() -
 
 
 @pytest.mark.asyncio
-async def test_upstream_close_cleanup_uses_injected_scheduler_timeout() -> None:
+async def test_upstream_close_cleanup_uses_injected_scheduler_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     @asynccontextmanager
     async def repo_factory() -> AsyncIterator[SimpleNamespace]:
         yield SimpleNamespace(request_logs=_RequestLogsRecorder(), api_keys=object())
@@ -1452,6 +1454,14 @@ async def test_upstream_close_cleanup_uses_injected_scheduler_timeout() -> None:
     )
     close_started = asyncio.Event()
     close_cancelled = False
+    cancellation_schedulers: list[Any] = []
+    original_await_cancelled_task = proxy_service._await_cancelled_task
+
+    async def capture_cancellation_scheduler(*args: Any, **kwargs: Any) -> bool:
+        cancellation_schedulers.append(kwargs["scheduler"])
+        return await original_await_cancelled_task(*args, **kwargs)
+
+    monkeypatch.setattr(proxy_service, "_await_cancelled_task", capture_cancellation_scheduler)
 
     async def close() -> None:
         nonlocal close_cancelled
@@ -1479,6 +1489,7 @@ async def test_upstream_close_cleanup_uses_injected_scheduler_timeout() -> None:
     await cleanup
 
     assert close_cancelled is True
+    assert cancellation_schedulers == [scheduler]
     assert service._background_cleanup_tasks == set()
 
 

--- a/tests/unit/test_websocket_terminal_cancellation.py
+++ b/tests/unit/test_websocket_terminal_cancellation.py
@@ -1376,6 +1376,8 @@ async def test_terminal_message_cancellation_is_bounded_by_shared_deadline(
 async def test_terminal_message_cancellation_without_drain_leaves_owned_task_running(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
     child_cancelled = asyncio.Event()
     release_child = asyncio.Event()
 
@@ -1387,12 +1389,19 @@ async def test_terminal_message_cancellation_without_drain_leaves_owned_task_run
             raise
 
     monkeypatch.setattr(proxy_service, "_TASK_CANCEL_TIMEOUT_SECONDS", 0.01)
-    child = asyncio.create_task(owned_child())
+    child = scheduler.create_task(owned_child())
 
-    await websocket_mixin._await_owned_websocket_task_after_reader_cancellation(
-        child,
-        failure_message="test child failure",
+    waiter = scheduler.create_task(
+        websocket_mixin._await_owned_websocket_task_after_reader_cancellation(
+            child,
+            failure_message="test child failure",
+            scheduler=scheduler,
+        )
     )
+    await scheduler.drain()
+    assert not waiter.done()
+    await scheduler.advance(0.01)
+    await waiter
 
     assert child_cancelled.is_set() is False
     assert child.done() is False

--- a/tests/unit/test_work_admission_wait.py
+++ b/tests/unit/test_work_admission_wait.py
@@ -8,21 +8,42 @@ when the semaphore is locked.
 from __future__ import annotations
 
 import asyncio
-import time
 
 import pytest
 
 from app.core.clients.proxy import ProxyResponseError
 from app.modules.proxy.work_admission import WorkAdmissionController
+from tests.simulation.virtual_time import VirtualClock, VirtualScheduler
 
 pytestmark = pytest.mark.unit
+
+
+def _virtual_controller(
+    *,
+    token_refresh_limit: int,
+    websocket_connect_limit: int,
+    response_create_limit: int,
+    compact_response_create_limit: int,
+    admission_wait_timeout_seconds: float,
+) -> tuple[WorkAdmissionController, VirtualClock, VirtualScheduler]:
+    clock = VirtualClock()
+    scheduler = VirtualScheduler(clock)
+    controller = WorkAdmissionController(
+        token_refresh_limit=token_refresh_limit,
+        websocket_connect_limit=websocket_connect_limit,
+        response_create_limit=response_create_limit,
+        compact_response_create_limit=compact_response_create_limit,
+        admission_wait_timeout_seconds=admission_wait_timeout_seconds,
+        scheduler=scheduler,
+    )
+    return controller, clock, scheduler
 
 
 @pytest.mark.asyncio
 async def test_admission_waits_before_rejecting() -> None:
     """When all slots are taken, a second request should wait up to the
     configured timeout before being rejected — not fail instantly."""
-    controller = WorkAdmissionController(
+    controller, clock, scheduler = _virtual_controller(
         token_refresh_limit=1,
         websocket_connect_limit=0,
         response_create_limit=0,
@@ -31,22 +52,25 @@ async def test_admission_waits_before_rejecting() -> None:
     )
     lease = await controller.acquire_token_refresh()
 
-    start = time.monotonic()
+    start = clock.monotonic()
+    acquire_task = scheduler.create_task(controller.acquire_token_refresh())
+    await scheduler.drain()
+    assert not acquire_task.done()
+    await scheduler.advance(0.5)
     with pytest.raises(ProxyResponseError) as exc_info:
-        await controller.acquire_token_refresh()
-    elapsed = time.monotonic() - start
+        await acquire_task
+    elapsed = clock.monotonic() - start
 
     lease.release()
     assert exc_info.value.status_code == 429
-    # Must have waited at least ~0.4s (near the 0.5s timeout), not instant
-    assert elapsed >= 0.3, f"Rejected too fast: {elapsed:.3f}s — should wait ~0.5s"
+    assert elapsed >= 0.5, f"Rejected too fast: {elapsed:.3f}s - should wait ~0.5s"
 
 
 @pytest.mark.asyncio
 async def test_admission_succeeds_when_slot_frees_during_wait() -> None:
     """If a slot becomes available during the wait window, the second
     request should succeed instead of timing out."""
-    controller = WorkAdmissionController(
+    controller, clock, scheduler = _virtual_controller(
         token_refresh_limit=1,
         websocket_connect_limit=0,
         response_create_limit=0,
@@ -56,25 +80,28 @@ async def test_admission_succeeds_when_slot_frees_during_wait() -> None:
     lease = await controller.acquire_token_refresh()
 
     async def release_after_delay() -> None:
-        await asyncio.sleep(0.2)
+        await scheduler.sleep(0.2)
         lease.release()
 
-    asyncio.create_task(release_after_delay())
+    scheduler.create_task(release_after_delay())
 
-    start = time.monotonic()
-    second_lease = await controller.acquire_token_refresh()
-    elapsed = time.monotonic() - start
+    start = clock.monotonic()
+    acquire_task = scheduler.create_task(controller.acquire_token_refresh())
+    await scheduler.drain()
+    assert not acquire_task.done()
+    await scheduler.advance(0.2)
+    second_lease = await acquire_task
+    elapsed = clock.monotonic() - start
 
     second_lease.release()
-    # Should have acquired within ~0.2-0.5s, NOT timed out at 2s
-    assert elapsed < 1.0, f"Took too long: {elapsed:.3f}s — slot freed at 0.2s"
+    assert elapsed < 1.0, f"Took too long: {elapsed:.3f}s - slot freed at 0.2s"
 
 
 @pytest.mark.asyncio
 async def test_admission_concurrent_burst_queues_not_rejects() -> None:
     """Multiple concurrent requests should queue and be served as slots
     free up, rather than all being instantly rejected."""
-    controller = WorkAdmissionController(
+    controller, _clock, scheduler = _virtual_controller(
         token_refresh_limit=2,
         websocket_connect_limit=0,
         response_create_limit=0,
@@ -92,23 +119,29 @@ async def test_admission_concurrent_burst_queues_not_rejects() -> None:
         try:
             lease = await controller.acquire_token_refresh()
             results.append(f"{name}:ok")
-            await asyncio.sleep(release_after)
+            await scheduler.sleep(release_after)
             lease.release()
         except ProxyResponseError:
             results.append(f"{name}:rejected")
 
     # Release slots staggered
     async def release_staggered() -> None:
-        await asyncio.sleep(0.1)
+        await scheduler.sleep(0.1)
         lease1.release()
-        await asyncio.sleep(0.1)
+        await scheduler.sleep(0.1)
         lease2.release()
 
     tasks = [
-        asyncio.create_task(try_acquire("a", 0.05)),
-        asyncio.create_task(try_acquire("b", 0.05)),
-        asyncio.create_task(release_staggered()),
+        scheduler.create_task(try_acquire("a", 0.05)),
+        scheduler.create_task(try_acquire("b", 0.05)),
+        scheduler.create_task(release_staggered()),
     ]
+    await scheduler.drain()
+    assert not all(task.done() for task in tasks)
+    await scheduler.advance(0.1)
+    await scheduler.advance(0.05)
+    await scheduler.advance(0.05)
+    await scheduler.advance(0.05)
     await asyncio.gather(*tasks)
 
     # Both queued requests should have succeeded
@@ -118,7 +151,7 @@ async def test_admission_concurrent_burst_queues_not_rejects() -> None:
 @pytest.mark.asyncio
 async def test_response_create_admission_waits() -> None:
     """The response_create gate should also wait, not reject instantly."""
-    controller = WorkAdmissionController(
+    controller, clock, scheduler = _virtual_controller(
         token_refresh_limit=0,
         websocket_connect_limit=0,
         response_create_limit=1,
@@ -128,14 +161,18 @@ async def test_response_create_admission_waits() -> None:
     lease = await controller.acquire_response_create()
 
     async def release_after_delay() -> None:
-        await asyncio.sleep(0.15)
+        await scheduler.sleep(0.15)
         lease.release()
 
-    asyncio.create_task(release_after_delay())
+    scheduler.create_task(release_after_delay())
 
-    start = time.monotonic()
-    second = await controller.acquire_response_create()
-    elapsed = time.monotonic() - start
+    start = clock.monotonic()
+    acquire_task = scheduler.create_task(controller.acquire_response_create())
+    await scheduler.drain()
+    assert not acquire_task.done()
+    await scheduler.advance(0.15)
+    second = await acquire_task
+    elapsed = clock.monotonic() - start
 
     second.release()
     assert elapsed < 0.4, f"Took too long: {elapsed:.3f}s"
@@ -144,7 +181,7 @@ async def test_response_create_admission_waits() -> None:
 @pytest.mark.asyncio
 async def test_disabled_gate_always_admits() -> None:
     """Gates with limit=0 should always admit without waiting."""
-    controller = WorkAdmissionController(
+    controller, _clock, _scheduler = _virtual_controller(
         token_refresh_limit=0,
         websocket_connect_limit=0,
         response_create_limit=0,


### PR DESCRIPTION
Adds a virtual-clock + controlled-scheduler simulation harness so the proxy turn lifecycle can be tested deterministically instead of via wall-clock sleeps and production flakes. This is the implementation-level leg of the codex-lb verification effort (alongside the TLA+ model #1621 and the timeout-invariant linter #1622).

**Production unchanged**: new `app/core/clock.py` (Clock/Scheduler protocols with RealClock/RealScheduler as the defaults + tolerant `scheduler_for`/`clock_for` accessors). Clock threaded through ProxyService/LoadBalancer/retry-circuit; scheduler through work-admission/bridge/websocket sleep+wait_for+task-spawn sites, so a simulation owns every task a turn spawns.

**Tests**:
- 3 audit-listed timing tests converted to virtual time (work-admission wait, streaming-timeout hardening, http-bridge cancel/drain) — same behavioral assertions, no real sleeps.
- A schedule-exploring property test: 200 seeded schedules interleaving admission-wait / upstream-terminal / downstream-cancel / retry as concurrent virtual tasks, asserting exactly one terminal outcome per request and exactly-once release of the response-create / api-key / account leases, on real product release paths.
- A canary that runs the property checker against a double-release-on-cancel toy and asserts it FAILS — plus 3 more planted mutants the checker rejects while accepting the correct implementation.

Runs in ~2s wall (33 tests), 3 consecutive green. openspec change `add-deterministic-proxy-simulation` validates strictly. The 2 pre-existing `test_v1_responses_http_bridge_reconnects*` failures also fail on plain origin/main (baseline, not introduced here).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable clock and scheduling controls for proxy operations.
  * Added deterministic virtual-time simulation for validating proxy lifecycle behavior.
* **Bug Fixes**
  * Improved timeout, cancellation, cleanup, retry, reconnection, and resource-release handling across HTTP and WebSocket flows.
  * Strengthened session ownership, admission timeouts, and rate-limit recovery behavior.
* **Tests**
  * Expanded coverage for timing, cancellation ordering, admission control, lease release, retry handling, and exactly-once request completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->