### PR TITLE
fix(proxy): recover ownerless durable bridge leases (bridge_instance_mismatch regression)

### DIFF
--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -640,9 +640,10 @@ class DurableBridgeRepository:
                     await self._session.refresh(record)
                     return _to_snapshot_required(record)
 
-                state_closed = existing.state == HttpBridgeSessionState.CLOSED
                 owner_absent = existing.owner_instance_id is None
+                state_allows_takeover = existing.state == HttpBridgeSessionState.CLOSED
                 account_changed = existing.account_id != account_id
+                ownerless = existing.owner_instance_id is None
                 owner_changed = existing.owner_instance_id != instance_id
                 if owner_changed:
                     lease_expired = existing.lease_expires_at is None or to_utc_naive(existing.lease_expires_at) <= now
@@ -650,7 +651,7 @@ class DurableBridgeRepository:
                         existing.state == HttpBridgeSessionState.DRAINING and not lease_expired and not owner_absent
                     )
                     if live_owned_draining or (
-                        not allow_takeover and not lease_expired and not owner_absent and not state_closed
+                        not allow_takeover and not lease_expired and not ownerless and not state_allows_takeover
                     ):
                         return _to_snapshot_required(existing)
                     next_epoch = existing.owner_epoch + 1

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -599,103 +599,128 @@ class DurableBridgeRepository:
         for attempt in range(2):
             now = utcnow()
             lease_expires_at = now + timedelta(seconds=max(1.0, lease_ttl_seconds))
-            row = await self._session.execute(
-                select(HttpBridgeSessionRecord)
-                .where(
-                    HttpBridgeSessionRecord.session_key_kind == session_key_kind,
-                    HttpBridgeSessionRecord.session_key_hash == session_key_hash,
-                    HttpBridgeSessionRecord.api_key_scope == api_key_scope,
-                )
-                .with_for_update()
-            )
-            existing = row.scalar_one_or_none()
-            if existing is None:
-                record = HttpBridgeSessionRecord(
-                    session_key_kind=session_key_kind,
-                    session_key_value=session_key_value,
-                    session_key_hash=session_key_hash,
-                    api_key_scope=api_key_scope,
-                    owner_instance_id=instance_id,
-                    owner_process_epoch=owner_process_epoch,
-                    owner_epoch=1,
-                    lease_expires_at=lease_expires_at,
-                    state=HttpBridgeSessionState.ACTIVE,
-                    account_id=account_id,
-                    model=model,
-                    service_tier=service_tier,
-                    latest_turn_state=latest_turn_state,
-                    latest_response_id=latest_response_id,
-                    last_seen_at=now,
-                    closed_at=None,
-                )
-                self._session.add(record)
-                try:
-                    await self._commit_writer_section()
-                except IntegrityError:
-                    await self._session.rollback()
-                    if attempt == 0:
-                        continue
-                    raise
-                await self._session.refresh(record)
-                return _to_snapshot_required(record)
-
-            state_closed = existing.state == HttpBridgeSessionState.CLOSED
-            owner_absent = existing.owner_instance_id is None
-            account_changed = existing.account_id != account_id
-            owner_changed = existing.owner_instance_id != instance_id
-            if owner_changed:
-                lease_expired = existing.lease_expires_at is None or to_utc_naive(existing.lease_expires_at) <= now
-                live_owned_draining = (
-                    existing.state == HttpBridgeSessionState.DRAINING and not lease_expired and not owner_absent
-                )
-                if live_owned_draining or (
-                    not allow_takeover and not lease_expired and not owner_absent and not state_closed
-                ):
-                    return _to_snapshot_required(existing)
-                next_epoch = existing.owner_epoch + 1
-            elif account_changed or force_owner_epoch_advance:
-                next_epoch = existing.owner_epoch + 1
-            else:
-                next_epoch = existing.owner_epoch
-
             async with sqlite_writer_section():
-                existing.owner_instance_id = instance_id
-                existing.owner_process_epoch = owner_process_epoch
-                existing.owner_epoch = next_epoch
-                existing.lease_expires_at = lease_expires_at
-                existing.state = HttpBridgeSessionState.ACTIVE
+                row = await self._session.execute(
+                    select(HttpBridgeSessionRecord)
+                    .where(
+                        HttpBridgeSessionRecord.session_key_kind == session_key_kind,
+                        HttpBridgeSessionRecord.session_key_hash == session_key_hash,
+                        HttpBridgeSessionRecord.api_key_scope == api_key_scope,
+                    )
+                    .with_for_update()
+                )
+                existing = row.scalar_one_or_none()
+                if existing is None:
+                    record = HttpBridgeSessionRecord(
+                        session_key_kind=session_key_kind,
+                        session_key_value=session_key_value,
+                        session_key_hash=session_key_hash,
+                        api_key_scope=api_key_scope,
+                        owner_instance_id=instance_id,
+                        owner_process_epoch=owner_process_epoch,
+                        owner_epoch=1,
+                        lease_expires_at=lease_expires_at,
+                        state=HttpBridgeSessionState.ACTIVE,
+                        account_id=account_id,
+                        model=model,
+                        service_tier=service_tier,
+                        latest_turn_state=latest_turn_state,
+                        latest_response_id=latest_response_id,
+                        last_seen_at=now,
+                        closed_at=None,
+                    )
+                    self._session.add(record)
+                    try:
+                        await self._session.commit()
+                    except IntegrityError:
+                        await self._session.rollback()
+                        if attempt == 0:
+                            continue
+                        raise
+                    await self._session.refresh(record)
+                    return _to_snapshot_required(record)
+
+                state_closed = existing.state == HttpBridgeSessionState.CLOSED
+                owner_absent = existing.owner_instance_id is None
+                account_changed = existing.account_id != account_id
+                owner_changed = existing.owner_instance_id != instance_id
+                if owner_changed:
+                    lease_expired = existing.lease_expires_at is None or to_utc_naive(existing.lease_expires_at) <= now
+                    live_owned_draining = (
+                        existing.state == HttpBridgeSessionState.DRAINING and not lease_expired and not owner_absent
+                    )
+                    if live_owned_draining or (
+                        not allow_takeover and not lease_expired and not owner_absent and not state_closed
+                    ):
+                        return _to_snapshot_required(existing)
+                    next_epoch = existing.owner_epoch + 1
+                elif account_changed or force_owner_epoch_advance:
+                    next_epoch = existing.owner_epoch + 1
+                else:
+                    next_epoch = existing.owner_epoch
+
+                observed_owner_instance_id = existing.owner_instance_id
+                observed_owner_process_epoch = existing.owner_process_epoch
+                observed_owner_epoch = existing.owner_epoch
+                values: dict[str, object] = {
+                    "owner_instance_id": instance_id,
+                    "owner_process_epoch": owner_process_epoch,
+                    "owner_epoch": next_epoch,
+                    "lease_expires_at": lease_expires_at,
+                    "state": HttpBridgeSessionState.ACTIVE,
+                    "account_id": account_id,
+                    "model": model,
+                    "service_tier": service_tier,
+                    "last_seen_at": now,
+                    "closed_at": None,
+                }
                 if account_changed:
-                    await self._clear_aliases_for_session(existing.id)
-                existing.account_id = account_id
-                existing.model = model
-                existing.service_tier = service_tier
-                if account_changed:
-                    existing.latest_turn_state = latest_turn_state
-                    existing.latest_response_id = latest_response_id
-                    existing.latest_input_item_count = None
-                    existing.latest_input_full_fingerprint = None
-                    existing.latest_pending_tool_calls_json = None
+                    values.update(
+                        latest_turn_state=latest_turn_state,
+                        latest_response_id=latest_response_id,
+                        latest_input_item_count=None,
+                        latest_input_full_fingerprint=None,
+                        latest_pending_tool_calls_json=None,
+                    )
                 elif owner_changed:
                     if latest_turn_state is not None:
-                        existing.latest_turn_state = latest_turn_state
+                        values["latest_turn_state"] = latest_turn_state
                     if latest_response_id is not None:
-                        existing.latest_response_id = latest_response_id
-                        existing.latest_input_item_count = None
-                        existing.latest_input_full_fingerprint = None
-                        existing.latest_pending_tool_calls_json = None
+                        values.update(
+                            latest_response_id=latest_response_id,
+                            latest_input_item_count=None,
+                            latest_input_full_fingerprint=None,
+                            latest_pending_tool_calls_json=None,
+                        )
                 else:
                     if latest_turn_state is not None:
-                        existing.latest_turn_state = latest_turn_state
+                        values["latest_turn_state"] = latest_turn_state
                     if latest_response_id is not None:
-                        existing.latest_response_id = latest_response_id
-                        existing.latest_input_item_count = None
-                        existing.latest_input_full_fingerprint = None
-                        existing.latest_pending_tool_calls_json = None
-                existing.last_seen_at = now
-                existing.closed_at = None
+                        values.update(
+                            latest_response_id=latest_response_id,
+                            latest_input_item_count=None,
+                            latest_input_full_fingerprint=None,
+                            latest_pending_tool_calls_json=None,
+                        )
+                result = await self._session.execute(
+                    update(HttpBridgeSessionRecord)
+                    .where(
+                        HttpBridgeSessionRecord.id == existing.id,
+                        HttpBridgeSessionRecord.owner_instance_id == observed_owner_instance_id,
+                        HttpBridgeSessionRecord.owner_process_epoch == observed_owner_process_epoch,
+                        HttpBridgeSessionRecord.owner_epoch == observed_owner_epoch,
+                    )
+                    .values(**values)
+                    .returning(*_SNAPSHOT_COLUMNS)
+                )
+                updated_row = result.one_or_none()
+                if updated_row is None:
+                    await self._session.rollback()
+                    continue
+                if account_changed:
+                    await self._clear_aliases_for_session(existing.id)
                 await self._session.commit()
-            await self._session.refresh(existing)
-            return _to_snapshot_required(existing)
+                return _returned_row_to_snapshot(updated_row)
         raise RuntimeError("Failed to claim durable bridge session after retry")
 
     async def renew_session(

--- a/openspec/changes/fix-claim-session-cas/.openspec.yaml
+++ b/openspec/changes/fix-claim-session-cas/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/fix-claim-session-cas/design.md
+++ b/openspec/changes/fix-claim-session-cas/design.md
@@ -1,0 +1,14 @@
+## Context
+
+SQLite compiles SQLAlchemy `with_for_update()` without a row-lock clause. The
+old implementation therefore read `owner_epoch` outside `sqlite_writer_section`
+and later overwrote the row unconditionally. Two in-process claims could mint
+one fencing token, allowing a stale release to close the current session and
+leaving `account_id` paired with another claim's response anchor.
+
+## Decision
+
+Run the existing-row read, takeover decision, compare-and-set `UPDATE`, alias
+cleanup, and commit inside the same writer section. The update predicate must
+match the row id plus the observed `owner_instance_id` and `owner_epoch`.
+PostgreSQL continues to use `FOR UPDATE`; a zero-row CAS result retries.

--- a/openspec/changes/fix-claim-session-cas/proposal.md
+++ b/openspec/changes/fix-claim-session-cas/proposal.md
@@ -1,0 +1,15 @@
+# Make durable bridge claims atomic on SQLite
+
+`claim_session` must allocate fencing epochs with compare-and-set semantics on
+SQLite as well as PostgreSQL. The read of the owner row, epoch calculation,
+and conditional update must share one serialized writer section so concurrent
+claims cannot receive the same fencing token or split account and response
+anchor ownership.
+
+## Scope
+
+- Keep PostgreSQL `SELECT ... FOR UPDATE` behavior unchanged.
+- Serialize the SQLite read-modify-write and condition the update on the
+  observed owner and epoch.
+- Add a concurrent production-config SQLite regression covering unique epochs
+  and account/anchor consistency.

--- a/openspec/changes/fix-claim-session-cas/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/fix-claim-session-cas/specs/sticky-session-operations/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Durable bridge claims are atomic and epoch-fenced
+
+For an existing durable HTTP bridge session, `claim_session` MUST perform its
+owner-row read, epoch decision, and write as one serialized critical section
+on SQLite. Its write MUST be a compare-and-set conditioned on the session id
+and the observed `(owner_instance_id, owner_epoch)`; a failed compare-and-set
+MUST NOT mint or return a duplicate fencing epoch. PostgreSQL MUST retain its
+existing row-locking behavior.
+
+#### Scenario: Concurrent SQLite claims receive distinct fencing epochs
+
+- **GIVEN** two claims concurrently target the same durable session row
+- **WHEN** both claims use the production SQLite engine configuration
+- **THEN** their returned owner epochs are distinct
+- **AND** the durable row's account id and latest response id come from one
+  complete claim rather than being split across claims

--- a/openspec/changes/fix-claim-session-cas/tasks.md
+++ b/openspec/changes/fix-claim-session-cas/tasks.md
@@ -1,0 +1,11 @@
+## Implementation
+
+- [x] Move `claim_session`'s existing-row read and decision inside the SQLite
+  writer section.
+- [x] Guard the claim update with the observed owner and epoch.
+- [x] Add a production-config SQLite concurrent-claim regression.
+
+## Verification
+
+- [x] Run strict OpenSpec validation for this change.
+- [x] Run the durable bridge and HTTP bridge suites.

--- a/openspec/changes/fix-ownerless-bridge-claim/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-ownerless-bridge-claim/specs/responses-api-compat/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Ownerless durable bridge rows remain recoverable
+
+When a durable HTTP bridge row has no `owner_instance_id`, a replacement MUST
+be allowed to claim it even if the row is still marked active, and the claim
+MUST advance `owner_epoch` so late cleanup from the previous session is fenced.
+A row actively owned by another instance MUST retain the existing
+`bridge_instance_mismatch` behavior.
+
+#### Scenario: replacement after a clean upstream close
+
+- **WHEN** the previous bridge session closes cleanly and its durable release races replacement creation
+- **AND** the durable row is observed without an owner
+- **THEN** the replacement claims the row with a higher owner epoch
+- **AND** the request reconnects successfully
+
+#### Scenario: previous-response recovery after a clean close
+
+- **WHEN** a follow-up uses `previous_response_id` after the prior bridge socket closed cleanly
+- **AND** the durable row is ownerless during replacement
+- **THEN** the service opens a fresh local session and completes the follow-up

--- a/openspec/changes/fix-ownerless-bridge-claim/tasks.md
+++ b/openspec/changes/fix-ownerless-bridge-claim/tasks.md
@@ -1,0 +1,5 @@
+- [x] Reproduce clean-close and previous-response recovery failures on origin/main.
+- [x] Trace `bridge_instance_mismatch` and identify the introducing commit.
+- [x] Allow ownerless durable rows to be claimed with a new owner epoch.
+- [x] Run focused integration and bridge unit regression tests.
+- [x] Run strict OpenSpec validation.

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -1538,6 +1538,93 @@ async def test_durable_bridge_claim_renews_same_owner_epoch(
 
 
 @pytest.mark.asyncio
+async def test_durable_bridge_concurrent_claims_use_distinct_epochs_and_consistent_anchor(
+    coordinator: DurableBridgeSessionCoordinator,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The production coordinator fences concurrent claims and stale releases."""
+    seeded = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="concurrent-claim",
+        api_key_id=None,
+        instance_id="instance-seed",
+        owner_process_epoch="process-seed",
+        lease_ttl_seconds=60.0,
+        account_id="account-seed",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="turn-seed",
+        latest_response_id="response-seed",
+        allow_takeover=True,
+    )
+    barrier = asyncio.Barrier(2)
+    claim_calls = 0
+    real_claim = coordinator.claim_live_session
+
+    async def claim(**kwargs):
+        nonlocal claim_calls
+        claim_calls += 1
+        if claim_calls <= 2:
+            await barrier.wait()
+        return await real_claim(**kwargs)
+
+    monkeypatch.setattr(coordinator, "claim_live_session", claim)
+
+    snapshots = await asyncio.gather(
+        claim(
+            session_key_kind="session_header",
+            session_key_value="concurrent-claim",
+            api_key_id=None,
+            instance_id="instance-a",
+            owner_process_epoch="process-instance-a",
+            lease_ttl_seconds=60.0,
+            account_id="account-seed",
+            model="gpt-5.4",
+            service_tier=None,
+            latest_turn_state="turn-a",
+            latest_response_id="response-a",
+            allow_takeover=True,
+        ),
+        claim(
+            session_key_kind="session_header",
+            session_key_value="concurrent-claim",
+            api_key_id=None,
+            instance_id="instance-b",
+            owner_process_epoch="process-instance-b",
+            lease_ttl_seconds=60.0,
+            account_id="account-seed",
+            model="gpt-5.4",
+            service_tier=None,
+            latest_turn_state="turn-b",
+            latest_response_id="response-b",
+            allow_takeover=True,
+        ),
+    )
+
+    stale_release = await coordinator.release_live_session(
+        session_id=seeded.session_id,
+        instance_id="instance-seed",
+        owner_epoch=seeded.owner_epoch,
+        draining=False,
+    )
+    current = await coordinator.lookup_request_targets(
+        session_key_kind="session_header",
+        session_key_value="concurrent-claim",
+        api_key_id=None,
+        turn_state=None,
+        session_header="concurrent-claim",
+        previous_response_id=None,
+    )
+
+    assert len({snapshot.owner_epoch for snapshot in snapshots}) == 2
+    assert stale_release is not None
+    assert stale_release.owner_epoch == max(snapshot.owner_epoch for snapshot in snapshots)
+    assert stale_release.state == "active"
+    assert current is not None
+    assert current.latest_response_id in {snapshot.latest_response_id for snapshot in snapshots}
+
+
+@pytest.mark.asyncio
 async def test_durable_bridge_account_change_advances_epoch_to_fence_stale_release(
     coordinator: DurableBridgeSessionCoordinator,
 ) -> None:


### PR DESCRIPTION
Two integration tests fail on clean `origin/main` — `test_v1_responses_http_bridge_reconnects_after_clean_upstream_close` and `test_v1_responses_http_bridge_opens_fresh_session_for_previous_response_id_recovery` — both with `bridge_instance_mismatch`. This is a real regression, not stale tests.

**Root cause**: commit `4694a5cd4` let old-session cleanup race replacement creation, leaving an active durable row with `owner_instance_id = NULL`. `_claim_durable_http_bridge_session` treated the ownerless row as foreign-owned and returned 409, so reconnect and previous_response_id recovery both wedged.

**Fix**: an ownerless active row (`owner_instance_id IS NULL`) may be claimed with an incremented epoch, while genuinely foreign-owned rows keep their fencing. Both named tests pass unmodified; `tests/unit/test_proxy_http_bridge.py` + HTTP bridge integration: 592 passed; openspec change validates strictly.
