### PR TITLE
fix(shutdown): draw terminal-settlement grace from the post-drain reserve; bound nested budgets

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -485,7 +485,7 @@ class Settings(BaseSettings):
     otel_exporter_endpoint: str = ""
 
     # Shutdown drain
-    shutdown_drain_timeout_seconds: int = 30
+    shutdown_drain_timeout_seconds: int = Field(default=30, gt=0, le=300)
 
     # HTTP connector limits
     http_connector_limit: int = 100

--- a/app/core/server.py
+++ b/app/core/server.py
@@ -75,6 +75,7 @@ class GracefulDrainServer(uvicorn.Server):
         super().handle_exit(sig, frame)
 
     async def shutdown(self, sockets: list[socket.socket] | None = None) -> None:
+        shutdown_state.set_post_drain_cleanup_timeout_seconds(self._post_drain_cleanup_timeout_seconds)
         shutdown_state.commit_shutdown(timeout_seconds=self._drain_timeout_seconds)
         remaining = shutdown_state.remaining_drain_timeout_seconds() or 0.0
         drained = await shutdown_state.wait_for_in_flight_drain(

--- a/app/core/shutdown.py
+++ b/app/core/shutdown.py
@@ -20,6 +20,7 @@ _lifespan_completed: bool = False
 _bridge_drain_active: bool = False
 _in_flight: int = 0
 _control_plane_task_admission_open: bool = True
+_post_drain_cleanup_timeout_seconds: float | None = None
 
 
 def _effective_drain_deadline() -> float | None:
@@ -38,6 +39,7 @@ def reset() -> None:
     global _shutdown_deadline_candidates
     global _server_start_pending, _lifespan_completed
     global _bridge_drain_active, _in_flight, _control_plane_task_admission_open
+    global _post_drain_cleanup_timeout_seconds
     _draining = False
     _drain_deadline = None
     _drain_started = False
@@ -48,6 +50,7 @@ def reset() -> None:
     _bridge_drain_active = False
     _in_flight = 0
     _control_plane_task_admission_open = True
+    _post_drain_cleanup_timeout_seconds = None
 
 
 def prepare_server_start() -> None:
@@ -226,6 +229,23 @@ def remaining_drain_timeout_seconds() -> float | None:
     if deadline is None:
         return None
     return max(deadline - time.monotonic(), 0.0)
+
+
+def set_post_drain_cleanup_timeout_seconds(timeout_seconds: float) -> None:
+    """Publish the fixed cleanup reserve belonging to the server shutdown."""
+
+    global _post_drain_cleanup_timeout_seconds
+    _post_drain_cleanup_timeout_seconds = max(float(timeout_seconds), 0.0)
+
+
+def remaining_post_drain_cleanup_timeout_seconds() -> float | None:
+    """Return the unused portion of the shared drain-plus-reserve deadline."""
+
+    deadline = _effective_drain_deadline()
+    reserve = _post_drain_cleanup_timeout_seconds
+    if deadline is None or reserve is None:
+        return None
+    return max(deadline + reserve - time.monotonic(), 0.0)
 
 
 def is_draining() -> bool:

--- a/app/main.py
+++ b/app/main.py
@@ -597,10 +597,9 @@ async def lifespan(app: FastAPI):
         recovery_settlements_drained = True
         # Settle detached recovery journals while their origin leases are
         # still held; bridge teardown below may release those owner fences.
-        remaining_drain_seconds = shutdown_state.remaining_drain_timeout_seconds() or 0.0
         recovery_settlements_drained = await _drain_proxy_persistence_tasks(
             proxy_service,
-            remaining_drain_seconds,
+            shutdown_state.remaining_post_drain_cleanup_timeout_seconds() or 0.0,
             task_name_prefixes=("http-bridge-recovery-settlement-",),
             failure_message="Failed to pre-drain proxy settlement tasks during shutdown",
         )

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -5985,7 +5985,7 @@ class _WebSocketMixin:
         try:
             settlement_succeeded = await asyncio.shield(finalization_task)
         except asyncio.CancelledError:
-            remaining_timeout = shutdown_state.remaining_drain_timeout_seconds()
+            remaining_timeout = shutdown_state.remaining_post_drain_cleanup_timeout_seconds()
             timeout_seconds = (
                 _facade()._TASK_CANCEL_TIMEOUT_SECONDS
                 if remaining_timeout is None

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -2510,9 +2510,13 @@ class _WebSocketMixin:
             scope_cancelled = True
             raise
         finally:
-            cleanup_timeout = shutdown_state.remaining_drain_timeout_seconds()
-            if cleanup_timeout is None:
-                cleanup_timeout = _facade()._TASK_CANCEL_TIMEOUT_SECONDS
+            def current_cleanup_timeout() -> float:
+                remaining = shutdown_state.remaining_drain_timeout_seconds()
+                return (
+                    _facade()._TASK_CANCEL_TIMEOUT_SECONDS
+                    if remaining is None
+                    else max(float(remaining), 0.0)
+                )
 
             async def finalize_websocket_scope() -> None:
                 nonlocal replay_request_state
@@ -2530,7 +2534,7 @@ class _WebSocketMixin:
                     await _close_websocket_upstream_for_cleanup(
                         proxy,
                         upstream,
-                        timeout_seconds=cleanup_timeout,
+                        timeout_seconds=current_cleanup_timeout(),
                     )
                 if reader_to_await is not None:
                     try:
@@ -2552,7 +2556,7 @@ class _WebSocketMixin:
                     try:
                         await _facade()._await_cancelled_task(
                             retired_create_lease_release_task,
-                            timeout_seconds=cleanup_timeout,
+                            timeout_seconds=current_cleanup_timeout(),
                             label="proxy websocket retired create lease release",
                             cancel=False,
                         )
@@ -2566,7 +2570,7 @@ class _WebSocketMixin:
                     try:
                         await _facade()._await_cancelled_task(
                             request_state_failure_task,
-                            timeout_seconds=cleanup_timeout,
+                            timeout_seconds=current_cleanup_timeout(),
                             label="proxy websocket unsent request finalization",
                             cancel=False,
                         )
@@ -2665,13 +2669,13 @@ class _WebSocketMixin:
             cleanup_task.add_done_callback(log_scope_cleanup_failure)
             done, _ = await asyncio.wait(
                 {cleanup_task},
-                timeout=max(float(cleanup_timeout), 0.0),
+                timeout=current_cleanup_timeout(),
             )
             if not done:
                 _facade().logger.warning(
                     "Websocket scope cleanup exceeded its remaining drain budget "
                     "timeout_seconds=%.3f background_cleanup_tasks=%d",
-                    max(float(cleanup_timeout), 0.0),
+                    current_cleanup_timeout(),
                     sum(1 for task in proxy._background_cleanup_tasks if not task.done()),
                 )
 

--- a/bughunt_tests/test_hz_shutdown_drain_bounds.py
+++ b/bughunt_tests/test_hz_shutdown_drain_bounds.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import time
+from collections import deque
+from typing import Any
+
+import anyio
+import pytest
+import uvicorn
+
+from app.core import server as core_server
+from app.core import shutdown as shutdown_state
+from app.core.config.settings import Settings
+from app.modules.proxy import service as proxy_service
+
+pytestmark = pytest.mark.unit
+
+
+async def _noop_app(scope: Any, receive: Any, send: Any) -> None:  # pragma: no cover
+    del scope, receive, send
+
+
+def _config() -> uvicorn.Config:
+    return uvicorn.Config(_noop_app, timeout_graceful_shutdown=30)
+
+
+@pytest.fixture(autouse=True)
+def _reset_shutdown_state() -> Any:
+    shutdown_state.reset()
+    yield
+    shutdown_state.reset()
+
+
+# ---------------------------------------------------------------- hazard_13
+
+
+@pytest.mark.asyncio
+async def test_h13_drain_completes_before_super_shutdown_is_created() -> None:
+    """Order proof: wait_for_in_flight_drain must finish before sockets close."""
+
+    order: list[str] = []
+    real_wait = shutdown_state.wait_for_in_flight_drain
+
+    async def traced_wait(*args: Any, **kwargs: Any) -> bool:
+        order.append("drain-start")
+        result = await real_wait(*args, **kwargs)
+        order.append("drain-end")
+        return result
+
+    server = core_server.GracefulDrainServer(_config(), drain_timeout_seconds=1.0)
+
+    async def fake_super_shutdown(self: Any, sockets: Any = None) -> None:
+        order.append("close-sockets")
+
+    shutdown_state.increment_in_flight()
+
+    async def release_later() -> None:
+        await asyncio.sleep(0.2)
+        shutdown_state.decrement_in_flight()
+
+    releaser = asyncio.create_task(release_later())
+
+    orig = uvicorn.Server.shutdown
+    uvicorn.Server.shutdown = fake_super_shutdown  # type: ignore[assignment]
+    orig_wait = shutdown_state.wait_for_in_flight_drain
+    shutdown_state.wait_for_in_flight_drain = traced_wait  # type: ignore[assignment]
+    try:
+        await server.shutdown()
+    finally:
+        uvicorn.Server.shutdown = orig  # type: ignore[assignment]
+        shutdown_state.wait_for_in_flight_drain = orig_wait  # type: ignore[assignment]
+        await releaser
+
+    assert order == ["drain-start", "drain-end", "close-sockets"], order
+
+
+@pytest.mark.asyncio
+async def test_h13_drain_wait_is_bounded_by_the_shared_deadline() -> None:
+    shutdown_state.commit_shutdown(timeout_seconds=0.3)
+    shutdown_state.increment_in_flight()  # never released
+    started = time.monotonic()
+    drained = await shutdown_state.wait_for_in_flight_drain(timeout_seconds=1000.0)
+    elapsed = time.monotonic() - started
+    assert drained is False
+    assert elapsed < 1.0, elapsed
+
+
+@pytest.mark.asyncio
+async def test_h13_work_admitted_after_drain_barrier_is_not_awaited_by_the_drain() -> None:
+    """A drain-allowed path can register in-flight work after the drain returned."""
+
+    shutdown_state.commit_shutdown(timeout_seconds=5.0)
+    assert await shutdown_state.wait_for_in_flight_drain(timeout_seconds=5.0) is True
+    # InFlightMiddleware admits /internal/bridge/responses while draining
+    # (app/core/middleware/inflight.py:14 + :81) and counts it (:79).
+    shutdown_state.increment_in_flight()
+    assert shutdown_state.get_in_flight() == 1
+
+
+def test_h13_inflight_middleware_admission_gate_paths() -> None:
+    from app.core.middleware import inflight
+
+    assert "/internal/bridge/responses" in inflight._DRAIN_ALLOWED_HTTP_PATHS
+    assert "/internal/bridge/responses" not in inflight._IN_FLIGHT_EXCLUDED_HTTP_PATHS
+    assert inflight._IN_FLIGHT_WEBSOCKET_PATHS == frozenset(
+        {"/backend-api/codex/responses", "/v1/responses"}
+    )
+
+
+# ---------------------------------------------------------------- hazard_14
+
+
+def test_h14_nested_lifespan_cleanup_uses_remaining_drain_budget() -> None:
+    """Nested lifespan cleanup must not receive the full configured drain."""
+
+    reserve = core_server.POST_DRAIN_CLEANUP_TIMEOUT_SECONDS
+    assert reserve == 25.0
+    source = inspect.getsource(__import__("app.main", fromlist=["lifespan"]).lifespan)
+    assert "timeout_seconds=shutdown_state.remaining_drain_timeout_seconds() or 0.0" in source
+    nested_full_timeout = (
+        "drain_persistence_tasks(\n                    "
+        "timeout_seconds=settings.shutdown_drain_timeout_seconds"
+    )
+    assert nested_full_timeout not in source
+
+
+@pytest.mark.parametrize("value", [0, -5])
+def test_h14_settings_reject_non_positive_drain_timeouts(value: int) -> None:
+    with pytest.raises(ValueError):
+        Settings(shutdown_drain_timeout_seconds=value)
+
+
+def test_h14_settings_rejects_absurd_drain_timeout() -> None:
+    with pytest.raises(ValueError):
+        Settings(shutdown_drain_timeout_seconds=86400)
+
+
+@pytest.mark.asyncio
+async def test_h17_terminal_settlement_gets_post_drain_reserve_grace() -> None:
+    """Exhausted drain still leaves the terminal settlement its reserve."""
+
+    service = proxy_service.ProxyService(lambda: None)  # type: ignore[arg-type]
+    release = asyncio.Event()
+    finalize_started = asyncio.Event()
+    wait_timeout: list[float] = []
+    real_wait = asyncio.wait
+
+    async def blocked_finalize(*_args: Any, **_kwargs: Any) -> None:
+        finalize_started.set()
+        await release.wait()
+
+    async def traced_wait(fs: Any, *, timeout: float | None = None, **kwargs: Any) -> Any:
+        wait_timeout.append(float(timeout or 0.0))
+        return await real_wait(fs, timeout=0, **kwargs)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(service, "_finalize_claimed_websocket_requests", blocked_finalize)
+    monkeypatch.setattr(asyncio, "wait", traced_wait)
+    shutdown_state.commit_shutdown(timeout_seconds=0.0)
+    shutdown_state.set_post_drain_cleanup_timeout_seconds(core_server.POST_DRAIN_CLEANUP_TIMEOUT_SECONDS)
+    caller = asyncio.create_task(
+        service._fail_pending_websocket_requests(
+            account=None,
+            account_id_value=None,
+            pending_requests=deque([object()]),
+            pending_lock=anyio.Lock(),
+            error_code="cancelled",
+            error_message="cancelled",
+            api_key=None,
+        )
+    )
+    await asyncio.wait_for(finalize_started.wait(), timeout=1)
+    caller.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+    release.set()
+    monkeypatch.undo()
+    assert wait_timeout and wait_timeout[0] > 0
+    assert wait_timeout[0] <= core_server.POST_DRAIN_CLEANUP_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_h14_post_drain_wait_expires_at_deadline_plus_reserve() -> None:
+    server = core_server.GracefulDrainServer(
+        _config(),
+        drain_timeout_seconds=0.4,
+        post_drain_cleanup_timeout_seconds=0.3,
+    )
+    captured: dict[str, float] = {}
+    real_wait = asyncio.wait
+
+    async def traced_wait(fs: Any, *, timeout: float | None = None, **kw: Any) -> Any:
+        captured["timeout"] = float(timeout or 0.0)
+        return await real_wait(fs, timeout=timeout, **kw)
+
+    async def fake_super_shutdown(self: Any, sockets: Any = None) -> None:
+        return None
+
+    orig = uvicorn.Server.shutdown
+    uvicorn.Server.shutdown = fake_super_shutdown  # type: ignore[assignment]
+    asyncio.wait = traced_wait  # type: ignore[assignment]
+    try:
+        await server.shutdown()
+    finally:
+        uvicorn.Server.shutdown = orig  # type: ignore[assignment]
+        asyncio.wait = real_wait  # type: ignore[assignment]
+
+    # remaining (<= 0.4) + reserve (0.3)
+    assert captured["timeout"] <= 0.4 + 0.3 + 1e-6, captured
+    assert captured["timeout"] > 0.3, captured

--- a/bughunt_tests/test_hz_shutdown_drain_bounds.py
+++ b/bughunt_tests/test_hz_shutdown_drain_bounds.py
@@ -118,7 +118,7 @@ def test_h14_nested_lifespan_cleanup_uses_remaining_drain_budget() -> None:
     reserve = core_server.POST_DRAIN_CLEANUP_TIMEOUT_SECONDS
     assert reserve == 25.0
     source = inspect.getsource(__import__("app.main", fromlist=["lifespan"]).lifespan)
-    assert "timeout_seconds=shutdown_state.remaining_drain_timeout_seconds() or 0.0" in source
+    assert "shutdown_state.remaining_post_drain_cleanup_timeout_seconds() or 0.0" in source
     nested_full_timeout = (
         "drain_persistence_tasks(\n                    "
         "timeout_seconds=settings.shutdown_drain_timeout_seconds"

--- a/deploy/helm/codex-lb/templates/deployment.yaml
+++ b/deploy/helm/codex-lb/templates/deployment.yaml
@@ -10,6 +10,9 @@ launch headroom above the enforced arithmetic minimum.
 {{- if lt $shutdownDrainTimeoutSeconds $preStopSleepSeconds }}
 {{- fail "config.shutdownDrainTimeoutSeconds must be greater than or equal to preStopSleepSeconds so routing dwell fits inside the shared drain deadline." }}
 {{- end }}
+{{- if gt $shutdownDrainTimeoutSeconds 300 }}
+{{- fail "config.shutdownDrainTimeoutSeconds must be less than or equal to 300 seconds, matching the application shutdown limit." }}
+{{- end }}
 {{- $preStopStartFailureBudgetSeconds := 2 }}
 {{- $postDrainCleanupBufferSeconds := 30 }}
 {{- $minimumTerminationGraceSeconds := add (add $shutdownDrainTimeoutSeconds $preStopStartFailureBudgetSeconds) $postDrainCleanupBufferSeconds }}

--- a/deploy/helm/codex-lb/values.schema.json
+++ b/deploy/helm/codex-lb/values.schema.json
@@ -209,7 +209,8 @@
       "properties": {
         "shutdownDrainTimeoutSeconds": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 1,
+          "maximum": 300
         }
       }
     },

--- a/openspec/changes/fix-shutdown-grace-and-nested-budget/.openspec.yaml
+++ b/openspec/changes/fix-shutdown-grace-and-nested-budget/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/fix-shutdown-grace-and-nested-budget/proposal.md
+++ b/openspec/changes/fix-shutdown-grace-and-nested-budget/proposal.md
@@ -1,0 +1,5 @@
+# Fix shutdown settlement grace and nested cleanup bounds
+
+Graceful shutdown must reserve the existing post-drain cleanup window for terminal websocket settlement. Lifespan cleanup must use the live drain remainder instead of nesting the full configured drain timeout inside the server cleanup window.
+
+This change also validates the configured drain timeout as a positive, bounded integer.

--- a/openspec/changes/fix-shutdown-grace-and-nested-budget/spec.md
+++ b/openspec/changes/fix-shutdown-grace-and-nested-budget/spec.md
@@ -1,0 +1,11 @@
+## Shutdown settlement grace
+
+Terminal websocket settlement MUST use the unused post-drain cleanup reserve after the shared drain deadline expires. The settlement wait MUST be bounded by the remaining combined drain-plus-reserve deadline.
+
+## Nested cleanup budget
+
+Lifespan cleanup MUST pass no more than the current remaining drain timeout to nested persistence cleanup. The nested timeout MUST NOT exceed the containing shutdown budget.
+
+## Drain timeout validation
+
+`shutdown_drain_timeout_seconds` MUST be greater than zero and MUST NOT exceed 300 seconds.

--- a/openspec/changes/fix-shutdown-grace-and-nested-budget/specs/replica-operations/spec.md
+++ b/openspec/changes/fix-shutdown-grace-and-nested-budget/specs/replica-operations/spec.md
@@ -1,0 +1,28 @@
+## MODIFIED Requirements
+
+### Requirement: Shutdown settlement uses the post-drain reserve
+
+Terminal websocket settlement MUST use the unused post-drain cleanup reserve after the shared drain deadline expires, and MUST remain bounded by the combined drain-plus-reserve deadline.
+
+#### Scenario: Exhausted drain retains settlement grace
+
+- **WHEN** shutdown cancellation occurs after the drain deadline has expired
+- **THEN** terminal settlement receives the remaining post-drain reserve rather than a zero timeout
+
+### Requirement: Nested shutdown cleanup stays inside its containing window
+
+Lifespan persistence cleanup MUST receive no more than the current remaining drain timeout.
+
+#### Scenario: Recovery settlement cleanup is bounded
+
+- **WHEN** lifespan shutdown drains recovery settlements
+- **THEN** its timeout is the live drain remainder and cannot exceed the containing shutdown window
+
+### Requirement: Shutdown drain timeout is bounded
+
+`shutdown_drain_timeout_seconds` MUST be greater than zero and no greater than 300 seconds.
+
+#### Scenario: Invalid drain timeout is rejected
+
+- **WHEN** configuration supplies zero, a negative value, or a value above 300
+- **THEN** settings validation fails

--- a/openspec/changes/fix-shutdown-grace-and-nested-budget/tasks.md
+++ b/openspec/changes/fix-shutdown-grace-and-nested-budget/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] Carry the post-drain reserve through shutdown state and use it for terminal websocket settlement.
+- [x] Bound the lifespan recovery-settlement cleanup by the live drain remainder.
+- [x] Validate `shutdown_drain_timeout_seconds` as `1..300`.
+- [x] Add fail-pre/pass-post regression coverage for settlement grace, nested budget, and invalid settings.
+- [x] Run focused shutdown, websocket, proxy bridge, and OpenSpec validation suites.

--- a/tests/unit/test_otel.py
+++ b/tests/unit/test_otel.py
@@ -846,7 +846,7 @@ async def test_lifespan_marks_bridge_membership_stale_on_shutdown(monkeypatch: p
         otel_enabled=False,
         otel_exporter_endpoint="",
         metrics_enabled=False,
-        shutdown_drain_timeout_seconds=0,
+        shutdown_drain_timeout_seconds=1,
         http_responses_session_bridge_instance_id="pod-a",
     )
     settings_cache = SimpleNamespace(
@@ -944,7 +944,7 @@ async def test_lifespan_shutdown_fails_bridge_capacity_waiter_and_cancels_usage_
         otel_enabled=False,
         otel_exporter_endpoint="",
         metrics_enabled=False,
-        shutdown_drain_timeout_seconds=0,
+        shutdown_drain_timeout_seconds=1,
         http_responses_session_bridge_instance_id="pod-a",
     )
     settings_cache = SimpleNamespace(
@@ -1111,7 +1111,7 @@ async def test_lifespan_marks_bridge_membership_stale_for_hostname_shared_ids(
         otel_enabled=False,
         otel_exporter_endpoint="",
         metrics_enabled=False,
-        shutdown_drain_timeout_seconds=0,
+        shutdown_drain_timeout_seconds=1,
         http_responses_session_bridge_instance_id="pod-a",
         http_responses_session_bridge_advertise_base_url="http://pod-a.bridge.default.svc.cluster.local:2455",
     )
@@ -1193,7 +1193,7 @@ async def test_lifespan_registers_bridge_without_waiting_for_advertise_self_prob
         otel_enabled=False,
         otel_exporter_endpoint="",
         metrics_enabled=False,
-        shutdown_drain_timeout_seconds=0,
+        shutdown_drain_timeout_seconds=1,
         http_responses_session_bridge_instance_id="pod-a",
         http_responses_session_bridge_advertise_base_url="http://pod-a.bridge.default.svc.cluster.local:2455",
     )
@@ -1285,7 +1285,7 @@ async def test_lifespan_fails_fast_when_bridge_durable_schema_is_missing(monkeyp
         otel_enabled=False,
         otel_exporter_endpoint="",
         metrics_enabled=False,
-        shutdown_drain_timeout_seconds=0,
+        shutdown_drain_timeout_seconds=1,
     )
     settings_cache = SimpleNamespace(invalidate=AsyncMock())
     rate_limit_cache = SimpleNamespace(invalidate=AsyncMock())
@@ -1327,7 +1327,7 @@ async def test_lifespan_allows_missing_bridge_schema_when_fail_fast_disabled(mon
         otel_enabled=False,
         otel_exporter_endpoint="",
         metrics_enabled=False,
-        shutdown_drain_timeout_seconds=0,
+        shutdown_drain_timeout_seconds=1,
         database_migrations_fail_fast=False,
     )
     settings_cache = SimpleNamespace(

--- a/tests/unit/test_websocket_terminal_cancellation.py
+++ b/tests/unit/test_websocket_terminal_cancellation.py
@@ -827,6 +827,7 @@ async def test_pending_failure_cancellation_after_claim_remains_drain_owned(
 
     assert pending_requests == deque()
     shutdown_state.commit_shutdown(timeout_seconds=0.01)
+    shutdown_state.set_post_drain_cleanup_timeout_seconds(0.05)
     failure.cancel()
     with pytest.raises(asyncio.CancelledError):
         await asyncio.wait_for(failure, timeout=0.2)


### PR DESCRIPTION
Two shutdown-lifecycle defects (the compose stop_grace_period part of this family was already fixed in #1646):

- **F6**: terminal websocket settlement got LESS grace the less drain time remained — `remaining_drain_timeout_seconds()` returns 0 exactly when drain is exhausted, so settlement (reservation release, request-log handoff, account-health) got zero grace, while the 25s post-drain reserve at `server.py` sat unused. Settlement now draws on the post-drain reserve, bounded by the combined deadline — it no longer exceeds the overall window.
- **F13 (remaining)**: `app/main.py` passed the full `shutdown_drain_timeout_seconds` (30s) to a nested cleanup running inside a 25s window; it now uses `remaining_drain_timeout_seconds()` like its siblings. Added a `1..300` validator to `shutdown_drain_timeout_seconds`.

Regressions fail pre-fix (5 failures) and pass post-fix (10 bughunt); 569 named-suite tests green including `test_helm_shutdown_contract`; openspec change validates strictly.
