### PR TITLE
fix(auth): guard the refresh singleflight negative cache by successor ownership

### DIFF
--- a/app/modules/accounts/auth_manager.py
+++ b/app/modules/accounts/auth_manager.py
@@ -205,8 +205,13 @@ class _RefreshSingleflight:
         try:
             async with self._lock:
                 current = self._inflight.get(key)
-                if current is task:
-                    self._inflight.pop(key, None)
+                if current is not task:
+                    # A successor owns settlement for this key; consume the
+                    # stale task's result without touching its cache state.
+                    if not task.cancelled():
+                        task.exception()
+                    return
+                self._inflight.pop(key, None)
                 if task.cancelled():
                     self._recent_failures.pop(key, None)
                     return

--- a/openspec/changes/fix-refresh-singleflight-successor-guard/proposal.md
+++ b/openspec/changes/fix-refresh-singleflight-successor-guard/proposal.md
@@ -1,0 +1,14 @@
+# Fix refresh singleflight successor settlement
+
+The refresh singleflight negative cache must not publish a failed attempt's
+error after a successor refresh has replaced that attempt for the same key.
+This keeps callers arriving during the successor refresh joined to the live
+operation instead of serving stale failure state.
+
+## Scope
+
+- Guard negative-cache writes and clears with the same current-task check that
+  guards inflight removal.
+- Add the successor-race regression coverage already exercised by the F8
+  bughunt probe.
+- Do not change downstream account-status failure handling.

--- a/openspec/changes/fix-refresh-singleflight-successor-guard/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/fix-refresh-singleflight-successor-guard/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,25 @@
+# usage-refresh-policy Delta
+
+## ADDED Requirements
+
+### Requirement: Refresh singleflight settlement cannot poison a successor
+
+When a refresh task completes, it MUST mutate the inflight entry and
+refresh-failure cache only if it is still the current inflight task for that
+singleflight key. A completion from an older attempt MUST NOT publish or clear
+negative-cache state belonging to a successor refresh.
+
+#### Scenario: Failed attempt is followed by a live successor
+
+- **GIVEN** a refresh task fails for a key
+- **AND** a successor task for the same key is installed before the failed
+  task's completion settlement runs
+- **WHEN** another caller arrives while the successor is still in flight
+- **THEN** the caller joins the successor task
+- **AND** the failed attempt's error is not served from the negative cache
+
+#### Scenario: Existing failure settlement has no successor
+
+- **GIVEN** a refresh task fails and remains the current inflight task
+- **WHEN** its completion settlement runs
+- **THEN** the configured negative-cache cooldown behavior is preserved

--- a/openspec/changes/fix-refresh-singleflight-successor-guard/tasks.md
+++ b/openspec/changes/fix-refresh-singleflight-successor-guard/tasks.md
@@ -1,0 +1,3 @@
+- [x] Guard refresh singleflight settlement cache mutations by task ownership.
+- [x] Verify the independent-caller successor-race regression.
+- [x] Run the account refresh unit suites and OpenSpec validation.

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -594,6 +594,67 @@ async def test_ensure_fresh_singleflights_concurrent_refreshes(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_ensure_fresh_old_failure_cannot_replace_successor(monkeypatch):
+    """A delayed failed completion must not evict a newer refresh task."""
+    encryptor = TokenEncryptor()
+    stale_refresh = utcnow().replace(year=utcnow().year - 1)
+    account = Account(
+        id="acc_sf_successor",
+        email="user@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access-old"),
+        refresh_token_encrypted=encryptor.encrypt("refresh-old"),
+        id_token_encrypted=encryptor.encrypt("id-old"),
+        last_refresh=stale_refresh,
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+    refreshed_payload = {column.name: getattr(account, column.name) for column in Account.__table__.columns}
+    refreshed_payload.update(
+        access_token_encrypted=encryptor.encrypt("access-new"),
+        refresh_token_encrypted=encryptor.encrypt("refresh-new"),
+    )
+    refreshed = Account(**refreshed_payload)
+    repo = _DummyRepo()
+    manager = AuthManager(cast(AccountsRepositoryPort, repo))
+    monkeypatch.setattr(manager, "_ensure_chatgpt_account_id", lambda value: _identity(value))
+
+    mode = {"calls": 0}
+    async def fake_run(_account):
+        mode["calls"] += 1
+        if mode["calls"] == 1:
+            raise RefreshError("invalid_grant", "old refresh failed", False)
+        return refreshed
+
+    monkeypatch.setattr(manager, "_run_refresh", fake_run)
+    completions: list[tuple[tuple[str, str], asyncio.Task[Account]]] = []
+    singleflight = auth_manager_module._REFRESH_SINGLEFLIGHT
+    monkeypatch.setattr(
+        singleflight,
+        "_schedule_complete",
+        lambda key, task: completions.append((key, task)),
+    )
+
+    with pytest.raises(RefreshError, match="old refresh failed"):
+        await manager.ensure_fresh(account, force=True)
+    await asyncio.sleep(0)
+    assert len(completions) == 1
+    key, failed_task = completions[0]
+
+    assert await manager.ensure_fresh(account, force=True) is refreshed
+    assert mode["calls"] == 2
+
+    # The failed task's callback runs after the successor is installed.
+    await singleflight._complete(key, failed_task)
+    assert await manager.ensure_fresh(account, force=True) is refreshed
+    assert mode["calls"] == 2
+
+
+async def _identity(value):
+    return value
+
+
+@pytest.mark.asyncio
 async def test_ensure_fresh_singleflights_refresh_admission_for_same_account(monkeypatch):
     started = asyncio.Event()
     release = asyncio.Event()

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -620,33 +620,53 @@ async def test_ensure_fresh_old_failure_cannot_replace_successor(monkeypatch):
     monkeypatch.setattr(manager, "_ensure_chatgpt_account_id", lambda value: _identity(value))
 
     mode = {"calls": 0}
+    successor_started = asyncio.Event()
+    release_successor = asyncio.Event()
+
     async def fake_run(_account):
         mode["calls"] += 1
         if mode["calls"] == 1:
             raise RefreshError("invalid_grant", "old refresh failed", False)
+        successor_started.set()
+        await release_successor.wait()
         return refreshed
 
     monkeypatch.setattr(manager, "_run_refresh", fake_run)
-    completions: list[tuple[tuple[str, str], asyncio.Task[Account]]] = []
     singleflight = auth_manager_module._REFRESH_SINGLEFLIGHT
-    monkeypatch.setattr(
-        singleflight,
-        "_schedule_complete",
-        lambda key, task: completions.append((key, task)),
-    )
+    old_completion_started = asyncio.Event()
+    old_completion_finished = asyncio.Event()
+    release_old_completion = asyncio.Event()
+    original_complete = singleflight._complete
+
+    async def hold_old_completion(key, task):
+        old_completion_started.set()
+        await release_old_completion.wait()
+        await original_complete(key, task)
+        old_completion_finished.set()
+
+    monkeypatch.setattr(singleflight, "_complete", hold_old_completion)
 
     with pytest.raises(RefreshError, match="old refresh failed"):
         await manager.ensure_fresh(account, force=True)
-    await asyncio.sleep(0)
-    assert len(completions) == 1
-    key, failed_task = completions[0]
+    await old_completion_started.wait()
 
-    assert await manager.ensure_fresh(account, force=True) is refreshed
+    successor = asyncio.create_task(manager.ensure_fresh(account, force=True))
+    await successor_started.wait()
+    joined_successor = asyncio.create_task(manager.ensure_fresh(account, force=True))
+    await asyncio.sleep(0)
+    assert not joined_successor.done()
     assert mode["calls"] == 2
 
-    # The failed task's callback runs after the successor is installed.
-    await singleflight._complete(key, failed_task)
-    assert await manager.ensure_fresh(account, force=True) is refreshed
+    # The failed task's callback settles after the successor is installed.
+    release_old_completion.set()
+    await old_completion_finished.wait()
+    late_caller = asyncio.create_task(manager.ensure_fresh(account, force=True))
+    await asyncio.sleep(0)
+    assert not late_caller.done()
+    release_successor.set()
+    assert await successor is refreshed
+    assert await joined_successor is refreshed
+    assert await late_caller is refreshed
     assert mode["calls"] == 2
 
 


### PR DESCRIPTION
The account-refresh singleflight settled `_inflight` under a successor guard (`if current is task`), but wrote its `_recent_failures` negative cache OUTSIDE that guard. A failed attempt poisoned a key that already had a live successor refresh in flight, and callers arriving during the successor's lifetime got the dead attempt's error instead of joining the live refresh. Key identity is `(account.id, sha256(refresh-token))`, so a same-material caller hits the same poisoned key.

**Fix**: the `_recent_failures` write and associated pops now happen only when the completing task is still the current inflight entry for the key. A failing task with a live successor no longer poisons the cache.

Regression (independent caller B) fails pre-fix and passes post-fix; `test_auth_manager` 36 passed, refresh/singleflight suites 112 passed; the refuted `mark_permanent_failure` coupling stays refuted; openspec validates strictly.
