### PR TITLE
docs: add joschi655 to contributors

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1203,6 +1203,15 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "joschi655",
+      "name": "Oskar Jonathan Johannes Breitfeld",
+      "avatar_url": "https://avatars.githubusercontent.com/u/183807437?v=4",
+      "profile": "https://github.com/joschi655",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,


### PR DESCRIPTION
Add the author of merged commit af5051f87 (#1611) to .all-contributorsrc.

This unblocks the Contributors attribution check currently failing on open PR merge heads.