### PR TITLE
feat(auth): enable Auth Guardian by default and cover paused accounts

### DIFF
--- a/app/core/auth/guardian.py
+++ b/app/core/auth/guardian.py
@@ -23,9 +23,9 @@ from app.modules.proxy.account_cache import get_account_selection_cache
 logger = logging.getLogger(__name__)
 
 # Guardian cadence and backoff tuning (fixed; issue #1340 / PRINCIPLES.md P2).
-# The guardian is an off-by-default background refresher; these values are
-# implementation details, not operator contract. ``AuthGuardianScheduler``
-# keeps them as constructor fields so tests can exercise the behavior.
+# The guardian is a background refresher; these values are implementation
+# details, not operator contract. ``AuthGuardianScheduler`` keeps them as
+# constructor fields so tests can exercise the behavior.
 _INTERVAL_SECONDS = 21600
 _MAX_REFRESH_AGE_SECONDS = 43200
 _BATCH_SIZE = 100
@@ -33,6 +33,10 @@ _CONCURRENCY = 3
 _JITTER_SECONDS = 300.0
 _FAILURE_BACKOFF_BASE_SECONDS = 300.0
 _FAILURE_BACKOFF_MAX_SECONDS = 3600.0
+
+# RATE_LIMITED and QUOTA_EXCEEDED recover to ACTIVE through usage-refresh
+# reconciliation, then become guardian-eligible within the max-age window.
+_AUTH_GUARDIAN_ELIGIBLE_STATUSES = frozenset({AccountStatus.ACTIVE, AccountStatus.PAUSED})
 
 
 _T = TypeVar("_T")
@@ -165,7 +169,7 @@ class AuthGuardianScheduler:
                 if account is None:
                     self._failures.pop(account_id, None)
                     return
-                if not _auth_guardian_account_is_stale_active(
+                if not _auth_guardian_account_is_stale_eligible(
                     account,
                     now=self.now(),
                     max_age_seconds=self.max_age_seconds,
@@ -242,7 +246,7 @@ def select_auth_guardian_candidates(
     candidates = [
         account
         for account in accounts
-        if _auth_guardian_account_is_stale_active(
+        if _auth_guardian_account_is_stale_eligible(
             account,
             now=now,
             max_age_seconds=max_age_seconds,
@@ -280,13 +284,13 @@ def build_auth_guardian_scheduler() -> AuthGuardianScheduler:
     )
 
 
-def _auth_guardian_account_is_stale_active(
+def _auth_guardian_account_is_stale_eligible(
     account: Account,
     *,
     now: datetime,
     max_age_seconds: int,
 ) -> bool:
-    if account.status != AccountStatus.ACTIVE:
+    if account.status not in _AUTH_GUARDIAN_ELIGIBLE_STATUSES:
         return False
     age = to_utc_naive(now) - to_utc_naive(account.last_refresh)
     return age > timedelta(seconds=max_age_seconds)

--- a/app/core/auth/guardian.py
+++ b/app/core/auth/guardian.py
@@ -169,6 +169,7 @@ class AuthGuardianScheduler:
                 if account is None:
                     self._failures.pop(account_id, None)
                     return
+                source_status = account.status.value
                 if not _auth_guardian_account_is_stale_eligible(
                     account,
                     now=self.now(),
@@ -189,9 +190,11 @@ class AuthGuardianScheduler:
                     if exc.is_permanent:
                         get_account_selection_cache().invalidate()
                     logger.warning(
-                        "Auth Guardian refresh failed account_id=%s account_alias=%s code=%s permanent=%s transport=%s",
+                        "Auth Guardian refresh failed account_id=%s account_alias=%s status=%s code=%s permanent=%s "
+                        "transport=%s",
                         account.id,
                         _safe_account_alias(account),
+                        source_status,
                         exc.code,
                         exc.is_permanent,
                         exc.transport_error,
@@ -200,9 +203,10 @@ class AuthGuardianScheduler:
                 except Exception as exc:
                     self._record_failure(account_id)
                     logger.warning(
-                        "Auth Guardian refresh failed account_id=%s account_alias=%s error_type=%s",
+                        "Auth Guardian refresh failed account_id=%s account_alias=%s status=%s error_type=%s",
                         account.id,
                         _safe_account_alias(account),
+                        source_status,
                         exc.__class__.__name__,
                         exc_info=True,
                     )
@@ -210,9 +214,10 @@ class AuthGuardianScheduler:
                 self._failures.pop(account_id, None)
                 get_account_selection_cache().invalidate()
                 logger.info(
-                    "Auth Guardian refreshed account_id=%s account_alias=%s",
+                    "Auth Guardian refreshed account_id=%s account_alias=%s status=%s",
                     account.id,
                     _safe_account_alias(account),
+                    source_status,
                 )
 
     def _in_backoff(self, account_id: str) -> bool:

--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -279,7 +279,7 @@ class Settings(BaseSettings):
     # refresh-admission wait AND the OAuth exchange, and a healthy claimant
     # must not lose its claim mid-work.
     token_refresh_claim_ttl_seconds: float = Field(default=30.0, gt=0)
-    auth_guardian_enabled: bool = False
+    auth_guardian_enabled: bool = True
     transcription_request_budget_seconds: float = Field(default=120.0, gt=0)
     token_refresh_interval_days: int = 8
     usage_fetch_timeout_seconds: float = 10.0

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -129,7 +129,7 @@ the host side of the compose `ports` mapping instead.
 
 | Environment variable | Type | Default |
 | --- | --- | --- |
-| `CODEX_LB_AUTH_GUARDIAN_ENABLED` | `bool` | `False` |
+| `CODEX_LB_AUTH_GUARDIAN_ENABLED` | `bool` | `True` |
 | `CODEX_LB_TOKEN_REFRESH_CLAIM_TTL_SECONDS` | `float` | `30.0` |
 | `CODEX_LB_TOKEN_REFRESH_INTERVAL_DAYS` | `int` | `8` |
 | `CODEX_LB_TOKEN_REFRESH_TIMEOUT_SECONDS` | `float` | `8.0` |

--- a/openspec/changes/enable-auth-guardian-default-and-paused/proposal.md
+++ b/openspec/changes/enable-auth-guardian-default-and-paused/proposal.md
@@ -1,0 +1,47 @@
+# Enable Auth Guardian by default and cover paused accounts
+
+## Why
+
+Operators with many linked accounts report refresh tokens silently expiring on
+rarely used accounts. The Auth Guardian scheduler (added in
+`add-auth-guardian-refresh`) already solves this, but two gaps keep the
+protection from actually reaching the accounts that need it most:
+
+1. `CODEX_LB_AUTH_GUARDIAN_ENABLED` defaults to `False`, so the base install
+   has no proactive keepalive at all. The guardian is invisible (no dashboard
+   surface), so most operators never learn the switch exists until a token has
+   already expired.
+2. The candidate filter only admits `active` accounts. Pausing an account is
+   the natural way to shelve a rarely used account, and it is exactly the
+   account whose refresh token will rot — paused accounts receive no traffic,
+   never hit the reactive 401 refresh path, and are skipped by the usage
+   refresh scheduler.
+
+## What Changes
+
+- `auth_guardian_enabled` setting default flips `False` -> `True`. The
+  existing multi-replica leader guard is unchanged: multi-replica rings
+  without leader election still self-disable with a warning, so the flipped
+  default cannot introduce concurrent force-refreshes.
+- Auth Guardian candidate selection admits `paused` accounts in addition to
+  `active` ones. `reauth_required` and `deactivated` stay excluded (their
+  refresh tokens are known-bad or intentionally retired). Credential refresh
+  does not change a paused account's routing eligibility: it stays out of
+  request routing. A permanent refresh failure still transitions the account
+  to its documented permanent-failure status exactly as it does for active
+  accounts today.
+
+## Impact
+
+- Affected specs: `usage-refresh-policy` (proactive credential refresh
+  requirement).
+- Affected code: `app/core/config/settings.py`,
+  `app/core/auth/guardian.py`, `docs/reference/settings.md`, unit and
+  settings-default tests.
+- Base-install behavior change: background OAuth token refresh runs by
+  default. Bounded by existing constants (interval 6h, staleness gate 12h,
+  batch 100, concurrency 3, jitter, per-account failure backoff) and
+  leader-gated, so upstream load is negligible and strictly bounded.
+- Simplicity gates: no new setting, no new required setup step. The flip
+  makes the feature a zero-config working default (P1); the existing
+  `CODEX_LB_AUTH_GUARDIAN_ENABLED=false` opt-out is preserved.

--- a/openspec/changes/enable-auth-guardian-default-and-paused/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/enable-auth-guardian-default-and-paused/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Proactive active account credential refresh
+
+Codex-LB SHALL periodically refresh account credentials in the background when an account's last refresh is older than a configured maximum age. Accounts with status `active` or `paused` SHALL be eligible for proactive credential refresh; accounts with status `reauth_required` or `deactivated` SHALL NOT be selected. Proactive credential refresh MUST NOT change a paused account's routing eligibility: a paused account remains excluded from request routing regardless of refresh outcome, except that a permanent refresh failure transitions the account to its documented permanent-failure status the same way it does for active accounts. The proactive refresh scheduler SHALL be enabled by default with zero required configuration, and `CODEX_LB_AUTH_GUARDIAN_ENABLED=false` SHALL disable it. The multi-replica leader guard remains a precondition for any refresh work.
+
+#### Scenario: Idle active account becomes stale
+
+- **GIVEN** an account has status `active`
+- **AND** its `last_refresh` is older than the configured Auth Guardian max age
+- **WHEN** Auth Guardian runs on the elected leader
+- **THEN** Codex-LB force-refreshes that account without requiring request traffic to select it first
+
+#### Scenario: Idle paused account keeps its refresh token alive
+
+- **GIVEN** an account has status `paused`
+- **AND** its `last_refresh` is older than the configured Auth Guardian max age
+- **WHEN** Auth Guardian runs on the elected leader
+- **THEN** Codex-LB force-refreshes that account's credentials
+- **AND** the account's status remains `paused`
+- **AND** the account remains excluded from request routing
+
+#### Scenario: Known-bad credentials are not refreshed
+
+- **GIVEN** an account has status `reauth_required` or `deactivated`
+- **AND** its `last_refresh` is older than the configured Auth Guardian max age
+- **WHEN** Auth Guardian selects refresh candidates
+- **THEN** the account is not selected
+
+#### Scenario: Guardian runs on a default install
+
+- **GIVEN** a single-replica deployment with no `CODEX_LB_AUTH_GUARDIAN_*` configuration
+- **WHEN** the Auth Guardian scheduler is built
+- **THEN** the scheduler is enabled

--- a/openspec/changes/enable-auth-guardian-default-and-paused/tasks.md
+++ b/openspec/changes/enable-auth-guardian-default-and-paused/tasks.md
@@ -1,0 +1,24 @@
+## 1. Default-on guardian
+
+- [x] 1.1 Flip `auth_guardian_enabled` default to `True` in
+      `app/core/config/settings.py`.
+- [x] 1.2 Update `docs/reference/settings.md` default column for
+      `CODEX_LB_AUTH_GUARDIAN_ENABLED`.
+- [x] 1.3 Update `tests/unit/test_settings_multi_replica.py` default
+      assertion and add a build-path test asserting the scheduler is enabled
+      with default settings on a single replica.
+
+## 2. Paused account coverage
+
+- [x] 2.1 Admit `paused` accounts in the guardian staleness predicate in
+      `app/core/auth/guardian.py`; keep `reauth_required`/`deactivated`
+      excluded.
+- [x] 2.2 Unit tests: paused+stale account is selected as a candidate and
+      refreshed; fresh paused account is skipped; `reauth_required` and
+      `deactivated` accounts are never selected; paused account status is
+      unchanged after successful refresh.
+
+## 3. Spec sync
+
+- [ ] 3.1 Apply the delta to `openspec/specs/usage-refresh-policy/spec.md`
+      when archiving.

--- a/tests/unit/test_auth_guardian.py
+++ b/tests/unit/test_auth_guardian.py
@@ -89,9 +89,13 @@ def test_select_auth_guardian_candidates_returns_stale_eligible_accounts_only() 
         _account("quota-exceeded", status=AccountStatus.QUOTA_EXCEEDED, last_refresh=now - timedelta(hours=24)),
     ]
 
-    selected = select_auth_guardian_candidates(accounts, now=now, max_age_seconds=12 * 3600, limit=3)
+    selected = select_auth_guardian_candidates(accounts, now=now, max_age_seconds=12 * 3600, limit=10)
 
     assert [account.id for account in selected] == ["oldest-active", "stale-paused", "stale-active"]
+
+    batched = select_auth_guardian_candidates(accounts, now=now, max_age_seconds=12 * 3600, limit=2)
+
+    assert [account.id for account in batched] == ["oldest-active", "stale-paused"]
 
 
 def test_default_auth_manager_factory_uses_owned_refresh_repo() -> None:

--- a/tests/unit/test_auth_guardian.py
+++ b/tests/unit/test_auth_guardian.py
@@ -5,7 +5,6 @@ import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
-from types import SimpleNamespace
 from typing import cast
 
 import pytest
@@ -76,19 +75,23 @@ class _AccountSelectionCache:
         self.invalidate_calls += 1
 
 
-def test_select_auth_guardian_candidates_returns_stale_active_only() -> None:
+def test_select_auth_guardian_candidates_returns_stale_eligible_accounts_only() -> None:
     now = datetime(2026, 1, 2, 12, 0, 0)
     accounts = [
         _account("fresh-active", status=AccountStatus.ACTIVE, last_refresh=now - timedelta(hours=1)),
         _account("stale-active", status=AccountStatus.ACTIVE, last_refresh=now - timedelta(hours=13)),
         _account("oldest-active", status=AccountStatus.ACTIVE, last_refresh=now - timedelta(hours=20)),
-        _account("paused", status=AccountStatus.PAUSED, last_refresh=now - timedelta(hours=20)),
-        _account("reauth", status=AccountStatus.REAUTH_REQUIRED, last_refresh=now - timedelta(hours=20)),
+        _account("stale-paused", status=AccountStatus.PAUSED, last_refresh=now - timedelta(hours=18)),
+        _account("fresh-paused", status=AccountStatus.PAUSED, last_refresh=now - timedelta(hours=1)),
+        _account("reauth", status=AccountStatus.REAUTH_REQUIRED, last_refresh=now - timedelta(hours=24)),
+        _account("deactivated", status=AccountStatus.DEACTIVATED, last_refresh=now - timedelta(hours=24)),
+        _account("rate-limited", status=AccountStatus.RATE_LIMITED, last_refresh=now - timedelta(hours=24)),
+        _account("quota-exceeded", status=AccountStatus.QUOTA_EXCEEDED, last_refresh=now - timedelta(hours=24)),
     ]
 
-    selected = select_auth_guardian_candidates(accounts, now=now, max_age_seconds=12 * 3600, limit=2)
+    selected = select_auth_guardian_candidates(accounts, now=now, max_age_seconds=12 * 3600, limit=3)
 
-    assert [account.id for account in selected] == ["oldest-active", "stale-active"]
+    assert [account.id for account in selected] == ["oldest-active", "stale-paused", "stale-active"]
 
 
 def test_default_auth_manager_factory_uses_owned_refresh_repo() -> None:
@@ -107,6 +110,19 @@ def test_build_auth_guardian_scheduler_allows_single_replica_without_leader_elec
 
     scheduler = build_auth_guardian_scheduler()
 
+    assert scheduler.enabled is True
+
+
+def test_build_auth_guardian_scheduler_enabled_by_default_for_single_replica(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CODEX_LB_AUTH_GUARDIAN_ENABLED", raising=False)
+    settings = _settings(leader_election_enabled=True)
+    monkeypatch.setattr(settings_module, "get_settings", lambda: settings)
+
+    scheduler = build_auth_guardian_scheduler()
+
+    assert settings.auth_guardian_enabled is True
     assert scheduler.enabled is True
 
 
@@ -203,7 +219,7 @@ async def test_auth_guardian_refresh_once_refreshes_stale_active_and_skips_other
     accounts = [
         _account("fresh-active", status=AccountStatus.ACTIVE, last_refresh=now - timedelta(hours=1)),
         _account("stale-active", status=AccountStatus.ACTIVE, last_refresh=now - timedelta(hours=13)),
-        _account("paused", status=AccountStatus.PAUSED, last_refresh=now - timedelta(hours=13)),
+        _account("reauth", status=AccountStatus.REAUTH_REQUIRED, last_refresh=now - timedelta(hours=13)),
     ]
     repo = _Repo(accounts)
     calls: list[str] = []
@@ -229,6 +245,37 @@ async def test_auth_guardian_refresh_once_refreshes_stale_active_and_skips_other
     await scheduler._refresh_once()
 
     assert calls == ["stale-active"]
+
+
+@pytest.mark.asyncio
+async def test_auth_guardian_refresh_once_refreshes_stale_paused_without_changing_status() -> None:
+    now = datetime(2026, 1, 2, 12, 0, 0)
+    paused = _account("stale-paused", status=AccountStatus.PAUSED, last_refresh=now - timedelta(hours=13))
+    repo = _Repo([paused])
+    calls: list[str] = []
+
+    @asynccontextmanager
+    async def repo_factory() -> AsyncIterator[_Repo]:
+        yield repo
+
+    scheduler = AuthGuardianScheduler(
+        interval_seconds=21600,
+        enabled=True,
+        max_age_seconds=12 * 3600,
+        batch_size=10,
+        concurrency=1,
+        jitter_seconds=0.0,
+        leader_election_factory=lambda: _Leader(),
+        repo_factory=repo_factory,
+        auth_manager_factory=lambda _repo: _AuthManager(calls),
+        sleep=lambda _delay: _noop_sleep(),
+        now=lambda: now,
+    )
+
+    await scheduler._refresh_once()
+
+    assert calls == ["stale-paused"]
+    assert paused.status is AccountStatus.PAUSED
 
 
 @pytest.mark.asyncio
@@ -610,12 +657,16 @@ async def _noop_sleep() -> None:
 
 def _settings(
     *,
-    auth_guardian_enabled: bool,
     leader_election_enabled: bool,
+    auth_guardian_enabled: bool | None = None,
     instance_ring: list[str] | None = None,
-) -> SimpleNamespace:
-    return SimpleNamespace(
-        auth_guardian_enabled=auth_guardian_enabled,
+) -> settings_module.Settings:
+    settings = settings_module.Settings(
+        _env_file=None,
         leader_election_enabled=leader_election_enabled,
+        http_responses_session_bridge_instance_id="pod-a",
         http_responses_session_bridge_instance_ring=instance_ring or [],
     )
+    if auth_guardian_enabled is not None:
+        settings.auth_guardian_enabled = auth_guardian_enabled
+    return settings

--- a/tests/unit/test_auth_manager.py
+++ b/tests/unit/test_auth_manager.py
@@ -242,6 +242,42 @@ async def test_ensure_fresh_detached_refresh_owns_session_on_caller_cancel(monke
 
 
 @pytest.mark.asyncio
+async def test_ensure_fresh_preserves_paused_status_on_success(monkeypatch):
+    async def _fake_refresh(_: str, **_kwargs: object) -> TokenRefreshResult:
+        return TokenRefreshResult(
+            access_token="access-new",
+            refresh_token="refresh-new",
+            id_token="id-new",
+            account_id="acc_paused",
+            plan_type="plus",
+            email=None,
+        )
+
+    monkeypatch.setattr(auth_manager_module, "refresh_access_token", _fake_refresh)
+
+    encryptor = TokenEncryptor()
+    account = Account(
+        id="acc_paused",
+        email="user@example.com",
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access-old"),
+        refresh_token_encrypted=encryptor.encrypt("refresh-old"),
+        id_token_encrypted=encryptor.encrypt("id-old"),
+        last_refresh=utcnow(),
+        status=AccountStatus.PAUSED,
+        deactivation_reason=None,
+    )
+    repo = _DummyRepo()
+    manager = AuthManager(cast(AccountsRepositoryPort, repo))
+
+    await manager.ensure_fresh(account, force=True)
+
+    assert account.status is AccountStatus.PAUSED
+    assert repo.status_payload is None
+    assert repo.tokens_payload is not None
+
+
+@pytest.mark.asyncio
 async def test_refresh_account_preserves_plan_type_when_missing(monkeypatch):
     async def _fake_refresh(_: str, **_kwargs: object) -> TokenRefreshResult:
         return TokenRefreshResult(

--- a/tests/unit/test_settings_multi_replica.py
+++ b/tests/unit/test_settings_multi_replica.py
@@ -16,7 +16,7 @@ def test_settings_multi_replica_defaults():
     assert settings.log_format == "text"
     assert settings.leader_election_enabled is True
     assert settings.leader_election_ttl_seconds == 60
-    assert settings.auth_guardian_enabled is False
+    assert settings.auth_guardian_enabled is True
     assert settings.circuit_breaker_enabled is False
     assert settings.backpressure_max_concurrent_requests == 0
     assert settings.bulkhead_proxy_limit == 512


### PR DESCRIPTION
## Summary

Operators with many linked accounts report refresh tokens silently expiring on rarely used accounts (external feedback: codex-lb "lacks proactive keepalive; with many accounts, RTs on rarely-used accounts can expire"). Auth Guardian (#928) already solves this, but two gaps keep the protection from reaching the accounts that need it most:

1. `CODEX_LB_AUTH_GUARDIAN_ENABLED` defaults to `False`, and there is no dashboard surface, so the base install has no keepalive and most operators never learn the switch exists until a token is already dead.
2. The candidate filter admits only `active` accounts. Pausing an account is the natural way to shelve a rarely used one — and a paused account receives no traffic, never hits the reactive 401 refresh path, and is skipped by the usage refresh scheduler, so it is exactly the account whose refresh token rots.

## Changes

- **Default-on**: `auth_guardian_enabled` flips `False` → `True`. The multi-replica leader guard is untouched: multi-replica rings without leader election still self-disable with a warning, so the flipped default cannot introduce concurrent force-refreshes.
- **Paused coverage**: candidate selection uses an explicit `_AUTH_GUARDIAN_ELIGIBLE_STATUSES = frozenset({ACTIVE, PAUSED})`. `reauth_required`/`deactivated` stay excluded (known-bad or intentionally retired credentials). `rate_limited`/`quota_exceeded` are deliberately not included — they recover to `active` via the usage-refresh reconcile loop and become guardian-eligible then.
- A successful refresh does not change a paused account's status or routing eligibility; permanent refresh failures transition status exactly as they do for active accounts today.
- Docs default column updated; helper renamed `_auth_guardian_account_is_stale_active` → `_auth_guardian_account_is_stale_eligible`.

## OpenSpec

- Change folder: `openspec/changes/enable-auth-guardian-default-and-paused/` (proposal, tasks, `usage-refresh-policy` delta with paused/known-bad/default-install scenarios). `openspec validate enable-auth-guardian-default-and-paused` → valid.

## Simplicity

- No new settings, no new required setup step. This makes an existing feature a zero-config working default (P1); `CODEX_LB_AUTH_GUARDIAN_ENABLED=false` remains the opt-out. `.env.example` untouched.

## Tests

- `uv run pytest tests/unit -q` → 5739 passed, 3 skipped (pre-existing T21 skips)
- `uv run pytest tests/integration/test_auth_guardian_multi_replica.py -q` → 2 passed (untouched)
- New/updated unit coverage: stale paused selected + refreshed with status still `PAUSED`; fresh paused skipped; `reauth_required`/`deactivated`/`rate_limited`/`quota_exceeded` never selected; `build_auth_guardian_scheduler()` enabled with default settings on a single replica (test helper now constructs real `Settings(_env_file=None)` so a default regression fails the test).
- `make lint`, `uv run ty check` → clean. `uv.lock` untouched.

## Behavior note for reviewers

Base-install behavior change: background OAuth token refresh now runs by default, bounded by the existing fixed cadence (interval 6h, staleness gate 12h, batch 100, concurrency 3, jitter, per-account failure backoff) and leader-gated. Upstream load is negligible: one token refresh per account per 12h worst case.
