### PR TITLE
chore: release v1.23.0-beta.5

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.23.0-beta.4"  # x-release-please-version
+__version__ = "1.23.0-beta.5"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.23.0-beta.4
-appVersion: 1.23.0-beta.4
+version: 1.23.0-beta.5
+appVersion: 1.23.0-beta.5
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.23.0-beta.4",
+  "version": "1.23.0-beta.5",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.23.0-beta.4"
+version = "1.23.0-beta.5"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.23.0-beta.4"
+version = "1.23.0-beta.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.23.0-beta.5 for the 1.23.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.23.0-beta.5 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1472; no manual beta workflow dispatch is required.

## Changes since v1.23.0-beta.4
- feat(auth): enable Auth Guardian by default and cover paused accounts (#1662) (ebb0525)
- fix(db): keep api-key reservation accounting at full durability (#1665) (
5b81f2)
- fix(usage): keep the covering read path effective on append-heavy usage_history (#1666) (
967114)
- fix(api-keys): make the shutdown flush of last_used_at coalescing lossless (#1667) (
0fcb6a)
- fix(auth): keep guardian candidates session-safe (#1669) (
ff2920)
- fix(proxy): never inject a cross-account previous_response_id anchor (takeover of #1274) (#1638) (
683970)
- fix(proxy): detect stalled upstream websockets (#1579) (
a0a977)
- fix(proxy): fail over stuck HTTP bridge owner requests to a fresh account (#1401) (
f2f8f9)
- fix(proxy): complete Codex compaction SSE lifecycle (#1634) (
7f91b9)
- fix(proxy): recover dead durable bridge anchors fast (#1625) (
85f1ee)

## Release-candidate validation
Validated candidate: fe1ba4154c967e54bf2ff5c3aad1802936be7966

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates — CI green at fe1ba415 (unit, integration-core 1-3 + required, integration-bridge, PostgreSQL, migration checks sqlite+postgres; all non-guard checks success)
- [x] Frontend tests/build — CI green at fe1ba415 (frontend lint/typecheck/tests/build, dashboard browser smoke)
- [x] Wheel/package validation — CI `Package (build)` green at fe1ba415 (sdist/wheel build + verify)
- [x] Docker/container smoke — image built locally from fe1ba415 (sha256:150a1ead1385); booted against a scratch postgres:18-alpine: alembic migrated an empty DB to head `20260806_120000_add_http_bridge_owner_process_epoch` (54 tables; conversation presence satellite present; `usage_history` autovacuum reloptions codified as `insert_scale_factor=0.02/insert_threshold=50000/analyze_scale_factor=0.02`), `/` 200, `/api/runtime/version` and `/v1/models` 401 (auth enforced), 0 error signatures in logs
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required — this beta deploys to the production pool immediately after publish for the release-channel soak; live-path verification happens there with the rollback runbook staged (deploy.sh cutover records tag+revision; the schema delta since beta.4 is additive — one state column via the bridge owner-epoch migration and reloption tuning — with tested downgrades)

## Install after publish
```bash
uvx --from "codex-lb==1.23.0b5" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.23.0-beta.5
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.23.0-beta.5 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.23.0.