### PR TITLE
fix(db): keep api-key reservation accounting at full durability

### DIFF
--- a/app/db/session.py
+++ b/app/db/session.py
@@ -299,15 +299,14 @@ async def get_background_session() -> AsyncIterator[AsyncSession]:
 async def relax_commit_durability(session: AsyncSession) -> None:
     """Relax commit durability for the current telemetry write transaction.
 
-    High-frequency append-only accounting/telemetry writes (request logs,
-    API-key usage reservations, usage history entries) dominate the slow-query
-    profile on PostgreSQL because every commit waits for a WAL fsync. Those
-    rows describe in-flight requests: if the server crashes, the in-flight
-    requests are lost anyway, so losing the final unflushed WAL window (bounded
-    by three times ``wal_writer_delay`` — up to ~600 ms at the default 200 ms
-    setting) keeps accounting semantics identical. For such transactions
-    this helper emits ``SET LOCAL synchronous_commit = off`` so the commit
-    returns without waiting for the WAL flush.
+    High-frequency append-only telemetry writes (request-log inserts, usage
+    history appends) dominate the slow-query profile on PostgreSQL because
+    every commit waits for a WAL fsync. Those rows are pure observability:
+    losing the final unflushed WAL window (bounded by three times
+    ``wal_writer_delay`` — up to ~600 ms at the default 200 ms setting) keeps
+    accounting semantics identical. For such transactions this helper emits
+    ``SET LOCAL synchronous_commit = off`` so the commit returns without
+    waiting for the WAL flush.
 
     ``SET LOCAL`` is transaction-scoped: PostgreSQL reverts it automatically
     at COMMIT/ROLLBACK, so nothing leaks onto the pooled connection. Executed
@@ -318,7 +317,11 @@ async def relax_commit_durability(session: AsyncSession) -> None:
 
     No-op on SQLite (durability there is governed by ``PRAGMA synchronous``).
     MUST NOT be used for configuration writes (accounts, API keys, settings,
-    limits management): those keep full durability.
+    limits management) or for API-key usage-reservation accounting (creation,
+    settlement, stale release): on external/HA PostgreSQL a server failover
+    does not kill in-flight application requests, so an acked-but-lost
+    reservation commit would desynchronize the accounting ledger from
+    requests that still complete. Those paths keep full durability.
     """
     bind = session.get_bind()
     if bind is None or bind.dialect.name != "postgresql":

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -27,7 +27,7 @@ from app.db.models import (
     RequestLog,
     RequestUsageHourlyRollup,
 )
-from app.db.session import relax_commit_durability, sqlite_writer_section
+from app.db.session import sqlite_writer_section
 from app.modules.accounts.usage_rollup import api_key_usage_aggregate_stmt, read_api_key_rollup_state
 from app.modules.accounts.usage_time_rollup import HOURLY_BUCKET_SECONDS, WARMUP_REQUEST_KINDS, to_dimension
 from app.modules.accounts.usage_time_rollup_read import RawWindow, raw_windows_clause, read_hourly_window
@@ -595,10 +595,11 @@ class ApiKeysRepository:
         model: str,
         items: list[UsageReservationItemData],
     ) -> None:
-        # Telemetry write: reservation creation (and the limit counters it
-        # rides with) is per-request usage accounting, so the enclosing
-        # transaction's commit may skip the synchronous WAL flush.
-        await relax_commit_durability(self._session)
+        # Reservation accounting keeps full commit durability. On external/HA
+        # PostgreSQL a server failover does not kill in-flight application
+        # requests, so an acked-but-lost commit here would desynchronize the
+        # reservation ledger from requests that still complete (settlement
+        # invariant).
         reservation = ApiKeyUsageReservation(
             id=reservation_id,
             api_key_id=key_id,
@@ -731,11 +732,13 @@ class ApiKeysRepository:
         cached_input_tokens: int | None,
         cost_microdollars: int | None,
     ) -> None:
-        # Telemetry write: reservation settlement (finalize/fail/release,
-        # including the last_used_at touch that rides the same transaction)
-        # is per-request usage accounting, so the enclosing transaction's
-        # commit may skip the synchronous WAL flush.
-        await relax_commit_durability(self._session)
+        # Reservation accounting keeps full commit durability. Settlement
+        # (finalize/fail/release) is what puts completed-request usage on the
+        # books: on external/HA PostgreSQL a failover does not kill the
+        # application request, so an acked-but-lost settlement commit would
+        # leave the reservation "reserved" until the stale-release scheduler
+        # reverses the counters and records zero actual usage — dropping a
+        # completed request from token/cost/rate-limit accounting.
         await self._session.execute(
             update(ApiKeyUsageReservation)
             .where(ApiKeyUsageReservation.id == reservation_id)
@@ -792,14 +795,13 @@ class ApiKeysRepository:
                     if not reservation_ids:
                         break
 
-                    # Telemetry write: stale-reservation release settles the
-                    # same per-request accounting rows as the request-path
-                    # settlement (reservation status flip plus limit-counter
-                    # adjustments), and a crash-lost batch is simply reclaimed
-                    # by the next scheduler run. Each batch commits its own
-                    # transaction, so relax every batch individually.
-                    await relax_commit_durability(self._session)
-
+                    # Reservation accounting keeps full commit durability:
+                    # each batch flips reservation status and reverses limit
+                    # counters, mutating the same ledger as the request-path
+                    # settlement, so its durability must not depend on which
+                    # path settles the row. On external/HA PostgreSQL an
+                    # acked-but-lost batch commit silently reverts rows the
+                    # scheduler already reported as released.
                     item_result = await self._session.execute(
                         select(
                             ApiKeyUsageReservationItem.reservation_id,

--- a/openspec/changes/async-commit-telemetry-writes/proposal.md
+++ b/openspec/changes/async-commit-telemetry-writes/proposal.md
@@ -2,16 +2,17 @@
 
 ## Why
 
-On the production PostgreSQL deployment (15 accounts, 4.5M request logs), 93% of slow queries over 500 ms are write-path fsync waits: `INSERT request_logs` (667 calls / 30.8 s per 10 min), `INSERT api_key_usage_reservations` (1,612 calls / 25.7 s), and the settlement `UPDATE api_keys SET last_used_at` (616 calls / 44.6 s). Every one of these commits pays a synchronous WAL flush for rows that are pure per-request accounting/telemetry. If the database server crashes, the in-flight requests those rows describe are lost anyway, so losing the final few hundred milliseconds of unflushed WAL changes nothing about accounting semantics — full durability buys these transactions nothing.
+On the production PostgreSQL deployment (15 accounts, 4.5M request logs), 93% of slow queries over 500 ms are write-path fsync waits: `INSERT request_logs` (667 calls / 30.8 s per 10 min), `INSERT api_key_usage_reservations` (1,612 calls / 25.7 s), and the settlement `UPDATE api_keys SET last_used_at` (616 calls / 44.6 s). For rows that are pure observability (request logs, usage-history samples), losing the final few hundred milliseconds of unflushed WAL after a server crash changes nothing about accounting semantics — full durability buys those transactions nothing.
+
+Reservation accounting is different (adversarial review P1 on PR #1628): on external/HA PostgreSQL, a database failover does not kill in-flight application requests. If an acked-but-lost settlement commit is dropped in the failover, the reservation stays `reserved`, the stale-release scheduler later reverses the limit counters and records zero actual usage, and a request that actually completed disappears from token/cost/rate-limit accounting — violating the settlement invariant. So reservation writes must keep full durability.
 
 ## What Changes
 
 - Add a shared helper `relax_commit_durability(session)` in `app/db/session.py` that emits `SET LOCAL synchronous_commit = off` inside the current write transaction when the session's dialect is PostgreSQL, and is a no-op otherwise (SQLite durability stays governed by `PRAGMA synchronous`). `SET LOCAL` is transaction-scoped, so PostgreSQL reverts it automatically at COMMIT/ROLLBACK and nothing leaks onto pooled connections.
 - Invoke the helper inside the high-frequency append-only telemetry write transactions:
   - `RequestLogsRepository.add_log` (request-log insert),
-  - `ApiKeysRepository.create_usage_reservation` and `ApiKeysRepository.settle_usage_reservation` (usage-reservation creation and finalize/fail/release settlement, including the `last_used_at` touch and limit-counter adjustments that ride the same transactions),
-  - `ApiKeysRepository.release_stale_usage_reservations` (the scheduler's stale-reservation release settles the same accounting rows batch by batch; a crash-lost batch is reclaimed by the next scheduler run),
   - `UsageRepository.add_entry`, `UsageRepository.add_account_snapshot`, and `AdditionalUsageRepository.add_entry` (usage-history appends).
+- API-key usage-reservation accounting keeps full durability: `ApiKeysRepository.create_usage_reservation`, `ApiKeysRepository.settle_usage_reservation`, and `ApiKeysRepository.release_stale_usage_reservations` MUST NOT call the helper. An acked-but-lost reservation commit on an HA PostgreSQL failover desynchronizes the reservation ledger from requests that still complete (see Why).
 - Configuration writes (account/key/limit/setting mutations, migrations, schedulers' state) are explicitly NOT relaxed and keep full durability.
 - No new settings (reduce-settings-surface policy): the behavior is an unconditional application constant of the telemetry write paths.
 
@@ -23,10 +24,10 @@ None.
 
 ### Modified Capabilities
 
-- `database-backends`: add the telemetry-write durability contract — which write transactions qualify as telemetry, the bounded-loss semantics they accept, the requirement that the relaxation is transaction-scoped (`SET LOCAL`) and PostgreSQL-only, and the requirement that configuration writes keep full durability.
+- `database-backends`: add the telemetry-write durability contract — which write transactions qualify as telemetry, the bounded-loss semantics they accept, the requirement that the relaxation is transaction-scoped (`SET LOCAL`) and PostgreSQL-only — and the counterpart requirement that API-key usage-reservation accounting (creation, settlement, stale release) and configuration writes retain full durability.
 
 ## Impact
 
-- Affected code: `app/db/session.py` (helper), `app/modules/request_logs/repository.py`, `app/modules/api_keys/repository.py`, `app/modules/usage/repository.py`.
-- Affected tests: new unit test for the helper's dialect guard; new PostgreSQL integration tests proving in-transaction application, automatic revert after COMMIT/ROLLBACK, the outside-transaction WARNING trap, telemetry paths emitting the relaxation, and configuration writes not emitting it.
-- Crash-loss contract: on a PostgreSQL server crash, committed telemetry rows within the final unflushed WAL window — bounded by three times `wal_writer_delay`, up to ~600 ms at the default 200 ms setting — may be lost; replication/failover semantics of `synchronous_commit = off` are identical to local-crash semantics for these rows. No API change, no frontend change, no migration, no new settings.
+- Affected code: `app/db/session.py` (helper), `app/modules/request_logs/repository.py`, `app/modules/usage/repository.py`; `app/modules/api_keys/repository.py` documents (and tests enforce) that reservation paths stay fully durable.
+- Affected tests: new unit test for the helper's dialect guard; new PostgreSQL integration tests proving in-transaction application, automatic revert after COMMIT/ROLLBACK, the outside-transaction WARNING trap, telemetry paths emitting the relaxation, and reservation/configuration writes not emitting it.
+- Crash-loss contract: on a PostgreSQL server crash, committed telemetry rows within the final unflushed WAL window — bounded by three times `wal_writer_delay`, up to ~600 ms at the default 200 ms setting — may be lost. Reservation accounting accepts no such loss window. No API change, no frontend change, no migration, no new settings.

--- a/openspec/changes/async-commit-telemetry-writes/specs/database-backends/spec.md
+++ b/openspec/changes/async-commit-telemetry-writes/specs/database-backends/spec.md
@@ -2,11 +2,11 @@
 
 ### Requirement: Telemetry write transactions relax commit durability on PostgreSQL
 
-A write transaction is classified as a **telemetry write** when it only appends or settles per-request accounting rows whose loss on a database-server crash is semantically equivalent to losing the in-flight request they describe: request-log inserts (`request_logs`), API-key usage-reservation creation and settlement (`api_key_usage_reservations` and the limit-counter / `last_used_at` statements riding the same transaction) — including the scheduler's stale-reservation release, whose batches settle the same rows and are re-derived by the next scheduler run if a crash loses them — and usage-history appends (`usage_history`, `additional_usage_history`).
+A write transaction is classified as a **telemetry write** when it only appends observability rows whose loss on a database-server crash changes nothing about accounting semantics: request-log inserts (`request_logs`) and usage-history appends (`usage_history`, `additional_usage_history`). API-key usage-reservation accounting is explicitly NOT telemetry (see the reservation-durability requirement below).
 
 On PostgreSQL, every telemetry write transaction MUST execute `SET LOCAL synchronous_commit = off` within the transaction itself, so its commit does not wait for the synchronous WAL flush. The relaxation MUST be transaction-scoped (`SET LOCAL`, never `SET`): it reverts automatically at COMMIT or ROLLBACK and MUST NOT leak onto the pooled connection. Because PostgreSQL only emits a WARNING — and applies nothing — when `SET LOCAL` runs outside a transaction, the relaxation MUST be issued through the transaction's own session (SQLAlchemy autobegin opens the transaction at that statement when none is open yet). On SQLite and any other non-PostgreSQL dialect the relaxation MUST be a no-op.
 
-The accepted loss contract is: after a PostgreSQL server crash, telemetry rows committed within the final unflushed WAL window (bounded by three times `wal_writer_delay` — up to ~600 ms at the default 200 ms setting) may be lost. Because such a crash also destroys every in-flight request, accounting semantics are unchanged. Configuration writes — account, API-key, limit, and settings mutations, schema migrations, scheduler coordination state — MUST NOT relax commit durability.
+The accepted loss contract is: after a PostgreSQL server crash, telemetry rows committed within the final unflushed WAL window (bounded by three times `wal_writer_delay` — up to ~600 ms at the default 200 ms setting) may be lost. Configuration writes — account, API-key, limit, and settings mutations, schema migrations, scheduler coordination state — MUST NOT relax commit durability.
 
 #### Scenario: Relaxation applies inside the telemetry write transaction
 
@@ -29,14 +29,8 @@ The accepted loss contract is: after a PostgreSQL server crash, telemetry rows c
 #### Scenario: Telemetry write paths emit the relaxation on PostgreSQL
 
 - **GIVEN** a PostgreSQL backend
-- **WHEN** a request log is inserted, a usage reservation is created or settled, or a usage-history entry is appended
+- **WHEN** a request log is inserted or a usage-history entry is appended
 - **THEN** the statements executed by that transaction include `SET LOCAL synchronous_commit = off` before the commit
-
-#### Scenario: Scheduler stale-reservation release relaxes commit durability
-
-- **GIVEN** a PostgreSQL backend holding a stale usage reservation (heartbeat stopped or past the maximum age)
-- **WHEN** the stale-reservation release settles a batch (status flip to `released` plus its limit-counter adjustments)
-- **THEN** each batch transaction executes `SET LOCAL synchronous_commit = off` before its commit, matching the request-path settlement of the same rows
 
 #### Scenario: Configuration writes keep full durability
 
@@ -49,3 +43,27 @@ The accepted loss contract is: after a PostgreSQL server crash, telemetry rows c
 - **GIVEN** a SQLite backend (file or `:memory:`)
 - **WHEN** any telemetry write path invokes the durability relaxation helper
 - **THEN** no statement is emitted and SQLite durability remains governed by its existing PRAGMA configuration
+
+### Requirement: API-key usage-reservation accounting retains full commit durability
+
+API-key usage-reservation writes — reservation creation, settlement (finalize/fail/release, including the limit-counter adjustments riding the same transaction), and the scheduler's stale-reservation release — MUST NOT relax commit durability. Their transactions MUST NOT execute `SET LOCAL synchronous_commit = off`.
+
+Rationale: the "crash loses the in-flight request anyway" argument that justifies relaxing telemetry writes does not hold for reservation accounting on external or highly-available PostgreSQL. A database failover there does not kill in-flight application requests: the application receives the commit acknowledgement, the request completes, and it is served to the caller. If that acked settlement commit is lost in the failover, the reservation stays `reserved`, the stale-reservation release later reverses the limit counters and records zero actual usage, and a request that actually completed disappears from token, cost, and rate-limit accounting — violating the settlement invariant. Stale-release batches mutate the same ledger and MUST keep the same durability so that a release's durability never depends on which path settles the row.
+
+#### Scenario: Reservation creation keeps full durability
+
+- **GIVEN** a PostgreSQL backend
+- **WHEN** a usage reservation is created
+- **THEN** the statements executed by that transaction never include `SET LOCAL synchronous_commit = off`
+
+#### Scenario: Reservation settlement keeps full durability
+
+- **GIVEN** a PostgreSQL backend holding a `reserved` usage reservation
+- **WHEN** the reservation is settled (finalized, failed, or released)
+- **THEN** the statements executed by that transaction never include `SET LOCAL synchronous_commit = off`
+
+#### Scenario: Stale-reservation release keeps full durability
+
+- **GIVEN** a PostgreSQL backend holding a stale usage reservation (heartbeat stopped or past the maximum age)
+- **WHEN** the stale-reservation release settles a batch (status flip to `released` plus its limit-counter adjustments)
+- **THEN** no batch transaction executes `SET LOCAL synchronous_commit = off`

--- a/openspec/changes/async-commit-telemetry-writes/tasks.md
+++ b/openspec/changes/async-commit-telemetry-writes/tasks.md
@@ -7,13 +7,12 @@
 ## 2. Telemetry write call sites
 
 - [x] 2.1 `RequestLogsRepository.add_log`: relax as the first statement of the insert transaction.
-- [x] 2.2 `ApiKeysRepository.create_usage_reservation` and `ApiKeysRepository.settle_usage_reservation`: relax the reservation-creation and settlement transactions (covers finalize/fail/release plus the `last_used_at` touch riding the settlement commit).
-- [x] 2.2b `ApiKeysRepository.release_stale_usage_reservations`: relax each stale-release batch transaction (scheduler path settles the same accounting rows as the request-path release).
-- [x] 2.3 `UsageRepository.add_entry`, `UsageRepository.add_account_snapshot`, `AdditionalUsageRepository.add_entry`: relax the usage-history append transactions.
+- [x] 2.2 `UsageRepository.add_entry`, `UsageRepository.add_account_snapshot`, `AdditionalUsageRepository.add_entry`: relax the usage-history append transactions.
+- [x] 2.3 Keep API-key usage-reservation accounting at full durability: `ApiKeysRepository.create_usage_reservation`, `ApiKeysRepository.settle_usage_reservation`, and `ApiKeysRepository.release_stale_usage_reservations` MUST NOT call the helper (adversarial review P1: acked-but-lost settlement on an HA PostgreSQL failover strands the reservation as `reserved` and the stale release reverses counters for a request that completed).
 - [x] 2.4 Confirm no configuration write path (account/key/limit management, schedulers, migrations) calls the helper.
 
 ## 3. Verification
 
 - [x] 3.1 Unit test: helper executes `SET LOCAL` only for PostgreSQL sessions and is a no-op for SQLite.
-- [x] 3.2 PostgreSQL integration tests: `SHOW synchronous_commit` inside the relaxed transaction reports `off`; after COMMIT and after ROLLBACK the session default (`on`) is restored; `SET LOCAL` outside a transaction (autocommit) does not stick (the WARNING trap); telemetry write paths (including the scheduler's stale-reservation release) emit the relaxation and a configuration write does not.
+- [x] 3.2 PostgreSQL integration tests: `SHOW synchronous_commit` inside the relaxed transaction reports `off`; after COMMIT and after ROLLBACK the session default (`on`) is restored; `SET LOCAL` outside a transaction (autocommit) does not stick (the WARNING trap); telemetry write paths emit the relaxation; reservation creation/settlement/stale-release and configuration writes do not.
 - [x] 3.3 Register the integration test module in `POSTGRES_PYTEST_TARGETS`; run ruff check, ruff format, ty, and the unit suite (SQLite) plus the new integration module against PostgreSQL.

--- a/tests/integration/test_db_commit_durability.py
+++ b/tests/integration/test_db_commit_durability.py
@@ -59,6 +59,13 @@ def _assert_not_relaxed(statements: list[str]) -> None:
     assert all(_SET_LOCAL_FRAGMENT not in statement for statement in statements), statements
 
 
+def _assert_executed_without_relaxation(statements: list[str], statement_fragment: str) -> None:
+    assert any(statement_fragment in statement for statement in statements), (
+        f"no {statement_fragment!r} captured in {statements!r}"
+    )
+    _assert_not_relaxed(statements)
+
+
 def _make_account(account_id: str) -> Account:
     encryptor = TokenEncryptor()
     return Account(
@@ -154,7 +161,13 @@ async def test_request_log_insert_transaction_relaxes_commit_durability(db_setup
 
 
 @pytest.mark.asyncio
-async def test_usage_reservation_creation_and_settlement_relax_commit_durability(db_setup) -> None:
+async def test_usage_reservation_creation_and_settlement_keep_full_commit_durability(db_setup) -> None:
+    """Regression: reservation accounting must NOT relax commit durability
+    (adversarial review P1 on PR #1628). On external/HA PostgreSQL a failover
+    does not kill in-flight application requests, so an acked-but-lost
+    settlement commit would strand the reservation as ``reserved`` and the
+    stale release would reverse the counters for a request that completed.
+    """
     _require_postgres()
     async with SessionLocal() as session:
         repo = ApiKeysRepository(session)
@@ -168,7 +181,7 @@ async def test_usage_reservation_creation_and_settlement_relax_commit_durability
         with _captured_statements() as statements:
             await repo.create_usage_reservation(reservation_id, key_id=key_id, model="gpt-5", items=[])
             await repo.commit()
-        _assert_relaxed_before(statements, "INSERT INTO api_key_usage_reservations")
+        _assert_executed_without_relaxation(statements, "INSERT INTO api_key_usage_reservations")
 
         with _captured_statements() as statements:
             await repo.settle_usage_reservation(
@@ -180,7 +193,7 @@ async def test_usage_reservation_creation_and_settlement_relax_commit_durability
                 cost_microdollars=0,
             )
             await repo.commit()
-        _assert_relaxed_before(statements, "UPDATE api_key_usage_reservations")
+        _assert_executed_without_relaxation(statements, "UPDATE api_key_usage_reservations")
         assert coalescer.pending_snapshot() == {key_id: used_at}
         assert await coalescer.flush() == 1
         updated = await repo.get_by_id(key_id)
@@ -189,11 +202,11 @@ async def test_usage_reservation_creation_and_settlement_relax_commit_durability
 
 
 @pytest.mark.asyncio
-async def test_stale_usage_reservation_release_relaxes_commit_durability(db_setup) -> None:
+async def test_stale_usage_reservation_release_keeps_full_commit_durability(db_setup) -> None:
     """Regression: the scheduler's stale-reservation release settles the same
     per-request accounting rows as the request-path settlement, so each batch
-    transaction must relax commit durability too — durability of a release
-    must not depend on which path fires (adversarial review P2).
+    must keep the same full durability — durability of a release must not
+    depend on which path fires (adversarial review P1 on PR #1628).
     """
     _require_postgres()
     async with SessionLocal() as session:
@@ -210,7 +223,7 @@ async def test_stale_usage_reservation_release_relaxes_commit_durability(db_setu
             released_count = await repo.release_stale_usage_reservations(cutoff=utcnow() + timedelta(hours=1))
 
         assert released_count == 1
-        _assert_relaxed_before(statements, "UPDATE api_key_usage_reservations")
+        _assert_executed_without_relaxation(statements, "UPDATE api_key_usage_reservations")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Resolves the unresolved P1 from the codex review thread on #1628:

> `api_key_usage_reservations` creation/settlement/stale-release must not relax commit durability — on external/HA PostgreSQL (or any crash that takes down only the database while the app survives and reconnects) an acked-but-lost settlement commit leaves the reservation `reserved`; `release_stale_usage_reservations` then reverses the limit counters and records zero actual usage, and a request that actually completed drops out of token/cost/rate-limit accounting (settlement invariant, AGENTS.md).

## Changes

- Remove `relax_commit_durability` from `create_usage_reservation`, `settle_usage_reservation`, and `release_stale_usage_reservations` (all reservation-path call sites). `request_logs` inserts and `usage_history`/`additional_usage_history` appends keep the #1628 relaxation — those rows are pure observability whose sub-second loss coincides with losing the requests themselves.
- OpenSpec (`async-commit-telemetry-writes`, still active, amended per convention): reservation accounting excluded from the telemetry classification; new requirement "API-key usage-reservation accounting retains full commit durability" with creation/settlement/stale-release scenarios.
- Integration tests inverted: statement capture asserts the reservation transactions execute **without** `SET LOCAL synchronous_commit`; telemetry and configuration-write coverage unchanged.

## Verification

ruff/format/ty clean; SQLite targeted suites 122 passed; PostgreSQL `test_db_commit_durability.py` 12/12; `openspec validate --specs` 49/49.

No `Fixes #N` — addresses a review finding on a merged PR, not a filed issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)