### PR TITLE
fix(usage): keep the covering read path effective on append-heavy usage_history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,14 @@ POSTGRES_PYTEST_TARGETS := \
 	tests/integration/test_accounts_api_probe.py::test_reimport_clears_pending_downgrade_evidence \
 	tests/integration/test_repositories.py::test_replace_reauthorized_discards_pending_downgrade_evidence \
 	tests/integration/test_repositories.py::test_upsert_account_slot_discards_pending_downgrade_evidence_on_reimport \
-	tests/integration/test_migrations.py::test_account_plan_downgrade_observations_migration_upgrade_and_downgrade
+	tests/integration/test_migrations.py::test_account_plan_downgrade_observations_migration_upgrade_and_downgrade \
+	tests/integration/test_usage_repository.py::test_bulk_history_since_primary_query_plan_is_index_only_postgresql \
+	tests/integration/test_usage_repository.py::test_bulk_history_since_cutoff_query_plan_is_index_only_postgresql \
+	tests/integration/test_usage_repository.py::test_bulk_history_since_secondary_query_plan_is_index_only_postgresql \
+	tests/integration/test_usage_repository.py::test_bulk_history_since_covered_read_matches_non_covered_read_postgresql \
+	tests/integration/test_migrations.py::test_usage_history_bulk_covering_indexes_migration_upgrade_and_downgrade \
+	tests/integration/test_migrations.py::test_usage_history_covering_index_migration_repairs_invalid_leftover_postgresql \
+	tests/integration/test_migrations.py::test_usage_history_autovacuum_tuning_migration_sets_and_resets_reloptions_postgresql
 SHELL := /bin/bash
 
 .PHONY: help

--- a/app/db/alembic/versions/20260808_000000_tune_usage_history_autovacuum.py
+++ b/app/db/alembic/versions/20260808_000000_tune_usage_history_autovacuum.py
@@ -1,0 +1,54 @@
+"""Tune usage_history autovacuum so the covering read path stays index-only.
+
+The covering indexes from ``20260806_020000`` only pay off while the
+visibility map is fresh: ``usage_history`` is append-heavy (high-frequency
+usage snapshots, no updates or deletes), and PostgreSQL's default
+insert-driven autovacuum trigger (20% of the table) lets the freshly
+appended pages sit without an all-visible bit for a long time, turning the
+"index-only" scan into one heap fetch per row — exactly the regression the
+covering indexes were built to remove. This was observed on the reference
+deployment and resolved by manually applying the settings below plus a
+one-off ``VACUUM ANALYZE``; this revision codifies the settings.
+
+Mirrors ``20260717_000000_optimize_dashboard_hot_path_indexes``, which set
+the same parameters on the other two insert-heavy tables
+(``request_logs``, ``additional_usage_history``). ``ALTER TABLE ... SET``
+is idempotent, so re-applying on a deployment that already carries the
+manual settings is harmless. Non-PostgreSQL backends are a no-op (SQLite
+has no visibility map and serves this read from its snapshot cache).
+
+Revision ID: 20260808_000000_tune_usage_history_autovacuum
+Revises: 20260806_020000_add_usage_history_bulk_covering_indexes
+Create Date: 2026-08-08 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260808_000000_tune_usage_history_autovacuum"
+down_revision = "20260806_020000_add_usage_history_bulk_covering_indexes"
+branch_labels = None
+depends_on = None
+
+_POSTGRES_AUTOVACUUM_SETTINGS = (
+    "autovacuum_vacuum_insert_scale_factor = 0.02, "
+    "autovacuum_vacuum_insert_threshold = 50000, "
+    "autovacuum_analyze_scale_factor = 0.02"
+)
+_POSTGRES_AUTOVACUUM_RESET = (
+    "autovacuum_vacuum_insert_scale_factor, autovacuum_vacuum_insert_threshold, autovacuum_analyze_scale_factor"
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(sa.text(f"ALTER TABLE usage_history SET ({_POSTGRES_AUTOVACUUM_SETTINGS})"))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute(sa.text(f"ALTER TABLE usage_history RESET ({_POSTGRES_AUTOVACUUM_RESET})"))

--- a/openspec/changes/usage-history-bulk-covering-index/proposal.md
+++ b/openspec/changes/usage-history-bulk-covering-index/proposal.md
@@ -47,6 +47,16 @@ slow-query log.
   `postgresql_include=[...]`) and register them in
   `_MANUAL_DRIFT_INDEX_REQUIREMENTS` so a missing index fails schema-drift
   checks fast on both backends.
+- Tune `usage_history` insert-driven autovacuum on PostgreSQL
+  (`autovacuum_vacuum_insert_scale_factor = 0.02`,
+  `autovacuum_vacuum_insert_threshold = 50000`,
+  `autovacuum_analyze_scale_factor = 0.02`, mirroring `20260717_000000`
+  for `request_logs`/`additional_usage_history`): the table is
+  append-heavy, and with the default insert trigger the visibility map
+  goes stale enough that the covering "index-only" scans degrade into
+  per-row heap fetches (observed on the reference deployment; resolved
+  there by the same settings applied manually — the migration codifies
+  them and is idempotent over that hotfix).
 - No query text changes; results are byte-identical.
 
 ### Deliberately kept (write-amplification note)
@@ -101,7 +111,9 @@ declared closed.
 
 ## Impact
 
-One Alembic revision (two covering indexes; `CREATE INDEX CONCURRENTLY`
-on PostgreSQL with invalid-leftover repair), `app/db/models.py` index
-declarations, `app/db/migrate.py` manual drift index list. No API or
-query change; read results are unchanged.
+Two Alembic revisions (two covering indexes via `CREATE INDEX
+CONCURRENTLY` on PostgreSQL with invalid-leftover repair; `usage_history`
+insert-driven autovacuum tuning), `app/db/models.py` index declarations,
+`app/db/migrate.py` manual drift index list, `Makefile`
+`POSTGRES_PYTEST_TARGETS` registration for the PostgreSQL-only tests. No
+API or query change; read results are unchanged.

--- a/openspec/changes/usage-history-bulk-covering-index/specs/query-caching/spec.md
+++ b/openspec/changes/usage-history-bulk-covering-index/specs/query-caching/spec.md
@@ -34,3 +34,28 @@ schema parity but MAY omit the covering payload.
 - **GIVEN** a database whose `usage_history` table lacks one of the covering indexes
 - **WHEN** the schema drift check runs
 - **THEN** it MUST report the missing index by name
+
+### Requirement: Append-heavy usage-history visibility is maintained for the covering path
+Covering indexes alone do not keep the bulk read heap-free: `usage_history`
+is append-heavy (high-frequency inserts, no updates or deletes), and with
+PostgreSQL's default insert-driven autovacuum trigger the freshly appended
+pages stay outside the visibility map long enough that "index-only" scans
+degrade into per-row heap fetches. The `usage_history` table on PostgreSQL
+MUST therefore carry per-table insert-driven autovacuum tuning
+(`autovacuum_vacuum_insert_scale_factor = 0.02`,
+`autovacuum_vacuum_insert_threshold = 50000`,
+`autovacuum_analyze_scale_factor = 0.02`, matching the tuning already
+applied to the other insert-heavy tables by `20260717_000000`) so the
+visibility map stays fresh and the covering read path remains index-only.
+Non-PostgreSQL backends MUST NOT be affected (no visibility map).
+
+#### Scenario: Migration sets the insert-driven autovacuum parameters
+- **GIVEN** a PostgreSQL database migrated past the covering-index revision
+- **WHEN** the autovacuum tuning revision is applied
+- **THEN** `usage_history` reloptions MUST include `autovacuum_vacuum_insert_scale_factor=0.02`, `autovacuum_vacuum_insert_threshold=50000`, and `autovacuum_analyze_scale_factor=0.02`
+- **AND** downgrading the revision MUST reset those three parameters
+
+#### Scenario: Re-applying over a manually tuned deployment is harmless
+- **GIVEN** a PostgreSQL deployment where the identical autovacuum settings were already applied manually (the reference deployment's hotfix)
+- **WHEN** the autovacuum tuning revision is applied
+- **THEN** the migration MUST complete without error and leave the same settings in place

--- a/openspec/changes/usage-history-bulk-covering-index/tasks.md
+++ b/openspec/changes/usage-history-bulk-covering-index/tasks.md
@@ -33,3 +33,23 @@
       re-applied migration rebuilds it as a valid covering index.
 - [x] 2.5 Gates: `uv run ruff check .`, `uv run ruff format .`,
       `uv run ty check app`, targeted pytest on SQLite and PostgreSQL.
+
+## 3. Hardening (post-review follow-up)
+
+- [x] 3.1 Alembic revision `20260808_000000_tune_usage_history_autovacuum`:
+      insert-driven autovacuum tuning for `usage_history`
+      (`autovacuum_vacuum_insert_scale_factor = 0.02`,
+      `autovacuum_vacuum_insert_threshold = 50000`,
+      `autovacuum_analyze_scale_factor = 0.02`), mirroring
+      `20260717_000000` for the other insert-heavy tables; downgrade
+      RESETs, non-PostgreSQL no-op, idempotent over the reference
+      deployment's manual hotfix.
+- [x] 3.2 PostgreSQL round-trip test for the reloptions (set on upgrade,
+      reset on downgrade, harmless re-apply over the manual hotfix).
+- [x] 3.3 Register the PostgreSQL-only covering-path tests (plan-shape,
+      row-equality, migration round-trip/repair, autovacuum reloptions)
+      in `POSTGRES_PYTEST_TARGETS` so CI runs them against PostgreSQL.
+- [x] 3.4 Grow the plan-shape fixture to hundreds of rows per account so
+      the covering index wins the cost comparison deterministically
+      (20-row fixtures tie with the non-covering key twin on
+      PostgreSQL 16 and flake); verify 3 consecutive PostgreSQL runs.

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -1295,6 +1295,64 @@ async def test_usage_history_covering_index_migration_repairs_invalid_leftover_p
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(
+    not _is_postgresql_database_url(_DATABASE_URL),
+    reason="PostgreSQL-only autovacuum reloptions test",
+)
+async def test_usage_history_autovacuum_tuning_migration_sets_and_resets_reloptions_postgresql(db_setup):
+    """The autovacuum tuning revision round-trips and tolerates manual pre-application.
+
+    ``usage_history`` is append-heavy, so a stale visibility map silently
+    degrades the covering indexes' index-only scans into per-row heap
+    fetches. Pins that the migration sets the insert-driven autovacuum
+    parameters, that downgrade resets them, and that re-applying over a
+    deployment that already carries the identical manual ``ALTER TABLE``
+    (the reference deployment's hotfix) is harmless.
+    """
+    from alembic import command
+
+    from app.db.migrate import _build_alembic_config
+
+    parent_revision = "20260806_020000_add_usage_history_bulk_covering_indexes"
+    expected_options = {
+        "autovacuum_vacuum_insert_scale_factor=0.02",
+        "autovacuum_vacuum_insert_threshold=50000",
+        "autovacuum_analyze_scale_factor=0.02",
+    }
+
+    async def _usage_history_reloptions() -> set[str]:
+        async with SessionLocal() as session:
+            options = (
+                await session.execute(text("SELECT reloptions FROM pg_class WHERE relname = 'usage_history'"))
+            ).scalar_one()
+            return set(options or ())
+
+    result = await run_startup_migrations(_DATABASE_URL)
+    assert result.current_revision == _HEAD_REVISION
+    assert expected_options <= await _usage_history_reloptions()
+
+    await to_thread.run_sync(lambda: command.downgrade(_build_alembic_config(_DATABASE_URL), parent_revision))
+    assert not (expected_options & await _usage_history_reloptions())
+
+    # Simulate the reference deployment's manual hotfix, then re-apply the
+    # migration on top of it: ALTER TABLE ... SET is idempotent.
+    async with SessionLocal() as session:
+        await session.execute(
+            text(
+                "ALTER TABLE usage_history SET ("
+                "autovacuum_vacuum_insert_scale_factor = 0.02, "
+                "autovacuum_vacuum_insert_threshold = 50000, "
+                "autovacuum_analyze_scale_factor = 0.02)"
+            )
+        )
+        await session.commit()
+
+    rerun = await run_startup_migrations(_DATABASE_URL)
+    assert rerun.current_revision == _HEAD_REVISION
+    assert expected_options <= await _usage_history_reloptions()
+
+
+@pytest.mark.asyncio
 async def test_account_plan_downgrade_observations_migration_upgrade_and_downgrade(tmp_path):
     """Round-trip the plan-downgrade evidence migration through Alembic itself.
 

--- a/tests/integration/test_usage_repository.py
+++ b/tests/integration/test_usage_repository.py
@@ -360,20 +360,43 @@ async def test_latest_by_account_primary_query_plan_uses_normalized_window_index
     assert "Seq Scan" not in plan_json
 
 
+# Snapshots per (account, window shape). Sized so the covering indexes win
+# the cost comparison decisively: with only a handful of rows the covering
+# index and its non-covering key twin cost within noise of each other on a
+# fresh PostgreSQL and the EXPLAIN assertions below flake (observed on
+# PostgreSQL 16). Hundreds of rows per account separate the index-only path
+# by a wide margin while keeping the seed fast (single bulk INSERT).
+_BULK_PLAN_FIXTURE_SNAPSHOTS_PER_WINDOW = 150
+
+
 async def _seed_bulk_history_plan_fixture(session: AsyncSession) -> None:
+    from app.db.models import UsageHistory
+
     now = utcnow()
     accounts_repo = AccountsRepository(session)
-    repo = UsageRepository(session)
     await accounts_repo.upsert(_make_account("acc1"))
     await accounts_repo.upsert(_make_account("acc2"))
 
-    for offset in range(4):
-        recorded_at = now - timedelta(minutes=30 * offset)
-        await repo.add_entry("acc1", 10.0 + offset, window=None, recorded_at=recorded_at, window_minutes=300)
-        await repo.add_entry("acc1", 20.0 + offset, window="primary", recorded_at=recorded_at, window_minutes=300)
-        await repo.add_entry("acc1", 30.0 + offset, window="secondary", recorded_at=recorded_at, window_minutes=10080)
-        await repo.add_entry("acc2", 40.0 + offset, window="primary", recorded_at=recorded_at, window_minutes=300)
-        await repo.add_entry("acc2", 50.0 + offset, window="secondary", recorded_at=recorded_at, window_minutes=10080)
+    def _entry(account_id: str, used_percent: float, window: str | None, recorded_at, window_minutes: int):
+        return UsageHistory(
+            account_id=account_id,
+            used_percent=used_percent,
+            window=window,
+            recorded_at=recorded_at,
+            window_minutes=window_minutes,
+        )
+
+    entries: list[UsageHistory] = []
+    for offset in range(_BULK_PLAN_FIXTURE_SNAPSHOTS_PER_WINDOW):
+        # 90-second steps keep every row inside the 5-hour query window.
+        recorded_at = now - timedelta(seconds=90 * offset)
+        entries.append(_entry("acc1", 10.0 + offset, None, recorded_at, 300))
+        entries.append(_entry("acc1", 20.0 + offset, "primary", recorded_at, 300))
+        entries.append(_entry("acc1", 30.0 + offset, "secondary", recorded_at, 10080))
+        entries.append(_entry("acc2", 40.0 + offset, "primary", recorded_at, 300))
+        entries.append(_entry("acc2", 50.0 + offset, "secondary", recorded_at, 10080))
+    session.add_all(entries)
+    await session.commit()
 
     await _vacuum_analyze_usage_history(session)
 
@@ -550,8 +573,9 @@ async def test_bulk_history_since_covered_read_matches_non_covered_read_postgres
 
     assert _sorted_rows(covered) == _sorted_rows(non_covered)
     assert set(covered) == {"acc1", "acc2"}
-    assert len(covered["acc1"]) == 8  # four NULL-window + four 'primary' snapshots
-    assert len(covered["acc2"]) == 4
+    # NULL-window + 'primary' snapshots for acc1, 'primary' only for acc2.
+    assert len(covered["acc1"]) == 2 * _BULK_PLAN_FIXTURE_SNAPSHOTS_PER_WINDOW
+    assert len(covered["acc2"]) == _BULK_PLAN_FIXTURE_SNAPSHOTS_PER_WINDOW
 
 
 def test_bulk_history_since_sqlite_cache_reuses_superset_and_picks_up_appends(tmp_path):


### PR DESCRIPTION
Follow-up to #1629, addressing the codex post-merge review (1×P1, 2×P2).

## Why

`usage_history` receives per-minute snapshots, so without insert-vacuum tuning the visibility map goes stale and the new `INCLUDE` indexes degrade to heap-fetching Index Only Scans — observed in production (Heap Fetches 155/155, ~1.5 s bulk reads) and fixed there by a manual `ALTER TABLE ... SET (autovacuum_*)` + `VACUUM ANALYZE` (0.2 ms after). This PR codifies that fix and closes two test-coverage gaps.

## Changes

- New migration `20260808_000000_tune_usage_history_autovacuum`: PG-only `autovacuum_vacuum_insert_scale_factor=0.02 / insert_threshold=50000 / analyze_scale_factor=0.02` on `usage_history` (RESET on downgrade), mirroring `20260717_000000`'s pattern; idempotent over the production manual hotfix (covered by a dedicated round-trip test that pre-applies the manual ALTER).
- `POSTGRES_PYTEST_TARGETS` now runs the 7 covering-path PG tests (plan assertions, covered-read equality, invalid-leftover repair, both round-trips) — they previously never ran in CI.
- Plan-assertion fixture grown 20 → 750 rows (seeded via one `add_all` commit) so the covering index wins deterministically instead of tying with the non-covering candidate; verified 3 consecutive PG runs.

## Verification

ruff/format/ty clean; SQLite 47 passed; PG `make test-postgres` 127 passed (new targets included); migration checks clean on both backends (`current_revision=20260808_000000_...`, drift none); `openspec validate --specs` 49/49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)