### PR TITLE
fix(auth): keep guardian candidates session-safe

### DIFF
--- a/app/core/auth/guardian.py
+++ b/app/core/auth/guardian.py
@@ -153,12 +153,12 @@ class AuthGuardianScheduler:
                     max_age_seconds=self.max_age_seconds,
                     limit=len(accounts),
                 )
-                candidates = [account for account in candidates if not self._in_backoff(account.id)]
-                candidates = candidates[: max(0, self.batch_size)]
-            if not candidates:
+                candidate_ids = [account.id for account in candidates if not self._in_backoff(account.id)]
+                candidate_ids = candidate_ids[: max(0, self.batch_size)]
+            if not candidate_ids:
                 return
             semaphore = asyncio.Semaphore(max(1, self.concurrency))
-            await asyncio.gather(*(self._refresh_candidate(account.id, semaphore) for account in candidates))
+            await asyncio.gather(*(self._refresh_candidate(account_id, semaphore) for account_id in candidate_ids))
 
     async def _refresh_candidate(self, account_id: str, semaphore: asyncio.Semaphore) -> None:
         if self._in_backoff(account_id):

--- a/openspec/changes/fix-auth-guardian-detached-candidates/.openspec.yaml
+++ b/openspec/changes/fix-auth-guardian-detached-candidates/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/fix-auth-guardian-detached-candidates/context.md
+++ b/openspec/changes/fix-auth-guardian-detached-candidates/context.md
@@ -1,0 +1,24 @@
+## Purpose and scope
+
+Auth Guardian proactively refreshes stale eligible account credentials without request traffic. This change repairs candidate handoff between two intentionally separate database-session scopes. It does not alter eligibility, cadence, batching, concurrency, leader election, token rotation, or account status behavior.
+
+## Decision rationale
+
+The scheduler needs only stable account IDs after candidate selection. Copying those scalar IDs before the query session closes preserves the existing ownership model: the query session selects work, and each refresh worker opens its own session to re-read current account state. Keeping the query session open across concurrent refreshes would lengthen transaction lifetime and risk sharing one `AsyncSession` across tasks.
+
+## Constraints and failure modes
+
+- A read query starts an implicit SQLAlchemy transaction. The background-session cleanup rolls that transaction back, which expires loaded attributes before close detaches the instances.
+- Detached ORM instances cannot lazy-load expired attributes, including the primary key in this observed lifecycle.
+- A failure to snapshot IDs inside the query scope aborts the entire pass before per-account isolation and backoff can apply.
+- Each refresh worker must continue to re-read the account so eligibility and credentials are current at execution time.
+
+## Concrete example
+
+Given a stale paused account with ID `account-a`, candidate selection copies `account-a` while its query session is active. After that session closes, the worker receives the plain string `account-a`, opens its own repository session, re-reads the account, and performs the existing forced refresh path.
+
+## Related contracts
+
+- Normative delta: `specs/usage-refresh-policy/spec.md` in this change.
+- Existing capability: `openspec/specs/usage-refresh-policy/spec.md`.
+- Upstream report: `Soju06/codex-lb#1668`.

--- a/openspec/changes/fix-auth-guardian-detached-candidates/design.md
+++ b/openspec/changes/fix-auth-guardian-detached-candidates/design.md
@@ -1,0 +1,33 @@
+## Context
+
+See `proposal.md` for motivation and `context.md` for the observed SQLAlchemy lifecycle. Candidate selection and per-account refresh deliberately use separate repository sessions, but the current handoff carries ORM instances rather than the scalar identity each worker needs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve the existing short candidate-query transaction and separately owned refresh sessions.
+- Make the regression executable against a real async SQLAlchemy session lifecycle.
+
+**Non-Goals:**
+
+- Change guardian eligibility, scheduling, leader election, batching, concurrency, backoff, or refresh semantics.
+- Change shared session cleanup behavior for unrelated background tasks.
+
+## Decisions
+
+### Snapshot scalar IDs inside the candidate-query session
+
+Selection, backoff filtering, and batch truncation will produce a list of account ID strings before the repository context exits. Workers will receive those strings and keep the existing fresh `get_by_id` step.
+
+Keeping the selection session open through `asyncio.gather` was rejected because it lengthens the transaction and would tempt concurrent tasks to share one `AsyncSession`. Changing global rollback/expiration behavior was rejected because the guardian does not need detached ORM objects and shared cleanup semantics have broader risk.
+
+### Reproduce the real lifecycle at the scheduler boundary
+
+The regression test will construct a real async SQLAlchemy repository session whose context cleanup rolls back and closes it, then invoke one guardian pass through the scheduler interface. Existing fakes remain useful for scheduling cases but cannot model ORM expiration and detachment.
+
+## Risks / Trade-offs
+
+- [A selected account changes before its worker starts] → Keep the existing per-worker re-read and eligibility check.
+- [A test-only session lifecycle diverges from production cleanup] → Use the same rollback-then-close behavior that production `close_session` applies rather than manually expiring one attribute.
+- [The fix accidentally changes batch ordering or limits] → Derive IDs only after the existing ordering, backoff filtering, and truncation steps.

--- a/openspec/changes/fix-auth-guardian-detached-candidates/proposal.md
+++ b/openspec/changes/fix-auth-guardian-detached-candidates/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Auth Guardian currently carries SQLAlchemy `Account` instances beyond the session that loaded them. A normal background-session rollback expires those instances, so any stale eligible account aborts the whole proactive refresh pass with `DetachedInstanceError` now that the guardian is enabled by default.
+
+## What Changes
+
+- Require Auth Guardian to preserve stable candidate identities across the candidate-query session boundary.
+- Snapshot candidate account IDs while the query session is active, then perform each refresh in its separately owned session.
+- Add a regression test that exercises the real SQLAlchemy session lifecycle instead of relying only on an in-memory repository fake.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `usage-refresh-policy`: Auth Guardian refresh passes must remain executable after the candidate-query session closes.
+
+## Impact
+
+- Affected code: `app/core/auth/guardian.py`.
+- Affected tests: Auth Guardian unit coverage with a real async SQLAlchemy session lifecycle.
+- No API, schema, migration, configuration, dependency, or dashboard changes.

--- a/openspec/changes/fix-auth-guardian-detached-candidates/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/fix-auth-guardian-detached-candidates/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Auth Guardian candidate handoff survives session closure
+
+Auth Guardian MUST preserve stable account identities while its candidate-query session is active and MUST execute selected refresh work after that session closes without reading unloaded or expired state from detached persistence objects. Each selected account MUST still be re-read in the separately owned refresh session before eligibility is confirmed and credentials are refreshed.
+
+#### Scenario: Stale candidate crosses the query-session boundary
+
+- **GIVEN** a stale eligible account is selected during an Auth Guardian pass
+- **WHEN** the candidate-query session closes before per-account refresh work begins
+- **THEN** Auth Guardian refreshes the selected account without a detached-instance failure
+- **AND** the refresh worker re-reads the account in its own session before refreshing it

--- a/openspec/changes/fix-auth-guardian-detached-candidates/tasks.md
+++ b/openspec/changes/fix-auth-guardian-detached-candidates/tasks.md
@@ -1,0 +1,15 @@
+## 1. Regression coverage
+
+- [x] 1.1 Add a scheduler-level test that loads a stale eligible account through a real async SQLAlchemy session and reproduces the detached candidate failure after session cleanup.
+- [x] 1.2 Run the focused regression test against the current implementation and confirm it fails with `DetachedInstanceError` for the expected session-boundary reason.
+
+## 2. Implementation
+
+- [x] 2.1 Snapshot filtered and batch-limited candidate account IDs before the candidate-query repository session closes.
+- [x] 2.2 Run the focused Auth Guardian tests and confirm the new regression and existing scheduling behaviors pass.
+
+## 3. Verification
+
+- [x] 3.1 Run strict OpenSpec validation and verify the implementation against this change.
+- [x] 3.2 Run the proportionate repository lint, type, and test gates for the changed Python and OpenSpec surfaces.
+- [x] 3.3 Review the final diff for issue scope, session ownership, and simplicity-gate compliance.

--- a/tests/unit/test_auth_guardian.py
+++ b/tests/unit/test_auth_guardian.py
@@ -8,13 +8,16 @@ from datetime import datetime, timedelta
 from typing import cast
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.auth import guardian as guardian_module
 from app.core.auth.guardian import AuthGuardianScheduler, build_auth_guardian_scheduler, select_auth_guardian_candidates
 from app.core.auth.refresh import RefreshError
 from app.core.config import settings as settings_module
-from app.db.models import Account, AccountStatus
+from app.db.models import Account, AccountStatus, Base
+from app.db.session import close_session
 from app.modules.accounts.auth_manager import AuthManager
+from app.modules.accounts.repository import AccountsRepository
 
 pytestmark = pytest.mark.unit
 
@@ -280,6 +283,48 @@ async def test_auth_guardian_refresh_once_refreshes_stale_paused_without_changin
 
     assert calls == ["stale-paused"]
     assert paused.status is AccountStatus.PAUSED
+
+
+@pytest.mark.asyncio
+async def test_auth_guardian_refresh_once_survives_candidate_session_close() -> None:
+    now = datetime(2026, 1, 2, 12, 0, 0)
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+        async with session_factory() as session:
+            session.add(_account("stale-active", status=AccountStatus.ACTIVE, last_refresh=now - timedelta(hours=13)))
+            await session.commit()
+
+        @asynccontextmanager
+        async def repo_factory() -> AsyncIterator[AccountsRepository]:
+            session: AsyncSession = session_factory()
+            try:
+                yield AccountsRepository(session)
+            finally:
+                await close_session(session)
+
+        calls: list[str] = []
+        scheduler = AuthGuardianScheduler(
+            interval_seconds=21600,
+            enabled=True,
+            max_age_seconds=12 * 3600,
+            batch_size=10,
+            concurrency=1,
+            jitter_seconds=0.0,
+            leader_election_factory=lambda: _Leader(),
+            repo_factory=repo_factory,
+            auth_manager_factory=lambda _repo: _AuthManager(calls),
+            sleep=lambda _delay: _noop_sleep(),
+            now=lambda: now,
+        )
+
+        await scheduler._refresh_once()
+
+        assert calls == ["stale-active"]
+    finally:
+        await engine.dispose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Keep Auth Guardian candidate handoff session-safe by snapshotting scalar account IDs before the candidate-query session closes. This prevents stale eligible accounts from aborting the proactive refresh pass with `DetachedInstanceError`.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: Fixes #1668

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/fix-auth-guardian-detached-candidates/`

## Changes

- Snapshot filtered, batch-limited candidate IDs while their query session is active, then retain the existing separately owned per-account refresh sessions.
- Add a scheduler-level regression using a real async SQLAlchemy session lifecycle; it reproduced the production `DetachedInstanceError` before the fix.
- Add a normative session-boundary requirement plus proposal, context, design, and completed tasks.

## Test plan

```text
uv run pytest tests/unit/test_auth_guardian.py::test_auth_guardian_refresh_once_survives_candidate_session_close -q
# RED before implementation: DetachedInstanceError at account.id
# GREEN after implementation: 1 passed

uv run pytest tests/unit/test_auth_guardian.py -q
# 20 passed

npx --yes @fission-ai/openspec@latest validate fix-auth-guardian-detached-candidates --type change --strict --no-interactive
# valid

npx --yes @fission-ai/openspec@latest validate --specs --strict --no-interactive
# 49 passed, 0 failed

uv run ruff format --check app/core/auth/guardian.py tests/unit/test_auth_guardian.py
uv run ruff check app/core/auth/guardian.py tests/unit/test_auth_guardian.py
uv run ty check app/core/auth/guardian.py tests/unit/test_auth_guardian.py
# all passed
```

The required full local parity hook was also run. It reached `1705 passed, 23 skipped` but failed four unrelated load-sensitive integration cases: three SIGTERM/websocket shutdown tests and one realtime sideband-route parametrization. Rerunning exactly those four cases in isolation passed `4 passed` in 7.58 seconds. Cloud CI remains the authoritative full gate.

## Screenshots / output

No dashboard-visible change. The failing production surface is covered by the real-session regression above.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran `uv run pre-commit run local-ci --hook-stage manual --all-files` and the relevant focused checks locally.
- [x] If touching specs: strict OpenSpec validation passes and verification is clean.
- [x] Simplicity gates reviewed: no setting, setup, README, environment, navigation, or dashboard changes.
- [x] CHANGELOG is not edited by hand.
