### PR TITLE
fix(proxy): normalize timestamptz lease expiry in durable lease liveness check

### DIFF
--- a/app/modules/proxy/durable_bridge_coordinator.py
+++ b/app/modules/proxy/durable_bridge_coordinator.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.clients.proxy import ProxyResponseError
 from app.core.errors import openai_error
+from app.core.utils.time import to_utc_naive
 from app.db.models import HttpBridgeSessionState
 from app.db.session import close_session
 from app.modules.proxy.continuity import is_http_bridge_account_neutral_replay
@@ -51,7 +52,11 @@ class DurableBridgeLookup:
             return False
         if self.lease_expires_at is None:
             return False
-        return self.lease_expires_at > now
+        # lease_expires_at is a timestamptz column: PostgreSQL yields it
+        # offset-aware while the app clock (utcnow) and SQLite yield naive
+        # UTC. Normalize both sides — comparing them raw raises TypeError
+        # on the anchored-lookup hot path.
+        return to_utc_naive(self.lease_expires_at) > to_utc_naive(now)
 
 
 class DurableBridgeSessionCoordinator:

--- a/openspec/changes/recover-bridge-restart-anchors/specs/responses-api-compat/spec.md
+++ b/openspec/changes/recover-bridge-restart-anchors/specs/responses-api-compat/spec.md
@@ -107,3 +107,9 @@ exist. The default threshold MUST be no greater than seven failures.
 - **AND** retires the session despite the admission waiter
 - **AND** the next attach starts from fresh durable state rather than the
   poisoned previous-response anchor
+
+#### Scenario: Lease liveness comparison is timezone-safe
+- **GIVEN** a durable bridge session whose `lease_expires_at` was read from a `timestamptz` column (offset-aware) on PostgreSQL
+- **WHEN** the dead-owner classifier evaluates lease liveness against the application's naive-UTC clock
+- **THEN** both timestamps MUST be normalized to naive UTC before comparison
+- **AND** the anchored-lookup path MUST NOT raise on mixed-awareness datetimes

--- a/openspec/changes/recover-bridge-restart-anchors/tasks.md
+++ b/openspec/changes/recover-bridge-restart-anchors/tasks.md
@@ -8,3 +8,5 @@
   `test_quota_planner_warm_now_keeps_bootstrap_for_metadata_less_primary_rows`
   failure that reproduces on clean `origin/main`.
 - [x] Commit and push `bridge-restart-recovery`.
+
+- [x] 3.9 Post-deploy regression: normalize timestamptz lease expiry vs naive clock in `lease_is_active` (production TypeError on the anchored-lookup path in v1.23.0-beta.5).

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -3045,3 +3045,45 @@ async def test_durable_bridge_retry_circuit_round_trip(
     assert cleared.consecutive_failures == 0
     assert cleared.cooldown_until_epoch == 0.0
     assert cleared.last_detail is None
+
+
+def _lookup_with_lease(lease_expires_at):
+    from app.db.models import HttpBridgeSessionState
+    from app.modules.proxy.durable_bridge_coordinator import DurableBridgeLookup
+
+    return DurableBridgeLookup(
+        session_id="sess-tz",
+        canonical_kind="session_header",
+        canonical_key="key-tz",
+        api_key_scope="scope-tz",
+        account_id="acc-tz",
+        owner_instance_id="instance-a",
+        owner_epoch=1,
+        lease_expires_at=lease_expires_at,
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state=None,
+        latest_response_id=None,
+    )
+
+
+def test_lease_is_active_accepts_timestamptz_aware_expiry():
+    """lease_expires_at is a timestamptz column: PostgreSQL yields it
+    offset-aware while utcnow() (and SQLite) are naive UTC. The raw
+    comparison raised TypeError on the anchored-lookup hot path in
+    production (v1.23.0-beta.5); lease_is_active must normalize."""
+    from datetime import timedelta, timezone
+
+    from app.core.utils.time import utcnow
+
+    naive_now = utcnow()
+    aware_future = (naive_now + timedelta(minutes=5)).replace(tzinfo=timezone.utc)
+    aware_past = (naive_now - timedelta(minutes=5)).replace(tzinfo=timezone.utc)
+
+    assert _lookup_with_lease(aware_future).lease_is_active(now=naive_now) is True
+    assert _lookup_with_lease(aware_past).lease_is_active(now=naive_now) is False
+    # Naive expiry against an aware clock must normalize the same way.
+    aware_now = naive_now.replace(tzinfo=timezone.utc)
+    assert _lookup_with_lease(naive_now + timedelta(minutes=5)).lease_is_active(now=aware_now) is True
+    # Existing naive-vs-naive behaviour is unchanged.
+    assert _lookup_with_lease(naive_now + timedelta(minutes=5)).lease_is_active(now=naive_now) is True
+    assert _lookup_with_lease(None).lease_is_active(now=naive_now) is False


### PR DESCRIPTION
## Why

Production regression in v1.23.0-beta.5: `lease_expires_at` is a `timestamptz` column, so PostgreSQL yields it **offset-aware**, while `utcnow()` (and SQLite in tests) are naive UTC. The dead-owner classifier added in #1625 (`_http_bridge_durable_owner_is_dead` → `lease_is_active(now=utcnow())`) is the first Python-side comparison of the two — every anchored durable lookup raised `TypeError: can't compare offset-naive and offset-aware datetimes` (~12 failed requests/min observed after cutover). The unit suites run on SQLite (naive round-trip), which is why 744 bridge tests passed without catching it.

Production is currently running a container hot-patch with this exact normalization; this PR makes it real and will ship in the next beta.

## What

- `DurableBridgeLookup.lease_is_active` normalizes both sides with the existing `to_utc_naive` helper (comment records the column-type provenance).
- Regression tests cover aware-expiry vs naive clock (the production failure), naive vs aware clock, naive/naive, and the `None` guard.
- OpenSpec: timezone-safety scenario appended to the still-active `recover-bridge-restart-anchors` change.

## Verification

`tests/unit/test_durable_bridge_sessions.py` 53 passed (new test fails with TypeError on the old code) + `test_proxy_http_bridge.py` green; ruff/format/ty clean.

Follow-up noted: 24 `DateTime(timezone=True)` columns exist repo-wide — a lint or fixture that runs the unit dataclasses against aware datetimes would catch this class of bug systematically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)