### PR TITLE
chore: release v1.23.0-beta.6

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.23.0-beta.5"  # x-release-please-version
+__version__ = "1.23.0-beta.6"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.23.0-beta.5
-appVersion: 1.23.0-beta.5
+version: 1.23.0-beta.6
+appVersion: 1.23.0-beta.6
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.23.0-beta.5",
+  "version": "1.23.0-beta.6",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.23.0-beta.5"
+version = "1.23.0-beta.6"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.23.0-beta.5"
+version = "1.23.0-beta.6"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.23.0-beta.6 for the 1.23.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.23.0-beta.6 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1472; no manual beta workflow dispatch is required.

## Changes since v1.23.0-beta.5
- fix(proxy): normalize timestamptz lease expiry in durable lease liveness check (#1673) (7913ff9)

## Release-candidate validation
Validated candidate: 670ccd4a464a3ad61535df9e03c02b238d1cb5c2

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates — CI green at 670ccd4a (unit, integration matrices, migration checks sqlite+postgres)
- [x] Frontend tests/build — CI green at 670ccd4a
- [x] Wheel/package validation — CI `Package (build)` green at 670ccd4a
- [x] Docker/container smoke — image built locally from 670ccd4a (sha256:7617fd4c4f8d); booted against a scratch postgres:18-alpine: alembic head `20260806_120000_add_http_bridge_owner_process_epoch`, endpoints 200/401, 0 error signatures, AND the beta.5 production regression scenario re-executed in-container (timestamptz-aware lease vs naive clock through `lease_is_active`) returning correctly instead of raising
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required — this beta replaces the hot-patched beta.5 production container with the clean #1673 fix; live-path verification continues on the production pool with the rollback runbook staged (no schema delta since beta.5)

## Install after publish
```bash
uvx --from "codex-lb==1.23.0b6" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.23.0-beta.6
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.23.0-beta.6 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.23.0.