### PR TITLE
feat(model-sources): configure reasoning efforts

### DIFF
--- a/app/modules/model_sources/catalog.py
+++ b/app/modules/model_sources/catalog.py
@@ -4,6 +4,7 @@ import json
 
 from app.core.openai.model_registry import (
     MODEL_SOURCE_KIND_OPENAI_COMPATIBLE,
+    ReasoningLevel,
     UpstreamModel,
 )
 from app.core.types import JsonValue
@@ -56,6 +57,13 @@ def _to_upstream_model(source: ModelSource, source_model: ModelSourceModel) -> U
     # source identifiers must not leak to proxy clients.
     raw["model_provider"] = "codex-lb"
 
+    reasoning_levels = _source_reasoning_levels(raw)
+    default_reasoning_level = raw.get("default_reasoning_level")
+    if not isinstance(default_reasoning_level, str) or default_reasoning_level not in {
+        level.effort for level in reasoning_levels
+    }:
+        default_reasoning_level = reasoning_levels[0].effort if reasoning_levels else None
+
     input_modalities = ("text", "image") if source_model.supports_vision else ("text",)
     display_name = source_model.display_name or source_model.model
     return UpstreamModel(
@@ -64,8 +72,8 @@ def _to_upstream_model(source: ModelSource, source_model: ModelSourceModel) -> U
         description=display_name,
         context_window=context_window,
         input_modalities=input_modalities,
-        supported_reasoning_levels=(),
-        default_reasoning_level=None,
+        supported_reasoning_levels=reasoning_levels,
+        default_reasoning_level=default_reasoning_level,
         supports_reasoning_summaries=False,
         support_verbosity=False,
         default_verbosity=None,
@@ -79,6 +87,36 @@ def _to_upstream_model(source: ModelSource, source_model: ModelSourceModel) -> U
         source_id=source.id,
         raw=raw,
     )
+
+
+def _source_reasoning_levels(raw: dict[str, JsonValue]) -> tuple[ReasoningLevel, ...]:
+    if raw.get("supports_reasoning") is not True:
+        return ()
+    configured = raw.get("supported_reasoning_levels")
+    if not is_json_list(configured):
+        return ()
+
+    levels: list[ReasoningLevel] = []
+    seen: set[str] = set()
+    for item in configured:
+        effort: str | None = None
+        description: str | None = None
+        if isinstance(item, str):
+            effort = item.strip().lower()
+        elif is_json_mapping(item):
+            raw_effort = item.get("effort")
+            raw_description = item.get("description")
+            if isinstance(raw_effort, str):
+                effort = raw_effort.strip().lower()
+            if isinstance(raw_description, str) and raw_description.strip():
+                description = raw_description.strip()
+        if not effort or effort == "none" or effort in seen:
+            continue
+        seen.add(effort)
+        levels.append(
+            ReasoningLevel(effort=effort, description=description or f"{effort} reasoning effort")
+        )
+    return tuple(levels)
 
 
 def source_model_supports_reasoning(source: ModelSource, model: str) -> bool:

--- a/frontend/src/features/model-sources/components/model-source-edit-dialog.tsx
+++ b/frontend/src/features/model-sources/components/model-source-edit-dialog.tsx
@@ -17,6 +17,7 @@ import { ModelSourceFormFields } from "@/features/model-sources/components/model
 import {
   createModelSourceFormSchema,
   draftFromSource,
+  mergeReasoningMetadata,
   modelIdsToInput,
   modelSourceDraftReducer,
   type ModelSourceDraft,
@@ -41,8 +42,6 @@ type ModelDraftChangeFlags = {
   supportsVision: boolean;
   supportsReasoning: boolean;
 };
-
-const SUPPORTS_REASONING_KEY = "supports_reasoning";
 
 function parsePositiveInt(value: string): number | null {
   const trimmed = value.trim();
@@ -84,35 +83,15 @@ function getModelDraftChangeFlags(
     supportsStreaming: draft.supportsStreaming !== initialDraft.supportsStreaming,
     supportsTools: draft.supportsTools !== initialDraft.supportsTools,
     supportsVision: draft.supportsVision !== initialDraft.supportsVision,
-    supportsReasoning: draft.supportsReasoning !== initialDraft.supportsReasoning,
+    supportsReasoning:
+      draft.supportsReasoning !== initialDraft.supportsReasoning ||
+      JSON.stringify(draft.reasoningEfforts) !== JSON.stringify(initialDraft.reasoningEfforts) ||
+      draft.defaultReasoningEffort !== initialDraft.defaultReasoningEffort,
   };
 }
 
 function hasAnyModelDraftChange(flags: ModelDraftChangeFlags): boolean {
   return Object.values(flags).some(Boolean);
-}
-
-function mergeReasoningMetadata(
-  existingMetadata: string | null | undefined,
-  supportsReasoning: boolean,
-): string | null {
-  let metadata: Record<string, unknown> = {};
-  if (existingMetadata) {
-    try {
-      const parsed: unknown = JSON.parse(existingMetadata);
-      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        metadata = parsed as Record<string, unknown>;
-      }
-    } catch {
-      metadata = {};
-    }
-  }
-  if (supportsReasoning) {
-    metadata[SUPPORTS_REASONING_KEY] = true;
-  } else {
-    delete metadata[SUPPORTS_REASONING_KEY];
-  }
-  return Object.keys(metadata).length > 0 ? JSON.stringify(metadata) : null;
 }
 
 function buildModelInputs(
@@ -155,7 +134,12 @@ function buildModelInputs(
         ? parseNonNegativeFloat(draft.audioPerMinute)
         : existingModel?.audioPerMinute ?? null,
       rawMetadataJson: draftChangeFlags.supportsReasoning
-        ? mergeReasoningMetadata(existingModel?.rawMetadataJson, draft.supportsReasoning)
+        ? mergeReasoningMetadata(
+            existingModel?.rawMetadataJson,
+            draft.supportsReasoning,
+            draft.reasoningEfforts,
+            draft.defaultReasoningEffort,
+          )
         : existingModel?.rawMetadataJson ?? null,
       isEnabled: existingModel?.isEnabled ?? true,
     };

--- a/frontend/src/features/model-sources/components/model-source-form-fields.tsx
+++ b/frontend/src/features/model-sources/components/model-source-form-fields.tsx
@@ -4,10 +4,12 @@ import { useTranslation } from "react-i18next";
 import { Checkbox } from "@/components/ui/checkbox";
 import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type {
   ModelSourceDraft,
   ModelSourceFormValues,
 } from "@/features/model-sources/components/model-source-form";
+import { REASONING_EFFORT_OPTIONS } from "@/features/model-sources/components/model-source-form";
 
 type ModelSourceFormFieldsProps = {
   control: Control<ModelSourceFormValues>;
@@ -26,6 +28,8 @@ const CAPABILITY_TOGGLES = [
   ["supportsVision", "modelSources.capabilities.vision"] as const,
   ["supportsReasoning", "modelSources.capabilities.reasoning"] as const,
 ];
+
+const DEFAULT_REASONING_EFFORTS = ["low", "medium", "high"];
 
 export function ModelSourceFormFields({
   control,
@@ -175,12 +179,78 @@ export function ModelSourceFormFields({
           <label key={key} className="flex items-center gap-2 rounded-md border p-2 text-sm">
             <Checkbox
               checked={draft[key]}
-              onCheckedChange={(checked) => updateDraft({ [key]: checked === true })}
+              onCheckedChange={(checked) =>
+                updateDraft({
+                  [key]: checked === true,
+                  ...(key === "supportsReasoning" && checked === true
+                    ? {
+                        reasoningEfforts:
+                          draft.reasoningEfforts.length > 0
+                            ? draft.reasoningEfforts
+                            : DEFAULT_REASONING_EFFORTS,
+                        defaultReasoningEffort: draft.defaultReasoningEffort || "medium",
+                      }
+                    : {}),
+                })
+              }
             />
 	            {t(labelKey)}
           </label>
         ))}
       </div>
+
+      {draft.supportsReasoning ? (
+        <div className="space-y-3 rounded-md border p-3">
+          <div>
+            <div className="text-sm font-medium">{t("modelSources.fields.reasoningEfforts")}</div>
+            <p className="text-xs text-muted-foreground">
+              {t("modelSources.fields.reasoningEffortsDescription")}
+            </p>
+          </div>
+          <div className="grid gap-2 sm:grid-cols-3">
+            {REASONING_EFFORT_OPTIONS.map((effort) => (
+              <label key={effort} className="flex items-center gap-2 rounded-md border p-2 text-sm">
+                <Checkbox
+                  checked={draft.reasoningEfforts.includes(effort)}
+                  disabled={draft.reasoningEfforts.length === 1 && draft.reasoningEfforts.includes(effort)}
+                  onCheckedChange={(checked) => {
+                    const next = checked
+                      ? [...draft.reasoningEfforts, effort]
+                      : draft.reasoningEfforts.filter((value) => value !== effort);
+                    const nextDefault = next.includes(draft.defaultReasoningEffort)
+                      ? draft.defaultReasoningEffort
+                      : next[0] ?? "";
+                    updateDraft({ reasoningEfforts: next, defaultReasoningEffort: nextDefault });
+                  }}
+                />
+                {effort}
+              </label>
+            ))}
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs text-muted-foreground">
+              {t("modelSources.fields.defaultReasoningEffort")}
+            </label>
+            <Select
+              value={draft.defaultReasoningEffort}
+              onValueChange={(value) => updateDraft({ defaultReasoningEffort: value })}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {REASONING_EFFORT_OPTIONS.filter((effort) => draft.reasoningEfforts.includes(effort)).map(
+                  (effort) => (
+                    <SelectItem key={effort} value={effort}>
+                      {effort}
+                    </SelectItem>
+                  ),
+                )}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+      ) : null}
     </>
   );
 }

--- a/frontend/src/features/model-sources/components/model-source-form.ts
+++ b/frontend/src/features/model-sources/components/model-source-form.ts
@@ -35,6 +35,8 @@ export type ModelSourceDraft = {
   supportsTools: boolean;
   supportsVision: boolean;
   supportsReasoning: boolean;
+  reasoningEfforts: string[];
+  defaultReasoningEffort: string;
   contextWindow: string;
   maxOutputTokens: string;
   inputPer1M: string;
@@ -51,6 +53,8 @@ export const initialModelSourceDraft: ModelSourceDraft = {
   supportsTools: false,
   supportsVision: false,
   supportsReasoning: false,
+  reasoningEfforts: [],
+  defaultReasoningEffort: "",
   contextWindow: "",
   maxOutputTokens: "",
   inputPer1M: "",
@@ -84,9 +88,21 @@ function parseNonNegativeFloat(value: string): number | undefined {
 // model's raw metadata JSON, which the proxy reads to pass reasoning fields
 // through and to advertise supports_reasoning in /v1/models. Merge it into
 // any raw metadata the model already carries so other keys survive edits.
-export function mergeReasoningFlag(
+export const REASONING_EFFORT_OPTIONS = [
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "ultra",
+] as const;
+
+export function mergeReasoningMetadata(
   existing: string | null | undefined,
   supportsReasoning: boolean,
+  reasoningEfforts: string[] = [],
+  defaultReasoningEffort = "",
 ): string | null {
   let metadata: Record<string, unknown> = {};
   if (existing) {
@@ -101,8 +117,12 @@ export function mergeReasoningFlag(
   }
   if (supportsReasoning) {
     metadata.supports_reasoning = true;
+    metadata.supported_reasoning_levels = reasoningEfforts;
+    metadata.default_reasoning_level = defaultReasoningEffort;
   } else {
     delete metadata.supports_reasoning;
+    delete metadata.supported_reasoning_levels;
+    delete metadata.default_reasoning_level;
   }
   return Object.keys(metadata).length > 0 ? JSON.stringify(metadata) : null;
 }
@@ -135,7 +155,12 @@ export function modelInputsFromForm(
       cachedInputPer1M: cachedInputPer1M ?? null,
       outputPer1M: outputPer1M ?? null,
       audioPerMinute: audioPerMinute ?? null,
-      rawMetadataJson: mergeReasoningFlag(existingRawMetadata[model], draft.supportsReasoning),
+      rawMetadataJson: mergeReasoningMetadata(
+        existingRawMetadata[model],
+        draft.supportsReasoning,
+        draft.reasoningEfforts,
+        draft.defaultReasoningEffort,
+      ),
       isEnabled: existingEnabledByModel[model] ?? true,
     }));
 }
@@ -147,22 +172,43 @@ function numberToInput(value: number | null | undefined): string {
 // Derive the shared draft from an existing source. The create UI applies one
 // set of per-model settings to every model, so editing mirrors that by reading
 // the first model's values as the representative settings.
-function rawMetadataHasReasoning(rawMetadataJson: string | null | undefined): boolean {
-  if (!rawMetadataJson) return false;
+function parseReasoningMetadata(rawMetadataJson: string | null | undefined): {
+  supportsReasoning: boolean;
+  reasoningEfforts: string[];
+  defaultReasoningEffort: string;
+} {
+  const fallback = { supportsReasoning: false, reasoningEfforts: [], defaultReasoningEffort: "" };
+  if (!rawMetadataJson) return fallback;
   try {
     const parsed: unknown = JSON.parse(rawMetadataJson);
-    return (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      (parsed as Record<string, unknown>).supports_reasoning === true
-    );
+    if (typeof parsed !== "object" || parsed === null) return fallback;
+    const metadata = parsed as Record<string, unknown>;
+    const configuredEfforts = Array.isArray(metadata.supported_reasoning_levels)
+      ? metadata.supported_reasoning_levels.filter(
+          (value): value is string => typeof value === "string" && value !== "none",
+        )
+      : [];
+    const supportsReasoning = metadata.supports_reasoning === true;
+    const reasoningEfforts =
+      supportsReasoning && configuredEfforts.length === 0 ? ["low", "medium", "high"] : configuredEfforts;
+    return {
+      supportsReasoning,
+      reasoningEfforts,
+      defaultReasoningEffort:
+        typeof metadata.default_reasoning_level === "string"
+          ? metadata.default_reasoning_level
+          : supportsReasoning
+            ? "medium"
+            : "",
+    };
   } catch {
-    return false;
+    return fallback;
   }
 }
 
 export function draftFromSource(source: ModelSource): ModelSourceDraft {
   const firstModel = source.models[0];
+  const reasoningMetadata = parseReasoningMetadata(firstModel?.rawMetadataJson);
   return {
     supportsChatCompletions: source.supportsChatCompletions,
     supportsResponses: source.supportsResponses,
@@ -170,7 +216,9 @@ export function draftFromSource(source: ModelSource): ModelSourceDraft {
     supportsStreaming: firstModel?.supportsStreaming ?? true,
     supportsTools: firstModel?.supportsTools ?? false,
     supportsVision: firstModel?.supportsVision ?? false,
-    supportsReasoning: rawMetadataHasReasoning(firstModel?.rawMetadataJson),
+    supportsReasoning: reasoningMetadata.supportsReasoning,
+    reasoningEfforts: reasoningMetadata.reasoningEfforts,
+    defaultReasoningEffort: reasoningMetadata.defaultReasoningEffort,
     contextWindow: numberToInput(firstModel?.contextWindow),
     maxOutputTokens: numberToInput(firstModel?.maxOutputTokens),
     inputPer1M: numberToInput(firstModel?.inputPer1M),

--- a/frontend/src/features/model-sources/components/model-source-form.ts
+++ b/frontend/src/features/model-sources/components/model-source-form.ts
@@ -177,20 +177,37 @@ function parseReasoningMetadata(rawMetadataJson: string | null | undefined): {
   reasoningEfforts: string[];
   defaultReasoningEffort: string;
 } {
-  const fallback = { supportsReasoning: false, reasoningEfforts: [], defaultReasoningEffort: "" };
+  const fallback = {
+    supportsReasoning: false,
+    reasoningEfforts: [],
+    defaultReasoningEffort: "",
+  };
   if (!rawMetadataJson) return fallback;
   try {
     const parsed: unknown = JSON.parse(rawMetadataJson);
     if (typeof parsed !== "object" || parsed === null) return fallback;
     const metadata = parsed as Record<string, unknown>;
     const configuredEfforts = Array.isArray(metadata.supported_reasoning_levels)
-      ? metadata.supported_reasoning_levels.filter(
-          (value): value is string => typeof value === "string" && value !== "none",
-        )
+      ? metadata.supported_reasoning_levels
+          .flatMap((value): string[] => {
+            if (typeof value === "string") return [value];
+            if (
+              typeof value !== "object" ||
+              value === null ||
+              Array.isArray(value)
+            )
+              return [];
+            const effort = (value as Record<string, unknown>).effort;
+            return typeof effort === "string" ? [effort] : [];
+          })
+          .map((effort) => effort.trim().toLowerCase())
+          .filter((effort) => effort && effort !== "none")
       : [];
     const supportsReasoning = metadata.supports_reasoning === true;
     const reasoningEfforts =
-      supportsReasoning && configuredEfforts.length === 0 ? ["low", "medium", "high"] : configuredEfforts;
+      supportsReasoning && configuredEfforts.length === 0
+        ? ["low", "medium", "high"]
+        : configuredEfforts;
     return {
       supportsReasoning,
       reasoningEfforts,
@@ -232,10 +249,16 @@ export function modelIdsToInput(source: ModelSource): string {
   return source.models.map((model) => model.model).join(", ");
 }
 
-export function rawMetadataByModel(source: ModelSource): Record<string, string | null> {
-  return Object.fromEntries(source.models.map((model) => [model.model, model.rawMetadataJson]));
+export function rawMetadataByModel(
+  source: ModelSource,
+): Record<string, string | null> {
+  return Object.fromEntries(
+    source.models.map((model) => [model.model, model.rawMetadataJson]),
+  );
 }
 
 export function enabledByModel(source: ModelSource): Record<string, boolean> {
-  return Object.fromEntries(source.models.map((model) => [model.model, model.isEnabled]));
+  return Object.fromEntries(
+    source.models.map((model) => [model.model, model.isEnabled]),
+  );
 }

--- a/frontend/src/features/model-sources/components/model-source-reasoning-fields.test.tsx
+++ b/frontend/src/features/model-sources/components/model-source-reasoning-fields.test.tsx
@@ -7,7 +7,9 @@ import { renderWithProviders } from "@/test/utils";
 
 import { ModelSourceEditDialog } from "./model-source-edit-dialog";
 
-function reasoningSource(): ModelSource {
+function reasoningSource(
+  reasoningLevels: unknown[] = ["minimal", "low", "medium", "high", "xhigh"],
+): ModelSource {
   return {
     id: "src_reasoning",
     name: "reasoning-source",
@@ -39,7 +41,7 @@ function reasoningSource(): ModelSource {
         audioPerMinute: null,
         rawMetadataJson: JSON.stringify({
           supports_reasoning: true,
-          supported_reasoning_levels: ["minimal", "low", "medium", "high", "xhigh"],
+          supported_reasoning_levels: reasoningLevels,
           default_reasoning_level: "high",
         }),
         isEnabled: true,
@@ -69,14 +71,36 @@ describe("ModelSource reasoning controls", () => {
     expect(screen.getByRole("checkbox", { name: "minimal" })).toBeChecked();
     expect(screen.getByRole("checkbox", { name: "xhigh" })).toBeChecked();
 
+    await user.click(screen.getByRole("checkbox", { name: "xhigh" }));
     await user.click(screen.getByRole("button", { name: "Save" }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
 
-    const rawMetadata = JSON.parse(onSubmit.mock.calls[0][1].models[0].rawMetadataJson);
+    const rawMetadata = JSON.parse(
+      onSubmit.mock.calls[0][1].models[0].rawMetadataJson,
+    );
     expect(rawMetadata).toMatchObject({
       supports_reasoning: true,
-      supported_reasoning_levels: ["minimal", "low", "medium", "high", "xhigh"],
+      supported_reasoning_levels: ["minimal", "low", "medium", "high"],
       default_reasoning_level: "high",
     });
+  });
+
+  it("prefills descriptive reasoning-level objects", () => {
+    renderWithProviders(
+      <ModelSourceEditDialog
+        open
+        busy={false}
+        source={reasoningSource([
+          { effort: "minimal", description: "Smallest budget" },
+          { effort: "xhigh", description: "Largest budget" },
+        ])}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(screen.getByRole("checkbox", { name: "minimal" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "xhigh" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "low" })).not.toBeChecked();
   });
 });

--- a/frontend/src/features/model-sources/components/model-source-reasoning-fields.test.tsx
+++ b/frontend/src/features/model-sources/components/model-source-reasoning-fields.test.tsx
@@ -1,0 +1,82 @@
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ModelSource } from "@/features/model-sources/schemas";
+import { renderWithProviders } from "@/test/utils";
+
+import { ModelSourceEditDialog } from "./model-source-edit-dialog";
+
+function reasoningSource(): ModelSource {
+  return {
+    id: "src_reasoning",
+    name: "reasoning-source",
+    kind: "openai_compatible",
+    baseUrl: "https://api.example.com/v1",
+    isEnabled: true,
+    healthStatus: "unknown",
+    supportsChatCompletions: false,
+    supportsResponses: true,
+    supportsAudioTranscriptions: false,
+    timeoutSeconds: null,
+    maxConcurrency: null,
+    createdAt: "2026-08-08T00:00:00Z",
+    updatedAt: "2026-08-08T00:00:00Z",
+    models: [
+      {
+        id: 1,
+        sourceId: "src_reasoning",
+        model: "reasoning-model",
+        displayName: "Reasoning Model",
+        contextWindow: 32768,
+        maxOutputTokens: 4096,
+        supportsStreaming: true,
+        supportsTools: true,
+        supportsVision: false,
+        inputPer1M: null,
+        cachedInputPer1M: null,
+        outputPer1M: null,
+        audioPerMinute: null,
+        rawMetadataJson: JSON.stringify({
+          supports_reasoning: true,
+          supported_reasoning_levels: ["minimal", "low", "medium", "high", "xhigh"],
+          default_reasoning_level: "high",
+        }),
+        isEnabled: true,
+        createdAt: "2026-08-08T00:00:00Z",
+        updatedAt: "2026-08-08T00:00:00Z",
+      },
+    ],
+  };
+}
+
+describe("ModelSource reasoning controls", () => {
+  it("prefills and submits supported reasoning levels", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+    renderWithProviders(
+      <ModelSourceEditDialog
+        open
+        busy={false}
+        source={reasoningSource()}
+        onOpenChange={vi.fn()}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    expect(screen.getByRole("checkbox", { name: "Reasoning" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "minimal" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "xhigh" })).toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+
+    const rawMetadata = JSON.parse(onSubmit.mock.calls[0][1].models[0].rawMetadataJson);
+    expect(rawMetadata).toMatchObject({
+      supports_reasoning: true,
+      supported_reasoning_levels: ["minimal", "low", "medium", "high", "xhigh"],
+      default_reasoning_level: "high",
+    });
+  });
+});

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1375,5 +1375,8 @@
   "upstreamProxy.toasts.poolUpdateFailed": "Proxy pool update failed",
   "upstreamProxy.validation.hostRequired": "Host is required",
   "upstreamProxy.validation.nameRequired": "Name is required",
-  "upstreamProxy.validation.portInvalid": "Enter a port between 1 and 65535"
+  "upstreamProxy.validation.portInvalid": "Enter a port between 1 and 65535",
+  "modelSources.fields.reasoningEfforts": "Supported reasoning efforts",
+  "modelSources.fields.reasoningEffortsDescription": "Choose the effort levels accepted by this model and its default.",
+  "modelSources.fields.defaultReasoningEffort": "Default reasoning effort"
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1375,5 +1375,8 @@
   "upstreamProxy.toasts.poolUpdateFailed": "Pool 업데이트 실패",
   "upstreamProxy.validation.hostRequired": "Host는 필수입니다",
   "upstreamProxy.validation.nameRequired": "이름은 필수입니다",
-  "upstreamProxy.validation.portInvalid": "1부터 65535 사이의 port를 입력하세요"
+  "upstreamProxy.validation.portInvalid": "1부터 65535 사이의 port를 입력하세요",
+  "modelSources.fields.reasoningEfforts": "지원되는 추론 수준",
+  "modelSources.fields.reasoningEffortsDescription": "이 모델이 지원하는 추론 수준과 기본값을 선택하세요.",
+  "modelSources.fields.defaultReasoningEffort": "기본 추론 수준"
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1375,5 +1375,8 @@
   "upstreamProxy.toasts.poolUpdateFailed": "Pool 更新失败",
   "upstreamProxy.validation.hostRequired": "主机不能为空",
   "upstreamProxy.validation.nameRequired": "名称必填",
-  "upstreamProxy.validation.portInvalid": "请输入 1 到 65535 之间的端口"
+  "upstreamProxy.validation.portInvalid": "请输入 1 到 65535 之间的端口",
+  "modelSources.fields.reasoningEfforts": "支持的推理级别",
+  "modelSources.fields.reasoningEffortsDescription": "选择此模型支持的推理级别和默认级别。",
+  "modelSources.fields.defaultReasoningEffort": "默认推理级别"
 }

--- a/openspec/changes/configure-model-source-reasoning-efforts/proposal.md
+++ b/openspec/changes/configure-model-source-reasoning-efforts/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+OpenAI-compatible Model Sources can currently opt a model into reasoning, but
+they cannot declare which reasoning efforts the model accepts or which effort
+should be used by default. Clients may therefore expose an incorrect selector
+or send the unsupported `none` effort to providers such as Muse.
+
+## What Changes
+
+- Add operator controls to configure supported reasoning efforts and a default
+  effort for each Model Source model.
+- Persist the configuration in the existing model raw metadata field without
+  introducing new credentials, settings, or migrations.
+- Publish the configured levels and default through the existing OpenAI model
+  catalog representation used by `/v1/models`.
+- Accept both compact string levels and descriptive `{effort, description}`
+  metadata when reading existing configurations.
+- Preserve existing Model Source behavior when reasoning is disabled or no
+  effort metadata is configured.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `model-catalog-compat`: Define the reasoning-level metadata exposed for
+  OpenAI-compatible Model Source models.
+- `frontend-architecture`: Define the Model Source reasoning configuration
+  controls and persistence behavior.
+
+## Impact
+
+- Model Source catalog conversion and dashboard create/edit forms.
+- English, Korean, and Simplified Chinese Model Source copy.
+- Focused backend catalog and frontend form regression coverage.
+- No fallback routing, subscription selection, database migration, or API-key
+  accounting behavior changes.

--- a/openspec/changes/configure-model-source-reasoning-efforts/specs/frontend-architecture/spec.md
+++ b/openspec/changes/configure-model-source-reasoning-efforts/specs/frontend-architecture/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Model Source reasoning configuration is editable
+
+The Model Source create and edit forms MUST expose supported reasoning-effort
+controls when the Reasoning capability is enabled. The form MUST allow an
+operator to select one or more supported efforts, select one configured effort
+as the default, and persist the result in the model's existing raw metadata.
+The form MUST preserve both string and descriptive object representations when
+prefilling an existing source, and MUST prevent saving a reasoning model with
+no selected effort. Disabling Reasoning MUST remove the reasoning metadata
+managed by this form while preserving unrelated raw metadata.
+
+#### Scenario: Configure reasoning efforts for a new Model Source
+
+- **WHEN** an operator enables Reasoning in the Model Source form
+- **THEN** the form displays supported-effort controls and a default-effort
+  selector
+- **AND** the operator can select multiple efforts
+- **AND** the default selector contains only selected efforts
+
+#### Scenario: Edit saved reasoning metadata
+
+- **GIVEN** an existing Model Source stores string or descriptive reasoning
+  levels in raw metadata
+- **WHEN** an operator opens the edit form
+- **THEN** the saved efforts and valid default are prefilled
+- **AND** saving a reasoning change persists the selected levels and default
+
+#### Scenario: Disable reasoning without dropping unrelated metadata
+
+- **GIVEN** a Model Source has reasoning metadata and unrelated raw metadata
+- **WHEN** an operator disables Reasoning and saves
+- **THEN** the managed reasoning metadata is removed
+- **AND** unrelated raw metadata remains unchanged

--- a/openspec/changes/configure-model-source-reasoning-efforts/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/configure-model-source-reasoning-efforts/specs/model-catalog-compat/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: OpenAI-compatible Model Sources publish configured reasoning efforts
+
+When an enabled OpenAI-compatible Model Source model has raw metadata with
+`supports_reasoning: true`, the OpenAI-compatible model catalog MUST publish
+the configured `supported_reasoning_levels` as the model's supported reasoning
+levels and MUST publish a valid `default_reasoning_level`. String entries and
+descriptive objects with an `effort` string MUST both be accepted. Empty,
+duplicate, and `none` entries MUST NOT be advertised. When the configured
+default is absent or is not one of the published efforts, the first published
+effort MUST be used as the default. If reasoning is not enabled or no valid
+efforts are configured, the model MUST publish no supported reasoning levels
+and no default reasoning effort.
+
+#### Scenario: String reasoning levels are published
+
+- **GIVEN** a Model Source model has `supports_reasoning: true`
+- **AND** its metadata contains `supported_reasoning_levels` of
+  `["low", "medium", "high"]`
+- **AND** its metadata contains `default_reasoning_level: "high"`
+- **WHEN** the OpenAI-compatible model catalog is built
+- **THEN** the model publishes `low`, `medium`, and `high`
+- **AND** its default reasoning effort is `high`
+
+#### Scenario: Descriptive reasoning levels are published
+
+- **GIVEN** a Model Source model has `supports_reasoning: true`
+- **AND** its metadata contains descriptive levels with `effort` values
+  `minimal` and `xhigh`
+- **WHEN** the OpenAI-compatible model catalog is built
+- **THEN** both efforts are published
+- **AND** their descriptions are preserved
+
+#### Scenario: Invalid reasoning levels are filtered
+
+- **GIVEN** a Model Source model has reasoning metadata containing duplicate,
+  empty, and `none` entries
+- **WHEN** the OpenAI-compatible model catalog is built
+- **THEN** only valid unique efforts are published
+- **AND** `none` is not published
+
+#### Scenario: Reasoning metadata is ignored when disabled
+
+- **GIVEN** a Model Source model has configured effort metadata
+- **AND** `supports_reasoning` is not `true`
+- **WHEN** the OpenAI-compatible model catalog is built
+- **THEN** the model publishes no supported reasoning levels
+- **AND** it publishes no default reasoning effort

--- a/openspec/changes/configure-model-source-reasoning-efforts/tasks.md
+++ b/openspec/changes/configure-model-source-reasoning-efforts/tasks.md
@@ -1,0 +1,24 @@
+## 1. Catalog Contract
+
+- [x] 1.1 Parse configured string and descriptive reasoning levels in the
+      OpenAI-compatible Model Source catalog.
+- [x] 1.2 Filter invalid, duplicate, and `none` efforts and normalize the
+      published default.
+- [x] 1.3 Add catalog regressions for configured, invalid, and disabled
+      reasoning metadata.
+
+## 2. Dashboard Configuration
+
+- [x] 2.1 Add supported-effort and default-effort controls to the Model Source
+      create/edit form.
+- [x] 2.2 Preserve existing raw metadata and prefill both supported metadata
+      representations.
+- [x] 2.3 Add localized English, Korean, and Simplified Chinese copy.
+- [x] 2.4 Add frontend regressions for string and descriptive effort metadata.
+
+## 3. Verification
+
+- [ ] 3.1 Run focused backend and frontend tests, type checks, formatting, and
+      `git diff --check` after review fixes.
+- [ ] 3.2 Validate this change and the repository OpenSpec specifications in
+      strict mode.

--- a/tests/unit/test_model_sources_catalog.py
+++ b/tests/unit/test_model_sources_catalog.py
@@ -87,6 +87,55 @@ def test_source_models_to_upstream_models_preserves_source_identity() -> None:
     assert model.prefer_websockets is False
 
 
+def test_source_models_to_upstream_models_publishes_reasoning_levels() -> None:
+    source = ModelSource(
+        id="src_reasoning",
+        name="Meta",
+        kind=MODEL_SOURCE_KIND_OPENAI_COMPATIBLE,
+        base_url="https://api.meta.ai/v1",
+        is_enabled=True,
+        supports_responses=True,
+        models=[
+            ModelSourceModel(
+                model="muse-spark-1.2-contributor",
+                raw_metadata_json=json.dumps(
+                    {
+                        "supports_reasoning": True,
+                        "supported_reasoning_levels": ["minimal", "low", "medium", "high", "xhigh", "none"],
+                        "default_reasoning_level": "high",
+                    }
+                ),
+            )
+        ],
+    )
+
+    model = source_models_to_upstream_models([source])[0]
+
+    assert [level.effort for level in model.supported_reasoning_levels] == [
+        "minimal",
+        "low",
+        "medium",
+        "high",
+        "xhigh",
+    ]
+    assert model.default_reasoning_level == "high"
+
+
+def test_source_models_to_upstream_models_ignores_reasoning_levels_when_disabled() -> None:
+    source = _overrides_source(
+        {
+            "supports_reasoning": False,
+            "supported_reasoning_levels": ["low", "high"],
+            "default_reasoning_level": "high",
+        }
+    )
+
+    model = source_models_to_upstream_models([source])[0]
+
+    assert model.supported_reasoning_levels == ()
+    assert model.default_reasoning_level is None
+
+
 def test_source_models_to_upstream_models_defaults_missing_context_window() -> None:
     source = ModelSource(
         id="src_ollama",


### PR DESCRIPTION
## Summary

Add configurable reasoning-effort metadata for OpenAI-compatible Model Sources.

Operators can declare which reasoning efforts a configured model supports and choose its default effort. codex-lb publishes this information through the existing `/v1/models` catalog so Codex can expose the appropriate reasoning selector and avoid sending unsupported values such as `reasoning.effort: "none"`.

This is a separate, provider-capability feature. It does not change subscription account selection, quota detection, fallback routing, retry behavior, or reservation accounting.

## Behavior

- reasoning remains opt-in through the existing **Reasoning** capability toggle
- when enabled, operators can select supported efforts from:
  - `minimal`
  - `low`
  - `medium`
  - `high`
  - `xhigh`
  - `max`
  - `ultra`
- at least one effort must remain selected
- one selected effort is published as the model default
- invalid or stale defaults are normalized to the first configured effort
- `none` is filtered from the advertised reasoning levels
- configured effort metadata is preserved when editing other Model Source settings
- disabling Reasoning removes the reasoning capability metadata

## Model Metadata

The existing Model Source model metadata is extended with:

```json
{
  "supports_reasoning": true,
  "supported_reasoning_levels": ["low", "medium", "high"],
  "default_reasoning_level": "medium"
}
```

The catalog maps this metadata to the upstream model representation used by `/v1/models` and downstream Responses routing.

The parser also accepts descriptive level objects:

```json
{
  "supported_reasoning_levels": [
    {"effort": "low", "description": "Fast reasoning"},
    {"effort": "high", "description": "Deep reasoning"}
  ]
}
```

## Configuration / UI

The existing Model Source create/edit form now provides:

- supported reasoning-effort checkboxes
- a default reasoning-effort selector
- edit-time prefill from saved model metadata
- localized labels and descriptions for English, Korean, and Simplified Chinese

The settings are stored in the Model Source model's existing raw metadata field. No new environment variables, credentials, or database migration are introduced.

<img width="661" height="1232" alt="Screenshot 2026-08-09 at 10 08 23 PM" src="https://github.com/user-attachments/assets/f82f3432-4b91-4fc3-a37e-cc8490a5e785" />


## Compatibility

- existing Model Sources without reasoning metadata remain non-reasoning models
- existing sources with `supports_reasoning: true` but no explicit effort list receive conservative `low`, `medium`, and `high` UI defaults
- existing unrelated raw metadata is preserved during edits
- the change applies to OpenAI-compatible Model Source catalog entries only

## Validation

- Model Source catalog unit tests cover:
  - publishing configured effort levels
  - filtering `none`
  - validating the configured default
  - ignoring effort metadata when reasoning is disabled
- frontend regression coverage verifies that saved effort levels and the default are prefixed and submitted correctly
- frontend typecheck passed
- frontend formatting checks passed
- Python catalog compilation passed
- `git diff --check` passed
- runtime catalog verification confirmed Muse-style metadata publishes `minimal`, `low`, `medium`, `high`, and `xhigh`, with `high` as the default
- the production Docker image was built successfully

The focused Vitest command currently fails before test collection because the container test loader encounters an existing `z.object` initialization error in `src/features/api-keys/schemas.ts`; no reasoning test assertions execute in that failure.

## Scope

This change only describes model reasoning capabilities. It does not add new model-provider protocols or alter routing for realtime, websocket, file, compact, image, or standalone Chat Completions APIs.

## OpenSpec

Adds openspec/changes/configure-model-source-reasoning-efforts/ with normative requirements for the Model Source catalog contract and dashboard configuration behavior, plus implementation and verification tasks.

Strict OpenSpec validation remains pending because the openspec CLI is not installed in this environment.