### PR TITLE
fix(review): keep Codex review sessions resumable

### DIFF
--- a/.agents/skills/codex-review-loop/SKILL.md
+++ b/.agents/skills/codex-review-loop/SKILL.md
@@ -62,7 +62,9 @@ Launch the adversarial review as a background process.
 3. The script parses Codex output and returns the final review text. Review
    rollouts intentionally remain persistent so `codex resume` can recover a
    completed response when the invoking terminal disconnects or truncates its
-   output. Do not add `--ephemeral` to the wrapper.
+   output. Do not add `--ephemeral` to the wrapper. The wrapper also relies on
+   the configured non-interactive approval/sandbox policy because Codex CLI
+   0.147.0 removed the historical `--full-auto` argument from `exec review`.
 
 ### Error handling
 

--- a/.agents/skills/codex-review-loop/SKILL.md
+++ b/.agents/skills/codex-review-loop/SKILL.md
@@ -60,11 +60,12 @@ Launch the adversarial review as a background process.
    ```
 2. Inform the user the review is running (~20-50 min).
 3. The script parses Codex output and returns the final review text. Review
-   rollouts intentionally remain persistent so `codex resume` can recover a
-   completed response when the invoking terminal disconnects or truncates its
-   output. Do not add `--ephemeral` to the wrapper. The wrapper also relies on
-   the configured non-interactive approval/sandbox policy because Codex CLI
-   0.147.0 removed the historical `--full-auto` argument from `exec review`.
+   rollouts intentionally remain persistent. If terminal output is lost, use
+   `codex resume --include-non-interactive` to locate the review, or
+   `codex exec resume <SESSION_ID>` when its ID is known. Do not add
+   `--ephemeral` to the wrapper. The wrapper also relies on the configured
+   non-interactive approval/sandbox policy because Codex CLI 0.147.0 removed
+   the historical `--full-auto` argument from `exec review`.
 
 ### Error handling
 

--- a/.agents/skills/codex-review-loop/SKILL.md
+++ b/.agents/skills/codex-review-loop/SKILL.md
@@ -62,7 +62,7 @@ Launch the adversarial review as a background process.
 3. The script parses Codex output and returns the final review text. Review
    rollouts intentionally remain persistent. If terminal output is lost, use
    `codex resume --include-non-interactive` to locate the review, or
-   `codex exec resume <SESSION_ID>` when its ID is known. Do not add
+   `codex resume <SESSION_ID>` when its ID is known. Do not add
    `--ephemeral` to the wrapper. The wrapper also relies on the configured
    non-interactive approval/sandbox policy because Codex CLI 0.147.0 removed
    the historical `--full-auto` argument from `exec review`.

--- a/.agents/skills/codex-review-loop/SKILL.md
+++ b/.agents/skills/codex-review-loop/SKILL.md
@@ -59,7 +59,10 @@ Launch the adversarial review as a background process.
    cat <prompt-file> | bash <skill-dir>/scripts/codex-subagent.sh --uncommitted
    ```
 2. Inform the user the review is running (~20-50 min).
-3. The script parses Codex output and returns the final review text.
+3. The script parses Codex output and returns the final review text. Review
+   rollouts intentionally remain persistent so `codex resume` can recover a
+   completed response when the invoking terminal disconnects or truncates its
+   output. Do not add `--ephemeral` to the wrapper.
 
 ### Error handling
 

--- a/.agents/skills/codex-review-loop/scripts/codex-subagent.sh
+++ b/.agents/skills/codex-review-loop/scripts/codex-subagent.sh
@@ -33,11 +33,11 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Reviews commonly outlive the invoking terminal or exceed its output cap.
-# Keep the rollout persistent so its final response can be recovered with
-# `codex resume` after either failure; `--ephemeral` would discard that escape
-# hatch as soon as this process exits.
-CODEX_ARGS+=("--full-auto")
+# Reviews commonly outlive the invoking terminal or exceed its output cap, so
+# do not add `--ephemeral`: the persistent rollout is the recovery path after
+# either failure. Also do not restore the historical `--full-auto` argument;
+# Codex CLI 0.147.0 removed it from `exec review`, which already uses the
+# configured non-interactive approval and sandbox policy.
 
 # --- Model overrides ---
 if [[ -n "${CODEX_REVIEW_MODEL:-}" ]]; then

--- a/.agents/skills/codex-review-loop/scripts/codex-subagent.sh
+++ b/.agents/skills/codex-review-loop/scripts/codex-subagent.sh
@@ -33,7 +33,11 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-CODEX_ARGS+=("--full-auto" "--ephemeral")
+# Reviews commonly outlive the invoking terminal or exceed its output cap.
+# Keep the rollout persistent so its final response can be recovered with
+# `codex resume` after either failure; `--ephemeral` would discard that escape
+# hatch as soon as this process exits.
+CODEX_ARGS+=("--full-auto")
 
 # --- Model overrides ---
 if [[ -n "${CODEX_REVIEW_MODEL:-}" ]]; then

--- a/tests/unit/test_codex_review_wrapper.py
+++ b/tests/unit/test_codex_review_wrapper.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+_WRAPPER = _REPOSITORY_ROOT / ".agents/skills/codex-review-loop/scripts/codex-subagent.sh"
+
+
+@pytest.mark.parametrize(
+    ("review_target", "expected_target"),
+    [
+        pytest.param(("--base", "origin/main"), ["--base", "origin/main"], id="base"),
+        pytest.param(("--commit", "deadbeef"), ["--commit", "deadbeef"], id="commit"),
+        pytest.param(("--uncommitted",), ["--uncommitted"], id="uncommitted"),
+    ],
+)
+def test_codex_review_wrapper_forwards_supported_arguments_without_removed_flags(
+    tmp_path: Path,
+    review_target: tuple[str, ...],
+    expected_target: list[str],
+) -> None:
+    mock_bin = tmp_path / "bin"
+    mock_bin.mkdir()
+    args_path = tmp_path / "codex-args"
+    mock_codex = mock_bin / "codex"
+    mock_codex.write_text(
+        "#!/usr/bin/env bash\nprintf '%s\\0' \"$@\" > \"$MOCK_CODEX_ARGS_PATH\"\nprintf 'codex\\nreview clean\\n'\n",
+        encoding="utf-8",
+    )
+    mock_codex.chmod(0o755)
+    env = os.environ.copy()
+    env.update(
+        {
+            "CODEX_REVIEW_MODEL": "review-model",
+            "CODEX_REVIEW_REASONING": "high",
+            "MOCK_CODEX_ARGS_PATH": str(args_path),
+            "PATH": f"{mock_bin}{os.pathsep}{env['PATH']}",
+        }
+    )
+
+    result = subprocess.run(
+        [str(_WRAPPER), *review_target],
+        check=False,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "review clean\n"
+    forwarded_args = args_path.read_bytes().rstrip(b"\0").decode().split("\0")
+    assert forwarded_args == [
+        "exec",
+        "review",
+        *expected_target,
+        "-m",
+        "review-model",
+        "-c",
+        'model_reasoning_effort="high"',
+    ]
+    assert "--ephemeral" not in forwarded_args
+    assert "--full-auto" not in forwarded_args


### PR DESCRIPTION
## Summary

Long-running Codex reviews currently discard their rollout when the wrapper
exits. If the invoking terminal disconnects or truncates the final output, the
completed review cannot be recovered with `codex resume` and must be rerun.

This PR keeps review rollouts persistent, removes an obsolete option rejected
by the current Codex CLI, and records both compatibility contracts in the
wrapper and its skill guidance.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: none; this is a focused fix for a reproduced review-output loss.

## OpenSpec

- [x] Not applicable — docs / CI / chore only

## Origin and concurrent work

- #104 (`7c8a91f5`) introduced the `codex-review-loop` skill and its wrapper.
  The wrapper has appended `--ephemeral` unconditionally since that initial
  landing, even though reviews are documented as taking 20–50 minutes.
- A completed review recently lost its substantive final response to terminal
  output truncation. Because the wrapper had requested an ephemeral rollout,
  the recorded session id could not be resumed to recover that response.
- Codex CLI 0.147.0 no longer accepts the wrapper's historical `--full-auto`
  argument on `exec review`; the current review subcommand uses the configured
  non-interactive approval and sandbox policy.
- No open issue or PR matching persistent/ephemeral Codex review sessions was
  found when this PR was prepared.

## Changes

- Stop passing `--ephemeral` to `codex exec review` so completed sessions remain
  resumable.
- Remove the obsolete `--full-auto` argument rejected by Codex CLI 0.147.0;
  review-target and model options remain unchanged.
- Explain in the production wrapper why review rollouts must remain resumable.
- Update the review-loop guidance with the same persistence contract to prevent
  the implementation and instructions from drifting apart.

## Test plan

```text
bash -n .agents/skills/codex-review-loop/scripts/codex-subagent.sh

# Invoke the wrapper with a mock `codex` command that exits nonzero if it sees
# --ephemeral or --full-auto and otherwise emits a normal parsed final response.
bash .agents/skills/codex-review-loop/scripts/codex-subagent.sh --base main
# No findings.

git diff --check
rg 'CODEX_ARGS.*--(ephemeral|full-auto)' .agents/skills/codex-review-loop/scripts/codex-subagent.sh
# no matches
```

## Screenshots / output

No application, dashboard, or wire-format changes.

## Simplicity

- [x] Adds no setting, setup step, README section, environment variable, or
      dashboard surface.

## Checklist

- [x] Title is in Conventional Commits format.
- [x] No related public issue or overlapping PR was found.
- [x] Validated shell syntax, argument behavior, final-response parsing, and
      diff hygiene.
- [x] OpenSpec is not applicable to this internal agent-tooling correction.
- [x] Simplicity gates P1-P5 reviewed.
- [x] `CHANGELOG.md` was not edited.
