### PR TITLE
chore: release v1.23.0-beta.7

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.23.0-beta.6"  # x-release-please-version
+__version__ = "1.23.0-beta.7"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.23.0-beta.6
-appVersion: 1.23.0-beta.6
+version: 1.23.0-beta.7
+appVersion: 1.23.0-beta.7
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.23.0-beta.6",
+  "version": "1.23.0-beta.7",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.23.0-beta.6"
+version = "1.23.0-beta.7"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.23.0b6"
+version = "1.23.0-beta.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.23.0-beta.7 for the 1.23.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.23.0-beta.7 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1472; no manual beta workflow dispatch is required.

## Changes since v1.23.0-beta.6
- fix(fleet): expose quota snapshot refresh timestamp (#1640) (006eff9)
- feat(ui): add iso8601 date display format to settings (#1671) (
b03d39)

## Release-candidate validation
Validated candidate: de04aecf08687a18066bc0aeb9580f9c2f82ce11

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [ ] Backend/unit/integration gates
- [ ] Frontend tests/build
- [ ] Wheel/package validation
- [ ] Docker/container smoke
- [ ] Live upstream/account smoke
- [ ] Live upstream/account smoke not required

## Install after publish
```bash
uvx --from "codex-lb==1.23.0b7" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.23.0-beta.7
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.23.0-beta.7 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.23.0.
