### PR TITLE
fix(proxy): allow validated inline images on the HTTP responses bridge

### DIFF
--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import dataclasses
 import json
 import logging
@@ -233,6 +235,134 @@ logger = logging.getLogger("app.modules.proxy.service")
 T = TypeVar("T")
 _REQUEST_TRANSPORT_HTTP = "http"
 _RESPONSE_CREATE_GATE_RETRY_SLEEP_SECONDS = 10.0
+_INLINE_IMAGE_MIN_DIMENSION = 64
+_INLINE_IMAGE_MAX_PIXELS = 100_000_000
+_JPEG_START_OF_FRAME_MARKERS = frozenset(
+    {0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7, 0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF}
+)
+
+
+def _jpeg_dimensions(data: bytes) -> tuple[int, int] | None:
+    if not data.startswith(b"\xff\xd8"):
+        return None
+    offset = 2
+    while offset + 4 <= len(data):
+        if data[offset] != 0xFF:
+            offset += 1
+            continue
+        while offset < len(data) and data[offset] == 0xFF:
+            offset += 1
+        if offset >= len(data):
+            return None
+        marker = data[offset]
+        offset += 1
+        if marker in {0x01, 0xD8, 0xD9} or 0xD0 <= marker <= 0xD7:
+            continue
+        if offset + 2 > len(data):
+            return None
+        segment_length = int.from_bytes(data[offset : offset + 2], "big")
+        if segment_length < 2 or offset + segment_length > len(data):
+            return None
+        if marker in _JPEG_START_OF_FRAME_MARKERS:
+            if segment_length < 7:
+                return None
+            height = int.from_bytes(data[offset + 3 : offset + 5], "big")
+            width = int.from_bytes(data[offset + 5 : offset + 7], "big")
+            return width, height
+        offset += segment_length
+    return None
+
+
+def _webp_dimensions(data: bytes) -> tuple[int, int] | None:
+    if len(data) < 20 or not data.startswith(b"RIFF") or data[8:12] != b"WEBP":
+        return None
+    offset = 12
+    while offset + 8 <= len(data):
+        chunk_type = data[offset : offset + 4]
+        chunk_size = int.from_bytes(data[offset + 4 : offset + 8], "little")
+        payload_offset = offset + 8
+        payload_end = payload_offset + chunk_size
+        if payload_end > len(data):
+            return None
+        if chunk_type == b"VP8X" and chunk_size >= 10:
+            width = 1 + int.from_bytes(data[payload_offset + 4 : payload_offset + 7], "little")
+            height = 1 + int.from_bytes(data[payload_offset + 7 : payload_offset + 10], "little")
+            return width, height
+        if chunk_type == b"VP8 " and chunk_size >= 10 and (
+            data[payload_offset + 3 : payload_offset + 6] == b"\x9d\x01\x2a"
+        ):
+            width = int.from_bytes(data[payload_offset + 6 : payload_offset + 8], "little") & 0x3FFF
+            height = int.from_bytes(data[payload_offset + 8 : payload_offset + 10], "little") & 0x3FFF
+            return width, height
+        if chunk_type == b"VP8L" and chunk_size >= 5 and data[payload_offset] == 0x2F:
+            size_bits = int.from_bytes(data[payload_offset + 1 : payload_offset + 5], "little")
+            width = 1 + (size_bits & 0x3FFF)
+            height = 1 + ((size_bits >> 14) & 0x3FFF)
+            return width, height
+        offset = payload_end + (chunk_size & 1)
+    return None
+
+
+def _inline_image_dimensions(media_type: str, data: bytes) -> tuple[int, int] | None:
+    if media_type == "image/png":
+        if len(data) < 24 or not data.startswith(b"\x89PNG\r\n\x1a\n") or data[12:16] != b"IHDR":
+            return None
+        return int.from_bytes(data[16:20], "big"), int.from_bytes(data[20:24], "big")
+    if media_type == "image/gif":
+        if len(data) < 10 or data[:6] not in (b"GIF87a", b"GIF89a"):
+            return None
+        return int.from_bytes(data[6:8], "little"), int.from_bytes(data[8:10], "little")
+    if media_type == "image/jpeg":
+        return _jpeg_dimensions(data)
+    if media_type == "image/webp":
+        return _webp_dimensions(data)
+    return None
+
+
+def _inline_image_bytes_are_ws_safe(media_type: str, data: bytes) -> bool:
+    dimensions = _inline_image_dimensions(media_type, data)
+    if dimensions is None:
+        return False
+    width, height = dimensions
+    return (
+        width >= _INLINE_IMAGE_MIN_DIMENSION
+        and height >= _INLINE_IMAGE_MIN_DIMENSION
+        and width * height <= _INLINE_IMAGE_MAX_PIXELS
+    )
+
+
+def _responses_request_has_only_valid_inline_images(payload: ResponsesRequest) -> bool:
+    """Return whether every input image is a safe, recognized inline data URL for the WebSocket bridge."""
+    found_image = False
+
+    def visit(value: JsonValue) -> bool:
+        nonlocal found_image
+        if isinstance(value, dict):
+            if value.get("type") == "input_image":
+                found_image = True
+                image_url = value.get("image_url")
+                if not isinstance(image_url, str):
+                    return False
+                header, separator, encoded = image_url.partition(",")
+                if not separator or not encoded:
+                    return False
+                normalized_header = header.lower()
+                if not normalized_header.startswith("data:image/") or not normalized_header.endswith(";base64"):
+                    return False
+                media_type = normalized_header.removeprefix("data:").removesuffix(";base64")
+                try:
+                    data = base64.b64decode(encoded, validate=True)
+                except (binascii.Error, ValueError):
+                    return False
+                return _inline_image_bytes_are_ws_safe(media_type, data)
+            return all(visit(child) for child in value.values())
+        if isinstance(value, list):
+            return all(visit(item) for item in value)
+        return True
+
+    input_value = payload.input
+    return isinstance(input_value, list) and visit(input_value) and found_image
+
 
 
 def _http_bridge_continuity_bound_without_safe_replay(request_state: _WebSocketRequestState) -> bool:
@@ -889,7 +1019,8 @@ class _HTTPBridgeStreamingMixin:
             ("local file pin", local_file_owner_account_id),
         )
         ws_payload_budget_bytes = _ws_transport_payload_budget_bytes(_service_get_settings())
-        if runtime_config.enabled and payload_size_estimate_bytes > ws_payload_budget_bytes:
+        payload_fits_websocket = payload_size_estimate_bytes <= ws_payload_budget_bytes
+        if runtime_config.enabled and not payload_fits_websocket:
             logger.info(
                 "stream_responses bypassing http bridge for large payload size=%s budget=%s request_id=%s",
                 payload_size_estimate_bytes,
@@ -899,12 +1030,21 @@ class _HTTPBridgeStreamingMixin:
             runtime_config = dataclasses.replace(runtime_config, enabled=False)
         image_request = _responses_request_contains_input_image(payload)
         image_generation_request = _responses_request_uses_image_generation(payload)
-        force_upstream_stream_transport = "http" if image_request else None
-        if runtime_config.enabled and (image_request or image_generation_request):
+        image_websocket_eligible = (
+            image_request and payload_fits_websocket and _responses_request_has_only_valid_inline_images(payload)
+        )
+        force_upstream_stream_transport = "http" if image_request and not image_websocket_eligible else None
+        if runtime_config.enabled and image_websocket_eligible:
+            logger.info(
+                "stream_responses allowing validated inline image through http bridge request_id=%s",
+                request_id,
+            )
+        if runtime_config.enabled and ((image_request and not image_websocket_eligible) or image_generation_request):
             logger.info(
                 "stream_responses bypassing http bridge for image-capable request input_image=%s "
-                "image_generation=%s request_id=%s",
+                "image_websocket_eligible=%s image_generation=%s request_id=%s",
                 image_request,
+                image_websocket_eligible,
                 image_generation_request,
                 request_id,
             )

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -327,6 +327,9 @@ from app.modules.proxy._service.http_bridge.retry_circuit import (
     _HTTPBridgeRetryCircuitMixin,
     _initialize_http_bridge_retry_circuit,
 )
+from app.modules.proxy._service.http_bridge.streaming import (
+    _responses_request_has_only_valid_inline_images as _responses_request_has_only_valid_inline_images,
+)
 from app.modules.proxy._service.observability import _hash_identifier as _hash_identifier
 from app.modules.proxy._service.observability import _hash_identifier_or_none as _hash_identifier_or_none
 from app.modules.proxy._service.observability import _interesting_header_keys as _interesting_header_keys

--- a/openspec/changes/allow-validated-inline-images-on-http-bridge/proposal.md
+++ b/openspec/changes/allow-validated-inline-images-on-http-bridge/proposal.md
@@ -1,0 +1,72 @@
+# Change: allow-validated-inline-images-on-http-bridge
+
+## Why
+
+The HTTP responses bridge (WebSocket-backed) provides prompt-cache reuse,
+`previous_response_id` session continuity, and incremental input across
+multi-turn tool loops. Since #903 every request containing an `input_image`
+part bypasses the bridge and is forced onto the raw HTTP stream path, so a
+single historical inline image (e.g. a screenshot read by the agent) drops a
+long coding session onto HTTP for every later turn — losing the bridge's
+cache/session affinity even though the image is a perfectly valid inline
+`data:` URL.
+
+Live validation on a real proxy (codex-lb 1.22.0) showed the cost: image-heavy
+sessions over HTTP cached ~20-43% of input tokens while equivalent text-only
+WebSocket traffic cached ~93%; the same request over the WebSocket bridge
+cached 89% on the second call. OpenAI's Responses WebSocket accepts inline
+`data:image/...` input images; the bridge even contains the inlining logic for
+external image URLs (`_inline_http_bridge_image_urls`).
+
+The reason #903 bypasses unconditionally is that a malformed image could
+occupy a bridge pending slot until local timeouts instead of failing fast with
+upstream validation errors. That concern only applies to images the proxy has
+not validated.
+
+## What Changes
+
+- The image bridge bypass becomes conditional. A `/v1/responses` request with
+  `input_image` parts MAY use the HTTP responses bridge when **all** of the
+  following hold:
+  - the full payload fits the WebSocket transport payload budget
+    (`_ws_transport_payload_budget_bytes`);
+  - every `input_image` part is an inline `data:image/<type>;base64,...` URL;
+  - the base64 payload decodes;
+  - the decoded bytes match the declared media type and carry parseable
+    dimensions (PNG IHDR, GIF header, JPEG SOF, WebP VP8X/VP8/VP8L);
+  - each dimension is at least `_INLINE_IMAGE_MIN_DIMENSION` (64px) and the
+    total pixel count is at most `_INLINE_IMAGE_MAX_PIXELS` (100M), so
+    pathological/degenerate images cannot reach the upstream WebSocket.
+- If any check fails, the existing behavior is preserved: the bridge is
+  bypassed and the request is forced onto the raw HTTP stream path with
+  `upstream_stream_transport_override="http"`, keeping fast upstream
+  validation errors for invalid image payloads.
+- `image_generation` tool requests keep the existing unconditional bypass
+  (they are not inline-image validation cases).
+- Image requests that pass validation still exercise the bridge's existing
+  request-local guards (size budget, admission, retry safety); they are not a
+  new hole around `_raise_for_unsupported_input_image_references`, which still
+  rejects `file_id`/`sediment://` references before this decision runs.
+
+## Impact
+
+- Valid inline images (the common case: agent screenshots, user attachments)
+  regain HTTP bridge prompt-cache/session reuse and per-turn incremental
+  continuity.
+- Invalid, truncated, mismatched, or degenerate inline images still fail fast
+  on the raw HTTP path instead of occupying bridge pending slots.
+- No API, schema, or configuration surface changes; the validation is purely
+  request-local and conservative (fail closed to HTTP on any doubt).
+
+## Verification
+
+- Unit: `_responses_request_has_only_valid_inline_images` accepts real
+  PNG/WebP/JPEG inline images (nested content and tool output) and rejects
+  tiny (1x1), non-base64, non-image, and external-URL inputs.
+- Unit: `_stream_http_bridge_or_retry` uses the bridge for a valid 64x64
+  inline PNG and bypasses to HTTP (override `"http"`) for a 1x1 PNG.
+- Existing #903 regression tests still pass unchanged (truncated PNG fixtures
+  remain on the HTTP path).
+- Live (1.22.0 install, patched): valid inline PNG → `upstream_transport=websocket`,
+  second identical request `cached_tokens` 7,936/8,916 (~89%); invalid base64
+  image → HTTP 400 `invalid_value` in ~0.45s; 1x1 PNG → HTTP transport.

--- a/openspec/changes/allow-validated-inline-images-on-http-bridge/specs/responses-api-compat/spec.md
+++ b/openspec/changes/allow-validated-inline-images-on-http-bridge/specs/responses-api-compat/spec.md
@@ -1,0 +1,68 @@
+# responses-api-compat delta
+
+## MODIFIED Requirements
+
+### Requirement: Responses input images bypass the HTTP bridge
+
+The service MUST bypass the HTTP responses bridge when a `/v1/responses`,
+`/backend-api/codex/responses`, `/responses/compact`, or `/v1/responses/compact`
+request contains any `input_image` part in top-level input items, nested
+message content, or tool output content, and send the request over the raw HTTP
+Responses stream path, **unless every `input_image` part is a validated inline
+image**. This bypass MUST happen after rejecting unsupported uploaded-image
+references and MUST be limited to the current request; subsequent text-only
+requests MAY continue using the HTTP responses bridge.
+
+An inline `input_image` part is validated when ALL of the following hold:
+
+- the part carries an inline `data:image/<type>;base64,...` URL;
+- the base64 payload decodes;
+- the decoded bytes match the declared media type and carry parseable
+  dimensions (PNG IHDR, GIF header, JPEG SOF, or WebP VP8X/VP8/VP8L);
+- each dimension is at least 64 pixels and the total pixel count is at most
+  100,000,000;
+- the serialized request fits the WebSocket transport payload budget.
+
+When every `input_image` part in the request is validated this way and the
+payload fits the WebSocket budget, the HTTP responses bridge MAY be used for
+the request instead of the raw HTTP path. When any `input_image` part fails
+validation (or the payload exceeds the WebSocket budget), the service MUST
+send the request over the raw HTTP stream path with the upstream stream
+transport forced to HTTP.
+
+The raw HTTP path is the source of truth for image validation and upstream image
+error semantics. The bridge MUST NOT hold image requests waiting for
+`response.created` when upstream rejects an invalid inline image payload.
+
+#### Scenario: Nested input_image bypasses bridge
+
+- **GIVEN** the HTTP responses bridge is enabled
+- **WHEN** a Responses request contains a nested content part with `type = "input_image"`
+- **AND** the image is not a validated inline image (for example, an external URL or undecodable base64)
+- **THEN** the request is sent through the raw HTTP stream path
+- **AND** the HTTP responses bridge is not used for that request
+
+#### Scenario: Validated inline image uses the bridge
+
+- **GIVEN** the HTTP responses bridge is enabled
+- **WHEN** a Responses request contains an `input_image` part with a valid inline
+  `data:image/png;base64,...` URL whose decoded bytes parse as a PNG with
+  dimensions within the allowed range
+- **AND** the serialized request fits the WebSocket transport payload budget
+- **THEN** the request MAY be sent through the HTTP responses bridge
+- **AND** the request is not forced onto the raw HTTP stream path
+
+#### Scenario: Degenerate inline image bypasses the bridge
+
+- **GIVEN** the HTTP responses bridge is enabled
+- **WHEN** a Responses request contains an `input_image` part with a valid base64
+  PNG that is 1x1 pixel
+- **THEN** the request is sent through the raw HTTP stream path with the
+  upstream stream transport forced to HTTP
+
+#### Scenario: Image bypass does not disable future text bridge use
+
+- **GIVEN** the HTTP responses bridge is enabled
+- **WHEN** an image-bearing request bypasses the bridge
+- **THEN** the bypass applies only to that request
+- **AND** a later text-only request can still use the HTTP responses bridge

--- a/openspec/changes/allow-validated-inline-images-on-http-bridge/tasks.md
+++ b/openspec/changes/allow-validated-inline-images-on-http-bridge/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: allow-validated-inline-images-on-http-bridge
+
+## 1. Implementation
+
+- [x] 1.1 `app/modules/proxy/_service/http_bridge/streaming.py`: add
+      `_responses_request_has_only_valid_inline_images` (inline `data:image/*;base64`
+      check + media-type signature/dimension parsing for PNG/GIF/JPEG/WebP with
+      min-dimension and max-pixel guards) and gate the image bypass on it:
+      bridge allowed only when the payload fits the WS budget and every inline
+      image validates; otherwise preserve the HTTP override.
+- [x] 1.2 `app/modules/proxy/service.py`: re-export
+      `_responses_request_has_only_valid_inline_images` for tests/observability.
+
+## 2. Regression coverage
+
+- [x] 2.1 Unit: `_responses_request_has_only_valid_inline_images` accepts
+      real inline PNG (nested message content and tool output) and rejects
+      text-only payloads.
+- [x] 2.2 Unit: the same helper rejects tiny (1x1) images, invalid base64,
+      non-image bytes, and external `https://` image URLs.
+- [x] 2.3 Unit: `_stream_http_bridge_or_retry` routes a valid 64x64 inline PNG
+      through the bridge (no upstream transport override).
+- [x] 2.4 Unit: `_stream_http_bridge_or_retry` bypasses the bridge for a 1x1
+      inline PNG with `upstream_stream_transport_override="http"`.
+- [x] 2.5 Existing #903 tests (`test_stream_http_bridge_or_retry_bypasses_bridge_for_input_image`,
+      `test_responses_request_contains_input_image_detects_supported_shapes`)
+      pass unchanged with truncated-PNG fixtures still on the HTTP path.
+
+## 3. Verification
+
+- [x] 3.1 `uv run ruff check` on modified source and tests.
+- [x] 3.2 `uv run pytest tests/unit/test_proxy_utils.py -q` (993 passed).
+- [x] 3.3 `uv run ty check` on modified source and tests.
+- [x] 3.4 Live validation on codex-lb 1.22.0: valid inline PNG → websocket
+      upstream with ~89% cache on the second identical request; invalid
+      base64 → HTTP 400 `invalid_value` fast-fail; 1x1 PNG → HTTP transport.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import errno
 import gc
 import hashlib
@@ -8,7 +10,9 @@ import json
 import logging
 import socket
 import ssl
+import struct
 import time
+import zlib
 from collections import deque
 from collections.abc import Callable, Mapping, Sequence
 from contextlib import asynccontextmanager, suppress
@@ -3587,6 +3591,233 @@ async def test_stream_http_bridge_or_retry_bypasses_bridge_for_input_image(monke
 
     assert disabled_bridge_output == ["data: retry\n\n"]
     assert calls == [("retry", payload, None, 180.0, "http")]
+
+
+def _make_test_png(width: int, height: int) -> bytes:
+    def chunk(kind: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + kind
+            + data
+            + struct.pack(">I", binascii.crc32(kind + data) & 0xFFFFFFFF)
+        )
+
+    scanline = b"\x00" + b"\x00\x00\x00" * width
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(scanline * height))
+        + chunk(b"IEND", b"")
+    )
+
+
+def test_responses_request_has_only_valid_inline_images_accepts_real_inline_images() -> None:
+    png = _make_test_png(64, 64)
+    png_url = "data:image/png;base64," + base64.b64encode(png).decode("ascii")
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "hi",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "describe"},
+                        {"type": "input_image", "image_url": png_url},
+                    ],
+                }
+            ],
+        }
+    )
+    assert proxy_service._responses_request_has_only_valid_inline_images(payload) is True
+
+    tool_output = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "hi",
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": [{"type": "input_image", "image_url": png_url}],
+                }
+            ],
+        }
+    )
+    assert proxy_service._responses_request_has_only_valid_inline_images(tool_output) is True
+
+    text_only = ResponsesRequest.model_validate({"model": "gpt-5.5", "instructions": "hi", "input": "hello"})
+    assert proxy_service._responses_request_has_only_valid_inline_images(text_only) is False
+
+
+def test_responses_request_has_only_valid_inline_images_rejects_unsafe_images() -> None:
+    tiny_png = _make_test_png(1, 1)
+    tiny_png = _make_test_png(1, 1)
+    tiny_url = "data:image/png;base64," + base64.b64encode(tiny_png).decode("ascii")
+
+    def make_payload(image_url: str) -> ResponsesRequest:
+        return ResponsesRequest.model_validate(
+            {
+                "model": "gpt-5.5",
+                "instructions": "hi",
+                "input": [{"type": "input_image", "image_url": image_url}],
+            }
+        )
+
+    assert proxy_service._responses_request_has_only_valid_inline_images(make_payload(tiny_url)) is False
+    assert (
+        proxy_service._responses_request_has_only_valid_inline_images(make_payload("data:image/png;base64,%%%"))
+        is False
+    )
+    assert (
+        proxy_service._responses_request_has_only_valid_inline_images(
+            make_payload("data:image/png;base64," + base64.b64encode(b"not an image").decode("ascii"))
+        )
+        is False
+    )
+    assert (
+        proxy_service._responses_request_has_only_valid_inline_images(make_payload("https://example.com/image.png"))
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_http_bridge_or_retry_uses_bridge_for_valid_inline_image(monkeypatch):
+    png_url = "data:image/png;base64," + base64.b64encode(_make_test_png(64, 64)).decode("ascii")
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings()
+    settings.http_responses_stream_request_budget_seconds = 180.0
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        proxy_service,
+        "_http_bridge_runtime_config",
+        lambda _dashboard_settings, _app_settings: proxy_service._HTTPBridgeRuntimeConfig(
+            enabled=True,
+            idle_ttl_seconds=30.0,
+            codex_idle_ttl_seconds=30.0,
+            max_sessions=8,
+            queue_limit=16,
+            prompt_cache_idle_ttl_seconds=30.0,
+            gateway_safe_mode=False,
+        ),
+    )
+    png_url = "data:image/png;base64," + base64.b64encode(_make_test_png(64, 64)).decode("ascii")
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "hi",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "describe"},
+                        {"type": "input_image", "image_url": png_url},
+                    ],
+                }
+            ],
+        }
+    )
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+
+    calls: list[tuple[str, object, str | None]] = []
+
+    async def fake_stream_with_retry(payload, headers, *, rewritten_file_account_id=None, **kwargs):
+        del payload, headers
+        calls.append(("retry", rewritten_file_account_id, kwargs.get("upstream_stream_transport_override")))
+        yield "data: retry\n\n"
+
+    async def fake_stream_via_http_bridge(payload, headers, **kwargs):
+        del payload, headers, kwargs
+        calls.append(("bridge", None, None))
+        yield "data: bridge\n\n"
+
+    monkeypatch.setattr(service, "_stream_with_retry", fake_stream_with_retry)
+    monkeypatch.setattr(service, "_stream_via_http_bridge", fake_stream_via_http_bridge)
+
+    output = [
+        line
+        async for line in service._stream_http_bridge_or_retry(
+            payload=payload,
+            headers={},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+        )
+    ]
+
+    assert output == ["data: bridge\n\n"]
+    assert calls == [("bridge", None, None)]
+
+
+@pytest.mark.asyncio
+async def test_stream_http_bridge_or_retry_bypasses_bridge_for_tiny_inline_image(monkeypatch):
+    png_url = "data:image/png;base64," + base64.b64encode(_make_test_png(1, 1)).decode("ascii")
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    settings = _make_proxy_settings()
+    settings.http_responses_stream_request_budget_seconds = 180.0
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        proxy_service,
+        "_http_bridge_runtime_config",
+        lambda _dashboard_settings, _app_settings: proxy_service._HTTPBridgeRuntimeConfig(
+            enabled=True,
+            idle_ttl_seconds=30.0,
+            codex_idle_ttl_seconds=30.0,
+            max_sessions=8,
+            queue_limit=16,
+            prompt_cache_idle_ttl_seconds=30.0,
+            gateway_safe_mode=False,
+        ),
+    )
+    png_url = "data:image/png;base64," + base64.b64encode(_make_test_png(1, 1)).decode("ascii")
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.5",
+            "instructions": "hi",
+            "input": [{"type": "input_image", "image_url": png_url}],
+        }
+    )
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+
+    calls: list[tuple[str, object, str | None]] = []
+
+    async def fake_stream_with_retry(payload, headers, *, rewritten_file_account_id=None, **kwargs):
+        del payload, headers
+        calls.append(("retry", rewritten_file_account_id, kwargs.get("upstream_stream_transport_override")))
+        yield "data: retry\n\n"
+
+    async def fake_stream_via_http_bridge(payload, headers, **kwargs):
+        del payload, headers, kwargs
+        calls.append(("bridge", None, None))
+        yield "data: bridge\n\n"
+
+    monkeypatch.setattr(service, "_stream_with_retry", fake_stream_with_retry)
+    monkeypatch.setattr(service, "_stream_via_http_bridge", fake_stream_via_http_bridge)
+
+    output = [
+        line
+        async for line in service._stream_http_bridge_or_retry(
+            payload=payload,
+            headers={},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+        )
+    ]
+
+    assert output == ["data: retry\n\n"]
+    assert calls == [("retry", None, "http")]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Since #903, every Responses request carrying an `input_image` part bypasses the HTTP responses bridge and is forced onto the raw HTTP stream path. That means one historical inline image (e.g. an agent screenshot read mid-task) drops a long coding session onto HTTP for every later turn, losing the bridge's prompt-cache reuse and `previous_response_id` session continuity — even though the image is a perfectly valid inline `data:` URL that the upstream WebSocket accepts.

This PR makes the bypass conditional: the HTTP responses bridge may serve image-bearing requests when **all** of:

- the serialized payload fits the WebSocket transport payload budget (`_ws_transport_payload_budget_bytes`);
- every `input_image` part is an inline `data:image/<type>;base64,...` URL;
- the base64 decodes and the bytes match the declared media type with parseable dimensions (PNG IHDR / GIF header / JPEG SOF / WebP VP8X/VP8/VP8L);
- each dimension is ≥ 64px and total pixels ≤ 100M (degenerate-image guard).

Any failed check preserves the #903 behavior exactly: raw HTTP stream path with `upstream_stream_transport_override="http"`, so invalid images still fail fast with upstream validation errors instead of occupying bridge pending slots. `image_generation` tool requests keep the unconditional bypass. `_raise_for_unsupported_input_image_references` still runs before this decision.

## Why

Live validation on codex-lb 1.22.0: image-heavy sessions over HTTP cached ~20–43% of input tokens while equivalent text-only WebSocket traffic cached ~93%; the same inline-image request over the WebSocket bridge cached 89% on the second call. OpenAI's Responses WebSocket mode accepts inline `data:image/...` inputs, and the bridge already carries the external-URL inlining logic (`_inline_http_bridge_image_urls`).

## Test Plan

- `uv run ruff check app/modules/proxy/_service/http_bridge/streaming.py app/modules/proxy/service.py tests/unit/test_proxy_utils.py`
- `uv run ty check app/modules/proxy/_service/http_bridge/streaming.py app/modules/proxy/service.py tests/unit/test_proxy_utils.py`
- `uv run pytest tests/unit/test_proxy_utils.py -q` (993 passed)
- New unit coverage: validation helper accepts real inline PNG (nested + tool output), rejects tiny/invalid/external images; bridge routing uses the bridge for a valid 64×64 PNG and bypasses to HTTP for a 1×1 PNG. Existing #903 regression tests pass unchanged.

## Live Validation

- Valid inline PNG → `upstream_transport=websocket`; second identical request `cached_tokens` 7,936/8,916 (~89%).
- Invalid base64 image → HTTP 400 `invalid_value` in ~0.45 s.
- 1×1 PNG → HTTP transport (dimension guard).