### PR TITLE
chore: release v1.23.1-beta.1

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.23.0"  # x-release-please-version
+__version__ = "1.23.1-beta.1"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.23.0
-appVersion: 1.23.0
+version: 1.23.1-beta.1
+appVersion: 1.23.1-beta.1
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.23.0",
+  "version": "1.23.1-beta.1",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.23.0"
+version = "1.23.1-beta.1"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.23.0"
+version = "1.23.1-beta.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.23.1-beta.1 for the 1.23.1 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.23.1-beta.1 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1692; no manual beta workflow dispatch is required.

## Changes since v1.23.0
- fix(quota-planner): compare warmup reset epochs in UTC (#1623) (e4fa3f2)
- fix(proxy): release the API-key reservation on all exits of the models endpoints (#1653) (
700788)
- fix(compact): omit oversized non-state tool tail (#1235) (
edb373)
- fix(dashboard): separate quota and purchased credits (#1670) (
4a08d9)
- fix(dashboard): exclude cancelled/client_disconnected from error rate (#1696) (
8a7d95)
- fix(proxy): durably recover hard HTTP bridge operations (#1657) (
7a0b67)
- fix(http-bridge): keep idle retirements out of retry circuit (#1677) (
7c4671)
- feat(reset-credits): add refresh scheduler enable toggle (#1701) (
6509dd)

## Release-candidate validation
Validated candidate: c2654a1365542717241629055988a428b9c39a49

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [ ] Backend/unit/integration gates
- [ ] Frontend tests/build
- [ ] Wheel/package validation
- [ ] Docker/container smoke
- [ ] Live upstream/account smoke
- [ ] Live upstream/account smoke not required

## Install after publish
```bash
uvx --from "codex-lb==1.23.1b1" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.23.1-beta.1
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.23.1-beta.1 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.23.1.
