### PR TITLE
test(proxy): add property tests for response payload invariants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ poc/
 __pycache__/
 *.py[cod]
 .pytest_cache/
+.hypothesis/
 .mypy_cache/
 .ruff_cache/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ dev = [
     "openai>=2.16.0",
     "pytest-xdist>=3.8.0",
     "pytest-cov>=7.1.0",
+    "hypothesis>=6.165.3",
 ]
 docs = [
     "mkdocs-material>=9.6",

--- a/tests/unit/hypothesis_strategies.py
+++ b/tests/unit/hypothesis_strategies.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from hypothesis import strategies as st
+
+json_scalars = st.one_of(
+    st.none(),
+    st.booleans(),
+    st.integers(min_value=-10_000, max_value=10_000),
+    st.floats(allow_nan=False, allow_infinity=False, width=32),
+    st.text(max_size=80),
+)
+
+json_values = st.recursive(
+    json_scalars,
+    lambda children: st.one_of(
+        st.lists(children, max_size=5),
+        st.dictionaries(st.text(max_size=20), children, max_size=5),
+    ),
+    max_leaves=20,
+)
+
+json_objects = st.dictionaries(
+    st.text(max_size=20),
+    json_values,
+    max_size=8,
+)
+
+json_arrays = st.lists(json_values, max_size=8)

--- a/tests/unit/hypothesis_strategies.py
+++ b/tests/unit/hypothesis_strategies.py
@@ -19,6 +19,8 @@ json_values = st.recursive(
     max_leaves=20,
 )
 
+json_directive_types = json_values.filter(lambda value: value is not None and value != "message")
+
 json_objects = st.dictionaries(
     st.text(max_size=20),
     json_values,

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -1,24 +1,34 @@
 from __future__ import annotations
 
 import json
+import re
+from copy import deepcopy
 from typing import Mapping, cast
 
 import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from pydantic import ValidationError
 
 from app.core.openai.exceptions import ClientPayloadError
 from app.core.openai.requests import (
     _ESTIMATED_CHARS_PER_TOKEN,
     _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS,
+    _UNSUPPORTED_UPSTREAM_FIELDS,
     ResponsesCompactRequest,
     ResponsesRequest,
+    _estimated_json_array_item_tokens,
     _estimated_json_tokens,
     _input_image_file_reference,
+    _sanitize_input_items,
+    _strip_unsupported_fields,
+    _trim_compact_input_for_upstream,
     extract_input_file_ids,
     extract_input_image_file_references,
 )
 from app.core.openai.v1_requests import V1ResponsesCompactRequest, V1ResponsesRequest
 from app.core.types import JsonValue
+from tests.unit.hypothesis_strategies import json_arrays, json_objects, json_values
 
 
 def test_responses_requires_instructions():
@@ -113,6 +123,52 @@ def test_known_unsupported_upstream_fields_are_stripped():
     assert "truncation" not in dumped
     assert "user" not in dumped
     assert dumped["custom_field"] == "kept"
+
+
+@given(json_arrays)
+def test_sanitize_input_items_is_idempotent_for_json(input_items):
+    original = deepcopy(input_items)
+    try:
+        sanitized = _sanitize_input_items(input_items)
+    except ValueError:
+        # Tool items without a usable call ID are deliberately rejected.
+        return
+
+    assert input_items == original
+    assert _sanitize_input_items(deepcopy(sanitized)) == sanitized
+
+
+@given(
+    role=st.sampled_from(["system", "developer"]),
+    item_type=json_values,
+    extra=json_objects,
+)
+def test_sanitize_input_items_preserves_typed_directives(role, item_type, extra):
+    directive = dict(extra)
+    directive.update({"role": role, "type": item_type})
+
+    assert _sanitize_input_items([directive]) == [directive]
+
+
+@given(payload=json_objects.map(lambda value: {key: item for key, item in value.items() if key != "input"}))
+def test_strip_unsupported_fields_is_idempotent(payload):
+    payload = cast(dict[str, JsonValue], payload)
+    first = _strip_unsupported_fields(deepcopy(payload))
+    second = _strip_unsupported_fields(deepcopy(first))
+
+    assert second == first
+    assert _UNSUPPORTED_UPSTREAM_FIELDS.isdisjoint(first)
+
+
+@given(namespace=json_values)
+def test_strip_unsupported_fields_namespace_flag_controls_replayed_calls(namespace):
+    payload = cast(dict[str, JsonValue], {"input": [{"type": "function_call", "namespace": namespace}]})
+
+    preserved = _strip_unsupported_fields(deepcopy(payload), strip_replayed_tool_call_namespaces=False)
+    stripped = _strip_unsupported_fields(deepcopy(payload))
+
+    assert preserved["input"] == payload["input"]
+    assert stripped["input"] == [{"type": "function_call"}]
 
 
 def test_responses_preserves_service_tier():
@@ -1161,6 +1217,163 @@ def test_compact_many_small_items_include_array_wire_framing_in_budget():
     assert len(dumped_input) < len(input_items)
     wire_bytes = len(json.dumps(dumped_input, ensure_ascii=True, sort_keys=True).encode("utf-8"))
     assert wire_bytes <= _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS * _ESTIMATED_CHARS_PER_TOKEN
+
+
+@given(input_items=json_arrays)
+@settings(max_examples=30, deadline=None)
+def test_compact_trim_leaves_budget_fitting_json_unchanged(input_items):
+    if _estimated_json_tokens(input_items) > _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS:
+        return
+
+    payload = cast(dict[str, JsonValue], {"input": deepcopy(input_items)})
+    original = deepcopy(payload["input"])
+
+    _trim_compact_input_for_upstream(payload)
+
+    assert payload["input"] == original
+
+
+@given(size=st.integers(min_value=400_000, max_value=500_000))
+@settings(max_examples=8, deadline=None)
+def test_compact_trim_keeps_budget_order_and_is_stable(size):
+    input_items = [
+        {"id": "head", "role": "user", "content": "head"},
+        {"id": "middle", "role": "assistant", "content": "x" * size},
+        {"id": "latest", "role": "user", "content": "latest"},
+    ]
+    payload = cast(dict[str, JsonValue], {"input": input_items})
+
+    _trim_compact_input_for_upstream(payload)
+    trimmed_input = cast(list[JsonValue], deepcopy(payload["input"]))
+
+    assert _estimated_json_tokens(trimmed_input) <= _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS
+    retained_ids = [item["id"] for item in trimmed_input if isinstance(item, dict) and isinstance(item.get("id"), str)]
+    assert retained_ids == ["head", "latest"]
+
+    _trim_compact_input_for_upstream(payload)
+    assert payload["input"] == trimmed_input
+
+
+@given(size=st.integers(min_value=400_000, max_value=500_000))
+@settings(max_examples=8, deadline=None)
+def test_compact_trim_marker_accounts_for_omitted_middle_item(size):
+    input_items = [
+        {"id": "head", "role": "user", "content": "head"},
+        {"id": "middle", "role": "assistant", "content": "x" * size},
+        {"id": "latest", "role": "user", "content": "latest"},
+    ]
+    payload = cast(dict[str, JsonValue], {"input": input_items})
+
+    _trim_compact_input_for_upstream(payload)
+    trimmed_input = cast(list[JsonValue], payload["input"])
+
+    marker = next(
+        item
+        for item in trimmed_input
+        if isinstance(item, dict) and "[compact trim] Omitted " in str(item.get("content"))
+    )
+    marker_text = str(marker["content"])
+    match = re.search(r"Omitted (\d+) input items \(~(\d+) estimated tokens\)", marker_text)
+
+    assert match is not None
+    assert match.groups() == ("1", str(_estimated_json_array_item_tokens(cast(JsonValue, input_items[1]))))
+
+
+@given(
+    pair=st.sampled_from(
+        [
+            ("function_call", "function_call_output"),
+            ("custom_tool_call", "custom_tool_call_output"),
+            ("apply_patch_call", "apply_patch_call_output"),
+        ]
+    ),
+    filler_size=st.integers(min_value=300_000, max_value=400_000),
+)
+@settings(max_examples=8, deadline=None)
+def test_compact_trim_keeps_generated_tool_pairs(pair, filler_size):
+    call_type, output_type = pair
+    call = {
+        "type": call_type,
+        "name": "exec_command",
+        "call_id": "call-generated",
+        "arguments" if call_type == "function_call" else "input": "{}",
+    }
+    if call_type == "apply_patch_call":
+        call = {
+            "type": call_type,
+            "call_id": "call-generated",
+            "operation": {"patch": "noop"},
+        }
+    output = {"type": output_type, "call_id": "call-generated", "output": "result"}
+    payload = cast(
+        dict[str, JsonValue],
+        {
+            "input": [
+                {"role": "assistant", "content": "x" * filler_size},
+                call,
+                output,
+            ]
+        },
+    )
+
+    _trim_compact_input_for_upstream(payload)
+    trimmed_input = cast(list[JsonValue], payload["input"])
+
+    assert call in trimmed_input
+    assert output in trimmed_input
+    assert _estimated_json_tokens(trimmed_input) <= _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS
+
+
+@given(anchor=st.sampled_from(["goal", "plan"]), filler_size=st.integers(350_000, 450_000))
+@settings(max_examples=8, deadline=None)
+def test_compact_trim_keeps_generated_state_anchor(anchor, filler_size):
+    anchor_text = (
+        '<codex_internal_context source="goal">continue the goal</codex_internal_context>'
+        if anchor == "goal"
+        else "<collaboration_mode># Plan Mode"
+    )
+    anchor_item = {
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": anchor_text}],
+    }
+    payload = cast(
+        dict[str, JsonValue],
+        {
+            "input": [
+                {"role": "user", "content": "head"},
+                {"role": "assistant", "content": "x" * filler_size},
+                anchor_item,
+                {"role": "user", "content": "latest"},
+            ]
+        },
+    )
+
+    _trim_compact_input_for_upstream(payload)
+    trimmed_input = cast(list[JsonValue], payload["input"])
+
+    assert anchor_item in trimmed_input
+    assert _estimated_json_tokens(trimmed_input) <= _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS
+
+
+@given(size=st.integers(min_value=400_000, max_value=500_000))
+@settings(max_examples=8, deadline=None)
+def test_compact_trim_rejects_generated_oversized_latest_item(size):
+    payload = cast(
+        dict[str, JsonValue],
+        {
+            "input": [
+                {"role": "assistant", "content": "head"},
+                {"role": "user", "content": "x" * size},
+            ]
+        },
+    )
+
+    with pytest.raises(ClientPayloadError) as raised:
+        _trim_compact_input_for_upstream(payload)
+
+    assert raised.value.param == "input"
+    assert raised.value.code == "responses_compact_input_too_large"
 
 
 def test_compact_trims_oversized_input_by_estimated_tokens_with_head_tail_and_marker():

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -28,7 +28,7 @@ from app.core.openai.requests import (
 )
 from app.core.openai.v1_requests import V1ResponsesCompactRequest, V1ResponsesRequest
 from app.core.types import JsonValue
-from tests.unit.hypothesis_strategies import json_arrays, json_objects, json_values
+from tests.unit.hypothesis_strategies import json_arrays, json_directive_types, json_objects, json_values
 
 
 def test_responses_requires_instructions():
@@ -126,6 +126,7 @@ def test_known_unsupported_upstream_fields_are_stripped():
 
 
 @given(json_arrays)
+@settings(deadline=None)
 def test_sanitize_input_items_is_idempotent_for_json(input_items):
     original = deepcopy(input_items)
     try:
@@ -140,9 +141,10 @@ def test_sanitize_input_items_is_idempotent_for_json(input_items):
 
 @given(
     role=st.sampled_from(["system", "developer"]),
-    item_type=json_values,
+    item_type=json_directive_types,
     extra=json_objects,
 )
+@settings(deadline=None)
 def test_sanitize_input_items_preserves_typed_directives(role, item_type, extra):
     directive = dict(extra)
     directive.update({"role": role, "type": item_type})
@@ -151,6 +153,7 @@ def test_sanitize_input_items_preserves_typed_directives(role, item_type, extra)
 
 
 @given(payload=json_objects.map(lambda value: {key: item for key, item in value.items() if key != "input"}))
+@settings(deadline=None)
 def test_strip_unsupported_fields_is_idempotent(payload):
     payload = cast(dict[str, JsonValue], payload)
     first = _strip_unsupported_fields(deepcopy(payload))
@@ -161,6 +164,7 @@ def test_strip_unsupported_fields_is_idempotent(payload):
 
 
 @given(namespace=json_values)
+@settings(deadline=None)
 def test_strip_unsupported_fields_namespace_flag_controls_replayed_calls(namespace):
     payload = cast(dict[str, JsonValue], {"input": [{"type": "function_call", "namespace": namespace}]})
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -25,6 +25,8 @@ import pytest
 from aiohttp.client_exceptions import ClientConnectorCertificateError
 from aiohttp.client_reqrep import ConnectionKey, RequestInfo
 from fastapi import WebSocket
+from hypothesis import given, settings
+from hypothesis import strategies as st
 from starlette.requests import Request
 from starlette.responses import StreamingResponse
 from websockets.exceptions import ConnectionClosedError
@@ -98,6 +100,7 @@ from app.modules.proxy.work_admission import AdmissionLease
 from app.modules.request_logs.repository import PreviousResponseOwnerRecord, RequestLogsRepository
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
 from tests.unit._proxy_test_helpers import runtime_basic_auth_url
+from tests.unit.hypothesis_strategies import json_objects, json_values
 
 pytestmark = pytest.mark.unit
 
@@ -21977,6 +21980,131 @@ def test_slim_response_create_ignores_malformed_unhashable_item_type():
     assert first_item["content"] == [
         {"type": "input_text", "text": proxy_service._RESPONSE_CREATE_IMAGE_OMISSION_NOTICE}
     ]
+
+
+def _non_user_item(value: JsonValue) -> JsonValue:
+    if not isinstance(value, dict):
+        return value
+    item = dict(value)
+    if item.get("role") == "user":
+        item["role"] = "assistant"
+    return item
+
+
+@given(
+    extra=json_objects,
+    historical=st.lists(json_values.map(_non_user_item), max_size=5),
+    recent=st.lists(json_values.map(_non_user_item), max_size=5),
+)
+@settings(max_examples=30, deadline=None)
+def test_slim_response_create_preserves_recent_suffix_and_top_level_fields(extra, historical, recent):
+    recent_user = {"role": "user", "content": "latest request"}
+    payload = cast(
+        dict[str, JsonValue],
+        {
+            **{key: value for key, value in extra.items() if key != "input"},
+            "input": [*historical, recent_user, *recent],
+        },
+    )
+    original = deepcopy(payload)
+    original_input = cast(list[JsonValue], original["input"])
+
+    slimmed_payload, _ = proxy_service._slim_response_create_payload_for_upstream(payload, max_bytes=256)
+
+    assert payload == original
+    assert {key: value for key, value in slimmed_payload.items() if key != "input"} == {
+        key: value for key, value in original.items() if key != "input"
+    }
+    slimmed_input = cast(list[JsonValue], slimmed_payload["input"])
+    preserve_from = len(historical)
+    assert slimmed_input[preserve_from:] == original_input[preserve_from:]
+    assert json.dumps(slimmed_input[preserve_from:], ensure_ascii=True, sort_keys=True) == json.dumps(
+        original_input[preserve_from:], ensure_ascii=True, sort_keys=True
+    )
+
+
+@given(
+    cases=st.lists(
+        st.sampled_from(["top_image", "content_image", "tool_image", "file_image", "plain"]),
+        min_size=1,
+        max_size=5,
+    )
+)
+@settings(max_examples=30, deadline=None)
+def test_slim_response_create_counts_historical_image_replacements_and_is_idempotent(cases):
+    historical: list[JsonValue] = []
+    expected_images = 0
+    inline_url = "data:image/png;base64,AAAA"
+    for index, case in enumerate(cases):
+        if case == "top_image":
+            historical.append({"type": "input_image", "image_url": inline_url, "id": f"image-{index}"})
+            expected_images += 1
+        elif case == "content_image":
+            historical.append(
+                {
+                    "role": "assistant",
+                    "content": [{"type": "input_image", "image_url": inline_url, "id": f"image-{index}"}],
+                }
+            )
+            expected_images += 1
+        elif case == "tool_image":
+            historical.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": f"call-{index}",
+                    "output": [{"type": "input_image", "image_url": inline_url}],
+                }
+            )
+            expected_images += 1
+        elif case == "file_image":
+            historical.append({"type": "input_image", "image_url": "file-id", "id": f"file-{index}"})
+        else:
+            historical.append({"role": "assistant", "content": f"ordinary-{index}"})
+
+    latest = {"role": "user", "content": "latest"}
+    payload = cast(dict[str, JsonValue], {"input": [*historical, latest]})
+    original = deepcopy(payload)
+
+    slimmed_payload, summary = proxy_service._slim_response_create_payload_for_upstream(payload, max_bytes=256)
+
+    assert payload == original
+    if expected_images:
+        assert summary is not None
+        assert summary["historical_images_slimmed"] == expected_images
+    else:
+        assert summary is None
+    assert cast(list[JsonValue], slimmed_payload["input"])[-1] == latest
+
+    second_payload, second_summary = proxy_service._slim_response_create_payload_for_upstream(
+        slimmed_payload, max_bytes=256
+    )
+    assert second_payload == slimmed_payload
+    assert second_summary is None
+
+
+@given(sizes=st.lists(st.integers(min_value=0, max_value=34 * 1024), min_size=1, max_size=5))
+@settings(max_examples=30, deadline=None)
+def test_slim_response_create_counts_oversized_historical_tool_outputs(sizes):
+    historical = [
+        {
+            "type": "custom_tool_call_output",
+            "call_id": f"call-{index}",
+            "output": "x" * size,
+        }
+        for index, size in enumerate(sizes)
+    ]
+    latest = {"role": "user", "content": "latest"}
+    payload = cast(dict[str, JsonValue], {"input": [*historical, latest]})
+
+    slimmed_payload, summary = proxy_service._slim_response_create_payload_for_upstream(payload, max_bytes=256)
+
+    expected_count = sum(size > 32 * 1024 for size in sizes)
+    if expected_count:
+        assert summary is not None
+        assert summary["historical_tool_outputs_slimmed"] == expected_count
+    else:
+        assert summary is None
+    assert cast(list[JsonValue], slimmed_payload["input"])[-1] == latest
 
 
 def test_websocket_receive_timeout_prefers_idle_timeout_when_budget_allows(monkeypatch):

--- a/tests/unit/test_sse.py
+++ b/tests/unit/test_sse.py
@@ -6,16 +6,20 @@ from collections.abc import AsyncIterator
 from typing import Any, cast
 
 import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
 
 from app.core.openai.parsing import parse_sse_event
 from app.core.utils.sse import (
     CODEX_KEEPALIVE_FRAME,
     SSE_KEEPALIVE_FRAME,
     extract_sse_data,
+    format_sse_data,
     format_sse_event,
     inject_sse_keepalives,
     parse_sse_data_json,
 )
+from tests.unit.hypothesis_strategies import json_objects, json_values
 
 pytestmark = pytest.mark.unit
 
@@ -24,6 +28,58 @@ def test_format_sse_event_serializes_payload():
     payload = {"type": "response.completed", "response": {"id": "resp_1"}}
     result = format_sse_event(payload)
     assert result == 'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_1"}}\n\n'
+
+
+@given(payload=json_objects)
+@settings(max_examples=40, deadline=None)
+def test_format_sse_event_round_trips_arbitrary_json_objects(payload):
+    assert parse_sse_data_json(format_sse_event(payload)) == payload
+
+
+@given(payload=json_objects)
+@settings(max_examples=40, deadline=None)
+def test_format_sse_data_round_trips_arbitrary_json_objects(payload):
+    assert parse_sse_data_json(format_sse_data(payload)) == payload
+
+
+@given(
+    boundary=st.sampled_from(["\r", "\n", "\r\n"]),
+    key=st.text(max_size=40),
+    value=st.integers(),
+)
+@settings(max_examples=30, deadline=None)
+def test_sse_line_boundaries_are_equivalent_in_multiline_data(boundary, key, value):
+    encoded_key = json.dumps(key, ensure_ascii=True)
+    block = f"data: {{{encoded_key}:" + boundary + f"data: {value}}}" + boundary * 2
+
+    assert parse_sse_data_json(block) == {key: value}
+
+
+@given(text=st.text(max_size=80))
+@settings(max_examples=30, deadline=None)
+def test_sse_unicode_line_separators_remain_data(text):
+    payload = {"value": f"before{text}\u2028middle\u2029after"}
+    block = "data: " + json.dumps(payload, ensure_ascii=False) + "\n\n"
+
+    assert parse_sse_data_json(block) == payload
+
+
+@given(
+    boundary=st.sampled_from(["\r", "\n", "\r\n"]),
+    first=st.text(alphabet=st.characters(blacklist_categories=("C", "Z")), min_size=1, max_size=40),
+    second=st.text(alphabet=st.characters(blacklist_categories=("C", "Z")), min_size=1, max_size=40),
+)
+@settings(max_examples=30, deadline=None)
+def test_sse_multiline_data_ignores_comments_and_joins_with_newline(boundary, first, second):
+    block = f": comment{boundary}data: {first}{boundary}event: ignored{boundary}data: {second}{boundary}{boundary}"
+
+    assert extract_sse_data(block) == f"{first}\n{second}"
+
+
+@given(value=st.one_of(st.none(), st.booleans(), st.integers(), st.lists(json_values, max_size=4)))
+@settings(max_examples=30, deadline=None)
+def test_parse_sse_data_json_rejects_non_object_json(value):
+    assert parse_sse_data_json("data: " + json.dumps(value) + "\n\n") is None
 
 
 async def _agen(items: list[str]) -> AsyncIterator[str]:

--- a/uv.lock
+++ b/uv.lock
@@ -534,6 +534,7 @@ tracing = [
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "hypothesis" },
     { name = "openai" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -590,6 +591,7 @@ provides-extras = ["metrics", "tracing"]
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "hypothesis", specifier = ">=6.165.3" },
     { name = "openai", specifier = ">=2.16.0" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=9.0.2" },
@@ -1161,6 +1163,52 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.165.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/7a/7a277ac07776191be594f74f6425649d529e4876f7d3ff1ee96d393ffdbc/hypothesis-6.165.3.tar.gz", hash = "sha256:687c5abb1a9c11478577c2cf18685c0eb82150d278477d3e14da290a1ef2a098", size = 502263, upload-time = "2026-08-11T01:23:09.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/c7/18152acad5f85f91554b2030000319b952a54151509953651ec40f37d50d/hypothesis-6.165.3-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:56af539c811b11ab5475704c300b8f0b46cc6dd0edc267e02a16487e803c77f8", size = 781671, upload-time = "2026-08-11T01:22:09.176Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/77/4293ea8a7fdb713956a8bf460b9070115df69f8216a900507633f9cdb225/hypothesis-6.165.3-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f40c10cfdb1ea2cd75e5d4e6e0cfdcb6198ab8406e8922666480e6dc11eea341", size = 777291, upload-time = "2026-08-11T01:22:15.991Z" },
+    { url = "https://files.pythonhosted.org/packages/02/fa/fa2071a6afaefc082dc7a033f41ae61436caf442d5973ba8ca9c29a69460/hypothesis-6.165.3-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a0854b1de4577f7e1beb1d681360285b5d678b65a809787ff4eab5b8b25efca", size = 1106490, upload-time = "2026-08-11T01:22:07.858Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/86/de724b7f9cd10e3be4efa21770457172e549d7576b1d8e29d6177eef5e47/hypothesis-6.165.3-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:360991cda8e488924905af48949033b90d4877ac97b9ad5d826d4d0f5a4b8cfb", size = 1135054, upload-time = "2026-08-11T01:22:29.499Z" },
+    { url = "https://files.pythonhosted.org/packages/12/6a/96721cf447bd3c64b5e6843dde4444b20f3ddd901ad366cc73d0e7314bf5/hypothesis-6.165.3-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf502000f4a8ef4c9ab9493ca3b4fe17ae3033c18a8e2a31cdd69515dc7d97be", size = 1155997, upload-time = "2026-08-11T01:21:48.496Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ae/a793cce6497f233b155f97684bf7d0e424c25613dd87b8af8a4e87820232/hypothesis-6.165.3-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:b9fcf47ad18f87f7c15bd36289bd45708bbfd250129d73bf554653e2f9afc931", size = 1111326, upload-time = "2026-08-11T01:22:21.9Z" },
+    { url = "https://files.pythonhosted.org/packages/28/8d/dc3cdfd55843d038effa2458a9c9bd73002218a8c0fd58c2c0ab7fa328db/hypothesis-6.165.3-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb05529cbcab5a317d03d7bb0e90d382f79ef1643e3568577916d0e24bfe70b", size = 1148079, upload-time = "2026-08-11T01:21:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4b/2f62924ac41f3d3482b29ded4c213f27ff4a103e56e84eeb528d4900cac7/hypothesis-6.165.3-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:57eae10a64340cd621a78eae9cb0459bd68ea99fbaa933c4f00e34d5087b6376", size = 1281862, upload-time = "2026-08-11T01:21:39.274Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d4/01c78b7b7348b6e8cef9b999109dfb93b14c7e1e38bc22170129f8b17181/hypothesis-6.165.3-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:19df0f2239052e9a870634a1d9bcdff95e2a2ab508573e5dd5c3d1ca545f5b3c", size = 1408437, upload-time = "2026-08-11T01:22:13.243Z" },
+    { url = "https://files.pythonhosted.org/packages/35/76/e940b5a5aaf75bcd4784f1f3f9bf2b9a642a706bc0a9639077ca84f1325f/hypothesis-6.165.3-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:9781a8026adff4b4516404cf0e5f2cadcb471318c2882a264e1c57c4c092266f", size = 1281168, upload-time = "2026-08-11T01:21:58.964Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/84/b153e81a614f45e0902e3b9e8a8b079e64214c50abb6fbe9acc62ccf686d/hypothesis-6.165.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1dd7e05f88e3e108a5e4f5f71a3eaf205559e8951e3c1f1ffd04cea82ed3b731", size = 1323263, upload-time = "2026-08-11T01:21:52.374Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e5144d9e91ab7260650cb1ee032ca23208d49ebb1334845baf6407c1a9d9/hypothesis-6.165.3-cp310-abi3-win32.whl", hash = "sha256:d1389bda38cb222acc109aef5b31643ce799a39a76294a50ad8b84e32f92d76d", size = 667499, upload-time = "2026-08-11T01:21:47.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/18/f008b6f1f1c293d51c2776f8815d95bccb777dcf87df2a0ab56b273b47dc/hypothesis-6.165.3-cp310-abi3-win_amd64.whl", hash = "sha256:10cda6988ca4b1da389548b6fdd71af236b588a601fc1757e56eb8988e4240d8", size = 673643, upload-time = "2026-08-11T01:22:46.975Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3e/95cba31dbe775b99a4548cdae192e1ad15cee7b64fbdfe6cd4c9d00031b4/hypothesis-6.165.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:447f139d6dd70a5d8b178ef507463fb0430ace9ce42e3b2351d2803a391fe774", size = 783183, upload-time = "2026-08-11T01:22:45.286Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0e/51bf125cdf7855b69097b8f59c73ef3cf5f4e3d68a16e808d2d1f08a1ff1/hypothesis-6.165.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6152c718606f1705e673c6b30a6ebd3ff08d340da85291dd3c432c73b28a9b3a", size = 774820, upload-time = "2026-08-11T01:22:24.825Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/69/b954f742b97441a5c49f8f8704826ee0637a6cce3a7d06ce85fbefc54ac5/hypothesis-6.165.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27fe7826ad83ccc2e8062f0fab43b137bab34cef1a149a926b34a7b8382ee22c", size = 1105186, upload-time = "2026-08-11T01:21:41.733Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/8a/33e41d9cc1be7661e0b4129c225a93c3f12544714300aadb95ae7eedf894/hypothesis-6.165.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1ff92876a324f7b9cdb92cedf103e380b7a12aa7df55ebcb16dd0f495a879e8", size = 1155215, upload-time = "2026-08-11T01:22:06.604Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/53/ba09526c9100ace5752908ac7251d2dc3960ce7e0e97a31152aaa26c33ee/hypothesis-6.165.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:53f1564c97d27fc109f212404d49cd71d7789777dbe0685628ffe9838df56240", size = 1279245, upload-time = "2026-08-11T01:21:56.182Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/fc637d355791a65364a3409ff06ade7ba5d3fc6f1d07a729781dec315fa0/hypothesis-6.165.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:788a9b0a7aae719a2b71a1c2f07e51deb1d0fe990164a9090c686833ed4bfbad", size = 1322370, upload-time = "2026-08-11T01:22:48.492Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8d/826053ba0263143fed2b0e8af009dc868d8a932e7246e191deb8ca7ce8ff/hypothesis-6.165.3-cp313-cp313-win_amd64.whl", hash = "sha256:37830f0795abfdf738d2a5b6f829a73f3ab498de45a2e61b0bf3bd38d8c9ddb9", size = 670804, upload-time = "2026-08-11T01:22:00.103Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/27/3230f8de3d853b2b547731916ae1d1026bd197cd3f2d35dafc0b445da46b/hypothesis-6.165.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:38826441dbf528cc156388d0a05526086a12da3e1348353d3fa14de03e57c4b2", size = 783286, upload-time = "2026-08-11T01:22:40.816Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/28/9f9ca830d376c50babe55c616f6d99eea886c6ebcd8b512dcd5d56f9e40c/hypothesis-6.165.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:87490115edd34a246a4ba8b1144cbdf571438c46c406ece05caf65908667c9a9", size = 774963, upload-time = "2026-08-11T01:23:05.409Z" },
+    { url = "https://files.pythonhosted.org/packages/33/3c/3c81f08ec1edce160da509c5785d78c0e25a7913899c4b9ff724bfd01420/hypothesis-6.165.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f51f4346cfa26bca68c68f7bbbd2b1812208bc9f572187c95ecab080ed402153", size = 1105730, upload-time = "2026-08-11T01:22:42.311Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b5/f6f81b9aec9999ec63920d168617cab67a038be05487eff3410ccd072bfe/hypothesis-6.165.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4da89eb4b36b3260ff714d2ecc3274b9bd599fd96687d2d9ed53d5e1a801a7a7", size = 1155383, upload-time = "2026-08-11T01:21:57.58Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/27/7f3a8c6101675bf95c80cd8c9173d65892ca0b7b640551156dc4537fab1f/hypothesis-6.165.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:eb6d31c14d7bdfe03e501d88ee296c149a74cc93e3d01c76ea335e64ee5f33ec", size = 1279606, upload-time = "2026-08-11T01:22:37.56Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/16/0c23e06a24e421e532f62a95021fae34f685f3a194c081c6991b4ab202b3/hypothesis-6.165.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0863e1a9258bc103abe616fa9471cfa66a1535ea404dd8a0bf360e0a29502397", size = 1322697, upload-time = "2026-08-11T01:22:27.857Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/56/8356dadf45e5c635b46aa2b57fa74f3210250a8e38b860b6b75f50ed0b42/hypothesis-6.165.3-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:53c56155f2cfbb45ec97fef9ea3b8453b4a34c48c3c5cacee16f97dd2a037994", size = 614859, upload-time = "2026-08-11T01:22:01.304Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/124d4faf235219acd685c359760a5cb3995609bc50ce465e54c3249841ee/hypothesis-6.165.3-cp314-cp314-win_amd64.whl", hash = "sha256:c48f41e950b5e602e2fdf8f92dcc8ac7bf715a003bf822afb7c9d5cbc41bc344", size = 670600, upload-time = "2026-08-11T01:22:10.356Z" },
+    { url = "https://files.pythonhosted.org/packages/01/7a/41ac5e68d9ce079d1b76d4c54126354df61b948c3d519d1289aca877eedc/hypothesis-6.165.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:9563d3040178fb1f522665bcec6458cc0d21ab77d7c637058a8be4ea8c01d236", size = 781746, upload-time = "2026-08-11T01:22:34.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/fb/7ecc21aae63a83dbc8036f9a0544c6b3d798db566b97b5202bdf8e770f80/hypothesis-6.165.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1fe1783543b43ba9808c016950e5e84b3804dc3365ba77c37c427b5896a558a1", size = 773382, upload-time = "2026-08-11T01:22:55.279Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/f2/9cc2a4768f9a483b12e307ba585f5eb9c7f5500bd16ff82ddbf62a9a1b88/hypothesis-6.165.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ea34806a4df4e8305a096dcf8e53cdd903c96c1e0d2dd5b001d2283f639c3f1", size = 1103911, upload-time = "2026-08-11T01:23:00.286Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9e/b551a494f84976ee5bb9374c197ccc126dea2ec6f22098d5f70705237473/hypothesis-6.165.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d188454b95ce46ba991e3c52161255d76af25170ad28591f6b30b045e501216e", size = 1154060, upload-time = "2026-08-11T01:22:20.413Z" },
+    { url = "https://files.pythonhosted.org/packages/69/37/8e22a236f1f1e599525549a34672fb0523109f571486fe209b12a84a942e/hypothesis-6.165.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a1c47b15ce97a9b1346bc7d7013c5f215380f78ae01c0f73a1638bd8b98bdd76", size = 1277631, upload-time = "2026-08-11T01:22:30.965Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0f/feb33bfc23853b4ba6360ff5e34235cd8bea0d7dd1eb21e17491f581c4e2/hypothesis-6.165.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:996077ef7a3bb332b6638f698ddf7555c82784b58dde80eeba3f07c0a322b40f", size = 1321326, upload-time = "2026-08-11T01:21:45.089Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3b/ad56b56540a0719f493edec0dd442ebb21272147d2482ef505d19760a6d3/hypothesis-6.165.3-cp314-cp314t-win_amd64.whl", hash = "sha256:57a8273bdafe3f450afe66999fd130d4935d775eaf4ef63fcac0bee8015fc512", size = 670613, upload-time = "2026-08-11T01:22:05.294Z" },
 ]
 
 [[package]]
@@ -2422,6 +2470,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add dev-only Hypothesis property tests for Responses payload sanitization and compact trimming, SSE framing, and historical response.create payload slimming. This implements the maintainer-recommended first, pure-function slice of #1595 without adding lifecycle simulation infrastructure or changing production behavior.

## Type of change

- [ ] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [x] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: Refs #1595

## OpenSpec

- [ ] This PR includes / updates an OpenSpec change
- [x] Not applicable — test-only/dev-tool change exempt under CONTRIBUTING; no observable behavior, requirement, contract, or schema changes
- [x] This PR touches codex-faithful request/response and SSE paths only through tests and preserves upstream-equivalent behavior

Change directory: N/A

## Changes

- Add bounded reusable Hypothesis strategies for arbitrary JSON values, arrays, and objects.
- Property-test request input sanitization, unsupported-field stripping, compact token budgets, marker accounting, state anchors, and tool-call pairing.
- Property-test SSE JSON round trips, CR/LF/CRLF boundaries, Unicode line separators, multiline data, and non-object rejection.
- Property-test historical response.create slimming while preserving the recent suffix, top-level fields, file references, and caller payload immutability.
- Keep Hypothesis in the development dependency group only.

## Test plan

```text
uv run pytest tests/unit/test_openai_requests.py tests/unit/test_sse.py tests/unit/test_proxy_utils.py -q
# 1188 passed

uv run ty check
# All checks passed

uv run ruff check tests/unit/test_openai_requests.py tests/unit/test_sse.py tests/unit/test_proxy_utils.py tests/unit/hypothesis_strategies.py
# All checks passed

uv run ruff format --check tests/unit/test_openai_requests.py tests/unit/test_sse.py tests/unit/test_proxy_utils.py tests/unit/hypothesis_strategies.py
# 4 files already formatted

make test-unit
# 5766 passed, 70 skipped

npx --yes @fission-ai/openspec@1.8.0 validate --specs
# 49 passed, 0 failed
```

## Screenshots / output

Not applicable; this is a test-only change with no user-visible surface.

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `make test-unit` target and focused lint/type/test checks locally.
- [x] OpenSpec is not modified; main specs validate successfully.
- [x] Simplicity gates reviewed: no setting, default, README section, `.env.example` entry, or dashboard surface is added.
- [x] CHANGELOG is not edited by hand.
