### PR TITLE
feat(reset-credits): add refresh scheduler enable toggle

### DIFF
--- a/app/core/config/settings.py
+++ b/app/core/config/settings.py
@@ -287,6 +287,7 @@ class Settings(BaseSettings):
     usage_refresh_enabled: bool = True
     usage_refresh_interval_seconds: int = Field(default=60, gt=0)
     live_usage_ingestion_enabled: bool = True
+    rate_limit_reset_credits_refresh_enabled: bool = True
     rate_limit_reset_credits_refresh_interval_seconds: int = Field(default=60, gt=0)
     openai_cache_affinity_max_age_seconds: int = Field(default=1800, gt=0)
     warmup_model: str = "gpt-5.4-mini"

--- a/app/core/usage/reset_credits_refresh_scheduler.py
+++ b/app/core/usage/reset_credits_refresh_scheduler.py
@@ -64,11 +64,14 @@ class RateLimitResetCreditsRefreshScheduler:
 
     interval_seconds: int
     rng: random.Random = field(default_factory=random.Random)
+    enabled: bool = True
     _task: asyncio.Task[None] | None = None
     _stop: asyncio.Event = field(default_factory=asyncio.Event)
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
     async def start(self) -> None:
+        if not self.enabled:
+            return
         if self._task and not self._task.done():
             return
         self._stop.clear()
@@ -386,4 +389,5 @@ def build_rate_limit_reset_credits_scheduler() -> RateLimitResetCreditsRefreshSc
     settings = get_settings()
     return RateLimitResetCreditsRefreshScheduler(
         interval_seconds=settings.rate_limit_reset_credits_refresh_interval_seconds,
+        enabled=settings.rate_limit_reset_credits_refresh_enabled,
     )

--- a/app/core/usage/reset_credits_refresh_scheduler.py
+++ b/app/core/usage/reset_credits_refresh_scheduler.py
@@ -71,11 +71,29 @@ class RateLimitResetCreditsRefreshScheduler:
 
     async def start(self) -> None:
         if not self.enabled:
+            await self._warn_if_auto_redeem_conflicts()
             return
         if self._task and not self._task.done():
             return
         self._stop.clear()
         self._task = asyncio.create_task(self._run_loop())
+
+    async def _warn_if_auto_redeem_conflicts(self) -> None:
+        # The refresh loop is the only driver of automatic redemption, so a
+        # disabled scheduler silently starves a persisted auto-redeem opt-in.
+        try:
+            async with get_background_session() as session:
+                dashboard_settings = await SettingsRepository(session).get_or_create()
+                auto_redeem_enabled = dashboard_settings.auto_redeem_reset_credits_before_expiry
+        except Exception:
+            logger.exception("Reset credits auto-redeem conflict check failed")
+            return
+        if auto_redeem_enabled:
+            logger.warning(
+                "rate_limit_reset_credits_refresh_enabled=false disables automatic reset-credit "
+                "redemption, but dashboard setting auto_redeem_reset_credits_before_expiry is "
+                "enabled; credits will expire without redemption until polling is re-enabled"
+            )
 
     async def stop(self) -> None:
         if not self._task:

--- a/app/modules/settings/api.py
+++ b/app/modules/settings/api.py
@@ -20,6 +20,7 @@ from app.core.auth.dependencies import (
     validate_dashboard_session,
 )
 from app.core.clients.http import _build_ssl_context
+from app.core.config.settings import get_settings as get_app_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.crypto import TokenEncryptor
 from app.core.exceptions import DashboardBadRequestError, DashboardSettingsConflictError
@@ -562,6 +563,19 @@ async def update_settings(
         and payload.upstream_proxy_default_pool_id is not None
     ):
         await _validate_proxy_pool_id(context, payload.upstream_proxy_default_pool_id)
+    if (
+        payload.auto_redeem_reset_credits_before_expiry
+        and not current.auto_redeem_reset_credits_before_expiry
+        and not get_app_settings().rate_limit_reset_credits_refresh_enabled
+    ):
+        # The reset-credit refresh loop is the sole driver of automatic
+        # redemption; accepting the opt-in while polling is disabled would
+        # persist a setting that can never run.
+        raise DashboardBadRequestError(
+            "autoRedeemResetCreditsBeforeExpiry requires reset-credit polling; "
+            "set CODEX_LB_RATE_LIMIT_RESET_CREDITS_REFRESH_ENABLED=true first",
+            code="reset_credit_polling_disabled",
+        )
     try:
         legacy_threshold_provided = payload.sticky_reallocation_budget_threshold_pct is not None
         primary_threshold_provided = payload.sticky_reallocation_primary_budget_threshold_pct is not None

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -7,7 +7,7 @@ Regenerate with `uv run python scripts/generate_settings_reference.py`;
 `tests/unit/test_settings_reference.py` fails when this page drifts from
 `app/core/config/settings.py`.
 
-codex-lb currently exposes 126 settings. Every setting is an environment
+codex-lb currently exposes 127 settings. Every setting is an environment
 variable with the `CODEX_LB_` prefix (process environment or `.env` /
 `.env.local` next to the process). All defaults work with zero configuration —
 start from [Configuration](../configuration.md) for the handful that matter,
@@ -148,6 +148,7 @@ the host side of the compose `ports` mapping instead.
 | Environment variable | Type | Default |
 | --- | --- | --- |
 | `CODEX_LB_LIVE_USAGE_INGESTION_ENABLED` | `bool` | `True` |
+| `CODEX_LB_RATE_LIMIT_RESET_CREDITS_REFRESH_ENABLED` | `bool` | `True` |
 | `CODEX_LB_RATE_LIMIT_RESET_CREDITS_REFRESH_INTERVAL_SECONDS` | `int` | `60` |
 | `CODEX_LB_REQUEST_LOG_RETENTION_DAYS` | `int` | `0` |
 | `CODEX_LB_USAGE_FETCH_MAX_RETRIES` | `int` | `2` |

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -319,4 +319,4 @@ issue [#1340](https://github.com/Soju06/codex-lb/issues/1340)):
 
 ---
 
-*Specs: [user-documentation](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/user-documentation) · [responses-api-compat](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/responses-api-compat) · [deployment-installation](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/deployment-installation)*
+*Specs: [user-documentation](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/user-documentation) · [responses-api-compat](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/responses-api-compat) · [rate-limit-reset-credits](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/rate-limit-reset-credits) · [deployment-installation](https://github.com/Soju06/codex-lb/tree/main/openspec/specs/deployment-installation)*

--- a/openspec/changes/add-reset-credits-refresh-toggle/proposal.md
+++ b/openspec/changes/add-reset-credits-refresh-toggle/proposal.md
@@ -1,0 +1,19 @@
+## Why
+
+Reset-credit polling runs in every replica and issues one authenticated upstream `GET /wham/rate-limit-reset-credits` per eligible account per interval. Operators who do not use the reset-credit dashboard surface (or who run many replicas against large account fleets) currently have no way to shed that upstream call volume: the spec mandated that the scheduler always starts, and `rate_limit_reset_credits_refresh_interval_seconds` is constrained to positive values, so "off" is not expressible — stretching the interval still keeps periodic authenticated upstream traffic and the associated log/failure noise.
+
+## What Changes
+
+- Add setting `rate_limit_reset_credits_refresh_enabled` (default `true`) that gates background reset-credit polling.
+- When disabled, the scheduler's `start()` is a no-op: no background task is created, no upstream fetches occur, and snapshot caches simply stay empty (dashboard reads already handle a missing snapshot as `null`/`0`).
+- Default `true` preserves current zero-config behavior; nothing changes for existing deployments.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `rate-limit-reset-credits`: The scheduler starts with the application lifespan only when reset-credit polling is enabled, and the settings surface gains an enable/disable toggle alongside the existing interval control.

--- a/openspec/changes/add-reset-credits-refresh-toggle/specs/rate-limit-reset-credits/spec.md
+++ b/openspec/changes/add-reset-credits-refresh-toggle/specs/rate-limit-reset-credits/spec.md
@@ -25,7 +25,7 @@ The system SHALL poll upstream `GET /wham/rate-limit-reset-credits` for each eli
 
 ### Requirement: Reset credit polling interval is configurable
 
-The system SHALL expose setting `rate_limit_reset_credits_refresh_interval_seconds` (default `60`) to control the polling cadence. The system SHALL expose setting `rate_limit_reset_credits_refresh_enabled` (default `true`) to enable or disable background reset-credit polling. Because the refresh loop is the sole driver of automatic reset-credit redemption, disabling background polling SHALL also disable automatic redemption; when polling is disabled while the persisted dashboard setting `auto_redeem_reset_credits_before_expiry` is enabled, the system SHALL log a configuration-conflict warning at startup naming both settings.
+The system SHALL expose setting `rate_limit_reset_credits_refresh_interval_seconds` (default `60`) to control the polling cadence. The system SHALL expose setting `rate_limit_reset_credits_refresh_enabled` (default `true`) to enable or disable background reset-credit polling. Because the refresh loop is the sole driver of automatic reset-credit redemption, disabling background polling SHALL also disable automatic redemption; when polling is disabled while the persisted dashboard setting `auto_redeem_reset_credits_before_expiry` is enabled, the system SHALL log a configuration-conflict warning at startup naming both settings. While polling is disabled, the dashboard settings update SHALL reject a request that newly enables `auto_redeem_reset_credits_before_expiry` with a bad-request error naming the polling toggle; an already-persisted opt-in SHALL remain readable and re-savable so unrelated settings edits are not blocked.
 
 #### Scenario: Operator tunes the polling interval
 - **GIVEN** `rate_limit_reset_credits_refresh_interval_seconds` is set to `120`
@@ -44,3 +44,16 @@ The system SHALL expose setting `rate_limit_reset_credits_refresh_interval_secon
 - **WHEN** the application starts
 - **THEN** the system logs a configuration-conflict warning naming both settings
 - **AND** no automatic reset-credit redemption occurs while polling remains disabled
+
+#### Scenario: Auto-redeem opt-in is rejected while polling is disabled
+- **GIVEN** `rate_limit_reset_credits_refresh_enabled` is set to `false`
+- **AND** the persisted dashboard setting `auto_redeem_reset_credits_before_expiry` is `false`
+- **WHEN** a dashboard settings update sets `auto_redeem_reset_credits_before_expiry` to `true`
+- **THEN** the update is rejected with a bad-request error naming the polling toggle
+- **AND** the persisted setting remains `false`
+
+#### Scenario: Persisted auto-redeem does not block unrelated settings edits
+- **GIVEN** `rate_limit_reset_credits_refresh_enabled` is set to `false`
+- **AND** the persisted dashboard setting `auto_redeem_reset_credits_before_expiry` is already `true`
+- **WHEN** a full settings payload that keeps the opt-in unchanged is submitted
+- **THEN** the update succeeds

--- a/openspec/changes/add-reset-credits-refresh-toggle/specs/rate-limit-reset-credits/spec.md
+++ b/openspec/changes/add-reset-credits-refresh-toggle/specs/rate-limit-reset-credits/spec.md
@@ -25,7 +25,7 @@ The system SHALL poll upstream `GET /wham/rate-limit-reset-credits` for each eli
 
 ### Requirement: Reset credit polling interval is configurable
 
-The system SHALL expose setting `rate_limit_reset_credits_refresh_interval_seconds` (default `60`) to control the polling cadence. The system SHALL expose setting `rate_limit_reset_credits_refresh_enabled` (default `true`) to enable or disable background reset-credit polling.
+The system SHALL expose setting `rate_limit_reset_credits_refresh_interval_seconds` (default `60`) to control the polling cadence. The system SHALL expose setting `rate_limit_reset_credits_refresh_enabled` (default `true`) to enable or disable background reset-credit polling. Because the refresh loop is the sole driver of automatic reset-credit redemption, disabling background polling SHALL also disable automatic redemption; when polling is disabled while the persisted dashboard setting `auto_redeem_reset_credits_before_expiry` is enabled, the system SHALL log a configuration-conflict warning at startup naming both settings.
 
 #### Scenario: Operator tunes the polling interval
 - **GIVEN** `rate_limit_reset_credits_refresh_interval_seconds` is set to `120`
@@ -37,3 +37,10 @@ The system SHALL expose setting `rate_limit_reset_credits_refresh_interval_secon
 - **WHEN** the application starts
 - **THEN** the reset-credit polling scheduler does not create a background polling task
 - **AND** no upstream reset-credits fetches occur
+
+#### Scenario: Disabled polling conflicts with persisted auto-redeem opt-in
+- **GIVEN** `rate_limit_reset_credits_refresh_enabled` is set to `false`
+- **AND** the persisted dashboard setting `auto_redeem_reset_credits_before_expiry` is `true`
+- **WHEN** the application starts
+- **THEN** the system logs a configuration-conflict warning naming both settings
+- **AND** no automatic reset-credit redemption occurs while polling remains disabled

--- a/openspec/changes/add-reset-credits-refresh-toggle/specs/rate-limit-reset-credits/spec.md
+++ b/openspec/changes/add-reset-credits-refresh-toggle/specs/rate-limit-reset-credits/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: Reset credits are polled per account on a fixed cadence
+
+The system SHALL poll upstream `GET /wham/rate-limit-reset-credits` for each eligible account on a configurable cadence that defaults to 60 seconds, using that account's stored OAuth bearer token and `chatgpt-account-id`. The scheduler SHALL start with the application lifespan when reset-credit polling is enabled. Because snapshots are kept in process-local memory, every running replica SHALL refresh its own snapshot cache instead of relying on leader election, and the scheduler SHALL NOT be leader-gated while snapshots remain process-local. Each replica SHALL apply a randomized startup delay of up to one full interval and randomized per-tick jitter of +/-10% so replica ticks are desynchronized. The aggregate upstream fetch rate scales with the number of running replicas; `rate_limit_reset_credits_refresh_interval_seconds` is the operator control for total upstream load. The poll SHALL skip any account that is paused, requires reauthentication, deactivated, or lacks a usable `chatgpt-account-id`.
+
+#### Scenario: Default cadence polls every 60 seconds
+- **WHEN** the application starts with default settings
+- **THEN** each eligible account's credits are fetched from upstream at most once per 60 seconds plus the jitter bound
+
+#### Scenario: Every replica refreshes its local cache
+- **WHEN** the application is deployed with multiple running replicas
+- **THEN** each replica refreshes its own in-memory reset-credit snapshots on the configured cadence
+- **AND** dashboard reads served by any replica can observe populated reset-credit data after that replica's refresh tick
+
+#### Scenario: Two replicas do not fetch in lockstep
+- **GIVEN** two replicas start with identical configuration
+- **WHEN** their refresh loops run
+- **THEN** their startup delays are independent uniform draws over the full interval and each tick interval carries independent +/-10% jitter, so the replicas' tick times are not synchronized
+
+#### Scenario: Ineligible accounts are skipped
+- **WHEN** an account is persisted as `paused`, `reauth_required`, or `deactivated`
+- **THEN** the scheduler performs no upstream reset-credits fetch for that account
+- **AND** the cached snapshot for that account (if any) is left untouched by the skip
+
+### Requirement: Reset credit polling interval is configurable
+
+The system SHALL expose setting `rate_limit_reset_credits_refresh_interval_seconds` (default `60`) to control the polling cadence. The system SHALL expose setting `rate_limit_reset_credits_refresh_enabled` (default `true`) to enable or disable background reset-credit polling.
+
+#### Scenario: Operator tunes the polling interval
+- **GIVEN** `rate_limit_reset_credits_refresh_interval_seconds` is set to `120`
+- **WHEN** the application starts and runs
+- **THEN** each eligible account's credits are fetched from upstream at most once per 120 seconds
+
+#### Scenario: Operator disables background polling
+- **GIVEN** `rate_limit_reset_credits_refresh_enabled` is set to `false`
+- **WHEN** the application starts
+- **THEN** the reset-credit polling scheduler does not create a background polling task
+- **AND** no upstream reset-credits fetches occur

--- a/openspec/changes/add-reset-credits-refresh-toggle/tasks.md
+++ b/openspec/changes/add-reset-credits-refresh-toggle/tasks.md
@@ -9,6 +9,11 @@
 - [x] 2.1 Unit-test that `start()` creates no task when disabled and creates the loop task when enabled
 - [x] 2.2 Unit-test that the factory wires `rate_limit_reset_credits_refresh_enabled` from settings
 - [x] 2.3 Unit-test the disabled+auto-redeem conflict warning (warns when persisted opt-in is true, stays silent when false)
+- [x] 2.4 Route-level integration tests: PUT rejecting a new auto-redeem opt-in while polling is disabled (`reset_credit_polling_disabled`), and a full PUT with an already-persisted opt-in still succeeding
+
+## 3.5 Settings API guard
+
+- [x] 3.5.1 Reject a new `auto_redeem_reset_credits_before_expiry` opt-in in `app/modules/settings/api.py` while polling is disabled; keep already-persisted opt-ins re-savable
 
 ## 3. Spec
 

--- a/openspec/changes/add-reset-credits-refresh-toggle/tasks.md
+++ b/openspec/changes/add-reset-credits-refresh-toggle/tasks.md
@@ -2,11 +2,13 @@
 
 - [x] 1.1 Add `rate_limit_reset_credits_refresh_enabled: bool = True` to `app/core/config/settings.py` next to the existing interval setting
 - [x] 1.2 Add `enabled: bool = True` to `RateLimitResetCreditsRefreshScheduler` and make `start()` a no-op when disabled; wire the setting through `build_rate_limit_reset_credits_scheduler()`
+- [x] 1.3 On disabled `start()`, read the persisted dashboard settings and log a configuration-conflict warning when `auto_redeem_reset_credits_before_expiry` is enabled (the refresh loop is the sole auto-redeem driver)
 
 ## 2. Tests
 
 - [x] 2.1 Unit-test that `start()` creates no task when disabled and creates the loop task when enabled
 - [x] 2.2 Unit-test that the factory wires `rate_limit_reset_credits_refresh_enabled` from settings
+- [x] 2.3 Unit-test the disabled+auto-redeem conflict warning (warns when persisted opt-in is true, stays silent when false)
 
 ## 3. Spec
 

--- a/openspec/changes/add-reset-credits-refresh-toggle/tasks.md
+++ b/openspec/changes/add-reset-credits-refresh-toggle/tasks.md
@@ -1,0 +1,13 @@
+## 1. Settings and scheduler gate
+
+- [x] 1.1 Add `rate_limit_reset_credits_refresh_enabled: bool = True` to `app/core/config/settings.py` next to the existing interval setting
+- [x] 1.2 Add `enabled: bool = True` to `RateLimitResetCreditsRefreshScheduler` and make `start()` a no-op when disabled; wire the setting through `build_rate_limit_reset_credits_scheduler()`
+
+## 2. Tests
+
+- [x] 2.1 Unit-test that `start()` creates no task when disabled and creates the loop task when enabled
+- [x] 2.2 Unit-test that the factory wires `rate_limit_reset_credits_refresh_enabled` from settings
+
+## 3. Spec
+
+- [x] 3.1 Update the `rate-limit-reset-credits` delta: scheduler starts with the lifespan when polling is enabled; settings expose the toggle with default `true`

--- a/scripts/generate_settings_reference.py
+++ b/scripts/generate_settings_reference.py
@@ -262,6 +262,8 @@ def render_settings_reference() -> str:
             "(https://github.com/Soju06/codex-lb/tree/main/openspec/specs/user-documentation) · "
             "[responses-api-compat]"
             "(https://github.com/Soju06/codex-lb/tree/main/openspec/specs/responses-api-compat) · "
+            "[rate-limit-reset-credits]"
+            "(https://github.com/Soju06/codex-lb/tree/main/openspec/specs/rate-limit-reset-credits) · "
             "[deployment-installation]"
             "(https://github.com/Soju06/codex-lb/tree/main/openspec/specs/deployment-installation)*",
             "",

--- a/tests/integration/test_settings_api.py
+++ b/tests/integration/test_settings_api.py
@@ -1228,3 +1228,46 @@ async def test_retention_override_tri_state_echo_capture_and_clear(async_client,
         settings = await session.get(DashboardSettings, 1)
         assert settings is not None
         assert settings.request_log_retention_days is None
+
+
+@pytest.mark.asyncio
+async def test_auto_redeem_opt_in_rejected_while_reset_credit_polling_disabled(async_client, monkeypatch):
+    from types import SimpleNamespace
+
+    disabled = SimpleNamespace(rate_limit_reset_credits_refresh_enabled=False)
+    monkeypatch.setattr("app.modules.settings.api.get_app_settings", lambda: disabled)
+
+    response = await async_client.get("/api/settings")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["autoRedeemResetCreditsBeforeExpiry"] is False
+    payload["autoRedeemResetCreditsBeforeExpiry"] = True
+
+    response = await async_client.put("/api/settings", json=payload)
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "reset_credit_polling_disabled"
+
+
+@pytest.mark.asyncio
+async def test_full_put_with_persisted_auto_redeem_allowed_while_polling_disabled(async_client, monkeypatch):
+    from types import SimpleNamespace
+
+    async with SessionLocal() as session:
+        await session.execute(
+            text("UPDATE dashboard_settings SET auto_redeem_reset_credits_before_expiry = 1 WHERE id = 1")
+        )
+        await session.commit()
+
+    disabled = SimpleNamespace(rate_limit_reset_credits_refresh_enabled=False)
+    monkeypatch.setattr("app.modules.settings.api.get_app_settings", lambda: disabled)
+
+    response = await async_client.get("/api/settings")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["autoRedeemResetCreditsBeforeExpiry"] is True
+
+    response = await async_client.put("/api/settings", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["autoRedeemResetCreditsBeforeExpiry"] is True

--- a/tests/unit/test_rate_limit_reset_credits_scheduler.py
+++ b/tests/unit/test_rate_limit_reset_credits_scheduler.py
@@ -4,6 +4,7 @@ import asyncio
 import random
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -821,3 +822,48 @@ async def test_run_loop_stops_cleanly_during_startup_delay(monkeypatch: pytest.M
     await scheduler.stop()
 
     assert refreshed is False
+
+
+@pytest.mark.asyncio
+async def test_scheduler_start_is_noop_when_disabled() -> None:
+    scheduler = RateLimitResetCreditsRefreshScheduler(interval_seconds=60, enabled=False)
+
+    await scheduler.start()
+
+    assert scheduler._task is None
+
+
+@pytest.mark.asyncio
+async def test_scheduler_start_creates_task_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    started = asyncio.Event()
+
+    async def _fake_run_loop(self: RateLimitResetCreditsRefreshScheduler) -> None:
+        started.set()
+        await self._stop.wait()
+
+    monkeypatch.setattr(RateLimitResetCreditsRefreshScheduler, "_run_loop", _fake_run_loop)
+    scheduler = RateLimitResetCreditsRefreshScheduler(interval_seconds=60, enabled=True)
+
+    await scheduler.start()
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    assert scheduler._task is not None
+    assert not scheduler._task.done()
+    await scheduler.stop()
+    assert scheduler._task is None
+
+
+def test_build_scheduler_wires_enabled_setting(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        scheduler_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            rate_limit_reset_credits_refresh_enabled=False,
+            rate_limit_reset_credits_refresh_interval_seconds=123,
+        ),
+    )
+
+    scheduler = scheduler_module.build_rate_limit_reset_credits_scheduler()
+
+    assert scheduler.enabled is False
+    assert scheduler.interval_seconds == 123

--- a/tests/unit/test_rate_limit_reset_credits_scheduler.py
+++ b/tests/unit/test_rate_limit_reset_credits_scheduler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import random
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
@@ -824,13 +825,70 @@ async def test_run_loop_stops_cleanly_during_startup_delay(monkeypatch: pytest.M
     assert refreshed is False
 
 
+def _patch_dashboard_settings(monkeypatch: pytest.MonkeyPatch, *, auto_redeem: bool) -> None:
+    class _FakeSession:
+        def expunge_all(self) -> None:
+            return None
+
+    @asynccontextmanager
+    async def _fake_background_session():
+        yield _FakeSession()
+
+    monkeypatch.setattr(scheduler_module, "get_background_session", _fake_background_session)
+    monkeypatch.setattr(
+        scheduler_module,
+        "SettingsRepository",
+        lambda session: _FakeSettingsRepository(auto_redeem_reset_credits_before_expiry=auto_redeem),
+    )
+
+
 @pytest.mark.asyncio
-async def test_scheduler_start_is_noop_when_disabled() -> None:
+async def test_scheduler_start_is_noop_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_dashboard_settings(monkeypatch, auto_redeem=False)
     scheduler = RateLimitResetCreditsRefreshScheduler(interval_seconds=60, enabled=False)
 
     await scheduler.start()
 
     assert scheduler._task is None
+
+
+@pytest.mark.asyncio
+async def test_disabled_start_warns_on_persisted_auto_redeem_conflict(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _patch_dashboard_settings(monkeypatch, auto_redeem=True)
+    scheduler = RateLimitResetCreditsRefreshScheduler(interval_seconds=60, enabled=False)
+
+    with caplog.at_level(logging.WARNING):
+        await scheduler.start()
+
+    assert scheduler._task is None
+    conflict_warnings = [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+        and "auto_redeem_reset_credits_before_expiry" in record.getMessage()
+        and "rate_limit_reset_credits_refresh_enabled" in record.getMessage()
+    ]
+    assert conflict_warnings
+
+
+@pytest.mark.asyncio
+async def test_disabled_start_stays_silent_without_auto_redeem_opt_in(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _patch_dashboard_settings(monkeypatch, auto_redeem=False)
+    scheduler = RateLimitResetCreditsRefreshScheduler(interval_seconds=60, enabled=False)
+
+    with caplog.at_level(logging.WARNING):
+        await scheduler.start()
+
+    assert scheduler._task is None
+    assert not [
+        record
+        for record in caplog.records
+        if record.levelno >= logging.WARNING and "auto_redeem_reset_credits_before_expiry" in record.getMessage()
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_settings_reference.py
+++ b/tests/unit/test_settings_reference.py
@@ -56,7 +56,12 @@ ENV_EXAMPLE_PATH = REPO_ROOT / ".env.example"
 # These remain operator-selectable because deployments differ in recovery
 # safety policy and available persistence/latency budgets; their conservative
 # defaults preserve fail-closed behavior and bound background write work.
-MAX_SETTINGS_FIELDS = 126
+# 126 -> 127: rate_limit_reset_credits_refresh_enabled (reset-credit polling
+# toggle, #1701). Not a hardcoded default because "off" is a deployment
+# decision — operators who don't use the reset-credit surface shed the
+# per-replica authenticated upstream polling; default true keeps current
+# zero-config behavior and the interval setting alone cannot express "off".
+MAX_SETTINGS_FIELDS = 127
 
 
 def test_generated_settings_reference_matches_code() -> None:


### PR DESCRIPTION
## Summary

Adds `rate_limit_reset_credits_refresh_enabled` (default `true`) so operators can turn off background reset-credit polling. When disabled, `RateLimitResetCreditsRefreshScheduler.start()` is a no-op — no background task, no upstream `GET /wham/rate-limit-reset-credits` traffic; snapshot caches stay empty and dashboard reads already render a missing snapshot as `null`/`0`.

Standalone (no issue cover).

## Why not a default? (simplicity gate)

The default `true` **is** the current behavior — zero-config deployments change nothing. The toggle exists because "off" is not expressible today: the spec mandated the scheduler always starts, and `rate_limit_reset_credits_refresh_interval_seconds` is constrained `gt=0`, so operators who don't use the reset-credit surface (or run many replicas against large account fleets — every replica polls every account per tick) cannot shed that authenticated upstream call volume or its failure-log noise. An interval can be stretched but never expresses intent to stop calling upstream.

No `.env.example` entry is added (budgeted surface); the setting is discoverable via the settings reference.

## OpenSpec

`openspec/changes/add-reset-credits-refresh-toggle/` — modifies two `rate-limit-reset-credits` requirements: scheduler start becomes enabled-gated, and the settings requirement replaces the "SHALL NOT expose a toggle" clause. `openspec validate add-reset-credits-refresh-toggle` passes.

## Tests

- `start()` is a no-op when disabled (no task created)
- `start()` creates the loop task when enabled
- factory wires `rate_limit_reset_credits_refresh_enabled` from settings

`tests/unit/test_rate_limit_reset_credits_scheduler.py`: 26 passed locally; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)