### PR TITLE
chore: release v1.24.0-beta.1

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.23.0"  # x-release-please-version
+__version__ = "1.24.0-beta.1"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.23.0
-appVersion: 1.23.0
+version: 1.24.0-beta.1
+appVersion: 1.24.0-beta.1
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.23.0",
+  "version": "1.24.0-beta.1",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.23.0"
+version = "1.24.0-beta.1"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.23.0"
+version = "1.24.0-beta.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.24.0-beta.1 for the 1.24.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.24.0-beta.1 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1692; no manual beta workflow dispatch is required.

## Changes since v1.23.0
- fix(quota-planner): compare warmup reset epochs in UTC (#1623) (e4fa3f2)
- fix(proxy): release the API-key reservation on all exits of the models endpoints (#1653) (
700788)
- fix(compact): omit oversized non-state tool tail (#1235) (
edb373)
- fix(dashboard): separate quota and purchased credits (#1670) (
4a08d9)
- fix(dashboard): exclude cancelled/client_disconnected from error rate (#1696) (
8a7d95)
- fix(proxy): durably recover hard HTTP bridge operations (#1657) (
7a0b67)
- fix(http-bridge): keep idle retirements out of retry circuit (#1677) (
7c4671)
- feat(reset-credits): add refresh scheduler enable toggle (#1701) (
6509dd)
- feat(telemetry): anonymous usage telemetry with informed opt-out consent (#1618) (
debd7c)
- fix(dashboard): pin web asset MIME types against poisoned OS registries (#1709) (
2164b8)
- fix(dashboard): distinguish first-run empty states from filter mismatch (#1729) (
e43904)
- fix(chat): omit unset tools on mapped Responses payloads (#1725) (
db5776)
- fix(http-bridge): refuse foreign claims on live DRAINING leases (#1722) (
b50cb8)
- fix(proxy): keep stream idle timeouts account-neutral (#1718) (
64da34)
- fix(proxy): settle compact failover before account health (#1717) (
309320)
- fix(proxy): close non-stream chat collect and map error status (#1712) (
a85f71)
- fix(proxy): sweep idle bridge sessions without request traffic (#1747) (
3159eb)
- fix(cache): keep an aborted invalidation bump queued (#1748) (
714881)
- feat(db): report SQLite write transactions that outlive the busy timeout (#1752) (
6464e9)
- fix(proxy): fence successor bridge claims against the retiring predecessor (#1751) (
2c0dc5)
- fix(proxy): add explicit Daybreak capability routing (#1742) (
0031e3)
- fix(review): keep Codex review sessions resumable (#1678) (
e34db2)
- fix(accounts): recover Free accounts after reset (#1700) (
b43d0c)
- fix(proxy): keep file-pin owner on soft 1011 reconnect (#1761) (
f694c4)
- fix(proxy): persist file ownership across replicas (#1521) (
2cd52e)
- fix(proxy): scope backend Codex affinity by thread identity (#1703) (
35bbb0)
- fix(http-bridge): preserve goal-restart recovery across reconnects (#1680) (
5dc608)
- fix(dashboard): preserve cancelled request count (#1766) (
ef9c68)
- fix(dashboard): show cancelled request logs (#1769) (
5f2f72)
- fix(dashboard): surface upstream route metadata (#1767) (
e359d4)
- fix(models): correct GPT-5.6 context windows (#1691) (
8488bc)
- fix(auth): guard the refresh singleflight negative cache by successor ownership (#1652) (
4ace71)
- fix(http-bridge): dedupe retry circuit failures per send (#1743) (
5780a2)
- fix(proxy): abandon unavailable owner on thread-scoped goal restart (#1764) (
17ae86)
- fix(proxy): do not rewrite thread locality for a file-pin owner (#1765) (
34ef7b)
- fix(usage): settle live snapshots after account consolidation (#1773) (
3f66c2)
- fix(proxy): normalize single-account warmup failures (#1774) (
f92bc9)
- fix(proxy): settle terminal spool append failures (#1775) (
4e48f3)
- fix(proxy): hold fenced hard turns through cooldown (#1739) (
6ff51c)
- fix(proxy): stop abandoning an unresolved inflight session-creation future (#1644) (
57618c)
- fix(proxy): separate websocket scope cleanup budget (#1723) (
fd97cb)
- fix(proxy): route source-owned models off the WebSocket transport (#1659) (
08b84a)
- feat(proxy): report websocket cleanup phase (#1726) (
0c8d92)
- fix(proxy): complete disconnect cleanup — pool leak, charged reservation, mutable terminal reason (#1645) (
6cf7e6)
- fix(dashboard): show cancellation totals in reports (#1772) (
5d27f7)
- feat(model-sources): advertise operator-declared reasoning efforts (#1661) (
f1c8d5)
- feat(ui): customize dashboard request-log columns (#1503) (
138aa9)
- fix(proxy): keep abrupt eventless websocket drops account-neutral (#1777) (
6c97ad)
- fix(db): bound wedged SQLite session teardown and reclaim the connection (#1778) (
9eedb2)
- perf(proxy): disable permessage-deflate on direct-egress upstream websockets (#1786) (
2e4a58)
- perf(middleware): convert BaseHTTPMiddleware layers to pure ASGI (#1787) (
94057c)
- fix(compact): recover previous-response-pinned compaction from quota-excluded owners (#1780) (
120af7)
- perf: coalesce same-owner sticky session TTL refresh upserts (#1790) (
076aab)
- fix(server): serve h2c upgrade offers as plain HTTP/1.1 instead of rejecting them (#1782) (
8d265c)
- fix(db): add postgres shm_size and raise default pool headroom (#1791) (
539cf9)
- perf(dashboard): cap projections bulk usage-history read per account (#1779) (
d4c43e)
- perf(accounts): bound the account-listing live tail with a 2h fold lag and a 30s summary cache (#1792) (
c1caa4)
- perf(accounts): make account deletion a fast mark + background batch drain (#1795) (
d4f9e2)
- fix(usage): fence leaked live-usage-ingestor tasks and settle their failures deterministically (#1783) (
66fd10)
- fix(docker): upgrade util-linux family in runtime image for CVE-2026-53615 (#1796) (
0a4c0a)
- perf(proxy): validate stream payloads only for lifecycle events (#1784) (
9d9f09)
- perf(api-keys,proxy): shape ORM hot-path queries (#1788) (
7dacb0)
- perf(proxy): relay unmodified SSE frames verbatim (#1785) (
980572)
- perf(api-keys): skip usage reservations when no limit applies (#1789) (
8a2d06)

## Release-candidate validation
Validated candidate: 2d4a92f4406dbfcd4a56812b44c7bc84718cc767

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates — CI green at 2d4a92f4 (unit 6.2k, integration-core 3 shards + bridge + e2e, pytest PostgreSQL, migration checks sqlite+postgres, ruff, ty)
- [x] Frontend tests/build — CI green at 2d4a92f4 (vitest + coverage, tsc, eslint, vite build)
- [x] Wheel/package validation — CI `Package (build)` green at 2d4a92f4
- [x] Docker/container smoke — image built locally from 2d4a92f4 (sha256:232fd5ac7507); booted against a scratch postgres:18-alpine on an isolated network: alembic head `20260816_000000_add_account_pending_deletion` applied (script head verified in-container), `GET /health/ready` 200, unauthenticated `GET /api/dashboard/overview` 401 bootstrap_required, `POST /v1/responses` and `/v1/chat/completions` without key 401 invalid_api_key, 0 error signatures in app+postgres logs
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required — this train is the hot-path perf campaign (#1784/#1785/#1786/#1787/#1788/#1789) plus the slow-query campaign (#1779/#1790/#1792/#1795), all mechanism/perf changes verified byte- or semantics-identical by their suites; the only schema delta (`add_account_pending_deletion`, additive) was applied and verified in the container smoke. Live-path validation proceeds on the internal 113 pool immediately after publish with the previous stable image staged for one-line rollback, including the #1786 py-spy falsification check (deflate leaf must disappear)

## Install after publish
```bash
uvx --from "codex-lb==1.24.0b1" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.24.0-beta.1
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.24.0-beta.1 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.24.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application, frontend, and deployment package versions to **1.24.0-beta.1**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
