### PR TITLE
fix(compact): use Responses endpoint upstream

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -3618,6 +3618,7 @@ class _CompactCommandTransport:
         compact_timeout_seconds = _effective_compact_total_timeout(settings.upstream_compact_timeout_seconds)
         effective_connect_timeout = _effective_compact_connect_timeout(settings.upstream_connect_timeout_seconds)
         payload_dict = dict(self.payload.to_payload())
+        payload_dict["store"] = False
         if settings.image_inline_fetch_enabled:
             payload_dict = await _inline_input_image_urls(
                 payload_dict,

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -3599,7 +3599,7 @@ class _CompactCommandTransport:
     async def execute(self) -> CompactResponsePayload:
         settings = get_settings()
         upstream_base = settings.upstream_base_url.rstrip("/")
-        url = f"{upstream_base}/codex/responses/compact"
+        url = f"{upstream_base}/codex/responses"
         require_route_or_direct_egress_opt_in(
             route=self.route,
             allow_direct_egress=self.allow_direct_egress,

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1239,6 +1239,58 @@ async def _compact_response_payload_from_success_response(
     return await _codex_response_json(resp)
 
 
+def _normalize_compact_response_payload_shape(payload: JsonValue) -> JsonValue:
+    if not is_json_mapping(payload):
+        return payload
+    object_value = payload.get("object")
+    if isinstance(object_value, str) and object_value.startswith("response.compact"):
+        return payload
+    compaction_item = _compact_output_item_from_payload(payload)
+    if compaction_item is None:
+        return payload
+    normalized: dict[str, JsonValue] = {
+        "object": "response.compaction",
+        "output": [compaction_item],
+    }
+    for key in ("id", "status", "usage"):
+        value = payload.get(key)
+        if value is not None:
+            normalized[key] = value
+    return normalized
+
+
+def _compact_output_item_from_payload(payload: Mapping[str, JsonValue]) -> dict[str, JsonValue] | None:
+    output = payload.get("output")
+    if isinstance(output, list):
+        for raw_item in output:
+            if not is_json_mapping(raw_item):
+                continue
+            item_type = raw_item.get("type")
+            if isinstance(item_type, str) and item_type in {"compaction", "compaction_summary"}:
+                normalized = _normalize_compact_output_item(raw_item)
+                if normalized is not None:
+                    return normalized
+    summary = payload.get("compaction_summary")
+    if is_json_mapping(summary):
+        return _normalize_compact_output_item(summary)
+    return None
+
+
+def _normalize_compact_output_item(item: Mapping[str, JsonValue]) -> dict[str, JsonValue] | None:
+    encrypted_content = item.get("encrypted_content")
+    if not isinstance(encrypted_content, str):
+        return None
+    normalized: dict[str, JsonValue] = {
+        "type": "compaction",
+        "encrypted_content": encrypted_content,
+    }
+    for key in ("id", "status"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            normalized[key] = value
+    return normalized
+
+
 async def _error_response_body(resp: ErrorResponse) -> tuple[object | None, str | None]:
     try:
         return await resp.json(content_type=None), None
@@ -3795,6 +3847,7 @@ class _CompactCommandTransport:
                         failure_exception_type=failure_exception_type,
                         upstream_status_code=status_code,
                     ) from exc
+                data = _normalize_compact_response_payload_shape(data)
                 parsed = parse_compact_response_payload(data)
                 archive_json(
                     direction="server_to_codex",
@@ -3899,6 +3952,7 @@ class _CompactCommandTransport:
                         failure_exception_type=failure_exception_type,
                         upstream_status_code=resp.status,
                     ) from exc
+                data = _normalize_compact_response_payload_shape(data)
                 parsed = parse_compact_response_payload(data)
                 archive_json(
                     direction="server_to_codex",

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -450,6 +450,7 @@ class _CodexSSEResponse:
     def __init__(self, response: Any) -> None:
         self._response = response
         self.status = _codex_response_status(response)
+        self.headers = _codex_response_headers(response)
         self.content = _CodexSSEContent(response)
 
     async def json(self, *, content_type: str | None = None) -> JsonValue:
@@ -1200,6 +1201,39 @@ async def _iter_sse_events(
         if len(buffer) > max_event_bytes:
             raise StreamEventTooLargeError(len(buffer), max_event_bytes)
         yield bytes(buffer).decode("utf-8", errors="replace")
+
+
+async def _compact_response_payload_from_sse(resp: SSEResponse, idle_timeout_seconds: float, max_event_bytes: int) -> JsonValue:
+    last_payload: dict[str, JsonValue] | None = None
+    async for event_block in _iter_sse_events(resp, idle_timeout_seconds, max_event_bytes):
+        payload = parse_sse_data_json(event_block)
+        if payload is None:
+            continue
+        last_payload = payload
+        event_type = payload.get("type")
+        if event_type == "response.completed":
+            response = payload.get("response")
+            if isinstance(response, dict):
+                return response
+            raise ValueError("response.completed event missing response object")
+        if event_type in {"response.failed", "response.incomplete", "error"}:
+            raise ValueError(f"upstream SSE terminal event {event_type}")
+    if last_payload is not None:
+        raise ValueError("upstream SSE ended before response.completed")
+    raise ValueError("empty upstream SSE response")
+
+
+async def _compact_response_payload_from_success_response(
+    resp: Any,
+    *,
+    idle_timeout_seconds: float,
+    max_event_bytes: int,
+) -> JsonValue:
+    headers = _codex_response_headers(resp)
+    content_type = next((value for key, value in headers.items() if key.lower() == "content-type"), "")
+    if "text/event-stream" in content_type.lower():
+        return await _compact_response_payload_from_sse(cast(SSEResponse, resp), idle_timeout_seconds, max_event_bytes)
+    return await _codex_response_json(resp)
 
 
 async def _error_response_body(resp: ErrorResponse) -> tuple[object | None, str | None]:
@@ -3612,13 +3646,14 @@ class _CompactCommandTransport:
             self.headers,
             self.access_token,
             upstream_account_id,
-            accept="application/json",
+            accept="text/event-stream",
         )
         pre_request_started_at = time.monotonic()
         compact_timeout_seconds = _effective_compact_total_timeout(settings.upstream_compact_timeout_seconds)
         effective_connect_timeout = _effective_compact_connect_timeout(settings.upstream_connect_timeout_seconds)
         payload_dict = dict(self.payload.to_payload())
         payload_dict["store"] = False
+        payload_dict["stream"] = True
         if settings.image_inline_fetch_enabled:
             payload_dict = await _inline_input_image_urls(
                 payload_dict,
@@ -3738,7 +3773,11 @@ class _CompactCommandTransport:
                         upstream_status_code=status_code,
                     )
                 try:
-                    data = await _codex_response_json(resp)
+                    data = await _compact_response_payload_from_success_response(
+                        _CodexSSEResponse(resp),
+                        idle_timeout_seconds=compact_timeout_seconds or settings.stream_idle_timeout_seconds,
+                        max_event_bytes=settings.max_sse_event_bytes,
+                    )
                 except Exception as exc:
                     error_code = "upstream_error"
                     error_message = "Invalid JSON from upstream"
@@ -3816,7 +3855,11 @@ class _CompactCommandTransport:
                         upstream_status_code=resp.status,
                     )
                 try:
-                    data = await resp.json(content_type=None)
+                    data = await _compact_response_payload_from_success_response(
+                        resp,
+                        idle_timeout_seconds=compact_timeout_seconds or settings.stream_idle_timeout_seconds,
+                        max_event_bytes=settings.max_sse_event_bytes,
+                    )
                 except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as exc:
                     message = str(exc) or "Request to upstream timed out"
                     error_code = process_network_error_code(

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1231,7 +1231,10 @@ async def _compact_response_payload_from_success_response(
 ) -> JsonValue:
     headers = _codex_response_headers(resp)
     content_type = next((value for key, value in headers.items() if key.lower() == "content-type"), "")
-    if "text/event-stream" in content_type.lower():
+    content = getattr(resp, "content", None)
+    if "text/event-stream" in content_type.lower() or (
+        not content_type and callable(getattr(content, "iter_chunked", None))
+    ):
         return await _compact_response_payload_from_sse(cast(SSEResponse, resp), idle_timeout_seconds, max_event_bytes)
     return await _codex_response_json(resp)
 

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1399,6 +1399,32 @@ def _proxy_response_error_from_compact_sse_terminal(
     )
 
 
+def _proxy_response_error_from_compact_sse_stream_exception(
+    exc: StreamIdleTimeoutError | StreamEventTooLargeError,
+    *,
+    upstream_status_code: int | None,
+) -> ProxyResponseError:
+    if isinstance(exc, StreamIdleTimeoutError):
+        return ProxyResponseError(
+            502,
+            openai_error("stream_idle_timeout", "Upstream stream idle timeout"),
+            failure_phase="upstream",
+            failure_detail="stream_idle_timeout",
+            failure_exception_type=type(exc).__name__,
+            upstream_status_code=upstream_status_code,
+            upstream_error_code="stream_idle_timeout",
+        )
+    return ProxyResponseError(
+        502,
+        openai_error("stream_event_too_large", str(exc)),
+        failure_phase="upstream",
+        failure_detail=str(exc),
+        failure_exception_type=type(exc).__name__,
+        upstream_status_code=upstream_status_code,
+        upstream_error_code="stream_event_too_large",
+    )
+
+
 def _compact_sse_terminal_error_payload(
     payload: Mapping[str, JsonValue],
     event_type: object,
@@ -4000,6 +4026,11 @@ class _CompactCommandTransport:
                         idle_timeout_seconds=compact_timeout_seconds or settings.stream_idle_timeout_seconds,
                         max_event_bytes=settings.max_sse_event_bytes,
                     )
+                except (StreamIdleTimeoutError, StreamEventTooLargeError) as exc:
+                    raise _proxy_response_error_from_compact_sse_stream_exception(
+                        exc,
+                        upstream_status_code=status_code,
+                    ) from exc
                 except ProxyResponseError:
                     raise
                 except Exception as exc:
@@ -4106,6 +4137,11 @@ class _CompactCommandTransport:
                         failure_exception_type=failure_exception_type,
                         upstream_status_code=resp.status,
                         failed_session=_failed_shared_session_for_process_network_error(error_code, self.session),
+                    ) from exc
+                except (StreamIdleTimeoutError, StreamEventTooLargeError) as exc:
+                    raise _proxy_response_error_from_compact_sse_stream_exception(
+                        exc,
+                        upstream_status_code=resp.status,
                     ) from exc
                 except ProxyResponseError:
                     raise

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -437,11 +437,34 @@ SSEResponse: TypeAlias = aiohttp.ClientResponse | SSEResponseProtocol
 
 class _CodexSSEContent:
     def __init__(self, response: Any) -> None:
-        self._response = response
+        content = getattr(response, "content", None)
+        self._body = content if isinstance(content, bytes | bytearray) else None
+        self._content = content
 
     def iter_chunked(self, size: int) -> "SSEChunkIteratorProtocol":
-        del size
-        return cast(SSEChunkIteratorProtocol, self._response.content.iter_chunked(1024))
+        if self._body is not None:
+            return cast(SSEChunkIteratorProtocol, _BytesSSEChunkIterator(bytes(self._body), size))
+        if self._content is None:
+            raise TypeError("SSE response content is missing")
+        return cast(SSEChunkIteratorProtocol, self._content.iter_chunked(size))
+
+
+class _BytesSSEChunkIterator:
+    def __init__(self, body: bytes, size: int) -> None:
+        self._body = body
+        self._size = max(1, size)
+        self._offset = 0
+
+    def __aiter__(self) -> "_BytesSSEChunkIterator":
+        return self
+
+    async def __anext__(self) -> bytes:
+        if self._offset >= len(self._body):
+            raise StopAsyncIteration
+        end = min(len(self._body), self._offset + self._size)
+        chunk = self._body[self._offset : end]
+        self._offset = end
+        return chunk
 
 
 class _CodexSSEResponse:
@@ -1230,7 +1253,7 @@ async def _compact_response_payload_from_sse(
                 return response
             raise ValueError("response.completed event missing response object")
         if event_type in {"response.failed", "response.incomplete", "error"}:
-            raise ValueError(f"upstream SSE terminal event {event_type}")
+            raise _proxy_response_error_from_compact_sse_terminal(payload, event_type)
     if last_payload is not None:
         raise ValueError("upstream SSE ended before response.completed")
     raise ValueError("empty upstream SSE response")
@@ -1265,11 +1288,21 @@ def _normalize_compact_response_payload_shape(payload: JsonValue) -> JsonValue:
         "object": "response.compaction",
         "output": [compaction_item],
     }
-    for key in ("id", "status", "usage"):
+    for key in ("id", "status", "usage", "service_tier"):
         value = payload.get(key)
         if value is not None:
             normalized[key] = value
     return normalized
+
+
+def _responses_compact_payload_for_responses_endpoint(payload: ResponsesCompactRequest) -> dict[str, JsonValue]:
+    payload_dict = dict(payload.to_payload())
+    input_value = payload_dict.get("input")
+    input_items = list(input_value) if isinstance(input_value, list) else [input_value]
+    if not (input_items and is_json_mapping(input_items[-1]) and input_items[-1].get("type") == "compaction_trigger"):
+        input_items.append({"type": "compaction_trigger"})
+    payload_dict["input"] = input_items
+    return payload_dict
 
 
 def _compact_output_item_from_payload(payload: Mapping[str, JsonValue]) -> dict[str, JsonValue] | None:
@@ -1283,6 +1316,10 @@ def _compact_output_item_from_payload(payload: Mapping[str, JsonValue]) -> dict[
                 normalized = _normalize_compact_output_item(raw_item)
                 if normalized is not None:
                     return normalized
+        for raw_item in output:
+            if not is_json_mapping(raw_item):
+                continue
+            item_type = raw_item.get("type")
             if item_type == "message":
                 normalized = _compact_output_item_from_message(raw_item)
                 if normalized is not None:
@@ -1343,6 +1380,82 @@ def _normalize_compact_output_item(item: Mapping[str, JsonValue]) -> dict[str, J
         if isinstance(value, str) and value.strip():
             normalized[key] = value
     return normalized
+
+
+def _proxy_response_error_from_compact_sse_terminal(
+    payload: Mapping[str, JsonValue],
+    event_type: object,
+) -> ProxyResponseError:
+    error_payload = _compact_sse_terminal_error_payload(payload, event_type)
+    error_code, error_message = _error_details_from_envelope(error_payload)
+    status_code = _compact_sse_terminal_status_code(payload)
+    return ProxyResponseError(
+        status_code,
+        error_payload,
+        failure_phase="upstream",
+        failure_detail=error_message,
+        upstream_status_code=status_code,
+        upstream_error_code=error_code,
+    )
+
+
+def _compact_sse_terminal_error_payload(
+    payload: Mapping[str, JsonValue],
+    event_type: object,
+) -> OpenAIErrorEnvelope:
+    error = parse_error_payload(dict(payload))
+    if error:
+        return {"error": _openai_error_detail(error)}
+    if event_type == "error":
+        error_code = payload.get("code")
+        error_message = payload.get("message")
+        if isinstance(error_code, str) and error_code and isinstance(error_message, str) and error_message:
+            detail: OpenAIErrorDetail = {
+                "code": error_code,
+                "message": error_message,
+                "type": "server_error",
+            }
+            error_type = payload.get("type")
+            if isinstance(error_type, str) and error_type and error_type != "error":
+                detail["type"] = error_type
+            param = payload.get("param")
+            if isinstance(param, str) and param:
+                detail["param"] = param
+            return {"error": detail}
+    response = payload.get("response")
+    if is_json_mapping(response):
+        response_error = parse_error_payload(dict(response))
+        if response_error:
+            return {"error": _openai_error_detail(response_error)}
+    message = _extract_upstream_message(cast(Mapping[str, Any], payload))
+    if not message and is_json_mapping(response):
+        message = _extract_upstream_message(cast(Mapping[str, Any], response))
+    code = "upstream_error"
+    if event_type == "response.incomplete":
+        code = "incomplete"
+    elif event_type == "response.failed":
+        code = "upstream_error"
+    elif event_type == "error":
+        code = "upstream_error"
+    return openai_error(code, message or f"Upstream SSE terminal event: {event_type}")
+
+
+def _compact_sse_terminal_status_code(payload: Mapping[str, JsonValue]) -> int:
+    response = payload.get("response")
+    candidates: list[JsonValue] = []
+    if is_json_mapping(response):
+        candidates.extend(
+            [
+                response.get("status_code"),
+                response.get("statusCode"),
+                response.get("status"),
+            ]
+        )
+    candidates.extend([payload.get("status_code"), payload.get("statusCode"), payload.get("status")])
+    for value in candidates:
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+    return 502
 
 
 async def _error_response_body(resp: ErrorResponse) -> tuple[object | None, str | None]:
@@ -3760,7 +3873,7 @@ class _CompactCommandTransport:
         pre_request_started_at = time.monotonic()
         compact_timeout_seconds = _effective_compact_total_timeout(settings.upstream_compact_timeout_seconds)
         effective_connect_timeout = _effective_compact_connect_timeout(settings.upstream_connect_timeout_seconds)
-        payload_dict = dict(self.payload.to_payload())
+        payload_dict = _responses_compact_payload_for_responses_endpoint(self.payload)
         payload_dict["store"] = False
         payload_dict["stream"] = True
         if settings.image_inline_fetch_enabled:
@@ -3887,6 +4000,8 @@ class _CompactCommandTransport:
                         idle_timeout_seconds=compact_timeout_seconds or settings.stream_idle_timeout_seconds,
                         max_event_bytes=settings.max_sse_event_bytes,
                     )
+                except ProxyResponseError:
+                    raise
                 except Exception as exc:
                     error_code = "upstream_error"
                     error_message = "Invalid JSON from upstream"
@@ -3992,6 +4107,8 @@ class _CompactCommandTransport:
                         upstream_status_code=resp.status,
                         failed_session=_failed_shared_session_for_process_network_error(error_code, self.session),
                     ) from exc
+                except ProxyResponseError:
+                    raise
                 except Exception as exc:
                     error_code = "upstream_error"
                     error_message = "Invalid JSON from upstream"

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1203,17 +1203,30 @@ async def _iter_sse_events(
         yield bytes(buffer).decode("utf-8", errors="replace")
 
 
-async def _compact_response_payload_from_sse(resp: SSEResponse, idle_timeout_seconds: float, max_event_bytes: int) -> JsonValue:
+async def _compact_response_payload_from_sse(
+    resp: SSEResponse, idle_timeout_seconds: float, max_event_bytes: int
+) -> JsonValue:
     last_payload: dict[str, JsonValue] | None = None
+    output_items: dict[int, dict[str, JsonValue]] = {}
     async for event_block in _iter_sse_events(resp, idle_timeout_seconds, max_event_bytes):
         payload = parse_sse_data_json(event_block)
         if payload is None:
             continue
         last_payload = payload
         event_type = payload.get("type")
+        if event_type in {"response.output_item.added", "response.output_item.done"}:
+            output_index = payload.get("output_index")
+            item = payload.get("item")
+            if isinstance(output_index, int) and isinstance(item, dict):
+                output_items[output_index] = dict(item)
         if event_type == "response.completed":
             response = payload.get("response")
             if isinstance(response, dict):
+                existing_output = response.get("output")
+                if output_items and not (isinstance(existing_output, list) and existing_output):
+                    merged_response = dict(response)
+                    merged_response["output"] = [item for _, item in sorted(output_items.items())]
+                    return merged_response
                 return response
             raise ValueError("response.completed event missing response object")
         if event_type in {"response.failed", "response.incomplete", "error"}:
@@ -1270,9 +1283,50 @@ def _compact_output_item_from_payload(payload: Mapping[str, JsonValue]) -> dict[
                 normalized = _normalize_compact_output_item(raw_item)
                 if normalized is not None:
                     return normalized
+            if item_type == "message":
+                normalized = _compact_output_item_from_message(raw_item)
+                if normalized is not None:
+                    return normalized
     summary = payload.get("compaction_summary")
     if is_json_mapping(summary):
         return _normalize_compact_output_item(summary)
+    return None
+
+
+def _compact_output_item_from_message(item: Mapping[str, JsonValue]) -> dict[str, JsonValue] | None:
+    text = _compact_message_text(item)
+    if not text:
+        return None
+    normalized: dict[str, JsonValue] = {
+        "type": "compaction",
+        "encrypted_content": text,
+    }
+    for key in ("id", "status"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            normalized[key] = value
+    return normalized
+
+
+def _compact_message_text(item: Mapping[str, JsonValue]) -> str | None:
+    direct_text = item.get("text")
+    if isinstance(direct_text, str) and direct_text:
+        return direct_text
+    content = item.get("content")
+    content_parts: list[Mapping[str, JsonValue]]
+    if is_json_mapping(content):
+        content_parts = [content]
+    elif isinstance(content, list):
+        content_parts = [part for part in content if is_json_mapping(part)]
+    else:
+        content_parts = []
+    text_parts: list[str] = []
+    for part in content_parts:
+        text = part.get("text")
+        if isinstance(text, str) and text:
+            text_parts.append(text)
+    if text_parts:
+        return "".join(text_parts)
     return None
 
 

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -216,10 +216,11 @@ class _SseContent:
     async def iter_chunked(self, size: int):
         del size
         yield (
+            b'data: {"type":"response.output_item.done","output_index":0,'
+            b'"item":{"id":"msg_compact_summary_1","type":"message","role":"assistant",'
+            b'"status":"completed","content":[{"type":"output_text","text":"enc_compact_summary_1"}]}}\n\n'
             b'data: {"type":"response.completed","response":'
-            b'{"object":"response","id":"resp_compact_summary_1","status":"completed",'
-            b'"output":[{"id":"cmp_compact_summary_1","type":"compaction_summary",'
-            b'"encrypted_content":"enc_compact_summary_1"}]}}\n\n'
+            b'{"object":"response","id":"resp_compact_summary_1","status":"completed","output":[]}}\n\n'
         )
 
 
@@ -809,7 +810,12 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
     assert body["object"] == "response.compaction"
     assert body["id"] == "resp_compact_summary_1"
     assert body["output"] == [
-        {"id": "cmp_compact_summary_1", "type": "compaction", "encrypted_content": "enc_compact_summary_1"}
+        {
+            "id": "msg_compact_summary_1",
+            "type": "compaction",
+            "status": "completed",
+            "encrypted_content": "enc_compact_summary_1",
+        }
     ]
     assert _session_call_url(session).endswith("/codex/responses")
     call_json = _session_call_json(session)

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -791,7 +791,7 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
         "encrypted_content": "enc_compact_summary_1",
         "summary_text": "condensed thread state",
     }
-    assert _session_call_url(session).endswith("/codex/responses/compact")
+    assert _session_call_url(session).endswith("/codex/responses")
     call_json = _session_call_json(session)
     assert "stream" not in call_json
     assert "store" not in call_json

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -821,7 +821,8 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
     call_json = _session_call_json(session)
     assert call_json["stream"] is True
     assert call_json["store"] is False
-    assert session.calls[0]["headers"]["Accept"] == "text/event-stream"
+    call_headers = cast(dict[str, str], session.calls[0]["headers"])
+    assert call_headers["Accept"] == "text/event-stream"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -217,8 +217,9 @@ class _SseContent:
         del size
         yield (
             b'data: {"type":"response.completed","response":'
-            b'{"object":"response.compaction","compaction_summary":'
-            b'{"encrypted_content":"enc_compact_summary_1","summary_text":"condensed thread state"}}}\n\n'
+            b'{"object":"response","id":"resp_compact_summary_1","status":"completed",'
+            b'"output":[{"id":"cmp_compact_summary_1","type":"compaction_summary",'
+            b'"encrypted_content":"enc_compact_summary_1"}]}}\n\n'
         )
 
 
@@ -806,10 +807,10 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
     assert response.status_code == 200
     body = response.json()
     assert body["object"] == "response.compaction"
-    assert body["compaction_summary"] == {
-        "encrypted_content": "enc_compact_summary_1",
-        "summary_text": "condensed thread state",
-    }
+    assert body["id"] == "resp_compact_summary_1"
+    assert body["output"] == [
+        {"id": "cmp_compact_summary_1", "type": "compaction", "encrypted_content": "enc_compact_summary_1"}
+    ]
     assert _session_call_url(session).endswith("/codex/responses")
     call_json = _session_call_json(session)
     assert call_json["stream"] is True

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -225,7 +225,7 @@ class _SseContent:
 class _SseResponse:
     status = 200
     reason = "OK"
-    headers = {"content-type": "text/event-stream"}
+    headers: dict[str, str] = {}
     content = _SseContent()
 
     async def __aenter__(self):

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -212,8 +212,37 @@ class _JsonResponse:
         return _return_self().__await__()
 
 
+class _SseContent:
+    async def iter_chunked(self, size: int):
+        del size
+        yield (
+            b'data: {"type":"response.completed","response":'
+            b'{"object":"response.compaction","compaction_summary":'
+            b'{"encrypted_content":"enc_compact_summary_1","summary_text":"condensed thread state"}}}\n\n'
+        )
+
+
+class _SseResponse:
+    status = 200
+    reason = "OK"
+    headers = {"content-type": "text/event-stream"}
+    content = _SseContent()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def __await__(self):
+        async def _return_self():
+            return self
+
+        return _return_self().__await__()
+
+
 class _JsonSession:
-    def __init__(self, response: _JsonResponse) -> None:
+    def __init__(self, response: object) -> None:
         self._response = response
         self.calls: list[dict[str, object]] = []
 
@@ -762,17 +791,7 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
     response = await async_client.post("/api/accounts/import", files=files)
     assert response.status_code == 200
 
-    session = _JsonSession(
-        _JsonResponse(
-            {
-                "object": "response.compaction",
-                "compaction_summary": {
-                    "encrypted_content": "enc_compact_summary_1",
-                    "summary_text": "condensed thread state",
-                },
-            }
-        )
-    )
+    session = _JsonSession(_SseResponse())
 
     @contextlib.asynccontextmanager
     async def lease_session(session_override=None):
@@ -793,8 +812,9 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
     }
     assert _session_call_url(session).endswith("/codex/responses")
     call_json = _session_call_json(session)
-    assert "stream" not in call_json
+    assert call_json["stream"] is True
     assert call_json["store"] is False
+    assert session.calls[0]["headers"]["Accept"] == "text/event-stream"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -794,7 +794,7 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
     assert _session_call_url(session).endswith("/codex/responses")
     call_json = _session_call_json(session)
     assert "stream" not in call_json
-    assert "store" not in call_json
+    assert call_json["store"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -10,7 +10,7 @@ import pytest
 from aiohttp.client_reqrep import ConnectionKey
 
 import app.core.clients.proxy as proxy_module
-from app.core.clients.codex import CodexClient, CodexTransportError, CodexWebSocketResult
+from app.core.clients.codex import CodexClient, CodexRequestResult, CodexTransportError, CodexWebSocketResult
 from app.core.clients.files import create_file, finalize_file
 from app.core.clients.proxy import (
     ProxyResponseError,
@@ -38,6 +38,19 @@ class _CodexClient:
     async def request(self, method: str, url: str, *, route: ResolvedUpstreamRoute, **kwargs: Any) -> object:
         self.calls.append({"method": method, "url": url, "route": route, **kwargs})
         return self.response
+
+
+class _RouteMetadataCodexClient(_CodexClient):
+    async def request_with_route_metadata(
+        self,
+        method: str,
+        url: str,
+        *,
+        route: ResolvedUpstreamRoute,
+        **kwargs: Any,
+    ) -> CodexRequestResult:
+        self.calls.append({"method": method, "url": url, "route": route, **kwargs})
+        return CodexRequestResult(response=self.response, route=route, fallback_used=False)
 
 
 class _FailingRouteMetadataCodexClient:
@@ -87,6 +100,40 @@ class _CompactStreamResponse:
     status_code = 200
     headers: dict[str, str] = {}
     content = _CompactStreamContent()
+
+
+class _BufferedCompactStreamResponse:
+    status = 200
+    status_code = 200
+    headers = {"content-type": "text/event-stream"}
+    content = (
+        b'data: {"type":"response.completed","response":{"object":"response","id":"resp_compact_buffered",'
+        b'"status":"completed","service_tier":"default","output":['
+        b'{"id":"msg_history","type":"message","role":"assistant","status":"completed",'
+        b'"content":[{"type":"output_text","text":"historical plaintext"}]},'
+        b'{"id":"cmp_buffered","type":"compaction_summary","encrypted_content":"enc_buffered"}]}}\n\n'
+    )
+
+
+class _CompactTerminalErrorStreamResponse:
+    status = 200
+    status_code = 200
+    headers = {"content-type": "text/event-stream"}
+    content = (
+        b'data: {"type":"error","code":"rate_limit_exceeded","message":"quota closed",'
+        b'"param":"previous_response_id"}\n\n'
+    )
+
+
+class _CompactTerminalFailedStreamResponse:
+    status = 200
+    status_code = 200
+    headers = {"content-type": "text/event-stream"}
+    content = (
+        b'data: {"type":"response.failed","response":{"status_code":400,'
+        b'"error":{"code":"previous_response_not_found","message":"missing anchor",'
+        b'"type":"invalid_request_error","param":"previous_response_id"}}}\n\n'
+    )
 
 
 class _TranscribeResponse:
@@ -348,6 +395,83 @@ async def test_compact_responses_uses_codex_client_when_route_is_resolved(route:
     assert client.calls[0]["json"]["stream"] is True
     assert client.calls[0]["headers"]["Accept"] == "text/event-stream"
     assert trace.endpoint_id == "ep_1"
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_routed_buffered_sse_keeps_compact_protocol(route: ResolvedUpstreamRoute) -> None:
+    client = _RouteMetadataCodexClient(_BufferedCompactStreamResponse())
+    payload = ResponsesCompactRequest(model="gpt-5.2", instructions="Summarize.", input="hello")
+
+    response = await compact_responses(
+        payload,
+        {"user-agent": "codex"},
+        "access",
+        "chatgpt_account",
+        session=cast(Any, object()),
+        route=route,
+        codex_client=cast(Any, client),
+    )
+
+    sent_input = client.calls[0]["json"]["input"]
+    assert sent_input[-1] == {"type": "compaction_trigger"}
+    assert sum(1 for item in sent_input if isinstance(item, dict) and item.get("type") == "compaction_trigger") == 1
+    assert response.id == "resp_compact_buffered"
+    assert response.model_extra is not None
+    assert response.model_extra["service_tier"] == "default"
+    assert response.model_extra["output"] == [
+        {"id": "cmp_buffered", "type": "compaction", "encrypted_content": "enc_buffered"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_routed_terminal_sse_error_keeps_openai_envelope(
+    route: ResolvedUpstreamRoute,
+) -> None:
+    client = _RouteMetadataCodexClient(_CompactTerminalFailedStreamResponse())
+    payload = ResponsesCompactRequest(model="gpt-5.2", instructions="Summarize.", input="hello")
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await compact_responses(
+            payload,
+            {"user-agent": "codex"},
+            "access",
+            "chatgpt_account",
+            session=cast(Any, object()),
+            route=route,
+            codex_client=cast(Any, client),
+        )
+
+    error = exc_info.value.payload["error"]
+    assert error["code"] == "previous_response_not_found"
+    assert error["message"] == "missing anchor"
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] == "previous_response_id"
+    assert exc_info.value.failure_phase == "upstream"
+    assert exc_info.value.upstream_status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_routed_top_level_sse_error_preserves_fields(
+    route: ResolvedUpstreamRoute,
+) -> None:
+    client = _RouteMetadataCodexClient(_CompactTerminalErrorStreamResponse())
+    payload = ResponsesCompactRequest(model="gpt-5.2", instructions="Summarize.", input="hello")
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await compact_responses(
+            payload,
+            {"user-agent": "codex"},
+            "access",
+            "chatgpt_account",
+            session=cast(Any, object()),
+            route=route,
+            codex_client=cast(Any, client),
+        )
+
+    error = exc_info.value.payload["error"]
+    assert error["code"] == "rate_limit_exceeded"
+    assert error["message"] == "quota closed"
+    assert error["param"] == "previous_response_id"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -71,6 +71,21 @@ class _CompactResponse:
         return {"object": "response.compact", "id": "compact_1"}
 
 
+class _CompactStreamContent:
+    async def iter_chunked(self, size: int):
+        del size
+        yield (
+            b'data: {"type":"response.completed","response":'
+            b'{"object":"response.compact","id":"compact_1"}}\n\n'
+        )
+
+
+class _CompactStreamResponse:
+    status_code = 200
+    headers = {"content-type": "text/event-stream"}
+    content = _CompactStreamContent()
+
+
 class _TranscribeResponse:
     status_code = 200
     headers = {"content-type": "application/json"}
@@ -301,7 +316,7 @@ async def test_codex_control_request_uses_codex_client_when_route_is_resolved(ro
 
 @pytest.mark.asyncio
 async def test_compact_responses_uses_codex_client_when_route_is_resolved(route: ResolvedUpstreamRoute) -> None:
-    client = _CodexClient(_CompactResponse())
+    client = _CodexClient(_CompactStreamResponse())
     trace = UpstreamProxyRouteTrace()
     payload = ResponsesCompactRequest(model="gpt-5.2", instructions="Summarize.", input="hello")
 
@@ -321,6 +336,9 @@ async def test_compact_responses_uses_codex_client_when_route_is_resolved(route:
     assert client.calls[0]["url"].endswith("/backend-api/codex/responses")
     assert client.calls[0]["route"] is route
     assert client.calls[0]["json"]["model"] == "gpt-5.2"
+    assert client.calls[0]["json"]["store"] is False
+    assert client.calls[0]["json"]["stream"] is True
+    assert client.calls[0]["headers"]["Accept"] == "text/event-stream"
     assert trace.endpoint_id == "ep_1"
 
 

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -75,10 +75,11 @@ class _CompactStreamContent:
     async def iter_chunked(self, size: int):
         del size
         yield (
+            b'data: {"type":"response.output_item.done","output_index":0,'
+            b'"item":{"id":"msg_compact_1","type":"message","role":"assistant",'
+            b'"status":"completed","content":[{"type":"output_text","text":"enc_compact_1"}]}}\n\n'
             b'data: {"type":"response.completed","response":'
-            b'{"object":"response","id":"resp_compact_1","status":"completed",'
-            b'"output":[{"id":"cmp_1","type":"compaction_summary",'
-            b'"encrypted_content":"enc_compact_1"}]}}\n\n'
+            b'{"object":"response","id":"resp_compact_1","status":"completed","output":[]}}\n\n'
         )
 
 
@@ -336,7 +337,9 @@ async def test_compact_responses_uses_codex_client_when_route_is_resolved(route:
     assert response.object == "response.compaction"
     assert response.id == "resp_compact_1"
     assert response.model_extra == {
-        "output": [{"id": "cmp_1", "type": "compaction", "encrypted_content": "enc_compact_1"}]
+        "output": [
+            {"id": "msg_compact_1", "type": "compaction", "status": "completed", "encrypted_content": "enc_compact_1"}
+        ]
     }
     assert client.calls[0]["url"].endswith("/backend-api/codex/responses")
     assert client.calls[0]["route"] is route

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -76,7 +76,9 @@ class _CompactStreamContent:
         del size
         yield (
             b'data: {"type":"response.completed","response":'
-            b'{"object":"response.compact","id":"compact_1"}}\n\n'
+            b'{"object":"response","id":"resp_compact_1","status":"completed",'
+            b'"output":[{"id":"cmp_1","type":"compaction_summary",'
+            b'"encrypted_content":"enc_compact_1"}]}}\n\n'
         )
 
 
@@ -331,8 +333,11 @@ async def test_compact_responses_uses_codex_client_when_route_is_resolved(route:
         route_trace=trace,
     )
 
-    assert response.object == "response.compact"
-    assert response.id == "compact_1"
+    assert response.object == "response.compaction"
+    assert response.id == "resp_compact_1"
+    assert response.model_extra == {
+        "output": [{"id": "cmp_1", "type": "compaction", "encrypted_content": "enc_compact_1"}]
+    }
     assert client.calls[0]["url"].endswith("/backend-api/codex/responses")
     assert client.calls[0]["route"] is route
     assert client.calls[0]["json"]["model"] == "gpt-5.2"

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -318,7 +318,7 @@ async def test_compact_responses_uses_codex_client_when_route_is_resolved(route:
 
     assert response.object == "response.compact"
     assert response.id == "compact_1"
-    assert client.calls[0]["url"].endswith("/backend-api/codex/responses/compact")
+    assert client.calls[0]["url"].endswith("/backend-api/codex/responses")
     assert client.calls[0]["route"] is route
     assert client.calls[0]["json"]["model"] == "gpt-5.2"
     assert trace.endpoint_id == "ep_1"

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -82,7 +82,7 @@ class _CompactStreamContent:
 
 class _CompactStreamResponse:
     status_code = 200
-    headers = {"content-type": "text/event-stream"}
+    headers: dict[str, str] = {}
     content = _CompactStreamContent()
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10350,6 +10350,112 @@ async def test_compact_responses_defaults_to_no_configured_request_timeout(monke
     assert dumped["output"][0]["encrypted_content"] == "enc_summary_2"
 
 
+@pytest.mark.asyncio
+async def test_compact_responses_preserves_stream_idle_timeout_from_direct_sse(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 2.0
+        upstream_compact_timeout_seconds = 123.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        trace_channels = frozenset()
+
+    async def fake_compact_response_payload_from_success_response(*args: object, **kwargs: object) -> JsonValue:
+        del args, kwargs
+        raise proxy_module.StreamIdleTimeoutError()
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+    monkeypatch.setattr(
+        proxy_module,
+        "_compact_response_payload_from_success_response",
+        fake_compact_response_payload_from_success_response,
+    )
+
+    payload = proxy_module.ResponsesCompactRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+    session = _CompactSession(_compact_sse_response())
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await proxy_module.compact_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, session),
+        )
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 502
+    assert _proxy_error_code(exc) == "stream_idle_timeout"
+    assert _proxy_error_message(exc) == "Upstream stream idle timeout"
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_preserves_stream_event_too_large_from_routed_sse(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 2.0
+        upstream_compact_timeout_seconds = 123.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        trace_channels = frozenset()
+
+    oversized = proxy_module.StreamEventTooLargeError(4097, 1024)
+
+    async def fake_compact_response_payload_from_success_response(*args: object, **kwargs: object) -> JsonValue:
+        del args, kwargs
+        raise oversized
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+    monkeypatch.setattr(
+        proxy_module,
+        "_compact_response_payload_from_success_response",
+        fake_compact_response_payload_from_success_response,
+    )
+
+    route = ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="pool_compact",
+        endpoint=ResolvedProxyEndpoint("ep_compact", "http", "proxy.test", 8080),
+    )
+    codex_client = SimpleNamespace(
+        request_with_route_metadata=AsyncMock(
+            return_value=SimpleNamespace(
+                response=_compact_sse_response(),
+                route=route,
+                fallback_used=False,
+            )
+        )
+    )
+    payload = proxy_module.ResponsesCompactRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await proxy_module.compact_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, object()),
+            route=route,
+            codex_client=cast(proxy_module.CodexClient, codex_client),
+            allow_direct_egress=False,
+        )
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 502
+    assert _proxy_error_code(exc) == "stream_event_too_large"
+    assert _proxy_error_message(exc) == str(oversized)
+
+
 def test_sticky_key_for_responses_request_uses_bounded_cache_affinity():
     payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
     payload.prompt_cache_key = "thread_123"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -15,7 +15,7 @@ from contextlib import asynccontextmanager, suppress
 from copy import deepcopy
 from datetime import timedelta
 from types import SimpleNamespace
-from typing import Any, AsyncIterator, Iterator, Literal, Protocol, Self, cast
+from typing import Any, AsyncIterator, Iterator, Literal, Self, cast
 from unittest.mock import ANY, AsyncMock, MagicMock
 from unittest.mock import call as mock_call
 
@@ -5957,17 +5957,31 @@ class _JsonCompactResponse:
         return self._payload
 
 
+def _compact_sse_response(
+    *,
+    response_id: str = "resp_compact_1",
+    encrypted_content: str = "enc_summary_1",
+) -> "_SsePostResponse":
+    return _SsePostResponse(
+        [
+            (
+                b'data: {"type":"response.output_item.done","output_index":0,'
+                b'"item":{"id":"msg_compact_1","type":"message","role":"assistant",'
+                b'"status":"completed","content":[{"type":"output_text","text":"'
+                + encrypted_content.encode()
+                + b'"}]}}\n\n'
+            ),
+            (
+                b'data: {"type":"response.completed","response":{"object":"response","id":"'
+                + response_id.encode()
+                + b'","status":"completed","output":[]}}\n\n'
+            ),
+        ]
+    )
+
+
 class _CompactSession:
-    class _CompactResponseLike(Protocol):
-        status: int
-
-        async def __aenter__(self) -> Self: ...
-
-        async def __aexit__(self, exc_type: object | None, exc: BaseException | None, tb: object | None) -> bool: ...
-
-        async def json(self, *, content_type: str | None = None) -> dict[str, object]: ...
-
-    def __init__(self, response: _CompactResponseLike) -> None:
+    def __init__(self, response: object) -> None:
         self._response = response
         self.calls: list[dict[str, object]] = []
 
@@ -10034,6 +10048,8 @@ async def test_compact_responses_starts_upstream_timer_after_image_inlining(monk
         upstream_base_url = "https://chatgpt.com/backend-api"
         upstream_connect_timeout_seconds = 1.0
         upstream_compact_timeout_seconds = 12.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
         image_inline_fetch_enabled = True
         trace_channels = frozenset()
 
@@ -10062,11 +10078,7 @@ async def test_compact_responses_starts_upstream_timer_after_image_inlining(monk
     payload = proxy_module.ResponsesCompactRequest.model_validate(
         {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
     )
-    session = _CompactSession(
-        _JsonCompactResponse(
-            {"object": "response.compaction", "compaction_summary": {"encrypted_content": "enc_summary_1"}}
-        )
-    )
+    session = _CompactSession(_compact_sse_response(encrypted_content="enc_summary_1"))
 
     result = await proxy_module.compact_responses(
         payload,
@@ -10083,7 +10095,7 @@ async def test_compact_responses_starts_upstream_timer_after_image_inlining(monk
     assert timeout.sock_read == pytest.approx(6.5)
     dumped = result.model_dump(mode="json", exclude_none=True)
     assert dumped["object"] == "response.compaction"
-    assert dumped["compaction_summary"]["encrypted_content"] == "enc_summary_1"
+    assert dumped["output"][0]["encrypted_content"] == "enc_summary_1"
     assert recorded["started_at"] == 205.5
 
 
@@ -10093,6 +10105,8 @@ async def test_compact_responses_derives_lite_http_header_from_additional_tools(
         upstream_base_url = "https://chatgpt.com/backend-api"
         upstream_connect_timeout_seconds = 1.0
         upstream_compact_timeout_seconds = 12.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
         image_inline_fetch_enabled = False
         trace_channels = frozenset()
 
@@ -10129,11 +10143,7 @@ async def test_compact_responses_derives_lite_http_header_from_additional_tools(
             "reasoning": {"context": "turn", "effort": "high", "vendor_hint": 7},
         }
     )
-    session = _CompactSession(
-        _JsonCompactResponse(
-            {"object": "response.compaction", "compaction_summary": {"encrypted_content": "enc_summary_1"}}
-        )
-    )
+    session = _CompactSession(_compact_sse_response(encrypted_content="enc_summary_1"))
 
     await proxy_module.compact_responses(
         payload,
@@ -10224,11 +10234,14 @@ async def test_compact_responses_uses_configured_timeout_and_maps_read_timeout(m
         upstream_base_url = "https://chatgpt.com/backend-api"
         upstream_connect_timeout_seconds = 2.0
         upstream_compact_timeout_seconds = 123.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
         image_inline_fetch_enabled = False
         trace_channels = frozenset()
 
     class _TimeoutCompactResponse:
         status = 200
+        headers: dict[str, str] = {}
 
         async def __aenter__(self):
             return self
@@ -10236,8 +10249,13 @@ async def test_compact_responses_uses_configured_timeout_and_maps_read_timeout(m
         async def __aexit__(self, exc_type, exc, tb):
             return False
 
-        async def json(self, *, content_type=None):
-            raise proxy_module.aiohttp.SocketTimeoutError("Timeout on reading data from socket")
+        class _TimeoutContent:
+            async def iter_chunked(self, size: int):
+                del size
+                raise proxy_module.aiohttp.SocketTimeoutError("Timeout on reading data from socket")
+                yield b""
+
+        content = _TimeoutContent()
 
     monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
     monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
@@ -10274,6 +10292,8 @@ async def test_compact_responses_defaults_to_no_configured_request_timeout(monke
         upstream_base_url = "https://chatgpt.com/backend-api"
         upstream_connect_timeout_seconds = 2.0
         upstream_compact_timeout_seconds = None
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
         image_inline_fetch_enabled = False
         trace_channels = frozenset()
 
@@ -10284,11 +10304,7 @@ async def test_compact_responses_defaults_to_no_configured_request_timeout(monke
     payload = proxy_module.ResponsesCompactRequest.model_validate(
         {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
     )
-    session = _CompactSession(
-        _JsonCompactResponse(
-            {"object": "response.compaction", "compaction_summary": {"encrypted_content": "enc_summary_2"}}
-        )
-    )
+    session = _CompactSession(_compact_sse_response(response_id="resp_compact_2", encrypted_content="enc_summary_2"))
 
     result = await proxy_module.compact_responses(
         payload,
@@ -10305,7 +10321,7 @@ async def test_compact_responses_defaults_to_no_configured_request_timeout(monke
     assert timeout.sock_read is None
     dumped = result.model_dump(mode="json", exclude_none=True)
     assert dumped["object"] == "response.compaction"
-    assert dumped["compaction_summary"]["encrypted_content"] == "enc_summary_2"
+    assert dumped["output"][0]["encrypted_content"] == "enc_summary_2"
 
 
 def test_sticky_key_for_responses_request_uses_bounded_cache_affinity():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4827,6 +4827,32 @@ class _DummyResponse(proxy_module.SSEResponseProtocol):
         self.content = _DummyContent(chunks)
 
 
+@pytest.mark.asyncio
+async def test_compact_sse_terminal_error_preserves_error_envelope() -> None:
+    response = _DummyResponse(
+        [
+            (
+                b'data: {"type":"response.failed","response":{"status_code":400,'
+                b'"error":{"code":"previous_response_not_found","message":"missing anchor",'
+                b'"param":"previous_response_id"}}}\n\n'
+            )
+        ]
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await proxy_module._compact_response_payload_from_sse(
+            response,
+            idle_timeout_seconds=1.0,
+            max_event_bytes=4096,
+        )
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 400
+    assert _proxy_error_code(exc) == "previous_response_not_found"
+    assert _proxy_error_message(exc) == "missing anchor"
+    assert exc.payload["error"]["param"] == "previous_response_id"
+
+
 class _TranscribeResponse:
     def __init__(
         self,


### PR DESCRIPTION
## Summary

- route Codex remote compaction upstream calls to `/backend-api/codex/responses`
- keep codex-lb's public `/backend-api/codex/responses/compact` ingress unchanged
- update compact upstream path unit/integration tests

## Why

Live `codex-lb` saw upstream ChatGPT return `404 Not Found` for schema-valid compact calls sent to `POST https://chatgpt.com/backend-api/codex/responses/compact`.

Concrete live sample: request `93a9baaa-1a43-4580-a14f-62518b70a82f` recorded `upstream_status_code=404`, `error_code=upstream_error`, `error_message=Not Found`.

The current Codex client sends remote compaction through the normal Responses route with a terminal `compaction_trigger`; codex-lb already translates that ingress into a compact payload, so the upstream leg should use the surviving Responses endpoint.

## Validation

- `PYTHONFAULTHANDLER=1 uv run pytest -q tests/unit/test_codex_upstream_paths.py tests/integration/test_proxy_compact.py`
