### PR TITLE
fix(proxy): terminate suppressed duplicate tool-call replays

### DIFF
--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -921,11 +921,11 @@ class _StreamingMixin(_StreamingRetryMixin):
                         event_type,
                     ) = _facade()._build_rewritten_stream_response_failed_event(
                         response_id=response_id,
-                        error_code="stream_incomplete",
+                        error_code=_facade()._SUPPRESSED_DUPLICATE_TOOL_CALL_ERROR_CODE,
                         error_message=_facade()._SUPPRESSED_DUPLICATE_TOOL_CALL_MESSAGE,
                     )
                     status = "error"
-                    error_code = "stream_incomplete"
+                    error_code = _facade()._SUPPRESSED_DUPLICATE_TOOL_CALL_ERROR_CODE
                     error_message = _facade()._SUPPRESSED_DUPLICATE_TOOL_CALL_MESSAGE
                     settlement.record_success = False
                     settlement.account_health_error = False

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -1386,7 +1386,7 @@ def _rewrite_websocket_suppressed_duplicate_tool_call_completion_event(
     request_state: _WebSocketRequestState,
 ) -> tuple[OpenAIEvent | None, dict[str, JsonValue] | None, str | None, str]:
     rewritten_event_payload = response_failed_event(
-        "stream_incomplete",
+        _facade()._SUPPRESSED_DUPLICATE_TOOL_CALL_ERROR_CODE,
         _facade()._SUPPRESSED_DUPLICATE_TOOL_CALL_MESSAGE,
         error_type="server_error",
         response_id=_websocket_downstream_response_id(request_state),

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -5989,7 +5989,7 @@ class _WebSocketMixin:
                 "account_health_error_handled",
                 False,
             )
-        if request_state.suppressed_duplicate_tool_call and error_code == "stream_incomplete":
+        if request_state.suppressed_duplicate_tool_call:
             settlement.account_health_error = False
         if (
             error_code == "stream_incomplete"

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -876,6 +876,7 @@ _WEBSOCKET_AUTH_INVALIDATED_FAILURE_CODE = "account_auth_invalidated"
 _SUPPRESSED_DUPLICATE_TOOL_CALL_MESSAGE = (
     "Suppressed duplicate side-effect tool call; upstream response cannot be continued safely."
 )
+_SUPPRESSED_DUPLICATE_TOOL_CALL_ERROR_CODE = "duplicate_tool_call_replay_suppressed"
 _WEBSOCKET_PREVIOUS_RESPONSE_ACCOUNT_CACHE_LIMIT = 4096
 _WEBSOCKET_CONTINUITY_CACHE_LIMIT = 4096
 _SECURITY_WORK_AUTHORIZATION_REQUIRED_CODE = "security_work_authorization_required"

--- a/openspec/changes/report-suppressed-duplicate-tool-call-terminal/.openspec.yaml
+++ b/openspec/changes/report-suppressed-duplicate-tool-call-terminal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-20

--- a/openspec/changes/report-suppressed-duplicate-tool-call-terminal/proposal.md
+++ b/openspec/changes/report-suppressed-duplicate-tool-call-terminal/proposal.md
@@ -1,0 +1,14 @@
+# Report suppressed duplicate tool-call terminals
+
+## Why
+
+A duplicate side-effect tool-call replay cannot safely continue, but every
+transport still needs to settle the request and report the same retryable
+outcome.
+
+## What Changes
+
+- Emit a specific failed terminal instead of misclassifying the replay as an
+  incomplete upstream stream.
+- Keep settlement, durable operation persistence, and account-health fencing
+  aligned across direct SSE, the HTTP bridge, and WebSocket clients.

--- a/openspec/changes/report-suppressed-duplicate-tool-call-terminal/specs/responses-api-compat/spec.md
+++ b/openspec/changes/report-suppressed-duplicate-tool-call-terminal/specs/responses-api-compat/spec.md
@@ -1,0 +1,22 @@
+# responses-api-compat Delta
+
+## ADDED Requirements
+
+### Requirement: Suppressed duplicate side-effect replays receive a retryable terminal failure
+
+When a replayed side-effecting tool call is suppressed and its upstream turn subsequently reports `response.completed`, the proxy MUST deliver a `response.failed` terminal with code `duplicate_tool_call_replay_suppressed`; it MUST use the downstream response id, treat the request as non-success, persist a terminal durable HTTP-bridge operation when that transport is used, and MUST NOT penalize the upstream account for the intentionally fenced replay.
+
+#### Scenario: HTTP bridge client receives a terminal failure
+
+- **GIVEN** an HTTP bridge request suppresses a replayed side-effecting tool call
+- **WHEN** the upstream emits `response.completed` for that replay
+- **THEN** the client receives `response.failed` with code `duplicate_tool_call_replay_suppressed`
+- **AND** the bridge operation is terminal rather than left pending
+- **AND** the request is recorded as non-success
+
+#### Scenario: WebSocket and direct SSE have equivalent terminal semantics
+
+- **GIVEN** either a WebSocket or direct SSE request suppresses a replayed side-effecting tool call
+- **WHEN** the upstream emits `response.completed` for that replay
+- **THEN** the client receives the same `response.failed` code
+- **AND** the upstream account is not penalized for the intentionally suppressed replay

--- a/openspec/changes/report-suppressed-duplicate-tool-call-terminal/tasks.md
+++ b/openspec/changes/report-suppressed-duplicate-tool-call-terminal/tasks.md
@@ -1,0 +1,9 @@
+## 1. Implementation
+
+- [x] 1.1 Emit the explicit duplicate-tool-call replay failure from all terminal paths.
+- [x] 1.2 Preserve non-success settlement and account-health fencing.
+
+## 2. Validation
+
+- [x] 2.1 Run focused HTTP bridge and WebSocket regression tests.
+- [x] 2.2 Run strict OpenSpec validation.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -17138,10 +17138,10 @@ async def test_stream_responses_suppresses_contiguous_side_effect_replay_across_
     assert terminal_event["type"] == "response.failed"
     terminal_response = cast(dict[str, JsonValue], terminal_event["response"])
     terminal_error = cast(dict[str, JsonValue], terminal_response["error"])
-    assert terminal_error["code"] == "stream_incomplete"
+    assert terminal_error["code"] == "duplicate_tool_call_replay_suppressed"
     assert await service.drain_persistence_tasks(timeout_seconds=1)
     assert request_logs.calls[0]["status"] == "error"
-    assert request_logs.calls[0]["error_code"] == "stream_incomplete"
+    assert request_logs.calls[0]["error_code"] == "duplicate_tool_call_replay_suppressed"
 
 
 @pytest.mark.asyncio
@@ -44258,6 +44258,95 @@ async def test_http_bridge_tool_call_dedupe_survives_upstream_reconnect():
     assert forwarded_created is not None
     assert proxy_service.parse_sse_data_json(forwarded_created) == replay_created_payload
     assert event_queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_duplicate_tool_call_replay_emits_retryable_terminal_failure():
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req_bridge_duplicate_terminal",
+        model="gpt-5.1",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        response_id="resp_bridge_duplicate_terminal",
+        event_queue=asyncio.Queue(),
+        request_text='{"type":"response.create"}',
+        transport="http",
+    )
+    session = proxy_service._HTTPBridgeSession(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "bridge-duplicate-terminal", None),
+        headers={},
+        affinity=proxy_service._AffinityPolicy(),
+        request_model="gpt-5.1",
+        account=_make_account("acc_bridge_duplicate_terminal"),
+        upstream=AsyncMock(),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque([request_state]),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=0.0,
+        idle_ttl_seconds=30.0,
+    )
+    cast(Any, session.upstream).archive_received = MagicMock()
+    tool_payload = {
+        "type": "response.output_item.done",
+        "response_id": "resp_bridge_duplicate_terminal",
+        "item": {
+            "type": "function_call",
+            "name": "write_stdin",
+            "arguments": json.dumps({"session_id": 75180, "chars": ""}),
+            "call_id": "call_first",
+        },
+    }
+    replay_payload = {
+        **tool_payload,
+        "response_id": "resp_bridge_duplicate_terminal_replay",
+        "item": {**tool_payload["item"], "call_id": "call_replayed"},
+    }
+    replay_created_payload = {
+        "type": "response.created",
+        "response": {"id": "resp_bridge_duplicate_terminal_replay", "status": "in_progress"},
+    }
+    completed_payload = {
+        "type": "response.completed",
+        "response": {"id": "resp_bridge_duplicate_terminal_replay", "status": "completed", "output": []},
+    }
+
+    await service._process_http_bridge_upstream_text(session, json.dumps(tool_payload, separators=(",", ":")))
+    session.upstream_control = proxy_service._WebSocketUpstreamControl()
+    request_state.awaiting_response_created = True
+    request_state.response_id = None
+    await service._process_http_bridge_upstream_text(session, json.dumps(replay_created_payload, separators=(",", ":")))
+    await service._process_http_bridge_upstream_text(session, json.dumps(replay_payload, separators=(",", ":")))
+    await service._process_http_bridge_upstream_text(session, json.dumps(completed_payload, separators=(",", ":")))
+
+    event_queue = request_state.event_queue
+    assert event_queue is not None
+    first = await event_queue.get()
+    created = await event_queue.get()
+    terminal_block = await event_queue.get()
+    assert isinstance(first, str)
+    assert isinstance(created, str)
+    assert isinstance(terminal_block, str)
+    assert proxy_service.parse_sse_data_json(first) == tool_payload
+    assert proxy_service.parse_sse_data_json(created) == replay_created_payload
+    terminal = proxy_service.parse_sse_data_json(terminal_block)
+    assert isinstance(terminal, dict)
+    assert terminal["type"] == "response.failed"
+    terminal_response = terminal["response"]
+    assert isinstance(terminal_response, dict)
+    terminal_error = terminal_response["error"]
+    assert isinstance(terminal_error, dict)
+    assert terminal_error["code"] == "duplicate_tool_call_replay_suppressed"
+    assert await event_queue.get() is None
+    assert request_state.error_http_status_override == 502
+    assert session.upstream_control.reconnect_requested is True
+    assert await service.drain_persistence_tasks(timeout_seconds=1)
+    assert request_logs.calls[-1]["status"] == "error"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes duplicate same-response tool-call replay handling without leaving clients nonterminal. Suppressed duplicates now receive `response.failed` with `duplicate_tool_call_replay_suppressed` across direct SSE, HTTP bridge, and WebSocket; persistence, settlement, reconnect, and account health remain coherent. The unrelated `shell_command` dedupe expansion was removed from this PR as requested in review.\n\nValidation: 25 focused tests, ruff, ty, strict OpenSpec validation, and scope gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replay validation to prevent requests from being sent through an incorrect account.
  * Duplicate tool-call replays now return a clear `response.failed` result with a dedicated error code.
  * Preserved request completion, operation persistence, and reconnect behavior across supported transport types.
  * Prevented suppressed duplicate replays from incorrectly affecting account health.
* **Tests**
  * Added regression coverage for duplicate tool-call replay handling over HTTP bridge, WebSocket, and SSE.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->