### PR TITLE
fix(dashboard): pin web asset MIME types against poisoned OS registries

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import mimetypes
 import os
 import stat
 import sys
@@ -108,6 +109,32 @@ from app.modules.usage.additional_quota_keys import reload_additional_quota_regi
 from app.modules.usage.live_ingest import start_live_usage_ingestor, stop_live_usage_ingestor
 
 logger = logging.getLogger(__name__)
+
+# On Windows, ``mimetypes`` merges HKCR registry mappings where third-party
+# software commonly remaps web extensions (``.js`` -> ``text/plain``), and
+# browsers enforce strict MIME checking for ES module scripts, so a poisoned
+# mapping renders the dashboard as a blank page (issue #1698). ``FileResponse``
+# resolves ``media_type`` through ``mimetypes.guess_type``, so pin every
+# extension the built dashboard serves; ``add_type`` wins over the merged
+# registry table on all platforms.
+_WEB_ASSET_MIME_TYPES: dict[str, str] = {
+    ".js": "text/javascript",
+    ".mjs": "text/javascript",
+    ".css": "text/css",
+    ".svg": "image/svg+xml",
+    ".json": "application/json",
+    ".woff2": "font/woff2",
+    ".woff": "font/woff",
+    ".html": "text/html",
+}
+
+
+def _ensure_web_asset_mime_types() -> None:
+    for extension, mime_type in _WEB_ASSET_MIME_TYPES.items():
+        mimetypes.add_type(mime_type, extension)
+
+
+_ensure_web_asset_mime_types()
 
 
 def _log_abandoned_lease_release(task: asyncio.Task[None]) -> None:

--- a/openspec/changes/fix-windows-asset-mime-types/proposal.md
+++ b/openspec/changes/fix-windows-asset-mime-types/proposal.md
@@ -1,0 +1,18 @@
+## Why
+
+On Windows, Python's `mimetypes` merges file-type mappings from the `HKCR` registry, where third-party software commonly remaps web extensions (`.js` → `text/plain`). Starlette's `FileResponse` resolves `media_type` through `mimetypes.guess_type`, and browsers enforce strict MIME checking for ES module scripts, so on such machines every `/assets/*.js` response ships as `text/plain` and the dashboard renders as a blank page (issue #1698). macOS/Linux use the built-in table and never hit this.
+
+## What Changes
+
+- Pin the MIME type of every extension the built dashboard serves (`.js`, `.mjs`, `.css`, `.svg`, `.json`, `.woff`, `.woff2`, `.html`) via `mimetypes.add_type` at application import, which overrides the merged registry table on all platforms.
+- No behavior change on platforms whose default table is already correct — the pinned values equal the stdlib defaults.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `frontend-architecture`: Dashboard delivery additionally guarantees correct web MIME types independent of the host OS's `mimetypes` registry state.

--- a/openspec/changes/fix-windows-asset-mime-types/specs/frontend-architecture/spec.md
+++ b/openspec/changes/fix-windows-asset-mime-types/specs/frontend-architecture/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: Dashboard serving is compressed, cache-correct, and chart-lazy
+
+Dashboard API and static-asset responses MUST be served gzip-compressed when the client accepts it, while proxy paths MUST NOT pass through a compressing wrapper. Content-hashed assets under `/assets/` MUST be served with immutable year-long `Cache-Control`; `index.html` MUST remain `no-cache`. Chart vendor code MUST NOT load before first paint: it MUST live in an async-only chunk that is neither statically imported by the entry chunk nor modulepreloaded. Static assets MUST be served with their correct web MIME types (`.js`/`.mjs` as `text/javascript`, `.css` as `text/css`, `.svg` as `image/svg+xml`, `.json` as `application/json`, `.woff`/`.woff2` as `font/woff`/`font/woff2`, `.html` as `text/html`) regardless of the host operating system's `mimetypes` registry state, so strict browser MIME checking never rejects dashboard module scripts.
+
+#### Scenario: Assets are compressed and immutable
+
+- **WHEN** a browser requests a hashed asset under `/assets/` with `Accept-Encoding: gzip`
+- **THEN** the response is gzip-encoded
+- **AND** carries `Cache-Control: public, max-age=31536000, immutable`
+
+#### Scenario: index.html stays fresh across deploys
+
+- **WHEN** the SPA shell is requested
+- **THEN** the response carries `Cache-Control: no-cache`
+
+#### Scenario: Proxy streaming paths are never compressed by the dashboard wrapper
+
+- **WHEN** a request targets a proxy path (`/backend-api/*`, `/v1/*`)
+- **THEN** the dashboard gzip middleware passes it through untouched
+
+#### Scenario: Ranged asset requests bypass compression
+
+- **WHEN** an asset request carries a `Range` header
+- **THEN** the response is served uncompressed with a valid 206 `Content-Range` over unencoded bytes
+
+#### Scenario: Chart vendor code loads lazily
+
+- **WHEN** the built dashboard entry page loads
+- **THEN** the recharts chunk is not statically imported by the entry chunk and not modulepreloaded
+- **AND** charts render correctly once their async chunk loads
+
+#### Scenario: Module scripts survive a poisoned OS MIME registry
+
+- **GIVEN** the host operating system maps `.js` to `text/plain` in its `mimetypes` sources (e.g. Windows `HKCR` registry entries)
+- **WHEN** a browser requests a hashed `.js` asset under `/assets/`
+- **THEN** the response `Content-Type` is `text/javascript`
+- **AND** the dashboard SPA boots instead of failing strict module MIME checking

--- a/openspec/changes/fix-windows-asset-mime-types/tasks.md
+++ b/openspec/changes/fix-windows-asset-mime-types/tasks.md
@@ -1,0 +1,12 @@
+## 1. Fix
+
+- [x] 1.1 Register `mimetypes.add_type` overrides for all dashboard asset extensions at `app/main.py` import, before any `FileResponse` is constructed
+
+## 2. Tests
+
+- [x] 2.1 Route-level regression: with a poisoned `.js -> text/plain` mapping re-registered over, `GET /assets/*.js` serves `text/javascript` (the externally failing product path from issue #1698)
+- [x] 2.2 Unit: `_ensure_web_asset_mime_types()` restores every pinned extension after simulated registry poisoning
+
+## 3. Spec
+
+- [x] 3.1 Extend the `frontend-architecture` dashboard-delivery requirement with MIME-type correctness independent of the OS registry

--- a/tests/integration/test_health_and_errors.py
+++ b/tests/integration/test_health_and_errors.py
@@ -98,3 +98,50 @@ async def test_missing_static_asset_returns_not_found(async_client):
     assert response.status_code == 404
     assert response.json()["detail"] == "Not Found"
     assert response.headers["X-App-Version"] == __version__
+
+
+def test_ensure_web_asset_mime_types_overrides_poisoned_registry():
+    """Simulates the Windows HKCR poisoning from issue #1698.
+
+    ``mimetypes.add_type`` mutates the global table, so this test re-runs the
+    startup registration after poisoning and leaves the correct mappings in
+    place for the rest of the suite.
+    """
+    import mimetypes
+
+    from app.main import _WEB_ASSET_MIME_TYPES, _ensure_web_asset_mime_types
+
+    for extension in _WEB_ASSET_MIME_TYPES:
+        mimetypes.add_type("text/plain", extension)
+    assert mimetypes.guess_type("x.js")[0] == "text/plain"
+
+    _ensure_web_asset_mime_types()
+
+    for extension, expected in _WEB_ASSET_MIME_TYPES.items():
+        assert mimetypes.guess_type(f"x{extension}")[0] == expected, extension
+
+
+@pytest.mark.asyncio
+async def test_assets_js_served_as_javascript_despite_poisoned_registry(async_client):
+    """Product-path regression for issue #1698: /assets/*.js must serve
+    text/javascript even when the OS mimetypes sources map .js to text/plain,
+    or strict browser MIME checking rejects every dashboard module script."""
+    import mimetypes
+
+    from app.main import _ensure_web_asset_mime_types
+
+    asset_name = next(
+        (candidate.name for candidate in sorted((_STATIC_DIR / "assets").glob("*.js"))),
+        None,
+    )
+    assert asset_name is not None, "built dashboard assets missing; run cd frontend && bun run build"
+
+    mimetypes.add_type("text/plain", ".js")
+    try:
+        _ensure_web_asset_mime_types()
+        response = await async_client.get(f"/assets/{asset_name}")
+    finally:
+        _ensure_web_asset_mime_types()
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/javascript")


### PR DESCRIPTION
## Summary

Fixes #1698. On Windows, Python's `mimetypes` merges `HKCR` registry mappings where third-party software commonly remaps `.js` → `text/plain`. Starlette's `FileResponse` resolves `media_type` through `mimetypes.guess_type`, and browsers enforce strict MIME checking for ES module scripts — so every `/assets/*.js` ships as `text/plain` and the dashboard renders a blank page. macOS/Linux use the stdlib table and never hit it.

The fix registers `mimetypes.add_type` overrides for every extension the built dashboard serves (`.js .mjs .css .svg .json .woff .woff2 .html`) at `app/main.py` import, before any `FileResponse` is constructed. `add_type` wins over the merged registry table on all platforms, and the pinned values equal stdlib defaults elsewhere, so this is a strict no-op outside the poisoned case.

## OpenSpec

`openspec/changes/fix-windows-asset-mime-types/` — extends the `frontend-architecture` dashboard-delivery requirement with MIME correctness independent of OS registry state, plus a poisoned-registry scenario. Validation passes.

## Tests

- Product-path regression: poison `.js → text/plain`, re-run startup registration, `GET /assets/<real hash>.js` → `Content-Type: text/javascript` (this is exactly the externally failing path from the issue).
- Unit: `_ensure_web_asset_mime_types()` restores every pinned extension after poisoning.

No new settings; zero-config (simplicity gates N/A beyond that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)