### PR TITLE
fix(proxy): fence clean-close bridge replacements

### DIFF
--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -1549,11 +1549,13 @@ class _HTTPBridgeMixin(
                 await _raise_if_http_bridge_creation_superseded(self, key, inflight_future=inflight_future)
                 await self._claim_durable_http_bridge_session(
                     created_session,
-                    allow_takeover=_http_bridge_claim_allows_takeover(
-                        durable_lookup,
-                        force=force_durable_takeover,
+                    allow_takeover=(
+                        _http_bridge_claim_allows_takeover(
+                            durable_lookup,
+                            force=force_durable_takeover,
+                        )
+                        and (force_durable_takeover or not unrepresented_current_owner)
                     ),
-                    and (force_durable_takeover or not unrepresented_current_owner),
                     force_owner_epoch_advance=force_durable_takeover or unrepresented_current_owner,
                     # restart_takeover means recovering a row whose previous
                     # owner is genuinely gone. Every claim now advances the

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -513,7 +513,17 @@ class _HTTPBridgeMixin(
             continuity_error: ProxyResponseError | None = None
             owner_mismatch_error: ProxyResponseError | None = None
             owner_forward: _HTTPBridgeOwnerForward | None = None
-            force_durable_takeover = force_durable_takeover_after_detach
+            # A retiring reader removes its session from the local registry
+            # before durable release finishes. If the next request reaches
+            # creation in that window, there is no local object left to set
+            # ``force_durable_takeover_after_detach`` even though the durable
+            # row still represents the detached generation. Advance the epoch
+            # for that fresh local replacement so the late release is fenced.
+            unrepresented_current_owner = (
+                durable_lookup is not None
+                and durable_lookup.owner_instance_id == settings.http_responses_session_bridge_instance_id
+            )
+            force_durable_takeover = force_durable_takeover_after_detach or unrepresented_current_owner
             missing_turn_state_alias = False
             sessions_to_close_before_create: list[_HTTPBridgeSession] = []
             session_to_return_after_close: _HTTPBridgeSession | None = None

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -523,7 +523,7 @@ class _HTTPBridgeMixin(
                 durable_lookup is not None
                 and durable_lookup.owner_instance_id == settings.http_responses_session_bridge_instance_id
             )
-            force_durable_takeover = force_durable_takeover_after_detach or unrepresented_current_owner
+            force_durable_takeover = force_durable_takeover_after_detach
             missing_turn_state_alias = False
             sessions_to_close_before_create: list[_HTTPBridgeSession] = []
             session_to_return_after_close: _HTTPBridgeSession | None = None
@@ -1544,7 +1544,7 @@ class _HTTPBridgeMixin(
                         durable_lookup,
                         force=force_durable_takeover,
                     ),
-                    force_owner_epoch_advance=force_durable_takeover,
+                    force_owner_epoch_advance=force_durable_takeover or unrepresented_current_owner,
                     # restart_takeover means recovering a row whose previous
                     # owner is genuinely gone. Every claim now advances the
                     # epoch, so epoch > 1 alone would also count ordinary

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -437,6 +437,10 @@ class _HTTPBridgeMixin(
         model_transition_rebind = bool(
             durable_lookup is not None and not _http_bridge_models_compatible(durable_lookup.model, request_model)
         )
+        durable_lookup_owned_by_current_instance = bool(
+            durable_lookup is not None
+            and durable_lookup.owner_instance_id == settings.http_responses_session_bridge_instance_id
+        )
         if model_transition_rebind:
             durable_lookup = None
         if await _http_bridge_should_wait_for_registration(self, key, settings):
@@ -519,7 +523,7 @@ class _HTTPBridgeMixin(
             # ``force_durable_takeover_after_detach`` even though the durable
             # row still represents the detached generation. Advance the epoch
             # for that fresh local replacement so the late release is fenced.
-            unrepresented_current_owner = (
+            unrepresented_current_owner = durable_lookup_owned_by_current_instance or (
                 durable_lookup is not None
                 and durable_lookup.owner_instance_id == settings.http_responses_session_bridge_instance_id
             )
@@ -719,6 +723,7 @@ class _HTTPBridgeMixin(
                     model_transition_parent_key = key
                     key = fork_key
                     durable_lookup = None
+                    durable_lookup_owned_by_current_instance = False
                     force_durable_takeover_after_detach = False
                     locally_owned_fork_key = _http_bridge_locally_owned_fork_key(
                         fork_key, forwarded_request, forwarded_original_request_unanchored
@@ -1440,6 +1445,7 @@ class _HTTPBridgeMixin(
                     bind_account_neutral_recovery_owner(session)
                     model_transition_parent_key, key = key, fork_key
                     durable_lookup = None
+                    durable_lookup_owned_by_current_instance = False
                     force_durable_takeover_after_detach = False
                     locally_owned_fork_key = _http_bridge_locally_owned_fork_key(
                         fork_key, forwarded_request, forwarded_original_request_unanchored
@@ -1544,6 +1550,7 @@ class _HTTPBridgeMixin(
                         durable_lookup,
                         force=force_durable_takeover,
                     ),
+                    and (force_durable_takeover or not unrepresented_current_owner),
                     force_owner_epoch_advance=force_durable_takeover or unrepresented_current_owner,
                     # restart_takeover means recovering a row whose previous
                     # owner is genuinely gone. Every claim now advances the

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -349,6 +349,7 @@ class _HTTPBridgeMixin(
         allow_previous_response_recovery_rebind: bool = False,
         allow_bootstrap_owner_rebind: bool = False,
         durable_lookup: DurableBridgeLookup | None = None,
+        durable_model_transition_owned_by_current_instance: bool = False,
         request_stage: str = "first_turn",
         preferred_account_id: str | None = None,
         preferred_account_has_continuity_provenance: bool = False,
@@ -382,6 +383,7 @@ class _HTTPBridgeMixin(
         allow_previous_response_recovery_rebind: bool = False,
         allow_bootstrap_owner_rebind: bool = False,
         durable_lookup: DurableBridgeLookup | None = None,
+        durable_model_transition_owned_by_current_instance: bool = False,
         request_stage: str = "first_turn",
         preferred_account_id: str | None = None,
         preferred_account_has_continuity_provenance: bool = False,
@@ -414,6 +416,7 @@ class _HTTPBridgeMixin(
         allow_previous_response_recovery_rebind: bool = False,
         allow_bootstrap_owner_rebind: bool = False,
         durable_lookup: DurableBridgeLookup | None = None,
+        durable_model_transition_owned_by_current_instance: bool = False,
         request_stage: str = "first_turn",
         preferred_account_id: str | None = None,
         preferred_account_has_continuity_provenance: bool = False,
@@ -437,7 +440,7 @@ class _HTTPBridgeMixin(
         model_transition_rebind = bool(
             durable_lookup is not None and not _http_bridge_models_compatible(durable_lookup.model, request_model)
         )
-        durable_lookup_owned_by_current_instance = bool(
+        durable_lookup_owned_by_current_instance = durable_model_transition_owned_by_current_instance or bool(
             durable_lookup is not None
             and durable_lookup.owner_instance_id == settings.http_responses_session_bridge_instance_id
         )

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -1511,6 +1511,11 @@ class _HTTPBridgeStreamingMixin:
                 and durable_model_transition_lookup.latest_turn_state is not None
             )
         )
+        durable_model_transition_owned_by_current_instance = bool(
+            durable_model_transition_lookup is not None
+            and durable_model_transition_lookup.owner_instance_id
+            == _service_get_settings().http_responses_session_bridge_instance_id
+        )
         if durable_model_transition_lookup is not None:
             _log_http_bridge_event(
                 "model_transition_isolated",
@@ -1533,6 +1538,7 @@ class _HTTPBridgeStreamingMixin:
                     bridge_session_key.api_key_id,
                 )
                 force_local_recovery_creation = True
+                durable_model_transition_owned_by_current_instance = False
             durable_lookup = None
             dead_owner_anchor = False
         if durable_lookup is not None:
@@ -2061,6 +2067,9 @@ class _HTTPBridgeStreamingMixin:
                     forwarded_affinity_kind=forwarded_affinity_kind,
                     forwarded_affinity_key=forwarded_affinity_key,
                     durable_lookup=durable_lookup,
+                    durable_model_transition_owned_by_current_instance=(
+                        durable_model_transition_owned_by_current_instance
+                    ),
                     request_stage=request_state.request_stage,
                     preferred_account_id=request_state.preferred_account_id,
                     preferred_account_has_continuity_provenance=preferred_account_has_continuity_provenance,
@@ -2330,6 +2339,9 @@ class _HTTPBridgeStreamingMixin:
                                 and not owner_forward_fresh_replay
                             ),
                             durable_lookup=durable_lookup,
+                            durable_model_transition_owned_by_current_instance=(
+                                durable_model_transition_owned_by_current_instance
+                            ),
                             request_stage=(
                                 request_state.request_stage
                                 if owner_forward_fresh_replay
@@ -2950,6 +2962,9 @@ class _HTTPBridgeStreamingMixin:
                             forwarded_request=forwarded_request,
                             forwarded_original_request_unanchored=original_request_unanchored,
                             durable_lookup=durable_lookup,
+                            durable_model_transition_owned_by_current_instance=(
+                                durable_model_transition_owned_by_current_instance
+                            ),
                             request_stage=request_state.request_stage,
                             preferred_account_id=replacement_preferred_account_id,
                             preferred_account_has_continuity_provenance=preferred_account_has_continuity_provenance,
@@ -3313,6 +3328,9 @@ class _HTTPBridgeStreamingMixin:
                             allow_previous_response_recovery_rebind=allow_previous_response_recovery_rebind,
                             session_header_fallback_key=session_header_fallback_key,
                             durable_lookup=durable_lookup,
+                            durable_model_transition_owned_by_current_instance=(
+                                durable_model_transition_owned_by_current_instance
+                            ),
                             request_stage=retry_request_stage,
                             preferred_account_id=retry_preferred_account_id,
                             preferred_account_has_continuity_provenance=preferred_account_has_continuity_provenance,

--- a/openspec/changes/fence-clean-close-local-replacement/.openspec.yaml
+++ b/openspec/changes/fence-clean-close-local-replacement/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/fence-clean-close-local-replacement/proposal.md
+++ b/openspec/changes/fence-clean-close-local-replacement/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+An HTTP Responses bridge can receive `response.completed` and then observe a
+clean upstream WebSocket close while the next request for the same soft
+affinity key is starting. The retiring session is removed from the local
+registry before its durable release completes. A replacement created in that
+window can reuse the same durable owner epoch, allowing the retiring session's
+late fenced release to clear the replacement's ownership and produce an
+intermittent `bridge_instance_mismatch` response on a single instance.
+
+## What Changes
+
+- Treat a durable row owned by the current instance without a reusable local
+  session as a local replacement boundary.
+- Advance the durable owner epoch before publishing that fresh local session,
+  so cleanup from the detached generation is fenced out.
+- Add deterministic integration and repository-level regression coverage for
+  clean-close replacement overlapping a late durable release.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `responses-api-compat`
+
+## Impact
+
+- **Code:** HTTP bridge session creation and durable-ownership claim behavior.
+- **API:** no schema changes; the second request remains successful instead of
+  intermittently returning HTTP 409 on a single-instance clean-close rollover.
+- **Persistence:** replacement claims advance the existing durable owner epoch;
+  no migration is required.

--- a/openspec/changes/fence-clean-close-local-replacement/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fence-clean-close-local-replacement/specs/responses-api-compat/spec.md
@@ -30,6 +30,16 @@ existing owner-forwarding or mismatch behavior.
 - **WHEN** another compatible request reuses that session
 - **THEN** the durable owner epoch is not advanced solely because of reuse
 
+#### Scenario: model transition preserves the detached local generation fence
+
+- **GIVEN** a durable row still names the current instance after its local
+  generation has detached
+- **AND** the replacement request selects a model incompatible with that row
+- **WHEN** model filtering discards the durable lookup before session creation
+- **THEN** the replacement claim still advances the durable owner epoch
+- **AND** a delayed release from the previous model generation cannot clear the
+  replacement row
+
 #### Scenario: a live remote owner remains protected
 
 - **GIVEN** a durable bridge row has an unexpired lease owned by another live

--- a/openspec/changes/fence-clean-close-local-replacement/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fence-clean-close-local-replacement/specs/responses-api-compat/spec.md
@@ -34,6 +34,9 @@ existing owner-forwarding or mismatch behavior.
 
 - **GIVEN** a durable bridge row has an unexpired lease owned by another live
   instance
-- **WHEN** this instance cannot reuse a local session for that key
-- **THEN** it does not advance or take over the remote owner's epoch without
-  the existing takeover authorization
+- **AND** this instance previously observed its own detached generation before
+  the remote owner claimed the row
+- **WHEN** this instance attempts the local replacement claim
+- **THEN** it revalidates the owner under the durable row lock
+- **AND** it does not advance or take over the remote owner's epoch without the
+  existing takeover authorization

--- a/openspec/changes/fence-clean-close-local-replacement/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fence-clean-close-local-replacement/specs/responses-api-compat/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Fresh local bridge replacements fence detached generations
+
+When an HTTP Responses bridge creates a fresh local session for a durable key
+whose active row still names the current instance, and no reusable local
+session represents that durable generation, the replacement claim MUST advance
+the durable owner epoch before the replacement is published. A release from
+the detached local generation MUST be fenced out and MUST NOT clear the
+replacement's owner, lease, active state, or continuity anchors.
+
+Ordinary reuse of a registered local session MUST NOT advance the owner epoch,
+and an active row owned by another live instance MUST continue to follow the
+existing owner-forwarding or mismatch behavior.
+
+#### Scenario: clean-close replacement survives a late local release
+
+- **GIVEN** a local HTTP bridge session has delivered `response.completed`
+- **AND** its upstream WebSocket then closes cleanly
+- **AND** retirement detaches that session before its durable release completes
+- **WHEN** the next request creates a replacement for the same durable key
+- **THEN** the replacement claim advances the durable owner epoch
+- **AND** the detached generation's late release is fenced out
+- **AND** the next request does not receive `bridge_instance_mismatch`
+
+#### Scenario: registered local reuse keeps its generation
+
+- **GIVEN** the durable row and a reusable registered local session represent
+  the same current owner generation
+- **WHEN** another compatible request reuses that session
+- **THEN** the durable owner epoch is not advanced solely because of reuse
+
+#### Scenario: a live remote owner remains protected
+
+- **GIVEN** a durable bridge row has an unexpired lease owned by another live
+  instance
+- **WHEN** this instance cannot reuse a local session for that key
+- **THEN** it does not advance or take over the remote owner's epoch without
+  the existing takeover authorization

--- a/openspec/changes/fence-clean-close-local-replacement/tasks.md
+++ b/openspec/changes/fence-clean-close-local-replacement/tasks.md
@@ -1,0 +1,19 @@
+## 1. Durable replacement contract
+
+- [x] 1.1 Advance the durable owner epoch when a fresh local session replaces
+  an unrepresented durable generation owned by the current instance.
+- [x] 1.2 Preserve ordinary local reuse and cross-instance ownership checks.
+
+## 2. Regression coverage
+
+- [x] 2.1 Add a deterministic product-path test that overlaps clean-close
+  retirement with replacement creation and proves the second request succeeds.
+- [x] 2.2 Add focused ownership coverage proving the detached generation's
+  late release cannot clear the replacement owner.
+
+## 3. Verification
+
+- [x] 3.1 Run the focused HTTP bridge integration and durable-session tests
+  repeatedly.
+- [ ] 3.2 Run strict OpenSpec validation and the relevant lint/type/local CI
+  gates.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -7062,7 +7062,11 @@ async def test_v1_responses_http_bridge_does_not_register_turn_state_alias_befor
 
 
 @pytest.mark.asyncio
-async def test_v1_responses_http_bridge_reconnects_after_clean_upstream_close(async_client, monkeypatch):
+async def test_v1_responses_http_bridge_reconnects_after_clean_upstream_close(
+    async_client,
+    app_instance,
+    monkeypatch,
+):
     # The app lifespan registers the process hostname in the durable bridge
     # ring before this test installs its settings. Keep the test on that same
     # instance so the startup heartbeat cannot make the reconnect path look
@@ -7074,6 +7078,37 @@ async def test_v1_responses_http_bridge_reconnects_after_clean_upstream_close(as
     second_upstream = _FakeBridgeUpstreamWebSocket()
     upstreams = [first_upstream, second_upstream]
     connect_count = 0
+    service = get_proxy_service_for_app(app_instance)
+    release_started = asyncio.Event()
+    allow_release = asyncio.Event()
+    release_finished = asyncio.Event()
+    replacement_claimed = asyncio.Event()
+    claim_count = 0
+    released_lookup = None
+    original_claim_live_session = service._durable_bridge.claim_live_session
+    original_release_live_session = service._durable_bridge.release_live_session
+
+    async def overlap_replacement_claim_with_release(*args, **kwargs):
+        nonlocal claim_count
+        claim_count += 1
+        lookup = await original_claim_live_session(*args, **kwargs)
+        if claim_count == 2:
+            replacement_claimed.set()
+            await _wait_for_event(release_finished)
+            assert released_lookup is not None
+            # Model the repository refresh that can observe the concurrent
+            # release after the replacement commit. The returned owner must
+            # still be the replacement generation.
+            return released_lookup
+        return lookup
+
+    async def pause_retiring_release(*args, **kwargs):
+        nonlocal released_lookup
+        release_started.set()
+        await _wait_for_event(allow_release)
+        released_lookup = await original_release_live_session(*args, **kwargs)
+        release_finished.set()
+        return released_lookup
 
     async def fake_select_account_with_budget(
         self,
@@ -7138,6 +7173,8 @@ async def test_v1_responses_http_bridge_reconnects_after_clean_upstream_close(as
     monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
     monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
     monkeypatch.setattr(proxy_module, "core_stream_responses", fail_legacy_stream)
+    monkeypatch.setattr(service._durable_bridge, "claim_live_session", overlap_replacement_claim_with_release)
+    monkeypatch.setattr(service._durable_bridge, "release_live_session", pause_retiring_release)
 
     payload = {
         "model": "gpt-5.1",
@@ -7149,13 +7186,19 @@ async def test_v1_responses_http_bridge_reconnects_after_clean_upstream_close(as
         "prompt_cache_key": f"http-bridge-reconnect-thread-{account_id}",
     }
     first = await asyncio.wait_for(async_client.post("/v1/responses", json=payload), timeout=_TEST_SYNC_TIMEOUT_SECONDS)
-    second = await asyncio.wait_for(
-        async_client.post("/v1/responses", json=payload), timeout=_TEST_SYNC_TIMEOUT_SECONDS
-    )
+    await _wait_for_event(release_started)
+    second_task = asyncio.create_task(async_client.post("/v1/responses", json=payload))
+    await _wait_for_event(replacement_claimed)
+    allow_release.set()
+    second = await asyncio.wait_for(second_task, timeout=_TEST_SYNC_TIMEOUT_SECONDS)
 
     assert first.status_code == 200
     assert second.status_code == 200
+    assert claim_count == 2
     assert connect_count == 2
+    assert released_lookup is not None
+    assert released_lookup.owner_instance_id == socket.gethostname()
+    assert released_lookup.owner_epoch == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -1659,6 +1659,60 @@ async def test_durable_bridge_forced_generation_advance_fences_same_account_stal
 
 
 @pytest.mark.asyncio
+async def test_durable_bridge_forced_local_advance_does_not_take_over_new_remote_owner(
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    local = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-local-replacement-race",
+        api_key_id=None,
+        instance_id="instance-a",
+        owner_process_epoch="process-a",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="http_turn_1",
+        latest_response_id="resp_1",
+        allow_takeover=True,
+    )
+    remote = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-local-replacement-race",
+        api_key_id=None,
+        instance_id="instance-b",
+        owner_process_epoch="process-b",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="http_turn_1",
+        latest_response_id="resp_1",
+        allow_takeover=True,
+    )
+
+    stale_local_replacement = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-local-replacement-race",
+        api_key_id=None,
+        instance_id="instance-a",
+        owner_process_epoch="process-a",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="http_turn_1",
+        latest_response_id="resp_1",
+        allow_takeover=False,
+        force_owner_epoch_advance=True,
+    )
+
+    assert remote.owner_epoch == local.owner_epoch + 1
+    assert stale_local_replacement.owner_instance_id == "instance-b"
+    assert stale_local_replacement.owner_epoch == remote.owner_epoch
+
+
+@pytest.mark.asyncio
 async def test_durable_bridge_clear_response_anchor_nulls_anchor_fields_but_keeps_turn_state(
     coordinator: DurableBridgeSessionCoordinator,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -5147,7 +5147,16 @@ async def test_http_bridge_upstream_non_text_archives_with_request_archive_id(
             archive_received=archive_received,
         ),
     )
-    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_instance_id="instance-a"),
+    )
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_service_get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_instance_id="instance-a"),
+    )
     monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", AsyncMock(return_value=False))
     monkeypatch.setattr(service, "_fail_pending_websocket_requests", AsyncMock())
     monkeypatch.setattr(service, "_retire_stale_pending_http_bridge_session", AsyncMock())
@@ -10433,7 +10442,7 @@ def test_verified_durable_full_resend_proof_is_sealed_immutable_and_request_boun
         canonical_key="sid-proof",
         api_key_scope="__anonymous__",
         account_id="acc-proof",
-        owner_instance_id=None,
+        owner_instance_id="instance-a",
         owner_epoch=3,
         lease_expires_at=None,
         state=HttpBridgeSessionState.CLOSED,
@@ -22193,7 +22202,7 @@ async def test_durable_model_transition_preserves_owner_provenance_when_replacin
         canonical_key="http_turn_model_parent",
         api_key_scope="__anonymous__",
         account_id="acc-model-owner",
-        owner_instance_id=None,
+        owner_instance_id="instance-a",
         owner_epoch=1,
         lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
         state=HttpBridgeSessionState.ACTIVE,
@@ -22264,7 +22273,16 @@ async def test_durable_model_transition_preserves_owner_provenance_when_replacin
             ),
         ),
     )
-    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_instance_id="instance-a"),
+    )
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_service_get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_instance_id="instance-a"),
+    )
     monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
     monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
     monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
@@ -22292,6 +22310,7 @@ async def test_durable_model_transition_preserves_owner_provenance_when_replacin
     assert all(call["previous_response_id"] is None for call in creation_calls)
     assert all(call["preferred_account_id"] == "acc-model-owner" for call in creation_calls)
     assert all(call["preferred_account_has_continuity_provenance"] is True for call in creation_calls)
+    assert all(call["durable_model_transition_owned_by_current_instance"] is True for call in creation_calls)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -16322,6 +16322,62 @@ async def test_get_or_create_http_bridge_session_recovers_locally_when_stale_own
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_fences_unrepresented_local_owner_without_authorizing_takeover(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-clean-close", None)
+    created_session = _make_bridge_session(key=key, key_value="sid-clean-close")
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_create_http_bridge_session", AsyncMock(return_value=created_session))
+    claim_durable = AsyncMock()
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", claim_durable)
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_instance_id="instance-a"),
+    )
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ["instance-a"])),
+    )
+
+    resolved = await service._get_or_create_http_bridge_session(
+        key,
+        headers={"x-codex-session-id": "sid-clean-close"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-clean-close",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        api_key=None,
+        request_model="gpt-5.2",
+        idle_ttl_seconds=120.0,
+        max_sessions=8,
+        durable_lookup=proxy_service.DurableBridgeLookup(
+            session_id="durable-clean-close",
+            canonical_kind="session_header",
+            canonical_key="sid-clean-close",
+            api_key_scope="__anonymous__",
+            account_id="acc-bridge",
+            owner_instance_id="instance-a",
+            owner_epoch=1,
+            lease_expires_at=proxy_service.utcnow() + timedelta(seconds=60),
+            state=HttpBridgeSessionState.ACTIVE,
+            latest_turn_state=None,
+            latest_response_id=None,
+        ),
+    )
+
+    assert resolved is created_session
+    claim_durable.assert_awaited_once()
+    await_args = claim_durable.await_args
+    assert await_args is not None
+    assert await_args.kwargs["allow_takeover"] is False
+    assert await_args.kwargs["force_owner_epoch_advance"] is True
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_recovers_locally_when_owner_endpoint_missing_but_replay_anchor_exists(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -16378,6 +16378,63 @@ async def test_get_or_create_http_bridge_session_fences_unrepresented_local_owne
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_preserves_local_owner_fence_across_model_transition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "sid-model-transition", None)
+    created_session = _make_bridge_session(key=key, key_value="sid-model-transition")
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_create_http_bridge_session", AsyncMock(return_value=created_session))
+    claim_durable = AsyncMock()
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", claim_durable)
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_instance_id="instance-a"),
+    )
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ["instance-a"])),
+    )
+
+    resolved = await service._get_or_create_http_bridge_session(
+        key,
+        headers={"x-codex-session-id": "sid-model-transition"},
+        affinity=proxy_service._AffinityPolicy(
+            key="sid-model-transition",
+            kind=proxy_service.StickySessionKind.CODEX_SESSION,
+        ),
+        api_key=None,
+        request_model="gpt-5.2",
+        idle_ttl_seconds=120.0,
+        max_sessions=8,
+        durable_lookup=proxy_service.DurableBridgeLookup(
+            session_id="durable-model-transition",
+            canonical_kind="session_header",
+            canonical_key="sid-model-transition",
+            api_key_scope="__anonymous__",
+            account_id="acc-bridge",
+            owner_instance_id="instance-a",
+            owner_epoch=1,
+            lease_expires_at=proxy_service.utcnow() + timedelta(seconds=60),
+            state=HttpBridgeSessionState.ACTIVE,
+            latest_turn_state=None,
+            latest_response_id=None,
+            model="gpt-5.1",
+        ),
+    )
+
+    assert resolved is created_session
+    claim_durable.assert_awaited_once()
+    await_args = claim_durable.await_args
+    assert await_args is not None
+    assert await_args.kwargs["allow_takeover"] is False
+    assert await_args.kwargs["force_owner_epoch_advance"] is True
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_recovers_locally_when_owner_endpoint_missing_but_replay_anchor_exists(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fixes #1695

## Summary

- advance the durable owner epoch when a fresh local HTTP bridge session replaces an unrepresented generation still owned by this instance
- fence the retiring generation's late durable release so it cannot clear the replacement owner
- keep epoch advancement separate from takeover authorization, so a newly active remote owner remains protected
- preserve ordinary in-process session reuse and cross-instance owner checks
- add deterministic product-path, call-layer, and durable-repository regressions

## Verification

- regression fails deterministically with `409 bridge_instance_mismatch` before the fix
- clean-close regression passes 20 consecutive runs after the fix
- related HTTP bridge and durable-session suites: 183 passed
- `ruff check` and `ruff format --check` on changed Python files
- targeted `ty check` on changed Python files
- OpenSpec delta added under `fence-clean-close-local-replacement`

The OpenSpec CLI is not available in the local Python-only task environment, so strict OpenSpec validation is left to the repository CI.