### PR TITLE
fix(proxy): close non-stream chat collect and map error status

### DIFF
--- a/app/core/openai/chat_responses.py
+++ b/app/core/openai/chat_responses.py
@@ -459,6 +459,7 @@ async def collect_chat_completion(stream: AsyncIterator[str], model: str) -> Cha
     incomplete_reason: str | None = None
     tool_index = ToolCallIndex()
     tool_calls: list[ToolCallState] = []
+    terminal_error: ChatCompletionResult | None = None
 
     async for line in stream:
         payload = _parse_data(line)
@@ -477,6 +478,8 @@ async def collect_chat_completion(stream: AsyncIterator[str], model: str) -> Cha
         if tool_delta is not None:
             _merge_tool_call_delta(tool_calls, tool_delta)
         if event_type in ("response.failed", "error"):
+            if terminal_error is not None:
+                continue
             error = None
             if event_type == "response.failed":
                 response = payload.get("response")
@@ -488,9 +491,10 @@ async def collect_chat_completion(stream: AsyncIterator[str], model: str) -> Cha
                 maybe_error = payload.get("error")
                 if isinstance(maybe_error, dict):
                     error = maybe_error
-            if error is not None:
-                return _error_envelope_from_payload(error)
-            return _default_error_envelope()
+            terminal_error = _error_envelope_from_payload(error) if error is not None else _default_error_envelope()
+            continue
+        if terminal_error is not None:
+            continue
         if event_type in ("response.completed", "response.incomplete"):
             response = payload.get("response")
             if isinstance(response, dict):
@@ -500,6 +504,9 @@ async def collect_chat_completion(stream: AsyncIterator[str], model: str) -> Cha
                 usage = _parse_usage(response.get("usage"))
                 if event_type == "response.incomplete":
                     incomplete_reason = _finish_reason_from_incomplete(response)
+
+    if terminal_error is not None:
+        return terminal_error
 
     message_content: str | None = "".join(content_parts)
     message_refusal = "".join(refusal_parts) or None

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -3952,22 +3952,25 @@ async def v1_chat_completions(
         )
 
     try:
-        first = await stream.__anext__()
-    except StopAsyncIteration:
-        first = None
-    except ProxyResponseError as exc:
-        return _logged_error_json_response(request, exc.status_code, exc.payload, headers=rate_limit_headers)
+        try:
+            first = await stream.__anext__()
+        except StopAsyncIteration:
+            first = None
+        except ProxyResponseError as exc:
+            return _logged_error_json_response(request, exc.status_code, exc.payload, headers=rate_limit_headers)
 
-    stream_with_first = _prepend_first(first, stream)
-    result = await collect_chat_completion(stream_with_first, model=responses_payload.model)
+        result = await collect_chat_completion(
+            _prepend_first(first, stream),
+            model=responses_payload.model,
+        )
+    finally:
+        await _aclose_stream(stream)
     if isinstance(result, OpenAIErrorEnvelopeModel):
-        error = result.error
-        code = error.code if error else None
-        status_code = 503 if code in _UNAVAILABLE_SELECTION_ERROR_CODES else 502
+        status_code, envelope = _mask_previous_response_not_found_error(result)
         return _logged_error_json_response(
             request,
             status_code,
-            content=result.model_dump(mode="json", exclude_none=True),
+            content=envelope.model_dump(mode="json", exclude_none=True),
             headers=rate_limit_headers,
         )
     if cursor_compat_client and isinstance(result, ChatCompletion):
@@ -6898,7 +6901,7 @@ async def _log_source_chat_completion(
         )
 
 
-async def _aclose_stream(stream: AsyncIterator[bytes]) -> None:
+async def _aclose_stream(stream: AsyncIterator[object]) -> None:
     aclose = getattr(stream, "aclose", None)
     if aclose is not None:
         await aclose()

--- a/openspec/changes/close-nonstream-chat-collect/context.md
+++ b/openspec/changes/close-nonstream-chat-collect/context.md
@@ -1,0 +1,28 @@
+# Close non-stream Chat Completions collect
+
+## Purpose
+
+Keep non-streaming `/v1/chat/completions` on the same settlement and error-status
+contract as `/v1/responses` collect.
+
+## Decision
+
+Hold a reference to the `stream_responses` generator and `_aclose_stream` it in
+`finally` after collect. The startup probe already closes the generator when it
+sees an error event; this covers the probe-timeout path that then splits the
+stream with `__anext__` + `_prepend_first`.
+
+Reuse `_mask_previous_response_not_found_error` so status mapping cannot drift
+from Responses.
+
+## Failure mode
+
+If collect returns on the prepended first `response.failed` event, `_prepend_first`
+never enters `async for` on the live generator, so Python does not aclose it.
+Reservation release lives in that generator's `finally`.
+
+## Example
+
+Client: `POST /v1/chat/completions` `{ "model": "gpt-5.2", "messages": [...], "stream": false }`
+after the 2s startup probe timed out. First event is `response.failed` /
+`rate_limit_exceeded`. Response is `429` and the reservation row is `released`.

--- a/openspec/changes/close-nonstream-chat-collect/proposal.md
+++ b/openspec/changes/close-nonstream-chat-collect/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Non-streaming `POST /v1/chat/completions` takes the first SSE item off the
+upstream generator, then collects through a prepend wrapper. When that first
+item is `response.failed`, collect returns without closing the original
+generator. The stream `finally` (API-key reservation release and lease
+cleanup) does not run, and the route maps every collected error to HTTP 502
+except a small unavailable-selection set. The same failure on
+`POST /v1/responses` drains the generator and uses `_status_for_error`
+(429 for `rate_limit_exceeded`).
+
+## What Changes
+
+- Close the upstream `stream_responses` generator after non-stream chat
+  collect, including early `response.failed` / `error` returns.
+- Map collected Chat Completions error envelopes with the same HTTP status
+  helper as non-stream `/v1/responses`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `chat-completions-compat`: non-stream chat settles the upstream generator
+  and returns the Responses-aligned error status.
+
+## Impact
+
+Streaming Chat Completions and `/v1/responses` collect are unchanged. Clients
+that already treated every non-stream chat error as 502 will now see 429/401/
+400 when the envelope code already implied that.

--- a/openspec/changes/close-nonstream-chat-collect/specs/chat-completions-compat/spec.md
+++ b/openspec/changes/close-nonstream-chat-collect/specs/chat-completions-compat/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Non-streaming chat collect closes the upstream generator
+
+When `stream` is `false` or omitted, `POST /v1/chat/completions` MUST close the upstream Responses generator after collect returns or raises, including when the first consumed event is `response.failed` or `error`. Closing MUST run the generator finalizer so an open API-key reservation is released or settled before the HTTP response is returned.
+
+#### Scenario: First-event rate limit releases the reservation
+
+- **WHEN** the startup probe did not consume the stream
+- **AND** the first upstream event is `response.failed` with
+  `code=rate_limit_exceeded`
+- **AND** the request reserved API-key usage
+- **THEN** the reservation is released before the error response is returned
+
+### Requirement: Non-streaming chat errors use the Responses status map
+
+When non-streaming `POST /v1/chat/completions` returns an OpenAI error envelope collected from the upstream Responses stream, the HTTP status MUST match the non-streaming `/v1/responses` mapping for that envelope (`429` for `rate_limit_exceeded`, `503` for unavailable-selection codes, `401`/`400` where that path already maps them). The envelope body MUST remain an OpenAI error object.
+
+#### Scenario: Collected rate limit is 429
+
+- **WHEN** non-streaming chat collect returns
+  `{ "error": { "code": "rate_limit_exceeded", ... } }`
+- **THEN** the HTTP status is `429`
+- **AND** the body is that OpenAI error envelope

--- a/openspec/changes/close-nonstream-chat-collect/tasks.md
+++ b/openspec/changes/close-nonstream-chat-collect/tasks.md
@@ -1,0 +1,18 @@
+## 1. Implementation
+
+- [x] 1.1 Close the original `stream_responses` generator after non-stream
+  chat collect, including `__anext__` errors and early collect return.
+- [x] 1.2 Map collected chat error envelopes with `_status_for_error` /
+  `_mask_previous_response_not_found_error`.
+
+## 2. Regression coverage
+
+- [x] 2.1 Assert first-event `response.failed` closes the upstream generator.
+- [x] 2.2 Assert non-stream chat `rate_limit_exceeded` returns 429 and
+  releases the API-key reservation.
+
+## 3. Validation
+
+- [x] 3.1 Run the new chat collect regressions and existing chat completion
+  suites.
+- [x] 3.2 Run strict OpenSpec validation for this change.

--- a/openspec/specs/chat-completions-compat/context.md
+++ b/openspec/specs/chat-completions-compat/context.md
@@ -24,7 +24,10 @@ See `openspec/specs/chat-completions-compat/spec.md` for normative requirements.
 ## Failure Modes
 
 - **Upstream stream failure:** Emit an error chunk, then terminate with `data: [DONE]`.
-- **Non-stream failures:** Return an OpenAI error envelope with 5xx status.
+- **Non-stream failures:** Return an OpenAI error envelope. HTTP status follows
+  the same map as non-stream `/v1/responses` (`429` for `rate_limit_exceeded`,
+  not a blanket 502). The upstream Responses generator is closed so reservation
+  finalizers run even when the first collected event is `response.failed`.
 - **Invalid content types:** Reject with `invalid_request_error`.
 
 ## Examples

--- a/openspec/specs/chat-completions-compat/spec.md
+++ b/openspec/specs/chat-completions-compat/spec.md
@@ -106,6 +106,29 @@ When `stream` is `false` or omitted, the service MUST return a single `chat.comp
 - **WHEN** the upstream indicates a tool call sequence
 - **THEN** the returned `chat.completion` includes `tool_calls` and a `finish_reason` of `tool_calls`
 
+### Requirement: Non-streaming chat collect closes the upstream generator
+
+When `stream` is `false` or omitted, `POST /v1/chat/completions` MUST close the upstream Responses generator after collect returns or raises, including when the first consumed event is `response.failed` or `error`. Closing MUST run the generator finalizer so an open API-key reservation is released or settled before the HTTP response is returned.
+
+#### Scenario: First-event rate limit releases the reservation
+
+- **WHEN** the startup probe did not consume the stream
+- **AND** the first upstream event is `response.failed` with
+  `code=rate_limit_exceeded`
+- **AND** the request reserved API-key usage
+- **THEN** the reservation is released before the error response is returned
+
+### Requirement: Non-streaming chat errors use the Responses status map
+
+When non-streaming `POST /v1/chat/completions` returns an OpenAI error envelope collected from the upstream Responses stream, the HTTP status MUST match the non-streaming `/v1/responses` mapping for that envelope (`429` for `rate_limit_exceeded`, `503` for unavailable-selection codes, `401`/`400` where that path already maps them). The envelope body MUST remain an OpenAI error object.
+
+#### Scenario: Collected rate limit is 429
+
+- **WHEN** non-streaming chat collect returns
+  `{ "error": { "code": "rate_limit_exceeded", ... } }`
+- **THEN** the HTTP status is `429`
+- **AND** the body is that OpenAI error envelope
+
 ### Requirement: response_format mapping
 If the client sends `response_format`, the service MUST translate it to the Responses `text.format` controls. For `json_schema`, the schema payload MUST be validated and missing `json_schema` MUST result in a 4xx error with an OpenAI error envelope.
 
@@ -141,6 +164,10 @@ For upstream failures or invalid requests, the service MUST return an OpenAI err
 #### Scenario: Streaming error
 - **WHEN** the upstream returns a failure during streaming
 - **THEN** the service emits an error chunk and terminates the stream with `data: [DONE]`
+
+#### Scenario: Non-streaming collected rate limit
+- **WHEN** non-streaming collect returns `rate_limit_exceeded`
+- **THEN** the service returns that OpenAI error envelope with HTTP 429
 
 ### Requirement: Drop unknown message-object fields during coercion
 

--- a/tests/integration/test_proxy_chat_completions.py
+++ b/tests/integration/test_proxy_chat_completions.py
@@ -4,10 +4,13 @@ import base64
 import json
 
 import pytest
+from sqlalchemy import select
 from starlette.responses import JSONResponse
 
 import app.modules.proxy.api as proxy_api
 import app.modules.proxy.service as proxy_module
+from app.db.models import ApiKeyUsageReservation
+from app.db.session import SessionLocal
 
 pytestmark = pytest.mark.integration
 
@@ -179,6 +182,71 @@ async def test_v1_chat_completions_non_stream_forces_stream(async_client, monkey
 
     assert observed_stream["value"] is True
     assert body["object"] == "chat.completion"
+
+
+@pytest.mark.asyncio
+async def test_v1_chat_completions_non_stream_rate_limit_closes_stream_and_returns_429(async_client, monkeypatch):
+    # #given
+    email = "chat-nonstr-429@example.com"
+    raw_account_id = "acc_chat_nonstr_429"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    imported = await async_client.post("/api/accounts/import", files=files)
+    assert imported.status_code == 200
+
+    settings = await async_client.put(
+        "/api/settings",
+        json={
+            "stickyThreadsEnabled": False,
+            "preferEarlierResetAccounts": False,
+            "totpRequiredOnLogin": False,
+            "apiKeyAuthEnabled": True,
+        },
+    )
+    assert settings.status_code == 200
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "chat-nonstr-429",
+            "limits": [{"limitType": "total_tokens", "limitWindow": "weekly", "maxValue": 100_000}],
+        },
+    )
+    assert created.status_code == 200
+    key = created.json()["key"]
+    key_id = created.json()["id"]
+
+    async def passthrough_probe(stream, **_kwargs):
+        return stream, None
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        del payload, headers, access_token, account_id, base_url, raise_for_status
+        yield (
+            'data: {"type":"response.failed","response":{"error":'
+            '{"message":"limit","type":"rate_limit_error","code":"rate_limit_exceeded"}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_api, "_probe_chat_stream_startup_error", passthrough_probe)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    # #when
+    response = await async_client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"model": "gpt-5.2", "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    # #then
+    assert response.status_code == 429
+    body = response.json()
+    assert body["error"]["code"] == "rate_limit_exceeded"
+    async with SessionLocal() as session:
+        reservations = (
+            (await session.execute(select(ApiKeyUsageReservation).where(ApiKeyUsageReservation.api_key_id == key_id)))
+            .scalars()
+            .all()
+        )
+        assert len(reservations) == 1
+        assert reservations[0].status == "released"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_chat_response_mapping.py
+++ b/tests/unit/test_chat_response_mapping.py
@@ -429,6 +429,61 @@ async def test_collect_completion_returns_error_event():
 
 
 @pytest.mark.asyncio
+async def test_collect_completion_drains_after_first_failed_event():
+    # #given
+    closed = {"value": False}
+
+    async def _stream():
+        try:
+            yield (
+                'data: {"type":"response.failed","response":{"error":'
+                '{"message":"limit","type":"rate_limit_error","code":"rate_limit_exceeded"}}}\n\n'
+            )
+            yield 'data: {"type":"response.completed","response":{"id":"should-not-win"}}\n\n'
+        finally:
+            closed["value"] = True
+
+    # #when
+    result = await collect_chat_completion(_stream(), model="gpt-5.2")
+
+    # #then
+    assert isinstance(result, OpenAIErrorEnvelope)
+    assert result.error is not None
+    assert result.error.code == "rate_limit_exceeded"
+    assert closed["value"] is True
+
+
+@pytest.mark.asyncio
+async def test_collect_completion_drains_original_after_anext_split():
+    # #given
+    from app.modules.proxy.api import _prepend_first
+
+    closed = {"value": False}
+
+    async def _stream():
+        try:
+            yield (
+                'data: {"type":"response.failed","response":{"error":'
+                '{"message":"limit","type":"rate_limit_error","code":"rate_limit_exceeded"}}}\n\n'
+            )
+            yield 'data: {"type":"response.completed","response":{"id":"tail"}}\n\n'
+        finally:
+            closed["value"] = True
+
+    stream = _stream()
+    first = await stream.__anext__()
+
+    # #when
+    result = await collect_chat_completion(_prepend_first(first, stream), model="gpt-5.2")
+
+    # #then
+    assert isinstance(result, OpenAIErrorEnvelope)
+    assert result.error is not None
+    assert result.error.code == "rate_limit_exceeded"
+    assert closed["value"] is True
+
+
+@pytest.mark.asyncio
 async def test_collect_completion_includes_refusal_delta():
     lines = [
         'data: {"type":"response.refusal.delta","delta":"no"}\n\n',


### PR DESCRIPTION
## Summary

Non-streaming `POST /v1/chat/completions` took the first SSE item off the upstream generator and collected through a prepend wrapper. When that first item was `response.failed`, collect returned without draining the generator. The stream finalizer (API-key reservation release and lease cleanup) did not run, and the route mapped almost every collected error to HTTP 502. The same failure on `POST /v1/responses` already drains and uses `_status_for_error` (429 for `rate_limit_exceeded`).

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/close-nonstream-chat-collect/`

## Changes

- Drain `collect_chat_completion` after `response.failed` / `error` so the upstream generator can finish (same shape as `_collect_responses_payload`).
- `_aclose_stream` the non-stream chat iterator in `finally` after collect.
- Map collected chat error envelopes with `_mask_previous_response_not_found_error` / `_status_for_error`.

## Simplicity

No new setting, README section, or dashboard nav.

## Test plan

```
uv run pytest tests/unit/test_chat_response_mapping.py tests/integration/test_proxy_chat_completions.py -q
# 40 passed
openspec validate chat-completions-compat --strict
openspec validate close-nonstream-chat-collect --strict
```

Related work: reservation-exit fixes on models (`#1653`) are a sibling family, not this collect path.

## Checklist

- [x] Tests added for the failing product path
- [x] OpenSpec change kept in sync