### PR TITLE
fix(proxy):-restore-compaction-after-ChatGPT-retired-the-responses-compact-endpoint

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -3626,6 +3626,14 @@ class _CompactCommandTransport:
         # The retired compact endpoint accepted non-streaming JSON; the plain
         # responses endpoint requires streamed SSE.
         payload_dict["stream"] = True
+        # The API layer strips the terminal compaction_trigger input item
+        # before the compact service; the plain responses endpoint only
+        # recognises compaction through that item, so restore it upstream.
+        compact_input = payload_dict.get("input")
+        if isinstance(compact_input, list):
+            terminal = compact_input[-1] if compact_input else None
+            if not (isinstance(terminal, dict) and terminal.get("type") == "compaction_trigger"):
+                payload_dict["input"] = [*compact_input, {"type": "compaction_trigger"}]
         if settings.image_inline_fetch_enabled:
             payload_dict = await _inline_input_image_urls(
                 payload_dict,
@@ -4059,12 +4067,22 @@ async def _read_compact_sse_payload(response: Any) -> dict[str, Any]:
             events.append(event)
     completed: dict[str, Any] | None = None
     created_id: str | None = None
+    # The streamed responses contract carries output items in
+    # ``response.output_item.done`` events; ``response.completed`` echoes an
+    # empty ``output`` array, so items must be collected by output index.
+    items_by_index: dict[int, dict[str, Any]] = {}
     for event in events:
         event_type = event.get("type")
         if event_type == "response.created":
             created = event.get("response")
             if isinstance(created, dict) and created.get("id"):
                 created_id = created["id"]
+        elif event_type == "response.output_item.done":
+            item = event.get("item")
+            if isinstance(item, dict):
+                raw_index = event.get("output_index")
+                index = raw_index if isinstance(raw_index, int) else len(items_by_index)
+                items_by_index[index] = item
         elif event_type == "response.completed":
             completed = event.get("response")
     if not isinstance(completed, dict):
@@ -4074,8 +4092,9 @@ async def _read_compact_sse_payload(response: Any) -> dict[str, Any]:
         "id": completed.get("id") or created_id,
         "status": completed.get("status") or "completed",
     }
-    if completed.get("output"):
-        payload["output"] = completed["output"]
+    output = [items_by_index[index] for index in sorted(items_by_index)] if items_by_index else None
+    if output:
+        payload["output"] = output
     if completed.get("usage"):
         payload["usage"] = completed["usage"]
     if completed.get("error"):

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -3599,7 +3599,12 @@ class _CompactCommandTransport:
     async def execute(self) -> CompactResponsePayload:
         settings = get_settings()
         upstream_base = settings.upstream_base_url.rstrip("/")
-        url = f"{upstream_base}/codex/responses/compact"
+        # ChatGPT retired the dedicated ``/codex/responses/compact`` endpoint
+        # (returns 404 since 2026-08-12) and now serves compaction as a plain
+        # streamed ``/codex/responses`` request whose payload carries the
+        # compaction instruction. The response is SSE, folded back into the
+        # legacy ``response.compact`` shape in ``_read_compact_sse_payload``.
+        url = f"{upstream_base}/codex/responses"
         require_route_or_direct_egress_opt_in(
             route=self.route,
             allow_direct_egress=self.allow_direct_egress,
@@ -3618,6 +3623,9 @@ class _CompactCommandTransport:
         compact_timeout_seconds = _effective_compact_total_timeout(settings.upstream_compact_timeout_seconds)
         effective_connect_timeout = _effective_compact_connect_timeout(settings.upstream_connect_timeout_seconds)
         payload_dict = dict(self.payload.to_payload())
+        # The retired compact endpoint accepted non-streaming JSON; the plain
+        # responses endpoint requires streamed SSE.
+        payload_dict["stream"] = True
         if settings.image_inline_fetch_enabled:
             payload_dict = await _inline_input_image_urls(
                 payload_dict,
@@ -3737,7 +3745,7 @@ class _CompactCommandTransport:
                         upstream_status_code=status_code,
                     )
                 try:
-                    data = await _codex_response_json(resp)
+                    data = await _read_compact_sse_payload(resp)
                 except Exception as exc:
                     error_code = "upstream_error"
                     error_message = "Invalid JSON from upstream"
@@ -3815,7 +3823,7 @@ class _CompactCommandTransport:
                         upstream_status_code=resp.status,
                     )
                 try:
-                    data = await resp.json(content_type=None)
+                    data = await _read_compact_sse_payload(resp)
                 except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as exc:
                     message = str(exc) or "Request to upstream timed out"
                     error_code = process_network_error_code(
@@ -4017,6 +4025,62 @@ async def _codex_response_json(response: Any) -> Any:
         return result
     text = await _codex_response_text(response)
     return json.loads(text)
+
+
+async def _read_compact_sse_payload(response: Any) -> dict[str, Any]:
+    """Fold an upstream ``/codex/responses`` SSE stream into a compact payload.
+
+    ChatGPT retired the dedicated compact endpoint and serves compaction as a
+    streamed plain responses request. The SSE events are reassembled into the
+    legacy ``response.compact`` shape so downstream parsing is unchanged.
+    """
+    content = getattr(response, "content", None)
+    if isinstance(content, (bytes, bytearray)):
+        text = bytes(content).decode("utf-8", "replace")
+    elif isinstance(content, str):
+        text = content
+    elif isinstance(content, aiohttp.StreamReader):
+        chunks = [chunk async for chunk in content]
+        text = b"".join(chunks).decode("utf-8", "replace")
+    else:
+        text = await _codex_response_text(response)
+    events: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        if not line.startswith("data:"):
+            continue
+        raw = line[5:].strip()
+        if not raw:
+            continue
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+    completed: dict[str, Any] | None = None
+    created_id: str | None = None
+    for event in events:
+        event_type = event.get("type")
+        if event_type == "response.created":
+            created = event.get("response")
+            if isinstance(created, dict) and created.get("id"):
+                created_id = created["id"]
+        elif event_type == "response.completed":
+            completed = event.get("response")
+    if not isinstance(completed, dict):
+        raise ValueError("Upstream stream ended without response.completed")
+    payload: dict[str, Any] = {
+        "object": "response.compact",
+        "id": completed.get("id") or created_id,
+        "status": completed.get("status") or "completed",
+    }
+    if completed.get("output"):
+        payload["output"] = completed["output"]
+    if completed.get("usage"):
+        payload["usage"] = completed["usage"]
+    if completed.get("error"):
+        payload["error"] = completed["error"]
+    return payload
 
 
 async def _codex_response_text(response: Any) -> str:

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -983,7 +983,10 @@ def _strip_compact_unsupported_fields(payload: MutableJsonObject) -> MutableJson
     if is_json_mapping(normalized_payload):
         payload = dict(normalized_payload)
     _trim_compact_input_for_upstream(payload)
-    payload.pop("store", None)
+    # The retired compact endpoint never stored by definition; the plain
+    # responses endpoint (which serves compaction since 2026-08-12) rejects
+    # requests where ``store`` is absent, so it must be explicit.
+    payload["store"] = False
     payload.pop("text", None)
     payload.pop("tools", None)
     payload.pop("tool_choice", None)


### PR DESCRIPTION
## Summary

ChatGPT retired the dedicated compact endpoint `/backend-api/codex/responses/compact` on **2026-08-12 18:44 UTC**. Every compaction request through codex-lb has 404'd since then, regardless of client version or account — compaction is fully broken on the current release.

This PR restores compaction by serving it through the plain `/codex/responses` endpoint with the current v2 protocol:

1. **`fix(proxy): serve compaction via plain responses endpoint`** — route compact requests to `/codex/responses`, force `stream: true`, set `store: false` explicitly (the plain endpoint rejects requests without it with `400 Store must be set to false`), and re-append the terminal `compaction_trigger` input item that the API layer strips before the compact service.
2. **`fix(proxy): restore compaction trigger and collect streamed output items`** — the upstream compaction result is delivered via SSE `response.output_item.done` events (the `response.completed` payload has an empty `output` array). Fold those events back into the legacy `response.compact` payload, preserving `encrypted_content`, so the API layer's compaction validation passes (otherwise `502 Compact response did not include a compaction output item`).

## Protocol notes

- New protocol (verified against chatgpt.com on 2026-08-13): plain `POST /codex/responses` + `stream: true` + `store: false` + terminal `{"type":"compaction_trigger"}` input item + `x-codex-turn-metadata: {"request_kind":"compaction"}` header.
- The compaction item arrives as `{"id":"cmp_...","type":"compaction","encrypted_content":"..."}` inside `response.output_item.done` events, ordered by `output_index`.
- Client side (codex CLI) needs no changes — `compact_remote_v2` already speaks this protocol.

## Testing

- Full-path verification through the proxy: HTTP 200 with a compaction event stream; request logs record `compaction success`.
- Unit-tested the SSE fold-back against captured real upstream traffic.
