### PR TITLE
fix(proxy): settle compact failover before account health

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -478,6 +478,7 @@ class ProxyResponseError(Exception):
         upstream_error_code: str | None = None,
         failed_session: aiohttp.ClientSession | None = None,
         retry_after_seconds: int | None = None,
+        reservation_released: bool = False,
     ) -> None:
         super().__init__(f"Proxy response error ({status_code})")
         self.status_code = status_code
@@ -490,6 +491,7 @@ class ProxyResponseError(Exception):
         self.upstream_error_code = upstream_error_code
         self.failed_session = failed_session
         self.retry_after_seconds = retry_after_seconds
+        self.reservation_released = reservation_released
 
 
 def is_confirmed_pre_dispatch_transport_error(exc: ProxyResponseError) -> bool:

--- a/app/modules/proxy/_service/api_key_usage.py
+++ b/app/modules/proxy/_service/api_key_usage.py
@@ -306,6 +306,7 @@ class _ApiKeyUsageMixin:
         )
 
         proxy = cast(_ApiKeyUsageServiceProtocol, self)
+        reservation_released = False
         with anyio.CancelScope(shield=True):
             try:
                 async with proxy._repo_factory() as repos:
@@ -321,6 +322,7 @@ class _ApiKeyUsageMixin:
                         )
                     else:
                         await api_keys_service.release_usage_reservation(reservation_id)
+                reservation_released = True
             except Exception as exc:
                 logger.warning(
                     "Failed to settle compact API key reservation key_id=%s request_id=%s",
@@ -332,6 +334,7 @@ class _ApiKeyUsageMixin:
                     async with proxy._repo_factory() as repos:
                         api_keys_service = _service_api_keys_service()(repos.api_keys)
                         await api_keys_service.release_usage_reservation(reservation_id)
+                    reservation_released = True
                 except Exception:
                     logger.warning(
                         "Failed to release compact API key reservation after settlement failure "
@@ -350,6 +353,7 @@ class _ApiKeyUsageMixin:
                     failure_phase="usage_settlement",
                     failure_detail="compact_api_key_usage_persistence_failed",
                     failure_exception_type=type(exc).__name__,
+                    reservation_released=reservation_released,
                 ) from exc
 
     async def _settle_stream_api_key_usage(

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -722,6 +722,22 @@ class _CompactMixin:
                 await proxy._handle_proxy_error(failed_account, failed_exc)
                 await proxy._load_balancer.record_errors(failed_account, extra_error_count)
 
+        async def record_or_defer_stream_health(
+            failed_account: Account,
+            failed_error: Any,
+            failed_code: str,
+            failed_status: int | None = None,
+        ) -> None:
+            if api_key is not None and api_key_reservation is not None:
+                deferred_stream_health.append((failed_account, failed_error, failed_code, failed_status))
+                return
+            await proxy._handle_stream_error(
+                failed_account,
+                failed_error,
+                failed_code,
+                http_status=failed_status,
+            )
+
         try:
 
             async def _call_compact(
@@ -1114,7 +1130,7 @@ class _CompactMixin:
                             request_service_tier=request_service_tier,
                         )
                         _raise_proxy_unavailable(message)
-                    await proxy._handle_stream_error(
+                    await record_or_defer_stream_health(
                         account,
                         {"message": message},
                         "upstream_unavailable",
@@ -1341,7 +1357,7 @@ class _CompactMixin:
                                         request_service_tier=request_service_tier,
                                     )
                                     _raise_proxy_unavailable(message)
-                                await proxy._handle_stream_error(
+                                await record_or_defer_stream_health(
                                     account,
                                     {"message": message},
                                     "upstream_unavailable",
@@ -1524,22 +1540,12 @@ class _CompactMixin:
                         if action == "failover_next":
                             last_exc = exc
                             excluded_account_ids.add(account.id)
-                            if api_key is not None and api_key_reservation is not None:
-                                deferred_stream_health.append(
-                                    (
-                                        account,
-                                        _upstream_error_from_openai(error),
-                                        code,
-                                        exc.status_code,
-                                    )
-                                )
-                            else:
-                                await proxy._handle_stream_error(
-                                    account,
-                                    _upstream_error_from_openai(error),
-                                    code,
-                                    http_status=exc.status_code,
-                                )
+                            await record_or_defer_stream_health(
+                                account,
+                                _upstream_error_from_openai(error),
+                                code,
+                                exc.status_code,
+                            )
                             transient_exhausted = True
                             break
                         await settle_compact_usage(

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -695,19 +695,7 @@ class _CompactMixin:
         deferred_http_500_health: list[tuple[Account, ProxyResponseError, int]] = []
         deferred_proxy_health: list[tuple[Account, ProxyResponseError]] = []
 
-        async def settle_compact_usage(
-            *,
-            api_key: ApiKeyData | None,
-            api_key_reservation: ApiKeyUsageReservationData | None,
-            response: CompactResponsePayload | None,
-            request_service_tier: str | None,
-        ) -> None:
-            await proxy._settle_compact_api_key_usage(
-                api_key=api_key,
-                api_key_reservation=api_key_reservation,
-                response=response,
-                request_service_tier=request_service_tier,
-            )
+        async def flush_deferred_health() -> None:
             stream_pending = list(deferred_stream_health)
             deferred_stream_health.clear()
             http_500_pending = list(deferred_http_500_health)
@@ -726,6 +714,29 @@ class _CompactMixin:
                 await proxy._load_balancer.record_errors(failed_account, extra_error_count)
             for failed_account, failed_exc in proxy_pending:
                 await proxy._handle_proxy_error(failed_account, failed_exc)
+
+        async def settle_compact_usage(
+            *,
+            api_key: ApiKeyData | None,
+            api_key_reservation: ApiKeyUsageReservationData | None,
+            response: CompactResponsePayload | None,
+            request_service_tier: str | None,
+        ) -> None:
+            settlement_error: ProxyResponseError | None = None
+            try:
+                await proxy._settle_compact_api_key_usage(
+                    api_key=api_key,
+                    api_key_reservation=api_key_reservation,
+                    response=response,
+                    request_service_tier=request_service_tier,
+                )
+            except ProxyResponseError as exc:
+                if exc.failure_phase != "usage_settlement" or not exc.reservation_released:
+                    raise
+                settlement_error = exc
+            await flush_deferred_health()
+            if settlement_error is not None:
+                raise settlement_error
 
         async def record_or_defer_proxy_health(
             failed_account: Account,

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -691,6 +691,37 @@ class _CompactMixin:
             ("previous response", previous_response_preferred_account_id),
             ("input file", rewritten_file_account_id),
         )
+        deferred_stream_health: list[tuple[Account, Any, str, int | None]] = []
+        deferred_http_500_health: list[tuple[Account, ProxyResponseError, int]] = []
+
+        async def settle_compact_usage(
+            *,
+            api_key: ApiKeyData | None,
+            api_key_reservation: ApiKeyUsageReservationData | None,
+            response: CompactResponsePayload | None,
+            request_service_tier: str | None,
+        ) -> None:
+            await proxy._settle_compact_api_key_usage(
+                api_key=api_key,
+                api_key_reservation=api_key_reservation,
+                response=response,
+                request_service_tier=request_service_tier,
+            )
+            stream_pending = list(deferred_stream_health)
+            deferred_stream_health.clear()
+            http_500_pending = list(deferred_http_500_health)
+            deferred_http_500_health.clear()
+            for failed_account, failed_error, failed_code, failed_status in stream_pending:
+                await proxy._handle_stream_error(
+                    failed_account,
+                    failed_error,
+                    failed_code,
+                    http_status=failed_status,
+                )
+            for failed_account, failed_exc, extra_error_count in http_500_pending:
+                await proxy._handle_proxy_error(failed_account, failed_exc)
+                await proxy._load_balancer.record_errors(failed_account, extra_error_count)
+
         try:
 
             async def _call_compact(
@@ -845,31 +876,6 @@ class _CompactMixin:
             estimated_lease_tokens = _estimated_lease_tokens_from_request_usage_budget(
                 estimate_api_key_request_usage(payload)
             )
-            deferred_compact_health: list[tuple[Account, Any, str, int | None]] = []
-
-            async def settle_compact_usage(
-                *,
-                api_key: ApiKeyData | None,
-                api_key_reservation: ApiKeyUsageReservationData | None,
-                response: CompactResponsePayload | None,
-                request_service_tier: str | None,
-            ) -> None:
-                await proxy._settle_compact_api_key_usage(
-                    api_key=api_key,
-                    api_key_reservation=api_key_reservation,
-                    response=response,
-                    request_service_tier=request_service_tier,
-                )
-                pending = list(deferred_compact_health)
-                deferred_compact_health.clear()
-                for failed_account, failed_error, failed_code, failed_status in pending:
-                    await proxy._handle_stream_error(
-                        failed_account,
-                        failed_error,
-                        failed_code,
-                        http_status=failed_status,
-                    )
-
             for _account_attempt in range(_compact_max_account_attempts()):
                 selection = await proxy._select_account_with_budget_compatible(
                     deadline,
@@ -1372,10 +1378,13 @@ class _CompactMixin:
                                 account.id,
                                 transient_retries,
                             )
-                            await proxy._handle_proxy_error(account, exc)
-                            # Record remaining errors so total equals transient_retries,
-                            # meeting the load balancer backoff threshold (error_count >= 3).
-                            await proxy._load_balancer.record_errors(account, transient_retries - 1)
+                            if api_key is not None and api_key_reservation is not None:
+                                deferred_http_500_health.append((account, exc, transient_retries - 1))
+                            else:
+                                await proxy._handle_proxy_error(account, exc)
+                                # Record remaining errors so total equals transient_retries,
+                                # meeting the load balancer backoff threshold (error_count >= 3).
+                                await proxy._load_balancer.record_errors(account, transient_retries - 1)
                             last_exc = exc
                             excluded_account_ids.add(account.id)
                             transient_exhausted = True
@@ -1516,7 +1525,7 @@ class _CompactMixin:
                             last_exc = exc
                             excluded_account_ids.add(account.id)
                             if api_key is not None and api_key_reservation is not None:
-                                deferred_compact_health.append(
+                                deferred_stream_health.append(
                                     (
                                         account,
                                         _upstream_error_from_openai(error),
@@ -1574,7 +1583,7 @@ class _CompactMixin:
             route_fail_closed_reason = exc.reason
             log_error_code = "upstream_proxy_unavailable"
             log_error_message = exc.reason
-            await proxy._settle_compact_api_key_usage(
+            await settle_compact_usage(
                 api_key=api_key,
                 api_key_reservation=api_key_reservation,
                 response=None,

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -737,14 +737,28 @@ class _CompactMixin:
                 if exc.failure_phase != "usage_settlement" or not exc.reservation_released:
                     raise
                 settlement_error = exc
+            flush_task = asyncio.create_task(
+                flush_deferred_health(),
+                name=f"compact-deferred-health-{request_id}",
+            )
+            cancellation_pending = False
+            while not flush_task.done():
+                try:
+                    await asyncio.shield(flush_task)
+                except asyncio.CancelledError:
+                    cancellation_pending = True
+                except Exception:
+                    break
             try:
-                await flush_deferred_health()
+                flush_task.result()
             except Exception:
                 logger.warning(
                     "Failed to flush deferred compact account health request_id=%s",
                     request_id,
                     exc_info=True,
                 )
+            if cancellation_pending:
+                raise asyncio.CancelledError()
             if settlement_error is not None:
                 raise settlement_error
 

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -51,7 +51,12 @@ from app.modules.proxy.affinity import (
 )
 from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
 from app.modules.proxy.continuity import resolve_required_account_id
-from app.modules.proxy.helpers import _header_account_id, _normalize_error_code, _parse_openai_error
+from app.modules.proxy.helpers import (
+    _header_account_id,
+    _normalize_error_code,
+    _parse_openai_error,
+    classify_upstream_failure,
+)
 from app.modules.proxy.load_balancer import (
     AccountConcurrencyCaps,
     AccountLease,
@@ -840,6 +845,31 @@ class _CompactMixin:
             estimated_lease_tokens = _estimated_lease_tokens_from_request_usage_budget(
                 estimate_api_key_request_usage(payload)
             )
+            deferred_compact_health: list[tuple[Account, Any, str, int | None]] = []
+
+            async def settle_compact_usage(
+                *,
+                api_key: ApiKeyData | None,
+                api_key_reservation: ApiKeyUsageReservationData | None,
+                response: CompactResponsePayload | None,
+                request_service_tier: str | None,
+            ) -> None:
+                await proxy._settle_compact_api_key_usage(
+                    api_key=api_key,
+                    api_key_reservation=api_key_reservation,
+                    response=response,
+                    request_service_tier=request_service_tier,
+                )
+                pending = list(deferred_compact_health)
+                deferred_compact_health.clear()
+                for failed_account, failed_error, failed_code, failed_status in pending:
+                    await proxy._handle_stream_error(
+                        failed_account,
+                        failed_error,
+                        failed_code,
+                        http_status=failed_status,
+                    )
+
             for _account_attempt in range(_compact_max_account_attempts()):
                 selection = await proxy._select_account_with_budget_compatible(
                     deadline,
@@ -916,7 +946,7 @@ class _CompactMixin:
                     # is the sole settler) the API-key reservation would leak held
                     # quota. Settle BEFORE raising, mirroring the transport/permanent
                     # preflight branches above.
-                    await proxy._settle_compact_api_key_usage(
+                    await settle_compact_usage(
                         api_key=api_key,
                         api_key_reservation=api_key_reservation,
                         response=None,
@@ -934,7 +964,7 @@ class _CompactMixin:
                     await proxy._load_balancer.release_account_lease(selected_account_response_create_lease)
                     # Sole-settler leak guard (see above): settle the reservation
                     # before this budget-exhausted terminal raise.
-                    await proxy._settle_compact_api_key_usage(
+                    await settle_compact_usage(
                         api_key=api_key,
                         api_key_reservation=api_key_reservation,
                         response=None,
@@ -962,7 +992,7 @@ class _CompactMixin:
                     # ensure_fresh_with_budget translates terminal process-network
                     # recovery outcomes before the compact upstream settlement
                     # branches run, so this boundary owns reservation cleanup.
-                    await proxy._settle_compact_api_key_usage(
+                    await settle_compact_usage(
                         api_key=api_key,
                         api_key_reservation=api_key_reservation,
                         response=None,
@@ -983,7 +1013,7 @@ class _CompactMixin:
                             # reservation is finalized instead of leaking held
                             # API-key quota (matching the post-401 permanent
                             # branch, which settles before re-raising).
-                            await proxy._settle_compact_api_key_usage(
+                            await settle_compact_usage(
                                 api_key=api_key,
                                 api_key_reservation=api_key_reservation,
                                 response=None,
@@ -1030,7 +1060,7 @@ class _CompactMixin:
                                 # reservation. Settle it BEFORE raising so the
                                 # API-key reservation is finalized instead of leaking
                                 # held quota when the pinned refresh claim times out.
-                                await proxy._settle_compact_api_key_usage(
+                                await settle_compact_usage(
                                     api_key=api_key,
                                     api_key_reservation=api_key_reservation,
                                     response=None,
@@ -1063,7 +1093,7 @@ class _CompactMixin:
                     # Settle BEFORE raising, mirroring the claim-contention and
                     # post-401 transport branches.
                     if not _should_retry_transient_stream_error("upstream_unavailable", message):
-                        await proxy._settle_compact_api_key_usage(
+                        await settle_compact_usage(
                             api_key=api_key,
                             api_key_reservation=api_key_reservation,
                             response=None,
@@ -1071,7 +1101,7 @@ class _CompactMixin:
                         )
                         _raise_proxy_unavailable(message)
                     if preferred_account_id is not None:
-                        await proxy._settle_compact_api_key_usage(
+                        await settle_compact_usage(
                             api_key=api_key,
                             api_key_reservation=api_key_reservation,
                             response=None,
@@ -1100,7 +1130,7 @@ class _CompactMixin:
                     await proxy._load_balancer.release_account_lease(selected_account_response_create_lease)
                     # Sole-settler leak guard (see above): settle the reservation
                     # before this budget-exhausted terminal raise.
-                    await proxy._settle_compact_api_key_usage(
+                    await settle_compact_usage(
                         api_key=api_key,
                         api_key_reservation=api_key_reservation,
                         response=None,
@@ -1121,7 +1151,7 @@ class _CompactMixin:
                         network_recovery.log_recovered()
                         actual_service_tier = _service_tier_from_response(response)
                         await proxy._load_balancer.record_success(account)
-                        await proxy._settle_compact_api_key_usage(
+                        await settle_compact_usage(
                             api_key=api_key,
                             api_key_reservation=api_key_reservation,
                             response=response,
@@ -1134,7 +1164,7 @@ class _CompactMixin:
                             raise
                         compact_continuity_error = _compact_previous_response_not_found_error(exc)
                         if compact_continuity_error is not None:
-                            await proxy._settle_compact_api_key_usage(
+                            await settle_compact_usage(
                                 api_key=api_key,
                                 api_key_reservation=api_key_reservation,
                                 response=None,
@@ -1153,7 +1183,7 @@ class _CompactMixin:
                                 try:
                                     await proxy._handle_proxy_error(account, exc)
                                 except Exception:
-                                    await proxy._settle_compact_api_key_usage(
+                                    await settle_compact_usage(
                                         api_key=api_key,
                                         api_key_reservation=api_key_reservation,
                                         response=None,
@@ -1179,7 +1209,7 @@ class _CompactMixin:
                                     # the bridge/forwarded path (``owns_reservation``
                                     # false) the reservation would leak held quota.
                                     # Settle BEFORE raising.
-                                    await proxy._settle_compact_api_key_usage(
+                                    await settle_compact_usage(
                                         api_key=api_key,
                                         api_key_reservation=api_key_reservation,
                                         response=None,
@@ -1195,7 +1225,7 @@ class _CompactMixin:
                                 # A translated refresh-recovery error escapes the
                                 # current upstream-error handler, so settle before
                                 # handing it to the request-level error boundary.
-                                await proxy._settle_compact_api_key_usage(
+                                await settle_compact_usage(
                                     api_key=api_key,
                                     api_key_reservation=api_key_reservation,
                                     response=None,
@@ -1206,7 +1236,7 @@ class _CompactMixin:
                                 if isinstance(refresh_exc, RefreshError):
                                     if refresh_exc.is_permanent:
                                         await proxy._load_balancer.mark_permanent_failure(account, refresh_exc.code)
-                                        await proxy._settle_compact_api_key_usage(
+                                        await settle_compact_usage(
                                             api_key=api_key,
                                             api_key_reservation=api_key_reservation,
                                             response=None,
@@ -1249,7 +1279,7 @@ class _CompactMixin:
                                                 exc_info=True,
                                             )
                                         if preferred_account_id is not None:
-                                            await proxy._settle_compact_api_key_usage(
+                                            await settle_compact_usage(
                                                 api_key=api_key,
                                                 api_key_reservation=api_key_reservation,
                                                 response=None,
@@ -1266,7 +1296,7 @@ class _CompactMixin:
                                         # Non-transport, non-permanent RefreshError
                                         # keeps its prior escalation: re-raise the
                                         # original 401 to the caller.
-                                        await proxy._settle_compact_api_key_usage(
+                                        await settle_compact_usage(
                                             api_key=api_key,
                                             api_key_reservation=api_key_reservation,
                                             response=None,
@@ -1290,7 +1320,7 @@ class _CompactMixin:
                                     exc_info=True,
                                 )
                                 if not _should_retry_transient_stream_error("upstream_unavailable", message):
-                                    await proxy._settle_compact_api_key_usage(
+                                    await settle_compact_usage(
                                         api_key=api_key,
                                         api_key_reservation=api_key_reservation,
                                         response=None,
@@ -1298,7 +1328,7 @@ class _CompactMixin:
                                     )
                                     _raise_proxy_unavailable(message)
                                 if preferred_account_id is not None:
-                                    await proxy._settle_compact_api_key_usage(
+                                    await settle_compact_usage(
                                         api_key=api_key,
                                         api_key_reservation=api_key_reservation,
                                         response=None,
@@ -1367,7 +1397,7 @@ class _CompactMixin:
                         if recovery_decision == "retry":
                             continue
                         if recovery_decision == "exhausted":
-                            await proxy._settle_compact_api_key_usage(
+                            await settle_compact_usage(
                                 api_key=api_key,
                                 api_key_reservation=api_key_reservation,
                                 response=None,
@@ -1388,7 +1418,7 @@ class _CompactMixin:
                                 require_security_work_authorized = True
                                 transient_exhausted = True
                                 break
-                            await proxy._settle_compact_api_key_usage(
+                            await settle_compact_usage(
                                 api_key=api_key,
                                 api_key_reservation=api_key_reservation,
                                 response=None,
@@ -1401,7 +1431,7 @@ class _CompactMixin:
                             transient_exhausted = True
                             break
                         if _is_account_neutral_error_code(code):
-                            await proxy._settle_compact_api_key_usage(
+                            await settle_compact_usage(
                                 api_key=api_key,
                                 api_key_reservation=api_key_reservation,
                                 response=None,
@@ -1409,7 +1439,7 @@ class _CompactMixin:
                             )
                             raise
                         if code == "upstream_request_timeout":
-                            await proxy._settle_compact_api_key_usage(
+                            await settle_compact_usage(
                                 api_key=api_key,
                                 api_key_reservation=api_key_reservation,
                                 response=None,
@@ -1459,11 +1489,11 @@ class _CompactMixin:
                                 classified["failure_class"],
                             )
                             raise
-                        classified = await proxy._handle_stream_error(
-                            account,
-                            _upstream_error_from_openai(error),
-                            code,
+                        classified = classify_upstream_failure(
+                            error_code=code,
+                            error=_upstream_error_from_openai(error),
                             http_status=exc.status_code,
+                            phase="first_event",
                         )
                         if getattr(base_settings, "deterministic_failover_enabled", True):
                             action = failover_decision(
@@ -1485,19 +1515,41 @@ class _CompactMixin:
                         if action == "failover_next":
                             last_exc = exc
                             excluded_account_ids.add(account.id)
+                            if api_key is not None and api_key_reservation is not None:
+                                deferred_compact_health.append(
+                                    (
+                                        account,
+                                        _upstream_error_from_openai(error),
+                                        code,
+                                        exc.status_code,
+                                    )
+                                )
+                            else:
+                                await proxy._handle_stream_error(
+                                    account,
+                                    _upstream_error_from_openai(error),
+                                    code,
+                                    http_status=exc.status_code,
+                                )
                             transient_exhausted = True
                             break
-                        await proxy._settle_compact_api_key_usage(
+                        await settle_compact_usage(
                             api_key=api_key,
                             api_key_reservation=api_key_reservation,
                             response=None,
                             request_service_tier=request_service_tier,
                         )
+                        await proxy._handle_stream_error(
+                            account,
+                            _upstream_error_from_openai(error),
+                            code,
+                            http_status=exc.status_code,
+                        )
                         raise
                 if transient_exhausted:
                     continue  # outer loop: try different account
             # All account attempts exhausted — raise last error
-            await proxy._settle_compact_api_key_usage(
+            await settle_compact_usage(
                 api_key=api_key,
                 api_key_reservation=api_key_reservation,
                 response=None,

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -693,6 +693,7 @@ class _CompactMixin:
         )
         deferred_stream_health: list[tuple[Account, Any, str, int | None]] = []
         deferred_http_500_health: list[tuple[Account, ProxyResponseError, int]] = []
+        deferred_proxy_health: list[tuple[Account, ProxyResponseError]] = []
 
         async def settle_compact_usage(
             *,
@@ -711,6 +712,8 @@ class _CompactMixin:
             deferred_stream_health.clear()
             http_500_pending = list(deferred_http_500_health)
             deferred_http_500_health.clear()
+            proxy_pending = list(deferred_proxy_health)
+            deferred_proxy_health.clear()
             for failed_account, failed_error, failed_code, failed_status in stream_pending:
                 await proxy._handle_stream_error(
                     failed_account,
@@ -721,6 +724,17 @@ class _CompactMixin:
             for failed_account, failed_exc, extra_error_count in http_500_pending:
                 await proxy._handle_proxy_error(failed_account, failed_exc)
                 await proxy._load_balancer.record_errors(failed_account, extra_error_count)
+            for failed_account, failed_exc in proxy_pending:
+                await proxy._handle_proxy_error(failed_account, failed_exc)
+
+        async def record_or_defer_proxy_health(
+            failed_account: Account,
+            failed_exc: ProxyResponseError,
+        ) -> None:
+            if api_key is not None and api_key_reservation is not None:
+                deferred_proxy_health.append((failed_account, failed_exc))
+                return
+            await proxy._handle_proxy_error(failed_account, failed_exc)
 
         async def record_or_defer_stream_health(
             failed_account: Account,
@@ -1203,7 +1217,7 @@ class _CompactMixin:
                         if exc.status_code == 401:
                             if refresh_retry_used:
                                 try:
-                                    await proxy._handle_proxy_error(account, exc)
+                                    await record_or_defer_proxy_health(account, exc)
                                 except Exception:
                                     await settle_compact_usage(
                                         api_key=api_key,
@@ -1257,13 +1271,13 @@ class _CompactMixin:
                             except (RefreshError, aiohttp.ClientError, asyncio.TimeoutError) as refresh_exc:
                                 if isinstance(refresh_exc, RefreshError):
                                     if refresh_exc.is_permanent:
-                                        await proxy._load_balancer.mark_permanent_failure(account, refresh_exc.code)
                                         await settle_compact_usage(
                                             api_key=api_key,
                                             api_key_reservation=api_key_reservation,
                                             response=None,
                                             request_service_tier=request_service_tier,
                                         )
+                                        await proxy._load_balancer.mark_permanent_failure(account, refresh_exc.code)
                                         raise exc
                                     if is_transient_refresh_contention(refresh_exc):
                                         # Transient CROSS-REPLICA refresh contention

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -786,6 +786,23 @@ class _CompactMixin:
             if settlement_error is not None:
                 raise settlement_error
 
+        async def settle_on_terminal_exit() -> None:
+            if settlement_attempted:
+                return
+            try:
+                await settle_compact_usage(
+                    api_key=api_key,
+                    api_key_reservation=api_key_reservation,
+                    response=None,
+                    request_service_tier=request_service_tier,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to settle compact reservation after unexpected exit request_id=%s",
+                    request_id,
+                    exc_info=True,
+                )
+
         async def record_or_defer_proxy_health(
             failed_account: Account,
             failed_exc: ProxyResponseError,
@@ -1650,6 +1667,7 @@ class _CompactMixin:
                 openai_error("upstream_unavailable", "All account attempts exhausted"),
             )
         except ProxyResponseError as exc:
+            await settle_on_terminal_exit()
             failure_metadata = _request_log_failure_metadata(exc)
             error = _parse_openai_error(exc.payload)
             log_error_code = log_error_code or _normalize_error_code(
@@ -1673,20 +1691,7 @@ class _CompactMixin:
                 openai_error("upstream_proxy_unavailable", f"Upstream proxy route unavailable: {exc.reason}"),
             ) from exc
         except BaseException:
-            if not settlement_attempted:
-                try:
-                    await settle_compact_usage(
-                        api_key=api_key,
-                        api_key_reservation=api_key_reservation,
-                        response=None,
-                        request_service_tier=request_service_tier,
-                    )
-                except Exception:
-                    logger.warning(
-                        "Failed to settle compact reservation after unexpected exit request_id=%s",
-                        request_id,
-                        exc_info=True,
-                    )
+            await settle_on_terminal_exit()
             raise
         finally:
             usage = response.usage if response else None

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -704,17 +704,41 @@ class _CompactMixin:
             proxy_pending = list(deferred_proxy_health)
             deferred_proxy_health.clear()
             for failed_account, failed_error, failed_code, failed_status in stream_pending:
-                await proxy._handle_stream_error(
-                    failed_account,
-                    failed_error,
-                    failed_code,
-                    http_status=failed_status,
-                )
+                try:
+                    await proxy._handle_stream_error(
+                        failed_account,
+                        failed_error,
+                        failed_code,
+                        http_status=failed_status,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to flush deferred compact stream health account_id=%s request_id=%s",
+                        failed_account.id,
+                        request_id,
+                        exc_info=True,
+                    )
             for failed_account, failed_exc, extra_error_count in http_500_pending:
-                await proxy._handle_proxy_error(failed_account, failed_exc)
-                await proxy._load_balancer.record_errors(failed_account, extra_error_count)
+                try:
+                    await proxy._handle_proxy_error(failed_account, failed_exc)
+                    await proxy._load_balancer.record_errors(failed_account, extra_error_count)
+                except Exception:
+                    logger.warning(
+                        "Failed to flush deferred compact HTTP 500 health account_id=%s request_id=%s",
+                        failed_account.id,
+                        request_id,
+                        exc_info=True,
+                    )
             for failed_account, failed_exc in proxy_pending:
-                await proxy._handle_proxy_error(failed_account, failed_exc)
+                try:
+                    await proxy._handle_proxy_error(failed_account, failed_exc)
+                except Exception:
+                    logger.warning(
+                        "Failed to flush deferred compact proxy health account_id=%s request_id=%s",
+                        failed_account.id,
+                        request_id,
+                        exc_info=True,
+                    )
 
         async def settle_compact_usage(
             *,

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -694,6 +694,7 @@ class _CompactMixin:
         deferred_stream_health: list[tuple[Account, Any, str, int | None]] = []
         deferred_http_500_health: list[tuple[Account, ProxyResponseError, int]] = []
         deferred_proxy_health: list[tuple[Account, ProxyResponseError]] = []
+        settlement_attempted = False
 
         async def flush_deferred_health() -> None:
             stream_pending = list(deferred_stream_health)
@@ -722,6 +723,8 @@ class _CompactMixin:
             response: CompactResponsePayload | None,
             request_service_tier: str | None,
         ) -> None:
+            nonlocal settlement_attempted
+            settlement_attempted = True
             settlement_error: ProxyResponseError | None = None
             try:
                 await proxy._settle_compact_api_key_usage(
@@ -734,7 +737,14 @@ class _CompactMixin:
                 if exc.failure_phase != "usage_settlement" or not exc.reservation_released:
                     raise
                 settlement_error = exc
-            await flush_deferred_health()
+            try:
+                await flush_deferred_health()
+            except Exception:
+                logger.warning(
+                    "Failed to flush deferred compact account health request_id=%s",
+                    request_id,
+                    exc_info=True,
+                )
             if settlement_error is not None:
                 raise settlement_error
 
@@ -1624,6 +1634,22 @@ class _CompactMixin:
                 502,
                 openai_error("upstream_proxy_unavailable", f"Upstream proxy route unavailable: {exc.reason}"),
             ) from exc
+        except BaseException:
+            if not settlement_attempted:
+                try:
+                    await settle_compact_usage(
+                        api_key=api_key,
+                        api_key_reservation=api_key_reservation,
+                        response=None,
+                        request_service_tier=request_service_tier,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to settle compact reservation after unexpected exit request_id=%s",
+                        request_id,
+                        exc_info=True,
+                    )
+            raise
         finally:
             usage = response.usage if response else None
             reasoning_effort = payload.reasoning.effort if payload.reasoning else None

--- a/openspec/changes/settle-compact-failover-before-health/context.md
+++ b/openspec/changes/settle-compact-failover-before-health/context.md
@@ -19,3 +19,5 @@ that clients retry. Cancellation and other non-proxy exits skip the dedicated
 settle handlers, so they need an explicit settle-then-flush before the
 original exception continues. The flush itself is shielded so a cancel that
 arrives after queues are drained cannot drop the remaining health write.
+Each deferred entry is written independently so one persistence failure does
+not skip the other failed accounts.

--- a/openspec/changes/settle-compact-failover-before-health/context.md
+++ b/openspec/changes/settle-compact-failover-before-health/context.md
@@ -1,0 +1,8 @@
+Compact timeout already settles the API-key reservation before
+`_handle_stream_error`. The generic compact error path did the opposite:
+it wrote health, then either surfaced (settle + raise) or failed over
+without settling.
+
+`failover_next` cannot release the reservation immediately because the next
+account still uses that same reservation. Health is therefore deferred until
+the next settle (success, surface, timeout, or exhaustion).

--- a/openspec/changes/settle-compact-failover-before-health/context.md
+++ b/openspec/changes/settle-compact-failover-before-health/context.md
@@ -17,4 +17,5 @@ Once usage is finalized, a later deferred health-write failure is a local
 persistence problem. It must not convert a billed compact success into a 500
 that clients retry. Cancellation and other non-proxy exits skip the dedicated
 settle handlers, so they need an explicit settle-then-flush before the
-original exception continues.
+original exception continues. The flush itself is shielded so a cancel that
+arrives after queues are drained cannot drop the remaining health write.

--- a/openspec/changes/settle-compact-failover-before-health/context.md
+++ b/openspec/changes/settle-compact-failover-before-health/context.md
@@ -6,3 +6,9 @@ without settling.
 `failover_next` cannot release the reservation immediately because the next
 account still uses that same reservation. Health is therefore deferred until
 the next settle (success, surface, timeout, or exhaustion).
+
+`_settle_compact_api_key_usage` still raises `usage_settlement_failed` after
+a finalize failure even when its fail-safe release succeeds. That exception
+must carry whether the reservation is actually released so deferred health
+can flush before the 502 is surfaced. If the fail-safe release also fails,
+the reservation is still held and deferred health stays queued.

--- a/openspec/changes/settle-compact-failover-before-health/context.md
+++ b/openspec/changes/settle-compact-failover-before-health/context.md
@@ -12,3 +12,9 @@ a finalize failure even when its fail-safe release succeeds. That exception
 must carry whether the reservation is actually released so deferred health
 can flush before the 502 is surfaced. If the fail-safe release also fails,
 the reservation is still held and deferred health stays queued.
+
+Once usage is finalized, a later deferred health-write failure is a local
+persistence problem. It must not convert a billed compact success into a 500
+that clients retry. Cancellation and other non-proxy exits skip the dedicated
+settle handlers, so they need an explicit settle-then-flush before the
+original exception continues.

--- a/openspec/changes/settle-compact-failover-before-health/context.md
+++ b/openspec/changes/settle-compact-failover-before-health/context.md
@@ -20,4 +20,6 @@ settle handlers, so they need an explicit settle-then-flush before the
 original exception continues. The flush itself is shielded so a cancel that
 arrives after queues are drained cannot drop the remaining health write.
 Each deferred entry is written independently so one persistence failure does
-not skip the other failed accounts.
+not skip the other failed accounts. A later `_select_account_with_budget`
+timeout is a `ProxyResponseError`, so it must use the same settle-and-flush
+cleanup as other unsettled exits.

--- a/openspec/changes/settle-compact-failover-before-health/proposal.md
+++ b/openspec/changes/settle-compact-failover-before-health/proposal.md
@@ -10,6 +10,8 @@ request and can backoff an account that the request has not finished using.
 - Classify compact failover without writing health.
 - Keep the reservation across `failover_next` and defer the health write.
 - Flush deferred health only after `_settle_compact_api_key_usage`.
+- If finalize fails but fail-safe release succeeds, flush deferred health
+  before surfacing `usage_settlement_failed`.
 - Surface paths settle, then write health.
 
 ## Capabilities

--- a/openspec/changes/settle-compact-failover-before-health/proposal.md
+++ b/openspec/changes/settle-compact-failover-before-health/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Compact `failover_next` writes account health through `_handle_stream_error`
+while the API-key reservation is still reserved. The timeout branch already
+settles first. An open reservation plus a health penalty double-charges the
+request and can backoff an account that the request has not finished using.
+
+## What Changes
+
+- Classify compact failover without writing health.
+- Keep the reservation across `failover_next` and defer the health write.
+- Flush deferred health only after `_settle_compact_api_key_usage`.
+- Surface paths settle, then write health.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `usage-refresh-policy`: compact failover must settle the reservation
+  before any account-health write.
+
+## Impact
+
+Streaming SSE reservation paths and compact timeout/exhaustion terminals stay
+on their current settle-then-health order. No second reservation is acquired
+mid-request.

--- a/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Compact failover settles before account-health writes
 
-When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request.
+When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied.
 
 #### Scenario: Compact failover_next defers health until settle
 
@@ -52,3 +52,19 @@ When `compact_responses` holds an API-key usage reservation, it MUST NOT write a
 - **AND** the post-401 forced refresh raises a permanent `RefreshError`
 - **WHEN** the compact request records the permanent account failure
 - **THEN** the reservation is settled before `mark_permanent_failure`
+
+#### Scenario: Compact fallback release still flushes deferred health
+
+- **GIVEN** a compact request that deferred health on `failover_next`
+- **AND** a later account completes but usage finalization fails
+- **AND** the fail-safe reservation release succeeds
+- **WHEN** settlement surfaces `usage_settlement_failed`
+- **THEN** the deferred health write still runs
+- **AND** it runs before the `usage_settlement_failed` error is raised
+
+#### Scenario: Compact unsettled reservation keeps deferred health unapplied
+
+- **GIVEN** a compact request that deferred health on `failover_next`
+- **AND** both usage finalization and fail-safe release fail
+- **WHEN** settlement surfaces `usage_settlement_failed`
+- **THEN** the deferred health write does not run

--- a/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
@@ -38,3 +38,17 @@ When `compact_responses` holds an API-key usage reservation, it MUST NOT write a
 - **AND** the first account fails a retryable freshness/connect or post-401 forced-refresh transport error
 - **WHEN** a later account completes and settlement runs
 - **THEN** `_handle_stream_error` for the failed account runs only after that settlement
+
+#### Scenario: Compact second 401 failover defers health until settle
+
+- **GIVEN** a compact request with a held API-key reservation
+- **AND** the same account returns 401 again after a forced refresh
+- **WHEN** a later account completes and settlement runs
+- **THEN** `_handle_proxy_error` for the failed account runs only after that settlement
+
+#### Scenario: Compact permanent refresh settles before the health mark
+
+- **GIVEN** a compact request with a held API-key reservation
+- **AND** the post-401 forced refresh raises a permanent `RefreshError`
+- **WHEN** the compact request records the permanent account failure
+- **THEN** the reservation is settled before `mark_permanent_failure`

--- a/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Compact failover settles before account-health writes
 
-When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied.
+When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied. After a compact reservation is finalized, a deferred health-persistence failure MUST NOT replace the successful compact response. If compact exits through cancellation or any exception other than `ProxyResponseError` or `UpstreamProxyRouteError`, it MUST settle or release the reservation and flush deferred health before propagating that exception.
 
 #### Scenario: Compact failover_next defers health until settle
 
@@ -68,3 +68,18 @@ When `compact_responses` holds an API-key usage reservation, it MUST NOT write a
 - **AND** both usage finalization and fail-safe release fail
 - **WHEN** settlement surfaces `usage_settlement_failed`
 - **THEN** the deferred health write does not run
+
+#### Scenario: Compact success survives deferred health persistence failure
+
+- **GIVEN** a compact request that deferred health on `failover_next`
+- **AND** a later account completes and usage finalization succeeds
+- **WHEN** the deferred health write raises
+- **THEN** the successful compact response is still returned
+
+#### Scenario: Compact unexpected exit still flushes deferred health
+
+- **GIVEN** a compact request that deferred health on `failover_next`
+- **WHEN** the next account attempt raises cancellation or another non-proxy exception
+- **THEN** the reservation is settled or released
+- **AND** the deferred health write still runs
+- **AND** the original exception is propagated

--- a/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Compact failover settles before account-health writes
 
-When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied. After a compact reservation is finalized, a deferred health-persistence failure MUST NOT replace the successful compact response. If compact exits through cancellation or any exception other than `ProxyResponseError` or `UpstreamProxyRouteError`, it MUST settle or release the reservation and flush deferred health before propagating that exception. Deferred health flush MUST complete even if the compact request is cancelled while that flush is awaiting a health write. If one deferred health write fails, compact MUST still attempt the remaining deferred health writes.
+When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied. After a compact reservation is finalized, a deferred health-persistence failure MUST NOT replace the successful compact response. If compact exits through cancellation or any exception other than a `ProxyResponseError` that already settled, it MUST settle or release the reservation and flush deferred health before propagating that exception. A later account-selection budget timeout after `failover_next` MUST use that same settle-and-flush path. Deferred health flush MUST complete even if the compact request is cancelled while that flush is awaiting a health write. If one deferred health write fails, compact MUST still attempt the remaining deferred health writes.
 
 #### Scenario: Compact failover_next defers health until settle
 
@@ -96,3 +96,11 @@ When `compact_responses` holds an API-key usage reservation, it MUST NOT write a
 - **GIVEN** a compact request that deferred health for more than one failed account
 - **WHEN** the first deferred health write raises
 - **THEN** later deferred health writes are still attempted
+
+#### Scenario: Compact selection timeout after failover still flushes deferred health
+
+- **GIVEN** a compact request that deferred health on `failover_next`
+- **WHEN** selecting the next account exhausts the request budget
+- **THEN** the reservation is settled or released
+- **AND** the deferred health write still runs
+- **AND** the original budget-timeout error is propagated

--- a/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Compact failover settles before account-health writes
 
-When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied. After a compact reservation is finalized, a deferred health-persistence failure MUST NOT replace the successful compact response. If compact exits through cancellation or any exception other than `ProxyResponseError` or `UpstreamProxyRouteError`, it MUST settle or release the reservation and flush deferred health before propagating that exception.
+When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied. After a compact reservation is finalized, a deferred health-persistence failure MUST NOT replace the successful compact response. If compact exits through cancellation or any exception other than `ProxyResponseError` or `UpstreamProxyRouteError`, it MUST settle or release the reservation and flush deferred health before propagating that exception. Deferred health flush MUST complete even if the compact request is cancelled while that flush is awaiting a health write.
 
 #### Scenario: Compact failover_next defers health until settle
 
@@ -83,3 +83,10 @@ When `compact_responses` holds an API-key usage reservation, it MUST NOT write a
 - **THEN** the reservation is settled or released
 - **AND** the deferred health write still runs
 - **AND** the original exception is propagated
+
+#### Scenario: Compact deferred health flush completes under cancellation
+
+- **GIVEN** a compact request that deferred health on `failover_next`
+- **AND** a later account completed and settlement started flushing
+- **WHEN** the request is cancelled during the deferred health write
+- **THEN** the deferred health write still completes

--- a/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
@@ -31,3 +31,10 @@ When `compact_responses` holds an API-key usage reservation, it MUST NOT write a
 - **WHEN** the next account raises `UpstreamProxyRouteError`
 - **THEN** the reservation is settled
 - **AND** the deferred health write still runs
+
+#### Scenario: Compact refresh/connect failover defers health until settle
+
+- **GIVEN** a compact request with a held API-key reservation
+- **AND** the first account fails a retryable freshness/connect or post-401 forced-refresh transport error
+- **WHEN** a later account completes and settlement runs
+- **THEN** `_handle_stream_error` for the failed account runs only after that settlement

--- a/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Compact failover settles before account-health writes
+
+When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request.
+
+#### Scenario: Compact failover_next defers health until settle
+
+- **GIVEN** a compact request with a held API-key reservation
+- **AND** the first account fails with a `failover_next` class
+- **WHEN** a later account completes and settlement runs
+- **THEN** `_handle_stream_error` for the failed account runs only after that settlement
+- **AND** the request does not acquire another reservation
+
+#### Scenario: Compact timeout still settles before health
+
+- **GIVEN** a compact request whose upstream call times out
+- **WHEN** the timeout branch records account health
+- **THEN** the reservation is settled before `_handle_stream_error`

--- a/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
@@ -17,3 +17,17 @@ When `compact_responses` holds an API-key usage reservation, it MUST NOT write a
 - **GIVEN** a compact request whose upstream call times out
 - **WHEN** the timeout branch records account health
 - **THEN** the reservation is settled before `_handle_stream_error`
+
+#### Scenario: Compact HTTP 500 failover defers health until settle
+
+- **GIVEN** a compact request with a held API-key reservation
+- **AND** the first account exhausts same-account HTTP 500 retries
+- **WHEN** a later account completes and settlement runs
+- **THEN** `_handle_proxy_error` and extra `record_errors` for the failed account run only after that settlement
+
+#### Scenario: Compact route failure after failover still applies deferred health
+
+- **GIVEN** a compact request that deferred health on `failover_next`
+- **WHEN** the next account raises `UpstreamProxyRouteError`
+- **THEN** the reservation is settled
+- **AND** the deferred health write still runs

--- a/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
+++ b/openspec/changes/settle-compact-failover-before-health/specs/usage-refresh-policy/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Compact failover settles before account-health writes
 
-When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied. After a compact reservation is finalized, a deferred health-persistence failure MUST NOT replace the successful compact response. If compact exits through cancellation or any exception other than `ProxyResponseError` or `UpstreamProxyRouteError`, it MUST settle or release the reservation and flush deferred health before propagating that exception. Deferred health flush MUST complete even if the compact request is cancelled while that flush is awaiting a health write.
+When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied. After a compact reservation is finalized, a deferred health-persistence failure MUST NOT replace the successful compact response. If compact exits through cancellation or any exception other than `ProxyResponseError` or `UpstreamProxyRouteError`, it MUST settle or release the reservation and flush deferred health before propagating that exception. Deferred health flush MUST complete even if the compact request is cancelled while that flush is awaiting a health write. If one deferred health write fails, compact MUST still attempt the remaining deferred health writes.
 
 #### Scenario: Compact failover_next defers health until settle
 
@@ -90,3 +90,9 @@ When `compact_responses` holds an API-key usage reservation, it MUST NOT write a
 - **AND** a later account completed and settlement started flushing
 - **WHEN** the request is cancelled during the deferred health write
 - **THEN** the deferred health write still completes
+
+#### Scenario: Compact continues flushing after one deferred health write fails
+
+- **GIVEN** a compact request that deferred health for more than one failed account
+- **WHEN** the first deferred health write raises
+- **THEN** later deferred health writes are still attempted

--- a/openspec/changes/settle-compact-failover-before-health/tasks.md
+++ b/openspec/changes/settle-compact-failover-before-health/tasks.md
@@ -8,6 +8,10 @@
 
 - [x] 2.1 Assert compact `failover_next` with a held reservation settles
   before `_handle_stream_error`.
+- [x] 2.2 Assert exhausted HTTP 500 retries defer `_handle_proxy_error`
+  until settlement.
+- [x] 2.3 Assert `UpstreamProxyRouteError` after failover still flushes
+  deferred health.
 
 ## 3. Validation
 

--- a/openspec/changes/settle-compact-failover-before-health/tasks.md
+++ b/openspec/changes/settle-compact-failover-before-health/tasks.md
@@ -9,6 +9,8 @@
   fails.
 - [x] 1.5 Settle and flush deferred health on cancellation and other
   non-proxy exits.
+- [x] 1.6 Shield deferred health flush so cancellation during the write
+  still completes the penalty.
 
 ## 2. Regression coverage
 
@@ -30,6 +32,8 @@
   finalized compact success.
 - [x] 2.10 Assert cancellation or another non-proxy exit still settles and
   flushes deferred health.
+- [x] 2.11 Assert cancellation during deferred health flush still completes
+  the write.
 
 ## 3. Validation
 

--- a/openspec/changes/settle-compact-failover-before-health/tasks.md
+++ b/openspec/changes/settle-compact-failover-before-health/tasks.md
@@ -12,6 +12,8 @@
   until settlement.
 - [x] 2.3 Assert `UpstreamProxyRouteError` after failover still flushes
   deferred health.
+- [x] 2.4 Assert freshness/connect and post-401 refresh failovers defer
+  health until settlement.
 
 ## 3. Validation
 

--- a/openspec/changes/settle-compact-failover-before-health/tasks.md
+++ b/openspec/changes/settle-compact-failover-before-health/tasks.md
@@ -12,6 +12,8 @@
 - [x] 1.6 Shield deferred health flush so cancellation during the write
   still completes the penalty.
 - [x] 1.7 Continue remaining deferred health writes if one write fails.
+- [x] 1.8 Settle and flush deferred health when a later account selection
+  times out.
 
 ## 2. Regression coverage
 
@@ -37,6 +39,8 @@
   the write.
 - [x] 2.12 Assert a later deferred health write still runs after an earlier
   write fails.
+- [x] 2.13 Assert a post-failover account-selection timeout still flushes
+  deferred health.
 
 ## 3. Validation
 

--- a/openspec/changes/settle-compact-failover-before-health/tasks.md
+++ b/openspec/changes/settle-compact-failover-before-health/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] 1.1 Classify compact failover without writing health, and defer the
+  health write when a reservation is still held.
+- [x] 1.2 Flush deferred health only after `_settle_compact_api_key_usage`.
+
+## 2. Regression coverage
+
+- [x] 2.1 Assert compact `failover_next` with a held reservation settles
+  before `_handle_stream_error`.
+
+## 3. Validation
+
+- [x] 3.1 Run the new compact order regression and the existing compact
+  timeout settle-before-health test.
+- [x] 3.2 Run strict OpenSpec validation for this change.

--- a/openspec/changes/settle-compact-failover-before-health/tasks.md
+++ b/openspec/changes/settle-compact-failover-before-health/tasks.md
@@ -14,6 +14,9 @@
   deferred health.
 - [x] 2.4 Assert freshness/connect and post-401 refresh failovers defer
   health until settlement.
+- [x] 2.5 Assert a second 401 after forced refresh defers `_handle_proxy_error`.
+- [x] 2.6 Assert permanent post-401 refresh settles before
+  `mark_permanent_failure`.
 
 ## 3. Validation
 

--- a/openspec/changes/settle-compact-failover-before-health/tasks.md
+++ b/openspec/changes/settle-compact-failover-before-health/tasks.md
@@ -11,6 +11,7 @@
   non-proxy exits.
 - [x] 1.6 Shield deferred health flush so cancellation during the write
   still completes the penalty.
+- [x] 1.7 Continue remaining deferred health writes if one write fails.
 
 ## 2. Regression coverage
 
@@ -34,6 +35,8 @@
   flushes deferred health.
 - [x] 2.11 Assert cancellation during deferred health flush still completes
   the write.
+- [x] 2.12 Assert a later deferred health write still runs after an earlier
+  write fails.
 
 ## 3. Validation
 

--- a/openspec/changes/settle-compact-failover-before-health/tasks.md
+++ b/openspec/changes/settle-compact-failover-before-health/tasks.md
@@ -5,6 +5,10 @@
 - [x] 1.2 Flush deferred health only after `_settle_compact_api_key_usage`.
 - [x] 1.3 Flush deferred health when finalize fails but fail-safe release
   succeeds, then surface `usage_settlement_failed`.
+- [x] 1.4 Keep a finalized compact success when deferred health persistence
+  fails.
+- [x] 1.5 Settle and flush deferred health on cancellation and other
+  non-proxy exits.
 
 ## 2. Regression coverage
 
@@ -22,6 +26,10 @@
 - [x] 2.7 Assert fallback-release success still flushes deferred health
   before `usage_settlement_failed`.
 - [x] 2.8 Assert fallback-release failure keeps deferred health unapplied.
+- [x] 2.9 Assert a deferred health-persistence failure does not replace a
+  finalized compact success.
+- [x] 2.10 Assert cancellation or another non-proxy exit still settles and
+  flushes deferred health.
 
 ## 3. Validation
 

--- a/openspec/changes/settle-compact-failover-before-health/tasks.md
+++ b/openspec/changes/settle-compact-failover-before-health/tasks.md
@@ -3,6 +3,8 @@
 - [x] 1.1 Classify compact failover without writing health, and defer the
   health write when a reservation is still held.
 - [x] 1.2 Flush deferred health only after `_settle_compact_api_key_usage`.
+- [x] 1.3 Flush deferred health when finalize fails but fail-safe release
+  succeeds, then surface `usage_settlement_failed`.
 
 ## 2. Regression coverage
 
@@ -17,6 +19,9 @@
 - [x] 2.5 Assert a second 401 after forced refresh defers `_handle_proxy_error`.
 - [x] 2.6 Assert permanent post-401 refresh settles before
   `mark_permanent_failure`.
+- [x] 2.7 Assert fallback-release success still flushes deferred health
+  before `usage_settlement_failed`.
+- [x] 2.8 Assert fallback-release failure keeps deferred health unapplied.
 
 ## 3. Validation
 

--- a/openspec/specs/usage-refresh-policy/spec.md
+++ b/openspec/specs/usage-refresh-policy/spec.md
@@ -1257,7 +1257,7 @@ local writes but MUST NOT be the mechanism that guarantees dedup.
 
 ### Requirement: Compact failover settles before account-health writes
 
-When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied. After a compact reservation is finalized, a deferred health-persistence failure MUST NOT replace the successful compact response. If compact exits through cancellation or any exception other than `ProxyResponseError` or `UpstreamProxyRouteError`, it MUST settle or release the reservation and flush deferred health before propagating that exception. Deferred health flush MUST complete even if the compact request is cancelled while that flush is awaiting a health write.
+When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied. After a compact reservation is finalized, a deferred health-persistence failure MUST NOT replace the successful compact response. If compact exits through cancellation or any exception other than `ProxyResponseError` or `UpstreamProxyRouteError`, it MUST settle or release the reservation and flush deferred health before propagating that exception. Deferred health flush MUST complete even if the compact request is cancelled while that flush is awaiting a health write. If one deferred health write fails, compact MUST still attempt the remaining deferred health writes.
 
 #### Scenario: Compact failover_next defers health until settle
 
@@ -1345,6 +1345,12 @@ When `compact_responses` holds an API-key usage reservation, it MUST NOT write a
 - **AND** a later account completed and settlement started flushing
 - **WHEN** the request is cancelled during the deferred health write
 - **THEN** the deferred health write still completes
+
+#### Scenario: Compact continues flushing after one deferred health write fails
+
+- **GIVEN** a compact request that deferred health for more than one failed account
+- **WHEN** the first deferred health write raises
+- **THEN** later deferred health writes are still attempted
 
 ### Requirement: Compact budget-exhausted terminals settle the API-key reservation before raising
 

--- a/openspec/specs/usage-refresh-policy/spec.md
+++ b/openspec/specs/usage-refresh-policy/spec.md
@@ -1257,7 +1257,7 @@ local writes but MUST NOT be the mechanism that guarantees dedup.
 
 ### Requirement: Compact failover settles before account-health writes
 
-When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied.
+When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied. After a compact reservation is finalized, a deferred health-persistence failure MUST NOT replace the successful compact response. If compact exits through cancellation or any exception other than `ProxyResponseError` or `UpstreamProxyRouteError`, it MUST settle or release the reservation and flush deferred health before propagating that exception.
 
 #### Scenario: Compact failover_next defers health until settle
 
@@ -1323,6 +1323,21 @@ When `compact_responses` holds an API-key usage reservation, it MUST NOT write a
 - **AND** both usage finalization and fail-safe release fail
 - **WHEN** settlement surfaces `usage_settlement_failed`
 - **THEN** the deferred health write does not run
+
+#### Scenario: Compact success survives deferred health persistence failure
+
+- **GIVEN** a compact request that deferred health on `failover_next`
+- **AND** a later account completes and usage finalization succeeds
+- **WHEN** the deferred health write raises
+- **THEN** the successful compact response is still returned
+
+#### Scenario: Compact unexpected exit still flushes deferred health
+
+- **GIVEN** a compact request that deferred health on `failover_next`
+- **WHEN** the next account attempt raises cancellation or another non-proxy exception
+- **THEN** the reservation is settled or released
+- **AND** the deferred health write still runs
+- **AND** the original exception is propagated
 
 ### Requirement: Compact budget-exhausted terminals settle the API-key reservation before raising
 

--- a/openspec/specs/usage-refresh-policy/spec.md
+++ b/openspec/specs/usage-refresh-policy/spec.md
@@ -1257,7 +1257,7 @@ local writes but MUST NOT be the mechanism that guarantees dedup.
 
 ### Requirement: Compact failover settles before account-health writes
 
-When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied. After a compact reservation is finalized, a deferred health-persistence failure MUST NOT replace the successful compact response. If compact exits through cancellation or any exception other than `ProxyResponseError` or `UpstreamProxyRouteError`, it MUST settle or release the reservation and flush deferred health before propagating that exception.
+When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied. After a compact reservation is finalized, a deferred health-persistence failure MUST NOT replace the successful compact response. If compact exits through cancellation or any exception other than `ProxyResponseError` or `UpstreamProxyRouteError`, it MUST settle or release the reservation and flush deferred health before propagating that exception. Deferred health flush MUST complete even if the compact request is cancelled while that flush is awaiting a health write.
 
 #### Scenario: Compact failover_next defers health until settle
 
@@ -1338,6 +1338,13 @@ When `compact_responses` holds an API-key usage reservation, it MUST NOT write a
 - **THEN** the reservation is settled or released
 - **AND** the deferred health write still runs
 - **AND** the original exception is propagated
+
+#### Scenario: Compact deferred health flush completes under cancellation
+
+- **GIVEN** a compact request that deferred health on `failover_next`
+- **AND** a later account completed and settlement started flushing
+- **WHEN** the request is cancelled during the deferred health write
+- **THEN** the deferred health write still completes
 
 ### Requirement: Compact budget-exhausted terminals settle the API-key reservation before raising
 

--- a/openspec/specs/usage-refresh-policy/spec.md
+++ b/openspec/specs/usage-refresh-policy/spec.md
@@ -1257,7 +1257,7 @@ local writes but MUST NOT be the mechanism that guarantees dedup.
 
 ### Requirement: Compact failover settles before account-health writes
 
-When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied. After a compact reservation is finalized, a deferred health-persistence failure MUST NOT replace the successful compact response. If compact exits through cancellation or any exception other than `ProxyResponseError` or `UpstreamProxyRouteError`, it MUST settle or release the reservation and flush deferred health before propagating that exception. Deferred health flush MUST complete even if the compact request is cancelled while that flush is awaiting a health write. If one deferred health write fails, compact MUST still attempt the remaining deferred health writes.
+When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied. After a compact reservation is finalized, a deferred health-persistence failure MUST NOT replace the successful compact response. If compact exits through cancellation or any exception other than a `ProxyResponseError` that already settled, it MUST settle or release the reservation and flush deferred health before propagating that exception. A later account-selection budget timeout after `failover_next` MUST use that same settle-and-flush path. Deferred health flush MUST complete even if the compact request is cancelled while that flush is awaiting a health write. If one deferred health write fails, compact MUST still attempt the remaining deferred health writes.
 
 #### Scenario: Compact failover_next defers health until settle
 
@@ -1351,6 +1351,14 @@ When `compact_responses` holds an API-key usage reservation, it MUST NOT write a
 - **GIVEN** a compact request that deferred health for more than one failed account
 - **WHEN** the first deferred health write raises
 - **THEN** later deferred health writes are still attempted
+
+#### Scenario: Compact selection timeout after failover still flushes deferred health
+
+- **GIVEN** a compact request that deferred health on `failover_next`
+- **WHEN** selecting the next account exhausts the request budget
+- **THEN** the reservation is settled or released
+- **AND** the deferred health write still runs
+- **AND** the original budget-timeout error is propagated
 
 ### Requirement: Compact budget-exhausted terminals settle the API-key reservation before raising
 

--- a/openspec/specs/usage-refresh-policy/spec.md
+++ b/openspec/specs/usage-refresh-policy/spec.md
@@ -1294,6 +1294,20 @@ When `compact_responses` holds an API-key usage reservation, it MUST NOT write a
 - **WHEN** a later account completes and settlement runs
 - **THEN** `_handle_stream_error` for the failed account runs only after that settlement
 
+#### Scenario: Compact second 401 failover defers health until settle
+
+- **GIVEN** a compact request with a held API-key reservation
+- **AND** the same account returns 401 again after a forced refresh
+- **WHEN** a later account completes and settlement runs
+- **THEN** `_handle_proxy_error` for the failed account runs only after that settlement
+
+#### Scenario: Compact permanent refresh settles before the health mark
+
+- **GIVEN** a compact request with a held API-key reservation
+- **AND** the post-401 forced refresh raises a permanent `RefreshError`
+- **WHEN** the compact request records the permanent account failure
+- **THEN** the reservation is settled before `mark_permanent_failure`
+
 ### Requirement: Compact budget-exhausted terminals settle the API-key reservation before raising
 
 On the HTTP bridge / forwarded compact path the caller passes an `api_key_reservation_override` with `owns_reservation` false, making `compact_responses` the SOLE settler of the API-key usage reservation; therefore EVERY budget-exhausted terminal raise in the compact request path that is reached with a held, unsettled reservation MUST settle the compact API-key usage reservation (release it via `_settle_compact_api_key_usage` with `response` `None`) BEFORE raising the budget-exhausted `ProxyResponseError` (`upstream_request_timeout`), so held API-key quota is not leaked. This MUST apply to the outer-loop preflight budget terminals (before the freshness check, before the freshness reserve, and after the freshness check) and to the post-401 forced-refresh preflight budget terminal, each of which propagates straight to the outer `except ProxyResponseError` handler (which does not settle) and the `finally` (which only writes a request log). The terminal MUST preserve its prior escalation: it still raises the same `502` `upstream_request_timeout` error after settling, and it MUST still release the selected account's `response_create` lease where it already did so. A budget-exhausted terminal that is caught by an enclosing handler that already settles the reservation before raising — the inner upstream-call budget terminals, whose `upstream_request_timeout` error is settled by the retry loop's `upstream_request_timeout` / account-neutral branch — MUST NOT settle a second time, so the reservation is never double-settled.

--- a/openspec/specs/usage-refresh-policy/spec.md
+++ b/openspec/specs/usage-refresh-policy/spec.md
@@ -1257,7 +1257,7 @@ local writes but MUST NOT be the mechanism that guarantees dedup.
 
 ### Requirement: Compact failover settles before account-health writes
 
-When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request.
+When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request. If usage finalization fails but the fail-safe reservation release succeeds, compact MUST flush deferred health before surfacing `usage_settlement_failed`. If the reservation remains held because that fail-safe release also fails, deferred health MUST stay unapplied.
 
 #### Scenario: Compact failover_next defers health until settle
 
@@ -1307,6 +1307,22 @@ When `compact_responses` holds an API-key usage reservation, it MUST NOT write a
 - **AND** the post-401 forced refresh raises a permanent `RefreshError`
 - **WHEN** the compact request records the permanent account failure
 - **THEN** the reservation is settled before `mark_permanent_failure`
+
+#### Scenario: Compact fallback release still flushes deferred health
+
+- **GIVEN** a compact request that deferred health on `failover_next`
+- **AND** a later account completes but usage finalization fails
+- **AND** the fail-safe reservation release succeeds
+- **WHEN** settlement surfaces `usage_settlement_failed`
+- **THEN** the deferred health write still runs
+- **AND** it runs before the `usage_settlement_failed` error is raised
+
+#### Scenario: Compact unsettled reservation keeps deferred health unapplied
+
+- **GIVEN** a compact request that deferred health on `failover_next`
+- **AND** both usage finalization and fail-safe release fail
+- **WHEN** settlement surfaces `usage_settlement_failed`
+- **THEN** the deferred health write does not run
 
 ### Requirement: Compact budget-exhausted terminals settle the API-key reservation before raising
 

--- a/openspec/specs/usage-refresh-policy/spec.md
+++ b/openspec/specs/usage-refresh-policy/spec.md
@@ -1287,6 +1287,13 @@ When `compact_responses` holds an API-key usage reservation, it MUST NOT write a
 - **THEN** the reservation is settled
 - **AND** the deferred health write still runs
 
+#### Scenario: Compact refresh/connect failover defers health until settle
+
+- **GIVEN** a compact request with a held API-key reservation
+- **AND** the first account fails a retryable freshness/connect or post-401 forced-refresh transport error
+- **WHEN** a later account completes and settlement runs
+- **THEN** `_handle_stream_error` for the failed account runs only after that settlement
+
 ### Requirement: Compact budget-exhausted terminals settle the API-key reservation before raising
 
 On the HTTP bridge / forwarded compact path the caller passes an `api_key_reservation_override` with `owns_reservation` false, making `compact_responses` the SOLE settler of the API-key usage reservation; therefore EVERY budget-exhausted terminal raise in the compact request path that is reached with a held, unsettled reservation MUST settle the compact API-key usage reservation (release it via `_settle_compact_api_key_usage` with `response` `None`) BEFORE raising the budget-exhausted `ProxyResponseError` (`upstream_request_timeout`), so held API-key quota is not leaked. This MUST apply to the outer-loop preflight budget terminals (before the freshness check, before the freshness reserve, and after the freshness check) and to the post-401 forced-refresh preflight budget terminal, each of which propagates straight to the outer `except ProxyResponseError` handler (which does not settle) and the `finally` (which only writes a request log). The terminal MUST preserve its prior escalation: it still raises the same `502` `upstream_request_timeout` error after settling, and it MUST still release the selected account's `response_create` lease where it already did so. A budget-exhausted terminal that is caught by an enclosing handler that already settles the reservation before raising — the inner upstream-call budget terminals, whose `upstream_request_timeout` error is settled by the retry loop's `upstream_request_timeout` / account-neutral branch — MUST NOT settle a second time, so the reservation is never double-settled.

--- a/openspec/specs/usage-refresh-policy/spec.md
+++ b/openspec/specs/usage-refresh-policy/spec.md
@@ -1255,6 +1255,24 @@ local writes but MUST NOT be the mechanism that guarantees dedup.
 - **THEN** the unique constraint rejects the duplicate
 - **AND** the worker treats the rejection as a dedup skip rather than an error
 
+### Requirement: Compact failover settles before account-health writes
+
+When `compact_responses` holds an API-key usage reservation, it MUST NOT write account health for a compact upstream failure until that reservation has been settled or released. A `failover_next` decision MUST keep the same reservation for the next account and MUST defer the failed account's health write until the next settlement. Timeout and exhaustion terminals MUST keep settle-then-health order. Compact MUST NOT acquire a second reservation mid-request.
+
+#### Scenario: Compact failover_next defers health until settle
+
+- **GIVEN** a compact request with a held API-key reservation
+- **AND** the first account fails with a `failover_next` class
+- **WHEN** a later account completes and settlement runs
+- **THEN** `_handle_stream_error` for the failed account runs only after that settlement
+- **AND** the request does not acquire another reservation
+
+#### Scenario: Compact timeout still settles before health
+
+- **GIVEN** a compact request whose upstream call times out
+- **WHEN** the timeout branch records account health
+- **THEN** the reservation is settled before `_handle_stream_error`
+
 ### Requirement: Compact budget-exhausted terminals settle the API-key reservation before raising
 
 On the HTTP bridge / forwarded compact path the caller passes an `api_key_reservation_override` with `owns_reservation` false, making `compact_responses` the SOLE settler of the API-key usage reservation; therefore EVERY budget-exhausted terminal raise in the compact request path that is reached with a held, unsettled reservation MUST settle the compact API-key usage reservation (release it via `_settle_compact_api_key_usage` with `response` `None`) BEFORE raising the budget-exhausted `ProxyResponseError` (`upstream_request_timeout`), so held API-key quota is not leaked. This MUST apply to the outer-loop preflight budget terminals (before the freshness check, before the freshness reserve, and after the freshness check) and to the post-401 forced-refresh preflight budget terminal, each of which propagates straight to the outer `except ProxyResponseError` handler (which does not settle) and the `finally` (which only writes a request log). The terminal MUST preserve its prior escalation: it still raises the same `502` `upstream_request_timeout` error after settling, and it MUST still release the selected account's `response_create` lease where it already did so. A budget-exhausted terminal that is caught by an enclosing handler that already settles the reservation before raising — the inner upstream-call budget terminals, whose `upstream_request_timeout` error is settled by the retry loop's `upstream_request_timeout` / account-neutral branch — MUST NOT settle a second time, so the reservation is never double-settled.

--- a/openspec/specs/usage-refresh-policy/spec.md
+++ b/openspec/specs/usage-refresh-policy/spec.md
@@ -1273,6 +1273,20 @@ When `compact_responses` holds an API-key usage reservation, it MUST NOT write a
 - **WHEN** the timeout branch records account health
 - **THEN** the reservation is settled before `_handle_stream_error`
 
+#### Scenario: Compact HTTP 500 failover defers health until settle
+
+- **GIVEN** a compact request with a held API-key reservation
+- **AND** the first account exhausts same-account HTTP 500 retries
+- **WHEN** a later account completes and settlement runs
+- **THEN** `_handle_proxy_error` and extra `record_errors` for the failed account run only after that settlement
+
+#### Scenario: Compact route failure after failover still applies deferred health
+
+- **GIVEN** a compact request that deferred health on `failover_next`
+- **WHEN** the next account raises `UpstreamProxyRouteError`
+- **THEN** the reservation is settled
+- **AND** the deferred health write still runs
+
 ### Requirement: Compact budget-exhausted terminals settle the API-key reservation before raising
 
 On the HTTP bridge / forwarded compact path the caller passes an `api_key_reservation_override` with `owns_reservation` false, making `compact_responses` the SOLE settler of the API-key usage reservation; therefore EVERY budget-exhausted terminal raise in the compact request path that is reached with a held, unsettled reservation MUST settle the compact API-key usage reservation (release it via `_settle_compact_api_key_usage` with `response` `None`) BEFORE raising the budget-exhausted `ProxyResponseError` (`upstream_request_timeout`), so held API-key quota is not leaked. This MUST apply to the outer-loop preflight budget terminals (before the freshness check, before the freshness reserve, and after the freshness check) and to the post-401 forced-refresh preflight budget terminal, each of which propagates straight to the outer `except ProxyResponseError` handler (which does not settle) and the `finally` (which only writes a request log). The terminal MUST preserve its prior escalation: it still raises the same `502` `upstream_request_timeout` error after settling, and it MUST still release the selected account's `response_create` lease where it already did so. A budget-exhausted terminal that is caught by an enclosing handler that already settles the reservation before raising — the inner upstream-call budget terminals, whose `upstream_request_timeout` error is settled by the retry loop's `upstream_request_timeout` / account-neutral branch — MUST NOT settle a second time, so the reservation is never double-settled.

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -36168,6 +36168,121 @@ async def test_compact_unreleased_settlement_keeps_deferred_health(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_compact_success_survives_deferred_health_persistence_failure(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_compact_health_persist_a")
+    account_b = _make_account("acc_compact_health_persist_b")
+    seen_excluded_account_ids: list[set[str]] = []
+    call_order: list[str] = []
+    api_key = _make_api_key_data("key_compact_health_persist")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_health_persist",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+
+    async def handle_stream_error(*args: object, **kwargs: object):
+        del args, kwargs
+        call_order.append("handle_stream_error")
+        raise RuntimeError("deferred compact health persist failed")
+
+    async def settle_compact_api_key_usage(**kwargs: object) -> None:
+        del kwargs
+        call_order.append("settle_compact_api_key_usage")
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(
+                429,
+                openai_error("quota_exceeded", "quota exceeded"),
+                failure_phase="status",
+            )
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account_a, account_b]))
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock(side_effect=settle_compact_api_key_usage))
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    result = await service.compact_responses(
+        payload,
+        {"session_id": "sid-compact-health-persist"},
+        api_key=api_key,
+        api_key_reservation=reservation,
+    )
+
+    assert result.object == "response.compaction"
+    assert call_order == ["settle_compact_api_key_usage", "handle_stream_error"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exit_error",
+    [RuntimeError("compact account B exploded"), asyncio.CancelledError()],
+    ids=["runtime-error", "cancelled"],
+)
+async def test_compact_unexpected_exit_flushes_deferred_health(monkeypatch, exit_error: BaseException):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_compact_unexpected_exit_a")
+    account_b = _make_account("acc_compact_unexpected_exit_b")
+    seen_excluded_account_ids: list[set[str]] = []
+    call_order: list[str] = []
+    api_key = _make_api_key_data("key_compact_unexpected_exit")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_unexpected_exit",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+
+    async def handle_stream_error(*args: object, **kwargs: object):
+        del args, kwargs
+        call_order.append("handle_stream_error")
+        return {"failure_class": "quota"}
+
+    async def settle_compact_api_key_usage(**kwargs: object) -> None:
+        del kwargs
+        call_order.append("settle_compact_api_key_usage")
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(
+                429,
+                openai_error("quota_exceeded", "quota exceeded"),
+                failure_phase="status",
+            )
+        raise exit_error
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account_a, account_b]))
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock(side_effect=settle_compact_api_key_usage))
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    with pytest.raises(type(exit_error)):
+        await service.compact_responses(
+            payload,
+            {"session_id": "sid-compact-unexpected-exit"},
+            api_key=api_key,
+            api_key_reservation=reservation,
+        )
+
+    assert call_order == ["settle_compact_api_key_usage", "handle_stream_error"]
+
+
+@pytest.mark.asyncio
 async def test_ensure_fresh_with_timeout_bounds_whole_singleflight_wait(monkeypatch):
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_refresh_wait_bound")

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -35539,6 +35539,62 @@ async def test_compact_responses_surfaces_upstream_timeout_without_account_failo
 
 
 @pytest.mark.asyncio
+async def test_compact_failover_next_settles_before_account_health(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_compact_failover_settle_a")
+    account_b = _make_account("acc_compact_failover_settle_b")
+    seen_excluded_account_ids: list[set[str]] = []
+    call_order: list[str] = []
+    api_key = _make_api_key_data("key_compact_failover_settle")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_failover_settle",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+
+    async def handle_stream_error(*args: object, **kwargs: object):
+        del args, kwargs
+        call_order.append("handle_stream_error")
+        return {"failure_class": "quota"}
+
+    async def settle_compact_api_key_usage(**kwargs: object) -> None:
+        del kwargs
+        call_order.append("settle_compact_api_key_usage")
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(
+                429,
+                openai_error("quota_exceeded", "quota exceeded"),
+                failure_phase="status",
+            )
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account_a, account_b]))
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock(side_effect=settle_compact_api_key_usage))
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    result = await service.compact_responses(
+        payload,
+        {"session_id": "sid-compact-failover-settle"},
+        api_key=api_key,
+        api_key_reservation=reservation,
+    )
+
+    assert result.object == "response.compaction"
+    assert account_a.id in seen_excluded_account_ids[-1]
+    assert call_order == ["settle_compact_api_key_usage", "handle_stream_error"]
+
+
+@pytest.mark.asyncio
 async def test_ensure_fresh_with_timeout_bounds_whole_singleflight_wait(monkeypatch):
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_refresh_wait_bound")

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -34762,6 +34762,7 @@ async def test_compact_usage_settlement_surfaces_when_fail_safe_release_fails(mo
     assert _proxy_error_code(exc) == "usage_settlement_failed"
     assert exc.failure_phase == "usage_settlement"
     assert exc.failure_detail == "compact_api_key_usage_persistence_failed"
+    assert exc.reservation_released is False
     assert exc.failure_exception_type == "RuntimeError"
     assert isinstance(exc.__cause__, RuntimeError)
     assert str(exc.__cause__) == "compact finalize failed"
@@ -34776,6 +34777,53 @@ async def test_compact_usage_settlement_surfaces_when_fail_safe_release_fails(mo
     )
     primary_service.release_usage_reservation.assert_not_awaited()
     fail_safe_service.finalize_usage_reservation.assert_not_awaited()
+    fail_safe_service.release_usage_reservation.assert_awaited_once_with(reservation.reservation_id)
+
+
+@pytest.mark.asyncio
+async def test_compact_usage_settlement_marks_released_when_fail_safe_succeeds(monkeypatch):
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    api_key = _make_api_key_data("key_compact_fail_safe_release_succeeds")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_fail_safe_release_succeeds",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+    response = CompactResponsePayload.model_validate(
+        {
+            "object": "response.compaction",
+            "model": "gpt-5.1",
+            "output": [],
+            "usage": {"input_tokens": 7, "output_tokens": 3, "total_tokens": 10},
+        }
+    )
+    primary_service = SimpleNamespace(
+        finalize_usage_reservation=AsyncMock(side_effect=RuntimeError("compact finalize failed")),
+        release_usage_reservation=AsyncMock(),
+    )
+    fail_safe_service = SimpleNamespace(
+        finalize_usage_reservation=AsyncMock(),
+        release_usage_reservation=AsyncMock(),
+    )
+    service_factory = MagicMock(side_effect=[primary_service, fail_safe_service])
+    monkeypatch.setattr(proxy_service, "ApiKeysService", service_factory)
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service._settle_compact_api_key_usage(
+            api_key=api_key,
+            api_key_reservation=reservation,
+            response=response,
+            request_service_tier=None,
+        )
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 502
+    assert _proxy_error_code(exc) == "usage_settlement_failed"
+    assert exc.failure_phase == "usage_settlement"
+    assert exc.reservation_released is True
+    assert isinstance(exc.__cause__, RuntimeError)
+    primary_service.finalize_usage_reservation.assert_awaited_once()
+    primary_service.release_usage_reservation.assert_not_awaited()
     fail_safe_service.release_usage_reservation.assert_awaited_once_with(reservation.reservation_id)
 
 
@@ -35952,6 +36000,171 @@ async def test_compact_permanent_refresh_settles_before_mark_permanent(monkeypat
 
     assert exc_info.value.status_code == 401
     assert call_order == ["settle_compact_api_key_usage", "mark_permanent_failure"]
+
+
+@pytest.mark.asyncio
+async def test_compact_fallback_release_flushes_deferred_health(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_compact_fallback_flush_a")
+    account_b = _make_account("acc_compact_fallback_flush_b")
+    seen_excluded_account_ids: list[set[str]] = []
+    call_order: list[str] = []
+    api_key = _make_api_key_data("key_compact_fallback_flush")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_fallback_flush",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+
+    async def handle_stream_error(*args: object, **kwargs: object):
+        del args, kwargs
+        call_order.append("handle_stream_error")
+        return {"failure_class": "quota"}
+
+    async def finalize_usage_reservation(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        call_order.append("finalize_usage_reservation")
+        raise RuntimeError("compact finalize failed")
+
+    async def release_usage_reservation(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        call_order.append("release_usage_reservation")
+
+    primary_service = SimpleNamespace(
+        finalize_usage_reservation=AsyncMock(side_effect=finalize_usage_reservation),
+        release_usage_reservation=AsyncMock(),
+    )
+    fail_safe_service = SimpleNamespace(
+        finalize_usage_reservation=AsyncMock(),
+        release_usage_reservation=AsyncMock(side_effect=release_usage_reservation),
+    )
+    monkeypatch.setattr(proxy_service, "ApiKeysService", MagicMock(side_effect=[primary_service, fail_safe_service]))
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(
+                429,
+                openai_error("quota_exceeded", "quota exceeded"),
+                failure_phase="status",
+            )
+        return CompactResponsePayload.model_validate(
+            {
+                "object": "response.compaction",
+                "model": "gpt-5.1",
+                "output": [],
+                "usage": {"input_tokens": 7, "output_tokens": 3, "total_tokens": 10},
+            }
+        )
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account_a, account_b]))
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.compact_responses(
+            payload,
+            {"session_id": "sid-compact-fallback-flush"},
+            api_key=api_key,
+            api_key_reservation=reservation,
+        )
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert _proxy_error_code(exc) == "usage_settlement_failed"
+    assert exc.reservation_released is True
+    assert call_order == [
+        "finalize_usage_reservation",
+        "release_usage_reservation",
+        "handle_stream_error",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_compact_unreleased_settlement_keeps_deferred_health(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_compact_unreleased_health_a")
+    account_b = _make_account("acc_compact_unreleased_health_b")
+    seen_excluded_account_ids: list[set[str]] = []
+    call_order: list[str] = []
+    api_key = _make_api_key_data("key_compact_unreleased_health")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_unreleased_health",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+
+    async def handle_stream_error(*args: object, **kwargs: object):
+        del args, kwargs
+        call_order.append("handle_stream_error")
+        return {"failure_class": "quota"}
+
+    async def finalize_usage_reservation(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        call_order.append("finalize_usage_reservation")
+        raise RuntimeError("compact finalize failed")
+
+    async def release_usage_reservation(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        call_order.append("release_usage_reservation")
+        raise OSError("compact fail-safe release failed")
+
+    primary_service = SimpleNamespace(
+        finalize_usage_reservation=AsyncMock(side_effect=finalize_usage_reservation),
+        release_usage_reservation=AsyncMock(),
+    )
+    fail_safe_service = SimpleNamespace(
+        finalize_usage_reservation=AsyncMock(),
+        release_usage_reservation=AsyncMock(side_effect=release_usage_reservation),
+    )
+    monkeypatch.setattr(proxy_service, "ApiKeysService", MagicMock(side_effect=[primary_service, fail_safe_service]))
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(
+                429,
+                openai_error("quota_exceeded", "quota exceeded"),
+                failure_phase="status",
+            )
+        return CompactResponsePayload.model_validate(
+            {
+                "object": "response.compaction",
+                "model": "gpt-5.1",
+                "output": [],
+                "usage": {"input_tokens": 7, "output_tokens": 3, "total_tokens": 10},
+            }
+        )
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account_a, account_b]))
+    handle_stream_error_mock = AsyncMock(side_effect=handle_stream_error)
+    monkeypatch.setattr(service, "_handle_stream_error", handle_stream_error_mock)
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.compact_responses(
+            payload,
+            {"session_id": "sid-compact-unreleased-health"},
+            api_key=api_key,
+            api_key_reservation=reservation,
+        )
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert _proxy_error_code(exc) == "usage_settlement_failed"
+    assert exc.reservation_released is False
+    assert call_order == ["finalize_usage_reservation", "release_usage_reservation"]
+    handle_stream_error_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -35595,6 +35595,132 @@ async def test_compact_failover_next_settles_before_account_health(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_compact_http_500_failover_settles_before_account_health(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_compact_500_settle_a")
+    account_b = _make_account("acc_compact_500_settle_b")
+    seen_excluded_account_ids: list[set[str]] = []
+    call_order: list[str] = []
+    api_key = _make_api_key_data("key_compact_500_settle")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_500_settle",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+
+    async def handle_proxy_error(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        call_order.append("handle_proxy_error")
+
+    async def record_errors(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        call_order.append("record_errors")
+
+    async def settle_compact_api_key_usage(**kwargs: object) -> None:
+        del kwargs
+        call_order.append("settle_compact_api_key_usage")
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(
+                500,
+                openai_error("server_error", "server error"),
+                failure_phase="status",
+                retryable_same_contract=True,
+            )
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_compact_service, "_max_transient_same_account_retries", lambda: 1)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account_a, account_b]))
+    monkeypatch.setattr(service, "_handle_proxy_error", AsyncMock(side_effect=handle_proxy_error))
+    monkeypatch.setattr(service._load_balancer, "record_errors", AsyncMock(side_effect=record_errors))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock(side_effect=settle_compact_api_key_usage))
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    result = await service.compact_responses(
+        payload,
+        {"session_id": "sid-compact-500-settle"},
+        api_key=api_key,
+        api_key_reservation=reservation,
+    )
+
+    assert result.object == "response.compaction"
+    assert call_order[0] == "settle_compact_api_key_usage"
+    assert "handle_proxy_error" in call_order
+    assert call_order.index("settle_compact_api_key_usage") < call_order.index("handle_proxy_error")
+
+
+@pytest.mark.asyncio
+async def test_compact_route_error_after_failover_flushes_deferred_health(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_compact_route_flush_a")
+    account_b = _make_account("acc_compact_route_flush_b")
+    seen_excluded_account_ids: list[set[str]] = []
+    call_order: list[str] = []
+    api_key = _make_api_key_data("key_compact_route_flush")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_route_flush",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+
+    async def handle_stream_error(*args: object, **kwargs: object):
+        del args, kwargs
+        call_order.append("handle_stream_error")
+        return {"failure_class": "quota"}
+
+    async def settle_compact_api_key_usage(**kwargs: object) -> None:
+        del kwargs
+        call_order.append("settle_compact_api_key_usage")
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(
+                429,
+                openai_error("quota_exceeded", "quota exceeded"),
+                failure_phase="status",
+            )
+        raise AssertionError("account B should fail at route resolution")
+
+    async def resolve_route(account: Account, *, operation: str) -> None:
+        del operation
+        if account.id == account_b.id:
+            raise proxy_service.UpstreamProxyRouteError("pool_unavailable", account_id=account.id)
+        return None
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account_a, account_b]))
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock(side_effect=settle_compact_api_key_usage))
+    monkeypatch.setattr(service, "_resolve_upstream_route_for_account", resolve_route)
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.compact_responses(
+            payload,
+            {"session_id": "sid-compact-route-flush"},
+            api_key=api_key,
+            api_key_reservation=reservation,
+        )
+
+    assert _proxy_error_code(exc_info.value) == "upstream_proxy_unavailable"
+    assert call_order == ["settle_compact_api_key_usage", "handle_stream_error"]
+
+
+@pytest.mark.asyncio
 async def test_ensure_fresh_with_timeout_bounds_whole_singleflight_wait(monkeypatch):
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_refresh_wait_bound")

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -35721,6 +35721,123 @@ async def test_compact_route_error_after_failover_flushes_deferred_health(monkey
 
 
 @pytest.mark.asyncio
+async def test_compact_refresh_connect_failover_settles_before_account_health(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_compact_refresh_settle_a")
+    account_b = _make_account("acc_compact_refresh_settle_b")
+    seen_excluded_account_ids: list[set[str]] = []
+    call_order: list[str] = []
+    api_key = _make_api_key_data("key_compact_refresh_settle")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_refresh_settle",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+
+    async def handle_stream_error(*args: object, **kwargs: object):
+        del args, kwargs
+        call_order.append("handle_stream_error")
+        return {"failure_class": "retryable_transient"}
+
+    async def settle_compact_api_key_usage(**kwargs: object) -> None:
+        del kwargs
+        call_order.append("settle_compact_api_key_usage")
+
+    async def ensure_fresh(account: Account, **kwargs: object) -> Account:
+        del kwargs
+        if account.id == account_a.id:
+            raise aiohttp.ClientError("connection reset")
+        return account
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        if account_id == account_a.chatgpt_account_id:
+            raise AssertionError("account A should fail during freshness")
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=ensure_fresh))
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock(side_effect=settle_compact_api_key_usage))
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    result = await service.compact_responses(
+        payload,
+        {"session_id": "sid-compact-refresh-settle"},
+        api_key=api_key,
+        api_key_reservation=reservation,
+    )
+
+    assert result.object == "response.compaction"
+    assert call_order == ["settle_compact_api_key_usage", "handle_stream_error"]
+
+
+@pytest.mark.asyncio
+async def test_compact_post_401_refresh_failover_settles_before_account_health(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_compact_401_refresh_a")
+    account_b = _make_account("acc_compact_401_refresh_b")
+    seen_excluded_account_ids: list[set[str]] = []
+    call_order: list[str] = []
+    api_key = _make_api_key_data("key_compact_401_refresh")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_401_refresh",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+
+    async def handle_stream_error(*args: object, **kwargs: object):
+        del args, kwargs
+        call_order.append("handle_stream_error")
+        return {"failure_class": "retryable_transient"}
+
+    async def settle_compact_api_key_usage(**kwargs: object) -> None:
+        del kwargs
+        call_order.append("settle_compact_api_key_usage")
+
+    async def ensure_fresh(account: Account, **kwargs: object) -> Account:
+        if account.id == account_a.id and kwargs.get("force"):
+            raise aiohttp.ClientError("connection reset")
+        return account
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(
+                401,
+                openai_error("invalid_api_key", "token expired"),
+                failure_phase="status",
+            )
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=ensure_fresh))
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock(side_effect=settle_compact_api_key_usage))
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    result = await service.compact_responses(
+        payload,
+        {"session_id": "sid-compact-401-refresh"},
+        api_key=api_key,
+        api_key_reservation=reservation,
+    )
+
+    assert result.object == "response.compaction"
+    assert call_order == ["settle_compact_api_key_usage", "handle_stream_error"]
+
+
+@pytest.mark.asyncio
 async def test_ensure_fresh_with_timeout_bounds_whole_singleflight_wait(monkeypatch):
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_refresh_wait_bound")

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -36419,6 +36419,70 @@ async def test_compact_flush_continues_after_one_deferred_health_failure(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_compact_selection_timeout_after_failover_flushes_deferred_health(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_compact_select_timeout_a")
+    call_order: list[str] = []
+    api_key = _make_api_key_data("key_compact_select_timeout")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_select_timeout",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+    select_calls = 0
+
+    async def handle_stream_error(*args: object, **kwargs: object):
+        del args, kwargs
+        call_order.append("handle_stream_error")
+        return {"failure_class": "quota"}
+
+    async def settle_compact_api_key_usage(**kwargs: object) -> None:
+        del kwargs
+        call_order.append("settle_compact_api_key_usage")
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token, account_id
+        raise proxy_module.ProxyResponseError(
+            429,
+            openai_error("quota_exceeded", "quota exceeded"),
+            failure_phase="status",
+        )
+
+    async def select_with_budget(*args: object, **kwargs: object) -> AccountSelection:
+        del args, kwargs
+        nonlocal select_calls
+        select_calls += 1
+        if select_calls == 1:
+            return AccountSelection(account=account_a, error_message=None)
+        raise proxy_module.ProxyResponseError(
+            502,
+            openai_error("upstream_request_timeout", "Proxy request budget exhausted"),
+        )
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account_a))
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock(side_effect=settle_compact_api_key_usage))
+    monkeypatch.setattr(service, "_select_account_with_budget_compatible", select_with_budget)
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.compact_responses(
+            payload,
+            {"session_id": "sid-compact-select-timeout"},
+            api_key=api_key,
+            api_key_reservation=reservation,
+        )
+
+    assert _proxy_error_code(exc_info.value) == "upstream_request_timeout"
+    assert call_order == ["settle_compact_api_key_usage", "handle_stream_error"]
+
+
+@pytest.mark.asyncio
 async def test_ensure_fresh_with_timeout_bounds_whole_singleflight_wait(monkeypatch):
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_refresh_wait_bound")

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -36348,6 +36348,77 @@ async def test_compact_flush_completes_when_cancelled_during_health_write(monkey
 
 
 @pytest.mark.asyncio
+async def test_compact_flush_continues_after_one_deferred_health_failure(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_compact_flush_partial_a")
+    account_b = _make_account("acc_compact_flush_partial_b")
+    account_c = _make_account("acc_compact_flush_partial_c")
+    seen_excluded_account_ids: list[set[str]] = []
+    call_order: list[str] = []
+    api_key = _make_api_key_data("key_compact_flush_partial")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_flush_partial",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+
+    async def handle_stream_error(failed_account: Account, *args: object, **kwargs: object):
+        del args, kwargs
+        call_order.append(f"handle_stream_error:{failed_account.id}")
+        if failed_account.id == account_a.id:
+            raise RuntimeError("first deferred health persist failed")
+        return {"failure_class": "quota"}
+
+    async def settle_compact_api_key_usage(**kwargs: object) -> None:
+        del kwargs
+        call_order.append("settle_compact_api_key_usage")
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        if account_id in {account_a.chatgpt_account_id, account_b.chatgpt_account_id}:
+            raise proxy_module.ProxyResponseError(
+                429,
+                openai_error("quota_exceeded", "quota exceeded"),
+                failure_phase="status",
+            )
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    async def select_account(**kwargs: object) -> AccountSelection:
+        excluded_account_ids = set(cast(set[str] | None, kwargs.get("exclude_account_ids")) or set())
+        seen_excluded_account_ids.append(excluded_account_ids)
+        for account in (account_a, account_b, account_c):
+            if account.id not in excluded_account_ids:
+                return AccountSelection(account=account, error_message=None)
+        return AccountSelection(account=None, error_message="no accounts")
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(proxy_compact_service, "_compact_max_account_attempts", lambda: 3)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account_a, account_b, account_c]))
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock(side_effect=settle_compact_api_key_usage))
+    monkeypatch.setattr(service._load_balancer, "select_account", select_account)
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    result = await service.compact_responses(
+        payload,
+        {"session_id": "sid-compact-flush-partial"},
+        api_key=api_key,
+        api_key_reservation=reservation,
+    )
+
+    assert result.object == "response.compaction"
+    assert call_order == [
+        "settle_compact_api_key_usage",
+        f"handle_stream_error:{account_a.id}",
+        f"handle_stream_error:{account_b.id}",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_ensure_fresh_with_timeout_bounds_whole_singleflight_wait(monkeypatch):
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_refresh_wait_bound")

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -34,6 +34,7 @@ import app.core.clients.proxy as proxy_module
 import app.core.resilience.network_recovery as network_recovery_module
 import app.modules.proxy.load_balancer as load_balancer_module
 from app.core import shutdown as shutdown_state
+from app.core.auth.refresh import RefreshError
 from app.core.balancer.types import UpstreamError
 from app.core.clients.proxy import _build_upstream_headers, filter_inbound_headers
 from app.core.clients.proxy_websocket import (
@@ -35835,6 +35836,122 @@ async def test_compact_post_401_refresh_failover_settles_before_account_health(m
 
     assert result.object == "response.compaction"
     assert call_order == ["settle_compact_api_key_usage", "handle_stream_error"]
+
+
+@pytest.mark.asyncio
+async def test_compact_second_401_failover_settles_before_account_health(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_compact_second_401_a")
+    account_b = _make_account("acc_compact_second_401_b")
+    seen_excluded_account_ids: list[set[str]] = []
+    call_order: list[str] = []
+    api_key = _make_api_key_data("key_compact_second_401")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_second_401",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+
+    async def handle_proxy_error(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        call_order.append("handle_proxy_error")
+
+    async def settle_compact_api_key_usage(**kwargs: object) -> None:
+        del kwargs
+        call_order.append("settle_compact_api_key_usage")
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(
+                401,
+                openai_error("invalid_api_key", "token expired"),
+                failure_phase="status",
+            )
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account_a, account_a, account_b]))
+    monkeypatch.setattr(service, "_handle_proxy_error", AsyncMock(side_effect=handle_proxy_error))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock(side_effect=settle_compact_api_key_usage))
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    result = await service.compact_responses(
+        payload,
+        {"session_id": "sid-compact-second-401"},
+        api_key=api_key,
+        api_key_reservation=reservation,
+    )
+
+    assert result.object == "response.compaction"
+    assert call_order[0] == "settle_compact_api_key_usage"
+    assert "handle_proxy_error" in call_order
+    assert call_order.index("settle_compact_api_key_usage") < call_order.index("handle_proxy_error")
+
+
+@pytest.mark.asyncio
+async def test_compact_permanent_refresh_settles_before_mark_permanent(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_compact_permanent_refresh")
+    call_order: list[str] = []
+    api_key = _make_api_key_data("key_compact_permanent_refresh")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_permanent_refresh",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+
+    async def mark_permanent_failure(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        call_order.append("mark_permanent_failure")
+
+    async def settle_compact_api_key_usage(**kwargs: object) -> None:
+        del kwargs
+        call_order.append("settle_compact_api_key_usage")
+
+    async def ensure_fresh(target: Account, **kwargs: object) -> Account:
+        if kwargs.get("force"):
+            raise RefreshError("invalid_grant", "refresh rejected", True)
+        return target
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token, account_id
+        raise proxy_module.ProxyResponseError(
+            401,
+            openai_error("invalid_api_key", "token expired"),
+            failure_phase="status",
+        )
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=ensure_fresh))
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service._load_balancer, "mark_permanent_failure", AsyncMock(side_effect=mark_permanent_failure))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock(side_effect=settle_compact_api_key_usage))
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service.compact_responses(
+            payload,
+            {"session_id": "sid-compact-permanent-refresh"},
+            api_key=api_key,
+            api_key_reservation=reservation,
+        )
+
+    assert exc_info.value.status_code == 401
+    assert call_order == ["settle_compact_api_key_usage", "mark_permanent_failure"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -36283,6 +36283,71 @@ async def test_compact_unexpected_exit_flushes_deferred_health(monkeypatch, exit
 
 
 @pytest.mark.asyncio
+async def test_compact_flush_completes_when_cancelled_during_health_write(monkeypatch):
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account_a = _make_account("acc_compact_flush_cancel_a")
+    account_b = _make_account("acc_compact_flush_cancel_b")
+    seen_excluded_account_ids: list[set[str]] = []
+    call_order: list[str] = []
+    flush_started = asyncio.Event()
+    release_flush = asyncio.Event()
+    api_key = _make_api_key_data("key_compact_flush_cancel")
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_compact_flush_cancel",
+        key_id=api_key.id,
+        model="gpt-5.1",
+    )
+
+    async def handle_stream_error(*args: object, **kwargs: object):
+        del args, kwargs
+        flush_started.set()
+        await release_flush.wait()
+        call_order.append("handle_stream_error")
+        return {"failure_class": "quota"}
+
+    async def settle_compact_api_key_usage(**kwargs: object) -> None:
+        del kwargs
+        call_order.append("settle_compact_api_key_usage")
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token
+        if account_id == account_a.chatgpt_account_id:
+            raise proxy_module.ProxyResponseError(
+                429,
+                openai_error("quota_exceeded", "quota exceeded"),
+                failure_phase="status",
+            )
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(side_effect=[account_a, account_b]))
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock(side_effect=handle_stream_error))
+    monkeypatch.setattr(service, "_settle_compact_api_key_usage", AsyncMock(side_effect=settle_compact_api_key_usage))
+    monkeypatch.setattr(proxy_service, "core_compact_responses", fake_compact)
+    _install_two_account_selection(monkeypatch, service, account_a, account_b, seen_excluded_account_ids)
+
+    payload = ResponsesCompactRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": []})
+    task = asyncio.create_task(
+        service.compact_responses(
+            payload,
+            {"session_id": "sid-compact-flush-cancel"},
+            api_key=api_key,
+            api_key_reservation=reservation,
+        )
+    )
+    await asyncio.wait_for(flush_started.wait(), timeout=1)
+    task.cancel()
+    await asyncio.sleep(0)
+    release_flush.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert call_order == ["settle_compact_api_key_usage", "handle_stream_error"]
+
+
+@pytest.mark.asyncio
 async def test_ensure_fresh_with_timeout_bounds_whole_singleflight_wait(monkeypatch):
     service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
     account = _make_account("acc_refresh_wait_bound")


### PR DESCRIPTION
## Summary

Compact `failover_next` wrote account health while the API-key reservation was still reserved. The timeout branch already settled first. This defers that health write until the next settlement and keeps the same reservation for the next account.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/settle-compact-failover-before-health/`

## Changes

- Classify compact failover without writing health.
- Defer `_handle_stream_error` across `failover_next` when a reservation is held.
- Flush deferred health only after `_settle_compact_api_key_usage`.
- Surface paths settle, then write health.

## Simplicity

No new setting, README section, or dashboard nav.

## Test plan

```
uv run pytest tests/unit/test_proxy_utils.py::test_compact_failover_next_settles_before_account_health tests/unit/test_proxy_utils.py::test_compact_responses_surfaces_upstream_timeout_without_account_failover tests/integration/test_proxy_transient_retry.py::test_compact_quota_exceeded_transparent_failover -q
# 3 passed
openspec validate settle-compact-failover-before-health --strict
```

Related work: #1332 / #1558 / #1600 settle-before-health; compact timeout already had the order. Adjacent to, not stacked on, #1521.

## Checklist

- [x] Tests added for the failing product path
- [x] OpenSpec change kept in sync