### PR TITLE
fix(compact): harden replay recovery

### DIFF
--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -944,18 +944,20 @@ def _plaintext_compaction_replay_replacement(item: JsonValue) -> JsonValue | Non
         return None
     assert is_json_mapping(item)
     encrypted_content = item.get("encrypted_content")
-    if isinstance(encrypted_content, str) and _looks_like_provider_encrypted_content(encrypted_content):
+    if isinstance(encrypted_content, str):
         return None
 
     text = _compaction_plaintext_summary(item)
     if text is None:
-        return {"role": "assistant", "content": _COMPACT_STATE_TEXT_PREFIX + "[unverified compact state omitted]"}
-    return {"role": "assistant", "content": _COMPACT_STATE_TEXT_PREFIX + text}
+        return _assistant_compact_state_item("[unverified compact state omitted]")
+    return _assistant_compact_state_item(text)
 
 
-def _looks_like_provider_encrypted_content(value: str) -> bool:
-    stripped = value.strip()
-    return stripped.startswith("gAAAA") and len(stripped) >= 80
+def _assistant_compact_state_item(text: str) -> JsonValue:
+    return {
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": _COMPACT_STATE_TEXT_PREFIX + text}],
+    }
 
 
 def _compaction_plaintext_summary(item: Mapping[str, JsonValue]) -> str | None:

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -48,6 +48,7 @@ _COMPACT_TOOL_CALL_TYPE_BY_OUTPUT_TYPE: dict[str, str] = {
     "function_call_output": "function_call",
     "custom_tool_call_output": "custom_tool_call",
     "apply_patch_call_output": "apply_patch_call",
+    "tool_search_output": "tool_search_call",
 }
 _COMPACT_TOOL_CALL_ITEM_TYPES = frozenset(_COMPACT_TOOL_CALL_TYPE_BY_OUTPUT_TYPE.values())
 _COMPACT_TOOL_CALL_OUTPUT_ITEM_TYPES = frozenset(_COMPACT_TOOL_CALL_TYPE_BY_OUTPUT_TYPE)

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -869,6 +869,7 @@ def strip_replayed_tool_call_namespaces_from_payload(payload: MutableJsonObject)
 
 
 _POISONED_LOCAL_COMPACT_FALLBACK_TEXT = "Local compact fallback preserved the latest encrypted reasoning state."
+_COMPACT_STATE_TEXT_PREFIX = "[compact state] "
 _MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS = 100_000
 _COMPACT_UPSTREAM_HEAD_ESTIMATED_TOKENS = 12_000
 _ESTIMATED_CHARS_PER_TOKEN = 4
@@ -909,12 +910,10 @@ def _strip_poisoned_local_compact_fallback_items(payload: MutableJsonObject) -> 
     skip_next_poison_compaction = False
     changed = False
     for item in input_items:
-        if skip_next_poison_compaction and is_json_mapping(item) and item.get("type") == "compaction":
-            encrypted_content = item.get("encrypted_content")
-            if isinstance(encrypted_content, str) and encrypted_content:
-                skip_next_poison_compaction = False
-                changed = True
-                continue
+        if skip_next_poison_compaction and _is_compaction_item(item):
+            skip_next_poison_compaction = False
+            changed = True
+            continue
         skip_next_poison_compaction = False
 
         if _is_poisoned_local_compact_fallback_message(item):
@@ -922,10 +921,62 @@ def _strip_poisoned_local_compact_fallback_items(payload: MutableJsonObject) -> 
             changed = True
             continue
 
+        replacement = _plaintext_compaction_replay_replacement(item)
+        if replacement is not None:
+            kept.append(replacement)
+            changed = True
+            continue
+
         kept.append(item)
 
     if changed:
         payload["input"] = kept
+
+
+def _is_compaction_item(item: JsonValue) -> bool:
+    if not is_json_mapping(item):
+        return False
+    return item.get("type") in {"compaction", "compaction_summary"}
+
+
+def _plaintext_compaction_replay_replacement(item: JsonValue) -> JsonValue | None:
+    if not _is_compaction_item(item):
+        return None
+    assert is_json_mapping(item)
+    encrypted_content = item.get("encrypted_content")
+    if isinstance(encrypted_content, str) and _looks_like_provider_encrypted_content(encrypted_content):
+        return None
+
+    text = _compaction_plaintext_summary(item)
+    if text is None:
+        return {"role": "assistant", "content": _COMPACT_STATE_TEXT_PREFIX + "[unverified compact state omitted]"}
+    return {"role": "assistant", "content": _COMPACT_STATE_TEXT_PREFIX + text}
+
+
+def _looks_like_provider_encrypted_content(value: str) -> bool:
+    stripped = value.strip()
+    return stripped.startswith("gAAAA") and len(stripped) >= 80
+
+
+def _compaction_plaintext_summary(item: Mapping[str, JsonValue]) -> str | None:
+    for key in ("text", "summary"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    content = item.get("content")
+    if is_json_list(content):
+        text_parts: list[str] = []
+        for part in content:
+            if not is_json_mapping(part):
+                continue
+            part_text = part.get("text")
+            if isinstance(part_text, str) and part_text.strip():
+                text_parts.append(part_text.strip())
+        if text_parts:
+            return "\n".join(text_parts)
+
+    return None
 
 
 def _is_poisoned_local_compact_fallback_message(item: JsonValue) -> bool:

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -627,6 +627,23 @@ def _has_http_bridge_response_output_marker(item: JsonValue) -> bool:
     return status in {"completed", "in_progress"}
 
 
+def _http_bridge_pending_response_events_seen(pending_states: Sequence[Any]) -> int:
+    return max(
+        (
+            max(
+                int(getattr(state, "response_event_count", 0)),
+                int(
+                    getattr(state, "response_id", None) is not None
+                    or getattr(state, "latency_response_created_ms", None) is not None
+                    or bool(getattr(state, "downstream_visible", False))
+                ),
+            )
+            for state in pending_states
+        ),
+        default=0,
+    )
+
+
 def _http_bridge_input_item_type(item: JsonValue) -> str | None:
     if not isinstance(item, dict):
         return None

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -595,7 +595,7 @@ def _trim_http_bridge_previous_response_input_items(input_items: list[JsonValue]
             index
             for index, item in enumerate(input_items)
             if _http_bridge_input_item_type(item)
-            in {"function_call_output", "custom_tool_call_output", "apply_patch_call_output"}
+            in {"function_call_output", "custom_tool_call_output", "apply_patch_call_output", "tool_search_output"}
         ),
         None,
     )
@@ -609,7 +609,7 @@ def _trim_http_bridge_previous_response_input_items(input_items: list[JsonValue]
 
 def _is_http_bridge_previous_response_output_item(item: JsonValue) -> bool:
     item_type = _http_bridge_input_item_type(item)
-    if item_type in {"reasoning", "function_call", "custom_tool_call", "apply_patch_call"}:
+    if item_type in {"reasoning", "function_call", "custom_tool_call", "apply_patch_call", "tool_search_call"}:
         return _has_http_bridge_response_output_marker(item)
     if item_type != "message" or not isinstance(item, dict):
         return False

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -1511,18 +1511,29 @@ class _HTTPBridgeStreamingMixin:
             if durable_lookup is not None and not _http_bridge_models_compatible(durable_lookup.model, payload.model)
             else None
         )
+        durable_model_transition_uses_fresh_replay = (
+            durable_model_transition_lookup is not None
+            and not forwarded_request
+            and rewritten_file_account_id is None
+            and durable_full_resend_fresh_payload is not None
+            and durable_full_resend_has_safe_fresh_context
+            and durable_full_resend_is_account_neutral is True
+        )
         durable_model_transition_requires_owner = durable_model_transition_lookup is not None and (
-            payload.previous_response_id is not None
-            or bridge_session_key.strength == "hard"
-            or (
-                bridge_session_key.affinity_kind == "prompt_cache"
-                and _http_bridge_request_stage(
-                    headers=headers,
-                    payload=payload,
-                    durable_lookup=durable_model_transition_lookup,
+            not durable_model_transition_uses_fresh_replay
+            and (
+                payload.previous_response_id is not None
+                or bridge_session_key.strength == "hard"
+                or (
+                    bridge_session_key.affinity_kind == "prompt_cache"
+                    and _http_bridge_request_stage(
+                        headers=headers,
+                        payload=payload,
+                        durable_lookup=durable_model_transition_lookup,
+                    )
+                    == "follow_up"
+                    and durable_model_transition_lookup.latest_turn_state is not None
                 )
-                == "follow_up"
-                and durable_model_transition_lookup.latest_turn_state is not None
             )
         )
         if durable_model_transition_lookup is not None:
@@ -1536,7 +1547,36 @@ class _HTTPBridgeStreamingMixin:
                 model_class=_extract_model_class(payload.model) if payload.model else None,
                 owner_check_applied=durable_model_transition_requires_owner,
             )
-            if is_http_bridge_account_neutral_replay(
+            if durable_model_transition_uses_fresh_replay:
+                replay_kind, replay_key = make_http_bridge_account_neutral_replay_key(uuid4().hex)
+                bridge_session_key = _HTTPBridgeSessionKey(
+                    replay_kind,
+                    replay_key,
+                    bridge_session_key.api_key_id,
+                    strength="soft",
+                )
+                affinity = _AffinityPolicy()
+                incoming_turn_state_header = None
+                incoming_session_header = None
+                session_header_fallback_key = None
+                effective_payload = durable_full_resend_fresh_payload
+                untrimmed_effective_payload = durable_full_resend_fresh_payload
+                force_local_recovery_creation = True
+                preferred_account_has_continuity_provenance = False
+                _log_http_bridge_event(
+                    "model_transition_fresh_resend",
+                    bridge_session_key,
+                    account_id=durable_model_transition_lookup.account_id,
+                    model=payload.model,
+                    detail=(
+                        "outcome=account_neutral_full_resend_without_owner,"
+                        f"previous_model={durable_model_transition_lookup.model}"
+                    ),
+                    cache_key_family=bridge_session_key.affinity_kind,
+                    model_class=_extract_model_class(payload.model) if payload.model else None,
+                    owner_check_applied=False,
+                )
+            elif is_http_bridge_account_neutral_replay(
                 kind=durable_model_transition_lookup.canonical_kind,
                 key=durable_model_transition_lookup.canonical_key,
             ):
@@ -1719,6 +1759,7 @@ class _HTTPBridgeStreamingMixin:
             durable_lookup.account_id
             if (
                 durable_lookup is not None
+                and not durable_model_transition_uses_fresh_replay
                 and (
                     request_state.previous_response_id is not None
                     or bridge_session_key.strength == "hard"
@@ -1735,6 +1776,7 @@ class _HTTPBridgeStreamingMixin:
             request_state.preferred_account_id is None
             and durable_model_transition_lookup is not None
             and durable_model_transition_requires_owner
+            and not durable_model_transition_uses_fresh_replay
         ):
             request_state.preferred_account_id = durable_model_transition_lookup.account_id
         local_previous_response_owner: str | None = None
@@ -1856,6 +1898,7 @@ class _HTTPBridgeStreamingMixin:
 
         def durable_full_resend_allows_account_neutral_replay() -> bool:
             nonlocal durable_full_resend_fresh_payload
+            nonlocal durable_full_resend_has_safe_fresh_context
             nonlocal durable_full_resend_is_account_neutral
             nonlocal durable_full_resend_retains_prior_output
 
@@ -1881,7 +1924,17 @@ class _HTTPBridgeStreamingMixin:
                     stored_count=eligibility_projection.stored_prefix_count,
                     canonical_lite_developer_index=eligibility_projection.canonical_lite_developer_index,
                 )
-                if not durable_full_resend_retains_prior_output:
+                durable_full_resend_has_safe_fresh_context = durable_full_resend_retains_prior_output or (
+                    durable_lookup is not None
+                    and durable_lookup.latest_pending_tool_calls is not None
+                    and responses_input_suffix_matches_pending_tool_calls(
+                        eligibility_projection.input_items,
+                        stored_count=eligibility_projection.stored_prefix_count,
+                        pending_tool_calls=durable_lookup.latest_pending_tool_calls,
+                        canonical_lite_developer_index=eligibility_projection.canonical_lite_developer_index,
+                    )
+                )
+                if not durable_full_resend_has_safe_fresh_context:
                     return False
                 replay_projection = project_responses_input_for_account_neutral_fresh_replay(
                     cast(list[JsonValue], payload.input),
@@ -1892,7 +1945,7 @@ class _HTTPBridgeStreamingMixin:
                 durable_full_resend_fresh_payload = _http_bridge_payload_without_previous_response_id(
                     payload
                 ).model_copy(update={"input": replay_projection.input_items})
-            if not durable_full_resend_retains_prior_output:
+            if not durable_full_resend_has_safe_fresh_context:
                 return False
             if durable_full_resend_is_account_neutral is None:
                 durable_full_resend_is_account_neutral = _http_bridge_payload_is_account_neutral_fresh_replay(
@@ -2813,16 +2866,16 @@ class _HTTPBridgeStreamingMixin:
                     previous_request_state.proxy_injected_anchor_had_full_resend_payload
                 )
                 request_state.fresh_upstream_request_text = fresh_upstream_request_text
-                # The trim branch only fires when the untrimmed payload
-                # is a true full resend whose prefix exactly matches the
-                # already-stored context, so the unanchored request text
-                # is a safe fresh-turn replay target regardless of
-                # whether the anchor came from the durable or
-                # session-level injection path. Injection-only re-prepares
-                # keep the replay-safety decision made when the anchor was
-                # injected.
+                # The trim branch proves the upstream submission can omit the
+                # stored prefix, but it does not by itself prove that dropping
+                # the injected anchor is safe. Keep the original anchor site's
+                # decision unless this was a durable full-resend proof with a
+                # verified safe fresh suffix. Session-level anchors may still be
+                # compacted follow-ups whose prior context only exists behind
+                # previous_response_id.
                 request_state.fresh_upstream_request_is_retry_safe = (
-                    (durable_full_resend_anchor_count is None or durable_full_resend_has_safe_fresh_context)
+                    previous_request_state.fresh_upstream_request_is_retry_safe
+                    or (durable_full_resend_anchor_count is not None and durable_full_resend_has_safe_fresh_context)
                     if store_context_trim_applied
                     else previous_request_state.fresh_upstream_request_is_retry_safe
                 )
@@ -2937,6 +2990,7 @@ class _HTTPBridgeStreamingMixin:
                     owner_check_applied=True,
                 )
                 replacement_preferred_account_id = request_state.preferred_account_id
+                replacement_excluded_account_ids = set(request_state.excluded_account_ids)
                 if request_state.previous_response_id is not None and replacement_preferred_account_id is None:
                     replacement_preferred_account_id = session.account.id
                 elif replacement_preferred_account_id is None:
@@ -2949,9 +3003,8 @@ class _HTTPBridgeStreamingMixin:
                     # impossible (fallback_on_preferred_account_unavailable is
                     # False for exactly this pinned case below) and would
                     # keep poisoning every later recovery call on this
-                    # request, since excluded_account_ids persists on
-                    # request_state.
-                    request_state.excluded_account_ids.add(session.account.id)
+                    # request.
+                    replacement_excluded_account_ids.add(session.account.id)
                 while True:
                     try:
                         replacement_session = await self._get_or_create_http_bridge_session(
@@ -2984,7 +3037,7 @@ class _HTTPBridgeStreamingMixin:
                             request_usage_budget=request_state.request_usage_budget,
                             request_deadline=request_deadline,
                             session_header_fallback_key=session_header_fallback_key,
-                            exclude_account_ids=request_state.excluded_account_ids or None,
+                            exclude_account_ids=replacement_excluded_account_ids or None,
                             deferred_account_backoff_lifecycle=request_state.deferred_account_backoff_lifecycle,
                             defer_account_health_writes=request_state.api_key_reservation is not None,
                         )

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -561,6 +561,7 @@ _WEBSOCKET_TOOL_CALL_ITEM_TYPES_BY_OUTPUT_TYPE = {
     "function_call_output": "function_call",
     "custom_tool_call_output": "custom_tool_call",
     "apply_patch_call_output": "apply_patch_call",
+    "tool_search_output": "tool_search_call",
 }
 _WEBSOCKET_TOOL_CALL_ITEM_TYPES = frozenset(_WEBSOCKET_TOOL_CALL_ITEM_TYPES_BY_OUTPUT_TYPE.values())
 
@@ -1968,7 +1969,7 @@ def _trim_websocket_previous_response_input_items(input_items: list[JsonValue]) 
             index
             for index, item in enumerate(input_items)
             if _websocket_input_item_type(item)
-            in {"function_call_output", "custom_tool_call_output", "apply_patch_call_output"}
+            in {"function_call_output", "custom_tool_call_output", "apply_patch_call_output", "tool_search_output"}
         ),
         None,
     )
@@ -1984,7 +1985,7 @@ def _is_websocket_previous_response_output_item(item: JsonValue) -> bool:
     if isinstance(item, dict) and _websocket_input_item_type(item) is None and item.get("role") == "assistant":
         return True
     item_type = _websocket_input_item_type(item)
-    if item_type in {"reasoning", "function_call", "custom_tool_call", "apply_patch_call"}:
+    if item_type in {"reasoning", "function_call", "custom_tool_call", "apply_patch_call", "tool_search_call"}:
         return True
     if item_type != "message" or not isinstance(item, dict):
         return False

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -6332,7 +6332,7 @@ async def _compact_responses(
             await reservation_cleanup.release(action="compact response")
     result_payload = result.model_dump(mode="json", exclude_none=True)
     if codex_session_affinity:
-        result_payload = _normalize_codex_remote_compaction_v2_result(result, result_payload)
+        result_payload = _normalize_codex_remote_compaction_v2_result(result, result_payload, payload)
     return JSONResponse(
         content=result_payload,
         headers=rate_limit_headers,
@@ -6342,6 +6342,7 @@ async def _compact_responses(
 def _normalize_codex_remote_compaction_v2_result(
     payload: CompactResponsePayload,
     result_payload: dict[str, JsonValue],
+    compact_request: ResponsesCompactRequest,
 ) -> dict[str, JsonValue]:
     compaction_item = _compact_response_output_item(payload)
     if compaction_item is None:
@@ -6393,6 +6394,41 @@ def _normalize_compaction_output_item(item: Mapping[str, JsonValue]) -> dict[str
     return normalized
 
 
+def _compaction_output_item_id(value: JsonValue) -> str | None:
+    if not isinstance(value, str):
+        return None
+    item_id = value.strip()
+    if not item_id.startswith("cmp"):
+        return None
+    return item_id
+
+
+def _compaction_item_texts(value: JsonValue) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if not is_json_mapping(value):
+        return []
+    content = value.get("content")
+    if isinstance(content, str):
+        return [content]
+    if is_json_mapping(content):
+        content_items: list[JsonValue] = [content]
+    elif is_json_list(content):
+        content_items = content
+    else:
+        return []
+    texts: list[str] = []
+    for part in content_items:
+        if isinstance(part, str):
+            texts.append(part)
+            continue
+        if is_json_mapping(part):
+            text = part.get("text")
+            if isinstance(text, str):
+                texts.append(text)
+    return texts
+
+
 def _json_mapping_from_model_or_mapping(value: object) -> Mapping[str, JsonValue] | None:
     if is_json_mapping(value):
         return value
@@ -6418,13 +6454,15 @@ async def _synthetic_compaction_response_stream(
     response_id: str,
     usage: object | None,
 ) -> AsyncIterator[str]:
-    item = dict(compact_item)
-    item.setdefault("status", "completed")
+    compact_output: dict[str, JsonValue] = dict(compact_item)
+    compact_output.setdefault("status", "completed")
+    output_items: list[dict[str, JsonValue]] = [compact_output]
     completed_response: dict[str, JsonValue] = {
         "id": response_id,
         "object": "response",
         "status": "completed",
-        "output": [item],
+        # list is invariant, so the JSON-valid element type needs a cast here.
+        "output": cast(JsonValue, output_items),
     }
     usage_mapping = _json_mapping_from_model_or_mapping(usage)
     if usage_mapping is not None:
@@ -6441,29 +6479,33 @@ async def _synthetic_compaction_response_stream(
             },
         }
     )
-    yield format_sse_event(
-        {
-            "type": "response.output_item.added",
-            "sequence_number": 1,
-            "output_index": 0,
-            "item": {
-                **item,
-                "status": "in_progress",
-            },
-        }
-    )
-    yield format_sse_event(
-        {
-            "type": "response.output_item.done",
-            "sequence_number": 2,
-            "output_index": 0,
-            "item": item,
-        }
-    )
+    sequence_number = 1
+    for output_index, item in enumerate(output_items):
+        yield format_sse_event(
+            {
+                "type": "response.output_item.added",
+                "sequence_number": sequence_number,
+                "output_index": output_index,
+                "item": {
+                    **item,
+                    "status": "in_progress",
+                },
+            }
+        )
+        sequence_number += 1
+        yield format_sse_event(
+            {
+                "type": "response.output_item.done",
+                "sequence_number": sequence_number,
+                "output_index": output_index,
+                "item": item,
+            }
+        )
+        sequence_number += 1
     yield format_sse_event(
         {
             "type": "response.completed",
-            "sequence_number": 3,
+            "sequence_number": sequence_number,
             "response": completed_response,
         }
     )

--- a/app/modules/proxy/replay_safety.py
+++ b/app/modules/proxy/replay_safety.py
@@ -15,6 +15,7 @@ _TOOL_CALL_TYPE_BY_OUTPUT_TYPE = {
     "function_call_output": "function_call",
     "custom_tool_call_output": "custom_tool_call",
     "apply_patch_call_output": "apply_patch_call",
+    "tool_search_output": "tool_search_call",
 }
 _TOOL_CALL_TYPES = frozenset(_TOOL_CALL_TYPE_BY_OUTPUT_TYPE.values())
 _ACCOUNT_NEUTRAL_REPLAY_OMITTED_ITEM_TYPES = frozenset(
@@ -39,6 +40,7 @@ _ACCOUNT_NEUTRAL_INPUT_ITEM_TYPES = frozenset(
         "additional_tools",
         "apply_patch_call",
         "apply_patch_call_output",
+        "compaction",
         "custom_tool_call",
         "custom_tool_call_output",
         "function_call",
@@ -47,6 +49,8 @@ _ACCOUNT_NEUTRAL_INPUT_ITEM_TYPES = frozenset(
         "input_image",
         "input_text",
         "message",
+        "tool_search_call",
+        "tool_search_output",
     }
 )
 _ACCOUNT_NEUTRAL_MESSAGE_CONTENT_TYPES = frozenset(
@@ -65,6 +69,7 @@ _ACCOUNT_NEUTRAL_CONTENT_FIELDS = {
 }
 _ACCOUNT_NEUTRAL_INPUT_ITEM_FIELDS = {
     "additional_tools": frozenset({"role", "tools", "type"}),
+    "compaction": frozenset({"encrypted_content", "id", "status", "type"}),
     "apply_patch_call": frozenset(
         {
             "call_id",
@@ -92,6 +97,22 @@ _ACCOUNT_NEUTRAL_INPUT_ITEM_FIELDS = {
     ),
     "function_call_output": frozenset(
         {"call_id", "caller", "id", _INTERNAL_CHAT_MESSAGE_METADATA_FIELD, "output", "status", "type"}
+    ),
+    "tool_search_call": frozenset(
+        {"arguments", "call_id", "caller", "execution", "id", _INTERNAL_CHAT_MESSAGE_METADATA_FIELD, "status", "type"}
+    ),
+    "tool_search_output": frozenset(
+        {
+            "call_id",
+            "caller",
+            "execution",
+            "id",
+            _INTERNAL_CHAT_MESSAGE_METADATA_FIELD,
+            "output",
+            "status",
+            "tools",
+            "type",
+        }
     ),
 }
 _ACCOUNT_NEUTRAL_ITEM_STATUSES = frozenset({"completed", "failed"})
@@ -269,6 +290,10 @@ def responses_input_items_are_self_contained_fresh_replay(input_items: list[Json
         item_type = item_type_value if isinstance(item_type_value, str) else None
         if not _input_item_has_only_known_fields(item, item_type):
             return False
+        if item_type == "compaction":
+            if not _compaction_item_is_self_contained(item):
+                return False
+            continue
         call_id_value = item.get("call_id")
         call_id = call_id_value if isinstance(call_id_value, str) and call_id_value else None
         if item_type in _TOOL_CALL_TYPES:
@@ -628,6 +653,9 @@ def _tool_call_is_self_contained(item_type: str, item: Mapping[str, JsonValue]) 
         return _is_nonblank_string(item.get("name")) and isinstance(item.get("arguments"), str)
     if item_type == "custom_tool_call":
         return _is_nonblank_string(item.get("name")) and isinstance(item.get("input"), str)
+    if item_type == "tool_search_call":
+        arguments = item.get("arguments")
+        return isinstance(arguments, dict) and item.get("execution") in (None, "client")
     operation = item.get("operation")
     patch = item.get("patch")
     input_value = item.get("input")
@@ -638,6 +666,10 @@ def _tool_call_is_self_contained(item_type: str, item: Mapping[str, JsonValue]) 
     if "patch" in item:
         return _is_nonblank_string(patch)
     return _is_nonblank_string(input_value)
+
+
+def _compaction_item_is_self_contained(item: Mapping[str, JsonValue]) -> bool:
+    return item.get("status") in (None, "completed") and _is_nonblank_string(item.get("encrypted_content"))
 
 
 def _caller_is_self_contained(item: Mapping[str, JsonValue]) -> bool:
@@ -1017,6 +1049,8 @@ def _contains_account_scoped_input_state(value: JsonValue) -> bool:
                 return True
             if item_type == "additional_tools" and not _tools_are_account_neutral(current.get("tools")):
                 return True
+            if item_type == "compaction" and _compaction_item_is_self_contained(current):
+                continue
             if (
                 isinstance(item_type, str)
                 and (item_type.endswith("_call") or item_type.endswith("_call_output"))

--- a/app/modules/proxy/replay_safety.py
+++ b/app/modules/proxy/replay_safety.py
@@ -15,11 +15,10 @@ _TOOL_CALL_TYPE_BY_OUTPUT_TYPE = {
     "function_call_output": "function_call",
     "custom_tool_call_output": "custom_tool_call",
     "apply_patch_call_output": "apply_patch_call",
+    "tool_search_output": "tool_search_call",
 }
 _TOOL_CALL_TYPES = frozenset(_TOOL_CALL_TYPE_BY_OUTPUT_TYPE.values())
-_ACCOUNT_NEUTRAL_REPLAY_OMITTED_ITEM_TYPES = frozenset(
-    {"reasoning", "tool_search_call", "tool_search_output", "web_search_call"}
-)
+_ACCOUNT_NEUTRAL_REPLAY_OMITTED_ITEM_TYPES = frozenset({"reasoning", "web_search_call"})
 _INTERNAL_CHAT_MESSAGE_METADATA_FIELD = "internal_chat_message_metadata_passthrough"
 _ACCOUNT_NEUTRAL_INTERNAL_CHAT_MESSAGE_METADATA_FIELDS = frozenset({"turn_id"})
 _ACCOUNT_NEUTRAL_TOOL_TYPES = frozenset({"custom", "function", "web_search", "web_search_preview"})
@@ -39,6 +38,7 @@ _ACCOUNT_NEUTRAL_INPUT_ITEM_TYPES = frozenset(
         "additional_tools",
         "apply_patch_call",
         "apply_patch_call_output",
+        "compaction",
         "custom_tool_call",
         "custom_tool_call_output",
         "function_call",
@@ -47,6 +47,8 @@ _ACCOUNT_NEUTRAL_INPUT_ITEM_TYPES = frozenset(
         "input_image",
         "input_text",
         "message",
+        "tool_search_call",
+        "tool_search_output",
     }
 )
 _ACCOUNT_NEUTRAL_MESSAGE_CONTENT_TYPES = frozenset(
@@ -65,6 +67,7 @@ _ACCOUNT_NEUTRAL_CONTENT_FIELDS = {
 }
 _ACCOUNT_NEUTRAL_INPUT_ITEM_FIELDS = {
     "additional_tools": frozenset({"role", "tools", "type"}),
+    "compaction": frozenset({"encrypted_content", "id", "status", "type"}),
     "apply_patch_call": frozenset(
         {
             "call_id",
@@ -92,6 +95,22 @@ _ACCOUNT_NEUTRAL_INPUT_ITEM_FIELDS = {
     ),
     "function_call_output": frozenset(
         {"call_id", "caller", "id", _INTERNAL_CHAT_MESSAGE_METADATA_FIELD, "output", "status", "type"}
+    ),
+    "tool_search_call": frozenset(
+        {"arguments", "call_id", "caller", "execution", "id", _INTERNAL_CHAT_MESSAGE_METADATA_FIELD, "status", "type"}
+    ),
+    "tool_search_output": frozenset(
+        {
+            "call_id",
+            "caller",
+            "execution",
+            "id",
+            _INTERNAL_CHAT_MESSAGE_METADATA_FIELD,
+            "output",
+            "status",
+            "tools",
+            "type",
+        }
     ),
 }
 _ACCOUNT_NEUTRAL_ITEM_STATUSES = frozenset({"completed", "failed"})
@@ -176,6 +195,8 @@ def project_responses_input_for_account_neutral_fresh_replay(
 
     if stored_count <= 0 or stored_count > len(input_items):
         return None
+    if not _stored_prefix_compaction_boundary_is_safe(input_items, stored_count=stored_count):
+        return None
 
     projected_items: list[JsonValue] = []
     projected_stored_count = 0
@@ -207,6 +228,14 @@ def project_responses_input_for_account_neutral_fresh_replay(
         stored_prefix_count=projected_stored_count,
         canonical_lite_developer_index=canonical_lite_developer_index,
     )
+
+
+def _stored_prefix_compaction_boundary_is_safe(input_items: list[JsonValue], *, stored_count: int) -> bool:
+    stored_prefix = input_items[:stored_count]
+    for item in stored_prefix[:-1]:
+        if isinstance(item, dict) and item.get("type") == "compaction" and _compaction_item_is_self_contained(item):
+            return False
+    return True
 
 
 def _is_canonical_lite_tool_bundle(item: JsonValue) -> bool:
@@ -245,6 +274,8 @@ def _project_account_neutral_replay_item(
     ):
         return None
 
+    if item_type == "compaction":
+        return item
     if "id" not in item:
         return item
     projected_item = dict(item)
@@ -269,6 +300,10 @@ def responses_input_items_are_self_contained_fresh_replay(input_items: list[Json
         item_type = item_type_value if isinstance(item_type_value, str) else None
         if not _input_item_has_only_known_fields(item, item_type):
             return False
+        if item_type == "compaction":
+            if not _compaction_item_is_self_contained(item):
+                return False
+            continue
         call_id_value = item.get("call_id")
         call_id = call_id_value if isinstance(call_id_value, str) and call_id_value else None
         if item_type in _TOOL_CALL_TYPES:
@@ -324,7 +359,8 @@ def responses_input_suffix_retains_prior_output(
     if prefix_state is None:
         return False
     pending_suffix_calls, seen_suffix_call_ids = prefix_state
-    retained_output_seen = False
+    compact_context_prefix = _input_prefix_ends_with_self_contained_compaction(input_items[:stored_count])
+    retained_output_seen = compact_context_prefix
     retained_output_is_final_answer = False
     fresh_followup_seen = False
     fresh_followup_count = 0
@@ -364,6 +400,12 @@ def responses_input_suffix_retains_prior_output(
             if pending_suffix_calls[0] != (call_type, call_id):
                 return False
             pending_suffix_calls.popleft()
+            if compact_context_prefix and not pending_suffix_calls and call_type == "tool_search_call":
+                retained_output_seen = True
+                retained_output_is_final_answer = False
+                fresh_followup_seen = False
+                fresh_followup_count = 0
+                fresh_followup_is_user_message = False
             continue
         if item_type in (None, "message") and item.get("role") == "assistant":
             if pending_suffix_calls or not _is_retained_response_message(item):
@@ -394,6 +436,17 @@ def responses_input_suffix_retains_prior_output(
             continue
         return False
     return retained_output_seen and fresh_followup_seen and not pending_suffix_calls
+
+
+def _input_prefix_ends_with_self_contained_compaction(input_items: list[JsonValue]) -> bool:
+    if not input_items:
+        return False
+    last_item = input_items[-1]
+    return (
+        isinstance(last_item, dict)
+        and last_item.get("type") == "compaction"
+        and _compaction_item_is_self_contained(last_item)
+    )
 
 
 def responses_input_suffix_matches_pending_tool_calls(
@@ -628,6 +681,9 @@ def _tool_call_is_self_contained(item_type: str, item: Mapping[str, JsonValue]) 
         return _is_nonblank_string(item.get("name")) and isinstance(item.get("arguments"), str)
     if item_type == "custom_tool_call":
         return _is_nonblank_string(item.get("name")) and isinstance(item.get("input"), str)
+    if item_type == "tool_search_call":
+        arguments = item.get("arguments")
+        return isinstance(arguments, dict) and item.get("execution") in (None, "client")
     operation = item.get("operation")
     patch = item.get("patch")
     input_value = item.get("input")
@@ -638,6 +694,10 @@ def _tool_call_is_self_contained(item_type: str, item: Mapping[str, JsonValue]) 
     if "patch" in item:
         return _is_nonblank_string(patch)
     return _is_nonblank_string(input_value)
+
+
+def _compaction_item_is_self_contained(item: Mapping[str, JsonValue]) -> bool:
+    return item.get("status") in (None, "completed") and _is_nonblank_string(item.get("encrypted_content"))
 
 
 def _caller_is_self_contained(item: Mapping[str, JsonValue]) -> bool:
@@ -677,6 +737,13 @@ def _apply_patch_operation_is_self_contained(operation: JsonValue | None) -> boo
 def _tool_output_is_self_contained(item_type: str, item: Mapping[str, JsonValue]) -> bool:
     if item.get("status") not in (None, "completed", "failed"):
         return False
+    if item_type == "tool_search_output":
+        if item.get("execution") not in (None, "client"):
+            return False
+        if "tools" in item and not _tools_are_account_neutral(item.get("tools")):
+            return False
+        if _tool_search_output_tools_are_self_contained(item):
+            return True
     output = item.get("output")
     if isinstance(output, str):
         return True
@@ -689,6 +756,15 @@ def _tool_output_is_self_contained(item_type: str, item: Mapping[str, JsonValue]
             isinstance(part, dict) and _input_content_part_is_self_contained(part, allow_output=False)
             for part in output
         )
+    )
+
+
+def _tool_search_output_tools_are_self_contained(item: Mapping[str, JsonValue]) -> bool:
+    return (
+        item.get("execution") == "client"
+        and "tools" in item
+        and _tools_are_account_neutral(item.get("tools"))
+        and item.get("output") in (None, "")
     )
 
 
@@ -933,6 +1009,13 @@ def _input_items_have_valid_account_neutral_shape(input_items: list[JsonValue]) 
             if not _input_content_part_is_self_contained(item, allow_output=False):
                 return False
             continue
+        if item_type == "tool_search_output":
+            execution = item.get("execution")
+            if execution is not None and execution != "client":
+                return False
+            if "tools" in item and not _tools_are_account_neutral(item.get("tools")):
+                return False
+            continue
         if item_type == "additional_tools":
             if item.get("role") != "developer" or not _tools_are_account_neutral(item.get("tools")):
                 return False
@@ -1017,6 +1100,8 @@ def _contains_account_scoped_input_state(value: JsonValue) -> bool:
                 return True
             if item_type == "additional_tools" and not _tools_are_account_neutral(current.get("tools")):
                 return True
+            if item_type == "compaction" and _compaction_item_is_self_contained(current):
+                continue
             if (
                 isinstance(item_type, str)
                 and (item_type.endswith("_call") or item_type.endswith("_call_output"))

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -222,6 +222,9 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_payload_without_previous_response_id as _http_bridge_payload_without_previous_response_id,
 )
 from app.modules.proxy._service.http_bridge.helpers import (
+    _http_bridge_pending_response_events_seen as _http_bridge_pending_response_events_seen,
+)
+from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_precreated_retry_failure_error as _http_bridge_precreated_retry_failure_error,
 )
 from app.modules.proxy._service.http_bridge.helpers import (
@@ -2594,19 +2597,11 @@ def _service_tier_from_event_payload(payload: dict[str, JsonValue] | None) -> st
 
 
 def _effective_service_tier(requested_service_tier: str | None, actual_service_tier: str | None) -> str | None:
-    if isinstance(actual_service_tier, str):
-        return actual_service_tier
-    if isinstance(requested_service_tier, str):
-        return requested_service_tier
-    return None
+    return actual_service_tier if isinstance(actual_service_tier, str) else requested_service_tier
 
 
 def _normalize_service_tier_value(value: JsonValue) -> str | None:
     if not isinstance(value, str):
         return None
     stripped = value.strip()
-    if not stripped:
-        return None
-    if stripped.lower() == "fast":
-        return "priority"
-    return stripped
+    return "priority" if stripped.lower() == "fast" else stripped or None

--- a/openspec/changes/archive/2026-08-13-classify-tool-search-missing-tool-output/proposal.md
+++ b/openspec/changes/archive/2026-08-13-classify-tool-search-missing-tool-output/proposal.md
@@ -37,6 +37,10 @@ item type is real, only the classifier list is stale.
   there is nothing for the continuity recovery paths to do with it.
 - Add regression coverage for the classifier and for the HTTP-bridge masking
   surface.
+- Treat `tool_search_call` / `tool_search_output` like the other client-side
+  tool pairs when trimming already-stored previous-response replay prefixes, so
+  compaction-preserved tool-search pairs do not get resent in full on top of a
+  `previous_response_id` anchor.
 
 ## Non-goals
 

--- a/openspec/changes/archive/2026-08-13-classify-tool-search-missing-tool-output/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-08-13-classify-tool-search-missing-tool-output/specs/responses-api-compat/spec.md
@@ -18,3 +18,18 @@ The service MUST classify an upstream `invalid_request_error` with `param=input`
 #### Scenario: hosted web search wording stays unclassified
 - **WHEN** upstream emits `invalid_request_error` with `param=input` and a message starting `No tool output found for web search call`
 - **THEN** the service does not treat it as a missing-tool-output continuity error
+
+### Requirement: Previous-response replay trimming handles tool-search output pairs
+When a Responses HTTP bridge or WebSocket continuation carries `previous_response_id` and replays already-stored response output items before a fresh `tool_search_output`, the service MUST trim the replayed `tool_search_call` prefix and preserve the `tool_search_output` plus the fresh turn. The service MUST NOT forward both the replayed `tool_search_call` and its `tool_search_output` on top of the `previous_response_id` anchor.
+
+#### Scenario: HTTP bridge trims replayed tool-search call prefix
+- **GIVEN** an HTTP bridge session has a completed previous response
+- **WHEN** the next request carries `previous_response_id` and input `[tool_search_call, tool_search_output, user_message]`
+- **THEN** the upstream request keeps the same `previous_response_id`
+- **AND** its input is `[tool_search_output, user_message]`
+
+#### Scenario: WebSocket bridge trims replayed tool-search call prefix
+- **GIVEN** a WebSocket Responses session has a completed previous response
+- **WHEN** the next request carries `previous_response_id` and input `[tool_search_call, tool_search_output, user_message]`
+- **THEN** the upstream request keeps the same `previous_response_id`
+- **AND** its input is `[tool_search_output, user_message]`

--- a/openspec/changes/archive/2026-08-13-classify-tool-search-missing-tool-output/tasks.md
+++ b/openspec/changes/archive/2026-08-13-classify-tool-search-missing-tool-output/tasks.md
@@ -3,4 +3,5 @@
 - [x] Extend the missing-tool-output message classifier with the tool-search wording.
 - [x] Keep the hosted `web search call` wording unclassified.
 - [x] Add classifier and HTTP-bridge masking regression coverage.
+- [x] Trim replayed tool-search call prefixes on previous-response HTTP bridge and WebSocket continuations.
 - [x] Run focused unit tests, lint/format, type check, architecture check, diff check, and strict OpenSpec validation.

--- a/openspec/changes/preserve-opaque-compaction-replays/proposal.md
+++ b/openspec/changes/preserve-opaque-compaction-replays/proposal.md
@@ -1,0 +1,17 @@
+## Why
+
+PR #1720 rewrites plaintext compaction replays before forwarding them upstream, but the current branch still treats only one ciphertext shape as provider-authored. Any other non-empty `encrypted_content` string is rewritten into synthetic assistant text, which drops the authoritative compact item identity and ciphertext even though the proxy's own compaction output normalizer preserves opaque encrypted strings unchanged.
+
+The branch also synthesizes assistant replacements after request validation, so compact replays forwarded as plaintext summaries can bypass the canonical assistant-content normalization path and still reach upstream with raw string `content`.
+
+## What Changes
+
+- Preserve any compaction item that already carries string `encrypted_content`; only rewrite plaintext summary/text/content shapes that lack encrypted payload.
+- Emit rewritten plaintext compact-state summaries in canonical assistant `output_text` form so both standard and compact Responses payloads stay upstream-compatible.
+- Document the replay-sanitization contract under `responses-api-compat`.
+
+## Impact
+
+- Prevents compact replay continuity loss for opaque provider envelopes.
+- Keeps plaintext local summaries replay-safe without relying on post-validation string content.
+- Aligns PR #1720's behavior change with the repository's OpenSpec-first merge gate.

--- a/openspec/changes/preserve-opaque-compaction-replays/specs/responses-api-compat/spec.md
+++ b/openspec/changes/preserve-opaque-compaction-replays/specs/responses-api-compat/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Compaction replay sanitization preserves opaque encrypted state
+
+When a standard or compact Responses request replays a historical compaction item, the proxy MUST preserve that item unchanged whenever it already carries string `encrypted_content`. The proxy MUST NOT infer local plaintext provenance from ciphertext prefix or length heuristics, and MUST NOT replace such an item with synthetic assistant text solely because the encrypted payload shape is unfamiliar.
+
+When the replayed compaction item instead carries plaintext `summary`, `text`, or text-bearing `content` without string `encrypted_content`, the proxy MAY rewrite it into assistant context for upstream compatibility. Any assistant replacement synthesized during request serialization MUST use the canonical assistant content schema (`output_text` content parts), not a raw string `content` field.
+
+#### Scenario: compact replay keeps opaque encrypted content
+
+- **WHEN** `/backend-api/codex/responses/compact` receives a replayed `compaction` item whose `encrypted_content` is a non-empty opaque string
+- **THEN** the forwarded upstream payload preserves that compaction item unchanged
+- **AND** its `id`, `status`, and `encrypted_content` remain intact
+
+#### Scenario: plaintext compact summary rewrites to canonical assistant content
+
+- **WHEN** a replayed compact request contains a historical `compaction` item with plaintext `summary` and no string `encrypted_content`
+- **THEN** the proxy rewrites it to an assistant item with `content` as an `output_text` array
+- **AND** the synthesized text begins with the compact-state prefix used for local plaintext summaries

--- a/openspec/changes/preserve-opaque-compaction-replays/tasks.md
+++ b/openspec/changes/preserve-opaque-compaction-replays/tasks.md
@@ -1,0 +1,13 @@
+## 1. Spec
+
+- [x] 1.1 Add a `responses-api-compat` delta for compact replay sanitization requirements.
+
+## 2. Implementation
+
+- [x] 2.1 Preserve opaque encrypted compaction items instead of inferring ciphertext provenance from prefix shape.
+- [x] 2.2 Normalize synthesized plaintext compact-state assistant replacements to canonical `output_text` content arrays.
+
+## 3. Verification
+
+- [x] 3.1 Run focused unit/integration pytest coverage for compact replay handling.
+- [x] 3.2 Run `ruff check` and `ruff format --check` on touched files.

--- a/openspec/changes/recover-post-compact-bridge-replays/proposal.md
+++ b/openspec/changes/recover-post-compact-bridge-replays/proposal.md
@@ -1,0 +1,28 @@
+# Recover post-compact HTTP bridge replays
+
+## Why
+
+Post-compaction Codex turns can carry a compact context item, completed
+tool-search call/output side effects, and a fresh user message. When the HTTP
+bridge treats a session-level compact-anchor trim as a generically safe fresh
+replay, later recovery may drop the durable context or tool-search side effects
+that make the follow-up self-contained.
+
+## What Changes
+
+- Treat completed `compaction` items with encrypted content as self-contained
+  account-neutral replay context.
+- Preserve completed `tool_search_call` / `tool_search_output` pairs when
+  projecting a compacted fresh replay payload.
+- Preserve compact context when projecting a fresh replay payload, while removing
+  response-owned ids.
+- Keep session-level compact-anchor trim safety separate from durable full-resend
+  proof; trimming a stored prefix does not automatically make an unanchored
+  replay safe.
+- Retire stale response-create gate holders with evidence about whether upstream
+  response events were already observed, so wedged bridge sessions take the
+  existing recovery/quarantine path.
+
+## Impact
+
+Post-compaction follow-up turns recover with the compact context preserved.

--- a/openspec/changes/recover-post-compact-bridge-replays/specs/responses-api-compat/spec.md
+++ b/openspec/changes/recover-post-compact-bridge-replays/specs/responses-api-compat/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Post-compact bridge replays preserve compact context
+
+codex-lb MUST treat completed post-compaction replay context as self-contained when an HTTP bridge or Responses WebSocket request must recover a follow-up turn after compaction. A projected fresh replay payload MUST retain that compact context while removing response-owned bookkeeping ids.
+
+Trimming a stored prefix because a session-level compact anchor was injected
+MUST NOT by itself mark the unanchored request safe to replay. The proxy may
+mark the unanchored request replay-safe only when the original anchor site had
+already made that decision or when a durable full-resend proof shows the fresh
+suffix is self-contained.
+
+Account-neutral recovery MAY select another eligible account after the previous
+owner has been excluded or proved silent. Requests that explicitly require a
+preferred previous-response owner MUST continue to fail closed when that owner
+is unavailable.
+
+#### Scenario: id-free completed compaction and tool-search context survives fresh replay projection
+
+- **GIVEN** a follow-up payload starts with a completed `compaction` item whose
+  encrypted content is non-empty
+- **AND** that compaction item does not carry an `id`
+- **AND** the payload also carries a completed `tool_search_call` /
+  `tool_search_output` pair followed by a fresh user message
+- **WHEN** codex-lb projects an account-neutral fresh replay payload
+- **THEN** the projected payload includes the compaction item
+- **AND** it preserves the completed tool-search pair without response-owned ids
+- **AND** the projected payload is eligible for account-neutral replay
+
+#### Scenario: session-level compact trim does not fabricate replay safety
+
+- **GIVEN** a session-level compact anchor trimmed a stored prefix from a
+  follow-up request
+- **AND** the original request state was not already known to be safe as an
+  unanchored fresh replay
+- **WHEN** the bridge records the retained fresh request text
+- **THEN** codex-lb does not mark that retained request as retry-safe solely
+  because the trim happened
+
+#### Scenario: account-neutral recovery can leave a silent owner
+
+- **GIVEN** an account-neutral HTTP bridge recovery request excludes the previous
+  owner account after it failed to acknowledge `response.create`
+- **WHEN** another eligible account is available
+- **THEN** codex-lb reconnects on that replacement account and sends the retained
+  request there
+
+#### Scenario: required previous-response owner still fails closed
+
+- **GIVEN** a follow-up request explicitly requires its preferred
+  previous-response owner account
+- **WHEN** that owner is unavailable
+- **THEN** codex-lb returns the previous-response-owner-unavailable failure
+  instead of silently rebinding the request to another account

--- a/openspec/changes/recover-post-compact-bridge-replays/tasks.md
+++ b/openspec/changes/recover-post-compact-bridge-replays/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [x] Accept compact context and tool-search call/output pairs in account-neutral replay safety checks.
+- [x] Preserve completed compaction items in projected fresh replay payloads without retaining response-owned ids.
+- [x] Keep session-level trim safety from overriding the original replay-safety decision unless a durable full-resend proof exists.
+- [x] Allow account-neutral bridge recovery to select another eligible account after the silent owner is excluded.
+- [x] Keep explicit required-owner continuity failures fail-closed.
+- [x] Pass response-event evidence into stale response-create gate retirement.
+- [x] Add replay-safety and HTTP bridge regression coverage for post-compact recovery.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -13488,6 +13488,162 @@ async def test_retry_http_bridge_precreated_request_ignores_existing_response_id
 
 
 @pytest.mark.asyncio
+async def test_retry_account_neutral_precreated_request_switches_from_silent_account(app_instance, monkeypatch):
+    from app.modules.proxy.continuity import make_http_bridge_account_neutral_replay_key
+
+    service = get_proxy_service_for_app(app_instance)
+    recovery_kind, recovery_key = make_http_bridge_account_neutral_replay_key("retry-silent-account")
+    first_account = cast(Account, SimpleNamespace(id="acct-silent", status=AccountStatus.ACTIVE, plan_type="plus"))
+    replacement_account = cast(
+        Account,
+        SimpleNamespace(id="acct-replacement", status=AccountStatus.ACTIVE, plan_type="plus"),
+    )
+    replacement_upstream = _RecordingUpstreamWebSocket()
+    session = proxy_module._HTTPBridgeSession(
+        key=proxy_module._HTTPBridgeSessionKey(recovery_kind, recovery_key, None),
+        headers={"x-codex-turn-state": "stale-turn-state"},
+        affinity=proxy_module._AffinityPolicy(),
+        request_model="gpt-5.5",
+        account=first_account,
+        upstream=cast(proxy_module.UpstreamWebSocket, _SilentUpstreamWebSocket()),
+        upstream_control=proxy_module._WebSocketUpstreamControl(),
+        pending_lock=anyio.Lock(),
+        pending_requests=deque(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+    )
+    request_state = proxy_module._WebSocketRequestState(
+        request_id="req-account-neutral-precreated-retry",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        transport="http",
+        response_create_gate_acquired=True,
+        request_text=json.dumps({"type": "response.create", "model": "gpt-5.5", "input": []}),
+    )
+    session.pending_requests.append(request_state)
+    reconnect_calls: list[dict[str, object]] = []
+
+    async def fake_reconnect(
+        self,
+        target_session,
+        *,
+        request_state,
+        restart_reader=False,
+        require_same_account=False,
+        require_preferred_account=False,
+    ):
+        del self, restart_reader
+        reconnect_calls.append(
+            {
+                "require_same_account": require_same_account,
+                "require_preferred_account": require_preferred_account,
+                "preferred_account_id": target_session.account.id,
+                "excluded_account_ids": set(request_state.excluded_account_ids),
+            }
+        )
+        target_session.account = replacement_account
+        target_session.upstream = replacement_upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_reconnect_http_bridge_session", fake_reconnect)
+
+    assert await service._retry_http_bridge_precreated_request(session) is True
+
+    assert reconnect_calls == [
+        {
+            "require_same_account": True,
+            "require_preferred_account": True,
+            "preferred_account_id": "acct-silent",
+            "excluded_account_ids": set(),
+        }
+    ]
+    assert request_state.preferred_account_id == "acct-silent"
+    assert session.account.id == "acct-replacement"
+    assert replacement_upstream.sent_text == [request_state.request_text]
+
+
+@pytest.mark.asyncio
+async def test_reconnect_required_owner_still_fails_when_owner_unavailable(app_instance, monkeypatch):
+    service = get_proxy_service_for_app(app_instance)
+    owner_account = cast(
+        Account,
+        SimpleNamespace(id="acct-owner-required", status=AccountStatus.ACTIVE, plan_type="plus"),
+    )
+    session = proxy_module._HTTPBridgeSession(
+        key=proxy_module._HTTPBridgeSessionKey("prompt_cache", "required-owner-reconnect", None),
+        headers={},
+        affinity=proxy_module._AffinityPolicy(),
+        request_model="gpt-5.5",
+        account=owner_account,
+        upstream=cast(proxy_module.UpstreamWebSocket, _SilentUpstreamWebSocket()),
+        upstream_control=proxy_module._WebSocketUpstreamControl(),
+        pending_lock=anyio.Lock(),
+        pending_requests=deque(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+    )
+    request_state = proxy_module._WebSocketRequestState(
+        request_id="req-required-owner-reconnect",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        transport="http",
+        response_create_gate_acquired=True,
+        request_text=json.dumps({"type": "response.create", "model": "gpt-5.5", "input": []}),
+    )
+    request_state.preferred_account_id = owner_account.id
+    selection_calls: list[dict[str, object]] = []
+
+    async def fake_select_account_with_budget_for_stream(self, deadline, **kwargs):
+        del self, deadline
+        selection_calls.append(
+            {
+                "preferred_account_id": kwargs.get("preferred_account_id"),
+                "preferred_account_is_continuity_owner": kwargs.get("preferred_account_is_continuity_owner"),
+                "fallback_on_preferred_account_unavailable": kwargs.get("fallback_on_preferred_account_unavailable"),
+            }
+        )
+        return AccountSelection(
+            account=None,
+            error_message="Required continuity owner account no longer exists",
+            error_code=CONTINUITY_OWNER_UNAVAILABLE,
+        )
+
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "_select_account_with_budget_for_stream",
+        fake_select_account_with_budget_for_stream,
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await service._reconnect_http_bridge_session(
+            session,
+            request_state=request_state,
+            require_preferred_account=True,
+        )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.payload["error"]["code"] == "previous_response_owner_unavailable"
+    assert selection_calls == [
+        {
+            "preferred_account_id": owner_account.id,
+            "preferred_account_is_continuity_owner": False,
+            "fallback_on_preferred_account_unavailable": False,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_v1_responses_http_bridge_send_failure_returns_upstream_unavailable(
     async_client,
     app_instance,

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -5723,121 +5723,6 @@ async def test_v1_responses_http_bridge_trims_replayed_apply_patch_previous_resp
 
 
 @pytest.mark.asyncio
-async def test_v1_responses_http_bridge_trims_replayed_tool_search_previous_response_prefix(
-    async_client,
-    monkeypatch,
-):
-    _install_bridge_settings(monkeypatch, enabled=True)
-    account_id = await _import_account(
-        async_client,
-        "acc_http_bridge_tool_search_trim",
-        "http-bridge-tool-search-trim@example.com",
-    )
-    account = await _get_account(account_id)
-    fake_upstream = _FakeBridgeUpstreamWebSocket()
-
-    async def fake_select_account_with_budget(
-        self,
-        deadline,
-        *,
-        request_id,
-        kind,
-        request_stage="first_turn",
-        sticky_key,
-        sticky_kind,
-        reallocate_sticky,
-        sticky_max_age_seconds,
-        prefer_earlier_reset_accounts,
-        routing_strategy,
-        model,
-        exclude_account_ids=None,
-        additional_limit_name=None,
-        api_key=None,
-        preferred_account_id=None,
-    ):
-        del preferred_account_id
-        del (
-            self,
-            deadline,
-            request_id,
-            kind,
-            request_stage,
-            sticky_key,
-            sticky_kind,
-            reallocate_sticky,
-            sticky_max_age_seconds,
-            prefer_earlier_reset_accounts,
-            routing_strategy,
-            model,
-            exclude_account_ids,
-            additional_limit_name,
-        )
-        return AccountSelection(account=account, error_message=None, error_code=None)
-
-    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
-        del self, force, timeout_seconds
-        return target
-
-    async def fake_connect_responses_websocket(
-        headers,
-        access_token,
-        account_id_header,
-        *,
-        base_url=None,
-        session=None,
-    ):
-        del headers, access_token, account_id_header, base_url, session
-        return fake_upstream
-
-    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
-    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
-    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
-
-    first = await async_client.post(
-        "/v1/responses",
-        json={
-            "model": "gpt-5.1",
-            "instructions": "Search the tools.",
-            "input": [{"role": "user", "content": [{"type": "input_text", "text": "find context"}]}],
-            "prompt_cache_key": "http-bridge-tool-search-trim-1",
-        },
-    )
-    assert first.status_code == 200
-    first_body = first.json()
-    assert first_body["id"] == "resp_bridge_1"
-
-    replayed_tool_search_call = {
-        "id": "tsc_replay",
-        "type": "tool_search_call",
-        "status": "completed",
-        "call_id": "call_search_1",
-    }
-    replayed_tool_search_output = {
-        "type": "tool_search_output",
-        "call_id": "call_search_1",
-        "output": [{"title": "context result"}],
-    }
-    next_user_message = {"role": "user", "content": [{"type": "input_text", "text": "continue"}]}
-    second = await async_client.post(
-        "/v1/responses",
-        json={
-            "model": "gpt-5.1",
-            "instructions": "Search the tools.",
-            "previous_response_id": first_body["id"],
-            "input": [replayed_tool_search_call, replayed_tool_search_output, next_user_message],
-            "prompt_cache_key": "http-bridge-tool-search-trim-1",
-        },
-    )
-    assert second.status_code == 200
-    assert second.json()["id"] == "resp_bridge_2"
-
-    assert len(fake_upstream.sent_text) == 2
-    second_upstream_payload = json.loads(fake_upstream.sent_text[1])
-    assert second_upstream_payload["previous_response_id"] == "resp_bridge_1"
-    assert second_upstream_payload["input"] == [replayed_tool_search_output, next_user_message]
-
-
-@pytest.mark.asyncio
 async def test_backend_responses_http_bridge_lite_request_omits_synthesized_tools(
     async_client,
     monkeypatch,
@@ -7434,6 +7319,201 @@ async def test_v1_responses_http_bridge_refresh_failure_returns_proxy_error(asyn
     assert response.status_code == 401
     assert response.json()["error"]["code"] == "invalid_api_key"
     assert "x-codex-turn-state" not in response.headers
+
+
+@pytest.mark.asyncio
+async def test_v1_responses_http_bridge_trims_replayed_tool_search_previous_response_prefix(
+    async_client,
+    monkeypatch,
+):
+    _install_bridge_settings(monkeypatch, enabled=True)
+    account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_tool_search_trim",
+        "http-bridge-tool-search-trim@example.com",
+    )
+    account = await _get_account(account_id)
+    fake_upstream = _FakeBridgeUpstreamWebSocket()
+
+    async def fake_select_account_with_budget(
+        self,
+        deadline,
+        *,
+        request_id,
+        kind,
+        request_stage="first_turn",
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset_accounts,
+        routing_strategy,
+        model,
+        exclude_account_ids=None,
+        additional_limit_name=None,
+        api_key=None,
+        preferred_account_id=None,
+    ):
+        del preferred_account_id
+        del (
+            self,
+            deadline,
+            request_id,
+            kind,
+            request_stage,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset_accounts,
+            routing_strategy,
+            model,
+            exclude_account_ids,
+            additional_limit_name,
+        )
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        return fake_upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    first = await async_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "Search the tools.",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "find context"}]}],
+            "prompt_cache_key": "http-bridge-tool-search-trim-1",
+        },
+    )
+    assert first.status_code == 200
+    first_body = first.json()
+    assert first_body["id"] == "resp_bridge_1"
+
+    replayed_tool_search_call = {
+        "id": "tsc_replay",
+        "type": "tool_search_call",
+        "status": "completed",
+        "call_id": "call_search_1",
+    }
+    replayed_tool_search_output = {
+        "type": "tool_search_output",
+        "call_id": "call_search_1",
+        "output": [{"title": "context result"}],
+    }
+    next_user_message = {"role": "user", "content": [{"type": "input_text", "text": "continue"}]}
+    second = await async_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "Search the tools.",
+            "previous_response_id": first_body["id"],
+            "input": [replayed_tool_search_call, replayed_tool_search_output, next_user_message],
+            "prompt_cache_key": "http-bridge-tool-search-trim-1",
+        },
+    )
+    assert second.status_code == 200
+    assert second.json()["id"] == "resp_bridge_2"
+
+    assert len(fake_upstream.sent_text) == 2
+    second_upstream_payload = json.loads(fake_upstream.sent_text[1])
+    assert second_upstream_payload["previous_response_id"] == "resp_bridge_1"
+    assert second_upstream_payload["input"] == [replayed_tool_search_output, next_user_message]
+
+
+@pytest.mark.asyncio
+async def test_retry_account_neutral_precreated_request_switches_from_silent_account(app_instance, monkeypatch):
+    from app.modules.proxy.continuity import make_http_bridge_account_neutral_replay_key
+
+    service = get_proxy_service_for_app(app_instance)
+    recovery_kind, recovery_key = make_http_bridge_account_neutral_replay_key("retry-silent-account")
+    first_account = cast(Account, SimpleNamespace(id="acct-silent", status=AccountStatus.ACTIVE, plan_type="plus"))
+    replacement_account = cast(
+        Account,
+        SimpleNamespace(id="acct-replacement", status=AccountStatus.ACTIVE, plan_type="plus"),
+    )
+    replacement_upstream = _RecordingUpstreamWebSocket()
+    session = proxy_module._HTTPBridgeSession(
+        key=proxy_module._HTTPBridgeSessionKey(recovery_kind, recovery_key, None),
+        headers={"x-codex-turn-state": "stale-turn-state"},
+        affinity=proxy_module._AffinityPolicy(),
+        request_model="gpt-5.5",
+        account=first_account,
+        upstream=cast(proxy_module.UpstreamWebSocket, _SilentUpstreamWebSocket()),
+        upstream_control=proxy_module._WebSocketUpstreamControl(),
+        pending_lock=anyio.Lock(),
+        pending_requests=deque(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=1,
+        last_used_at=time.monotonic(),
+        idle_ttl_seconds=120.0,
+    )
+    request_state = proxy_module._WebSocketRequestState(
+        request_id="req-account-neutral-precreated-retry",
+        model="gpt-5.5",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        awaiting_response_created=True,
+        transport="http",
+        response_create_gate_acquired=True,
+        request_text=json.dumps({"type": "response.create", "model": "gpt-5.5", "input": []}),
+    )
+    session.pending_requests.append(request_state)
+    reconnect_calls: list[dict[str, object]] = []
+
+    async def fake_reconnect(
+        self,
+        target_session,
+        *,
+        request_state,
+        restart_reader=False,
+        require_same_account=False,
+        require_preferred_account=False,
+    ):
+        del self, restart_reader
+        reconnect_calls.append(
+            {
+                "require_same_account": require_same_account,
+                "require_preferred_account": require_preferred_account,
+                "preferred_account_id": target_session.account.id,
+                "excluded_account_ids": set(request_state.excluded_account_ids),
+            }
+        )
+        target_session.account = replacement_account
+        target_session.upstream = replacement_upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_reconnect_http_bridge_session", fake_reconnect)
+
+    assert await service._retry_http_bridge_precreated_request(session) is True
+
+    assert reconnect_calls == [
+        {
+            "require_same_account": False,
+            "require_preferred_account": False,
+            "preferred_account_id": "acct-silent",
+            "excluded_account_ids": {"acct-silent"},
+        }
+    ]
+    assert request_state.preferred_account_id is None
+    assert session.account.id == "acct-replacement"
+    assert replacement_upstream.sent_text == [request_state.request_text]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -5723,6 +5723,121 @@ async def test_v1_responses_http_bridge_trims_replayed_apply_patch_previous_resp
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_http_bridge_trims_replayed_tool_search_previous_response_prefix(
+    async_client,
+    monkeypatch,
+):
+    _install_bridge_settings(monkeypatch, enabled=True)
+    account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_tool_search_trim",
+        "http-bridge-tool-search-trim@example.com",
+    )
+    account = await _get_account(account_id)
+    fake_upstream = _FakeBridgeUpstreamWebSocket()
+
+    async def fake_select_account_with_budget(
+        self,
+        deadline,
+        *,
+        request_id,
+        kind,
+        request_stage="first_turn",
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset_accounts,
+        routing_strategy,
+        model,
+        exclude_account_ids=None,
+        additional_limit_name=None,
+        api_key=None,
+        preferred_account_id=None,
+    ):
+        del preferred_account_id
+        del (
+            self,
+            deadline,
+            request_id,
+            kind,
+            request_stage,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset_accounts,
+            routing_strategy,
+            model,
+            exclude_account_ids,
+            additional_limit_name,
+        )
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        return fake_upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    first = await async_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "Search the tools.",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "find context"}]}],
+            "prompt_cache_key": "http-bridge-tool-search-trim-1",
+        },
+    )
+    assert first.status_code == 200
+    first_body = first.json()
+    assert first_body["id"] == "resp_bridge_1"
+
+    replayed_tool_search_call = {
+        "id": "tsc_replay",
+        "type": "tool_search_call",
+        "status": "completed",
+        "call_id": "call_search_1",
+    }
+    replayed_tool_search_output = {
+        "type": "tool_search_output",
+        "call_id": "call_search_1",
+        "output": [{"title": "context result"}],
+    }
+    next_user_message = {"role": "user", "content": [{"type": "input_text", "text": "continue"}]}
+    second = await async_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "Search the tools.",
+            "previous_response_id": first_body["id"],
+            "input": [replayed_tool_search_call, replayed_tool_search_output, next_user_message],
+            "prompt_cache_key": "http-bridge-tool-search-trim-1",
+        },
+    )
+    assert second.status_code == 200
+    assert second.json()["id"] == "resp_bridge_2"
+
+    assert len(fake_upstream.sent_text) == 2
+    second_upstream_payload = json.loads(fake_upstream.sent_text[1])
+    assert second_upstream_payload["previous_response_id"] == "resp_bridge_1"
+    assert second_upstream_payload["input"] == [replayed_tool_search_output, next_user_message]
+
+
+@pytest.mark.asyncio
 async def test_backend_responses_http_bridge_lite_request_omits_synthesized_tools(
     async_client,
     monkeypatch,

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -7437,7 +7437,7 @@ async def test_v1_responses_http_bridge_trims_replayed_tool_search_previous_resp
 
 
 @pytest.mark.asyncio
-async def test_retry_account_neutral_precreated_request_switches_from_silent_account(app_instance, monkeypatch):
+async def test_retry_account_neutral_precreated_request_keeps_silent_owner(app_instance, monkeypatch):
     from app.modules.proxy.continuity import make_http_bridge_account_neutral_replay_key
 
     service = get_proxy_service_for_app(app_instance)
@@ -7505,13 +7505,13 @@ async def test_retry_account_neutral_precreated_request_switches_from_silent_acc
 
     assert reconnect_calls == [
         {
-            "require_same_account": False,
-            "require_preferred_account": False,
+            "require_same_account": True,
+            "require_preferred_account": True,
             "preferred_account_id": "acct-silent",
-            "excluded_account_ids": {"acct-silent"},
+            "excluded_account_ids": set(),
         }
     ]
-    assert request_state.preferred_account_id is None
+    assert request_state.preferred_account_id == "acct-silent"
     assert session.account.id == "acct-replacement"
     assert replacement_upstream.sent_text == [request_state.request_text]
 
@@ -13680,86 +13680,6 @@ async def test_retry_http_bridge_precreated_request_ignores_existing_response_id
 
     assert await service._retry_http_bridge_precreated_request(session) is True
     assert replacement_upstream.sent_text == [retry_request.request_text]
-
-
-@pytest.mark.asyncio
-async def test_retry_account_neutral_precreated_request_switches_from_silent_account(app_instance, monkeypatch):
-    from app.modules.proxy.continuity import make_http_bridge_account_neutral_replay_key
-
-    service = get_proxy_service_for_app(app_instance)
-    recovery_kind, recovery_key = make_http_bridge_account_neutral_replay_key("retry-silent-account")
-    first_account = cast(Account, SimpleNamespace(id="acct-silent", status=AccountStatus.ACTIVE, plan_type="plus"))
-    replacement_account = cast(
-        Account,
-        SimpleNamespace(id="acct-replacement", status=AccountStatus.ACTIVE, plan_type="plus"),
-    )
-    replacement_upstream = _RecordingUpstreamWebSocket()
-    session = proxy_module._HTTPBridgeSession(
-        key=proxy_module._HTTPBridgeSessionKey(recovery_kind, recovery_key, None),
-        headers={"x-codex-turn-state": "stale-turn-state"},
-        affinity=proxy_module._AffinityPolicy(),
-        request_model="gpt-5.5",
-        account=first_account,
-        upstream=cast(proxy_module.UpstreamWebSocket, _SilentUpstreamWebSocket()),
-        upstream_control=proxy_module._WebSocketUpstreamControl(),
-        pending_lock=anyio.Lock(),
-        pending_requests=deque(),
-        response_create_gate=asyncio.Semaphore(1),
-        queued_request_count=1,
-        last_used_at=time.monotonic(),
-        idle_ttl_seconds=120.0,
-    )
-    request_state = proxy_module._WebSocketRequestState(
-        request_id="req-account-neutral-precreated-retry",
-        model="gpt-5.5",
-        service_tier=None,
-        reasoning_effort=None,
-        api_key_reservation=None,
-        started_at=time.monotonic(),
-        awaiting_response_created=True,
-        transport="http",
-        response_create_gate_acquired=True,
-        request_text=json.dumps({"type": "response.create", "model": "gpt-5.5", "input": []}),
-    )
-    session.pending_requests.append(request_state)
-    reconnect_calls: list[dict[str, object]] = []
-
-    async def fake_reconnect(
-        self,
-        target_session,
-        *,
-        request_state,
-        restart_reader=False,
-        require_same_account=False,
-        require_preferred_account=False,
-    ):
-        del self, restart_reader
-        reconnect_calls.append(
-            {
-                "require_same_account": require_same_account,
-                "require_preferred_account": require_preferred_account,
-                "preferred_account_id": target_session.account.id,
-                "excluded_account_ids": set(request_state.excluded_account_ids),
-            }
-        )
-        target_session.account = replacement_account
-        target_session.upstream = replacement_upstream
-
-    monkeypatch.setattr(proxy_module.ProxyService, "_reconnect_http_bridge_session", fake_reconnect)
-
-    assert await service._retry_http_bridge_precreated_request(session) is True
-
-    assert reconnect_calls == [
-        {
-            "require_same_account": True,
-            "require_preferred_account": True,
-            "preferred_account_id": "acct-silent",
-            "excluded_account_ids": set(),
-        }
-    ]
-    assert request_state.preferred_account_id == "acct-silent"
-    assert session.account.id == "acct-replacement"
-    assert replacement_upstream.sent_text == [request_state.request_text]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -396,11 +396,18 @@ async def test_proxy_compact_sanitizes_plaintext_replay_before_upstream(async_cl
         {"role": "user", "content": "before"},
         {
             "role": "assistant",
-            "content": "[compact state] I have the concrete code and evidence blockers in hand.",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "[compact state] I have the concrete code and evidence blockers in hand.",
+                }
+            ],
         },
         {
-            "role": "assistant",
-            "content": "[compact state] [unverified compact state omitted]",
+            "id": "cmp_opaque_state",
+            "type": "compaction",
+            "status": "completed",
+            "encrypted_content": "opaque-provider-envelope-without-recognized-prefix",
         },
         {"role": "user", "content": "continue"},
     ]

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -475,68 +475,6 @@ async def test_proxy_compact_preserves_historical_code_mode_side_effect_pair_bef
 
 
 @pytest.mark.asyncio
-async def test_proxy_compact_preserves_tool_search_pair_before_ordinary_tail(async_client, monkeypatch):
-    email = "compact-tool-search@example.com"
-    raw_account_id = "acc_compact_tool_search"
-    files = {"auth_json": ("auth.json", json.dumps(_make_auth_json(raw_account_id, email)), "application/json")}
-    response = await async_client.post("/api/accounts/import", files=files)
-    assert response.status_code == 200
-
-    seen_payloads: list[dict[str, object]] = []
-
-    async def fake_compact(payload, headers, access_token, account_id):
-        del headers, access_token, account_id
-        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
-        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
-
-    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
-    tool_call = {
-        "type": "tool_search_call",
-        "call_id": "call-search-tail",
-        "status": "completed",
-        "execution": "client",
-        "arguments": {"query": "codex-lb compaction tool search"},
-    }
-    tool_output = {
-        "type": "tool_search_output",
-        "call_id": "call-search-tail",
-        "output": [{"title": "codex-lb compaction result"}],
-    }
-    ordinary_tail = {"role": "assistant", "content": "ordinary tail " + "x" * 500_000}
-    latest_request = {"role": "user", "content": "latest request"}
-    payload = {
-        "model": "gpt-5.6-sol",
-        "instructions": "hi",
-        "input": [
-            {"role": "user", "content": "initial request"},
-            {"role": "assistant", "content": "older answer " + "y" * 500_000},
-            tool_call,
-            ordinary_tail,
-            tool_output,
-            latest_request,
-        ],
-    }
-
-    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
-
-    assert response.status_code == 200
-    assert len(seen_payloads) == 1
-    upstream_input = seen_payloads[0]["input"]
-    assert isinstance(upstream_input, list)
-    assert tool_call in upstream_input
-    assert tool_output in upstream_input
-    assert latest_request in upstream_input
-    assert all(
-        not (
-            isinstance(item, dict)
-            and item.get("role") == "assistant"
-            and item.get("content") == [{"type": "output_text", "text": ordinary_tail["content"]}]
-        )
-        for item in upstream_input
-    )
-
-
-@pytest.mark.asyncio
 async def test_proxy_compact_omits_oversized_optional_tool_tail_before_upstream(async_client, monkeypatch):
     email = "compact-optional-tail@example.com"
     raw_account_id = "acc_compact_optional_tail"
@@ -961,6 +899,68 @@ async def test_proxy_compact_masks_previous_response_not_found(async_client, mon
     assert body["error"]["code"] == "stream_incomplete"
     assert body["error"]["message"] == "Upstream websocket closed before response.completed"
     assert "resp_compact_missing" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_preserves_tool_search_pair_before_ordinary_tail(async_client, monkeypatch):
+    email = "compact-tool-search@example.com"
+    raw_account_id = "acc_compact_tool_search"
+    files = {"auth_json": ("auth.json", json.dumps(_make_auth_json(raw_account_id, email)), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payloads: list[dict[str, object]] = []
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del headers, access_token, account_id
+        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+    tool_call = {
+        "type": "tool_search_call",
+        "call_id": "call-search-tail",
+        "status": "completed",
+        "execution": "client",
+        "arguments": {"query": "codex-lb compaction tool search"},
+    }
+    tool_output = {
+        "type": "tool_search_output",
+        "call_id": "call-search-tail",
+        "output": [{"title": "codex-lb compaction result"}],
+    }
+    ordinary_tail = {"role": "assistant", "content": "ordinary tail " + "x" * 500_000}
+    latest_request = {"role": "user", "content": "latest request"}
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "hi",
+        "input": [
+            {"role": "user", "content": "initial request"},
+            {"role": "assistant", "content": "older answer " + "y" * 500_000},
+            tool_call,
+            ordinary_tail,
+            tool_output,
+            latest_request,
+        ],
+    }
+
+    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
+
+    assert response.status_code == 200
+    assert len(seen_payloads) == 1
+    upstream_input = seen_payloads[0]["input"]
+    assert isinstance(upstream_input, list)
+    assert tool_call in upstream_input
+    assert tool_output in upstream_input
+    assert latest_request in upstream_input
+    assert all(
+        not (
+            isinstance(item, dict)
+            and item.get("role") == "assistant"
+            and item.get("content") == [{"type": "output_text", "text": ordinary_tail["content"]}]
+        )
+        for item in upstream_input
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -351,6 +351,62 @@ async def test_proxy_compact_strips_tool_fields_before_upstream(async_client, mo
 
 
 @pytest.mark.asyncio
+async def test_proxy_compact_sanitizes_plaintext_replay_before_upstream(async_client, monkeypatch):
+    email = "compact-plaintext-replay@example.com"
+    raw_account_id = "acc_compact_plaintext_replay"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payloads: list[dict[str, object]] = []
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del headers, access_token, account_id
+        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    payload = {
+        "model": "gpt-5.5",
+        "instructions": "compact",
+        "input": [
+            {"role": "user", "content": "before"},
+            {
+                "id": "cmp_local_summary",
+                "type": "compaction",
+                "status": "completed",
+                "summary": "I have the concrete code and evidence blockers in hand.",
+            },
+            {
+                "id": "cmp_opaque_state",
+                "type": "compaction",
+                "status": "completed",
+                "encrypted_content": "opaque-provider-envelope-without-recognized-prefix",
+            },
+            {"role": "user", "content": "continue"},
+        ],
+    }
+    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
+
+    assert response.status_code == 200
+    assert len(seen_payloads) == 1
+    assert seen_payloads[0]["input"] == [
+        {"role": "user", "content": "before"},
+        {
+            "role": "assistant",
+            "content": "[compact state] I have the concrete code and evidence blockers in hand.",
+        },
+        {
+            "role": "assistant",
+            "content": "[compact state] [unverified compact state omitted]",
+        },
+        {"role": "user", "content": "continue"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_proxy_compact_preserves_historical_code_mode_side_effect_pair_before_ordinary_tail(
     async_client, monkeypatch
 ):

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -665,6 +665,68 @@ async def test_proxy_compact_normalizes_summary_output_for_codex_remote_v2(async
 
 
 @pytest.mark.asyncio
+async def test_proxy_compact_preserves_single_output_item_with_skill_context(async_client, monkeypatch):
+    email = "compact-skill-recovery@example.com"
+    raw_account_id = "acc_compact_skill_recovery"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del payload, headers, access_token, account_id
+        return CompactResponsePayload.model_validate(
+            {
+                "object": "response.compaction",
+                "compaction_summary": {
+                    "id": "cmp_skill_recovery",
+                    "encrypted_content": "enc_skill_recovery",
+                },
+            }
+        )
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    payload = {
+        "model": "gpt-5.5",
+        "instructions": "Compact the conversation.",
+        "input": [
+            {"type": "message", "role": "user", "content": "hello"},
+            {
+                "type": "message",
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": (
+                            "<skill>\n"
+                            "<name>grill-me</name>\n"
+                            "<path>/home/kom/.codex/skills/grill-me/SKILL.md</path>\n"
+                            "---\n"
+                            "name: grill-me\n"
+                            "---\n"
+                            "Ask one question at a time.\n"
+                            "</skill>"
+                        ),
+                    }
+                ],
+            },
+        ],
+    }
+    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
+
+    assert response.status_code == 200
+    output = response.json()["output"]
+    assert output == [
+        {
+            "id": "cmp_skill_recovery",
+            "type": "compaction",
+            "encrypted_content": "enc_skill_recovery",
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_proxy_compact_headers_include_monthly_only_credits(async_client, monkeypatch):
     email = "compact-monthly@example.com"
     raw_account_id = "acc_compact_monthly"

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -475,6 +475,68 @@ async def test_proxy_compact_preserves_historical_code_mode_side_effect_pair_bef
 
 
 @pytest.mark.asyncio
+async def test_proxy_compact_preserves_tool_search_pair_before_ordinary_tail(async_client, monkeypatch):
+    email = "compact-tool-search@example.com"
+    raw_account_id = "acc_compact_tool_search"
+    files = {"auth_json": ("auth.json", json.dumps(_make_auth_json(raw_account_id, email)), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payloads: list[dict[str, object]] = []
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del headers, access_token, account_id
+        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+    tool_call = {
+        "type": "tool_search_call",
+        "call_id": "call-search-tail",
+        "status": "completed",
+        "execution": "client",
+        "arguments": {"query": "codex-lb compaction tool search"},
+    }
+    tool_output = {
+        "type": "tool_search_output",
+        "call_id": "call-search-tail",
+        "output": [{"title": "codex-lb compaction result"}],
+    }
+    ordinary_tail = {"role": "assistant", "content": "ordinary tail " + "x" * 500_000}
+    latest_request = {"role": "user", "content": "latest request"}
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "hi",
+        "input": [
+            {"role": "user", "content": "initial request"},
+            {"role": "assistant", "content": "older answer " + "y" * 500_000},
+            tool_call,
+            ordinary_tail,
+            tool_output,
+            latest_request,
+        ],
+    }
+
+    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
+
+    assert response.status_code == 200
+    assert len(seen_payloads) == 1
+    upstream_input = seen_payloads[0]["input"]
+    assert isinstance(upstream_input, list)
+    assert tool_call in upstream_input
+    assert tool_output in upstream_input
+    assert latest_request in upstream_input
+    assert all(
+        not (
+            isinstance(item, dict)
+            and item.get("role") == "assistant"
+            and item.get("content") == [{"type": "output_text", "text": ordinary_tail["content"]}]
+        )
+        for item in upstream_input
+    )
+
+
+@pytest.mark.asyncio
 async def test_proxy_compact_omits_oversized_optional_tool_tail_before_upstream(async_client, monkeypatch):
     email = "compact-optional-tail@example.com"
     raw_account_id = "acc_compact_optional_tail"

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -2398,6 +2398,89 @@ def test_compact_trimming_preserves_codex_goal_context_anchor_from_middle():
     assert dumped_input[-1] == input_items[-1]
 
 
+def test_compact_trimming_does_not_anchor_active_skill_context_from_middle():
+    skill_context = {
+        "type": "message",
+        "role": "user",
+        "content": [
+            {
+                "type": "input_text",
+                "text": (
+                    "<skill>\n"
+                    "<name>grill-me</name>\n"
+                    "<path>/home/kom/.codex/skills/grill-me/SKILL.md</path>\n"
+                    "---\n"
+                    "name: grill-me\n"
+                    "---\n"
+                    "Ask one question at a time and keep the interview mode active.\n"
+                    "</skill>"
+                ),
+            }
+        ],
+    }
+    input_items = [
+        {"role": "user", "content": "initial instructions"},
+        {"role": "assistant", "content": "x" * 300_000},
+        skill_context,
+        {"role": "assistant", "content": "y" * 500_000},
+        {"role": "user", "content": "latest request"},
+    ]
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": input_items,
+    }
+
+    request = ResponsesCompactRequest.model_validate(payload)
+    dumped = request.to_payload()
+    dumped_input = dumped["input"]
+
+    assert isinstance(dumped_input, list)
+    assert dumped_input[0] == input_items[0]
+    assert dumped_input[-1] == input_items[-1]
+    assert skill_context not in dumped_input
+    assert input_items[1] not in dumped_input
+    assert input_items[3] not in dumped_input
+
+
+def test_compact_trimming_does_not_anchor_plain_skill_catalog_mentions():
+    catalog_context = {
+        "type": "message",
+        "role": "user",
+        "content": [
+            {
+                "type": "input_text",
+                "text": (
+                    "<skills_instructions>\n"
+                    "- grill-me: Interview the user one question at a time.\n"
+                    "</skills_instructions>"
+                ),
+            }
+        ],
+    }
+    input_items = [
+        {"role": "user", "content": "initial instructions"},
+        {"role": "assistant", "content": "x" * 300_000},
+        catalog_context,
+        {"role": "assistant", "content": "y" * 500_000},
+        {"role": "user", "content": "latest request"},
+    ]
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": input_items,
+    }
+
+    request = ResponsesCompactRequest.model_validate(payload)
+    dumped = request.to_payload()
+    dumped_input = dumped["input"]
+
+    assert isinstance(dumped_input, list)
+    assert catalog_context not in dumped_input
+    assert dumped_input[0] == input_items[0]
+    assert dumped_input[-1] == input_items[-1]
+
+
 def test_compact_trimming_preserves_non_message_developer_directive_from_middle():
     developer_directive = {
         "type": "future_directive",

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -1227,6 +1227,104 @@ def test_compact_strips_poisoned_local_compact_fallback_items():
     assert request.to_payload()["input"] == [{"role": "user", "content": "continue"}]
 
 
+def test_compact_rewrites_plaintext_compaction_replay_without_encrypted_content():
+    payload = {
+        "model": "gpt-5.5",
+        "instructions": "compact",
+        "input": [
+            {"role": "user", "content": "before"},
+            {
+                "id": "cmp_019ffa20-5e74-7b93-a86e-3c74bcf5521a",
+                "type": "compaction",
+                "status": "completed",
+                "encrypted_content": "I have the concrete code and evidence blockers in hand.",
+            },
+            {"role": "user", "content": "continue"},
+        ],
+    }
+
+    request = ResponsesCompactRequest.model_validate(payload)
+
+    assert request.to_payload()["input"] == [
+        {"role": "user", "content": "before"},
+        {
+            "role": "assistant",
+            "content": "[compact state] [unverified compact state omitted]",
+        },
+        {"role": "user", "content": "continue"},
+    ]
+
+
+def test_compact_rewrites_plaintext_compaction_replay_summary():
+    payload = {
+        "model": "gpt-5.5",
+        "instructions": "compact",
+        "input": [
+            {"role": "user", "content": "before"},
+            {
+                "id": "cmp_local_summary",
+                "type": "compaction",
+                "status": "completed",
+                "summary": "I have the concrete code and evidence blockers in hand.",
+            },
+            {"role": "user", "content": "continue"},
+        ],
+    }
+
+    request = ResponsesCompactRequest.model_validate(payload)
+
+    assert request.to_payload()["input"] == [
+        {"role": "user", "content": "before"},
+        {
+            "role": "assistant",
+            "content": "[compact state] I have the concrete code and evidence blockers in hand.",
+        },
+        {"role": "user", "content": "continue"},
+    ]
+
+
+def test_compact_preserves_provider_encrypted_compaction_replay():
+    encrypted_content = "gAAAA" + "A" * 80
+    payload = {
+        "model": "gpt-5.5",
+        "instructions": "compact",
+        "input": [
+            {
+                "id": "cmp_valid_provider_state",
+                "type": "compaction",
+                "status": "completed",
+                "encrypted_content": encrypted_content,
+            },
+            {"role": "user", "content": "continue"},
+        ],
+    }
+
+    request = ResponsesCompactRequest.model_validate(payload)
+
+    assert request.to_payload()["input"] == payload["input"]
+
+
+def test_responses_preserves_provider_encrypted_compaction_replay():
+    encrypted_content = "gAAAA" + "A" * 80
+    payload = {
+        "model": "gpt-5.5",
+        "instructions": "continue",
+        "input": [
+            {
+                "id": "cmp_valid_provider_state",
+                "type": "compaction",
+                "status": "completed",
+                "encrypted_content": encrypted_content,
+            },
+            {"role": "user", "content": "continue"},
+        ],
+    }
+
+    request = ResponsesRequest.model_validate(payload)
+
+    assert request.to_payload()["input"] == payload["input"]
+
+
 def test_compact_does_not_trim_many_small_input_items_for_upstream():
     input_items = [{"role": "user", "content": f"item {idx}"} for idx in range(356)]
     payload = {

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -1227,7 +1227,7 @@ def test_compact_strips_poisoned_local_compact_fallback_items():
     assert request.to_payload()["input"] == [{"role": "user", "content": "continue"}]
 
 
-def test_compact_rewrites_plaintext_compaction_replay_without_encrypted_content():
+def test_compact_preserves_opaque_encrypted_compaction_replay():
     payload = {
         "model": "gpt-5.5",
         "instructions": "compact",
@@ -1245,14 +1245,7 @@ def test_compact_rewrites_plaintext_compaction_replay_without_encrypted_content(
 
     request = ResponsesCompactRequest.model_validate(payload)
 
-    assert request.to_payload()["input"] == [
-        {"role": "user", "content": "before"},
-        {
-            "role": "assistant",
-            "content": "[compact state] [unverified compact state omitted]",
-        },
-        {"role": "user", "content": "continue"},
-    ]
+    assert request.to_payload()["input"] == payload["input"]
 
 
 def test_compact_rewrites_plaintext_compaction_replay_summary():
@@ -1277,7 +1270,12 @@ def test_compact_rewrites_plaintext_compaction_replay_summary():
         {"role": "user", "content": "before"},
         {
             "role": "assistant",
-            "content": "[compact state] I have the concrete code and evidence blockers in hand.",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "[compact state] I have the concrete code and evidence blockers in hand.",
+                }
+            ],
         },
         {"role": "user", "content": "continue"},
     ]
@@ -1315,6 +1313,26 @@ def test_responses_preserves_provider_encrypted_compaction_replay():
                 "type": "compaction",
                 "status": "completed",
                 "encrypted_content": encrypted_content,
+            },
+            {"role": "user", "content": "continue"},
+        ],
+    }
+
+    request = ResponsesRequest.model_validate(payload)
+
+    assert request.to_payload()["input"] == payload["input"]
+
+
+def test_responses_preserves_opaque_encrypted_compaction_replay():
+    payload = {
+        "model": "gpt-5.5",
+        "instructions": "continue",
+        "input": [
+            {
+                "id": "cmp_opaque_provider_state",
+                "type": "compaction",
+                "status": "completed",
+                "encrypted_content": "opaque-provider-envelope-without-recognized-prefix",
             },
             {"role": "user", "content": "continue"},
         ],

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -1171,6 +1171,42 @@ def test_compact_strips_tool_fields():
     assert "text" not in dumped
 
 
+def test_compact_trimming_keeps_tool_search_outputs_with_matching_calls():
+    tool_call = {
+        "type": "tool_search_call",
+        "call_id": "call_search_tail",
+        "status": "completed",
+        "execution": "client",
+        "arguments": {"query": "spawn_agent multi-agent schema", "limit": 8},
+    }
+    tool_output = {
+        "type": "tool_search_output",
+        "call_id": "call_search_tail",
+        "output": "Found matching tools",
+    }
+    input_items = [
+        {"role": "user", "content": "initial instructions"},
+        {"role": "assistant", "content": "x" * 500_000},
+        tool_call,
+        {"role": "assistant", "content": "y" * 500_000},
+        tool_output,
+        {"role": "user", "content": "latest request"},
+    ]
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": input_items,
+    }
+
+    request = ResponsesCompactRequest.model_validate(payload)
+    dumped = request.to_payload()
+    dumped_input = dumped["input"]
+
+    assert isinstance(dumped_input, list)
+    assert tool_call in dumped_input
+    assert tool_output in dumped_input
+
+
 def test_responses_strips_poisoned_local_compact_fallback_items():
     poisoned_message = {
         "type": "message",
@@ -3006,42 +3042,6 @@ def test_compact_trimming_keeps_selected_tool_calls_with_matching_outputs():
         {"role": "assistant", "content": "x" * 500_000},
         tool_output,
         {"role": "assistant", "content": "y" * 500_000},
-        {"role": "user", "content": "latest request"},
-    ]
-    payload = {
-        "model": "gpt-5.1",
-        "instructions": "hi",
-        "input": input_items,
-    }
-
-    request = ResponsesCompactRequest.model_validate(payload)
-    dumped = request.to_payload()
-    dumped_input = dumped["input"]
-
-    assert isinstance(dumped_input, list)
-    assert tool_call in dumped_input
-    assert tool_output in dumped_input
-
-
-def test_compact_trimming_keeps_tool_search_outputs_with_matching_calls():
-    tool_call = {
-        "type": "tool_search_call",
-        "call_id": "call_search_tail",
-        "status": "completed",
-        "execution": "client",
-        "arguments": {"query": "spawn_agent multi-agent schema", "limit": 8},
-    }
-    tool_output = {
-        "type": "tool_search_output",
-        "call_id": "call_search_tail",
-        "output": "Found matching tools",
-    }
-    input_items = [
-        {"role": "user", "content": "initial instructions"},
-        {"role": "assistant", "content": "x" * 500_000},
-        tool_call,
-        {"role": "assistant", "content": "y" * 500_000},
-        tool_output,
         {"role": "user", "content": "latest request"},
     ]
     payload = {

--- a/tests/unit/test_openai_requests.py
+++ b/tests/unit/test_openai_requests.py
@@ -3023,6 +3023,42 @@ def test_compact_trimming_keeps_selected_tool_calls_with_matching_outputs():
     assert tool_output in dumped_input
 
 
+def test_compact_trimming_keeps_tool_search_outputs_with_matching_calls():
+    tool_call = {
+        "type": "tool_search_call",
+        "call_id": "call_search_tail",
+        "status": "completed",
+        "execution": "client",
+        "arguments": {"query": "spawn_agent multi-agent schema", "limit": 8},
+    }
+    tool_output = {
+        "type": "tool_search_output",
+        "call_id": "call_search_tail",
+        "output": "Found matching tools",
+    }
+    input_items = [
+        {"role": "user", "content": "initial instructions"},
+        {"role": "assistant", "content": "x" * 500_000},
+        tool_call,
+        {"role": "assistant", "content": "y" * 500_000},
+        tool_output,
+        {"role": "user", "content": "latest request"},
+    ]
+    payload = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": input_items,
+    }
+
+    request = ResponsesCompactRequest.model_validate(payload)
+    dumped = request.to_payload()
+    dumped_input = dumped["input"]
+
+    assert isinstance(dumped_input, list)
+    assert tool_call in dumped_input
+    assert tool_output in dumped_input
+
+
 def test_compact_trimming_reconciles_duplicate_tool_call_ids_by_occurrence():
     first_tool_call = {
         "type": "function_call",

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -2586,8 +2586,10 @@ async def test_response_create_gate_timeout_retires_old_pending_without_upstream
         *,
         detail: str,
         retry_circuit_attempt_selection: proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection,
+        response_events_seen: int | None = None,
     ) -> None:
         assert retry_circuit_attempt_selection.kind == "absent"
+        del response_events_seen
         retire_calls.append(detail)
         retire_session.closed = True
 
@@ -2695,8 +2697,10 @@ async def test_response_create_gate_timeout_retires_closed_anchored_pending_with
         *,
         detail: str,
         retry_circuit_attempt_selection: proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection,
+        response_events_seen: int | None = None,
     ) -> None:
         assert retry_circuit_attempt_selection.kind == "absent"
+        del response_events_seen
         retire_calls.append(detail)
         retire_session.closed = True
 
@@ -2786,8 +2790,10 @@ async def test_response_create_gate_timeout_retires_old_precreated_request_after
         *,
         detail: str,
         retry_circuit_attempt_selection: proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection,
+        response_events_seen: int | None = None,
     ) -> None:
         assert retry_circuit_attempt_selection.kind == "absent"
+        del response_events_seen
         retire_calls.append(detail)
         retire_session.closed = True
 
@@ -2888,7 +2894,9 @@ async def test_response_create_gate_timeout_does_not_retire_active_response_prog
         retire_session: proxy_service._HTTPBridgeSession,
         *,
         detail: str,
+        response_events_seen: int | None = None,
     ) -> None:
+        del response_events_seen
         retire_calls.append(detail)
         retire_session.closed = True
 
@@ -24134,18 +24142,19 @@ async def test_stream_via_http_bridge_fails_closed_before_file_affinity_when_pre
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("unsafe_replay_input", "replace_retired_gate", "stored_model"),
+    ("unsafe_replay_input", "replace_retired_gate", "stored_model", "pending_manifest_replay"),
     [
-        (None, False, None),
-        (None, False, "gpt-5.3"),
-        (None, True, None),
-        ("conversation", False, None),
-        ("file", False, None),
-        ("missing_prior_output", False, None),
-        ("orphan_output", False, None),
-        ("response_owned_developer", False, None),
-        ("response_owned_stored_developer", False, None),
-        ("missing_owner", False, None),
+        pytest.param(None, False, None, False, id="retained-output"),
+        pytest.param(None, False, "gpt-5.3", False, id="retained-output-stored-model"),
+        pytest.param(None, True, None, False, id="retained-output-replace-retired-gate"),
+        pytest.param(None, False, None, True, id="pending-tool-manifest"),
+        pytest.param("conversation", False, None, False, id="conversation"),
+        pytest.param("file", False, None, False, id="file"),
+        pytest.param("missing_prior_output", False, None, False, id="missing-prior-output"),
+        pytest.param("orphan_output", False, None, False, id="orphan-output"),
+        pytest.param("response_owned_developer", False, None, False, id="response-owned-developer"),
+        pytest.param("response_owned_stored_developer", False, None, False, id="response-owned-stored-developer"),
+        pytest.param("missing_owner", False, None, False, id="missing-owner"),
     ],
 )
 async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_when_owner_is_unavailable(
@@ -24153,6 +24162,7 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
     unsafe_replay_input: str | None,
     replace_retired_gate: bool,
     stored_model: str | None,
+    pending_manifest_replay: bool,
 ) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     account_neutral_classifier = Mock(
@@ -24207,16 +24217,14 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
         )
     elif unsafe_replay_input == "orphan_output":
         historical_input.append({"type": "function_call_output", "call_id": "call_missing", "output": "orphan output"})
-    historical_input.append(
-        {
-            "type": "function_call",
-            "id": "fc_owner",
-            "call_id": "call_old",
-            "name": "lookup",
-            "arguments": "{}",
-            "internal_chat_message_metadata_passthrough": owner_metadata,
-        }
-    )
+    retained_boundary_call: proxy_service.JsonValue = {
+        "type": "function_call",
+        "id": "fc_owner",
+        "call_id": "call_old",
+        "name": "lookup",
+        "arguments": "{}",
+        "internal_chat_message_metadata_passthrough": owner_metadata,
+    }
     retained_boundary_output: proxy_service.JsonValue = {
         "type": "function_call_output",
         "call_id": "call_old",
@@ -24228,6 +24236,21 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
         "content": [{"type": "input_text", "text": "next question"}],
         "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
     }
+    pending_tool_loop: list[proxy_service.JsonValue] = [
+        {
+            "type": "function_call",
+            "call_id": "call_pending",
+            "name": "lookup",
+            "arguments": "{}",
+            "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_pending",
+            "output": "fresh result",
+            "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+        },
+    ]
     retained_prior_output: proxy_service.JsonValue = {
         "type": "message",
         "id": "msg_owner",
@@ -24252,6 +24275,7 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
             "call_id": "call_search",
             "execution": "client",
             "status": "completed",
+            "output": "found docs",
             "tools": [],
             "internal_chat_message_metadata_passthrough": owner_metadata,
         },
@@ -24268,10 +24292,17 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
         "instructions": "hi",
         "input": [
             *historical_input,
+            retained_boundary_call,
             retained_boundary_output,
             *completed_search_bookkeeping,
-            *([] if unsafe_replay_input == "missing_prior_output" else [retained_prior_output]),
-            new_input,
+            *(
+                pending_tool_loop
+                if pending_manifest_replay
+                else [
+                    *([] if unsafe_replay_input == "missing_prior_output" else [retained_prior_output]),
+                    new_input,
+                ]
+            ),
             *(
                 [
                     {
@@ -24290,6 +24321,16 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
     if unsafe_replay_input == "conversation":
         payload_data["conversation"] = "conv_owner_scoped"
     payload = proxy_service.ResponsesRequest.model_validate(payload_data)
+    stored_context_items = (
+        [
+            *historical_input,
+            retained_boundary_call,
+            retained_boundary_output,
+            *completed_search_bookkeeping,
+        ]
+        if pending_manifest_replay
+        else historical_input
+    )
     durable_lookup = proxy_service.DurableBridgeLookup(
         session_id="durable-owner-unavailable",
         canonical_kind="session_header",
@@ -24302,9 +24343,10 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
         state=HttpBridgeSessionState.ACTIVE,
         latest_turn_state="sid-owner-unavailable",
         latest_response_id="resp_completed_anchor",
-        latest_input_item_count=len(historical_input),
-        latest_input_full_fingerprint=proxy_service._fingerprint_input_items(historical_input),
+        latest_input_item_count=len(stored_context_items),
+        latest_input_full_fingerprint=proxy_service._fingerprint_input_items(stored_context_items),
         model=stored_model,
+        latest_pending_tool_calls={"call_pending": "function_call"} if pending_manifest_replay else None,
     )
     owner_unavailable = ProxyResponseError(
         502,
@@ -24339,9 +24381,7 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
     replacement_session = _make_bridge_session(key=session.key, key_value=session.key.affinity_key)
     get_or_create = AsyncMock(
         side_effect=(
-            [owner_unavailable, session, replacement_session]
-            if replace_retired_gate
-            else [owner_unavailable, capacity_unavailable, session]
+            [owner_unavailable, session, replacement_session] if replace_retired_gate else [owner_unavailable, session]
         )
     )
     captured_request_states: list[proxy_service._WebSocketRequestState] = []
@@ -24452,13 +24492,13 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
     chunks = [chunk async for chunk in stream]
 
     assert chunks == ['data: {"type":"response.completed"}\n\n']
-    assert get_or_create.await_count == 3
+    assert get_or_create.await_count == (3 if replace_retired_gate else 2)
     first_call = get_or_create.await_args_list[0]
     second_call = get_or_create.await_args_list[1]
-    third_call = get_or_create.await_args_list[2]
+    third_call = get_or_create.await_args_list[2] if replace_retired_gate else None
     assert first_call.kwargs["previous_response_id"] is None
-    assert first_call.kwargs["preferred_account_id"] == "acc-owner"
-    assert first_call.kwargs["allow_forward_to_owner"] is True
+    assert first_call.kwargs["preferred_account_id"] == (None if stored_model else "acc-owner")
+    assert first_call.kwargs["allow_forward_to_owner"] is (False if stored_model else True)
     assert second_call.kwargs["previous_response_id"] is None
     assert second_call.kwargs["preferred_account_id"] is None
     assert second_call.kwargs["durable_lookup"] is None
@@ -24466,29 +24506,30 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
         kind=second_call.args[0].affinity_kind,
         key=second_call.args[0].affinity_key,
     )
-    assert second_call.args[0] == third_call.args[0]
+    if third_call is not None:
+        assert second_call.args[0] == third_call.args[0]
     assert second_call.args[0] != first_call.args[0]
     assert second_call.kwargs["affinity"] == proxy_service._AffinityPolicy()
     assert second_call.kwargs["session_header_fallback_key"] is None
-    assert second_call.kwargs["exclude_account_ids"] == {"acc-owner"}
+    assert second_call.kwargs["exclude_account_ids"] == (None if stored_model else {"acc-owner"})
     assert second_call.kwargs["allow_forward_to_owner"] is False
     assert all(key.lower() != "x-codex-turn-state" for key in second_call.kwargs["headers"])
-    assert third_call.kwargs["previous_response_id"] is None
-    assert third_call.kwargs["preferred_account_id"] is None
-    assert third_call.kwargs["durable_lookup"] is None
+    if third_call is not None:
+        assert third_call.kwargs["previous_response_id"] is None
+        assert third_call.kwargs["preferred_account_id"] is None
+        assert third_call.kwargs["durable_lookup"] is None
     # When the fresh-replay session's own gate later times out (session.account
     # is "acc-fallback"), the next replacement must also exclude it — a
     # "replacement" that could legally reselect the account that just proved
     # stuck isn't a replacement at all.
-    assert third_call.kwargs["exclude_account_ids"] == (
-        {"acc-owner", "acc-fallback"} if replace_retired_gate else {"acc-owner"}
-    )
-    assert third_call.kwargs["allow_forward_to_owner"] is False
+    if third_call is not None:
+        assert third_call.kwargs["exclude_account_ids"] == {"acc-owner", "acc-fallback"}
+        assert third_call.kwargs["allow_forward_to_owner"] is False
     assert captured_request_states[0].previous_response_id is None
     assert captured_request_states[0].enforce_openai_sdk_contract is False
     replay_payload = json.loads(captured_text_data[0])
     assert "previous_response_id" not in replay_payload
-    assert replay_payload["input"] == [
+    expected_replay_input = [
         {
             "role": "user",
             "content": [{"type": "input_text", "text": "old question"}],
@@ -24508,19 +24549,44 @@ async def test_stream_via_http_bridge_projects_plaintext_durable_full_resend_whe
             "internal_chat_message_metadata_passthrough": owner_metadata,
         },
         {
-            "type": "message",
-            "role": "assistant",
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "docs"},
+            "execution": "client",
             "status": "completed",
-            "phase": "final_answer",
-            "content": [{"type": "output_text", "text": "old answer"}],
             "internal_chat_message_metadata_passthrough": owner_metadata,
         },
         {
-            "role": "user",
-            "content": [{"type": "input_text", "text": "next question"}],
-            "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "client",
+            "status": "completed",
+            "output": "found docs",
+            "tools": [],
+            "internal_chat_message_metadata_passthrough": owner_metadata,
         },
     ]
+    if pending_manifest_replay:
+        expected_replay_input.extend(pending_tool_loop)
+    else:
+        expected_replay_input.extend(
+            [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "completed",
+                    "phase": "final_answer",
+                    "content": [{"type": "output_text", "text": "old answer"}],
+                    "internal_chat_message_metadata_passthrough": owner_metadata,
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "next question"}],
+                    "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+                },
+            ]
+        )
+    assert replay_payload["input"] == expected_replay_input
     assert "encrypted_content" not in captured_text_data[0]
     assert all("id" not in item for item in replay_payload["input"])
     account_neutral_classifier.assert_called_once()
@@ -24803,6 +24869,393 @@ async def test_durable_model_transition_preserves_owner_provenance_when_replacin
     assert all(call["previous_response_id"] is None for call in creation_calls)
     assert all(call["preferred_account_id"] == "acc-model-owner" for call in creation_calls)
     assert all(call["preferred_account_has_continuity_provenance"] is True for call in creation_calls)
+
+
+@pytest.mark.asyncio
+async def test_durable_model_transition_full_resend_uses_account_neutral_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    owner_metadata: proxy_service.JsonValue = {"turn_id": "turn-owner"}
+    historical_input: list[proxy_service.JsonValue] = [
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "old question"}],
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "function_call",
+            "id": "fc_owner",
+            "call_id": "call_old",
+            "name": "lookup",
+            "arguments": "{}",
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+    ]
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.3-codex-spark",
+            "instructions": "hi",
+            "input": [
+                *historical_input,
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_old",
+                    "output": "old output",
+                    "internal_chat_message_metadata_passthrough": owner_metadata,
+                },
+                {
+                    "type": "message",
+                    "id": "msg_owner",
+                    "role": "assistant",
+                    "status": "completed",
+                    "phase": "final_answer",
+                    "content": [{"type": "output_text", "text": "old answer"}],
+                    "internal_chat_message_metadata_passthrough": owner_metadata,
+                },
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "next question"}],
+                    "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+                },
+            ],
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-model-full-resend",
+        canonical_kind="session_header",
+        canonical_key="shared-root",
+        api_key_scope="__anonymous__",
+        account_id="acc-model-owner",
+        owner_instance_id="instance-a",
+        owner_epoch=18,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state="http_turn_parent",
+        latest_response_id="resp_model_parent",
+        latest_input_item_count=len(historical_input),
+        latest_input_full_fingerprint=proxy_service._fingerprint_input_items(historical_input),
+        model="gpt-5.4-mini",
+    )
+    captured_keys: list[proxy_service._HTTPBridgeSessionKey] = []
+    captured_kwargs: list[dict[str, Any]] = []
+    captured_text_data: list[str] = []
+
+    async def fake_get_or_create(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        captured_keys.append(key)
+        captured_kwargs.append(kwargs)
+        session = _make_bridge_session(key=key, key_value=key.affinity_key)
+        session.account = cast(Any, SimpleNamespace(id="acc-fresh", status=AccountStatus.ACTIVE))
+        session.request_model = payload.model
+        return session
+
+    async def fake_stream_events(
+        _session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        **_kwargs: Any,
+    ):
+        assert request_state.previous_response_id is None
+        assert request_state.preferred_account_id is None
+        captured_text_data.append(text_data)
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_http_bridge_can_forward_to_active_owner", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={
+                "authorization": "Bearer test-token",
+                "x-codex-session-id": "shared-root",
+                "x-codex-turn-state": "http_turn_child",
+            },
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert len(captured_keys) == 1
+    assert is_http_bridge_account_neutral_replay(
+        kind=captured_keys[0].affinity_kind,
+        key=captured_keys[0].affinity_key,
+    )
+    assert captured_keys[0].strength == "soft"
+    assert captured_kwargs[0]["durable_lookup"] is None
+    assert captured_kwargs[0]["previous_response_id"] is None
+    assert captured_kwargs[0]["preferred_account_id"] is None
+    assert captured_kwargs[0]["preferred_account_has_continuity_provenance"] is False
+    assert captured_kwargs[0]["allow_forward_to_owner"] is False
+    assert captured_kwargs[0]["headers"] == {"authorization": "Bearer test-token"}
+    replay_payload = json.loads(captured_text_data[0])
+    assert "previous_response_id" not in replay_payload
+    assert replay_payload["model"] == "gpt-5.3-codex-spark"
+    assert replay_payload["input"][-1]["content"] == [{"type": "input_text", "text": "next question"}]
+    assert all("id" not in item for item in replay_payload["input"])
+
+
+@pytest.mark.asyncio
+async def test_durable_model_transition_full_resend_pending_tool_context_uses_account_neutral_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    owner_metadata: proxy_service.JsonValue = {"turn_id": "turn-owner"}
+    stored_context_items: list[proxy_service.JsonValue] = [
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "old question"}],
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "function_call",
+            "id": "fc_owner",
+            "call_id": "call_old",
+            "name": "lookup",
+            "arguments": "{}",
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_old",
+            "output": "old output",
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "tool_search_call",
+            "id": "tsc_owner",
+            "call_id": "call_search",
+            "arguments": {"query": "docs"},
+            "execution": "client",
+            "status": "completed",
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "client",
+            "status": "completed",
+            "output": "found docs",
+            "tools": [],
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+    ]
+    pending_tool_loop: list[proxy_service.JsonValue] = [
+        {
+            "type": "function_call",
+            "id": "fc_pending",
+            "call_id": "call_pending",
+            "name": "lookup_pending",
+            "arguments": "{}",
+            "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_pending",
+            "output": "fresh result",
+            "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+        },
+    ]
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.3-codex-spark",
+            "instructions": "hi",
+            "input": [*stored_context_items, *pending_tool_loop],
+        }
+    )
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-model-pending-tool",
+        canonical_kind="session_header",
+        canonical_key="shared-root",
+        api_key_scope="__anonymous__",
+        account_id="acc-model-owner",
+        owner_instance_id="instance-a",
+        owner_epoch=18,
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+        latest_turn_state="http_turn_parent",
+        latest_response_id="resp_model_parent",
+        latest_input_item_count=len(stored_context_items),
+        latest_input_full_fingerprint=proxy_service._fingerprint_input_items(stored_context_items),
+        latest_pending_tool_calls={"call_pending": "function_call"},
+        model="gpt-5.4-mini",
+    )
+    captured_keys: list[proxy_service._HTTPBridgeSessionKey] = []
+    captured_kwargs: list[dict[str, Any]] = []
+    captured_text_data: list[str] = []
+
+    async def fake_get_or_create(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: Any,
+    ) -> proxy_service._HTTPBridgeSession:
+        captured_keys.append(key)
+        captured_kwargs.append(kwargs)
+        session = _make_bridge_session(key=key, key_value=key.affinity_key)
+        session.account = cast(Any, SimpleNamespace(id="acc-fresh", status=AccountStatus.ACTIVE))
+        session.request_model = payload.model
+        return session
+
+    async def fake_stream_events(
+        _session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        **_kwargs: Any,
+    ):
+        assert request_state.previous_response_id is None
+        assert request_state.preferred_account_id is None
+        captured_text_data.append(text_data)
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings_cache",
+        lambda: cast(
+            Any,
+            SimpleNamespace(
+                get=AsyncMock(
+                    return_value=SimpleNamespace(
+                        sticky_threads_enabled=False,
+                        openai_cache_affinity_max_age_seconds=1800,
+                        http_responses_session_bridge_prompt_cache_idle_ttl_seconds=3600,
+                        http_responses_session_bridge_gateway_safe_mode=False,
+                    )
+                )
+            ),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_http_bridge_can_forward_to_active_owner", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_via_http_bridge(
+            payload,
+            headers={
+                "authorization": "Bearer test-token",
+                "x-codex-session-id": "shared-root",
+                "x-codex-turn-state": "http_turn_child",
+            },
+            codex_session_affinity=True,
+            propagate_http_errors=True,
+            openai_cache_affinity=True,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            idle_ttl_seconds=120.0,
+            codex_idle_ttl_seconds=1800.0,
+            max_sessions=8,
+            queue_limit=4,
+        )
+    ]
+
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert len(captured_keys) == 1
+    assert is_http_bridge_account_neutral_replay(
+        kind=captured_keys[0].affinity_kind,
+        key=captured_keys[0].affinity_key,
+    )
+    assert captured_keys[0].strength == "soft"
+    assert captured_kwargs[0]["durable_lookup"] is None
+    assert captured_kwargs[0]["previous_response_id"] is None
+    assert captured_kwargs[0]["preferred_account_id"] is None
+    assert captured_kwargs[0]["preferred_account_has_continuity_provenance"] is False
+    assert captured_kwargs[0]["allow_forward_to_owner"] is False
+    replay_payload = json.loads(captured_text_data[0])
+    assert "previous_response_id" not in replay_payload
+    assert replay_payload["model"] == "gpt-5.3-codex-spark"
+    assert replay_payload["input"] == [
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "old question"}],
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "function_call",
+            "call_id": "call_old",
+            "name": "lookup",
+            "arguments": "{}",
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_old",
+            "output": "old output",
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "docs"},
+            "execution": "client",
+            "status": "completed",
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "client",
+            "status": "completed",
+            "output": "found docs",
+            "tools": [],
+            "internal_chat_message_metadata_passthrough": owner_metadata,
+        },
+        {
+            "type": "function_call",
+            "call_id": "call_pending",
+            "name": "lookup_pending",
+            "arguments": "{}",
+            "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_pending",
+            "output": "fresh result",
+            "internal_chat_message_metadata_passthrough": {"turn_id": "turn-next"},
+        },
+    ]
+    assert all("id" not in item for item in replay_payload["input"])
 
 
 @pytest.mark.asyncio
@@ -30743,13 +31196,37 @@ async def test_retire_stale_pending_http_bridge_session_quarantines_wedged_reatt
     await service._retire_stale_pending_http_bridge_session(
         session,
         detail="response_create_gate_timeout_stuck_pending",
-        response_events_seen=wedged.response_event_count,
     )
 
     assert session.quarantined is expect_quarantined
     assert (
         http_bridge_quarantine_module._http_bridge_session_key_quarantined(service, session.key) is expect_quarantined
     )
+
+
+@pytest.mark.asyncio
+async def test_retire_stale_pending_http_bridge_session_recomputes_event_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    eventful = _make_wedged_reattach_request_state(request_id="req-direct-retire-eventful")
+    eventful.response_id = "resp_eventful_direct_retire"
+    eventful.latency_response_created_ms = 700
+    session = _make_bridge_session(
+        key_value="quarantine-direct-retire-eventful",
+        pending_requests=deque([eventful]),
+        queued_request_count=1,
+    )
+    record_failure = AsyncMock()
+    monkeypatch.setattr(service, "_close_http_bridge_session_bounded", AsyncMock())
+    monkeypatch.setattr(service, "_record_http_bridge_retry_circuit_failure", record_failure)
+
+    await service._retire_stale_pending_http_bridge_session(
+        session,
+        detail="response_create_gate_timeout_stuck_pending",
+    )
+
+    record_failure.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -23092,6 +23092,34 @@ def test_websocket_client_previous_response_full_resend_retry_allows_self_contai
     )
 
 
+def test_websocket_client_previous_response_full_resend_retry_allows_tool_search_history() -> None:
+    self_contained_tool_search_history: list[JsonValue] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "search tools"}]},
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "mcp tools"},
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "output": [{"title": "tool_search"}],
+            "status": "completed",
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert (
+        proxy_service._websocket_client_previous_response_full_resend_is_retry_safe(
+            previous_response_id="resp_client_anchor",
+            input_value=self_contained_tool_search_history,
+            continuity_state=None,
+        )
+        is True
+    )
+
+
 @pytest.mark.asyncio
 async def test_prepare_websocket_response_create_request_fills_interrupted_pending_tool_outputs(monkeypatch):
     request_logs = _RequestLogsRecorder()
@@ -43369,6 +43397,48 @@ def test_trim_websocket_previous_response_input_items_handles_apply_patch_replay
     trimmed = proxy_service._trim_websocket_previous_response_input_items(input_items)
 
     assert trimmed == input_items[2:]
+
+
+def test_trim_http_bridge_previous_response_input_items_handles_tool_search_replay():
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "id": "tsc_replay",
+            "call_id": "call_search_1",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search_1",
+            "output": [{"title": "result"}],
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    trimmed = proxy_service._trim_http_bridge_previous_response_input_items(input_items)
+
+    assert trimmed == input_items[1:]
+
+
+def test_trim_websocket_previous_response_input_items_handles_tool_search_replay():
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "id": "tsc_replay",
+            "call_id": "call_search_1",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search_1",
+            "output": [{"title": "result"}],
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    trimmed = proxy_service._trim_websocket_previous_response_input_items(input_items)
+
+    assert trimmed == input_items[1:]
 
 
 def test_prepare_response_bridge_request_state_keeps_unconfirmed_missing_tool_output_history():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -21275,6 +21275,76 @@ async def test_select_websocket_connect_account_stream_cap_is_local_overload(mon
     assert sent_payload["error"]["type"] == "rate_limit_error"
 
 
+def test_websocket_client_previous_response_full_resend_retry_allows_tool_search_history() -> None:
+    self_contained_tool_search_history: list[JsonValue] = [
+        {"role": "user", "content": [{"type": "input_text", "text": "search tools"}]},
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "mcp tools"},
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "output": [{"title": "tool_search"}],
+            "status": "completed",
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert (
+        proxy_service._websocket_client_previous_response_full_resend_is_retry_safe(
+            previous_response_id="resp_client_anchor",
+            input_value=self_contained_tool_search_history,
+            continuity_state=None,
+        )
+        is True
+    )
+
+
+def test_trim_http_bridge_previous_response_input_items_handles_tool_search_replay():
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "id": "tsc_replay",
+            "call_id": "call_search_1",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search_1",
+            "output": [{"title": "result"}],
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    trimmed = proxy_service._trim_http_bridge_previous_response_input_items(input_items)
+
+    assert trimmed == input_items[1:]
+
+
+def test_trim_websocket_previous_response_input_items_handles_tool_search_replay():
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "id": "tsc_replay",
+            "call_id": "call_search_1",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search_1",
+            "output": [{"title": "result"}],
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    trimmed = proxy_service._trim_websocket_previous_response_input_items(input_items)
+
+    assert trimmed == input_items[1:]
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("error_code", "error_message"),
@@ -23086,34 +23156,6 @@ def test_websocket_client_previous_response_full_resend_retry_allows_self_contai
         proxy_service._websocket_client_previous_response_full_resend_is_retry_safe(
             previous_response_id="resp_client_anchor",
             input_value=self_contained_tool_history,
-            continuity_state=None,
-        )
-        is True
-    )
-
-
-def test_websocket_client_previous_response_full_resend_retry_allows_tool_search_history() -> None:
-    self_contained_tool_search_history: list[JsonValue] = [
-        {"role": "user", "content": [{"type": "input_text", "text": "search tools"}]},
-        {
-            "type": "tool_search_call",
-            "call_id": "call_search",
-            "arguments": {"query": "mcp tools"},
-            "status": "completed",
-        },
-        {
-            "type": "tool_search_output",
-            "call_id": "call_search",
-            "output": [{"title": "tool_search"}],
-            "status": "completed",
-        },
-        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
-    ]
-
-    assert (
-        proxy_service._websocket_client_previous_response_full_resend_is_retry_safe(
-            previous_response_id="resp_client_anchor",
-            input_value=self_contained_tool_search_history,
             continuity_state=None,
         )
         is True
@@ -43397,48 +43439,6 @@ def test_trim_websocket_previous_response_input_items_handles_apply_patch_replay
     trimmed = proxy_service._trim_websocket_previous_response_input_items(input_items)
 
     assert trimmed == input_items[2:]
-
-
-def test_trim_http_bridge_previous_response_input_items_handles_tool_search_replay():
-    input_items: list[JsonValue] = [
-        {
-            "type": "tool_search_call",
-            "id": "tsc_replay",
-            "call_id": "call_search_1",
-            "status": "completed",
-        },
-        {
-            "type": "tool_search_output",
-            "call_id": "call_search_1",
-            "output": [{"title": "result"}],
-        },
-        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
-    ]
-
-    trimmed = proxy_service._trim_http_bridge_previous_response_input_items(input_items)
-
-    assert trimmed == input_items[1:]
-
-
-def test_trim_websocket_previous_response_input_items_handles_tool_search_replay():
-    input_items: list[JsonValue] = [
-        {
-            "type": "tool_search_call",
-            "id": "tsc_replay",
-            "call_id": "call_search_1",
-            "status": "completed",
-        },
-        {
-            "type": "tool_search_output",
-            "call_id": "call_search_1",
-            "output": [{"title": "result"}],
-        },
-        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
-    ]
-
-    trimmed = proxy_service._trim_websocket_previous_response_input_items(input_items)
-
-    assert trimmed == input_items[1:]
 
 
 def test_prepare_response_bridge_request_state_keeps_unconfirmed_missing_tool_output_history():

--- a/tests/unit/test_replay_safety.py
+++ b/tests/unit/test_replay_safety.py
@@ -152,51 +152,6 @@ def test_account_neutral_fresh_replay_accepts_self_contained_payloads(
     assert responses_payload_is_account_neutral_fresh_replay(payload) is True
 
 
-def test_account_neutral_fresh_replay_accepts_compaction_context_item() -> None:
-    payload: dict[str, JsonValue] = {
-        "input": [
-            {
-                "type": "compaction",
-                "status": "completed",
-                "encrypted_content": "encrypted-compact-context",
-            },
-            {
-                "type": "message",
-                "role": "user",
-                "content": [{"type": "input_text", "text": "continue"}],
-            },
-        ],
-    }
-
-    assert responses_payload_is_account_neutral_fresh_replay(payload) is True
-
-
-def test_account_neutral_replay_projection_preserves_compaction_without_response_id() -> None:
-    input_items: list[JsonValue] = [
-        {
-            "type": "compaction",
-            "id": "cmp_owner_a",
-            "status": "completed",
-            "encrypted_content": "encrypted-compact-context",
-        },
-        {
-            "type": "message",
-            "role": "user",
-            "content": [{"type": "input_text", "text": "continue"}],
-        },
-    ]
-
-    projection = project_responses_input_for_account_neutral_fresh_replay(input_items, stored_count=1)
-
-    assert projection is not None
-    assert projection.input_items[0] == {
-        "type": "compaction",
-        "status": "completed",
-        "encrypted_content": "encrypted-compact-context",
-    }
-    assert responses_payload_is_account_neutral_fresh_replay({"input": projection.input_items}) is True
-
-
 def test_account_neutral_replay_projection_removes_response_owned_bookkeeping() -> None:
     metadata = {"turn_id": "turn_owner_a"}
     input_items: list[JsonValue] = [
@@ -372,27 +327,6 @@ def test_account_neutral_replay_projection_preserves_noncompleted_search_state_t
     assert projection is not None
     assert any(isinstance(item, dict) and item.get("type") == search_item["type"] for item in projection.input_items)
     assert responses_payload_is_account_neutral_fresh_replay({"input": projection.input_items}) is False
-
-
-def test_account_neutral_fresh_replay_accepts_self_contained_tool_search_pair() -> None:
-    input_items: list[JsonValue] = [
-        {
-            "type": "tool_search_call",
-            "call_id": "call_search",
-            "arguments": {"query": "codex-lb"},
-            "status": "completed",
-        },
-        {
-            "type": "tool_search_output",
-            "call_id": "call_search",
-            "output": "Found codex-lb",
-            "status": "completed",
-        },
-        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
-    ]
-
-    assert responses_input_items_are_self_contained_fresh_replay(input_items) is True
-    assert responses_payload_is_account_neutral_fresh_replay({"input": input_items}) is True
 
 
 @pytest.mark.parametrize(
@@ -780,6 +714,46 @@ def test_full_resend_suffix_accepts_only_self_contained_tool_loops(
         )
         is expected
     )
+
+
+def test_account_neutral_fresh_replay_accepts_compaction_context_item() -> None:
+    payload: dict[str, JsonValue] = {
+        "input": [
+            {
+                "type": "compaction",
+                "status": "completed",
+                "encrypted_content": "encrypted-compact-context",
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "continue"}],
+            },
+        ],
+    }
+
+    assert responses_payload_is_account_neutral_fresh_replay(payload) is True
+
+
+def test_account_neutral_fresh_replay_accepts_self_contained_tool_search_pair() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb"},
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "output": "Found codex-lb",
+            "status": "completed",
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert responses_input_items_are_self_contained_fresh_replay(input_items) is True
+    assert responses_payload_is_account_neutral_fresh_replay({"input": input_items}) is True
 
 
 def test_full_resend_tool_loop_manifest_tolerates_fresh_developer_interleave_after_historical_one() -> None:

--- a/tests/unit/test_replay_safety.py
+++ b/tests/unit/test_replay_safety.py
@@ -10,6 +10,7 @@ from app.modules.proxy.continuity import (
 )
 from app.modules.proxy.replay_safety import (
     project_responses_input_for_account_neutral_fresh_replay,
+    responses_input_items_are_self_contained_fresh_replay,
     responses_input_suffix_matches_pending_tool_calls,
     responses_input_suffix_retains_prior_output,
     responses_payload_is_account_neutral_fresh_replay,
@@ -149,6 +150,51 @@ def test_account_neutral_fresh_replay_accepts_self_contained_payloads(
     payload: dict[str, JsonValue],
 ) -> None:
     assert responses_payload_is_account_neutral_fresh_replay(payload) is True
+
+
+def test_account_neutral_fresh_replay_accepts_compaction_context_item() -> None:
+    payload: dict[str, JsonValue] = {
+        "input": [
+            {
+                "type": "compaction",
+                "status": "completed",
+                "encrypted_content": "encrypted-compact-context",
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "continue"}],
+            },
+        ],
+    }
+
+    assert responses_payload_is_account_neutral_fresh_replay(payload) is True
+
+
+def test_account_neutral_replay_projection_preserves_compaction_without_response_id() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "compaction",
+            "id": "cmp_owner_a",
+            "status": "completed",
+            "encrypted_content": "encrypted-compact-context",
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "continue"}],
+        },
+    ]
+
+    projection = project_responses_input_for_account_neutral_fresh_replay(input_items, stored_count=1)
+
+    assert projection is not None
+    assert projection.input_items[0] == {
+        "type": "compaction",
+        "status": "completed",
+        "encrypted_content": "encrypted-compact-context",
+    }
+    assert responses_payload_is_account_neutral_fresh_replay({"input": projection.input_items}) is True
 
 
 def test_account_neutral_replay_projection_removes_response_owned_bookkeeping() -> None:
@@ -326,6 +372,27 @@ def test_account_neutral_replay_projection_preserves_noncompleted_search_state_t
     assert projection is not None
     assert any(isinstance(item, dict) and item.get("type") == search_item["type"] for item in projection.input_items)
     assert responses_payload_is_account_neutral_fresh_replay({"input": projection.input_items}) is False
+
+
+def test_account_neutral_fresh_replay_accepts_self_contained_tool_search_pair() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb"},
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "output": "Found codex-lb",
+            "status": "completed",
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert responses_input_items_are_self_contained_fresh_replay(input_items) is True
+    assert responses_payload_is_account_neutral_fresh_replay({"input": input_items}) is True
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_replay_safety.py
+++ b/tests/unit/test_replay_safety.py
@@ -10,6 +10,7 @@ from app.modules.proxy.continuity import (
 )
 from app.modules.proxy.replay_safety import (
     project_responses_input_for_account_neutral_fresh_replay,
+    responses_input_items_are_self_contained_fresh_replay,
     responses_input_suffix_matches_pending_tool_calls,
     responses_input_suffix_retains_prior_output,
     responses_payload_is_account_neutral_fresh_replay,
@@ -151,6 +152,278 @@ def test_account_neutral_fresh_replay_accepts_self_contained_payloads(
     assert responses_payload_is_account_neutral_fresh_replay(payload) is True
 
 
+def test_account_neutral_fresh_replay_accepts_compaction_context_item() -> None:
+    payload: dict[str, JsonValue] = {
+        "input": [
+            {
+                "type": "compaction",
+                "status": "completed",
+                "encrypted_content": "encrypted-compact-context",
+            },
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "continue"}],
+            },
+        ],
+    }
+
+    assert responses_payload_is_account_neutral_fresh_replay(payload) is True
+
+
+def test_account_neutral_replay_projection_preserves_owner_bound_compaction_id_to_fail_closed() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "compaction",
+            "id": "cmp_owner_a",
+            "status": "completed",
+            "encrypted_content": "encrypted-compact-context",
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "continue"}],
+        },
+    ]
+
+    projection = project_responses_input_for_account_neutral_fresh_replay(input_items, stored_count=1)
+
+    assert projection is not None
+    assert projection.input_items[0] == {
+        "type": "compaction",
+        "id": "cmp_owner_a",
+        "status": "completed",
+        "encrypted_content": "encrypted-compact-context",
+    }
+    assert responses_payload_is_account_neutral_fresh_replay({"input": projection.input_items}) is False
+
+
+def test_account_neutral_replay_projection_accepts_compaction_without_owner_id() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "compaction",
+            "status": "completed",
+            "encrypted_content": "encrypted-compact-context",
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "continue"}],
+        },
+    ]
+
+    projection = project_responses_input_for_account_neutral_fresh_replay(input_items, stored_count=1)
+
+    assert projection is not None
+    assert projection.input_items[0] == {
+        "type": "compaction",
+        "status": "completed",
+        "encrypted_content": "encrypted-compact-context",
+    }
+    assert responses_payload_is_account_neutral_fresh_replay({"input": projection.input_items}) is True
+
+
+def test_account_neutral_replay_projection_rejects_compaction_before_later_raw_prefix_bookkeeping() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "compaction",
+            "status": "completed",
+            "encrypted_content": "encrypted-compact-context",
+        },
+        {
+            "type": "web_search_call",
+            "id": "ws_owner_a",
+            "action": {"type": "search", "query": "codex-lb"},
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb"},
+            "execution": "client",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "client",
+            "output": "result",
+            "status": "completed",
+            "tools": [],
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "continue after compaction"}],
+        },
+    ]
+
+    assert project_responses_input_for_account_neutral_fresh_replay(input_items, stored_count=2) is None
+
+
+def test_account_neutral_replay_projection_preserves_post_compact_tool_search_context_without_owner_id() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "compaction",
+            "status": "completed",
+            "encrypted_content": "encrypted-compact-context",
+        },
+        {
+            "type": "tool_search_call",
+            "id": "tsc_owner_a",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb post compact replay"},
+            "execution": "client",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "id": "tso_owner_a",
+            "call_id": "call_search",
+            "output": "replay fix candidate",
+            "execution": "client",
+            "status": "completed",
+            "tools": [],
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "continue after compaction"}],
+        },
+    ]
+
+    projection = project_responses_input_for_account_neutral_fresh_replay(input_items, stored_count=1)
+
+    assert projection is not None
+    assert projection.stored_prefix_count == 1
+    assert projection.input_items == [
+        {
+            "type": "compaction",
+            "status": "completed",
+            "encrypted_content": "encrypted-compact-context",
+        },
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb post compact replay"},
+            "execution": "client",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "output": "replay fix candidate",
+            "execution": "client",
+            "status": "completed",
+            "tools": [],
+        },
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "continue after compaction"}],
+        },
+    ]
+    assert (
+        responses_input_suffix_retains_prior_output(
+            projection.input_items,
+            stored_count=projection.stored_prefix_count,
+        )
+        is True
+    )
+    assert responses_payload_is_account_neutral_fresh_replay({"input": projection.input_items}) is True
+
+
+def test_account_neutral_fresh_replay_accepts_self_contained_tool_search_pair() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb"},
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "output": "Found codex-lb",
+            "status": "completed",
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert responses_input_items_are_self_contained_fresh_replay(input_items) is True
+    assert responses_payload_is_account_neutral_fresh_replay({"input": input_items}) is True
+
+
+def test_account_neutral_fresh_replay_accepts_tools_only_client_tool_search_output() -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb"},
+            "execution": "client",
+            "status": "completed",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "client",
+            "status": "completed",
+            "tools": [],
+        },
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert responses_input_items_are_self_contained_fresh_replay(input_items) is True
+    assert responses_payload_is_account_neutral_fresh_replay({"input": input_items}) is True
+
+
+@pytest.mark.parametrize(
+    "tool_search_output",
+    [
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "server",
+            "status": "completed",
+            "tools": [],
+            "output": "Found codex-lb",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "client",
+            "status": "completed",
+            "tools": [{"type": "file_search", "vector_store_ids": ["vs_owner"]}],
+            "output": "Found codex-lb",
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "client",
+            "status": "completed",
+            "tools": [{"type": "function", "name": "lookup", "namespace": "private"}],
+            "output": "Found codex-lb",
+        },
+    ],
+)
+def test_account_neutral_fresh_replay_rejects_account_scoped_tool_search_output(
+    tool_search_output: dict[str, JsonValue],
+) -> None:
+    input_items: list[JsonValue] = [
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "codex-lb"},
+            "execution": "client",
+            "status": "completed",
+        },
+        tool_search_output,
+        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
+    ]
+
+    assert responses_payload_is_account_neutral_fresh_replay({"input": input_items}) is False
+
+
 def test_account_neutral_replay_projection_removes_response_owned_bookkeeping() -> None:
     metadata = {"turn_id": "turn_owner_a"}
     input_items: list[JsonValue] = [
@@ -195,8 +468,10 @@ def test_account_neutral_replay_projection_removes_response_owned_bookkeeping() 
         },
         {
             "type": "tool_search_output",
+            "id": "tso_owner_a",
             "call_id": "call_search",
             "execution": "client",
+            "output": "search result",
             "status": "completed",
             "tools": [],
             "internal_chat_message_metadata_passthrough": metadata,
@@ -248,6 +523,23 @@ def test_account_neutral_replay_projection_removes_response_owned_bookkeeping() 
             "call_id": "call_boundary",
             "output": "/workspace",
             "status": "completed",
+            "internal_chat_message_metadata_passthrough": metadata,
+        },
+        {
+            "type": "tool_search_call",
+            "call_id": "call_search",
+            "arguments": {"query": "github"},
+            "execution": "client",
+            "status": "completed",
+            "internal_chat_message_metadata_passthrough": metadata,
+        },
+        {
+            "type": "tool_search_output",
+            "call_id": "call_search",
+            "execution": "client",
+            "output": "search result",
+            "status": "completed",
+            "tools": [],
             "internal_chat_message_metadata_passthrough": metadata,
         },
         {

--- a/tests/unit/test_replay_safety.py
+++ b/tests/unit/test_replay_safety.py
@@ -1007,46 +1007,6 @@ def test_full_resend_suffix_accepts_only_self_contained_tool_loops(
     )
 
 
-def test_account_neutral_fresh_replay_accepts_compaction_context_item() -> None:
-    payload: dict[str, JsonValue] = {
-        "input": [
-            {
-                "type": "compaction",
-                "status": "completed",
-                "encrypted_content": "encrypted-compact-context",
-            },
-            {
-                "type": "message",
-                "role": "user",
-                "content": [{"type": "input_text", "text": "continue"}],
-            },
-        ],
-    }
-
-    assert responses_payload_is_account_neutral_fresh_replay(payload) is True
-
-
-def test_account_neutral_fresh_replay_accepts_self_contained_tool_search_pair() -> None:
-    input_items: list[JsonValue] = [
-        {
-            "type": "tool_search_call",
-            "call_id": "call_search",
-            "arguments": {"query": "codex-lb"},
-            "status": "completed",
-        },
-        {
-            "type": "tool_search_output",
-            "call_id": "call_search",
-            "output": "Found codex-lb",
-            "status": "completed",
-        },
-        {"role": "user", "content": [{"type": "input_text", "text": "continue"}]},
-    ]
-
-    assert responses_input_items_are_self_contained_fresh_replay(input_items) is True
-    assert responses_payload_is_account_neutral_fresh_replay({"input": input_items}) is True
-
-
 def test_full_resend_tool_loop_manifest_tolerates_fresh_developer_interleave_after_historical_one() -> None:
     stored_input: list[JsonValue] = [
         {"role": "user", "content": "first question"},


### PR DESCRIPTION
## Summary

- sanitize plaintext compaction replays while preserving opaque provider-encrypted state
- preserve valid tool-search and compact replay pairs without allowing owner-bound state to move accounts
- recover post-compaction bridge replays with bounded, fail-closed continuity handling

## Scope

Absorbs #1744. Its active-skill recovery and bridge replay safeguards are now in this branch, rebased on current `main`; #1744 will close once this current head passes CI.

## Validation

- `uv run ruff check` on changed Python paths
- `uv run ty check` on changed runtime paths
- `openspec validate preserve-opaque-compaction-replays --strict`
- `openspec validate recover-post-compact-bridge-replays --strict`
- compact/replay unit and integration suites, including bridge owner-affinity regressions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation recovery after compaction, preserving encrypted context and usable summaries.
  * Prevented duplicate or incomplete tool-search history during continued requests and retries.
  * Improved reconnect behavior while maintaining required session continuity and account restrictions.
  * Safer handling of replay boundaries reduces failures and prevents invalid historical data from being resent.
  * Corrected service-tier normalization and fallback behavior.

* **Documentation**
  * Added compatibility requirements and recovery guidance for compaction and tool-search replay scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->