### PR TITLE
fix(http-bridge): refuse foreign claims on live DRAINING leases

### DIFF
--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -1577,6 +1577,18 @@ def _http_bridge_allow_durable_takeover(lookup: DurableBridgeLookup | None) -> b
     return _http_bridge_durable_lookup_allows_turn_state_takeover(lookup)
 
 
+def _http_bridge_claim_allows_takeover(
+    lookup: DurableBridgeLookup | None,
+    *,
+    force: bool,
+) -> bool:
+    if _http_bridge_allow_durable_takeover(lookup):
+        return True
+    if not force:
+        return False
+    return lookup is None or lookup.state != "draining"
+
+
 def _http_bridge_has_durable_recovery_anchor(
     *,
     previous_response_id: str | None,
@@ -2697,6 +2709,7 @@ for _helper_name in (
     "_durable_bridge_lookup_active_owner",
     "_durable_bridge_lookup_allows_local_reuse",
     "_http_bridge_allow_durable_takeover",
+    "_http_bridge_claim_allows_takeover",
     "_http_bridge_has_durable_recovery_anchor",
     "_http_bridge_can_local_recover_without_ring",
     "_http_bridge_can_single_instance_owner_takeover_without_anchor",

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -69,7 +69,6 @@ from app.core.utils.time import to_utc_naive, utcnow
 from app.db.models import (
     AccountStatus,
     DashboardSettings,
-    HttpBridgeSessionState,
     StickySessionKind,
 )
 from app.modules.api_keys.service import (
@@ -1575,15 +1574,7 @@ def _durable_bridge_lookup_allows_local_reuse(
 
 
 def _http_bridge_allow_durable_takeover(lookup: DurableBridgeLookup | None) -> bool:
-    owner_instance = _durable_bridge_lookup_active_owner(lookup)
-    if owner_instance is None:
-        return True
-    if lookup is None:
-        return False
-    return lookup.state in {
-        HttpBridgeSessionState.DRAINING,
-        HttpBridgeSessionState.CLOSED,
-    }
+    return _http_bridge_durable_lookup_allows_turn_state_takeover(lookup)
 
 
 def _http_bridge_has_durable_recovery_anchor(

--- a/app/modules/proxy/_service/http_bridge/mixin.py
+++ b/app/modules/proxy/_service/http_bridge/mixin.py
@@ -74,11 +74,11 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _durable_bridge_lookup_allows_local_reuse,
     _forwarded_http_bridge_session_key,
     _http_bridge_alias_target_is_stale,
-    _http_bridge_allow_durable_takeover,
     _http_bridge_can_local_recover_without_ring,
     _http_bridge_can_recover_during_drain,
     _http_bridge_can_single_instance_owner_takeover_without_anchor,
     _http_bridge_can_single_instance_prompt_cache_takeover_without_anchor,
+    _http_bridge_claim_allows_takeover,
     _http_bridge_compatible,
     _http_bridge_continuity_lost_error_envelope,
     _http_bridge_endpoint_matches_current_instance,
@@ -1526,7 +1526,10 @@ class _HTTPBridgeMixin(
                 created_session = await create_session(key, **create_kwargs)
                 await self._claim_durable_http_bridge_session(
                     created_session,
-                    allow_takeover=force_durable_takeover or _http_bridge_allow_durable_takeover(durable_lookup),
+                    allow_takeover=_http_bridge_claim_allows_takeover(
+                        durable_lookup,
+                        force=force_durable_takeover,
+                    ),
                     force_owner_epoch_advance=force_durable_takeover,
                 )
                 async with self._http_bridge_lock:

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -639,15 +639,13 @@ class DurableBridgeRepository:
                 await self._session.refresh(record)
                 return _to_snapshot_required(record)
 
-            state_allows_takeover = existing.state in {
-                HttpBridgeSessionState.DRAINING,
-                HttpBridgeSessionState.CLOSED,
-            }
+            state_closed = existing.state == HttpBridgeSessionState.CLOSED
+            owner_absent = existing.owner_instance_id is None
             account_changed = existing.account_id != account_id
             owner_changed = existing.owner_instance_id != instance_id
             if owner_changed:
                 lease_expired = existing.lease_expires_at is None or to_utc_naive(existing.lease_expires_at) <= now
-                if not allow_takeover and not lease_expired and not state_allows_takeover:
+                if not allow_takeover and not lease_expired and not owner_absent and not state_closed:
                     return _to_snapshot_required(existing)
                 next_epoch = existing.owner_epoch + 1
             elif account_changed or force_owner_epoch_advance:

--- a/app/modules/proxy/durable_bridge_repository.py
+++ b/app/modules/proxy/durable_bridge_repository.py
@@ -645,7 +645,12 @@ class DurableBridgeRepository:
             owner_changed = existing.owner_instance_id != instance_id
             if owner_changed:
                 lease_expired = existing.lease_expires_at is None or to_utc_naive(existing.lease_expires_at) <= now
-                if not allow_takeover and not lease_expired and not owner_absent and not state_closed:
+                live_owned_draining = (
+                    existing.state == HttpBridgeSessionState.DRAINING and not lease_expired and not owner_absent
+                )
+                if live_owned_draining or (
+                    not allow_takeover and not lease_expired and not owner_absent and not state_closed
+                ):
                     return _to_snapshot_required(existing)
                 next_epoch = existing.owner_epoch + 1
             elif account_changed or force_owner_epoch_advance:

--- a/openspec/changes/fail-closed-draining-live-lease-claim/context.md
+++ b/openspec/changes/fail-closed-draining-live-lease-claim/context.md
@@ -1,0 +1,14 @@
+Turn-state owner-forward already refuses takeover while a DRAINING owner
+still holds a live lease. Durable `claim_session` used a weaker predicate:
+`DRAINING` or `CLOSED` counted as `state_allows_takeover`, so
+`allow_takeover=False` was ignored. `_http_bridge_allow_durable_takeover`
+had the same hole and fed local session create.
+
+The live-owner check already exists: `_durable_bridge_lookup_active_owner`
+returns None for closed, missing owner, or expired lease. Claim and local
+create now use that rule. CLOSED, expired, and ownerless DRAINING rows stay
+recoverable after the draining replica finishes or dies.
+
+Example: instance A marks its session DRAINING during preStop with 60s left
+on the lease. Instance B claims the same session key with
+`allow_takeover=False`. Owner stays A and state stays DRAINING.

--- a/openspec/changes/fail-closed-draining-live-lease-claim/context.md
+++ b/openspec/changes/fail-closed-draining-live-lease-claim/context.md
@@ -7,8 +7,11 @@ had the same hole and fed local session create.
 The live-owner check already exists: `_durable_bridge_lookup_active_owner`
 returns None for closed, missing owner, or expired lease. Claim and local
 create now use that rule. Forced recovery after a missing ring endpoint
-must not override a live DRAINING owner. CLOSED, expired, and ownerless
-DRAINING rows stay recoverable after the draining replica finishes or dies.
+must not override a live DRAINING owner. The locked claim row is the
+source of that decision, so a stale ACTIVE lookup cannot authorize a
+steal after the owner has started draining. CLOSED, expired, and
+ownerless DRAINING rows stay recoverable after the draining replica
+finishes or dies.
 
 Example: instance A marks its session DRAINING during preStop with 60s left
 on the lease. Instance B claims the same session key with

--- a/openspec/changes/fail-closed-draining-live-lease-claim/context.md
+++ b/openspec/changes/fail-closed-draining-live-lease-claim/context.md
@@ -6,8 +6,9 @@ had the same hole and fed local session create.
 
 The live-owner check already exists: `_durable_bridge_lookup_active_owner`
 returns None for closed, missing owner, or expired lease. Claim and local
-create now use that rule. CLOSED, expired, and ownerless DRAINING rows stay
-recoverable after the draining replica finishes or dies.
+create now use that rule. Forced recovery after a missing ring endpoint
+must not override a live DRAINING owner. CLOSED, expired, and ownerless
+DRAINING rows stay recoverable after the draining replica finishes or dies.
 
 Example: instance A marks its session DRAINING during preStop with 60s left
 on the lease. Instance B claims the same session key with

--- a/openspec/changes/fail-closed-draining-live-lease-claim/proposal.md
+++ b/openspec/changes/fail-closed-draining-live-lease-claim/proposal.md
@@ -1,0 +1,26 @@
+# Why
+
+Shutdown marks durable HTTP-bridge rows `DRAINING` before releasing the lease
+so the owner can finish an in-flight turn. A foreign
+`claim_live_session(..., allow_takeover=False)` still steals that row because
+`DRAINING` is treated as takeover-eligible even while the lease is live.
+Turn-state owner-forward already fails closed. Local create and durable claim
+do not, so two replicas can own one session during rolling drain.
+
+# What Changes
+
+- Treat a live DRAINING lease like a live ACTIVE lease for foreign claims.
+- Align `_http_bridge_allow_durable_takeover` with the turn-state helper.
+- Keep expired, released, and CLOSED rows takeover-eligible.
+
+# Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: durable claim and local session create must fail
+  closed on a live DRAINING lease.
+
+# Impact
+
+Turn-state forward-failure 503 stays as it is. Expired or ownerless DRAINING
+rows can still be taken over after the draining owner releases or lapses.

--- a/openspec/changes/fail-closed-draining-live-lease-claim/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fail-closed-draining-live-lease-claim/specs/responses-api-compat/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Live DRAINING durable leases reject foreign claims
 
-When a durable HTTP-bridge session is `DRAINING` and another instance still holds an unexpired lease, a foreign `claim_live_session` with `allow_takeover` false MUST leave the current owner and lease unchanged. Local session create MUST use the same live-owner predicate as turn-state takeover and MUST NOT treat `DRAINING` alone, or a forced recovery after a missing ring endpoint, as permission to steal a live `DRAINING` lease. Expired, released, or `CLOSED` rows MUST remain takeover-eligible.
+When a durable HTTP-bridge session is `DRAINING` and another instance still holds an unexpired lease, a foreign `claim_live_session` MUST leave the current owner and lease unchanged even when `allow_takeover` is true. Local session create MUST use the same live-owner predicate as turn-state takeover and MUST NOT treat `DRAINING` alone, or a forced recovery after a missing ring endpoint, as permission to steal a live `DRAINING` lease. The locked claim row, not a stale pre-claim lookup, MUST be the source of the `DRAINING` decision. Expired, released, or `CLOSED` rows MUST remain takeover-eligible.
 
 #### Scenario: Foreign claim refuses a live DRAINING lease
 
@@ -12,6 +12,15 @@ When a durable HTTP-bridge session is `DRAINING` and another instance still hold
 - **THEN** the row owner remains A
 - **AND** the row stays `DRAINING`
 - **AND** A's lease expiry is unchanged
+
+#### Scenario: Forced claim still refuses after an ACTIVE lookup becomes live DRAINING
+
+- **GIVEN** instance A owns a durable session whose lookup snapshot is still `ACTIVE`
+- **AND** instance B would force takeover because A's endpoint is missing
+- **AND** A marks the row `DRAINING` with a live lease before B's claim lock
+- **WHEN** B claims the same key with `allow_takeover` true
+- **THEN** the row owner remains A
+- **AND** the row stays `DRAINING`
 
 #### Scenario: Missing owner endpoint does not force-steal a live DRAINING lease
 

--- a/openspec/changes/fail-closed-draining-live-lease-claim/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fail-closed-draining-live-lease-claim/specs/responses-api-compat/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Live DRAINING durable leases reject foreign claims
+
+When a durable HTTP-bridge session is `DRAINING` and another instance still holds an unexpired lease, a foreign `claim_live_session` with `allow_takeover` false MUST leave the current owner and lease unchanged. Local session create MUST use the same live-owner predicate as turn-state takeover and MUST NOT treat `DRAINING` alone as permission to steal. Expired, released, or `CLOSED` rows MUST remain takeover-eligible.
+
+#### Scenario: Foreign claim refuses a live DRAINING lease
+
+- **GIVEN** instance A owns a durable session whose state is `DRAINING`
+- **AND** A's lease is still unexpired
+- **WHEN** instance B claims the same key with `allow_takeover` false
+- **THEN** the row owner remains A
+- **AND** the row stays `DRAINING`
+- **AND** A's lease expiry is unchanged
+
+#### Scenario: Expired DRAINING row remains takeover-eligible
+
+- **GIVEN** a `DRAINING` durable session whose lease is expired or whose owner is released
+- **WHEN** another instance claims the same key
+- **THEN** that instance becomes the owner
+- **AND** the row becomes `ACTIVE`

--- a/openspec/changes/fail-closed-draining-live-lease-claim/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fail-closed-draining-live-lease-claim/specs/responses-api-compat/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: Live DRAINING durable leases reject foreign claims
 
-When a durable HTTP-bridge session is `DRAINING` and another instance still holds an unexpired lease, a foreign `claim_live_session` with `allow_takeover` false MUST leave the current owner and lease unchanged. Local session create MUST use the same live-owner predicate as turn-state takeover and MUST NOT treat `DRAINING` alone as permission to steal. Expired, released, or `CLOSED` rows MUST remain takeover-eligible.
+When a durable HTTP-bridge session is `DRAINING` and another instance still holds an unexpired lease, a foreign `claim_live_session` with `allow_takeover` false MUST leave the current owner and lease unchanged. Local session create MUST use the same live-owner predicate as turn-state takeover and MUST NOT treat `DRAINING` alone, or a forced recovery after a missing ring endpoint, as permission to steal a live `DRAINING` lease. Expired, released, or `CLOSED` rows MUST remain takeover-eligible.
 
 #### Scenario: Foreign claim refuses a live DRAINING lease
 
@@ -12,6 +12,15 @@ When a durable HTTP-bridge session is `DRAINING` and another instance still hold
 - **THEN** the row owner remains A
 - **AND** the row stays `DRAINING`
 - **AND** A's lease expiry is unchanged
+
+#### Scenario: Missing owner endpoint does not force-steal a live DRAINING lease
+
+- **GIVEN** instance A owns a durable session whose state is `DRAINING`
+- **AND** A's lease is still unexpired
+- **AND** the ring cannot resolve A's endpoint
+- **WHEN** instance B creates a local HTTP-bridge session for the same key
+- **THEN** the durable claim is issued with `allow_takeover` false
+- **AND** A's owner and lease remain unchanged
 
 #### Scenario: Expired DRAINING row remains takeover-eligible
 

--- a/openspec/changes/fail-closed-draining-live-lease-claim/tasks.md
+++ b/openspec/changes/fail-closed-draining-live-lease-claim/tasks.md
@@ -4,6 +4,8 @@
   lease is still live.
 - [x] 1.2 Align `_http_bridge_allow_durable_takeover` with the live-owner
   turn-state helper.
+- [x] 1.3 Mask forced local recovery so a missing ring endpoint cannot
+  steal a live DRAINING lease.
 
 ## 2. Regression coverage
 
@@ -11,6 +13,8 @@
   `mark_instance_draining` keeps the original owner.
 - [x] 2.2 Assert `_http_bridge_allow_durable_takeover` is false for a live
   DRAINING lookup and true for expired or released DRAINING.
+- [x] 2.3 Assert get-or-create claims with `allow_takeover` false when the
+  durable lookup is live DRAINING and the owner endpoint is missing.
 
 ## 3. Validation
 

--- a/openspec/changes/fail-closed-draining-live-lease-claim/tasks.md
+++ b/openspec/changes/fail-closed-draining-live-lease-claim/tasks.md
@@ -6,6 +6,8 @@
   turn-state helper.
 - [x] 1.3 Mask forced local recovery so a missing ring endpoint cannot
   steal a live DRAINING lease.
+- [x] 1.4 Refuse live DRAINING on the locked claim row even when
+  `allow_takeover` is true.
 
 ## 2. Regression coverage
 
@@ -15,6 +17,8 @@
   DRAINING lookup and true for expired or released DRAINING.
 - [x] 2.3 Assert get-or-create claims with `allow_takeover` false when the
   durable lookup is live DRAINING and the owner endpoint is missing.
+- [x] 2.4 Assert get-or-create does not steal when an ACTIVE lookup becomes
+  live DRAINING before the locked claim.
 
 ## 3. Validation
 

--- a/openspec/changes/fail-closed-draining-live-lease-claim/tasks.md
+++ b/openspec/changes/fail-closed-draining-live-lease-claim/tasks.md
@@ -1,0 +1,19 @@
+## 1. Implementation
+
+- [x] 1.1 Refuse foreign `claim_session` when the row is DRAINING and the
+  lease is still live.
+- [x] 1.2 Align `_http_bridge_allow_durable_takeover` with the live-owner
+  turn-state helper.
+
+## 2. Regression coverage
+
+- [x] 2.1 Assert `claim_live_session(allow_takeover=False)` after
+  `mark_instance_draining` keeps the original owner.
+- [x] 2.2 Assert `_http_bridge_allow_durable_takeover` is false for a live
+  DRAINING lookup and true for expired or released DRAINING.
+
+## 3. Validation
+
+- [x] 3.1 Run the new claim and helper tests plus the existing turn-state
+  fail-closed tests.
+- [x] 3.2 Run strict OpenSpec validation for this change.

--- a/openspec/specs/responses-api-compat/context.md
+++ b/openspec/specs/responses-api-compat/context.md
@@ -35,7 +35,7 @@ See `openspec/specs/responses-api-compat/spec.md` for normative requirements.
 - Upstream Responses WebSockets use transport ping/pong control frames to detect a black-holed connection without confusing valid application-event silence with an idle turn. Direct and routed connections reuse `proxy_downstream_websocket_idle_timeout_seconds` for this zero-config liveness budget.
 - A post-send liveness timeout is delivery-ambiguous. It remains account-neutral, is never transparently replayed, and retires the affected upstream socket so a client retry opens a fresh route without risking duplicated model work or tool side effects.
 - HTTP bridge settlement ownership is explicit: `closed` rejects new work but does not imply that a submitter owns existing siblings. Only a liveness-failed send claims whole-deque settlement under the lifecycle lock; otherwise the reader remains responsible for settling pending requests when the transport dies.
-- A DRAINING durable row with a live lease is still owned. Foreign `claim_live_session` and local session create must not steal it; expired or ownerless DRAINING rows remain recoverable.
+- A DRAINING durable row with a live lease is still owned. Foreign `claim_live_session` and local session create must not steal it, including when forced recovery would otherwise run because the owner endpoint is missing; expired or ownerless DRAINING rows remain recoverable.
 - Hard-affinity retry-circuit evidence is request-lifecycle evidence: retirement counts only while the bridge still owns an eventless pending request. Idle no-pending retirement remains observable but neutral, so routine socket churn cannot manufacture the first strike for a later real timeout.
 
 ## Fast Mode and Service Tiers

--- a/openspec/specs/responses-api-compat/context.md
+++ b/openspec/specs/responses-api-compat/context.md
@@ -35,6 +35,7 @@ See `openspec/specs/responses-api-compat/spec.md` for normative requirements.
 - Upstream Responses WebSockets use transport ping/pong control frames to detect a black-holed connection without confusing valid application-event silence with an idle turn. Direct and routed connections reuse `proxy_downstream_websocket_idle_timeout_seconds` for this zero-config liveness budget.
 - A post-send liveness timeout is delivery-ambiguous. It remains account-neutral, is never transparently replayed, and retires the affected upstream socket so a client retry opens a fresh route without risking duplicated model work or tool side effects.
 - HTTP bridge settlement ownership is explicit: `closed` rejects new work but does not imply that a submitter owns existing siblings. Only a liveness-failed send claims whole-deque settlement under the lifecycle lock; otherwise the reader remains responsible for settling pending requests when the transport dies.
+- A DRAINING durable row with a live lease is still owned. Foreign `claim_live_session` and local session create must not steal it; expired or ownerless DRAINING rows remain recoverable.
 - Hard-affinity retry-circuit evidence is request-lifecycle evidence: retirement counts only while the bridge still owns an eventless pending request. Idle no-pending retirement remains observable but neutral, so routine socket churn cannot manufacture the first strike for a later real timeout.
 
 ## Fast Mode and Service Tiers

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -594,7 +594,7 @@ When a Responses follow-up depends on previously established continuity state, t
 
 ### Requirement: Live DRAINING durable leases reject foreign claims
 
-When a durable HTTP-bridge session is `DRAINING` and another instance still holds an unexpired lease, a foreign `claim_live_session` with `allow_takeover` false MUST leave the current owner and lease unchanged. Local session create MUST use the same live-owner predicate as turn-state takeover and MUST NOT treat `DRAINING` alone, or a forced recovery after a missing ring endpoint, as permission to steal a live `DRAINING` lease. Expired, released, or `CLOSED` rows MUST remain takeover-eligible.
+When a durable HTTP-bridge session is `DRAINING` and another instance still holds an unexpired lease, a foreign `claim_live_session` MUST leave the current owner and lease unchanged even when `allow_takeover` is true. Local session create MUST use the same live-owner predicate as turn-state takeover and MUST NOT treat `DRAINING` alone, or a forced recovery after a missing ring endpoint, as permission to steal a live `DRAINING` lease. The locked claim row, not a stale pre-claim lookup, MUST be the source of the `DRAINING` decision. Expired, released, or `CLOSED` rows MUST remain takeover-eligible.
 
 #### Scenario: Foreign claim refuses a live DRAINING lease
 
@@ -604,6 +604,15 @@ When a durable HTTP-bridge session is `DRAINING` and another instance still hold
 - **THEN** the row owner remains A
 - **AND** the row stays `DRAINING`
 - **AND** A's lease expiry is unchanged
+
+#### Scenario: Forced claim still refuses after an ACTIVE lookup becomes live DRAINING
+
+- **GIVEN** instance A owns a durable session whose lookup snapshot is still `ACTIVE`
+- **AND** instance B would force takeover because A's endpoint is missing
+- **AND** A marks the row `DRAINING` with a live lease before B's claim lock
+- **WHEN** B claims the same key with `allow_takeover` true
+- **THEN** the row owner remains A
+- **AND** the row stays `DRAINING`
 
 #### Scenario: Missing owner endpoint does not force-steal a live DRAINING lease
 

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -594,7 +594,7 @@ When a Responses follow-up depends on previously established continuity state, t
 
 ### Requirement: Live DRAINING durable leases reject foreign claims
 
-When a durable HTTP-bridge session is `DRAINING` and another instance still holds an unexpired lease, a foreign `claim_live_session` with `allow_takeover` false MUST leave the current owner and lease unchanged. Local session create MUST use the same live-owner predicate as turn-state takeover and MUST NOT treat `DRAINING` alone as permission to steal. Expired, released, or `CLOSED` rows MUST remain takeover-eligible.
+When a durable HTTP-bridge session is `DRAINING` and another instance still holds an unexpired lease, a foreign `claim_live_session` with `allow_takeover` false MUST leave the current owner and lease unchanged. Local session create MUST use the same live-owner predicate as turn-state takeover and MUST NOT treat `DRAINING` alone, or a forced recovery after a missing ring endpoint, as permission to steal a live `DRAINING` lease. Expired, released, or `CLOSED` rows MUST remain takeover-eligible.
 
 #### Scenario: Foreign claim refuses a live DRAINING lease
 
@@ -604,6 +604,15 @@ When a durable HTTP-bridge session is `DRAINING` and another instance still hold
 - **THEN** the row owner remains A
 - **AND** the row stays `DRAINING`
 - **AND** A's lease expiry is unchanged
+
+#### Scenario: Missing owner endpoint does not force-steal a live DRAINING lease
+
+- **GIVEN** instance A owns a durable session whose state is `DRAINING`
+- **AND** A's lease is still unexpired
+- **AND** the ring cannot resolve A's endpoint
+- **WHEN** instance B creates a local HTTP-bridge session for the same key
+- **THEN** the durable claim is issued with `allow_takeover` false
+- **AND** A's owner and lease remain unchanged
 
 #### Scenario: Expired DRAINING row remains takeover-eligible
 

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -592,6 +592,26 @@ When a Responses follow-up depends on previously established continuity state, t
 - **AND** the takeover retry carries the fresh durable lookup as its continuity anchor even when the turn-state alias registration was lost
 - **AND** a fresh durable lookup showing a live lease held by another instance — even for a DRAINING row — still fails closed with the retryable `bridge_owner_unreachable` error
 
+### Requirement: Live DRAINING durable leases reject foreign claims
+
+When a durable HTTP-bridge session is `DRAINING` and another instance still holds an unexpired lease, a foreign `claim_live_session` with `allow_takeover` false MUST leave the current owner and lease unchanged. Local session create MUST use the same live-owner predicate as turn-state takeover and MUST NOT treat `DRAINING` alone as permission to steal. Expired, released, or `CLOSED` rows MUST remain takeover-eligible.
+
+#### Scenario: Foreign claim refuses a live DRAINING lease
+
+- **GIVEN** instance A owns a durable session whose state is `DRAINING`
+- **AND** A's lease is still unexpired
+- **WHEN** instance B claims the same key with `allow_takeover` false
+- **THEN** the row owner remains A
+- **AND** the row stays `DRAINING`
+- **AND** A's lease expiry is unchanged
+
+#### Scenario: Expired DRAINING row remains takeover-eligible
+
+- **GIVEN** a `DRAINING` durable session whose lease is expired or whose owner is released
+- **WHEN** another instance claims the same key
+- **THEN** that instance becomes the owner
+- **AND** the row becomes `ACTIVE`
+
 ### Requirement: Hard continuity owner lookup fails closed
 
 When a request depends on hard continuity ownership, the service MUST fail

--- a/tests/unit/test_bridge_ring_lifecycle.py
+++ b/tests/unit/test_bridge_ring_lifecycle.py
@@ -31,6 +31,7 @@ from app.db.models import (
 from app.modules.proxy import service as proxy_service
 from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_allow_durable_takeover,
+    _http_bridge_claim_allows_takeover,
     _http_bridge_durable_lookup_allows_turn_state_takeover,
 )
 from app.modules.proxy.continuity import make_http_bridge_account_neutral_replay_key
@@ -1983,3 +1984,16 @@ def test_durable_lookup_allows_turn_state_takeover_requires_inactive_lease() -> 
     assert _http_bridge_allow_durable_takeover(expired_draining) is True
     assert _http_bridge_allow_durable_takeover(released_draining) is True
     assert _http_bridge_allow_durable_takeover(closed) is True
+    assert _http_bridge_claim_allows_takeover(live_draining, force=True) is False
+    assert _http_bridge_claim_allows_takeover(expired_draining, force=True) is True
+    assert _http_bridge_claim_allows_takeover(released_draining, force=True) is True
+    assert _http_bridge_claim_allows_takeover(closed, force=True) is True
+    live_active = _durable_lookup(
+        session_id="sess-5",
+        owner_instance_id="instance-b",
+        owner_epoch=1,
+        state=HttpBridgeSessionState.ACTIVE,
+        lease_seconds_from_now=60.0,
+    )
+    assert _http_bridge_claim_allows_takeover(live_active, force=True) is True
+    assert _http_bridge_claim_allows_takeover(live_active, force=False) is False

--- a/tests/unit/test_bridge_ring_lifecycle.py
+++ b/tests/unit/test_bridge_ring_lifecycle.py
@@ -30,6 +30,7 @@ from app.db.models import (
 )
 from app.modules.proxy import service as proxy_service
 from app.modules.proxy._service.http_bridge.helpers import (
+    _http_bridge_allow_durable_takeover,
     _http_bridge_durable_lookup_allows_turn_state_takeover,
 )
 from app.modules.proxy.continuity import make_http_bridge_account_neutral_replay_key
@@ -1978,3 +1979,7 @@ def test_durable_lookup_allows_turn_state_takeover_requires_inactive_lease() -> 
     assert allows(expired_draining) is True
     assert allows(released_draining) is True
     assert allows(closed) is True
+    assert _http_bridge_allow_durable_takeover(live_draining) is False
+    assert _http_bridge_allow_durable_takeover(expired_draining) is True
+    assert _http_bridge_allow_durable_takeover(released_draining) is True
+    assert _http_bridge_allow_durable_takeover(closed) is True

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -2441,6 +2441,48 @@ async def test_claim_refuses_live_draining_lease_without_allow_takeover(
 
 
 @pytest.mark.asyncio
+async def test_claim_refuses_live_draining_lease_even_with_allow_takeover(
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    claimed = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-draining-force",
+        api_key_id=None,
+        instance_id="instance-a",
+        owner_process_epoch="test-process",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="http_turn_1",
+        latest_response_id="resp_1",
+        allow_takeover=True,
+    )
+    updated = await coordinator.mark_instance_draining(instance_id="instance-a")
+    assert updated == 1
+
+    refused = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-draining-force",
+        api_key_id=None,
+        instance_id="instance-b",
+        owner_process_epoch="test-process-b",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="http_turn_2",
+        latest_response_id="resp_2",
+        allow_takeover=True,
+    )
+
+    assert refused.owner_instance_id == "instance-a"
+    assert refused.state == "draining"
+    assert refused.lease_expires_at == claimed.lease_expires_at
+    assert refused.lease_is_active(now=utcnow()) is True
+
+
+@pytest.mark.asyncio
 async def test_claim_takes_over_expired_draining_lease(
     coordinator: DurableBridgeSessionCoordinator,
     async_session_factory: Callable[[], AsyncSession],

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -2399,6 +2399,96 @@ async def test_mark_instance_draining_keeps_current_owner_lease_active(
 
 
 @pytest.mark.asyncio
+async def test_claim_refuses_live_draining_lease_without_allow_takeover(
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    claimed = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-draining-claim",
+        api_key_id=None,
+        instance_id="instance-a",
+        owner_process_epoch="test-process",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="http_turn_1",
+        latest_response_id="resp_1",
+        allow_takeover=True,
+    )
+    updated = await coordinator.mark_instance_draining(instance_id="instance-a")
+    assert updated == 1
+
+    refused = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-draining-claim",
+        api_key_id=None,
+        instance_id="instance-b",
+        owner_process_epoch="test-process-b",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="http_turn_2",
+        latest_response_id="resp_2",
+        allow_takeover=False,
+    )
+
+    assert refused.owner_instance_id == "instance-a"
+    assert refused.state == "draining"
+    assert refused.lease_expires_at == claimed.lease_expires_at
+    assert refused.lease_is_active(now=utcnow()) is True
+
+
+@pytest.mark.asyncio
+async def test_claim_takes_over_expired_draining_lease(
+    coordinator: DurableBridgeSessionCoordinator,
+    async_session_factory: Callable[[], AsyncSession],
+) -> None:
+    claimed = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-draining-expired",
+        api_key_id=None,
+        instance_id="instance-a",
+        owner_process_epoch="test-process",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="http_turn_1",
+        latest_response_id="resp_1",
+        allow_takeover=True,
+    )
+    updated = await coordinator.mark_instance_draining(instance_id="instance-a")
+    assert updated == 1
+
+    async with async_session_factory() as session:
+        record = await session.get(HttpBridgeSessionRecord, claimed.session_id)
+        assert record is not None
+        record.lease_expires_at = utcnow() - timedelta(seconds=1)
+        await session.commit()
+
+    stolen = await coordinator.claim_live_session(
+        session_key_kind="session_header",
+        session_key_value="sid-draining-expired",
+        api_key_id=None,
+        instance_id="instance-b",
+        owner_process_epoch="test-process-b",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="http_turn_2",
+        latest_response_id="resp_2",
+        allow_takeover=False,
+    )
+
+    assert stolen.owner_instance_id == "instance-b"
+    assert stolen.state == "active"
+    assert stolen.lease_is_active(now=utcnow()) is True
+
+
+@pytest.mark.asyncio
 async def test_startup_purges_owned_bridge_rows(
     coordinator: DurableBridgeSessionCoordinator,
     async_session_factory: Callable[[], AsyncSession],

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -16385,6 +16385,72 @@ async def test_get_or_create_http_bridge_session_recovers_locally_when_owner_end
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_http_bridge_session_does_not_force_takeover_live_draining_lease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    key = proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_123", None)
+    created_session = proxy_service._HTTPBridgeSession(
+        key=key,
+        headers={"x-codex-turn-state": "http_turn_123"},
+        affinity=proxy_service._AffinityPolicy(key="http_turn_123"),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=2.0,
+        idle_ttl_seconds=120.0,
+    )
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_create_http_bridge_session", AsyncMock(return_value=created_session))
+    claim_durable = AsyncMock()
+    monkeypatch.setattr(service, "_claim_durable_http_bridge_session", claim_durable)
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-b"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ["instance-a", "instance-b"])),
+    )
+    service._ring_membership = cast(Any, SimpleNamespace(resolve_endpoint=AsyncMock(return_value=None)))
+
+    resolved = await service._get_or_create_http_bridge_session(
+        key,
+        headers={"x-codex-turn-state": "http_turn_123"},
+        affinity=proxy_service._AffinityPolicy(key="http_turn_123"),
+        api_key=None,
+        request_model="gpt-5.4",
+        idle_ttl_seconds=120.0,
+        max_sessions=8,
+        previous_response_id="resp_prev_1",
+        allow_forward_to_owner=True,
+        durable_lookup=proxy_service.DurableBridgeLookup(
+            session_id="durable-1",
+            canonical_kind="turn_state_header",
+            canonical_key="http_turn_123",
+            api_key_scope="__anonymous__",
+            account_id="acc-1",
+            owner_instance_id="instance-b",
+            owner_epoch=2,
+            lease_expires_at=proxy_service.utcnow() + timedelta(seconds=60),
+            state=HttpBridgeSessionState.DRAINING,
+            latest_turn_state="http_turn_123",
+            latest_response_id="resp_prev_1",
+        ),
+    )
+
+    assert resolved is created_session
+    claim_durable.assert_awaited_once()
+    await_args = claim_durable.await_args
+    assert await_args is not None
+    assert await_args.kwargs["allow_takeover"] is False
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_http_bridge_session_recovers_locally_without_anchor_for_single_instance_stale_owner(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -9,6 +9,7 @@ import pickle
 import subprocess
 import time
 from collections import deque
+from collections.abc import Callable
 from contextlib import nullcontext
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta, timezone
@@ -20,6 +21,7 @@ import aiohttp
 import anyio
 import pytest
 from fastapi import WebSocket
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from websockets.exceptions import ConnectionClosedError
 from websockets.frames import Close
 
@@ -36,7 +38,7 @@ from app.core.clients.proxy_websocket import (
 from app.core.config.settings import Settings
 from app.core.errors import openai_error
 from app.core.utils.request_id import get_request_id, reset_request_scope_id, set_request_scope_id
-from app.db.models import AccountStatus, HttpBridgeSessionState
+from app.db.models import AccountStatus, Base, HttpBridgeSessionState
 from app.modules.proxy import http_bridge_forwarding as http_bridge_forwarding_module
 from app.modules.proxy import service as proxy_service
 from app.modules.proxy._service import support as proxy_support_module
@@ -16448,6 +16450,102 @@ async def test_get_or_create_http_bridge_session_does_not_force_takeover_live_dr
     await_args = claim_durable.await_args
     assert await_args is not None
     assert await_args.kwargs["allow_takeover"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_does_not_steal_when_active_lookup_becomes_live_draining(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    coordinator = DurableBridgeSessionCoordinator(cast(Callable[[], AsyncSession], session_factory))
+    stale_lookup = await coordinator.claim_live_session(
+        session_key_kind="turn_state_header",
+        session_key_value="http_turn_race",
+        api_key_id=None,
+        instance_id="instance-b",
+        owner_process_epoch="test-process-b",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state="http_turn_race",
+        latest_response_id="resp_prev_1",
+        allow_takeover=True,
+    )
+    assert stale_lookup.state == HttpBridgeSessionState.ACTIVE
+
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    service._durable_bridge = coordinator
+    key = proxy_service._HTTPBridgeSessionKey("turn_state_header", "http_turn_race", None)
+    created_session = proxy_service._HTTPBridgeSession(
+        key=key,
+        headers={"x-codex-turn-state": "http_turn_race"},
+        affinity=proxy_service._AffinityPolicy(key="http_turn_race"),
+        request_model="gpt-5.4",
+        account=cast(Any, SimpleNamespace(id="acc-1", status=AccountStatus.ACTIVE)),
+        upstream=cast(UpstreamWebSocket, SimpleNamespace(close=AsyncMock())),
+        upstream_control=proxy_service._WebSocketUpstreamControl(),
+        pending_requests=deque(),
+        pending_lock=anyio.Lock(),
+        response_create_gate=asyncio.Semaphore(1),
+        queued_request_count=0,
+        last_used_at=2.0,
+        idle_ttl_seconds=120.0,
+    )
+    monkeypatch.setattr(service, "_prune_http_bridge_sessions_locked", Mock(return_value=[]))
+    monkeypatch.setattr(service, "_create_http_bridge_session", AsyncMock(return_value=created_session))
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(http_responses_session_bridge_instance_id="instance-a"),
+    )
+    monkeypatch.setattr(proxy_service, "_http_bridge_owner_instance", AsyncMock(return_value="instance-b"))
+    monkeypatch.setattr(
+        proxy_service,
+        "_active_http_bridge_instance_ring",
+        AsyncMock(return_value=("instance-a", ["instance-a", "instance-b"])),
+    )
+    service._ring_membership = cast(Any, SimpleNamespace(resolve_endpoint=AsyncMock(return_value=None)))
+
+    real_claim = coordinator.claim_live_session
+
+    async def claim_after_drain(*args: Any, **kwargs: Any) -> DurableBridgeLookup:
+        await coordinator.mark_instance_draining(instance_id="instance-b")
+        return await real_claim(*args, **kwargs)
+
+    monkeypatch.setattr(coordinator, "claim_live_session", claim_after_drain)
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await service._get_or_create_http_bridge_session(
+            key,
+            headers={"x-codex-turn-state": "http_turn_race"},
+            affinity=proxy_service._AffinityPolicy(key="http_turn_race"),
+            api_key=None,
+            request_model="gpt-5.4",
+            idle_ttl_seconds=120.0,
+            max_sessions=8,
+            previous_response_id="resp_prev_1",
+            allow_forward_to_owner=True,
+            durable_lookup=stale_lookup,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.payload["error"]["code"] == "bridge_instance_mismatch"
+    after = await coordinator.lookup_request_targets(
+        session_key_kind="turn_state_header",
+        session_key_value="http_turn_race",
+        api_key_id=None,
+        turn_state="http_turn_race",
+        session_header=None,
+        previous_response_id="resp_prev_1",
+    )
+    assert after is not None
+    assert after.owner_instance_id == "instance-b"
+    assert after.state == HttpBridgeSessionState.DRAINING
+    await engine.dispose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Shutdown marks durable HTTP-bridge rows `DRAINING` before releasing the lease so the owner can finish an in-flight turn. Foreign `claim_live_session(..., allow_takeover=False)` still stole that row because `DRAINING` counted as takeover-eligible while the lease was live. Turn-state owner-forward already fails closed. Claim and local session create now use the same live-owner predicate.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: discovery candidate `CLB-20260813-04` (no numbered GitHub issue)

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/fail-closed-draining-live-lease-claim/`

## Changes

- Refuse foreign `claim_session` when the row is `DRAINING` and the lease is still live.
- Align `_http_bridge_allow_durable_takeover` with the turn-state live-owner helper.
- Keep expired, released, and `CLOSED` rows takeover-eligible.
- Add claim-refuse and expired-takeover regressions plus helper coverage.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config**
- [x] No new required setup step
- No new settings
- [x] README sections / `.env.example` / dashboard nav within budget

## Test plan

```
pytest tests/unit/test_durable_bridge_sessions.py -k "claim_refuses_live_draining_lease_without_allow_takeover or claim_takes_over_expired_draining_lease or mark_instance_draining_keeps_current_owner_lease_active"
pytest tests/unit/test_bridge_ring_lifecycle.py -k "durable_lookup_allows_turn_state_takeover_requires_inactive_lease or turn_state_forward_failure_fails_closed_when_draining_lease_is_live or turn_state_forward_failure_fails_closed_with_live_lease or turn_state_forward_failure_recovers_locally_when_lease_released"
openspec validate fail-closed-draining-live-lease-claim --strict
```

Local results: 7 focused tests passed. ruff/ty clean on the changed files. Strict OpenSpec change validation passed. Full local CI not run; GitHub required CI is the integration gate.

## Related work

No open issue or PR already fixes live-`DRAINING` claim steal. Nearby work stays complementary: `#1648` recovers ownerless leases (still takeover-eligible here), `#1716` reconciles in-memory sessions after leader purge, and the existing turn-state helper already fails closed on a live `DRAINING` lease.

## Checklist

- [x] Title is in Conventional Commits format
- [x] Added or updated tests covering the change
- [x] Ran the relevant unit subset locally
- [x] OpenSpec change validated strictly
- [x] CHANGELOG is not edited by hand