### PR TITLE
fix(chat): omit unset tools on mapped Responses payloads

### DIFF
--- a/app/core/openai/chat_requests.py
+++ b/app/core/openai/chat_requests.py
@@ -124,14 +124,17 @@ class ChatCompletionsRequest(BaseModel):
     @model_validator(mode="after")
     def _validate_tools(self) -> "ChatCompletionsRequest":
         responses_shaped_payload = not self.messages and self.input is not None
-        self.tools = validate_tool_types(
+        validated = validate_tool_types(
             self.tools,
             allow_builtin_tools=responses_shaped_payload,
         )
+        if validated != self.tools:
+            self.tools = validated
         return self
 
     def to_responses_request(self) -> ResponsesRequest:
         data = self.model_dump(mode="json", exclude_none=True)
+        tools_were_set = "tools" in self.model_fields_set
         messages = data.pop("messages", None)
         data.pop("store", None)
         data.pop("n", None)
@@ -160,7 +163,8 @@ class ChatCompletionsRequest(BaseModel):
             # a missing or explicitly empty `messages` field.
             if not isinstance(data.get("instructions"), str):
                 data["instructions"] = ""
-            data["tools"] = raw_tools
+            if tools_were_set:
+                data["tools"] = raw_tools
             if raw_tool_choice is not None:
                 data["tool_choice"] = raw_tool_choice
             return ResponsesRequest.model_validate(data)
@@ -177,7 +181,8 @@ class ChatCompletionsRequest(BaseModel):
         )
         data["instructions"] = instructions
         data["input"] = input_items
-        data["tools"] = tools
+        if tools_were_set:
+            data["tools"] = tools
         if tool_choice is not None:
             data["tool_choice"] = tool_choice
         return ResponsesRequest.model_validate(data)

--- a/openspec/changes/omit-unset-chat-tools/context.md
+++ b/openspec/changes/omit-unset-chat-tools/context.md
@@ -1,0 +1,14 @@
+Responses Lite and `/v1/responses` already drop synthesized top-level
+`tools` via `model_fields_set` (issue #1184). Chat conversion was left out
+of that change because `_normalize_chat_tools` always constructed a list,
+and source-routed chat already popped empty arrays.
+
+The Codex-backend chat path still goes through `to_responses_request()`
+and then `to_payload()`. An omitted chat `tools` field becomes
+`"tools": []` on the upstream Responses body. Models that reject an
+explicit empty tools param can 400 the same way Lite did.
+
+Example: `POST /v1/chat/completions` with
+`{"model":"gpt-5.2","messages":[{"role":"user","content":"hi"}]}`.
+The mapped payload must not contain `tools`. The same request with
+`"tools": []` must still forward `[]`.

--- a/openspec/changes/omit-unset-chat-tools/proposal.md
+++ b/openspec/changes/omit-unset-chat-tools/proposal.md
@@ -1,0 +1,27 @@
+# Why
+
+`/v1/chat/completions` maps onto Responses. `ChatCompletionsRequest.tools`
+uses `default_factory=list`, and `to_responses_request()` always writes
+`tools` onto the converted request. That marks the field as set, so
+`ResponsesRequest.to_payload()` forwards a synthesized `"tools": []` the
+client never sent. The Responses and `/v1/responses` omit path already
+avoids this (issue #1184). Chat still does not.
+
+# What Changes
+
+- Propagate chat `tools` omission through `to_responses_request()`.
+- Keep an explicit client-sent `[]` on the mapped Responses payload.
+- Leave source-routed chat sanitization as a second, independent omit.
+
+# Capabilities
+
+### Modified Capabilities
+
+- `chat-completions-compat`: omitted chat `tools` must stay omitted on the
+  mapped Responses wire payload.
+
+# Impact
+
+Source-routed chat already drops empty `tools` in
+`sanitize_source_chat_payload`. Codex-backend chat inherits the same omit
+rule as `/v1/responses`. Explicit tools, including `[]`, stay intact.

--- a/openspec/changes/omit-unset-chat-tools/specs/chat-completions-compat/spec.md
+++ b/openspec/changes/omit-unset-chat-tools/specs/chat-completions-compat/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Chat Completions omit unset tools on the mapped Responses payload
+
+When a `/v1/chat/completions` request omits the top-level `tools` field, the mapped Responses request MUST leave `tools` unset and the forwarded upstream payload MUST NOT include `tools`. An explicit client-sent empty `tools` array MUST still be forwarded as `[]`.
+
+#### Scenario: Omitted chat tools stay omitted upstream
+
+- **GIVEN** a Chat Completions request with `messages` and no `tools` field
+- **WHEN** the service maps the request to Responses and forwards it
+- **THEN** `tools` is absent from the mapped request field set
+- **AND** the upstream payload does not include `tools`
+
+#### Scenario: Explicit empty chat tools stay explicit
+
+- **GIVEN** a Chat Completions request that sends `"tools": []`
+- **WHEN** the service maps the request to Responses
+- **THEN** the mapped payload includes `"tools": []`

--- a/openspec/changes/omit-unset-chat-tools/tasks.md
+++ b/openspec/changes/omit-unset-chat-tools/tasks.md
@@ -1,0 +1,19 @@
+## 1. Implementation
+
+- [x] 1.1 Omit `tools` from `ChatCompletionsRequest.to_responses_request()`
+  when the client did not send the field.
+- [x] 1.2 Keep an explicit client-sent empty `tools` array on the mapped
+  Responses request.
+
+## 2. Regression coverage
+
+- [x] 2.1 Assert omitted chat `tools` stay out of `model_fields_set` and
+  `to_payload()`.
+- [x] 2.2 Assert explicit `tools: []` still appears on the mapped payload.
+- [x] 2.3 Assert `/v1/chat/completions` does not forward synthesized
+  `tools` to the Codex stream.
+
+## 3. Validation
+
+- [x] 3.1 Run the new mapping and chat-completions tests.
+- [x] 3.2 Run strict OpenSpec validation for this change.

--- a/openspec/specs/chat-completions-compat/context.md
+++ b/openspec/specs/chat-completions-compat/context.md
@@ -19,6 +19,7 @@ See `openspec/specs/chat-completions-compat/spec.md` for normative requirements.
 - Oversized image data URLs (>8MB) are dropped from user inputs.
 - Audio input (`input_audio`) is not supported and is rejected.
 - Built-in Responses tools are preserved only on the Responses-shaped passthrough path; ordinary chat-message payloads keep the narrower chat tool policy.
+- Omitted top-level `tools` stay omitted on the mapped Responses payload. `default_factory=list` plus an unconditional `to_responses_request()` write used to synthesize `"tools": []` and mark the field as set, which bypassed the Responses omit path (issue #1184). An explicit client-sent `[]` is still forwarded.
 - `response_format` is translated to `text.format` with JSON schema validation.
 
 ## Failure Modes

--- a/openspec/specs/chat-completions-compat/spec.md
+++ b/openspec/specs/chat-completions-compat/spec.md
@@ -52,6 +52,23 @@ The service MUST map chat messages into the Responses request format by merging 
 - **WHEN** the client sets `tool_choice` to `none`, `auto`, or `required`
 - **THEN** the service forwards the value consistently in the mapped Responses request
 
+### Requirement: Chat Completions omit unset tools on the mapped Responses payload
+
+When a `/v1/chat/completions` request omits the top-level `tools` field, the mapped Responses request MUST leave `tools` unset and the forwarded upstream payload MUST NOT include `tools`. An explicit client-sent empty `tools` array MUST still be forwarded as `[]`.
+
+#### Scenario: Omitted chat tools stay omitted upstream
+
+- **GIVEN** a Chat Completions request with `messages` and no `tools` field
+- **WHEN** the service maps the request to Responses and forwards it
+- **THEN** `tools` is absent from the mapped request field set
+- **AND** the upstream payload does not include `tools`
+
+#### Scenario: Explicit empty chat tools stay explicit
+
+- **GIVEN** a Chat Completions request that sends `"tools": []`
+- **WHEN** the service maps the request to Responses
+- **THEN** the mapped payload includes `"tools": []`
+
 ### Requirement: Preserve service_tier in Chat Completions mapping
 When a Chat Completions request includes `service_tier`, the service MUST preserve that field when mapping the request to the internal Responses payload.
 

--- a/tests/integration/test_proxy_chat_completions.py
+++ b/tests/integration/test_proxy_chat_completions.py
@@ -58,6 +58,33 @@ async def test_v1_chat_completions_stream(async_client, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_v1_chat_completions_omits_synthesized_tools(async_client, monkeypatch):
+    email = "chatnotools@example.com"
+    raw_account_id = "acc_chatnotools"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payload: dict[str, object] = {}
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
+        del headers, access_token, account_id, base_url, raise_for_status, kwargs
+        seen_payload.update(payload.to_payload())
+        yield 'data: {"type":"response.output_text.delta","delta":"hi"}\n\n'
+        yield 'data: {"type":"response.completed","response":{"id":"resp_chat_no_tools"}}\n\n'
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.2", "messages": [{"role": "user", "content": "hi"}], "stream": True}
+    async with async_client.stream("POST", "/v1/chat/completions", json=payload) as resp:
+        assert resp.status_code == 200
+        _ = [line async for line in resp.aiter_lines() if line]
+
+    assert "tools" not in seen_payload
+
+
+@pytest.mark.asyncio
 async def test_v1_chat_completions_opportunistic_denial_runs_before_api_key_reservation(async_client, monkeypatch):
     settings = await async_client.put(
         "/api/settings",

--- a/tests/unit/test_chat_request_mapping.py
+++ b/tests/unit/test_chat_request_mapping.py
@@ -10,6 +10,50 @@ from app.core.openai.chat_requests import ChatCompletionsRequest
 from app.core.types import JsonValue
 
 
+def test_chat_to_responses_omits_unset_tools() -> None:
+    req = ChatCompletionsRequest.model_validate(
+        {
+            "model": "gpt-5.2",
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+    )
+
+    responses = req.to_responses_request()
+
+    assert "tools" not in req.model_fields_set
+    assert "tools" not in responses.model_fields_set
+    assert "tools" not in responses.to_payload()
+
+
+def test_chat_to_responses_preserves_explicit_empty_tools() -> None:
+    req = ChatCompletionsRequest.model_validate(
+        {
+            "model": "gpt-5.2",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [],
+        }
+    )
+
+    responses = req.to_responses_request()
+
+    assert responses.to_payload()["tools"] == []
+
+
+def test_chat_responses_shaped_payload_omits_unset_tools() -> None:
+    req = ChatCompletionsRequest.model_validate(
+        {
+            "model": "gpt-5.2",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        }
+    )
+
+    responses = req.to_responses_request()
+
+    assert "tools" not in req.model_fields_set
+    assert "tools" not in responses.model_fields_set
+    assert "tools" not in responses.to_payload()
+
+
 def test_chat_messages_to_responses_mapping():
     payload = {
         "model": "gpt-5.2",


### PR DESCRIPTION
## Summary

`/v1/chat/completions` maps onto Responses. `ChatCompletionsRequest.tools` uses `default_factory=list`, the tools validator assigned that default back onto the model (marking the field as set), and `to_responses_request()` always wrote `tools` onto the converted request. Clients that omitted `tools` still forwarded `"tools": []`, which bypasses the Responses omit path from #1184.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: discovery candidate `CLB-20260813-05` (no numbered GitHub issue). Follow-on to #1184 / omit-synthesized-top-level-tools.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change

Change directory: `openspec/changes/omit-unset-chat-tools/`

## Changes

- Stop the chat tools validator from marking an omitted `tools` field as set.
- Omit `tools` from `to_responses_request()` unless the client sent the field.
- Keep an explicit client-sent `[]` on the mapped payload.
- Add mapping + `/v1/chat/completions` regressions.

## Simplicity

- [x] New feature defaults to **off** or works with **zero config**
- [x] No new required setup step
- No new settings
- [x] README sections / `.env.example` / dashboard nav within budget

## Test plan

```
pytest tests/unit/test_chat_request_mapping.py
pytest tests/integration/test_proxy_chat_completions.py -k "omits_synthesized_tools or v1_chat_completions_stream"
openspec validate omit-unset-chat-tools --strict
```

Local results: 60 unit + 2 integration tests passed. ruff/ty clean on the changed files. Strict OpenSpec change validation passed. Full local CI not run; GitHub required CI is the integration gate.

## Related work

No open issue or PR already omits unset chat `tools`. Nearby merged work (`#1184`, archived `omit-synthesized-top-level-tools`) fixed Responses and `/v1/responses`; it left chat conversion out of scope. Source-routed chat already drops empty `tools` in `sanitize_source_chat_payload`; this covers the Codex-backend mapping path.

## Checklist

- [x] Title is in Conventional Commits format
- [x] Added or updated tests covering the change
- [x] Ran the relevant unit/integration subset locally
- [x] OpenSpec change validated strictly
- [x] CHANGELOG is not edited by hand