### PR TITLE
fix(proxy): demote quarantined bridge reattach keys

### DIFF
--- a/app/modules/proxy/_service/http_bridge/quarantine.py
+++ b/app/modules/proxy/_service/http_bridge/quarantine.py
@@ -43,6 +43,7 @@ class _HTTPBridgeQuarantineEntry:
     consecutive_eventless_timeouts: int = 0
     last_touched_monotonic: float = 0.0
     reason: str | None = None
+    generation: int = 0
 
 
 def _http_bridge_quarantine_registry(
@@ -100,6 +101,16 @@ def _http_bridge_session_key_quarantined(service: Any, key: _HTTPBridgeSessionKe
     return entry is not None and entry.quarantined_until > now
 
 
+def _http_bridge_session_key_quarantine_generation(service: Any, key: _HTTPBridgeSessionKey) -> int | None:
+    registry = _http_bridge_quarantine_registry(service)
+    now = time.monotonic()
+    _prune_http_bridge_quarantine_registry(registry, now)
+    entry = registry.get(key)
+    if entry is None or entry.quarantined_until <= now:
+        return None
+    return entry.generation
+
+
 def _quarantine_http_bridge_session(service: Any, session: _HTTPBridgeSession, *, reason: str) -> None:
     """Quarantine a bridge session that has proven silent/wedged.
 
@@ -113,6 +124,7 @@ def _quarantine_http_bridge_session(service: Any, session: _HTTPBridgeSession, *
     entry.quarantined_until = max(entry.quarantined_until, now + _HTTP_BRIDGE_QUARANTINE_TTL_SECONDS)
     entry.last_touched_monotonic = now
     entry.reason = reason
+    entry.generation += 1
     _prune_http_bridge_quarantine_registry(registry, now)
     session.quarantined = True
     if already_quarantined:
@@ -169,21 +181,41 @@ def _record_http_bridge_quarantine_eventless_timeout(service: Any, session: _HTT
     )
 
 
-def _clear_http_bridge_quarantine(service: Any, session: _HTTPBridgeSession) -> None:
-    """A completed response on this key disproves the wedge; drop all state."""
+def _clear_http_bridge_quarantine_key(
+    service: Any,
+    key: _HTTPBridgeSessionKey,
+    *,
+    account_id: str | None,
+    model: str | None,
+    generation: int | None = None,
+) -> None:
+    """A completed response on a recovery key disproves the original wedge."""
     registry = _http_bridge_quarantine_registry(service)
-    session.quarantined = False
-    entry = registry.pop(session.key, None)
+    entry = registry.get(key)
     if entry is None:
         return
+    if generation is not None and entry.generation != generation:
+        return
+    registry.pop(key, None)
     if entry.quarantined_until <= time.monotonic():
         return
     _log_http_bridge_event(
         "session_quarantine_cleared",
+        key,
+        account_id=account_id,
+        model=model,
+        detail=f"reason={entry.reason}",
+        cache_key_family=key.affinity_kind,
+        model_class=_extract_model_class(model) if model else None,
+    )
+
+
+def _clear_http_bridge_quarantine(service: Any, session: _HTTPBridgeSession) -> None:
+    """A completed response on this key disproves the wedge; drop all state."""
+    session.quarantined = False
+    _clear_http_bridge_quarantine_key(
+        service,
         session.key,
         account_id=session.account.id,
         model=session.request_model,
-        detail=f"reason={entry.reason}",
-        cache_key_family=session.key.affinity_kind,
-        model_class=_extract_model_class(session.request_model) if session.request_model else None,
     )

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -109,7 +109,7 @@ from app.modules.proxy._service.http_bridge.owner_forwarding import (
     _owner_forward_failure_allows_local_recovery,
 )
 from app.modules.proxy._service.http_bridge.quarantine import (
-    _http_bridge_session_key_quarantined,
+    _http_bridge_session_key_quarantine_generation,
 )
 from app.modules.proxy._service.http_bridge.service_stubs import (
     _build_rewritten_stream_response_failed_event,
@@ -1352,6 +1352,8 @@ class _HTTPBridgeStreamingMixin:
         # dispatch genuinely goes unanchored instead of rebuilding the same
         # wedged reattach through the session-state side door.
         fresh_reattach_anchor_suppressed_quarantined = False
+        fresh_reattach_quarantine_clear_key: _HTTPBridgeSessionKey | None = None
+        fresh_reattach_quarantine_clear_generation: int | None = None
 
         def classify_durable_full_resend(
             lookup: DurableBridgeLookup,
@@ -1421,6 +1423,12 @@ class _HTTPBridgeStreamingMixin:
                 durable_full_resend_is_account_neutral = _http_bridge_payload_is_account_neutral_fresh_replay(
                     durable_full_resend_fresh_payload
                 )
+                # The durable recovery-attempt fence keys persisted
+                # ``http_bridge_recovery_attempts`` rows. Hash the same
+                # unprojected body main has always hashed: a projected body
+                # would mint a different fingerprint, so a row written
+                # before a restart would stop matching and the one-shot
+                # replay fence would silently open once.
                 _fresh_state, fresh_replay_text = prepare_bridge_request(
                     _http_bridge_payload_without_previous_response_id(payload)
                 )
@@ -1585,6 +1593,12 @@ class _HTTPBridgeStreamingMixin:
                     replay_kind,
                     replay_key,
                     bridge_session_key.api_key_id,
+                    # This is a one-shot fresh recovery dispatch after the
+                    # original hard key was quarantined. Keep the
+                    # account-neutral marker for replay guards, but do not hash
+                    # the random recovery key through durable hard-owner
+                    # routing before the wedged upstream proof can run.
+                    strength="soft",
                 )
                 force_local_recovery_creation = True
             durable_lookup = None
@@ -1611,13 +1625,21 @@ class _HTTPBridgeStreamingMixin:
                 and durable_lookup.latest_response_id is not None
                 and (not payload_looks_like_full_resend or durable_anchor_trimmable)
             )
-            if payload_looks_like_full_resend and _http_bridge_session_key_quarantined(self, bridge_session_key):
+            quarantine_generation = (
+                _http_bridge_session_key_quarantine_generation(self, bridge_session_key)
+                if payload_looks_like_full_resend
+                else None
+            )
+            if quarantine_generation is not None:
                 # The previous attach on this key proved silent/wedged
                 # (#1534). The client's own payload already carries the full
                 # conversation, so send it unanchored on the fresh path
-                # instead of rebuilding the same reattach. Delta-only
-                # payloads keep the anchor: it is their only way to convey
-                # prior context (same boundary as the fenced anchor clear).
+                # instead of rebuilding the same reattach. Only cross accounts
+                # once the sealed durable full-resend proof matches this
+                # payload; otherwise keep the durable owner while dropping the
+                # poisoned anchor. Delta-only payloads keep the anchor: it is
+                # their only way to convey prior context (same boundary as the
+                # fenced anchor clear).
                 # Evaluated independently of the fresh-reattach eligibility
                 # above: even when that gate is already false (for example a
                 # conversation-scoped payload, a live alias session, or an
@@ -1627,6 +1649,35 @@ class _HTTPBridgeStreamingMixin:
                 # paths below.
                 fresh_reattach_can_use_durable_anchor = False
                 fresh_reattach_anchor_suppressed_quarantined = True
+                if (
+                    durable_full_resend_proof is not None
+                    and durable_full_resend_proof.matches(payload, durable_lookup)
+                    and durable_full_resend_fresh_payload is not None
+                    and durable_full_resend_is_account_neutral is True
+                ):
+                    effective_payload = durable_full_resend_fresh_payload
+                    untrimmed_effective_payload = durable_full_resend_fresh_payload
+                    fresh_reattach_quarantine_clear_key = bridge_session_key
+                    fresh_reattach_quarantine_clear_generation = quarantine_generation
+                    # Name the recovery key after the body this dispatch
+                    # actually sends, not after the recovery-attempt fence
+                    # fingerprint: the two hash different bodies and must
+                    # not be conflated.
+                    _quarantine_replay_state, quarantine_replay_text = prepare_bridge_request(
+                        durable_full_resend_fresh_payload
+                    )
+                    del _quarantine_replay_state
+                    replay_nonce = durable_bridge_hash(quarantine_replay_text)
+                    replay_kind, replay_key = make_http_bridge_account_neutral_replay_key(replay_nonce)
+                    bridge_session_key = _HTTPBridgeSessionKey(
+                        replay_kind,
+                        replay_key,
+                        bridge_session_key.api_key_id,
+                        strength="soft",
+                    )
+                    force_local_recovery_creation = True
+                    incoming_session_header = None
+                    session_header_fallback_key = None
                 _log_http_bridge_event(
                     "fresh_reattach_anchor_skipped_quarantined",
                     bridge_session_key,
@@ -1731,6 +1782,8 @@ class _HTTPBridgeStreamingMixin:
         request_state, text_data = prepare_bridge_request(effective_payload)
         request_state.enforce_openai_sdk_contract = enforce_openai_sdk_contract
         request_state.affinity_policy = affinity
+        request_state.quarantine_clear_key = fresh_reattach_quarantine_clear_key
+        request_state.quarantine_clear_generation = fresh_reattach_quarantine_clear_generation
         _apply_http_bridge_downstream_turn_state(
             request_state,
             downstream_turn_state=downstream_turn_state,

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import replace
 from typing import Any, TypeVar, cast
 
@@ -49,6 +49,7 @@ from app.core.usage.live_hub import publish_live_usage
 from app.core.usage.live_snapshots import EVENT_MARKER, parse_rate_limit_event_text
 from app.core.utils.request_id import reset_request_id, set_request_id
 from app.core.utils.sse import format_sse_event, parse_sse_data_json
+from app.core.utils.time import utcnow
 from app.modules.proxy._service.api_key_usage import (
     _API_KEY_RESERVATION_HEARTBEAT_SECONDS as _API_KEY_RESERVATION_HEARTBEAT_SECONDS,
 )
@@ -72,6 +73,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
 )
 from app.modules.proxy._service.http_bridge.quarantine import (
     _clear_http_bridge_quarantine,
+    _clear_http_bridge_quarantine_key,
     _record_http_bridge_quarantine_eventless_timeout,
     _record_http_bridge_quarantine_wedged_pending,
 )
@@ -195,6 +197,7 @@ from app.modules.proxy.affinity import (
     _extract_model_class,
 )
 from app.modules.proxy.continuity import is_http_bridge_account_neutral_replay
+from app.modules.proxy.durable_bridge_runtime import http_bridge_owner_process_epoch
 from app.modules.proxy.helpers import (
     _normalize_error_code,
     is_upstream_model_capacity_error,
@@ -208,6 +211,74 @@ from app.modules.proxy.tool_call_dedupe import (
 )
 
 logger = logging.getLogger("app.modules.proxy.service")
+
+
+async def _advance_http_bridge_quarantine_clear_key(
+    service: Any,
+    *,
+    key: Any,
+    api_key_id: str | None,
+    account_id: str,
+    response_id: str,
+    input_item_count: int | None,
+    input_full_fingerprint: str | None,
+    pending_tool_calls: Mapping[str, str] | None,
+) -> bool:
+    lookup = await service._durable_bridge.lookup_request_targets(
+        session_key_kind=key.affinity_kind,
+        session_key_value=key.affinity_key,
+        api_key_id=api_key_id,
+        turn_state=None,
+        session_header=None,
+        previous_response_id=None,
+    )
+    if lookup is None:
+        return False
+    settings = _service_get_settings()
+    instance_id = settings.http_responses_session_bridge_instance_id
+    active_lookup = lookup
+    if not active_lookup.lease_is_active(now=utcnow()) or active_lookup.owner_instance_id != instance_id:
+        claimed_lookup = await service._durable_bridge.claim_live_session(
+            session_key_kind=key.affinity_kind,
+            session_key_value=key.affinity_key,
+            api_key_id=api_key_id,
+            instance_id=instance_id,
+            lease_ttl_seconds=_http_bridge_durable_lease_ttl_seconds(),
+            account_id=active_lookup.account_id,
+            model=active_lookup.model,
+            service_tier=None,
+            latest_turn_state=active_lookup.latest_turn_state,
+            latest_response_id=active_lookup.latest_response_id,
+            allow_takeover=False,
+            owner_process_epoch=http_bridge_owner_process_epoch(),
+        )
+        if claimed_lookup.owner_instance_id != instance_id:
+            return False
+        active_lookup = claimed_lookup
+    if active_lookup.account_id != account_id:
+        rebound = await service._durable_bridge.rebind_session_account(
+            session_id=active_lookup.session_id,
+            api_key_id=api_key_id,
+            instance_id=instance_id,
+            owner_epoch=active_lookup.owner_epoch,
+            account_id=account_id,
+            clear_continuity=True,
+        )
+        if not rebound:
+            return False
+    advanced = await service._durable_bridge.renew_live_session(
+        session_id=active_lookup.session_id,
+        api_key_id=api_key_id,
+        instance_id=instance_id,
+        owner_epoch=active_lookup.owner_epoch,
+        lease_ttl_seconds=_http_bridge_durable_lease_ttl_seconds(),
+        latest_response_id=response_id,
+        latest_input_item_count=input_item_count,
+        latest_input_full_fingerprint=input_full_fingerprint,
+        latest_pending_tool_calls=pending_tool_calls,
+    )
+    return advanced is not None
+
 
 _HTTP_BRIDGE_RECOVERY_SETTLEMENT_RETRY_DELAYS = (
     0.25,
@@ -2783,6 +2854,38 @@ class _HTTPBridgeUpstreamEventsMixin:
         ):
             await self._clear_http_bridge_retry_circuit(session)
             _clear_http_bridge_quarantine(self, session)
+            if terminal_request_state.quarantine_clear_key is not None:
+                quarantine_advanced = False
+                if response_id is not None:
+                    try:
+                        quarantine_advanced = await _advance_http_bridge_quarantine_clear_key(
+                            self,
+                            key=terminal_request_state.quarantine_clear_key,
+                            api_key_id=session.key.api_key_id,
+                            account_id=session.account.id,
+                            response_id=response_id,
+                            input_item_count=(
+                                terminal_request_state.input_item_count
+                                if terminal_request_state.input_item_count > 0
+                                else None
+                            ),
+                            input_full_fingerprint=(
+                                terminal_request_state.input_full_fingerprint
+                                if terminal_request_state.input_item_count > 0
+                                else None
+                            ),
+                            pending_tool_calls=_durable_pending_tool_call_manifest(terminal_request_state, payload),
+                        )
+                    except Exception:
+                        logger.warning("Failed to advance quarantined HTTP bridge continuity", exc_info=True)
+                if quarantine_advanced:
+                    _clear_http_bridge_quarantine_key(
+                        self,
+                        terminal_request_state.quarantine_clear_key,
+                        account_id=session.account.id,
+                        model=session.request_model,
+                        generation=terminal_request_state.quarantine_clear_generation,
+                    )
 
         normalize_error_event = (
             terminal_request_state is None or terminal_request_state.enforce_openai_sdk_contract

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -988,6 +988,8 @@ class _WebSocketRequestState:
     skip_request_log: bool = False
     previous_response_id: str | None = None
     session_id: str | None = None
+    quarantine_clear_key: _HTTPBridgeSessionKey | None = None
+    quarantine_clear_generation: int | None = None
     # Session headers provide locality, but only a previous response or
     # explicit turn-state header guarantees continuity for stale recovery.
     hard_continuity_anchor: bool = False

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -7594,7 +7594,7 @@ async def test_v1_responses_http_bridge_reconnects_after_clean_upstream_close(as
         # Scope the soft-affinity key to this test's account so a parallel or
         # ordered integration run cannot inherit another instance's durable
         # owner and turn the reconnect assertion into a 409 race.
-        "prompt_cache_key": f"http-bridge-reconnect-thread-{account_id}",
+        "prompt_cache_key": f"http-bridge-reconnect-thread-{account_id}-{time.monotonic_ns()}",
     }
     first = await asyncio.wait_for(async_client.post("/v1/responses", json=payload), timeout=_TEST_SYNC_TIMEOUT_SECONDS)
     second = await asyncio.wait_for(
@@ -7682,6 +7682,7 @@ async def test_v1_responses_http_bridge_opens_fresh_session_for_previous_respons
     monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
     monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
 
+    prompt_cache_key = f"http-bridge-previous-response-reconnect-{account_id}-{time.monotonic_ns()}"
     first = await asyncio.wait_for(
         async_client.post(
             "/v1/responses",
@@ -7689,7 +7690,7 @@ async def test_v1_responses_http_bridge_opens_fresh_session_for_previous_respons
                 "model": "gpt-5.1",
                 "instructions": "Return exactly OK.",
                 "input": "hello",
-                "prompt_cache_key": "http-bridge-previous-response-reconnect",
+                "prompt_cache_key": prompt_cache_key,
             },
         ),
         timeout=_TEST_SYNC_TIMEOUT_SECONDS,
@@ -7704,7 +7705,7 @@ async def test_v1_responses_http_bridge_opens_fresh_session_for_previous_respons
                 "model": "gpt-5.1",
                 "instructions": "Return exactly OK.",
                 "input": "hello-again",
-                "prompt_cache_key": "http-bridge-previous-response-reconnect",
+                "prompt_cache_key": prompt_cache_key,
                 "previous_response_id": first_body["id"],
             },
         ),
@@ -7761,6 +7762,7 @@ async def test_v1_responses_http_bridge_classifies_responses_lite_developer_inte
         "acc_http_bridge_preserve_fresh_reattach",
         "http-bridge-preserve-fresh-reattach@example.com",
     )
+    scenario_key = f"{account_id}-{time.monotonic_ns()}"
     account = await _get_account(account_id)
     first_upstream = _ClosingInterruptedCustomToolUpstreamWebSocket("resp_preserve_source")
     replay_upstream = _FakeBridgeUpstreamWebSocket("resp_preserve_replay")
@@ -7811,7 +7813,7 @@ async def test_v1_responses_http_bridge_classifies_responses_lite_developer_inte
     monkeypatch.setattr(service._durable_bridge, "release_live_session", delay_predecessor_release)
     monkeypatch.setattr(service._durable_bridge, "claim_live_session", observe_replacement_claim)
 
-    session_headers = {"x-codex-session-id": "fresh-reattach-full-resend"}
+    session_headers = {"x-codex-session-id": f"fresh-reattach-full-resend-{scenario_key}"}
     historical_input = [
         *([leading_input_item] if leading_input_item is not None else []),
         {
@@ -15341,7 +15343,7 @@ async def test_v1_responses_http_bridge_quarantines_reattach_that_streams_withou
     monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
     monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
 
-    session_headers = {"x-codex-session-id": "quarantine-silent-reattach"}
+    session_headers = {"x-codex-session-id": f"quarantine-silent-reattach-{account_id}-{time.monotonic_ns()}"}
     historical_input = [
         {"role": "user", "content": [{"type": "input_text", "text": "leading question"}]},
         {
@@ -15513,9 +15515,10 @@ async def test_v1_responses_http_bridge_quarantined_unsafe_full_resend_dispatche
     # The turn-state header makes the bridge session a true Codex continuity
     # session (``session.codex_session``), which is what arms the session-level
     # anchor injection this regression guards against.
+    scenario_key = f"{account_id}-{time.monotonic_ns()}"
     session_headers = {
-        "x-codex-session-id": "quarantine-unsafe-suffix-reattach",
-        "x-codex-turn-state": "quarantine-unsafe-suffix-turn",
+        "x-codex-session-id": f"quarantine-unsafe-suffix-reattach-{scenario_key}",
+        "x-codex-turn-state": f"quarantine-unsafe-suffix-turn-{scenario_key}",
     }
     historical_input = [
         {"role": "user", "content": [{"type": "input_text", "text": "leading question"}]},

--- a/tests/unit/test_durable_bridge_sessions.py
+++ b/tests/unit/test_durable_bridge_sessions.py
@@ -1880,6 +1880,54 @@ async def test_durable_bridge_release_without_draining_marks_session_closed(
 
 
 @pytest.mark.asyncio
+async def test_durable_bridge_ownerless_active_row_can_be_reclaimed_without_takeover(
+    coordinator: DurableBridgeSessionCoordinator,
+) -> None:
+    claimed = await coordinator.claim_live_session(
+        session_key_kind="prompt_cache",
+        session_key_value="ownerless-reclaim",
+        api_key_id=None,
+        instance_id="instance-a",
+        owner_process_epoch="test-process-a",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id=None,
+        allow_takeover=True,
+    )
+    released = await coordinator.release_live_session(
+        session_id=claimed.session_id,
+        instance_id="instance-a",
+        owner_epoch=claimed.owner_epoch,
+        draining=True,
+    )
+
+    assert released is not None
+    assert released.owner_instance_id is None
+
+    reclaimed = await coordinator.claim_live_session(
+        session_key_kind="prompt_cache",
+        session_key_value="ownerless-reclaim",
+        api_key_id=None,
+        instance_id="instance-b",
+        owner_process_epoch="test-process-b",
+        lease_ttl_seconds=60.0,
+        account_id="acc-1",
+        model="gpt-5.4",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id=None,
+        allow_takeover=False,
+    )
+
+    assert reclaimed.session_id == claimed.session_id
+    assert reclaimed.owner_instance_id == "instance-b"
+    assert reclaimed.owner_epoch == claimed.owner_epoch + 1
+
+
+@pytest.mark.asyncio
 async def test_durable_bridge_takeover_clears_stale_recovery_anchor_for_fresh_session(
     coordinator: DurableBridgeSessionCoordinator,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -59,6 +59,7 @@ from app.modules.proxy.durable_bridge_coordinator import DurableBridgeLookup, Du
 from app.modules.proxy.durable_bridge_repository import (
     DurableBridgeAliasRegistration,
     DurableBridgeAliasRegistrationReceipt,
+    durable_bridge_hash,
 )
 from app.modules.proxy.durable_bridge_runtime import http_bridge_owner_process_epoch
 from app.modules.proxy.http_bridge_event_batcher import TerminalOperationEventAppendResult
@@ -13698,6 +13699,7 @@ async def test_stream_via_http_bridge_preserves_context_after_owner_unavailable(
     retained_output = {
         "type": "message",
         "role": "assistant",
+        "id": "msg_response_owned",
         "content": [{"type": "output_text", "text": "two"}],
     }
     input_items = [*prefix_items]
@@ -30869,6 +30871,53 @@ def test_http_bridge_quarantine_clear_restores_session_reusability() -> None:
     assert http_bridge_quarantine_module._http_bridge_session_key_quarantined(service, session.key) is False
 
 
+def test_http_bridge_quarantine_clear_generation_rejects_stale_recovery() -> None:
+    service = SimpleNamespace()
+    session = _make_bridge_session(key_value="quarantine-clear-generation")
+
+    http_bridge_quarantine_module._quarantine_http_bridge_session(
+        service,
+        session,
+        reason="reattach_missing_response_created",
+    )
+    first_generation = http_bridge_quarantine_module._http_bridge_session_key_quarantine_generation(
+        service,
+        session.key,
+    )
+    assert first_generation is not None
+
+    http_bridge_quarantine_module._quarantine_http_bridge_session(
+        service,
+        session,
+        reason="repeated_eventless_timeout",
+    )
+    assert http_bridge_quarantine_module._http_bridge_session_key_quarantine_generation(service, session.key) != (
+        first_generation
+    )
+
+    http_bridge_quarantine_module._clear_http_bridge_quarantine_key(
+        service,
+        session.key,
+        account_id="acc-late-recovery",
+        model="gpt-5.6-sol",
+        generation=first_generation,
+    )
+    assert http_bridge_quarantine_module._http_bridge_session_key_quarantined(service, session.key) is True
+
+    current_generation = http_bridge_quarantine_module._http_bridge_session_key_quarantine_generation(
+        service,
+        session.key,
+    )
+    http_bridge_quarantine_module._clear_http_bridge_quarantine_key(
+        service,
+        session.key,
+        account_id="acc-current-recovery",
+        model="gpt-5.6-sol",
+        generation=current_generation,
+    )
+    assert http_bridge_quarantine_module._http_bridge_session_key_quarantined(service, session.key) is False
+
+
 def test_http_bridge_session_reusable_for_lookup_excludes_quarantined() -> None:
     service = SimpleNamespace()
     session = _make_bridge_session(key_value="quarantine-reuse")
@@ -31239,41 +31288,47 @@ async def test_stream_http_bridge_quarantined_full_resend_stays_unanchored_when_
     unanchored instead of restoring the wedged durable anchor through session
     hydration and session-level injection."""
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
-    historical_input = [
-        {"role": "user", "content": [{"type": "input_text", "text": "leading question"}]},
-        {
-            "type": "additional_tools",
-            "role": "developer",
-            "tools": [{"type": "custom", "name": "shell"}],
-        },
-        {
-            "type": "message",
-            "role": "developer",
-            "content": [{"type": "input_text", "text": "canonical Lite instructions"}],
-        },
-        {"role": "user", "content": [{"type": "input_text", "text": "first question"}]},
-        {
-            "type": "custom_tool_call",
-            "call_id": "call_historical_shell",
-            "name": "shell",
-            "input": "printf historical",
-        },
-        {"role": "developer", "content": [{"type": "input_text", "text": "historical control"}]},
-        {
-            "type": "custom_tool_call_output",
-            "call_id": "call_historical_shell",
-            "output": "historical",
-        },
-    ]
-    # Full resend with a trimmable durable prefix and a fresh suffix that does
-    # NOT retain the prior output (plain user turn).
+    historical_input = [{"role": "user", "content": "one"}]
+    retained_output = {
+        "type": "message",
+        "role": "assistant",
+        "id": "msg_response_owned",
+        "content": [{"type": "output_text", "text": "two"}],
+    }
+    projected_retained_output = {
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "two"}],
+    }
+    retains_prior_output = True
+    account_neutral_payload = True
+    expected_account_neutral = True
+    fresh_suffix = (
+        [
+            retained_output,
+            {"role": "user", "content": [{"type": "input_text", "text": "safe follow-up"}]},
+        ]
+        if retains_prior_output
+        else [{"role": "user", "content": [{"type": "input_text", "text": "follow-up without prior output"}]}]
+    )
+    expected_projected_input = (
+        [
+            *historical_input,
+            projected_retained_output,
+            {"role": "user", "content": [{"type": "input_text", "text": "safe follow-up"}]},
+        ]
+        if retains_prior_output
+        else [{"role": "user", "content": [{"type": "input_text", "text": "follow-up without prior output"}]}]
+    )
+    # Full resend with a trimmable durable prefix. Only the variant retaining
+    # prior output is safe to replay account-neutrally.
     payload = proxy_service.ResponsesRequest.model_validate(
         {
             "model": "gpt-5.6-sol",
             "instructions": "test",
             "input": [
                 *historical_input,
-                {"role": "user", "content": [{"type": "input_text", "text": "follow-up without prior output"}]},
+                *fresh_suffix,
             ],
         }
     )
@@ -31303,8 +31358,7 @@ async def test_stream_http_bridge_quarantined_full_resend_stays_unanchored_when_
         quarantined_session,
         reason="reattach_missing_response_created",
     )
-    fresh_session = _make_bridge_session(key=bridge_key, key_value=bridge_key.affinity_key)
-    fresh_session.codex_session = True
+    fresh_session: proxy_service._HTTPBridgeSession | None = None
 
     prepared_payloads: list[proxy_service.ResponsesRequest] = []
 
@@ -31333,17 +31387,25 @@ async def test_stream_http_bridge_quarantined_full_resend_stays_unanchored_when_
         request_state.previous_response_id = prepared_payload.previous_response_id
         return request_state, json.dumps(dict(prepared_payload.to_payload()), separators=(",", ":"))
 
+    captured_keys: list[proxy_service._HTTPBridgeSessionKey] = []
+    captured_kwargs: list[dict[str, object]] = []
+    captured_request_states: list[proxy_service._WebSocketRequestState] = []
+
     async def fake_get_or_create(
         key: proxy_service._HTTPBridgeSessionKey,
         **kwargs: object,
     ) -> proxy_service._HTTPBridgeSession:
-        del kwargs
-        assert key == bridge_key
+        nonlocal fresh_session
+        captured_keys.append(key)
+        captured_kwargs.append(dict(kwargs))
+        fresh_session = _make_bridge_session(key=key, key_value=key.affinity_key)
+        fresh_session.codex_session = True
         return fresh_session
 
     dispatched_text: list[str] = []
 
     async def fake_stream_events(*args: object, **kwargs: object):
+        captured_request_states.append(cast(proxy_service._WebSocketRequestState, kwargs["request_state"]))
         dispatched_text.append(cast(str, kwargs["text_data"]))
         yield 'data: {"type":"response.completed"}\n\n'
 
@@ -31369,6 +31431,12 @@ async def test_stream_http_bridge_quarantined_full_resend_stays_unanchored_when_
     monkeypatch.setattr(http_bridge_streaming_module, "_http_bridge_runtime_config", lambda *args: runtime_config)
     monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
     monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+    account_neutral_classifier = Mock(return_value=account_neutral_payload)
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_http_bridge_payload_is_account_neutral_fresh_replay",
+        account_neutral_classifier,
+    )
     # The bypass shape: a live (alias) session makes the fresh-reattach
     # durable-anchor gate false before the quarantine is ever consulted.
     monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=True))
@@ -31390,14 +31458,350 @@ async def test_stream_http_bridge_quarantined_full_resend_stays_unanchored_when_
     chunks = [chunk async for chunk in stream]
 
     assert chunks == ['data: {"type":"response.completed"}\n\n']
+    assert len(captured_keys) == 1
+    assert (captured_keys[0] != bridge_key) is expected_account_neutral
+    assert captured_keys[0].strength == ("soft" if expected_account_neutral else "hard")
+    assert (
+        is_http_bridge_account_neutral_replay(
+            kind=captured_keys[0].affinity_kind,
+            key=captured_keys[0].affinity_key,
+        )
+        is expected_account_neutral
+    )
+    assert captured_kwargs[0]["headers"] == (
+        {} if expected_account_neutral else {"x-codex-session-id": bridge_key.affinity_key}
+    )
+    assert captured_kwargs[0]["preferred_account_id"] == (None if expected_account_neutral else "acc-bridge")
     assert len(dispatched_text) == 1
     dispatched_payload = json.loads(dispatched_text[0])
     # Genuinely unanchored: the suppressed durable anchor did not come back
     # through session hydration or session-level injection, and the client's
     # payload was not prefix-trimmed against the durable stored context.
     assert "previous_response_id" not in dispatched_payload
-    assert len(dispatched_payload["input"]) == len(historical_input) + 1
+    assert dispatched_payload["input"] == expected_projected_input
+    assert fresh_session is not None
     assert fresh_session.last_completed_response_id is None
+    assert len(captured_request_states) == 1
+    assert (captured_request_states[0].quarantine_clear_key == bridge_key) is expected_account_neutral
+    assert (captured_request_states[0].quarantine_clear_generation is not None) is expected_account_neutral
+    expected_replay_kind, expected_replay_key = make_http_bridge_account_neutral_replay_key(
+        durable_bridge_hash(dispatched_text[0])
+    )
+    if expected_account_neutral:
+        assert captured_keys[0].affinity_kind == expected_replay_kind
+        assert captured_keys[0].affinity_key == expected_replay_key
+    if retains_prior_output:
+        account_neutral_classifier.assert_called_once()
+    else:
+        account_neutral_classifier.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_quarantined_full_resend_recovery_fence_survives_restart_fingerprint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The quarantine demotion must not re-key the durable recovery fence.
+
+    ``durable_recovery_attempt_fingerprint`` is the primary key of persisted
+    ``http_bridge_recovery_attempts`` rows, so it must keep hashing the
+    unprojected request body. A row journalled before a restart has to still
+    match after it, otherwise the one-shot replay fence silently opens once.
+    The quarantine recovery key is named after the projected body that this
+    dispatch actually sends, which is a different hash on purpose.
+    """
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    historical_input = [{"role": "user", "content": "one"}]
+    retained_output = {
+        "type": "message",
+        "role": "assistant",
+        "id": "msg_response_owned",
+        "content": [{"type": "output_text", "text": "two"}],
+    }
+    payload = proxy_service.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.6-sol",
+            "instructions": "test",
+            "input": [
+                *historical_input,
+                retained_output,
+                {"role": "user", "content": [{"type": "input_text", "text": "safe follow-up"}]},
+            ],
+        }
+    )
+    bridge_key = proxy_service._HTTPBridgeSessionKey("session_header", "quarantine-fence-restart", None)
+    prefix_fingerprint = http_bridge_streaming_module._fingerprint_input_items(
+        cast(list[Any], payload.input)[: len(historical_input)]
+    )
+    # The restart shape: the durable row survived, but its owner's lease died
+    # with the process that wrote the recovery-attempt row.
+    durable_lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-quarantine-fence",
+        canonical_kind=bridge_key.affinity_kind,
+        canonical_key=bridge_key.affinity_key,
+        api_key_scope="__anonymous__",
+        account_id="acc-bridge",
+        owner_instance_id="instance-before-restart",
+        owner_epoch=4,
+        lease_expires_at=proxy_service.utcnow() - timedelta(seconds=120),
+        state=HttpBridgeSessionState.CLOSED,
+        latest_turn_state=None,
+        latest_response_id="resp_wedged_anchor",
+        model="gpt-5.6-sol",
+        latest_input_item_count=len(historical_input),
+        latest_input_full_fingerprint=prefix_fingerprint,
+    )
+    quarantined_session = _make_bridge_session(key=bridge_key, key_value=bridge_key.affinity_key)
+    http_bridge_quarantine_module._quarantine_http_bridge_session(
+        service,
+        quarantined_session,
+        reason="reattach_missing_response_created",
+    )
+
+    def render_bridge_text(rendered_payload: proxy_service.ResponsesRequest) -> str:
+        return json.dumps(dict(rendered_payload.to_payload()), separators=(",", ":"))
+
+    # What a pre-restart process journalled: the hash of the unprojected body.
+    persisted_fence_fingerprint = durable_bridge_hash(
+        render_bridge_text(http_bridge_streaming_module._http_bridge_payload_without_previous_response_id(payload))
+    )
+
+    def fake_prepare(
+        prepared_payload: proxy_service.ResponsesRequest,
+        _headers: dict[str, str] | Any,
+        *,
+        api_key: proxy_service.ApiKeyData | None,
+        api_key_reservation: proxy_service.ApiKeyUsageReservationData | None,
+        request_id: str,
+        client_ip: str | None = None,
+        **prepare_kwargs: object,
+    ) -> tuple[proxy_service._WebSocketRequestState, str]:
+        del api_key, api_key_reservation, request_id, client_ip, prepare_kwargs
+        request_state = proxy_service._WebSocketRequestState(
+            request_id="req-quarantine-fence",
+            model=prepared_payload.model,
+            service_tier=None,
+            reasoning_effort=None,
+            api_key_reservation=None,
+            started_at=time.monotonic(),
+            event_queue=asyncio.Queue(),
+            transport="http",
+        )
+        request_state.previous_response_id = prepared_payload.previous_response_id
+        return request_state, render_bridge_text(prepared_payload)
+
+    captured_keys: list[proxy_service._HTTPBridgeSessionKey] = []
+
+    async def fake_get_or_create(
+        key: proxy_service._HTTPBridgeSessionKey,
+        **kwargs: object,
+    ) -> proxy_service._HTTPBridgeSession:
+        del kwargs
+        captured_keys.append(key)
+        fresh_session = _make_bridge_session(key=key, key_value=key.affinity_key)
+        fresh_session.codex_session = True
+        return fresh_session
+
+    dispatched_text: list[str] = []
+
+    async def fake_stream_events(*args: object, **kwargs: object):
+        del args
+        dispatched_text.append(cast(str, kwargs["text_data"]))
+        yield 'data: {"type":"response.completed"}\n\n'
+
+    dashboard_settings = SimpleNamespace(
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=1800,
+    )
+    runtime_config = SimpleNamespace(
+        enabled=True,
+        idle_ttl_seconds=120.0,
+        codex_idle_ttl_seconds=1800.0,
+        max_sessions=8,
+        queue_limit=4,
+        prompt_cache_idle_ttl_seconds=120.0,
+        gateway_safe_mode=False,
+    )
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_service_get_settings_cache",
+        lambda: SimpleNamespace(get=AsyncMock(return_value=dashboard_settings)),
+    )
+    monkeypatch.setattr(http_bridge_streaming_module, "_service_get_settings", _make_app_settings)
+    monkeypatch.setattr(http_bridge_streaming_module, "_http_bridge_runtime_config", lambda *args: runtime_config)
+    monkeypatch.setattr(service, "_resolve_file_account_for_responses", AsyncMock(return_value=None))
+    monkeypatch.setattr(service._durable_bridge, "lookup_request_targets", AsyncMock(return_value=durable_lookup))
+
+    claim_instance_id = _make_app_settings().http_responses_session_bridge_instance_id
+    claimed_lookup = replace(
+        durable_lookup,
+        owner_instance_id=claim_instance_id,
+        owner_epoch=durable_lookup.owner_epoch + 1,
+        lease_expires_at=proxy_service.utcnow() + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+    )
+    lookup_recovery_attempt = AsyncMock(return_value=SimpleNamespace(request_fingerprint=persisted_fence_fingerprint))
+    mark_recovery_attempt_replayed = AsyncMock(return_value=True)
+    monkeypatch.setattr(service._durable_bridge, "lookup_recovery_attempt", lookup_recovery_attempt)
+    monkeypatch.setattr(service._durable_bridge, "claim_live_session", AsyncMock(return_value=claimed_lookup))
+    monkeypatch.setattr(service._durable_bridge, "mark_recovery_attempt_replayed", mark_recovery_attempt_replayed)
+    monkeypatch.setattr(
+        http_bridge_streaming_module,
+        "_http_bridge_payload_is_account_neutral_fresh_replay",
+        Mock(return_value=True),
+    )
+    monkeypatch.setattr(service, "_http_bridge_has_live_local_session", AsyncMock(return_value=True))
+    monkeypatch.setattr(service, "_http_bridge_can_forward_to_active_owner", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_prepare_http_bridge_request", fake_prepare)
+    monkeypatch.setattr(service, "_get_or_create_http_bridge_session", fake_get_or_create)
+    monkeypatch.setattr(service, "_stream_http_bridge_session_events", fake_stream_events)
+
+    stream = service._stream_http_bridge_or_retry(
+        payload,
+        {"x-codex-session-id": bridge_key.affinity_key},
+        codex_session_affinity=True,
+        propagate_http_errors=True,
+        openai_cache_affinity=False,
+        api_key=None,
+        api_key_reservation=None,
+        suppress_text_done_events=False,
+    )
+    chunks = [chunk async for chunk in stream]
+    assert chunks == ['data: {"type":"response.completed"}\n\n']
+
+    # The fence looked the persisted row up under the fingerprint that row was
+    # written with, so the one-shot replay guard still holds after the restart.
+    lookup_recovery_attempt.assert_awaited_once_with(
+        session_id=durable_lookup.session_id,
+        request_fingerprint=persisted_fence_fingerprint,
+    )
+    mark_recovery_attempt_replayed.assert_awaited_once_with(
+        session_id=durable_lookup.session_id,
+        api_key_id=None,
+        instance_id=claim_instance_id,
+        owner_epoch=claimed_lookup.owner_epoch,
+        request_fingerprint=persisted_fence_fingerprint,
+    )
+
+    # Negative control. The body this recovery actually dispatches is the
+    # projected one, and its hash is NOT the fence fingerprint. Hashing the
+    # projected body into ``durable_recovery_attempt_fingerprint`` is exactly
+    # the regression this test pins shut: the lookup above would have missed
+    # the persisted row and handed out a second "first" replay.
+    assert len(dispatched_text) == 1
+    dispatched_payload = json.loads(dispatched_text[0])
+    assert dispatched_payload["input"] == [
+        *historical_input,
+        {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "two"}]},
+        {"role": "user", "content": [{"type": "input_text", "text": "safe follow-up"}]},
+    ]
+    projected_body_fingerprint = durable_bridge_hash(dispatched_text[0])
+    assert projected_body_fingerprint != persisted_fence_fingerprint
+    fence_await = lookup_recovery_attempt.await_args
+    assert fence_await is not None
+    assert fence_await.kwargs["request_fingerprint"] != projected_body_fingerprint
+
+    # The poisoned hard key was not reused for the recovery dispatch.
+    assert len(captured_keys) == 1
+    assert captured_keys[0] != bridge_key
+    assert is_http_bridge_account_neutral_replay(
+        kind=captured_keys[0].affinity_kind,
+        key=captured_keys[0].affinity_key,
+    )
+
+
+@pytest.mark.asyncio
+async def test_advance_http_bridge_quarantine_clear_key_rebinds_and_updates_original_continuity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = SimpleNamespace()
+    key = proxy_service._HTTPBridgeSessionKey("session_header", "quarantine-original", None)
+    lookup = proxy_service.DurableBridgeLookup(
+        session_id="durable-original",
+        canonical_kind=key.affinity_kind,
+        canonical_key=key.affinity_key,
+        api_key_scope="__anonymous__",
+        account_id="acc-old",
+        owner_instance_id=None,
+        owner_epoch=7,
+        lease_expires_at=proxy_service.utcnow() - timedelta(seconds=60),
+        state=HttpBridgeSessionState.CLOSED,
+        latest_turn_state=None,
+        latest_response_id="resp-stale",
+        model="gpt-5.6-sol",
+    )
+    claimed_lookup = replace(
+        lookup,
+        owner_instance_id=_make_app_settings().http_responses_session_bridge_instance_id,
+        owner_epoch=lookup.owner_epoch + 1,
+        lease_expires_at=proxy_service.utcnow() + timedelta(seconds=60),
+        state=HttpBridgeSessionState.ACTIVE,
+    )
+    service._durable_bridge = SimpleNamespace(
+        lookup_request_targets=AsyncMock(return_value=lookup),
+        claim_live_session=AsyncMock(return_value=claimed_lookup),
+        rebind_session_account=AsyncMock(return_value=True),
+        renew_live_session=AsyncMock(
+            return_value=replace(claimed_lookup, account_id="acc-new", latest_response_id="resp-new")
+        ),
+    )
+    monkeypatch.setattr(http_bridge_upstream_events_module, "_service_get_settings", _make_app_settings)
+
+    advanced = await http_bridge_upstream_events_module._advance_http_bridge_quarantine_clear_key(
+        service,
+        key=key,
+        api_key_id=None,
+        account_id="acc-new",
+        response_id="resp-new",
+        input_item_count=3,
+        input_full_fingerprint="fp-new",
+        pending_tool_calls={"call_1": "function_call"},
+    )
+
+    assert advanced is True
+    service._durable_bridge.lookup_request_targets.assert_awaited_once_with(
+        session_key_kind=key.affinity_kind,
+        session_key_value=key.affinity_key,
+        api_key_id=None,
+        turn_state=None,
+        session_header=None,
+        previous_response_id=None,
+    )
+    service._durable_bridge.claim_live_session.assert_awaited_once_with(
+        session_key_kind=key.affinity_kind,
+        session_key_value=key.affinity_key,
+        api_key_id=None,
+        instance_id=_make_app_settings().http_responses_session_bridge_instance_id,
+        lease_ttl_seconds=pytest.approx(http_bridge_helpers_module._http_bridge_durable_lease_ttl_seconds()),
+        account_id="acc-old",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        latest_turn_state=None,
+        latest_response_id="resp-stale",
+        allow_takeover=False,
+        owner_process_epoch=http_bridge_owner_process_epoch(),
+    )
+    service._durable_bridge.rebind_session_account.assert_awaited_once_with(
+        session_id=claimed_lookup.session_id,
+        api_key_id=None,
+        instance_id=_make_app_settings().http_responses_session_bridge_instance_id,
+        owner_epoch=claimed_lookup.owner_epoch,
+        account_id="acc-new",
+        clear_continuity=True,
+    )
+    service._durable_bridge.renew_live_session.assert_awaited_once()
+    renew_kwargs = service._durable_bridge.renew_live_session.await_args.kwargs
+    assert renew_kwargs == {
+        "session_id": claimed_lookup.session_id,
+        "api_key_id": None,
+        "instance_id": _make_app_settings().http_responses_session_bridge_instance_id,
+        "owner_epoch": claimed_lookup.owner_epoch,
+        "lease_ttl_seconds": renew_kwargs["lease_ttl_seconds"],
+        "latest_response_id": "resp-new",
+        "latest_input_item_count": 3,
+        "latest_input_full_fingerprint": "fp-new",
+        "latest_pending_tool_calls": {"call_1": "function_call"},
+    }
+    assert renew_kwargs["lease_ttl_seconds"] > 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- route quarantined full-resend HTTP bridge reattaches onto a fresh account-neutral replay key
- clear stale session affinity inputs before session creation so poisoned hard keys cannot rebuild the same wedged bridge
- tighten the quarantine regression test to assert the fresh key and stripped headers

## Validation
- `uv run --frozen pytest -q tests/unit/test_proxy_http_bridge.py::test_stream_http_bridge_quarantined_full_resend_stays_unanchored_when_reattach_gate_already_false`
- `uv run --frozen pytest -q tests/unit/test_proxy_http_bridge.py -q`

## Notes
This is the focused public carrier for the post-compaction live hang class where a quarantined hard session key could suppress the durable anchor but still create/reuse the same poisoned bridge key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of interrupted HTTP bridge sessions while preventing stale recovery events from clearing newer quarantine states.
  * Added safer replay handling for quarantined requests, including account-neutral recovery when durable request validation succeeds.
  * Preserved session continuity, ownership, and response metadata during quarantine clearing and reconnection.
* **Tests**
  * Expanded coverage for restart recovery, session reclamation, replay safeguards, and generation-based quarantine behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->