### PR TITLE
fix(proxy): hold fenced hard turns through cooldown

### DIFF
--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -218,6 +218,7 @@ _HTTP_BRIDGE_CLEAN_CLOSE_RETRY_JITTER_MAX_SECONDS = 2.0
 
 _REQUEST_TRANSPORT_HTTP = "http"
 _WEBSOCKET_AUTH_INVALIDATED_FAILURE_CODE = "account_auth_invalidated"
+_HTTP_BRIDGE_SAME_ANCHOR_PRECREATED_MAX_REPLAYS = 1
 _NO_SECURITY_WORK_AUTHORIZED_ACCOUNTS_CODE = "no_security_work_authorized_accounts"
 _SECURITY_WORK_NO_AUTHORIZED_ACCOUNTS_MESSAGE = (
     "Upstream flagged this request as possible cybersecurity work, but no account is marked as authorized for "
@@ -327,6 +328,23 @@ def _http_bridge_client_full_history_recovery_error() -> OpenAIErrorEnvelope:
     )
     payload["error"]["param"] = "previous_response_id"
     return payload
+
+
+def _http_bridge_can_replay_same_anchor_before_created(request_state: _WebSocketRequestState) -> bool:
+    if not request_state.request_text:
+        return False
+    if request_state.missing_response_created_retry_count >= _HTTP_BRIDGE_SAME_ANCHOR_PRECREATED_MAX_REPLAYS:
+        return False
+    return (
+        request_state.previous_response_id is not None
+        and request_state.response_id is None
+        and request_state.awaiting_response_created
+        and request_state.response_event_count == 0
+        and request_state.last_downstream_sequence_number is None
+        and not request_state.downstream_visible
+        and not request_state.upstream_model_output_seen
+        and not request_state.file_required_preferred_account
+    )
 
 
 async def _rollback_http_bridge_recovery_turn_state_registration(
@@ -2856,6 +2874,7 @@ class _HTTPBridgeRequestSubmitMixin:
         *,
         request_state: _WebSocketRequestState | None = None,
         restart_reader: bool = False,
+        allow_same_anchor_before_created: bool = False,
     ) -> bool:
         clean_close_retry_max_count = self._http_bridge_clean_close_retry_max_count()
         account_neutral_recovery = is_http_bridge_account_neutral_replay(
@@ -2863,8 +2882,16 @@ class _HTTPBridgeRequestSubmitMixin:
             key=session.key.affinity_key,
         )
 
+        hard_owner_bound = _http_bridge_key_strength(session.key) == "hard"
+
         def request_is_retryable(request_state: _WebSocketRequestState) -> bool:
             if _websocket_request_can_replay_before_visible_output(request_state):
+                return True
+            if (
+                allow_same_anchor_before_created
+                and hard_owner_bound
+                and _http_bridge_can_replay_same_anchor_before_created(request_state)
+            ):
                 return True
             if (
                 clean_close_retry_max_count <= 0
@@ -2886,6 +2913,7 @@ class _HTTPBridgeRequestSubmitMixin:
         fresh_hard_request_account_switch_candidate = False
         proof_gated_continuity_replay_candidate = False
         server_anchored_replay_candidate = False
+        eventless_same_anchor_replay_candidate = False
         if session.key.strength == "hard":
             async with session.pending_lock:
                 retryable_candidates = [
@@ -2911,12 +2939,21 @@ class _HTTPBridgeRequestSubmitMixin:
                         and candidate.replay_count == 0
                     )
                     server_anchored_replay_candidate = _http_bridge_server_anchored_replay_enabled(candidate)
+                    eventless_same_anchor_replay_candidate = (
+                        allow_same_anchor_before_created
+                        and hard_owner_bound
+                        and _http_bridge_can_replay_same_anchor_before_created(candidate)
+                        and not (
+                            candidate.fresh_upstream_request_is_retry_safe and candidate.fresh_upstream_request_text
+                        )
+                    )
         if not await self._http_bridge_precreated_retry_allowed(
             session,
             allow_fresh_hard_account_switch=fresh_hard_request_account_switch_candidate,
             allow_proof_gated_continuity_replay=(
                 proof_gated_continuity_replay_candidate or server_anchored_replay_candidate
             ),
+            allow_eventless_same_anchor_replay=eventless_same_anchor_replay_candidate,
         ):
             return False
 
@@ -2924,7 +2961,6 @@ class _HTTPBridgeRequestSubmitMixin:
             kind=session.key.affinity_kind,
             key=session.key.affinity_key,
         )
-        hard_owner_bound = _http_bridge_key_strength(session.key) == "hard"
         async with session.pending_lock:
             if request_state is not None:
                 if (
@@ -2945,8 +2981,24 @@ class _HTTPBridgeRequestSubmitMixin:
                     return False
                 request_state = retryable_requests[0]
             model_fallback_replay = request_state.precreated_replay_reason == _ACCOUNT_MODEL_UNSUPPORTED_ERROR_CODE
-            if request_state.previous_response_id is not None and not (
-                request_state.fresh_upstream_request_is_retry_safe and request_state.fresh_upstream_request_text
+            eventless_same_anchor_replay = (
+                allow_same_anchor_before_created
+                and hard_owner_bound
+                and _http_bridge_can_replay_same_anchor_before_created(request_state)
+                and not (
+                    request_state.fresh_upstream_request_is_retry_safe and request_state.fresh_upstream_request_text
+                )
+            )
+            if (
+                request_state.previous_response_id is not None
+                and not (
+                    request_state.fresh_upstream_request_is_retry_safe and request_state.fresh_upstream_request_text
+                )
+                and not (
+                    allow_same_anchor_before_created
+                    and hard_owner_bound
+                    and _http_bridge_can_replay_same_anchor_before_created(request_state)
+                )
             ):
                 # Once a continuation is pending upstream, reconnecting without
                 # replay cannot complete the current request, while replaying it
@@ -3046,10 +3098,16 @@ class _HTTPBridgeRequestSubmitMixin:
                 request_state.clean_close_retry_close_generation = close_generation
             if additional_clean_close_retry:
                 request_state.clean_close_replay_count += 1
+            if eventless_same_anchor_replay:
+                request_state.missing_response_created_retry_count += 1
         retry_jitter_seconds = (
             self._http_bridge_clean_close_retry_jitter_seconds() if additional_clean_close_retry else 0.0
         )
-        retry_event = "retry_precreated_clean_close" if additional_clean_close_retry else "retry_precreated"
+        retry_event = (
+            "retry_precreated_same_anchor"
+            if eventless_same_anchor_replay
+            else ("retry_precreated_clean_close" if additional_clean_close_retry else "retry_precreated")
+        )
         _log_http_bridge_event(
             retry_event,
             session.key,

--- a/app/modules/proxy/_service/http_bridge/retry_circuit.py
+++ b/app/modules/proxy/_service/http_bridge/retry_circuit.py
@@ -262,6 +262,7 @@ class _HTTPBridgeRetryCircuitMixin:
         allow_fresh_hard_account_switch: bool = False,
         allow_proof_gated_continuity_replay: bool = False,
         allow_operation_fenced_continuity_replay: bool = False,
+        allow_eventless_same_anchor_replay: bool = False,
     ) -> bool:
         """Avoid replaying a repeatedly failing hard-affinity request in a tight loop."""
         if session.key.strength != "hard":
@@ -278,6 +279,7 @@ class _HTTPBridgeRetryCircuitMixin:
                     and state.half_open_until > now
                     and not allow_fresh_hard_account_switch
                     and not allow_proof_gated_continuity_replay
+                    and not allow_eventless_same_anchor_replay
                 ):
                     if PROMETHEUS_AVAILABLE and http_bridge_retry_circuit_total is not None:
                         http_bridge_retry_circuit_total.labels(outcome="suppressed").inc()
@@ -317,6 +319,16 @@ class _HTTPBridgeRetryCircuitMixin:
             if allow_operation_fenced_continuity_replay:
                 logger.info(
                     "http_bridge_retry_circuit event=bypass_operation_fenced_continuity_replay bridge_kind=%s "
+                    "bridge_key=%s failures=%s retry_after_seconds=%.1f",
+                    session.key.affinity_kind,
+                    _hash_identifier(session.key.affinity_key),
+                    state.consecutive_failures,
+                    retry_after,
+                )
+                return True
+            if allow_eventless_same_anchor_replay:
+                logger.info(
+                    "http_bridge_retry_circuit event=bypass_eventless_same_anchor_replay bridge_kind=%s "
                     "bridge_key=%s failures=%s retry_after_seconds=%.1f",
                     session.key.affinity_kind,
                     _hash_identifier(session.key.affinity_key),

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -3613,10 +3613,82 @@ class _HTTPBridgeStreamingMixin:
                     ),
                 )
 
+        def operation_fenced_cooldown_wait_enabled() -> bool:
+            """Allow a hard turn to wait until its durable fence can arbitrate recovery."""
+            return (
+                getattr(
+                    _service_get_settings(),
+                    "http_responses_session_bridge_ambiguous_continuation_recovery_mode",
+                    "fail_closed",
+                )
+                in {"server_anchored_replay_once", "server_indefinite_recovery"}
+                and request_state.hard_continuity_anchor
+                and session.durable_session_id is not None
+                and session.durable_owner_epoch is not None
+                and request_state.response_id is None
+                and request_state.response_event_count == 0
+            )
+
         def continuity_bound_without_safe_replay() -> bool:
             """Do not hold a client stream through a cooldown we cannot use."""
             return _http_bridge_continuity_bound_without_safe_replay(request_state) and not (
-                _http_bridge_server_anchored_replay_enabled(request_state)
+                _http_bridge_server_anchored_replay_enabled(request_state) or operation_fenced_cooldown_wait_enabled()
+            )
+
+        async def wait_through_operation_fenced_startup_cooldown() -> bool:
+            if session.key.strength != "hard" or not operation_fenced_cooldown_wait_enabled():
+                return False
+            retry_cooldown_seconds = await self._http_bridge_precreated_retry_cooldown_seconds(session)
+            if retry_cooldown_seconds <= 0:
+                return False
+            remaining_budget_seconds = request_deadline - _service_time().monotonic()
+            if remaining_budget_seconds <= 0:
+                return False
+            wait_seconds = min(retry_cooldown_seconds, remaining_budget_seconds)
+            _log_http_bridge_event(
+                "wait_operation_fenced_cooldown",
+                session.key,
+                account_id=session.account.id,
+                model=session.request_model,
+                detail="hard_turn_operation_fence",
+                cache_key_family=session.key.affinity_kind,
+            )
+            logger.info(
+                "HTTP bridge waiting through retry-circuit cooldown before durable hard-turn arbitration "
+                "request_id=%s wait_seconds=%.1f remaining_budget_seconds=%.1f",
+                request_state.request_id,
+                wait_seconds,
+                remaining_budget_seconds,
+            )
+            # No upstream request has been dispatched on this path.  After the
+            # cooldown, normal submission still has to create or claim the
+            # durable operation fence before response.create can be sent.
+            await asyncio.sleep(wait_seconds)
+            return True
+
+        async def operation_fenced_request_budget_terminal_event() -> str | None:
+            if not operation_fenced_cooldown_wait_enabled() or _service_time().monotonic() < request_deadline:
+                return None
+            await self._release_websocket_request_state_reservation(request_state)
+            request_state.api_key_reservation = None
+            if propagate_http_errors:
+                raise ProxyResponseError(
+                    503,
+                    openai_error(
+                        "upstream_request_timeout",
+                        "HTTP responses session bridge recovery exceeded the request budget.",
+                        error_type="server_error",
+                    ),
+                )
+            return format_sse_event(
+                cast(
+                    Mapping[str, JsonValue],
+                    response_failed_event(
+                        "stream_idle_timeout",
+                        "HTTP responses session bridge recovery exceeded the request budget",
+                        response_id=_websocket_downstream_response_id(request_state),
+                    ),
+                )
             )
 
         async def startup_continuity_cooldown_terminal_event() -> str | None:
@@ -3687,6 +3759,12 @@ class _HTTPBridgeStreamingMixin:
             )
 
         while True:
+            budget_terminal_event = await operation_fenced_request_budget_terminal_event()
+            if budget_terminal_event is not None:
+                yield budget_terminal_event
+                return
+            if await wait_through_operation_fenced_startup_cooldown():
+                continue
             startup_terminal_event = await startup_continuity_cooldown_terminal_event()
             if startup_terminal_event is not None:
                 yield startup_terminal_event

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -1288,14 +1288,19 @@ class _HTTPBridgeUpstreamEventsMixin:
                                     _extract_model_class(session.request_model) if session.request_model else None
                                 ),
                             )
-                            # A fresh, self-contained hard request can use the
-                            # same bounded pre-created recovery as the idle
-                            # timeout path. Keep the session open until the
-                            # recovery routine claims the handoff; otherwise
-                            # its retry gate would reject the request as
-                            # already retired. Continuity-bound requests still
-                            # fail closed in _retry_http_bridge_precreated_request.
-                            retried = await self._retry_http_bridge_precreated_request(session)
+                            # A fresh, self-contained hard request, or the
+                            # narrower eventless same-anchor continuation
+                            # recovery, can use the same bounded pre-created
+                            # path. Keep the session open until the recovery
+                            # routine claims the handoff; otherwise its retry
+                            # gate would reject the request as already
+                            # retired. Continuity requests that do not satisfy
+                            # the narrow proof still fail closed in
+                            # _retry_http_bridge_precreated_request.
+                            retried = await self._retry_http_bridge_precreated_request(
+                                session,
+                                allow_same_anchor_before_created=True,
+                            )
                             if retried:
                                 continue
                             session.closed = True

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -817,6 +817,10 @@ class _WebSocketRequestState:
     request_usage_budget: ApiKeyRequestUsageBudget | None = None
     request_text: str | None = None
     replay_count: int = 0
+    # Counts the one watchdog-owned same-anchor recovery permitted after an
+    # eventless pre-response-created timeout. Keep this separate from
+    # ``replay_count``, which tracks client/security/fresh-replay attempts.
+    missing_response_created_retry_count: int = 0
     # Counts only the one extra replay permitted after the initial recovery
     # replay when the replacement upstream socket also closes cleanly before
     # producing any response event.

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -2522,8 +2522,10 @@ class _WebSocketMixin:
             task_cleanup_timeout = (
                 _facade()._TASK_CANCEL_TIMEOUT_SECONDS if remaining_drain_timeout is None else cleanup_timeout
             )
+            cleanup_phase = "not_started"
 
             async def finalize_websocket_scope() -> None:
+                nonlocal cleanup_phase
                 nonlocal replay_request_state
                 nonlocal request_state_failure_task
                 nonlocal request_state_to_fail
@@ -2536,6 +2538,7 @@ class _WebSocketMixin:
                     # release that wait.
                     reader_to_await.cancel()
                 if upstream is not None:
+                    cleanup_phase = "upstream_close"
                     await _close_websocket_upstream_for_cleanup(
                         proxy,
                         upstream,
@@ -2543,6 +2546,7 @@ class _WebSocketMixin:
                     )
                 if reader_to_await is not None:
                     try:
+                        cleanup_phase = "upstream_reader"
                         await _facade()._await_cancelled_task(
                             reader_to_await,
                             label="proxy websocket upstream reader",
@@ -2559,6 +2563,7 @@ class _WebSocketMixin:
                     upstream_reader = None
                 if retired_create_lease_release_task is not None:
                     try:
+                        cleanup_phase = "retired_create_lease"
                         await _facade()._await_cancelled_task(
                             retired_create_lease_release_task,
                             timeout_seconds=task_cleanup_timeout,
@@ -2573,6 +2578,7 @@ class _WebSocketMixin:
                     retired_create_lease_release_task = None
                 if request_state_failure_task is not None:
                     try:
+                        cleanup_phase = "unsent_request"
                         await _facade()._await_cancelled_task(
                             request_state_failure_task,
                             timeout_seconds=task_cleanup_timeout,
@@ -2589,6 +2595,7 @@ class _WebSocketMixin:
                     replay_request_state = upstream_control.replay_request_state
                     upstream_control.replay_request_state = None
                 if request_state_to_fail is not None:
+                    cleanup_phase = "unsent_request"
                     await proxy._fail_pending_websocket_requests(
                         account=None,
                         account_id_value=account.id if account is not None else upstream_account_id,
@@ -2607,6 +2614,7 @@ class _WebSocketMixin:
                     )
                     request_state_to_fail = None
                 if replay_request_state is not None:
+                    cleanup_phase = "replay_request"
                     await proxy._fail_pending_websocket_requests(
                         account=None,
                         account_id_value=account.id if account is not None else upstream_account_id,
@@ -2624,6 +2632,7 @@ class _WebSocketMixin:
                         penalize_account=False,
                     )
                 client_disconnected = downstream_activity.disconnected
+                cleanup_phase = "pending_requests"
                 await proxy._fail_pending_websocket_requests(
                     account=None if client_disconnected or scope_cancelled else account,
                     account_id_value=account.id if account is not None else upstream_account_id,
@@ -2646,6 +2655,7 @@ class _WebSocketMixin:
                     penalize_account=not (client_disconnected or scope_cancelled),
                 )
                 try:
+                    cleanup_phase = "connection_lease"
                     await release_current_account_lease()
                 except Exception:
                     # Connection-lease cleanup must never replace cancellation
@@ -2654,6 +2664,7 @@ class _WebSocketMixin:
                         "Failed to release websocket connection lease during scope cleanup",
                         exc_info=True,
                     )
+                cleanup_phase = "complete"
 
             cleanup_task = asyncio.create_task(
                 finalize_websocket_scope(),
@@ -2679,8 +2690,9 @@ class _WebSocketMixin:
             if not done:
                 _facade().logger.warning(
                     "Websocket scope cleanup exceeded its remaining drain budget "
-                    "timeout_seconds=%.3f background_cleanup_tasks=%d",
+                    "timeout_seconds=%.3f cleanup_phase=%s background_cleanup_tasks=%d",
                     max(float(cleanup_timeout), 0.0),
+                    cleanup_phase,
                     sum(1 for task in proxy._background_cleanup_tasks if not task.done()),
                 )
 

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -492,6 +492,9 @@ def _facade() -> Any:
 logger = logging.getLogger(__name__)
 
 _WEBSOCKET_PINNED_REFRESH_UNAVAILABLE_MESSAGE = "Account refresh is temporarily unavailable; retry later."
+# Scope teardown coordinates several request/lease finalizers; keep its normal
+# observation budget separate from the short generic child-task cancel bound.
+_WEBSOCKET_SCOPE_CLEANUP_TIMEOUT_SECONDS = 5.0
 _CAPABILITY_REQUIRED_NO_AUTHORIZED_ACCOUNTS_MESSAGE = (
     "This request requires Trusted Access for Cyber, but no eligible account is marked as "
     "security-work-authorized. codex-lb did not fall back to an ordinary account."
@@ -2510,9 +2513,15 @@ class _WebSocketMixin:
             scope_cancelled = True
             raise
         finally:
-            cleanup_timeout = shutdown_state.remaining_drain_timeout_seconds()
-            if cleanup_timeout is None:
-                cleanup_timeout = _facade()._TASK_CANCEL_TIMEOUT_SECONDS
+            remaining_drain_timeout = shutdown_state.remaining_drain_timeout_seconds()
+            cleanup_timeout = (
+                _WEBSOCKET_SCOPE_CLEANUP_TIMEOUT_SECONDS
+                if remaining_drain_timeout is None
+                else max(float(remaining_drain_timeout), 0.0)
+            )
+            task_cleanup_timeout = (
+                _facade()._TASK_CANCEL_TIMEOUT_SECONDS if remaining_drain_timeout is None else cleanup_timeout
+            )
 
             async def finalize_websocket_scope() -> None:
                 nonlocal replay_request_state
@@ -2552,7 +2561,7 @@ class _WebSocketMixin:
                     try:
                         await _facade()._await_cancelled_task(
                             retired_create_lease_release_task,
-                            timeout_seconds=cleanup_timeout,
+                            timeout_seconds=task_cleanup_timeout,
                             label="proxy websocket retired create lease release",
                             cancel=False,
                         )
@@ -2566,7 +2575,7 @@ class _WebSocketMixin:
                     try:
                         await _facade()._await_cancelled_task(
                             request_state_failure_task,
-                            timeout_seconds=cleanup_timeout,
+                            timeout_seconds=task_cleanup_timeout,
                             label="proxy websocket unsent request finalization",
                             cancel=False,
                         )

--- a/openspec/changes/attribute-websocket-scope-cleanup-phase/proposal.md
+++ b/openspec/changes/attribute-websocket-scope-cleanup-phase/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+When WebSocket scope cleanup exceeds its drain budget, the warning reports the
+timeout and total background cleanup task count but not the operation that is
+still blocked. Operators cannot distinguish an upstream-close stall from
+reader observation, request finalization, or lease release without reproducing
+the incident under instrumentation.
+
+## What Changes
+
+- Track the current WebSocket scope cleanup phase locally while the existing
+  finalization sequence runs.
+- Add that fixed, low-cardinality phase to the existing timeout warning.
+- Keep cleanup ordering, timeout budgets, retries, and ownership unchanged.
+- Do not log request ids, account ids, payloads, credentials, or exception
+  content in the phase field.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `proxy-runtime-observability`: WebSocket scope cleanup timeout warnings MUST
+  identify the blocked cleanup phase with a fixed low-cardinality value.
+
+## Impact
+
+`app/modules/proxy/_service/websocket/mixin.py` and its route-level WebSocket
+cleanup regression coverage. No API, schema, setting, timeout, or dashboard
+change.

--- a/openspec/changes/attribute-websocket-scope-cleanup-phase/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/attribute-websocket-scope-cleanup-phase/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,27 @@
+# proxy-runtime-observability Delta
+
+## ADDED Requirements
+
+### Requirement: WebSocket scope cleanup timeout identifies its blocked phase
+
+When WebSocket scope finalization exceeds its cleanup budget, the proxy MUST
+include the current cleanup phase in the existing warning. The phase MUST be a
+fixed low-cardinality value that identifies the cleanup operation and MUST NOT
+contain request ids, account ids, request payloads, credentials, or exception
+content. This diagnostic MUST NOT change cleanup ordering, timeout budgets,
+retry behavior, or task ownership.
+
+#### Scenario: Pending request finalization exceeds the cleanup budget
+
+- **GIVEN** a cancelled WebSocket scope whose pending request finalization does
+  not finish within the cleanup budget
+- **WHEN** the proxy emits the cleanup-budget warning
+- **THEN** the warning includes `cleanup_phase=pending_requests`
+- **AND** the cleanup remains owned by the existing background drain
+
+#### Scenario: Diagnostic phase remains low-cardinality
+
+- **WHEN** any WebSocket scope cleanup phase exceeds the cleanup budget
+- **THEN** the warning identifies only a fixed cleanup phase
+- **AND** the phase contains no request id, account id, payload, credential, or
+  exception content

--- a/openspec/changes/attribute-websocket-scope-cleanup-phase/tasks.md
+++ b/openspec/changes/attribute-websocket-scope-cleanup-phase/tasks.md
@@ -1,0 +1,12 @@
+## 1. Implementation
+
+- [x] 1.1 Track the current fixed WebSocket scope cleanup phase.
+- [x] 1.2 Include the phase in the existing cleanup-budget warning without
+      changing cleanup control flow or timeout behavior.
+
+## 2. Validation
+
+- [x] 2.1 Add a route-level regression proving a blocked request-finalization
+      cleanup is attributed to `pending_requests`.
+- [x] 2.2 Run focused WebSocket tests, proxy integration tests, lint, type
+      checks, architecture checks, and strict OpenSpec validation.

--- a/openspec/changes/hold-operation-fenced-hard-turn-cooldown/.openspec.yaml
+++ b/openspec/changes/hold-operation-fenced-hard-turn-cooldown/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/hold-operation-fenced-hard-turn-cooldown/design.md
+++ b/openspec/changes/hold-operation-fenced-hard-turn-cooldown/design.md
@@ -1,0 +1,40 @@
+## Context
+
+Hard turn-state requests can omit `previous_response_id` while still carrying a
+real Codex turn-state continuity anchor. Their replay identity is protected by
+the durable operation ledger, but the startup cooldown guard runs before
+operation registration. It therefore classifies the request as continuity-bound
+without safe replay and returns 503 before the ledger can serialize recovery.
+
+The HTTP response already includes `Retry-After`, and an already-started SSE
+failure includes an SSE `retry:` directive. Production telemetry shows Codex
+Desktop retrying in milliseconds anyway, so another client hint does not address
+the observed failure mode.
+
+## Decision
+
+Treat a turn-state-only hard request as eligible to wait through cooldown only
+when all of the following hold:
+
+- recovery mode is `server_anchored_replay_once` or
+  `server_indefinite_recovery`;
+- the request has a real hard continuity anchor;
+- the bridge has both a durable session id and current owner epoch;
+- no response id or upstream response event has been observed; and
+- request budget remains.
+
+The wait is clamped to the smaller of cooldown remaining and request budget.
+It does not reserve a replay, mutate the operation journal, or send upstream.
+When the cooldown expires, normal submission performs the existing operation
+fingerprint lookup and atomic recovery claim. One-shot mode keeps its existing
+maximum of one recovery dispatch; indefinite mode retains its existing explicit
+opt-in semantics.
+
+## Explicit exclusions
+
+- No change to the default `fail_closed` mode.
+- No transparent replay without a durable session and owner fence.
+- No cross-account, file-pinned, image, soft-affinity, or eventful recovery.
+- No weakening of operation fingerprint, ownership, or replay-count checks.
+- No infinite retry added by this change; bounded one-shot mode is the
+  recommended deployment setting for this incident class.

--- a/openspec/changes/hold-operation-fenced-hard-turn-cooldown/proposal.md
+++ b/openspec/changes/hold-operation-fenced-hard-turn-cooldown/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+When two eventless upstream attempts open the HTTP bridge retry circuit, Codex
+Desktop immediately retries the same hard turn-state request. The bridge
+currently returns a startup 503 before consulting the durable operation ledger.
+Codex does not honor the full retry-circuit delay and can exhaust its client
+retry budget during the cooldown, pausing the task even though the bridge and
+VPS remain healthy.
+
+## What Changes
+
+- In an explicitly enabled server recovery mode, hold a turn-state-only hard
+  continuation through the active retry-circuit cooldown before submission.
+- Require a live durable session id and owner epoch, zero response events, and
+  no response id before waiting.
+- Dispatch nothing while waiting. After cooldown, use the existing durable
+  operation ledger and one-shot/indefinite recovery policy to arbitrate whether
+  the request may be created, claimed, replayed, or failed closed.
+- Preserve the current immediate 503 for the default `fail_closed` mode,
+  in-memory fallback sessions, soft affinity, and eventful requests.
+- Emit a low-cardinality bridge event when the operation-fenced wait begins.
+
+## Impact
+
+- HTTP Responses bridge startup behavior during retry-circuit cooldown.
+- No database schema, public API, account routing, or default configuration
+  change.

--- a/openspec/changes/hold-operation-fenced-hard-turn-cooldown/specs/responses-api-compat/spec.md
+++ b/openspec/changes/hold-operation-fenced-hard-turn-cooldown/specs/responses-api-compat/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Operation-fenced hard turns preserve client retry budget during cooldown
+
+When a hard turn-state HTTP bridge request arrives during retry-circuit cooldown,
+the proxy MUST keep the request pending until cooldown expires only if an
+explicit server recovery mode is enabled, the request has not observed a
+response id or response event, and the bridge has a live durable session and
+owner epoch. The proxy MUST NOT dispatch upstream while waiting. After the wait,
+the request MUST pass through the existing durable operation-ledger admission
+before any `response.create` is sent.
+
+#### Scenario: One-shot hard turn waits before durable arbitration
+
+- **GIVEN** `server_anchored_replay_once` is enabled
+- **AND** a turn-state-only hard continuation has a live durable owner
+- **AND** its retry circuit is cooling down before submission
+- **WHEN** the request reaches bridge startup
+- **THEN** the proxy waits for the bounded cooldown instead of returning 503
+- **AND** it sends no upstream request during the wait
+- **AND** normal durable operation admission runs after cooldown
+
+#### Scenario: Missing durable fence remains fail closed
+
+- **GIVEN** a turn-state-only hard continuation has no durable session or owner
+  epoch
+- **WHEN** its retry circuit is cooling down
+- **THEN** the proxy does not wait or dispatch upstream
+- **AND** it returns the existing cooldown failure with a retry hint
+
+#### Scenario: Default mode remains fail closed
+
+- **GIVEN** ambiguous continuation recovery mode is `fail_closed`
+- **WHEN** any continuity-bound hard request arrives during cooldown
+- **THEN** the proxy preserves the existing immediate cooldown failure
+- **AND** it does not create or claim a durable recovery operation
+
+#### Scenario: Request budget expires while waiting
+
+- **GIVEN** an operation-fenced hard turn is allowed to wait through cooldown
+- **AND** its request budget expires before the cooldown does
+- **WHEN** the bounded wait reaches the request deadline
+- **THEN** the proxy releases the request reservation and returns a terminal
+  timeout
+- **AND** it does not submit `response.create` after the deadline

--- a/openspec/changes/hold-operation-fenced-hard-turn-cooldown/tasks.md
+++ b/openspec/changes/hold-operation-fenced-hard-turn-cooldown/tasks.md
@@ -1,0 +1,8 @@
+- [x] 1. Reproduce the production turn-state-only startup cooldown as a unit
+      regression that currently returns 503 before submission.
+- [x] 2. Hold only explicitly enabled, zero-event, durable operation-fenced hard
+      turns through the bounded cooldown.
+- [x] 3. Preserve fail-closed behavior when the durable session/owner proof is
+      absent and keep one-shot recovery bounded by the existing atomic claim.
+- [x] 4. Run focused tests, relevant bridge suites, Ruff, type/architecture
+      checks, whitespace checks, and strict OpenSpec validation.

--- a/openspec/changes/recover-precreated-anchored-bridge/.openspec.yaml
+++ b/openspec/changes/recover-precreated-anchored-bridge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/recover-precreated-anchored-bridge/design.md
+++ b/openspec/changes/recover-precreated-anchored-bridge/design.md
@@ -1,0 +1,32 @@
+## Context
+
+The eventless watchdog already owns the pending request under the session
+lifecycle lock, cancels the old receive task, and invokes
+`_retry_http_bridge_precreated_request` before terminal retirement. The generic
+replay predicate intentionally rejects an anchored continuation because a
+second ambiguous submission can duplicate a turn. That predicate is too broad
+for the narrower watchdog state: a hard owner has not observed any upstream
+response event, and the request has no downstream-visible output.
+
+## Decision
+
+Add a call-site-only opt-in to the existing pre-created retry path. The opt-in
+is accepted only when the session key is hard and the request satisfies a new
+pure predicate for the zero-event, pre-`response.created` same-anchor case. The
+retry remains on the established account and carries the existing anchor; it
+does not clear continuity, select another account, or use a fresh unanchored
+replay body.
+
+The recovery budget is one additional dispatch for this watchdog event. The
+existing `replay_count` and clean-close controls remain authoritative, and the
+predicate refuses a second attempt. If reconnect or resend fails, the current
+fail-closed retirement path settles the request and releases its gate and
+reservation exactly as before.
+
+## Explicit exclusions
+
+- No default-on indefinite recovery or multi-account replay.
+- No retry after `response.created`, any response event, model output, or
+  downstream sequence/output.
+- No changes to durable recovery journal semantics or operation settlement.
+- No changes to direct WebSocket behavior.

--- a/openspec/changes/recover-precreated-anchored-bridge/proposal.md
+++ b/openspec/changes/recover-precreated-anchored-bridge/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+An HTTP Responses bridge can send a hard-continuity `response.create` and
+remain completely silent before upstream emits `response.created`. The current
+eventless watchdog retires the bridge because the generic pre-created replay
+guard treats an anchored continuation as unsafe, even when no response event,
+model output, or downstream output exists. Codex then exhausts its own retry
+budget and pauses the task instead of receiving a bounded server-side recovery.
+
+## What Changes
+
+- Permit one same-account, same-anchor pre-created recovery after the
+  eventless response-created watchdog fires.
+- Keep the recovery proof narrow: hard bridge ownership, an existing
+  `previous_response_id`, no response id, zero response events, no downstream
+  sequence/output, and no model output.
+- Keep durable operation fencing, account ownership, admission, reservation
+  settlement, and the existing terminal retirement path unchanged.
+- Preserve fail-closed behavior for file-pinned requests, requests with any
+  response/model/downstream output, soft affinity, and subsequent retries.
+- Add route-level regression coverage for a silent upstream followed by a
+  successful replacement socket, plus negative coverage for unsafe continuations.
+
+## Impact
+
+- HTTP Responses bridge pre-created timeout/reconnect behavior.
+- No public API, database schema, environment variable, or WebSocket policy
+  change.

--- a/openspec/changes/recover-precreated-anchored-bridge/specs/responses-api-compat/spec.md
+++ b/openspec/changes/recover-precreated-anchored-bridge/specs/responses-api-compat/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Eventless hard continuations receive one bounded recovery
+
+When an HTTP Responses bridge request has a hard continuity owner and its
+upstream socket reaches the missing-`response.created` watchdog before any
+upstream response event, the service MUST allow at most one same-account,
+same-`previous_response_id` reconnect and resend if all of the following hold:
+the request has no assigned response id, no downstream sequence or visible
+output, no upstream model output, and remains pending under the current bridge
+session. The retry MUST preserve the existing durable operation fence,
+admission leases, API-key reservation lifecycle, and account ownership. If the
+bounded recovery does not succeed, the service MUST use the existing terminal
+retirement path.
+
+#### Scenario: Silent hard continuation reconnects once
+
+- **GIVEN** a hard HTTP bridge request carries `previous_response_id`
+- **AND** the first upstream socket receives `response.create` but emits no
+  response event before the client-safe watchdog deadline
+- **WHEN** the watchdog handles the timeout
+- **THEN** the bridge reconnects on the same account and resends the unchanged
+  anchored request at most once
+- **AND** a replacement socket that emits a normal response completes the
+  original HTTP request without requiring a client retry
+
+#### Scenario: Eventless recovery remains fail-closed after one attempt
+
+- **GIVEN** the first replacement socket also fails before any response event
+- **WHEN** the bounded recovery is exhausted
+- **THEN** the request is settled through the existing terminal failure path
+- **AND** the bridge session is retired rather than retried indefinitely
+
+#### Scenario: Unsafe continuation is not replayed
+
+- **GIVEN** an anchored request has a response id, any response event, model
+  output, downstream-visible output, downstream sequence, soft affinity, or a
+  file-pinned account requirement
+- **WHEN** the upstream socket becomes eventless before completion
+- **THEN** the bridge MUST NOT use the same-anchor eventless recovery
+- **AND** it MUST preserve the existing fail-closed behavior

--- a/openspec/changes/recover-precreated-anchored-bridge/tasks.md
+++ b/openspec/changes/recover-precreated-anchored-bridge/tasks.md
@@ -1,0 +1,9 @@
+- [x] 1. Add the narrow same-anchor pre-created recovery predicate and pass its
+      opt-in only from the missing-`response.created` watchdog.
+- [x] 2. Keep account, durable-operation, admission, and reservation ownership
+      unchanged across the recovery; retire and settle on failure.
+- [x] 3. Add route-level regression coverage for silent upstream recovery and
+      exhaustion, plus negative unsafe-continuation coverage.
+- [x] 4. Run targeted pytest, Ruff, type/architecture checks, whitespace checks,
+      and strict OpenSpec validation via
+      `npx --yes @fission-ai/openspec@1.9.0`.

--- a/openspec/changes/websocket-scope-cleanup-budget/.openspec.yaml
+++ b/openspec/changes/websocket-scope-cleanup-budget/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/websocket-scope-cleanup-budget/design.md
+++ b/openspec/changes/websocket-scope-cleanup-budget/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The WebSocket handler publishes one tracked `finalize_websocket_scope()` task
+from its `finally` block. The task must preserve cancellation while completing
+the terminal request cleanup sequence. During process drain,
+`shutdown_state.remaining_drain_timeout_seconds()` provides the shared absolute
+deadline. Outside drain it returns `None`, so the current code falls back to
+the generic one-second `_TASK_CANCEL_TIMEOUT_SECONDS` value.
+
+The generic timeout is used across HTTP bridge and proxy child-task cancellation
+paths. Increasing it globally would slow unrelated cancellation and would
+change the semantics of a helper that is intentionally a short cancellation
+observation bound. The scope finalizer needs a different bounded allowance
+because its work is a sequence of request-state and lease finalization steps.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give normal direct WebSocket scope cleanup enough bounded time for the
+  existing request finalization and lease-release sequence.
+- Preserve the existing tracked-task ownership and cancellation behavior when
+  the bound is reached.
+- Keep shutdown cleanup governed by the one shared remaining drain deadline.
+- Prove the behavior through the real WebSocket route finalizer.
+
+**Non-Goals:**
+
+- Changing the `response.created` watchdog or any upstream request budget.
+- Retrying, replaying, or moving an interrupted request to another account.
+- Increasing the generic `_TASK_CANCEL_TIMEOUT_SECONDS` value.
+- Adding an operator setting, environment variable, database state, or a new
+  background cleanup registry.
+
+## Decisions
+
+1. **Use one internal five-second scope budget.** The value is deliberately
+   fixed and bounded because this is a lifecycle safety allowance, not an
+   operator tuning surface. Five seconds is long enough to absorb ordinary
+   persistence/lease scheduling variance while still returning promptly when
+   teardown is stuck.
+
+2. **Prefer the active drain deadline.** When shutdown drain is active, the
+   finalizer continues to use the remaining shared deadline exactly as today.
+   The normal-operation budget is only the fallback for the no-drain case and
+   cannot extend process shutdown.
+
+3. **Keep child cancellation semantics separate.** Individual task waits keep
+   the one-second generic cancellation bound during normal operation. During
+   drain they remain capped by the shared remaining deadline. Only the outer
+   scope-finalization wait receives the five-second normal-operation allowance.
+
+4. **Retain tracked cleanup after the bound.** `asyncio.wait()` continues to
+   observe the finalizer without cancelling it at the scope budget. The
+   existing `_background_cleanup_tasks` registry and persistence drain remain
+   the owner of unfinished cleanup, so a timeout is honest and does not cause
+   lease or request finalization to be abandoned.
+
+## Verification Strategy
+
+- Run the focused WebSocket terminal-cancellation tests, including a regression
+  that lowers the generic task timeout and delays finalization beyond it while
+  allowing completion within the separate scope budget.
+- Run Ruff check/format on changed Python files, the proxy architecture check,
+  and the applicable type/test targets.
+- Validate the OpenSpec delta if the CLI is available; otherwise record the
+  unavailable local CLI as a handoff limitation and keep the artifacts in the
+  repository for CI validation.

--- a/openspec/changes/websocket-scope-cleanup-budget/proposal.md
+++ b/openspec/changes/websocket-scope-cleanup-budget/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Direct Responses WebSocket scope teardown currently reuses the generic
+`_TASK_CANCEL_TIMEOUT_SECONDS` value as its entire normal-operation cleanup
+budget. That value is intentionally one second for individual task
+cancellation, but scope teardown can also have to finalize request logs,
+release response-create ownership, and release the account connection lease.
+Under ordinary load those operations can exceed one second, producing
+`Websocket scope cleanup exceeded its remaining drain budget` even when the
+server is not draining. The cleanup task remains tracked, but the warning and
+unfinished teardown increase the chance of follow-up reconnect churn.
+
+## What Changes
+
+- Give normal-operation WebSocket scope teardown its own fixed five-second
+  bounded budget.
+- Keep the existing one-second generic task-cancellation timeout for ordinary
+  child-task waits.
+- Continue using the remaining shared shutdown deadline whenever process drain
+  is active; the new budget must not extend shutdown.
+- Add a route-level cancellation regression proving that cleanup which takes
+  longer than the generic task timeout can still finish within the scope budget
+  and does not leave an orphaned cleanup task.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `responses-api-compat`: Direct Responses WebSocket scope cleanup has a
+  separate bounded normal-operation budget while preserving the shared
+  shutdown deadline and task ownership guarantees.
+
+## Impact
+
+The change is limited to the direct Responses WebSocket finalizer, its focused
+unit coverage, and the OpenSpec contract. It adds no setting, dependency,
+database migration, API shape, upstream watchdog change, or retry policy.

--- a/openspec/changes/websocket-scope-cleanup-budget/specs/responses-api-compat/spec.md
+++ b/openspec/changes/websocket-scope-cleanup-budget/specs/responses-api-compat/spec.md
@@ -1,0 +1,39 @@
+# responses-api-compat Delta
+
+## ADDED Requirements
+
+### Requirement: Direct WebSocket scope cleanup has a bounded normal-operation budget
+
+When a direct Responses WebSocket scope exits while the process is not using an
+active shutdown drain deadline, the proxy MUST allow its existing scope
+finalization task a fixed five-second bounded observation budget, separate from
+the one-second generic child-task cancellation timeout. The finalizer MUST
+continue to own request finalization and lease cleanup through that budget. If
+the budget expires, the proxy MUST preserve the existing cancellation result,
+leave unfinished cleanup tracked by the existing cleanup-task registry, and
+MUST NOT cancel or silently abandon that cleanup solely because the observation
+budget expired.
+
+When an active shutdown drain deadline exists, the proxy MUST use the remaining
+shared drain deadline instead of the normal-operation budget, so normal cleanup
+allowance MUST NOT extend process shutdown.
+
+#### Scenario: normal scope cleanup outlives generic child cancellation
+
+- **GIVEN** a direct Responses WebSocket scope is cancelled while its existing
+  request finalization takes longer than the generic one-second child-task
+  cancellation timeout
+- **AND** the finalization completes within the five-second normal-operation
+  scope budget
+- **WHEN** scope cleanup runs
+- **THEN** the finalizer completes and request/lease ownership is released
+- **AND** the scope preserves its cancellation result
+- **AND** no cleanup task remains orphaned after the finalizer completes
+
+#### Scenario: shutdown drain remains the upper bound
+
+- **GIVEN** a direct Responses WebSocket scope is cancelled while an active
+  shutdown drain deadline has less than five seconds remaining
+- **WHEN** scope cleanup runs
+- **THEN** the remaining shared drain deadline remains the upper bound
+- **AND** the normal-operation five-second budget does not extend shutdown

--- a/openspec/changes/websocket-scope-cleanup-budget/tasks.md
+++ b/openspec/changes/websocket-scope-cleanup-budget/tasks.md
@@ -1,0 +1,23 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add a real direct Responses WebSocket cancellation regression that
+  distinguishes the generic task timeout from the scope cleanup budget.
+- [x] 1.2 Confirm the regression fails against the baseline implementation and
+  passes with the scoped budget.
+
+## 2. Scope Cleanup Budget
+
+- [x] 2.1 Add the fixed normal-operation WebSocket scope cleanup budget.
+- [x] 2.2 Preserve the active shared shutdown deadline and one-second generic
+  child-task cancellation behavior.
+- [x] 2.3 Keep unfinished cleanup tracked and prevent cancellation/lease
+  ownership regressions when the bound expires.
+
+## 3. Verification
+
+- [x] 3.1 Run focused WebSocket terminal-cancellation tests.
+- [x] 3.2 Run changed-file Ruff check/format, proxy architecture checks, and
+  applicable type checks.
+- [x] 3.3 Validate the OpenSpec delta and inspect the final diff/status.
+- [ ] 3.4 Open a Draft PR targeting upstream `main` and add the live 1.23.0
+  evidence to issue #1711.

--- a/tests/integration/test_http_responses_bridge.py
+++ b/tests/integration/test_http_responses_bridge.py
@@ -8915,6 +8915,247 @@ async def test_v1_responses_http_bridge_retries_once_when_upstream_closes_before
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_http_bridge_retries_when_upstream_never_acknowledges_response_create(
+    async_client,
+    monkeypatch,
+):
+    _install_bridge_settings_with_limits(
+        monkeypatch,
+        enabled=True,
+    )
+    proxy_module.get_settings().http_responses_session_bridge_stuck_gate_retire_after_seconds = 0.01
+    account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_missing_created_retry",
+        "http-bridge-missing-created-retry@example.com",
+    )
+    account = await _get_account(account_id)
+    silent_upstream = _SilentUpstreamWebSocket()
+    recovered_upstream = _FakeBridgeUpstreamWebSocket()
+    upstreams = [silent_upstream, recovered_upstream]
+    connect_count = 0
+
+    async def fake_select_account_with_budget(
+        self,
+        deadline,
+        *,
+        request_id,
+        kind,
+        request_stage="first_turn",
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset_accounts,
+        routing_strategy,
+        model,
+        exclude_account_ids=None,
+        additional_limit_name=None,
+        api_key=None,
+        preferred_account_id=None,
+    ):
+        del preferred_account_id
+        del (
+            self,
+            deadline,
+            request_id,
+            kind,
+            request_stage,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset_accounts,
+            routing_strategy,
+            model,
+            exclude_account_ids,
+            additional_limit_name,
+            api_key,
+        )
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        nonlocal connect_count
+        upstream = upstreams[connect_count]
+        connect_count += 1
+        return upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    response = await asyncio.wait_for(
+        async_client.post(
+            "/v1/responses",
+            json={
+                "model": "gpt-5.1",
+                "instructions": "Return exactly OK.",
+                "input": "retry missing response.created",
+                "prompt_cache_key": "missing-created-retry-key",
+            },
+        ),
+        timeout=_TEST_SYNC_TIMEOUT_SECONDS,
+    )
+
+    assert response.status_code == 200
+    assert connect_count == 2
+    assert silent_upstream.closed is True
+    assert len(silent_upstream.sent_text) == 1
+    assert len(recovered_upstream.sent_text) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "replacement_recovers",
+    [
+        pytest.param(True, id="replacement-completes"),
+        pytest.param(False, id="replacement-is-also-silent"),
+    ],
+)
+async def test_v1_responses_http_bridge_recovers_eventless_anchored_continuation(
+    async_client,
+    monkeypatch,
+    replacement_recovers,
+):
+    """A silent hard continuation gets one bounded same-anchor recovery."""
+
+    class _FirstThenSilentUpstream(_FakeBridgeUpstreamWebSocket):
+        async def send_text(self, text: str) -> None:
+            if self.sent_text:
+                self.sent_text.append(text)
+                return
+            await super().send_text(text)
+
+    _install_bridge_settings_with_limits(
+        monkeypatch,
+        enabled=True,
+    )
+    proxy_module.get_settings().http_responses_session_bridge_stuck_gate_retire_after_seconds = 0.01
+    account_id = await _import_account(
+        async_client,
+        "acc_http_bridge_anchored_missing_created_retry",
+        "http-bridge-anchored-missing-created-retry@example.com",
+    )
+    account = await _get_account(account_id)
+    first_then_silent_upstream = _FirstThenSilentUpstream("resp_anchored_first")
+    recovered_upstream = (
+        _FakeBridgeUpstreamWebSocket("resp_anchored_recovered") if replacement_recovers else _SilentUpstreamWebSocket()
+    )
+    upstreams = [first_then_silent_upstream, recovered_upstream]
+    connect_count = 0
+
+    async def fake_select_account_with_budget(
+        self,
+        deadline,
+        *,
+        request_id,
+        kind,
+        request_stage="first_turn",
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset_accounts,
+        routing_strategy,
+        model,
+        exclude_account_ids=None,
+        additional_limit_name=None,
+        api_key=None,
+        preferred_account_id=None,
+    ):
+        del preferred_account_id
+        del (
+            self,
+            deadline,
+            request_id,
+            kind,
+            request_stage,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset_accounts,
+            routing_strategy,
+            model,
+            exclude_account_ids,
+            additional_limit_name,
+            api_key,
+        )
+        return AccountSelection(account=account, error_message=None, error_code=None)
+
+    async def fake_ensure_fresh_with_budget(self, target, *, force=False, timeout_seconds):
+        del self, force, timeout_seconds
+        return target
+
+    async def fake_connect_responses_websocket(
+        headers,
+        access_token,
+        account_id_header,
+        *,
+        base_url=None,
+        session=None,
+    ):
+        del headers, access_token, account_id_header, base_url, session
+        nonlocal connect_count
+        upstream = upstreams[connect_count]
+        connect_count += 1
+        return upstream
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_select_account_with_budget", fake_select_account_with_budget)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh_with_budget)
+    monkeypatch.setattr(proxy_module, "connect_responses_websocket", fake_connect_responses_websocket)
+
+    session_headers = {"session_id": "hard-eventless-anchored-continuation"}
+    first_response = await async_client.post(
+        "/v1/responses",
+        headers=session_headers,
+        json={
+            "model": "gpt-5.1",
+            "instructions": "Return exactly OK.",
+            "input": "first turn",
+            "prompt_cache_key": "anchored-missing-created-key",
+        },
+    )
+    assert first_response.status_code == 200, first_response.text
+    previous_response_id = first_response.json()["id"]
+
+    second_response = await asyncio.wait_for(
+        async_client.post(
+            "/v1/responses",
+            headers=session_headers,
+            json={
+                "model": "gpt-5.1",
+                "instructions": "Return exactly OK.",
+                "input": "anchored continuation",
+                "previous_response_id": previous_response_id,
+                "prompt_cache_key": "anchored-missing-created-key",
+            },
+        ),
+        timeout=_TEST_SYNC_TIMEOUT_SECONDS,
+    )
+
+    assert second_response.status_code == (200 if replacement_recovers else 502), second_response.text
+    assert connect_count == 2
+    assert first_then_silent_upstream.closed is True
+    assert len(first_then_silent_upstream.sent_text) == 2
+    assert len(recovered_upstream.sent_text) == 1
+    assert json.loads(first_then_silent_upstream.sent_text[1])["previous_response_id"] == previous_response_id
+    assert json.loads(recovered_upstream.sent_text[0])["previous_response_id"] == previous_response_id
+
+
+@pytest.mark.asyncio
 async def test_backend_responses_http_bridge_retries_precreated_server_overload(async_client, monkeypatch):
     _install_bridge_settings(monkeypatch, enabled=True)
     account_id = await _import_account(

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -5485,6 +5485,168 @@ async def test_http_bridge_startup_cooldown_releases_api_key_reservation(
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_one_shot_hard_turn_waits_through_startup_cooldown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="sid-hard-turn-cooldown-wait")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-hard-turn-cooldown-wait",
+        model="gpt-5.6",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        event_queue=asyncio.Queue(),
+        transport="http",
+        session_id="turn-state-hard-anchor",
+        hard_continuity_anchor=True,
+    )
+    session.durable_session_id = "durable-hard-turn-cooldown-wait"
+    session.durable_owner_epoch = 7
+    cooldown = AsyncMock(side_effect=[0.01, 0.0])
+    submit = AsyncMock(side_effect=RuntimeError("submitted after cooldown"))
+    sleeps: list[float] = []
+
+    async def sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(
+            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_anchored_replay_once",
+        ),
+    )
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_cooldown_seconds", cooldown)
+    monkeypatch.setattr(service, "_submit_http_bridge_request", submit)
+    monkeypatch.setattr(http_bridge_streaming_module.asyncio, "sleep", sleep)
+
+    with pytest.raises(RuntimeError, match="submitted after cooldown"):
+        async for _ in service._stream_http_bridge_session_events(
+            session,
+            request_state=request_state,
+            text_data='{"type":"response.create"}',
+            queue_limit=8,
+            propagate_http_errors=True,
+            downstream_turn_state="turn-state-hard-anchor",
+        ):
+            pass
+
+    assert sleeps == [pytest.approx(0.01)]
+    assert cooldown.await_count == 2
+    submit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_one_shot_hard_turn_without_durable_fence_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="sid-hard-turn-no-durable-fence")
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-hard-turn-no-durable-fence",
+        model="gpt-5.6",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=time.monotonic(),
+        event_queue=asyncio.Queue(),
+        transport="http",
+        session_id="turn-state-without-durable-fence",
+        hard_continuity_anchor=True,
+    )
+    submit = AsyncMock()
+    sleep = AsyncMock()
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(
+            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_anchored_replay_once",
+        ),
+    )
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_cooldown_seconds", AsyncMock(return_value=30.0))
+    monkeypatch.setattr(service, "_submit_http_bridge_request", submit)
+    monkeypatch.setattr(http_bridge_streaming_module.asyncio, "sleep", sleep)
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        async for _ in service._stream_http_bridge_session_events(
+            session,
+            request_state=request_state,
+            text_data='{"type":"response.create"}',
+            queue_limit=8,
+            propagate_http_errors=True,
+            downstream_turn_state="turn-state-without-durable-fence",
+        ):
+            pass
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.payload["error"]["code"] == "upstream_request_timeout"
+    submit.assert_not_awaited()
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_one_shot_hard_turn_does_not_submit_after_wait_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="sid-hard-turn-wait-budget")
+    session.durable_session_id = "durable-hard-turn-wait-budget"
+    session.durable_owner_epoch = 9
+    reservation = cast(Any, object())
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="req-hard-turn-wait-budget",
+        model="gpt-5.6",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=reservation,
+        started_at=time.monotonic(),
+        event_queue=asyncio.Queue(),
+        transport="http",
+        session_id="turn-state-wait-budget",
+        hard_continuity_anchor=True,
+    )
+    clock = SimpleNamespace(now=100.0)
+    submit = AsyncMock()
+    release = AsyncMock()
+
+    async def sleep(delay: float) -> None:
+        clock.now += delay
+
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: _make_app_settings(
+            http_responses_session_bridge_ambiguous_continuation_recovery_mode="server_anchored_replay_once",
+        ),
+    )
+    monkeypatch.setattr(http_bridge_streaming_module._service_time(), "monotonic", lambda: clock.now)
+    monkeypatch.setattr(service, "_http_bridge_precreated_retry_cooldown_seconds", AsyncMock(return_value=30.0))
+    monkeypatch.setattr(service, "_submit_http_bridge_request", submit)
+    monkeypatch.setattr(service, "_release_websocket_request_state_reservation", release)
+    monkeypatch.setattr(http_bridge_streaming_module.asyncio, "sleep", sleep)
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        async for _ in service._stream_http_bridge_session_events(
+            session,
+            request_state=request_state,
+            text_data='{"type":"response.create"}',
+            queue_limit=8,
+            propagate_http_errors=True,
+            downstream_turn_state="turn-state-wait-budget",
+            request_deadline=105.0,
+        ):
+            pass
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.payload["error"]["code"] == "upstream_request_timeout"
+    submit.assert_not_awaited()
+    release.assert_awaited_once_with(request_state)
+    assert request_state.api_key_reservation is None
+
+
+@pytest.mark.asyncio
 async def test_http_bridge_replay_detach_releases_reservation_without_pending_ownership(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -828,6 +828,62 @@ def _make_eventless_http_bridge_owner(
     )
 
 
+@pytest.mark.parametrize(
+    ("field_name", "field_value"),
+    [
+        ("previous_response_id", None),
+        ("response_id", "resp-created"),
+        ("response_event_count", 1),
+        ("downstream_visible", True),
+        ("last_downstream_sequence_number", 0),
+        ("upstream_model_output_seen", True),
+        ("awaiting_response_created", False),
+        ("file_required_preferred_account", True),
+        ("missing_response_created_retry_count", 1),
+    ],
+)
+def test_http_bridge_same_anchor_eventless_recovery_requires_unambiguous_owner_state(
+    field_name: str,
+    field_value: object,
+) -> None:
+    request_state = _make_eventless_http_bridge_owner()
+    request_state.request_text = '{"type":"response.create","input":"continue"}'
+    request_state.previous_response_id = "resp-parent"
+    setattr(request_state, field_name, field_value)
+
+    assert http_bridge_request_submit_module._http_bridge_can_replay_same_anchor_before_created(request_state) is False
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_same_anchor_eventless_recovery_requires_hard_session_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = _make_eventless_http_bridge_owner()
+    request_state.request_text = '{"type":"response.create","input":"continue"}'
+    request_state.previous_response_id = "resp-parent"
+    session = _make_bridge_session(
+        key=proxy_service._HTTPBridgeSessionKey("prompt_cache", "soft-anchor", None),
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+    session.last_upstream_close_code = 1011
+    session.upstream = cast(UpstreamWebSocket, SimpleNamespace(send_text=AsyncMock(), close=AsyncMock()))
+    reconnect = AsyncMock()
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(service, "_reconnect_http_bridge_session", reconnect)
+
+    assert (
+        await service._retry_http_bridge_precreated_request(
+            session,
+            allow_same_anchor_before_created=True,
+        )
+        is False
+    )
+    reconnect.assert_not_awaited()
+    assert request_state.missing_response_created_retry_count == 0
+
+
 class _SilentEventlessUpstream:
     """Upstream double that never produces a response event, for eventless-timeout tests."""
 
@@ -22466,7 +22522,7 @@ async def test_http_bridge_reader_wakes_and_retires_lone_eventless_owner_without
     assert owner.response_event_count == (1 if leading_telemetry else 0)
     if leading_telemetry:
         assert owner.latency_first_upstream_event_ms is not None
-    retry_precreated.assert_awaited_once_with(session)
+    retry_precreated.assert_awaited_once_with(session, allow_same_anchor_before_created=True)
     assert write_request_log.await_count == 2
     assert {call.kwargs["error_code"] for call in write_request_log.await_args_list} == {"upstream_request_timeout"}
     fail_reader.assert_awaited_once()

--- a/tests/unit/test_websocket_terminal_cancellation.py
+++ b/tests/unit/test_websocket_terminal_cancellation.py
@@ -152,6 +152,7 @@ async def test_transport_end_replay_requires_send_boundary_only_for_direct_webso
 @pytest.mark.asyncio
 async def test_cancelled_websocket_scope_cleanup_is_deadline_bounded_and_remains_drain_owned(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     @asynccontextmanager
     async def repo_factory() -> AsyncIterator[SimpleNamespace]:
@@ -213,6 +214,7 @@ async def test_cancelled_websocket_scope_cleanup_is_deadline_bounded_and_remains
     )
     await asyncio.wait_for(receive_started.wait(), timeout=1)
 
+    caplog.set_level(logging.WARNING)
     shutdown_state.commit_shutdown(timeout_seconds=0.1)
     started_at = asyncio.get_running_loop().time()
     scope_task.cancel()
@@ -230,6 +232,11 @@ async def test_cancelled_websocket_scope_cleanup_is_deadline_bounded_and_remains
         task.get_name() == "proxy-websocket-finalization-scope-cleanup"
         for task in service._background_cleanup_tasks
         if not task.done()
+    )
+    assert any(
+        "Websocket scope cleanup exceeded its remaining drain budget" in message
+        and "cleanup_phase=pending_requests" in message
+        for message in caplog.messages
     )
 
     persistence_drain = asyncio.create_task(service.drain_persistence_tasks(timeout_seconds=1))

--- a/tests/unit/test_websocket_terminal_cancellation.py
+++ b/tests/unit/test_websocket_terminal_cancellation.py
@@ -241,6 +241,89 @@ async def test_cancelled_websocket_scope_cleanup_is_deadline_bounded_and_remains
 
 
 @pytest.mark.asyncio
+async def test_normal_websocket_scope_cleanup_uses_separate_scope_budget(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    @asynccontextmanager
+    async def repo_factory() -> AsyncIterator[SimpleNamespace]:
+        yield SimpleNamespace(request_logs=_RequestLogsRecorder(), api_keys=object())
+
+    service = proxy_service.ProxyService(cast(proxy_service.ProxyRepoFactory, repo_factory))
+    settings = SimpleNamespace(
+        prefer_earlier_reset_accounts=False,
+        sticky_threads_enabled=False,
+        openai_cache_affinity_max_age_seconds=0,
+        prohibit_fast_mode=False,
+    )
+
+    class _SettingsCache:
+        async def get(self) -> SimpleNamespace:
+            return settings
+
+    receive_started = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    class _BlockingDownstreamWebSocket:
+        async def receive(self) -> dict[str, object]:
+            receive_started.set()
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+        async def close(self, code: int = 1000, reason: str | None = None) -> None:
+            del code, reason
+
+    async def block_cleanup(*_args: object, **_kwargs: object) -> None:
+        cleanup_started.set()
+        await release_cleanup.wait()
+
+    async def release_cleanup_after_scope_budget_margin() -> None:
+        await asyncio.sleep(0.03)
+        release_cleanup.set()
+
+    monkeypatch.setattr(proxy_service, "_TASK_CANCEL_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(websocket_mixin, "_WEBSOCKET_SCOPE_CLEANUP_TIMEOUT_SECONDS", 0.08)
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache())
+    monkeypatch.setattr(
+        proxy_service,
+        "get_settings",
+        lambda: SimpleNamespace(proxy_downstream_websocket_idle_timeout_seconds=30.0),
+    )
+    monkeypatch.setattr(proxy_service, "_routing_strategy", lambda _settings: "usage_weighted")
+    monkeypatch.setattr(service, "_websocket_continuity_state_for_request", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(service, "_fail_pending_websocket_requests", block_cleanup)
+    monkeypatch.setattr(service._load_balancer, "release_account_lease", AsyncMock())
+    caplog.set_level(logging.WARNING)
+
+    scope_task = asyncio.create_task(
+        service.proxy_responses_websocket(
+            cast(WebSocket, _BlockingDownstreamWebSocket()),
+            {},
+            codex_session_affinity=False,
+            openai_cache_affinity=False,
+            api_key=None,
+        )
+    )
+    await asyncio.wait_for(receive_started.wait(), timeout=1)
+
+    started_at = asyncio.get_running_loop().time()
+    scope_task.cancel()
+    await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+    release_task = asyncio.create_task(release_cleanup_after_scope_budget_margin())
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(scope_task, timeout=0.5)
+    elapsed = asyncio.get_running_loop().time() - started_at
+    await release_task
+    await asyncio.sleep(0)
+
+    assert elapsed >= 0.02
+    assert "Websocket scope cleanup exceeded its remaining drain budget" not in caplog.messages
+    assert service._background_cleanup_tasks == set()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "failing_child",
     ["retired_create_lease_release", "unsent_request_finalization"],

--- a/tests/unit/test_websocket_terminal_cancellation.py
+++ b/tests/unit/test_websocket_terminal_cancellation.py
@@ -278,10 +278,6 @@ async def test_normal_websocket_scope_cleanup_uses_separate_scope_budget(
         cleanup_started.set()
         await release_cleanup.wait()
 
-    async def release_cleanup_after_scope_budget_margin() -> None:
-        await asyncio.sleep(0.03)
-        release_cleanup.set()
-
     monkeypatch.setattr(proxy_service, "_TASK_CANCEL_TIMEOUT_SECONDS", 0.01)
     monkeypatch.setattr(websocket_mixin, "_WEBSOCKET_SCOPE_CLEANUP_TIMEOUT_SECONDS", 0.08)
     monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache())
@@ -307,18 +303,16 @@ async def test_normal_websocket_scope_cleanup_uses_separate_scope_budget(
     )
     await asyncio.wait_for(receive_started.wait(), timeout=1)
 
-    started_at = asyncio.get_running_loop().time()
     scope_task.cancel()
     await asyncio.wait_for(cleanup_started.wait(), timeout=1)
-    release_task = asyncio.create_task(release_cleanup_after_scope_budget_margin())
+    await asyncio.sleep(0.03)
+    assert scope_task.done() is False
+    release_cleanup.set()
 
     with pytest.raises(asyncio.CancelledError):
         await asyncio.wait_for(scope_task, timeout=0.5)
-    elapsed = asyncio.get_running_loop().time() - started_at
-    await release_task
     await asyncio.sleep(0)
 
-    assert elapsed >= 0.02
     assert "Websocket scope cleanup exceeded its remaining drain budget" not in caplog.messages
     assert service._background_cleanup_tasks == set()
 


### PR DESCRIPTION
Closes #1737.

## Summary

- keep an explicitly enabled hard turn-state request pending through an active HTTP bridge retry-circuit cooldown
- require a live durable session and owner epoch, zero response events, and no response id before waiting
- send nothing upstream during the wait; after cooldown, preserve the existing durable operation-ledger arbitration and one-shot recovery cap
- fail closed when durable proof is unavailable or the request budget expires
- preserve the default `fail_closed` behavior
- add low-cardinality wait telemetry and strict OpenSpec coverage

## Why

Production telemetry showed two eventless upstream failures opening a 60-second retry circuit. Codex Desktop retried in milliseconds despite the HTTP/SSE retry hints, exhausting its retry budget against startup 503 responses. Turn-state-only hard continuity was rejected before the durable operation ledger could arbitrate bounded recovery.

The recommended deployment mode for this incident class is `server_anchored_replay_once`; this PR does not make recovery default-on or add unbounded retries.

## Validation

- `5871 passed, 70 skipped` — complete unit suite
- `553 passed` — HTTP bridge unit file
- `129 passed` — HTTP bridge integration suite
- focused production-shape, no-durable-fence, and expired-budget regressions pass
- Ruff check and format pass
- `ty check` passes
- proxy architecture check passes
- strict OpenSpec validation passes for this change
- `git diff --check` passes

The full repository OpenSpec sweep contains unrelated pre-existing incomplete changes; this change validates independently under `--strict`.