### PR TITLE
fix(http-bridge): dedupe retry circuit failures per send

### DIFF
--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -771,7 +771,6 @@ def _http_bridge_retry_circuit_attempt_for_pending_requests(
         if (
             request_state.transport != _REQUEST_TRANSPORT_HTTP
             or request_state.skip_request_log
-            or request_state.response_create_sent_at is None
             or request_state.response_id is not None
             or request_state.latency_response_created_ms is not None
             or request_state.response_event_count != 0

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -126,6 +126,7 @@ from app.modules.proxy._service.support import (
     _REQUEST_TRANSPORT_HTTP,
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
     _http_bridge_session_supports_service_tier,
+    _HTTPBridgeResponseCreateAttempt,
     _HTTPBridgeSession,
     _HTTPBridgeSessionKey,
     _WebSocketRequestState,
@@ -749,6 +750,45 @@ def _http_bridge_eventless_precreated_deadline(
         float(stuck_gate_retire_after_seconds),
         _HTTP_BRIDGE_EVENTLESS_RESPONSE_CREATED_MAX_SECONDS,
     )
+
+
+def _http_bridge_retry_circuit_attempt_for_pending_requests(
+    request_states: Sequence[_WebSocketRequestState],
+) -> _HTTPBridgeResponseCreateAttempt | None:
+    eligible_attempts: list[_HTTPBridgeResponseCreateAttempt] = []
+    recorded_attempts: list[_HTTPBridgeResponseCreateAttempt] = []
+    settled_attempts: list[_HTTPBridgeResponseCreateAttempt] = []
+    for request_state in request_states:
+        attempt = getattr(request_state, "response_create_attempt", None)
+        if attempt is None:
+            continue
+        if attempt.retry_circuit_failure_recorded:
+            recorded_attempts.append(attempt)
+            continue
+        if attempt.disarmed or attempt.response_observed:
+            settled_attempts.append(attempt)
+            continue
+        if (
+            request_state.transport != _REQUEST_TRANSPORT_HTTP
+            or request_state.skip_request_log
+            or request_state.response_create_sent_at is None
+            or request_state.response_id is not None
+            or request_state.latency_response_created_ms is not None
+            or request_state.response_event_count != 0
+            or request_state.downstream_visible
+        ):
+            continue
+        eligible_attempts.append(attempt)
+
+    for attempts in (eligible_attempts, recorded_attempts, settled_attempts):
+        candidate: _HTTPBridgeResponseCreateAttempt | None = None
+        for attempt in attempts:
+            if candidate is not None and candidate is not attempt:
+                return None
+            candidate = attempt
+        if candidate is not None:
+            return candidate
+    return None
 
 
 def _http_bridge_session_has_admission_waiter(session: object | None) -> bool:

--- a/app/modules/proxy/_service/http_bridge/helpers.py
+++ b/app/modules/proxy/_service/http_bridge/helpers.py
@@ -127,6 +127,7 @@ from app.modules.proxy._service.support import (
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
     _http_bridge_session_supports_service_tier,
     _HTTPBridgeResponseCreateAttempt,
+    _HTTPBridgeRetryCircuitAttemptSelection,
     _HTTPBridgeSession,
     _HTTPBridgeSessionKey,
     _WebSocketRequestState,
@@ -752,16 +753,18 @@ def _http_bridge_eventless_precreated_deadline(
     )
 
 
-def _http_bridge_retry_circuit_attempt_for_pending_requests(
+def _http_bridge_retry_circuit_attempt_selection_for_pending_requests(
     request_states: Sequence[_WebSocketRequestState],
-) -> _HTTPBridgeResponseCreateAttempt | None:
+) -> _HTTPBridgeRetryCircuitAttemptSelection:
     eligible_attempts: list[_HTTPBridgeResponseCreateAttempt] = []
     recorded_attempts: list[_HTTPBridgeResponseCreateAttempt] = []
     settled_attempts: list[_HTTPBridgeResponseCreateAttempt] = []
+    attempt_seen = False
     for request_state in request_states:
         attempt = getattr(request_state, "response_create_attempt", None)
         if attempt is None:
             continue
+        attempt_seen = True
         if attempt.retry_circuit_failure_recorded:
             recorded_attempts.append(attempt)
             continue
@@ -779,15 +782,21 @@ def _http_bridge_retry_circuit_attempt_for_pending_requests(
             continue
         eligible_attempts.append(attempt)
 
-    for attempts in (eligible_attempts, recorded_attempts, settled_attempts):
-        candidate: _HTTPBridgeResponseCreateAttempt | None = None
+    for kind, attempts in (
+        ("eligible", eligible_attempts),
+        ("recorded", recorded_attempts),
+        ("settled", settled_attempts),
+    ):
+        unique_attempts: list[_HTTPBridgeResponseCreateAttempt] = []
         for attempt in attempts:
-            if candidate is not None and candidate is not attempt:
-                return None
-            candidate = attempt
-        if candidate is not None:
-            return candidate
-    return None
+            if not any(candidate is attempt for candidate in unique_attempts):
+                unique_attempts.append(attempt)
+        if unique_attempts:
+            return _HTTPBridgeRetryCircuitAttemptSelection(
+                kind=kind,
+                attempts=tuple(unique_attempts),
+            )
+    return _HTTPBridgeRetryCircuitAttemptSelection(kind="ineligible" if attempt_seen else "absent")
 
 
 def _http_bridge_session_has_admission_waiter(session: object | None) -> bool:

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -83,6 +83,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_prewarm_enabled,
     _http_bridge_request_budget_seconds,
     _http_bridge_request_counts_against_queue,
+    _http_bridge_retry_circuit_attempt_for_pending_requests,
     _log_http_bridge_event,
     _record_continuity_fail_closed,
     _record_http_bridge_prewarm_outcome,
@@ -144,6 +145,7 @@ from app.modules.proxy._service.support import (
     _clear_websocket_request_error_overrides,
     _copy_websocket_route_metadata_from_session,
     _event_type_from_payload,
+    _HTTPBridgeResponseCreateAttempt,
     _HTTPBridgeSession,
     _request_log_client_fields,
     _websocket_request_can_replay_before_visible_output,
@@ -355,6 +357,9 @@ async def _send_http_bridge_request_text_with_archive_id(
         on_send_started()
     token = set_request_id(request_state.archive_request_id)
     try:
+        request_state.response_create_attempt_count += 1
+        attempt = _HTTPBridgeResponseCreateAttempt(ordinal=request_state.response_create_attempt_count)
+        request_state.response_create_attempt = attempt
         request_state.response_create_sent_at = _service_time().monotonic()
         session.upstream_reader_wakeup.set()
         try:
@@ -363,7 +368,9 @@ async def _send_http_bridge_request_text_with_archive_id(
             # A failed or cancelled send is settled by its caller. Disarm the
             # owner watchdog before lifecycle ownership is released so the
             # reader cannot race that cleanup and settle the request twice.
-            request_state.response_create_sent_at = None
+            attempt.disarmed = True
+            if request_state.response_create_attempt is attempt:
+                request_state.response_create_sent_at = None
             session.upstream_reader_wakeup.set()
             raise
     finally:
@@ -2624,12 +2631,20 @@ class _HTTPBridgeRequestSubmitMixin:
                 stale_requests.append(request_state)
         if not stale_requests:
             return
+        retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(tuple(stale_requests))
         # A stale gate holder that streamed response events without ever
         # receiving ``response.created`` proves the reattach wedge (#1534)
         # even when the session itself survives with other active requests.
         _record_http_bridge_quarantine_wedged_pending(self, session, stale_requests)
         if response_events_seen == 0:
-            await self._record_http_bridge_retry_circuit_failure(session, detail=detail)
+            if retry_circuit_attempt is None:
+                await self._record_http_bridge_retry_circuit_failure(session, detail=detail)
+            else:
+                await self._record_http_bridge_retry_circuit_failure(
+                    session,
+                    detail=detail,
+                    attempt=retry_circuit_attempt,
+                )
         await self._fail_pending_websocket_requests(
             account=session.account,
             account_id_value=session.account.id,
@@ -2699,6 +2714,7 @@ class _HTTPBridgeRequestSubmitMixin:
         retry_circuit_detail: str | None = None,
         response_events_seen: int | None = None,
         retired_request_count: int | None = None,
+        retry_circuit_attempt: _HTTPBridgeResponseCreateAttempt | None = None,
     ) -> None:
         async with session.pending_lock:
             retired_request_states = list(session.pending_requests)
@@ -2730,6 +2746,8 @@ class _HTTPBridgeRequestSubmitMixin:
                     ),
                     default=0,
                 )
+            if retry_circuit_attempt is None:
+                retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(retired_request_states)
         # Direct retirement (for example the all-stale stuck-gate path, where
         # the wedged reattach is the only pending request) cancels the reader
         # and fails the pendings without passing the partial-cleanup hook or
@@ -2748,10 +2766,17 @@ class _HTTPBridgeRequestSubmitMixin:
         # that handoff, genuine pre-response failures disappear from circuit
         # accounting while idle closes and request failures look identical.
         if retired_request_count > 0 and response_events_seen == 0:
-            await self._record_http_bridge_retry_circuit_failure(
-                session,
-                detail=retry_circuit_detail or detail,
-            )
+            if isinstance(retry_circuit_attempt, _HTTPBridgeResponseCreateAttempt):
+                await self._record_http_bridge_retry_circuit_failure(
+                    session,
+                    detail=retry_circuit_detail or detail,
+                    attempt=retry_circuit_attempt,
+                )
+            else:
+                await self._record_http_bridge_retry_circuit_failure(
+                    session,
+                    detail=retry_circuit_detail or detail,
+                )
         session.closed = True
         async with self._http_bridge_lock:
             if self._http_bridge_sessions.get(session.key) is session:

--- a/app/modules/proxy/_service/http_bridge/request_submit.py
+++ b/app/modules/proxy/_service/http_bridge/request_submit.py
@@ -7,7 +7,7 @@ import math
 import random
 from collections import deque
 from collections.abc import Callable
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from typing import Any, Literal, Mapping, cast
 from uuid import uuid4
 
@@ -83,7 +83,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_prewarm_enabled,
     _http_bridge_request_budget_seconds,
     _http_bridge_request_counts_against_queue,
-    _http_bridge_retry_circuit_attempt_for_pending_requests,
+    _http_bridge_retry_circuit_attempt_selection_for_pending_requests,
     _log_http_bridge_event,
     _record_continuity_fail_closed,
     _record_http_bridge_prewarm_outcome,
@@ -146,6 +146,7 @@ from app.modules.proxy._service.support import (
     _copy_websocket_route_metadata_from_session,
     _event_type_from_payload,
     _HTTPBridgeResponseCreateAttempt,
+    _HTTPBridgeRetryCircuitAttemptSelection,
     _HTTPBridgeSession,
     _request_log_client_fields,
     _websocket_request_can_replay_before_visible_output,
@@ -226,6 +227,16 @@ _SECURITY_WORK_NO_AUTHORIZED_ACCOUNTS_MESSAGE = (
     "security work. codex-lb is continuing with normal account selection; the upstream request may still fail until "
     "an account with Trusted Access for Cyber is marked as security-work-authorized."
 )
+
+
+@dataclass(frozen=True, slots=True)
+class _HTTPBridgeStaleGateSnapshot:
+    pending_states: list[_WebSocketRequestState]
+    queued_count: int
+    threshold_seconds: float
+    stale_request_states: list[_WebSocketRequestState]
+    should_retire: bool
+    retry_circuit_attempt_selection: _HTTPBridgeRetryCircuitAttemptSelection
 
 
 def _http_bridge_client_full_history_recovery_enabled(request_state: _WebSocketRequestState) -> bool:
@@ -2609,7 +2620,15 @@ class _HTTPBridgeRequestSubmitMixin:
         request_states: list[_WebSocketRequestState],
         *,
         detail: str,
+        retry_circuit_attempt_selection: _HTTPBridgeRetryCircuitAttemptSelection | None = None,
     ) -> None:
+        if retry_circuit_attempt_selection is None:
+            # Capture the physical sends before waiting for pending ownership.
+            # A concurrent recovery may replace request_state.response_create_attempt
+            # while this task is suspended on pending_lock.
+            retry_circuit_attempt_selection = _http_bridge_retry_circuit_attempt_selection_for_pending_requests(
+                request_states
+            )
         stale_requests: deque[_WebSocketRequestState] = deque()
         response_events_seen = 0
         async with session.pending_lock:
@@ -2631,20 +2650,16 @@ class _HTTPBridgeRequestSubmitMixin:
                 stale_requests.append(request_state)
         if not stale_requests:
             return
-        retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(tuple(stale_requests))
         # A stale gate holder that streamed response events without ever
         # receiving ``response.created`` proves the reattach wedge (#1534)
         # even when the session itself survives with other active requests.
         _record_http_bridge_quarantine_wedged_pending(self, session, stale_requests)
         if response_events_seen == 0:
-            if retry_circuit_attempt is None:
-                await self._record_http_bridge_retry_circuit_failure(session, detail=detail)
-            else:
-                await self._record_http_bridge_retry_circuit_failure(
-                    session,
-                    detail=detail,
-                    attempt=retry_circuit_attempt,
-                )
+            await self._record_http_bridge_retry_circuit_failure_for_attempt_selection(
+                session,
+                detail=detail,
+                selection=retry_circuit_attempt_selection,
+            )
         await self._fail_pending_websocket_requests(
             account=session.account,
             account_id_value=session.account.id,
@@ -2687,6 +2702,37 @@ class _HTTPBridgeRequestSubmitMixin:
             return stale_states, False
         return [], bool(stale_states)
 
+    async def _snapshot_http_bridge_stale_gate_state(
+        self: Any,
+        session: "_HTTPBridgeSession",
+        *,
+        now: float,
+    ) -> _HTTPBridgeStaleGateSnapshot:
+        threshold_seconds = float(
+            getattr(_service_get_settings(), "http_responses_session_bridge_stuck_gate_retire_after_seconds", 300.0)
+        )
+        async with session.pending_lock:
+            pending_states = list(session.pending_requests)
+            stale_request_states, should_retire = self._classify_http_bridge_stale_gate_holders(
+                pending_states,
+                now=now,
+                threshold_seconds=threshold_seconds,
+                session_closed=session.closed,
+            )
+            retry_circuit_request_states = (
+                stale_request_states if stale_request_states else (pending_states if should_retire else ())
+            )
+            return _HTTPBridgeStaleGateSnapshot(
+                pending_states=pending_states,
+                queued_count=session.queued_request_count,
+                threshold_seconds=threshold_seconds,
+                stale_request_states=stale_request_states,
+                should_retire=should_retire,
+                retry_circuit_attempt_selection=(
+                    _http_bridge_retry_circuit_attempt_selection_for_pending_requests(retry_circuit_request_states)
+                ),
+            )
+
     async def _retire_http_bridge_after_drain_if_ready(self: Any, session: "_HTTPBridgeSession") -> bool:
         if not (session.upstream_control.reconnect_requested and session.upstream_control.retire_after_drain):
             return False
@@ -2714,7 +2760,7 @@ class _HTTPBridgeRequestSubmitMixin:
         retry_circuit_detail: str | None = None,
         response_events_seen: int | None = None,
         retired_request_count: int | None = None,
-        retry_circuit_attempt: _HTTPBridgeResponseCreateAttempt | None = None,
+        retry_circuit_attempt_selection: _HTTPBridgeRetryCircuitAttemptSelection | None = None,
     ) -> None:
         async with session.pending_lock:
             retired_request_states = list(session.pending_requests)
@@ -2746,8 +2792,10 @@ class _HTTPBridgeRequestSubmitMixin:
                     ),
                     default=0,
                 )
-            if retry_circuit_attempt is None:
-                retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(retired_request_states)
+            if retry_circuit_attempt_selection is None:
+                retry_circuit_attempt_selection = _http_bridge_retry_circuit_attempt_selection_for_pending_requests(
+                    retired_request_states
+                )
         # Direct retirement (for example the all-stale stuck-gate path, where
         # the wedged reattach is the only pending request) cancels the reader
         # and fails the pendings without passing the partial-cleanup hook or
@@ -2766,17 +2814,11 @@ class _HTTPBridgeRequestSubmitMixin:
         # that handoff, genuine pre-response failures disappear from circuit
         # accounting while idle closes and request failures look identical.
         if retired_request_count > 0 and response_events_seen == 0:
-            if isinstance(retry_circuit_attempt, _HTTPBridgeResponseCreateAttempt):
-                await self._record_http_bridge_retry_circuit_failure(
-                    session,
-                    detail=retry_circuit_detail or detail,
-                    attempt=retry_circuit_attempt,
-                )
-            else:
-                await self._record_http_bridge_retry_circuit_failure(
-                    session,
-                    detail=retry_circuit_detail or detail,
-                )
+            await self._record_http_bridge_retry_circuit_failure_for_attempt_selection(
+                session,
+                detail=retry_circuit_detail or detail,
+                selection=retry_circuit_attempt_selection,
+            )
         session.closed = True
         async with self._http_bridge_lock:
             if self._http_bridge_sessions.get(session.key) is session:

--- a/app/modules/proxy/_service/http_bridge/retry_circuit.py
+++ b/app/modules/proxy/_service/http_bridge/retry_circuit.py
@@ -9,7 +9,11 @@ import anyio
 
 from app.core.metrics.prometheus import PROMETHEUS_AVAILABLE, http_bridge_retry_circuit_total
 from app.modules.proxy._service.observability import _hash_identifier
-from app.modules.proxy._service.support import _HTTPBridgeResponseCreateAttempt, _HTTPBridgeSession
+from app.modules.proxy._service.support import (
+    _HTTPBridgeResponseCreateAttempt,
+    _HTTPBridgeRetryCircuitAttemptSelection,
+    _HTTPBridgeSession,
+)
 from app.modules.proxy.durable_bridge_repository import DURABLE_BRIDGE_RETRY_CIRCUIT_STATE_TTL_SECONDS
 
 logger = logging.getLogger(__name__)
@@ -78,6 +82,11 @@ def _record_http_bridge_retry_circuit_duplicate_suppressed(
 
 
 class _HTTPBridgeRetryCircuitMixin:
+    async def _http_bridge_retry_circuit_current_count(self: Any, session: _HTTPBridgeSession) -> int:
+        async with self._http_bridge_retry_circuit_lock:
+            current_state = self._http_bridge_retry_circuits.get(session.key)
+            return current_state.consecutive_failures if current_state is not None else 0
+
     async def _await_http_bridge_retry_circuit_attempt_settlement(
         self: Any,
         session: _HTTPBridgeSession,
@@ -88,13 +97,7 @@ class _HTTPBridgeRetryCircuitMixin:
         settled = attempt.retry_circuit_failure_settled
         if settled is not None:
             await settled.wait()
-        async with self._http_bridge_retry_circuit_lock:
-            current_state = self._http_bridge_retry_circuits.get(session.key)
-            consecutive_failures = (
-                attempt.retry_circuit_failure_count
-                if attempt.retry_circuit_failure_count is not None
-                else (current_state.consecutive_failures if current_state is not None else 0)
-            )
+        consecutive_failures = await self._http_bridge_retry_circuit_current_count(session)
         _record_http_bridge_retry_circuit_duplicate_suppressed(
             session,
             attempt=attempt,
@@ -102,6 +105,50 @@ class _HTTPBridgeRetryCircuitMixin:
             detail=detail,
         )
         return consecutive_failures
+
+    async def _record_http_bridge_retry_circuit_failure_for_attempt_selection(
+        self: Any,
+        session: _HTTPBridgeSession,
+        *,
+        detail: str,
+        selection: _HTTPBridgeRetryCircuitAttemptSelection,
+    ) -> int | None:
+        attempt = selection.attempt
+        if attempt is not None:
+            return await self._record_http_bridge_retry_circuit_failure(
+                session,
+                detail=detail,
+                attempt=attempt,
+            )
+        if selection.kind == "absent":
+            return await self._record_http_bridge_retry_circuit_failure(session, detail=detail)
+        if selection.kind == "recorded":
+            for recorded_attempt in selection.attempts:
+                settled = recorded_attempt.retry_circuit_failure_settled
+                if settled is not None:
+                    await settled.wait()
+            consecutive_failures = await self._http_bridge_retry_circuit_current_count(session)
+            for recorded_attempt in selection.attempts:
+                _record_http_bridge_retry_circuit_duplicate_suppressed(
+                    session,
+                    attempt=recorded_attempt,
+                    consecutive_failures=consecutive_failures,
+                    detail=detail,
+                )
+            return consecutive_failures
+
+        outcome = "ambiguous_suppressed" if selection.ambiguous else "ineligible_suppressed"
+        if PROMETHEUS_AVAILABLE and http_bridge_retry_circuit_total is not None:
+            http_bridge_retry_circuit_total.labels(outcome=outcome).inc()
+        logger.info(
+            "http_bridge_retry_circuit event=%s bridge_kind=%s bridge_key=%s detail=%s candidate_attempts=%s",
+            outcome,
+            session.key.affinity_kind,
+            _hash_identifier(session.key.affinity_key),
+            detail,
+            len(selection.attempts),
+        )
+        return None
 
     def _prune_http_bridge_retry_circuit_state(self: Any, now: float) -> None:
         expiry = now - DURABLE_BRIDGE_RETRY_CIRCUIT_STATE_TTL_SECONDS
@@ -440,7 +487,6 @@ class _HTTPBridgeRetryCircuitMixin:
                 if scoped_attempt is not None:
                     scoped_attempt.retry_circuit_failure_recorded = True
                     scoped_attempt.retry_circuit_failure_settled = anyio.Event()
-                    scoped_attempt.retry_circuit_failure_count = None
                 state.consecutive_failures += 1
                 state.last_detail = detail
                 if state.consecutive_failures >= threshold:
@@ -478,7 +524,6 @@ class _HTTPBridgeRetryCircuitMixin:
             return consecutive_failures
         finally:
             if scoped_attempt is not None and scoped_attempt.retry_circuit_failure_settled is not None:
-                scoped_attempt.retry_circuit_failure_count = state.consecutive_failures
                 scoped_attempt.retry_circuit_failure_settled.set()
 
     async def _clear_http_bridge_retry_circuit(self: Any, session: _HTTPBridgeSession) -> None:

--- a/app/modules/proxy/_service/http_bridge/retry_circuit.py
+++ b/app/modules/proxy/_service/http_bridge/retry_circuit.py
@@ -78,6 +78,31 @@ def _record_http_bridge_retry_circuit_duplicate_suppressed(
 
 
 class _HTTPBridgeRetryCircuitMixin:
+    async def _await_http_bridge_retry_circuit_attempt_settlement(
+        self: Any,
+        session: _HTTPBridgeSession,
+        *,
+        attempt: _HTTPBridgeResponseCreateAttempt,
+        detail: str,
+    ) -> int:
+        settled = attempt.retry_circuit_failure_settled
+        if settled is not None:
+            await settled.wait()
+        async with self._http_bridge_retry_circuit_lock:
+            current_state = self._http_bridge_retry_circuits.get(session.key)
+            consecutive_failures = (
+                attempt.retry_circuit_failure_count
+                if attempt.retry_circuit_failure_count is not None
+                else (current_state.consecutive_failures if current_state is not None else 0)
+            )
+        _record_http_bridge_retry_circuit_duplicate_suppressed(
+            session,
+            attempt=attempt,
+            consecutive_failures=consecutive_failures,
+            detail=detail,
+        )
+        return consecutive_failures
+
     def _prune_http_bridge_retry_circuit_state(self: Any, now: float) -> None:
         expiry = now - DURABLE_BRIDGE_RETRY_CIRCUIT_STATE_TTL_SECONDS
         for key, state in list(self._http_bridge_retry_circuits.items()):
@@ -383,16 +408,11 @@ class _HTTPBridgeRetryCircuitMixin:
         scoped_attempt = attempt
         if scoped_attempt is not None:
             if scoped_attempt.retry_circuit_failure_recorded:
-                async with self._http_bridge_retry_circuit_lock:
-                    current_state = self._http_bridge_retry_circuits.get(session.key)
-                    consecutive_failures = current_state.consecutive_failures if current_state is not None else 0
-                _record_http_bridge_retry_circuit_duplicate_suppressed(
+                return await self._await_http_bridge_retry_circuit_attempt_settlement(
                     session,
                     attempt=scoped_attempt,
-                    consecutive_failures=consecutive_failures,
                     detail=detail,
                 )
-                return consecutive_failures
             if scoped_attempt.disarmed or scoped_attempt.response_observed:
                 return None
 
@@ -402,14 +422,11 @@ class _HTTPBridgeRetryCircuitMixin:
         max_backoff = max(base_backoff, _HTTP_BRIDGE_RETRY_CIRCUIT_MAX_BACKOFF_SECONDS)
         clean_close_max_backoff = max(0.001, _HTTP_BRIDGE_RETRY_CIRCUIT_CLEAN_CLOSE_MAX_BACKOFF_SECONDS)
         now = time.monotonic()
-        duplicate_suppressed = False
-        consecutive_failures = 0
+        duplicate_attempt: _HTTPBridgeResponseCreateAttempt | None = None
         state: _HTTPBridgeRetryCircuitState | None = None
         async with self._http_bridge_retry_circuit_lock:
             if scoped_attempt is not None and scoped_attempt.retry_circuit_failure_recorded:
-                state = self._http_bridge_retry_circuits.get(session.key)
-                consecutive_failures = state.consecutive_failures if state is not None else 0
-                duplicate_suppressed = True
+                duplicate_attempt = scoped_attempt
             elif scoped_attempt is not None and (scoped_attempt.disarmed or scoped_attempt.response_observed):
                 return None
             else:
@@ -422,8 +439,9 @@ class _HTTPBridgeRetryCircuitMixin:
                 state.half_open_until = 0.0
                 if scoped_attempt is not None:
                     scoped_attempt.retry_circuit_failure_recorded = True
+                    scoped_attempt.retry_circuit_failure_settled = anyio.Event()
+                    scoped_attempt.retry_circuit_failure_count = None
                 state.consecutive_failures += 1
-                consecutive_failures = state.consecutive_failures
                 state.last_detail = detail
                 if state.consecutive_failures >= threshold:
                     backoff = min(
@@ -444,21 +462,24 @@ class _HTTPBridgeRetryCircuitMixin:
                         backoff,
                         detail,
                     )
-        if duplicate_suppressed:
-            assert scoped_attempt is not None
-            _record_http_bridge_retry_circuit_duplicate_suppressed(
+        if duplicate_attempt is not None:
+            return await self._await_http_bridge_retry_circuit_attempt_settlement(
                 session,
-                attempt=scoped_attempt,
-                consecutive_failures=consecutive_failures,
+                attempt=duplicate_attempt,
                 detail=detail,
             )
-            return consecutive_failures
         assert state is not None
-        await self._persist_http_bridge_retry_circuit(session, state)
-        async with self._http_bridge_retry_circuit_lock:
-            if self._http_bridge_retry_circuits.get(session.key) is state:
-                self._http_bridge_retry_circuit_loaded_keys.add(session.key)
-            return state.consecutive_failures
+        try:
+            await self._persist_http_bridge_retry_circuit(session, state)
+            async with self._http_bridge_retry_circuit_lock:
+                if self._http_bridge_retry_circuits.get(session.key) is state:
+                    self._http_bridge_retry_circuit_loaded_keys.add(session.key)
+                consecutive_failures = state.consecutive_failures
+            return consecutive_failures
+        finally:
+            if scoped_attempt is not None and scoped_attempt.retry_circuit_failure_settled is not None:
+                scoped_attempt.retry_circuit_failure_count = state.consecutive_failures
+                scoped_attempt.retry_circuit_failure_settled.set()
 
     async def _clear_http_bridge_retry_circuit(self: Any, session: _HTTPBridgeSession) -> None:
         if session.key.strength != "hard":

--- a/app/modules/proxy/_service/http_bridge/retry_circuit.py
+++ b/app/modules/proxy/_service/http_bridge/retry_circuit.py
@@ -9,7 +9,7 @@ import anyio
 
 from app.core.metrics.prometheus import PROMETHEUS_AVAILABLE, http_bridge_retry_circuit_total
 from app.modules.proxy._service.observability import _hash_identifier
-from app.modules.proxy._service.support import _HTTPBridgeSession
+from app.modules.proxy._service.support import _HTTPBridgeResponseCreateAttempt, _HTTPBridgeSession
 from app.modules.proxy.durable_bridge_repository import DURABLE_BRIDGE_RETRY_CIRCUIT_STATE_TTL_SECONDS
 
 logger = logging.getLogger(__name__)
@@ -55,6 +55,26 @@ def _initialize_http_bridge_retry_circuit(service: Any, reset_transient_cache: A
     service._http_bridge_retry_circuit_loaded_keys = set()
     service._http_bridge_retry_circuit_persisted_keys = set()
     service._http_bridge_retry_circuit_lock = anyio.Lock()
+
+
+def _record_http_bridge_retry_circuit_duplicate_suppressed(
+    session: _HTTPBridgeSession,
+    *,
+    attempt: _HTTPBridgeResponseCreateAttempt,
+    consecutive_failures: int,
+    detail: str,
+) -> None:
+    if PROMETHEUS_AVAILABLE and http_bridge_retry_circuit_total is not None:
+        http_bridge_retry_circuit_total.labels(outcome="duplicate_suppressed").inc()
+    logger.info(
+        "http_bridge_retry_circuit event=duplicate_suppressed bridge_kind=%s bridge_key=%s "
+        "failures=%s detail=%s attempt=%s",
+        session.key.affinity_kind,
+        _hash_identifier(session.key.affinity_key),
+        consecutive_failures,
+        detail,
+        attempt.ordinal,
+    )
 
 
 class _HTTPBridgeRetryCircuitMixin:
@@ -354,10 +374,27 @@ class _HTTPBridgeRetryCircuitMixin:
         session: _HTTPBridgeSession,
         *,
         detail: str,
+        attempt: _HTTPBridgeResponseCreateAttempt | None = None,
     ) -> int | None:
         detail = _HTTP_BRIDGE_RETRY_CIRCUIT_DETAIL_ALIASES.get(detail, detail)
         if session.key.strength != "hard" or detail not in _HTTP_BRIDGE_RETRY_CIRCUIT_FAILURE_DETAILS:
             return None
+
+        scoped_attempt = attempt
+        if scoped_attempt is not None:
+            if scoped_attempt.retry_circuit_failure_recorded:
+                async with self._http_bridge_retry_circuit_lock:
+                    current_state = self._http_bridge_retry_circuits.get(session.key)
+                    consecutive_failures = current_state.consecutive_failures if current_state is not None else 0
+                _record_http_bridge_retry_circuit_duplicate_suppressed(
+                    session,
+                    attempt=scoped_attempt,
+                    consecutive_failures=consecutive_failures,
+                    detail=detail,
+                )
+                return consecutive_failures
+            if scoped_attempt.disarmed or scoped_attempt.response_observed:
+                return None
 
         await self._load_http_bridge_retry_circuit(session)
         threshold = max(1, _HTTP_BRIDGE_RETRY_CIRCUIT_FAILURE_THRESHOLD)
@@ -365,35 +402,58 @@ class _HTTPBridgeRetryCircuitMixin:
         max_backoff = max(base_backoff, _HTTP_BRIDGE_RETRY_CIRCUIT_MAX_BACKOFF_SECONDS)
         clean_close_max_backoff = max(0.001, _HTTP_BRIDGE_RETRY_CIRCUIT_CLEAN_CLOSE_MAX_BACKOFF_SECONDS)
         now = time.monotonic()
+        duplicate_suppressed = False
+        consecutive_failures = 0
+        state: _HTTPBridgeRetryCircuitState | None = None
         async with self._http_bridge_retry_circuit_lock:
-            state = self._http_bridge_retry_circuits.setdefault(
-                session.key,
-                _HTTPBridgeRetryCircuitState(last_touched_monotonic=now),
+            if scoped_attempt is not None and scoped_attempt.retry_circuit_failure_recorded:
+                state = self._http_bridge_retry_circuits.get(session.key)
+                consecutive_failures = state.consecutive_failures if state is not None else 0
+                duplicate_suppressed = True
+            elif scoped_attempt is not None and (scoped_attempt.disarmed or scoped_attempt.response_observed):
+                return None
+            else:
+                state = self._http_bridge_retry_circuits.setdefault(
+                    session.key,
+                    _HTTPBridgeRetryCircuitState(last_touched_monotonic=now),
+                )
+                state.last_touched_monotonic = now
+                state.last_failure_monotonic = now
+                state.half_open_until = 0.0
+                if scoped_attempt is not None:
+                    scoped_attempt.retry_circuit_failure_recorded = True
+                state.consecutive_failures += 1
+                consecutive_failures = state.consecutive_failures
+                state.last_detail = detail
+                if state.consecutive_failures >= threshold:
+                    backoff = min(
+                        max_backoff,
+                        base_backoff * (2 ** min(state.consecutive_failures - threshold, 30)),
+                    )
+                    if detail == "clean_close":
+                        backoff = min(backoff, clean_close_max_backoff)
+                    state.cooldown_until = max(state.cooldown_until, now + backoff)
+                    if PROMETHEUS_AVAILABLE and http_bridge_retry_circuit_total is not None:
+                        http_bridge_retry_circuit_total.labels(outcome="opened").inc()
+                    logger.warning(
+                        "http_bridge_retry_circuit event=opened bridge_kind=%s bridge_key=%s "
+                        "failures=%s cooldown_seconds=%.1f detail=%s",
+                        session.key.affinity_kind,
+                        _hash_identifier(session.key.affinity_key),
+                        state.consecutive_failures,
+                        backoff,
+                        detail,
+                    )
+        if duplicate_suppressed:
+            assert scoped_attempt is not None
+            _record_http_bridge_retry_circuit_duplicate_suppressed(
+                session,
+                attempt=scoped_attempt,
+                consecutive_failures=consecutive_failures,
+                detail=detail,
             )
-            state.last_touched_monotonic = now
-            state.last_failure_monotonic = now
-            state.half_open_until = 0.0
-            state.consecutive_failures += 1
-            state.last_detail = detail
-            if state.consecutive_failures >= threshold:
-                backoff = min(
-                    max_backoff,
-                    base_backoff * (2 ** min(state.consecutive_failures - threshold, 30)),
-                )
-                if detail == "clean_close":
-                    backoff = min(backoff, clean_close_max_backoff)
-                state.cooldown_until = max(state.cooldown_until, now + backoff)
-                if PROMETHEUS_AVAILABLE and http_bridge_retry_circuit_total is not None:
-                    http_bridge_retry_circuit_total.labels(outcome="opened").inc()
-                logger.warning(
-                    "http_bridge_retry_circuit event=opened bridge_kind=%s bridge_key=%s "
-                    "failures=%s cooldown_seconds=%.1f detail=%s",
-                    session.key.affinity_kind,
-                    _hash_identifier(session.key.affinity_key),
-                    state.consecutive_failures,
-                    backoff,
-                    detail,
-                )
+            return consecutive_failures
+        assert state is not None
         await self._persist_http_bridge_retry_circuit(session, state)
         async with self._http_bridge_retry_circuit_lock:
             if self._http_bridge_retry_circuits.get(session.key) is state:

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -86,7 +86,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_request_needs_unanchored_handoff,
     _http_bridge_request_stage,
     _http_bridge_requires_cluster_registration,
-    _http_bridge_retry_circuit_attempt_for_pending_requests,
+    _http_bridge_retry_circuit_attempt_selection_for_pending_requests,
     _http_bridge_runtime_config,
     _http_bridge_should_attempt_local_bootstrap_rebind,
     _http_bridge_should_attempt_local_previous_response_recovery,
@@ -3996,8 +3996,8 @@ class _HTTPBridgeStreamingMixin:
                         if not completed_delivery_in_progress:
                             keepalive_count += 1
                         if not completed_delivery_in_progress and keepalive_count >= max_keepalive_count:
-                            timed_out_retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(
-                                (request_state,)
+                            timed_out_retry_circuit_attempt_selection = (
+                                _http_bridge_retry_circuit_attempt_selection_for_pending_requests((request_state,))
                             )
                             if not response_started:
                                 retried = False
@@ -4189,17 +4189,11 @@ class _HTTPBridgeStreamingMixin:
                                             if keepalive_event is not None:
                                                 yield keepalive_event
                                             continue
-                                        if timed_out_retry_circuit_attempt is None:
-                                            await self._record_http_bridge_retry_circuit_failure(
-                                                session,
-                                                detail="stream_idle_timeout",
-                                            )
-                                        else:
-                                            await self._record_http_bridge_retry_circuit_failure(
-                                                session,
-                                                detail="stream_idle_timeout",
-                                                attempt=timed_out_retry_circuit_attempt,
-                                            )
+                                        await self._record_http_bridge_retry_circuit_failure_for_attempt_selection(
+                                            session,
+                                            detail="stream_idle_timeout",
+                                            selection=timed_out_retry_circuit_attempt_selection,
+                                        )
                                         if PROMETHEUS_AVAILABLE and stream_idle_timeout_total is not None:
                                             stream_idle_timeout_total.labels(surface="http_bridge").inc()
                                         logger.info(

--- a/app/modules/proxy/_service/http_bridge/streaming.py
+++ b/app/modules/proxy/_service/http_bridge/streaming.py
@@ -86,6 +86,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_request_needs_unanchored_handoff,
     _http_bridge_request_stage,
     _http_bridge_requires_cluster_registration,
+    _http_bridge_retry_circuit_attempt_for_pending_requests,
     _http_bridge_runtime_config,
     _http_bridge_should_attempt_local_bootstrap_rebind,
     _http_bridge_should_attempt_local_previous_response_recovery,
@@ -3995,6 +3996,9 @@ class _HTTPBridgeStreamingMixin:
                         if not completed_delivery_in_progress:
                             keepalive_count += 1
                         if not completed_delivery_in_progress and keepalive_count >= max_keepalive_count:
+                            timed_out_retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(
+                                (request_state,)
+                            )
                             if not response_started:
                                 retried = False
                                 if not circuit_keepalive_waiting:
@@ -4185,10 +4189,17 @@ class _HTTPBridgeStreamingMixin:
                                             if keepalive_event is not None:
                                                 yield keepalive_event
                                             continue
-                                        await self._record_http_bridge_retry_circuit_failure(
-                                            session,
-                                            detail="stream_idle_timeout",
-                                        )
+                                        if timed_out_retry_circuit_attempt is None:
+                                            await self._record_http_bridge_retry_circuit_failure(
+                                                session,
+                                                detail="stream_idle_timeout",
+                                            )
+                                        else:
+                                            await self._record_http_bridge_retry_circuit_failure(
+                                                session,
+                                                detail="stream_idle_timeout",
+                                                attempt=timed_out_retry_circuit_attempt,
+                                            )
                                         if PROMETHEUS_AVAILABLE and stream_idle_timeout_total is not None:
                                             stream_idle_timeout_total.labels(surface="http_bridge").inc()
                                         logger.info(

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -59,6 +59,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_eventless_precreated_deadline,
     _http_bridge_request_budget_seconds,
     _http_bridge_request_counts_against_queue,
+    _http_bridge_retry_circuit_attempt_for_pending_requests,
     _log_http_bridge_event,
     _normalize_http_bridge_error_event,
     _record_http_bridge_stuck_retire,
@@ -136,6 +137,7 @@ from app.modules.proxy._service.support import (
     _clear_websocket_request_error_overrides,
     _event_type_from_payload,
     _HTTPBridgeCompletedDeliveryScope,
+    _HTTPBridgeResponseCreateAttempt,
     _HTTPBridgeSession,
     _pop_websocket_deferred_reasoning_downstream_texts,
     _record_response_event,
@@ -210,6 +212,7 @@ _HTTP_BRIDGE_RECOVERY_SETTLEMENT_RETRY_DELAYS = (
     120.0,
 )
 _HTTP_BRIDGE_RECOVERY_SETTLEMENT_LEASE_REFRESH_INTERVAL_SECONDS = 10.0
+_UNSET_HTTP_BRIDGE_RETRY_CIRCUIT_ATTEMPT = object()
 
 # A single missing response.created is not proof that an account is bad: the
 # upstream may have accepted the request while the transport was silent. Only
@@ -910,6 +913,9 @@ class _HTTPBridgeUpstreamEventsMixin:
         upstream_close_code: int | None = None,
         response_events_seen: int | None = None,
         transport_classification: str | None = None,
+        retry_circuit_attempt: _HTTPBridgeResponseCreateAttempt | None | object = (
+            _UNSET_HTTP_BRIDGE_RETRY_CIRCUIT_ATTEMPT
+        ),
     ) -> bool:
         session.closed = True
         async with session.pending_lock:
@@ -924,6 +930,13 @@ class _HTTPBridgeUpstreamEventsMixin:
                 default=0,
             )
             pending_request_states = list(session.pending_requests)
+        if retry_circuit_attempt is _UNSET_HTTP_BRIDGE_RETRY_CIRCUIT_ATTEMPT:
+            retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(pending_request_states)
+        retry_circuit_attempt_kwargs = (
+            {"retry_circuit_attempt": retry_circuit_attempt}
+            if isinstance(retry_circuit_attempt, _HTTPBridgeResponseCreateAttempt)
+            else {}
+        )
         # The #1534 wedge shape: a reattached stream that streamed response
         # events whose ``response.created`` was never assigned. The eventless
         # watchdog and the durable-anchor clear both key on
@@ -1041,10 +1054,17 @@ class _HTTPBridgeUpstreamEventsMixin:
                         None,
                     )
                 if failed_pending_count > 0 and retry_circuit_detail is not None:
-                    consecutive_failures = await self._record_http_bridge_retry_circuit_failure(
-                        session,
-                        detail=retry_circuit_detail,
-                    )
+                    if isinstance(retry_circuit_attempt, _HTTPBridgeResponseCreateAttempt):
+                        consecutive_failures = await self._record_http_bridge_retry_circuit_failure(
+                            session,
+                            detail=retry_circuit_detail,
+                            attempt=retry_circuit_attempt,
+                        )
+                    else:
+                        consecutive_failures = await self._record_http_bridge_retry_circuit_failure(
+                            session,
+                            detail=retry_circuit_detail,
+                        )
                     poison_after_deferred_failures = bool(
                         retry_circuit_detail == "stream_idle_timeout"
                         and observed_response_events == 0
@@ -1059,6 +1079,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                             session,
                             detail="repeated_zero_event_idle_timeout",
                             response_events_seen=observed_response_events,
+                            **retry_circuit_attempt_kwargs,
                         )
                         force_retire = True
                     else:
@@ -1091,6 +1112,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                         retry_circuit_detail="clean_close",
                         response_events_seen=observed_response_events,
                         retired_request_count=failed_pending_count,
+                        **retry_circuit_attempt_kwargs,
                     )
                 else:
                     await self._retire_stale_pending_http_bridge_session(
@@ -1104,6 +1126,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                         # strike. The deferred/poison branch records its own
                         # strike above and intentionally does not pass it.
                         retired_request_count=failed_pending_count,
+                        **retry_circuit_attempt_kwargs,
                     )
         return force_retire or session.admission_waiter_count == 0
 
@@ -1204,6 +1227,9 @@ class _HTTPBridgeUpstreamEventsMixin:
                                 ]
                                 if not expired_request_states:
                                     continue
+                                expired_retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(
+                                    expired_request_states
+                                )
                                 pending_count = len(session.pending_requests)
                                 # A delta-only request has no other way to
                                 # convey prior context once its anchor is
@@ -1261,6 +1287,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                                     penalize_account=False,
                                     retire_detail=_HTTP_BRIDGE_MISSING_RESPONSE_CREATED_TIMEOUT_DETAIL,
                                     force_retire=True,
+                                    retry_circuit_attempt=expired_retry_circuit_attempt,
                                 )
                                 break
                             # A successfully cancelled receive cannot deliver
@@ -1306,9 +1333,14 @@ class _HTTPBridgeUpstreamEventsMixin:
                                 penalize_account=False,
                                 retire_detail=_HTTP_BRIDGE_MISSING_RESPONSE_CREATED_TIMEOUT_DETAIL,
                                 force_retire=True,
+                                retry_circuit_attempt=expired_retry_circuit_attempt,
                             )
                         break
 
+                    async with session.pending_lock:
+                        retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(
+                            tuple(session.pending_requests)
+                        )
                     if receive_task is not None:
                         receive_cancelled = await _cancel_http_bridge_reader_child(
                             receive_task,
@@ -1326,6 +1358,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                             session,
                             error_code=receive_timeout.error_code,
                             error_message=receive_timeout.error_message,
+                            retry_circuit_attempt=retry_circuit_attempt,
                         )
                     break
 

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -59,7 +59,7 @@ from app.modules.proxy._service.http_bridge.helpers import (
     _http_bridge_eventless_precreated_deadline,
     _http_bridge_request_budget_seconds,
     _http_bridge_request_counts_against_queue,
-    _http_bridge_retry_circuit_attempt_for_pending_requests,
+    _http_bridge_retry_circuit_attempt_selection_for_pending_requests,
     _log_http_bridge_event,
     _normalize_http_bridge_error_event,
     _record_http_bridge_stuck_retire,
@@ -137,8 +137,9 @@ from app.modules.proxy._service.support import (
     _clear_websocket_request_error_overrides,
     _event_type_from_payload,
     _HTTPBridgeCompletedDeliveryScope,
-    _HTTPBridgeResponseCreateAttempt,
+    _HTTPBridgeRetryCircuitAttemptSelection,
     _HTTPBridgeSession,
+    _mark_response_create_attempt_observed,
     _pop_websocket_deferred_reasoning_downstream_texts,
     _record_response_event,
     _signal_propagated_capacity_startup_ready,
@@ -212,8 +213,6 @@ _HTTP_BRIDGE_RECOVERY_SETTLEMENT_RETRY_DELAYS = (
     120.0,
 )
 _HTTP_BRIDGE_RECOVERY_SETTLEMENT_LEASE_REFRESH_INTERVAL_SECONDS = 10.0
-_UNSET_HTTP_BRIDGE_RETRY_CIRCUIT_ATTEMPT = object()
-
 # A single missing response.created is not proof that an account is bad: the
 # upstream may have accepted the request while the transport was silent. Only
 # repeated failures on separate bridge retirements are allowed to influence
@@ -913,9 +912,7 @@ class _HTTPBridgeUpstreamEventsMixin:
         upstream_close_code: int | None = None,
         response_events_seen: int | None = None,
         transport_classification: str | None = None,
-        retry_circuit_attempt: _HTTPBridgeResponseCreateAttempt | None | object = (
-            _UNSET_HTTP_BRIDGE_RETRY_CIRCUIT_ATTEMPT
-        ),
+        retry_circuit_attempt_selection: _HTTPBridgeRetryCircuitAttemptSelection | None = None,
     ) -> bool:
         session.closed = True
         async with session.pending_lock:
@@ -930,13 +927,13 @@ class _HTTPBridgeUpstreamEventsMixin:
                 default=0,
             )
             pending_request_states = list(session.pending_requests)
-        if retry_circuit_attempt is _UNSET_HTTP_BRIDGE_RETRY_CIRCUIT_ATTEMPT:
-            retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(pending_request_states)
-        retry_circuit_attempt_kwargs = (
-            {"retry_circuit_attempt": retry_circuit_attempt}
-            if isinstance(retry_circuit_attempt, _HTTPBridgeResponseCreateAttempt)
-            else {}
-        )
+        if retry_circuit_attempt_selection is None:
+            retry_circuit_attempt_selection = _http_bridge_retry_circuit_attempt_selection_for_pending_requests(
+                pending_request_states
+            )
+        retry_circuit_attempt_kwargs = {
+            "retry_circuit_attempt_selection": retry_circuit_attempt_selection,
+        }
         # The #1534 wedge shape: a reattached stream that streamed response
         # events whose ``response.created`` was never assigned. The eventless
         # watchdog and the durable-anchor clear both key on
@@ -1054,17 +1051,11 @@ class _HTTPBridgeUpstreamEventsMixin:
                         None,
                     )
                 if failed_pending_count > 0 and retry_circuit_detail is not None:
-                    if isinstance(retry_circuit_attempt, _HTTPBridgeResponseCreateAttempt):
-                        consecutive_failures = await self._record_http_bridge_retry_circuit_failure(
-                            session,
-                            detail=retry_circuit_detail,
-                            attempt=retry_circuit_attempt,
-                        )
-                    else:
-                        consecutive_failures = await self._record_http_bridge_retry_circuit_failure(
-                            session,
-                            detail=retry_circuit_detail,
-                        )
+                    consecutive_failures = await self._record_http_bridge_retry_circuit_failure_for_attempt_selection(
+                        session,
+                        detail=retry_circuit_detail,
+                        selection=retry_circuit_attempt_selection,
+                    )
                     poison_after_deferred_failures = bool(
                         retry_circuit_detail == "stream_idle_timeout"
                         and observed_response_events == 0
@@ -1138,12 +1129,10 @@ class _HTTPBridgeUpstreamEventsMixin:
         relay_upstream = session.upstream
         receive_task: asyncio.Task[UpstreamWebSocketMessage] | None = None
         wakeup_task: asyncio.Task[bool] | None = None
-        reader_failure_retry_circuit_attempt: _HTTPBridgeResponseCreateAttempt | None | object = (
-            _UNSET_HTTP_BRIDGE_RETRY_CIRCUIT_ATTEMPT
-        )
+        reader_failure_retry_circuit_attempt_selection: _HTTPBridgeRetryCircuitAttemptSelection | None = None
         try:
             while True:
-                reader_failure_retry_circuit_attempt = _UNSET_HTTP_BRIDGE_RETRY_CIRCUIT_ATTEMPT
+                reader_failure_retry_circuit_attempt_selection = None
                 # Clear before taking the deadline snapshot. A send before the
                 # clear is represented by its timestamp; a send after it leaves
                 # the event set and wakes the persistent receive wait below.
@@ -1231,10 +1220,12 @@ class _HTTPBridgeUpstreamEventsMixin:
                                 ]
                                 if not expired_request_states:
                                     continue
-                                expired_retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(
-                                    expired_request_states
+                                expired_retry_circuit_attempt_selection = (
+                                    _http_bridge_retry_circuit_attempt_selection_for_pending_requests(
+                                        expired_request_states
+                                    )
                                 )
-                                reader_failure_retry_circuit_attempt = expired_retry_circuit_attempt
+                                reader_failure_retry_circuit_attempt_selection = expired_retry_circuit_attempt_selection
                                 pending_count = len(session.pending_requests)
                                 # A delta-only request has no other way to
                                 # convey prior context once its anchor is
@@ -1292,7 +1283,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                                     penalize_account=False,
                                     retire_detail=_HTTP_BRIDGE_MISSING_RESPONSE_CREATED_TIMEOUT_DETAIL,
                                     force_retire=True,
-                                    retry_circuit_attempt=expired_retry_circuit_attempt,
+                                    retry_circuit_attempt_selection=expired_retry_circuit_attempt_selection,
                                 )
                                 break
                             # A successfully cancelled receive cannot deliver
@@ -1338,15 +1329,17 @@ class _HTTPBridgeUpstreamEventsMixin:
                                 penalize_account=False,
                                 retire_detail=_HTTP_BRIDGE_MISSING_RESPONSE_CREATED_TIMEOUT_DETAIL,
                                 force_retire=True,
-                                retry_circuit_attempt=expired_retry_circuit_attempt,
+                                retry_circuit_attempt_selection=expired_retry_circuit_attempt_selection,
                             )
                         break
 
                     async with session.pending_lock:
-                        retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(
-                            tuple(session.pending_requests)
+                        retry_circuit_attempt_selection = (
+                            _http_bridge_retry_circuit_attempt_selection_for_pending_requests(
+                                tuple(session.pending_requests)
+                            )
                         )
-                        reader_failure_retry_circuit_attempt = retry_circuit_attempt
+                        reader_failure_retry_circuit_attempt_selection = retry_circuit_attempt_selection
                     if receive_task is not None:
                         receive_cancelled = await _cancel_http_bridge_reader_child(
                             receive_task,
@@ -1364,7 +1357,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                             session,
                             error_code=receive_timeout.error_code,
                             error_message=receive_timeout.error_message,
-                            retry_circuit_attempt=retry_circuit_attempt,
+                            retry_circuit_attempt_selection=retry_circuit_attempt_selection,
                         )
                     break
 
@@ -1388,8 +1381,10 @@ class _HTTPBridgeUpstreamEventsMixin:
                         (request_state.response_event_count for request_state in session.pending_requests),
                         default=0,
                     )
-                    reader_failure_retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(
-                        tuple(session.pending_requests)
+                    reader_failure_retry_circuit_attempt_selection = (
+                        _http_bridge_retry_circuit_attempt_selection_for_pending_requests(
+                            tuple(session.pending_requests)
+                        )
                     )
                 _archive_http_bridge_upstream_message(session, message, archive_request_state)
                 session.last_upstream_close_generation += 1
@@ -1431,7 +1426,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                             if close_classification is not None
                             else "websocket_transport_error"
                         ),
-                        retry_circuit_attempt=reader_failure_retry_circuit_attempt,
+                        retry_circuit_attempt_selection=reader_failure_retry_circuit_attempt_selection,
                         penalize_account=(
                             not account_neutral and not (message.kind == "close" and close_classification == "clean")
                         ),
@@ -1448,6 +1443,17 @@ class _HTTPBridgeUpstreamEventsMixin:
         except asyncio.CancelledError:
             raise
         except Exception as exc:
+            if reader_failure_retry_circuit_attempt_selection is None:
+                # A receive/processing exception can jump here before the
+                # ordinary timeout or close branches publish their snapshot.
+                # Capture before waiting for lifecycle ownership so a
+                # concurrent recovery cannot replace the failed physical send.
+                async with session.pending_lock:
+                    reader_failure_retry_circuit_attempt_selection = (
+                        _http_bridge_retry_circuit_attempt_selection_for_pending_requests(
+                            tuple(session.pending_requests)
+                        )
+                    )
             logger.warning(
                 "HTTP bridge upstream reader crashed account_id=%s bridge_kind=%s",
                 session.account.id,
@@ -1456,11 +1462,6 @@ class _HTTPBridgeUpstreamEventsMixin:
             )
             error_code = exc.error_code if isinstance(exc, UpstreamWebSocketTransportError) else "stream_incomplete"
             account_neutral = is_account_neutral_websocket_error_code(error_code)
-            retry_circuit_attempt_kwargs = (
-                {"retry_circuit_attempt": reader_failure_retry_circuit_attempt}
-                if reader_failure_retry_circuit_attempt is not _UNSET_HTTP_BRIDGE_RETRY_CIRCUIT_ATTEMPT
-                else {}
-            )
             async with session.lifecycle_lock:
                 if not (
                     session.liveness_settlement_owner == "send"
@@ -1477,7 +1478,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                             else "HTTP bridge upstream reader crashed before response.completed"
                         ),
                         penalize_account=not account_neutral,
-                        **retry_circuit_attempt_kwargs,
+                        retry_circuit_attempt_selection=reader_failure_retry_circuit_attempt_selection,
                         # Preserve ordinary crash handoff behavior, but never hand
                         # a heartbeat-expired socket to an admission waiter.
                         **({"force_retire": True} if error_code == UPSTREAM_WEBSOCKET_LIVENESS_TIMEOUT_CODE else {}),
@@ -1672,6 +1673,12 @@ class _HTTPBridgeUpstreamEventsMixin:
             pending_request_count = len(session.pending_requests)
 
             if matched_request_state is not None:
+                # The deferred reasoning prelude intentionally skips ordinary
+                # response-event accounting below, but it still proves that the
+                # physical response.create received an upstream response. Publish
+                # that attempt transition before any later recovery await can
+                # classify the send as eventless.
+                _mark_response_create_attempt_observed(matched_request_state, event_type)
                 now = _service_time().monotonic()
                 if matched_request_state.latency_first_upstream_event_ms is None:
                     matched_request_state.latency_first_upstream_event_ms = int(

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -1382,6 +1382,9 @@ class _HTTPBridgeUpstreamEventsMixin:
                         (request_state.response_event_count for request_state in session.pending_requests),
                         default=0,
                     )
+                    retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(
+                        tuple(session.pending_requests)
+                    )
                 _archive_http_bridge_upstream_message(session, message, archive_request_state)
                 session.last_upstream_close_generation += 1
                 session.last_upstream_close_code = message.close_code
@@ -1422,6 +1425,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                             if close_classification is not None
                             else "websocket_transport_error"
                         ),
+                        retry_circuit_attempt=retry_circuit_attempt,
                         penalize_account=(
                             not account_neutral and not (message.kind == "close" and close_classification == "clean")
                         ),

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -1138,8 +1138,12 @@ class _HTTPBridgeUpstreamEventsMixin:
         relay_upstream = session.upstream
         receive_task: asyncio.Task[UpstreamWebSocketMessage] | None = None
         wakeup_task: asyncio.Task[bool] | None = None
+        reader_failure_retry_circuit_attempt: _HTTPBridgeResponseCreateAttempt | None | object = (
+            _UNSET_HTTP_BRIDGE_RETRY_CIRCUIT_ATTEMPT
+        )
         try:
             while True:
+                reader_failure_retry_circuit_attempt = _UNSET_HTTP_BRIDGE_RETRY_CIRCUIT_ATTEMPT
                 # Clear before taking the deadline snapshot. A send before the
                 # clear is represented by its timestamp; a send after it leaves
                 # the event set and wakes the persistent receive wait below.
@@ -1230,6 +1234,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                                 expired_retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(
                                     expired_request_states
                                 )
+                                reader_failure_retry_circuit_attempt = expired_retry_circuit_attempt
                                 pending_count = len(session.pending_requests)
                                 # A delta-only request has no other way to
                                 # convey prior context once its anchor is
@@ -1341,6 +1346,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                         retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(
                             tuple(session.pending_requests)
                         )
+                        reader_failure_retry_circuit_attempt = retry_circuit_attempt
                     if receive_task is not None:
                         receive_cancelled = await _cancel_http_bridge_reader_child(
                             receive_task,
@@ -1382,7 +1388,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                         (request_state.response_event_count for request_state in session.pending_requests),
                         default=0,
                     )
-                    retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(
+                    reader_failure_retry_circuit_attempt = _http_bridge_retry_circuit_attempt_for_pending_requests(
                         tuple(session.pending_requests)
                     )
                 _archive_http_bridge_upstream_message(session, message, archive_request_state)
@@ -1425,7 +1431,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                             if close_classification is not None
                             else "websocket_transport_error"
                         ),
-                        retry_circuit_attempt=retry_circuit_attempt,
+                        retry_circuit_attempt=reader_failure_retry_circuit_attempt,
                         penalize_account=(
                             not account_neutral and not (message.kind == "close" and close_classification == "clean")
                         ),
@@ -1450,6 +1456,11 @@ class _HTTPBridgeUpstreamEventsMixin:
             )
             error_code = exc.error_code if isinstance(exc, UpstreamWebSocketTransportError) else "stream_incomplete"
             account_neutral = is_account_neutral_websocket_error_code(error_code)
+            retry_circuit_attempt_kwargs = (
+                {"retry_circuit_attempt": reader_failure_retry_circuit_attempt}
+                if reader_failure_retry_circuit_attempt is not _UNSET_HTTP_BRIDGE_RETRY_CIRCUIT_ATTEMPT
+                else {}
+            )
             async with session.lifecycle_lock:
                 if not (
                     session.liveness_settlement_owner == "send"
@@ -1466,6 +1477,7 @@ class _HTTPBridgeUpstreamEventsMixin:
                             else "HTTP bridge upstream reader crashed before response.completed"
                         ),
                         penalize_account=not account_neutral,
+                        **retry_circuit_attempt_kwargs,
                         # Preserve ordinary crash handoff behavior, but never hand
                         # a heartbeat-expired socket to an admission waiter.
                         **({"force_retire": True} if error_code == UPSTREAM_WEBSOCKET_LIVENESS_TIMEOUT_CODE else {}),

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -769,6 +769,14 @@ class _DeferredAccountBackoffTracker:
     current_lifecycle: _DeferredAccountBackoffLifecycle | None = None
 
 
+@dataclass(eq=False, slots=True)
+class _HTTPBridgeResponseCreateAttempt:
+    ordinal: int
+    disarmed: bool = False
+    response_observed: bool = False
+    retry_circuit_failure_recorded: bool = False
+
+
 @dataclass
 class _WebSocketRequestState:
     request_id: str
@@ -791,6 +799,8 @@ class _WebSocketRequestState:
     # send. Retries replace this value so admission wait and prior attempts do
     # not age a fresh send into the eventless owner deadline.
     response_create_sent_at: float | None = None
+    response_create_attempt_count: int = 0
+    response_create_attempt: _HTTPBridgeResponseCreateAttempt | None = None
     bridge_queue_wait_started_at: float | None = None
     # Monotonic deadline of the original bridge request budget. Retry and
     # recovery paths re-prepare request states with a fresh started_at, so
@@ -1304,6 +1314,9 @@ def _clear_websocket_deferred_reasoning_downstream_texts(request_state: _WebSock
 def _record_response_event(request_state: _WebSocketRequestState | None, event_type: str | None) -> None:
     if request_state is None or event_type is None or not event_type.startswith("response."):
         return
+    attempt = request_state.response_create_attempt
+    if attempt is not None:
+        attempt.response_observed = True
     request_state.last_upstream_activity_at = time.monotonic()
     if event_type in {"response.failed", "response.incomplete"}:
         return

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -775,6 +775,8 @@ class _HTTPBridgeResponseCreateAttempt:
     disarmed: bool = False
     response_observed: bool = False
     retry_circuit_failure_recorded: bool = False
+    retry_circuit_failure_settled: anyio.Event | None = None
+    retry_circuit_failure_count: int | None = None
 
 
 @dataclass

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -776,7 +776,25 @@ class _HTTPBridgeResponseCreateAttempt:
     response_observed: bool = False
     retry_circuit_failure_recorded: bool = False
     retry_circuit_failure_settled: anyio.Event | None = None
-    retry_circuit_failure_count: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class _HTTPBridgeRetryCircuitAttemptSelection:
+    kind: Literal["absent", "eligible", "recorded", "settled", "ineligible"]
+    attempts: tuple[_HTTPBridgeResponseCreateAttempt, ...] = ()
+
+    def __post_init__(self) -> None:
+        carries_attempts = self.kind in {"eligible", "recorded", "settled"}
+        if carries_attempts != bool(self.attempts):
+            raise ValueError(f"invalid retry-circuit attempt selection: {self.kind}")
+
+    @property
+    def attempt(self) -> _HTTPBridgeResponseCreateAttempt | None:
+        return self.attempts[0] if len(self.attempts) == 1 else None
+
+    @property
+    def ambiguous(self) -> bool:
+        return len(self.attempts) > 1
 
 
 @dataclass
@@ -1313,12 +1331,21 @@ def _clear_websocket_deferred_reasoning_downstream_texts(request_state: _WebSock
         request_state.deferred_reasoning_downstream_texts = []
 
 
-def _record_response_event(request_state: _WebSocketRequestState | None, event_type: str | None) -> None:
+def _mark_response_create_attempt_observed(
+    request_state: _WebSocketRequestState | None,
+    event_type: str | None,
+) -> None:
     if request_state is None or event_type is None or not event_type.startswith("response."):
         return
     attempt = request_state.response_create_attempt
     if attempt is not None:
         attempt.response_observed = True
+
+
+def _record_response_event(request_state: _WebSocketRequestState | None, event_type: str | None) -> None:
+    if request_state is None or event_type is None or not event_type.startswith("response."):
+        return
+    _mark_response_create_attempt_observed(request_state, event_type)
     request_state.last_upstream_activity_at = time.monotonic()
     if event_type in {"response.failed", "response.incomplete"}:
         return

--- a/app/modules/proxy/service.py
+++ b/app/modules/proxy/service.py
@@ -1309,25 +1309,19 @@ class ProxyService(
             pending_request_ages_seconds: list[float] | None = None
             should_retire_stuck_session = False
             stale_pending_requests_to_fail: list[_WebSocketRequestState] = []
+            retry_circuit_attempt_selection = None
             if bridge_session is not None:
                 now = time.monotonic()
-                async with bridge_session.pending_lock:
-                    pending_states = list(bridge_session.pending_requests)
-                    pending_count = len(pending_states)
-                    queued_count = bridge_session.queued_request_count
+                stale_gate_snapshot = await self._snapshot_http_bridge_stale_gate_state(bridge_session, now=now)
+                pending_states = stale_gate_snapshot.pending_states
+                pending_count = len(pending_states)
+                queued_count = stale_gate_snapshot.queued_count
+                threshold_seconds = stale_gate_snapshot.threshold_seconds
+                stale_pending_requests_to_fail = stale_gate_snapshot.stale_request_states
+                should_retire_stuck_session = stale_gate_snapshot.should_retire
+                retry_circuit_attempt_selection = stale_gate_snapshot.retry_circuit_attempt_selection
                 pending_request_ids = [state.request_log_id or state.request_id for state in pending_states]
                 pending_request_ages_seconds = [max(0.0, now - state.started_at) for state in pending_states]
-                threshold_seconds = float(
-                    getattr(get_settings(), "http_responses_session_bridge_stuck_gate_retire_after_seconds", 300.0)
-                )
-                stale_pending_requests_to_fail, should_retire_stuck_session = (
-                    self._classify_http_bridge_stale_gate_holders(
-                        pending_states,
-                        now=now,
-                        threshold_seconds=threshold_seconds,
-                        session_closed=bridge_session.closed,
-                    )
-                )
                 if not should_retire_stuck_session and any(
                     max(0.0, now - state.started_at) >= threshold_seconds for state in pending_states
                 ):
@@ -1375,6 +1369,7 @@ class ProxyService(
                     bridge_session,
                     stale_pending_requests_to_fail,
                     detail="response_create_gate_timeout_stuck_pending",
+                    retry_circuit_attempt_selection=retry_circuit_attempt_selection,
                 )
             elif bridge_session is not None and should_retire_stuck_session:
                 _record_http_bridge_stuck_retire(
@@ -1384,6 +1379,7 @@ class ProxyService(
                 await self._retire_stale_pending_http_bridge_session(
                     bridge_session,
                     detail="response_create_gate_timeout_stuck_pending",
+                    retry_circuit_attempt_selection=retry_circuit_attempt_selection,
                 )
             raise _http_bridge_startup_wait_timeout_error(
                 "http_bridge_response_create_gate",

--- a/openspec/changes/dedupe-http-bridge-retry-circuit-attempts/design.md
+++ b/openspec/changes/dedupe-http-bridge-retry-circuit-attempts/design.md
@@ -20,8 +20,9 @@ rolling-upgrade contract unnecessarily.
 
 Each upstream send creates a new attempt object stored on its request state.
 The object carries a diagnostic ordinal plus `disarmed`, `response_observed`,
-and `retry_circuit_failure_recorded` state. Observers capture the object itself,
-not merely the request's current ordinal.
+and `retry_circuit_failure_recorded` state. It also carries a settlement signal,
+but deliberately does not cache a historical failure count. Observers capture
+the object itself, not merely the request's current ordinal.
 
 An older observer therefore retains the identity of the send it classified even
 if a retry replaces the request state's current attempt. The old object remains
@@ -36,10 +37,28 @@ cancellation disarms it using the same cleanup boundary that clears
 the reader performs another await. An observer that has not already recorded
 the attempt must not record it after either condition wins.
 
-If the failure was already recorded, later duplicate observers receive the
-current circuit count without another increment. This preserves the reader's
-existing threshold-dependent durable-anchor handling even when the downstream
-stream was the first observer.
+If the failure was already recorded, later duplicate observers wait for its
+durable merge to settle and then read the live circuit state without another
+increment. This means a later independent attempt is reflected in the returned
+count, while a successful response that cleared the circuit is reported as
+zero. It preserves the reader's existing threshold-dependent durable-anchor
+handling without allowing a cached count from an older send to reopen or poison
+state that has since changed.
+
+### Distinguish absent attribution from ambiguous attribution
+
+Failure funnels pass an explicit selection result rather than overloading
+`None`. `absent` means the legacy path has no attempt object and may use the
+unscoped recorder. `eligible`, `recorded`, and `settled` retain the exact object
+identities, including multiple candidates. `ineligible` means an attempt was
+present but lifecycle evidence makes it unsafe to charge.
+
+A single candidate is handled with the normal attempt-scoped recorder. Multiple
+eligible or settled candidates are deliberately suppressed rather than falling
+back to an unscoped strike, because an unscoped increment cannot identify which
+physical send it represents and can double-count a later observer. Multiple
+already-recorded candidates wait for settlement and return the live circuit
+count without incrementing.
 
 ### Claim under the existing retry-circuit lock
 
@@ -52,12 +71,24 @@ No new lock is introduced. Failure paths release `pending_lock` before entering
 the recorder, and no retry-circuit path acquires `pending_lock` or
 `lifecycle_lock` while holding the retry-circuit lock.
 
-### Capture before recovery awaits
+### Capture before ownership and recovery awaits
 
-The downstream timeout and reader watchdog capture the classified attempt before
-calling retry, reconnect, receive cancellation, or settlement helpers. Reading
-the request state's current attempt afterward could attribute an old timeout to
-a newer retry or suppress the old failure incorrectly.
+The response-create gate classifies stale owners and snapshots their attempts
+while holding `pending_lock`. Shared cleanup also snapshots before it waits to
+acquire that lock, so callers that do not provide a locked snapshot still retain
+the pre-wait identity. The downstream timeout and reader watchdog likewise
+capture before calling retry, reconnect, receive cancellation, or settlement
+helpers. Reading the request state's current attempt afterward could attribute
+an old timeout to a newer retry or suppress the old failure incorrectly.
+
+### Mark lifecycle observation before deferred delivery
+
+Some reasoning prelude events are intentionally deferred and therefore do not
+increment the ordinary response-event counter. They still prove that upstream
+accepted and began answering the physical `response.create`. The matched
+attempt is marked observed immediately, before deferred-delivery branching or
+any later await, while the existing event-count and downstream-visibility
+semantics remain unchanged.
 
 ### Keep replica behavior unchanged
 
@@ -77,12 +108,21 @@ conflict merging continues to combine genuinely independent replica failures.
   observer into another strike.
 - If a successful terminal response clears the circuit before a delayed
   duplicate observer resumes, the retained attempt marker prevents the old
-  observer from recreating the cleared failure.
+  observer from recreating the cleared failure and the live count returned to
+  it is zero.
+- If a cleanup snapshot contains multiple eligible sends, it records none at
+  that ambiguous boundary. Later observers that retain an exact send identity
+  can still claim each genuine failure independently.
+- If response accounting is deferred for a reasoning prelude, the attempt's
+  observed marker still wins against an eventless timeout without making the
+  deferred event visible or incrementing its ordinary event count.
 
 ## Example
 
 Attempt A is sent and remains eventless. The downstream stream watchdog and the
 reader watchdog both capture A. The downstream task claims A first, records
 failure count 1, and persists once. The reader later sees that A is already
-recorded, returns count 1, and does not persist. If recovery sends attempt B and
-B also fails, B is claimed independently and opens the circuit at count 2.
+recorded, waits for settlement, reads the live count, and does not persist. If
+recovery sends attempt B and B also fails before that reader resumes, the reader
+returns the current count 2 without adding a third strike. If a successful
+response clears the state instead, it returns 0.

--- a/openspec/changes/dedupe-http-bridge-retry-circuit-attempts/design.md
+++ b/openspec/changes/dedupe-http-bridge-retry-circuit-attempts/design.md
@@ -1,0 +1,88 @@
+# Design: attempt-scoped retry-circuit recording
+
+## Context
+
+All HTTP bridge upstream sends pass through
+`_send_http_bridge_request_text_with_archive_id`, but retry-circuit failures can
+be reported by four paths: partial stale cleanup, direct stale retirement, the
+upstream reader failure funnel, and downstream stream-idle handling. These
+paths may run concurrently and may await recovery or settlement before they
+record the failure.
+
+The durable retry-circuit upsert intentionally merges separate writes as
+separate observations. It cannot infer that two writes came from the same
+physical send, and adding a durable attempt key would expand the schema and the
+rolling-upgrade contract unnecessarily.
+
+## Decisions
+
+### Keep identity process-local and object-scoped
+
+Each upstream send creates a new attempt object stored on its request state.
+The object carries a diagnostic ordinal plus `disarmed`, `response_observed`,
+and `retry_circuit_failure_recorded` state. Observers capture the object itself,
+not merely the request's current ordinal.
+
+An older observer therefore retains the identity of the send it classified even
+if a retry replaces the request state's current attempt. The old object remains
+alive only while an observer references it, so no unbounded generation set is
+needed.
+
+### Preserve the existing failure eligibility contract
+
+Creating an attempt does not itself record a failure. A send exception or
+cancellation disarms it using the same cleanup boundary that clears
+`response_create_sent_at`. A matched `response.*` event marks it observed before
+the reader performs another await. An observer that has not already recorded
+the attempt must not record it after either condition wins.
+
+If the failure was already recorded, later duplicate observers receive the
+current circuit count without another increment. This preserves the reader's
+existing threshold-dependent durable-anchor handling even when the downstream
+stream was the first observer.
+
+### Claim under the existing retry-circuit lock
+
+The attempt marker and `consecutive_failures` increment are changed in the same
+critical section guarded by `_http_bridge_retry_circuit_lock`. Durable I/O stays
+outside that lock. Duplicate calls may both perform the existing durable load,
+but only the first claim persists a failure.
+
+No new lock is introduced. Failure paths release `pending_lock` before entering
+the recorder, and no retry-circuit path acquires `pending_lock` or
+`lifecycle_lock` while holding the retry-circuit lock.
+
+### Capture before recovery awaits
+
+The downstream timeout and reader watchdog capture the classified attempt before
+calling retry, reconnect, receive cancellation, or settlement helpers. Reading
+the request state's current attempt afterward could attribute an old timeout to
+a newer retry or suppress the old failure incorrectly.
+
+### Keep replica behavior unchanged
+
+The active owner alone holds the upstream WebSocket and its request state, so
+duplicate local observers share one attempt object. Owner forwarding does not
+create another upstream send on the forwarding replica. A replay after owner
+handoff is a new send and is intentionally a new strike. Existing durable
+conflict merging continues to combine genuinely independent replica failures.
+
+## Failure Modes
+
+- If durable lookup or persistence fails, the first claim remains in local
+  circuit state as it does today; a duplicate observer must not retry the write
+  because the durable upsert would interpret it as a second failure.
+- If a response event wins before the first claim, the attempt is not counted.
+  If a failure claim wins first, a later response cannot turn a duplicate
+  observer into another strike.
+- If a successful terminal response clears the circuit before a delayed
+  duplicate observer resumes, the retained attempt marker prevents the old
+  observer from recreating the cleared failure.
+
+## Example
+
+Attempt A is sent and remains eventless. The downstream stream watchdog and the
+reader watchdog both capture A. The downstream task claims A first, records
+failure count 1, and persists once. The reader later sees that A is already
+recorded, returns count 1, and does not persist. If recovery sends attempt B and
+B also fails, B is claimed independently and opens the circuit at count 2.

--- a/openspec/changes/dedupe-http-bridge-retry-circuit-attempts/proposal.md
+++ b/openspec/changes/dedupe-http-bridge-retry-circuit-attempts/proposal.md
@@ -1,0 +1,60 @@
+# Deduplicate HTTP bridge retry-circuit failures by send attempt
+
+## Summary
+
+An eventless HTTP bridge `response.create` can be observed by both the upstream
+reader watchdog and the downstream stream-idle watchdog. Each observer currently
+persists an independent retry-circuit failure even though both are reporting the
+same upstream send. With the default threshold of two, one silent send can
+therefore open the circuit and make a later request fail locally with HTTP 503.
+
+Track the individual process-local upstream send attempt and let all failure
+observers claim that attempt through the existing retry-circuit lock. The first
+eligible observer records and persists the failure; later observers of the same
+attempt reuse the resulting count without incrementing or persisting again.
+
+## Why
+
+The retry circuit is intended to protect a hard-affinity key after repeated
+failures. A single upstream send observed through two local timeout paths is one
+failure, not two. Durable conflict merging deliberately treats independent
+persistence calls as independent failures, so deduplication must happen before
+the durable write.
+
+A time-window or session-key dedupe would hide legitimate retries. A single
+"last generation" marker is also insufficient because an observer for an older
+send may resume after a newer send has started. A stable object per send keeps
+old and new attempts distinct without adding a durable identifier or an
+unbounded process-level set.
+
+## What Changes
+
+- Create a process-local attempt object immediately before every HTTP bridge
+  upstream `response.create` send.
+- Disarm that attempt when the send fails or is cancelled, and mark it observed
+  when a matching upstream response lifecycle event wins the race.
+- Capture the attempt at the moment a watchdog classifies a timeout, before any
+  recovery, reconnect, or cleanup await can install a newer attempt.
+- Pass the captured attempt through all retry-circuit failure funnels.
+- Atomically claim the attempt and increment the circuit under the existing
+  retry-circuit lock; only the first claim performs durable persistence.
+- Emit low-cardinality observability when a duplicate observer is suppressed.
+
+## Impact
+
+- One eventless send contributes at most one consecutive retry-circuit failure.
+- A separately dispatched retry or replay remains a distinct eligible failure
+  and can open the circuit as the second strike.
+- Existing circuit thresholds, cooldowns, error envelopes, account-health
+  handling, continuity guards, and durable conflict merging remain unchanged.
+- No schema migration, runtime setting, or operator action is required.
+
+## Non-Goals
+
+- Determining or eliminating the upstream cause of an eventless send.
+- Changing the eventless timeout, stream-idle timeout, retry threshold, or
+  cooldown durations.
+- Adding cross-replica send-attempt identifiers. Only the active bridge owner
+  owns the upstream socket; a send after owner handoff is a new physical attempt.
+- Changing replay eligibility, account selection, or continuity fail-closed
+  behavior.

--- a/openspec/changes/dedupe-http-bridge-retry-circuit-attempts/proposal.md
+++ b/openspec/changes/dedupe-http-bridge-retry-circuit-attempts/proposal.md
@@ -34,10 +34,17 @@ unbounded process-level set.
 - Disarm that attempt when the send fails or is cancelled, and mark it observed
   when a matching upstream response lifecycle event wins the race.
 - Capture the attempt at the moment a watchdog classifies a timeout, before any
-  recovery, reconnect, or cleanup await can install a newer attempt.
-- Pass the captured attempt through all retry-circuit failure funnels.
+  pending-ownership, recovery, reconnect, or cleanup await can install a newer
+  attempt.
+- Pass an explicit absent/eligible/recorded/settled/ineligible selection through
+  all retry-circuit failure funnels so ambiguous attribution cannot become an
+  unscoped strike.
 - Atomically claim the attempt and increment the circuit under the existing
   retry-circuit lock; only the first claim performs durable persistence.
+- Let duplicate observers wait for settlement and then read the live circuit
+  count instead of caching a historical count on the attempt.
+- Mark matched response lifecycle events on the attempt even when reasoning
+  prelude delivery and ordinary event accounting are deferred.
 - Emit low-cardinality observability when a duplicate observer is suppressed.
 
 ## Impact
@@ -45,6 +52,10 @@ unbounded process-level set.
 - One eventless send contributes at most one consecutive retry-circuit failure.
 - A separately dispatched retry or replay remains a distinct eligible failure
   and can open the circuit as the second strike.
+- A delayed observer sees later independent failures or a successful clear in
+  the current circuit state without adding another strike.
+- Ambiguous multi-pending cleanup fails safe by undercounting at that boundary,
+  never by creating an unattributed failure that could double-count a send.
 - Existing circuit thresholds, cooldowns, error envelopes, account-health
   handling, continuity guards, and durable conflict merging remain unchanged.
 - No schema migration, runtime setting, or operator action is required.

--- a/openspec/changes/dedupe-http-bridge-retry-circuit-attempts/specs/responses-api-compat/spec.md
+++ b/openspec/changes/dedupe-http-bridge-retry-circuit-attempts/specs/responses-api-compat/spec.md
@@ -12,12 +12,24 @@ as a new send attempt and MAY contribute the next eligible failure under the
 existing retry-circuit policy.
 
 The proxy MUST capture the attempt being classified before awaiting recovery,
-reconnection, or settlement that can dispatch a newer attempt. A send attempt
-that is disarmed by send-failure or cancellation cleanup, or that observes a
-matching upstream response lifecycle event before its first failure claim,
-MUST NOT add a retry-circuit failure. Deduplication MUST NOT change existing
-failure classes, thresholds, cooldowns, continuity guards, or cross-replica
-conflict merging.
+reconnection, settlement, or pending-request ownership that can dispatch a
+newer attempt. When stale ownership is classified while holding the pending
+lock, the classified request set and its attempt selection MUST come from that
+same snapshot. A send attempt that is disarmed by send-failure or cancellation
+cleanup, or that observes a matching upstream response lifecycle event before
+its first failure claim, MUST NOT add a retry-circuit failure. A matched
+response lifecycle event MUST mark its attempt observed even when downstream
+delivery or ordinary response-event accounting is intentionally deferred.
+
+The proxy MUST distinguish a failure path with no attempt identity from one
+whose attempt identity is present but ineligible or ambiguous. Only the former
+MAY preserve legacy unscoped recording. An ineligible attempt or multiple
+eligible candidates MUST NOT fall back to an unscoped failure. Duplicate
+observers MUST wait for the first claim's settlement and then use the current
+circuit count; they MUST NOT expose a cached historical count after a later
+failure or successful clear. Deduplication MUST NOT change existing failure
+classes, thresholds, cooldowns, continuity guards, or cross-replica conflict
+merging.
 
 #### Scenario: reader and downstream watchdogs observe one eventless send
 
@@ -42,6 +54,7 @@ conflict merging.
 - **WHEN** the delayed observer resumes after attempt B is current
 - **THEN** it does not increment or persist another failure for attempt A
 - **AND** it does not mark attempt B as recorded
+- **AND** it observes the current circuit count, including attempt B's independent failure
 
 #### Scenario: an upstream response wins the timeout race
 
@@ -49,8 +62,34 @@ conflict merging.
 - **WHEN** a matching upstream response lifecycle event is observed before the attempt's first failure claim
 - **THEN** that attempt does not contribute a retry-circuit failure
 
+#### Scenario: a deferred reasoning prelude wins the timeout race
+
+- **GIVEN** a matched reasoning lifecycle event is held for deferred downstream delivery
+- **AND** ordinary response-event accounting remains zero for that prelude
+- **WHEN** an eventless failure observer evaluates the same send attempt
+- **THEN** the attempt is already marked as response-observed
+- **AND** it does not contribute or persist a retry-circuit failure
+- **AND** deferred-delivery and downstream-visibility behavior remain unchanged
+
+#### Scenario: multiple pending attempts are ambiguous at a shared failure boundary
+
+- **GIVEN** a shared cleanup boundary contains multiple distinct eligible send attempts
+- **WHEN** the boundary cannot attribute its failure to exactly one physical send
+- **THEN** it does not fall back to an unscoped retry-circuit failure
+- **AND** it does not mark any candidate attempt as recorded
+- **AND** a later observer with an exact attempt identity can still record each genuine failure independently
+
+#### Scenario: pending-lock wait cannot replace the classified attempt
+
+- **GIVEN** stale cleanup captures attempt A for a request before acquiring pending ownership
+- **AND** recovery installs attempt B while cleanup is waiting for the pending lock
+- **WHEN** cleanup later records the classified failure
+- **THEN** it retains attempt A's identity
+- **AND** it does not mark attempt B as recorded
+
 #### Scenario: a cleared circuit is not recreated by a delayed duplicate
 
 - **GIVEN** a send attempt contributed a failure and a later successful terminal response cleared the circuit
 - **WHEN** another observer of the old send attempt resumes
 - **THEN** the old observer does not recreate or persist the cleared failure
+- **AND** it receives the current circuit count of zero

--- a/openspec/changes/dedupe-http-bridge-retry-circuit-attempts/specs/responses-api-compat/spec.md
+++ b/openspec/changes/dedupe-http-bridge-retry-circuit-attempts/specs/responses-api-compat/spec.md
@@ -1,0 +1,56 @@
+# responses-api-compat Delta
+
+## ADDED Requirements
+
+### Requirement: HTTP bridge retry circuits count each upstream send attempt at most once
+
+For an HTTP Responses bridge request, multiple local failure observers that
+classify the same upstream `response.create` send attempt MUST contribute at
+most one consecutive retry-circuit failure and at most one durable failure
+persistence operation. A separately dispatched retry or replay MUST be treated
+as a new send attempt and MAY contribute the next eligible failure under the
+existing retry-circuit policy.
+
+The proxy MUST capture the attempt being classified before awaiting recovery,
+reconnection, or settlement that can dispatch a newer attempt. A send attempt
+that is disarmed by send-failure or cancellation cleanup, or that observes a
+matching upstream response lifecycle event before its first failure claim,
+MUST NOT add a retry-circuit failure. Deduplication MUST NOT change existing
+failure classes, thresholds, cooldowns, continuity guards, or cross-replica
+conflict merging.
+
+#### Scenario: reader and downstream watchdogs observe one eventless send
+
+- **GIVEN** one hard-affinity HTTP bridge `response.create` send remains eventless
+- **AND** the upstream reader watchdog and downstream stream-idle watchdog both classify that send
+- **WHEN** both observers report the retry-circuit failure
+- **THEN** the circuit's consecutive failure count increases by exactly one
+- **AND** the failure is durably persisted exactly once
+- **AND** the default two-failure circuit does not open from that send alone
+
+#### Scenario: a separately dispatched retry is a second failure
+
+- **GIVEN** one send attempt has already contributed one retry-circuit failure
+- **WHEN** a later retry or replay dispatches a new `response.create` and that attempt also fails eligibility checks
+- **THEN** the new attempt contributes a second failure
+- **AND** the existing threshold and cooldown behavior may open the circuit
+
+#### Scenario: a delayed old observer cannot count a newer attempt
+
+- **GIVEN** an observer captured attempt A before recovery dispatched attempt B
+- **AND** attempt A has already contributed its failure
+- **WHEN** the delayed observer resumes after attempt B is current
+- **THEN** it does not increment or persist another failure for attempt A
+- **AND** it does not mark attempt B as recorded
+
+#### Scenario: an upstream response wins the timeout race
+
+- **GIVEN** a watchdog is evaluating an eventless send attempt
+- **WHEN** a matching upstream response lifecycle event is observed before the attempt's first failure claim
+- **THEN** that attempt does not contribute a retry-circuit failure
+
+#### Scenario: a cleared circuit is not recreated by a delayed duplicate
+
+- **GIVEN** a send attempt contributed a failure and a later successful terminal response cleared the circuit
+- **WHEN** another observer of the old send attempt resumes
+- **THEN** the old observer does not recreate or persist the cleared failure

--- a/openspec/changes/dedupe-http-bridge-retry-circuit-attempts/tasks.md
+++ b/openspec/changes/dedupe-http-bridge-retry-circuit-attempts/tasks.md
@@ -9,6 +9,8 @@
 - [x] 2.2 Capture and thread the classified attempt through all retry-circuit failure paths.
 - [x] 2.3 Claim the attempt atomically with the circuit increment and suppress duplicate persistence.
 - [x] 2.4 Add low-cardinality duplicate-suppression observability without new settings or schema.
+- [x] 2.5 Represent absent, ineligible, and ambiguous attempt attribution explicitly; never use ambiguous `None` as an unscoped fallback.
+- [x] 2.6 Read live circuit state after duplicate settlement and mark deferred response lifecycle events observed without changing delivery accounting.
 
 ## 3. Coverage
 
@@ -16,6 +18,7 @@
 - [x] 3.2 Prove a new send is a new strike and a delayed observer of an old send is not.
 - [x] 3.3 Cover response-wins, send-failure/cancellation, successful reset, and multiple-pending races.
 - [x] 3.4 Preserve clean-close, continuity, owner-handoff, and durable conflict-merge coverage.
+- [x] 3.5 Cover pending-lock attempt replacement, ambiguous selection suppression, deferred reasoning observation, and live-count changes after later failures or clear.
 
 ## 4. Verification
 

--- a/openspec/changes/dedupe-http-bridge-retry-circuit-attempts/tasks.md
+++ b/openspec/changes/dedupe-http-bridge-retry-circuit-attempts/tasks.md
@@ -1,0 +1,25 @@
+## 1. Specification
+
+- [x] 1.1 Add the attempt-scoped retry-circuit requirement and race scenarios.
+- [x] 1.2 Validate the change in strict mode.
+
+## 2. Implementation
+
+- [x] 2.1 Add the process-local HTTP bridge send-attempt state and lifecycle transitions.
+- [x] 2.2 Capture and thread the classified attempt through all retry-circuit failure paths.
+- [x] 2.3 Claim the attempt atomically with the circuit increment and suppress duplicate persistence.
+- [x] 2.4 Add low-cardinality duplicate-suppression observability without new settings or schema.
+
+## 3. Coverage
+
+- [x] 3.1 Add a full HTTP bridge regression where reader and downstream watchdogs observe one send.
+- [x] 3.2 Prove a new send is a new strike and a delayed observer of an old send is not.
+- [x] 3.3 Cover response-wins, send-failure/cancellation, successful reset, and multiple-pending races.
+- [x] 3.4 Preserve clean-close, continuity, owner-handoff, and durable conflict-merge coverage.
+
+## 4. Verification
+
+- [x] 4.1 Run focused HTTP bridge and durable retry-circuit tests.
+- [x] 4.2 Run Ruff, formatting checks, and the full unit suite.
+- [x] 4.3 Validate the OpenSpec change strictly and validate all main specs.
+- [x] 4.4 Review the final diff for lock ordering, persistence cardinality, scope creep, and rollback compatibility.

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -931,7 +931,15 @@ def test_http_bridge_eventless_precreated_deadline_survives_reasoning_prelude_wi
 async def test_process_http_bridge_upstream_text_anchors_deferred_reasoning_prelude_without_created() -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     request_state = _make_eventless_http_bridge_owner(sent_at=time.monotonic() - 2.0)
+    attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    request_state.response_create_attempt = attempt
     session = _make_bridge_session(pending_requests=deque([request_state]), queued_request_count=1)
+    lookup_retry_circuit = AsyncMock(return_value=None)
+    persist_retry_circuit = AsyncMock(return_value=None)
+    service._durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=lookup_retry_circuit,
+        persist_retry_circuit=persist_retry_circuit,
+    )
 
     await service._process_http_bridge_upstream_text(
         session,
@@ -948,6 +956,7 @@ async def test_process_http_bridge_upstream_text_anchors_deferred_reasoning_prel
     assert request_state.response_id is None
     assert request_state.downstream_visible is False
     assert request_state.upstream_model_output_seen is True
+    assert attempt.response_observed is True
     assert request_state.last_upstream_activity_at is not None
     sent_at = request_state.response_create_sent_at
     assert sent_at is not None
@@ -961,6 +970,22 @@ async def test_process_http_bridge_upstream_text_anchors_deferred_reasoning_prel
         == request_state.last_upstream_activity_at
         + http_bridge_helpers_module._HTTP_BRIDGE_EVENTLESS_RESPONSE_CREATED_MAX_SECONDS
     )
+    selection = http_bridge_helpers_module._http_bridge_retry_circuit_attempt_selection_for_pending_requests(
+        (request_state,)
+    )
+    assert selection.kind == "settled"
+    assert selection.attempt is attempt
+    assert (
+        await service._record_http_bridge_retry_circuit_failure_for_attempt_selection(
+            session,
+            detail="stream_idle_timeout",
+            selection=selection,
+        )
+        is None
+    )
+    assert session.key not in cast(Any, service)._http_bridge_retry_circuits
+    lookup_retry_circuit.assert_not_awaited()
+    persist_retry_circuit.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -2353,7 +2378,9 @@ async def test_response_create_gate_timeout_retires_old_pending_without_upstream
         retire_session: proxy_service._HTTPBridgeSession,
         *,
         detail: str,
+        retry_circuit_attempt_selection: proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection,
     ) -> None:
+        assert retry_circuit_attempt_selection.kind == "absent"
         retire_calls.append(detail)
         retire_session.closed = True
 
@@ -2460,7 +2487,9 @@ async def test_response_create_gate_timeout_retires_closed_anchored_pending_with
         retire_session: proxy_service._HTTPBridgeSession,
         *,
         detail: str,
+        retry_circuit_attempt_selection: proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection,
     ) -> None:
+        assert retry_circuit_attempt_selection.kind == "absent"
         retire_calls.append(detail)
         retire_session.closed = True
 
@@ -2549,7 +2578,9 @@ async def test_response_create_gate_timeout_retires_old_precreated_request_after
         retire_session: proxy_service._HTTPBridgeSession,
         *,
         detail: str,
+        retry_circuit_attempt_selection: proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection,
     ) -> None:
+        assert retry_circuit_attempt_selection.kind == "absent"
         retire_calls.append(detail)
         retire_session.closed = True
 
@@ -22558,11 +22589,11 @@ async def test_http_bridge_stream_and_reader_count_one_eventless_send_once(
         restart_reader: bool = False,
     ) -> bool:
         if restart_reader:
-            await asyncio.wait_for(reader_retry_started.wait(), timeout=0.5)
+            await asyncio.wait_for(reader_retry_started.wait(), timeout=2.0)
             return False
         request_state.response_create_sent_at = None
         reader_retry_started.set()
-        await asyncio.wait_for(release_reader_retry.wait(), timeout=0.5)
+        await asyncio.wait_for(release_reader_retry.wait(), timeout=2.0)
         return False
 
     monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
@@ -23372,6 +23403,7 @@ async def test_http_bridge_liveness_timeout_is_neutral_not_replayed_and_forces_r
         detail=UPSTREAM_WEBSOCKET_LIVENESS_TIMEOUT_CODE,
         response_events_seen=0,
         retired_request_count=1,
+        retry_circuit_attempt_selection=proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection(kind="absent"),
     )
     assert session.queued_request_count == 0
     assert session.closed is True
@@ -23525,8 +23557,9 @@ async def test_http_bridge_liveness_send_receive_race_settles_request_once(
     assert retire_call.kwargs["detail"] == UPSTREAM_WEBSOCKET_LIVENESS_TIMEOUT_CODE
     assert retire_call.kwargs["response_events_seen"] == 0
     assert retire_call.kwargs["retired_request_count"] == 2
-    assert retire_call.kwargs["retry_circuit_attempt"] is request_state.response_create_attempt
     assert request_state.response_create_attempt is not None
+    retry_circuit_attempt_selection = retire_call.kwargs["retry_circuit_attempt_selection"]
+    assert retry_circuit_attempt_selection.attempt is request_state.response_create_attempt
     assert request_state.response_create_attempt.disarmed is True
 
 
@@ -23650,6 +23683,7 @@ async def test_http_bridge_closed_without_liveness_claim_still_settles_pending_s
         detail=UPSTREAM_WEBSOCKET_LIVENESS_TIMEOUT_CODE,
         response_events_seen=0,
         retired_request_count=2,
+        retry_circuit_attempt_selection=proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection(kind="absent"),
     )
 
 
@@ -23711,14 +23745,17 @@ async def test_http_bridge_retry_send_network_failure_is_neutral_and_not_replaye
 
     await service._relay_http_bridge_upstream_messages(session)
 
-    assert failure_calls == [
-        {
-            "error_code": "proxy_network_unavailable",
-            "error_message": "Codex upstream websocket send failed: OSError",
-            "penalize_account": False,
-            "retry_circuit_attempt": first_attempt,
-        }
-    ]
+    assert len(failure_calls) == 1
+    failure_call = failure_calls[0]
+    assert failure_call["error_code"] == "proxy_network_unavailable"
+    assert failure_call["error_message"] == "Codex upstream websocket send failed: OSError"
+    assert failure_call["penalize_account"] is False
+    retry_circuit_attempt_selection = failure_call["retry_circuit_attempt_selection"]
+    assert isinstance(
+        retry_circuit_attempt_selection,
+        proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection,
+    )
+    assert retry_circuit_attempt_selection.attempt is first_attempt
     assert request_state.replay_count == 1
     retry_send.assert_awaited_once()
     assert request_state.response_create_attempt is not first_attempt
@@ -23782,6 +23819,7 @@ async def test_http_bridge_clean_close_before_response_does_not_penalize_account
         detail="stream_incomplete",
         response_events_seen=0,
         retired_request_count=0,
+        retry_circuit_attempt_selection=proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection(kind="absent"),
     )
 
 
@@ -23828,7 +23866,93 @@ async def test_http_bridge_clean_close_retry_failure_preserves_pre_recovery_atte
     await service._relay_http_bridge_upstream_messages(session)
 
     assert len(failure_calls) == 1
-    assert failure_calls[0]["retry_circuit_attempt"] is original_attempt
+    retry_circuit_attempt_selection = failure_calls[0]["retry_circuit_attempt_selection"]
+    assert isinstance(
+        retry_circuit_attempt_selection,
+        proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection,
+    )
+    assert retry_circuit_attempt_selection.attempt is original_attempt
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_reader_exception_captures_attempt_before_lifecycle_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = _make_eventless_http_bridge_owner(request_id="req-reader-exception-attempt")
+    request_state.started_at = time.monotonic()
+    request_state.response_create_sent_at = None
+    original_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    replacement_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=2)
+    request_state.response_create_attempt = original_attempt
+    session = _make_bridge_session(
+        key_value="bridge-reader-exception-attempt",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+    session.upstream = cast(
+        UpstreamWebSocket,
+        SimpleNamespace(
+            receive=AsyncMock(
+                return_value=UpstreamWebSocketMessage(
+                    kind="text",
+                    text='{"type":"response.created","response":{"id":"resp_reader_exception"}}',
+                )
+            ),
+            close=AsyncMock(),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+    monkeypatch.setattr(
+        service,
+        "_process_http_bridge_upstream_text",
+        AsyncMock(side_effect=RuntimeError("processing failed")),
+    )
+    attempt_captured = asyncio.Event()
+    original_selector = (
+        http_bridge_upstream_events_module._http_bridge_retry_circuit_attempt_selection_for_pending_requests
+    )
+
+    def capture_attempt_before_lifecycle_wait(
+        request_states: tuple[proxy_service._WebSocketRequestState, ...],
+    ) -> proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection:
+        selection = original_selector(request_states)
+        attempt_captured.set()
+        return selection
+
+    monkeypatch.setattr(
+        http_bridge_upstream_events_module,
+        "_http_bridge_retry_circuit_attempt_selection_for_pending_requests",
+        capture_attempt_before_lifecycle_wait,
+    )
+    failure_calls: list[dict[str, object]] = []
+
+    async def fail_reader(
+        target_session: proxy_service._HTTPBridgeSession,
+        **kwargs: object,
+    ) -> bool:
+        assert target_session is session
+        failure_calls.append(dict(kwargs))
+        target_session.closed = True
+        return True
+
+    monkeypatch.setattr(service, "_fail_http_bridge_reader_and_maybe_retire", fail_reader)
+
+    async with session.lifecycle_lock:
+        relay_task = asyncio.create_task(service._relay_http_bridge_upstream_messages(session))
+        await asyncio.wait_for(attempt_captured.wait(), timeout=1.0)
+        request_state.response_create_attempt = replacement_attempt
+
+    await asyncio.wait_for(relay_task, timeout=1.0)
+
+    assert len(failure_calls) == 1
+    retry_circuit_attempt_selection = failure_calls[0]["retry_circuit_attempt_selection"]
+    assert isinstance(
+        retry_circuit_attempt_selection,
+        proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection,
+    )
+    assert retry_circuit_attempt_selection.attempt is original_attempt
+    assert replacement_attempt.retry_circuit_failure_recorded is False
 
 
 @pytest.mark.asyncio
@@ -24597,12 +24721,15 @@ async def test_http_bridge_retry_circuit_claims_one_attempt_once_across_concurre
 
 
 @pytest.mark.asyncio
-async def test_http_bridge_retry_circuit_duplicate_waits_for_persisted_merge() -> None:
+async def test_http_bridge_retry_circuit_duplicate_waits_for_persisted_merge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     service = proxy_service.ProxyService(cast(Any, nullcontext()))
     session = _make_bridge_session(key_value="bridge-attempt-persist-merge")
     attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
     persist_started = asyncio.Event()
     allow_persist = asyncio.Event()
+    duplicate_wait_started = asyncio.Event()
 
     async def persist_retry_circuit(**_kwargs: object) -> SimpleNamespace:
         persist_started.set()
@@ -24617,6 +24744,26 @@ async def test_http_bridge_retry_circuit_duplicate_waits_for_persisted_merge() -
     service._durable_bridge = SimpleNamespace(
         lookup_retry_circuit=AsyncMock(return_value=None),
         persist_retry_circuit=AsyncMock(side_effect=persist_retry_circuit),
+    )
+    await_attempt_settlement = service._await_http_bridge_retry_circuit_attempt_settlement
+
+    async def track_attempt_settlement(
+        target_session: proxy_service._HTTPBridgeSession,
+        *,
+        attempt: proxy_support_module._HTTPBridgeResponseCreateAttempt,
+        detail: str,
+    ) -> int:
+        duplicate_wait_started.set()
+        return await await_attempt_settlement(
+            target_session,
+            attempt=attempt,
+            detail=detail,
+        )
+
+    monkeypatch.setattr(
+        service,
+        "_await_http_bridge_retry_circuit_attempt_settlement",
+        track_attempt_settlement,
     )
 
     first_task = asyncio.create_task(
@@ -24634,7 +24781,7 @@ async def test_http_bridge_retry_circuit_duplicate_waits_for_persisted_merge() -
             attempt=attempt,
         )
     )
-    await asyncio.sleep(0)
+    await asyncio.wait_for(duplicate_wait_started.wait(), timeout=0.5)
     assert duplicate_task.done() is False
 
     allow_persist.set()
@@ -24643,7 +24790,8 @@ async def test_http_bridge_retry_circuit_duplicate_waits_for_persisted_merge() -
     assert await asyncio.wait_for(duplicate_task, timeout=0.5) == 2
     state = cast(Any, service)._http_bridge_retry_circuits[session.key]
     assert state.consecutive_failures == 2
-    assert attempt.retry_circuit_failure_count == 2
+    assert attempt.retry_circuit_failure_settled is not None
+    assert attempt.retry_circuit_failure_settled.is_set() is True
 
 
 @pytest.mark.asyncio
@@ -24826,30 +24974,172 @@ def test_http_bridge_retry_circuit_attempt_selection_prefers_one_eventless_owner
     responded.response_event_count = 1
     responded.response_id = "resp-attempt-responded"
 
-    assert (
-        http_bridge_helpers_module._http_bridge_retry_circuit_attempt_for_pending_requests((responded, eventless))
-        is eventless_attempt
+    selection = http_bridge_helpers_module._http_bridge_retry_circuit_attempt_selection_for_pending_requests(
+        (responded, eventless)
     )
-    assert (
-        http_bridge_helpers_module._http_bridge_retry_circuit_attempt_for_pending_requests((responded,))
-        is responded_attempt
+    assert selection.kind == "eligible"
+    assert selection.attempt is eventless_attempt
+
+    selection = http_bridge_helpers_module._http_bridge_retry_circuit_attempt_selection_for_pending_requests(
+        (responded,)
     )
+    assert selection.kind == "settled"
+    assert selection.attempt is responded_attempt
 
     reconnecting = _make_eventless_http_bridge_owner(request_id="req-attempt-reconnecting")
     reconnecting_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
     reconnecting.response_create_attempt = reconnecting_attempt
     reconnecting.response_create_sent_at = None
-    assert (
-        http_bridge_helpers_module._http_bridge_retry_circuit_attempt_for_pending_requests((reconnecting,))
-        is reconnecting_attempt
+    selection = http_bridge_helpers_module._http_bridge_retry_circuit_attempt_selection_for_pending_requests(
+        (reconnecting,)
     )
+    assert selection.kind == "eligible"
+    assert selection.attempt is reconnecting_attempt
 
     other_eventless = _make_eventless_http_bridge_owner(request_id="req-attempt-other-eventless")
-    other_eventless.response_create_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    other_eventless_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    other_eventless.response_create_attempt = other_eventless_attempt
+    selection = http_bridge_helpers_module._http_bridge_retry_circuit_attempt_selection_for_pending_requests(
+        (eventless, other_eventless)
+    )
+    assert selection.kind == "eligible"
+    assert selection.ambiguous is True
+    assert selection.attempt is None
+    assert selection.attempts == (eventless_attempt, other_eventless_attempt)
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_retry_circuit_ambiguous_attempts_never_fall_back_to_unscoped_failure() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="bridge-attempt-ambiguous")
+    first_request = _make_eventless_http_bridge_owner(request_id="req-attempt-ambiguous-first")
+    second_request = _make_eventless_http_bridge_owner(request_id="req-attempt-ambiguous-second")
+    first_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    second_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    first_request.response_create_attempt = first_attempt
+    second_request.response_create_attempt = second_attempt
+    lookup_retry_circuit = AsyncMock(return_value=None)
+    persist_retry_circuit = AsyncMock(return_value=None)
+    service._durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=lookup_retry_circuit,
+        persist_retry_circuit=persist_retry_circuit,
+    )
+    selection = http_bridge_helpers_module._http_bridge_retry_circuit_attempt_selection_for_pending_requests(
+        (first_request, second_request)
+    )
+
+    assert selection.kind == "eligible"
+    assert selection.ambiguous is True
     assert (
-        http_bridge_helpers_module._http_bridge_retry_circuit_attempt_for_pending_requests((eventless, other_eventless))
+        await service._record_http_bridge_retry_circuit_failure_for_attempt_selection(
+            session,
+            detail="stream_idle_timeout",
+            selection=selection,
+        )
         is None
     )
+    assert session.key not in cast(Any, service)._http_bridge_retry_circuits
+    assert first_attempt.retry_circuit_failure_recorded is False
+    assert second_attempt.retry_circuit_failure_recorded is False
+    lookup_retry_circuit.assert_not_awaited()
+    persist_retry_circuit.assert_not_awaited()
+
+    first_count = await service._record_http_bridge_retry_circuit_failure(
+        session,
+        detail="stream_idle_timeout",
+        attempt=first_attempt,
+    )
+    second_count = await service._record_http_bridge_retry_circuit_failure(
+        session,
+        detail="stream_idle_timeout",
+        attempt=second_attempt,
+    )
+
+    assert (first_count, second_count) == (1, 2)
+    assert persist_retry_circuit.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_retry_circuit_ineligible_attempt_never_falls_back_to_unscoped_failure() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="bridge-attempt-ineligible")
+    request_state = _make_eventless_http_bridge_owner(request_id="req-attempt-ineligible")
+    attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    request_state.response_create_attempt = attempt
+    request_state.response_event_count = 1
+    lookup_retry_circuit = AsyncMock(return_value=None)
+    persist_retry_circuit = AsyncMock(return_value=None)
+    service._durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=lookup_retry_circuit,
+        persist_retry_circuit=persist_retry_circuit,
+    )
+    selection = http_bridge_helpers_module._http_bridge_retry_circuit_attempt_selection_for_pending_requests(
+        (request_state,)
+    )
+
+    assert selection.kind == "ineligible"
+    assert selection.attempt is None
+    assert (
+        await service._record_http_bridge_retry_circuit_failure_for_attempt_selection(
+            session,
+            detail="stream_idle_timeout",
+            selection=selection,
+        )
+        is None
+    )
+    assert session.key not in cast(Any, service)._http_bridge_retry_circuits
+    assert attempt.retry_circuit_failure_recorded is False
+    lookup_retry_circuit.assert_not_awaited()
+    persist_retry_circuit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_retry_circuit_multiple_recorded_attempts_report_live_count_without_increment() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="bridge-attempt-recorded-selection")
+    first_request = _make_eventless_http_bridge_owner(request_id="req-attempt-recorded-first")
+    second_request = _make_eventless_http_bridge_owner(request_id="req-attempt-recorded-second")
+    first_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    second_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    first_request.response_create_attempt = first_attempt
+    second_request.response_create_attempt = second_attempt
+    persist_retry_circuit = AsyncMock(return_value=None)
+    service._durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=AsyncMock(return_value=None),
+        persist_retry_circuit=persist_retry_circuit,
+    )
+    assert (
+        await service._record_http_bridge_retry_circuit_failure(
+            session,
+            detail="stream_idle_timeout",
+            attempt=first_attempt,
+        )
+        == 1
+    )
+    assert (
+        await service._record_http_bridge_retry_circuit_failure(
+            session,
+            detail="stream_idle_timeout",
+            attempt=second_attempt,
+        )
+        == 2
+    )
+    selection = http_bridge_helpers_module._http_bridge_retry_circuit_attempt_selection_for_pending_requests(
+        (first_request, second_request)
+    )
+
+    assert selection.kind == "recorded"
+    assert selection.ambiguous is True
+    assert (
+        await service._record_http_bridge_retry_circuit_failure_for_attempt_selection(
+            session,
+            detail="stream_idle_timeout",
+            selection=selection,
+        )
+        == 2
+    )
+    assert cast(Any, service)._http_bridge_retry_circuits[session.key].consecutive_failures == 2
+    assert persist_retry_circuit.await_count == 2
 
 
 @pytest.mark.parametrize(
@@ -25312,6 +25602,7 @@ async def test_http_bridge_repeated_zero_event_idle_timeouts_poison_anchor_with_
         session,
         detail="repeated_zero_event_idle_timeout",
         response_events_seen=0,
+        retry_circuit_attempt_selection=proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection(kind="absent"),
     )
 
 
@@ -25396,6 +25687,7 @@ async def test_http_bridge_eventless_timeout_force_retires_with_admission_waiter
         detail="missing_response_created_timeout",
         response_events_seen=0,
         retired_request_count=0,
+        retry_circuit_attempt_selection=proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection(kind="absent"),
     )
     fail_pending_await_args = fail_pending.await_args
     assert fail_pending_await_args is not None
@@ -25425,6 +25717,7 @@ async def test_http_bridge_reader_failure_retires_without_waiters_when_notificat
         detail="stream_incomplete",
         response_events_seen=0,
         retired_request_count=0,
+        retry_circuit_attempt_selection=proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection(kind="absent"),
     )
 
 
@@ -26945,6 +27238,67 @@ async def test_fail_stale_http_bridge_pending_requests_quarantines_wedged_gate_h
     # The wedged holder saw response events, so the eventless retry circuit
     # is deliberately not charged for it.
     record_failure.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fail_stale_http_bridge_pending_requests_captures_attempt_before_pending_lock_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = _make_eventless_http_bridge_owner(request_id="req-stale-attempt-snapshot")
+    original_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    replacement_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=2)
+    request_state.response_create_attempt = original_attempt
+    session = _make_bridge_session(
+        key_value="stale-attempt-snapshot",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+    attempt_captured = asyncio.Event()
+    original_selector = (
+        http_bridge_request_submit_module._http_bridge_retry_circuit_attempt_selection_for_pending_requests
+    )
+
+    def capture_attempt_before_lock(
+        request_states: list[proxy_service._WebSocketRequestState],
+    ) -> proxy_support_module._HTTPBridgeRetryCircuitAttemptSelection:
+        selection = original_selector(request_states)
+        attempt_captured.set()
+        return selection
+
+    monkeypatch.setattr(
+        http_bridge_request_submit_module,
+        "_http_bridge_retry_circuit_attempt_selection_for_pending_requests",
+        capture_attempt_before_lock,
+    )
+    record_failure = AsyncMock(return_value=1)
+    monkeypatch.setattr(
+        service,
+        "_record_http_bridge_retry_circuit_failure_for_attempt_selection",
+        record_failure,
+    )
+    monkeypatch.setattr(service, "_fail_pending_websocket_requests", AsyncMock())
+
+    async with session.pending_lock:
+        fail_task = asyncio.create_task(
+            service._fail_stale_http_bridge_pending_requests(
+                session,
+                [request_state],
+                detail="response_create_gate_timeout_stuck_pending",
+            )
+        )
+        await asyncio.wait_for(attempt_captured.wait(), timeout=0.5)
+        request_state.response_create_attempt = replacement_attempt
+
+    await asyncio.wait_for(fail_task, timeout=0.5)
+
+    record_failure.assert_awaited_once()
+    record_failure_call = record_failure.await_args
+    assert record_failure_call is not None
+    selection = record_failure_call.kwargs["selection"]
+    assert selection.kind == "eligible"
+    assert selection.attempt is original_attempt
+    assert replacement_attempt.retry_circuit_failure_recorded is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -23758,6 +23758,52 @@ async def test_http_bridge_clean_close_before_response_does_not_penalize_account
 
 
 @pytest.mark.asyncio
+async def test_http_bridge_clean_close_retry_failure_preserves_pre_recovery_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    request_state = _make_eventless_http_bridge_owner(request_id="req-clean-close-retry-attempt")
+    original_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    replacement_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=2)
+    request_state.response_create_attempt = original_attempt
+    session = _make_bridge_session(
+        key_value="bridge-clean-close-retry-attempt",
+        pending_requests=deque([request_state]),
+        queued_request_count=1,
+    )
+    session.upstream = cast(
+        UpstreamWebSocket,
+        SimpleNamespace(
+            receive=AsyncMock(return_value=UpstreamWebSocketMessage(kind="close", close_code=1000)),
+            close=AsyncMock(),
+        ),
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: _make_app_settings())
+
+    async def retry_precreated(target_session: Any, **_kwargs: object) -> bool:
+        assert target_session is session
+        request_state.response_create_attempt = replacement_attempt
+        request_state.response_create_sent_at = None
+        return False
+
+    failure_calls: list[dict[str, object]] = []
+
+    async def fail_reader(target_session: Any, **kwargs: object) -> bool:
+        assert target_session is session
+        failure_calls.append(dict(kwargs))
+        target_session.closed = True
+        return True
+
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
+    monkeypatch.setattr(service, "_fail_http_bridge_reader_and_maybe_retire", fail_reader)
+
+    await service._relay_http_bridge_upstream_messages(session)
+
+    assert len(failure_calls) == 1
+    assert failure_calls[0]["retry_circuit_attempt"] is original_attempt
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("routed", [False, True], ids=["direct-close", "routed-receive-error"])
 async def test_http_bridge_reader_maps_ordinary_websocket_receive_failure_to_stream_incomplete(
     monkeypatch: pytest.MonkeyPatch,
@@ -24520,6 +24566,56 @@ async def test_http_bridge_retry_circuit_claims_one_attempt_once_across_concurre
     assert state.cooldown_until == 0.0
     assert attempt.retry_circuit_failure_recorded is True
     assert persist_retry_circuit.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_retry_circuit_duplicate_waits_for_persisted_merge() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="bridge-attempt-persist-merge")
+    attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    persist_started = asyncio.Event()
+    allow_persist = asyncio.Event()
+
+    async def persist_retry_circuit(**_kwargs: object) -> SimpleNamespace:
+        persist_started.set()
+        await asyncio.wait_for(allow_persist.wait(), timeout=0.5)
+        return SimpleNamespace(
+            consecutive_failures=2,
+            cooldown_until_epoch=time.time() + 60.0,
+            last_detail="stream_idle_timeout",
+            updated_at_epoch=time.time(),
+        )
+
+    service._durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=AsyncMock(return_value=None),
+        persist_retry_circuit=AsyncMock(side_effect=persist_retry_circuit),
+    )
+
+    first_task = asyncio.create_task(
+        service._record_http_bridge_retry_circuit_failure(
+            session,
+            detail="stream_idle_timeout",
+            attempt=attempt,
+        )
+    )
+    await asyncio.wait_for(persist_started.wait(), timeout=0.5)
+    duplicate_task = asyncio.create_task(
+        service._record_http_bridge_retry_circuit_failure(
+            session,
+            detail="stream_idle_timeout",
+            attempt=attempt,
+        )
+    )
+    await asyncio.sleep(0)
+    assert duplicate_task.done() is False
+
+    allow_persist.set()
+
+    assert await asyncio.wait_for(first_task, timeout=0.5) == 2
+    assert await asyncio.wait_for(duplicate_task, timeout=0.5) == 2
+    state = cast(Any, service)._http_bridge_retry_circuits[session.key]
+    assert state.consecutive_failures == 2
+    assert attempt.retry_circuit_failure_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -991,6 +991,7 @@ async def test_http_bridge_send_replaces_timestamp_and_wakes_existing_reader(
         request_state,
         "first",
     )
+    first_attempt = request_state.response_create_attempt
     session.upstream_reader_wakeup.clear()
     await http_bridge_request_submit_module._send_http_bridge_request_text_with_archive_id(
         session,
@@ -1000,6 +1001,11 @@ async def test_http_bridge_send_replaces_timestamp_and_wakes_existing_reader(
 
     assert seen_sent_ats == [100.0, 200.0]
     assert request_state.response_create_sent_at == 200.0
+    assert first_attempt is not None
+    assert first_attempt.ordinal == 1
+    assert request_state.response_create_attempt is not first_attempt
+    assert request_state.response_create_attempt is not None
+    assert request_state.response_create_attempt.ordinal == 2
     assert session.upstream_reader_wakeup.is_set() is True
 
 
@@ -1035,6 +1041,8 @@ async def test_http_bridge_failed_send_disarms_eventless_deadline(
         )
 
     assert request_state.response_create_sent_at is None
+    assert request_state.response_create_attempt is not None
+    assert request_state.response_create_attempt.disarmed is True
     assert session.upstream_reader_wakeup.is_set() is True
     assert (
         http_bridge_helpers_module._http_bridge_eventless_precreated_deadline(
@@ -22477,6 +22485,99 @@ async def test_http_bridge_reader_wakes_and_retires_lone_eventless_owner_without
         session=session,
     )
     assert "http_bridge_event event=missing_response_created_timeout" in caplog.text
+    if leading_telemetry:
+        assert session.key not in service._http_bridge_retry_circuits
+    else:
+        assert service._http_bridge_retry_circuits[session.key].consecutive_failures == 1
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_stream_and_reader_count_one_eventless_send_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    upstream = _SilentEventlessUpstream()
+    session = _make_bridge_session(key_value="eventless-observer-race")
+    session.upstream = cast(UpstreamWebSocket, upstream)
+    service._http_bridge_sessions[session.key] = session
+    settings = _make_app_settings(
+        sse_keepalive_interval_seconds=0.005,
+        stream_idle_timeout_seconds=0.3,
+        http_responses_session_bridge_request_budget_seconds=1.0,
+        http_responses_session_bridge_stuck_gate_retire_after_seconds=0.02,
+    )
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(http_bridge_streaming_module, "_stream_keepalive_max_count", lambda: 1)
+    monkeypatch.setattr(proxy_service, "_HTTP_BRIDGE_STARTUP_KEEPALIVE_GRACE_SECONDS", 0.001)
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", AsyncMock(return_value=False))
+    monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
+    monkeypatch.setattr(service, "_write_request_log", AsyncMock())
+    persist_retry_circuit = AsyncMock(return_value=None)
+    service._durable_bridge = cast(
+        Any,
+        SimpleNamespace(
+            lookup_retry_circuit=AsyncMock(return_value=None),
+            persist_retry_circuit=persist_retry_circuit,
+        ),
+    )
+
+    async def submit(
+        target_session: proxy_service._HTTPBridgeSession,
+        *,
+        request_state: proxy_service._WebSocketRequestState,
+        text_data: str,
+        queue_limit: int,
+    ) -> None:
+        del queue_limit
+        gate = target_session.response_create_gate
+        await gate.acquire()
+        request_state.response_create_gate = gate
+        request_state.response_create_gate_acquired = True
+        request_state.awaiting_response_created = True
+        request_state.request_text = text_data
+        async with target_session.pending_lock:
+            target_session.pending_requests.append(request_state)
+            target_session.queued_request_count = 1
+        await http_bridge_request_submit_module._send_http_bridge_request_text_with_archive_id(
+            target_session,
+            request_state,
+            text_data,
+        )
+
+    monkeypatch.setattr(service, "_submit_http_bridge_request", submit)
+    request_state = _make_eventless_http_bridge_owner(request_id="req-eventless-observer-race", sent_at=0.0)
+    request_state.started_at = time.monotonic()
+    request_state.response_create_sent_at = None
+    request_state.response_create_gate = None
+    request_state.response_create_gate_acquired = False
+
+    reader_task = asyncio.create_task(service._relay_http_bridge_upstream_messages(session))
+    await asyncio.wait_for(upstream.first_receive_started.wait(), timeout=0.5)
+    stream = service._stream_http_bridge_session_events(
+        session,
+        request_state=request_state,
+        text_data='{"type":"response.create","model":"gpt-5.6-sol","input":"hello"}',
+        queue_limit=8,
+        propagate_http_errors=False,
+        downstream_turn_state=None,
+    )
+    try:
+        terminal = await asyncio.wait_for(anext(stream), timeout=1.0)
+        assert '"code":"stream_idle_timeout"' in terminal
+        await asyncio.wait_for(reader_task, timeout=1.0)
+
+        state = cast(Any, service)._http_bridge_retry_circuits[session.key]
+        assert state.consecutive_failures == 1
+        assert state.cooldown_until == 0.0
+        assert request_state.response_create_attempt is not None
+        assert request_state.response_create_attempt.retry_circuit_failure_recorded is True
+        assert persist_retry_circuit.await_count == 1
+    finally:
+        if not reader_task.done():
+            reader_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await reader_task
+        await stream.aclose()
 
 
 @pytest.mark.asyncio
@@ -23397,12 +23498,16 @@ async def test_http_bridge_liveness_send_receive_race_settles_request_once(
     assert session.queued_request_count == 0
     assert session.closed is True
     assert session.liveness_settlement_owner == "send"
-    retire.assert_awaited_once_with(
-        session,
-        detail=UPSTREAM_WEBSOCKET_LIVENESS_TIMEOUT_CODE,
-        response_events_seen=0,
-        retired_request_count=2,
-    )
+    retire.assert_awaited_once()
+    retire_call = retire.await_args
+    assert retire_call is not None
+    assert retire_call.args == (session,)
+    assert retire_call.kwargs["detail"] == UPSTREAM_WEBSOCKET_LIVENESS_TIMEOUT_CODE
+    assert retire_call.kwargs["response_events_seen"] == 0
+    assert retire_call.kwargs["retired_request_count"] == 2
+    assert retire_call.kwargs["retry_circuit_attempt"] is request_state.response_create_attempt
+    assert request_state.response_create_attempt is not None
+    assert request_state.response_create_attempt.disarmed is True
 
 
 @pytest.mark.asyncio
@@ -24373,6 +24478,245 @@ async def test_http_bridge_retry_circuit_counts_stream_idle_timeout() -> None:
     await service._record_http_bridge_retry_circuit_failure(hard_session, detail="stream_idle_timeout")
 
     assert cast(Any, service)._http_bridge_retry_circuits[hard_session.key].consecutive_failures == 1
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_retry_circuit_claims_one_attempt_once_across_concurrent_observers() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="bridge-attempt-concurrent")
+    attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    both_lookups_started = asyncio.Event()
+    lookup_count = 0
+
+    async def lookup_retry_circuit(**_kwargs: object) -> None:
+        nonlocal lookup_count
+        lookup_count += 1
+        if lookup_count == 2:
+            both_lookups_started.set()
+        await asyncio.wait_for(both_lookups_started.wait(), timeout=0.5)
+
+    persist_retry_circuit = AsyncMock(return_value=None)
+    service._durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=AsyncMock(side_effect=lookup_retry_circuit),
+        persist_retry_circuit=persist_retry_circuit,
+    )
+
+    results = await asyncio.gather(
+        service._record_http_bridge_retry_circuit_failure(
+            session,
+            detail="stream_idle_timeout",
+            attempt=attempt,
+        ),
+        service._record_http_bridge_retry_circuit_failure(
+            session,
+            detail="stream_idle_timeout",
+            attempt=attempt,
+        ),
+    )
+
+    state = cast(Any, service)._http_bridge_retry_circuits[session.key]
+    assert results == [1, 1]
+    assert state.consecutive_failures == 1
+    assert state.cooldown_until == 0.0
+    assert attempt.retry_circuit_failure_recorded is True
+    assert persist_retry_circuit.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_retry_circuit_duplicate_does_not_retry_failed_persistence(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="bridge-attempt-persist-failure")
+    attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    persist_retry_circuit = AsyncMock(side_effect=RuntimeError("durable write unavailable"))
+    service._durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=AsyncMock(return_value=None),
+        persist_retry_circuit=persist_retry_circuit,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        first_count = await service._record_http_bridge_retry_circuit_failure(
+            session,
+            detail="stream_idle_timeout",
+            attempt=attempt,
+        )
+        duplicate_count = await service._record_http_bridge_retry_circuit_failure(
+            session,
+            detail="stream_idle_timeout",
+            attempt=attempt,
+        )
+
+    assert (first_count, duplicate_count) == (1, 1)
+    assert cast(Any, service)._http_bridge_retry_circuits[session.key].consecutive_failures == 1
+    assert persist_retry_circuit.await_count == 1
+    assert "Failed to persist HTTP bridge retry circuit" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_retry_circuit_counts_distinct_send_attempts_and_not_delayed_old_observer() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="bridge-attempt-generations")
+    persist_retry_circuit = AsyncMock(return_value=None)
+    service._durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=AsyncMock(return_value=None),
+        persist_retry_circuit=persist_retry_circuit,
+    )
+    first_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    second_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=2)
+
+    first_count = await service._record_http_bridge_retry_circuit_failure(
+        session,
+        detail="stream_idle_timeout",
+        attempt=first_attempt,
+    )
+    second_count = await service._record_http_bridge_retry_circuit_failure(
+        session,
+        detail="stream_idle_timeout",
+        attempt=second_attempt,
+    )
+    delayed_first_count = await service._record_http_bridge_retry_circuit_failure(
+        session,
+        detail="stream_idle_timeout",
+        attempt=first_attempt,
+    )
+
+    state = cast(Any, service)._http_bridge_retry_circuits[session.key]
+    assert (first_count, second_count, delayed_first_count) == (1, 2, 2)
+    assert state.consecutive_failures == 2
+    assert state.cooldown_until > time.monotonic()
+    assert first_attempt.retry_circuit_failure_recorded is True
+    assert second_attempt.retry_circuit_failure_recorded is True
+    assert persist_retry_circuit.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_retry_circuit_does_not_claim_attempt_when_response_wins_lookup_race() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="bridge-attempt-response-race")
+    request_state = _make_eventless_http_bridge_owner()
+    attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    request_state.response_create_attempt = attempt
+    lookup_started = asyncio.Event()
+    release_lookup = asyncio.Event()
+
+    async def lookup_retry_circuit(**_kwargs: object) -> None:
+        lookup_started.set()
+        await asyncio.wait_for(release_lookup.wait(), timeout=0.5)
+
+    persist_retry_circuit = AsyncMock(return_value=None)
+    service._durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=AsyncMock(side_effect=lookup_retry_circuit),
+        persist_retry_circuit=persist_retry_circuit,
+    )
+    record_task = asyncio.create_task(
+        service._record_http_bridge_retry_circuit_failure(
+            session,
+            detail="stream_idle_timeout",
+            attempt=attempt,
+        )
+    )
+    await asyncio.wait_for(lookup_started.wait(), timeout=0.5)
+
+    proxy_support_module._record_response_event(request_state, "response.created")
+    release_lookup.set()
+
+    assert await asyncio.wait_for(record_task, timeout=0.5) is None
+    assert attempt.response_observed is True
+    assert attempt.retry_circuit_failure_recorded is False
+    assert session.key not in cast(Any, service)._http_bridge_retry_circuits
+    persist_retry_circuit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_retry_circuit_ignores_disarmed_send_attempt() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="bridge-attempt-disarmed")
+    attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1, disarmed=True)
+    lookup_retry_circuit = AsyncMock(return_value=None)
+    persist_retry_circuit = AsyncMock(return_value=None)
+    service._durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=lookup_retry_circuit,
+        persist_retry_circuit=persist_retry_circuit,
+    )
+
+    result = await service._record_http_bridge_retry_circuit_failure(
+        session,
+        detail="stream_idle_timeout",
+        attempt=attempt,
+    )
+
+    assert result is None
+    assert attempt.retry_circuit_failure_recorded is False
+    assert session.key not in cast(Any, service)._http_bridge_retry_circuits
+    lookup_retry_circuit.assert_not_awaited()
+    persist_retry_circuit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_bridge_retry_circuit_delayed_duplicate_does_not_recreate_cleared_state() -> None:
+    service = proxy_service.ProxyService(cast(Any, nullcontext()))
+    session = _make_bridge_session(key_value="bridge-attempt-reset-race")
+    attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    lookup_retry_circuit = AsyncMock(return_value=None)
+    persist_retry_circuit = AsyncMock(return_value=None)
+    service._durable_bridge = SimpleNamespace(
+        lookup_retry_circuit=lookup_retry_circuit,
+        persist_retry_circuit=persist_retry_circuit,
+    )
+
+    assert (
+        await service._record_http_bridge_retry_circuit_failure(
+            session,
+            detail="stream_idle_timeout",
+            attempt=attempt,
+        )
+        == 1
+    )
+    await service._clear_http_bridge_retry_circuit(session)
+    lookup_count_after_clear = lookup_retry_circuit.await_count
+
+    assert (
+        await service._record_http_bridge_retry_circuit_failure(
+            session,
+            detail="stream_idle_timeout",
+            attempt=attempt,
+        )
+        == 0
+    )
+    assert session.key not in cast(Any, service)._http_bridge_retry_circuits
+    assert lookup_retry_circuit.await_count == lookup_count_after_clear
+    assert persist_retry_circuit.await_count == 1
+
+
+def test_http_bridge_retry_circuit_attempt_selection_prefers_one_eventless_owner() -> None:
+    eventless = _make_eventless_http_bridge_owner(request_id="req-attempt-eventless")
+    eventless_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    eventless.response_create_attempt = eventless_attempt
+    responded = _make_eventless_http_bridge_owner(request_id="req-attempt-responded")
+    responded_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(
+        ordinal=1,
+        response_observed=True,
+    )
+    responded.response_create_attempt = responded_attempt
+    responded.response_event_count = 1
+    responded.response_id = "resp-attempt-responded"
+
+    assert (
+        http_bridge_helpers_module._http_bridge_retry_circuit_attempt_for_pending_requests((responded, eventless))
+        is eventless_attempt
+    )
+    assert (
+        http_bridge_helpers_module._http_bridge_retry_circuit_attempt_for_pending_requests((responded,))
+        is responded_attempt
+    )
+
+    other_eventless = _make_eventless_http_bridge_owner(request_id="req-attempt-other-eventless")
+    other_eventless.response_create_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    assert (
+        http_bridge_helpers_module._http_bridge_retry_circuit_attempt_for_pending_requests((eventless, other_eventless))
+        is None
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_proxy_http_bridge.py
+++ b/tests/unit/test_proxy_http_bridge.py
@@ -22501,15 +22501,14 @@ async def test_http_bridge_stream_and_reader_count_one_eventless_send_once(
     session.upstream = cast(UpstreamWebSocket, upstream)
     service._http_bridge_sessions[session.key] = session
     settings = _make_app_settings(
-        sse_keepalive_interval_seconds=0.005,
+        sse_keepalive_interval_seconds=0.02,
         stream_idle_timeout_seconds=0.3,
         http_responses_session_bridge_request_budget_seconds=1.0,
-        http_responses_session_bridge_stuck_gate_retire_after_seconds=0.02,
+        http_responses_session_bridge_stuck_gate_retire_after_seconds=0.005,
     )
     monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
     monkeypatch.setattr(http_bridge_streaming_module, "_stream_keepalive_max_count", lambda: 1)
     monkeypatch.setattr(proxy_service, "_HTTP_BRIDGE_STARTUP_KEEPALIVE_GRACE_SECONDS", 0.001)
-    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", AsyncMock(return_value=False))
     monkeypatch.setattr(service, "_handle_stream_error", AsyncMock())
     monkeypatch.setattr(service, "_write_request_log", AsyncMock())
     persist_retry_circuit = AsyncMock(return_value=None)
@@ -22550,6 +22549,23 @@ async def test_http_bridge_stream_and_reader_count_one_eventless_send_once(
     request_state.response_create_sent_at = None
     request_state.response_create_gate = None
     request_state.response_create_gate_acquired = False
+    reader_retry_started = asyncio.Event()
+    release_reader_retry = asyncio.Event()
+
+    async def retry_precreated(
+        _session: proxy_service._HTTPBridgeSession,
+        *,
+        restart_reader: bool = False,
+    ) -> bool:
+        if restart_reader:
+            await asyncio.wait_for(reader_retry_started.wait(), timeout=0.5)
+            return False
+        request_state.response_create_sent_at = None
+        reader_retry_started.set()
+        await asyncio.wait_for(release_reader_retry.wait(), timeout=0.5)
+        return False
+
+    monkeypatch.setattr(service, "_retry_http_bridge_precreated_request", retry_precreated)
 
     reader_task = asyncio.create_task(service._relay_http_bridge_upstream_messages(session))
     await asyncio.wait_for(upstream.first_receive_started.wait(), timeout=0.5)
@@ -22562,8 +22578,11 @@ async def test_http_bridge_stream_and_reader_count_one_eventless_send_once(
         downstream_turn_state=None,
     )
     try:
-        terminal = await asyncio.wait_for(anext(stream), timeout=1.0)
+        terminal_task = asyncio.create_task(anext(stream))
+        await asyncio.wait_for(reader_retry_started.wait(), timeout=1.0)
+        terminal = await asyncio.wait_for(terminal_task, timeout=1.0)
         assert '"code":"stream_idle_timeout"' in terminal
+        release_reader_retry.set()
         await asyncio.wait_for(reader_task, timeout=1.0)
 
         state = cast(Any, service)._http_bridge_retry_circuits[session.key]
@@ -22573,6 +22592,7 @@ async def test_http_bridge_stream_and_reader_count_one_eventless_send_once(
         assert request_state.response_create_attempt.retry_circuit_failure_recorded is True
         assert persist_retry_circuit.await_count == 1
     finally:
+        release_reader_retry.set()
         if not reader_task.done():
             reader_task.cancel()
             with pytest.raises(asyncio.CancelledError):
@@ -23649,6 +23669,10 @@ async def test_http_bridge_retry_send_network_failure_is_neutral_and_not_replaye
         request_text='{"type":"response.create","model":"gpt-5.4","input":"hello"}',
         transport="http",
     )
+    first_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    request_state.response_create_attempt_count = 1
+    request_state.response_create_attempt = first_attempt
+    request_state.response_create_sent_at = time.monotonic()
     session = _make_bridge_session(
         key_value="bridge-retry-send-network",
         pending_requests=deque([request_state]),
@@ -23692,10 +23716,14 @@ async def test_http_bridge_retry_send_network_failure_is_neutral_and_not_replaye
             "error_code": "proxy_network_unavailable",
             "error_message": "Codex upstream websocket send failed: OSError",
             "penalize_account": False,
+            "retry_circuit_attempt": first_attempt,
         }
     ]
     assert request_state.replay_count == 1
     retry_send.assert_awaited_once()
+    assert request_state.response_create_attempt is not first_attempt
+    assert request_state.response_create_attempt is not None
+    assert request_state.response_create_attempt.disarmed is True
     assert session.closed is True
 
 
@@ -24805,6 +24833,15 @@ def test_http_bridge_retry_circuit_attempt_selection_prefers_one_eventless_owner
     assert (
         http_bridge_helpers_module._http_bridge_retry_circuit_attempt_for_pending_requests((responded,))
         is responded_attempt
+    )
+
+    reconnecting = _make_eventless_http_bridge_owner(request_id="req-attempt-reconnecting")
+    reconnecting_attempt = proxy_support_module._HTTPBridgeResponseCreateAttempt(ordinal=1)
+    reconnecting.response_create_attempt = reconnecting_attempt
+    reconnecting.response_create_sent_at = None
+    assert (
+        http_bridge_helpers_module._http_bridge_retry_circuit_attempt_for_pending_requests((reconnecting,))
+        is reconnecting_attempt
     )
 
     other_eventless = _make_eventless_http_bridge_owner(request_id="req-attempt-other-eventless")

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -36172,6 +36172,7 @@ async def test_response_create_admission_stuck_gate_retire_ignores_draining_pend
         bridge_session,
         [stale_gate_holder],
         detail="response_create_gate_timeout_stuck_pending",
+        retry_circuit_attempt_selection=proxy_support._HTTPBridgeRetryCircuitAttemptSelection(kind="absent"),
     )
 
 


### PR DESCRIPTION
## Summary

- assign a process-local identity to each physical HTTP bridge `response.create` send
- thread the captured attempt through stream-idle, reader, stale-cleanup, and retirement failure funnels
- claim retry-circuit failures atomically so duplicate observers neither increment nor persist twice
- preserve the latest idle-retirement request-count guard and existing retry/cooldown behavior
- add OpenSpec coverage and end-to-end race regression tests

## Root cause

The upstream reader watchdog and downstream stream-idle watchdog can classify the same eventless `response.create` send independently. Each path previously persisted a retry-circuit failure, so the default two-failure threshold could open from one physical send.

Durable conflict merging cannot distinguish duplicate local observations from independent failures. The deduplication therefore needs to happen before persistence while retaining the exact send attempt across recovery awaits.

## Impact

One eventless send now contributes at most one retry-circuit failure and one durable write. A separately dispatched retry remains a distinct attempt and can contribute the next strike. No schema, setting, error-envelope, account-health, or continuity-policy changes are introduced.

## Validation

- `5865 passed, 70 skipped` — full unit suite
- `549 passed` — HTTP bridge unit suite
- `236 passed` — HTTP Responses/WebSocket bridge integration suite
- `1716 passed, 23 skipped` — core integration suite; one unrelated graceful-shutdown readiness timing failure passed on clean `main` and then passed 3 consecutive reruns on this branch
- `30 passed` — retry-circuit focused tests
- Ruff check and format, ty, proxy architecture check
- strict OpenSpec change validation and all 57 main specs
- frontend production build

## Issue relationship

Related to #1737 as a partial mitigation only. This PR does not close that issue because #1737 also covers cooldown handling after two genuinely distinct failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate retry-circuit failures when multiple monitors observe the same HTTP bridge request.
  * Improved handling of timeouts, connection closures, and recovery races.
  * Ensured completed, canceled, or failed sends are excluded from inaccurate failure counts.
  * Preserved separate tracking for genuine retries and replayed requests.

* **Documentation**
  * Added design documentation and requirements for reliable retry-circuit failure tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->