### PR TITLE
fix(proxy): reject duplicate compact triggers locally

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -3618,6 +3618,7 @@ class _CompactCommandTransport:
         compact_timeout_seconds = _effective_compact_total_timeout(settings.upstream_compact_timeout_seconds)
         effective_connect_timeout = _effective_compact_connect_timeout(settings.upstream_connect_timeout_seconds)
         payload_dict = dict(self.payload.to_payload())
+        payload_dict["store"] = False
         if settings.image_inline_fetch_enabled:
             payload_dict = await _inline_input_image_urls(
                 payload_dict,

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -3599,7 +3599,7 @@ class _CompactCommandTransport:
     async def execute(self) -> CompactResponsePayload:
         settings = get_settings()
         upstream_base = settings.upstream_base_url.rstrip("/")
-        url = f"{upstream_base}/codex/responses/compact"
+        url = f"{upstream_base}/codex/responses"
         require_route_or_direct_egress_opt_in(
             route=self.route,
             allow_direct_egress=self.allow_direct_egress,

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1239,6 +1239,58 @@ async def _compact_response_payload_from_success_response(
     return await _codex_response_json(resp)
 
 
+def _normalize_compact_response_payload_shape(payload: JsonValue) -> JsonValue:
+    if not is_json_mapping(payload):
+        return payload
+    object_value = payload.get("object")
+    if isinstance(object_value, str) and object_value.startswith("response.compact"):
+        return payload
+    compaction_item = _compact_output_item_from_payload(payload)
+    if compaction_item is None:
+        return payload
+    normalized: dict[str, JsonValue] = {
+        "object": "response.compaction",
+        "output": [compaction_item],
+    }
+    for key in ("id", "status", "usage"):
+        value = payload.get(key)
+        if value is not None:
+            normalized[key] = value
+    return normalized
+
+
+def _compact_output_item_from_payload(payload: Mapping[str, JsonValue]) -> dict[str, JsonValue] | None:
+    output = payload.get("output")
+    if isinstance(output, list):
+        for raw_item in output:
+            if not is_json_mapping(raw_item):
+                continue
+            item_type = raw_item.get("type")
+            if isinstance(item_type, str) and item_type in {"compaction", "compaction_summary"}:
+                normalized = _normalize_compact_output_item(raw_item)
+                if normalized is not None:
+                    return normalized
+    summary = payload.get("compaction_summary")
+    if is_json_mapping(summary):
+        return _normalize_compact_output_item(summary)
+    return None
+
+
+def _normalize_compact_output_item(item: Mapping[str, JsonValue]) -> dict[str, JsonValue] | None:
+    encrypted_content = item.get("encrypted_content")
+    if not isinstance(encrypted_content, str):
+        return None
+    normalized: dict[str, JsonValue] = {
+        "type": "compaction",
+        "encrypted_content": encrypted_content,
+    }
+    for key in ("id", "status"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            normalized[key] = value
+    return normalized
+
+
 async def _error_response_body(resp: ErrorResponse) -> tuple[object | None, str | None]:
     try:
         return await resp.json(content_type=None), None
@@ -3795,6 +3847,7 @@ class _CompactCommandTransport:
                         failure_exception_type=failure_exception_type,
                         upstream_status_code=status_code,
                     ) from exc
+                data = _normalize_compact_response_payload_shape(data)
                 parsed = parse_compact_response_payload(data)
                 archive_json(
                     direction="server_to_codex",
@@ -3899,6 +3952,7 @@ class _CompactCommandTransport:
                         failure_exception_type=failure_exception_type,
                         upstream_status_code=resp.status,
                     ) from exc
+                data = _normalize_compact_response_payload_shape(data)
                 parsed = parse_compact_response_payload(data)
                 archive_json(
                     direction="server_to_codex",

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1483,7 +1483,32 @@ def _compact_sse_terminal_status_code(payload: Mapping[str, JsonValue]) -> int:
     for value in candidates:
         if isinstance(value, int) and not isinstance(value, bool):
             return value
+    for candidate in (response, payload):
+        if not is_json_mapping(candidate):
+            continue
+        error = parse_error_payload(dict(candidate))
+        if error is None:
+            continue
+        inferred_status = _status_code_from_openai_error(error)
+        if inferred_status is not None:
+            return inferred_status
     return 502
+
+
+def _status_code_from_openai_error(error: OpenAIError) -> int | None:
+    error_type = error.type
+    error_code = error.code
+    if error_type == "authentication_error" or error_code == "invalid_api_key":
+        return 401
+    if error_type == "permission_error" or error_code == "insufficient_permissions":
+        return 403
+    if error_code == "not_found":
+        return 404
+    if error_type == "rate_limit_error" or error_code in {"rate_limit_exceeded", "usage_limit_reached"}:
+        return 429
+    if error_type == "invalid_request_error":
+        return 400
+    return None
 
 
 async def _error_response_body(resp: ErrorResponse) -> tuple[object | None, str | None]:

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -450,6 +450,7 @@ class _CodexSSEResponse:
     def __init__(self, response: Any) -> None:
         self._response = response
         self.status = _codex_response_status(response)
+        self.headers = _codex_response_headers(response)
         self.content = _CodexSSEContent(response)
 
     async def json(self, *, content_type: str | None = None) -> JsonValue:
@@ -1200,6 +1201,39 @@ async def _iter_sse_events(
         if len(buffer) > max_event_bytes:
             raise StreamEventTooLargeError(len(buffer), max_event_bytes)
         yield bytes(buffer).decode("utf-8", errors="replace")
+
+
+async def _compact_response_payload_from_sse(resp: SSEResponse, idle_timeout_seconds: float, max_event_bytes: int) -> JsonValue:
+    last_payload: dict[str, JsonValue] | None = None
+    async for event_block in _iter_sse_events(resp, idle_timeout_seconds, max_event_bytes):
+        payload = parse_sse_data_json(event_block)
+        if payload is None:
+            continue
+        last_payload = payload
+        event_type = payload.get("type")
+        if event_type == "response.completed":
+            response = payload.get("response")
+            if isinstance(response, dict):
+                return response
+            raise ValueError("response.completed event missing response object")
+        if event_type in {"response.failed", "response.incomplete", "error"}:
+            raise ValueError(f"upstream SSE terminal event {event_type}")
+    if last_payload is not None:
+        raise ValueError("upstream SSE ended before response.completed")
+    raise ValueError("empty upstream SSE response")
+
+
+async def _compact_response_payload_from_success_response(
+    resp: Any,
+    *,
+    idle_timeout_seconds: float,
+    max_event_bytes: int,
+) -> JsonValue:
+    headers = _codex_response_headers(resp)
+    content_type = next((value for key, value in headers.items() if key.lower() == "content-type"), "")
+    if "text/event-stream" in content_type.lower():
+        return await _compact_response_payload_from_sse(cast(SSEResponse, resp), idle_timeout_seconds, max_event_bytes)
+    return await _codex_response_json(resp)
 
 
 async def _error_response_body(resp: ErrorResponse) -> tuple[object | None, str | None]:
@@ -3612,13 +3646,14 @@ class _CompactCommandTransport:
             self.headers,
             self.access_token,
             upstream_account_id,
-            accept="application/json",
+            accept="text/event-stream",
         )
         pre_request_started_at = time.monotonic()
         compact_timeout_seconds = _effective_compact_total_timeout(settings.upstream_compact_timeout_seconds)
         effective_connect_timeout = _effective_compact_connect_timeout(settings.upstream_connect_timeout_seconds)
         payload_dict = dict(self.payload.to_payload())
         payload_dict["store"] = False
+        payload_dict["stream"] = True
         if settings.image_inline_fetch_enabled:
             payload_dict = await _inline_input_image_urls(
                 payload_dict,
@@ -3738,7 +3773,11 @@ class _CompactCommandTransport:
                         upstream_status_code=status_code,
                     )
                 try:
-                    data = await _codex_response_json(resp)
+                    data = await _compact_response_payload_from_success_response(
+                        _CodexSSEResponse(resp),
+                        idle_timeout_seconds=compact_timeout_seconds or settings.stream_idle_timeout_seconds,
+                        max_event_bytes=settings.max_sse_event_bytes,
+                    )
                 except Exception as exc:
                     error_code = "upstream_error"
                     error_message = "Invalid JSON from upstream"
@@ -3816,7 +3855,11 @@ class _CompactCommandTransport:
                         upstream_status_code=resp.status,
                     )
                 try:
-                    data = await resp.json(content_type=None)
+                    data = await _compact_response_payload_from_success_response(
+                        resp,
+                        idle_timeout_seconds=compact_timeout_seconds or settings.stream_idle_timeout_seconds,
+                        max_event_bytes=settings.max_sse_event_bytes,
+                    )
                 except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as exc:
                     message = str(exc) or "Request to upstream timed out"
                     error_code = process_network_error_code(

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1231,7 +1231,10 @@ async def _compact_response_payload_from_success_response(
 ) -> JsonValue:
     headers = _codex_response_headers(resp)
     content_type = next((value for key, value in headers.items() if key.lower() == "content-type"), "")
-    if "text/event-stream" in content_type.lower():
+    content = getattr(resp, "content", None)
+    if "text/event-stream" in content_type.lower() or (
+        not content_type and callable(getattr(content, "iter_chunked", None))
+    ):
         return await _compact_response_payload_from_sse(cast(SSEResponse, resp), idle_timeout_seconds, max_event_bytes)
     return await _codex_response_json(resp)
 

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1399,6 +1399,32 @@ def _proxy_response_error_from_compact_sse_terminal(
     )
 
 
+def _proxy_response_error_from_compact_sse_stream_exception(
+    exc: StreamIdleTimeoutError | StreamEventTooLargeError,
+    *,
+    upstream_status_code: int | None,
+) -> ProxyResponseError:
+    if isinstance(exc, StreamIdleTimeoutError):
+        return ProxyResponseError(
+            502,
+            openai_error("stream_idle_timeout", "Upstream stream idle timeout"),
+            failure_phase="upstream",
+            failure_detail="stream_idle_timeout",
+            failure_exception_type=type(exc).__name__,
+            upstream_status_code=upstream_status_code,
+            upstream_error_code="stream_idle_timeout",
+        )
+    return ProxyResponseError(
+        502,
+        openai_error("stream_event_too_large", str(exc)),
+        failure_phase="upstream",
+        failure_detail=str(exc),
+        failure_exception_type=type(exc).__name__,
+        upstream_status_code=upstream_status_code,
+        upstream_error_code="stream_event_too_large",
+    )
+
+
 def _compact_sse_terminal_error_payload(
     payload: Mapping[str, JsonValue],
     event_type: object,
@@ -4000,6 +4026,11 @@ class _CompactCommandTransport:
                         idle_timeout_seconds=compact_timeout_seconds or settings.stream_idle_timeout_seconds,
                         max_event_bytes=settings.max_sse_event_bytes,
                     )
+                except (StreamIdleTimeoutError, StreamEventTooLargeError) as exc:
+                    raise _proxy_response_error_from_compact_sse_stream_exception(
+                        exc,
+                        upstream_status_code=status_code,
+                    ) from exc
                 except ProxyResponseError:
                     raise
                 except Exception as exc:
@@ -4106,6 +4137,11 @@ class _CompactCommandTransport:
                         failure_exception_type=failure_exception_type,
                         upstream_status_code=resp.status,
                         failed_session=_failed_shared_session_for_process_network_error(error_code, self.session),
+                    ) from exc
+                except (StreamIdleTimeoutError, StreamEventTooLargeError) as exc:
+                    raise _proxy_response_error_from_compact_sse_stream_exception(
+                        exc,
+                        upstream_status_code=resp.status,
                     ) from exc
                 except ProxyResponseError:
                     raise

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -437,11 +437,34 @@ SSEResponse: TypeAlias = aiohttp.ClientResponse | SSEResponseProtocol
 
 class _CodexSSEContent:
     def __init__(self, response: Any) -> None:
-        self._response = response
+        content = getattr(response, "content", None)
+        self._body = content if isinstance(content, bytes | bytearray) else None
+        self._content = content
 
     def iter_chunked(self, size: int) -> "SSEChunkIteratorProtocol":
-        del size
-        return cast(SSEChunkIteratorProtocol, self._response.content.iter_chunked(1024))
+        if self._body is not None:
+            return cast(SSEChunkIteratorProtocol, _BytesSSEChunkIterator(bytes(self._body), size))
+        if self._content is None:
+            raise TypeError("SSE response content is missing")
+        return cast(SSEChunkIteratorProtocol, self._content.iter_chunked(size))
+
+
+class _BytesSSEChunkIterator:
+    def __init__(self, body: bytes, size: int) -> None:
+        self._body = body
+        self._size = max(1, size)
+        self._offset = 0
+
+    def __aiter__(self) -> "_BytesSSEChunkIterator":
+        return self
+
+    async def __anext__(self) -> bytes:
+        if self._offset >= len(self._body):
+            raise StopAsyncIteration
+        end = min(len(self._body), self._offset + self._size)
+        chunk = self._body[self._offset : end]
+        self._offset = end
+        return chunk
 
 
 class _CodexSSEResponse:
@@ -1230,7 +1253,7 @@ async def _compact_response_payload_from_sse(
                 return response
             raise ValueError("response.completed event missing response object")
         if event_type in {"response.failed", "response.incomplete", "error"}:
-            raise ValueError(f"upstream SSE terminal event {event_type}")
+            raise _proxy_response_error_from_compact_sse_terminal(payload, event_type)
     if last_payload is not None:
         raise ValueError("upstream SSE ended before response.completed")
     raise ValueError("empty upstream SSE response")
@@ -1265,11 +1288,21 @@ def _normalize_compact_response_payload_shape(payload: JsonValue) -> JsonValue:
         "object": "response.compaction",
         "output": [compaction_item],
     }
-    for key in ("id", "status", "usage"):
+    for key in ("id", "status", "usage", "service_tier"):
         value = payload.get(key)
         if value is not None:
             normalized[key] = value
     return normalized
+
+
+def _responses_compact_payload_for_responses_endpoint(payload: ResponsesCompactRequest) -> dict[str, JsonValue]:
+    payload_dict = dict(payload.to_payload())
+    input_value = payload_dict.get("input")
+    input_items = list(input_value) if isinstance(input_value, list) else [input_value]
+    if not (input_items and is_json_mapping(input_items[-1]) and input_items[-1].get("type") == "compaction_trigger"):
+        input_items.append({"type": "compaction_trigger"})
+    payload_dict["input"] = input_items
+    return payload_dict
 
 
 def _compact_output_item_from_payload(payload: Mapping[str, JsonValue]) -> dict[str, JsonValue] | None:
@@ -1283,6 +1316,10 @@ def _compact_output_item_from_payload(payload: Mapping[str, JsonValue]) -> dict[
                 normalized = _normalize_compact_output_item(raw_item)
                 if normalized is not None:
                     return normalized
+        for raw_item in output:
+            if not is_json_mapping(raw_item):
+                continue
+            item_type = raw_item.get("type")
             if item_type == "message":
                 normalized = _compact_output_item_from_message(raw_item)
                 if normalized is not None:
@@ -1343,6 +1380,82 @@ def _normalize_compact_output_item(item: Mapping[str, JsonValue]) -> dict[str, J
         if isinstance(value, str) and value.strip():
             normalized[key] = value
     return normalized
+
+
+def _proxy_response_error_from_compact_sse_terminal(
+    payload: Mapping[str, JsonValue],
+    event_type: object,
+) -> ProxyResponseError:
+    error_payload = _compact_sse_terminal_error_payload(payload, event_type)
+    error_code, error_message = _error_details_from_envelope(error_payload)
+    status_code = _compact_sse_terminal_status_code(payload)
+    return ProxyResponseError(
+        status_code,
+        error_payload,
+        failure_phase="upstream",
+        failure_detail=error_message,
+        upstream_status_code=status_code,
+        upstream_error_code=error_code,
+    )
+
+
+def _compact_sse_terminal_error_payload(
+    payload: Mapping[str, JsonValue],
+    event_type: object,
+) -> OpenAIErrorEnvelope:
+    error = parse_error_payload(dict(payload))
+    if error:
+        return {"error": _openai_error_detail(error)}
+    if event_type == "error":
+        error_code = payload.get("code")
+        error_message = payload.get("message")
+        if isinstance(error_code, str) and error_code and isinstance(error_message, str) and error_message:
+            detail: OpenAIErrorDetail = {
+                "code": error_code,
+                "message": error_message,
+                "type": "server_error",
+            }
+            error_type = payload.get("type")
+            if isinstance(error_type, str) and error_type and error_type != "error":
+                detail["type"] = error_type
+            param = payload.get("param")
+            if isinstance(param, str) and param:
+                detail["param"] = param
+            return {"error": detail}
+    response = payload.get("response")
+    if is_json_mapping(response):
+        response_error = parse_error_payload(dict(response))
+        if response_error:
+            return {"error": _openai_error_detail(response_error)}
+    message = _extract_upstream_message(cast(Mapping[str, Any], payload))
+    if not message and is_json_mapping(response):
+        message = _extract_upstream_message(cast(Mapping[str, Any], response))
+    code = "upstream_error"
+    if event_type == "response.incomplete":
+        code = "incomplete"
+    elif event_type == "response.failed":
+        code = "upstream_error"
+    elif event_type == "error":
+        code = "upstream_error"
+    return openai_error(code, message or f"Upstream SSE terminal event: {event_type}")
+
+
+def _compact_sse_terminal_status_code(payload: Mapping[str, JsonValue]) -> int:
+    response = payload.get("response")
+    candidates: list[JsonValue] = []
+    if is_json_mapping(response):
+        candidates.extend(
+            [
+                response.get("status_code"),
+                response.get("statusCode"),
+                response.get("status"),
+            ]
+        )
+    candidates.extend([payload.get("status_code"), payload.get("statusCode"), payload.get("status")])
+    for value in candidates:
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+    return 502
 
 
 async def _error_response_body(resp: ErrorResponse) -> tuple[object | None, str | None]:
@@ -3760,7 +3873,7 @@ class _CompactCommandTransport:
         pre_request_started_at = time.monotonic()
         compact_timeout_seconds = _effective_compact_total_timeout(settings.upstream_compact_timeout_seconds)
         effective_connect_timeout = _effective_compact_connect_timeout(settings.upstream_connect_timeout_seconds)
-        payload_dict = dict(self.payload.to_payload())
+        payload_dict = _responses_compact_payload_for_responses_endpoint(self.payload)
         payload_dict["store"] = False
         payload_dict["stream"] = True
         if settings.image_inline_fetch_enabled:
@@ -3887,6 +4000,8 @@ class _CompactCommandTransport:
                         idle_timeout_seconds=compact_timeout_seconds or settings.stream_idle_timeout_seconds,
                         max_event_bytes=settings.max_sse_event_bytes,
                     )
+                except ProxyResponseError:
+                    raise
                 except Exception as exc:
                     error_code = "upstream_error"
                     error_message = "Invalid JSON from upstream"
@@ -3992,6 +4107,8 @@ class _CompactCommandTransport:
                         upstream_status_code=resp.status,
                         failed_session=_failed_shared_session_for_process_network_error(error_code, self.session),
                     ) from exc
+                except ProxyResponseError:
+                    raise
                 except Exception as exc:
                     error_code = "upstream_error"
                     error_message = "Invalid JSON from upstream"

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1203,17 +1203,30 @@ async def _iter_sse_events(
         yield bytes(buffer).decode("utf-8", errors="replace")
 
 
-async def _compact_response_payload_from_sse(resp: SSEResponse, idle_timeout_seconds: float, max_event_bytes: int) -> JsonValue:
+async def _compact_response_payload_from_sse(
+    resp: SSEResponse, idle_timeout_seconds: float, max_event_bytes: int
+) -> JsonValue:
     last_payload: dict[str, JsonValue] | None = None
+    output_items: dict[int, dict[str, JsonValue]] = {}
     async for event_block in _iter_sse_events(resp, idle_timeout_seconds, max_event_bytes):
         payload = parse_sse_data_json(event_block)
         if payload is None:
             continue
         last_payload = payload
         event_type = payload.get("type")
+        if event_type in {"response.output_item.added", "response.output_item.done"}:
+            output_index = payload.get("output_index")
+            item = payload.get("item")
+            if isinstance(output_index, int) and isinstance(item, dict):
+                output_items[output_index] = dict(item)
         if event_type == "response.completed":
             response = payload.get("response")
             if isinstance(response, dict):
+                existing_output = response.get("output")
+                if output_items and not (isinstance(existing_output, list) and existing_output):
+                    merged_response = dict(response)
+                    merged_response["output"] = [item for _, item in sorted(output_items.items())]
+                    return merged_response
                 return response
             raise ValueError("response.completed event missing response object")
         if event_type in {"response.failed", "response.incomplete", "error"}:
@@ -1270,9 +1283,50 @@ def _compact_output_item_from_payload(payload: Mapping[str, JsonValue]) -> dict[
                 normalized = _normalize_compact_output_item(raw_item)
                 if normalized is not None:
                     return normalized
+            if item_type == "message":
+                normalized = _compact_output_item_from_message(raw_item)
+                if normalized is not None:
+                    return normalized
     summary = payload.get("compaction_summary")
     if is_json_mapping(summary):
         return _normalize_compact_output_item(summary)
+    return None
+
+
+def _compact_output_item_from_message(item: Mapping[str, JsonValue]) -> dict[str, JsonValue] | None:
+    text = _compact_message_text(item)
+    if not text:
+        return None
+    normalized: dict[str, JsonValue] = {
+        "type": "compaction",
+        "encrypted_content": text,
+    }
+    for key in ("id", "status"):
+        value = item.get(key)
+        if isinstance(value, str) and value.strip():
+            normalized[key] = value
+    return normalized
+
+
+def _compact_message_text(item: Mapping[str, JsonValue]) -> str | None:
+    direct_text = item.get("text")
+    if isinstance(direct_text, str) and direct_text:
+        return direct_text
+    content = item.get("content")
+    content_parts: list[Mapping[str, JsonValue]]
+    if is_json_mapping(content):
+        content_parts = [content]
+    elif isinstance(content, list):
+        content_parts = [part for part in content if is_json_mapping(part)]
+    else:
+        content_parts = []
+    text_parts: list[str] = []
+    for part in content_parts:
+        text = part.get("text")
+        if isinstance(text, str) and text:
+            text_parts.append(text)
+    if text_parts:
+        return "".join(text_parts)
     return None
 
 

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -1230,33 +1230,49 @@ def _compact_terminal_required_indices(
     latest_index = len(input_value) - 1
     latest_mapping = _json_mapping_or_none(input_value[latest_index])
     latest_type = latest_mapping.get("type") if latest_mapping is not None else None
+    terminal_trigger_indices: set[int] = set()
+    if latest_type == "compaction_trigger":
+        terminal_trigger_indices.add(latest_index)
+        if latest_index == 0:
+            return terminal_trigger_indices, True, False
+        latest_index -= 1
+        latest_mapping = _json_mapping_or_none(input_value[latest_index])
+        latest_type = latest_mapping.get("type") if latest_mapping is not None else None
+
+    def with_terminal_trigger(indices: set[int]) -> set[int]:
+        return indices | terminal_trigger_indices
+
     if latest_type not in _COMPACT_TOOL_CALL_ITEM_TYPES | _COMPACT_TOOL_CALL_OUTPUT_ITEM_TYPES:
-        return {latest_index}, True, False
+        return with_terminal_trigger({latest_index}), True, False
     if latest_mapping is not None and _compact_item_is_state_anchor(latest_mapping):
-        return _compact_required_terminal_indices(input_value, latest_index, token_counts), True, True
+        terminal_indices = _compact_required_terminal_indices(input_value, latest_index, token_counts)
+        return with_terminal_trigger(terminal_indices), True, True
     if latest_mapping is not None and _compact_item_has_elidable_inline_image(latest_mapping):
-        return _compact_required_terminal_indices(input_value, latest_index, token_counts), True, True
+        terminal_indices = _compact_required_terminal_indices(input_value, latest_index, token_counts)
+        return with_terminal_trigger(terminal_indices), True, True
     matching_call_index = _compact_matching_tool_call_index(input_value, latest_index)
     if latest_mapping is not None and _compact_terminal_item_is_side_effect(
         input_value,
         latest_index,
         matching_call_index=matching_call_index,
     ):
-        return _compact_required_terminal_indices(input_value, latest_index, token_counts), True, True
+        terminal_indices = _compact_required_terminal_indices(input_value, latest_index, token_counts)
+        return with_terminal_trigger(terminal_indices), True, True
     if latest_type in _COMPACT_TOOL_CALL_OUTPUT_ITEM_TYPES and has_continuity_anchor and matching_call_index is None:
-        return {latest_index}, True, False
+        return with_terminal_trigger({latest_index}), True, False
     if latest_type in _COMPACT_TOOL_CALL_ITEM_TYPES:
-        return _compact_required_terminal_indices(input_value, latest_index, token_counts), True, True
+        terminal_indices = _compact_required_terminal_indices(input_value, latest_index, token_counts)
+        return with_terminal_trigger(terminal_indices), True, True
 
     paired_tail = _compact_reconciled_tool_call_indices(
         input_value,
-        {latest_index},
+        with_terminal_trigger({latest_index}),
         token_counts=token_counts,
         token_budget=_MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS,
     )
     if latest_index in paired_tail:
-        return paired_tail, False, False
-    return set(), False, False
+        return paired_tail, bool(terminal_trigger_indices), False
+    return terminal_trigger_indices, bool(terminal_trigger_indices), False
 
 
 def _compact_item_has_elidable_inline_image(item: JsonValue) -> bool:

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -1215,6 +1215,12 @@ def _compact_discard_consumed_continuity_output_pairs(
     latest_index = len(input_value) - 1
     latest_mapping = _json_mapping_or_none(input_value[latest_index])
     latest_type = latest_mapping.get("type") if latest_mapping is not None else None
+    if latest_type == "compaction_trigger":
+        if latest_index == 0:
+            return
+        latest_index -= 1
+        latest_mapping = _json_mapping_or_none(input_value[latest_index])
+        latest_type = latest_mapping.get("type") if latest_mapping is not None else None
     if (
         latest_mapping is None
         or not isinstance(latest_type, str)
@@ -1289,7 +1295,7 @@ def _compact_terminal_required_indices(
         token_budget=_MAX_COMPACT_UPSTREAM_ESTIMATED_TOKENS,
     )
     if latest_index in paired_tail:
-        return paired_tail, bool(terminal_trigger_indices), False
+        return paired_tail, False, False
     return terminal_trigger_indices, bool(terminal_trigger_indices), False
 
 

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -731,7 +731,9 @@ class ResponsesRequest(BaseModel):
         return payload
 
     def to_payload(self) -> JsonObject:
-        return _strip_unsupported_fields(self.model_dump_for_forwarding())
+        payload = _strip_unsupported_fields(self.model_dump_for_forwarding())
+        _normalize_compaction_trigger_singleton(payload)
+        return payload
 
     def to_replay_safety_payload(self) -> JsonObject:
         return _strip_unsupported_fields(self.model_dump_for_forwarding(), strip_replayed_tool_call_namespaces=False)
@@ -998,18 +1000,12 @@ def _normalize_compaction_trigger_singleton(payload: MutableJsonObject) -> None:
     if not is_json_list(input_value) or not input_value:
         return
 
-    trigger_items = [
-        item
-        for item in input_value
-        if is_json_mapping(item) and item.get("type") == "compaction_trigger"
-    ]
+    trigger_items = [item for item in input_value if is_json_mapping(item) and item.get("type") == "compaction_trigger"]
     if not trigger_items:
         return
 
     payload["input"] = [
-        item
-        for item in input_value
-        if not (is_json_mapping(item) and item.get("type") == "compaction_trigger")
+        item for item in input_value if not (is_json_mapping(item) and item.get("type") == "compaction_trigger")
     ]
     cast(list[JsonValue], payload["input"]).append({"type": "compaction_trigger"})
 

--- a/app/core/openai/requests.py
+++ b/app/core/openai/requests.py
@@ -983,6 +983,7 @@ def _strip_compact_unsupported_fields(payload: MutableJsonObject) -> MutableJson
     if is_json_mapping(normalized_payload):
         payload = dict(normalized_payload)
     _trim_compact_input_for_upstream(payload)
+    _normalize_compaction_trigger_singleton(payload)
     payload.pop("store", None)
     payload.pop("text", None)
     payload.pop("tools", None)
@@ -990,6 +991,27 @@ def _strip_compact_unsupported_fields(payload: MutableJsonObject) -> MutableJson
     payload.pop("client_metadata", None)
     payload["parallel_tool_calls"] = False
     return payload
+
+
+def _normalize_compaction_trigger_singleton(payload: MutableJsonObject) -> None:
+    input_value = payload.get("input")
+    if not is_json_list(input_value) or not input_value:
+        return
+
+    trigger_items = [
+        item
+        for item in input_value
+        if is_json_mapping(item) and item.get("type") == "compaction_trigger"
+    ]
+    if not trigger_items:
+        return
+
+    payload["input"] = [
+        item
+        for item in input_value
+        if not (is_json_mapping(item) and item.get("type") == "compaction_trigger")
+    ]
+    cast(list[JsonValue], payload["input"]).append({"type": "compaction_trigger"})
 
 
 def _trim_compact_input_for_upstream(payload: MutableJsonObject) -> None:

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -474,6 +474,7 @@ from app.modules.proxy.request_policy import (
     openai_invalid_payload_error,
     openai_validation_error,
     validate_model_access,
+    validate_top_level_compaction_trigger_input_shape,
 )
 from app.modules.proxy.selection_errors import USAGE_LIMIT_REACHED, selection_failure_response
 from app.modules.proxy.tool_call_dedupe import (
@@ -2705,6 +2706,7 @@ class _WebSocketMixin:
             header_values=capability_header_values,
             client_metadata_values=_websocket_capability_metadata_values(payload),
         )
+        validate_top_level_compaction_trigger_input_shape(payload)
         responses_payload = normalize_responses_request_payload(
             payload,
             openai_compat=openai_cache_affinity,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -5057,7 +5057,14 @@ async def _stream_responses(
                     prompt_cache_key_alias = payload.model_extra.get("promptCacheKey")
                     if isinstance(prompt_cache_key_alias, str) and "prompt_cache_key" not in compact_payload_data:
                         compact_payload_data["prompt_cache_key"] = prompt_cache_key_alias
-                compact_payload_data["input"] = compact_trigger_input
+                # The main /responses route trims the terminal trigger before
+                # compaction so the compact budget and image elision see only
+                # the history to summarize. The upstream /compact contract
+                # still requires exactly one terminal trigger on the wire.
+                compact_payload_data["input"] = [
+                    *compact_trigger_input,
+                    {"type": "compaction_trigger"},
+                ]
                 if payload.previous_response_id is not None:
                     compact_payload_data["previous_response_id"] = payload.previous_response_id
                 if payload.conversation is not None:

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -5558,6 +5558,11 @@ async def _compact_responses(
     )
     validate_model_access(api_key, payload.model)
     try:
+        strip_terminal_compaction_trigger_input(payload, strip_trigger=False)
+    except ClientPayloadError as exc:
+        error = openai_client_payload_error(exc)
+        return _logged_error_json_response(request, 400, error)
+    try:
         request_usage_budget = estimate_api_key_request_usage(payload)
     except ClientPayloadError as exc:
         error = openai_client_payload_error(exc)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1185,7 +1185,7 @@ async def responses_websocket(
 )
 async def v1_responses(
     request: Request,
-    payload: V1ResponsesRequest = Body(...),
+    payload_data: JsonValue = Body(...),
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> Response:
@@ -1193,6 +1193,9 @@ async def v1_responses(
     if capability_transport_denial is not None:
         return capability_transport_denial
     try:
+        if is_json_mapping(payload_data):
+            validate_top_level_compaction_trigger_input_shape(payload_data)
+        payload = V1ResponsesRequest.model_validate(payload_data)
         responses_payload = payload.to_responses_request()
         enforce_strict_text_format(responses_payload)
         enforce_strict_function_tools_format(responses_payload.tools)

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -241,6 +241,7 @@ from app.modules.proxy.request_policy import (
     sanitize_source_chat_payload,
     strip_terminal_compaction_trigger_input,
     validate_model_access,
+    validate_top_level_compaction_trigger_input_shape,
 )
 from app.modules.proxy.schemas import (
     AccountPoolUsageResponse,
@@ -5495,13 +5496,23 @@ async def _collect_responses(
 )
 async def responses_compact(
     request: Request,
-    payload: ResponsesCompactRequest = Body(...),
+    payload_data: JsonValue = Body(...),
     context: ProxyContext = Depends(get_proxy_context),
     api_key: ApiKeyData | None = Security(validate_proxy_api_key),
 ) -> JSONResponse:
     capability_transport_denial = await _required_capability_http_transport_denial(request, api_key)
     if capability_transport_denial is not None:
         return capability_transport_denial
+    try:
+        if is_json_mapping(payload_data):
+            validate_top_level_compaction_trigger_input_shape(payload_data)
+        payload = ResponsesCompactRequest.model_validate(payload_data)
+    except ClientPayloadError as exc:
+        error = openai_client_payload_error(exc)
+        return _logged_error_json_response(request, 400, error)
+    except ValidationError as exc:
+        error = openai_validation_error(exc)
+        return _logged_error_json_response(request, 400, error)
     return await _compact_responses(
         request,
         payload,
@@ -5564,11 +5575,6 @@ async def _compact_responses(
         service_tier_was_enforced=service_tier_was_enforced,
     )
     validate_model_access(api_key, payload.model)
-    try:
-        strip_terminal_compaction_trigger_input(payload, strip_trigger=False)
-    except ClientPayloadError as exc:
-        error = openai_client_payload_error(exc)
-        return _logged_error_json_response(request, 400, error)
     try:
         request_usage_budget = estimate_api_key_request_usage(payload)
     except ClientPayloadError as exc:

--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 
 from pydantic import ValidationError
 
@@ -570,6 +571,13 @@ def normalize_responses_request_payload(
     return responses
 
 
+def validate_top_level_compaction_trigger_input_shape(payload: Mapping[str, JsonValue]) -> None:
+    input_value = payload.get("input")
+    if not is_json_list(input_value):
+        return
+    _validate_terminal_compaction_trigger_input_items(input_value)
+
+
 def strip_terminal_compaction_trigger_input(
     payload: ResponsesRequest | ResponsesCompactRequest,
     *,
@@ -578,14 +586,28 @@ def strip_terminal_compaction_trigger_input(
     input_value = payload.input
     if not is_json_list(input_value):
         return None
+    return _strip_terminal_compaction_trigger_input_items(input_value, strip_trigger=strip_trigger)
 
-    stripped_input: list[JsonValue] = []
+
+def _strip_terminal_compaction_trigger_input_items(
+    input_value: list[JsonValue],
+    *,
+    strip_trigger: bool,
+) -> list[JsonValue] | None:
+    trigger_seen = _validate_terminal_compaction_trigger_input_items(input_value)
+    if not trigger_seen:
+        return None
+    if not strip_trigger:
+        return input_value
+    return [item for item in input_value if not (is_json_mapping(item) and item.get("type") == "compaction_trigger")]
+
+
+def _validate_terminal_compaction_trigger_input_items(input_value: list[JsonValue]) -> bool:
     trigger_seen = False
     last_index = len(input_value) - 1
 
     for index, item in enumerate(input_value):
         if not (is_json_mapping(item) and item.get("type") == "compaction_trigger"):
-            stripped_input.append(item)
             continue
 
         if trigger_seen or index != last_index:
@@ -597,11 +619,7 @@ def strip_terminal_compaction_trigger_input(
             )
         trigger_seen = True
 
-    if not trigger_seen:
-        return None
-    if not strip_trigger:
-        return input_value
-    return stripped_input
+    return trigger_seen
 
 
 def enforce_strict_text_format(request: ResponsesRequest) -> None:

--- a/app/modules/proxy/request_policy.py
+++ b/app/modules/proxy/request_policy.py
@@ -570,7 +570,11 @@ def normalize_responses_request_payload(
     return responses
 
 
-def strip_terminal_compaction_trigger_input(payload: ResponsesRequest) -> list[JsonValue] | None:
+def strip_terminal_compaction_trigger_input(
+    payload: ResponsesRequest | ResponsesCompactRequest,
+    *,
+    strip_trigger: bool = True,
+) -> list[JsonValue] | None:
     input_value = payload.input
     if not is_json_list(input_value):
         return None
@@ -595,6 +599,8 @@ def strip_terminal_compaction_trigger_input(payload: ResponsesRequest) -> list[J
 
     if not trigger_seen:
         return None
+    if not strip_trigger:
+        return input_value
     return stripped_input
 
 

--- a/openspec/changes/document-compact-trigger-proxy-contract/proposal.md
+++ b/openspec/changes/document-compact-trigger-proxy-contract/proposal.md
@@ -1,0 +1,19 @@
+## Why
+
+PR 1749 changes the Codex proxy contract for compact-trigger turns, but the PR
+head lacks the focused OpenSpec change required for proxy-routing and API-shape
+behavior. We need a narrow change record that matches the existing
+implementation without broadening scope.
+
+## What Changes
+
+- Document that `POST /backend-api/codex/responses` terminal compaction
+  triggers produce exactly one terminal `compaction` item on the internal
+  compact wire.
+- Document that malformed top-level trigger placement is rejected locally
+  before upstream compact handling.
+
+## Impact
+
+- `responses-api-compat` change record only
+- No behavior changes beyond the already-implemented proxy contract

--- a/openspec/changes/document-compact-trigger-proxy-contract/specs/responses-api-compat/spec.md
+++ b/openspec/changes/document-compact-trigger-proxy-contract/specs/responses-api-compat/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Codex compaction triggers are bridged into compact output
+
+The proxy SHALL remove a single terminal top-level `{"type":"compaction_trigger"}` item from `POST /backend-api/codex/responses` before compact-input preparation, the internal compact request MUST contain exactly one terminal `compaction_trigger` item on the compact wire, and the proxy MUST reject duplicate or non-terminal top-level `compaction_trigger` placement locally with HTTP 400 `invalid_request_error` before upstream compact handling.
+
+#### Scenario: terminal trigger becomes one compact-wire trigger
+
+- **WHEN** a `POST /backend-api/codex/responses` request ends with exactly one
+  top-level `compaction_trigger`
+- **THEN** the proxy strips that trigger before compact-input preparation
+- **AND** the internal compact request contains exactly one terminal
+  `compaction_trigger` item on its `input` array
+
+#### Scenario: malformed trigger placement is rejected locally
+
+- **WHEN** a `POST /backend-api/codex/responses` or
+  `POST /backend-api/codex/responses/compact` request contains duplicate or
+  non-terminal top-level `compaction_trigger` items
+- **THEN** the proxy returns HTTP 400 with `invalid_request_error`
+- **AND** it does not attempt upstream compact handling

--- a/openspec/changes/document-compact-trigger-proxy-contract/tasks.md
+++ b/openspec/changes/document-compact-trigger-proxy-contract/tasks.md
@@ -1,0 +1,10 @@
+## 1. Document the contract
+
+- [x] 1.1 Add a focused `responses-api-compat` delta for the compact-trigger
+  proxy-routing contract.
+- [x] 1.2 Cover exactly one terminal compact-wire `compaction_trigger` and
+  local malformed-placement rejection.
+
+## 2. Validate the change
+
+- [x] 2.1 Run `openspec validate document-compact-trigger-proxy-contract --strict`.

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -216,10 +216,11 @@ class _SseContent:
     async def iter_chunked(self, size: int):
         del size
         yield (
+            b'data: {"type":"response.output_item.done","output_index":0,'
+            b'"item":{"id":"msg_compact_summary_1","type":"message","role":"assistant",'
+            b'"status":"completed","content":[{"type":"output_text","text":"enc_compact_summary_1"}]}}\n\n'
             b'data: {"type":"response.completed","response":'
-            b'{"object":"response","id":"resp_compact_summary_1","status":"completed",'
-            b'"output":[{"id":"cmp_compact_summary_1","type":"compaction_summary",'
-            b'"encrypted_content":"enc_compact_summary_1"}]}}\n\n'
+            b'{"object":"response","id":"resp_compact_summary_1","status":"completed","output":[]}}\n\n'
         )
 
 
@@ -809,7 +810,12 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
     assert body["object"] == "response.compaction"
     assert body["id"] == "resp_compact_summary_1"
     assert body["output"] == [
-        {"id": "cmp_compact_summary_1", "type": "compaction", "encrypted_content": "enc_compact_summary_1"}
+        {
+            "id": "msg_compact_summary_1",
+            "type": "compaction",
+            "status": "completed",
+            "encrypted_content": "enc_compact_summary_1",
+        }
     ]
     assert _session_call_url(session).endswith("/codex/responses")
     call_json = _session_call_json(session)

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -791,7 +791,7 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
         "encrypted_content": "enc_compact_summary_1",
         "summary_text": "condensed thread state",
     }
-    assert _session_call_url(session).endswith("/codex/responses/compact")
+    assert _session_call_url(session).endswith("/codex/responses")
     call_json = _session_call_json(session)
     assert "stream" not in call_json
     assert "store" not in call_json

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -395,7 +395,6 @@ async def test_proxy_compact_preserves_historical_code_mode_side_effect_pair_bef
         )
         for item in upstream_input
     )
-
 @pytest.mark.asyncio
 async def test_proxy_compact_omits_oversized_optional_tool_tail_before_upstream(async_client, monkeypatch):
     email = "compact-optional-tail@example.com"

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -337,6 +337,67 @@ async def test_proxy_compact_strips_tool_fields_before_upstream(async_client, mo
 
 
 @pytest.mark.asyncio
+async def test_proxy_compact_preserves_historical_code_mode_side_effect_pair_before_ordinary_tail(
+    async_client, monkeypatch
+):
+    email = "compact-side-effect@example.com"
+    raw_account_id = "acc_compact_side_effect"
+    files = {"auth_json": ("auth.json", json.dumps(_make_auth_json(raw_account_id, email)), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payloads: list[dict[str, object]] = []
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del headers, access_token, account_id
+        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+    side_effect_call = {
+        "type": "custom_tool_call",
+        "name": "exec",
+        "call_id": "call-code-mode-exec",
+        "input": json.dumps({"command": "git status --short"}),
+    }
+    side_effect_output = {
+        "type": "custom_tool_call_output",
+        "call_id": "call-code-mode-exec",
+        "output": "clean",
+    }
+    ordinary_tail = {"role": "assistant", "content": "ordinary tail " + "x" * 500_000}
+    payload = {
+        "model": "gpt-5.6-sol",
+        "instructions": "",
+        "input": [
+            {"role": "user", "content": "perform a code-mode action"},
+            {"role": "assistant", "content": "prefix " + "y" * 260_000},
+            side_effect_call,
+            side_effect_output,
+            ordinary_tail,
+            {"role": "user", "content": "continue after compaction"},
+        ],
+    }
+
+    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
+
+    assert response.status_code == 200
+    assert len(seen_payloads) == 1
+    upstream_input = seen_payloads[0]["input"]
+    assert isinstance(upstream_input, list)
+    assert side_effect_call in upstream_input
+    assert side_effect_output in upstream_input
+    assert all(
+        not (
+            isinstance(item, dict)
+            and item.get("role") == "assistant"
+            and item.get("content") == [{"type": "output_text", "text": ordinary_tail["content"]}]
+        )
+        for item in upstream_input
+    )
+
+
+@pytest.mark.asyncio
 async def test_proxy_compact_rejects_duplicate_compaction_trigger_before_upstream(async_client, monkeypatch):
     email = "compact-duplicate-trigger@example.com"
     raw_account_id = "acc_compact_duplicate_trigger"
@@ -407,67 +468,6 @@ async def test_proxy_compact_preserves_single_terminal_compaction_trigger(async_
         {"role": "user", "content": "hello"},
         {"type": "compaction_trigger"},
     ]
-
-
-@pytest.mark.asyncio
-async def test_proxy_compact_preserves_historical_code_mode_side_effect_pair_before_ordinary_tail(
-    async_client, monkeypatch
-):
-    email = "compact-side-effect@example.com"
-    raw_account_id = "acc_compact_side_effect"
-    files = {"auth_json": ("auth.json", json.dumps(_make_auth_json(raw_account_id, email)), "application/json")}
-    response = await async_client.post("/api/accounts/import", files=files)
-    assert response.status_code == 200
-
-    seen_payloads: list[dict[str, object]] = []
-
-    async def fake_compact(payload, headers, access_token, account_id):
-        del headers, access_token, account_id
-        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
-        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
-
-    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
-    side_effect_call = {
-        "type": "custom_tool_call",
-        "name": "exec",
-        "call_id": "call-code-mode-exec",
-        "input": json.dumps({"command": "git status --short"}),
-    }
-    side_effect_output = {
-        "type": "custom_tool_call_output",
-        "call_id": "call-code-mode-exec",
-        "output": "clean",
-    }
-    ordinary_tail = {"role": "assistant", "content": "ordinary tail " + "x" * 500_000}
-    payload = {
-        "model": "gpt-5.6-sol",
-        "instructions": "",
-        "input": [
-            {"role": "user", "content": "perform a code-mode action"},
-            {"role": "assistant", "content": "prefix " + "y" * 260_000},
-            side_effect_call,
-            side_effect_output,
-            ordinary_tail,
-            {"role": "user", "content": "continue after compaction"},
-        ],
-    }
-
-    response = await async_client.post("/backend-api/codex/responses/compact", json=payload)
-
-    assert response.status_code == 200
-    assert len(seen_payloads) == 1
-    upstream_input = seen_payloads[0]["input"]
-    assert isinstance(upstream_input, list)
-    assert side_effect_call in upstream_input
-    assert side_effect_output in upstream_input
-    assert all(
-        not (
-            isinstance(item, dict)
-            and item.get("role") == "assistant"
-            and item.get("content") == [{"type": "output_text", "text": ordinary_tail["content"]}]
-        )
-        for item in upstream_input
-    )
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -395,6 +395,8 @@ async def test_proxy_compact_preserves_historical_code_mode_side_effect_pair_bef
         )
         for item in upstream_input
     )
+
+
 @pytest.mark.asyncio
 async def test_proxy_compact_omits_oversized_optional_tool_tail_before_upstream(async_client, monkeypatch):
     email = "compact-optional-tail@example.com"

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -821,7 +821,8 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
     call_json = _session_call_json(session)
     assert call_json["stream"] is True
     assert call_json["store"] is False
-    assert session.calls[0]["headers"]["Accept"] == "text/event-stream"
+    call_headers = cast(dict[str, str], session.calls[0]["headers"])
+    assert call_headers["Accept"] == "text/event-stream"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -217,8 +217,9 @@ class _SseContent:
         del size
         yield (
             b'data: {"type":"response.completed","response":'
-            b'{"object":"response.compaction","compaction_summary":'
-            b'{"encrypted_content":"enc_compact_summary_1","summary_text":"condensed thread state"}}}\n\n'
+            b'{"object":"response","id":"resp_compact_summary_1","status":"completed",'
+            b'"output":[{"id":"cmp_compact_summary_1","type":"compaction_summary",'
+            b'"encrypted_content":"enc_compact_summary_1"}]}}\n\n'
         )
 
 
@@ -806,10 +807,10 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
     assert response.status_code == 200
     body = response.json()
     assert body["object"] == "response.compaction"
-    assert body["compaction_summary"] == {
-        "encrypted_content": "enc_compact_summary_1",
-        "summary_text": "condensed thread state",
-    }
+    assert body["id"] == "resp_compact_summary_1"
+    assert body["output"] == [
+        {"id": "cmp_compact_summary_1", "type": "compaction", "encrypted_content": "enc_compact_summary_1"}
+    ]
     assert _session_call_url(session).endswith("/codex/responses")
     call_json = _session_call_json(session)
     assert call_json["stream"] is True

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -397,80 +397,6 @@ async def test_proxy_compact_preserves_historical_code_mode_side_effect_pair_bef
     )
 
 
-@pytest.mark.asyncio
-async def test_proxy_compact_rejects_duplicate_compaction_trigger_before_upstream(async_client, monkeypatch):
-    email = "compact-duplicate-trigger@example.com"
-    raw_account_id = "acc_compact_duplicate_trigger"
-    auth_json = _make_auth_json(raw_account_id, email)
-    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
-    response = await async_client.post("/api/accounts/import", files=files)
-    assert response.status_code == 200
-
-    async def fake_compact(*args, **kwargs):
-        del args, kwargs
-        pytest.fail("compact should not be called when input contains duplicate compaction_trigger items")
-
-    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
-
-    response = await async_client.post(
-        "/backend-api/codex/responses/compact",
-        json={
-            "model": "gpt-5.1",
-            "instructions": "hi",
-            "input": [
-                {"role": "user", "content": "hello"},
-                {"type": "compaction_trigger"},
-                {"type": "compaction_trigger"},
-            ],
-        },
-    )
-
-    assert response.status_code == 400
-    error = response.json()["error"]
-    assert error["type"] == "invalid_request_error"
-    assert error["code"] == "invalid_request_error"
-    assert error["param"] == "input"
-
-
-@pytest.mark.asyncio
-async def test_proxy_compact_preserves_single_terminal_compaction_trigger(async_client, monkeypatch):
-    email = "compact-single-trigger@example.com"
-    raw_account_id = "acc_compact_single_trigger"
-    auth_json = _make_auth_json(raw_account_id, email)
-    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
-    response = await async_client.post("/api/accounts/import", files=files)
-    assert response.status_code == 200
-
-    seen_payloads: list[dict[str, object]] = []
-
-    async def fake_compact(payload, headers, access_token, account_id):
-        del headers, access_token, account_id
-        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
-        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
-
-    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
-
-    response = await async_client.post(
-        "/backend-api/codex/responses/compact",
-        json={
-            "model": "gpt-5.1",
-            "instructions": "hi",
-            "input": [
-                {"role": "user", "content": "hello"},
-                {"type": "compaction_trigger"},
-            ],
-        },
-    )
-
-    assert response.status_code == 200
-    assert len(seen_payloads) == 1
-    assert seen_payloads[0]["input"] == [
-        {"role": "user", "content": "hello"},
-        {"type": "compaction_trigger"},
-    ]
-
-
-@pytest.mark.asyncio
 async def test_proxy_compact_omits_oversized_optional_tool_tail_before_upstream(async_client, monkeypatch):
     email = "compact-optional-tail@example.com"
     raw_account_id = "acc_compact_optional_tail"
@@ -557,6 +483,79 @@ async def test_proxy_compact_surfaces_additional_quota_exhausted(async_client):
     assert response.status_code == 503
     error = response.json()["error"]
     assert error["code"] == "quota_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_rejects_duplicate_compaction_trigger_before_upstream(async_client, monkeypatch):
+    email = "compact-duplicate-trigger@example.com"
+    raw_account_id = "acc_compact_duplicate_trigger"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_compact(*args, **kwargs):
+        del args, kwargs
+        pytest.fail("compact should not be called when input contains duplicate compaction_trigger items")
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {"role": "user", "content": "hello"},
+                {"type": "compaction_trigger"},
+                {"type": "compaction_trigger"},
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["type"] == "invalid_request_error"
+    assert error["code"] == "invalid_request_error"
+    assert error["param"] == "input"
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_preserves_single_terminal_compaction_trigger(async_client, monkeypatch):
+    email = "compact-single-trigger@example.com"
+    raw_account_id = "acc_compact_single_trigger"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payloads: list[dict[str, object]] = []
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del headers, access_token, account_id
+        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {"role": "user", "content": "hello"},
+                {"type": "compaction_trigger"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert len(seen_payloads) == 1
+    assert seen_payloads[0]["input"] == [
+        {"role": "user", "content": "hello"},
+        {"type": "compaction_trigger"},
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -225,7 +225,7 @@ class _SseContent:
 class _SseResponse:
     status = 200
     reason = "OK"
-    headers = {"content-type": "text/event-stream"}
+    headers: dict[str, str] = {}
     content = _SseContent()
 
     async def __aenter__(self):

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -486,79 +486,6 @@ async def test_proxy_compact_surfaces_additional_quota_exhausted(async_client):
 
 
 @pytest.mark.asyncio
-async def test_proxy_compact_rejects_duplicate_compaction_trigger_before_upstream(async_client, monkeypatch):
-    email = "compact-duplicate-trigger@example.com"
-    raw_account_id = "acc_compact_duplicate_trigger"
-    auth_json = _make_auth_json(raw_account_id, email)
-    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
-    response = await async_client.post("/api/accounts/import", files=files)
-    assert response.status_code == 200
-
-    async def fake_compact(*args, **kwargs):
-        del args, kwargs
-        pytest.fail("compact should not be called when input contains duplicate compaction_trigger items")
-
-    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
-
-    response = await async_client.post(
-        "/backend-api/codex/responses/compact",
-        json={
-            "model": "gpt-5.1",
-            "instructions": "hi",
-            "input": [
-                {"role": "user", "content": "hello"},
-                {"type": "compaction_trigger"},
-                {"type": "compaction_trigger"},
-            ],
-        },
-    )
-
-    assert response.status_code == 400
-    error = response.json()["error"]
-    assert error["type"] == "invalid_request_error"
-    assert error["code"] == "invalid_request_error"
-    assert error["param"] == "input"
-
-
-@pytest.mark.asyncio
-async def test_proxy_compact_preserves_single_terminal_compaction_trigger(async_client, monkeypatch):
-    email = "compact-single-trigger@example.com"
-    raw_account_id = "acc_compact_single_trigger"
-    auth_json = _make_auth_json(raw_account_id, email)
-    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
-    response = await async_client.post("/api/accounts/import", files=files)
-    assert response.status_code == 200
-
-    seen_payloads: list[dict[str, object]] = []
-
-    async def fake_compact(payload, headers, access_token, account_id):
-        del headers, access_token, account_id
-        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
-        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
-
-    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
-
-    response = await async_client.post(
-        "/backend-api/codex/responses/compact",
-        json={
-            "model": "gpt-5.1",
-            "instructions": "hi",
-            "input": [
-                {"role": "user", "content": "hello"},
-                {"type": "compaction_trigger"},
-            ],
-        },
-    )
-
-    assert response.status_code == 200
-    assert len(seen_payloads) == 1
-    assert seen_payloads[0]["input"] == [
-        {"role": "user", "content": "hello"},
-        {"type": "compaction_trigger"},
-    ]
-
-
-@pytest.mark.asyncio
 async def test_proxy_compact_success(async_client, monkeypatch):
     email = "compact@example.com"
     raw_account_id = "acc_compact"
@@ -1720,3 +1647,76 @@ async def test_proxy_compact_output_round_trips_into_followup_responses_without_
 
     assert response.status_code == 200
     assert seen_inputs == [compact_window["output"]]
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_rejects_duplicate_compaction_trigger_before_upstream(async_client, monkeypatch):
+    email = "compact-duplicate-trigger@example.com"
+    raw_account_id = "acc_compact_duplicate_trigger"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_compact(*args, **kwargs):
+        del args, kwargs
+        pytest.fail("compact should not be called when input contains duplicate compaction_trigger items")
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {"role": "user", "content": "hello"},
+                {"type": "compaction_trigger"},
+                {"type": "compaction_trigger"},
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["type"] == "invalid_request_error"
+    assert error["code"] == "invalid_request_error"
+    assert error["param"] == "input"
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_preserves_single_terminal_compaction_trigger(async_client, monkeypatch):
+    email = "compact-single-trigger@example.com"
+    raw_account_id = "acc_compact_single_trigger"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payloads: list[dict[str, object]] = []
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del headers, access_token, account_id
+        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {"role": "user", "content": "hello"},
+                {"type": "compaction_trigger"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert len(seen_payloads) == 1
+    assert seen_payloads[0]["input"] == [
+        {"role": "user", "content": "hello"},
+        {"type": "compaction_trigger"},
+    ]

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -212,8 +212,37 @@ class _JsonResponse:
         return _return_self().__await__()
 
 
+class _SseContent:
+    async def iter_chunked(self, size: int):
+        del size
+        yield (
+            b'data: {"type":"response.completed","response":'
+            b'{"object":"response.compaction","compaction_summary":'
+            b'{"encrypted_content":"enc_compact_summary_1","summary_text":"condensed thread state"}}}\n\n'
+        )
+
+
+class _SseResponse:
+    status = 200
+    reason = "OK"
+    headers = {"content-type": "text/event-stream"}
+    content = _SseContent()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def __await__(self):
+        async def _return_self():
+            return self
+
+        return _return_self().__await__()
+
+
 class _JsonSession:
-    def __init__(self, response: _JsonResponse) -> None:
+    def __init__(self, response: object) -> None:
         self._response = response
         self.calls: list[dict[str, object]] = []
 
@@ -762,17 +791,7 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
     response = await async_client.post("/api/accounts/import", files=files)
     assert response.status_code == 200
 
-    session = _JsonSession(
-        _JsonResponse(
-            {
-                "object": "response.compaction",
-                "compaction_summary": {
-                    "encrypted_content": "enc_compact_summary_1",
-                    "summary_text": "condensed thread state",
-                },
-            }
-        )
-    )
+    session = _JsonSession(_SseResponse())
 
     @contextlib.asynccontextmanager
     async def lease_session(session_override=None):
@@ -793,8 +812,9 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
     }
     assert _session_call_url(session).endswith("/codex/responses")
     call_json = _session_call_json(session)
-    assert "stream" not in call_json
+    assert call_json["stream"] is True
     assert call_json["store"] is False
+    assert session.calls[0]["headers"]["Accept"] == "text/event-stream"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -396,7 +396,7 @@ async def test_proxy_compact_preserves_historical_code_mode_side_effect_pair_bef
         for item in upstream_input
     )
 
-
+@pytest.mark.asyncio
 async def test_proxy_compact_omits_oversized_optional_tool_tail_before_upstream(async_client, monkeypatch):
     email = "compact-optional-tail@example.com"
     raw_account_id = "acc_compact_optional_tail"
@@ -1647,76 +1647,3 @@ async def test_proxy_compact_output_round_trips_into_followup_responses_without_
 
     assert response.status_code == 200
     assert seen_inputs == [compact_window["output"]]
-
-
-@pytest.mark.asyncio
-async def test_proxy_compact_rejects_duplicate_compaction_trigger_before_upstream(async_client, monkeypatch):
-    email = "compact-duplicate-trigger@example.com"
-    raw_account_id = "acc_compact_duplicate_trigger"
-    auth_json = _make_auth_json(raw_account_id, email)
-    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
-    response = await async_client.post("/api/accounts/import", files=files)
-    assert response.status_code == 200
-
-    async def fake_compact(*args, **kwargs):
-        del args, kwargs
-        pytest.fail("compact should not be called when input contains duplicate compaction_trigger items")
-
-    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
-
-    response = await async_client.post(
-        "/backend-api/codex/responses/compact",
-        json={
-            "model": "gpt-5.1",
-            "instructions": "hi",
-            "input": [
-                {"role": "user", "content": "hello"},
-                {"type": "compaction_trigger"},
-                {"type": "compaction_trigger"},
-            ],
-        },
-    )
-
-    assert response.status_code == 400
-    error = response.json()["error"]
-    assert error["type"] == "invalid_request_error"
-    assert error["code"] == "invalid_request_error"
-    assert error["param"] == "input"
-
-
-@pytest.mark.asyncio
-async def test_proxy_compact_preserves_single_terminal_compaction_trigger(async_client, monkeypatch):
-    email = "compact-single-trigger@example.com"
-    raw_account_id = "acc_compact_single_trigger"
-    auth_json = _make_auth_json(raw_account_id, email)
-    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
-    response = await async_client.post("/api/accounts/import", files=files)
-    assert response.status_code == 200
-
-    seen_payloads: list[dict[str, object]] = []
-
-    async def fake_compact(payload, headers, access_token, account_id):
-        del headers, access_token, account_id
-        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
-        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
-
-    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
-
-    response = await async_client.post(
-        "/backend-api/codex/responses/compact",
-        json={
-            "model": "gpt-5.1",
-            "instructions": "hi",
-            "input": [
-                {"role": "user", "content": "hello"},
-                {"type": "compaction_trigger"},
-            ],
-        },
-    )
-
-    assert response.status_code == 200
-    assert len(seen_payloads) == 1
-    assert seen_payloads[0]["input"] == [
-        {"role": "user", "content": "hello"},
-        {"type": "compaction_trigger"},
-    ]

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -794,7 +794,7 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
     assert _session_call_url(session).endswith("/codex/responses")
     call_json = _session_call_json(session)
     assert "stream" not in call_json
-    assert "store" not in call_json
+    assert call_json["store"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -337,6 +337,79 @@ async def test_proxy_compact_strips_tool_fields_before_upstream(async_client, mo
 
 
 @pytest.mark.asyncio
+async def test_proxy_compact_rejects_duplicate_compaction_trigger_before_upstream(async_client, monkeypatch):
+    email = "compact-duplicate-trigger@example.com"
+    raw_account_id = "acc_compact_duplicate_trigger"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_compact(*args, **kwargs):
+        del args, kwargs
+        pytest.fail("compact should not be called when input contains duplicate compaction_trigger items")
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {"role": "user", "content": "hello"},
+                {"type": "compaction_trigger"},
+                {"type": "compaction_trigger"},
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["type"] == "invalid_request_error"
+    assert error["code"] == "invalid_request_error"
+    assert error["param"] == "input"
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_preserves_single_terminal_compaction_trigger(async_client, monkeypatch):
+    email = "compact-single-trigger@example.com"
+    raw_account_id = "acc_compact_single_trigger"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payloads: list[dict[str, object]] = []
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del headers, access_token, account_id
+        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {"role": "user", "content": "hello"},
+                {"type": "compaction_trigger"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert len(seen_payloads) == 1
+    assert seen_payloads[0]["input"] == [
+        {"role": "user", "content": "hello"},
+        {"type": "compaction_trigger"},
+    ]
+
+
+@pytest.mark.asyncio
 async def test_proxy_compact_preserves_historical_code_mode_side_effect_pair_before_ordinary_tail(
     async_client, monkeypatch
 ):

--- a/tests/integration/test_proxy_compact_triggers.py
+++ b/tests/integration/test_proxy_compact_triggers.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import base64
+import json
+from typing import cast
+
+import pytest
+
+import app.modules.proxy.service as proxy_module
+from app.core.openai.models import CompactResponsePayload
+
+pytestmark = pytest.mark.integration
+
+
+def _encode_jwt(payload: dict) -> str:
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    body = base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+    return f"header.{body}.sig"
+
+
+def _make_auth_json(account_id: str, email: str, *, plan_type: str = "plus") -> dict:
+    payload = {
+        "email": email,
+        "chatgpt_account_id": account_id,
+        "https://api.openai.com/auth": {"chatgpt_plan_type": plan_type},
+    }
+    return {
+        "tokens": {
+            "idToken": _encode_jwt(payload),
+            "accessToken": "access-token",
+            "refreshToken": "refresh-token",
+            "accountId": account_id,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_rejects_duplicate_compaction_trigger_before_upstream(async_client, monkeypatch):
+    email = "compact-duplicate-trigger@example.com"
+    raw_account_id = "acc_compact_duplicate_trigger"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_compact(*args, **kwargs):
+        del args, kwargs
+        pytest.fail("compact should not be called when input contains duplicate compaction_trigger items")
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {"role": "user", "content": "hello"},
+                {"type": "compaction_trigger"},
+                {"type": "compaction_trigger"},
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["type"] == "invalid_request_error"
+    assert error["code"] == "invalid_request_error"
+    assert error["param"] == "input"
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_preserves_single_terminal_compaction_trigger(async_client, monkeypatch):
+    email = "compact-single-trigger@example.com"
+    raw_account_id = "acc_compact_single_trigger"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payloads: list[dict[str, object]] = []
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del headers, access_token, account_id
+        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {"role": "user", "content": "hello"},
+                {"type": "compaction_trigger"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert len(seen_payloads) == 1
+    assert seen_payloads[0]["input"] == [
+        {"role": "user", "content": "hello"},
+        {"type": "compaction_trigger"},
+    ]

--- a/tests/integration/test_proxy_compact_triggers.py
+++ b/tests/integration/test_proxy_compact_triggers.py
@@ -70,6 +70,44 @@ async def test_proxy_compact_rejects_duplicate_compaction_trigger_before_upstrea
 
 
 @pytest.mark.asyncio
+async def test_proxy_compact_rejects_non_terminal_compaction_trigger_before_instruction_hoist(
+    async_client,
+    monkeypatch,
+):
+    email = "compact-trigger-hoist@example.com"
+    raw_account_id = "acc_compact_trigger_hoist"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    async def fake_compact(*args, **kwargs):
+        del args, kwargs
+        pytest.fail("compact should not be called when a trailing developer message hides a non-terminal trigger")
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "",
+            "input": [
+                {"role": "user", "content": "hello"},
+                {"type": "compaction_trigger"},
+                {"role": "developer", "content": "still trailing after the trigger"},
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    error = response.json()["error"]
+    assert error["type"] == "invalid_request_error"
+    assert error["code"] == "invalid_request_error"
+    assert error["param"] == "input"
+
+
+@pytest.mark.asyncio
 async def test_proxy_compact_preserves_single_terminal_compaction_trigger(async_client, monkeypatch):
     email = "compact-single-trigger@example.com"
     raw_account_id = "acc_compact_single_trigger"
@@ -94,6 +132,44 @@ async def test_proxy_compact_preserves_single_terminal_compaction_trigger(async_
             "instructions": "hi",
             "input": [
                 {"role": "user", "content": "hello"},
+                {"type": "compaction_trigger"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert len(seen_payloads) == 1
+    assert seen_payloads[0]["input"] == [
+        {"role": "user", "content": "hello"},
+        {"type": "compaction_trigger"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_v1_proxy_compact_keeps_trigger_handling_unchanged(async_client, monkeypatch):
+    email = "v1-compact-trigger-unchanged@example.com"
+    raw_account_id = "acc_v1_compact_trigger_unchanged"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+
+    seen_payloads: list[dict[str, object]] = []
+
+    async def fake_compact(payload, headers, access_token, account_id):
+        del headers, access_token, account_id
+        seen_payloads.append(cast(dict[str, object], payload.to_payload()))
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    monkeypatch.setattr(proxy_module, "core_compact_responses", fake_compact)
+
+    response = await async_client.post(
+        "/v1/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "input": [
+                {"role": "user", "content": "hello"},
+                {"type": "compaction_trigger"},
                 {"type": "compaction_trigger"},
             ],
         },

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -2640,6 +2640,34 @@ async def test_v1_responses_compact_invalid_messages_returns_openai_400(async_cl
 
 
 @pytest.mark.asyncio
+async def test_v1_responses_rejects_duplicate_top_level_compaction_trigger(async_client, monkeypatch):
+    async def fail_stream(*args, **kwargs):
+        del args, kwargs
+        pytest.fail("malformed top-level compaction_trigger must fail before upstream streaming")
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fail_stream)
+
+    resp = await async_client.post(
+        "/v1/responses",
+        json={
+            "model": "gpt-5.2",
+            "input": [
+                {"role": "user", "content": "hello"},
+                {"type": "compaction_trigger"},
+                {"type": "compaction_trigger"},
+            ],
+            "stream": False,
+        },
+    )
+
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["error"]["type"] == "invalid_request_error"
+    assert body["error"]["code"] == "invalid_request_error"
+    assert body["error"]["param"] == "input"
+
+
+@pytest.mark.asyncio
 async def test_v1_chat_completions_invalid_tool_calls_returns_openai_400(async_client):
     payload = {
         "model": "gpt-5.2",

--- a/tests/integration/test_proxy_responses.py
+++ b/tests/integration/test_proxy_responses.py
@@ -658,6 +658,8 @@ async def test_proxy_responses_compaction_trigger_elides_required_tool_image_and
     assert "Image Size: 1512x982." in compact_input_json
     assert "Omitted inline image bytes that were already observed before compaction" in compact_input_json
     assert "data:image/png;base64" not in compact_input_json
+    assert compact_input[-1] == {"type": "compaction_trigger"}
+    assert sum(1 for item in compact_input if item.get("type") == "compaction_trigger") == 1
     assert seen_payload["previous_response_id"] == "resp_compact_anchor"
     assert seen_payload["account_id"] == raw_account_id
     compact_payload = cast(Mapping[str, object], seen_payload["payload"])

--- a/tests/integration/test_proxy_websocket_responses.py
+++ b/tests/integration/test_proxy_websocket_responses.py
@@ -8678,7 +8678,6 @@ def test_backend_responses_websocket_rejects_oversized_response_create_before_up
     assert duplicate_event["status"] == 400
     assert len(list(tmp_path.glob("*.response-create.json.gz"))) == 1
     assert len(list(tmp_path.glob("*.meta.json"))) == 1
-
     meta_files[0].unlink()
     with TestClient(app_instance) as client:
         orphan_retry_event = send_oversized_request()
@@ -8689,6 +8688,88 @@ def test_backend_responses_websocket_rejects_oversized_response_create_before_up
         if (tmp_path / f"{dump_path.name[: -len('.response-create.json.gz')]}.meta.json").exists()
     ]
     assert complete_pairs
+
+
+def test_backend_responses_websocket_rejects_non_terminal_compaction_trigger_before_upstream(
+    app_instance,
+    monkeypatch,
+):
+    class _FakeSettingsCache:
+        async def get(self):
+            return _websocket_settings()
+
+    async def allow_firewall(_websocket):
+        return None
+
+    async def allow_proxy_api_key(_authorization: str | None, *, request: object | None = None):
+        return None
+
+    async def fail_connect_proxy_websocket(
+        self,
+        headers,
+        *,
+        sticky_key,
+        sticky_kind,
+        reallocate_sticky,
+        sticky_max_age_seconds,
+        prefer_earlier_reset,
+        prefer_earlier_reset_window,
+        routing_strategy,
+        model,
+        request_state,
+        api_key,
+        client_send_lock,
+        websocket,
+    ):
+        del (
+            self,
+            headers,
+            sticky_key,
+            sticky_kind,
+            reallocate_sticky,
+            sticky_max_age_seconds,
+            prefer_earlier_reset,
+            prefer_earlier_reset_window,
+            routing_strategy,
+            model,
+            request_state,
+            api_key,
+            client_send_lock,
+            websocket,
+        )
+        raise AssertionError("malformed compaction trigger must fail before upstream websocket connect")
+
+    monkeypatch.setattr(proxy_api_module, "_websocket_firewall_denial_response", allow_firewall)
+    monkeypatch.setattr(proxy_api_module, "validate_proxy_api_key_authorization", allow_proxy_api_key)
+    monkeypatch.setattr(proxy_module, "get_settings_cache", lambda: _FakeSettingsCache())
+    monkeypatch.setattr(proxy_module.ProxyService, "_connect_proxy_websocket", fail_connect_proxy_websocket)
+
+    request_payload = {
+        "type": "response.create",
+        "model": "gpt-5.4",
+        "instructions": "",
+        "input": [
+            {"role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+            {"type": "compaction_trigger"},
+            {"role": "developer", "content": [{"type": "input_text", "text": "still trailing"}]},
+        ],
+        "stream": True,
+    }
+
+    with TestClient(app_instance) as client:
+        with client.websocket_connect("/backend-api/codex/responses") as websocket:
+            websocket.send_text(json.dumps(request_payload))
+            error_event = json.loads(websocket.receive_text())
+
+    assert error_event["type"] == "error"
+    assert error_event["status"] == 400
+    assert error_event["error"]["code"] == "invalid_request_error"
+    assert error_event["error"]["type"] == "invalid_request_error"
+    assert error_event["error"]["param"] == "input"
+    assert (
+        "compaction_trigger must appear exactly once as the final top-level input item"
+        in error_event["error"]["message"]
+    )
 
 
 def test_backend_responses_websocket_slims_historical_inline_artifacts_and_succeeds(

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -10,7 +10,7 @@ import pytest
 from aiohttp.client_reqrep import ConnectionKey
 
 import app.core.clients.proxy as proxy_module
-from app.core.clients.codex import CodexClient, CodexTransportError, CodexWebSocketResult
+from app.core.clients.codex import CodexClient, CodexRequestResult, CodexTransportError, CodexWebSocketResult
 from app.core.clients.files import create_file, finalize_file
 from app.core.clients.proxy import (
     ProxyResponseError,
@@ -38,6 +38,19 @@ class _CodexClient:
     async def request(self, method: str, url: str, *, route: ResolvedUpstreamRoute, **kwargs: Any) -> object:
         self.calls.append({"method": method, "url": url, "route": route, **kwargs})
         return self.response
+
+
+class _RouteMetadataCodexClient(_CodexClient):
+    async def request_with_route_metadata(
+        self,
+        method: str,
+        url: str,
+        *,
+        route: ResolvedUpstreamRoute,
+        **kwargs: Any,
+    ) -> CodexRequestResult:
+        self.calls.append({"method": method, "url": url, "route": route, **kwargs})
+        return CodexRequestResult(response=self.response, route=route, fallback_used=False)
 
 
 class _FailingRouteMetadataCodexClient:
@@ -87,6 +100,40 @@ class _CompactStreamResponse:
     status_code = 200
     headers: dict[str, str] = {}
     content = _CompactStreamContent()
+
+
+class _BufferedCompactStreamResponse:
+    status = 200
+    status_code = 200
+    headers = {"content-type": "text/event-stream"}
+    content = (
+        b'data: {"type":"response.completed","response":{"object":"response","id":"resp_compact_buffered",'
+        b'"status":"completed","service_tier":"default","output":['
+        b'{"id":"msg_history","type":"message","role":"assistant","status":"completed",'
+        b'"content":[{"type":"output_text","text":"historical plaintext"}]},'
+        b'{"id":"cmp_buffered","type":"compaction_summary","encrypted_content":"enc_buffered"}]}}\n\n'
+    )
+
+
+class _CompactTerminalErrorStreamResponse:
+    status = 200
+    status_code = 200
+    headers = {"content-type": "text/event-stream"}
+    content = (
+        b'data: {"type":"error","code":"rate_limit_exceeded","message":"quota closed",'
+        b'"param":"previous_response_id"}\n\n'
+    )
+
+
+class _CompactTerminalFailedStreamResponse:
+    status = 200
+    status_code = 200
+    headers = {"content-type": "text/event-stream"}
+    content = (
+        b'data: {"type":"response.failed","response":{"status_code":400,'
+        b'"error":{"code":"previous_response_not_found","message":"missing anchor",'
+        b'"type":"invalid_request_error","param":"previous_response_id"}}}\n\n'
+    )
 
 
 class _TranscribeResponse:
@@ -348,6 +395,83 @@ async def test_compact_responses_uses_codex_client_when_route_is_resolved(route:
     assert client.calls[0]["json"]["stream"] is True
     assert client.calls[0]["headers"]["Accept"] == "text/event-stream"
     assert trace.endpoint_id == "ep_1"
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_routed_buffered_sse_keeps_compact_protocol(route: ResolvedUpstreamRoute) -> None:
+    client = _RouteMetadataCodexClient(_BufferedCompactStreamResponse())
+    payload = ResponsesCompactRequest(model="gpt-5.2", instructions="Summarize.", input="hello")
+
+    response = await compact_responses(
+        payload,
+        {"user-agent": "codex"},
+        "access",
+        "chatgpt_account",
+        session=cast(Any, object()),
+        route=route,
+        codex_client=cast(Any, client),
+    )
+
+    sent_input = client.calls[0]["json"]["input"]
+    assert sent_input[-1] == {"type": "compaction_trigger"}
+    assert sum(1 for item in sent_input if isinstance(item, dict) and item.get("type") == "compaction_trigger") == 1
+    assert response.id == "resp_compact_buffered"
+    assert response.model_extra is not None
+    assert response.model_extra["service_tier"] == "default"
+    assert response.model_extra["output"] == [
+        {"id": "cmp_buffered", "type": "compaction", "encrypted_content": "enc_buffered"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_routed_terminal_sse_error_keeps_openai_envelope(
+    route: ResolvedUpstreamRoute,
+) -> None:
+    client = _RouteMetadataCodexClient(_CompactTerminalFailedStreamResponse())
+    payload = ResponsesCompactRequest(model="gpt-5.2", instructions="Summarize.", input="hello")
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await compact_responses(
+            payload,
+            {"user-agent": "codex"},
+            "access",
+            "chatgpt_account",
+            session=cast(Any, object()),
+            route=route,
+            codex_client=cast(Any, client),
+        )
+
+    error = exc_info.value.payload["error"]
+    assert error["code"] == "previous_response_not_found"
+    assert error["message"] == "missing anchor"
+    assert error["type"] == "invalid_request_error"
+    assert error["param"] == "previous_response_id"
+    assert exc_info.value.failure_phase == "upstream"
+    assert exc_info.value.upstream_status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_routed_top_level_sse_error_preserves_fields(
+    route: ResolvedUpstreamRoute,
+) -> None:
+    client = _RouteMetadataCodexClient(_CompactTerminalErrorStreamResponse())
+    payload = ResponsesCompactRequest(model="gpt-5.2", instructions="Summarize.", input="hello")
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await compact_responses(
+            payload,
+            {"user-agent": "codex"},
+            "access",
+            "chatgpt_account",
+            session=cast(Any, object()),
+            route=route,
+            codex_client=cast(Any, client),
+        )
+
+    error = exc_info.value.payload["error"]
+    assert error["code"] == "rate_limit_exceeded"
+    assert error["message"] == "quota closed"
+    assert error["param"] == "previous_response_id"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -71,6 +71,21 @@ class _CompactResponse:
         return {"object": "response.compact", "id": "compact_1"}
 
 
+class _CompactStreamContent:
+    async def iter_chunked(self, size: int):
+        del size
+        yield (
+            b'data: {"type":"response.completed","response":'
+            b'{"object":"response.compact","id":"compact_1"}}\n\n'
+        )
+
+
+class _CompactStreamResponse:
+    status_code = 200
+    headers = {"content-type": "text/event-stream"}
+    content = _CompactStreamContent()
+
+
 class _TranscribeResponse:
     status_code = 200
     headers = {"content-type": "application/json"}
@@ -301,7 +316,7 @@ async def test_codex_control_request_uses_codex_client_when_route_is_resolved(ro
 
 @pytest.mark.asyncio
 async def test_compact_responses_uses_codex_client_when_route_is_resolved(route: ResolvedUpstreamRoute) -> None:
-    client = _CodexClient(_CompactResponse())
+    client = _CodexClient(_CompactStreamResponse())
     trace = UpstreamProxyRouteTrace()
     payload = ResponsesCompactRequest(model="gpt-5.2", instructions="Summarize.", input="hello")
 
@@ -321,6 +336,9 @@ async def test_compact_responses_uses_codex_client_when_route_is_resolved(route:
     assert client.calls[0]["url"].endswith("/backend-api/codex/responses")
     assert client.calls[0]["route"] is route
     assert client.calls[0]["json"]["model"] == "gpt-5.2"
+    assert client.calls[0]["json"]["store"] is False
+    assert client.calls[0]["json"]["stream"] is True
+    assert client.calls[0]["headers"]["Accept"] == "text/event-stream"
     assert trace.endpoint_id == "ep_1"
 
 

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -75,10 +75,11 @@ class _CompactStreamContent:
     async def iter_chunked(self, size: int):
         del size
         yield (
+            b'data: {"type":"response.output_item.done","output_index":0,'
+            b'"item":{"id":"msg_compact_1","type":"message","role":"assistant",'
+            b'"status":"completed","content":[{"type":"output_text","text":"enc_compact_1"}]}}\n\n'
             b'data: {"type":"response.completed","response":'
-            b'{"object":"response","id":"resp_compact_1","status":"completed",'
-            b'"output":[{"id":"cmp_1","type":"compaction_summary",'
-            b'"encrypted_content":"enc_compact_1"}]}}\n\n'
+            b'{"object":"response","id":"resp_compact_1","status":"completed","output":[]}}\n\n'
         )
 
 
@@ -336,7 +337,9 @@ async def test_compact_responses_uses_codex_client_when_route_is_resolved(route:
     assert response.object == "response.compaction"
     assert response.id == "resp_compact_1"
     assert response.model_extra == {
-        "output": [{"id": "cmp_1", "type": "compaction", "encrypted_content": "enc_compact_1"}]
+        "output": [
+            {"id": "msg_compact_1", "type": "compaction", "status": "completed", "encrypted_content": "enc_compact_1"}
+        ]
     }
     assert client.calls[0]["url"].endswith("/backend-api/codex/responses")
     assert client.calls[0]["route"] is route

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -136,6 +136,21 @@ class _CompactTerminalFailedStreamResponse:
     )
 
 
+class _CompactTerminalFailedStreamWithoutStatusResponse:
+    status = 200
+    status_code = 200
+    headers = {"content-type": "text/event-stream"}
+
+    def __init__(self, error_type: str, error_code: str) -> None:
+        self.content = (
+            b'data: {"type":"response.failed","response":{"status":"failed","error":{"code":"'
+            + error_code.encode("utf-8")
+            + b'","message":"mapped from error detail","type":"'
+            + error_type.encode("utf-8")
+            + b'"}}}\n\n'
+        )
+
+
 class _TranscribeResponse:
     status_code = 200
     headers = {"content-type": "application/json"}
@@ -448,6 +463,41 @@ async def test_compact_responses_routed_terminal_sse_error_keeps_openai_envelope
     assert error["param"] == "previous_response_id"
     assert exc_info.value.failure_phase == "upstream"
     assert exc_info.value.upstream_status_code == 400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error_type", "error_code", "expected_status"),
+    [
+        ("invalid_request_error", "invalid_request_error", 400),
+        ("authentication_error", "invalid_api_key", 401),
+        ("rate_limit_error", "rate_limit_exceeded", 429),
+    ],
+)
+async def test_compact_responses_terminal_sse_error_infers_status_from_error_detail(
+    route: ResolvedUpstreamRoute,
+    error_type: str,
+    error_code: str,
+    expected_status: int,
+) -> None:
+    client = _RouteMetadataCodexClient(_CompactTerminalFailedStreamWithoutStatusResponse(error_type, error_code))
+    payload = ResponsesCompactRequest(model="gpt-5.2", instructions="Summarize.", input="hello")
+
+    with pytest.raises(ProxyResponseError) as exc_info:
+        await compact_responses(
+            payload,
+            {"user-agent": "codex"},
+            "access",
+            "chatgpt_account",
+            session=cast(Any, object()),
+            route=route,
+            codex_client=cast(Any, client),
+        )
+
+    assert exc_info.value.status_code == expected_status
+    assert exc_info.value.upstream_status_code == expected_status
+    assert exc_info.value.payload["error"]["type"] == error_type
+    assert exc_info.value.payload["error"]["code"] == error_code
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -76,7 +76,9 @@ class _CompactStreamContent:
         del size
         yield (
             b'data: {"type":"response.completed","response":'
-            b'{"object":"response.compact","id":"compact_1"}}\n\n'
+            b'{"object":"response","id":"resp_compact_1","status":"completed",'
+            b'"output":[{"id":"cmp_1","type":"compaction_summary",'
+            b'"encrypted_content":"enc_compact_1"}]}}\n\n'
         )
 
 
@@ -331,8 +333,11 @@ async def test_compact_responses_uses_codex_client_when_route_is_resolved(route:
         route_trace=trace,
     )
 
-    assert response.object == "response.compact"
-    assert response.id == "compact_1"
+    assert response.object == "response.compaction"
+    assert response.id == "resp_compact_1"
+    assert response.model_extra == {
+        "output": [{"id": "cmp_1", "type": "compaction", "encrypted_content": "enc_compact_1"}]
+    }
     assert client.calls[0]["url"].endswith("/backend-api/codex/responses")
     assert client.calls[0]["route"] is route
     assert client.calls[0]["json"]["model"] == "gpt-5.2"

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -318,7 +318,7 @@ async def test_compact_responses_uses_codex_client_when_route_is_resolved(route:
 
     assert response.object == "response.compact"
     assert response.id == "compact_1"
-    assert client.calls[0]["url"].endswith("/backend-api/codex/responses/compact")
+    assert client.calls[0]["url"].endswith("/backend-api/codex/responses")
     assert client.calls[0]["route"] is route
     assert client.calls[0]["json"]["model"] == "gpt-5.2"
     assert trace.endpoint_id == "ep_1"

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -82,7 +82,7 @@ class _CompactStreamContent:
 
 class _CompactStreamResponse:
     status_code = 200
-    headers = {"content-type": "text/event-stream"}
+    headers: dict[str, str] = {}
     content = _CompactStreamContent()
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10305,7 +10305,8 @@ async def test_compact_responses_without_trigger_canonicalization_hits_upstream_
 
         def post(self, url: str, *, json=None, headers=None, timeout=None):
             self.calls.append({"url": url, "json": json, "headers": headers, "timeout": timeout})
-            compact_input = cast(list[dict[str, object]], json["input"])
+            upstream_payload = cast(dict[str, object], json)
+            compact_input = cast(list[dict[str, object]], upstream_payload["input"])
             trigger_count = sum(1 for item in compact_input if item.get("type") == "compaction_trigger")
             if trigger_count > 1:
                 return _DuplicateTriggerResponse(
@@ -10388,7 +10389,8 @@ async def test_compact_responses_without_trigger_canonicalization_hits_upstream_
     assert exc.status_code == 400
     assert _proxy_error_code(exc) == "invalid_request_error"
     assert _proxy_error_message(exc) == "Only one 'compaction_trigger' item may be provided"
-    compact_input = cast(list[dict[str, object]], session.calls[0]["json"]["input"])
+    upstream_payload = cast(dict[str, object], session.calls[0]["json"])
+    compact_input = cast(list[dict[str, object]], upstream_payload["input"])
     assert sum(1 for item in compact_input if item.get("type") == "compaction_trigger") == 2
 
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10122,6 +10122,8 @@ async def test_compact_responses_derives_lite_http_header_from_additional_tools(
         upstream_base_url = "https://chatgpt.com/backend-api"
         upstream_connect_timeout_seconds = 1.0
         upstream_compact_timeout_seconds = 12.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
         image_inline_fetch_enabled = False
         trace_channels = frozenset()
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -31,6 +31,7 @@ from websockets.exceptions import ConnectionClosedError
 from websockets.frames import Close
 
 import app.core.clients.proxy as proxy_module
+import app.core.openai.requests as openai_requests_module
 import app.core.resilience.network_recovery as network_recovery_module
 import app.modules.proxy.load_balancer as load_balancer_module
 from app.core import shutdown as shutdown_state
@@ -10276,6 +10277,69 @@ def test_responses_wire_payload_normalizes_internal_duplicate_compaction_trigger
         {"role": "user", "content": "hello"},
         {"type": "compaction_trigger"},
     ]
+
+
+def test_compact_wire_payload_omits_oversized_optional_tool_tail_even_with_terminal_trigger():
+    payload = proxy_module.ResponsesCompactRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "",
+            "input": [
+                {
+                    "type": "function_call",
+                    "name": "read_file",
+                    "call_id": "call_route_tail",
+                    "arguments": "x" * 450_000,
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_route_tail",
+                    "output": "latest ordinary result",
+                },
+                {"type": "compaction_trigger"},
+            ],
+        }
+    )
+
+    dumped = payload.to_payload()
+    compact_input = cast(list[dict[str, object]], dumped["input"])
+
+    assert compact_input[-1] == {"type": "compaction_trigger"}
+    assert all(item.get("call_id") != "call_route_tail" for item in compact_input if isinstance(item, dict))
+    assert "[compact trim]" in json.dumps(compact_input)
+    assert "latest ordinary result" not in json.dumps(compact_input)
+
+
+def test_compact_discard_consumed_continuity_output_pairs_treats_terminal_trigger_as_suffix():
+    input_items: list[JsonValue] = [
+        {
+            "type": "function_call",
+            "name": "read_file",
+            "call_id": "call_reused",
+            "arguments": '{"path":"old.txt"}',
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_reused",
+            "output": "consumed old output",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_reused",
+            "output": "latest output from the prior response",
+        },
+        {"type": "compaction_trigger"},
+    ]
+    selected_indices = {0, 1, 2, 3}
+    required_indices = {2, 3}
+
+    openai_requests_module._compact_discard_consumed_continuity_output_pairs(
+        input_items,
+        selected_indices=selected_indices,
+        required_indices=required_indices,
+    )
+
+    assert selected_indices == {2, 3}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10350,6 +10350,112 @@ async def test_compact_responses_defaults_to_no_configured_request_timeout(monke
     assert dumped["output"][0]["encrypted_content"] == "enc_summary_2"
 
 
+@pytest.mark.asyncio
+async def test_compact_responses_preserves_stream_idle_timeout_from_direct_sse(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 2.0
+        upstream_compact_timeout_seconds = 123.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        trace_channels = frozenset()
+
+    async def fake_compact_response_payload_from_success_response(*args: object, **kwargs: object) -> JsonValue:
+        del args, kwargs
+        raise proxy_module.StreamIdleTimeoutError()
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+    monkeypatch.setattr(
+        proxy_module,
+        "_compact_response_payload_from_success_response",
+        fake_compact_response_payload_from_success_response,
+    )
+
+    payload = proxy_module.ResponsesCompactRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+    session = _CompactSession(_compact_sse_response())
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await proxy_module.compact_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, session),
+        )
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 502
+    assert _proxy_error_code(exc) == "stream_idle_timeout"
+    assert _proxy_error_message(exc) == "Upstream stream idle timeout"
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_preserves_stream_event_too_large_from_routed_sse(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 2.0
+        upstream_compact_timeout_seconds = 123.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        trace_channels = frozenset()
+
+    oversized = proxy_module.StreamEventTooLargeError(4097, 1024)
+
+    async def fake_compact_response_payload_from_success_response(*args: object, **kwargs: object) -> JsonValue:
+        del args, kwargs
+        raise oversized
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+    monkeypatch.setattr(
+        proxy_module,
+        "_compact_response_payload_from_success_response",
+        fake_compact_response_payload_from_success_response,
+    )
+
+    route = ResolvedUpstreamRoute(
+        mode="account_bound",
+        pool_id="pool_compact",
+        endpoint=ResolvedProxyEndpoint("ep_compact", "http", "proxy.test", 8080),
+    )
+    codex_client = SimpleNamespace(
+        request_with_route_metadata=AsyncMock(
+            return_value=SimpleNamespace(
+                response=_compact_sse_response(),
+                route=route,
+                fallback_used=False,
+            )
+        )
+    )
+    payload = proxy_module.ResponsesCompactRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await proxy_module.compact_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, object()),
+            route=route,
+            codex_client=cast(proxy_module.CodexClient, codex_client),
+            allow_direct_egress=False,
+        )
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 502
+    assert _proxy_error_code(exc) == "stream_event_too_large"
+    assert _proxy_error_message(exc) == str(oversized)
+
+
 def test_sticky_key_for_responses_request_uses_bounded_cache_affinity():
     payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
     payload.prompt_cache_key = "thread_123"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10192,6 +10192,8 @@ async def test_compact_responses_normalizes_preexisting_terminal_trigger_without
         upstream_base_url = "https://chatgpt.com/backend-api"
         upstream_connect_timeout_seconds = 1.0
         upstream_compact_timeout_seconds = 12.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
         image_inline_fetch_enabled = False
         trace_channels = frozenset()
 

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10185,6 +10185,192 @@ async def test_compact_responses_derives_lite_http_header_from_additional_tools(
 
 
 @pytest.mark.asyncio
+async def test_compact_responses_normalizes_preexisting_terminal_trigger_without_losing_tool_tail(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 1.0
+        upstream_compact_timeout_seconds = 12.0
+        image_inline_fetch_enabled = False
+        trace_channels = frozenset()
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+
+    payload = proxy_module.ResponsesCompactRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {"role": "user", "content": "hello"},
+                {
+                    "type": "custom_tool_call",
+                    "name": "functions.exec_command",
+                    "call_id": "call_compact_tail",
+                    "input": "{\"cmd\":\"pytest\"}",
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_compact_tail",
+                    "output": "failed",
+                },
+                {"type": "compaction_trigger"},
+            ],
+        }
+    )
+    session = _CompactSession(
+        _JsonCompactResponse(
+            {"object": "response.compaction", "compaction_summary": {"encrypted_content": "enc_summary_1"}}
+        )
+    )
+
+    await proxy_module.compact_responses(
+        payload,
+        headers={},
+        access_token="token",
+        account_id="acc_1",
+        session=cast(proxy_module.aiohttp.ClientSession, session),
+    )
+
+    upstream_payload = cast(dict[str, object], session.calls[0]["json"])
+    compact_input = cast(list[dict[str, object]], upstream_payload["input"])
+    assert compact_input[-1] == {"type": "compaction_trigger"}
+    assert sum(1 for item in compact_input if item.get("type") == "compaction_trigger") == 1
+    assert compact_input[:-1] == [
+        {"role": "user", "content": "hello"},
+        {
+            "type": "custom_tool_call",
+            "name": "functions.exec_command",
+            "call_id": "call_compact_tail",
+            "input": '{"cmd":"pytest"}',
+        },
+        {
+            "type": "custom_tool_call_output",
+            "call_id": "call_compact_tail",
+            "output": "failed",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_without_trigger_canonicalization_hits_upstream_duplicate_trigger_error(monkeypatch):
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_connect_timeout_seconds = 1.0
+        upstream_compact_timeout_seconds = 12.0
+        image_inline_fetch_enabled = False
+        trace_channels = frozenset()
+
+    class _DuplicateTriggerResponse:
+        status = 400
+        reason = "Bad Request"
+
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def json(self, *, content_type=None):
+            return self._payload
+
+    class _DuplicateTriggerSession:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def post(self, url: str, *, json=None, headers=None, timeout=None):
+            self.calls.append({"url": url, "json": json, "headers": headers, "timeout": timeout})
+            compact_input = cast(list[dict[str, object]], json["input"])
+            trigger_count = sum(1 for item in compact_input if item.get("type") == "compaction_trigger")
+            if trigger_count > 1:
+                return _DuplicateTriggerResponse(
+                    {
+                        "error": {
+                            "message": "Only one 'compaction_trigger' item may be provided",
+                            "type": "invalid_request_error",
+                            "param": "input",
+                            "code": "invalid_request_error",
+                        }
+                    }
+                )
+            return _JsonCompactResponse(
+                {"object": "response.compaction", "compaction_summary": {"encrypted_content": "enc_summary_1"}}
+            )
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+
+    payload = proxy_module.ResponsesCompactRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {"role": "user", "content": "hello"},
+                {
+                    "type": "custom_tool_call",
+                    "name": "functions.exec_command",
+                    "call_id": "call_compact_tail",
+                    "input": "{\"cmd\":\"pytest\"}",
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_compact_tail",
+                    "output": "failed",
+                },
+                {"type": "compaction_trigger"},
+                {"type": "compaction_trigger"},
+            ],
+        }
+    )
+    monkeypatch.setattr(
+        payload,
+        "to_payload",
+        lambda: {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {"role": "user", "content": "hello"},
+                {
+                    "type": "custom_tool_call",
+                    "name": "functions.exec_command",
+                    "call_id": "call_compact_tail",
+                    "input": '{"cmd":"pytest"}',
+                },
+                {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call_compact_tail",
+                    "output": "failed",
+                },
+                {"type": "compaction_trigger"},
+                {"type": "compaction_trigger"},
+            ],
+            "parallel_tool_calls": False,
+        },
+    )
+    session = _DuplicateTriggerSession()
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await proxy_module.compact_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_1",
+            session=cast(proxy_module.aiohttp.ClientSession, session),
+        )
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 400
+    assert _proxy_error_code(exc) == "invalid_request_error"
+    assert _proxy_error_message(exc) == "Only one 'compaction_trigger' item may be provided"
+    compact_input = cast(list[dict[str, object]], session.calls[0]["json"]["input"])
+    assert sum(1 for item in compact_input if item.get("type") == "compaction_trigger") == 2
+
+
+@pytest.mark.asyncio
 async def test_compact_responses_rejects_image_inlining_that_exceeds_wire_budget(monkeypatch):
     class Settings:
         upstream_base_url = "https://chatgpt.com/backend-api"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -10207,7 +10207,7 @@ async def test_compact_responses_normalizes_preexisting_terminal_trigger_without
                     "type": "custom_tool_call",
                     "name": "functions.exec_command",
                     "call_id": "call_compact_tail",
-                    "input": "{\"cmd\":\"pytest\"}",
+                    "input": '{"cmd":"pytest"}',
                 },
                 {
                     "type": "custom_tool_call_output",
@@ -10249,6 +10249,28 @@ async def test_compact_responses_normalizes_preexisting_terminal_trigger_without
             "call_id": "call_compact_tail",
             "output": "failed",
         },
+    ]
+
+
+def test_responses_wire_payload_normalizes_internal_duplicate_compaction_trigger():
+    payload = proxy_module.ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "compact",
+            "input": [
+                {"role": "user", "content": "hello"},
+                {"type": "compaction_trigger"},
+                {"type": "compaction_trigger"},
+            ],
+            "stream": True,
+            "store": False,
+        }
+    ).to_payload()
+
+    compact_input = cast(list[dict[str, object]], payload["input"])
+    assert compact_input == [
+        {"role": "user", "content": "hello"},
+        {"type": "compaction_trigger"},
     ]
 
 
@@ -10314,7 +10336,7 @@ async def test_compact_responses_without_trigger_canonicalization_hits_upstream_
                     "type": "custom_tool_call",
                     "name": "functions.exec_command",
                     "call_id": "call_compact_tail",
-                    "input": "{\"cmd\":\"pytest\"}",
+                    "input": '{"cmd":"pytest"}',
                 },
                 {
                     "type": "custom_tool_call_output",

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -15,7 +15,7 @@ from contextlib import asynccontextmanager, suppress
 from copy import deepcopy
 from datetime import timedelta
 from types import SimpleNamespace
-from typing import Any, AsyncIterator, Iterator, Literal, Protocol, Self, cast
+from typing import Any, AsyncIterator, Iterator, Literal, Self, cast
 from unittest.mock import ANY, AsyncMock, MagicMock
 from unittest.mock import call as mock_call
 
@@ -5957,17 +5957,31 @@ class _JsonCompactResponse:
         return self._payload
 
 
+def _compact_sse_response(
+    *,
+    response_id: str = "resp_compact_1",
+    encrypted_content: str = "enc_summary_1",
+) -> "_SsePostResponse":
+    return _SsePostResponse(
+        [
+            (
+                b'data: {"type":"response.output_item.done","output_index":0,'
+                b'"item":{"id":"msg_compact_1","type":"message","role":"assistant",'
+                b'"status":"completed","content":[{"type":"output_text","text":"'
+                + encrypted_content.encode()
+                + b'"}]}}\n\n'
+            ),
+            (
+                b'data: {"type":"response.completed","response":{"object":"response","id":"'
+                + response_id.encode()
+                + b'","status":"completed","output":[]}}\n\n'
+            ),
+        ]
+    )
+
+
 class _CompactSession:
-    class _CompactResponseLike(Protocol):
-        status: int
-
-        async def __aenter__(self) -> Self: ...
-
-        async def __aexit__(self, exc_type: object | None, exc: BaseException | None, tb: object | None) -> bool: ...
-
-        async def json(self, *, content_type: str | None = None) -> dict[str, object]: ...
-
-    def __init__(self, response: _CompactResponseLike) -> None:
+    def __init__(self, response: object) -> None:
         self._response = response
         self.calls: list[dict[str, object]] = []
 
@@ -10034,6 +10048,8 @@ async def test_compact_responses_starts_upstream_timer_after_image_inlining(monk
         upstream_base_url = "https://chatgpt.com/backend-api"
         upstream_connect_timeout_seconds = 1.0
         upstream_compact_timeout_seconds = 12.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
         image_inline_fetch_enabled = True
         trace_channels = frozenset()
 
@@ -10062,11 +10078,7 @@ async def test_compact_responses_starts_upstream_timer_after_image_inlining(monk
     payload = proxy_module.ResponsesCompactRequest.model_validate(
         {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
     )
-    session = _CompactSession(
-        _JsonCompactResponse(
-            {"object": "response.compaction", "compaction_summary": {"encrypted_content": "enc_summary_1"}}
-        )
-    )
+    session = _CompactSession(_compact_sse_response(encrypted_content="enc_summary_1"))
 
     result = await proxy_module.compact_responses(
         payload,
@@ -10083,7 +10095,7 @@ async def test_compact_responses_starts_upstream_timer_after_image_inlining(monk
     assert timeout.sock_read == pytest.approx(6.5)
     dumped = result.model_dump(mode="json", exclude_none=True)
     assert dumped["object"] == "response.compaction"
-    assert dumped["compaction_summary"]["encrypted_content"] == "enc_summary_1"
+    assert dumped["output"][0]["encrypted_content"] == "enc_summary_1"
     assert recorded["started_at"] == 205.5
 
 
@@ -10093,6 +10105,8 @@ async def test_compact_responses_derives_lite_http_header_from_additional_tools(
         upstream_base_url = "https://chatgpt.com/backend-api"
         upstream_connect_timeout_seconds = 1.0
         upstream_compact_timeout_seconds = 12.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
         image_inline_fetch_enabled = False
         trace_channels = frozenset()
 
@@ -10129,11 +10143,7 @@ async def test_compact_responses_derives_lite_http_header_from_additional_tools(
             "reasoning": {"context": "turn", "effort": "high", "vendor_hint": 7},
         }
     )
-    session = _CompactSession(
-        _JsonCompactResponse(
-            {"object": "response.compaction", "compaction_summary": {"encrypted_content": "enc_summary_1"}}
-        )
-    )
+    session = _CompactSession(_compact_sse_response(encrypted_content="enc_summary_1"))
 
     await proxy_module.compact_responses(
         payload,
@@ -10224,11 +10234,14 @@ async def test_compact_responses_uses_configured_timeout_and_maps_read_timeout(m
         upstream_base_url = "https://chatgpt.com/backend-api"
         upstream_connect_timeout_seconds = 2.0
         upstream_compact_timeout_seconds = 123.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
         image_inline_fetch_enabled = False
         trace_channels = frozenset()
 
     class _TimeoutCompactResponse:
         status = 200
+        headers: dict[str, str] = {}
 
         async def __aenter__(self):
             return self
@@ -10236,8 +10249,13 @@ async def test_compact_responses_uses_configured_timeout_and_maps_read_timeout(m
         async def __aexit__(self, exc_type, exc, tb):
             return False
 
-        async def json(self, *, content_type=None):
-            raise proxy_module.aiohttp.SocketTimeoutError("Timeout on reading data from socket")
+        class _TimeoutContent:
+            async def iter_chunked(self, size: int):
+                del size
+                raise proxy_module.aiohttp.SocketTimeoutError("Timeout on reading data from socket")
+                yield b""
+
+        content = _TimeoutContent()
 
     monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
     monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
@@ -10274,6 +10292,8 @@ async def test_compact_responses_defaults_to_no_configured_request_timeout(monke
         upstream_base_url = "https://chatgpt.com/backend-api"
         upstream_connect_timeout_seconds = 2.0
         upstream_compact_timeout_seconds = None
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
         image_inline_fetch_enabled = False
         trace_channels = frozenset()
 
@@ -10284,11 +10304,7 @@ async def test_compact_responses_defaults_to_no_configured_request_timeout(monke
     payload = proxy_module.ResponsesCompactRequest.model_validate(
         {"model": "gpt-5.1", "instructions": "hi", "input": [{"role": "user", "content": "hi"}]}
     )
-    session = _CompactSession(
-        _JsonCompactResponse(
-            {"object": "response.compaction", "compaction_summary": {"encrypted_content": "enc_summary_2"}}
-        )
-    )
+    session = _CompactSession(_compact_sse_response(response_id="resp_compact_2", encrypted_content="enc_summary_2"))
 
     result = await proxy_module.compact_responses(
         payload,
@@ -10305,7 +10321,7 @@ async def test_compact_responses_defaults_to_no_configured_request_timeout(monke
     assert timeout.sock_read is None
     dumped = result.model_dump(mode="json", exclude_none=True)
     assert dumped["object"] == "response.compaction"
-    assert dumped["compaction_summary"]["encrypted_content"] == "enc_summary_2"
+    assert dumped["output"][0]["encrypted_content"] == "enc_summary_2"
 
 
 def test_sticky_key_for_responses_request_uses_bounded_cache_affinity():

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -4827,6 +4827,32 @@ class _DummyResponse(proxy_module.SSEResponseProtocol):
         self.content = _DummyContent(chunks)
 
 
+@pytest.mark.asyncio
+async def test_compact_sse_terminal_error_preserves_error_envelope() -> None:
+    response = _DummyResponse(
+        [
+            (
+                b'data: {"type":"response.failed","response":{"status_code":400,'
+                b'"error":{"code":"previous_response_not_found","message":"missing anchor",'
+                b'"param":"previous_response_id"}}}\n\n'
+            )
+        ]
+    )
+
+    with pytest.raises(proxy_module.ProxyResponseError) as exc_info:
+        await proxy_module._compact_response_payload_from_sse(
+            response,
+            idle_timeout_seconds=1.0,
+            max_event_bytes=4096,
+        )
+
+    exc = _assert_proxy_response_error(exc_info.value)
+    assert exc.status_code == 400
+    assert _proxy_error_code(exc) == "previous_response_not_found"
+    assert _proxy_error_message(exc) == "missing anchor"
+    assert exc.payload["error"]["param"] == "previous_response_id"
+
+
 class _TranscribeResponse:
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- validate `/responses/compact` input for duplicate or misplaced `compaction_trigger` items before calling upstream
- preserve the single valid terminal trigger when forwarding compact requests
- add regression coverage for duplicate rejection and single-trigger forwarding

## Validation
- `uv run pytest -q tests/integration/test_proxy_compact.py -k 'duplicate_compaction_trigger_before_upstream or preserves_single_terminal_compaction_trigger'`\n- `uv run pytest -q tests/integration/test_proxy_responses.py -k 'rejects_malformed_compaction_trigger'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Compact responses now use streaming output for improved compatibility and real-time handling.
  - Buffered and streamed compact responses are normalized consistently, including completion and error results.
  - Response headers and streamed content are preserved more reliably.

- **Bug Fixes**
  - Invalid, duplicate, or misplaced compaction triggers now receive clear HTTP 400 validation errors.
  - Valid requests retain exactly one terminal compaction trigger.
  - Stream idle timeouts and oversized events now produce structured errors.
  - Tool-call context and continuity information are preserved during compaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->