### PR TITLE
feat(db): report SQLite write transactions that outlive the busy timeout

### DIFF
--- a/app/db/session.py
+++ b/app/db/session.py
@@ -206,17 +206,12 @@ def _install_sqlite_long_write_watchdog(engine: Engine) -> None:
             info["sqlite_write_task"] = _current_task_name_best_effort()
         info["sqlite_last_write_statement"] = preview
 
-    def _report_and_reset(conn: object, *, outcome: str) -> None:
-        info = getattr(conn, "info", None)
-        if info is None:
+    def _finalize_pending_report(info: dict[str, object]) -> None:
+        pending = info.pop("sqlite_write_pending_report", None)
+        if not isinstance(pending, tuple):
             return
-        started_at = info.pop("sqlite_write_started_at", None)
-        first_statement = info.pop("sqlite_first_write_statement", None)
-        last_statement = info.pop("sqlite_last_write_statement", None)
-        task_name = info.pop("sqlite_write_task", None)
-        if started_at is None:
-            return
-        held_seconds = time.monotonic() - started_at
+        started_at, outcome, first_statement, last_statement, task_name = pending
+        held_seconds = time.monotonic() - float(started_at)
         if held_seconds < _SQLITE_LONG_WRITE_TRANSACTION_WARN_SECONDS:
             return
         logger.warning(
@@ -229,13 +224,43 @@ def _install_sqlite_long_write_watchdog(engine: Engine) -> None:
             last_statement,
         )
 
+    def _mark_transaction_ending(conn: object, *, outcome: str) -> None:
+        # ConnectionEvents.commit/rollback fire BEFORE the DBAPI call, and a
+        # wedged rollback is exactly the holder this watchdog hunts — reporting
+        # here would exclude the wedge itself from the measured hold. Stash the
+        # report and finalize it at the first proof the DBAPI transaction ended:
+        # the connection's next transaction beginning, or the connection going
+        # back to the pool.
+        info = getattr(conn, "info", None)
+        if info is None:
+            return
+        started_at = info.pop("sqlite_write_started_at", None)
+        first_statement = info.pop("sqlite_first_write_statement", None)
+        last_statement = info.pop("sqlite_last_write_statement", None)
+        task_name = info.pop("sqlite_write_task", None)
+        if started_at is None:
+            return
+        info["sqlite_write_pending_report"] = (started_at, outcome, first_statement, last_statement, task_name)
+
     @event.listens_for(engine, "commit")
-    def _report_on_commit(conn: object) -> None:
-        _report_and_reset(conn, outcome="commit")
+    def _mark_on_commit(conn: object) -> None:
+        _mark_transaction_ending(conn, outcome="commit")
 
     @event.listens_for(engine, "rollback")
-    def _report_on_rollback(conn: object) -> None:
-        _report_and_reset(conn, outcome="rollback")
+    def _mark_on_rollback(conn: object) -> None:
+        _mark_transaction_ending(conn, outcome="rollback")
+
+    @event.listens_for(engine, "begin")
+    def _finalize_on_next_begin(conn: object) -> None:
+        info = getattr(conn, "info", None)
+        if info is not None:
+            _finalize_pending_report(info)
+
+    @event.listens_for(engine, "checkin")
+    def _finalize_on_checkin(dbapi_connection: object, connection_record: object) -> None:
+        info = getattr(connection_record, "info", None)
+        if info is not None:
+            _finalize_pending_report(info)
 
 
 def _create_main_engine(url: str) -> AsyncEngine:

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -48,6 +48,11 @@ _SQLITE_WRITE_STATEMENT_PREFIXES = (
     "drop",
     "alter",
     "vacuum",
+    # BEGIN IMMEDIATE/EXCLUSIVE acquire the writer slot with no DML at all
+    # (e.g. AccountsRepository._acquire_sqlite_merge_lock); a plain deferred
+    # BEGIN does not and stays untracked.
+    "begin immediate",
+    "begin exclusive",
 )
 _SQLITE_WATCHDOG_STATEMENT_PREVIEW_CHARS = 300
 
@@ -239,6 +244,13 @@ def _install_sqlite_long_write_watchdog(engine: Engine) -> None:
         last_statement = info.pop("sqlite_last_write_statement", None)
         task_name = info.pop("sqlite_write_task", None)
         if started_at is None:
+            # A rollback after a commit whose DBAPI call raised: the pending
+            # report already holds outcome=commit, but the transaction is in
+            # fact ending by rollback — rewrite the outcome so the report does
+            # not claim a durable commit that never happened.
+            pending = info.get("sqlite_write_pending_report")
+            if outcome == "rollback" and isinstance(pending, tuple) and pending[1] == "commit":
+                info["sqlite_write_pending_report"] = (pending[0], "commit_failed_rollback", *pending[2:])
             return
         info["sqlite_write_pending_report"] = (started_at, outcome, first_statement, last_statement, task_name)
 
@@ -261,6 +273,19 @@ def _install_sqlite_long_write_watchdog(engine: Engine) -> None:
         info = getattr(connection_record, "info", None)
         if info is not None:
             _finalize_pending_report(info)
+
+    @event.listens_for(engine, "handle_error")
+    def _flip_outcome_on_failed_end(exception_context: object) -> None:
+        # A DBAPI commit that raises still ends the transaction, but by
+        # rollback; the pending report marked at the commit event must not
+        # claim a durable commit that never happened.
+        connection = getattr(exception_context, "connection", None)
+        info = getattr(connection, "info", None) if connection is not None else None
+        if info is None:
+            return
+        pending = info.get("sqlite_write_pending_report")
+        if isinstance(pending, tuple) and pending[1] == "commit":
+            info["sqlite_write_pending_report"] = (pending[0], "commit_failed_rollback", *pending[2:])
 
 
 def _create_main_engine(url: str) -> AsyncEngine:

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import sqlite3
+import time
 from contextlib import asynccontextmanager
 from enum import StrEnum
 from pathlib import Path
@@ -33,6 +34,22 @@ logger = logging.getLogger(__name__)
 
 _SQLITE_BUSY_TIMEOUT_MS = 30_000
 _SQLITE_BUSY_TIMEOUT_SECONDS = _SQLITE_BUSY_TIMEOUT_MS / 1000
+# A write transaction holding SQLite's single writer slot past the busy
+# timeout is exactly the holder that makes every other writer surface
+# "database is locked" (issue #1682); the watchdog below reports it with the
+# statements it ran, since the stall is nondeterministic and self-recovers.
+_SQLITE_LONG_WRITE_TRANSACTION_WARN_SECONDS = _SQLITE_BUSY_TIMEOUT_SECONDS
+_SQLITE_WRITE_STATEMENT_PREFIXES = (
+    "insert",
+    "update",
+    "delete",
+    "replace",
+    "create",
+    "drop",
+    "alter",
+    "vacuum",
+)
+_SQLITE_WATCHDOG_STATEMENT_PREVIEW_CHARS = 300
 
 # PostgreSQL pool checkout timeout and connection recycle window. Fixed
 # application constants (issue #1340): recycle keeps pooled connections
@@ -135,6 +152,85 @@ def _configure_sqlite_engine(engine: Engine, *, enable_wal: bool) -> None:
             cursor.execute(f"PRAGMA busy_timeout={_SQLITE_BUSY_TIMEOUT_MS}")
         finally:
             cursor.close()
+
+    _install_sqlite_long_write_watchdog(engine)
+
+
+def _current_task_name_best_effort() -> str:
+    # Sync engine events run inside the greenlet driving the async engine on
+    # the event loop thread, so the owning task is normally visible; never let
+    # diagnostics raise into the query path.
+    try:
+        task = asyncio.current_task()
+    except RuntimeError:
+        return "<no-loop>"
+    if task is None:
+        return "<no-task>"
+    return task.get_name()
+
+
+def _install_sqlite_long_write_watchdog(engine: Engine) -> None:
+    """Report write transactions that outlive the SQLite busy timeout.
+
+    In WAL mode a transaction takes the single writer slot at its first write
+    statement, not at BEGIN, so the window is measured from the first write to
+    commit/rollback. The report fires when the holder finally ends — the stall
+    in issue #1682 self-recovers, so identifying the holder post-hoc is the
+    point; a live sampler is not needed to attribute it.
+    """
+
+    @event.listens_for(engine, "before_cursor_execute")
+    def _track_write_statements(
+        conn: object,
+        cursor: object,
+        statement: str,
+        parameters: object,
+        context: object,
+        executemany: bool,
+    ) -> None:
+        stripped = statement.lstrip().lower()
+        if not stripped.startswith(_SQLITE_WRITE_STATEMENT_PREFIXES):
+            return
+        info = getattr(conn, "info", None)
+        if info is None:
+            return
+        preview = statement[:_SQLITE_WATCHDOG_STATEMENT_PREVIEW_CHARS]
+        if "sqlite_write_started_at" not in info:
+            info["sqlite_write_started_at"] = time.monotonic()
+            info["sqlite_first_write_statement"] = preview
+            info["sqlite_write_task"] = _current_task_name_best_effort()
+        info["sqlite_last_write_statement"] = preview
+
+    def _report_and_reset(conn: object, *, outcome: str) -> None:
+        info = getattr(conn, "info", None)
+        if info is None:
+            return
+        started_at = info.pop("sqlite_write_started_at", None)
+        first_statement = info.pop("sqlite_first_write_statement", None)
+        last_statement = info.pop("sqlite_last_write_statement", None)
+        task_name = info.pop("sqlite_write_task", None)
+        if started_at is None:
+            return
+        held_seconds = time.monotonic() - started_at
+        if held_seconds < _SQLITE_LONG_WRITE_TRANSACTION_WARN_SECONDS:
+            return
+        logger.warning(
+            "sqlite_long_write_transaction held_seconds=%.1f outcome=%s task=%s first_statement=%r "
+            "last_statement=%r — this writer starved every other writer past busy_timeout (issue #1682)",
+            held_seconds,
+            outcome,
+            task_name,
+            first_statement,
+            last_statement,
+        )
+
+    @event.listens_for(engine, "commit")
+    def _report_on_commit(conn: object) -> None:
+        _report_and_reset(conn, outcome="commit")
+
+    @event.listens_for(engine, "rollback")
+    def _report_on_rollback(conn: object) -> None:
+        _report_and_reset(conn, outcome="rollback")
 
 
 def _create_main_engine(url: str) -> AsyncEngine:

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -179,7 +179,7 @@ def _install_sqlite_long_write_watchdog(engine: Engine) -> None:
     point; a live sampler is not needed to attribute it.
     """
 
-    @event.listens_for(engine, "before_cursor_execute")
+    @event.listens_for(engine, "after_cursor_execute")
     def _track_write_statements(
         conn: object,
         cursor: object,
@@ -188,6 +188,11 @@ def _install_sqlite_long_write_watchdog(engine: Engine) -> None:
         context: object,
         executemany: bool,
     ) -> None:
+        # after_cursor_execute, not before: the first write statement may wait
+        # up to busy_timeout for the writer slot before failing, and timing
+        # from before the execute would report that victim as the holder. The
+        # slot is only held once a write statement has SUCCEEDED, so the clock
+        # starts there.
         stripped = statement.lstrip().lower()
         if not stripped.startswith(_SQLITE_WRITE_STATEMENT_PREFIXES):
             return

--- a/openspec/changes/report-sqlite-long-write-holders/proposal.md
+++ b/openspec/changes/report-sqlite-long-write-holders/proposal.md
@@ -1,0 +1,19 @@
+## Why
+
+Issue #1682: a single-instance SQLite deployment hit a self-sustaining ~17-minute `database is locked` stall that blocked leader re-election. The log evidence shows the lease loss was a symptom — some connection held SQLite's single writer slot past the 30-second busy timeout, starving every other writer, and recovered spontaneously when the holder finally finished. The repro is nondeterministic and the holder's identity never appears in any log, so the stall cannot currently be attributed, and any teardown/deadline fix would be guesswork until it is.
+
+## What Changes
+
+- Every SQLite engine gains a long-write-transaction watchdog: the first write statement in a transaction starts the clock (WAL takes the writer slot at the first write, not at BEGIN), and when the transaction commits or rolls back after holding longer than the busy timeout, a WARNING reports the held duration, outcome, owning task name, and the first and last write statements.
+- Post-hoc by design: the stall self-recovers, so identifying the holder when it ends is sufficient for attribution and needs no sampler thread. Read-only transactions never report; fast writes never report.
+- No new settings: the threshold is the existing busy timeout — a writer holding longer is precisely the one making every other writer surface `database is locked`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `database-backends`: SQLite write-lock stalls are attributable from the log.

--- a/openspec/changes/report-sqlite-long-write-holders/specs/database-backends/spec.md
+++ b/openspec/changes/report-sqlite-long-write-holders/specs/database-backends/spec.md
@@ -2,13 +2,19 @@
 
 ### Requirement: SQLite write-lock stalls are attributable
 
-When a SQLite write transaction holds the writer slot longer than the configured busy timeout, the system MUST report it at WARNING when the transaction ends, including the held duration, whether it committed or rolled back, the owning task where available, and the first and last write statements it executed. The window MUST be measured from the completion of the transaction's first successful write statement — a statement still waiting in the busy timeout has not acquired the slot, so a victim of the stall is never reported as its holder — and read-only transactions, which never take the writer slot in WAL, are never reported. The watchdog MUST NOT raise into the query path and MUST NOT require configuration.
+When a SQLite write transaction holds the writer slot longer than the configured busy timeout, the system MUST report it at WARNING once the transaction has actually ended — the end-of-transaction call itself can be the stall, so the report MUST be deferred to the first proof the DBAPI transaction is over (the connection's next transaction, or its return to the pool) and MUST include that call in the measured hold, including the held duration, whether it committed or rolled back, the owning task where available, and the first and last write statements it executed. The window MUST be measured from the completion of the transaction's first successful write statement — a statement still waiting in the busy timeout has not acquired the slot, so a victim of the stall is never reported as its holder — and read-only transactions, which never take the writer slot in WAL, are never reported. The watchdog MUST NOT raise into the query path and MUST NOT require configuration.
 
 #### Scenario: The starving writer is identified when it finally ends
 
 - **GIVEN** a write transaction that held the writer slot past the busy timeout while other writers surfaced `database is locked`
 - **WHEN** it commits or rolls back
 - **THEN** a warning reports its duration, outcome, task, and first/last write statements
+
+#### Scenario: A stalled commit or rollback is inside the measured hold
+
+- **GIVEN** a write transaction whose commit or rollback call itself stalls past the busy timeout
+- **WHEN** the connection next begins a transaction or returns to the pool
+- **THEN** the report fires with the stall included in the held duration
 
 #### Scenario: A victim waiting out the busy timeout is not reported as the holder
 

--- a/openspec/changes/report-sqlite-long-write-holders/specs/database-backends/spec.md
+++ b/openspec/changes/report-sqlite-long-write-holders/specs/database-backends/spec.md
@@ -2,13 +2,25 @@
 
 ### Requirement: SQLite write-lock stalls are attributable
 
-When a SQLite write transaction holds the writer slot longer than the configured busy timeout, the system MUST report it at WARNING once the transaction has actually ended — the end-of-transaction call itself can be the stall, so the report MUST be deferred to the first proof the DBAPI transaction is over (the connection's next transaction, or its return to the pool) and MUST include that call in the measured hold, including the held duration, whether it committed or rolled back, the owning task where available, and the first and last write statements it executed. The window MUST be measured from the completion of the transaction's first successful write statement — a statement still waiting in the busy timeout has not acquired the slot, so a victim of the stall is never reported as its holder — and read-only transactions, which never take the writer slot in WAL, are never reported. The watchdog MUST NOT raise into the query path and MUST NOT require configuration.
+When a SQLite write transaction holds the writer slot longer than the configured busy timeout, the system MUST report it at WARNING once the transaction has actually ended — the end-of-transaction call itself can be the stall, so the report MUST be deferred to the first proof the DBAPI transaction is over (the connection's next transaction, or its return to the pool) and MUST include that call in the measured hold, including the held duration, whether it committed or rolled back, the owning task where available, and the first and last write statements it executed. The window MUST be measured from the completion of the transaction's first successful write statement — including a bare `BEGIN IMMEDIATE`/`BEGIN EXCLUSIVE`, which acquires the writer slot with no DML — a statement still waiting in the busy timeout has not acquired the slot, so a victim of the stall is never reported as its holder — and read-only transactions, which never take the writer slot in WAL, are never reported. The watchdog MUST NOT raise into the query path and MUST NOT require configuration.
 
 #### Scenario: The starving writer is identified when it finally ends
 
 - **GIVEN** a write transaction that held the writer slot past the busy timeout while other writers surfaced `database is locked`
 - **WHEN** it commits or rolls back
 - **THEN** a warning reports its duration, outcome, task, and first/last write statements
+
+#### Scenario: A BEGIN IMMEDIATE holder with no DML is attributed
+
+- **GIVEN** a transaction that acquired the writer slot via `BEGIN IMMEDIATE` and ran only reads
+- **WHEN** it holds past the busy timeout
+- **THEN** it is reported like any other write holder
+
+#### Scenario: A failed commit is not reported as a durable commit
+
+- **GIVEN** a write transaction whose DBAPI commit raises and is rolled back
+- **WHEN** the report fires
+- **THEN** its outcome states the commit failed and rolled back
 
 #### Scenario: A stalled commit or rollback is inside the measured hold
 

--- a/openspec/changes/report-sqlite-long-write-holders/specs/database-backends/spec.md
+++ b/openspec/changes/report-sqlite-long-write-holders/specs/database-backends/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: SQLite write-lock stalls are attributable
+
+When a SQLite write transaction holds the writer slot longer than the configured busy timeout, the system MUST report it at WARNING when the transaction ends, including the held duration, whether it committed or rolled back, the owning task where available, and the first and last write statements it executed. The window MUST be measured from the transaction's first write statement, so read-only transactions — which never take the writer slot in WAL — are never reported. The watchdog MUST NOT raise into the query path and MUST NOT require configuration.
+
+#### Scenario: The starving writer is identified when it finally ends
+
+- **GIVEN** a write transaction that held the writer slot past the busy timeout while other writers surfaced `database is locked`
+- **WHEN** it commits or rolls back
+- **THEN** a warning reports its duration, outcome, task, and first/last write statements
+
+#### Scenario: Healthy traffic is silent
+
+- **WHEN** read-only transactions and writes completing under the threshold run
+- **THEN** no long-write report is produced

--- a/openspec/changes/report-sqlite-long-write-holders/specs/database-backends/spec.md
+++ b/openspec/changes/report-sqlite-long-write-holders/specs/database-backends/spec.md
@@ -2,13 +2,19 @@
 
 ### Requirement: SQLite write-lock stalls are attributable
 
-When a SQLite write transaction holds the writer slot longer than the configured busy timeout, the system MUST report it at WARNING when the transaction ends, including the held duration, whether it committed or rolled back, the owning task where available, and the first and last write statements it executed. The window MUST be measured from the transaction's first write statement, so read-only transactions — which never take the writer slot in WAL — are never reported. The watchdog MUST NOT raise into the query path and MUST NOT require configuration.
+When a SQLite write transaction holds the writer slot longer than the configured busy timeout, the system MUST report it at WARNING when the transaction ends, including the held duration, whether it committed or rolled back, the owning task where available, and the first and last write statements it executed. The window MUST be measured from the completion of the transaction's first successful write statement — a statement still waiting in the busy timeout has not acquired the slot, so a victim of the stall is never reported as its holder — and read-only transactions, which never take the writer slot in WAL, are never reported. The watchdog MUST NOT raise into the query path and MUST NOT require configuration.
 
 #### Scenario: The starving writer is identified when it finally ends
 
 - **GIVEN** a write transaction that held the writer slot past the busy timeout while other writers surfaced `database is locked`
 - **WHEN** it commits or rolls back
 - **THEN** a warning reports its duration, outcome, task, and first/last write statements
+
+#### Scenario: A victim waiting out the busy timeout is not reported as the holder
+
+- **GIVEN** a write statement that spends the busy timeout waiting for the slot and fails with `database is locked`
+- **WHEN** its transaction rolls back
+- **THEN** no long-write report attributes the wait to that transaction
 
 #### Scenario: Healthy traffic is silent
 

--- a/openspec/changes/report-sqlite-long-write-holders/tasks.md
+++ b/openspec/changes/report-sqlite-long-write-holders/tasks.md
@@ -1,0 +1,9 @@
+## 1. Watchdog
+
+- [x] 1.1 Track the first write statement per connection transaction and report at commit/rollback when the hold exceeded the busy timeout, with duration, outcome, task name, and first/last write statements
+- [x] 1.2 Install it from `_configure_sqlite_engine` so the main, background, and memory engines are all covered
+
+## 2. Tests
+
+- [x] 2.1 A write transaction over the threshold is reported with its statement and outcome
+- [x] 2.2 Read-only transactions and fast writes stay silent

--- a/openspec/changes/report-sqlite-long-write-holders/tasks.md
+++ b/openspec/changes/report-sqlite-long-write-holders/tasks.md
@@ -9,3 +9,4 @@
 - [x] 2.2 Read-only transactions and fast writes stay silent
 - [x] 2.3 A write that fails while waiting for the slot does not report its victim transaction as the holder
 - [x] 2.4 A stalled transaction end is included in the measured hold (fails on report-at-event code)
+- [x] 2.5 A bare BEGIN IMMEDIATE holder is attributed; a DBAPI commit failure reports commit_failed_rollback

--- a/openspec/changes/report-sqlite-long-write-holders/tasks.md
+++ b/openspec/changes/report-sqlite-long-write-holders/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Watchdog
 
-- [x] 1.1 Track from the completion of the first successful write statement (after_cursor_execute — a statement waiting in the busy timeout has not acquired the slot) and report at commit/rollback when the hold exceeded the busy timeout, with duration, outcome, task name, and first/last write statements
+- [x] 1.1 Track from the completion of the first successful write statement (after_cursor_execute — a statement waiting in the busy timeout has not acquired the slot) and report at commit/rollback when the hold exceeded the busy timeout, with duration, outcome, task name, and first/last write statements; the report is deferred to the next begin or pool checkin so a stalled commit/rollback is inside the measured hold
 - [x] 1.2 Install it from `_configure_sqlite_engine` so the main, background, and memory engines are all covered
 
 ## 2. Tests
@@ -8,3 +8,4 @@
 - [x] 2.1 A write transaction over the threshold is reported with its statement and outcome
 - [x] 2.2 Read-only transactions and fast writes stay silent
 - [x] 2.3 A write that fails while waiting for the slot does not report its victim transaction as the holder
+- [x] 2.4 A stalled transaction end is included in the measured hold (fails on report-at-event code)

--- a/openspec/changes/report-sqlite-long-write-holders/tasks.md
+++ b/openspec/changes/report-sqlite-long-write-holders/tasks.md
@@ -1,9 +1,10 @@
 ## 1. Watchdog
 
-- [x] 1.1 Track the first write statement per connection transaction and report at commit/rollback when the hold exceeded the busy timeout, with duration, outcome, task name, and first/last write statements
+- [x] 1.1 Track from the completion of the first successful write statement (after_cursor_execute — a statement waiting in the busy timeout has not acquired the slot) and report at commit/rollback when the hold exceeded the busy timeout, with duration, outcome, task name, and first/last write statements
 - [x] 1.2 Install it from `_configure_sqlite_engine` so the main, background, and memory engines are all covered
 
 ## 2. Tests
 
 - [x] 2.1 A write transaction over the threshold is reported with its statement and outcome
 - [x] 2.2 Read-only transactions and fast writes stay silent
+- [x] 2.3 A write that fails while waiting for the slot does not report its victim transaction as the holder

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -1008,3 +1008,56 @@ async def test_sqlite_long_write_watchdog_does_not_blame_a_victim_waiting_for_th
     finally:
         await victim_engine.dispose()
         await holder_engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_long_write_watchdog_includes_a_slow_transaction_end_in_the_hold(
+    tmp_path, monkeypatch, caplog
+) -> None:
+    """ConnectionEvents.commit/rollback fire before the DBAPI call, and a
+    wedged rollback is exactly the holder this watchdog hunts. The report is
+    deferred to the first proof the transaction ended (next begin on the
+    connection, or pool checkin), so the wedge itself is inside the measured
+    hold."""
+    monkeypatch.setattr(session_module, "_SQLITE_LONG_WRITE_TRANSACTION_WARN_SECONDS", 0.15)
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'slow-end.db'}",
+        poolclass=NullPool,
+        connect_args={"timeout": 5.0},
+    )
+    session_module._install_sqlite_long_write_watchdog(engine.sync_engine)
+
+    # A commit whose DBAPI call itself stalls: the event fires, then the
+    # "driver" spends longer than the threshold before the transaction is over.
+    real_commit_events = []
+
+    @sa_event.listens_for(engine.sync_engine, "commit")
+    def _stall_after_mark(conn) -> None:
+        # Runs after the watchdog's own commit listener marked the pending
+        # report; the sleep stands in for a wedged DBAPI commit/rollback.
+        real_commit_events.append(True)
+        import time as _time
+
+        _time.sleep(0.2)
+
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+        caplog.clear()
+
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        with caplog.at_level(logging.WARNING, logger=session_module.__name__):
+            async with factory() as session:
+                await session.execute(sa_text("DELETE FROM accounts"))
+                await session.commit()
+
+        records = [
+            record
+            for record in caplog.records
+            if record.levelno == logging.WARNING and "sqlite_long_write_transaction" in record.getMessage()
+        ]
+        assert real_commit_events, "the stalling commit listener must have run"
+        assert records, "a hold whose transaction end itself stalls must still be reported"
+        assert "outcome=commit" in records[0].getMessage()
+    finally:
+        await engine.dispose()

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -12,6 +12,7 @@ from typing import Any, cast
 
 import pytest
 from sqlalchemy import event as sa_event
+from sqlalchemy import text as sa_text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
@@ -877,3 +878,85 @@ async def test_relax_commit_durability_emits_set_local_for_postgresql_sessions()
     await session_module.relax_commit_durability(cast(session_module.AsyncSession, _FakeSession()))
 
     assert executed == ["SET LOCAL synchronous_commit = off"]
+
+
+@pytest.mark.asyncio
+async def test_sqlite_long_write_watchdog_reports_the_holder(tmp_path, monkeypatch, caplog) -> None:
+    """Issue #1682: a write transaction outliving the busy timeout is the
+    holder that makes every other writer surface 'database is locked'. The
+    watchdog must attribute it — duration, first/last write statement, task —
+    when it finally ends, since the stall self-recovers."""
+    monkeypatch.setattr(session_module, "_SQLITE_LONG_WRITE_TRANSACTION_WARN_SECONDS", 0.0)
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'watchdog.db'}",
+        poolclass=NullPool,
+        connect_args={"timeout": 5.0},
+    )
+    session_module._configure_sqlite_engine(engine.sync_engine, enable_wal=True)
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+        caplog.clear()
+
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        with caplog.at_level(logging.WARNING, logger=session_module.__name__):
+            async with factory() as session:
+                session.add(
+                    Account(
+                        id="acc-watchdog",
+                        chatgpt_account_id="workspace-w",
+                        email="watchdog@example.com",
+                        plan_type="plus",
+                        access_token_encrypted=b"a",
+                        refresh_token_encrypted=b"r",
+                        id_token_encrypted=b"i",
+                        last_refresh=datetime(2025, 1, 1),
+                        status=AccountStatus.ACTIVE,
+                    )
+                )
+                await session.commit()
+
+        records = [
+            record
+            for record in caplog.records
+            if record.levelno == logging.WARNING and "sqlite_long_write_transaction" in record.getMessage()
+        ]
+        assert records, "the watchdog must report a write transaction over the threshold"
+        message = records[0].getMessage()
+        assert "outcome=commit" in message
+        assert "INSERT INTO accounts" in message
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_long_write_watchdog_stays_silent_below_threshold_and_for_reads(tmp_path, caplog) -> None:
+    """Fast writes and read-only transactions (which never take the writer
+    slot in WAL) must not produce reports."""
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'quiet.db'}",
+        poolclass=NullPool,
+        connect_args={"timeout": 5.0},
+    )
+    session_module._configure_sqlite_engine(engine.sync_engine, enable_wal=True)
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+        caplog.clear()
+
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        with caplog.at_level(logging.WARNING, logger=session_module.__name__):
+            async with factory() as session:
+                (await session.execute(sa_text("SELECT count(*) FROM accounts"))).scalar_one()
+                await session.commit()
+            async with factory() as session:
+                await session.execute(sa_text("DELETE FROM accounts"))
+                await session.commit()
+
+        assert not [
+            record
+            for record in caplog.records
+            if record.levelno >= logging.WARNING and "sqlite_long_write_transaction" in record.getMessage()
+        ]
+    finally:
+        await engine.dispose()

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -1061,3 +1061,90 @@ async def test_sqlite_long_write_watchdog_includes_a_slow_transaction_end_in_the
         assert "outcome=commit" in records[0].getMessage()
     finally:
         await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_long_write_watchdog_tracks_begin_immediate_holders(tmp_path, monkeypatch, caplog) -> None:
+    """BEGIN IMMEDIATE acquires the writer slot with no DML at all (the
+    accounts merge lock does exactly this), so a holder that never runs a
+    write statement must still be attributed."""
+    monkeypatch.setattr(session_module, "_SQLITE_LONG_WRITE_TRANSACTION_WARN_SECONDS", 0.0)
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'immediate.db'}",
+        poolclass=NullPool,
+        connect_args={"timeout": 5.0},
+    )
+    session_module._install_sqlite_long_write_watchdog(engine.sync_engine)
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+        caplog.clear()
+
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        with caplog.at_level(logging.WARNING, logger=session_module.__name__):
+            async with factory() as session:
+                await session.execute(sa_text("BEGIN IMMEDIATE"))
+                (await session.execute(sa_text("SELECT count(*) FROM accounts"))).scalar_one()
+                await session.commit()
+
+        records = [
+            record
+            for record in caplog.records
+            if record.levelno == logging.WARNING and "sqlite_long_write_transaction" in record.getMessage()
+        ]
+        assert records, "a BEGIN IMMEDIATE holder with no DML must still be attributed"
+        assert "BEGIN IMMEDIATE" in records[0].getMessage()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_long_write_watchdog_reports_a_failed_commit_as_rollback(tmp_path, monkeypatch, caplog) -> None:
+    """A commit whose DBAPI call raises is followed by a rollback; the report
+    must not claim a durable commit that never happened."""
+    monkeypatch.setattr(session_module, "_SQLITE_LONG_WRITE_TRANSACTION_WARN_SECONDS", 0.0)
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'failed-commit.db'}",
+        poolclass=NullPool,
+        connect_args={"timeout": 5.0},
+    )
+    session_module._install_sqlite_long_write_watchdog(engine.sync_engine)
+
+    fail_next_commit = {"armed": False}
+
+    from sqlalchemy.dialects.sqlite.aiosqlite import AsyncAdapt_aiosqlite_connection
+
+    real_commit = AsyncAdapt_aiosqlite_connection.commit
+
+    def failing_commit(self) -> None:
+        if fail_next_commit["armed"]:
+            fail_next_commit["armed"] = False
+            raise RuntimeError("simulated DBAPI commit failure")
+        real_commit(self)
+
+    monkeypatch.setattr(AsyncAdapt_aiosqlite_connection, "commit", failing_commit)
+
+    try:
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+        caplog.clear()
+
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        with caplog.at_level(logging.WARNING, logger=session_module.__name__):
+            async with factory() as session:
+                await session.execute(sa_text("DELETE FROM accounts"))
+                fail_next_commit["armed"] = True
+                with pytest.raises(Exception):
+                    await session.commit()
+                await session.rollback()
+
+        records = [
+            record
+            for record in caplog.records
+            if record.levelno == logging.WARNING and "sqlite_long_write_transaction" in record.getMessage()
+        ]
+        assert records
+        assert "outcome=commit_failed_rollback" in records[0].getMessage()
+        assert "outcome=commit " not in records[0].getMessage()
+    finally:
+        await engine.dispose()

--- a/tests/unit/test_db_session.py
+++ b/tests/unit/test_db_session.py
@@ -960,3 +960,51 @@ async def test_sqlite_long_write_watchdog_stays_silent_below_threshold_and_for_r
         ]
     finally:
         await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_sqlite_long_write_watchdog_does_not_blame_a_victim_waiting_for_the_lock(
+    tmp_path, monkeypatch, caplog
+) -> None:
+    """A write statement can spend the whole busy timeout waiting for the slot
+    and fail with 'database is locked'. That transaction never held the slot,
+    so its rollback must not be reported as the holder — the clock starts only
+    after the first write statement succeeds."""
+    monkeypatch.setattr(session_module, "_SQLITE_LONG_WRITE_TRANSACTION_WARN_SECONDS", 0.2)
+    db_path = tmp_path / "victim.db"
+    holder_engine = create_async_engine(
+        f"sqlite+aiosqlite:///{db_path}", poolclass=NullPool, connect_args={"timeout": 5.0}
+    )
+    # Victim gets a short busy timeout so the test stays fast; install the
+    # watchdog directly because the pragma configurer would override the
+    # driver timeout with the production 30s busy_timeout.
+    victim_engine = create_async_engine(
+        f"sqlite+aiosqlite:///{db_path}", poolclass=NullPool, connect_args={"timeout": 0.4}
+    )
+    session_module._install_sqlite_long_write_watchdog(victim_engine.sync_engine)
+    try:
+        async with holder_engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+        caplog.clear()
+
+        holder_factory = async_sessionmaker(holder_engine, expire_on_commit=False)
+        victim_factory = async_sessionmaker(victim_engine, expire_on_commit=False)
+        with caplog.at_level(logging.WARNING, logger=session_module.__name__):
+            async with holder_factory() as holder_session:
+                # Journal mode: this write holds the database lock until commit.
+                await holder_session.execute(sa_text("DELETE FROM accounts"))
+                async with victim_factory() as victim_session:
+                    with pytest.raises(Exception, match="database is locked"):
+                        await victim_session.execute(sa_text("DELETE FROM accounts"))
+                    await victim_session.rollback()
+                await holder_session.commit()
+
+        blamed = [
+            record
+            for record in caplog.records
+            if record.levelno >= logging.WARNING and "sqlite_long_write_transaction" in record.getMessage()
+        ]
+        assert not blamed, "the victim's busy-timeout wait must not be reported as a held slot"
+    finally:
+        await victim_engine.dispose()
+        await holder_engine.dispose()


### PR DESCRIPTION
The watchdog promised on #1682 (part 1 of the plan there). **Refs #1682** — deliberately not `Fixes`: this attributes the stall, it does not yet remove it.

## Why observability first

The reported ~17-minute `database is locked` stall is nondeterministic, self-recovers, and the holder's identity never reaches any log — the renewal timeouts and lease loss in the report are symptoms that start *after* some connection has already been sitting on SQLite's single writer slot. I looked at bounding the shielded session teardown as a fix and deliberately did not ship it blind: abandoning a wedged rollback does not release the write lock (the underlying aiosqlite worker still holds it), so without knowing the actual holder such a change is guesswork with real semantics risk. Attribution first; the targeted fix second.

## What it does

Every SQLite engine (main, background, memory) reports at WARNING, when the transaction ends, any write transaction that held the writer slot past the busy timeout:

```
sqlite_long_write_transaction held_seconds=1042.7 outcome=rollback task=proxy-... first_statement='INSERT INTO ...' last_statement='UPDATE ...'
```

- **Window = first write statement → commit/rollback.** WAL takes the writer slot at the first write, not at BEGIN, so read-only transactions never report.
- **Post-hoc by design.** The stall self-recovers, so the holder is identified the moment it finally ends; no sampler thread, no overhead beyond two dict writes per write statement.
- **No new settings** (simplicity gates): the threshold *is* the busy timeout — a writer holding longer is precisely the one making every other writer surface `database is locked`.
- Diagnostics never raise into the query path; task-name capture is best-effort.

@dpearson2699 this is the build to run when you can — one occurrence with this in the log should name the holder, and then part 2 (the actual fix) stops being speculative.

## Tests

- Over-threshold write transaction reports with duration, outcome and statement (threshold pinned to 0 in the test).
- Read-only transactions and fast writes stay silent.

## OpenSpec

`openspec/changes/report-sqlite-long-write-holders/` — ADDED requirement on `database-backends`. Validation passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
