### PR TITLE
fix(dashboard): show cancelled request logs

### DIFF
--- a/app/modules/request_logs/mappers.py
+++ b/app/modules/request_logs/mappers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import cast as typing_cast
 
 from app.core.usage.logs import (
+    CANCELLED_STATUS,
     RequestLogLike,
     cached_input_tokens_from_log,
     cost_breakdown_from_log,
@@ -19,6 +20,8 @@ QUOTA_CODES = {"insufficient_quota", "usage_not_included", "quota_exceeded"}
 def normalize_log_status(status: str, error_code: str | None) -> str:
     if status == "success":
         return "ok"
+    if status == CANCELLED_STATUS:
+        return "cancelled"
     if error_code in RATE_LIMIT_CODES:
         return "rate_limit"
     if error_code in QUOTA_CODES:

--- a/app/modules/request_logs/repository.py
+++ b/app/modules/request_logs/repository.py
@@ -96,6 +96,7 @@ class _DemandCountParams:
     models: list[str] | None
     reasoning_efforts: list[str] | None
     include_success: bool
+    include_cancelled: bool
     include_error_other: bool
 
 
@@ -1206,6 +1207,7 @@ class RequestLogsRepository:
         models: list[str] | None = None,
         reasoning_efforts: list[str] | None = None,
         include_success: bool = True,
+        include_cancelled: bool = True,
         include_error_other: bool = True,
         error_codes_in: list[str] | None = None,
         error_codes_excluding: list[str] | None = None,
@@ -1225,6 +1227,7 @@ class RequestLogsRepository:
             models=models,
             reasoning_efforts=reasoning_efforts,
             include_success=include_success,
+            include_cancelled=include_cancelled,
             include_error_other=include_error_other,
             error_codes_in=error_codes_in,
             error_codes_excluding=error_codes_excluding,
@@ -1258,6 +1261,7 @@ class RequestLogsRepository:
                 models=models,
                 reasoning_efforts=reasoning_efforts,
                 include_success=include_success,
+                include_cancelled=include_cancelled,
                 include_error_other=include_error_other,
             )
 
@@ -1275,6 +1279,7 @@ class RequestLogsRepository:
             tuple(models or ()),
             tuple(reasoning_efforts or ()),
             include_success,
+            include_cancelled,
             include_error_other,
             tuple(sorted(error_codes_in)) if error_codes_in else None,
             tuple(sorted(error_codes_excluding)) if error_codes_excluding else None,
@@ -1363,6 +1368,8 @@ class RequestLogsRepository:
         statuses = []
         if params.include_success:
             statuses.append("success")
+        if params.include_cancelled:
+            statuses.append(CANCELLED_STATUS)
         if params.include_error_other:
             statuses.append("error")
         if statuses:
@@ -1427,6 +1434,7 @@ class RequestLogsRepository:
             models=models,
             reasoning_efforts=reasoning_efforts,
             include_success=True,
+            include_cancelled=True,
             include_error_other=True,
             error_codes_in=None,
             error_codes_excluding=None,
@@ -1441,6 +1449,7 @@ class RequestLogsRepository:
             models=models,
             reasoning_efforts=reasoning_efforts,
             include_success=True,
+            include_cancelled=True,
             include_error_other=True,
             error_codes_in=None,
             error_codes_excluding=None,
@@ -1569,6 +1578,7 @@ class RequestLogsRepository:
         models: list[str] | None = None,
         reasoning_efforts: list[str] | None = None,
         include_success: bool = True,
+        include_cancelled: bool = True,
         include_error_other: bool = True,
         error_codes_in: list[str] | None = None,
         error_codes_excluding: list[str] | None = None,
@@ -1610,6 +1620,8 @@ class RequestLogsRepository:
         status_conditions = []
         if include_success:
             status_conditions.append(RequestLog.status == "success")
+        if include_cancelled:
+            status_conditions.append(RequestLog.status == CANCELLED_STATUS)
         if error_codes_in:
             status_conditions.append(and_(RequestLog.status == "error", RequestLog.error_code.in_(error_codes_in)))
         if include_error_other:

--- a/app/modules/request_logs/service.py
+++ b/app/modules/request_logs/service.py
@@ -40,6 +40,7 @@ class RequestLogApiKeyOption:
 @dataclass(frozen=True, slots=True)
 class RequestLogStatusFilter:
     include_success: bool
+    include_cancelled: bool
     include_error_other: bool
     error_codes_in: list[str] | None
     error_codes_excluding: list[str] | None
@@ -117,6 +118,7 @@ class RequestLogsService:
             models=models,
             reasoning_efforts=reasoning_efforts,
             include_success=status_filter.include_success,
+            include_cancelled=status_filter.include_cancelled,
             include_error_other=status_filter.include_error_other,
             error_codes_in=status_filter.error_codes_in,
             error_codes_excluding=status_filter.error_codes_excluding,
@@ -230,6 +232,7 @@ def _map_status_filter(status: list[str] | None) -> RequestLogStatusFilter:
     if not status:
         return RequestLogStatusFilter(
             include_success=True,
+            include_cancelled=True,
             include_error_other=True,
             error_codes_in=None,
             error_codes_excluding=None,
@@ -238,12 +241,14 @@ def _map_status_filter(status: list[str] | None) -> RequestLogStatusFilter:
     if not normalized or "all" in normalized:
         return RequestLogStatusFilter(
             include_success=True,
+            include_cancelled=True,
             include_error_other=True,
             error_codes_in=None,
             error_codes_excluding=None,
         )
 
     include_success = "ok" in normalized
+    include_cancelled = "cancelled" in normalized
     include_rate_limit = "rate_limit" in normalized
     include_quota = "quota" in normalized
     include_error_other = "error" in normalized
@@ -256,6 +261,7 @@ def _map_status_filter(status: list[str] | None) -> RequestLogStatusFilter:
 
     return RequestLogStatusFilter(
         include_success=include_success,
+        include_cancelled=include_cancelled,
         include_error_other=include_error_other,
         error_codes_in=sorted(error_codes_in) if error_codes_in else None,
         error_codes_excluding=sorted(RATE_LIMIT_CODES | QUOTA_CODES) if include_error_other else None,
@@ -264,7 +270,7 @@ def _map_status_filter(status: list[str] | None) -> RequestLogStatusFilter:
 
 def _normalize_status_values(values: list[tuple[str, str | None]]) -> list[str]:
     normalized = {normalize_log_status(status, error_code) for status, error_code in values}
-    ordered = ["ok", "rate_limit", "quota", "error"]
+    ordered = ["ok", "cancelled", "rate_limit", "quota", "error"]
     return [status for status in ordered if status in normalized]
 
 

--- a/frontend/src/features/dashboard/components/filters/request-filters.test.tsx
+++ b/frontend/src/features/dashboard/components/filters/request-filters.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { RequestFilters, type RequestFiltersProps } from "@/features/dashboard/components/filters/request-filters";
@@ -17,14 +18,17 @@ const BASE_FILTERS: FilterState = {
   offset: 0,
 };
 
-function renderFilters(overrides: Partial<FilterState> = {}) {
+function renderFilters(
+  overrides: Partial<FilterState> = {},
+  statusOptions: RequestFiltersProps["statusOptions"] = EMPTY_OPTIONS,
+) {
   const filters = { ...BASE_FILTERS, ...overrides };
   const props: RequestFiltersProps = {
     filters,
     accountOptions: EMPTY_OPTIONS,
     apiKeyOptions: EMPTY_OPTIONS,
     modelOptions: EMPTY_OPTIONS,
-    statusOptions: EMPTY_OPTIONS,
+    statusOptions,
     onSearchChange: vi.fn(),
     onTimeframeChange: vi.fn(),
     onAccountChange: vi.fn(),
@@ -39,6 +43,22 @@ function renderFilters(overrides: Partial<FilterState> = {}) {
 }
 
 describe("RequestFilters conversation badge", () => {
+  it("renders cancelled as a selectable status option", async () => {
+    const user = userEvent.setup();
+    const props = renderFilters({}, [{ value: "cancelled", label: "Cancelled" }]);
+
+    await user.click(screen.getByRole("button", { name: "Statuses" }));
+    const [option] = await screen.findAllByRole("menuitemcheckbox");
+    expect(option).toBeDefined();
+    if (!option) {
+      throw new Error("Expected the cancelled status option");
+    }
+
+    await user.click(option);
+
+    expect(props.onStatusChange).toHaveBeenCalledWith(["cancelled"]);
+  });
+
   it("renders no badge when conversationId is null", () => {
     renderFilters();
     expect(screen.queryByText(/conv/i)).not.toBeInTheDocument();

--- a/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.test.tsx
@@ -181,6 +181,55 @@ describe("RecentRequestsTable", () => {
     expect(writeText).toHaveBeenCalledWith(longError);
   });
 
+  it("renders cancelled requests with a distinct non-error badge", () => {
+    render(
+      <RecentRequestsTable
+        {...PAGINATION_PROPS}
+        accounts={[]}
+        requests={[
+          {
+            requestedAt: ISO,
+            accountId: "acc-cancelled",
+            planType: "plus",
+            apiKeyName: "Key Cancelled",
+            apiKeyId: "key-cancelled",
+            requestId: "req-cancelled",
+            conversationId: null,
+            requestKind: "normal",
+            model: "gpt-5.1",
+            source: null,
+            serviceTier: null,
+            requestedServiceTier: null,
+            actualServiceTier: null,
+            transport: "http",
+            ...NULL_USERAGENT_METADATA,
+            status: "cancelled",
+            errorCode: "client_disconnected",
+            errorMessage: null,
+            ...NULL_FAILURE_METADATA,
+            tokens: 1,
+            inputTokens: 1,
+            outputTokens: 0,
+            outputTokensRaw: 0,
+            reasoningTokens: null,
+            cachedInputTokens: 0,
+            reasoningEffort: null,
+            costUsd: 0,
+            costBreakdown: null,
+            latencyMs: 10,
+            latencyFirstTokenMs: null,
+            latencyQueueMs: null,
+          },
+        ]}
+      />,
+    );
+
+    const badge = screen.getByText("Cancelled");
+
+    expect(badge).toHaveClass("bg-sky-500/15");
+    expect(badge).not.toHaveClass("bg-zinc-500/15");
+  });
+
   it("shows TTFT and output-token TPS beside tokens", () => {
     render(
       <RecentRequestsTable

--- a/frontend/src/features/dashboard/components/recent-requests-table.tsx
+++ b/frontend/src/features/dashboard/components/recent-requests-table.tsx
@@ -42,6 +42,7 @@ import {
 
 const STATUS_CLASS_MAP: Record<string, string> = {
   ok: "bg-emerald-500/15 text-emerald-700 border-emerald-500/20 hover:bg-emerald-500/20 dark:text-emerald-400",
+  cancelled: "bg-sky-500/15 text-sky-700 border-sky-500/20 hover:bg-sky-500/20 dark:text-sky-400",
   rate_limit: "bg-orange-500/15 text-orange-700 border-orange-500/20 hover:bg-orange-500/20 dark:text-orange-400",
   quota: "bg-red-500/15 text-red-700 border-red-500/20 hover:bg-red-500/20 dark:text-red-400",
   error: "bg-zinc-500/15 text-zinc-700 border-zinc-500/20 hover:bg-zinc-500/20 dark:text-zinc-400",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -666,6 +666,7 @@
   "dashboard.quotaLabels.weekly": "Weekly",
   "dashboard.requestStatus.error": "Error",
   "dashboard.requestStatus.ok": "OK",
+  "dashboard.requestStatus.cancelled": "Cancelled",
   "dashboard.requestStatus.quota": "Quota",
   "dashboard.requestStatus.rate_limit": "Rate limit",
   "dashboard.requestDetails.clientIp": "Client IP",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -666,6 +666,7 @@
   "dashboard.quotaLabels.weekly": "Weekly",
   "dashboard.requestStatus.error": "오류",
   "dashboard.requestStatus.ok": "정상",
+  "dashboard.requestStatus.cancelled": "취소됨",
   "dashboard.requestStatus.quota": "Quota",
   "dashboard.requestStatus.rate_limit": "Rate limit",
   "dashboard.requestDetails.clientIp": "Client IP",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -666,6 +666,7 @@
   "dashboard.quotaLabels.weekly": "每周",
   "dashboard.requestStatus.error": "错误",
   "dashboard.requestStatus.ok": "正常",
+  "dashboard.requestStatus.cancelled": "已取消",
   "dashboard.requestStatus.quota": "Quota",
   "dashboard.requestStatus.rate_limit": "Rate limit",
   "dashboard.requestDetails.clientIp": "客户端 IP",

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -53,7 +53,7 @@ import {
 } from "@/test/mocks/factories";
 
 const MODEL_OPTION_DELIMITER = ":::";
-const STATUS_ORDER = ["ok", "rate_limit", "quota", "error"] as const;
+const STATUS_ORDER = ["ok", "cancelled", "rate_limit", "quota", "error"] as const;
 
 // ── Zod schemas for mock request bodies ──
 

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -90,6 +90,7 @@ export const MESSAGE_TONE_META = {
 
 export const REQUEST_STATUS_LABELS: Record<string, string> = {
   ok: "OK",
+  cancelled: "Cancelled",
   rate_limit: "Rate limit",
   quota: "Quota",
   error: "Error",

--- a/openspec/changes/show-cancelled-request-logs/design.md
+++ b/openspec/changes/show-cancelled-request-logs/design.md
@@ -1,0 +1,85 @@
+## Context
+
+Cancellation persistence and aggregate accounting are already correct:
+downstream disconnects are stored with `status='cancelled'`, and shared usage
+logic classifies them as non-errors. The defect begins in the Request Logs
+read path. Its filter model has booleans for success and error rows only, so
+the raw query, filter facets, count cache, and demand-rollup count all omit
+cancelled rows. If a cancelled row were allowed through independently, the
+mapper would currently expose it as `error`.
+
+The frontend already transports arbitrary repeated status query values and
+builds filter options from the server response. It needs only a localized,
+visually distinct cancelled presentation once the backend exposes the status.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep the unfiltered list, filtered list, status facet, and displayed total
+  aligned for cancelled rows.
+- Preserve the invariant that cancelled and error are separate terminal
+  statuses.
+- Reuse the existing Request Logs filter and badge primitives.
+
+**Non-Goals:**
+
+- Change cancellation persistence or proxy disconnect handling.
+- Change error/cancellation aggregate metrics, Reports, or live usage.
+- Add a migration, setting, navigation item, or new dashboard primitive.
+- Backfill or rewrite historical request logs.
+
+## Decisions
+
+### Thread an explicit cancelled inclusion flag through the existing read path
+
+Add `include_cancelled` beside the existing success/error filter fields. The
+default and `all` paths enable it; the explicit `cancelled` filter enables
+only it; the explicit `error` filter continues to match persisted error rows
+excluding rate-limit and quota codes.
+
+The flag also participates in the count-cache key and
+`_DemandCountParams`. The demand-rollup count adds the persisted
+`cancelled` status when enabled. This keeps pagination totals equal to the
+rows that can actually be listed across folded and raw windows.
+
+Alternative considered: classify cancelled rows under the existing error
+branch. That contradicts the canonical non-error contract and would make the
+error filter semantically wrong.
+
+### Preserve additive frontend compatibility
+
+Keep the existing string-based API and URL status schemas. They intentionally
+permit a mixed-version frontend to transport an unfamiliar additive status.
+Add the known `cancelled` label, locale entries, and badge class without
+turning the boundary into a closed enum.
+
+Alternative considered: replace status strings with a closed Zod enum. That
+would reject future additive statuses and break the existing stale-filter
+recovery behavior.
+
+### Reuse the current badge primitive
+
+Use the existing outline badge and its status-class map with a neutral sky
+treatment distinct from success, rate-limit, quota, and error. No design token
+or reusable component is introduced.
+
+## Risks / Trade-offs
+
+- [Risk] Raw rows become visible while folded totals remain too small
+  → Include cancelled in the demand-rollup status filter and count-cache
+  signature; cover total and filter behavior through the public API.
+- [Risk] Cancelled leaks into the error filter
+  → Seed both cancellation and genuine error controls and assert each explicit
+  filter independently.
+- [Risk] Mixed-version status values stop parsing
+  → Retain open string schemas and add presentation only for the known value.
+
+## Migration Plan
+
+Ship as an additive read-path and presentation change. Rollback restores the
+previous omission without changing stored data or schema.
+
+## Open Questions
+
+None.

--- a/openspec/changes/show-cancelled-request-logs/proposal.md
+++ b/openspec/changes/show-cancelled-request-logs/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Request logs persist downstream disconnects as `status='cancelled'`, but the
+Request Logs read path only includes persisted `success` and `error` rows.
+Cancelled requests therefore disappear from the unfiltered operator list and
+cannot be selected through the status filter even though cancellation metrics
+remain visible elsewhere.
+
+## What Changes
+
+- Include persisted cancelled rows in the default Request Logs listing and its
+  rollup-backed total.
+- Expose cancelled rows as the distinct public status `cancelled`.
+- Add a `cancelled` status facet whose filter remains separate from genuine
+  errors.
+- Render and localize a distinct cancelled badge in the dashboard.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `usage-error-metrics`: Persisted cancellations remain visible and
+  distinguishable from errors on the Request Logs operator surface.
+
+## Impact
+
+Request-log repository filtering/counting, service status mapping, dashboard
+status labels, and focused backend/frontend regression tests. No database
+migration, request producer, metric calculation, setting, navigation item, or
+deployment change.

--- a/openspec/changes/show-cancelled-request-logs/specs/usage-error-metrics/spec.md
+++ b/openspec/changes/show-cancelled-request-logs/specs/usage-error-metrics/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Cancelled request logs remain visible and distinct
+
+The Request Logs operator surface MUST include persisted
+`status='cancelled'` rows in its unfiltered listing and total. Such rows MUST
+be exposed with public status `cancelled`, MUST be available through a
+`cancelled` status option and filter, and MUST NOT be returned by the `error`
+status filter. The dashboard MUST render the status with localized cancelled
+copy and a visual treatment distinct from error.
+
+#### Scenario: Unfiltered Request Logs include cancellations
+
+- **GIVEN** one persisted cancelled request and one persisted genuine error
+- **WHEN** an operator requests the unfiltered Request Logs list
+- **THEN** both requests are returned and included in the total
+- **AND** the cancelled request exposes public status `cancelled`
+
+#### Scenario: Cancelled and error filters remain separate
+
+- **GIVEN** one persisted cancelled request and one persisted genuine error
+- **WHEN** an operator filters Request Logs by `cancelled`
+- **THEN** only the cancelled request is returned
+- **AND WHEN** the operator filters Request Logs by `error`
+- **THEN** only the genuine error is returned
+
+#### Scenario: Dashboard presents a cancelled status
+
+- **GIVEN** Request Logs contain a persisted cancelled request
+- **WHEN** the dashboard loads status options and renders the request
+- **THEN** the status filter includes a localized Cancelled option
+- **AND** the row and request details use the localized cancelled label
+- **AND** the cancelled badge is visually distinct from the error badge

--- a/openspec/changes/show-cancelled-request-logs/tasks.md
+++ b/openspec/changes/show-cancelled-request-logs/tasks.md
@@ -1,0 +1,21 @@
+## 1. Backend Request Logs contract
+
+- [x] 1.1 Add failing public API regressions for unfiltered, cancelled-filter,
+  error-filter, and status-option behavior
+- [x] 1.2 Include cancelled rows in raw listing predicates, rollup-backed
+  totals, and cache signatures
+- [x] 1.3 Expose persisted cancelled rows as public status `cancelled`
+
+## 2. Frontend presentation
+
+- [x] 2.1 Add a failing rendered-table regression for the localized,
+  non-error cancelled badge
+- [x] 2.2 Add cancelled status fallback text, locale strings, and a distinct
+  existing-badge treatment
+
+## 3. Validation
+
+- [x] 3.1 Run focused backend and frontend regressions
+- [x] 3.2 Run affected lint, type, build, and OpenSpec validation
+- [x] 3.3 Exercise unfiltered, cancelled-filter, and error-filter behavior
+  through the running dashboard and capture before/after evidence

--- a/tests/integration/test_request_logs_filters.py
+++ b/tests/integration/test_request_logs_filters.py
@@ -47,6 +47,81 @@ def _cost(
     )
 
 
+async def _seed_cancelled_and_error_logs() -> None:
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_cancelled_filter", "cancelled-filter@example.com"))
+
+        await logs_repo.add_log(
+            account_id="acc_cancelled_filter",
+            request_id="req_cancelled_filter",
+            model="gpt-5.1",
+            input_tokens=1,
+            output_tokens=0,
+            latency_ms=10,
+            status="cancelled",
+            error_code="client_disconnected",
+            requested_at=now - timedelta(minutes=1),
+        )
+        await logs_repo.add_log(
+            account_id="acc_cancelled_filter",
+            request_id="req_cancelled_error_control",
+            model="gpt-5.1",
+            input_tokens=1,
+            output_tokens=0,
+            latency_ms=10,
+            status="error",
+            error_code="upstream_error",
+            error_message="upstream failure",
+            requested_at=now,
+        )
+
+
+@pytest.mark.asyncio
+async def test_request_logs_unfiltered_includes_cancelled(async_client, db_setup):
+    await _seed_cancelled_and_error_logs()
+
+    response = await async_client.get("/api/request-logs?limit=10")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 2
+    assert {request["requestId"]: request["status"] for request in payload["requests"]} == {
+        "req_cancelled_error_control": "error",
+        "req_cancelled_filter": "cancelled",
+    }
+
+
+@pytest.mark.asyncio
+async def test_request_logs_status_cancelled_filters_cancelled(async_client, db_setup):
+    await _seed_cancelled_and_error_logs()
+
+    response = await async_client.get("/api/request-logs?status=cancelled&limit=10")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 1
+    assert [(request["requestId"], request["status"]) for request in payload["requests"]] == [
+        ("req_cancelled_filter", "cancelled")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_request_logs_status_error_excludes_cancelled(async_client, db_setup):
+    await _seed_cancelled_and_error_logs()
+
+    response = await async_client.get("/api/request-logs?status=error&limit=10")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 1
+    assert [(request["requestId"], request["status"]) for request in payload["requests"]] == [
+        ("req_cancelled_error_control", "error")
+    ]
+
+
 @pytest.mark.asyncio
 async def test_request_logs_status_ok_filters_success(async_client, db_setup):
     now = utcnow()

--- a/tests/integration/test_request_usage_rollup_parity.py
+++ b/tests/integration/test_request_usage_rollup_parity.py
@@ -140,9 +140,9 @@ def _corpus() -> list[RequestLog]:
     for offset in (timedelta(hours=30), timedelta(days=5, hours=1), timedelta(days=9, hours=20)):
         rows.append(_log(BASE + offset, request_id_suffix="w", request_kind="warmup", cost_usd=0.002))
         rows.append(_log(BASE + offset + timedelta(minutes=20), request_id_suffix="lw", request_kind="limit_warmup"))
-    # Cancelled rows on both sides of every candidate watermark: the listing
-    # count's default status split (success+error) must exclude them from
-    # the folded sum and the raw tail alike.
+    # Cancelled rows on both sides of every candidate watermark: the default
+    # listing must include them as a distinct status in both the folded sum
+    # and the raw tail.
     for offset in (timedelta(days=1, hours=5), timedelta(days=9, hours=23)):
         rows.append(
             _log(
@@ -330,9 +330,18 @@ async def _listing_totals(logs: RequestLogsRepository, lead_since: datetime) -> 
 
     return {
         "default": await _total(),
-        "success_only": await _total(include_error_other=False),
-        "error_only": await _total(include_success=False),
-        "no_status_filter": await _total(include_success=False, include_error_other=False),
+        "success_only": await _total(include_cancelled=False, include_error_other=False),
+        "cancelled_only": await _total(
+            include_success=False,
+            include_cancelled=True,
+            include_error_other=False,
+        ),
+        "error_only": await _total(include_success=False, include_cancelled=False),
+        "no_status_filter": await _total(
+            include_success=False,
+            include_cancelled=False,
+            include_error_other=False,
+        ),
         "windowed": await _total(since=lead_since, until=UNTIL_UNALIGNED),
         "folded_only": await _total(since=FOLDED_ONLY_WINDOW[0], until=FOLDED_ONLY_WINDOW[1]),
         "tail_only": await _total(since=TAIL_ONLY_WINDOW[0], until=TAIL_ONLY_WINDOW[1]),

--- a/tests/test_request_logs_options_api.py
+++ b/tests/test_request_logs_options_api.py
@@ -30,6 +30,31 @@ def _make_account(account_id: str, email: str) -> Account:
 
 
 @pytest.mark.asyncio
+async def test_request_logs_options_include_cancelled_status(async_client, db_setup):
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_opt_cancelled", "cancelled@example.com"))
+        await logs_repo.add_log(
+            account_id="acc_opt_cancelled",
+            request_id="req_opt_cancelled",
+            model="gpt-5.1",
+            input_tokens=1,
+            output_tokens=0,
+            latency_ms=10,
+            status="cancelled",
+            error_code="client_disconnected",
+            requested_at=now,
+        )
+
+    response = await async_client.get("/api/request-logs/options")
+
+    assert response.status_code == 200
+    assert response.json()["statuses"] == ["cancelled"]
+
+
+@pytest.mark.asyncio
 async def test_request_logs_options_returns_distinct_accounts_and_models(async_client, db_setup):
     now = utcnow()
     async with SessionLocal() as session:


### PR DESCRIPTION
## Summary

- include persisted `cancelled` rows in Request Logs list predicates,
  rollup-backed totals, cache signatures, and status facets
- expose cancellation as public status `cancelled`, with filters kept separate
  from genuine errors
- render a localized sky-colored Cancelled badge and selectable status option
  in the dashboard

Fixes #1768.

Related historical work: #1323 added cancellation persistence and #1552 added
aggregate cancellation metrics; neither made cancelled rows visible in
Request Logs.

## OpenSpec

- `openspec/changes/show-cancelled-request-logs/`
- `openspec validate show-cancelled-request-logs --strict` — pass
- The repository-wide `openspec validate --specs` still reports the same eight
  pre-existing main-spec validation failures on `ef9c68e0`; this PR does not
  edit `openspec/specs/**`.

## Screenshots

### Before

Two persisted requests exist, but Request Logs exposes only Error and the
status menu has no Cancelled option.

![Before — cancelled request omitted](https://raw.githubusercontent.com/mastertyko/codex-lb/431eaec99954a62b0173bd779f3bc517fdd1b616/.github/pr-assets/cancelled-request-logs/before.png)

### After

Both rows are visible, Cancelled has a distinct badge, and the status menu
offers separate Cancelled and Error filters.

![After — cancelled request visible](https://raw.githubusercontent.com/mastertyko/codex-lb/431eaec99954a62b0173bd779f3bc517fdd1b616/.github/pr-assets/cancelled-request-logs/after.png)

<details>
<summary>Responsive and zh-CN evidence</summary>

![390px mobile](https://raw.githubusercontent.com/mastertyko/codex-lb/431eaec99954a62b0173bd779f3bc517fdd1b616/.github/pr-assets/cancelled-request-logs/mobile.png)

![768px zh-CN](https://raw.githubusercontent.com/mastertyko/codex-lb/431eaec99954a62b0173bd779f3bc517fdd1b616/.github/pr-assets/cancelled-request-logs/zh-CN.png)

</details>

## Verification

- `make lint typecheck`
- focused Request Logs and rollup regressions: 82 passed
- `make frontend-lint frontend-typecheck frontend-test frontend-build`
  - full frontend coverage suite: 143 files, exit 0
  - production build: pass
- live API:
  - unfiltered: total 2, Cancelled + Error
  - `status=cancelled`: only Cancelled
  - `status=error`: only genuine Error
  - options: Cancelled + Error
  - invalid `limit=0`: 422
- real Chromium:
  - unfiltered rows, both status filters, and cancelled request details
  - 1280px before/after, 390px mobile, and 768px zh-CN
- five independent post-implementation reviews: goal, quality, security,
  hands-on QA, and historical context all pass

## Simplicity

- zero-config behavior; no new `CODEX_LB_*` setting
- no database migration, dependency, navigation item, or new UI primitive
- reuses the existing Request Logs filter model and badge component
- one concern: visibility of already-persisted cancelled request logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cancelled requests now appear in request logs and totals by default.
  * Added a dedicated **Cancelled** status filter, separate from error requests.
  * Cancelled requests display with a distinct status badge.
  * Added localized labels in English, Korean, and Simplified Chinese.

* **Bug Fixes**
  * Cancelled requests are no longer misclassified as errors or omitted from status options.

* **Tests**
  * Added coverage for filtering, totals, status options, localization, and cancelled-request presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->