### PR TITLE
fix(proxy): normalize single-account warmup failures

### DIFF
--- a/app/modules/proxy/_service/warmup.py
+++ b/app/modules/proxy/_service/warmup.py
@@ -248,7 +248,6 @@ class _WarmupMixin:
                     headers=filtered_headers,
                     warmup_model=effective_model,
                     prohibit_fast_mode=prohibit_fast_mode,
-                    allow_pre_submit_errors_as_result=len(accounts_to_submit) > 1,
                 )
 
         submission_results = await asyncio.gather(*(_submit_account_warmup(account) for account in accounts_to_submit))
@@ -300,7 +299,6 @@ class _WarmupMixin:
         headers: Mapping[str, str],
         warmup_model: str,
         prohibit_fast_mode: bool,
-        allow_pre_submit_errors_as_result: bool = False,
     ) -> _WarmupSubmitResult:
         started_at = time.monotonic()
         useragent, useragent_group, conversation_id = _request_log_client_fields(headers)
@@ -423,13 +421,9 @@ class _WarmupMixin:
         except ProxyAuthError as exc:
             error_code = "auth_error"
             error_message = str(exc) or "Warmup authentication failed"
-            if not allow_pre_submit_errors_as_result:
-                raise
         except ProxyRateLimitError as exc:
             error_code = "rate_limit_exceeded"
             error_message = str(exc) or "Warmup request was rate limited"
-            if not allow_pre_submit_errors_as_result:
-                raise
         except Exception as exc:
             error_code = "upstream_error"
             error_message = str(exc) or "Warmup request failed"

--- a/openspec/changes/normalize-single-account-warmup-summary/.openspec.yaml
+++ b/openspec/changes/normalize-single-account-warmup-summary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/openspec/changes/normalize-single-account-warmup-summary/design.md
+++ b/openspec/changes/normalize-single-account-warmup-summary/design.md
@@ -1,0 +1,33 @@
+## Context
+
+Warmup already returns a structured result for each submitted account, but `_submit_warmup_request` conditionally re-raises `ProxyAuthError` and `ProxyRateLimitError` when the submission pool contains only one account. The production FastAPI exception handlers then return top-level 401 or 429 envelopes instead of the warmup response model.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make ordinary auth and rate-limit failures use the existing failed-account representation for every pool cardinality.
+- Preserve request logging, result ordering, bounded scheduling, and response schema.
+- Prove the behavior through the production FastAPI route.
+
+**Non-Goals:**
+- Change API-key authentication for calling the warmup endpoint.
+- Change account selection, eligibility, concurrency, or upstream routing.
+- Change invalid-mode or strict-eligibility `ValueError` handling.
+- Change global auth or rate-limit exception envelopes for other endpoints.
+
+## Decisions
+
+### Decision: Normalize at the existing per-account submission boundary
+
+Always convert `ProxyAuthError` and `ProxyRateLimitError` inside `_submit_warmup_request`, where account identity and request-log fields are already available. This removes the cardinality-dependent re-raise without adding route-specific exception handling or changing global handlers.
+
+Alternative considered: catch these exceptions in `_run_v1_warmup`. This was rejected because the route no longer has the per-account result context and would duplicate service normalization.
+
+### Decision: Keep the existing response model unchanged
+
+Use the existing `WarmupFailedAccountData` mapping and error codes (`auth_error` and `rate_limit_exceeded`). No API schema or scheduling changes are required.
+
+## Risks / Trade-offs
+
+- **[Risk] A caller may have relied on the undocumented one-account 401/429 behavior** -> **Mitigation:** the cardinality-independent HTTP 200 summary is already the normative contract and existing multi-account behavior.
+- **[Risk] Broad exception handling could accidentally change unrelated failures** -> **Mitigation:** remove only the conditional re-raise for the two named exception classes and cover both through FastAPI integration tests.

--- a/openspec/changes/normalize-single-account-warmup-summary/proposal.md
+++ b/openspec/changes/normalize-single-account-warmup-summary/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+A warmup request with one eligible account currently returns a top-level 401 or 429 when that account fails authentication or rate limiting, while the same failure in a larger pool is represented in the documented HTTP 200 per-account summary. Pool cardinality should not change the endpoint contract or remove the account-level diagnostic.
+
+## What Changes
+
+- Normalize single-account `ProxyAuthError` and `ProxyRateLimitError` failures into the existing `failed` summary entries.
+- Preserve the existing summary schema, multi-account behavior, invalid-request handling, account selection, scheduling, and global exception envelopes outside warmup.
+- Add production FastAPI integration coverage for both single-account failure classes.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-warmup`: Clarify that ordinary per-account authentication and rate-limit failures return the structured HTTP 200 summary regardless of target-pool cardinality.
+
+## Impact
+
+The change is limited to the warmup service's pre-submit error normalization, its integration coverage, and the `proxy-warmup` contract. It adds no dependencies, settings, routes, or schema fields.

--- a/openspec/changes/normalize-single-account-warmup-summary/specs/proxy-warmup/spec.md
+++ b/openspec/changes/normalize-single-account-warmup-summary/specs/proxy-warmup/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Warmup endpoint is exposed on the v1 proxy surface
+The system SHALL expose `POST /v1/warmup` on the same authenticated proxy surface as other `/v1/*` routes. The endpoint SHALL accept a JSON body with `mode` and SHALL return HTTP 200 with a structured JSON summary of submitted, skipped, and failed account warmups for every valid execution. Per-account `ProxyAuthError` and `ProxyRateLimitError` failures SHALL be represented in the `failed` summary regardless of the number of target accounts.
+
+The system SHALL also expose `POST /v1/warmup/{mode}` on the same authenticated proxy surface. That route SHALL not require a request body and SHALL execute the same warmup behavior as the body-based route for the supplied `mode`.
+
+#### Scenario: Authenticated warmup request succeeds
+- **WHEN** a client calls `POST /v1/warmup` with a valid API key and valid mode
+- **THEN** the system returns 200 with a per-account warmup result summary
+
+#### Scenario: Single-account authentication failure returns summary
+- **WHEN** a valid warmup request targets exactly one account and its submission raises `ProxyAuthError`
+- **THEN** the system returns 200 with `total_accounts=1` and one `failed` entry with error code `auth_error`
+
+#### Scenario: Single-account rate-limit failure returns summary
+- **WHEN** a valid warmup request targets exactly one account and its submission raises `ProxyRateLimitError`
+- **THEN** the system returns 200 with `total_accounts=1` and one `failed` entry with error code `rate_limit_exceeded`
+
+#### Scenario: Invalid mode is rejected
+- **WHEN** a client calls `POST /v1/warmup` with an unsupported mode value
+- **THEN** the system returns a 400 invalid request error
+
+#### Scenario: Path-based warmup request succeeds without a body
+- **WHEN** a client calls `POST /v1/warmup/normal` with a valid API key and no request body
+- **THEN** the system returns 200 with the same per-account warmup result summary as the body-based route

--- a/openspec/changes/normalize-single-account-warmup-summary/tasks.md
+++ b/openspec/changes/normalize-single-account-warmup-summary/tasks.md
@@ -12,4 +12,4 @@
 
 - [x] 3.1 Capture focused GREEN and adjacent warmup integration results.
 - [x] 3.2 Run strict OpenSpec validation, affected lint/type checks, and production FastAPI surface proof.
-- [ ] 3.3 Review the committed diff independently and address in-scope findings.
+- [x] 3.3 Review the committed diff independently and address in-scope findings.

--- a/openspec/changes/normalize-single-account-warmup-summary/tasks.md
+++ b/openspec/changes/normalize-single-account-warmup-summary/tasks.md
@@ -1,0 +1,15 @@
+## 1. Contract
+
+- [x] 1.1 Define the cardinality-independent warmup failure contract and implementation boundaries.
+- [x] 1.2 Sync the clarified requirement to the main `proxy-warmup` specification.
+
+## 2. Regression and implementation
+
+- [x] 2.1 Add production FastAPI integration coverage for one-account auth and rate-limit failures and capture the failing baseline.
+- [x] 2.2 Remove only the single-account conditional re-raise for `ProxyAuthError` and `ProxyRateLimitError`.
+
+## 3. Verification
+
+- [x] 3.1 Capture focused GREEN and adjacent warmup integration results.
+- [x] 3.2 Run strict OpenSpec validation, affected lint/type checks, and production FastAPI surface proof.
+- [ ] 3.3 Review the committed diff independently and address in-scope findings.

--- a/openspec/specs/proxy-warmup/spec.md
+++ b/openspec/specs/proxy-warmup/spec.md
@@ -4,13 +4,21 @@
 TBD - created by archiving change add-v1-warmup-endpoint. Update Purpose after archive.
 ## Requirements
 ### Requirement: Warmup endpoint is exposed on the v1 proxy surface
-The system SHALL expose `POST /v1/warmup` on the same authenticated proxy surface as other `/v1/*` routes. The endpoint SHALL accept a JSON body with `mode` and SHALL return a structured JSON summary of submitted, skipped, and failed account warmups.
+The system SHALL expose `POST /v1/warmup` on the same authenticated proxy surface as other `/v1/*` routes. The endpoint SHALL accept a JSON body with `mode` and SHALL return HTTP 200 with a structured JSON summary of submitted, skipped, and failed account warmups for every valid execution. Per-account `ProxyAuthError` and `ProxyRateLimitError` failures SHALL be represented in the `failed` summary regardless of the number of target accounts.
 
 The system SHALL also expose `POST /v1/warmup/{mode}` on the same authenticated proxy surface. That route SHALL not require a request body and SHALL execute the same warmup behavior as the body-based route for the supplied `mode`.
 
 #### Scenario: Authenticated warmup request succeeds
 - **WHEN** a client calls `POST /v1/warmup` with a valid API key and valid mode
 - **THEN** the system returns 200 with a per-account warmup result summary
+
+#### Scenario: Single-account authentication failure returns summary
+- **WHEN** a valid warmup request targets exactly one account and its submission raises `ProxyAuthError`
+- **THEN** the system returns 200 with `total_accounts=1` and one `failed` entry with error code `auth_error`
+
+#### Scenario: Single-account rate-limit failure returns summary
+- **WHEN** a valid warmup request targets exactly one account and its submission raises `ProxyRateLimitError`
+- **THEN** the system returns 200 with `total_accounts=1` and one `failed` entry with error code `rate_limit_exceeded`
 
 #### Scenario: Invalid mode is rejected
 - **WHEN** a client calls `POST /v1/warmup` with an unsupported mode value

--- a/tests/integration/test_proxy_warmup.py
+++ b/tests/integration/test_proxy_warmup.py
@@ -15,7 +15,7 @@ from app.core.auth.refresh import RefreshError
 from app.core.clients.proxy import ProxyResponseError
 from app.core.config.settings import get_settings
 from app.core.errors import openai_error
-from app.core.exceptions import ProxyRateLimitError
+from app.core.exceptions import ProxyAuthError, ProxyRateLimitError
 from app.core.openai.models import CompactResponsePayload
 from app.core.upstream_proxy import ResolvedProxyEndpoint, ResolvedUpstreamRoute, UpstreamProxyRouteError
 from app.core.utils.time import utcnow
@@ -960,6 +960,62 @@ async def test_warmup_runs_parallel_with_max_five_accounts(async_client, monkeyp
     assert len(payload["submitted"]) == total_accounts
     assert payload["failed"] == []
     assert peak_compact_calls == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error_type", "error_code", "error_message"),
+    [
+        (ProxyAuthError, "auth_error", "account unauthorized"),
+        (ProxyRateLimitError, "rate_limit_exceeded", "account limited"),
+    ],
+    ids=["auth", "rate-limit"],
+)
+async def test_single_account_pre_submit_failure_returns_summary(
+    async_client,
+    monkeypatch,
+    error_type,
+    error_code,
+    error_message,
+):
+    await _enable_api_key_auth(async_client)
+    raw_account_id = "acc-warmup-single-failure"
+    account_id = await _import_account(async_client, raw_account_id, "warmup-single-failure@example.com")
+    await _add_primary_usage(account_id, used_percent=0.0, window_minutes=300)
+    _, key = await _create_api_key(async_client, name="warmup-single-failure")
+
+    async def _fake_ensure_fresh(self, account, *, force=False, timeout_seconds=None):
+        del self, force, timeout_seconds
+        return account
+
+    async def _fake_compact(payload, headers, access_token, upstream_account_id, session=None):
+        del payload, headers, access_token, session
+        assert upstream_account_id == raw_account_id
+        raise error_type(error_message)
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", _fake_ensure_fresh)
+    monkeypatch.setattr(proxy_module, "core_compact_responses", _fake_compact)
+
+    response = await async_client.post(
+        "/v1/warmup",
+        headers={"Authorization": f"Bearer {key}"},
+        json={"mode": "force"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "mode": "force",
+        "total_accounts": 1,
+        "submitted": [],
+        "skipped": [],
+        "failed": [
+            {
+                "account_id": account_id,
+                "error_code": error_code,
+                "error_message": error_message,
+            }
+        ],
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Normalize one-account warmup authentication and rate-limit failures into the documented HTTP 200 per-account summary. This removes a cardinality-only contract divergence while preserving account selection, bounded scheduling, invalid-request handling, and unrelated global exception envelopes.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] `feat:` — new user-facing feature or capability
- [ ] `refactor:` — internal refactor (no behavior change, no API change)
- [ ] `docs:` — documentation only
- [ ] `chore:` / `ci:` / `build:` — tooling, CI, packaging
- [ ] `test:` — test-only change
- [ ] **Breaking change**

Linked issue: None. A bounded issue/PR overlap search found no existing work for this warmup summary mismatch.

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] Not applicable — bug fix that matches the existing spec
- [ ] Not applicable — docs / CI / chore only
- [ ] This PR touches a codex-faithful path and preserves upstream-equivalent behavior

Change directory: `openspec/changes/normalize-single-account-warmup-summary/`

## Changes

- Always represent warmup `ProxyAuthError` and `ProxyRateLimitError` as failed-account entries, including one-account pools.
- Add parametrized production FastAPI integration coverage for both failure classes.
- Clarify and sync the cardinality-independent `proxy-warmup` contract.

## Test plan

```text
uv run pytest tests/integration/test_proxy_warmup.py -k single_account_pre_submit_failure_returns_summary
# 2 passed, 18 deselected

uv run pytest tests/integration/test_proxy_warmup.py
# 20 passed

uv run ruff check app/modules/proxy/_service/warmup.py tests/integration/test_proxy_warmup.py
uv run ruff format --check app/modules/proxy/_service/warmup.py tests/integration/test_proxy_warmup.py
uv run ty check app/modules/proxy/_service/warmup.py tests/integration/test_proxy_warmup.py
# all passed

uv run openspec validate normalize-single-account-warmup-summary --strict
uv run openspec validate proxy-warmup --type spec --strict
# both valid
```

The repository-wide OpenSpec scan also reported eight pre-existing invalid capabilities outside this change; the changed capability and change folder pass strict validation. Packaging/build was not run because this source/spec-only fix does not change packaging inputs.

## Screenshots / output

Production FastAPI test-client proof (relevant fields):

```text
auth:       status=200 total_accounts=1 failed_count=1 error_code=auth_error
rate-limit: status=200 total_accounts=1 failed_count=1 error_code=rate_limit_exceeded
```

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] No related issue or discussion was found to link.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant local lint, type, integration, and OpenSpec subsets.
- [x] Scoped strict OpenSpec validation and implementation verification are clean.
- [x] Simplicity gates reviewed: no settings, setup steps, README, dashboard, or default changes.
- [x] CHANGELOG is not edited by hand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Warmup requests now consistently return structured HTTP 200 summaries for authentication and rate-limit failures, including single-account requests.
  - Failed accounts display the appropriate error status, code, and message instead of triggering conditional request failures.
  - Existing body-based and path-based warmup behavior remains supported, including validation and unsupported-mode responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->