### PR TITLE
fix(compact): recover previous-response-pinned compaction from quota-excluded owners

### DIFF
--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -515,6 +515,16 @@ def _compact_replay_history_retains_prior_output(input_items: list[JsonValue]) -
     The split is anchored at the last assistant message so the shared suffix
     walk proves exactly that segment; anything it cannot prove stays
     owner-bound.
+
+    This is the evidence ceiling of the #1490 rescope: completeness relative to
+    the anchored conversation is not provable from the payload alone, and the
+    durable prefix metadata that could prove it is deliberately not consulted
+    here. A delta resend that itself carries a completed assistant exchange
+    ahead of the fresh input is indistinguishable from a full resend and is
+    recovered as the client's authoritative local history — the same trust the
+    shared account-neutral fresh-replay rules already grant a normal turn that
+    abandons an unavailable owner. The rejected shapes below are the ones the
+    transcript walk can actually refute.
     """
 
     last_assistant_index: int | None = None

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -9,6 +9,7 @@ from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, NoReturn, Protocol, TypeVar, cast
 
 import aiohttp
+from pydantic import ValidationError
 
 from app.core.auth.refresh import RefreshError, is_transient_refresh_contention, refresh_contention_kind
 from app.core.balancer import ResetPreferenceWindow, RoutingStrategy, failover_decision
@@ -23,6 +24,7 @@ from app.core.clients.proxy import compact_responses as core_compact_responses
 from app.core.config.settings import get_settings
 from app.core.config.settings_cache import get_settings_cache
 from app.core.errors import openai_error
+from app.core.openai.exceptions import ClientPayloadError
 from app.core.openai.models import CompactResponsePayload
 from app.core.openai.requests import ResponsesCompactRequest
 from app.core.resilience.network_recovery import ProcessNetworkRecovery
@@ -30,7 +32,7 @@ from app.core.types import JsonValue
 from app.core.upstream_proxy import ResolvedUpstreamRoute, UpstreamProxyRouteError
 from app.core.utils.request_id import ensure_request_id, get_request_id
 from app.core.utils.retry import backoff_seconds
-from app.db.models import Account, DashboardSettings, StickySessionKind
+from app.db.models import Account, AccountStatus, DashboardSettings, StickySessionKind
 from app.modules.api_keys.service import (
     ApiKeyData,
     ApiKeyRequestUsageBudget,
@@ -51,7 +53,10 @@ from app.modules.proxy.affinity import (
     _thread_codex_session_affinity,
 )
 from app.modules.proxy.api_key_usage import estimate_api_key_request_usage
-from app.modules.proxy.continuity import resolve_required_account_id
+from app.modules.proxy.continuity import (
+    resolve_required_account_id,
+    without_http_bridge_session_affinity_headers,
+)
 from app.modules.proxy.helpers import (
     _header_account_id,
     _normalize_error_code,
@@ -63,6 +68,10 @@ from app.modules.proxy.load_balancer import (
     AccountLease,
     AccountSelection,
     effective_account_concurrency_caps,
+)
+from app.modules.proxy.replay_safety import (
+    responses_input_suffix_retains_prior_output,
+    responses_payload_is_account_neutral_fresh_replay,
 )
 from app.modules.proxy.selection_errors import selection_failure_response
 from app.modules.proxy.work_admission import AdmissionLease, WorkAdmissionController
@@ -138,6 +147,8 @@ class _CompactServiceProtocol(Protocol):
         api_key: ApiKeyData | None,
         fail_on_missing: bool = True,
     ) -> str | None: ...
+
+    async def _compact_owner_selection_loss_is_quota_caused(self, account_id: str) -> bool: ...
 
     async def _ensure_fresh_with_budget(
         self, account: Account, *, force: bool = False, timeout_seconds: float | None = None
@@ -480,7 +491,131 @@ def _service_tier_from_compact_payload(payload: ResponsesCompactRequest) -> str 
     return normalize(payload.service_tier)
 
 
+# Account statuses that prove the pinned owner's selection-time loss is caused
+# by upstream quota/rate-limit state rather than authentication, deactivation,
+# or an operator pause. Only these authorize account-neutral replay recovery.
+_COMPACT_OWNER_QUOTA_UNAVAILABLE_STATUSES = (
+    AccountStatus.RATE_LIMITED,
+    AccountStatus.QUOTA_EXCEEDED,
+)
+
+
+def _compact_replay_history_retains_prior_output(input_items: list[JsonValue]) -> bool:
+    """Prove the carried history retains prior assistant output before new input.
+
+    A self-contained account-neutral ``input`` is not by itself a full resend:
+    a client could send only the turns after ``previous_response_id`` (for
+    example two fresh user messages) and rely on the owner account to hold the
+    earlier conversation, so replaying without the anchor would compact a
+    truncated history. Without durable prefix metadata for the compact surface,
+    the strongest client-side evidence of a full resend is the same
+    retained-prior-output shape the HTTP bridge replay path trusts: the input
+    must parse as a clean transcript whose final segment is the previous
+    response's completed assistant output followed only by fresh client input.
+    The split is anchored at the last assistant message so the shared suffix
+    walk proves exactly that segment; anything it cannot prove stays
+    owner-bound.
+    """
+
+    last_assistant_index: int | None = None
+    for index in range(len(input_items) - 1, -1, -1):
+        item = input_items[index]
+        if isinstance(item, dict) and item.get("type") in (None, "message") and item.get("role") == "assistant":
+            last_assistant_index = index
+            break
+    # ``responses_input_suffix_retains_prior_output`` requires a non-empty
+    # stored prefix, so a history that opens with (or lacks) assistant output
+    # cannot be proven and stays owner-bound.
+    if last_assistant_index is None or last_assistant_index == 0:
+        return False
+    return responses_input_suffix_retains_prior_output(
+        input_items,
+        stored_count=last_assistant_index,
+    )
+
+
+def _compact_account_neutral_replay_payload(
+    payload: ResponsesCompactRequest,
+) -> ResponsesCompactRequest | None:
+    """Return the anchor-free replay payload for a verified full resend.
+
+    A compact request pinned only by ``previous_response_id`` may move off an
+    unselectable owner account when the history it carries is provably
+    account-neutral: the upstream-bound payload without the anchor must pass
+    the shared fresh-replay validation, so no encrypted or compaction state,
+    server-assigned item ids, account-scoped file/container handles,
+    conversation/prompt handles, or hosted/MCP state can reach the replacement
+    account.
+
+    Neutrality is checked on the serialized upstream-bound payload, never on
+    the request model, and the serialized history must additionally be a
+    complete resend. ``to_payload`` can still drop history on the wire: it
+    strips poisoned local-compact fallback messages together with their
+    trailing encrypted compaction item, and it trims oversized inputs down to a
+    head, a trim marker, and a tail. Both remain multi-item account-neutral
+    lists. Sending either to a replacement account without the anchor would
+    compact an incomplete conversation, because only the owner can resolve the
+    omitted context from the dropped anchor. So the wire input must be
+    item-for-item identical to the validated request input, must still carry
+    more than one item, and must retain prior assistant output ahead of the new
+    client input (see ``_compact_replay_history_retains_prior_output``).
+    """
+
+    previous_response_id = getattr(payload, "previous_response_id", None)
+    if not isinstance(previous_response_id, str) or not previous_response_id.strip():
+        return None
+    if not isinstance(payload.input, list):
+        return None
+    replay_source = payload.model_dump(mode="json", exclude_none=True)
+    replay_source.pop("previous_response_id", None)
+    request_input = replay_source.get("input")
+    if not isinstance(request_input, list) or len(request_input) <= 1:
+        return None
+    try:
+        replay_payload = ResponsesCompactRequest.model_validate(replay_source)
+        replay_wire_payload = replay_payload.to_payload()
+    except (ValidationError, ClientPayloadError):
+        return None
+    replay_wire_input = replay_wire_payload.get("input")
+    if not isinstance(replay_wire_input, list) or len(replay_wire_input) <= 1:
+        return None
+    if replay_wire_input != request_input:
+        return None
+    if not responses_payload_is_account_neutral_fresh_replay(replay_wire_payload):
+        return None
+    if not _compact_replay_history_retains_prior_output(cast(list[JsonValue], replay_wire_input)):
+        return None
+    return replay_payload
+
+
 class _CompactMixin:
+    async def _compact_owner_selection_loss_is_quota_caused(self, account_id: str) -> bool:
+        """Return whether the pinned owner is unselectable because of quota state.
+
+        Account-neutral replay off a pinned previous-response owner is legal
+        only for owner loss the owner's quota state caused. At selection time
+        that evidence is the owner's own persisted status: ``RATE_LIMITED`` or
+        ``QUOTA_EXCEEDED`` is the same upstream usage-exhaustion state the
+        selector consulted. Authentication loss (``REAUTH_REQUIRED``,
+        ``DEACTIVATED``), operator pauses, local capacity caps on an ``ACTIVE``
+        account, and a failed lookup all stay owner-bound.
+        """
+
+        proxy = cast(_CompactServiceProtocol, self)
+        try:
+            async with proxy._repo_factory() as repos:
+                account = await repos.accounts.get_by_id_fresh(account_id)
+                # Read inside the repository scope: the session expires ORM
+                # attributes when it closes.
+                status = account.status if account is not None else None
+        except Exception:
+            logger.warning(
+                "Compact previous-response owner status lookup failed; keeping the request owner-bound",
+                exc_info=True,
+            )
+            return False
+        return status in _COMPACT_OWNER_QUOTA_UNAVAILABLE_STATUSES
+
     async def _resolve_compact_turn_state_owner(
         self,
         *,
@@ -1063,6 +1198,15 @@ class _CompactMixin:
             last_exc: ProxyResponseError | None = None
             network_recovery = ProcessNetworkRecovery(transport="compact", request_id=request_id)
             excluded_account_ids: set[str] = set()
+            # Account-neutral replay off a pinned previous-response owner is only
+            # legal for owner loss the owner's quota state caused: either the
+            # owner was never usable at selection time, or it was excluded
+            # mid-request by a pre-visible quota / rate-limit failure. Post-
+            # selection authentication, refresh, transport, and transient
+            # failures also exclude the owner, and those keep their existing
+            # owner-bound handling instead of moving the history to another
+            # account.
+            owner_quota_failover_eligible = False
             require_security_work_authorized = False
             estimated_lease_tokens = _estimated_lease_tokens_from_request_usage_budget(
                 estimate_api_key_request_usage(payload)
@@ -1118,6 +1262,116 @@ class _CompactMixin:
                             fallback_on_preferred_account_unavailable=preferred_account_id is None,
                         )
                         account = selection.account
+                    if (
+                        account is None
+                        and previous_response_preferred_account_id is not None
+                        and preferred_account_id == previous_response_preferred_account_id
+                        and turn_state_owner_account_id is None
+                        and rewritten_file_account_id is None
+                    ):
+                        # Narrowed alias: the structural gate above proves the
+                        # pin is exactly the previous-response owner.
+                        unavailable_owner_account_id = previous_response_preferred_account_id
+                        # The pinned previous-response owner cannot be selected.
+                        # A full resend that is provably account-neutral on the
+                        # wire needs nothing from the owner, so the stale anchor
+                        # can be dropped and the compact can move to a healthy
+                        # account instead of wedging the session until the
+                        # owner's quota window resets — the same selection-time
+                        # escape normal turns already have. Turn-state and file
+                        # pins never reach this branch and stay owner-bound.
+                        recovery_blocked_reason: str | None = None
+                        if previous_response_lookup_session_id is not None:
+                            # A session/turn-state identity on the request can
+                            # bind live or durable HTTP-bridge continuity rows
+                            # that still name the lost owner. Without the
+                            # rebinding machinery this recovery deliberately
+                            # avoids, moving the history would strand that
+                            # continuity, so session-scoped requests stay
+                            # owner-bound.
+                            recovery_blocked_reason = "session_scoped_continuity"
+                        elif (
+                            affinity.kind == StickySessionKind.CODEX_SESSION
+                            or affinity.legacy_selection_key is not None
+                            or affinity.require_unambiguous_account
+                        ):
+                            # CODEX_SESSION affinity (turn-state, thread, or
+                            # session-header keys, including raw legacy rows)
+                            # is session ownership this recovery would have to
+                            # rebind, so those requests stay owner-bound.
+                            # PROMPT_CACHE / STICKY_THREAD keys are soft cache
+                            # locality the sticky selection path already falls
+                            # back from on an unavailable account — the compact
+                            # routes derive one unconditionally — so they gate
+                            # nothing here and the recovery reselection flows
+                            # through that same existing sticky handling.
+                            recovery_blocked_reason = "session_affinity"
+                        elif not (
+                            owner_quota_failover_eligible
+                            or (
+                                unavailable_owner_account_id not in excluded_account_ids
+                                and await proxy._compact_owner_selection_loss_is_quota_caused(
+                                    unavailable_owner_account_id
+                                )
+                            )
+                        ):
+                            recovery_blocked_reason = "non_quota_owner_loss"
+                        replay_payload: ResponsesCompactRequest | None = None
+                        if recovery_blocked_reason is None:
+                            replay_payload = _compact_account_neutral_replay_payload(payload)
+                            if replay_payload is None:
+                                recovery_blocked_reason = "history_not_account_neutral"
+                        if replay_payload is None:
+                            logger.info(
+                                "Compact previous-response owner unavailable; staying owner-bound "
+                                "request_id=%s owner_account_id=%s blocked_reason=%s selection_error_code=%s",
+                                request_id,
+                                preferred_account_id,
+                                recovery_blocked_reason,
+                                selection.error_code,
+                            )
+                            _record_continuity_fail_closed(
+                                surface="compact",
+                                reason="owner_account_unavailable",
+                                previous_response_id=previous_response_id
+                                if isinstance(previous_response_id, str)
+                                else None,
+                                session_id=previous_response_lookup_session_id,
+                                upstream_error_code=selection.error_code,
+                            )
+                        else:
+                            logger.warning(
+                                "Compact previous-response owner unavailable; replaying verified "
+                                "account-neutral full resend request_id=%s owner_account_id=%s "
+                                "selection_error_code=%s",
+                                request_id,
+                                preferred_account_id,
+                                selection.error_code,
+                            )
+                            excluded_account_ids.add(unavailable_owner_account_id)
+                            payload = replay_payload
+                            filtered = without_http_bridge_session_affinity_headers(filtered)
+                            preferred_account_id = None
+                            previous_response_preferred_account_id = None
+                            selection = await proxy._select_account_with_budget_compatible(
+                                deadline,
+                                request_id=request_id,
+                                kind="compact",
+                                api_key=api_key,
+                                affinity_policy=affinity,
+                                prefer_earlier_reset_accounts=prefer_earlier_reset,
+                                prefer_earlier_reset_window=_prefer_earlier_reset_window(settings),
+                                routing_strategy=routing_strategy,
+                                model=payload.model,
+                                service_tier=payload.service_tier,
+                                exclude_account_ids=excluded_account_ids,
+                                preferred_account_id=None,
+                                require_security_work_authorized=require_security_work_authorized,
+                                lease_kind="response_create",
+                                estimated_lease_tokens=estimated_lease_tokens,
+                                fallback_on_preferred_account_unavailable=True,
+                            )
+                            account = selection.account
                     if account is not None:
                         pass
                     elif last_exc is not None:
@@ -1713,6 +1967,14 @@ class _CompactMixin:
                             action,
                         )
                         if action == "failover_next":
+                            if account.id == preferred_account_id and classified["failure_class"] in (
+                                "rate_limit",
+                                "quota",
+                            ):
+                                # Only a pre-visible quota / rate-limit exclusion
+                                # of the pinned owner makes account-neutral replay
+                                # recovery eligible for the remaining attempts.
+                                owner_quota_failover_eligible = True
                             last_exc = exc
                             excluded_account_ids.add(account.id)
                             await record_or_defer_stream_health(

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -1296,11 +1296,9 @@ class _CompactMixin:
                         account is None
                         and previous_response_preferred_account_id is not None
                         and preferred_account_id == previous_response_preferred_account_id
-                        and turn_state_owner_account_id is None
-                        and rewritten_file_account_id is None
                     ):
                         # Narrowed alias: the structural gate above proves the
-                        # pin is exactly the previous-response owner.
+                        # selection pin names the previous-response owner.
                         unavailable_owner_account_id = previous_response_preferred_account_id
                         # The pinned previous-response owner cannot be selected.
                         # A full resend that is provably account-neutral on the
@@ -1309,9 +1307,19 @@ class _CompactMixin:
                         # account instead of wedging the session until the
                         # owner's quota window resets — the same selection-time
                         # escape normal turns already have. Turn-state and file
-                        # pins never reach this branch and stay owner-bound.
+                        # pins keep the request owner-bound (the first blocked
+                        # reason below), but their selection failure still
+                        # records the fail-closed outcome on the common path.
                         recovery_blocked_reason: str | None = None
-                        if previous_response_lookup_session_id is not None:
+                        if turn_state_owner_account_id is not None or rewritten_file_account_id is not None:
+                            # The previous-response owner is also pinned by a
+                            # turn-state or input-file owner. Those pins are
+                            # account ownership this recovery must never move,
+                            # so the request stays owner-bound regardless of
+                            # the owner's quota state — but the unavailable
+                            # owner still fails closed and must be recorded.
+                            recovery_blocked_reason = "additional_owner_pins"
+                        elif previous_response_lookup_session_id is not None:
                             # A session/turn-state identity on the request can
                             # bind live or durable HTTP-bridge continuity rows
                             # that still name the lost owner. Without the

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -70,6 +70,7 @@ from app.modules.proxy.load_balancer import (
     effective_account_concurrency_caps,
 )
 from app.modules.proxy.replay_safety import (
+    project_responses_input_for_account_neutral_fresh_replay,
     responses_input_suffix_retains_prior_output,
     responses_payload_is_account_neutral_fresh_replay,
 )
@@ -538,9 +539,22 @@ def _compact_replay_history_retains_prior_output(input_items: list[JsonValue]) -
     # cannot be proven and stays owner-bound.
     if last_assistant_index is None or last_assistant_index == 0:
         return False
-    return responses_input_suffix_retains_prior_output(
+    # The projection is an identity transform for input that already passed
+    # the account-neutral fresh-replay gate (no server-assigned ids, no
+    # reasoning or omitted bookkeeping types survive that gate), but it is the
+    # shared authority for recognizing the canonical Responses-Lite developer
+    # instruction behind an ``additional_tools`` bundle — without that index
+    # the suffix walk would reject every Lite full resend.
+    projection = project_responses_input_for_account_neutral_fresh_replay(
         input_items,
         stored_count=last_assistant_index,
+    )
+    if projection is None:
+        return False
+    return responses_input_suffix_retains_prior_output(
+        projection.input_items,
+        stored_count=projection.stored_prefix_count,
+        canonical_lite_developer_index=projection.canonical_lite_developer_index,
     )
 
 
@@ -1316,6 +1330,18 @@ class _CompactMixin:
                             # nothing here and the recovery reselection flows
                             # through that same existing sticky handling.
                             recovery_blocked_reason = "session_affinity"
+                        elif (
+                            not owner_quota_failover_eligible
+                            and selection.error_code == "preferred_account_unavailable"
+                        ):
+                            # The selector skipped the owner before evaluating
+                            # its availability (API-key assignment scope,
+                            # single-account routing, or an in-request
+                            # exclusion that was not a pre-visible quota
+                            # failover). Policy-caused loss must not become
+                            # replay-eligible just because the owner's
+                            # persisted status happens to be quota-exhausted.
+                            recovery_blocked_reason = "owner_skipped_by_policy"
                         elif not (
                             owner_quota_failover_eligible
                             or (

--- a/app/modules/proxy/_service/compact.py
+++ b/app/modules/proxy/_service/compact.py
@@ -571,8 +571,14 @@ def _compact_account_neutral_replay_payload(
     conversation/prompt handles, or hosted/MCP state can reach the replacement
     account.
 
-    Neutrality is checked on the serialized upstream-bound payload, never on
-    the request model, and the serialized history must additionally be a
+    Neutrality is checked on the serialized upstream-bound payload
+    (``to_payload``), never on the request model, matching how the HTTP bridge
+    replay paths apply the shared gate to pre-transport serializations. The
+    compact transport applies two further mutations after this serialization —
+    the Responses-Lite ``reasoning.context`` control and inline image
+    fetching — both proxy-injected, account-agnostic, and applied identically
+    to the owner send and the replay send, so they are not part of the client
+    payload being proven. The serialized history must additionally be a
     complete resend. ``to_payload`` can still drop history on the wire: it
     strips poisoned local-compact fallback messages together with their
     trailing encrypted compaction item, and it trims oversized inputs down to a

--- a/openspec/changes/fix-compact-previous-response-quota-failover/proposal.md
+++ b/openspec/changes/fix-compact-previous-response-quota-failover/proposal.md
@@ -1,0 +1,47 @@
+# Fix Compact Previous-Response Quota Failover
+
+## Why
+
+When a long conversation's previous-response owner account is quota-excluded and the next
+client action is a compaction, the compact request wedges the session. The compact path pins
+selection to the resolved owner (`fallback_on_preferred_account_unavailable` is false whenever
+a pin exists) and raises the selection failure straight to the client (`429
+usage_limit_reached` / 503, or the owner's in-request 429). Because the pin re-resolves the
+same exhausted owner on every retry, the client cannot compact — and cannot shrink its history
+to continue — until the owner's quota window resets.
+
+Normal turns already escape exactly this state through account-neutral fresh replay (strip the
+stale `previous_response_id` anchor, verify the payload is a self-contained account-neutral
+full resend, exclude the dead owner, reselect). This change gives the compact surface the same
+selection-time recovery, rescoped per the maintainer review on PR #1490: activation only for
+`previous_response_id`-only pins over self-contained histories, reusing the existing
+account-neutral fresh-replay gates, gated on quota-caused owner exclusion, with no
+continuity-rebind/CAS/fencing machinery.
+
+## What Changes
+
+- When a compact request is pinned **only** by `previous_response_id` (no turn-state owner, no
+  input-file owner, no session identity on the request, no session-ownership affinity) and
+  account selection cannot return the pinned owner, the proxy attempts account-neutral
+  fresh-replay recovery instead of failing: it verifies the anchor-free upstream compact
+  payload against the shared account-neutral fresh-replay rules plus the retained-prior-output
+  transcript shape, and on success removes `previous_response_id`, strips downstream
+  session/turn affinity aliases from upstream-bound headers, excludes the unavailable owner,
+  and reselects among the remaining eligible accounts.
+- Recovery activates only for quota-caused owner loss: the owner's persisted status is
+  `RATE_LIMITED`/`QUOTA_EXCEEDED` at selection time, or the owner was excluded mid-request by
+  a pre-visible quota/rate-limit failover. Post-selection authentication, refresh, transport,
+  and transient exclusions keep their existing owner-bound surfaces.
+- Every request outside the gate keeps today's fail-closed behavior, now also recorded on the
+  existing `continuity_fail_closed` observability counter (surface `compact`, reason
+  `owner_account_unavailable`).
+
+## Impact
+
+- Affected specs: `responses-api-compat` (one added requirement).
+- Affected code: `app/modules/proxy/_service/compact.py` only (recovery branch in the account
+  selection loop, a payload-verification helper reusing `app/modules/proxy/replay_safety.py`
+  and `app/modules/proxy/continuity.py`, and an owner-status quota check).
+- No new settings, endpoints, schemas, durable-bridge methods, or dashboard surfaces.
+  Reservation settlement is unchanged: recovery introduces no new terminal raise; existing
+  settle-before-raise sites still cover every exit.

--- a/openspec/changes/fix-compact-previous-response-quota-failover/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-compact-previous-response-quota-failover/specs/responses-api-compat/spec.md
@@ -30,8 +30,14 @@ continuity-rebind machinery, so anything that would need rebinding stays owner-b
 Prompt-cache and sticky-thread locality keys are advisory cache locality that ordinary sticky
 selection already falls back from and do not block recovery.
 
-Local verification MUST run against the exact upstream-bound compact payload without
-`previous_response_id`, after every wire transformation the compact serializer applies. It
+Local verification MUST run against the exact serialized upstream-bound compact payload
+without `previous_response_id`, after every transformation the compact serializer applies.
+Transport-stage mutations that follow that serialization are outside the client payload being
+proven and MUST be limited to proxy-injected, account-agnostic controls that are applied
+identically to the owner send and the replay send (the Responses-Lite
+`reasoning.context` control and inline image fetching); they carry no client or account
+state, so the shared account-neutral rules — which the HTTP bridge replay paths likewise
+apply to pre-transport serializations — retain their meaning. It
 MUST require that serialized `input` to be a list of more than one item that is item-for-item
 identical to the validated request `input`, so that no request whose wire history is dropped
 or trimmed — including single-item collapse and oversized-input trim markers — is ever

--- a/openspec/changes/fix-compact-previous-response-quota-failover/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-compact-previous-response-quota-failover/specs/responses-api-compat/spec.md
@@ -14,10 +14,13 @@ Recovery MUST activate only for quota-caused owner loss. At selection time, befo
 was ever used for the request, the owner's persisted account status MUST be rate-limited or
 quota-exhausted; an owner unselectable for any other reason (re-authentication required,
 deactivated, paused, local capacity caps on an active account, or a failed status lookup)
-stays owner-bound. Mid-request, only a pre-visible quota or rate-limit failure of the pinned
-owner that permits failover makes recovery eligible; post-selection authentication, refresh,
-transport, timeout, and transient exclusions of the pinned owner keep their existing
-owner-bound handling.
+stays owner-bound. An owner the selector skipped for routing policy — API-key assignment
+scope, single-account routing, or a prior in-request exclusion — MUST stay owner-bound
+regardless of its persisted quota status, because policy, not quota, caused that selection
+loss. Mid-request, only a pre-visible quota or rate-limit failure of the pinned owner that
+permits failover makes recovery eligible; post-selection authentication, refresh, transport,
+timeout, and transient exclusions of the pinned owner keep their existing owner-bound
+handling.
 
 Recovery MUST NOT activate when the request carries a session identity (a turn-state or
 session header) that can bind live or durable HTTP-bridge continuity, or when the resolved
@@ -86,6 +89,22 @@ the remaining eligible accounts with fallback enabled.
 - **WHEN** reselection cannot return the now-excluded owner
 - **THEN** the proxy surfaces the owner's authentication failure
 - **AND** account-neutral fresh-replay recovery does not activate and no part of the payload is sent to another account
+
+#### Scenario: Policy-skipped owner stays owner-bound despite quota status
+
+- **GIVEN** a previous-response-pinned compact request whose owner account is excluded by API-key assignment scope or single-account routing
+- **AND** that owner's persisted status is coincidentally rate-limited or quota-exhausted
+- **WHEN** pinned account selection skips the owner
+- **THEN** the request fails with the existing selection error
+- **AND** account-neutral fresh-replay recovery does not activate
+
+#### Scenario: Responses-Lite full resend behind a canonical tool bundle is recoverable
+
+- **GIVEN** a quota-excluded previous-response-pinned compact request whose `input` opens with a canonical `additional_tools` bundle and its immediately following developer instruction
+- **AND** the remaining transcript retains prior assistant output ahead of fresh client input and passes the account-neutral fresh-replay rules
+- **WHEN** pinned account selection cannot return the owner
+- **THEN** the shared canonical-Lite prefix handling recognizes the developer instruction
+- **AND** the recovery replays the anchor-free payload on another eligible account
 
 #### Scenario: Non-quota owner loss at selection time stays owner-bound
 

--- a/openspec/changes/fix-compact-previous-response-quota-failover/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-compact-previous-response-quota-failover/specs/responses-api-compat/spec.md
@@ -156,6 +156,14 @@ the remaining eligible accounts with fallback enabled.
 - **THEN** the request fails closed with the existing continuity or selection error
 - **AND** account-neutral fresh-replay recovery does not activate
 
+#### Scenario: Additional owner pins record the fail-closed outcome
+
+- **GIVEN** a compact request whose `previous_response_id` owner is also resolved by a turn-state or input-file pin naming the same account
+- **WHEN** the pinned owner cannot be selected
+- **THEN** the request fails closed with the existing selection error
+- **AND** account-neutral fresh-replay recovery does not activate
+- **AND** the continuity fail-closed counter records the compact-surface outcome
+
 #### Scenario: Unresolvable previous-response owner remains fail-closed
 
 - **GIVEN** a compact request whose `previous_response_id` owner cannot be resolved from any record

--- a/openspec/changes/fix-compact-previous-response-quota-failover/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-compact-previous-response-quota-failover/specs/responses-api-compat/spec.md
@@ -1,0 +1,128 @@
+## ADDED Requirements
+
+### Requirement: Compact requests recover from quota-caused previous-response owner loss
+
+When a compact request is pinned to a previous-response owner account, that pin is the only
+continuity pin (no client-supplied turn-state owner and no input-file owner), and account
+selection cannot return the pinned owner, the proxy MUST attempt account-neutral fresh-replay
+recovery before surfacing the failure, provided every activation gate below holds. Outside the
+gates the proxy MUST keep today's fail-closed failure for that request, MUST NOT send any part
+of the payload to another account, and MUST record the fail-closed outcome on the continuity
+fail-closed observability counter for the compact surface.
+
+Recovery MUST activate only for quota-caused owner loss. At selection time, before the owner
+was ever used for the request, the owner's persisted account status MUST be rate-limited or
+quota-exhausted; an owner unselectable for any other reason (re-authentication required,
+deactivated, paused, local capacity caps on an active account, or a failed status lookup)
+stays owner-bound. Mid-request, only a pre-visible quota or rate-limit failure of the pinned
+owner that permits failover makes recovery eligible; post-selection authentication, refresh,
+transport, timeout, and transient exclusions of the pinned owner keep their existing
+owner-bound handling.
+
+Recovery MUST NOT activate when the request carries a session identity (a turn-state or
+session header) that can bind live or durable HTTP-bridge continuity, or when the resolved
+affinity is session ownership (a Codex-session affinity key, a raw legacy session row, or a
+conversation handle requiring an unambiguous owner): this recovery deliberately carries no
+continuity-rebind machinery, so anything that would need rebinding stays owner-bound.
+Prompt-cache and sticky-thread locality keys are advisory cache locality that ordinary sticky
+selection already falls back from and do not block recovery.
+
+Local verification MUST run against the exact upstream-bound compact payload without
+`previous_response_id`, after every wire transformation the compact serializer applies. It
+MUST require that serialized `input` to be a list of more than one item that is item-for-item
+identical to the validated request `input`, so that no request whose wire history is dropped
+or trimmed — including single-item collapse and oversized-input trim markers — is ever
+replayed on another account, which could not resolve the omitted owner-resident context. It
+MUST validate that same serialized payload against the shared account-neutral fresh-replay
+rules: self-contained tool call/output pairing, no server-assigned item ids, no encrypted or
+compaction state, no nonblank conversation or prompt handles, no account-scoped
+file/container/vector handles, no hosted/MCP call state, and only recognized account-neutral
+fields and shapes. Because a self-contained payload may still be a delta that relies on the
+owner to hold the earlier conversation, the serialized `input` MUST additionally parse as a
+transcript whose final segment retains completed assistant output followed only by fresh
+client input, using the shared retained-prior-output rule anchored at the last assistant
+message. Histories those gates cannot prove — including delta-shaped inputs without retained
+assistant output and transcripts without fresh follow-up input — stay owner-bound.
+
+For an eligible recovery, the proxy MUST remove `previous_response_id` from the upstream
+compact payload, strip downstream session/turn affinity aliases from the upstream-bound
+headers, exclude the unavailable owner account from the remaining attempts, and reselect among
+the remaining eligible accounts with fallback enabled.
+
+#### Scenario: Quota-excluded owner at selection time fails over with a verified full resend
+
+- **GIVEN** account A owns the previous response referenced by a compact request and account B is eligible
+- **AND** account A's persisted status is rate-limited or quota-exhausted
+- **AND** the compact payload carries an account-neutral full-resend `input` that retains prior assistant output ahead of the new client input
+- **AND** the request carries no session identity and no session-ownership affinity
+- **WHEN** pinned account selection cannot return account A
+- **THEN** the proxy sends the compact upstream exactly once on account B without `previous_response_id`
+- **AND** the compact response is returned successfully
+
+#### Scenario: Owner exhausts quota during the compact request
+
+- **GIVEN** the pinned previous-response owner is selected for a compact request
+- **AND** the upstream compact fails with a pre-visible quota or rate-limit error that permits failover
+- **WHEN** reselection cannot return the now-excluded owner
+- **THEN** the proxy applies the same account-neutral fresh-replay recovery on another eligible account
+- **AND** the owner's quota failure is not surfaced to the client when the recovery succeeds
+
+#### Scenario: Post-selection authentication failure on the pinned owner stays owner-bound
+
+- **GIVEN** the pinned previous-response owner is selected for a compact request with an account-neutral full-resend `input`
+- **AND** the upstream compact fails with `401` again after the forced token refresh, which excludes the owner from the remaining attempts
+- **WHEN** reselection cannot return the now-excluded owner
+- **THEN** the proxy surfaces the owner's authentication failure
+- **AND** account-neutral fresh-replay recovery does not activate and no part of the payload is sent to another account
+
+#### Scenario: Non-quota owner loss at selection time stays owner-bound
+
+- **GIVEN** a previous-response-pinned compact request whose owner account is paused, deactivated, or requires re-authentication
+- **WHEN** pinned account selection cannot return the owner
+- **THEN** the request fails with the existing selection error
+- **AND** account-neutral fresh-replay recovery does not activate
+- **AND** the continuity fail-closed counter records the compact-surface outcome
+
+#### Scenario: Non-neutral compact payload stays fail-closed
+
+- **GIVEN** a pinned compact request whose `input` retains encrypted compaction state, server-assigned item ids, or account-scoped file handles
+- **WHEN** the quota-excluded pinned owner cannot be selected
+- **THEN** the request fails with the existing selection or upstream error
+- **AND** no part of the payload is sent to another account
+- **AND** the continuity fail-closed counter records the compact-surface outcome
+
+#### Scenario: Delta-shaped history without retained output stays fail-closed
+
+- **GIVEN** a pinned compact request whose multi-item `input` carries no retained assistant output ahead of fresh client input
+- **WHEN** the quota-excluded pinned owner cannot be selected
+- **THEN** the request fails with the existing selection or upstream error
+- **AND** the proxy keeps the anchor and sends no part of the payload to another account
+
+#### Scenario: History the wire serializer shortens stays fail-closed
+
+- **GIVEN** a pinned compact request whose `input` loses history when serialized for upstream, either collapsing to a single item or being trimmed to a head, trim marker, and tail
+- **WHEN** the quota-excluded pinned owner cannot be selected
+- **THEN** the request fails with the existing selection or upstream error
+- **AND** the proxy does not replay the shortened history on another account
+
+#### Scenario: Session-identified compact stays owner-bound
+
+- **GIVEN** a pinned compact request that carries a session or turn-state identity able to bind live or durable HTTP-bridge continuity
+- **WHEN** the quota-excluded pinned owner cannot be selected
+- **THEN** the request fails with the existing selection error
+- **AND** account-neutral fresh-replay recovery does not activate
+
+#### Scenario: Turn-state-pinned and file-pinned compacts remain owner-bound
+
+- **GIVEN** a compact request pinned by a client-supplied turn-state owner or an input-file owner
+- **WHEN** that owner account cannot be selected
+- **THEN** the request fails closed with the existing continuity or selection error
+- **AND** account-neutral fresh-replay recovery does not activate
+
+#### Scenario: Unresolvable previous-response owner remains fail-closed
+
+- **GIVEN** a compact request whose `previous_response_id` owner cannot be resolved from any record
+- **AND** more than one account is eligible
+- **WHEN** the request is evaluated before account selection
+- **THEN** the request fails with `previous_response_owner_unavailable`
+- **AND** the proxy does not treat the missing owner as a selector result or replay on another account

--- a/openspec/changes/fix-compact-previous-response-quota-failover/specs/responses-api-compat/spec.md
+++ b/openspec/changes/fix-compact-previous-response-quota-failover/specs/responses-api-compat/spec.md
@@ -44,6 +44,18 @@ client input, using the shared retained-prior-output rule anchored at the last a
 message. Histories those gates cannot prove — including delta-shaped inputs without retained
 assistant output and transcripts without fresh follow-up input — stay owner-bound.
 
+This transcript-shape rule is the evidence ceiling of this scope: completeness relative to the
+anchored conversation is not provable from the payload alone, and the durable prefix metadata
+that could prove it is deliberately not consulted here (per the maintainer rescope of the
+original change, which excluded durable-bridge plumbing from this recovery). A delta resend
+that itself carries a completed assistant exchange ahead of the fresh input is therefore
+indistinguishable from a full resend and MAY be recovered as the client's authoritative local
+history — the same trust the shared account-neutral fresh-replay rules already grant a normal
+turn that abandons an unavailable owner. Clients that resend partial histories under a
+previous-response anchor accept summarization over that partial history when the owner is
+quota-lost; the alternative surface is the current hard failure until the owner's quota
+window resets.
+
 For an eligible recovery, the proxy MUST remove `previous_response_id` from the upstream
 compact payload, strip downstream session/turn affinity aliases from the upstream-bound
 headers, exclude the unavailable owner account from the remaining attempts, and reselect among

--- a/openspec/changes/fix-compact-previous-response-quota-failover/tasks.md
+++ b/openspec/changes/fix-compact-previous-response-quota-failover/tasks.md
@@ -16,8 +16,9 @@
   `without_http_bridge_session_affinity_headers`, and reselect with fallback enabled.
 - [x] 3. Keep every other case fail-closed and record `continuity_fail_closed` (surface
   `compact`, reason `owner_account_unavailable`) when the pinned selection failure is
-  surfaced: session identity on the request, session-ownership affinity, non-quota owner
-  loss, and unverifiable histories.
+  surfaced: additional turn-state/input-file owner pins on the same owner, session identity
+  on the request, session-ownership affinity, non-quota owner loss, and unverifiable
+  histories.
 - [x] 4. Add unit tests for the verification helper (eligible full resend; missing anchor;
   single-item and string inputs; server-assigned ids; encrypted compaction state; delta
   histories without retained output; transcripts without fresh follow-up input; wire-trimmed

--- a/openspec/changes/fix-compact-previous-response-quota-failover/tasks.md
+++ b/openspec/changes/fix-compact-previous-response-quota-failover/tasks.md
@@ -1,0 +1,31 @@
+# Tasks
+
+- [x] 1. Add a compact account-neutral replay verification helper in
+  `app/modules/proxy/_service/compact.py` that returns the anchor-free
+  `ResponsesCompactRequest` only when the request carries `previous_response_id`, a
+  list-shaped `input` with more than one item, an upstream-bound serialization that is
+  item-for-item identical to the validated request `input`, passes
+  `responses_payload_is_account_neutral_fresh_replay`, and retains prior assistant output
+  ahead of new client input via `responses_input_suffix_retains_prior_output`.
+- [x] 2. In the `compact_responses` account-selection loop, when selection returns no account
+  and the request is pinned only by the previous-response owner, activate recovery for a
+  verified payload when the owner loss is quota-caused (persisted
+  `RATE_LIMITED`/`QUOTA_EXCEEDED` status at selection time, or a pre-visible quota/rate-limit
+  in-request failover of the owner): exclude the owner, drop the pin, strip session/turn
+  affinity aliases from upstream-bound headers via
+  `without_http_bridge_session_affinity_headers`, and reselect with fallback enabled.
+- [x] 3. Keep every other case fail-closed and record `continuity_fail_closed` (surface
+  `compact`, reason `owner_account_unavailable`) when the pinned selection failure is
+  surfaced: session identity on the request, session-ownership affinity, non-quota owner
+  loss, and unverifiable histories.
+- [x] 4. Add unit tests for the verification helper (eligible full resend; missing anchor;
+  single-item and string inputs; server-assigned ids; encrypted compaction state; delta
+  histories without retained output; transcripts without fresh follow-up input; wire-trimmed
+  oversized histories).
+- [x] 5. Add integration regression tests at `POST /backend-api/codex/responses/compact`:
+  selection-time quota loss recovers on the other account without `previous_response_id`;
+  mid-request owner 429 recovers the same way; repeated post-refresh 401 stays owner-bound;
+  delta histories, account-scoped histories, session-identified requests, and paused owners
+  stay fail-closed with nothing sent to another account.
+- [x] 6. Run `uv run ruff check`, `uv run ruff format --check`, `uv run ty check`, and the
+  unit + compact integration suites; validate the change with strict OpenSpec validation.

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import contextlib
 import json
+import logging
 from datetime import timedelta, timezone
 from typing import cast
 from unittest.mock import AsyncMock
@@ -1998,3 +1999,46 @@ async def test_proxy_compact_pinned_owner_policy_skip_stays_owner_bound_despite_
 
     assert response.status_code >= 400
     assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_pinned_owner_with_additional_turn_state_pin_records_fail_closed(
+    async_client, monkeypatch, caplog
+):
+    """A previous-response pin accompanied by a turn-state pin on the same
+    owner stays owner-bound (recovery never activates for additional owner
+    pins), but the unavailable owner must still record the compact
+    continuity_fail_closed outcome on the common pinned-selection failure
+    path instead of skipping the recording branch entirely."""
+    owner_account_id = await _import_account(
+        async_client, email="compact-multipin-owner@example.com", raw_account_id="acc_multipin_owner"
+    )
+    await _import_account(async_client, email="compact-multipin-alt@example.com", raw_account_id="acc_multipin_alt")
+    await _mark_account_status(owner_account_id, AccountStatus.RATE_LIMITED)
+    _pin_previous_response_owner(monkeypatch, owner_account_id)
+
+    async def fake_turn_state_owner(self, *, turn_state, api_key, fail_on_missing=True):
+        del self, turn_state, api_key, fail_on_missing
+        return owner_account_id
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_resolve_compact_turn_state_owner", fake_turn_state_owner)
+
+    calls: list[tuple[str | None, dict[str, object], dict[str, str]]] = []
+    monkeypatch.setattr(proxy_module, "core_compact_responses", _recording_compact(calls))
+
+    with caplog.at_level(logging.INFO):
+        response = await async_client.post(
+            "/backend-api/codex/responses/compact",
+            json={
+                "model": "gpt-5.1",
+                "instructions": "hi",
+                "input": _NEUTRAL_FULL_RESEND_INPUT,
+                "previous_response_id": "resp_multipin_anchor",
+            },
+            headers={"x-codex-turn-state": "ts-multipin-owner-bound"},
+        )
+
+    assert response.status_code >= 400
+    assert calls == []
+    assert "blocked_reason=additional_owner_pins" in caplog.text
+    assert "continuity_fail_closed surface=compact reason=owner_account_unavailable" in caplog.text

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -22,6 +22,7 @@ from app.db.models import Account, AccountStatus
 from app.db.session import SessionLocal
 from app.modules.api_keys.repository import ApiKeysRepository
 from app.modules.api_keys.service import ApiKeyCreateData, ApiKeysService
+from app.modules.proxy.account_cache import get_account_selection_cache
 from app.modules.proxy.rate_limit_cache import get_rate_limit_headers_cache
 from app.modules.usage.repository import AdditionalUsageRepository, UsageRepository
 
@@ -1655,3 +1656,303 @@ async def test_proxy_compact_output_round_trips_into_followup_responses_without_
 
     assert response.status_code == 200
     assert seen_inputs == [compact_window["output"]]
+
+
+_NEUTRAL_FULL_RESEND_INPUT: list[dict[str, object]] = [
+    {"role": "user", "content": "hello"},
+    {"role": "assistant", "content": [{"type": "output_text", "text": "hi there"}]},
+    {"role": "user", "content": "please compact"},
+]
+
+
+async def _import_account(async_client, *, email: str, raw_account_id: str) -> str:
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    response = await async_client.post("/api/accounts/import", files=files)
+    assert response.status_code == 200
+    return generate_unique_account_id(raw_account_id, email)
+
+
+async def _mark_account_status(account_id: str, status: AccountStatus) -> None:
+    async with SessionLocal() as session:
+        account = await session.get(Account, account_id)
+        assert account is not None
+        account.status = status
+        if status in (AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED):
+            account.reset_at = int(utcnow().replace(tzinfo=timezone.utc).timestamp()) + 3600
+        await session.commit()
+    get_account_selection_cache().invalidate()
+
+
+def _pin_previous_response_owner(monkeypatch, owner_account_id: str) -> None:
+    async def fake_owner(self, *, previous_response_id, api_key, session_id=None, surface, **kwargs):
+        del self, previous_response_id, api_key, session_id, surface, kwargs
+        return owner_account_id
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_resolve_websocket_previous_response_owner", fake_owner)
+
+
+def _recording_compact(
+    calls: list[tuple[str | None, dict[str, object], dict[str, str]]],
+    *,
+    fail_accounts_with: dict[str, ProxyResponseError] | None = None,
+):
+    async def fake_compact(payload, headers, access_token, account_id):
+        del access_token
+        calls.append((account_id, cast(dict[str, object], payload.to_payload()), dict(headers)))
+        if fail_accounts_with and account_id in fail_accounts_with:
+            raise fail_accounts_with[account_id]
+        return CompactResponsePayload.model_validate({"object": "response.compaction", "output": []})
+
+    return fake_compact
+
+
+def _usage_limit_429() -> ProxyResponseError:
+    return ProxyResponseError(
+        429,
+        {
+            "error": {
+                "type": "usage_limit_reached",
+                "message": "limit reached",
+                "plan_type": "plus",
+                "resets_at": int(utcnow().replace(tzinfo=timezone.utc).timestamp()) + 3600,
+            }
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_pinned_owner_selection_time_quota_loss_replays_account_neutral_full_resend(
+    async_client, monkeypatch
+):
+    """A previous-response-pinned compact whose owner is quota-excluded at
+    selection time recovers by dropping the anchor and replaying the verified
+    account-neutral full resend on a healthy account instead of wedging."""
+    owner_account_id = await _import_account(
+        async_client, email="compact-quota-owner@example.com", raw_account_id="acc_quota_owner"
+    )
+    await _import_account(async_client, email="compact-quota-alt@example.com", raw_account_id="acc_quota_alt")
+    await _mark_account_status(owner_account_id, AccountStatus.RATE_LIMITED)
+    _pin_previous_response_owner(monkeypatch, owner_account_id)
+
+    calls: list[tuple[str | None, dict[str, object], dict[str, str]]] = []
+    monkeypatch.setattr(proxy_module, "core_compact_responses", _recording_compact(calls))
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": _NEUTRAL_FULL_RESEND_INPUT,
+            "previous_response_id": "resp_quota_anchor",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert [account_id for account_id, _payload, _headers in calls] == ["acc_quota_alt"]
+    replay_payload = calls[0][1]
+    assert "previous_response_id" not in replay_payload
+    assert replay_payload["input"] == _NEUTRAL_FULL_RESEND_INPUT
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_pinned_owner_in_request_quota_429_replays_account_neutral_full_resend(
+    async_client, monkeypatch
+):
+    """An owner that 429s mid-request (pre-visible quota failover) is excluded
+    and the verified account-neutral full resend recovers on the other account
+    instead of re-raising the owner's 429 forever."""
+    owner_account_id = await _import_account(
+        async_client, email="compact-429-owner@example.com", raw_account_id="acc_429_owner"
+    )
+    await _import_account(async_client, email="compact-429-alt@example.com", raw_account_id="acc_429_alt")
+    _pin_previous_response_owner(monkeypatch, owner_account_id)
+
+    calls: list[tuple[str | None, dict[str, object], dict[str, str]]] = []
+    monkeypatch.setattr(
+        proxy_module,
+        "core_compact_responses",
+        _recording_compact(calls, fail_accounts_with={"acc_429_owner": _usage_limit_429()}),
+    )
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": _NEUTRAL_FULL_RESEND_INPUT,
+            "previous_response_id": "resp_429_anchor",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert [account_id for account_id, _payload, _headers in calls] == ["acc_429_owner", "acc_429_alt"]
+    owner_payload, replay_payload = calls[0][1], calls[1][1]
+    assert owner_payload["previous_response_id"] == "resp_429_anchor"
+    assert "previous_response_id" not in replay_payload
+    assert replay_payload["input"] == owner_payload["input"]
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_pinned_owner_post_selection_401_stays_owner_bound(async_client, monkeypatch):
+    """A repeated 401 after the forced refresh excludes the owner for a
+    non-quota reason, so account-neutral replay must not activate and the
+    owner's authentication failure surfaces unchanged."""
+    owner_account_id = await _import_account(
+        async_client, email="compact-401-owner@example.com", raw_account_id="acc_401_owner"
+    )
+    await _import_account(async_client, email="compact-401-alt@example.com", raw_account_id="acc_401_alt")
+    _pin_previous_response_owner(monkeypatch, owner_account_id)
+
+    async def fake_ensure_fresh(self, account, *, force=False, timeout_seconds=None):
+        del self, force, timeout_seconds
+        return account
+
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh)
+
+    calls: list[tuple[str | None, dict[str, object], dict[str, str]]] = []
+    unauthorized = ProxyResponseError(401, openai_error("unauthorized", "token rejected"))
+    monkeypatch.setattr(
+        proxy_module,
+        "core_compact_responses",
+        _recording_compact(calls, fail_accounts_with={"acc_401_owner": unauthorized}),
+    )
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": _NEUTRAL_FULL_RESEND_INPUT,
+            "previous_response_id": "resp_401_anchor",
+        },
+    )
+
+    assert response.status_code == 401
+    assert [account_id for account_id, _payload, _headers in calls] == ["acc_401_owner", "acc_401_owner"]
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_pinned_owner_quota_loss_stays_owner_bound_without_retained_prior_output(
+    async_client, monkeypatch
+):
+    """A multi-item history without retained assistant output cannot be proven
+    a full resend (it may be a delta the owner account resolves through the
+    anchor), so nothing is sent to another account."""
+    owner_account_id = await _import_account(
+        async_client, email="compact-delta-owner@example.com", raw_account_id="acc_delta_owner"
+    )
+    await _import_account(async_client, email="compact-delta-alt@example.com", raw_account_id="acc_delta_alt")
+    await _mark_account_status(owner_account_id, AccountStatus.RATE_LIMITED)
+    _pin_previous_response_owner(monkeypatch, owner_account_id)
+
+    calls: list[tuple[str | None, dict[str, object], dict[str, str]]] = []
+    monkeypatch.setattr(proxy_module, "core_compact_responses", _recording_compact(calls))
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {"role": "user", "content": "first delta turn"},
+                {"role": "user", "content": "second delta turn"},
+            ],
+            "previous_response_id": "resp_delta_anchor",
+        },
+    )
+
+    assert response.status_code >= 400
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_pinned_owner_quota_loss_stays_owner_bound_with_account_scoped_history(
+    async_client, monkeypatch
+):
+    """A history carrying account-scoped state (an encrypted compaction item)
+    fails the shared account-neutral fresh-replay gate and never crosses
+    accounts."""
+    owner_account_id = await _import_account(
+        async_client, email="compact-scoped-owner@example.com", raw_account_id="acc_scoped_owner"
+    )
+    await _import_account(async_client, email="compact-scoped-alt@example.com", raw_account_id="acc_scoped_alt")
+    await _mark_account_status(owner_account_id, AccountStatus.RATE_LIMITED)
+    _pin_previous_response_owner(monkeypatch, owner_account_id)
+
+    calls: list[tuple[str | None, dict[str, object], dict[str, str]]] = []
+    monkeypatch.setattr(proxy_module, "core_compact_responses", _recording_compact(calls))
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [
+                {"type": "compaction", "encrypted_content": "enc_owner_scoped_state"},
+                *_NEUTRAL_FULL_RESEND_INPUT,
+            ],
+            "previous_response_id": "resp_scoped_anchor",
+        },
+    )
+
+    assert response.status_code >= 400
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_pinned_owner_quota_loss_stays_owner_bound_with_session_identity(async_client, monkeypatch):
+    """A session identity on the request can bind live or durable HTTP-bridge
+    continuity that still names the lost owner; without rebinding machinery the
+    request stays owner-bound."""
+    owner_account_id = await _import_account(
+        async_client, email="compact-session-owner@example.com", raw_account_id="acc_session_owner"
+    )
+    await _import_account(async_client, email="compact-session-alt@example.com", raw_account_id="acc_session_alt")
+    await _mark_account_status(owner_account_id, AccountStatus.RATE_LIMITED)
+    _pin_previous_response_owner(monkeypatch, owner_account_id)
+
+    calls: list[tuple[str | None, dict[str, object], dict[str, str]]] = []
+    monkeypatch.setattr(proxy_module, "core_compact_responses", _recording_compact(calls))
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": _NEUTRAL_FULL_RESEND_INPUT,
+            "previous_response_id": "resp_session_anchor",
+        },
+        headers={"session_id": "sid-compact-session-bound"},
+    )
+
+    assert response.status_code >= 400
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_pinned_owner_non_quota_loss_stays_owner_bound(async_client, monkeypatch):
+    """An owner unselectable for a non-quota reason (operator pause) keeps
+    today's fail-closed surface; recovery requires quota-caused owner loss."""
+    owner_account_id = await _import_account(
+        async_client, email="compact-paused-owner@example.com", raw_account_id="acc_paused_owner"
+    )
+    await _import_account(async_client, email="compact-paused-alt@example.com", raw_account_id="acc_paused_alt")
+    await _mark_account_status(owner_account_id, AccountStatus.PAUSED)
+    _pin_previous_response_owner(monkeypatch, owner_account_id)
+
+    calls: list[tuple[str | None, dict[str, object], dict[str, str]]] = []
+    monkeypatch.setattr(proxy_module, "core_compact_responses", _recording_compact(calls))
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": _NEUTRAL_FULL_RESEND_INPUT,
+            "previous_response_id": "resp_paused_anchor",
+        },
+    )
+
+    assert response.status_code >= 400
+    assert calls == []

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -1956,3 +1956,45 @@ async def test_proxy_compact_pinned_owner_non_quota_loss_stays_owner_bound(async
 
     assert response.status_code >= 400
     assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_proxy_compact_pinned_owner_policy_skip_stays_owner_bound_despite_quota_status(async_client, monkeypatch):
+    """An owner the selector skips for routing policy (API-key assignment
+    scope) must stay owner-bound even when its persisted status happens to be
+    quota-exhausted: policy, not quota, caused the selection loss."""
+    owner_account_id = await _import_account(
+        async_client, email="compact-policy-owner@example.com", raw_account_id="acc_policy_owner"
+    )
+    alt_account_id = await _import_account(
+        async_client, email="compact-policy-alt@example.com", raw_account_id="acc_policy_alt"
+    )
+    await _mark_account_status(owner_account_id, AccountStatus.RATE_LIMITED)
+    _pin_previous_response_owner(monkeypatch, owner_account_id)
+
+    settings_resp = await async_client.put(
+        "/api/settings",
+        json={"totpRequiredOnLogin": False, "apiKeyAuthEnabled": True},
+    )
+    assert settings_resp.status_code == 200
+    _key_id, key = await _create_api_key(
+        name="compact-policy-scope-key",
+        assigned_account_ids=[alt_account_id],
+    )
+
+    calls: list[tuple[str | None, dict[str, object], dict[str, str]]] = []
+    monkeypatch.setattr(proxy_module, "core_compact_responses", _recording_compact(calls))
+
+    response = await async_client.post(
+        "/backend-api/codex/responses/compact",
+        json={
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": _NEUTRAL_FULL_RESEND_INPUT,
+            "previous_response_id": "resp_policy_anchor",
+        },
+        headers={"authorization": f"Bearer {key}"},
+    )
+
+    assert response.status_code >= 400
+    assert calls == []

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -45743,3 +45743,109 @@ async def test_inline_http_bridge_image_urls_rejects_when_fetch_fails(monkeypatc
 
     assert exc_info.value.status_code == 400
     assert "image_download_failed" in json.dumps(exc_info.value.payload)
+
+
+_COMPACT_REPLAY_NEUTRAL_INPUT: list[dict[str, object]] = [
+    {"role": "user", "content": "hello"},
+    {"role": "assistant", "content": [{"type": "output_text", "text": "hi there"}]},
+    {"role": "user", "content": "please compact"},
+]
+
+
+def _compact_replay_request(**overrides: object) -> ResponsesCompactRequest:
+    source: dict[str, object] = {
+        "model": "gpt-5.1",
+        "instructions": "hi",
+        "input": _COMPACT_REPLAY_NEUTRAL_INPUT,
+        "previous_response_id": "resp_anchor",
+    }
+    source.update(overrides)
+    return ResponsesCompactRequest.model_validate(source)
+
+
+def test_compact_account_neutral_replay_payload_accepts_verified_full_resend() -> None:
+    replay = proxy_compact_service._compact_account_neutral_replay_payload(_compact_replay_request())
+    assert replay is not None
+    assert getattr(replay, "previous_response_id", None) is None
+    assert replay.input == _COMPACT_REPLAY_NEUTRAL_INPUT
+    assert "previous_response_id" not in replay.to_payload()
+
+
+def test_compact_account_neutral_replay_payload_requires_previous_response_anchor() -> None:
+    payload = ResponsesCompactRequest.model_validate(
+        {"model": "gpt-5.1", "instructions": "hi", "input": _COMPACT_REPLAY_NEUTRAL_INPUT}
+    )
+    assert proxy_compact_service._compact_account_neutral_replay_payload(payload) is None
+
+
+def test_compact_account_neutral_replay_payload_rejects_single_item_and_string_inputs() -> None:
+    single_item = _compact_replay_request(input=[{"role": "user", "content": "hello"}])
+    assert proxy_compact_service._compact_account_neutral_replay_payload(single_item) is None
+    string_input = _compact_replay_request(input="hello there")
+    assert proxy_compact_service._compact_account_neutral_replay_payload(string_input) is None
+
+
+def test_compact_account_neutral_replay_payload_rejects_server_assigned_item_ids() -> None:
+    payload = _compact_replay_request(
+        input=[
+            {"role": "user", "content": "hello"},
+            {
+                "type": "message",
+                "id": "msg_server_assigned",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "hi there"}],
+            },
+            {"role": "user", "content": "please compact"},
+        ]
+    )
+    assert proxy_compact_service._compact_account_neutral_replay_payload(payload) is None
+
+
+def test_compact_account_neutral_replay_payload_rejects_encrypted_compaction_state() -> None:
+    payload = _compact_replay_request(
+        input=[
+            {"type": "compaction", "encrypted_content": "enc_owner_scoped"},
+            *_COMPACT_REPLAY_NEUTRAL_INPUT,
+        ]
+    )
+    assert proxy_compact_service._compact_account_neutral_replay_payload(payload) is None
+
+
+def test_compact_account_neutral_replay_payload_rejects_history_without_retained_output() -> None:
+    # Two fresh user turns may be a delta the owner resolves through the
+    # anchor; without retained assistant output the full resend is unproven.
+    payload = _compact_replay_request(
+        input=[
+            {"role": "user", "content": "first delta turn"},
+            {"role": "user", "content": "second delta turn"},
+        ]
+    )
+    assert proxy_compact_service._compact_account_neutral_replay_payload(payload) is None
+
+
+def test_compact_account_neutral_replay_payload_rejects_history_without_fresh_followup() -> None:
+    # A transcript that ends on assistant output has no new client input after
+    # the retained output, so the retained-prior-output proof fails closed.
+    payload = _compact_replay_request(
+        input=[
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": [{"type": "output_text", "text": "hi there"}]},
+        ]
+    )
+    assert proxy_compact_service._compact_account_neutral_replay_payload(payload) is None
+
+
+def test_compact_account_neutral_replay_payload_rejects_wire_trimmed_history() -> None:
+    # An oversized history is trimmed on the wire to a head, marker, and tail;
+    # replaying that shortened transcript would compact an incomplete
+    # conversation, so the wire input must stay item-for-item identical.
+    oversized = "x" * 600_000
+    payload = _compact_replay_request(
+        input=[
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": [{"type": "output_text", "text": oversized}]},
+            {"role": "assistant", "content": [{"type": "output_text", "text": "hi there"}]},
+            {"role": "user", "content": "please compact"},
+        ]
+    )
+    assert proxy_compact_service._compact_account_neutral_replay_payload(payload) is None

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -45849,3 +45849,25 @@ def test_compact_account_neutral_replay_payload_rejects_wire_trimmed_history() -
         ]
     )
     assert proxy_compact_service._compact_account_neutral_replay_payload(payload) is None
+
+
+def test_compact_account_neutral_replay_payload_accepts_canonical_lite_full_resend() -> None:
+    # A Responses-Lite history opens with the additional_tools bundle and its
+    # canonical developer instruction; the shared projection must recognize
+    # that developer message so the Lite surface stays recoverable.
+    payload = _compact_replay_request(
+        input=[
+            {
+                "type": "additional_tools",
+                "role": "developer",
+                "tools": [{"type": "function", "name": "exec", "parameters": {"type": "object"}}],
+            },
+            {"type": "message", "role": "developer", "content": [{"type": "input_text", "text": "instructions"}]},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": [{"type": "output_text", "text": "hi there"}]},
+            {"role": "user", "content": "please compact"},
+        ]
+    )
+    replay = proxy_compact_service._compact_account_neutral_replay_payload(payload)
+    assert replay is not None
+    assert getattr(replay, "previous_response_id", None) is None


### PR DESCRIPTION
## Problem

When a long conversation's previous-response owner account is quota-excluded and the next client action is a compaction, the session wedges: the compact path pins selection to the resolved owner (`fallback_on_preferred_account_unavailable` is false whenever a pin exists), the selection failure surfaces straight to the client (429 `usage_limit_reached` / 503, or the owner's in-request 429), and every retry re-resolves the same dead owner until its quota window resets. The client cannot compact — and cannot shrink its history to continue — exactly when it most needs to.

## Root cause

Normal turns already escape this state via account-neutral fresh replay (drop the stale `previous_response_id` anchor, verify the payload is a self-contained account-neutral full resend, exclude the dead owner, reselect). The compact surface had no equivalent selection-time recovery.

## Fix (rescoped per the maintainer review on #1490)

This is the rescoped takeover announced in the 08-10 review and 08-16 close of #1490, carrying the core diagnosis and recovery shape forward at the prescribed scope — `compact.py`-only, no durable-bridge or continuity-rebind/CAS/fencing machinery:

- **Activation**: only when the pin is exclusively `previous_response_id` — no turn-state owner, no input-file owner, no session/turn-state identity on the request (which could bind live or durable HTTP-bridge continuity), and no session-ownership affinity (`CODEX_SESSION` keys, raw legacy rows, conversation handles). Prompt-cache/sticky-thread locality keys do not block: they are advisory, the sticky path already falls back from them, and the compact routes derive one unconditionally — a literal prompt-cache-absence gate would make the recovery unreachable.
- **Quota-caused owner loss only**: at selection time the owner's persisted status must be `RATE_LIMITED`/`QUOTA_EXCEEDED`; mid-request only a pre-visible quota/rate-limit failover of the owner qualifies. Policy skips (API-key assignment scope, single-account routing) stay owner-bound regardless of coincidental quota status; post-selection auth/refresh/transport/timeout exclusions keep their existing owner-bound surfaces.
- **History verification reuses the existing gates**: the anchor-free `to_payload()` serialization must keep a multi-item `input` item-for-item identical to the validated request input (wire-trimmed or collapsed histories fail closed), pass `responses_payload_is_account_neutral_fresh_replay`, and retain prior assistant output ahead of fresh client input via the shared `responses_input_suffix_retains_prior_output` walk (through the shared account-neutral projection, so canonical Responses-Lite bundles are recognized).
- **Recovery action**: exclude the owner, drop the anchor, strip session/turn affinity aliases from upstream-bound headers (`without_http_bridge_session_affinity_headers`), reselect with fallback enabled. Everything outside the gate keeps today's fail-closed surface, now recorded on the existing `continuity_fail_closed` counter (surface `compact`, reason `owner_account_unavailable`). Reservation settlement is untouched — recovery adds no terminal raise.

**Acknowledged evidence ceiling** (stated in the spec delta): completeness relative to the anchor is not provable from the payload alone, and the durable prefix metadata that could prove it is excluded by the rescope. A delta resend that itself carries a completed assistant exchange is indistinguishable from a full resend and is recovered as the client's authoritative local history — the same trust the fresh-replay rules already grant a normal turn abandoning an unavailable owner.

## OpenSpec

`openspec/changes/fix-compact-previous-response-quota-failover/` — one ADDED requirement in `responses-api-compat`, validated with `--strict`.

## Test evidence

RED/GREEN proven: with the app change stashed, the two recovery tests fail with today's wedge (429 re-raised / selection failure, no failover) and all fail-closed tests pass; with the fix all pass.

- Integration (`tests/integration/test_proxy_compact.py`, 8 new): selection-time quota loss recovers on the other account without the anchor; in-request owner 429 recovers the same way; repeated post-refresh 401 stays owner-bound (upstream called twice, owner only); delta history without retained output, encrypted-compaction history, session-identified request, paused owner, and scope-skipped owner with coincidental quota status all stay fail-closed with zero cross-account sends.
- Unit (`tests/unit/test_proxy_utils.py`, 10 new): eligible full resend; canonical Responses-Lite bundle resend; missing anchor; single-item/string inputs; server-assigned ids; encrypted compaction state; assistant-less delta; transcript without fresh follow-up; wire-trimmed oversized history.
- Gates: `uv run ruff check` / `ruff format --check` / `ty check` clean; `openspec validate --strict` passes; `tests/integration/test_proxy_compact.py` + `tests/unit/test_proxy_utils.py` = 1098 passed; adjacent suites (`test_replay_safety`, `test_selection_errors`, `test_proxy_responses`, `test_proxy_transient_retry`, `test_proxy_sticky_sessions`) green except one pre-existing timing flake (`test_codex_goal_restart_cannot_retire_owner_outside_api_key_scope`) that also fails without this change under host load.

## Codex review (local CLI, 3 rounds)

1. P1: delta carrying a completed exchange is indistinguishable from a full resend → acknowledged evidence ceiling of the prescribed scope; spec/docstring now state it explicitly instead of overclaiming.
2. P1: Responses-Lite full resends rejected (missing canonical developer index) → fixed via the shared projection, mirroring the HTTP-bridge caller, with a unit test proving the index is load-bearing. P2: policy-skipped owner could recover through coincidental quota status → fixed by gating on the selector's `preferred_account_unavailable` rejection cause, with an integration test.
3. P1: transport-stage Lite `reasoning.context` injection happens after the validated serialization → those mutations are proxy-injected, account-agnostic, and applied identically to owner and replay sends (the HTTP bridge applies the same shared gate to pre-transport serializations); spec/docstring now state that boundary precisely.

## Attribution

Carries forward the core diagnosis and recovery design from #1490. Credit to @Iweisc for the original fix and iteration, and @Komzpa for the continuation/rebase work; both are credited in the commit trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)