### PR TITLE
fix(server): serve h2c upgrade offers as plain HTTP/1.1 instead of rejecting them

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -126,14 +126,9 @@ def _load_graceful_drain_server():
 
 
 def _load_http_protocol_class() -> Any:
-    try:
-        from app.core.http_protocol import UpgradeTolerantHttpToolsProtocol
-    except ImportError:
-        # Without httptools uvicorn's "auto" selection falls back to the
-        # pure-Python h11 implementation, which already serves non-WebSocket
-        # upgrade offers (h2c) as plain HTTP/1.1.
-        return "auto"
-    return UpgradeTolerantHttpToolsProtocol
+    from app.core.http_protocol import load_http_protocol_class
+
+    return load_http_protocol_class()
 
 
 def _load_shutdown_drain_timeout_seconds() -> int:

--- a/app/cli.py
+++ b/app/cli.py
@@ -125,6 +125,17 @@ def _load_graceful_drain_server():
     return GracefulDrainServer
 
 
+def _load_http_protocol_class() -> Any:
+    try:
+        from app.core.http_protocol import UpgradeTolerantHttpToolsProtocol
+    except ImportError:
+        # Without httptools uvicorn's "auto" selection falls back to the
+        # pure-Python h11 implementation, which already serves non-WebSocket
+        # upgrade offers (h2c) as plain HTTP/1.1.
+        return "auto"
+    return UpgradeTolerantHttpToolsProtocol
+
+
 def _load_shutdown_drain_timeout_seconds() -> int:
     from app.core.config.settings import get_settings
 
@@ -140,6 +151,11 @@ def _run_server(app: str, **kwargs: Any) -> None:
         # this explicitly prevents Uvicorn from treating ambient
         # WEB_CONCURRENCY as an unsupported multiprocess launch.
         workers=1,
+        # Serve valid HTTP/1.1 requests that opportunistically offer an h2c
+        # upgrade (JetBrains/Ktor clients) instead of rejecting them; the
+        # stock httptools protocol drops the body or answers 400. See
+        # app/core/http_protocol.py and issue #1757.
+        http=_load_http_protocol_class(),
         timeout_graceful_shutdown=drain_timeout_seconds,
         **kwargs,
     )

--- a/app/core/http_protocol.py
+++ b/app/core/http_protocol.py
@@ -83,10 +83,20 @@ class UpgradeTolerantH11Protocol(H11Protocol):
     """
 
     def _should_upgrade(self) -> bool:
-        if offers_ignorable_upgrade(self.headers):
-            self.headers[:] = without_upgrade_headers(self.headers)
+        # Reimplements the stock decision on top of combined Connection fields
+        # (RFC 9110 section 5.3): the stock ``_get_upgrade`` keeps only the
+        # last field's tokens, so ``Connection: Upgrade`` followed by
+        # ``Connection: keep-alive`` would hide the offer entirely.
+        upgrade = combined_upgrade_offer(self.headers)
+        if upgrade is None:
             return False
-        return super()._should_upgrade()
+        if upgrade == b"websocket":
+            if self._should_upgrade_to_ws():
+                return True
+            self._unsupported_upgrade_warning()
+            return False
+        self.headers[:] = without_upgrade_headers(self.headers)
+        return False
 
 
 def load_http_protocol_class() -> type[asyncio.Protocol]:

--- a/app/core/http_protocol.py
+++ b/app/core/http_protocol.py
@@ -1,145 +1,100 @@
-"""Uvicorn HTTP protocol that tolerates opportunistic non-WebSocket upgrade offers.
+"""Uvicorn HTTP protocol selection tolerant of opportunistic upgrade offers.
 
-Uvicorn's ``auto`` HTTP implementation picks the ``httptools`` parser whenever
-the ``httptools`` package is importable (it is, transitively via
-``fastapi[standard]``). That parser treats *any* HTTP/1.1 request carrying
-``Connection: Upgrade`` as a protocol switch: httptools raises
-``HttpParserUpgrade`` at the end of the headers, never delivers the body, and
-uvicorn only handles the WebSocket case. For every other ``Upgrade`` offer —
-most notably the cleartext HTTP/2 (``h2c``) offer JetBrains/Ktor clients attach
-to ordinary Responses API POSTs — uvicorn logs "Unsupported upgrade request."
-and stops feeding the parser. Two failure shapes follow:
+JetBrains/Ktor clients attach cleartext HTTP/2 upgrade headers
+(``Connection: Upgrade, HTTP2-Settings`` + ``Upgrade: h2c`` +
+``HTTP2-Settings``) to ordinary HTTP/1.1 Responses API POSTs. RFC 9110
+section 7.8 lets a server ignore such an offer and answer over HTTP/1.1 —
+upstream OpenAI endpoints do exactly that — but uvicorn's stock protocol
+implementations either wedge on the offer (httptools) or leak the declined
+offer's hop-by-hop headers into the ASGI scope (h11). See
+https://github.com/Soju06/codex-lb/issues/1757 and the module docstring of
+``app.core.http_protocol_httptools`` for the full failure analysis.
 
-- body coalesced with the headers: the body is silently dropped, so the
-  application sees an empty body (422 from request validation);
-- headers and body written as separate segments (Ktor's write pattern): the
-  next bytes hit the wedged parser, ``HttpParserError`` follows, and the client
-  receives ``400 Bad Request / Invalid HTTP request received.``
-
-RFC 9110 section 7.8 lets a server ignore an upgrade offer and answer over
-HTTP/1.1 — upstream OpenAI endpoints do exactly that. This subclass neutralizes
-non-WebSocket upgrade offers: the request head is replayed through a fresh
-parser with the declined offer's hop-by-hop headers removed, and the request is
-served as plain HTTP/1.1. Legitimate WebSocket upgrades keep the stock path.
-
-See https://github.com/Soju06/codex-lb/issues/1757.
+This module exposes :func:`load_http_protocol_class`, which returns the
+tolerant httptools subclass when httptools is importable (matching uvicorn's
+``auto`` preference) and an h11 subclass with the same header hygiene
+otherwise.
 """
 
 from __future__ import annotations
 
-import httptools
-from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
+import asyncio
+
+from uvicorn.protocols.http.h11_impl import H11Protocol
 
 # Hop-by-hop headers that only exist to carry the declined protocol switch.
 # ``HTTP2-Settings`` is defined exclusively for the h2c upgrade (RFC 9113
 # section 3.1) and MUST NOT be forwarded once the offer is declined.
-_UPGRADE_HOP_BY_HOP_HEADERS = frozenset({b"upgrade", b"http2-settings"})
+UPGRADE_HOP_BY_HOP_HEADERS = frozenset({b"upgrade", b"http2-settings"})
 
 
-class UpgradeTolerantHttpToolsProtocol(HttpToolsProtocol):
-    """httptools protocol that serves non-WebSocket upgrade offers as HTTP/1.1."""
+def combined_upgrade_offer(headers: list[tuple[bytes, bytes]]) -> bytes | None:
+    """Return the offered ``Upgrade`` token, honoring repeated ``Connection`` fields.
 
-    def _active_parser(self) -> httptools.HttpRequestParser:
-        # The base class only clears ``self.parser`` in connection_lost, after
-        # which no parser callback or data_received can run.
-        parser = self.parser
-        assert parser is not None
-        return parser
+    Unlike uvicorn's ``_get_upgrade`` — which keeps only the tokens of the
+    *last* ``Connection`` field, so ``Connection: Upgrade`` followed by
+    ``Connection: keep-alive`` hides the offer — repeated fields are combined
+    per RFC 9110 section 5.3. Header names must already be lowercased (both
+    uvicorn implementations store them that way).
+    """
+    connection_tokens: list[bytes] = []
+    upgrade: bytes | None = None
+    for name, value in headers:
+        if name == b"connection":
+            connection_tokens.extend(token.lower().strip() for token in value.split(b","))
+        elif name == b"upgrade":
+            upgrade = value.lower()
+    if b"upgrade" in connection_tokens:
+        return upgrade
+    return None
 
-    def _offers_ignorable_upgrade(self) -> bool:
-        """True when the current request offers a non-WebSocket protocol switch."""
-        upgrade = self._get_upgrade()
-        return upgrade is not None and upgrade != b"websocket"
 
-    def _paused_on_ignorable_upgrade(self) -> bool:
-        return self._active_parser().should_upgrade() and self._offers_ignorable_upgrade()
+def offers_ignorable_upgrade(headers: list[tuple[bytes, bytes]]) -> bool:
+    """True when the request offers a non-WebSocket protocol switch (e.g. h2c)."""
+    upgrade = combined_upgrade_offer(headers)
+    return upgrade is not None and upgrade != b"websocket"
 
-    # -- Parser callbacks --------------------------------------------------
-    # For an upgrade-offering request httptools fires on_headers_complete and
-    # on_message_complete *before* feed_data raises HttpParserUpgrade, and it
-    # never delivers the body. The stock callbacks would therefore start the
-    # ASGI cycle with an empty-but-complete body. Defer instead: data_received
-    # replays the sanitized request through a fresh parser, and these callbacks
-    # then run with ``should_upgrade()`` false.
 
-    def on_headers_complete(self) -> None:
-        if self._paused_on_ignorable_upgrade():
-            return
-        super().on_headers_complete()
-
-    def on_body(self, body: bytes) -> None:
-        if self._paused_on_ignorable_upgrade():
-            return
-        super().on_body(body)
-
-    def on_message_complete(self) -> None:
-        if self._paused_on_ignorable_upgrade():
-            return
-        super().on_message_complete()
-
-    def data_received(self, data: bytes) -> None:
-        # Mirrors HttpToolsProtocol.data_received; the upgrade branch cannot be
-        # intercepted from outside because the stock method swallows the
-        # HttpParserUpgrade exception itself.
-        self._unset_keepalive_if_required()
-
-        try:
-            self._active_parser().feed_data(data)
-        except httptools.HttpParserError:
-            msg = "Invalid HTTP request received."
-            self.logger.warning(msg)
-            self.send_400_response(msg)
-        except httptools.HttpParserUpgrade as exc:
-            if self._should_upgrade():
-                self.handle_websocket_upgrade()
-            elif self._offers_ignorable_upgrade():
-                self._continue_as_plain_http(data, exc)
-            else:
-                self._unsupported_upgrade_warning()
-
-    def _continue_as_plain_http(self, data: bytes, exc: httptools.HttpParserUpgrade) -> None:
-        """Decline the offered protocol switch and serve the request as HTTP/1.1."""
-        self.logger.debug(
-            "Ignoring unsupported upgrade offer %r; serving the request as plain HTTP/1.1.",
-            self._get_upgrade(),
-        )
-        # httptools pauses at the end of the headers; the exception argument is
-        # the offset of the first unparsed byte in this segment (the body when
-        # it arrived coalesced with the headers).
-        offset = exc.args[0] if exc.args else len(data)
-        head = self._sanitized_request_head()
-        self.parser = httptools.HttpRequestParser(self)
-        try:
-            self.parser.set_dangerous_leniencies(lenient_data_after_close=True)
-        except AttributeError:  # pragma: no cover - httptools < 0.6.3
-            pass
-        # Recurse with the rebuilt request. The sanitized head no longer
-        # carries upgrade headers, so this parse cannot raise
-        # HttpParserUpgrade again; malformed leftover bytes keep the stock 400
-        # handling. Later segments of a split request feed the fresh parser
-        # through the normal data_received path.
-        self.data_received(head + data[offset:])
-
-    def _sanitized_request_head(self) -> bytes:
-        """Rebuild the parsed request head without the declined upgrade offer.
-
-        ``self.url`` and ``self.headers`` were accumulated by the parser
-        callbacks of the aborted parse (header names already lowercased), so
-        the head is complete even when the client split it across segments.
-        """
-        parser = self._active_parser()
-        method = parser.get_method()
-        http_version = parser.get_http_version().encode("ascii")
-        lines = [b"%s %s HTTP/%s\r\n" % (method, self.url, http_version)]
-        for name, value in self.headers:
-            if name in _UPGRADE_HOP_BY_HOP_HEADERS:
+def without_upgrade_headers(headers: list[tuple[bytes, bytes]]) -> list[tuple[bytes, bytes]]:
+    """Drop the declined offer's hop-by-hop headers and ``Connection`` tokens."""
+    sanitized: list[tuple[bytes, bytes]] = []
+    for name, value in headers:
+        if name in UPGRADE_HOP_BY_HOP_HEADERS:
+            continue
+        if name == b"connection":
+            tokens = [token.strip() for token in value.split(b",")]
+            kept = [token for token in tokens if token and token.lower() not in UPGRADE_HOP_BY_HOP_HEADERS]
+            if not kept:
                 continue
-            if name == b"connection":
-                tokens = [token.strip() for token in value.split(b",")]
-                kept = [token for token in tokens if token and token.lower() not in _UPGRADE_HOP_BY_HOP_HEADERS]
-                if not kept:
-                    continue
-                value = b", ".join(kept)
-            lines.append(b"%s: %s\r\n" % (name, value))
-        lines.append(b"\r\n")
-        return b"".join(lines)
+            value = b", ".join(kept)
+        sanitized.append((name, value))
+    return sanitized
+
+
+class UpgradeTolerantH11Protocol(H11Protocol):
+    """h11 protocol that hides declined non-WebSocket upgrade offers from the app.
+
+    The stock h11 implementation already serves such requests as plain
+    HTTP/1.1 with the full body, but it exposes the declined offer's
+    hop-by-hop headers in the ASGI scope and logs a spurious
+    "Unsupported upgrade request." warning. ``_should_upgrade`` is the seam:
+    it runs right after ``self.headers`` (the same list object referenced by
+    ``scope["headers"]``) is populated, so sanitizing in place here is enough.
+    """
+
+    def _should_upgrade(self) -> bool:
+        if offers_ignorable_upgrade(self.headers):
+            self.headers[:] = without_upgrade_headers(self.headers)
+            return False
+        return super()._should_upgrade()
+
+
+def load_http_protocol_class() -> type[asyncio.Protocol]:
+    """Return the HTTP protocol implementation for ``uvicorn.Config(http=...)``."""
+    try:
+        from app.core.http_protocol_httptools import UpgradeTolerantHttpToolsProtocol
+    except ImportError:
+        # httptools is an optional (transitive) dependency; uvicorn's "auto"
+        # selection would fall back to h11 as well.
+        return UpgradeTolerantH11Protocol
+    return UpgradeTolerantHttpToolsProtocol

--- a/app/core/http_protocol.py
+++ b/app/core/http_protocol.py
@@ -1,0 +1,145 @@
+"""Uvicorn HTTP protocol that tolerates opportunistic non-WebSocket upgrade offers.
+
+Uvicorn's ``auto`` HTTP implementation picks the ``httptools`` parser whenever
+the ``httptools`` package is importable (it is, transitively via
+``fastapi[standard]``). That parser treats *any* HTTP/1.1 request carrying
+``Connection: Upgrade`` as a protocol switch: httptools raises
+``HttpParserUpgrade`` at the end of the headers, never delivers the body, and
+uvicorn only handles the WebSocket case. For every other ``Upgrade`` offer —
+most notably the cleartext HTTP/2 (``h2c``) offer JetBrains/Ktor clients attach
+to ordinary Responses API POSTs — uvicorn logs "Unsupported upgrade request."
+and stops feeding the parser. Two failure shapes follow:
+
+- body coalesced with the headers: the body is silently dropped, so the
+  application sees an empty body (422 from request validation);
+- headers and body written as separate segments (Ktor's write pattern): the
+  next bytes hit the wedged parser, ``HttpParserError`` follows, and the client
+  receives ``400 Bad Request / Invalid HTTP request received.``
+
+RFC 9110 section 7.8 lets a server ignore an upgrade offer and answer over
+HTTP/1.1 — upstream OpenAI endpoints do exactly that. This subclass neutralizes
+non-WebSocket upgrade offers: the request head is replayed through a fresh
+parser with the declined offer's hop-by-hop headers removed, and the request is
+served as plain HTTP/1.1. Legitimate WebSocket upgrades keep the stock path.
+
+See https://github.com/Soju06/codex-lb/issues/1757.
+"""
+
+from __future__ import annotations
+
+import httptools
+from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
+
+# Hop-by-hop headers that only exist to carry the declined protocol switch.
+# ``HTTP2-Settings`` is defined exclusively for the h2c upgrade (RFC 9113
+# section 3.1) and MUST NOT be forwarded once the offer is declined.
+_UPGRADE_HOP_BY_HOP_HEADERS = frozenset({b"upgrade", b"http2-settings"})
+
+
+class UpgradeTolerantHttpToolsProtocol(HttpToolsProtocol):
+    """httptools protocol that serves non-WebSocket upgrade offers as HTTP/1.1."""
+
+    def _active_parser(self) -> httptools.HttpRequestParser:
+        # The base class only clears ``self.parser`` in connection_lost, after
+        # which no parser callback or data_received can run.
+        parser = self.parser
+        assert parser is not None
+        return parser
+
+    def _offers_ignorable_upgrade(self) -> bool:
+        """True when the current request offers a non-WebSocket protocol switch."""
+        upgrade = self._get_upgrade()
+        return upgrade is not None and upgrade != b"websocket"
+
+    def _paused_on_ignorable_upgrade(self) -> bool:
+        return self._active_parser().should_upgrade() and self._offers_ignorable_upgrade()
+
+    # -- Parser callbacks --------------------------------------------------
+    # For an upgrade-offering request httptools fires on_headers_complete and
+    # on_message_complete *before* feed_data raises HttpParserUpgrade, and it
+    # never delivers the body. The stock callbacks would therefore start the
+    # ASGI cycle with an empty-but-complete body. Defer instead: data_received
+    # replays the sanitized request through a fresh parser, and these callbacks
+    # then run with ``should_upgrade()`` false.
+
+    def on_headers_complete(self) -> None:
+        if self._paused_on_ignorable_upgrade():
+            return
+        super().on_headers_complete()
+
+    def on_body(self, body: bytes) -> None:
+        if self._paused_on_ignorable_upgrade():
+            return
+        super().on_body(body)
+
+    def on_message_complete(self) -> None:
+        if self._paused_on_ignorable_upgrade():
+            return
+        super().on_message_complete()
+
+    def data_received(self, data: bytes) -> None:
+        # Mirrors HttpToolsProtocol.data_received; the upgrade branch cannot be
+        # intercepted from outside because the stock method swallows the
+        # HttpParserUpgrade exception itself.
+        self._unset_keepalive_if_required()
+
+        try:
+            self._active_parser().feed_data(data)
+        except httptools.HttpParserError:
+            msg = "Invalid HTTP request received."
+            self.logger.warning(msg)
+            self.send_400_response(msg)
+        except httptools.HttpParserUpgrade as exc:
+            if self._should_upgrade():
+                self.handle_websocket_upgrade()
+            elif self._offers_ignorable_upgrade():
+                self._continue_as_plain_http(data, exc)
+            else:
+                self._unsupported_upgrade_warning()
+
+    def _continue_as_plain_http(self, data: bytes, exc: httptools.HttpParserUpgrade) -> None:
+        """Decline the offered protocol switch and serve the request as HTTP/1.1."""
+        self.logger.debug(
+            "Ignoring unsupported upgrade offer %r; serving the request as plain HTTP/1.1.",
+            self._get_upgrade(),
+        )
+        # httptools pauses at the end of the headers; the exception argument is
+        # the offset of the first unparsed byte in this segment (the body when
+        # it arrived coalesced with the headers).
+        offset = exc.args[0] if exc.args else len(data)
+        head = self._sanitized_request_head()
+        self.parser = httptools.HttpRequestParser(self)
+        try:
+            self.parser.set_dangerous_leniencies(lenient_data_after_close=True)
+        except AttributeError:  # pragma: no cover - httptools < 0.6.3
+            pass
+        # Recurse with the rebuilt request. The sanitized head no longer
+        # carries upgrade headers, so this parse cannot raise
+        # HttpParserUpgrade again; malformed leftover bytes keep the stock 400
+        # handling. Later segments of a split request feed the fresh parser
+        # through the normal data_received path.
+        self.data_received(head + data[offset:])
+
+    def _sanitized_request_head(self) -> bytes:
+        """Rebuild the parsed request head without the declined upgrade offer.
+
+        ``self.url`` and ``self.headers`` were accumulated by the parser
+        callbacks of the aborted parse (header names already lowercased), so
+        the head is complete even when the client split it across segments.
+        """
+        parser = self._active_parser()
+        method = parser.get_method()
+        http_version = parser.get_http_version().encode("ascii")
+        lines = [b"%s %s HTTP/%s\r\n" % (method, self.url, http_version)]
+        for name, value in self.headers:
+            if name in _UPGRADE_HOP_BY_HOP_HEADERS:
+                continue
+            if name == b"connection":
+                tokens = [token.strip() for token in value.split(b",")]
+                kept = [token for token in tokens if token and token.lower() not in _UPGRADE_HOP_BY_HOP_HEADERS]
+                if not kept:
+                    continue
+                value = b", ".join(kept)
+            lines.append(b"%s: %s\r\n" % (name, value))
+        lines.append(b"\r\n")
+        return b"".join(lines)

--- a/app/core/http_protocol.py
+++ b/app/core/http_protocol.py
@@ -29,24 +29,31 @@ UPGRADE_HOP_BY_HOP_HEADERS = frozenset({b"upgrade", b"http2-settings"})
 
 
 def combined_upgrade_offer(headers: list[tuple[bytes, bytes]]) -> bytes | None:
-    """Return the offered ``Upgrade`` token, honoring repeated ``Connection`` fields.
+    """Return the accepted ``Upgrade`` token, honoring repeated/list-valued fields.
 
     Unlike uvicorn's ``_get_upgrade`` — which keeps only the tokens of the
-    *last* ``Connection`` field, so ``Connection: Upgrade`` followed by
-    ``Connection: keep-alive`` hides the offer — repeated fields are combined
-    per RFC 9110 section 5.3. Header names must already be lowercased (both
-    uvicorn implementations store them that way).
+    *last* ``Connection`` field (so ``Connection: Upgrade`` followed by
+    ``Connection: keep-alive`` hides the offer) and the last ``Upgrade``
+    field's raw value (so ``Upgrade: websocket, h2c`` matches nothing) —
+    repeated fields are combined per RFC 9110 section 5.3 and the ``Upgrade``
+    protocol list is tokenized per section 7.8. ``websocket`` is returned
+    whenever it is among the offered protocols (the server may pick any
+    offered protocol it supports); otherwise the client's first preference is
+    returned. Header names must already be lowercased (both uvicorn
+    implementations store them that way).
     """
     connection_tokens: list[bytes] = []
-    upgrade: bytes | None = None
+    upgrade_tokens: list[bytes] = []
     for name, value in headers:
         if name == b"connection":
             connection_tokens.extend(token.lower().strip() for token in value.split(b","))
         elif name == b"upgrade":
-            upgrade = value.lower()
-    if b"upgrade" in connection_tokens:
-        return upgrade
-    return None
+            upgrade_tokens.extend(token for token in (token.lower().strip() for token in value.split(b",")) if token)
+    if b"upgrade" not in connection_tokens or not upgrade_tokens:
+        return None
+    if b"websocket" in upgrade_tokens:
+        return b"websocket"
+    return upgrade_tokens[0]
 
 
 def offers_ignorable_upgrade(headers: list[tuple[bytes, bytes]]) -> bool:

--- a/app/core/http_protocol_httptools.py
+++ b/app/core/http_protocol_httptools.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import httptools
 from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
 
-from app.core.http_protocol import offers_ignorable_upgrade, without_upgrade_headers
+from app.core.http_protocol import combined_upgrade_offer, offers_ignorable_upgrade, without_upgrade_headers
 
 
 class UpgradeTolerantHttpToolsProtocol(HttpToolsProtocol):
@@ -42,6 +42,14 @@ class UpgradeTolerantHttpToolsProtocol(HttpToolsProtocol):
         parser = self.parser
         assert parser is not None
         return parser
+
+    def _should_upgrade(self) -> bool:
+        # Combine repeated Connection fields (RFC 9110 section 5.3) so a
+        # trailing ``Connection: keep-alive`` field cannot hide a WebSocket
+        # handshake from the protocol switch (the stock ``_get_upgrade`` keeps
+        # only the last field's tokens). Also used by the stock parser
+        # callbacks to defer body handling until the handoff.
+        return combined_upgrade_offer(self.headers) == b"websocket" and self._should_upgrade_to_ws()
 
     def _paused_on_ignorable_upgrade(self) -> bool:
         return self._active_parser().should_upgrade() and offers_ignorable_upgrade(self.headers)

--- a/app/core/http_protocol_httptools.py
+++ b/app/core/http_protocol_httptools.py
@@ -1,0 +1,127 @@
+"""Uvicorn httptools protocol that tolerates non-WebSocket upgrade offers.
+
+Uvicorn's ``auto`` HTTP implementation picks the ``httptools`` parser whenever
+the ``httptools`` package is importable (it is, transitively via
+``fastapi[standard]``). That parser treats *any* HTTP/1.1 request carrying
+``Connection: Upgrade`` as a protocol switch: httptools raises
+``HttpParserUpgrade`` at the end of the headers, never delivers the body, and
+uvicorn only handles the WebSocket case. For every other ``Upgrade`` offer —
+most notably the cleartext HTTP/2 (``h2c``) offer JetBrains/Ktor clients attach
+to ordinary Responses API POSTs — uvicorn logs "Unsupported upgrade request."
+and stops feeding the parser. Two failure shapes follow:
+
+- body coalesced with the headers: the body is silently dropped, so the
+  application sees an empty body (422 from request validation);
+- headers and body written as separate segments (Ktor's write pattern): the
+  next bytes hit the wedged parser, ``HttpParserError`` follows, and the client
+  receives ``400 Bad Request / Invalid HTTP request received.``
+
+RFC 9110 section 7.8 lets a server ignore an upgrade offer and answer over
+HTTP/1.1 — upstream OpenAI endpoints do exactly that. This subclass neutralizes
+non-WebSocket upgrade offers: the request head is replayed through a fresh
+parser with the declined offer's hop-by-hop headers removed, and the request is
+served as plain HTTP/1.1. Legitimate WebSocket upgrades keep the stock path.
+
+See https://github.com/Soju06/codex-lb/issues/1757.
+"""
+
+from __future__ import annotations
+
+import httptools
+from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
+
+from app.core.http_protocol import offers_ignorable_upgrade, without_upgrade_headers
+
+
+class UpgradeTolerantHttpToolsProtocol(HttpToolsProtocol):
+    """httptools protocol that serves non-WebSocket upgrade offers as HTTP/1.1."""
+
+    def _active_parser(self) -> httptools.HttpRequestParser:
+        # The base class only clears ``self.parser`` in connection_lost, after
+        # which no parser callback or data_received can run.
+        parser = self.parser
+        assert parser is not None
+        return parser
+
+    def _paused_on_ignorable_upgrade(self) -> bool:
+        return self._active_parser().should_upgrade() and offers_ignorable_upgrade(self.headers)
+
+    # -- Parser callbacks --------------------------------------------------
+    # For an upgrade-offering request httptools fires on_headers_complete and
+    # on_message_complete *before* feed_data raises HttpParserUpgrade, and it
+    # never delivers the body. The stock callbacks would therefore start the
+    # ASGI cycle with an empty-but-complete body. Defer instead: data_received
+    # replays the sanitized request through a fresh parser, and these callbacks
+    # then run with ``should_upgrade()`` false.
+
+    def on_headers_complete(self) -> None:
+        if self._paused_on_ignorable_upgrade():
+            return
+        super().on_headers_complete()
+
+    def on_body(self, body: bytes) -> None:
+        if self._paused_on_ignorable_upgrade():
+            return
+        super().on_body(body)
+
+    def on_message_complete(self) -> None:
+        if self._paused_on_ignorable_upgrade():
+            return
+        super().on_message_complete()
+
+    def data_received(self, data: bytes) -> None:
+        # Mirrors HttpToolsProtocol.data_received; the upgrade branch cannot be
+        # intercepted from outside because the stock method swallows the
+        # HttpParserUpgrade exception itself.
+        self._unset_keepalive_if_required()
+
+        try:
+            self._active_parser().feed_data(data)
+        except httptools.HttpParserError:
+            msg = "Invalid HTTP request received."
+            self.logger.warning(msg)
+            self.send_400_response(msg)
+        except httptools.HttpParserUpgrade as exc:
+            if self._should_upgrade():
+                self.handle_websocket_upgrade()
+            elif offers_ignorable_upgrade(self.headers):
+                self._continue_as_plain_http(data, exc)
+            else:
+                self._unsupported_upgrade_warning()
+
+    def _continue_as_plain_http(self, data: bytes, exc: httptools.HttpParserUpgrade) -> None:
+        """Decline the offered protocol switch and serve the request as HTTP/1.1."""
+        self.logger.debug(
+            "Ignoring unsupported upgrade offer; serving the request as plain HTTP/1.1.",
+        )
+        # httptools pauses at the end of the headers; the exception argument is
+        # the offset of the first unparsed byte in this segment (the body when
+        # it arrived coalesced with the headers).
+        offset = exc.args[0] if exc.args else len(data)
+        head = self._sanitized_request_head()
+        self.parser = httptools.HttpRequestParser(self)
+        try:
+            self.parser.set_dangerous_leniencies(lenient_data_after_close=True)
+        except AttributeError:  # pragma: no cover - httptools < 0.6.3
+            pass
+        # Recurse with the rebuilt request. The sanitized head no longer
+        # carries upgrade headers, so this parse cannot raise
+        # HttpParserUpgrade again; malformed leftover bytes keep the stock 400
+        # handling. Later segments of a split request feed the fresh parser
+        # through the normal data_received path.
+        self.data_received(head + data[offset:])
+
+    def _sanitized_request_head(self) -> bytes:
+        """Rebuild the parsed request head without the declined upgrade offer.
+
+        ``self.url`` and ``self.headers`` were accumulated by the parser
+        callbacks of the aborted parse (header names already lowercased), so
+        the head is complete even when the client split it across segments.
+        """
+        parser = self._active_parser()
+        method = parser.get_method()
+        http_version = parser.get_http_version().encode("ascii")
+        lines = [b"%s %s HTTP/%s\r\n" % (method, self.url, http_version)]
+        lines.extend(b"%s: %s\r\n" % (name, value) for name, value in without_upgrade_headers(self.headers))
+        lines.append(b"\r\n")
+        return b"".join(lines)

--- a/app/core/http_protocol_httptools.py
+++ b/app/core/http_protocol_httptools.py
@@ -83,22 +83,32 @@ class UpgradeTolerantHttpToolsProtocol(HttpToolsProtocol):
         # HttpParserUpgrade exception itself.
         self._unset_keepalive_if_required()
 
-        try:
-            self._active_parser().feed_data(data)
-        except httptools.HttpParserError:
-            msg = "Invalid HTTP request received."
-            self.logger.warning(msg)
-            self.send_400_response(msg)
-        except httptools.HttpParserUpgrade as exc:
-            if self._should_upgrade():
-                self.handle_websocket_upgrade()
-            elif offers_ignorable_upgrade(self.headers):
-                self._continue_as_plain_http(data, exc)
-            else:
-                self._unsupported_upgrade_warning()
+        # Replay declined offers iteratively, not recursively: a single
+        # segment can pipeline many upgrade-offering requests (one replay
+        # each), so recursion depth would be attacker-controlled — ~66KB of
+        # minimal h2c GETs already exceeds Python's default 1000-frame limit,
+        # and the RecursionError would escape into the event loop and abort
+        # the connection. Each replay strips at least one declined offer from
+        # ``data``, so the loop terminates.
+        while True:
+            try:
+                self._active_parser().feed_data(data)
+            except httptools.HttpParserError:
+                msg = "Invalid HTTP request received."
+                self.logger.warning(msg)
+                self.send_400_response(msg)
+            except httptools.HttpParserUpgrade as exc:
+                if self._should_upgrade():
+                    self.handle_websocket_upgrade()
+                elif offers_ignorable_upgrade(self.headers):
+                    data = self._continue_as_plain_http(data, exc)
+                    continue
+                else:
+                    self._unsupported_upgrade_warning()
+            return
 
-    def _continue_as_plain_http(self, data: bytes, exc: httptools.HttpParserUpgrade) -> None:
-        """Decline the offered protocol switch and serve the request as HTTP/1.1."""
+    def _continue_as_plain_http(self, data: bytes, exc: httptools.HttpParserUpgrade) -> bytes:
+        """Decline the offered protocol switch; return the bytes to re-feed as HTTP/1.1."""
         self.logger.debug(
             "Ignoring unsupported upgrade offer; serving the request as plain HTTP/1.1.",
         )
@@ -112,12 +122,13 @@ class UpgradeTolerantHttpToolsProtocol(HttpToolsProtocol):
             self.parser.set_dangerous_leniencies(lenient_data_after_close=True)
         except AttributeError:  # pragma: no cover - httptools < 0.6.3
             pass
-        # Recurse with the rebuilt request. The sanitized head no longer
-        # carries upgrade headers, so this parse cannot raise
-        # HttpParserUpgrade again; malformed leftover bytes keep the stock 400
+        # The sanitized head no longer carries upgrade headers, so re-feeding
+        # it cannot pause the fresh parser on the same offer (a *pipelined*
+        # follow-up offer pauses again and takes another loop iteration in
+        # data_received); malformed leftover bytes keep the stock 400
         # handling. Later segments of a split request feed the fresh parser
         # through the normal data_received path.
-        self.data_received(head + data[offset:])
+        return head + data[offset:]
 
     def _sanitized_request_head(self) -> bytes:
         """Rebuild the parsed request head without the declined upgrade offer.

--- a/openspec/changes/serve-h2c-upgrade-offers-as-http11/proposal.md
+++ b/openspec/changes/serve-h2c-upgrade-offers-as-http11/proposal.md
@@ -36,6 +36,8 @@ offer and answer over HTTP/1.1, which is what upstream OpenAI endpoints do.
 
 ## Impact
 
-`app/cli.py` server bootstrap and a new `app/core/http_protocol.py` uvicorn
-protocol subclass, plus transport-level regression coverage. No dashboard,
-API, schema, or configuration change.
+`app/cli.py` server bootstrap and new `app/core/http_protocol.py` /
+`app/core/http_protocol_httptools.py` uvicorn protocol subclasses (the h11
+variant covers the httptools-less fallback with the same header hygiene), plus
+transport-level regression coverage. No dashboard, API, schema, or
+configuration change.

--- a/openspec/changes/serve-h2c-upgrade-offers-as-http11/proposal.md
+++ b/openspec/changes/serve-h2c-upgrade-offers-as-http11/proposal.md
@@ -1,0 +1,41 @@
+# Serve h2c Upgrade Offers as Plain HTTP/1.1
+
+## Why
+
+JetBrains/Ktor clients attach opportunistic cleartext HTTP/2 upgrade headers
+(`Connection: Upgrade, HTTP2-Settings` + `Upgrade: h2c` + `HTTP2-Settings`) to
+ordinary HTTP/1.1 Responses API POSTs. The server's httptools-based HTTP parser
+treats any such request as a protocol switch and wedges: a body coalesced with
+the headers is silently dropped (the application validates an empty body and
+returns 422), and a body written as a separate segment — Ktor's write pattern —
+is answered with `400 Invalid HTTP request received.` before authentication
+ever runs (issue #1757). RFC 9110 §7.8 allows a server to ignore an upgrade
+offer and answer over HTTP/1.1, which is what upstream OpenAI endpoints do.
+
+## What Changes
+
+- Serve valid HTTP/1.1 requests that offer a non-WebSocket protocol switch
+  (such as `h2c`) as normal HTTP/1.1 requests, with the full body delivered to
+  the application for both client segmentations.
+- Strip the declined offer's hop-by-hop headers (`Upgrade`, `HTTP2-Settings`,
+  and their `Connection` tokens) before the request reaches the application.
+- Keep genuine WebSocket upgrades switching protocols exactly as today.
+- No new settings, budgets, or defaults; no API or schema change.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `http-ingress-limits`: raw HTTP ingress MUST serve non-WebSocket HTTP/1.1
+  upgrade offers as plain HTTP/1.1 instead of dropping the body or rejecting
+  the request.
+
+## Impact
+
+`app/cli.py` server bootstrap and a new `app/core/http_protocol.py` uvicorn
+protocol subclass, plus transport-level regression coverage. No dashboard,
+API, schema, or configuration change.

--- a/openspec/changes/serve-h2c-upgrade-offers-as-http11/specs/http-ingress-limits/spec.md
+++ b/openspec/changes/serve-h2c-upgrade-offers-as-http11/specs/http-ingress-limits/spec.md
@@ -1,0 +1,43 @@
+# http-ingress-limits Delta
+
+## ADDED Requirements
+
+### Requirement: Non-WebSocket upgrade offers are served as plain HTTP/1.1
+
+The server MUST serve a valid HTTP/1.1 request that offers a non-WebSocket
+protocol switch (`Connection: Upgrade` with an `Upgrade` token other than
+`websocket`, such as `h2c`) as a normal HTTP/1.1 request. The complete request
+body MUST reach the application whether it arrives coalesced with the headers
+or in later TCP segments, and the offer MUST NOT cause the request or the
+connection to be rejected. The declined offer's hop-by-hop headers (`Upgrade`,
+`HTTP2-Settings`, and their `Connection` tokens) MUST NOT be exposed to the
+application. Genuine WebSocket upgrade requests MUST keep completing the
+protocol switch.
+
+#### Scenario: h2c offer with the body coalesced with the headers
+
+- **WHEN** a client sends an HTTP/1.1 POST carrying `Connection: Upgrade,
+  HTTP2-Settings`, `Upgrade: h2c`, and `HTTP2-Settings` headers with the body
+  in the same TCP segment as the headers
+- **THEN** the application receives the complete request body
+- **AND** the application does not observe the `Upgrade`, `HTTP2-Settings`, or
+  `Connection: Upgrade` headers
+
+#### Scenario: h2c offer with the body in a separate segment
+
+- **WHEN** the same request arrives with the headers and the body written as
+  separate TCP segments
+- **THEN** the application receives the complete request body
+- **AND** the server does not answer `400 Bad Request` at the protocol layer
+
+#### Scenario: Connection stays usable after a declined offer
+
+- **WHEN** a request with a declined h2c offer completes on a keep-alive
+  connection
+- **THEN** a subsequent plain HTTP/1.1 request on the same connection is
+  served normally
+
+#### Scenario: WebSocket upgrades still switch protocols
+
+- **WHEN** a client requests a WebSocket upgrade (`Upgrade: websocket`)
+- **THEN** the protocol switch completes and WebSocket messages flow

--- a/openspec/changes/serve-h2c-upgrade-offers-as-http11/specs/http-ingress-limits/spec.md
+++ b/openspec/changes/serve-h2c-upgrade-offers-as-http11/specs/http-ingress-limits/spec.md
@@ -30,6 +30,14 @@ protocol switch.
 - **THEN** the application receives the complete request body
 - **AND** the server does not answer `400 Bad Request` at the protocol layer
 
+#### Scenario: Repeated Connection fields do not hide the offer
+
+- **WHEN** the h2c offer arrives with `Connection: Upgrade, HTTP2-Settings`
+  followed by a second `Connection: keep-alive` field
+- **THEN** the application receives the complete request body
+- **AND** the surviving `Connection` tokens (such as `keep-alive`) are
+  preserved while the upgrade tokens are removed
+
 #### Scenario: Connection stays usable after a declined offer
 
 - **WHEN** a request with a declined h2c offer completes on a keep-alive

--- a/openspec/changes/serve-h2c-upgrade-offers-as-http11/specs/http-ingress-limits/spec.md
+++ b/openspec/changes/serve-h2c-upgrade-offers-as-http11/specs/http-ingress-limits/spec.md
@@ -45,6 +45,12 @@ protocol switch.
 - **THEN** a subsequent plain HTTP/1.1 request on the same connection is
   served normally
 
+#### Scenario: Pipelined offers in one segment do not exhaust the server
+
+- **WHEN** a single TCP segment pipelines many upgrade-offering requests
+- **THEN** every request is served as plain HTTP/1.1 without the per-offer
+  replay growing the call stack or aborting the connection
+
 #### Scenario: WebSocket upgrades still switch protocols
 
 - **WHEN** a client requests a WebSocket upgrade (`Upgrade: websocket`)

--- a/openspec/changes/serve-h2c-upgrade-offers-as-http11/tasks.md
+++ b/openspec/changes/serve-h2c-upgrade-offers-as-http11/tasks.md
@@ -10,6 +10,10 @@
 - [x] 1.3 Classify upgrade offers by combining repeated `Connection` fields
       (RFC 9110 §5.3) so a second `Connection: keep-alive` field cannot hide
       the offer and reproduce the body loss.
+- [x] 1.4 Replay declined offers iteratively (loop in `data_received`) rather
+      than recursively, so a segment pipelining many upgrade-offering requests
+      cannot drive attacker-controlled recursion depth (RecursionError
+      escaping into the event loop) or pin per-frame byte copies.
 
 ## 2. Validation
 
@@ -20,5 +24,8 @@
 - [x] 2.2 Add a live-server regression over real sockets using the production
       protocol wiring, including a real WebSocket upgrade that must keep
       completing, plus a canary pinning the stock uvicorn defect.
-- [x] 2.3 Run focused tests, lint, type checks, and strict OpenSpec
+- [x] 2.3 Add a regression pipelining 2000 h2c offers in one segment: all are
+      served and the connection survives (raised RecursionError when the
+      replay was recursive).
+- [x] 2.4 Run focused tests, lint, type checks, and strict OpenSpec
       validation.

--- a/openspec/changes/serve-h2c-upgrade-offers-as-http11/tasks.md
+++ b/openspec/changes/serve-h2c-upgrade-offers-as-http11/tasks.md
@@ -4,8 +4,12 @@
       protocol: replay the request head without the declined offer's
       hop-by-hop headers and serve the request as plain HTTP/1.1.
 - [x] 1.2 Wire the tolerant protocol into the server bootstrap, falling back
-      to uvicorn's `auto` selection (h11 already behaves correctly) when
-      httptools is unavailable.
+      to an h11 subclass with the same header hygiene when httptools is
+      unavailable (stock h11 already delivers the body but exposes the
+      declined offer's headers).
+- [x] 1.3 Classify upgrade offers by combining repeated `Connection` fields
+      (RFC 9110 §5.3) so a second `Connection: keep-alive` field cannot hide
+      the offer and reproduce the body loss.
 
 ## 2. Validation
 

--- a/openspec/changes/serve-h2c-upgrade-offers-as-http11/tasks.md
+++ b/openspec/changes/serve-h2c-upgrade-offers-as-http11/tasks.md
@@ -1,0 +1,20 @@
+## 1. Implementation
+
+- [x] 1.1 Neutralize non-WebSocket upgrade offers in the httptools HTTP
+      protocol: replay the request head without the declined offer's
+      hop-by-hop headers and serve the request as plain HTTP/1.1.
+- [x] 1.2 Wire the tolerant protocol into the server bootstrap, falling back
+      to uvicorn's `auto` selection (h11 already behaves correctly) when
+      httptools is unavailable.
+
+## 2. Validation
+
+- [x] 2.1 Add transport-level regressions: h2c offer with coalesced
+      header/body and with split segments both reach the application with the
+      full body and succeed; the declined offer's headers are not exposed; the
+      connection stays reusable.
+- [x] 2.2 Add a live-server regression over real sockets using the production
+      protocol wiring, including a real WebSocket upgrade that must keep
+      completing, plus a canary pinning the stock uvicorn defect.
+- [x] 2.3 Run focused tests, lint, type checks, and strict OpenSpec
+      validation.

--- a/tests/integration/test_http_upgrade_tolerance.py
+++ b/tests/integration/test_http_upgrade_tolerance.py
@@ -29,7 +29,8 @@ from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
 from uvicorn.server import ServerState
 
 from app.cli import _load_http_protocol_class
-from app.core.http_protocol import UpgradeTolerantHttpToolsProtocol
+from app.core.http_protocol import UpgradeTolerantH11Protocol
+from app.core.http_protocol_httptools import UpgradeTolerantHttpToolsProtocol
 
 pytestmark = pytest.mark.integration
 
@@ -115,7 +116,7 @@ class _FakeTransport(asyncio.Transport):
         return default
 
 
-def _make_protocol(protocol_class: type[HttpToolsProtocol]) -> tuple[HttpToolsProtocol, _FakeTransport]:
+def _make_protocol(protocol_class: type[Any]) -> tuple[Any, _FakeTransport]:
     config = uvicorn.Config(app=_echo_app, lifespan="off")
     config.load()
     protocol = protocol_class(config=config, server_state=ServerState(), app_state={})
@@ -178,6 +179,57 @@ async def test_h2c_offer_keeps_connection_reusable_for_next_request() -> None:
     raw_response = await _wait_for_response(transport)
     assert raw_response.startswith(b"HTTP/1.1 200 OK"), raw_response
     assert _parse_json_body(raw_response)["echo"] == "hi"
+
+
+async def test_h2c_offer_with_repeated_connection_fields_is_served_as_http11() -> None:
+    """Repeated ``Connection`` fields must be combined when classifying the offer.
+
+    uvicorn's ``_get_upgrade`` keeps only the tokens of the last ``Connection``
+    field, so ``Connection: Upgrade`` followed by ``Connection: keep-alive``
+    would hide the offer and reproduce the original body loss.
+    """
+    head = (
+        b"POST /echo HTTP/1.1\r\n"
+        b"Host: 127.0.0.1\r\n"
+        b"Connection: Upgrade, HTTP2-Settings\r\n"
+        b"Upgrade: h2c\r\n"
+        b"HTTP2-Settings: AAMAAABkAARAAAAAAAIAAAAA\r\n"
+        b"Connection: keep-alive\r\n"
+        b"Content-Type: application/json\r\n"
+        b"Content-Length: " + str(len(_BODY)).encode() + b"\r\n"
+        b"\r\n"
+    )
+    protocol, transport = _make_protocol(UpgradeTolerantHttpToolsProtocol)
+
+    protocol.data_received(head)
+    await asyncio.sleep(0.01)
+    protocol.data_received(_BODY)
+
+    raw_response = await _wait_for_response(transport)
+    assert raw_response.startswith(b"HTTP/1.1 200 OK"), raw_response
+    payload = _parse_json_body(raw_response)
+    assert payload["echo"] == _BODY.decode()
+    assert "upgrade" not in payload["header_names"]
+    assert "http2-settings" not in payload["header_names"]
+    # The unrelated keep-alive token survives the sanitization.
+    assert "connection" in payload["header_names"]
+
+
+async def test_h11_fallback_serves_h2c_offer_and_hides_upgrade_headers() -> None:
+    """The httptools-less fallback keeps the body and the header hygiene."""
+    protocol, transport = _make_protocol(UpgradeTolerantH11Protocol)
+
+    protocol.data_received(_H2C_HEAD)
+    await asyncio.sleep(0.01)
+    protocol.data_received(_BODY)
+
+    raw_response = await _wait_for_response(transport)
+    assert raw_response.startswith(b"HTTP/1.1 200 OK"), raw_response
+    payload = _parse_json_body(raw_response)
+    assert payload["echo"] == _BODY.decode()
+    assert "upgrade" not in payload["header_names"]
+    assert "http2-settings" not in payload["header_names"]
+    assert "connection" not in payload["header_names"]
 
 
 async def test_stock_httptools_protocol_still_breaks_on_h2c_offers() -> None:

--- a/tests/integration/test_http_upgrade_tolerance.py
+++ b/tests/integration/test_http_upgrade_tolerance.py
@@ -278,6 +278,40 @@ async def test_websocket_handshake_with_repeated_connection_fields_switches_prot
     assert transport.protocol is not None
 
 
+async def test_websocket_handshake_with_multiple_upgrade_tokens_reaches_the_websocket_stack() -> None:
+    """``Upgrade: websocket, h2c`` must be classified as a WebSocket handshake.
+
+    The ``Upgrade`` field is a comma-separated protocol list (RFC 9110
+    section 7.8) and the server may pick any offered protocol it supports.
+    Matching the raw field value against ``websocket`` would misclassify the
+    handshake as an ignorable offer and answer it *as the application* over
+    plain HTTP/1.1 (with the WebSocket headers stripped from the scope). The
+    handshake verdict belongs to the WebSocket stack: uvicorn's default
+    ``websockets`` implementation currently rejects multi-token ``Upgrade``
+    values with 426, other implementations may complete the 101.
+    """
+    handshake = (
+        b"GET /ws HTTP/1.1\r\n"
+        b"Host: 127.0.0.1\r\n"
+        b"Connection: Upgrade\r\n"
+        b"Upgrade: websocket, h2c\r\n"
+        b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        b"Sec-WebSocket-Version: 13\r\n"
+        b"\r\n"
+    )
+    protocol, transport = _make_protocol(UpgradeTolerantHttpToolsProtocol)
+
+    protocol.data_received(handshake)
+
+    async with asyncio.timeout(5.0):
+        while b"\r\n\r\n" not in transport.buffer:
+            await asyncio.sleep(0.01)
+    status_line = bytes(transport.buffer).split(b"\r\n", 1)[0]
+    assert status_line in (b"HTTP/1.1 101 Switching Protocols", b"HTTP/1.1 426 Upgrade Required"), status_line
+    # The connection was handed off to the WebSocket protocol, not the app.
+    assert transport.protocol is not None
+
+
 async def test_live_v1_responses_route_serves_split_h2c_offer(db_setup, monkeypatch: pytest.MonkeyPatch) -> None:
     """Issue #1757's exact product path: split-written h2c POST to /v1/responses.
 

--- a/tests/integration/test_http_upgrade_tolerance.py
+++ b/tests/integration/test_http_upgrade_tolerance.py
@@ -1,0 +1,259 @@
+"""Regression tests for issue #1757: h2c upgrade offers must not break requests.
+
+JetBrains/Ktor clients opportunistically attach ``Connection: Upgrade`` +
+``Upgrade: h2c`` + ``HTTP2-Settings`` to plain HTTP/1.1 POSTs. The stock
+uvicorn httptools protocol treats any such request as a protocol switch and
+wedges the parser: a body coalesced with the headers is silently dropped, and
+a body written as a separate segment (Ktor's pattern) turns into
+``400 Invalid HTTP request received.``.
+
+The suite covers three layers:
+
+- protocol-level tests driving ``UpgradeTolerantHttpToolsProtocol`` through a
+  fake transport with both client segmentations;
+- canary tests pinning the stock behavior these fixes exist for (if a uvicorn
+  upgrade makes them fail, the subclass can likely be retired);
+- a live-server test using the production protocol wiring over real sockets,
+  including a real WebSocket upgrade that must keep completing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+import uvicorn
+from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol
+from uvicorn.server import ServerState
+
+from app.cli import _load_http_protocol_class
+from app.core.http_protocol import UpgradeTolerantHttpToolsProtocol
+
+pytestmark = pytest.mark.integration
+
+_BODY = json.dumps({"model": "gpt-5.6-luna", "input": "hello", "stream": False}).encode()
+_H2C_HEAD = (
+    b"POST /echo HTTP/1.1\r\n"
+    b"Host: 127.0.0.1\r\n"
+    b"Connection: Upgrade, HTTP2-Settings\r\n"
+    b"Upgrade: h2c\r\n"
+    b"HTTP2-Settings: AAMAAABkAARAAAAAAAIAAAAA\r\n"
+    b"Content-Type: application/json\r\n"
+    b"Content-Length: " + str(len(_BODY)).encode() + b"\r\n"
+    b"\r\n"
+)
+
+
+async def _echo_app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+    """Echo the request body and the header names the application observed."""
+    if scope["type"] == "websocket":
+        await receive()
+        await send({"type": "websocket.accept"})
+        message = await receive()
+        await send({"type": "websocket.send", "text": message.get("text", "")})
+        await send({"type": "websocket.close"})
+        return
+
+    assert scope["type"] == "http"
+    body = b""
+    while True:
+        message = await receive()
+        body += message.get("body", b"")
+        if not message.get("more_body", False):
+            break
+    payload = json.dumps(
+        {
+            "echo": body.decode(),
+            "header_names": sorted({name.decode() for name, _ in scope["headers"]}),
+        }
+    ).encode()
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"application/json"), (b"content-length", str(len(payload)).encode())],
+        }
+    )
+    await send({"type": "http.response.body", "body": payload})
+
+
+class _FakeTransport(asyncio.Transport):
+    def __init__(self) -> None:
+        super().__init__()
+        self.buffer = bytearray()
+        self.closed = False
+        self.protocol: asyncio.BaseProtocol | None = None
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    def is_closing(self) -> bool:
+        return self.closed
+
+    def close(self) -> None:
+        self.closed = True
+
+    def abort(self) -> None:
+        self.closed = True
+
+    def pause_reading(self) -> None:
+        pass
+
+    def resume_reading(self) -> None:
+        pass
+
+    def set_protocol(self, protocol: asyncio.BaseProtocol) -> None:
+        self.protocol = protocol
+
+    def get_extra_info(self, name: str, default: Any = None) -> Any:
+        if name == "sockname":
+            return ("127.0.0.1", 2455)
+        if name == "peername":
+            return ("127.0.0.1", 54321)
+        return default
+
+
+def _make_protocol(protocol_class: type[HttpToolsProtocol]) -> tuple[HttpToolsProtocol, _FakeTransport]:
+    config = uvicorn.Config(app=_echo_app, lifespan="off")
+    config.load()
+    protocol = protocol_class(config=config, server_state=ServerState(), app_state={})
+    transport = _FakeTransport()
+    protocol.connection_made(transport)
+    return protocol, transport
+
+
+async def _wait_for_response(transport: _FakeTransport, timeout: float = 5.0) -> bytes:
+    async with asyncio.timeout(timeout):
+        while b"\r\n\r\n" not in transport.buffer or not bytes(transport.buffer).split(b"\r\n\r\n", 1)[1]:
+            await asyncio.sleep(0.01)
+    return bytes(transport.buffer)
+
+
+def _parse_json_body(raw_response: bytes) -> dict[str, Any]:
+    _, _, body = raw_response.partition(b"\r\n\r\n")
+    return json.loads(body)
+
+
+async def test_h2c_offer_with_coalesced_body_is_served_as_http11() -> None:
+    protocol, transport = _make_protocol(UpgradeTolerantHttpToolsProtocol)
+
+    protocol.data_received(_H2C_HEAD + _BODY)
+
+    raw_response = await _wait_for_response(transport)
+    assert raw_response.startswith(b"HTTP/1.1 200 OK"), raw_response
+    payload = _parse_json_body(raw_response)
+    assert payload["echo"] == _BODY.decode()
+    # The declined offer's hop-by-hop headers must not reach the application.
+    assert "upgrade" not in payload["header_names"]
+    assert "http2-settings" not in payload["header_names"]
+    assert "connection" not in payload["header_names"]
+    assert not transport.closed
+
+
+async def test_h2c_offer_with_split_head_and_body_is_served_as_http11() -> None:
+    protocol, transport = _make_protocol(UpgradeTolerantHttpToolsProtocol)
+
+    protocol.data_received(_H2C_HEAD)
+    await asyncio.sleep(0.01)
+    protocol.data_received(_BODY)
+
+    raw_response = await _wait_for_response(transport)
+    assert raw_response.startswith(b"HTTP/1.1 200 OK"), raw_response
+    assert _parse_json_body(raw_response)["echo"] == _BODY.decode()
+    assert not transport.closed
+
+
+async def test_h2c_offer_keeps_connection_reusable_for_next_request() -> None:
+    protocol, transport = _make_protocol(UpgradeTolerantHttpToolsProtocol)
+
+    protocol.data_received(_H2C_HEAD + _BODY)
+    await _wait_for_response(transport)
+    transport.buffer.clear()
+
+    follow_up = b"POST /echo HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 2\r\n\r\nhi"
+    protocol.data_received(follow_up)
+
+    raw_response = await _wait_for_response(transport)
+    assert raw_response.startswith(b"HTTP/1.1 200 OK"), raw_response
+    assert _parse_json_body(raw_response)["echo"] == "hi"
+
+
+async def test_stock_httptools_protocol_still_breaks_on_h2c_offers() -> None:
+    """Canary pinning the upstream defect this module works around.
+
+    The stock parser drops a coalesced body (the application observes an empty
+    body) and answers 400 when the body arrives as a separate segment. If a
+    uvicorn/httptools upgrade makes this test fail, upstream has fixed
+    https://github.com/Soju06/codex-lb/issues/1757 and
+    ``UpgradeTolerantHttpToolsProtocol`` can likely be retired.
+    """
+    protocol, transport = _make_protocol(HttpToolsProtocol)
+    protocol.data_received(_H2C_HEAD + _BODY)
+    raw_response = await _wait_for_response(transport)
+    assert raw_response.startswith(b"HTTP/1.1 200 OK")
+    assert _parse_json_body(raw_response)["echo"] == ""  # body silently dropped
+
+    protocol, transport = _make_protocol(HttpToolsProtocol)
+    protocol.data_received(_H2C_HEAD)
+    await asyncio.sleep(0.01)
+    protocol.data_received(_BODY)
+    async with asyncio.timeout(5.0):
+        while b"Invalid HTTP request received." not in transport.buffer:
+            await asyncio.sleep(0.01)
+    # The body segment hits the wedged parser: the application never sees the
+    # payload and the client's request ends in a 400.
+    assert b'"echo": ""' in transport.buffer
+    assert b"HTTP/1.1 400 Bad Request" in transport.buffer
+
+
+async def test_live_server_serves_h2c_offers_and_websocket_upgrades() -> None:
+    """End-to-end proof over real sockets with the production protocol wiring."""
+    config = uvicorn.Config(
+        app=_echo_app,
+        host="127.0.0.1",
+        port=0,
+        http=_load_http_protocol_class(),
+        lifespan="off",
+        log_level="warning",
+    )
+    server = uvicorn.Server(config)
+    serve_task = asyncio.create_task(server.serve())
+    try:
+        async with asyncio.timeout(10.0):
+            while not server.started:
+                await asyncio.sleep(0.01)
+        port = server.servers[0].sockets[0].getsockname()[1]
+
+        # Ktor's write pattern: headers first, body as a separate segment.
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(_H2C_HEAD)
+        await writer.drain()
+        await asyncio.sleep(0.05)
+        writer.write(_BODY)
+        await writer.drain()
+        async with asyncio.timeout(10.0):
+            status_line = await reader.readline()
+            assert status_line == b"HTTP/1.1 200 OK\r\n"
+            raw_headers = await reader.readuntil(b"\r\n\r\n")
+            content_length = next(
+                int(line.split(b":", 1)[1])
+                for line in raw_headers.lower().splitlines()
+                if line.startswith(b"content-length:")
+            )
+            payload = json.loads(await reader.readexactly(content_length))
+        assert payload["echo"] == _BODY.decode()
+        writer.close()
+        await writer.wait_closed()
+
+        # A real WebSocket upgrade must keep switching protocols.
+        from websockets.asyncio.client import connect
+
+        async with connect(f"ws://127.0.0.1:{port}/ws") as websocket:
+            await websocket.send("ping")
+            assert await websocket.recv() == "ping"
+    finally:
+        server.should_exit = True
+        async with asyncio.timeout(10.0):
+            await serve_task

--- a/tests/integration/test_http_upgrade_tolerance.py
+++ b/tests/integration/test_http_upgrade_tolerance.py
@@ -232,6 +232,98 @@ async def test_h11_fallback_serves_h2c_offer_and_hides_upgrade_headers() -> None
     assert "connection" not in payload["header_names"]
 
 
+async def test_websocket_handshake_with_repeated_connection_fields_switches_protocols() -> None:
+    """Combined-field classification must not regress (or hide) WebSocket handoffs."""
+    handshake = (
+        b"GET /ws HTTP/1.1\r\n"
+        b"Host: 127.0.0.1\r\n"
+        b"Connection: Upgrade\r\n"
+        b"Upgrade: websocket\r\n"
+        b"Connection: keep-alive\r\n"
+        b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+        b"Sec-WebSocket-Version: 13\r\n"
+        b"\r\n"
+    )
+    protocol, transport = _make_protocol(UpgradeTolerantHttpToolsProtocol)
+
+    protocol.data_received(handshake)
+
+    async with asyncio.timeout(5.0):
+        while b"\r\n\r\n" not in transport.buffer:
+            await asyncio.sleep(0.01)
+    assert bytes(transport.buffer).startswith(b"HTTP/1.1 101 Switching Protocols"), bytes(transport.buffer)
+    # The connection was handed off to the WebSocket protocol.
+    assert transport.protocol is not None
+
+
+async def test_live_v1_responses_route_serves_split_h2c_offer(db_setup, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #1757's exact product path: split-written h2c POST to /v1/responses.
+
+    The request must traverse the parser into the application instead of the
+    stock transport-layer ``400 Invalid HTTP request received.``. With an
+    empty account pool the route deterministically answers a JSON
+    ``no_accounts`` 503 — reaching that error proves the request body was
+    delivered and parsed (the balancer logs the requested model), which is
+    exactly what the wedged stock parser prevented.
+    """
+    import app.main as main_module
+
+    async def _noop_init_db() -> None:
+        return None
+
+    monkeypatch.setattr(main_module, "init_db", _noop_init_db)
+    config = uvicorn.Config(
+        app=main_module.create_app(),
+        host="127.0.0.1",
+        port=0,
+        http=_load_http_protocol_class(),
+        log_level="warning",
+    )
+    server = uvicorn.Server(config)
+    serve_task = asyncio.create_task(server.serve())
+    try:
+        async with asyncio.timeout(10.0):
+            while not server.started:
+                await asyncio.sleep(0.01)
+        port = server.servers[0].sockets[0].getsockname()[1]
+
+        body = json.dumps({"model": "gpt-5.2", "input": "hello", "stream": False}).encode()
+        head = (
+            b"POST /v1/responses HTTP/1.1\r\n"
+            b"Host: 127.0.0.1\r\n"
+            b"Authorization: Bearer sk-bogus\r\n"
+            b"Connection: Upgrade, HTTP2-Settings\r\n"
+            b"Upgrade: h2c\r\n"
+            b"HTTP2-Settings: AAMAAABkAARAAAAAAAIAAAAA\r\n"
+            b"Content-Type: application/json\r\n"
+            b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+            b"\r\n"
+        )
+        reader, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.write(head)
+        await writer.drain()
+        await asyncio.sleep(0.05)
+        writer.write(body)
+        await writer.drain()
+        async with asyncio.timeout(10.0):
+            status_line = await reader.readline()
+            raw_headers = await reader.readuntil(b"\r\n\r\n")
+            content_length = next(
+                int(line.split(b":", 1)[1])
+                for line in raw_headers.lower().splitlines()
+                if line.startswith(b"content-length:")
+            )
+            payload = json.loads(await reader.readexactly(content_length))
+        assert status_line == b"HTTP/1.1 503 Service Unavailable\r\n", status_line
+        assert payload["error"]["code"] == "no_accounts", payload
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        server.should_exit = True
+        async with asyncio.timeout(15.0):
+            await serve_task
+
+
 async def test_stock_httptools_protocol_still_breaks_on_h2c_offers() -> None:
     """Canary pinning the upstream defect this module works around.
 

--- a/tests/integration/test_http_upgrade_tolerance.py
+++ b/tests/integration/test_http_upgrade_tolerance.py
@@ -87,7 +87,7 @@ class _FakeTransport(asyncio.Transport):
         self.closed = False
         self.protocol: asyncio.BaseProtocol | None = None
 
-    def write(self, data: bytes) -> None:
+    def write(self, data: bytes | bytearray | memoryview) -> None:
         self.buffer.extend(data)
 
     def is_closing(self) -> bool:
@@ -213,6 +213,28 @@ async def test_h2c_offer_with_repeated_connection_fields_is_served_as_http11() -
     assert "http2-settings" not in payload["header_names"]
     # The unrelated keep-alive token survives the sanitization.
     assert "connection" in payload["header_names"]
+
+
+async def test_pipelined_h2c_offers_in_one_segment_do_not_exhaust_the_stack() -> None:
+    """Many pipelined upgrade offers in one segment must not recurse per offer.
+
+    Each declined offer replays the remaining bytes through a fresh parser.
+    Done recursively that was one stack frame per pipelined request, so a
+    single ~66KB segment of minimal h2c GETs (well under asyncio's 256KiB
+    per-read buffer) raised RecursionError out of ``data_received``, aborting
+    the connection — and pinned an O(depth x segment) pile of byte copies
+    while unwinding. The replay must be iterative.
+    """
+    request = b"GET /echo HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: Upgrade\r\nUpgrade: h2c\r\n\r\n"
+    count = 2000  # ~148KB, double the depth that overflows the default 1000-frame stack
+    protocol, transport = _make_protocol(UpgradeTolerantHttpToolsProtocol)
+
+    protocol.data_received(request * count)  # raised RecursionError when replay was recursive
+
+    async with asyncio.timeout(30.0):
+        while transport.buffer.count(b"HTTP/1.1 200 OK") < count:
+            await asyncio.sleep(0.05)
+    assert not transport.closed
 
 
 async def test_h11_fallback_serves_h2c_offer_and_hides_upgrade_headers() -> None:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -253,7 +253,7 @@ def test_run_server_uses_graceful_server_and_shared_timeout(
 
     cli._run_server("app.main:app", host="127.0.0.1", port=2455)
 
-    from app.core.http_protocol import UpgradeTolerantHttpToolsProtocol
+    from app.core.http_protocol_httptools import UpgradeTolerantHttpToolsProtocol
 
     assert captured["config_args"] == ("app.main:app",)
     assert captured["config_kwargs"] == {
@@ -268,20 +268,22 @@ def test_run_server_uses_graceful_server_and_shared_timeout(
     assert captured["ran"] is True
 
 
-def test_load_http_protocol_class_falls_back_to_auto_without_httptools(
+def test_load_http_protocol_class_falls_back_to_h11_without_httptools(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from app.core.http_protocol import UpgradeTolerantH11Protocol
+
     real_import = builtins.__import__
 
     def fail_httptools_import(name: str, *args: object, **kwargs: object) -> object:
-        if name == "httptools" or name.startswith("app.core.http_protocol"):
+        if name in {"httptools", "app.core.http_protocol_httptools"}:
             raise ImportError(name)
         return real_import(name, *args, **kwargs)
 
-    monkeypatch.delitem(sys.modules, "app.core.http_protocol", raising=False)
+    monkeypatch.delitem(sys.modules, "app.core.http_protocol_httptools", raising=False)
     monkeypatch.setattr(builtins, "__import__", fail_httptools_import)
 
-    assert cli._load_http_protocol_class() == "auto"
+    assert cli._load_http_protocol_class() is UpgradeTolerantH11Protocol
 
 
 def test_run_server_pins_one_worker_despite_ambient_web_concurrency(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import builtins
 import json
 import logging
 import sqlite3
@@ -252,16 +253,35 @@ def test_run_server_uses_graceful_server_and_shared_timeout(
 
     cli._run_server("app.main:app", host="127.0.0.1", port=2455)
 
+    from app.core.http_protocol import UpgradeTolerantHttpToolsProtocol
+
     assert captured["config_args"] == ("app.main:app",)
     assert captured["config_kwargs"] == {
         "host": "127.0.0.1",
         "port": 2455,
         "workers": 1,
+        "http": UpgradeTolerantHttpToolsProtocol,
         "timeout_graceful_shutdown": 17,
     }
     assert captured["drain_timeout_seconds"] == 17
     assert captured["loaded"] is True
     assert captured["ran"] is True
+
+
+def test_load_http_protocol_class_falls_back_to_auto_without_httptools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    def fail_httptools_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "httptools" or name.startswith("app.core.http_protocol"):
+            raise ImportError(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.delitem(sys.modules, "app.core.http_protocol", raising=False)
+    monkeypatch.setattr(builtins, "__import__", fail_httptools_import)
+
+    assert cli._load_http_protocol_class() == "auto"
 
 
 def test_run_server_pins_one_worker_despite_ambient_web_concurrency(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -275,7 +275,7 @@ def test_load_http_protocol_class_falls_back_to_h11_without_httptools(
 
     real_import = builtins.__import__
 
-    def fail_httptools_import(name: str, *args: object, **kwargs: object) -> object:
+    def fail_httptools_import(name: str, *args: Any, **kwargs: Any) -> object:
         if name in {"httptools", "app.core.http_protocol_httptools"}:
             raise ImportError(name)
         return real_import(name, *args, **kwargs)


### PR DESCRIPTION
## Problem

JetBrains/Ktor clients (IntelliJ AI Assistant, issue repro) attach opportunistic cleartext HTTP/2 upgrade headers to ordinary HTTP/1.1 Responses API POSTs:

```http
Connection: Upgrade, HTTP2-Settings
Upgrade: h2c
HTTP2-Settings: <base64url>
```

codex-lb rejects or corrupts these requests **before auth ever runs**: Ktor's write pattern (headers and body as separate segments) gets `400 Bad Request / Invalid HTTP request received.`, and a body coalesced with the headers is silently dropped (empty ASGI body, 422 from request validation).

## Root cause

The server starts uvicorn with the default `http="auto"`, which picks the **httptools** parser (httptools ships transitively via `fastapi[standard]`, so it is present in the Docker image and the uvx env). uvicorn's httptools protocol treats *any* `Connection: Upgrade` request as a protocol switch: llhttp pauses at end-of-headers with `HttpParserUpgrade`, never delivers the body, and uvicorn only handles the WebSocket case — everything else logs "Unsupported upgrade request." and leaves the parser wedged. Verified callback order makes it worse: `on_headers_complete`/`on_message_complete` fire *before* the exception, so the stock protocol starts the ASGI cycle with an empty-but-complete body.

RFC 9110 §7.8 lets a server ignore an upgrade offer and answer over HTTP/1.1 — exactly what upstream OpenAI endpoints do.

## Fix (least invasive of the evaluated options)

`UpgradeTolerantHttpToolsProtocol` (registered via `uvicorn.Config(http=...)`) neutralizes **non-WebSocket** upgrade offers:

- the parser callbacks defer while the parser is paused on an ignorable offer (preventing the empty-body cycle);
- on `HttpParserUpgrade`, the accumulated request head is replayed through a fresh parser with the declined offer's hop-by-hop headers (`Upgrade`, `HTTP2-Settings`, and their `Connection` tokens) removed, so the request is served as plain HTTP/1.1 and the app never sees the declined offer;
- upgrade classification combines repeated `Connection` fields (RFC 9110 §5.3) — uvicorn's `_get_upgrade` keeps only the last field's tokens, which would both hide h2c offers and (fixed here for the handoff too) miss valid WebSocket handshakes;
- genuine WebSocket upgrades keep the stock handoff path;
- without httptools, the bootstrap falls back to `UpgradeTolerantH11Protocol`: stock h11 already delivers the body correctly, the subclass adds the same header hygiene.

**Alternatives evaluated:**
- **`http="h11"` globally**: fixes body delivery but leaks the declined offer's hop-by-hop headers into the ASGI scope, and costs ~40% parser-path throughput on a request-cycle microbench (httptools ≈5.9k req/s vs h11 ≈3.4k req/s at 64KiB bodies; the subclass is within noise of stock httptools — it only adds three C-call guards per request). Swapping the parser for all traffic is also a much larger behavioral change than fixing the one broken case.
- **uvicorn config flag**: none exists in the installed uvicorn (0.52.1) for upgrade handling.

## Test evidence

New `tests/integration/test_http_upgrade_tolerance.py` (all green; each fails on `main`'s wiring):

- h2c offer with **coalesced** header+body → 200 with the full body echoed; `upgrade`/`http2-settings`/`connection` never reach the app
- h2c offer with **split** segments (Ktor's pattern) → 200 with the full body
- **repeated `Connection` fields** (`Connection: Upgrade` … `Connection: keep-alive`) → 200, keep-alive token preserved
- connection stays **reusable** after a declined offer (keep-alive follow-up request served)
- h11 fallback serves the body and strips the declined offer's headers
- WebSocket handshake with repeated `Connection` fields → `101 Switching Protocols`
- live-server (real sockets, production protocol wiring): split h2c POST **to the real `/v1/responses` route** traverses into the app (deterministic `no_accounts` 503 on an empty pool proves body delivery), plus a real WebSocket round trip
- canary pinning the stock uvicorn defect (empty-body 200 + wire 400) so an upstream fix is noticed and the subclass can be retired
- `tests/unit/test_cli.py`: bootstrap passes the tolerant protocol to `uvicorn.Config`; httptools-less fallback resolves to the h11 subclass

RED proof on stock wiring (`http="auto"`, real socket, split write): app receives `{"echo": ""}` — body silently dropped; protocol-level split write → `400 Invalid HTTP request received.`

Suites on the final tree: `tests/unit` 6101 passed / 3 skipped; `tests/integration` 2135 passed / 29 skipped / 1 failed (`test_assets_js_served_as_javascript_despite_poisoned_registry`, pre-existing on pristine `origin/main`: requires built dashboard assets); `tests/e2e` 27 passed / 1 skipped. `ruff check`, `ruff format --check`, `ty check` clean; `openspec validate serve-h2c-upgrade-offers-as-http11 --strict` valid.

Local `codex review --base main`: round 1 → 2×P2 (repeated `Connection` fields classification; h11 fallback header hygiene) — both fixed; round 2 → 2×P2 (combined-field WebSocket handoff; regression at the real `/v1/responses` route) — both fixed; round 3 → clean, no findings.

## OpenSpec

`openspec/changes/serve-h2c-upgrade-offers-as-http11/` — delta on `http-ingress-limits`: non-WebSocket HTTP/1.1 upgrade offers MUST be served as plain HTTP/1.1 with full body delivery for both segmentations, declined hop-by-hop headers MUST NOT reach the application, and WebSocket upgrades MUST keep switching.

Fixes #1757

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP/2 cleartext upgrade requests are handled as standard HTTP/1.1 requests when appropriate.
  * Request bodies are preserved for complete, segmented, and pipelined requests.
  * WebSocket upgrades continue to work normally.
  * Connections remain reusable after handled upgrade offers.
* **Bug Fixes**
  * Upgrade-related headers are sanitized before requests reach the application.
  * Added fallback handling for environments without the optional HTTP parser.
* **Tests**
  * Added coverage for live server behavior, repeated headers, routing, WebSockets, and connection reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->