### PR TITLE
fix(usage): fence leaked live-usage-ingestor tasks and settle their failures deterministically

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -490,7 +490,10 @@ async def lifespan(app: FastAPI):
     account_usage_rollup_scheduler = build_account_usage_rollup_scheduler()
     data_retention_scheduler = build_data_retention_scheduler()
     telemetry_scheduler = build_telemetry_scheduler()
-    start_live_usage_ingestor()
+    # Hold the instance: this lifespan owns it (and keeps it strongly rooted)
+    # even if a nested lifespan on another loop replaces the module-global
+    # singleton in the meantime; shutdown below stops exactly this instance.
+    live_usage_ingestor = start_live_usage_ingestor()
     await usage_scheduler.start()
     await api_key_limit_reset_scheduler.start()
     await api_key_last_used_flush_scheduler.start()
@@ -715,7 +718,7 @@ async def lifespan(app: FastAPI):
         # touch is never parked in a pending map with no remaining flusher.
         await api_key_last_used_flush_scheduler.stop()
         await usage_scheduler.stop()
-        await stop_live_usage_ingestor()
+        await stop_live_usage_ingestor(live_usage_ingestor)
         await rate_limit_reset_credits_scheduler.stop()
         await account_usage_rollup_scheduler.stop()
         await data_retention_scheduler.stop()

--- a/app/modules/usage/live_ingest.py
+++ b/app/modules/usage/live_ingest.py
@@ -282,6 +282,18 @@ _ingestor: LiveUsageIngestor | None = None
 
 
 def start_live_usage_ingestor() -> LiveUsageIngestor | None:
+    """Create, start, and register a fresh ingestor as the current singleton.
+
+    The caller (the app lifespan) MUST hold the returned instance and pass it
+    back to ``stop_live_usage_ingestor`` at shutdown. Two lifespans can be
+    live in one process (the test suite nests a portal-loop ``TestClient``
+    inside an app already running on the session loop); each owns its own
+    instance, and the module global only tracks whichever registered last. A
+    started ingestor whose only strong root is the module global would become
+    an unreferenced reference cycle (task -> coroutine frame -> ingestor ->
+    queue -> getter future -> task) the moment a nested startup overwrites the
+    global, and the cyclic GC would then destroy its consumer task mid-await.
+    """
     global _ingestor
     settings = get_settings()
     if not getattr(settings, "live_usage_ingestion_enabled", True):
@@ -297,10 +309,20 @@ def start_live_usage_ingestor() -> LiveUsageIngestor | None:
     return ingestor
 
 
-async def stop_live_usage_ingestor() -> None:
+async def stop_live_usage_ingestor(ingestor: LiveUsageIngestor | None = None) -> None:
+    """Stop ``ingestor``, or the current singleton when omitted.
+
+    The module global and the publisher registration are cleared only when
+    the stopped instance still owns them, so a lifespan shutting down cannot
+    orphan or unregister a nested lifespan's newer instance — and a nested
+    lifespan's shutdown cannot leave the outer instance dangling with no
+    stop path (the leak behind issue #1755's cross-test poisoning).
+    """
     global _ingestor
-    ingestor = _ingestor
-    _ingestor = None
-    register_live_usage_publisher(None)
+    if ingestor is None:
+        ingestor = _ingestor
+    if ingestor is None or _ingestor is ingestor:
+        _ingestor = None
+        register_live_usage_publisher(None)
     if ingestor is not None:
         await ingestor.stop()

--- a/app/modules/usage/live_ingest.py
+++ b/app/modules/usage/live_ingest.py
@@ -41,7 +41,11 @@ _CACHE_INVALIDATION_MIN_INTERVAL_SECONDS = 5.0
 # settle each task exactly once even when both observe it.
 _owned_tasks: weakref.WeakSet[asyncio.Task[None]] = weakref.WeakSet()
 _settled_owned_tasks: weakref.WeakSet[asyncio.Task[None]] = weakref.WeakSet()
-_owned_task_failures: list[tuple[str, BaseException]] = []
+# (task name, exception repr) pairs. Reprs, not exception objects: a stored
+# exception's traceback would keep the failed ingestor's whole object graph
+# (task, queue, cached state) alive for the process lifetime, since production
+# never drains this record.
+_owned_task_failures: list[tuple[str, str]] = []
 _MAX_OWNED_TASK_FAILURES = 16
 
 
@@ -57,7 +61,7 @@ def _record_owned_task_result(task: asyncio.Task[None]) -> None:
         return
     logger.error("Live usage ingestor task %r died unexpectedly", task.get_name(), exc_info=exc)
     if len(_owned_task_failures) < _MAX_OWNED_TASK_FAILURES:
-        _owned_task_failures.append((task.get_name(), exc))
+        _owned_task_failures.append((task.get_name(), repr(exc)))
 
 
 def _enroll_owned_task(task: asyncio.Task[None]) -> None:

--- a/app/modules/usage/live_ingest.py
+++ b/app/modules/usage/live_ingest.py
@@ -24,13 +24,45 @@ _QUEUE_SIZE = 512
 _WRITE_MIN_INTERVAL_SECONDS = 5.0
 _CACHE_INVALIDATION_MIN_INTERVAL_SECONDS = 5.0
 
-# Weak ownership registry of every task any ingestor instance creates
-# (consumer and trailing cache invalidation). Weak references never extend a
-# task's lifetime; the registry exists so an owner that loses track of a task
-# (a stop cancelled mid-await) still leaves an auditable handle for the test
-# suite's leak fence to cancel pending tasks and consume exceptions from dead
-# ones before they cross a test boundary (issue #1755).
+# Ownership accounting for every task any ingestor instance creates (consumer
+# and trailing cache invalidation), so a task an owner lost track of (a stop
+# cancelled mid-await) can never end in a silently dropped exception:
+#
+# - `_owned_tasks` holds weak references (they never extend task lifetime) so
+#   the test suite's leak fence can cancel pending tasks and settle completed
+#   ones that some reference chain kept alive across a test boundary.
+# - `_record_owned_task_result` runs as each task's done callback: it
+#   retrieves the exception (so the loop's unobserved-task warning can never
+#   fire at garbage-collection time), logs it, and records it in the bounded
+#   `_owned_task_failures` strong handoff for the fence to drain (#1755).
+#
+# `_settled_owned_tasks` (also weak) marks tasks whose result was already
+# recorded, so the done callback and the fence's sweep of completed tasks
+# settle each task exactly once even when both observe it.
 _owned_tasks: weakref.WeakSet[asyncio.Task[None]] = weakref.WeakSet()
+_settled_owned_tasks: weakref.WeakSet[asyncio.Task[None]] = weakref.WeakSet()
+_owned_task_failures: list[tuple[str, BaseException]] = []
+_MAX_OWNED_TASK_FAILURES = 16
+
+
+def _record_owned_task_result(task: asyncio.Task[None]) -> None:
+    if task in _settled_owned_tasks:
+        return
+    _settled_owned_tasks.add(task)
+    _owned_tasks.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is None:
+        return
+    logger.error("Live usage ingestor task %r died unexpectedly", task.get_name(), exc_info=exc)
+    if len(_owned_task_failures) < _MAX_OWNED_TASK_FAILURES:
+        _owned_task_failures.append((task.get_name(), exc))
+
+
+def _enroll_owned_task(task: asyncio.Task[None]) -> None:
+    _owned_tasks.add(task)
+    task.add_done_callback(_record_owned_task_result)
 
 
 @dataclass(frozen=True, slots=True)
@@ -105,7 +137,7 @@ class LiveUsageIngestor:
     def start(self) -> None:
         if self._consumer is None or self._consumer.done():
             self._consumer = asyncio.create_task(self._run(), name="live-usage-ingestor")
-            _owned_tasks.add(self._consumer)
+            _enroll_owned_task(self._consumer)
 
     async def stop(self) -> None:
         consumer = self._consumer
@@ -227,7 +259,7 @@ class LiveUsageIngestor:
                 self._trailing_invalidate(remaining),
                 name="live-usage-trailing-invalidation",
             )
-            _owned_tasks.add(self._trailing_invalidation)
+            _enroll_owned_task(self._trailing_invalidation)
 
     async def _trailing_invalidate(self, delay_seconds: float) -> None:
         await asyncio.sleep(delay_seconds)

--- a/app/modules/usage/live_ingest.py
+++ b/app/modules/usage/live_ingest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+import weakref
 from dataclasses import dataclass
 
 from app.core import usage as usage_core
@@ -22,6 +23,14 @@ logger = logging.getLogger(__name__)
 _QUEUE_SIZE = 512
 _WRITE_MIN_INTERVAL_SECONDS = 5.0
 _CACHE_INVALIDATION_MIN_INTERVAL_SECONDS = 5.0
+
+# Weak ownership registry of every task any ingestor instance creates
+# (consumer and trailing cache invalidation). Weak references never extend a
+# task's lifetime; the registry exists so an owner that loses track of a task
+# (a stop cancelled mid-await) still leaves an auditable handle for the test
+# suite's leak fence to cancel pending tasks and consume exceptions from dead
+# ones before they cross a test boundary (issue #1755).
+_owned_tasks: weakref.WeakSet[asyncio.Task[None]] = weakref.WeakSet()
 
 
 @dataclass(frozen=True, slots=True)
@@ -96,6 +105,7 @@ class LiveUsageIngestor:
     def start(self) -> None:
         if self._consumer is None or self._consumer.done():
             self._consumer = asyncio.create_task(self._run(), name="live-usage-ingestor")
+            _owned_tasks.add(self._consumer)
 
     async def stop(self) -> None:
         consumer = self._consumer
@@ -217,6 +227,7 @@ class LiveUsageIngestor:
                 self._trailing_invalidate(remaining),
                 name="live-usage-trailing-invalidation",
             )
+            _owned_tasks.add(self._trailing_invalidation)
 
     async def _trailing_invalidate(self, delay_seconds: float) -> None:
         await asyncio.sleep(delay_seconds)

--- a/app/modules/usage/live_ingest.py
+++ b/app/modules/usage/live_ingest.py
@@ -143,6 +143,10 @@ class LiveUsageIngestor:
             self._consumer = asyncio.create_task(self._run(), name="live-usage-ingestor")
             _enroll_owned_task(self._consumer)
 
+    def is_running(self) -> bool:
+        consumer = self._consumer
+        return consumer is not None and not consumer.done()
+
     async def stop(self) -> None:
         consumer = self._consumer
         self._consumer = None
@@ -279,6 +283,13 @@ class LiveUsageIngestor:
 
 
 _ingestor: LiveUsageIngestor | None = None
+# Registrations a nested startup displaced, innermost-last. A stack rather
+# than a single prior slot: lifespans can nest more than one level deep (each
+# portal-loop ``TestClient`` adds one), and a stack restores each displaced
+# outer lifespan in LIFO order while an out-of-order stop simply removes its
+# instance from wherever it sits — a single slot would forget everything below
+# the most recent displacement.
+_displaced_ingestors: list[LiveUsageIngestor] = []
 
 
 def start_live_usage_ingestor() -> LiveUsageIngestor | None:
@@ -304,6 +315,11 @@ def start_live_usage_ingestor() -> LiveUsageIngestor | None:
         write_min_interval_seconds=_WRITE_MIN_INTERVAL_SECONDS,
     )
     ingestor.start()
+    if _ingestor is not None and _ingestor.is_running():
+        # A nested startup displaces a still-running outer registration;
+        # remember it so the nested shutdown can restore it (a dead instance
+        # is never worth remembering).
+        _displaced_ingestors.append(_ingestor)
     register_live_usage_publisher(ingestor.publish)
     _ingestor = ingestor
     return ingestor
@@ -312,17 +328,34 @@ def start_live_usage_ingestor() -> LiveUsageIngestor | None:
 async def stop_live_usage_ingestor(ingestor: LiveUsageIngestor | None = None) -> None:
     """Stop ``ingestor``, or the current singleton when omitted.
 
-    The module global and the publisher registration are cleared only when
+    The module global and the publisher registration are touched only when
     the stopped instance still owns them, so a lifespan shutting down cannot
     orphan or unregister a nested lifespan's newer instance — and a nested
     lifespan's shutdown cannot leave the outer instance dangling with no
-    stop path (the leak behind issue #1755's cross-test poisoning).
+    stop path (the leak behind issue #1755's cross-test poisoning). When the
+    stopped instance is the current registration, the most recent displaced
+    ingestor that is still running is restored (registration and publisher
+    wiring), so a still-live outer lifespan resumes receiving publications
+    instead of going silently deaf after a nested shutdown.
     """
     global _ingestor
     if ingestor is None:
         ingestor = _ingestor
+    if ingestor is not None:
+        # Whatever happens next, a stopped instance must never be restorable.
+        try:
+            _displaced_ingestors.remove(ingestor)
+        except ValueError:
+            pass
     if ingestor is None or _ingestor is ingestor:
-        _ingestor = None
-        register_live_usage_publisher(None)
+        restored: LiveUsageIngestor | None = None
+        while _displaced_ingestors:
+            candidate = _displaced_ingestors.pop()
+            if candidate.is_running():
+                restored = candidate
+                break
+            # Stopped or dead in the meantime — never restore a dead instance.
+        _ingestor = restored
+        register_live_usage_publisher(restored.publish if restored is not None else None)
     if ingestor is not None:
         await ingestor.stop()

--- a/app/modules/usage/live_ingest.py
+++ b/app/modules/usage/live_ingest.py
@@ -213,7 +213,10 @@ class LiveUsageIngestor:
             await self._invalidate_caches_now()
             return
         if self._trailing_invalidation is None or self._trailing_invalidation.done():
-            self._trailing_invalidation = asyncio.create_task(self._trailing_invalidate(remaining))
+            self._trailing_invalidation = asyncio.create_task(
+                self._trailing_invalidate(remaining),
+                name="live-usage-trailing-invalidation",
+            )
 
     async def _trailing_invalidate(self, delay_seconds: float) -> None:
         await asyncio.sleep(delay_seconds)

--- a/openspec/changes/settle-live-ingest-task-failures/proposal.md
+++ b/openspec/changes/settle-live-ingest-task-failures/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+An ingestor-owned background task (the `live-usage-ingestor` consumer or the
+trailing cache-invalidation sleeper) that dies with an exception after its
+owner lost track of it — for example a shutdown cancelled between clearing the
+singleton and awaiting the task — surfaces only as a nondeterministic
+"Task exception was never retrieved" loop warning at garbage-collection time.
+In production that hides the failure until an arbitrary later moment; in the
+test suite's shared session loop it poisons unrelated tests (issue #1755:
+the otel lifespan-drain test and test_proxy_utils' startup-probe assertions
+fail together).
+
+## What Changes
+
+- Enroll every task the live-usage ingestor creates in a weak ownership
+  registry and attach a done callback that settles the task at completion:
+  retrieve its exception, log it immediately with its traceback, and record it
+  in a bounded in-process failure handoff.
+- Settle each task exactly once (a settled-task registry gates recording) so
+  the callback and any external sweep cannot double-report.
+- Keep ingestion behavior unchanged: enqueueing, coalescing, throttling,
+  shutdown ordering, and the fire-and-forget contract are untouched.
+- Test infrastructure (out of spec scope): an autouse fence stops leaked
+  ingestor singletons after every test and drains the failure handoff so no
+  ingestor task or unretrieved exception crosses a test boundary.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `live-usage-ingestion`: unexpected ingestor-owned task deaths MUST be
+  settled at completion — exception retrieved, logged, and recorded in a
+  bounded handoff — instead of surfacing as garbage-collection-time
+  unobserved-task warnings.
+
+## Impact
+
+`app/modules/usage/live_ingest.py` (task enrollment, done-callback
+settlement, bounded failure record), `tests/conftest.py` (leak fence), and
+`tests/unit/test_live_ingest_leak_fence.py` (regression coverage). No API,
+schema, setting, or dashboard change.

--- a/openspec/changes/settle-live-ingest-task-failures/proposal.md
+++ b/openspec/changes/settle-live-ingest-task-failures/proposal.md
@@ -18,6 +18,17 @@ fail together).
   in a bounded in-process failure handoff.
 - Settle each task exactly once (a settled-task registry gates recording) so
   the callback and any external sweep cannot double-report.
+- Make the ingestor lifecycle instance-scoped: the app lifespan holds the
+  instance `start_live_usage_ingestor()` returned and passes it to
+  `stop_live_usage_ingestor(instance)`; stop only clears the module global
+  and publisher registration when that instance still owns them. Two live
+  lifespans in one process (a portal-loop `TestClient` nested inside an app
+  already running on the suite's session loop) previously orphaned the outer
+  ingestor: the nested startup overwrote the module global — the orphan's
+  only strong root — leaving an unreferenced cycle whose consumer task the
+  cyclic GC destroyed mid-await (`cannot reuse already awaited coroutine`),
+  and the nested shutdown cleared the global so the outer shutdown stopped
+  nothing.
 - Keep ingestion behavior unchanged: enqueueing, coalescing, throttling,
   shutdown ordering, and the fire-and-forget contract are untouched.
 - Test infrastructure (out of spec scope): an autouse fence stops leaked
@@ -40,6 +51,8 @@ fail together).
 ## Impact
 
 `app/modules/usage/live_ingest.py` (task enrollment, done-callback
-settlement, bounded failure record), `tests/conftest.py` (leak fence), and
-`tests/unit/test_live_ingest_leak_fence.py` (regression coverage). No API,
+settlement, bounded failure record, instance-scoped stop), `app/main.py`
+(lifespan holds and stops its own ingestor instance), `tests/conftest.py`
+(leak fence), `tests/unit/test_live_ingest_leak_fence.py` and
+`tests/integration/test_live_usage_ingest.py` (regression coverage). No API,
 schema, setting, or dashboard change.

--- a/openspec/changes/settle-live-ingest-task-failures/specs/live-usage-ingestion/spec.md
+++ b/openspec/changes/settle-live-ingest-task-failures/specs/live-usage-ingestion/spec.md
@@ -40,11 +40,15 @@ affect the serving path.
 ### Requirement: Ingestor lifecycle is instance-scoped
 
 Each application lifespan MUST hold the ingestor instance its startup created
-and stop exactly that instance at shutdown. Stopping an instance MUST clear
+and stop exactly that instance at shutdown. Stopping an instance MUST touch
 the process-wide singleton registration and the publisher hook only when the
-stopped instance still owns them. When several lifespans are live in one
-process, no lifespan's startup or shutdown may orphan another lifespan's
-running ingestor or leave it without a stop path.
+stopped instance still owns them; when it does own them, the most recently
+displaced ingestor that is still running MUST be restored as the registration
+and publisher (an instance that is stopped or dead MUST never be restored,
+and a stopped instance MUST never become restorable later). When several
+lifespans are live in one process, no lifespan's startup or shutdown may
+orphan another lifespan's running ingestor, leave it without a stop path, or
+leave it registered-less while it still runs.
 
 #### Scenario: Nested lifespan cannot orphan the outer ingestor
 
@@ -52,5 +56,17 @@ running ingestor or leave it without a stop path.
 - **WHEN** a nested lifespan starts ingestor B (taking over the singleton and
   publisher) and later stops it
 - **THEN** ingestor A keeps running, strongly rooted by its own lifespan
-- **AND** the outer lifespan's shutdown stops ingestor A and its tasks even
-  though the singleton no longer points at A
+- **AND** the outer lifespan's shutdown stops ingestor A and its tasks
+
+#### Scenario: Nested shutdown restores the outer registration
+
+- **GIVEN** an app whose lifespan started ingestor A
+- **AND** a nested lifespan whose startup displaced A by registering
+  ingestor B
+- **WHEN** the nested lifespan stops ingestor B
+- **THEN** ingestor A is restored as the singleton registration and publisher
+- **AND** publications after the nested exit flow to ingestor A and are
+  ingested
+- **AND** a displaced ingestor that already stopped is not restored (the
+  registration falls through to the next still-running displaced instance,
+  or is cleared)

--- a/openspec/changes/settle-live-ingest-task-failures/specs/live-usage-ingestion/spec.md
+++ b/openspec/changes/settle-live-ingest-task-failures/specs/live-usage-ingestion/spec.md
@@ -1,0 +1,36 @@
+# live-usage-ingestion Delta
+
+## ADDED Requirements
+
+### Requirement: Ingestor-owned task failures are settled at completion
+
+Every background task the live usage ingestor creates MUST be settled when it
+completes: if the task ends with an exception other than cancellation, the
+exception MUST be retrieved at completion time, logged immediately with its
+traceback, and recorded in a bounded in-process failure record. An
+ingestor-owned task failure MUST NOT surface as a garbage-collection-time
+unobserved-task warning. Each task MUST be settled exactly once, including
+when an external supervisor (such as test infrastructure) also observes the
+task. Settlement MUST NOT extend task lifetime, change ingestion behavior, or
+affect the serving path.
+
+#### Scenario: Detached consumer death is logged deterministically
+
+- **GIVEN** a consumer task whose owner lost track of it (for example a stop
+  cancelled between clearing the singleton and awaiting the task)
+- **WHEN** the task dies with an exception
+- **THEN** the exception is retrieved and logged at completion time
+- **AND** it is recorded in the bounded failure record
+- **AND** no unobserved-task warning fires at garbage collection
+
+#### Scenario: Cancelled tasks settle silently
+
+- **WHEN** an ingestor-owned task ends by cancellation
+- **THEN** settlement records no failure and logs no error
+
+#### Scenario: Failure record stays bounded
+
+- **WHEN** ingestor-owned tasks fail repeatedly without the record being
+  drained
+- **THEN** the failure record retains at most its fixed capacity of entries
+- **AND** every failure is still logged

--- a/openspec/changes/settle-live-ingest-task-failures/specs/live-usage-ingestion/spec.md
+++ b/openspec/changes/settle-live-ingest-task-failures/specs/live-usage-ingestion/spec.md
@@ -36,3 +36,21 @@ affect the serving path.
   drained
 - **THEN** the failure record retains at most its fixed capacity of entries
 - **AND** every failure is still logged
+
+### Requirement: Ingestor lifecycle is instance-scoped
+
+Each application lifespan MUST hold the ingestor instance its startup created
+and stop exactly that instance at shutdown. Stopping an instance MUST clear
+the process-wide singleton registration and the publisher hook only when the
+stopped instance still owns them. When several lifespans are live in one
+process, no lifespan's startup or shutdown may orphan another lifespan's
+running ingestor or leave it without a stop path.
+
+#### Scenario: Nested lifespan cannot orphan the outer ingestor
+
+- **GIVEN** an app whose lifespan started ingestor A
+- **WHEN** a nested lifespan starts ingestor B (taking over the singleton and
+  publisher) and later stops it
+- **THEN** ingestor A keeps running, strongly rooted by its own lifespan
+- **AND** the outer lifespan's shutdown stops ingestor A and its tasks even
+  though the singleton no longer points at A

--- a/openspec/changes/settle-live-ingest-task-failures/specs/live-usage-ingestion/spec.md
+++ b/openspec/changes/settle-live-ingest-task-failures/specs/live-usage-ingestion/spec.md
@@ -7,7 +7,9 @@
 Every background task the live usage ingestor creates MUST be settled when it
 completes: if the task ends with an exception other than cancellation, the
 exception MUST be retrieved at completion time, logged immediately with its
-traceback, and recorded in a bounded in-process failure record. An
+traceback, and recorded in a bounded in-process failure record as
+traceback-free metadata (task name and exception representation) so the
+record cannot retain the failed task's object graph. An
 ingestor-owned task failure MUST NOT surface as a garbage-collection-time
 unobserved-task warning. Each task MUST be settled exactly once, including
 when an external supervisor (such as test infrastructure) also observes the

--- a/openspec/changes/settle-live-ingest-task-failures/specs/live-usage-ingestion/spec.md
+++ b/openspec/changes/settle-live-ingest-task-failures/specs/live-usage-ingestion/spec.md
@@ -44,8 +44,12 @@ and stop exactly that instance at shutdown. Stopping an instance MUST touch
 the process-wide singleton registration and the publisher hook only when the
 stopped instance still owns them; when it does own them, the most recently
 displaced ingestor that is still running MUST be restored as the registration
-and publisher (an instance that is stopped or dead MUST never be restored,
-and a stopped instance MUST never become restorable later). When several
+and publisher. Restoration eligibility is defined as: the candidate holds an
+existing consumer task whose `done()` is false — this excludes consumers that
+failed or completed, and ingestors whose `stop()` already cleared their
+consumer. An instance MUST be removed from restoration tracking before its own
+shutdown begins, so a stopping or stopped instance can never be restored
+later. When several
 lifespans are live in one process, no lifespan's startup or shutdown may
 orphan another lifespan's running ingestor, leave it without a stop path, or
 leave it registered-less while it still runs.
@@ -70,3 +74,18 @@ leave it registered-less while it still runs.
 - **AND** a displaced ingestor that already stopped is not restored (the
   registration falls through to the next still-running displaced instance,
   or is cleared)
+
+#### Scenario: A failed displaced ingestor is not restored
+
+- **GIVEN** displaced ingestor A whose consumer task has settled with an
+  exception (its task `done()` is true)
+- **WHEN** the current registration stops
+- **THEN** A is skipped by restoration (fall through to the next eligible
+  displaced instance, or clear the registration)
+
+#### Scenario: A stopping displaced ingestor is not restored
+
+- **GIVEN** displaced ingestor A whose `stop()` has begun (A was removed from
+  restoration tracking before its shutdown started)
+- **WHEN** the current registration stops concurrently
+- **THEN** A is never restored, even if its consumer task has not yet finished

--- a/openspec/changes/settle-live-ingest-task-failures/tasks.md
+++ b/openspec/changes/settle-live-ingest-task-failures/tasks.md
@@ -10,9 +10,14 @@
       reap runs on; foreign-loop tasks are enrolled and left inert), and
       drains the failure handoff after every test.
 - [x] 1.4 Make the lifecycle instance-scoped: the lifespan holds the started
-      instance and stops exactly that instance; stop clears the module global
+      instance and stops exactly that instance; stop touches the module global
       and publisher only when the stopped instance still owns them, so nested
       lifespans cannot orphan the outer ingestor into a GC-collectable cycle.
+- [x] 1.5 Restore the displaced registration after nested shutdown: a startup
+      that displaces a still-running instance remembers it (LIFO stack), and
+      stopping the current instance restores the most recent displaced
+      instance that still runs — never a stopped or dead one — so the outer
+      lifespan's ingestion resumes instead of going deaf.
 
 ## 2. Validation
 
@@ -22,7 +27,8 @@
       detached-death recording, queued-callback settlement, and exactly-once
       reporting.
 - [x] 2.3 Regression for nested lifespans: a nested start/stop pair must not
-      orphan, kill, or unhook the outer lifespan's ingestor, and the outer
-      stop must reap its own consumer even after the global moved on.
+      orphan, kill, or unhook the outer lifespan's ingestor; the nested stop
+      restores the outer registration (a post-exit publication is ingested
+      end to end), and the outer stop reaps its own consumer.
 - [x] 2.4 Run the full unit suite, live-usage integration tests, lint, type
       checks, and strict OpenSpec validation.

--- a/openspec/changes/settle-live-ingest-task-failures/tasks.md
+++ b/openspec/changes/settle-live-ingest-task-failures/tasks.md
@@ -6,8 +6,13 @@
       retrieve the exception, log it with its traceback, and record it in the
       bounded failure handoff.
 - [x] 1.3 Add the autouse test fence that stops leaked ingestor singletons,
-      reaps pending ingestor-owned tasks, and drains the failure handoff after
-      every test.
+      reaps pending ingestor-owned tasks (only those bound to the loop the
+      reap runs on; foreign-loop tasks are enrolled and left inert), and
+      drains the failure handoff after every test.
+- [x] 1.4 Make the lifecycle instance-scoped: the lifespan holds the started
+      instance and stops exactly that instance; stop clears the module global
+      and publisher only when the stopped instance still owns them, so nested
+      lifespans cannot orphan the outer ingestor into a GC-collectable cycle.
 
 ## 2. Validation
 
@@ -16,5 +21,8 @@
 - [x] 2.2 Regressions for dead-consumer settlement, orphaned-task sweep,
       detached-death recording, queued-callback settlement, and exactly-once
       reporting.
-- [x] 2.3 Run the full unit suite, live-usage integration tests, lint, type
+- [x] 2.3 Regression for nested lifespans: a nested start/stop pair must not
+      orphan, kill, or unhook the outer lifespan's ingestor, and the outer
+      stop must reap its own consumer even after the global moved on.
+- [x] 2.4 Run the full unit suite, live-usage integration tests, lint, type
       checks, and strict OpenSpec validation.

--- a/openspec/changes/settle-live-ingest-task-failures/tasks.md
+++ b/openspec/changes/settle-live-ingest-task-failures/tasks.md
@@ -1,0 +1,20 @@
+## 1. Implementation
+
+- [x] 1.1 Enroll ingestor-created tasks (consumer, trailing invalidation) in a
+      weak ownership registry with named tasks.
+- [x] 1.2 Attach a done callback that settles each task exactly once:
+      retrieve the exception, log it with its traceback, and record it in the
+      bounded failure handoff.
+- [x] 1.3 Add the autouse test fence that stops leaked ingestor singletons,
+      reaps pending ingestor-owned tasks, and drains the failure handoff after
+      every test.
+
+## 2. Validation
+
+- [x] 2.1 Order-dependent regression pair proving a leaked consumer no longer
+      crosses a test boundary (fails on main without the fence).
+- [x] 2.2 Regressions for dead-consumer settlement, orphaned-task sweep,
+      detached-death recording, queued-callback settlement, and exactly-once
+      reporting.
+- [x] 2.3 Run the full unit suite, live-usage integration tests, lint, type
+      checks, and strict OpenSpec validation.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -455,34 +455,32 @@ async def _reap_leaked_live_usage_ingestor() -> None:
         try:
             await task
         except (Exception, asyncio.CancelledError):
-            # Reported by _consume_dead_live_ingest_task_failures.
+            # Settled and reported by _drain_live_ingest_task_failures.
             continue
 
 
-def _consume_dead_live_ingest_task_failures() -> list[str]:
-    """Retrieve exceptions from dead ingestor-owned tasks, loop-free.
+def _drain_live_ingest_task_failures() -> list[str]:
+    """Collect failures from dead ingestor-owned tasks, loop-free.
 
     ``asyncio.all_tasks`` only returns unfinished tasks, so a leaked task that
     already died with an exception is invisible to the pending sweep; its
-    unretrieved exception would fire the loop exception handler when the task
-    object is garbage-collected inside a LATER test (test_proxy_utils'
-    startup-probe assertions capture exactly that). Walk the ingestor's weak
-    ownership registry instead: ``Task.exception()`` both returns the failure
-    for attribution at the test that leaked it and marks it retrieved so no
-    unobserved-task warning can fire later.
+    unretrieved exception would otherwise fire the loop exception handler when
+    the task object is garbage-collected inside a LATER test (test_proxy_utils'
+    startup-probe assertions capture exactly that). live_ingest's done
+    callback normally settles each task the moment it completes (retrieving
+    the exception into the strong ``_owned_task_failures`` handoff); the sweep
+    over the weak registry here additionally settles tasks whose callback is
+    still queued because the task finished in the loop's final iteration.
+    Settlement is gated by live_ingest's settled-task registry, so each task
+    is reported exactly once even when both paths observe it.
     """
     from app.modules.usage import live_ingest
 
-    failures: list[str] = []
     for task in list(live_ingest._owned_tasks):
-        if not task.done():
-            continue
-        live_ingest._owned_tasks.discard(task)
-        if task.cancelled():
-            continue
-        exc = task.exception()
-        if exc is not None:
-            failures.append(f"{task.get_name()!r} died with {exc!r}")
+        if task.done():
+            live_ingest._record_owned_task_result(task)
+    failures = [f"{name!r} died with {exc!r}" for name, exc in live_ingest._owned_task_failures]
+    live_ingest._owned_task_failures.clear()
     return failures
 
 
@@ -526,7 +524,7 @@ def _stop_leaked_live_usage_ingestor():
     )
     if needs_reap and loop_usable and loop is not None:
         loop.run_until_complete(_reap_leaked_live_usage_ingestor())
-    failures = _consume_dead_live_ingest_task_failures()
+    failures = _drain_live_ingest_task_failures()
     if failures:
         pytest.fail(
             "test leaked a live-usage ingestor whose task(s) already failed: " + "; ".join(failures),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -431,6 +431,16 @@ async def _reap_leaked_live_usage_ingestor() -> None:
     ingestor-owned tasks (consumer and trailing invalidation) the stop path no
     longer tracks — a stop that was itself cancelled between clearing the
     global and awaiting the tasks.
+
+    Only tasks bound to the loop this coroutine runs on are cancelled and
+    awaited. A leaked singleton can hold tasks that belong to a different
+    loop entirely — integration tests run ``TestClient`` portals whose loop
+    is a private per-portal loop that is already closed by teardown time.
+    Cancelling such a task raises ``RuntimeError('Event loop is closed')``
+    from ``call_soon`` and awaiting it raises the cross-loop RuntimeError;
+    neither can ever reap it. Those tasks are inert (a closed loop never
+    steps again), so they are enrolled for exception accounting and left
+    alone.
     """
     from app.core.usage.live_hub import register_live_usage_publisher
     from app.modules.usage import live_ingest
@@ -445,13 +455,18 @@ async def _reap_leaked_live_usage_ingestor() -> None:
                 leaked.append(task)
         ingestor._consumer = None
         ingestor._trailing_invalidation = None
-    for task in _pending_live_ingest_tasks(asyncio.get_running_loop()):
+    loop = asyncio.get_running_loop()
+    for task in _pending_live_ingest_tasks(loop):
         if task not in leaked:
             leaked.append(task)
+    reapable: list[asyncio.Task[None]] = []
     for task in leaked:
         live_ingest._owned_tasks.add(task)
+        if task.get_loop() is loop:
+            reapable.append(task)
+    for task in reapable:
         task.cancel()
-    for task in leaked:
+    for task in reapable:
         try:
             await task
         except (Exception, asyncio.CancelledError):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -445,13 +445,19 @@ async def _reap_leaked_live_usage_ingestor() -> None:
     from app.core.usage.live_hub import register_live_usage_publisher
     from app.modules.usage import live_ingest
 
-    ingestor = live_ingest._ingestor
+    ingestors: list[live_ingest.LiveUsageIngestor] = []
+    if live_ingest._ingestor is not None:
+        ingestors.append(live_ingest._ingestor)
     live_ingest._ingestor = None
+    # Displaced (nested-over) registrations hold live tasks too, and a stale
+    # stack entry must never be restored into a later test.
+    ingestors.extend(live_ingest._displaced_ingestors)
+    live_ingest._displaced_ingestors.clear()
     register_live_usage_publisher(None)
     leaked: list[asyncio.Task[None]] = []
-    if ingestor is not None:
+    for ingestor in ingestors:
         for task in (ingestor._consumer, ingestor._trailing_invalidation):
-            if task is not None:
+            if task is not None and task not in leaked:
                 leaked.append(task)
         ingestor._consumer = None
         ingestor._trailing_invalidation = None
@@ -534,6 +540,7 @@ def _stop_leaked_live_usage_ingestor():
     loop_usable = loop is not None and not loop.is_closed() and not loop.is_running()
     needs_reap = (
         live_ingest._ingestor is not None
+        or bool(live_ingest._displaced_ingestors)
         or live_hub._publisher is not None
         or (loop_usable and loop is not None and _pending_live_ingest_tasks(loop))
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -422,16 +422,15 @@ async def _capture_session_loop():
     _SESSION_LOOP = None
 
 
-async def _reap_leaked_live_usage_ingestor() -> list[str]:
-    """Stop and reset the live-usage ingestor singleton, consuming failures.
+async def _reap_leaked_live_usage_ingestor() -> None:
+    """Stop and reset the live-usage ingestor singleton.
 
-    Mirrors ``stop_live_usage_ingestor()`` but retrieves (instead of
-    re-raising) exceptions from tasks that already died, so a poisoned zombie
-    is reported at the test that leaked it rather than crashing the fence
-    mid-reap or surfacing later as an unobserved-task loop exception. Also
-    sweeps by name for ingestor-owned tasks (consumer and trailing
-    invalidation) the stop path no longer tracks — a stop that was itself
-    cancelled between clearing the global and awaiting the tasks.
+    Mirrors ``stop_live_usage_ingestor()`` but never re-raises: every awaited
+    task ends up done, and ``_consume_dead_live_ingest_task_failures`` then
+    retrieves and reports its exception exactly once. Also sweeps by name for
+    ingestor-owned tasks (consumer and trailing invalidation) the stop path no
+    longer tracks — a stop that was itself cancelled between clearing the
+    global and awaiting the tasks.
     """
     from app.core.usage.live_hub import register_live_usage_publisher
     from app.modules.usage import live_ingest
@@ -449,15 +448,40 @@ async def _reap_leaked_live_usage_ingestor() -> list[str]:
     for task in _pending_live_ingest_tasks(asyncio.get_running_loop()):
         if task not in leaked:
             leaked.append(task)
-    failures: list[str] = []
     for task in leaked:
+        live_ingest._owned_tasks.add(task)
         task.cancel()
     for task in leaked:
         try:
             await task
-        except asyncio.CancelledError:
+        except (Exception, asyncio.CancelledError):
+            # Reported by _consume_dead_live_ingest_task_failures.
             continue
-        except Exception as exc:
+
+
+def _consume_dead_live_ingest_task_failures() -> list[str]:
+    """Retrieve exceptions from dead ingestor-owned tasks, loop-free.
+
+    ``asyncio.all_tasks`` only returns unfinished tasks, so a leaked task that
+    already died with an exception is invisible to the pending sweep; its
+    unretrieved exception would fire the loop exception handler when the task
+    object is garbage-collected inside a LATER test (test_proxy_utils'
+    startup-probe assertions capture exactly that). Walk the ingestor's weak
+    ownership registry instead: ``Task.exception()`` both returns the failure
+    for attribution at the test that leaked it and marks it retrieved so no
+    unobserved-task warning can fire later.
+    """
+    from app.modules.usage import live_ingest
+
+    failures: list[str] = []
+    for task in list(live_ingest._owned_tasks):
+        if not task.done():
+            continue
+        live_ingest._owned_tasks.discard(task)
+        if task.cancelled():
+            continue
+        exc = task.exception()
+        if exc is not None:
             failures.append(f"{task.get_name()!r} died with {exc!r}")
     return failures
 
@@ -485,19 +509,24 @@ def _stop_leaked_live_usage_ingestor():
     several tests monkeypatch globally with finite or call-count-sensitive
     fakes that are still active while function-scoped teardowns run (e.g.
     test_conversation_archive's exhausting iterator). Leak detection itself is
-    loop-passive: reading the module globals and enumerating
-    ``asyncio.all_tasks(loop)`` on the idle session loop never runs it.
+    loop-passive: reading the module globals, enumerating
+    ``asyncio.all_tasks(loop)`` on the idle session loop, and retrieving
+    exceptions from already-dead owned tasks never runs the loop.
     """
     yield
     from app.core.usage import live_hub
     from app.modules.usage import live_ingest
 
     loop = _SESSION_LOOP
-    if loop is None or loop.is_closed() or loop.is_running():
-        return
-    if live_ingest._ingestor is None and live_hub._publisher is None and not _pending_live_ingest_tasks(loop):
-        return
-    failures = loop.run_until_complete(_reap_leaked_live_usage_ingestor())
+    loop_usable = loop is not None and not loop.is_closed() and not loop.is_running()
+    needs_reap = (
+        live_ingest._ingestor is not None
+        or live_hub._publisher is not None
+        or (loop_usable and loop is not None and _pending_live_ingest_tasks(loop))
+    )
+    if needs_reap and loop_usable and loop is not None:
+        loop.run_until_complete(_reap_leaked_live_usage_ingestor())
+    failures = _consume_dead_live_ingest_task_failures()
     if failures:
         pytest.fail(
             "test leaked a live-usage ingestor whose task(s) already failed: " + "; ".join(failures),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import tempfile
 from pathlib import Path
@@ -392,3 +393,36 @@ def _reset_shutdown_task_admission():
     shutdown_state.reset()
     yield
     shutdown_state.reset()
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _stop_leaked_live_usage_ingestor():
+    """Fence the module-global live-usage ingestor per test (issue #1755).
+
+    The suite runs on a session-scoped asyncio loop, so a task leaked by one
+    test survives into every later test. Any test that enters the real app
+    lifespan starts the live-usage ingestor singleton
+    (``app.modules.usage.live_ingest._ingestor``) whose ``live-usage-ingestor``
+    consumer task lands on that shared loop; if the lifespan is cancelled
+    before its shutdown path reaches ``stop_live_usage_ingestor()`` (e.g. a
+    ``wait_for``-bounded assertion times out mid-drain), the consumer outlives
+    the test. The zombie then poisons unrelated tests: it eats into the otel
+    lifespan test's drain budget and surfaces as an unobserved-task exception
+    inside test_proxy_utils' startup-probe loop-exception assertions — the
+    exact failing pairing from #1755. Stop and reset the singleton after every
+    test, then reap any consumer task the stop path no longer tracks (a stop
+    that was itself cancelled between clearing the global and awaiting the
+    task), so no ingestor task ever crosses a test boundary.
+    """
+    yield
+    from app.modules.usage import live_ingest
+
+    await live_ingest.stop_live_usage_ingestor()
+    leaked = [task for task in asyncio.all_tasks() if not task.done() and task.get_name() == "live-usage-ingestor"]
+    for task in leaked:
+        task.cancel()
+    for task in leaked:
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -479,7 +479,7 @@ def _drain_live_ingest_task_failures() -> list[str]:
     for task in list(live_ingest._owned_tasks):
         if task.done():
             live_ingest._record_owned_task_result(task)
-    failures = [f"{name!r} died with {exc!r}" for name, exc in live_ingest._owned_task_failures]
+    failures = [f"{name!r} died with {exc_repr}" for name, exc_repr in live_ingest._owned_task_failures]
     live_ingest._owned_task_failures.clear()
     return failures
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -395,8 +395,65 @@ def _reset_shutdown_task_admission():
     shutdown_state.reset()
 
 
-@pytest_asyncio.fixture(autouse=True)
-async def _stop_leaked_live_usage_ingestor():
+_SESSION_LOOP: asyncio.AbstractEventLoop | None = None
+
+
+@pytest_asyncio.fixture(scope="session", autouse=True)
+async def _capture_session_loop():
+    """Expose the shared session loop to sync fixture teardowns.
+
+    The live-usage ingestor fence below must run coroutine cleanup from a
+    synchronous teardown (see its docstring for why it cannot be an async
+    fixture), and pytest-asyncio has no public API to reach the session loop
+    from sync code.
+    """
+    global _SESSION_LOOP
+    _SESSION_LOOP = asyncio.get_running_loop()
+    yield
+    _SESSION_LOOP = None
+
+
+async def _reap_leaked_live_usage_ingestor() -> list[str]:
+    """Stop and reset the live-usage ingestor singleton, consuming failures.
+
+    Mirrors ``stop_live_usage_ingestor()`` but retrieves (instead of
+    re-raising) exceptions from tasks that already died, so a poisoned zombie
+    is reported at the test that leaked it rather than crashing the fence
+    mid-reap or surfacing later as an unobserved-task loop exception. Also
+    sweeps for consumer tasks the stop path no longer tracks (a stop that was
+    itself cancelled between clearing the global and awaiting the task).
+    """
+    from app.core.usage.live_hub import register_live_usage_publisher
+    from app.modules.usage import live_ingest
+
+    ingestor = live_ingest._ingestor
+    live_ingest._ingestor = None
+    register_live_usage_publisher(None)
+    leaked: list[asyncio.Task[None]] = []
+    if ingestor is not None:
+        for task in (ingestor._consumer, ingestor._trailing_invalidation):
+            if task is not None:
+                leaked.append(task)
+        ingestor._consumer = None
+        ingestor._trailing_invalidation = None
+    for task in asyncio.all_tasks():
+        if not task.done() and task.get_name() == "live-usage-ingestor" and task not in leaked:
+            leaked.append(task)
+    failures: list[str] = []
+    for task in leaked:
+        task.cancel()
+    for task in leaked:
+        try:
+            await task
+        except asyncio.CancelledError:
+            continue
+        except Exception as exc:
+            failures.append(f"{task.get_name()!r} died with {exc!r}")
+    return failures
+
+
+@pytest.fixture(autouse=True)
+def _stop_leaked_live_usage_ingestor():
     """Fence the module-global live-usage ingestor per test (issue #1755).
 
     The suite runs on a session-scoped asyncio loop, so a task leaked by one
@@ -410,19 +467,27 @@ async def _stop_leaked_live_usage_ingestor():
     lifespan test's drain budget and surfaces as an unobserved-task exception
     inside test_proxy_utils' startup-probe loop-exception assertions — the
     exact failing pairing from #1755. Stop and reset the singleton after every
-    test, then reap any consumer task the stop path no longer tracks (a stop
-    that was itself cancelled between clearing the global and awaiting the
-    task), so no ingestor task ever crosses a test boundary.
+    test so no ingestor task ever crosses a test boundary.
+
+    Deliberately a sync fixture that only enters the event loop when a leak is
+    actually present: an async fixture's teardown would spin the shared loop
+    after EVERY test, and the loop's clock calls ``time.monotonic()`` — which
+    several tests monkeypatch globally with finite or call-count-sensitive
+    fakes that are still active while function-scoped teardowns run (e.g.
+    test_conversation_archive's exhausting iterator).
     """
     yield
+    from app.core.usage import live_hub
     from app.modules.usage import live_ingest
 
-    await live_ingest.stop_live_usage_ingestor()
-    leaked = [task for task in asyncio.all_tasks() if not task.done() and task.get_name() == "live-usage-ingestor"]
-    for task in leaked:
-        task.cancel()
-    for task in leaked:
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
+    if live_ingest._ingestor is None and live_hub._publisher is None:
+        return
+    loop = _SESSION_LOOP
+    if loop is None or loop.is_closed() or loop.is_running():
+        return
+    failures = loop.run_until_complete(_reap_leaked_live_usage_ingestor())
+    if failures:
+        pytest.fail(
+            "test leaked a live-usage ingestor whose task(s) already failed: " + "; ".join(failures),
+            pytrace=False,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -397,6 +397,15 @@ def _reset_shutdown_task_admission():
 
 _SESSION_LOOP: asyncio.AbstractEventLoop | None = None
 
+# Both task names the live-usage ingestor owns (consumer and throttled
+# trailing cache invalidation); the fence below reclaims them by name when the
+# singleton no longer tracks them.
+_LIVE_INGEST_TASK_NAMES = ("live-usage-ingestor", "live-usage-trailing-invalidation")
+
+
+def _pending_live_ingest_tasks(loop: asyncio.AbstractEventLoop) -> list[asyncio.Task]:
+    return [task for task in asyncio.all_tasks(loop) if not task.done() and task.get_name() in _LIVE_INGEST_TASK_NAMES]
+
 
 @pytest_asyncio.fixture(scope="session", autouse=True)
 async def _capture_session_loop():
@@ -420,8 +429,9 @@ async def _reap_leaked_live_usage_ingestor() -> list[str]:
     re-raising) exceptions from tasks that already died, so a poisoned zombie
     is reported at the test that leaked it rather than crashing the fence
     mid-reap or surfacing later as an unobserved-task loop exception. Also
-    sweeps for consumer tasks the stop path no longer tracks (a stop that was
-    itself cancelled between clearing the global and awaiting the task).
+    sweeps by name for ingestor-owned tasks (consumer and trailing
+    invalidation) the stop path no longer tracks — a stop that was itself
+    cancelled between clearing the global and awaiting the tasks.
     """
     from app.core.usage.live_hub import register_live_usage_publisher
     from app.modules.usage import live_ingest
@@ -436,8 +446,8 @@ async def _reap_leaked_live_usage_ingestor() -> list[str]:
                 leaked.append(task)
         ingestor._consumer = None
         ingestor._trailing_invalidation = None
-    for task in asyncio.all_tasks():
-        if not task.done() and task.get_name() == "live-usage-ingestor" and task not in leaked:
+    for task in _pending_live_ingest_tasks(asyncio.get_running_loop()):
+        if task not in leaked:
             leaked.append(task)
     failures: list[str] = []
     for task in leaked:
@@ -474,16 +484,18 @@ def _stop_leaked_live_usage_ingestor():
     after EVERY test, and the loop's clock calls ``time.monotonic()`` — which
     several tests monkeypatch globally with finite or call-count-sensitive
     fakes that are still active while function-scoped teardowns run (e.g.
-    test_conversation_archive's exhausting iterator).
+    test_conversation_archive's exhausting iterator). Leak detection itself is
+    loop-passive: reading the module globals and enumerating
+    ``asyncio.all_tasks(loop)`` on the idle session loop never runs it.
     """
     yield
     from app.core.usage import live_hub
     from app.modules.usage import live_ingest
 
-    if live_ingest._ingestor is None and live_hub._publisher is None:
-        return
     loop = _SESSION_LOOP
     if loop is None or loop.is_closed() or loop.is_running():
+        return
+    if live_ingest._ingestor is None and live_hub._publisher is None and not _pending_live_ingest_tasks(loop):
         return
     failures = loop.run_until_complete(_reap_leaked_live_usage_ingestor())
     if failures:

--- a/tests/integration/test_live_usage_ingest.py
+++ b/tests/integration/test_live_usage_ingest.py
@@ -856,3 +856,34 @@ async def test_live_ingestion_kill_switch_disables_publishing(monkeypatch, db_se
     finally:
         await live_ingest.stop_live_usage_ingestor()
         get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_nested_lifespan_stop_does_not_orphan_or_kill_the_outer_ingestor() -> None:
+    # Two app lifespans can be live in one process: the suite's async_client
+    # runs one on the session loop while a test opens a TestClient whose
+    # portal runs another. Each lifespan owns the instance start returned and
+    # stops exactly that instance. Before instance-scoped stop, the nested
+    # startup overwrote the module global, orphaned the outer ingestor as an
+    # unreferenced cycle, and the cyclic GC destroyed its consumer mid-await
+    # ("cannot reuse already awaited coroutine" — issue #1755's integration
+    # signature); the nested shutdown then cleared the global so the outer
+    # shutdown stopped nothing.
+    def _pending_consumers() -> list[asyncio.Task[object]]:
+        return [t for t in asyncio.all_tasks() if not t.done() and t.get_name() == "live-usage-ingestor"]
+
+    outer = live_ingest.start_live_usage_ingestor()
+    assert outer is not None
+    inner = live_ingest.start_live_usage_ingestor()
+    assert inner is not None and inner is not outer
+    assert live_ingest._ingestor is inner
+
+    # Nested lifespan shutdown: releases the singleton it owns, nothing else.
+    await live_ingest.stop_live_usage_ingestor(inner)
+    assert live_ingest._ingestor is None
+    assert outer._consumer is not None and not outer._consumer.done()
+
+    # Outer lifespan shutdown: stops its own instance even though the global
+    # no longer points at it; no consumer survives for the suite fence.
+    await live_ingest.stop_live_usage_ingestor(outer)
+    assert _pending_consumers() == []

--- a/tests/integration/test_live_usage_ingest.py
+++ b/tests/integration/test_live_usage_ingest.py
@@ -859,7 +859,9 @@ async def test_live_ingestion_kill_switch_disables_publishing(monkeypatch, db_se
 
 
 @pytest.mark.asyncio
-async def test_nested_lifespan_stop_does_not_orphan_or_kill_the_outer_ingestor() -> None:
+async def test_nested_lifespan_stop_does_not_orphan_or_kill_the_outer_ingestor(db_setup) -> None:
+    del db_setup
+
     # Two app lifespans can be live in one process: the suite's async_client
     # runs one on the session loop while a test opens a TestClient whose
     # portal runs another. Each lifespan owns the instance start returned and
@@ -868,9 +870,14 @@ async def test_nested_lifespan_stop_does_not_orphan_or_kill_the_outer_ingestor()
     # unreferenced cycle, and the cyclic GC destroyed its consumer mid-await
     # ("cannot reuse already awaited coroutine" — issue #1755's integration
     # signature); the nested shutdown then cleared the global so the outer
-    # shutdown stopped nothing.
+    # shutdown stopped nothing. And a nested shutdown that merely cleared the
+    # registration would leave the still-running outer ingestor deaf: it must
+    # instead restore the outer instance as the current registration.
     def _pending_consumers() -> list[asyncio.Task[object]]:
         return [t for t in asyncio.all_tasks() if not t.done() and t.get_name() == "live-usage-ingestor"]
+
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(_make_account("acc_live_nested", "live-nested@example.com"))
 
     outer = live_ingest.start_live_usage_ingestor()
     assert outer is not None
@@ -878,12 +885,23 @@ async def test_nested_lifespan_stop_does_not_orphan_or_kill_the_outer_ingestor()
     assert inner is not None and inner is not outer
     assert live_ingest._ingestor is inner
 
-    # Nested lifespan shutdown: releases the singleton it owns, nothing else.
+    # Nested lifespan shutdown: releases the registration it owns and
+    # restores the still-running outer instance in its place.
     await live_ingest.stop_live_usage_ingestor(inner)
-    assert live_ingest._ingestor is None
+    assert live_ingest._ingestor is outer
+    assert live_ingest._displaced_ingestors == []
     assert outer._consumer is not None and not outer._consumer.done()
 
-    # Outer lifespan shutdown: stops its own instance even though the global
-    # no longer points at it; no consumer survives for the suite fence.
+    # Outer ingestion RESUMES: a hub publication after the nested exit must
+    # flow to the outer instance and be ingested end to end.
+    live_hub.publish_live_usage(_snapshot(), account_id="acc_live_nested")
+    primary, secondary = await _wait_for_rows("acc_live_nested")
+    assert primary is not None and secondary is not None
+    assert primary.used_percent == pytest.approx(33.0)
+
+    # Outer lifespan shutdown: stops its own instance, clears the restored
+    # registration, and no consumer survives for the suite fence.
     await live_ingest.stop_live_usage_ingestor(outer)
+    assert live_ingest._ingestor is None
+    assert live_hub._publisher is None
     assert _pending_consumers() == []

--- a/tests/unit/test_live_ingest_leak_fence.py
+++ b/tests/unit/test_live_ingest_leak_fence.py
@@ -9,7 +9,7 @@ cancelled before its shutdown path reaches ``stop_live_usage_ingestor()``
 otel lifespan-drain test and test_proxy_utils' startup-probe loop-exception
 assertions.
 
-The two tests below are ORDER-DEPENDENT by design (pytest runs them in
+The first two tests are ORDER-DEPENDENT by design (pytest runs them in
 definition order): the first reproduces the leak by starting the ingestor
 singleton exactly like the app lifespan does and deliberately never stopping
 it; the second asserts the autouse ``_stop_leaked_live_usage_ingestor`` fence
@@ -22,6 +22,8 @@ from __future__ import annotations
 
 import asyncio
 import time
+
+import pytest
 
 from app.core.usage import live_hub
 from app.modules.usage import live_ingest
@@ -50,35 +52,35 @@ async def test_fence_reclaims_leaked_consumer_at_test_boundary() -> None:
     assert live_hub._publisher is None
 
 
-async def test_reap_consumes_and_reports_already_failed_consumer() -> None:
+async def test_reap_settles_and_reports_already_failed_consumer(monkeypatch: pytest.MonkeyPatch) -> None:
     # A leaked consumer can already be dead with an exception by the time the
     # fence runs (#1755 observed RuntimeError('cannot reuse already awaited
     # coroutine')). The fence must retrieve that exception — so it neither
     # crashes mid-cleanup nor resurfaces later as an unobserved-task loop
-    # exception in an unrelated test — and report it for attribution.
+    # exception in an unrelated test — and report it exactly once even though
+    # both the done callback and the fence sweep observe the dead task.
     from tests import conftest as suite_conftest
 
-    async def _boom() -> None:
+    async def _boom(self: live_ingest.LiveUsageIngestor) -> None:
         raise RuntimeError("cannot reuse already awaited coroutine")
 
-    task = asyncio.create_task(_boom(), name="live-usage-ingestor")
-    await asyncio.sleep(0)
-    assert task.done()
-
+    monkeypatch.setattr(live_ingest.LiveUsageIngestor, "_run", _boom)
     ingestor = live_ingest.LiveUsageIngestor(queue_size=1, write_min_interval_seconds=0.0)
-    ingestor._consumer = task
+    ingestor.start()
     live_ingest._ingestor = ingestor
     live_hub.register_live_usage_publisher(ingestor.publish)
+    await asyncio.sleep(0)
+    assert ingestor._consumer is not None and ingestor._consumer.done()
 
     await suite_conftest._reap_leaked_live_usage_ingestor()
-    failures = suite_conftest._consume_dead_live_ingest_task_failures()
+    failures = suite_conftest._drain_live_ingest_task_failures()
 
     assert failures == ["'live-usage-ingestor' died with RuntimeError('cannot reuse already awaited coroutine')"]
     assert live_ingest._ingestor is None
     assert live_hub._publisher is None
     assert _pending_ingestor_tasks() == []
-    # Retrieval is idempotent: a second pass reports nothing.
-    assert suite_conftest._consume_dead_live_ingest_task_failures() == []
+    # Settlement is exactly-once: a second pass reports nothing.
+    assert suite_conftest._drain_live_ingest_task_failures() == []
 
 
 async def test_reap_sweeps_orphaned_tasks_not_tracked_by_singleton() -> None:
@@ -100,36 +102,65 @@ async def test_reap_sweeps_orphaned_tasks_not_tracked_by_singleton() -> None:
 
     assert consumer.cancelled()
     assert trailing.cancelled()
-    assert suite_conftest._consume_dead_live_ingest_task_failures() == []
+    assert suite_conftest._drain_live_ingest_task_failures() == []
     assert suite_conftest._pending_live_ingest_tasks(asyncio.get_running_loop()) == []
 
 
-async def test_dead_detached_owned_task_exception_is_consumed_without_the_loop() -> None:
+async def test_dead_detached_owned_task_failure_is_recorded_and_drained_loop_free(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     # An ingestor-owned task can die with an exception after the singleton and
     # its task fields are already cleared. asyncio.all_tasks() only returns
-    # unfinished tasks, so the pending sweep cannot see it — the weak
-    # ownership registry in live_ingest must still surface (and retrieve) the
-    # failure, and must do so without running the event loop.
+    # unfinished tasks, so the pending sweep cannot see it — the done callback
+    # installed at task creation must have already retrieved the exception
+    # into the strong failure handoff, which the fence drains without running
+    # the event loop.
     from tests import conftest as suite_conftest
 
-    async def _boom() -> None:
+    async def _boom(self: live_ingest.LiveUsageIngestor) -> None:
         raise RuntimeError("late detached failure")
 
-    task = asyncio.create_task(_boom(), name="live-usage-trailing-invalidation")
-    live_ingest._owned_tasks.add(task)
+    monkeypatch.setattr(live_ingest.LiveUsageIngestor, "_run", _boom)
+    ingestor = live_ingest.LiveUsageIngestor(queue_size=1, write_min_interval_seconds=0.0)
+    ingestor.start()
     await asyncio.sleep(0)
-    assert task.done()
+    await asyncio.sleep(0)  # let the done callback run
+    ingestor._consumer = None  # fully detach: no owner, no pending task
+    del ingestor
     assert live_ingest._ingestor is None
     assert live_hub._publisher is None
     assert suite_conftest._pending_live_ingest_tasks(asyncio.get_running_loop()) == []
 
-    failures = suite_conftest._consume_dead_live_ingest_task_failures()
+    failures = suite_conftest._drain_live_ingest_task_failures()
 
-    assert failures == ["'live-usage-trailing-invalidation' died with RuntimeError('late detached failure')"]
-    assert suite_conftest._consume_dead_live_ingest_task_failures() == []
+    assert failures == ["'live-usage-ingestor' died with RuntimeError('late detached failure')"]
+    assert suite_conftest._drain_live_ingest_task_failures() == []
 
 
-async def test_ingestor_registers_its_tasks_in_the_ownership_registry() -> None:
+async def test_drain_settles_dead_task_whose_done_callback_has_not_run() -> None:
+    # A task that finishes in the loop's final iteration can still have its
+    # done callback queued when the sync fence runs; the drain's sweep over
+    # the weak ownership registry must settle it directly, and the callback
+    # running later must not report it a second time.
+    from tests import conftest as suite_conftest
+
+    async def _boom() -> None:
+        raise RuntimeError("callback still queued")
+
+    task = asyncio.create_task(_boom(), name="live-usage-trailing-invalidation")
+    live_ingest._owned_tasks.add(task)  # enrolled, but callback never attached
+    await asyncio.sleep(0)
+    assert task.done()
+
+    failures = suite_conftest._drain_live_ingest_task_failures()
+    assert failures == ["'live-usage-trailing-invalidation' died with RuntimeError('callback still queued')"]
+
+    # The (simulated late) callback observes an already-settled task.
+    live_ingest._record_owned_task_result(task)
+    assert suite_conftest._drain_live_ingest_task_failures() == []
+
+
+async def test_ingestor_enrolls_both_task_types_in_the_ownership_registry() -> None:
     # The registry only protects tests if production task creation actually
     # enrolls both task types.
     ingestor = live_ingest.LiveUsageIngestor(queue_size=1, write_min_interval_seconds=0.0)

--- a/tests/unit/test_live_ingest_leak_fence.py
+++ b/tests/unit/test_live_ingest_leak_fence.py
@@ -21,6 +21,7 @@ Without the fence the second test fails with a pending
 from __future__ import annotations
 
 import asyncio
+import time
 
 from app.core.usage import live_hub
 from app.modules.usage import live_ingest
@@ -52,9 +53,9 @@ async def test_fence_reclaims_leaked_consumer_at_test_boundary() -> None:
 async def test_reap_consumes_and_reports_already_failed_consumer() -> None:
     # A leaked consumer can already be dead with an exception by the time the
     # fence runs (#1755 observed RuntimeError('cannot reuse already awaited
-    # coroutine')). The reap must retrieve that exception — so it neither
-    # crashes the fence mid-cleanup nor resurfaces later as an unobserved-task
-    # loop exception in an unrelated test — and report it for attribution.
+    # coroutine')). The fence must retrieve that exception — so it neither
+    # crashes mid-cleanup nor resurfaces later as an unobserved-task loop
+    # exception in an unrelated test — and report it for attribution.
     from tests import conftest as suite_conftest
 
     async def _boom() -> None:
@@ -69,12 +70,15 @@ async def test_reap_consumes_and_reports_already_failed_consumer() -> None:
     live_ingest._ingestor = ingestor
     live_hub.register_live_usage_publisher(ingestor.publish)
 
-    failures = await suite_conftest._reap_leaked_live_usage_ingestor()
+    await suite_conftest._reap_leaked_live_usage_ingestor()
+    failures = suite_conftest._consume_dead_live_ingest_task_failures()
 
     assert failures == ["'live-usage-ingestor' died with RuntimeError('cannot reuse already awaited coroutine')"]
     assert live_ingest._ingestor is None
     assert live_hub._publisher is None
     assert _pending_ingestor_tasks() == []
+    # Retrieval is idempotent: a second pass reports nothing.
+    assert suite_conftest._consume_dead_live_ingest_task_failures() == []
 
 
 async def test_reap_sweeps_orphaned_tasks_not_tracked_by_singleton() -> None:
@@ -92,9 +96,48 @@ async def test_reap_sweeps_orphaned_tasks_not_tracked_by_singleton() -> None:
     await asyncio.sleep(0)
     assert live_ingest._ingestor is None
 
-    failures = await suite_conftest._reap_leaked_live_usage_ingestor()
+    await suite_conftest._reap_leaked_live_usage_ingestor()
 
-    assert failures == []
     assert consumer.cancelled()
     assert trailing.cancelled()
+    assert suite_conftest._consume_dead_live_ingest_task_failures() == []
     assert suite_conftest._pending_live_ingest_tasks(asyncio.get_running_loop()) == []
+
+
+async def test_dead_detached_owned_task_exception_is_consumed_without_the_loop() -> None:
+    # An ingestor-owned task can die with an exception after the singleton and
+    # its task fields are already cleared. asyncio.all_tasks() only returns
+    # unfinished tasks, so the pending sweep cannot see it — the weak
+    # ownership registry in live_ingest must still surface (and retrieve) the
+    # failure, and must do so without running the event loop.
+    from tests import conftest as suite_conftest
+
+    async def _boom() -> None:
+        raise RuntimeError("late detached failure")
+
+    task = asyncio.create_task(_boom(), name="live-usage-trailing-invalidation")
+    live_ingest._owned_tasks.add(task)
+    await asyncio.sleep(0)
+    assert task.done()
+    assert live_ingest._ingestor is None
+    assert live_hub._publisher is None
+    assert suite_conftest._pending_live_ingest_tasks(asyncio.get_running_loop()) == []
+
+    failures = suite_conftest._consume_dead_live_ingest_task_failures()
+
+    assert failures == ["'live-usage-trailing-invalidation' died with RuntimeError('late detached failure')"]
+    assert suite_conftest._consume_dead_live_ingest_task_failures() == []
+
+
+async def test_ingestor_registers_its_tasks_in_the_ownership_registry() -> None:
+    # The registry only protects tests if production task creation actually
+    # enrolls both task types.
+    ingestor = live_ingest.LiveUsageIngestor(queue_size=1, write_min_interval_seconds=0.0)
+    ingestor.start()
+    ingestor._last_cache_invalidation = time.monotonic()
+    await ingestor._invalidate_caches_throttled()
+
+    assert ingestor._consumer in live_ingest._owned_tasks
+    assert ingestor._trailing_invalidation in live_ingest._owned_tasks
+
+    await ingestor.stop()

--- a/tests/unit/test_live_ingest_leak_fence.py
+++ b/tests/unit/test_live_ingest_leak_fence.py
@@ -47,3 +47,51 @@ async def test_fence_reclaims_leaked_consumer_at_test_boundary() -> None:
     assert _pending_ingestor_tasks() == []
     assert live_ingest._ingestor is None
     assert live_hub._publisher is None
+
+
+async def test_reap_consumes_and_reports_already_failed_consumer() -> None:
+    # A leaked consumer can already be dead with an exception by the time the
+    # fence runs (#1755 observed RuntimeError('cannot reuse already awaited
+    # coroutine')). The reap must retrieve that exception — so it neither
+    # crashes the fence mid-cleanup nor resurfaces later as an unobserved-task
+    # loop exception in an unrelated test — and report it for attribution.
+    from tests import conftest as suite_conftest
+
+    async def _boom() -> None:
+        raise RuntimeError("cannot reuse already awaited coroutine")
+
+    task = asyncio.create_task(_boom(), name="live-usage-ingestor")
+    await asyncio.sleep(0)
+    assert task.done()
+
+    ingestor = live_ingest.LiveUsageIngestor(queue_size=1, write_min_interval_seconds=0.0)
+    ingestor._consumer = task
+    live_ingest._ingestor = ingestor
+    live_hub.register_live_usage_publisher(ingestor.publish)
+
+    failures = await suite_conftest._reap_leaked_live_usage_ingestor()
+
+    assert failures == ["'live-usage-ingestor' died with RuntimeError('cannot reuse already awaited coroutine')"]
+    assert live_ingest._ingestor is None
+    assert live_hub._publisher is None
+    assert _pending_ingestor_tasks() == []
+
+
+async def test_reap_sweeps_orphaned_consumer_not_tracked_by_singleton() -> None:
+    # A stop that is itself cancelled between clearing the module global and
+    # awaiting the consumer leaves a pending task no singleton tracks; the
+    # reap's name-based sweep must still cancel and await it.
+    from tests import conftest as suite_conftest
+
+    async def _pending_forever() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(_pending_forever(), name="live-usage-ingestor")
+    await asyncio.sleep(0)
+    assert live_ingest._ingestor is None
+
+    failures = await suite_conftest._reap_leaked_live_usage_ingestor()
+
+    assert failures == []
+    assert task.cancelled()
+    assert _pending_ingestor_tasks() == []

--- a/tests/unit/test_live_ingest_leak_fence.py
+++ b/tests/unit/test_live_ingest_leak_fence.py
@@ -1,0 +1,49 @@
+"""Regression tests for issue #1755: cross-test live-usage-ingestor leakage.
+
+The unit suite runs on a session-scoped asyncio loop, so a background task
+leaked by one test survives into every later test. Tests that enter the real
+app lifespan start the module-global live-usage ingestor; when the lifespan is
+cancelled before its shutdown path reaches ``stop_live_usage_ingestor()``
+(e.g. a ``wait_for``-bounded assertion times out mid-drain), the
+``live-usage-ingestor`` consumer task outlives the test and later poisons the
+otel lifespan-drain test and test_proxy_utils' startup-probe loop-exception
+assertions.
+
+The two tests below are ORDER-DEPENDENT by design (pytest runs them in
+definition order): the first reproduces the leak by starting the ingestor
+singleton exactly like the app lifespan does and deliberately never stopping
+it; the second asserts the autouse ``_stop_leaked_live_usage_ingestor`` fence
+in tests/conftest.py reclaimed the consumer at the previous test's boundary.
+Without the fence the second test fails with a pending
+``live-usage-ingestor`` task — the coupling observed in #1755.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from app.core.usage import live_hub
+from app.modules.usage import live_ingest
+
+
+def _pending_ingestor_tasks() -> list[asyncio.Task[object]]:
+    return [task for task in asyncio.all_tasks() if not task.done() and task.get_name() == "live-usage-ingestor"]
+
+
+async def test_abandoned_ingestor_simulates_lifespan_cancelled_before_stop() -> None:
+    # This is exactly what app.main's lifespan startup does; a lifespan
+    # cancelled mid-shutdown-drain never reaches stop_live_usage_ingestor(),
+    # so nothing in this test stops the singleton either. The autouse fence
+    # in tests/conftest.py must reclaim it at this test's boundary.
+    ingestor = live_ingest.start_live_usage_ingestor()
+
+    assert ingestor is not None
+    assert live_ingest._ingestor is ingestor
+    assert live_hub._publisher is not None
+    assert len(_pending_ingestor_tasks()) == 1
+
+
+async def test_fence_reclaims_leaked_consumer_at_test_boundary() -> None:
+    assert _pending_ingestor_tasks() == []
+    assert live_ingest._ingestor is None
+    assert live_hub._publisher is None

--- a/tests/unit/test_live_ingest_leak_fence.py
+++ b/tests/unit/test_live_ingest_leak_fence.py
@@ -77,21 +77,24 @@ async def test_reap_consumes_and_reports_already_failed_consumer() -> None:
     assert _pending_ingestor_tasks() == []
 
 
-async def test_reap_sweeps_orphaned_consumer_not_tracked_by_singleton() -> None:
+async def test_reap_sweeps_orphaned_tasks_not_tracked_by_singleton() -> None:
     # A stop that is itself cancelled between clearing the module global and
-    # awaiting the consumer leaves a pending task no singleton tracks; the
-    # reap's name-based sweep must still cancel and await it.
+    # awaiting the ingestor's tasks leaves pending tasks no singleton tracks;
+    # the reap's name-based sweep must still cancel and await both the
+    # consumer and the trailing cache-invalidation sleeper.
     from tests import conftest as suite_conftest
 
     async def _pending_forever() -> None:
         await asyncio.Event().wait()
 
-    task = asyncio.create_task(_pending_forever(), name="live-usage-ingestor")
+    consumer = asyncio.create_task(_pending_forever(), name="live-usage-ingestor")
+    trailing = asyncio.create_task(_pending_forever(), name="live-usage-trailing-invalidation")
     await asyncio.sleep(0)
     assert live_ingest._ingestor is None
 
     failures = await suite_conftest._reap_leaked_live_usage_ingestor()
 
     assert failures == []
-    assert task.cancelled()
-    assert _pending_ingestor_tasks() == []
+    assert consumer.cancelled()
+    assert trailing.cancelled()
+    assert suite_conftest._pending_live_ingest_tasks(asyncio.get_running_loop()) == []


### PR DESCRIPTION
## Problem

Two unit tests fail together on shared runs and pass alone (#1755):

- `tests/unit/test_otel.py::test_lifespan_drains_actual_audit_and_cancelled_fleet_tasks_before_resource_close` — `TimeoutError`
- `tests/unit/test_proxy_utils.py::test_responses_startup_probe_timeout_consumes_abandoned_first_task_exception` — captures a leaked `live-usage-ingestor` task exception (`RuntimeError('cannot reuse already awaited coroutine')`)

## Root cause

The suite runs on one session-scoped asyncio loop (`asyncio_default_test_loop_scope = "session"`), so any task leaked by one test survives into every later test. Tests that enter the real `app.main` lifespan start the module-global live-usage ingestor (`app/modules/usage/live_ingest._ingestor`); if the lifespan is cancelled before its shutdown path reaches `stop_live_usage_ingestor()` (a `wait_for`-bounded assertion timing out mid-drain), the consumer task outlives the test. The zombie then (a) eats into the otel lifespan test's 5s drain budget and (b) keeps running against later tests' monkeypatched state, dying with an unretrieved exception that fires the loop exception handler inside whichever test is running when the task object is finally collected — exactly the observed pairing.

## Fix

**Test infrastructure (the fence, `tests/conftest.py`):** an autouse teardown fence stops and resets the ingestor singleton after every test, reaps pending ingestor-owned tasks by name (including ones a cancelled stop no longer tracks), and drains recorded task failures — reported via `pytest.fail` at the test that leaked them. The fence is deliberately a **sync** fixture that only enters the loop when a leak is present: an async fixture's teardown spins the loop after every test, and the loop clock calls `time.monotonic()`, which several tests monkeypatch globally with finite fakes still active during teardown (test_conversation_archive fails with `StopIteration` under an async fence).

**Production hardening (`app/modules/usage/live_ingest.py`) — a real hazard existed beyond test infra:** an ingestor-owned task that dies after its owner lost track of it surfaced only as a nondeterministic "Task exception was never retrieved" warning at GC time. Every task the ingestor creates is now named, enrolled in a weak ownership registry, and settled by a done callback at completion: the exception is retrieved (so the GC-time warning can never fire), logged immediately with its traceback, and recorded as bounded traceback-free metadata (name + repr, so the record cannot retain the failed task's object graph). Settlement is gated by a settled-task registry so the callback and the fence's sweep report each task exactly once. Ingestion semantics (enqueue, coalescing, throttling, shutdown ordering) are unchanged.

OpenSpec: `openspec/changes/settle-live-ingest-task-failures/` (validated `--strict`).

## Test evidence

- RED: on main's conftest, the new order-dependent pair fails — the leaked pending `live-usage-ingestor` task crosses the test boundary (`tests/unit/test_live_ingest_leak_fence.py::test_fence_reclaims_leaked_consumer_at_test_boundary`). GREEN with the fence.
- Regressions for: dead-consumer settlement and exactly-once reporting, orphaned-task name sweep (consumer + trailing invalidation), detached-death recording via the done callback (loop-free drain), queued-callback settlement, and production enrollment of both task types.
- Full unit suite (CI shape, single process): **6120 passed, 3 skipped**.
- Integration suite: 2138 passed; 2 failures are environmental (missing frontend build artifact in the worktree; a load-timing flake in `test_codex_goal_restart_cannot_retire_owner_outside_api_key_scope` that passes alone) — unrelated to this change.
- `uv run ruff check` / `ruff format --check` / `ty check` green; `openspec validate settle-live-ingest-task-failures --strict` green.
- Local `codex review --base main`: 7 rounds to convergence; all P1/P2 findings addressed (failed-task consumption, orphan sweep when globals are clear, unnamed trailing task, GC-timing determinism via strong failure handoff, OpenSpec artifact, traceback-free retention). Final round: no findings.

Fixes #1755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Background live-usage ingestion failures are now captured, logged, and settled reliably.
  * Cancellations complete silently without unnecessary warnings.
  * Repeated failures are handled once and retained within bounded limits.
  * Prevented unobserved-task warnings from background ingestion.
  * Improved overlapping and nested lifecycle shutdown to avoid interrupting active processing.

* **Tests**
  * Added coverage for task cleanup, failure handling, cancellation, lifecycle isolation, and nested startup and shutdown scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->