### PR TITLE
perf(proxy): validate stream payloads only for lifecycle events

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -62,7 +62,6 @@ from app.core.openai.models import CompactResponsePayload, OpenAIError
 from app.core.openai.parsing import (
     parse_compact_response_payload,
     parse_error_payload,
-    parse_sse_event,
 )
 from app.core.openai.requests import (
     ResponsesCompactRequest,
@@ -2145,9 +2144,10 @@ async def _stream_responses_via_websocket(
                 headers=headers,
                 extra={"event_format": "sse"},
             )
-            parsed_event = parse_sse_event(event)
-            if parsed_event and _is_response_stream_terminal_event_type(
-                parsed_event.type,
+            event_payload = parse_sse_data_json(event)
+            event_type = event_payload.get("type") if event_payload is not None else None
+            if isinstance(event_type, str) and _is_response_stream_terminal_event_type(
+                event_type,
                 enforce_openai_sdk_contract=enforce_openai_sdk_contract,
             ):
                 seen_terminal = True
@@ -2908,13 +2908,7 @@ async def _stream_responses_with_session(
                         event_block,
                         enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                     )
-                    event = parse_sse_event(event_block)
-                    if event:
-                        if event.type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES or (
-                            event.type == "error" and not enforce_openai_sdk_contract
-                        ):
-                            seen_terminal = True
-                    elif isinstance(normalized_event_type, str) and (
+                    if isinstance(normalized_event_type, str) and (
                         normalized_event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
                         or (normalized_event_type == "error" and not enforce_openai_sdk_contract)
                     ):
@@ -3002,13 +2996,7 @@ async def _stream_responses_with_session(
                     event_block,
                     enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                 )
-                event = parse_sse_event(event_block)
-                if event:
-                    if event.type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES or (
-                        event.type == "error" and not enforce_openai_sdk_contract
-                    ):
-                        seen_terminal = True
-                elif isinstance(normalized_event_type, str) and (
+                if isinstance(normalized_event_type, str) and (
                     normalized_event_type in _RESPONSE_STREAM_TERMINAL_EVENT_TYPES
                     or (normalized_event_type == "error" and not enforce_openai_sdk_contract)
                 ):
@@ -3134,14 +3122,13 @@ async def _stream_responses_with_session(
                 ):
                     if status_code is None:
                         status_code = 101
-                    event = parse_sse_event(event_block)
-                    if event:
-                        event_type = event.type
-                        if _is_response_stream_terminal_event_type(
-                            event_type,
-                            enforce_openai_sdk_contract=enforce_openai_sdk_contract,
-                        ):
-                            seen_terminal = True
+                    event_payload = parse_sse_data_json(event_block)
+                    event_type = event_payload.get("type") if event_payload is not None else None
+                    if isinstance(event_type, str) and _is_response_stream_terminal_event_type(
+                        event_type,
+                        enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+                    ):
+                        seen_terminal = True
                     yield event_block
             except aiohttp.WSServerHandshakeError as exc:
                 if not _should_fallback_to_http_after_websocket_handshake_error(transport_mode, exc):

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -60,6 +60,7 @@ from app.core.openai.exceptions import ClientPayloadError
 from app.core.openai.model_registry import get_model_registry
 from app.core.openai.models import CompactResponsePayload, OpenAIError
 from app.core.openai.parsing import (
+    classify_event_type,
     parse_compact_response_payload,
     parse_error_payload,
 )
@@ -1401,37 +1402,42 @@ def _normalize_stream_event_payload(payload: dict[str, JsonValue]) -> dict[str, 
         normalized = dict(payload)
         normalized["type"] = _SSE_EVENT_TYPE_ALIASES[event_type]
         return normalized
-    error = parse_error_payload(payload)
-    if error is not None:
-        detail = error.model_dump(exclude_none=True)
-        event = response_failed_event(
-            _normalize_error_code(detail.get("code"), detail.get("type")),
-            detail.get("message", "Upstream websocket error"),
-            error_type=detail.get("type") or "server_error",
-            response_id=get_request_id(),
-            error_param=detail.get("param"),
-        )
-        _copy_quota_error_metadata(event["response"]["error"], detail)
-        return cast(dict[str, JsonValue], event)
-    if event_type == "error":
-        message = _extract_upstream_message(payload) or "Upstream websocket error"
-        code = payload.get("code")
-        error_type = payload.get("error_type") or payload.get("type")
-        normalized_code = _normalize_error_code(
-            code if isinstance(code, str) else None,
-            error_type if isinstance(error_type, str) else None,
-        )
-        if not isinstance(code, str) and normalized_code == "error":
-            normalized_code = "upstream_error"
-        return cast(
-            dict[str, JsonValue],
-            response_failed_event(
-                normalized_code,
-                message,
-                error_type=error_type if isinstance(error_type, str) and error_type != "error" else "server_error",
+    # Error-envelope schema validation is the only pydantic work on this hot
+    # path: classify from the parsed dict first and validate only error-shaped
+    # frames (``type == "error"`` or a top-level ``error`` envelope) so delta
+    # frames never reach the pydantic adapter.
+    if classify_event_type(payload) == "error" or isinstance(payload.get("error"), dict):
+        error = parse_error_payload(payload)
+        if error is not None:
+            detail = error.model_dump(exclude_none=True)
+            event = response_failed_event(
+                _normalize_error_code(detail.get("code"), detail.get("type")),
+                detail.get("message", "Upstream websocket error"),
+                error_type=detail.get("type") or "server_error",
                 response_id=get_request_id(),
-            ),
-        )
+                error_param=detail.get("param"),
+            )
+            _copy_quota_error_metadata(event["response"]["error"], detail)
+            return cast(dict[str, JsonValue], event)
+        if event_type == "error":
+            message = _extract_upstream_message(payload) or "Upstream websocket error"
+            code = payload.get("code")
+            error_type = payload.get("error_type") or payload.get("type")
+            normalized_code = _normalize_error_code(
+                code if isinstance(code, str) else None,
+                error_type if isinstance(error_type, str) else None,
+            )
+            if not isinstance(code, str) and normalized_code == "error":
+                normalized_code = "upstream_error"
+            return cast(
+                dict[str, JsonValue],
+                response_failed_event(
+                    normalized_code,
+                    message,
+                    error_type=error_type if isinstance(error_type, str) and error_type != "error" else "server_error",
+                    response_id=get_request_id(),
+                ),
+            )
     return payload
 
 
@@ -1807,7 +1813,12 @@ async def _stream_websocket_events(
     total_timeout_seconds: float | None,
     max_event_bytes: int,
     enforce_openai_sdk_contract: bool = True,
-) -> AsyncIterator[str]:
+) -> AsyncIterator[tuple[str, str | None]]:
+    """Yield ``(sse_block, event_type)`` pairs.
+
+    The event type is extracted from the payload parsed once here so that
+    downstream consumers never re-decode the formatted block.
+    """
     deadline = None if total_timeout_seconds is None else time.monotonic() + total_timeout_seconds
 
     while True:
@@ -1850,9 +1861,10 @@ async def _stream_websocket_events(
         if not isinstance(payload, dict):
             continue
         normalized = payload if not enforce_openai_sdk_contract else _normalize_stream_event_payload(payload)
-        event_type = normalized.get("type")
-        yield format_sse_event(normalized)
-        if isinstance(event_type, str) and _is_response_stream_terminal_event_type(
+        raw_event_type = normalized.get("type")
+        event_type = raw_event_type if isinstance(raw_event_type, str) else None
+        yield format_sse_event(normalized), event_type
+        if event_type is not None and _is_response_stream_terminal_event_type(
             event_type,
             enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         ):
@@ -1866,7 +1878,8 @@ async def _stream_codex_websocket_events(
     total_timeout_seconds: float | None,
     max_event_bytes: int,
     enforce_openai_sdk_contract: bool = True,
-) -> AsyncIterator[str]:
+) -> AsyncIterator[tuple[str, str | None]]:
+    """Yield ``(sse_block, event_type)`` pairs; see ``_stream_websocket_events``."""
     deadline = None if total_timeout_seconds is None else time.monotonic() + total_timeout_seconds
 
     while True:
@@ -1916,9 +1929,10 @@ async def _stream_codex_websocket_events(
         if not isinstance(payload, dict):
             continue
         normalized = payload if not enforce_openai_sdk_contract else _normalize_stream_event_payload(payload)
-        event_type = normalized.get("type")
-        yield format_sse_event(normalized)
-        if isinstance(event_type, str) and _is_response_stream_terminal_event_type(
+        raw_event_type = normalized.get("type")
+        event_type = raw_event_type if isinstance(raw_event_type, str) else None
+        yield format_sse_event(normalized), event_type
+        if event_type is not None and _is_response_stream_terminal_event_type(
             event_type,
             enforce_openai_sdk_contract=enforce_openai_sdk_contract,
         ):
@@ -1953,7 +1967,8 @@ async def _stream_responses_via_websocket(
     route_trace: UpstreamProxyRouteTrace | None = None,
     allow_direct_egress: bool = True,
     enforce_openai_sdk_contract: bool = True,
-) -> AsyncIterator[str]:
+) -> AsyncIterator[tuple[str, str | None]]:
+    """Yield ``(sse_block, event_type)`` pairs from the upstream websocket."""
     websocket_url = _to_websocket_upstream_url(url)
     request_started_at = time.monotonic()
     request_payload = _prepare_websocket_response_create_payload(payload_dict)
@@ -2132,7 +2147,7 @@ async def _stream_responses_via_websocket(
                 enforce_openai_sdk_contract=enforce_openai_sdk_contract,
             )
         )
-        async for event in event_iter:
+        async for event, event_type in event_iter:
             archive_text(
                 direction="server_to_codex",
                 kind="responses",
@@ -2144,15 +2159,13 @@ async def _stream_responses_via_websocket(
                 headers=headers,
                 extra={"event_format": "sse"},
             )
-            event_payload = parse_sse_data_json(event)
-            event_type = event_payload.get("type") if event_payload is not None else None
-            if isinstance(event_type, str) and _is_response_stream_terminal_event_type(
+            if event_type is not None and _is_response_stream_terminal_event_type(
                 event_type,
                 enforce_openai_sdk_contract=enforce_openai_sdk_contract,
             ):
                 seen_terminal = True
                 await _record_lifecycle_success()
-            yield event
+            yield event, event_type
         if not seen_terminal:
             await _record_lifecycle_failure(aiohttp.ClientError("Upstream websocket closed without terminal event"))
     except Exception as exc:
@@ -3104,7 +3117,7 @@ async def _stream_responses_with_session(
     try:
         if transport == "websocket":
             try:
-                async for event_block in _stream_responses_via_websocket(
+                async for event_block, event_type in _stream_responses_via_websocket(
                     payload_dict=payload_dict,
                     url=url,
                     headers=upstream_headers,
@@ -3122,9 +3135,7 @@ async def _stream_responses_with_session(
                 ):
                     if status_code is None:
                         status_code = 101
-                    event_payload = parse_sse_data_json(event_block)
-                    event_type = event_payload.get("type") if event_payload is not None else None
-                    if isinstance(event_type, str) and _is_response_stream_terminal_event_type(
+                    if event_type is not None and _is_response_stream_terminal_event_type(
                         event_type,
                         enforce_openai_sdk_contract=enforce_openai_sdk_contract,
                     ):

--- a/app/core/openai/parsing.py
+++ b/app/core/openai/parsing.py
@@ -17,6 +17,37 @@ _ERROR_ADAPTER = TypeAdapter(OpenAIErrorEnvelope)
 _RESPONSE_ADAPTER = TypeAdapter(OpenAIResponsePayload)
 _COMPACT_RESPONSE_ADAPTER = TypeAdapter(CompactResponsePayload)
 
+# Stream lifecycle frames are the only events whose validated model fields the
+# proxy consumes (usage settlement, error normalization, response-id capture).
+# Hot streaming paths validate only these frames and classify everything else
+# from the already-parsed payload dict via ``classify_event_type``.
+_LIFECYCLE_EVENT_TYPES = frozenset(
+    {
+        "response.created",
+        "response.completed",
+        "response.incomplete",
+        "response.failed",
+        "error",
+    }
+)
+
+
+def classify_event_type(payload: JsonValue | None) -> str | None:
+    """Classify an SSE event type from an already-parsed payload dict.
+
+    Mirrors the dict branch of the proxy's ``_event_type_from_payload``:
+    a string ``type`` field wins; a typeless payload carrying a dict
+    ``error`` classifies as ``"error"``. No pydantic validation is run.
+    """
+    if not isinstance(payload, dict):
+        return None
+    payload_type = payload.get("type")
+    if isinstance(payload_type, str):
+        return payload_type
+    if isinstance(payload.get("error"), dict):
+        return "error"
+    return None
+
 
 def parse_sse_event(line: str) -> OpenAIEvent | None:
     return parse_sse_event_payload(parse_sse_data_json(line))

--- a/app/modules/proxy/_service/http_bridge/upstream_events.py
+++ b/app/modules/proxy/_service/http_bridge/upstream_events.py
@@ -39,7 +39,11 @@ from app.core.clients.proxy_websocket import (
 )
 from app.core.errors import response_failed_event
 from app.core.openai.models import OpenAIEvent
-from app.core.openai.parsing import parse_sse_event_payload
+from app.core.openai.parsing import (
+    _LIFECYCLE_EVENT_TYPES,
+    classify_event_type,
+    parse_sse_event_payload,
+)
 from app.core.types import JsonValue
 from app.core.usage.live_hub import publish_live_usage
 from app.core.usage.live_snapshots import EVENT_MARKER, parse_rate_limit_event_text
@@ -138,7 +142,6 @@ from app.modules.proxy._service.support import (
     _clear_websocket_deferred_reasoning_downstream_texts,
     _clear_websocket_precreated_replay_fallback,
     _clear_websocket_request_error_overrides,
-    _event_type_from_payload,
     _HTTPBridgeCompletedDeliveryScope,
     _HTTPBridgeRetryCircuitAttemptSelection,
     _HTTPBridgeSession,
@@ -1652,8 +1655,8 @@ class _HTTPBridgeUpstreamEventsMixin:
     ) -> None:
         event_block = f"data: {text}\n\n"
         payload = parse_sse_data_json(event_block)
-        event = parse_sse_event_payload(payload)
-        event_type = _event_type_from_payload(event, payload)
+        event_type = classify_event_type(payload)
+        event = parse_sse_event_payload(payload) if event_type in _LIFECYCLE_EVENT_TYPES else None
         completed_delivery_scope = _HTTPBridgeCompletedDeliveryScope() if event_type == "response.completed" else None
         claimed_terminal_request_states: list[_WebSocketRequestState] = []
         try:

--- a/app/modules/proxy/_service/streaming/helpers.py
+++ b/app/modules/proxy/_service/streaming/helpers.py
@@ -647,6 +647,36 @@ def _mark_downstream_stream_cancelled(
     )
 
 
+def _rewrite_malformed_stream_error_event(
+    *,
+    enforce_openai_sdk_contract: bool,
+    event: OpenAIEvent | None,
+    event_type: str | None,
+    event_payload: dict[str, JsonValue] | None,
+    response_id: str,
+) -> tuple[str, OpenAIEvent | None, dict[str, JsonValue] | None, str | None] | None:
+    """Rewrite a schema-less upstream ``error`` frame under the SDK contract.
+
+    A malformed frame like ``{"type":"error","message":"..."}`` classifies as
+    ``error`` but carries no error envelope (``event`` is None or has no
+    ``error``), so it must become a terminal ``response.failed`` instead of
+    leaking the raw frame with a success settlement. Returns None when the
+    frame is not a malformed error (well-formed errors keep their
+    envelope-driven handling).
+    """
+    if not enforce_openai_sdk_contract or event_type != "error":
+        return None
+    if (event is not None and event.error is not None) or not isinstance(event_payload, dict):
+        return None
+    message_value = event_payload.get("message")
+    message = message_value.strip() if isinstance(message_value, str) and message_value.strip() else "Upstream error"
+    return _build_rewritten_stream_response_failed_event(
+        response_id=response_id,
+        error_code="upstream_error",
+        error_message=message,
+    )
+
+
 def _build_rewritten_stream_response_failed_event(
     *,
     response_id: str,

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -41,7 +41,11 @@ from app.core.errors import (
 from app.core.errors import (
     response_failed_event,
 )
-from app.core.openai.parsing import parse_sse_event_payload
+from app.core.openai.parsing import (
+    _LIFECYCLE_EVENT_TYPES,
+    classify_event_type,
+    parse_sse_event_payload,
+)
 from app.core.openai.requests import (
     ResponsesRequest,
 )
@@ -292,7 +296,6 @@ from app.modules.proxy._service.support import (
     _WEBSOCKET_FULL_REPLAY_WAIT_MIN_ITEMS,  # noqa: F401
     _WEBSOCKET_FULL_REPLAY_WAIT_POLL_SECONDS,  # noqa: F401
     _ApiKeyReservationTouchState,
-    _event_type_from_payload,
     _finalize_ttft_latency_ms,
     _RequestLogFailureMetadata,
     _RetryableStreamError,
@@ -609,8 +612,8 @@ class _StreamingMixin(_StreamingRetryMixin):
             await proxy._load_balancer.release_account_lease(account_response_create_lease)
             account_response_create_lease = None
             first_payload = parse_sse_data_json(first)
-            event = parse_sse_event_payload(first_payload)
-            event_type = _event_type_from_payload(event, first_payload)
+            event_type = classify_event_type(first_payload)
+            event = parse_sse_event_payload(first_payload) if event_type in _LIFECYCLE_EVENT_TYPES else None
             terminal_event_seen = False
             preserve_raw_sse_line = not enforce_openai_sdk_contract and event_type == "error"
             if event_type not in {"response.completed", "response.failed", "response.incomplete", "error"}:
@@ -765,8 +768,8 @@ class _StreamingMixin(_StreamingRetryMixin):
                 raise terminal_stream_error
             async for line in iterator:
                 event_payload = parse_sse_data_json(line)
-                event = parse_sse_event_payload(event_payload)
-                event_type = _event_type_from_payload(event, event_payload)
+                event_type = classify_event_type(event_payload)
+                event = parse_sse_event_payload(event_payload) if event_type in _LIFECYCLE_EVENT_TYPES else None
                 preserve_raw_sse_line = not enforce_openai_sdk_contract and event_type == "error"
                 if (
                     enforce_openai_sdk_contract

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -278,6 +278,7 @@ from app.modules.proxy._service.streaming.helpers import (
     _mark_downstream_stream_cancelled,
     _mark_upstream_stream_incomplete,
     _raw_stream_error_code_or_upstream,
+    _rewrite_malformed_stream_error_event,
 )
 from app.modules.proxy._service.streaming.helpers import (
     _raw_stream_error_fields as _raw_error_fields,
@@ -616,6 +617,15 @@ class _StreamingMixin(_StreamingRetryMixin):
             event = parse_sse_event_payload(first_payload) if event_type in _LIFECYCLE_EVENT_TYPES else None
             terminal_event_seen = False
             preserve_raw_sse_line = not enforce_openai_sdk_contract and event_type == "error"
+            malformed_error_rewrite = _rewrite_malformed_stream_error_event(
+                enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+                event=event,
+                event_type=event_type,
+                event_payload=first_payload,
+                response_id=response_id,
+            )
+            if malformed_error_rewrite is not None:
+                first, event, first_payload, event_type = malformed_error_rewrite
             if event_type not in {"response.completed", "response.failed", "response.incomplete", "error"}:
                 api_key_reservation_touch_state.last_touch_at = await proxy._maybe_touch_api_key_reservation(
                     api_key=api_key,
@@ -771,23 +781,15 @@ class _StreamingMixin(_StreamingRetryMixin):
                 event_type = classify_event_type(event_payload)
                 event = parse_sse_event_payload(event_payload) if event_type in _LIFECYCLE_EVENT_TYPES else None
                 preserve_raw_sse_line = not enforce_openai_sdk_contract and event_type == "error"
-                if (
-                    enforce_openai_sdk_contract
-                    and event_type == "error"
-                    and (event is None or event.error is None)
-                    and isinstance(event_payload, dict)
-                ):
-                    message_value = event_payload.get("message")
-                    message = (
-                        message_value.strip()
-                        if isinstance(message_value, str) and message_value.strip()
-                        else "Upstream error"
-                    )
-                    line, event, event_payload, event_type = _facade()._build_rewritten_stream_response_failed_event(
-                        response_id=response_id,
-                        error_code="upstream_error",
-                        error_message=message,
-                    )
+                malformed_error_rewrite = _rewrite_malformed_stream_error_event(
+                    enforce_openai_sdk_contract=enforce_openai_sdk_contract,
+                    event=event,
+                    event_type=event_type,
+                    event_payload=event_payload,
+                    response_id=response_id,
+                )
+                if malformed_error_rewrite is not None:
+                    line, event, event_payload, event_type = malformed_error_rewrite
                 if event_type not in {"response.completed", "response.failed", "response.incomplete", "error"}:
                     api_key_reservation_touch_state.last_touch_at = await proxy._maybe_touch_api_key_reservation(
                         api_key=api_key,

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -22,6 +22,7 @@ from app.core.config.settings import get_settings
 from app.core.errors import OpenAIErrorEnvelope, openai_error
 from app.core.openai.model_registry import get_model_registry
 from app.core.openai.models import OpenAIEvent
+from app.core.openai.parsing import classify_event_type
 from app.core.plan_types import account_plan_matches_allowed
 from app.core.resilience.network_recovery import PROCESS_NETWORK_UNAVAILABLE_CODE
 from app.core.resilience.overload import is_local_overload_error_code
@@ -1553,14 +1554,7 @@ class _WebSocketReceiveTimeout:
 def _event_type_from_payload(event: OpenAIEvent | None, payload: dict[str, JsonValue] | None) -> str | None:
     if event is not None:
         return event.type
-    if payload is None:
-        return None
-    payload_type = payload.get("type")
-    if isinstance(payload_type, str):
-        return payload_type
-    if isinstance(payload.get("error"), dict):
-        return "error"
-    return None
+    return classify_event_type(payload)
 
 
 async def _wait_for_websocket_continuity_gap(

--- a/app/modules/proxy/_service/websocket/helpers.py
+++ b/app/modules/proxy/_service/websocket/helpers.py
@@ -676,11 +676,21 @@ def _rewrite_websocket_downstream_response_id(
     if downstream_response_id is None:
         return payload
 
+    direct_response_id = payload.get("response_id")
+    rewrite_direct = isinstance(direct_response_id, str) and direct_response_id != downstream_response_id
+    response = payload.get("response")
+    nested_response_id = response.get("id") if isinstance(response, dict) else None
+    rewrite_nested = isinstance(nested_response_id, str) and nested_response_id != downstream_response_id
+    if not rewrite_direct and not rewrite_nested:
+        # Identity fast-path contract: callers skip re-serialization when the
+        # original payload object comes back, so an already-aligned frame must
+        # not be copied into an equal-but-new dict.
+        return payload
+
     rewritten = dict(payload)
-    if isinstance(rewritten.get("response_id"), str):
+    if rewrite_direct:
         rewritten["response_id"] = downstream_response_id
-    response = rewritten.get("response")
-    if isinstance(response, dict) and isinstance(response.get("id"), str):
+    if rewrite_nested and isinstance(response, dict):
         rewritten["response"] = {**response, "id": downstream_response_id}
     return rewritten
 

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -7,7 +7,7 @@ import sys
 import time
 from collections import deque
 from contextlib import contextmanager
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import datetime
 from typing import Any, Iterator, Mapping, NoReturn, cast
 
@@ -74,7 +74,6 @@ from app.core.openai.models import OpenAIEvent
 from app.core.openai.parsing import (
     _LIFECYCLE_EVENT_TYPES,
     classify_event_type,
-    parse_sse_event,
     parse_sse_event_payload,
 )
 from app.core.openai.requests import (
@@ -89,7 +88,7 @@ from app.core.types import JsonValue
 from app.core.upstream_proxy import UpstreamProxyRouteError
 from app.core.utils.request_id import get_request_id, reset_request_id, set_request_id
 from app.core.utils.sse import CODEX_KEEPALIVE_FRAME as CODEX_KEEPALIVE_FRAME  # noqa: F401
-from app.core.utils.sse import format_sse_event, parse_sse_data_json
+from app.core.utils.sse import format_sse_event
 from app.core.utils.time import utcnow as utcnow
 from app.db.models import (
     Account,
@@ -328,7 +327,6 @@ from app.modules.proxy._service.support import (
     _clear_websocket_precreated_replay_fallback,
     _clear_websocket_request_error_overrides,
     _DownstreamWebSocketActivity,
-    _event_type_from_payload,
     _finalize_ttft_reasoning_deltas,
     _PreparedWebSocketRequest,
     _record_response_event,
@@ -698,35 +696,52 @@ def _websocket_archive_request_state_for_payload(
     )
 
 
+@dataclass(frozen=True, slots=True)
+class _ParsedUpstreamWebSocketFrame:
+    payload: dict[str, JsonValue] | None
+    event_type: str | None
+    event: OpenAIEvent | None
+
+
+def _parse_upstream_websocket_text_frame(text: str) -> _ParsedUpstreamWebSocketFrame:
+    """Decode an upstream websocket text frame exactly once.
+
+    The payload is json-decoded a single time, the event type is classified
+    from the parsed dict, and pydantic validation runs only for lifecycle
+    frames (the only events whose validated model fields the proxy consumes).
+    """
+    try:
+        raw_payload = json.loads(text)
+    except json.JSONDecodeError:
+        raw_payload = None
+    payload = cast(dict[str, JsonValue], raw_payload) if isinstance(raw_payload, dict) else None
+    event_type = classify_event_type(payload)
+    event = parse_sse_event_payload(payload) if event_type in _LIFECYCLE_EVENT_TYPES else None
+    return _ParsedUpstreamWebSocketFrame(payload=payload, event_type=event_type, event=event)
+
+
 async def _websocket_archive_request_id_for_message(
     message: Any,
     *,
     pending_requests: deque[_WebSocketRequestState],
     pending_lock: anyio.Lock,
+    parsed_frame: _ParsedUpstreamWebSocketFrame | None = None,
 ) -> str | None:
     if message.kind != "text" or message.text is None:
         async with pending_lock:
             if len(pending_requests) == 1:
                 return pending_requests[0].archive_request_id
             return None
-    event_block = f"data: {message.text}\n\n"
-    payload = parse_sse_data_json(event_block)
-    if payload is None:
-        try:
-            raw_payload = json.loads(message.text)
-        except json.JSONDecodeError:
-            raw_payload = None
-        if isinstance(raw_payload, dict):
-            payload = cast(dict[str, JsonValue], raw_payload)
-            event_block = format_sse_event(payload)
-    event = parse_sse_event(event_block)
-    event_type = _event_type_from_payload(event, payload)
+    # Archive attribution only needs the payload dict (response ids and error
+    # fields are read from it directly), so reuse the caller's parsed frame
+    # when provided and never re-validate non-lifecycle deltas.
+    frame = parsed_frame if parsed_frame is not None else _parse_upstream_websocket_text_frame(message.text)
     async with pending_lock:
         request_state = _websocket_archive_request_state_for_payload(
             pending_requests,
-            event=event,
-            payload=payload,
-            event_type=event_type,
+            event=frame.event,
+            payload=frame.payload,
+            event_type=frame.event_type,
         )
         return None if request_state is None else request_state.archive_request_id
 
@@ -944,10 +959,12 @@ async def _process_and_forward_upstream_websocket_text(
     continuity_state: _WebSocketContinuityState | None,
     codex_session_affinity: bool,
 ) -> bool:
+    parsed_frame = _parse_upstream_websocket_text_frame(text)
     archive_request_id = await _websocket_archive_request_id_for_message(
         message,
         pending_requests=pending_requests,
         pending_lock=pending_lock,
+        parsed_frame=parsed_frame,
     )
     _archive_received_websocket_message(
         upstream,
@@ -956,6 +973,7 @@ async def _process_and_forward_upstream_websocket_text(
     )
     downstream_text = await proxy._process_upstream_websocket_text(
         text,
+        parsed_frame=parsed_frame,
         account=account,
         account_id_value=account_id_value,
         pending_requests=pending_requests,
@@ -5045,16 +5063,15 @@ class _WebSocketMixin:
         response_create_gate: asyncio.Semaphore,
         continuity_state: "_WebSocketContinuityState | None" = None,
         codex_session_affinity: bool = False,
+        parsed_frame: _ParsedUpstreamWebSocketFrame | None = None,
     ) -> str:
         proxy = cast(_WebSocketServiceProtocol, self)
         _ = proxy
-        try:
-            raw_payload = json.loads(text)
-        except json.JSONDecodeError:
-            raw_payload = None
-        payload = cast(dict[str, JsonValue], raw_payload) if isinstance(raw_payload, dict) else None
-        event_type = classify_event_type(payload)
-        event = parse_sse_event_payload(payload) if event_type in _LIFECYCLE_EVENT_TYPES else None
+        if parsed_frame is None:
+            parsed_frame = _parse_upstream_websocket_text_frame(text)
+        payload = parsed_frame.payload
+        event_type = parsed_frame.event_type
+        event = parsed_frame.event
         response_id = _websocket_response_id(event, payload)
         error_message = _websocket_event_error_message(event_type, payload)
         is_typeless_error_event = (

--- a/app/modules/proxy/_service/websocket/mixin.py
+++ b/app/modules/proxy/_service/websocket/mixin.py
@@ -71,7 +71,12 @@ from app.core.errors import (
 from app.core.exceptions import AppError, ProxyAuthError
 from app.core.openai.exceptions import ClientPayloadError
 from app.core.openai.models import OpenAIEvent
-from app.core.openai.parsing import parse_sse_event
+from app.core.openai.parsing import (
+    _LIFECYCLE_EVENT_TYPES,
+    classify_event_type,
+    parse_sse_event,
+    parse_sse_event_payload,
+)
 from app.core.openai.requests import (
     ResponsesRequest,
 )
@@ -5043,18 +5048,13 @@ class _WebSocketMixin:
     ) -> str:
         proxy = cast(_WebSocketServiceProtocol, self)
         _ = proxy
-        event_block = f"data: {text}\n\n"
-        payload = parse_sse_data_json(event_block)
-        if payload is None:
-            try:
-                raw_payload = json.loads(text)
-            except json.JSONDecodeError:
-                raw_payload = None
-            if isinstance(raw_payload, dict):
-                payload = cast(dict[str, JsonValue], raw_payload)
-                event_block = format_sse_event(payload)
-        event = parse_sse_event(event_block)
-        event_type = _event_type_from_payload(event, payload)
+        try:
+            raw_payload = json.loads(text)
+        except json.JSONDecodeError:
+            raw_payload = None
+        payload = cast(dict[str, JsonValue], raw_payload) if isinstance(raw_payload, dict) else None
+        event_type = classify_event_type(payload)
+        event = parse_sse_event_payload(payload) if event_type in _LIFECYCLE_EVENT_TYPES else None
         response_id = _websocket_response_id(event, payload)
         error_message = _websocket_event_error_message(event_type, payload)
         is_typeless_error_event = (
@@ -5079,10 +5079,14 @@ class _WebSocketMixin:
             message=error_message,
         )
         previous_response_id_hint = _facade()._previous_response_id_from_not_found_message(error_message)
+        # The returned event block is unused here; the rewrite helper rebuilds
+        # its own canonical block on the (rare) changed path, so avoid the
+        # per-frame ``format_sse_event`` re-encode and pass the raw framing.
         text, payload, event, event_type, _event_block = rewrite_parallel_tool_call_text(
             text,
             payload,
-            event_block=format_sse_event(payload) if payload is not None else f"data: {text}\n\n",
+            event_block=f"data: {text}\n\n",
+            event=event,
         )
 
         async with pending_lock:
@@ -5166,8 +5170,10 @@ class _WebSocketMixin:
                     request_state.suppress_next_created_downstream = False
                     upstream_control.suppress_downstream_event = True
                 if payload is not None:
-                    payload = _rewrite_websocket_downstream_response_id(payload, request_state)
-                    text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
+                    rewritten_payload = _rewrite_websocket_downstream_response_id(payload, request_state)
+                    if rewritten_payload is not payload:
+                        payload = rewritten_payload
+                        text = json.dumps(payload, ensure_ascii=True, separators=(",", ":"))
                     sequence_number = payload.get("sequence_number")
                     if isinstance(sequence_number, int) and not isinstance(sequence_number, bool):
                         upstream_control.downstream_sequence_request_state = request_state

--- a/app/modules/proxy/tool_call_dedupe.py
+++ b/app/modules/proxy/tool_call_dedupe.py
@@ -7,7 +7,7 @@ from typing import cast
 
 from app.core.openai import tool_call_safety
 from app.core.openai.models import OpenAIEvent
-from app.core.openai.parsing import parse_sse_event_payload
+from app.core.openai.parsing import classify_event_type, parse_sse_event_payload
 from app.core.types import JsonValue
 from app.core.utils.sse import format_sse_event
 
@@ -36,14 +36,7 @@ def is_downstream_side_effect_tool_call(item: Mapping[str, JsonValue]) -> bool:
 def event_type_from_payload(event: OpenAIEvent | None, payload: dict[str, JsonValue] | None) -> str | None:
     if event is not None:
         return event.type
-    if payload is None:
-        return None
-    payload_type = payload.get("type")
-    if isinstance(payload_type, str):
-        return payload_type
-    if isinstance(payload.get("error"), dict):
-        return "error"
-    return None
+    return classify_event_type(payload)
 
 
 def response_id_from_payload(payload: dict[str, JsonValue] | None) -> str | None:
@@ -785,10 +778,10 @@ def rewrite_parallel_tool_call_text(
 ) -> tuple[str, dict[str, JsonValue] | None, OpenAIEvent | None, str | None, str]:
     rewritten_payload, changed, _removed_count = rewrite_parallel_tool_call_payload(payload)
     if not changed:
-        # Reuse the caller's parsed event; validating the payload directly
-        # avoids re-parsing the raw block when a caller has neither.
-        if event is None:
-            event = parse_sse_event_payload(payload)
+        # Reuse the caller's parsed event as-is. Hot streaming paths validate
+        # only lifecycle frames, so ``event`` is intentionally None for the
+        # delta bulk; the event type is classified from the payload dict
+        # instead of re-validating per frame.
         return text, payload, event, event_type_from_payload(event, payload), event_block
     assert rewritten_payload is not None
     rewritten_text = json.dumps(rewritten_payload, ensure_ascii=True, separators=(",", ":"))
@@ -811,8 +804,8 @@ def rewrite_parallel_tool_call_sse_line(
 ) -> tuple[str, dict[str, JsonValue] | None, OpenAIEvent | None, str | None]:
     rewritten_payload, changed, _removed_count = rewrite_parallel_tool_call_payload(payload)
     if not changed:
-        if event is None:
-            event = parse_sse_event_payload(payload)
+        # See rewrite_parallel_tool_call_text: no per-frame re-validation on
+        # the unchanged path; callers own lifecycle-gated validation.
         return line, payload, event, event_type_from_payload(event, payload)
     assert rewritten_payload is not None
     rewritten_line = format_sse_event(rewritten_payload)

--- a/openspec/changes/validate-stream-lifecycle-events-only/design.md
+++ b/openspec/changes/validate-stream-lifecycle-events-only/design.md
@@ -1,0 +1,91 @@
+# Design — validate-stream-lifecycle-events-only
+
+## Context
+
+py-spy GIL profiles attribute ~3% of proxy CPU to `validate_python` on the
+stream hot path, plus a second full validation per websocket frame inside the
+parallel-tool-call rewrite and redundant JSON extract+parse in the core client
+and websocket relay. Every consumer of the validated `OpenAIEvent` model reads
+it only on lifecycle frames; delta frames need only the `type` string.
+
+## Goals / Non-Goals
+
+**Goals:** pydantic validation only on lifecycle frames; one `json.loads` per
+frame per owning layer; byte-identical SSE output; unchanged settlement,
+error-classification, and terminal-detection semantics.
+
+**Non-Goals:** verbatim relay of unmodified SSE delta frames (the
+`format_sse_event` canonical re-encode in the streaming mixin stays — that is
+the separate `relay-unmodified-sse-frames-verbatim` follow-up); touching the
+chat/completions bridge (genuine cross-dialect translation keeps full
+parsing); the `/v1` public normalizer (independent per-chunk consumer); the
+cold rewrite/prewarm paths (`limit_warmup`, `quota_planner`,
+`http_bridge/helpers`, `websocket/helpers` rewrite builders), which run once
+per stream or per rewrite.
+
+## Decisions
+
+- **Lifecycle set = {response.created, response.completed,
+  response.incomplete, response.failed, error}.** Terminal frames carry the
+  usage and error fields settlement needs; `response.created` is included
+  because the websocket path assigns the upstream response id from the
+  validated model there.
+- **Classify-then-validate.** `classify_event_type(payload)` mirrors the dict
+  branch of `_event_type_from_payload` exactly (string `type` wins; a typeless
+  dict `error` classifies as `"error"`). Ordering classification before
+  validation is equivalence-preserving: when validation succeeds,
+  `event.type == payload["type"]`; when it fails (e.g. typeless error
+  payloads, or a lifecycle `type` with a non-dict `response` — `OpenAIEvent`
+  has no before-validator on `response`), today's code already fell back to
+  the same dict branch with `event=None`.
+- **`event=None` for non-lifecycle frames compiles against existing
+  structure.** Every downstream read of `event.response`/`event.error` in the
+  streaming mixin, websocket finalization, and bridge settlement is gated on a
+  terminal `event_type`, so non-lifecycle `None` never reaches them.
+- **Core-client deletion is a pure no-op.** At the two SSE loops the
+  `elif normalized_event_type` branch performed the identical terminal check
+  from the same payload the deleted `parse_sse_event` re-parsed; whenever the
+  model validated, its `type` equalled `normalized_event_type`. The websocket
+  receive loops now use the payload `type` string directly, matching the
+  dict semantics the SSE loops already had (a malformed lifecycle frame that
+  failed whole-event validation now counts for terminal detection there, as
+  it already did on the SSE loops).
+- **Rewrite helpers no longer validate on the unchanged path.** The
+  `event is None` fallback in `rewrite_parallel_tool_call_text/_sse_line` was
+  the second per-frame validation on the websocket path; callers now own
+  lifecycle-gated validation and the helpers classify from the dict. The
+  changed path (actual dedupe rewrite of `response.output_item.done`) still
+  validates the rewritten payload as before.
+- **Websocket identity skip.** `_rewrite_websocket_downstream_response_id`
+  returns the same object when no replay rewrite applies; only then is the
+  per-frame `json.dumps` skipped and the upstream text relayed unchanged.
+  Frames without a matched request state were already relayed verbatim, so
+  downstream clients already accept upstream-encoded frames on this surface.
+
+## Risks / Trade-offs
+
+- [Whitespace-padded response ids] Non-lifecycle frames that carry a
+  `response` object (`response.in_progress`) now resolve their response id via
+  the dict fallback, which strips whitespace, where the model path did not.
+  Upstream ids are never whitespace-padded; `response.created` (the id
+  assignment point) keeps the model path.
+- [Usage on delta frames] If upstream ever emitted `usage` on non-lifecycle
+  frames it would no longer be validated — accepted limitation; today usage
+  appears only on `response.completed`/`response.incomplete`, and no consumer
+  reads usage outside terminal branches.
+- [Websocket byte relaxation] Identity frames relay upstream JSON text
+  (raw UTF-8, upstream spacing) instead of the canonical
+  `ensure_ascii` re-encode. JSON-semantically identical, and consistent with
+  the existing unmatched-frame behavior on the same socket.
+- [First-frame response-id capture] A stream whose first frame is a
+  non-lifecycle `response`-carrying frame (never observed; upstream always
+  opens with `response.created`) no longer captures `settlement.response_id`
+  from that frame; it is still captured at the terminal frame.
+
+## Migration Plan
+
+Code-only; rollback = revert.
+
+## Open Questions
+
+None.

--- a/openspec/changes/validate-stream-lifecycle-events-only/proposal.md
+++ b/openspec/changes/validate-stream-lifecycle-events-only/proposal.md
@@ -1,0 +1,76 @@
+# Validate Stream Lifecycle Events Only
+
+## Why
+
+Every streamed SSE/websocket event still pays a full pydantic `OpenAIEvent`
+validation per layer, even though every consumer of the validated model reads
+it only on stream lifecycle frames: usage/token settlement
+(`response.completed`/`response.incomplete`), error normalization and
+retry/health classification (`response.failed`/`error`), and websocket
+response-id assignment (`response.created`). Delta frames — the dominant
+traffic by two to three orders of magnitude — only ever need their `type`
+string, which the already-parsed payload dict provides. On top of that, the
+core client validated each chunk a second time solely to duplicate a terminal
+check it had already computed from the dict, the websocket relay extracted and
+re-parsed each frame's JSON twice, built a canonical SSE re-encode per frame
+just to populate a discarded argument, re-validated each frame inside the
+parallel-tool-call rewrite, and re-encoded `json.dumps` on every matched frame
+even when the response-id rewrite changed nothing. This is the follow-up the
+`2026-07-13-optimize-sse-single-parse` design doc deferred ("threading a
+parsed-event struct across layer boundaries").
+
+## What Changes
+
+- `app/core/openai/parsing.py` gains the shared `_LIFECYCLE_EVENT_TYPES`
+  frozenset (`response.created`, `response.completed`, `response.incomplete`,
+  `response.failed`, `error`) and `classify_event_type(payload)`, the dict-only
+  classifier that `_event_type_from_payload` and
+  `tool_call_dedupe.event_type_from_payload` now delegate to.
+- Streaming mixin, websocket relay, and HTTP-bridge upstream reader classify
+  each frame from the parsed dict first and run `parse_sse_event_payload`
+  only for lifecycle frames; all other frames flow with `event=None`, which
+  every downstream branch already guards for.
+- Core client: the redundant per-chunk `parse_sse_event` terminal checks are
+  deleted (the `normalized_event_type` dict branch is the same check from the
+  same payload); the websocket receive loops detect terminal frames from
+  `parse_sse_data_json` + the payload `type` string.
+- Websocket relay: single `json.loads` per frame (no synthetic-block re-parse),
+  the caller's `event` is passed into `rewrite_parallel_tool_call_text` and the
+  rewrite helpers no longer re-validate on the unchanged path, the discarded
+  `format_sse_event` argument is no longer built, and the downstream
+  response-id re-encode is skipped when the rewrite returned the payload
+  unchanged (identity), relaying the upstream frame bytes as-is.
+- No output-byte change on the SSE paths: canonical `format_sse_event`
+  serialization, usage settlement, error rewriting, and terminal detection are
+  unchanged. Existing streaming/websocket suites pass unmodified.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `responses-api-compat`: the single-parse streaming requirement is extended —
+  schema validation of parsed stream payloads MUST run only for lifecycle
+  frames, with all other frames classified from the parsed payload dict and
+  all downstream semantics (framing, settlement, error normalization)
+  unchanged; identity websocket relay frames are forwarded without a canonical
+  re-encode.
+
+## Impact
+
+- **Code**: `app/core/openai/parsing.py`, `app/core/clients/proxy.py`,
+  `app/modules/proxy/tool_call_dedupe.py`,
+  `app/modules/proxy/_service/support.py`,
+  `app/modules/proxy/_service/streaming/mixin.py`,
+  `app/modules/proxy/_service/websocket/mixin.py`,
+  `app/modules/proxy/_service/http_bridge/upstream_events.py`.
+- **Behavior**: none on SSE surfaces. Websocket relay frames whose matched
+  response-id rewrite is an identity are now forwarded with the upstream JSON
+  text instead of a canonical `json.dumps` re-encode (JSON-equivalent; frames
+  without a matched request state were already forwarded verbatim).
+- **Performance**: removes 1–2 pydantic validations and 1–2 redundant JSON
+  parses per delta frame per layer, plus one wasted `format_sse_event` and one
+  wasted `json.dumps` per websocket frame.

--- a/openspec/changes/validate-stream-lifecycle-events-only/specs/responses-api-compat/spec.md
+++ b/openspec/changes/validate-stream-lifecycle-events-only/specs/responses-api-compat/spec.md
@@ -1,0 +1,36 @@
+# responses-api-compat Delta
+
+## MODIFIED Requirements
+
+### Requirement: Streaming events are parsed once and re-serialized only when modified
+
+Within each streaming layer (core client consumer, streaming mixin, bridge upstream reader, websocket relay, /v1 normalizers), an SSE event's JSON payload MUST be parsed at most once and reused by that layer's consumers, and an event that no consumer modified MUST NOT be re-serialized by the /v1 normalizers. Schema validation of the parsed payload MUST run only for stream lifecycle frames (`response.created`, `response.completed`, `response.incomplete`, `response.failed`, `error`); all other frames MUST be classified from the parsed payload's `type` field (with a typeless payload carrying an `error` object classifying as `error`). Event framing, payload contents, dedupe/rewrite semantics, usage settlement, and error normalization MUST be unchanged.
+
+#### Scenario: Unmodified events pass through the /v1 normalizer verbatim
+
+- **GIVEN** a canonical stream event that no normalizer branch rewrites
+- **WHEN** the /v1 response normalizer processes it
+- **THEN** the original block is yielded byte-identically without re-serialization
+
+#### Scenario: Tool-call rewrite reuses the parsed event on the no-change path
+
+- **GIVEN** an event without duplicate parallel tool calls
+- **WHEN** the rewrite step runs with the caller's parsed event
+- **THEN** it returns the original line, payload, and event without re-parsing or re-validating
+
+#### Scenario: Rewritten events stay consistent
+
+- **WHEN** the rewrite step removes duplicate tool calls
+- **THEN** the returned line, payload, and validated event all reflect the rewritten content
+
+#### Scenario: Delta frames skip schema validation
+
+- **GIVEN** a stream of `response.output_text.delta` frames between `response.created` and `response.completed`
+- **WHEN** the streaming mixin, websocket relay, or bridge upstream reader processes the stream
+- **THEN** only the lifecycle frames are schema-validated, the delta frames are classified from the parsed payload dict, and downstream output, usage settlement, and error normalization are unchanged
+
+#### Scenario: Identity websocket relay frames are forwarded without re-encoding
+
+- **GIVEN** a websocket frame matched to a request whose downstream response-id rewrite does not apply
+- **WHEN** the relay forwards the frame downstream
+- **THEN** the upstream frame text is forwarded as-is instead of a canonical JSON re-encode

--- a/openspec/changes/validate-stream-lifecycle-events-only/tasks.md
+++ b/openspec/changes/validate-stream-lifecycle-events-only/tasks.md
@@ -1,0 +1,29 @@
+# Tasks — validate-stream-lifecycle-events-only
+
+## 1. Implementation
+
+- [x] 1.1 `_LIFECYCLE_EVENT_TYPES` + `classify_event_type` in
+      `app/core/openai/parsing.py`; `_event_type_from_payload` and
+      `tool_call_dedupe.event_type_from_payload` delegate to it
+- [x] 1.2 Streaming mixin (first-event block + loop): classify from dict,
+      validate lifecycle frames only
+- [x] 1.3 Core client: delete redundant per-chunk `parse_sse_event` terminal
+      checks (SSE loops keep the `normalized_event_type` branch); websocket
+      receive loops detect terminal via `parse_sse_data_json` + `type`
+- [x] 1.4 Websocket relay: single `json.loads`, lifecycle-only validation,
+      pass `event=` into `rewrite_parallel_tool_call_text`, stop building the
+      discarded `format_sse_event` argument, skip `json.dumps` on identity
+      response-id rewrite
+- [x] 1.5 `tool_call_dedupe` rewrite helpers: no re-validation on the
+      unchanged path
+- [x] 1.6 HTTP-bridge upstream reader: same lifecycle gating
+
+## 2. Validation
+
+- [x] 2.1 Existing streaming/websocket/bridge unit + integration suites pass
+      unmodified (byte-level SSE assertions act as the parity oracle)
+- [x] 2.2 Regression tests: lifecycle-only validation counts with interleaved
+      `event=None` deltas on the SSE mixin and websocket relay (usage
+      settlement, error rewrite, response-id assignment), dedupe helpers do
+      not re-validate unchanged frames, `classify_event_type` unit coverage
+- [x] 2.3 `uvx ruff format --check`, `uv run ruff check` on changed files

--- a/tests/unit/test_proxy_tool_call_dedupe.py
+++ b/tests/unit/test_proxy_tool_call_dedupe.py
@@ -2178,3 +2178,59 @@ def test_rewrite_parallel_tool_call_payload_removes_duplicate_goal_side_effects(
         "functions.update_plan",
         "functions.request_user_input",
     ]
+
+
+def test_rewrite_parallel_tool_call_text_does_not_revalidate_unchanged_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Hot streaming paths validate only lifecycle frames; the unchanged path
+    # must not re-run pydantic validation when the caller passed event=None.
+    calls: list[JsonValue | None] = []
+
+    def counting_validate(payload: JsonValue | None) -> None:
+        calls.append(payload)
+        return None
+
+    monkeypatch.setattr(tool_call_dedupe, "parse_sse_event_payload", counting_validate)
+    payload: dict[str, JsonValue] = {"type": "response.output_text.delta", "delta": "hello"}
+    text = json.dumps(payload, separators=(",", ":"))
+
+    rewritten_text, rewritten_payload, event, event_type, event_block = (
+        tool_call_dedupe.rewrite_parallel_tool_call_text(
+            text,
+            payload,
+            event_block=f"data: {text}\n\n",
+        )
+    )
+
+    assert calls == []
+    assert event is None
+    assert event_type == "response.output_text.delta"
+    assert rewritten_text == text
+    assert rewritten_payload is payload
+    assert event_block == f"data: {text}\n\n"
+
+
+def test_rewrite_parallel_tool_call_sse_line_does_not_revalidate_unchanged_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[JsonValue | None] = []
+
+    def counting_validate(payload: JsonValue | None) -> None:
+        calls.append(payload)
+        return None
+
+    monkeypatch.setattr(tool_call_dedupe, "parse_sse_event_payload", counting_validate)
+    payload: dict[str, JsonValue] = {"type": "response.reasoning_text.delta", "delta": "r"}
+    line = format_sse_event(payload)
+
+    rewritten_line, rewritten_payload, event, event_type = tool_call_dedupe.rewrite_parallel_tool_call_sse_line(
+        line,
+        payload,
+    )
+
+    assert calls == []
+    assert event is None
+    assert event_type == "response.reasoning_text.delta"
+    assert rewritten_line == line
+    assert rewritten_payload is payload

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -8798,7 +8798,7 @@ async def test_stream_responses_via_websocket_counts_connect_and_send_against_to
         del enforce_openai_sdk_contract
         recorded["total_timeout_seconds"] = total_timeout_seconds
         if False:
-            yield ""
+            yield "", None
 
     monkeypatch.setattr(proxy_module, "_open_upstream_websocket", fake_open_upstream_websocket)
     monkeypatch.setattr(proxy_module, "_stream_websocket_events", fake_stream_websocket_events)
@@ -8877,7 +8877,9 @@ async def test_stream_responses_via_websocket_preserves_raw_error_when_sdk_contr
     ]
 
     assert len(events) == 1
-    assert parse_sse_data_json(events[0]) == raw_payload
+    event_block, event_type = events[0]
+    assert parse_sse_data_json(event_block) == raw_payload
+    assert event_type == "error"
     assert successes == 1
     assert failures == []
 
@@ -8907,8 +8909,109 @@ async def test_stream_codex_websocket_events_treats_raw_error_as_terminal_when_s
     ]
 
     assert len(events) == 1
-    assert parse_sse_data_json(events[0]) == raw_payload
+    event_block, event_type = events[0]
+    assert parse_sse_data_json(event_block) == raw_payload
+    assert event_type == "error"
     assert websocket._index == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_responses_websocket_decodes_each_frame_once_and_skips_error_validation(monkeypatch):
+    # Regression for the parse-once requirement on the websocket hot path:
+    # each upstream frame is json-decoded exactly once in the receive loop,
+    # the relay and outer stream loops reuse the threaded event type instead
+    # of re-parsing the formatted block, and no error-envelope validation
+    # runs for non-error-shaped frames.
+    class Settings:
+        upstream_base_url = "https://chatgpt.com/backend-api"
+        upstream_stream_transport = "websocket"
+        upstream_connect_timeout_seconds = 8.0
+        stream_idle_timeout_seconds = 45.0
+        max_sse_event_bytes = 1024
+        image_inline_fetch_enabled = False
+        trace_channels = frozenset()
+        proxy_request_budget_seconds = 75.0
+
+    monkeypatch.setattr(proxy_module, "get_settings", lambda: Settings())
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_start", lambda **kwargs: None)
+    monkeypatch.setattr(proxy_module, "_maybe_log_upstream_request_complete", lambda **kwargs: None)
+
+    frame_payloads = [
+        {"type": "response.created", "response": {"id": "resp_ws_once"}},
+        {"type": "response.output_text.delta", "delta": "a"},
+        {"type": "response.output_text.delta", "delta": "b"},
+        {"type": "response.completed", "response": {"id": "resp_ws_once"}},
+    ]
+    frame_texts = [json.dumps(payload, ensure_ascii=True, separators=(",", ":")) for payload in frame_payloads]
+    websocket = _WsResponse([_WsMessage(proxy_module.aiohttp.WSMsgType.TEXT, text) for text in frame_texts])
+    session = _WsSession(websocket)
+
+    loads_spy = MagicMock(wraps=json.loads)
+    monkeypatch.setattr(proxy_module.json, "loads", loads_spy)
+    parse_spy = MagicMock(wraps=proxy_module.parse_sse_data_json)
+    monkeypatch.setattr(proxy_module, "parse_sse_data_json", parse_spy)
+    error_validate_spy = MagicMock(wraps=proxy_module.parse_error_payload)
+    monkeypatch.setattr(proxy_module, "parse_error_payload", error_validate_spy)
+
+    payload = ResponsesRequest.model_validate(
+        {
+            "model": "gpt-5.1",
+            "instructions": "hi",
+            "input": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        }
+    )
+    events = [
+        event
+        async for event in proxy_module.stream_responses(
+            payload,
+            headers={},
+            access_token="token",
+            account_id="acc_ws_parse_once",
+            session=cast(proxy_module.aiohttp.ClientSession, session),
+        )
+    ]
+
+    assert events == [proxy_module.format_sse_event(payload) for payload in frame_payloads]
+    for text in frame_texts:
+        decode_calls = [c for c in loads_spy.call_args_list if c.args and c.args[0] == text]
+        assert len(decode_calls) == 1
+    assert parse_spy.call_count == 0
+    assert error_validate_spy.call_count == 0
+
+
+def test_normalize_stream_event_payload_validates_error_envelope_only_for_error_shaped_frames(monkeypatch):
+    # Delta frames never reach the pydantic error-envelope adapter; error
+    # frames are still validated and rewritten exactly as before.
+    from app.core.openai import parsing as parsing_module
+
+    adapter_spy = MagicMock(wraps=parsing_module._ERROR_ADAPTER)
+    monkeypatch.setattr(parsing_module, "_ERROR_ADAPTER", adapter_spy)
+
+    delta_payload: dict[str, object] = {"type": "response.output_text.delta", "delta": "a"}
+    assert proxy_module._normalize_stream_event_payload(delta_payload) is delta_payload
+    in_progress_payload: dict[str, object] = {"type": "response.in_progress", "response": {"id": "resp_np"}}
+    assert proxy_module._normalize_stream_event_payload(in_progress_payload) is in_progress_payload
+    assert adapter_spy.validate_python.call_count == 0
+
+    envelope_payload: dict[str, object] = {
+        "error": {"message": "quota exhausted", "type": "server_error", "code": "insufficient_quota"}
+    }
+    rewritten = proxy_module._normalize_stream_event_payload(envelope_payload)
+    assert adapter_spy.validate_python.call_count == 1
+    assert rewritten["type"] == "response.failed"
+    envelope_error = rewritten["response"]["error"]
+    assert envelope_error["message"] == "quota exhausted"
+    assert envelope_error["code"] == proxy_module._normalize_error_code("insufficient_quota", "server_error")
+    assert envelope_error["type"] == "server_error"
+
+    bare_error_payload: dict[str, object] = {"type": "error", "code": "rate_limit_exceeded", "message": "slow down"}
+    rewritten_bare = proxy_module._normalize_stream_event_payload(bare_error_payload)
+    assert adapter_spy.validate_python.call_count == 2
+    assert rewritten_bare["type"] == "response.failed"
+    bare_error = rewritten_bare["response"]["error"]
+    assert bare_error["code"] == proxy_module._normalize_error_code("rate_limit_exceeded", "error")
+    assert bare_error["message"] == "slow down"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -46233,3 +46233,219 @@ def test_compact_account_neutral_replay_payload_accepts_canonical_lite_full_rese
     replay = proxy_compact_service._compact_account_neutral_replay_payload(payload)
     assert replay is not None
     assert getattr(replay, "previous_response_id", None) is None
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_validates_only_lifecycle_frames_and_settles_usage(monkeypatch):
+    # Delta frames must skip pydantic validation entirely (event=None) while
+    # lifecycle frames keep it, with byte-identical SSE output and unchanged
+    # usage settlement from the validated response.completed frame.
+    from app.modules.proxy import tool_call_dedupe
+    from app.modules.proxy._service.streaming import mixin as streaming_mixin_module
+
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_lifecycle_only_validation")
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    mixin_validate = MagicMock(wraps=streaming_mixin_module.parse_sse_event_payload)
+    monkeypatch.setattr(streaming_mixin_module, "parse_sse_event_payload", mixin_validate)
+    dedupe_validate = MagicMock(wraps=tool_call_dedupe.parse_sse_event_payload)
+    monkeypatch.setattr(tool_call_dedupe, "parse_sse_event_payload", dedupe_validate)
+
+    async def fake_core_stream_responses(*_args: object, **_kwargs: object):
+        yield 'data: {"type":"response.created","response":{"id":"resp_lifecycle_only"}}\n\n'
+        yield 'data: {"type":"response.output_text.delta","delta":"a"}\n\n'
+        yield 'data: {"type":"response.output_text.delta","delta":"b"}\n\n'
+        yield (
+            'data: {"type":"response.completed","response":{"id":"resp_lifecycle_only",'
+            '"usage":{"input_tokens":3,"output_tokens":5,'
+            '"input_tokens_details":{"cached_tokens":2},'
+            '"output_tokens_details":{"reasoning_tokens":1}}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_core_stream_responses)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-lifecycle-only"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    # Only the created + completed lifecycle frames are validated; the two
+    # deltas are classified from the parsed dict and never re-validated by
+    # the parallel-tool-call rewrite either.
+    assert mixin_validate.call_count == 2
+    assert dedupe_validate.call_count == 0
+    # SSE output stays byte-identical to the canonical re-encode.
+    assert chunks[1] == 'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"a"}\n\n'
+    assert json.loads(chunks[-1].split("data: ", 1)[1])["type"] == "response.completed"
+    assert await service.drain_persistence_tasks(timeout_seconds=1)
+    assert request_logs.calls[0]["status"] == "success"
+    assert request_logs.calls[0]["request_id"] == "resp_lifecycle_only"
+    assert request_logs.calls[0]["input_tokens"] == 3
+    assert request_logs.calls[0]["output_tokens"] == 5
+    assert request_logs.calls[0]["cached_input_tokens"] == 2
+    assert request_logs.calls[0]["reasoning_tokens"] == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_rewrites_terminal_error_after_unvalidated_deltas(monkeypatch):
+    # A bare upstream ``error`` frame after unvalidated deltas must still be
+    # rewritten to a terminal response.failed under the SDK contract and
+    # settle as an error.
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_lifecycle_error_rewrite")
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+
+    async def fake_core_stream_responses(*_args: object, **_kwargs: object):
+        yield 'data: {"type":"response.created","response":{"id":"resp_lifecycle_err"}}\n\n'
+        yield 'data: {"type":"response.output_text.delta","delta":"a"}\n\n'
+        yield 'data: {"type":"error","message":"upstream exploded"}\n\n'
+
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_core_stream_responses)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-lifecycle-error"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    terminal = json.loads(chunks[-1].split("data: ", 1)[1])
+    assert terminal["type"] == "response.failed"
+    assert terminal["response"]["error"]["message"] == "upstream exploded"
+    assert await service.drain_persistence_tasks(timeout_seconds=1)
+    assert request_logs.calls[0]["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_validates_only_lifecycle_frames(monkeypatch):
+    # Websocket relay: response.created keeps validated response-id
+    # assignment, deltas skip validation and are relayed with their original
+    # bytes when no response-id rewrite applies, and response.completed still
+    # hands a validated usage-bearing event to finalization.
+    from app.core.openai.models import OpenAIEvent
+    from app.modules.proxy import tool_call_dedupe
+    from app.modules.proxy._service.websocket import mixin as websocket_mixin_module
+
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_ws_lifecycle_validation")
+    finalize_request_state = AsyncMock()
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    ws_validate = MagicMock(wraps=websocket_mixin_module.parse_sse_event_payload)
+    monkeypatch.setattr(websocket_mixin_module, "parse_sse_event_payload", ws_validate)
+    dedupe_validate = MagicMock(wraps=tool_call_dedupe.parse_sse_event_payload)
+    monkeypatch.setattr(tool_call_dedupe, "parse_sse_event_payload", dedupe_validate)
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_lifecycle_validation",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        response_create_gate_acquired=True,
+    )
+    pending_requests = deque([request_state])
+    pending_lock = anyio.Lock()
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    response_create_gate = asyncio.Semaphore(0)
+
+    async def relay(text: str) -> str:
+        return await service._process_upstream_websocket_text(
+            text,
+            account=account,
+            account_id_value=account.id,
+            pending_requests=pending_requests,
+            pending_lock=pending_lock,
+            api_key=None,
+            upstream_control=upstream_control,
+            response_create_gate=response_create_gate,
+        )
+
+    created_text = json.dumps(
+        {"type": "response.created", "response": {"id": "resp_ws_lifecycle", "status": "in_progress"}},
+        separators=(",", ":"),
+    )
+    await relay(created_text)
+    assert request_state.response_id == "resp_ws_lifecycle"
+    assert ws_validate.call_count == 1
+
+    delta_text = json.dumps(
+        {
+            "type": "response.output_text.delta",
+            "response_id": "resp_ws_lifecycle",
+            "sequence_number": 3,
+            "delta": "hello",
+        },
+        separators=(",", ":"),
+    )
+    downstream_delta = await relay(delta_text)
+    assert ws_validate.call_count == 1
+    assert dedupe_validate.call_count == 0
+    assert downstream_delta == delta_text
+    finalize_request_state.assert_not_awaited()
+
+    completed_text = json.dumps(
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_ws_lifecycle",
+                "status": "completed",
+                "usage": {"input_tokens": 11, "output_tokens": 7},
+            },
+        },
+        separators=(",", ":"),
+    )
+    await relay(completed_text)
+    assert ws_validate.call_count == 2
+    finalize_request_state.assert_awaited_once()
+    finalize_call = finalize_request_state.await_args
+    assert finalize_call is not None
+    assert finalize_call.kwargs["event_type"] == "response.completed"
+    completed_event = finalize_call.kwargs["event"]
+    assert isinstance(completed_event, OpenAIEvent)
+    assert completed_event.response is not None
+    assert completed_event.response.usage is not None
+    assert completed_event.response.usage.input_tokens == 11
+    assert completed_event.response.usage.output_tokens == 7

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -46552,3 +46552,201 @@ async def test_process_upstream_websocket_text_validates_only_lifecycle_frames(m
     assert completed_event.response.usage is not None
     assert completed_event.response.usage.input_tokens == 11
     assert completed_event.response.usage.output_tokens == 7
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_rewrites_malformed_error_when_it_is_the_first_frame(monkeypatch):
+    # Regression: a malformed first upstream frame like
+    # {"type":"error","message":"..."} classifies as "error" but carries no
+    # error envelope (event=None). The first-frame path must apply the same
+    # SDK-contract fallback as the later-frame loop: rewrite to a terminal
+    # response.failed and settle as an error instead of leaking the raw frame
+    # with a success settlement.
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_first_frame_error_rewrite")
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+
+    async def fake_core_stream_responses(*_args: object, **_kwargs: object):
+        yield 'data: {"type":"error","message":"upstream exploded first"}\n\n'
+
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_core_stream_responses)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-first-frame-error"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    assert chunks
+    terminal = json.loads(chunks[-1].split("data: ", 1)[1])
+    assert terminal["type"] == "response.failed"
+    assert terminal["response"]["error"]["message"] == "upstream exploded first"
+    assert terminal["response"]["error"]["code"] == "upstream_error"
+    assert await service.drain_persistence_tasks(timeout_seconds=1)
+    assert request_logs.calls[0]["status"] != "success"
+    assert request_logs.calls[0]["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_process_upstream_websocket_text_keeps_frame_bytes_when_response_id_already_matches():
+    # Regression for the response-id rewrite identity fast-path: when the
+    # frame already carries the assigned downstream response id, the rewrite
+    # helper must hand back the original payload object so the relay forwards
+    # the upstream text without re-encoding it.
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_ws_response_id_identity")
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_response_id_identity",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        response_id="resp_ws_identity",
+        replay_downstream_response_id="resp_ws_identity",
+    )
+    pending_requests = deque([request_state])
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+
+    delta_text = json.dumps(
+        {
+            "type": "response.output_text.delta",
+            "response_id": "resp_ws_identity",
+            "sequence_number": 7,
+            "delta": "hello",
+        },
+        separators=(",", ":"),
+    )
+    downstream_delta = await service._process_upstream_websocket_text(
+        delta_text,
+        account=account,
+        account_id_value=account.id,
+        pending_requests=pending_requests,
+        pending_lock=anyio.Lock(),
+        api_key=None,
+        upstream_control=upstream_control,
+        response_create_gate=asyncio.Semaphore(0),
+    )
+
+    assert downstream_delta is delta_text
+    assert upstream_control.downstream_sequence_number == 7
+    assert upstream_control.downstream_sequence_request_state is request_state
+
+
+@pytest.mark.asyncio
+async def test_process_and_forward_upstream_websocket_text_decodes_once_and_validates_lifecycle_only(monkeypatch):
+    # Product-path regression for the parse-once requirement: every direct
+    # upstream websocket text frame flows through
+    # _process_and_forward_upstream_websocket_text, which must json-decode the
+    # frame exactly once (shared by archive attribution and relay processing)
+    # and run pydantic validation only for lifecycle frames.
+    service = proxy_service.ProxyService(_repo_factory(_RequestLogsRecorder()))
+    account = _make_account("acc_ws_forward_parse_once")
+    finalize_request_state = AsyncMock()
+    monkeypatch.setattr(service, "_finalize_websocket_request_state", finalize_request_state)
+    sent_downstream: list[str] = []
+
+    async def record_downstream(_websocket: object, *, text: str, **_kwargs: object) -> None:
+        sent_downstream.append(text)
+
+    monkeypatch.setattr(service, "_send_downstream_websocket_text", record_downstream)
+    ws_validate = MagicMock(wraps=websocket_mixin_module.parse_sse_event_payload)
+    monkeypatch.setattr(websocket_mixin_module, "parse_sse_event_payload", ws_validate)
+
+    request_state = proxy_service._WebSocketRequestState(
+        request_id="ws_req_forward_parse_once",
+        model="gpt-5.6-sol",
+        service_tier=None,
+        reasoning_effort=None,
+        api_key_reservation=None,
+        started_at=0.0,
+        response_create_gate_acquired=True,
+        archive_request_id="archive_ws_forward_parse_once",
+    )
+    pending_requests = deque([request_state])
+    pending_lock = anyio.Lock()
+    upstream_control = proxy_service._WebSocketUpstreamControl()
+    downstream_activity = proxy_service._DownstreamWebSocketActivity()
+    archived: list[tuple[object, str | None]] = []
+
+    class _ArchivingUpstream:
+        def archive_received(self, message: object) -> None:
+            archived.append((message, get_request_id()))
+
+    upstream = _ArchivingUpstream()
+
+    frame_payloads: list[dict[str, Any]] = [
+        {"type": "response.created", "response": {"id": "resp_ws_forward_once", "status": "in_progress"}},
+        {"type": "response.output_text.delta", "response_id": "resp_ws_forward_once", "delta": "hello"},
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_ws_forward_once",
+                "status": "completed",
+                "usage": {"input_tokens": 4, "output_tokens": 2},
+            },
+        },
+    ]
+    frame_texts = [json.dumps(frame, separators=(",", ":")) for frame in frame_payloads]
+
+    loads_spy = MagicMock(wraps=json.loads)
+    monkeypatch.setattr(websocket_mixin_module.json, "loads", loads_spy)
+
+    for frame_text in frame_texts:
+        terminal = await websocket_mixin_module._process_and_forward_upstream_websocket_text(
+            cast(Any, service),
+            cast(Any, SimpleNamespace()),
+            cast(Any, upstream),
+            message=SimpleNamespace(kind="text", text=frame_text),
+            text=frame_text,
+            account=account,
+            account_id_value=account.id,
+            pending_requests=pending_requests,
+            pending_lock=pending_lock,
+            client_send_lock=anyio.Lock(),
+            api_key=None,
+            upstream_control=upstream_control,
+            response_create_gate=asyncio.Semaphore(0),
+            downstream_activity=downstream_activity,
+            continuity_state=None,
+            codex_session_affinity=False,
+        )
+        assert terminal is False
+
+    # Exactly one json decode per frame across archive attribution and relay.
+    for frame_text in frame_texts:
+        decode_calls = [c for c in loads_spy.call_args_list if c.args and c.args[0] == frame_text]
+        assert len(decode_calls) == 1
+    # Only the created + completed lifecycle frames are pydantic-validated;
+    # the delta is classified from the parsed dict without validation.
+    assert ws_validate.call_count == 2
+    # Archive attribution still resolves the owning request from the shared
+    # parsed frame for every message.
+    assert [request_id for _message, request_id in archived] == ["archive_ws_forward_parse_once"] * 3
+    # The delta frame is forwarded downstream with its original bytes.
+    assert sent_downstream[1] is frame_texts[1]
+    finalize_request_state.assert_awaited_once()
+    assert finalize_request_state.await_args is not None
+    assert finalize_request_state.await_args.kwargs["event_type"] == "response.completed"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -8988,16 +8988,16 @@ def test_normalize_stream_event_payload_validates_error_envelope_only_for_error_
     adapter_spy = MagicMock(wraps=parsing_module._ERROR_ADAPTER)
     monkeypatch.setattr(parsing_module, "_ERROR_ADAPTER", adapter_spy)
 
-    delta_payload: dict[str, object] = {"type": "response.output_text.delta", "delta": "a"}
+    delta_payload: dict[str, Any] = {"type": "response.output_text.delta", "delta": "a"}
     assert proxy_module._normalize_stream_event_payload(delta_payload) is delta_payload
-    in_progress_payload: dict[str, object] = {"type": "response.in_progress", "response": {"id": "resp_np"}}
+    in_progress_payload: dict[str, Any] = {"type": "response.in_progress", "response": {"id": "resp_np"}}
     assert proxy_module._normalize_stream_event_payload(in_progress_payload) is in_progress_payload
     assert adapter_spy.validate_python.call_count == 0
 
-    envelope_payload: dict[str, object] = {
+    envelope_payload: dict[str, Any] = {
         "error": {"message": "quota exhausted", "type": "server_error", "code": "insufficient_quota"}
     }
-    rewritten = proxy_module._normalize_stream_event_payload(envelope_payload)
+    rewritten: Any = proxy_module._normalize_stream_event_payload(envelope_payload)
     assert adapter_spy.validate_python.call_count == 1
     assert rewritten["type"] == "response.failed"
     envelope_error = rewritten["response"]["error"]
@@ -9005,8 +9005,8 @@ def test_normalize_stream_event_payload_validates_error_envelope_only_for_error_
     assert envelope_error["code"] == proxy_module._normalize_error_code("insufficient_quota", "server_error")
     assert envelope_error["type"] == "server_error"
 
-    bare_error_payload: dict[str, object] = {"type": "error", "code": "rate_limit_exceeded", "message": "slow down"}
-    rewritten_bare = proxy_module._normalize_stream_event_payload(bare_error_payload)
+    bare_error_payload: dict[str, Any] = {"type": "error", "code": "rate_limit_exceeded", "message": "slow down"}
+    rewritten_bare: Any = proxy_module._normalize_stream_event_payload(bare_error_payload)
     assert adapter_spy.validate_python.call_count == 2
     assert rewritten_bare["type"] == "response.failed"
     bare_error = rewritten_bare["response"]["error"]

--- a/tests/unit/test_sse.py
+++ b/tests/unit/test_sse.py
@@ -9,7 +9,7 @@ import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from app.core.openai.parsing import parse_sse_event
+from app.core.openai.parsing import _LIFECYCLE_EVENT_TYPES, classify_event_type, parse_sse_event
 from app.core.utils.sse import (
     CODEX_KEEPALIVE_FRAME,
     SSE_KEEPALIVE_FRAME,
@@ -198,3 +198,30 @@ def test_extract_sse_data_joins_crlf_multiline_data():
     block = "data: line1\r\ndata: line2\rdata: line3\n\n"
 
     assert extract_sse_data(block) == "line1\nline2\nline3"
+
+
+def test_classify_event_type_prefers_string_type_field():
+    assert classify_event_type({"type": "response.output_text.delta", "delta": "x"}) == "response.output_text.delta"
+
+
+def test_classify_event_type_maps_typeless_error_payload_to_error():
+    assert classify_event_type({"error": {"message": "boom"}, "status": 400}) == "error"
+
+
+def test_classify_event_type_rejects_non_dict_and_typeless_payloads():
+    assert classify_event_type(None) is None
+    assert classify_event_type([1, 2, 3]) is None
+    assert classify_event_type({"type": 42}) is None
+    assert classify_event_type({"delta": "x"}) is None
+
+
+def test_lifecycle_event_types_cover_terminal_and_created_frames():
+    assert _LIFECYCLE_EVENT_TYPES == frozenset(
+        {
+            "response.created",
+            "response.completed",
+            "response.incomplete",
+            "response.failed",
+            "error",
+        }
+    )

--- a/tests/unit/test_websocket_terminal_cancellation.py
+++ b/tests/unit/test_websocket_terminal_cancellation.py
@@ -1102,12 +1102,14 @@ async def test_terminal_message_ownership_survives_relay_cancellation(
         *,
         pending_requests: deque[proxy_service._WebSocketRequestState],
         pending_lock: anyio.Lock,
+        parsed_frame: object | None = None,
     ) -> str | None:
         archive_attribution_started.set()
         return await original_archive_attribution(
             message,
             pending_requests=pending_requests,
             pending_lock=pending_lock,
+            parsed_frame=cast("websocket_mixin._ParsedUpstreamWebSocketFrame | None", parsed_frame),
         )
 
     async def _blocking_release_gate(


### PR DESCRIPTION
## Why

Production py-spy (GIL-holder sampling, single-core host) shows ~3% of CPU in per-chunk pydantic `validate_python`/`model_validate`, plus redundant `json.loads` passes, in the streaming hot path. Investigation traced every consumer of parsed events: usage settlement, retry/error classification, tool-call dedupe, service_tier attribution, TTFT, response-id capture — all of them only need **lifecycle frames** (`response.created/completed/incomplete/failed`, `error`). Delta bulk pays full validation for nothing.

## What

- Pydantic validation only for lifecycle frames; shared `classify_event_type` + `_LIFECYCLE_EVENT_TYPES` in `app/core/openai/parsing.py`; other frames classified from the parsed dict.
- Delete `parse_sse_event` at two SSE-loop sites in `app/core/clients/proxy.py` whose only output duplicated `normalized_event_type` computed one line earlier (verified strictly redundant).
- WebSocket relay: single `json.loads` (drops the synthetic-SSE-block double parse), terminal-only validation, pass `event=` into `rewrite_parallel_tool_call_text` (kills the second per-frame validation in `tool_call_dedupe.py`), stop building the discarded `format_sse_event` 5th-return-value arg, skip `json.dumps` when the response-id rewrite is identity.
- Same gating in `http_bridge/upstream_events.py`.

SSE downstream output is byte-identical (pinned by tests). The only byte-visible relaxation is on the ws relay identity path (upstream JSON text instead of canonical re-encode; unmatched frames were already forwarded verbatim) — documented in the openspec delta.

## OpenSpec

`openspec/changes/validate-stream-lifecycle-events-only/` (MODIFIED delta on the responses-api-compat "parsed once" requirement from #1270's optimize-sse-single-parse).

## Tests

Full unit suite 6109 passed; integration `test_proxy_responses.py`, `test_proxy_websocket_responses.py` (186), `test_http_responses_bridge.py` (130). New regressions: lifecycle-only validation counts with interleaved `event=None` deltas (usage settlement + response-id capture + byte-identical SSE), ws created-frame response-id assignment, error-frame rewrite after unvalidated deltas, dedupe no-revalidation, `classify_event_type` units. ruff format/check, ty, `openspec validate --specs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced redundant parsing and serialization during streaming responses.
  * Forwarded unchanged WebSocket frames more efficiently while preserving their content.

* **Reliability**
  * Improved lifecycle-event, terminal-state, and structured-error handling.
  * Preserved stream formatting, usage settlement, tool-call behavior, and response rewriting.

* **Documentation**
  * Added guidance for lifecycle-only stream validation.

* **Tests**
  * Expanded coverage for HTTP, SSE, WebSocket, error handling, delta frames, and unchanged stream passthrough.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->