### PR TITLE
perf(proxy): relay unmodified SSE frames verbatim

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -88,7 +88,7 @@ from app.core.usage.live_hub import publish_live_usage
 from app.core.usage.live_snapshots import EVENT_MARKER, parse_rate_limit_event_text, parse_rate_limit_headers
 from app.core.utils.json_guards import is_json_mapping
 from app.core.utils.request_id import get_request_id
-from app.core.utils.sse import format_sse_event, parse_sse_data_json
+from app.core.utils.sse import format_sse_event, parse_sse_data_json, sse_event_type_from_block
 
 CODEX_INSTALLATION_ID_HEADER = "x-codex-installation-id"
 CODEX_TURN_METADATA_HEADER = "x-codex-turn-metadata"
@@ -125,6 +125,11 @@ _SSE_EVENT_TYPE_ALIASES = {
     "response.audio.delta": "response.output_audio.delta",
     "response.audio_transcript.delta": "response.output_audio_transcript.delta",
 }
+# Bare (unquoted) alias names gate the block-level alias normalizer: they
+# match both the JSON `"type":"<alias>"` in a data line and a stale
+# `event: <alias>` framing line. False positives (an alias name inside delta
+# text) just take the full-parse path.
+_SSE_EVENT_TYPE_ALIAS_MARKERS = tuple(_SSE_EVENT_TYPE_ALIASES)
 _SSE_LINE_BOUNDARY_RE = re.compile(r"\r\n|\r|\n")
 _RESPONSE_STREAM_TERMINAL_EVENT_TYPES = frozenset(
     {
@@ -1352,11 +1357,23 @@ def _normalize_sse_data_line(line: str) -> str:
     return line
 
 
+def _normalize_sse_event_type_line(line: str) -> str:
+    if not line.startswith("event:"):
+        return line
+    value = line[6:]
+    if value.startswith(" "):
+        value = value[1:]
+    normalized_type = _SSE_EVENT_TYPE_ALIASES.get(value)
+    if normalized_type is None:
+        return line
+    return f"event: {normalized_type}"
+
+
 def _normalize_sse_event_block(event_block: str) -> str:
     if not event_block:
         return event_block
 
-    if '"type":' not in event_block:
+    if not any(marker in event_block for marker in _SSE_EVENT_TYPE_ALIAS_MARKERS):
         return event_block
 
     if event_block.endswith("\r\n\r\n"):
@@ -1383,7 +1400,11 @@ def _normalize_sse_event_block(event_block: str) -> str:
     normalized_lines: list[str] = []
     changed = False
     for line in lines:
-        normalized_line = _normalize_sse_data_line(line)
+        # Rewrite both surfaces of a legacy alias: the JSON payload's `type`
+        # and the SSE `event:` framing line. Rewriting only the data line
+        # would emit mismatched framing when the block is relayed verbatim
+        # downstream instead of being re-serialized.
+        normalized_line = _normalize_sse_event_type_line(_normalize_sse_data_line(line))
         if normalized_line != line:
             changed = True
         normalized_lines.append(normalized_line)
@@ -1446,6 +1467,21 @@ def _normalize_stream_payload_for_http_block(
     *,
     enforce_openai_sdk_contract: bool = True,
 ) -> tuple[str, str | None]:
+    # Cheap path for the dominant delta traffic: a canonically framed block
+    # exposes its event type on the `event:` line, so no JSON parse is needed.
+    # Full parsing remains for `error` frames and any block carrying an
+    # `"error"` substring (the SDK-contract rewrite in
+    # `_normalize_stream_event_payload` keys off a top-level error envelope),
+    # legacy alias types (rewritten payloads), and non-canonical or data-only
+    # framing (the event type then comes from the payload itself).
+    cheap_event_type = sse_event_type_from_block(event_block)
+    if (
+        cheap_event_type is not None
+        and cheap_event_type != "error"
+        and cheap_event_type not in _SSE_EVENT_TYPE_ALIASES
+        and '"error"' not in event_block
+    ):
+        return event_block, cheap_event_type
     if not enforce_openai_sdk_contract:
         payload = parse_sse_data_json(event_block)
         if payload is None:

--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1369,6 +1369,56 @@ def _normalize_sse_event_type_line(line: str) -> str:
     return f"event: {normalized_type}"
 
 
+def _normalize_multi_data_sse_block(
+    event_block: str,
+    lines: list[str],
+    line_separator: str,
+    terminator: str,
+) -> str:
+    # Fragments of a payload split across multiple `data:` lines are not
+    # individually decodable, so alias detection must run on the combined
+    # payload (the SSE spec joins data-line values with "\n"). Decode it
+    # before touching the `event:` framing line so both surfaces are
+    # rewritten together; if the combined payload cannot be decoded, leave
+    # the whole block — framing line included — untouched rather than
+    # emitting a partially rewritten frame.
+    payload = parse_sse_data_json(event_block)
+    if payload is None:
+        return event_block
+
+    data_replacement: str | None = None
+    event_type = payload.get("type")
+    if isinstance(event_type, str) and event_type in _SSE_EVENT_TYPE_ALIASES:
+        payload["type"] = _SSE_EVENT_TYPE_ALIASES[event_type]
+        data_replacement = f"data: {json.dumps(payload, ensure_ascii=True, separators=(',', ':'))}"
+
+    normalized_lines: list[str] = []
+    changed = False
+    data_line_emitted = False
+    for line in lines:
+        if line.startswith("data:"):
+            if data_replacement is None:
+                normalized_lines.append(line)
+            elif not data_line_emitted:
+                # The rewritten payload re-serializes compactly, so the
+                # fragments collapse into one canonical `data:` line.
+                normalized_lines.append(data_replacement)
+                data_line_emitted = True
+                changed = True
+            continue
+        normalized_line = _normalize_sse_event_type_line(line)
+        if normalized_line != line:
+            changed = True
+        normalized_lines.append(normalized_line)
+    if not changed:
+        return event_block
+
+    normalized = line_separator.join(normalized_lines)
+    if terminator:
+        return normalized + terminator
+    return normalized
+
+
 def _normalize_sse_event_block(event_block: str) -> str:
     if not event_block:
         return event_block
@@ -1396,6 +1446,9 @@ def _normalize_sse_event_block(event_block: str) -> str:
     lines = _SSE_LINE_BOUNDARY_RE.split(body)
     if not lines:
         return event_block
+
+    if sum(1 for line in lines if line.startswith("data:")) > 1:
+        return _normalize_multi_data_sse_block(event_block, lines, line_separator, terminator)
 
     normalized_lines: list[str] = []
     changed = False

--- a/app/core/utils/sse.py
+++ b/app/core/utils/sse.py
@@ -20,6 +20,29 @@ _SSE_LINE_BOUNDARY = re.compile(r"\r\n|\r|\n")
 SSE_KEEPALIVE_FRAME = ": keepalive\n\n"
 CODEX_KEEPALIVE_FRAME = 'event: codex.keepalive\ndata: {"type":"codex.keepalive"}\n\n'
 
+# The exact single-event shape ``format_sse_event`` emits (and the upstream
+# Codex backend sends): a leading ``event: <type>`` line, one JSON-object
+# ``data:`` line, LF-only framing, and a blank-line terminator. Blocks that
+# match can expose their event type without a JSON parse and are safe to
+# relay downstream byte-for-byte.
+_CANONICAL_SSE_BLOCK = re.compile(r"\Aevent: ([^\r\n]+)\ndata: \{[^\r\n]*\n\n\Z")
+
+
+def sse_event_type_from_block(event_block: str) -> str | None:
+    """Cheaply extract the event type from a canonically framed SSE block.
+
+    Returns the ``event:`` line's value only when the block matches the exact
+    shape ``format_sse_event`` produces (see ``_CANONICAL_SSE_BLOCK``).
+    Anything else — data-only blocks, multi-line data, CR/CRLF framing,
+    comment or ``id:`` lines, non-object data payloads, or an ``event:`` field
+    that appears after ``data:`` (legal SSE, but not canonical here) — returns
+    ``None`` so callers fall back to a full parse.
+    """
+    match = _CANONICAL_SSE_BLOCK.match(event_block)
+    if match is None:
+        return None
+    return match.group(1)
+
 
 async def inject_sse_keepalives(
     source: AsyncIterator[str],

--- a/app/modules/proxy/_service/streaming/mixin.py
+++ b/app/modules/proxy/_service/streaming/mixin.py
@@ -303,6 +303,7 @@ from app.modules.proxy._service.support import (
     _StreamSettlement,
     _TerminalStreamError,
     _ttft_event_latency_ms,
+    _verbatim_relay_event_type,
     _WebSocketUpstreamControl,
 )
 from app.modules.proxy._service.support import (
@@ -525,6 +526,16 @@ class _StreamingMixin(_StreamingRetryMixin):
         response_create_lease = AdmissionLease(None, stage="response_create", request_id=request_id)
         account_response_create_lease: AccountLease | None = None
         api_key_reservation_touch_state = _ApiKeyReservationTouchState(last_touch_at=start)
+
+        async def _touch_api_key_reservation() -> None:
+            api_key_reservation_touch_state.last_touch_at = await proxy._maybe_touch_api_key_reservation(
+                api_key=api_key,
+                reservation=api_key_reservation,
+                last_touch_at=api_key_reservation_touch_state.last_touch_at,
+                request_id=request_id,
+                surface="stream",
+            )
+
         api_key_reservation_heartbeat_stop = asyncio.Event()
         api_key_reservation_heartbeat_task: asyncio.Task[None] | None = None
         if api_key_reservation is not None:
@@ -579,9 +590,8 @@ class _StreamingMixin(_StreamingRetryMixin):
                 error_code = "stream_incomplete"
                 error_message = "Upstream websocket closed before response.completed"
                 settlement.record_success = False
-                settlement.account_health_error = True
+                terminal_event_seen = settlement.account_health_error = True
                 settlement.error = {"message": error_message}
-                terminal_event_seen = True
                 yield format_sse_event(
                     response_failed_event(
                         error_code,
@@ -598,9 +608,8 @@ class _StreamingMixin(_StreamingRetryMixin):
                 error_code = "upstream_unavailable"
                 error_message = str(exc) or "Request to upstream timed out"
                 settlement.record_success = False
-                settlement.account_health_error = True
+                terminal_event_seen = settlement.account_health_error = True
                 settlement.error = {"message": error_message}
-                terminal_event_seen = True
                 yield format_sse_event(
                     response_failed_event(
                         error_code,
@@ -627,13 +636,7 @@ class _StreamingMixin(_StreamingRetryMixin):
             if malformed_error_rewrite is not None:
                 first, event, first_payload, event_type = malformed_error_rewrite
             if event_type not in {"response.completed", "response.failed", "response.incomplete", "error"}:
-                api_key_reservation_touch_state.last_touch_at = await proxy._maybe_touch_api_key_reservation(
-                    api_key=api_key,
-                    reservation=api_key_reservation,
-                    last_touch_at=api_key_reservation_touch_state.last_touch_at,
-                    request_id=request_id,
-                    surface="stream",
-                )
+                await _touch_api_key_reservation()
             event_service_tier = _facade()._service_tier_from_event_payload(first_payload)
             if event_service_tier is not None:
                 actual_service_tier = event_service_tier
@@ -777,6 +780,13 @@ class _StreamingMixin(_StreamingRetryMixin):
             if terminal_stream_error is not None:
                 raise terminal_stream_error
             async for line in iterator:
+                if verbatim_type := _verbatim_relay_event_type(line, latency_first_token_ms, ttft_reasoning_deltas):
+                    await _touch_api_key_reservation()
+                    if verbatim_type in _facade()._TEXT_DELTA_EVENT_TYPES:
+                        saw_text_delta = settlement.downstream_text_visible = True
+                    settlement.downstream_visible = True
+                    yield line
+                    continue
                 event_payload = parse_sse_data_json(line)
                 event_type = classify_event_type(event_payload)
                 event = parse_sse_event_payload(event_payload) if event_type in _LIFECYCLE_EVENT_TYPES else None
@@ -791,13 +801,7 @@ class _StreamingMixin(_StreamingRetryMixin):
                 if malformed_error_rewrite is not None:
                     line, event, event_payload, event_type = malformed_error_rewrite
                 if event_type not in {"response.completed", "response.failed", "response.incomplete", "error"}:
-                    api_key_reservation_touch_state.last_touch_at = await proxy._maybe_touch_api_key_reservation(
-                        api_key=api_key,
-                        reservation=api_key_reservation,
-                        last_touch_at=api_key_reservation_touch_state.last_touch_at,
-                        request_id=request_id,
-                        surface="stream",
-                    )
+                    await _touch_api_key_reservation()
                 event_service_tier = _facade()._service_tier_from_event_payload(event_payload)
                 if event_service_tier is not None:
                     actual_service_tier = event_service_tier

--- a/app/modules/proxy/_service/support.py
+++ b/app/modules/proxy/_service/support.py
@@ -28,6 +28,7 @@ from app.core.resilience.network_recovery import PROCESS_NETWORK_UNAVAILABLE_COD
 from app.core.resilience.overload import is_local_overload_error_code
 from app.core.types import JsonValue
 from app.core.upstream_proxy import ResolvedUpstreamRoute
+from app.core.utils.sse import sse_event_type_from_block
 from app.db.models import Account
 from app.modules.api_keys.service import (
     ApiKeyData,
@@ -265,6 +266,58 @@ def _finalize_ttft_latency_ms(
     started_at: float,
 ) -> int | None:
     return _ttft_latency_ms_from_visible_at(_finalize_ttft_reasoning_deltas(pending_reasoning_deltas), started_at)
+
+
+# Stream frames whose parsed payload feeds a real per-event consumer:
+# lifecycle/terminal handling and usage settlement (created/in_progress/
+# completed/failed/incomplete/error), parallel tool-call rewrite + duplicate
+# side-effect suppression (response.output_item.*), and text-done suppression
+# (response.output_text.done / response.content_part.done). Canonically framed
+# frames of any other type can relay upstream bytes verbatim once the TTFT
+# window is settled and no service-tier snapshot is present.
+_MUST_PARSE_STREAM_EVENT_TYPES = frozenset(
+    {
+        "response.created",
+        "response.in_progress",
+        "response.completed",
+        "response.failed",
+        "response.incomplete",
+        "error",
+        "response.output_item.added",
+        "response.output_item.done",
+        "response.output_text.done",
+        "response.content_part.done",
+    }
+)
+# Raw-line gate for service-tier attribution: response snapshots carry
+# `"service_tier"` in their JSON, and a false positive (the substring inside
+# delta text) merely takes the full-parse path.
+_SERVICE_TIER_MARKER = '"service_tier"'
+
+
+def _verbatim_relay_event_type(
+    line: str,
+    latency_first_token_ms: int | None,
+    pending_reasoning_deltas: dict[tuple[str | None, int | None, int | None], _TTFTReasoningDeltaState],
+) -> str | None:
+    """Return the cheap event type when a stream frame can relay verbatim.
+
+    Eligible frames are canonically framed (leading ``event: <type>`` line,
+    single JSON-object ``data:`` line — see ``sse_event_type_from_block``),
+    outside the must-parse set, past the TTFT first-token window (including a
+    pending reasoning-delta window), and free of the service-tier marker.
+    Everything else returns ``None`` and takes the full parse +
+    ``format_sse_event`` path, preserving the EventSource framing guarantee
+    for data-only blocks.
+    """
+    if latency_first_token_ms is None or pending_reasoning_deltas:
+        return None
+    if _SERVICE_TIER_MARKER in line:
+        return None
+    event_type = sse_event_type_from_block(line)
+    if event_type is None or event_type in _MUST_PARSE_STREAM_EVENT_TYPES:
+        return None
+    return event_type
 
 
 def _bind_propagated_capacity_startup_wait(event: asyncio.Event) -> Token[asyncio.Event | None]:

--- a/openspec/changes/relay-unmodified-sse-frames-verbatim/design.md
+++ b/openspec/changes/relay-unmodified-sse-frames-verbatim/design.md
@@ -1,0 +1,115 @@
+# Design — relay-unmodified-sse-frames-verbatim
+
+## Context
+
+Follow-up to `validate-stream-lifecycle-events-only` (stacked on it) and the
+second half of the deferral in `2026-07-13-optimize-sse-single-parse`: after
+lifecycle-only validation, every frame still pays one `json.loads` per owning
+layer and an unconditional `format_sse_event` re-encode in the streaming
+mixin. Delta frames after the first visible token have no per-event consumer,
+so their bytes can relay verbatim.
+
+## Goals / Non-Goals
+
+**Goals:** zero JSON parse and zero re-encode for canonically framed frames no
+consumer needs parsed; preserve every consumer's trigger surface (terminal
+settlement, error rewrite, tool-call rewrite/dedupe, text-done suppression,
+service-tier attribution, TTFT, reservation touches); keep the
+`5ee532cb` framing guarantee (data-only blocks are re-framed with
+`event: <type>` for EventSource clients); fix the stale-`event:`-line alias
+bug that verbatim relay would otherwise expose.
+
+**Non-Goals:** the chat/completions bridge (cross-dialect translation keeps
+full parsing); the `/v1` public normalizer (independent per-chunk consumer —
+verbatim blocks satisfy its identity gate unchanged, see below); the websocket
+relay and bridge upstream reader (every ws frame is parsed for response-id
+multiplexing; covered by the stacked lifecycle change); the first-event block
+in the streaming mixin (once per stream; retry classification lives there).
+
+## Decisions
+
+- **Cheap type = strict canonical shape.** `sse_event_type_from_block` matches
+  only `event: <type>\ndata: {…}\n\n` (single data line, LF framing,
+  JSON-object data). SSE legally allows the `event:` field after `data:`,
+  CR/CRLF framing, comments, and multi-line data — all of those return `None`
+  and take the existing full-parse path, so only blocks byte-shaped like
+  `format_sse_event` output (which is what the upstream Codex backend and our
+  own re-encodes emit) are eligible for verbatim relay. This resolves the
+  field-ordering checklist item.
+- **Must-parse set** = lifecycle/terminal frames (`response.created`,
+  `response.in_progress`, `response.completed`, `response.failed`,
+  `response.incomplete`, `error`) + tool-call item frames
+  (`response.output_item.added`, `response.output_item.done` — rewrite,
+  duplicate suppression, and TTFT item inspection) + text-done frames
+  (`response.output_text.done`, `response.content_part.done` — suppression
+  reads the payload's `part`). Everything else has no payload consumer outside
+  the gated windows below.
+- **TTFT window trigger.** The full parse also runs while
+  `latency_first_token_ms is None` **or** `ttft_reasoning_deltas` is
+  non-empty. Verified by reading `support.py`: `_ttft_event_latency_ms` (and
+  therefore all mutation of the pending reasoning-delta state) is invoked only
+  under the `latency_first_token_ms is None` guard (mixin loop and first-event
+  block), and the stream-end `_finalize_ttft_latency_ms` is gated on the same
+  condition — so the first clause alone already covers the pending window; the
+  explicit non-empty check is a defensive belt (pending entries can outlive
+  TTFT settlement, e.g. a second reasoning summary stream, but are never read
+  after it).
+- **Service-tier gate** stays on the raw line (`'"service_tier"'` substring),
+  not the event type, so a moved snapshot field still full-parses; false
+  positives (the substring inside delta text) just take the parse path.
+- **Verbatim branch bookkeeping.** The reservation touch (non-terminal frames
+  keep reservations alive), `saw_text_delta`, `settlement.downstream_visible`,
+  and `settlement.downstream_text_visible` are preserved; text flags derive
+  from the cheap type, which for canonical frames equals the payload type.
+- **Client normalizer laziness.** `_normalize_stream_payload_for_http_block`
+  returns the cheap type without parsing only when the block is canonical, the
+  type is not `error` and not a legacy alias, and the block has no `"error"`
+  substring. The substring guard is load-bearing: `parse_error_payload`
+  rewrites any payload carrying a top-level `error` envelope regardless of its
+  `type` (`OpenAIErrorEnvelope.error` is optional, so only an actual `error`
+  key triggers it), and response snapshots legitimately carry `"error":null` —
+  both stay on the full-parse path.
+- **Alias gate + stale `event:` line.** `_normalize_sse_event_block` now gates
+  on the three bare alias names (matching both `"type":"<alias>"` in data
+  lines and `event: <alias>` framing lines) instead of `'"type":'`, and
+  rewrites the `event:` line too. Previously only the data line was rewritten
+  and the mixin's unconditional re-encode masked the mismatch; under verbatim
+  relay the stale line would reach clients, so the fix lands in the same
+  change.
+- **/v1 identity gate verified for raw UTF-8.** `api.py` pass-through compares
+  parsed-payload *object identity* (`normalized_payload is parsed_payload`)
+  plus `_has_canonical_event_framing`, which checks only the
+  `event: <type>\n` prefix — no comparison against a re-serialization — so
+  verbatim raw-UTF-8 blocks pass through byte-identically (regression test
+  added).
+
+## Accepted limitations (documented drift)
+
+- **Byte-visible output change.** Unmodified delta frames now carry upstream
+  bytes (raw UTF-8, upstream key order/spacing) instead of the `ensure_ascii`
+  canonical re-encode. JSON-equivalent and SSE-valid; codified in the spec
+  delta.
+- **The `event:` framing line is trusted for non-parsed frames.** A
+  hypothetical upstream frame whose `event:` line disagrees with its payload
+  `type` (never emitted by upstream; our own re-encodes are consistent by
+  construction) would be classified by the framing line: a terminal payload
+  disguised under a delta `event:` line would relay verbatim and settle as
+  `stream_incomplete` at EOF instead of a terminal settlement. Today's
+  behavior for such frames differs only in which side wins; the `/v1`
+  normalizer still parses independently and enforces its own contract.
+- **Malformed-JSON canonical frames.** A canonical-looking block whose data is
+  not valid JSON relays verbatim (today it is also yielded unchanged — the
+  parse failure path skips the re-encode) but now sets `saw_text_delta` /
+  text-visibility from the framing line, which the parse path would not.
+  Only reachable from a misbehaving upstream.
+- **Usage on delta frames** would relay verbatim without settlement capture,
+  as under the stacked lifecycle change (upstream emits usage only on
+  terminal frames) — unchanged hedge, inherited.
+
+## Stacking note (delta-merge hazard)
+
+This change is stacked on `validate-stream-lifecycle-events-only` and MODIFIES
+the same `responses-api-compat` requirement. To avoid the concurrent-MODIFIED
+last-writer-wins loss (#1772), this change's delta contains the **union** text:
+the lifecycle-only validation clauses from the stacked change plus the
+verbatim-relay condition, so syncing/archiving in either order preserves both.

--- a/openspec/changes/relay-unmodified-sse-frames-verbatim/proposal.md
+++ b/openspec/changes/relay-unmodified-sse-frames-verbatim/proposal.md
@@ -1,0 +1,78 @@
+# Relay Unmodified SSE Frames Verbatim
+
+## Why
+
+Even after lifecycle-only validation (`validate-stream-lifecycle-events-only`),
+every streamed SSE frame still pays one `json.loads` per owning layer plus an
+unconditional `format_sse_event` re-encode in the streaming mixin, and the
+core client parses every frame's payload just to read its `type` for terminal
+detection. The dominant traffic — text/reasoning/tool-argument delta frames
+after the first visible token — has no per-event consumer at all: tool-call
+rewrite and duplicate suppression act only on `response.output_item.*`,
+text-done suppression only on `response.output_text.done` /
+`response.content_part.done`, service-tier attribution only on response
+snapshots carrying `"service_tier"`, TTFT only while the first-token window is
+open, and settlement/error handling only on lifecycle frames. This is the
+remaining half of the follow-up the `2026-07-13-optimize-sse-single-parse`
+design doc deferred, and py-spy attributes the `format_sse_event` `json.dumps`
+leaf plus 2–3 redundant `json.loads` per chunk to it.
+
+## What Changes
+
+- `app/core/utils/sse.py` gains `sse_event_type_from_block`: cheap event-type
+  extraction that matches only the exact canonical block shape
+  `format_sse_event` emits (leading `event: <type>` line, single JSON-object
+  `data:` line, LF framing). Data-only blocks, multi-line data, CR/CRLF
+  framing, and `event:` fields appearing after `data:` (legal SSE, but not
+  canonical here) return `None` so callers fall back to a full parse.
+- Streaming mixin hot loop: compute the cheap type first; run the full
+  parse only when the type is unavailable, is in the must-parse set
+  (lifecycle/terminal frames, `response.output_item.added`/`done`,
+  `response.output_text.done`, `response.content_part.done`), the TTFT
+  first-token window is open (including a pending reasoning-delta window), or
+  the raw line carries the `"service_tier"` marker. Otherwise the upstream
+  block is yielded verbatim — raw UTF-8 and upstream key order/spacing instead
+  of the `ensure_ascii` canonical re-encode — with text-visibility accounting
+  set from the cheap type. The first-event block stays fully parsed.
+- Core client `_normalize_stream_payload_for_http_block` becomes lazy: a
+  canonical non-error block without an `"error"` substring returns its cheap
+  type with no JSON parse; error frames, error-envelope payloads, alias types,
+  and non-canonical framing keep the full parse + rewrite path.
+- Core client `_normalize_sse_event_block` narrows its gate from `'"type":'`
+  (matches every event, gates nothing) to the three legacy alias substrings,
+  and — in the same change, because verbatim relay would otherwise expose the
+  latent bug — rewrites the stale `event:` framing line alongside the `data:`
+  payload when an alias fires.
+- The chat/completions bridge and the `/v1` public normalizer are untouched;
+  the `/v1` identity pass-through gate (parsed-payload object identity +
+  canonical framing prefix) accepts verbatim upstream blocks unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `responses-api-compat`: the single-parse streaming requirement gains the
+  verbatim-relay condition — a canonically framed frame that no per-event
+  consumer needs parsed MAY be relayed with upstream bytes verbatim
+  (JSON-equivalent, SSE-valid); all other frames keep the parse +
+  canonical-re-serialization path, and legacy alias rewrites MUST cover both
+  the `data:` payload and the `event:` framing line.
+
+## Impact
+
+- **Code**: `app/core/utils/sse.py`, `app/core/clients/proxy.py`,
+  `app/modules/proxy/_service/streaming/mixin.py`.
+- **Behavior**: byte-visible but JSON-equivalent — unmodified delta frames now
+  carry upstream bytes (raw UTF-8, upstream key order/spacing) instead of the
+  `ensure_ascii` canonical re-encode. Framing stays SSE-valid and named-event
+  clients keep seeing `event:` lines (non-canonical blocks still get
+  re-framed). Legacy `response.text.delta`-style upstreams now get a correct
+  `event:` line after alias rewrite (previously stale, masked by the mixin
+  re-encode).
+- **Performance**: removes the per-delta `json.loads` in the core client and
+  the mixin plus the per-delta `format_sse_event` re-encode for the dominant
+  post-first-token delta traffic.

--- a/openspec/changes/relay-unmodified-sse-frames-verbatim/specs/responses-api-compat/spec.md
+++ b/openspec/changes/relay-unmodified-sse-frames-verbatim/specs/responses-api-compat/spec.md
@@ -1,0 +1,68 @@
+# responses-api-compat Delta
+
+## MODIFIED Requirements
+
+### Requirement: Streaming events are parsed once and re-serialized only when modified
+
+Within each streaming layer (core client consumer, streaming mixin, bridge upstream reader, websocket relay, /v1 normalizers), an SSE event's JSON payload MUST be parsed at most once and reused by that layer's consumers, and an event that no consumer modified MUST NOT be re-serialized by the /v1 normalizers. Schema validation of the parsed payload MUST run only for stream lifecycle frames (`response.created`, `response.completed`, `response.incomplete`, `response.failed`, `error`); all other frames MUST be classified from the parsed payload's `type` field (with a typeless payload carrying an `error` object classifying as `error`).
+
+A canonically framed SSE block — a leading `event: <type>` line followed by a single JSON-object `data:` line with LF framing — whose type requires no per-event consumer MAY skip payload parsing entirely and be relayed downstream with the upstream bytes verbatim (raw UTF-8 and upstream key order/spacing preserved; JSON-equivalent to the canonical re-encode). A frame MUST take the parse path when any consumer needs it: lifecycle/terminal frames, tool-call item frames (`response.output_item.added`, `response.output_item.done`), text-done frames (`response.output_text.done`, `response.content_part.done`), frames arriving while the TTFT first-token window is open (including a pending reasoning-delta window), frames carrying a `"service_tier"` marker, and any block without canonical framing (data-only blocks, multi-line data, or an `event:` field that does not lead the block). A parsed frame MUST be re-serialized with canonical `event: <type>` + `data:` framing when modified or when its source block lacked canonical framing. Legacy event-type alias rewrites MUST cover both the `data:` payload type and the `event:` framing line. Event framing, payload contents, dedupe/rewrite semantics, usage settlement, and error normalization MUST be unchanged.
+
+#### Scenario: Unmodified events pass through the /v1 normalizer verbatim
+
+- **GIVEN** a canonical stream event that no normalizer branch rewrites
+- **WHEN** the /v1 response normalizer processes it
+- **THEN** the original block is yielded byte-identically without re-serialization
+
+#### Scenario: Tool-call rewrite reuses the parsed event on the no-change path
+
+- **GIVEN** an event without duplicate parallel tool calls
+- **WHEN** the rewrite step runs with the caller's parsed event
+- **THEN** it returns the original line, payload, and event without re-parsing or re-validating
+
+#### Scenario: Rewritten events stay consistent
+
+- **WHEN** the rewrite step removes duplicate tool calls
+- **THEN** the returned line, payload, and validated event all reflect the rewritten content
+
+#### Scenario: Delta frames skip schema validation
+
+- **GIVEN** a stream of `response.output_text.delta` frames between `response.created` and `response.completed`
+- **WHEN** the streaming mixin, websocket relay, or bridge upstream reader processes the stream
+- **THEN** only the lifecycle frames are schema-validated, the delta frames are classified from the parsed payload dict, and downstream output, usage settlement, and error normalization are unchanged
+
+#### Scenario: Identity websocket relay frames are forwarded without re-encoding
+
+- **GIVEN** a websocket frame matched to a request whose downstream response-id rewrite does not apply
+- **WHEN** the relay forwards the frame downstream
+- **THEN** the upstream frame text is forwarded as-is instead of a canonical JSON re-encode
+
+#### Scenario: Unmodified canonical delta frames relay upstream bytes verbatim
+
+- **GIVEN** a canonically framed `response.output_text.delta` frame containing raw UTF-8, arriving after the first visible token settled the TTFT window
+- **WHEN** the streaming mixin processes it
+- **THEN** the upstream block is yielded byte-identically without a JSON parse or `ensure_ascii` re-encode, and downstream text-visibility accounting still updates
+
+#### Scenario: Data-only frames regain canonical framing
+
+- **GIVEN** a delta frame without a leading `event:` line
+- **WHEN** the streaming mixin processes it after the TTFT window settles
+- **THEN** the frame is parsed and re-serialized with the canonical `event: <type>` line so named-event (EventSource) clients keep seeing the event name
+
+#### Scenario: Legacy alias frames are rewritten on both lines
+
+- **GIVEN** an upstream block whose `event:` line and `data:` payload both carry the legacy `response.text.delta` type
+- **WHEN** the core client normalizes the block
+- **THEN** both the `event:` framing line and the payload `type` read `response.output_text.delta`
+
+#### Scenario: Error frames keep the full parse and rewrite path
+
+- **GIVEN** a canonically framed `error` frame, or a frame whose payload carries a top-level `error` envelope
+- **WHEN** the core client normalizes the stream for the SDK contract
+- **THEN** the frame is parsed and rewritten to a terminal `response.failed` event exactly as before verbatim relay
+
+#### Scenario: /v1 identity pass-through accepts verbatim raw-UTF-8 blocks
+
+- **GIVEN** an upstream-verbatim canonical delta block containing raw UTF-8
+- **WHEN** the /v1 normalizer leaves the parsed payload unmodified
+- **THEN** the block passes through byte-identically (the identity gate compares parsed-payload object identity and the `event:` framing prefix, not re-serialized bytes)

--- a/openspec/changes/relay-unmodified-sse-frames-verbatim/tasks.md
+++ b/openspec/changes/relay-unmodified-sse-frames-verbatim/tasks.md
@@ -1,0 +1,34 @@
+# Tasks — relay-unmodified-sse-frames-verbatim
+
+## 1. Implementation
+
+- [x] 1.1 `sse_event_type_from_block` in `app/core/utils/sse.py`: strict
+      canonical-shape matcher (leading `event:` line, single JSON-object
+      `data:` line, LF framing); `None` otherwise
+- [x] 1.2 Streaming mixin hot loop: verbatim relay branch gated on cheap type
+      ∉ must-parse set, TTFT window settled (`latency_first_token_ms` set and
+      no pending reasoning deltas), and no `"service_tier"` marker; keeps
+      reservation touch + text-visibility accounting; first-event block stays
+      fully parsed
+- [x] 1.3 `_normalize_stream_payload_for_http_block`: lazy cheap-type return
+      for canonical non-error, non-alias blocks without an `"error"`
+      substring
+- [x] 1.4 `_normalize_sse_event_block`: gate narrowed from `'"type":'` to the
+      three alias substrings; alias rewrite covers the `event:` framing line
+      in addition to the `data:` payload
+
+## 2. Validation
+
+- [x] 2.1 Unit coverage for `sse_event_type_from_block` (canonical, raw
+      UTF-8, data-only, trailing `event:` ordering, CRLF/multi-line,
+      non-object data)
+- [x] 2.2 Mixin regressions: raw-UTF-8 delta relayed byte-identically with no
+      JSON parse after TTFT settles; data-only delta re-framed with
+      `event: <type>` (5ee532cb regression class); usage settlement unchanged
+- [x] 2.3 Client normalizer regressions: canonical frames skip `json.loads`;
+      `error` frames and top-level error envelopes still rewritten; alias
+      rewrite covers both lines; non-alias blocks skip the alias parse
+- [x] 2.4 `/v1` identity pass-through accepts verbatim raw-UTF-8 blocks
+      byte-identically
+- [x] 2.5 Existing streaming/contract/dedupe/TTFT suites pass; `uvx ruff
+      format --check`, `uv run ruff check` on changed files

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -1807,6 +1807,38 @@ async def test_normalize_public_stream_passes_canonical_unmutated_blocks_verbati
 
 
 @pytest.mark.asyncio
+async def test_normalize_public_stream_passes_raw_utf8_verbatim_blocks_byte_identically() -> None:
+    """Upstream-verbatim delta blocks (raw UTF-8, upstream key spacing — not
+    the ensure_ascii canonical re-encode) still satisfy the identity
+    pass-through gate: it compares parsed-payload object identity plus the
+    `event:` framing prefix, never re-serialized bytes."""
+    created = proxy_api_module.format_sse_event(
+        {"type": "response.created", "response": {"id": "resp_utf8", "output": []}}
+    )
+    verbatim_delta = (
+        "event: response.output_text.delta\n"
+        'data: {"type": "response.output_text.delta", "item_id": "msg_1", "output_index": 0, "delta": "안녕"}\n\n'
+    )
+    completed_payload: dict[str, Any] = {
+        "type": "response.completed",
+        "response": {
+            "id": "resp_utf8",
+            "output": [{"type": "message", "id": "msg_1", "content": [{"type": "output_text", "text": "안녕"}]}],
+        },
+    }
+    completed = proxy_api_module.format_sse_event(completed_payload)
+
+    blocks = [
+        block
+        async for block in proxy_api_module._normalize_public_responses_stream(
+            _iter_blocks(created, verbatim_delta, completed)
+        )
+    ]
+
+    assert verbatim_delta in blocks
+
+
+@pytest.mark.asyncio
 async def test_normalize_public_stream_reframes_data_only_blocks_with_event_name() -> None:
     """A data-only block (e.g. bridge-rewritten terminal event) must regain
     the canonical `event: <type>` line so named-event clients see it."""

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -46750,3 +46750,190 @@ async def test_process_and_forward_upstream_websocket_text_decodes_once_and_vali
     finalize_request_state.assert_awaited_once()
     assert finalize_request_state.await_args is not None
     assert finalize_request_state.await_args.kwargs["event_type"] == "response.completed"
+
+
+def test_normalize_sse_event_block_rewrites_alias_on_both_event_and_data_lines():
+    # A legacy alias must be rewritten on the SSE `event:` framing line too,
+    # not just inside the JSON payload — under verbatim relay a stale
+    # `event:` line would otherwise reach clients with mismatched framing.
+    block = 'event: response.text.delta\ndata: {"type":"response.text.delta","delta":"hi"}\n\n'
+
+    normalized = proxy_module._normalize_sse_event_block(block)
+
+    assert normalized == (
+        'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"hi"}\n\n'
+    )
+
+
+def test_normalize_sse_event_block_skips_json_parsing_for_non_alias_types(monkeypatch) -> None:
+    # The alias normalizer only inspects blocks carrying one of the legacy
+    # alias names; canonical event types pass through without a JSON parse.
+    block = 'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"hi"}\n\n'
+
+    def fail_json_parse(_: str) -> object:
+        raise AssertionError("json.loads should not run for blocks without an alias marker")
+
+    monkeypatch.setattr(proxy_module.json, "loads", fail_json_parse)
+
+    assert proxy_module._normalize_sse_event_block(block) == block
+
+
+def test_normalize_stream_payload_for_http_block_skips_parse_for_canonical_frames(monkeypatch) -> None:
+    block = 'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"hi"}\n\n'
+
+    def fail_json_parse(_: str) -> object:
+        raise AssertionError("json.loads should not run for canonical non-error frames")
+
+    monkeypatch.setattr(proxy_module.json, "loads", fail_json_parse)
+
+    assert proxy_module._normalize_stream_payload_for_http_block(block) == (block, "response.output_text.delta")
+    assert proxy_module._normalize_stream_payload_for_http_block(block, enforce_openai_sdk_contract=False) == (
+        block,
+        "response.output_text.delta",
+    )
+
+
+def test_normalize_stream_payload_for_http_block_still_rewrites_error_frames():
+    block = 'event: error\ndata: {"type":"error","message":"boom"}\n\n'
+
+    normalized_block, normalized_type = proxy_module._normalize_stream_payload_for_http_block(block)
+
+    assert normalized_type == "response.failed"
+    assert '"boom"' in normalized_block
+
+
+def test_normalize_stream_payload_for_http_block_still_rewrites_error_envelopes_on_non_error_types():
+    # A payload carrying a top-level error envelope is rewritten regardless of
+    # its event type; the `"error"` substring guard keeps it on the full-parse
+    # path.
+    block = (
+        "event: response.output_text.delta\n"
+        'data: {"type":"response.output_text.delta","error":{"message":"broken"},"delta":"hi"}\n\n'
+    )
+
+    normalized_block, normalized_type = proxy_module._normalize_stream_payload_for_http_block(block)
+
+    assert normalized_type == "response.failed"
+    assert '"broken"' in normalized_block
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_relays_unmodified_canonical_delta_frames_verbatim(monkeypatch):
+    # After the TTFT window settles, canonically framed delta frames are
+    # relayed with upstream bytes (raw UTF-8, upstream spacing) and are never
+    # JSON-parsed; usage settlement from the parsed terminal frame is
+    # unchanged.
+    from app.modules.proxy._service.streaming import mixin as streaming_mixin_module
+
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_verbatim_relay")
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+    mixin_parse = MagicMock(wraps=streaming_mixin_module.parse_sse_data_json)
+    monkeypatch.setattr(streaming_mixin_module, "parse_sse_data_json", mixin_parse)
+
+    verbatim_delta = (
+        'event: response.output_text.delta\ndata: {"type": "response.output_text.delta", "delta": "안녕 upstream"}\n\n'
+    )
+
+    async def fake_core_stream_responses(*_args: object, **_kwargs: object):
+        yield 'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_verbatim"}}\n\n'
+        yield 'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"a"}\n\n'
+        yield verbatim_delta
+        yield (
+            'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_verbatim",'
+            '"usage":{"input_tokens":3,"output_tokens":5}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_core_stream_responses)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-verbatim-relay"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    # created (lifecycle), the first delta (TTFT window still open), and
+    # completed (lifecycle) are parsed; the settled second delta is relayed
+    # without any JSON parse.
+    assert mixin_parse.call_count == 3
+    # Upstream bytes are preserved exactly: raw UTF-8 and upstream key
+    # spacing, not the ensure_ascii canonical re-encode.
+    assert chunks[2] == verbatim_delta
+    assert await service.drain_persistence_tasks(timeout_seconds=1)
+    assert request_logs.calls[0]["status"] == "success"
+    assert request_logs.calls[0]["input_tokens"] == 3
+    assert request_logs.calls[0]["output_tokens"] == 5
+
+
+@pytest.mark.asyncio
+async def test_stream_with_retry_reframes_data_only_delta_frames_after_ttft(monkeypatch):
+    # Data-only frames (no `event:` line, e.g. bridge rewrite leftovers) never
+    # take the verbatim path: they are parsed and re-serialized with canonical
+    # `event: <type>` framing so named-event (EventSource) clients keep seeing
+    # the event name — the 5ee532cb regression class.
+    settings = _make_proxy_settings()
+    request_logs = _RequestLogsRecorder()
+    service = proxy_service.ProxyService(_repo_factory(request_logs))
+    account = _make_account("acc_verbatim_data_only")
+
+    monkeypatch.setattr(proxy_service, "get_settings_cache", lambda: _SettingsCache(settings))
+    monkeypatch.setattr(proxy_service, "get_settings", lambda: settings)
+    monkeypatch.setattr(
+        service,
+        "_select_account_with_budget_compatible",
+        AsyncMock(return_value=AccountSelection(account=account, error_message=None)),
+    )
+    monkeypatch.setattr(service, "_ensure_fresh_with_budget", AsyncMock(return_value=account))
+
+    async def fake_core_stream_responses(*_args: object, **_kwargs: object):
+        yield 'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_data_only"}}\n\n'
+        yield 'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"a"}\n\n'
+        yield 'data: {"type":"response.output_text.delta","delta":"b"}\n\n'
+        yield (
+            'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_data_only",'
+            '"usage":{"input_tokens":1,"output_tokens":1}}}\n\n'
+        )
+
+    monkeypatch.setattr(proxy_service, "core_stream_responses", fake_core_stream_responses)
+
+    payload = ResponsesRequest.model_validate({"model": "gpt-5.1", "instructions": "hi", "input": [], "stream": True})
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_retry(
+            payload,
+            {"session_id": "sid-verbatim-data-only"},
+            codex_session_affinity=False,
+            propagate_http_errors=False,
+            openai_cache_affinity=False,
+            api_key=None,
+            api_key_reservation=None,
+            suppress_text_done_events=False,
+            request_transport="http",
+            upstream_stream_transport_override="http",
+        )
+    ]
+
+    assert chunks[2] == 'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"b"}\n\n'
+    assert await service.drain_persistence_tasks(timeout_seconds=1)
+    assert request_logs.calls[0]["status"] == "success"

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -46765,6 +46765,30 @@ def test_normalize_sse_event_block_rewrites_alias_on_both_event_and_data_lines()
     )
 
 
+def test_normalize_sse_event_block_rewrites_alias_split_across_data_lines():
+    # A legal SSE payload split across multiple `data:` lines is only
+    # decodable as the combined value (fragments joined with "\n"); the alias
+    # rewrite must still land on both the payload and the `event:` line.
+    block = 'event: response.text.delta\ndata: {"type":"response.text.delta",\ndata: "delta":"hi"}\n\n'
+
+    normalized = proxy_module._normalize_sse_event_block(block)
+
+    assert normalized == (
+        'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"hi"}\n\n'
+    )
+
+
+def test_normalize_sse_event_block_leaves_undecodable_multi_line_data_untouched():
+    # When the combined multi-line payload cannot be decoded, neither surface
+    # may be rewritten: rewriting only the `event:` framing line would emit a
+    # frame whose framing and payload disagree about the event type.
+    block = 'event: response.text.delta\ndata: {"type":"response.te\ndata: xt.delta","delta":"hi"}\n\n'
+
+    normalized = proxy_module._normalize_sse_event_block(block)
+
+    assert normalized == block
+
+
 def test_normalize_sse_event_block_skips_json_parsing_for_non_alias_types(monkeypatch) -> None:
     # The alias normalizer only inspects blocks carrying one of the legacy
     # alias names; canonical event types pass through without a JSON parse.

--- a/tests/unit/test_sse.py
+++ b/tests/unit/test_sse.py
@@ -18,6 +18,7 @@ from app.core.utils.sse import (
     format_sse_event,
     inject_sse_keepalives,
     parse_sse_data_json,
+    sse_event_type_from_block,
 )
 from tests.unit.hypothesis_strategies import json_objects, json_values
 
@@ -225,3 +226,40 @@ def test_lifecycle_event_types_cover_terminal_and_created_frames():
             "error",
         }
     )
+
+
+def test_sse_event_type_from_block_extracts_type_from_canonical_block():
+    block = 'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"hi"}\n\n'
+
+    assert sse_event_type_from_block(block) == "response.output_text.delta"
+
+
+def test_sse_event_type_from_block_accepts_raw_utf8_payloads():
+    block = 'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"안녕"}\n\n'
+
+    assert sse_event_type_from_block(block) == "response.output_text.delta"
+
+
+def test_sse_event_type_from_block_rejects_data_only_blocks():
+    assert sse_event_type_from_block('data: {"type":"response.output_text.delta","delta":"hi"}\n\n') is None
+
+
+def test_sse_event_type_from_block_rejects_trailing_event_field_ordering():
+    # `event:` after `data:` is legal SSE but not the canonical framing this
+    # proxy relays verbatim; callers must fall back to a full parse.
+    block = 'data: {"type":"response.output_text.delta","delta":"hi"}\nevent: response.output_text.delta\n\n'
+
+    assert sse_event_type_from_block(block) is None
+
+
+def test_sse_event_type_from_block_rejects_non_lf_framing_and_multiline_data():
+    crlf = 'event: response.output_text.delta\r\ndata: {"type":"response.output_text.delta"}\r\n\r\n'
+    multiline = 'event: response.output_text.delta\ndata: {"type":\ndata: "response.output_text.delta"}\n\n'
+
+    assert sse_event_type_from_block(crlf) is None
+    assert sse_event_type_from_block(multiline) is None
+
+
+def test_sse_event_type_from_block_rejects_non_object_data_payloads():
+    assert sse_event_type_from_block("event: done\ndata: [DONE]\n\n") is None
+    assert sse_event_type_from_block("event: ping\ndata: \n\n") is None


### PR DESCRIPTION
## Why

Stacked on #1784. After lifecycle-only validation, every delta chunk still pays `json.loads` per owning layer + an unconditional `format_sse_event` re-encode (the `json.dumps` leaf in the production py-spy profile). For same-dialect streams the pipeline is parse→noop→re-serialize. #1270 (optimize-sse-single-parse) named this exact step as its follow-up non-goal: "threading a parsed-event struct across layer boundaries".

## What

- Cheap event-type extraction first (`sse_event_type_from_block` in `app/core/utils/sse.py`); full parse only when the type is missing, in MUST_PARSE (lifecycle + output_item/output_text/content_part boundaries), the TTFT window is open (including pending_reasoning_deltas), or `"service_tier"` appears in the frame. Everything else — the dominant delta bulk — relays upstream bytes verbatim **iff** it passes the canonical `event:`-framing gate (the 5ee532cb EventSource regression guard); otherwise falls back to parse+`format_sse_event`.
- Lazy `_normalize_stream_payload_for_http_block` via the cheap type.
- Narrow `_normalize_sse_event_block`'s gate from `'"type":'` (matched every frame, gated nothing) to the 3 legacy alias substrings, and fix the stale-`event:`-line alias bug (previously masked by the mixin re-encode).
- First-event block stays fully parsed; chat bridge and /v1 public normalizer untouched.

Compat note: unmodified delta frames now carry upstream bytes (raw UTF-8, upstream spacing) instead of the `ensure_ascii` canonical re-encode — JSON-equivalent, SSE-valid, spec-amended.

## OpenSpec

`openspec/changes/relay-unmodified-sse-frames-verbatim/` — amends the responses-api-compat requirement to define the verbatim-relay condition.

## Tests

Byte-golden assertions rewritten to upstream-bytes expectations for deltas / canonical for rewritten & data-only frames; regressions: data-only block still gets framing, alias rewrite fixes both lines, raw-UTF-8 delta relay, /v1 identity pass-through on verbatim blocks, TTFT pending-reasoning window. Full targeted suites green; ruff/ty/openspec validate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)