### PR TITLE
perf(proxy): disable permessage-deflate on direct-egress upstream websockets

### DIFF
--- a/app/core/clients/proxy_websocket.py
+++ b/app/core/clients/proxy_websocket.py
@@ -934,6 +934,13 @@ async def _connect_upstream_websocket(
             ping_timeout=ping_timeout,
             max_size=settings.max_sse_event_bytes,
             proxy=proxy_url,
+            # Do not offer permessage-deflate upstream: the websockets library
+            # enables it by default, but the sibling upstream transports (the
+            # routed aiohttp path and the raw-handshake transport) already run
+            # uncompressed, and per-frame zlib decode on high-rate event
+            # streams burns CPU on the proxy host. The client-facing socket
+            # keeps negotiating permessage-deflate per responses-api-compat.
+            compression=None,
             **subprotocol_kwargs,
         )
     except asyncio.TimeoutError as exc:

--- a/openspec/changes/disable-upstream-websocket-compression/proposal.md
+++ b/openspec/changes/disable-upstream-websocket-compression/proposal.md
@@ -1,0 +1,63 @@
+# Proposal: disable-upstream-websocket-compression
+
+## Why
+
+The direct-egress upstream websocket transport (`websockets.asyncio.client.connect` in
+`app/core/clients/proxy_websocket.py`) passes no `compression` kwarg, so the websockets
+library default (`compression="deflate"`) silently offers and negotiates `permessage-deflate`
+with the upstream endpoint. No commit, spec, or comment ever chose this: the two sibling
+upstream transports already run uncompressed — the routed aiohttp path uses aiohttp's
+default `compress=0` (off), and the raw-handshake transport in `app/core/clients/proxy.py`
+sets `compress=False`/`compress=0` explicitly. Per-frame zlib decode of high-rate upstream
+event streams shows up as a measurable CPU leaf (~2.6% of profiled CPU) on the
+single-weak-core proxy host, where CPU — not LAN/WAN bandwidth — is the scarce resource.
+
+## What Changes
+
+- Pass `compression=None` at the single direct-egress `websocket_connect(...)` callsite,
+  so upstream direct-egress websockets (Responses websocket and realtime live sideband,
+  which share the callsite) no longer offer `permessage-deflate` in the handshake.
+- The client-facing socket is untouched: the existing normative requirement that the
+  server MUST continue to negotiate `permessage-deflate` on the client-facing websocket
+  (responses-api-compat, downstream ingress budget requirement) is unchanged, and uvicorn's
+  `ws_per_message_deflate` default stays enabled.
+- The routed aiohttp path and raw-handshake transport are untouched (already uncompressed).
+
+## Owner-visible caveats
+
+- **Codex CLI fingerprint divergence**: codex-lb impersonates the Codex CLI persona on
+  the upstream handshake, and the native Codex CLI (tungstenite with
+  `DeflateConfig::default()`) DOES offer `permessage-deflate`. Dropping the
+  `Sec-WebSocket-Extensions` offer makes the direct path's handshake differ from the
+  native client. Mitigating evidence: the routed aiohttp path and the raw-handshake path
+  already send no extension offer today and are accepted in production, so extension
+  parity is not currently maintained anywhere.
+- **Realtime live sideband shares the callsite**: the change applies to both
+  `_RESPONSES_WEBSOCKET_POLICY` and `_LIVE_SIDEBAND_WEBSOCKET_POLICY` sockets. Live
+  sideband frames (base64 audio) compress poorly anyway; if per-policy compression is
+  ever wanted, the kwarg can be lifted into `_UpstreamWebSocketPolicy`.
+- **WAN ingress bandwidth** from the upstream increases (JSON event streams compress
+  ~4-8x); this is a cost trade only, not a correctness change.
+- **Falsification test**: if a post-deploy profile still shows the `permessage_deflate`
+  decode leaf, the cost was downstream uvicorn decode (spec-protected, must keep) and
+  this change is a CPU no-op; revert is one line.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `responses-api-compat`: adds a requirement that direct-egress upstream websockets do
+  not offer `permessage-deflate`. The client-facing `permessage-deflate` MUST is
+  unchanged.
+
+## Impact
+
+- `app/core/clients/proxy_websocket.py`: one kwarg (`compression=None`) on the shared
+  direct-egress `websocket_connect` call; persona headers, subprotocols, ping-timeout
+  watchdog, max_size, and proxy resolution are unchanged.
+- `tests/unit/test_proxy_websocket_client.py`: kwargs assertion pins
+  `compression is None` on the direct transport contract.

--- a/openspec/changes/disable-upstream-websocket-compression/specs/responses-api-compat/spec.md
+++ b/openspec/changes/disable-upstream-websocket-compression/specs/responses-api-compat/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Direct-egress upstream websockets do not offer permessage-deflate
+When codex-lb opens a direct-egress upstream websocket (the Responses websocket or the
+realtime live sideband over the `websockets` transport, used when no upstream proxy route
+applies), it MUST NOT offer the `permessage-deflate` extension in the upstream handshake,
+matching the routed and raw-handshake upstream transports, which already run uncompressed.
+This requirement applies only to the proxy-to-upstream link: the server MUST continue to
+negotiate `permessage-deflate` on the client-facing websocket, as required by the
+downstream websocket ingress requirement.
+
+#### Scenario: Direct upstream handshake omits the compression extension offer
+
+- **WHEN** codex-lb connects an upstream websocket via the direct-egress `websockets` transport
+- **THEN** the handshake does not offer `permessage-deflate` (the transport is invoked with compression disabled)
+- **AND** persona headers, subprotocols, open-timeout, ping-timeout, message-size cap, and proxy resolution are unchanged
+
+#### Scenario: Client-facing compression negotiation is unchanged
+
+- **WHEN** a client connects to a Responses websocket route offering `permessage-deflate`
+- **THEN** the server still negotiates `permessage-deflate` on the client-facing socket
+- **AND** the downstream ingress budget continues to apply to the decompressed message size

--- a/openspec/changes/disable-upstream-websocket-compression/tasks.md
+++ b/openspec/changes/disable-upstream-websocket-compression/tasks.md
@@ -1,0 +1,13 @@
+## 1. Implementation
+
+- [x] 1.1 Pass `compression=None` at the direct-egress `websocket_connect` callsite in
+      `app/core/clients/proxy_websocket.py` so upstream direct-egress sockets stop
+      offering `permessage-deflate`. Leave the routed aiohttp path, raw-handshake
+      transport, and downstream uvicorn `ws_per_message_deflate` untouched.
+
+## 2. Validation
+
+- [x] 2.1 Extend the direct-transport kwargs assertions in
+      `tests/unit/test_proxy_websocket_client.py` with `compression is None`.
+- [x] 2.2 Run the proxy websocket client unit suite, lint, and strict OpenSpec
+      validation.

--- a/tests/unit/test_proxy_websocket_client.py
+++ b/tests/unit/test_proxy_websocket_client.py
@@ -416,6 +416,7 @@ async def test_connect_responses_websocket_uses_websockets_transport(monkeypatch
     assert "ping_interval" not in kwargs
     assert kwargs["ping_timeout"] == 120.0
     assert kwargs["max_size"] == 4321
+    assert kwargs["compression"] is None
     assert "subprotocols" not in kwargs
     additional_headers = cast(dict[str, str], kwargs["additional_headers"])
     assert additional_headers["Authorization"] == "Bearer access-token"


### PR DESCRIPTION
## Why

py-spy shows ~2.6% of GIL time in `permessage_deflate.decode`. The direct-egress upstream websocket (`websocket_connect` in `app/core/clients/proxy_websocket.py`) never chose compression — it's the silent websockets-17 library default (`compression="deflate"`). Both sibling upstream paths (routed aiohttp, raw handshake) already run uncompressed and are accepted upstream.

## What

One kwarg: `compression=None` at the shared `_connect_upstream_websocket` callsite (covers responses + live-sideband policies). Downstream client-facing `ws_per_message_deflate` untouched (spec MUST).

## Falsification test (built in)

Post-deploy py-spy: the `permessage_deflate` decode leaf should disappear. If it doesn't, the cost was downstream uvicorn decode and this is a CPU no-op — revert is one line.

## Owner-visible caveat

Native Codex CLI *does* offer permessage-deflate, so the direct path's handshake fingerprint diverges from the impersonated persona. Mitigating: the aiohttp/raw paths already send no extension offer and pass fine.

## OpenSpec

`openspec/changes/disable-upstream-websocket-compression/` (direct-egress sockets do not offer permessage-deflate; client-facing MUST unchanged).

## Tests

`test_proxy_websocket_client.py` 54 passed incl. new `assert kwargs["compression"] is None`; integration ws suite 125 passed; ruff/openspec validate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)