### PR TITLE
perf(middleware): convert BaseHTTPMiddleware layers to pure ASGI

### DIFF
--- a/app/core/middleware/api_firewall.py
+++ b/app/core/middleware/api_firewall.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
 from ipaddress import IPv4Network, IPv6Network
 from typing import cast
 
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse
+from starlette.datastructures import Headers
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from app.core.config.settings import get_settings
 from app.core.errors import openai_error
-from app.core.middleware.firewall_cache import get_firewall_ip_cache
+from app.core.middleware.firewall_cache import FirewallIPCache, get_firewall_ip_cache
 from app.core.request_locality import (
     FORWARDED_CHAIN_HEADER_NAMES,
     parse_trusted_proxy_networks,
@@ -20,27 +21,41 @@ from app.modules.firewall.repository import FirewallRepository
 from app.modules.firewall.service import FirewallRepositoryPort, FirewallService
 
 
-def add_api_firewall_middleware(app: FastAPI) -> None:
-    settings = get_settings()
-    trusted_proxy_networks = parse_trusted_proxy_networks(settings.firewall_trusted_proxy_cidrs)
-    firewall_cache = get_firewall_ip_cache()
+class ApiFirewallMiddleware:
+    """IP allowlist for ``/v1/*`` and ``/backend-api/codex/*`` HTTP requests.
 
-    @app.middleware("http")
-    async def api_firewall_middleware(
-        request: Request,
-        call_next: Callable[[Request], Awaitable[Response]],
-    ) -> Response:
-        path = request.url.path
-        if not _is_protected_api_path(path):
-            return await call_next(request)
+    Pure ASGI: unprotected paths pass through with a single prefix check, and
+    allow decisions are answered from the in-memory TTL cache; the database is
+    only consulted on a cache miss.
+    """
 
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        trust_proxy_headers: bool,
+        trusted_proxy_networks: tuple[IPv4Network | IPv6Network, ...],
+        firewall_cache: FirewallIPCache,
+    ) -> None:
+        self.app = app
+        self._trust_proxy_headers = trust_proxy_headers
+        self._trusted_proxy_networks = trusted_proxy_networks
+        self._firewall_cache = firewall_cache
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or not _is_protected_api_path(scope["path"]):
+            await self.app(scope, receive, send)
+            return
+
+        client = scope.get("client")
         client_ip = resolve_connection_client_ip(
-            request.headers,
-            request.client.host if request.client else None,
-            trust_proxy_headers=settings.firewall_trust_proxy_headers,
-            trusted_proxy_networks=trusted_proxy_networks,
+            Headers(scope=scope),
+            client[0] if client else None,
+            trust_proxy_headers=self._trust_proxy_headers,
+            trusted_proxy_networks=self._trusted_proxy_networks,
             allowed_proxy_header_names=FORWARDED_CHAIN_HEADER_NAMES,
         )
+        firewall_cache = self._firewall_cache
         cached_decision = await firewall_cache.is_allowed(client_ip) if client_ip is not None else None
         if cached_decision is not None:
             is_allowed = cached_decision
@@ -54,12 +69,24 @@ def add_api_firewall_middleware(app: FastAPI) -> None:
                 await firewall_cache.set(client_ip, is_allowed, if_version=version_before_read)
 
         if is_allowed:
-            return await call_next(request)
+            await self.app(scope, receive, send)
+            return
 
-        return JSONResponse(
+        response = JSONResponse(
             status_code=403,
             content=openai_error("ip_forbidden", "Access denied for client IP", error_type="access_error"),
         )
+        await response(scope, receive, send)
+
+
+def add_api_firewall_middleware(app: FastAPI) -> None:
+    settings = get_settings()
+    app.add_middleware(
+        ApiFirewallMiddleware,
+        trust_proxy_headers=settings.firewall_trust_proxy_headers,
+        trusted_proxy_networks=parse_trusted_proxy_networks(settings.firewall_trusted_proxy_cidrs),
+        firewall_cache=get_firewall_ip_cache(),
+    )
 
 
 def _is_protected_api_path(path: str) -> bool:

--- a/app/core/middleware/app_version.py
+++ b/app/core/middleware/app_version.py
@@ -1,20 +1,37 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
-
-from fastapi import FastAPI, Request
-from fastapi.responses import Response
+from fastapi import FastAPI
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app import __version__
 
 
+class AppVersionMiddleware:
+    """Append ``X-App-Version`` to every 200-499 HTTP response.
+
+    Pure ASGI (no ``BaseHTTPMiddleware``) so streaming responses relay chunks
+    without an extra task and memory-stream hop. 5xx responses and WebSocket
+    scopes never carry the header, and a route-owned ``X-App-Version`` value is
+    preserved (see ``openspec/specs/api-response-metadata/spec.md``).
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_app_version(message: Message) -> None:
+            if message["type"] == "http.response.start" and 200 <= message["status"] < 500:
+                headers = MutableHeaders(raw=message.setdefault("headers", []))
+                headers.setdefault("X-App-Version", __version__)
+            await send(message)
+
+        await self.app(scope, receive, send_with_app_version)
+
+
 def add_app_version_middleware(app: FastAPI) -> None:
-    @app.middleware("http")
-    async def app_version_middleware(
-        request: Request,
-        call_next: Callable[[Request], Awaitable[Response]],
-    ) -> Response:
-        response = await call_next(request)
-        if 200 <= response.status_code < 500:
-            response.headers.setdefault("X-App-Version", __version__)
-        return response
+    app.add_middleware(AppVersionMiddleware)

--- a/app/core/middleware/inflight.py
+++ b/app/core/middleware/inflight.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from importlib import import_module
+from types import ModuleType
 
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
@@ -37,6 +38,9 @@ _IN_FLIGHT_WEBSOCKET_PATHS = frozenset(
 class InFlightMiddleware:
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
+        # Resolved lazily on the first request (import-cycle safety) and cached
+        # so the hot path skips the per-request sys.modules lookup.
+        self._shutdown_state: ModuleType | None = None
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         scope_type = scope["type"]
@@ -44,7 +48,9 @@ class InFlightMiddleware:
             await self.app(scope, receive, send)
             return
 
-        shutdown_state = import_module("app.core.shutdown")
+        shutdown_state = self._shutdown_state
+        if shutdown_state is None:
+            shutdown_state = self._shutdown_state = import_module("app.core.shutdown")
 
         if scope_type == "websocket":
             # Register before checking the drain barrier. A synchronous signal

--- a/app/core/middleware/request_decompression.py
+++ b/app/core/middleware/request_decompression.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import gzip
 import io
 import zlib
-from collections.abc import Awaitable, Callable
 from typing import Protocol
 
 import zstandard as zstd
-from fastapi import FastAPI, Request
-from fastapi.responses import Response
+from fastapi import FastAPI
 from starlette._utils import get_route_path
-from starlette.requests import ClientDisconnect
+from starlette.datastructures import Headers
+from starlette.requests import ClientDisconnect, Request
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.core.middleware.request_body_limit import (
     REQUEST_BODY_TOO_LARGE_MESSAGE,
@@ -108,58 +108,110 @@ def _decompress_body(data: bytes, encodings: list[str], max_size: int) -> bytes:
     return result
 
 
-def _replace_request_body(request: Request, body: bytes) -> None:
-    request._body = body
+def _rewrite_scope_headers_for_body(scope: Scope, body_length: int) -> None:
+    """Drop content-encoding/content-length and declare the decompressed length."""
     headers: list[tuple[bytes, bytes]] = []
-    for key, value in request.scope.get("headers", []):
+    for key, value in scope.get("headers", []):
         if key.lower() in (b"content-encoding", b"content-length"):
             continue
         headers.append((key, value))
-    headers.append((b"content-length", str(len(body)).encode("ascii")))
-    request.scope["headers"] = headers
-    # Ensure subsequent request.headers reflects the updated scope headers.
-    request.__dict__.pop("_headers", None)
+    headers.append((b"content-length", str(body_length).encode("ascii")))
+    scope["headers"] = headers
 
 
-def add_request_decompression_middleware(app: FastAPI) -> None:
-    @app.middleware("http")
-    async def request_decompression_middleware(
-        request: Request,
-        call_next: Callable[[Request], Awaitable[Response]],
-    ) -> Response:
-        content_encoding = request.headers.get("content-encoding")
+async def _drain_request_body(receive: Receive) -> bytes:
+    """Read the full request body from ``receive``.
+
+    Mirrors ``Request.body()`` semantics: a mid-body ``http.disconnect`` raises
+    ``ClientDisconnect``, and receive failures propagate. The caller's
+    ``receive`` is the body-limit middleware's limited receive, so the wire-size
+    cap (``_RequestBodyTooLarge``) propagates through this drain unchanged.
+    """
+    chunks = bytearray()
+    while True:
+        message = await receive()
+        if message["type"] == "http.disconnect":
+            raise ClientDisconnect()
+        chunks.extend(message.get("body", b""))
+        if not message.get("more_body", False):
+            return bytes(chunks)
+
+
+class RequestDecompressionMiddleware:
+    """Decompress zstd/gzip/deflate request bodies with per-layer decode budgets.
+
+    Pure ASGI replacement for the previous ``BaseHTTPMiddleware`` dispatch:
+    requests without ``Content-Encoding`` (the common case) pass straight
+    through. Encoded requests are drained through the upstream receive (the
+    body-limit middleware's limited receive, so the wire-size cap still applies
+    to the compressed bytes), decompressed under the per-path budget, and the
+    downstream app is given a replay receive that yields the decompressed body
+    once and then delegates to the original receive so ``http.disconnect`` is
+    still observed (this replaces the ``_CachedRequest`` body replay the
+    BaseHTTP wrapper used to provide).
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        content_encoding = Headers(scope=scope).get("content-encoding")
         if not content_encoding:
-            return await call_next(request)
+            await self.app(scope, receive, send)
+            return
         encodings = [enc.strip().lower() for enc in content_encoding.split(",") if enc.strip()]
         if not encodings:
-            return await call_next(request)
-        max_size = request_body_limit_for_path(get_route_path(request.scope))
-        try:
-            body = await request.body()
-        except ClientDisconnect:
-            raise
+            await self.app(scope, receive, send)
+            return
+
+        max_size = request_body_limit_for_path(get_route_path(scope))
+        body = await _drain_request_body(receive)
         try:
             decompressed = _decompress_body(body, encodings, max_size)
         except _DecompressedBodyTooLarge:
-            return request_ingress_error_response(
-                request,
+            response = request_ingress_error_response(
+                Request(scope),
                 status_code=413,
                 code="payload_too_large",
                 message=REQUEST_BODY_TOO_LARGE_MESSAGE,
             )
+            await response(scope, receive, send)
+            return
         except ValueError:
-            return request_ingress_error_response(
-                request,
+            response = request_ingress_error_response(
+                Request(scope),
                 status_code=400,
                 code="invalid_request",
                 message="Unsupported Content-Encoding",
             )
+            await response(scope, receive, send)
+            return
         except Exception:
-            return request_ingress_error_response(
-                request,
+            response = request_ingress_error_response(
+                Request(scope),
                 status_code=400,
                 code="invalid_request",
                 message="Request body is compressed but could not be decompressed",
             )
-        _replace_request_body(request, decompressed)
-        return await call_next(request)
+            await response(scope, receive, send)
+            return
+
+        _rewrite_scope_headers_for_body(scope, len(decompressed))
+        body_replayed = False
+
+        async def replay_receive() -> Message:
+            nonlocal body_replayed
+            if not body_replayed:
+                body_replayed = True
+                return {"type": "http.request", "body": decompressed, "more_body": False}
+            return await receive()
+
+        await self.app(scope, replay_receive, send)
+
+
+def add_request_decompression_middleware(app: FastAPI) -> None:
+    app.add_middleware(RequestDecompressionMiddleware)

--- a/app/core/middleware/request_id.py
+++ b/app/core/middleware/request_id.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
 from uuid import uuid4
 
-from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
+from fastapi import FastAPI
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from app.core.utils.request_id import (
     clear_request_id,
@@ -16,22 +16,57 @@ from app.core.utils.request_id import (
 )
 
 
-def add_request_id_middleware(app: FastAPI) -> None:
-    @app.middleware("http")
-    async def request_id_middleware(
-        request: Request,
-        call_next: Callable[[Request], Awaitable[JSONResponse]],
-    ) -> JSONResponse:
-        inbound_request_id = request.headers.get("x-request-id") or request.headers.get("request-id")
-        request_id = inbound_request_id or str(uuid4())
+def _inbound_request_id(scope: Scope) -> str | None:
+    """Return the first ``x-request-id`` value, else the first ``request-id`` value."""
+    x_request_id: bytes | None = None
+    request_id: bytes | None = None
+    for name, value in scope.get("headers", []):
+        lowered = name.lower()
+        if x_request_id is None and lowered == b"x-request-id":
+            x_request_id = value
+        elif request_id is None and lowered == b"request-id":
+            request_id = value
+    inbound = x_request_id or request_id
+    if not inbound:
+        return None
+    return inbound.decode("latin-1")
+
+
+class RequestIdMiddleware:
+    """Bind request-id contextvars around the request and echo ``x-request-id``.
+
+    Pure ASGI: the contextvars are set and reset in the same task that runs the
+    downstream app, so they stay visible for the whole response stream (with
+    ``BaseHTTPMiddleware`` they were reset when the dispatch returned, before
+    the body finished streaming).
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_id = _inbound_request_id(scope) or str(uuid4())
         request_id_token = set_request_id(request_id)
         request_scope_token = set_request_scope_id(str(uuid4()))
+
+        async def send_with_request_id(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(raw=message.setdefault("headers", []))
+                headers.setdefault("x-request-id", request_id)
+            await send(message)
+
         try:
-            response = await call_next(request)
-            response.headers.setdefault("x-request-id", request_id)
-            return response
+            await self.app(scope, receive, send_with_request_id)
         finally:
             reset_request_scope_id(request_scope_token)
             reset_request_id(request_id_token)
             clear_request_scope_id()
             clear_request_id()
+
+
+def add_request_id_middleware(app: FastAPI) -> None:
+    app.add_middleware(RequestIdMiddleware)

--- a/app/core/middleware/required_capability_http.py
+++ b/app/core/middleware/required_capability_http.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Awaitable, Callable
 
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse
 from starlette._utils import get_route_path
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from app.core.auth.dependencies import validate_required_proxy_api_key_authorization
 from app.core.clients.proxy import CODEX_LB_REQUIRED_CAPABILITY_HEADER
@@ -19,6 +19,8 @@ from app.modules.proxy.images_observability import (
 )
 
 logger = logging.getLogger(__name__)
+
+_REQUIRED_CAPABILITY_HEADER_BYTES = CODEX_LB_REQUIRED_CAPABILITY_HEADER.lower().encode("latin-1")
 
 _JSON_BODY_DENY_PATHS = frozenset(
     {
@@ -41,23 +43,45 @@ def _is_pre_body_deny_path(path: str) -> bool:
     return normalized in _JSON_BODY_DENY_PATHS or normalized.startswith("/v1/warmup/")
 
 
-def add_required_capability_http_middleware(app: FastAPI) -> None:
-    @app.middleware("http")
-    async def required_capability_http_middleware(
-        request: Request,
-        call_next: Callable[[Request], Awaitable[Response]],
-    ) -> Response:
-        if request.method != "POST":
-            return await call_next(request)
-        if not request.headers.getlist(CODEX_LB_REQUIRED_CAPABILITY_HEADER):
-            return await call_next(request)
-        if not _is_pre_body_deny_path(get_route_path(request.scope)):
-            return await call_next(request)
+def _has_required_capability_header(scope: Scope) -> bool:
+    for name, _value in scope.get("headers", []):
+        if name.lower() == _REQUIRED_CAPABILITY_HEADER_BYTES:
+            return True
+    return False
+
+
+class RequiredCapabilityHttpMiddleware:
+    """Deny capability-marked POSTs on JSON-body proxy paths before the body is read.
+
+    Pure ASGI with cheap synchronous guards first; the ``Request`` object is
+    only constructed on the cold deny path.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if (
+            scope["type"] != "http"
+            or scope["method"] != "POST"
+            or not _has_required_capability_header(scope)
+            or not _is_pre_body_deny_path(get_route_path(scope))
+        ):
+            await self.app(scope, receive, send)
+            return
+
+        request = Request(scope)
         try:
             await validate_required_proxy_api_key_authorization(request.headers.get("authorization"))
         except ProxyAuthError as exc:
-            return _capability_error_response(request, exc)
-        return _capability_error_response(request, ProxyRequiredCapabilityTransportError())
+            response = _capability_error_response(request, exc)
+        else:
+            response = _capability_error_response(request, ProxyRequiredCapabilityTransportError())
+        await response(scope, receive, send)
+
+
+def add_required_capability_http_middleware(app: FastAPI) -> None:
+    app.add_middleware(RequiredCapabilityHttpMiddleware)
 
 
 def _capability_error_response(

--- a/tests/unit/test_app_version_middleware.py
+++ b/tests/unit/test_app_version_middleware.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
-from typing import cast
 
 import pytest
-from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse, Response
+from fastapi import FastAPI, Response
 from httpx import ASGITransport, AsyncClient
-from starlette.types import Message
 
 import app.main as main
 from app import __version__
@@ -17,98 +13,43 @@ from app.core.middleware.app_version import add_app_version_middleware
 
 pytestmark = pytest.mark.unit
 
-_Dispatch = Callable[[Request, Callable[[Request], Awaitable[Response]]], Awaitable[Response]]
+
+def _build_app(status_code: int, *, headers: dict[str, str] | None = None) -> FastAPI:
+    app = FastAPI()
+    add_app_version_middleware(app)
+
+    @app.get("/probe")
+    async def probe() -> Response:
+        return Response(status_code=status_code, headers=headers)
+
+    return app
 
 
 @pytest.mark.asyncio
 async def test_app_version_middleware_adds_header_to_2xx_response():
-    app = FastAPI()
-    add_app_version_middleware(app)
-    dispatch = cast(_Dispatch, app.user_middleware[0].kwargs["dispatch"])
+    transport = ASGITransport(app=_build_app(204))
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/probe")
 
-    request = Request(
-        {
-            "type": "http",
-            "http_version": "1.1",
-            "method": "GET",
-            "scheme": "http",
-            "path": "/health",
-            "raw_path": b"/health",
-            "query_string": b"",
-            "root_path": "",
-            "headers": [],
-            "client": ("testclient", 50000),
-            "server": ("testserver", 80),
-        },
-        receive=_empty_receive,
-    )
-
-    async def call_next(_: Request) -> JSONResponse:
-        return JSONResponse({"ok": True}, status_code=204)
-
-    response = await dispatch(request, call_next)
-
+    assert response.status_code == 204
     assert response.headers["X-App-Version"] == __version__
 
 
 @pytest.mark.asyncio
 async def test_app_version_middleware_skips_header_on_5xx_response():
-    app = FastAPI()
-    add_app_version_middleware(app)
-    dispatch = cast(_Dispatch, app.user_middleware[0].kwargs["dispatch"])
+    transport = ASGITransport(app=_build_app(503))
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/probe")
 
-    request = Request(
-        {
-            "type": "http",
-            "http_version": "1.1",
-            "method": "GET",
-            "scheme": "http",
-            "path": "/health",
-            "raw_path": b"/health",
-            "query_string": b"",
-            "root_path": "",
-            "headers": [],
-            "client": ("testclient", 50000),
-            "server": ("testserver", 80),
-        },
-        receive=_empty_receive,
-    )
-
-    async def call_next(_: Request) -> JSONResponse:
-        return JSONResponse({"error": "boom"}, status_code=503)
-
-    response = await dispatch(request, call_next)
-
+    assert response.status_code == 503
     assert "X-App-Version" not in response.headers
 
 
 @pytest.mark.asyncio
 async def test_app_version_middleware_preserves_existing_header_value():
-    app = FastAPI()
-    add_app_version_middleware(app)
-    dispatch = cast(_Dispatch, app.user_middleware[0].kwargs["dispatch"])
-
-    request = Request(
-        {
-            "type": "http",
-            "http_version": "1.1",
-            "method": "GET",
-            "scheme": "http",
-            "path": "/health",
-            "raw_path": b"/health",
-            "query_string": b"",
-            "root_path": "",
-            "headers": [],
-            "client": ("testclient", 50000),
-            "server": ("testserver", 80),
-        },
-        receive=_empty_receive,
-    )
-
-    async def call_next(_: Request) -> Response:
-        return Response(status_code=200, headers={"X-App-Version": "route-owned-version"})
-
-    response = await dispatch(request, call_next)
+    transport = ASGITransport(app=_build_app(200, headers={"X-App-Version": "route-owned-version"}))
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/probe")
 
     assert response.headers["X-App-Version"] == "route-owned-version"
 
@@ -145,7 +86,3 @@ async def test_app_version_middleware_adds_header_to_short_circuited_4xx_respons
 
     assert overloaded.status_code == 429
     assert overloaded.headers["X-App-Version"] == __version__
-
-
-async def _empty_receive() -> Message:
-    return {"type": "http.request", "body": b"", "more_body": False}

--- a/tests/unit/test_multipart_content_encoding_middleware.py
+++ b/tests/unit/test_multipart_content_encoding_middleware.py
@@ -6,7 +6,6 @@ from collections.abc import AsyncIterator
 import pytest
 from httpx import ASGITransport, AsyncByteStream, AsyncClient
 from starlette.datastructures import Headers
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.types import Message, Scope
 
@@ -22,6 +21,7 @@ from app.core.middleware.multipart_content_encoding import (
 )
 from app.core.middleware.path_rewrite import BackendApiCodexV1AliasMiddleware
 from app.core.middleware.request_body_limit import RequestBodyLimitMiddleware
+from app.core.middleware.request_decompression import RequestDecompressionMiddleware
 from app.main import create_app
 
 pytestmark = pytest.mark.unit
@@ -360,9 +360,7 @@ def test_production_middleware_order_composes_route_and_generic_ingress_guards()
     )
     limit_index = next(index for index, item in enumerate(middleware) if item.cls is RequestBodyLimitMiddleware)
     decompression_index = next(
-        index
-        for index, item in enumerate(middleware)
-        if item.cls is BaseHTTPMiddleware and item.kwargs.get("dispatch").__name__ == "request_decompression_middleware"
+        index for index, item in enumerate(middleware) if item.cls is RequestDecompressionMiddleware
     )
 
     assert alias_index < multipart_index < limit_index < decompression_index

--- a/tests/unit/test_request_body_limit_middleware.py
+++ b/tests/unit/test_request_body_limit_middleware.py
@@ -8,14 +8,16 @@ from typing import cast
 import pytest
 from fastapi import Body, Depends, FastAPI, HTTPException
 from httpx import ASGITransport, AsyncByteStream, AsyncClient
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.types import Message, Receive, Scope, Send
 
 from app.core.config.settings import get_settings
 from app.core.handlers import add_exception_handlers
 from app.core.middleware.path_rewrite import BackendApiCodexV1AliasMiddleware
 from app.core.middleware.request_body_limit import RequestBodyLimitMiddleware, add_request_body_limit_middleware
-from app.core.middleware.request_decompression import add_request_decompression_middleware
+from app.core.middleware.request_decompression import (
+    RequestDecompressionMiddleware,
+    add_request_decompression_middleware,
+)
 from app.main import create_app
 
 pytestmark = pytest.mark.unit
@@ -495,9 +497,7 @@ def test_production_middleware_order_keeps_alias_and_admission_outside_body_read
     alias_index = next(index for index, item in enumerate(middleware) if item.cls is BackendApiCodexV1AliasMiddleware)
     limit_index = next(index for index, item in enumerate(middleware) if item.cls is RequestBodyLimitMiddleware)
     decompression_index = next(
-        index
-        for index, item in enumerate(middleware)
-        if item.cls is BaseHTTPMiddleware and item.kwargs.get("dispatch").__name__ == "request_decompression_middleware"
+        index for index, item in enumerate(middleware) if item.cls is RequestDecompressionMiddleware
     )
 
     assert alias_index < limit_index < decompression_index

--- a/tests/unit/test_request_decompression_middleware.py
+++ b/tests/unit/test_request_decompression_middleware.py
@@ -1,24 +1,26 @@
 from __future__ import annotations
 
+import asyncio
 import gzip
 import json
 import zlib
-from collections.abc import Awaitable, Callable
-from typing import cast
+from collections.abc import AsyncIterator
 
 import pytest
 import zstandard as zstd
 from fastapi import FastAPI, Request
-from fastapi.responses import Response
-from httpx import ASGITransport, AsyncClient
+from fastapi.responses import StreamingResponse
+from httpx import ASGITransport, AsyncByteStream, AsyncClient
 from starlette.requests import ClientDisconnect
+from starlette.types import Message, Receive, Scope, Send
 
 from app.core.middleware.request_body_limit import add_request_body_limit_middleware
-from app.core.middleware.request_decompression import add_request_decompression_middleware
+from app.core.middleware.request_decompression import (
+    RequestDecompressionMiddleware,
+    add_request_decompression_middleware,
+)
 
 pytestmark = pytest.mark.unit
-
-_Dispatch = Callable[[Request, Callable[[Request], Awaitable[Response]]], Awaitable[Response]]
 
 
 def _build_echo_app(*, touch_headers: bool = False) -> FastAPI:
@@ -442,67 +444,131 @@ async def test_request_decompression_keeps_default_limit_for_other_routes(monkey
     assert response_data["error"]["code"] == "payload_too_large"
 
 
+def _encoded_post_scope() -> Scope:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/echo",
+        "raw_path": b"/echo",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"content-encoding", b"gzip"), (b"content-type", b"application/json")],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "state": {},
+    }
+
+
+async def _unused_send(message: Message) -> None:
+    raise AssertionError(f"send should not be reached, got {message['type']}")
+
+
 @pytest.mark.asyncio
 async def test_request_decompression_propagates_client_disconnect():
-    app = FastAPI()
-    add_request_decompression_middleware(app)
-    dispatch = cast(_Dispatch, app.user_middleware[0].kwargs["dispatch"])
+    async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+        raise AssertionError("downstream app should not run after client disconnect")
 
-    async def receive() -> dict[str, object]:
+    middleware = RequestDecompressionMiddleware(downstream)
+
+    async def receive() -> Message:
         return {"type": "http.disconnect"}
 
-    request = Request(
-        {
-            "type": "http",
-            "http_version": "1.1",
-            "method": "POST",
-            "scheme": "http",
-            "path": "/echo",
-            "raw_path": b"/echo",
-            "query_string": b"",
-            "root_path": "",
-            "headers": [(b"content-encoding", b"gzip"), (b"content-type", b"application/json")],
-            "client": ("testclient", 50000),
-            "server": ("testserver", 80),
-        },
-        receive=receive,
-    )
-
-    async def call_next(_: Request):
-        raise AssertionError("call_next should not run after client disconnect")
-
     with pytest.raises(ClientDisconnect):
-        await dispatch(request, call_next)
+        await middleware(_encoded_post_scope(), receive, _unused_send)
 
 
 @pytest.mark.asyncio
 async def test_request_decompression_propagates_body_read_failures():
-    app = FastAPI()
-    add_request_decompression_middleware(app)
-    dispatch = cast(_Dispatch, app.user_middleware[0].kwargs["dispatch"])
+    async def downstream(scope: Scope, receive: Receive, send: Send) -> None:
+        raise AssertionError("downstream app should not run when body read fails")
 
-    async def receive() -> dict[str, object]:
+    middleware = RequestDecompressionMiddleware(downstream)
+
+    async def receive() -> Message:
         raise RuntimeError("receive failed")
 
-    request = Request(
-        {
-            "type": "http",
-            "http_version": "1.1",
-            "method": "POST",
-            "scheme": "http",
-            "path": "/echo",
-            "raw_path": b"/echo",
-            "query_string": b"",
-            "root_path": "",
-            "headers": [(b"content-encoding", b"gzip"), (b"content-type", b"application/json")],
-            "client": ("testclient", 50000),
-            "server": ("testserver", 80),
-        },
-        receive=receive,
-    )
-
-    async def call_next(_: Request):
-        raise AssertionError("call_next should not run when body read fails")
-
     with pytest.raises(RuntimeError, match="receive failed"):
-        await dispatch(request, call_next)
+        await middleware(_encoded_post_scope(), receive, _unused_send)
+
+
+class _ChunkedBody(AsyncByteStream):
+    def __init__(self, *chunks: bytes) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for chunk in self._chunks:
+            yield chunk
+
+
+@pytest.mark.asyncio
+async def test_request_decompression_supports_chunked_compressed_upload():
+    app = _build_echo_app()
+
+    payload = {"hello": "chunked"}
+    compressed = gzip.compress(json.dumps(payload).encode("utf-8"))
+    assert len(compressed) > 10
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        resp = await client.post(
+            "/echo",
+            content=_ChunkedBody(compressed[:10], compressed[10:]),
+            headers={"Content-Encoding": "gzip", "Content-Type": "application/json"},
+        )
+
+    assert resp.status_code == 200
+    response_data = resp.json()
+    assert response_data["content_encoding"] is None
+    assert response_data["data"] == payload
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_mid_sse_stops_stream_after_replayed_body():
+    """Regression: without BaseHTTPMiddleware's receive wrapper, http.disconnect
+    must still reach StreamingResponse's disconnect listener through the
+    decompression middleware's replay receive."""
+    app = FastAPI()
+    add_request_decompression_middleware(app)
+    add_request_body_limit_middleware(app)
+
+    chunks_seen = asyncio.Event()
+    chunk_count = 0
+
+    @app.post("/stream")
+    async def stream(request: Request) -> StreamingResponse:
+        data = await request.json()
+        assert data == {"hello": "sse"}
+
+        async def event_stream() -> AsyncIterator[bytes]:
+            while True:
+                yield b"data: tick\n\n"
+                await asyncio.sleep(0)
+
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+    compressed = gzip.compress(json.dumps({"hello": "sse"}).encode("utf-8"))
+    scope = _encoded_post_scope()
+    scope["path"] = "/stream"
+    scope["raw_path"] = b"/stream"
+
+    body_messages = iter([{"type": "http.request", "body": compressed, "more_body": False}])
+
+    async def receive() -> Message:
+        for message in body_messages:
+            return message
+        # Simulate the client hanging up once a few SSE chunks have streamed.
+        await chunks_seen.wait()
+        return {"type": "http.disconnect"}
+
+    async def send(message: Message) -> None:
+        nonlocal chunk_count
+        if message["type"] == "http.response.body" and message.get("body"):
+            chunk_count += 1
+            if chunk_count >= 3:
+                chunks_seen.set()
+
+    await asyncio.wait_for(app(scope, receive, send), timeout=5)
+    assert chunk_count >= 3

--- a/tests/unit/test_request_id_middleware.py
+++ b/tests/unit/test_request_id_middleware.py
@@ -1,98 +1,86 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
-from typing import cast
 
 import pytest
-from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse, Response
-from starlette.types import Message
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
 
 from app.core.middleware.request_id import add_request_id_middleware
 from app.core.utils.request_id import get_request_id, get_request_scope_id
 
 pytestmark = pytest.mark.unit
 
-_Dispatch = Callable[[Request, Callable[[Request], Awaitable[Response]]], Awaitable[Response]]
+
+def _build_app(request_ids: list[str | None], scope_ids: list[str | None]) -> FastAPI:
+    app = FastAPI()
+    add_request_id_middleware(app)
+
+    @app.get("/health")
+    async def health() -> dict[str, bool]:
+        request_ids.append(get_request_id())
+        scope_ids.append(get_request_scope_id())
+        return {"ok": True}
+
+    return app
 
 
 @pytest.mark.asyncio
 async def test_request_id_middleware_resets_context_on_success():
-    app = FastAPI()
-    add_request_id_middleware(app)
-    dispatch = cast(_Dispatch, app.user_middleware[0].kwargs["dispatch"])
+    request_ids: list[str | None] = []
+    scope_ids: list[str | None] = []
+    transport = ASGITransport(app=_build_app(request_ids, scope_ids))
 
-    request = Request(
-        {
-            "type": "http",
-            "http_version": "1.1",
-            "method": "GET",
-            "scheme": "http",
-            "path": "/health",
-            "raw_path": b"/health",
-            "query_string": b"",
-            "root_path": "",
-            "headers": [(b"x-request-id", b"req-test-123")],
-            "client": ("testclient", 50000),
-            "server": ("testserver", 80),
-        },
-        receive=_empty_receive,
-    )
-
-    async def call_next(_: Request) -> JSONResponse:
-        assert get_request_id() == "req-test-123"
-        assert get_request_scope_id() not in {None, "req-test-123"}
-        return JSONResponse({"ok": True})
-
-    response = await dispatch(request, call_next)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/health", headers={"x-request-id": "req-test-123"})
 
     assert response.headers["x-request-id"] == "req-test-123"
+    assert request_ids == ["req-test-123"]
+    assert scope_ids[0] not in {None, "req-test-123"}
     assert get_request_id() is None
     assert get_request_scope_id() is None
 
 
 @pytest.mark.asyncio
+async def test_request_id_middleware_generates_id_when_missing():
+    request_ids: list[str | None] = []
+    scope_ids: list[str | None] = []
+    transport = ASGITransport(app=_build_app(request_ids, scope_ids))
+
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/health")
+
+    generated = response.headers["x-request-id"]
+    assert generated
+    assert request_ids == [generated]
+
+
+@pytest.mark.asyncio
+async def test_request_id_middleware_falls_back_to_request_id_header():
+    request_ids: list[str | None] = []
+    scope_ids: list[str | None] = []
+    transport = ASGITransport(app=_build_app(request_ids, scope_ids))
+
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        response = await client.get("/health", headers={"request-id": "legacy-456"})
+
+    assert response.headers["x-request-id"] == "legacy-456"
+    assert request_ids == ["legacy-456"]
+
+
+@pytest.mark.asyncio
 async def test_request_id_middleware_uses_distinct_server_scopes_for_duplicate_client_ids():
-    app = FastAPI()
-    add_request_id_middleware(app)
-    dispatch = cast(_Dispatch, app.user_middleware[0].kwargs["dispatch"])
-    scopes: list[str] = []
+    request_ids: list[str | None] = []
+    scope_ids: list[str | None] = []
+    transport = ASGITransport(app=_build_app(request_ids, scope_ids))
 
-    def make_request() -> Request:
-        return Request(
-            {
-                "type": "http",
-                "http_version": "1.1",
-                "method": "GET",
-                "scheme": "http",
-                "path": "/health",
-                "raw_path": b"/health",
-                "query_string": b"",
-                "root_path": "",
-                "headers": [(b"x-request-id", b"duplicate-client-id")],
-                "client": ("testclient", 50000),
-                "server": ("testserver", 80),
-            },
-            receive=_empty_receive,
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        first, second = await asyncio.gather(
+            client.get("/health", headers={"x-request-id": "duplicate-client-id"}),
+            client.get("/health", headers={"x-request-id": "duplicate-client-id"}),
         )
-
-    async def call_next(_: Request) -> JSONResponse:
-        assert get_request_id() == "duplicate-client-id"
-        scope = get_request_scope_id()
-        assert scope is not None
-        scopes.append(scope)
-        return JSONResponse({"ok": True})
-
-    first, second = await asyncio.gather(
-        dispatch(make_request(), call_next),
-        dispatch(make_request(), call_next),
-    )
 
     assert first.headers["x-request-id"] == "duplicate-client-id"
     assert second.headers["x-request-id"] == "duplicate-client-id"
-    assert len(set(scopes)) == 2
-
-
-async def _empty_receive() -> Message:
-    return {"type": "http.request", "body": b"", "more_body": False}
+    assert request_ids == ["duplicate-client-id", "duplicate-client-id"]
+    assert len(set(scope_ids)) == 2


### PR DESCRIPTION
## Why

5 of the 15 middleware layers (app_version, request_id, required_capability_http, api_firewall, request_decompression) are `@app.middleware("http")` BaseHTTPMiddleware wrappers. Each adds an anyio memory-stream hop + task switch **per SSE chunk** on the dominant streaming path, plus per-request task-group/stream/Event/_CachedRequest setup ×5. Profiled band: ~4-9% of CPU on a single-core host. Every layer's purpose was verified (none removable) — only the wrapper is fat.

## What

- Commit 1: four trivial conversions to pure ASGI classes at identical registration positions; hoist the per-request `import_module` in `inflight.py` into a cached attribute.
- Commit 2: `request_decompression` with explicit replay-receive (replaces starlette `_CachedRequest` semantics): mid-body disconnect, chunked uploads, `_RequestBodyTooLarge` propagation through `limited_receive` all covered.

No removals, no path-scoped mounts, no fusing; ordering invariants preserved verbatim. No openspec — mechanism only, identical envelopes/headers/ordering.

Known follow-ups deliberately NOT in scope: a 6th BaseHTTPMiddleware remains (`_image_route_started_at_middleware` in exception handlers wiring); metrics sits inside bulkhead so admission rejections are uncounted (pre-existing observability gap, owner call).

## Tests

`test_app_version_middleware.py`, `tests/integration/test_request_decompression.py`, http-ingress-limits + firewall (`test_firewall_ip_resolution.py`, `test_firewall_cache_ttl.py`) + request-id suites; new client-disconnect-mid-SSE regression (BaseHTTP's `receive_or_disconnect` short-circuit removed). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)