### PR TITLE
perf: coalesce same-owner sticky session TTL refresh upserts

### DIFF
--- a/app/modules/proxy/_load_balancer/sticky_selection.py
+++ b/app/modules/proxy/_load_balancer/sticky_selection.py
@@ -938,25 +938,35 @@ async def run_sticky_selection_path(
             assert sticky_kind is not None
             sticky_mutation = sticky_outcome.mutation
             assert sticky_mutation is not None
-            try:
-                async with owner._repo_factory() as repos:
-                    # A recovery-probe reservation is still reversible until
-                    # the runtime CAS below succeeds. Persist its thread row so
-                    # existing rollback machinery can restore it, but do not
-                    # publish an immutable process seed that cannot be safely
-                    # deleted after a concurrent sibling observes it.
-                    await _persist_sticky_mutation(
-                        sticky_repo=repos.sticky_sessions,
-                        sticky_key=sticky_key,
-                        sticky_kind=sticky_kind,
-                        mutation=sticky_mutation,
-                    )
-            except BaseException:
-                await owner.release_account_lease(selected_lease)
-                selected_lease = None
-                async with owner._runtime_lock:
-                    owner._release_due_probe_reservation_locked(probe_reservation)
-                raise
+            # A pure same-owner freshness rewrite may be omitted here exactly
+            # as on the non-probe path below (the row already holds this
+            # owner, so the rollback restores become no-ops and are skipped
+            # symmetrically). The probe path deliberately never initializes a
+            # seed, so only the deadline gates the skip.
+            probe_refresh_write_skipped = _sticky_refresh_write_skippable(
+                sticky_mutation,
+                initialize_seed_key=None,
+            )
+            if not probe_refresh_write_skipped:
+                try:
+                    async with owner._repo_factory() as repos:
+                        # A recovery-probe reservation is still reversible until
+                        # the runtime CAS below succeeds. Persist its thread row so
+                        # existing rollback machinery can restore it, but do not
+                        # publish an immutable process seed that cannot be safely
+                        # deleted after a concurrent sibling observes it.
+                        await _persist_sticky_mutation(
+                            sticky_repo=repos.sticky_sessions,
+                            sticky_key=sticky_key,
+                            sticky_kind=sticky_kind,
+                            mutation=sticky_mutation,
+                        )
+                except BaseException:
+                    await owner.release_account_lease(selected_lease)
+                    selected_lease = None
+                    async with owner._runtime_lock:
+                        owner._release_due_probe_reservation_locked(probe_reservation)
+                    raise
             try:
                 async with owner._runtime_lock:
                     assert probe_reservation is not None
@@ -974,14 +984,15 @@ async def run_sticky_selection_path(
                 selected_lease = None
                 async with owner._runtime_lock:
                     owner._release_due_probe_reservation_locked(probe_reservation)
-                async with owner._repo_factory() as repos:
-                    await _restore_sticky_mutation(
-                        sticky_repo=repos.sticky_sessions,
-                        sticky_key=sticky_key,
-                        sticky_kind=sticky_kind,
-                        expected_account_id=sticky_mutation.account_id,
-                        sticky_existing_account_id=sticky_existing_account_id,
-                    )
+                if not probe_refresh_write_skipped:
+                    async with owner._repo_factory() as repos:
+                        await _restore_sticky_mutation(
+                            sticky_repo=repos.sticky_sessions,
+                            sticky_key=sticky_key,
+                            sticky_kind=sticky_kind,
+                            expected_account_id=sticky_mutation.account_id,
+                            sticky_existing_account_id=sticky_existing_account_id,
+                        )
                 raise
             if not reservation_committed:
                 # Runtime health changed while account-state persistence
@@ -991,14 +1002,15 @@ async def run_sticky_selection_path(
                 # runtime snapshot.
                 await owner.release_account_lease(selected_lease)
                 selected_lease = None
-                async with owner._repo_factory() as repos:
-                    await _restore_sticky_mutation(
-                        sticky_repo=repos.sticky_sessions,
-                        sticky_key=sticky_key,
-                        sticky_kind=sticky_kind,
-                        expected_account_id=sticky_mutation.account_id,
-                        sticky_existing_account_id=sticky_existing_account_id,
-                    )
+                if not probe_refresh_write_skipped:
+                    async with owner._repo_factory() as repos:
+                        await _restore_sticky_mutation(
+                            sticky_repo=repos.sticky_sessions,
+                            sticky_key=sticky_key,
+                            sticky_kind=sticky_kind,
+                            expected_account_id=sticky_mutation.account_id,
+                            sticky_existing_account_id=sticky_existing_account_id,
+                        )
                 selected_snapshot = None
                 error_message = None
                 selected_states = []

--- a/app/modules/proxy/_load_balancer/sticky_selection.py
+++ b/app/modules/proxy/_load_balancer/sticky_selection.py
@@ -23,6 +23,7 @@ from app.core.balancer import (
     TrafficClass,
     select_account,
 )
+from app.core.utils.time import utcnow
 from app.db.models import Account, AccountStatus, AdditionalUsageHistory, StickySessionKind, UsageHistory
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.proxy._load_balancer.types import (
@@ -194,7 +195,7 @@ class StickySelectionOwner(Protocol):
         ignore_standard_quota: bool,
         allow_usage_exhaustion_error: bool = True,
         usage_exhaustion_states: Iterable[AccountState] | None = None,
-        sticky_refresh_skippable: bool = False,
+        sticky_refresh_skip_deadline: datetime | None = None,
     ) -> _StickySelectionOutcome: ...
 
     async def release_account_lease(self, lease: AccountLease | None) -> None: ...
@@ -244,6 +245,12 @@ class _StickyMutation:
     # ``None`` is an intentional delete; absence of a mutation means preserve
     # the current mapping until final admission succeeds.
     account_id: str | None
+    # Set only when this mutation is a pure same-owner freshness rewrite of a
+    # row this request's lookup observed inside the repository's refresh-skip
+    # window. The persist site revalidates the deadline against the clock at
+    # write time and may then omit the statement entirely; a mutation that
+    # rebinds, deletes, or must initialize a seed mapping never carries it.
+    refresh_skip_deadline: datetime | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -328,7 +335,13 @@ async def run_sticky_selection_path(
 
     sticky_existing_account_id: str | None | object = _STICKY_EXISTING_UNSET
     sticky_continuity_abandoned = False
-    sticky_refresh_skippable = False
+    sticky_refresh_skip_deadline: datetime | None = None
+    # A thread row whose process seed is still missing must keep its retention
+    # write: that write doubles as the seed-initialization carrier (see the
+    # ``initialize_seed_key`` argument at the persist site below), and
+    # suppressing it would let sibling threads select divergent owners until
+    # the skip window closes.
+    seed_initialization_pending = sticky_source == "thread_header" and sticky_seed_account_id is None
     # A source-qualified marker can be observed before this call or after a
     # retirement CAS miss. In both cases its retained owner is authoritative
     # exclusion evidence even though it is no longer affinity ownership for
@@ -359,10 +372,16 @@ async def run_sticky_selection_path(
                 # always has, rather than silently bypassing the ambiguous
                 # owner check below.
                 sticky_continuity_abandoned = sticky_owner_lookup.continuity_abandoned is True
-                # ``is True`` for the same test-double reason as above. The
-                # flag is only ever an optimization hint: False always falls
-                # back to today's write-on-every-request refresh behavior.
-                sticky_refresh_skippable = sticky_owner_lookup.refresh_can_be_skipped is True
+                # ``isinstance`` for the same test-double reason as above. The
+                # deadline is only ever an optimization hint: None always
+                # falls back to today's write-on-every-request refresh
+                # behavior, and seed-needing requests never skip.
+                observed_refresh_skip_deadline = sticky_owner_lookup.refresh_skip_deadline
+                sticky_refresh_skip_deadline = (
+                    observed_refresh_skip_deadline
+                    if isinstance(observed_refresh_skip_deadline, datetime) and not seed_initialization_pending
+                    else None
+                )
                 sticky_abandoned_account_id = sticky_owner_lookup.abandoned_account_id
                 if sticky_owner_lookup.continuity_abandoned is True and isinstance(
                     sticky_abandoned_account_id,
@@ -378,7 +397,7 @@ async def run_sticky_selection_path(
                 sticky_continuity_abandoned = False
                 # The freshness observation belongs to the namespaced row,
                 # not the raw legacy owner that now shadows it.
-                sticky_refresh_skippable = False
+                sticky_refresh_skip_deadline = None
         async with owner._runtime_lock:
             states, account_map = owner._prepare_sticky_selection_states(
                 selection_inputs,
@@ -652,7 +671,7 @@ async def run_sticky_selection_path(
                         routing_costs_by_account_id=effective_routing_costs,
                         allow_usage_exhaustion_error=allow_usage_exhaustion_error,
                         usage_exhaustion_states=states,
-                        sticky_refresh_skippable=sticky_refresh_skippable,
+                        sticky_refresh_skip_deadline=sticky_refresh_skip_deadline,
                     )
                     result = sticky_outcome.selection
                     if (
@@ -1064,27 +1083,27 @@ async def run_sticky_selection_path(
             assert sticky_kind is not None
             sticky_mutation = sticky_outcome.mutation
             assert sticky_mutation is not None
-            try:
-                async with owner._repo_factory() as repos:
-                    await _persist_sticky_mutation(
-                        sticky_repo=repos.sticky_sessions,
-                        sticky_key=sticky_key,
-                        sticky_kind=sticky_kind,
-                        mutation=sticky_mutation,
-                        initialize_seed_key=(
-                            sticky_seed_key
-                            if sticky_source == "thread_header" and sticky_seed_account_id is None
-                            else None
-                        ),
-                        initialize_seed_kind=sticky_seed_kind,
-                    )
-            except BaseException:
-                # Runtime admission may already be committed. Preserve
-                # its selection timestamp, but never leak the local
-                # concurrency lease when sticky persistence fails.
-                await owner.release_account_lease(selected_lease)
-                selected_lease = None
-                raise
+            initialize_seed_key = (
+                sticky_seed_key if sticky_source == "thread_header" and sticky_seed_account_id is None else None
+            )
+            if not _sticky_refresh_write_skippable(sticky_mutation, initialize_seed_key=initialize_seed_key):
+                try:
+                    async with owner._repo_factory() as repos:
+                        await _persist_sticky_mutation(
+                            sticky_repo=repos.sticky_sessions,
+                            sticky_key=sticky_key,
+                            sticky_kind=sticky_kind,
+                            mutation=sticky_mutation,
+                            initialize_seed_key=initialize_seed_key,
+                            initialize_seed_kind=sticky_seed_kind,
+                        )
+                except BaseException:
+                    # Runtime admission may already be committed. Preserve
+                    # its selection timestamp, but never leak the local
+                    # concurrency lease when sticky persistence fails.
+                    await owner.release_account_lease(selected_lease)
+                    selected_lease = None
+                    raise
         break
 
     return StickySelectionOutcome(
@@ -1121,7 +1140,7 @@ async def _select_with_stickiness(
     ignore_standard_quota: bool = False,
     allow_usage_exhaustion_error: bool = True,
     usage_exhaustion_states: Iterable[AccountState] | None = None,
-    sticky_refresh_skippable: bool = False,
+    sticky_refresh_skip_deadline: datetime | None = None,
 ) -> _StickySelectionOutcome:
     if not sticky_key or not sticky_repo:
         return _StickySelectionOutcome(
@@ -1149,10 +1168,14 @@ async def _select_with_stickiness(
         selection: SelectionResult,
         *,
         persist_account_id: str | None = None,
+        refresh_skip_deadline: datetime | None = None,
     ) -> _StickySelectionOutcome:
         mutation = pending_mutation
         if persist_account_id is not None:
-            mutation = _StickyMutation(account_id=persist_account_id)
+            mutation = _StickyMutation(
+                account_id=persist_account_id,
+                refresh_skip_deadline=refresh_skip_deadline,
+            )
         return _StickySelectionOutcome(selection=selection, mutation=mutation)
 
     if sticky_existing_account_id is _STICKY_EXISTING_UNSET:
@@ -1161,10 +1184,10 @@ async def _select_with_stickiness(
             kind=sticky_kind,
             max_age_seconds=sticky_max_age_seconds,
         )
-        # The skippable flag is only valid for the lookup that produced the
+        # The skip deadline is only valid for the lookup that produced the
         # caller's ``sticky_existing_account_id``; this fresh lookup did not
         # observe row freshness, so fall back to write-through refresh.
-        sticky_refresh_skippable = False
+        sticky_refresh_skip_deadline = None
     else:
         existing = sticky_existing_account_id if isinstance(sticky_existing_account_id, str) else None
     # When the pinned account is temporarily unavailable (rate-limited,
@@ -1208,11 +1231,14 @@ async def _select_with_stickiness(
             # Retaining the pinned owner persists only to advance
             # ``updated_at`` on TTL-based kinds. When this request's lookup
             # already observed the row inside the repository's refresh-skip
-            # window, skip that write: concurrent requests on a hot session
-            # otherwise serialize on the same row's upsert lock. Rebinds and
-            # deletes never consult this value and always write immediately.
-            pinned_refresh_account_id = (
-                pinned.account_id if sticky_max_age_seconds is not None and not sticky_refresh_skippable else None
+            # window, the persist site may skip that write after revalidating
+            # the observed deadline against the clock: concurrent requests on
+            # a hot session otherwise serialize on the same row's upsert
+            # lock. Rebinds and deletes never carry the deadline and always
+            # write immediately.
+            pinned_refresh_account_id = pinned.account_id if sticky_max_age_seconds is not None else None
+            pinned_refresh_skip_deadline = (
+                sticky_refresh_skip_deadline if pinned_refresh_account_id is not None else None
             )
             # Proactively rebind session affinity for any sticky kind
             # once the pinned account is already above the configured
@@ -1276,6 +1302,7 @@ async def _select_with_stickiness(
                     return finish_selection(
                         pinned_result,
                         persist_account_id=pinned_refresh_account_id,
+                        refresh_skip_deadline=pinned_refresh_skip_deadline,
                     )
             else:
                 # Reallocate only when a burn-first target exists and can
@@ -1330,6 +1357,7 @@ async def _select_with_stickiness(
                             return finish_selection(
                                 pinned_result,
                                 persist_account_id=pinned_refresh_account_id,
+                                refresh_skip_deadline=pinned_refresh_skip_deadline,
                             )
                 reallocate_sticky = True
             # Grace period: if the pinned account is rate-limited with a
@@ -1357,6 +1385,7 @@ async def _select_with_stickiness(
                     return finish_selection(
                         grace_result,
                         persist_account_id=pinned_refresh_account_id,
+                        refresh_skip_deadline=pinned_refresh_skip_deadline,
                     )
             if reallocate_sticky:
                 pending_mutation = _StickyMutation(account_id=None)
@@ -1406,6 +1435,27 @@ async def _select_with_stickiness(
             sticky_kind.value,
         )
     return finish_selection(chosen)
+
+
+def _sticky_refresh_write_skippable(
+    mutation: _StickyMutation,
+    *,
+    initialize_seed_key: str | None,
+) -> bool:
+    """Whether this mutation's write may be omitted at persist time.
+
+    True only for a pure same-owner freshness rewrite whose observed skip
+    deadline still holds now, at the moment the statement would otherwise be
+    issued — admission and account-state persistence sit between selection
+    and this point, so the deadline computed at lookup time must be
+    revalidated to keep the mapping's effective expiry within the documented
+    skip-window bound. Deletes and seed-initializing writes are never
+    skippable.
+    """
+    if mutation.account_id is None or initialize_seed_key is not None:
+        return False
+    deadline = mutation.refresh_skip_deadline
+    return isinstance(deadline, datetime) and utcnow() <= deadline
 
 
 async def _persist_sticky_mutation(

--- a/app/modules/proxy/_load_balancer/sticky_selection.py
+++ b/app/modules/proxy/_load_balancer/sticky_selection.py
@@ -336,12 +336,15 @@ async def run_sticky_selection_path(
     sticky_existing_account_id: str | None | object = _STICKY_EXISTING_UNSET
     sticky_continuity_abandoned = False
     sticky_refresh_skip_deadline: datetime | None = None
-    # A thread row whose process seed is still missing must keep its retention
-    # write: that write doubles as the seed-initialization carrier (see the
-    # ``initialize_seed_key`` argument at the persist site below), and
-    # suppressing it would let sibling threads select divergent owners until
-    # the skip window closes.
-    seed_initialization_pending = sticky_source == "thread_header" and sticky_seed_account_id is None
+    # A thread row whose process seed exists but is still unowned must keep
+    # its retention write: that write doubles as the seed-initialization
+    # carrier (see the ``initialize_seed_key`` argument at the persist site
+    # below), and suppressing it would let sibling threads select divergent
+    # owners until the skip window closes. Thread-only affinity without a
+    # seed key has nothing to initialize and stays skippable.
+    seed_initialization_pending = (
+        sticky_source == "thread_header" and sticky_seed_key is not None and sticky_seed_account_id is None
+    )
     # A source-qualified marker can be observed before this call or after a
     # retirement CAS miss. In both cases its retained owner is authoritative
     # exclusion evidence even though it is no longer affinity ownership for

--- a/app/modules/proxy/_load_balancer/sticky_selection.py
+++ b/app/modules/proxy/_load_balancer/sticky_selection.py
@@ -194,6 +194,7 @@ class StickySelectionOwner(Protocol):
         ignore_standard_quota: bool,
         allow_usage_exhaustion_error: bool = True,
         usage_exhaustion_states: Iterable[AccountState] | None = None,
+        sticky_refresh_skippable: bool = False,
     ) -> _StickySelectionOutcome: ...
 
     async def release_account_lease(self, lease: AccountLease | None) -> None: ...
@@ -327,6 +328,7 @@ async def run_sticky_selection_path(
 
     sticky_existing_account_id: str | None | object = _STICKY_EXISTING_UNSET
     sticky_continuity_abandoned = False
+    sticky_refresh_skippable = False
     # A source-qualified marker can be observed before this call or after a
     # retirement CAS miss. In both cases its retained owner is authoritative
     # exclusion evidence even though it is no longer affinity ownership for
@@ -357,6 +359,10 @@ async def run_sticky_selection_path(
                 # always has, rather than silently bypassing the ambiguous
                 # owner check below.
                 sticky_continuity_abandoned = sticky_owner_lookup.continuity_abandoned is True
+                # ``is True`` for the same test-double reason as above. The
+                # flag is only ever an optimization hint: False always falls
+                # back to today's write-on-every-request refresh behavior.
+                sticky_refresh_skippable = sticky_owner_lookup.refresh_can_be_skipped is True
                 sticky_abandoned_account_id = sticky_owner_lookup.abandoned_account_id
                 if sticky_owner_lookup.continuity_abandoned is True and isinstance(
                     sticky_abandoned_account_id,
@@ -370,6 +376,9 @@ async def run_sticky_selection_path(
                 # turn-state ownership.
                 sticky_existing_account_id = legacy_existing_account_id
                 sticky_continuity_abandoned = False
+                # The freshness observation belongs to the namespaced row,
+                # not the raw legacy owner that now shadows it.
+                sticky_refresh_skippable = False
         async with owner._runtime_lock:
             states, account_map = owner._prepare_sticky_selection_states(
                 selection_inputs,
@@ -643,6 +652,7 @@ async def run_sticky_selection_path(
                         routing_costs_by_account_id=effective_routing_costs,
                         allow_usage_exhaustion_error=allow_usage_exhaustion_error,
                         usage_exhaustion_states=states,
+                        sticky_refresh_skippable=sticky_refresh_skippable,
                     )
                     result = sticky_outcome.selection
                     if (
@@ -1111,6 +1121,7 @@ async def _select_with_stickiness(
     ignore_standard_quota: bool = False,
     allow_usage_exhaustion_error: bool = True,
     usage_exhaustion_states: Iterable[AccountState] | None = None,
+    sticky_refresh_skippable: bool = False,
 ) -> _StickySelectionOutcome:
     if not sticky_key or not sticky_repo:
         return _StickySelectionOutcome(
@@ -1150,6 +1161,10 @@ async def _select_with_stickiness(
             kind=sticky_kind,
             max_age_seconds=sticky_max_age_seconds,
         )
+        # The skippable flag is only valid for the lookup that produced the
+        # caller's ``sticky_existing_account_id``; this fresh lookup did not
+        # observe row freshness, so fall back to write-through refresh.
+        sticky_refresh_skippable = False
     else:
         existing = sticky_existing_account_id if isinstance(sticky_existing_account_id, str) else None
     # When the pinned account is temporarily unavailable (rate-limited,
@@ -1190,6 +1205,15 @@ async def _select_with_stickiness(
     if existing:
         pinned = next((state for state in states if state.account_id == existing), None)
         if pinned is not None:
+            # Retaining the pinned owner persists only to advance
+            # ``updated_at`` on TTL-based kinds. When this request's lookup
+            # already observed the row inside the repository's refresh-skip
+            # window, skip that write: concurrent requests on a hot session
+            # otherwise serialize on the same row's upsert lock. Rebinds and
+            # deletes never consult this value and always write immediately.
+            pinned_refresh_account_id = (
+                pinned.account_id if sticky_max_age_seconds is not None and not sticky_refresh_skippable else None
+            )
             # Proactively rebind session affinity for any sticky kind
             # once the pinned account is already above the configured
             # budget threshold. That preserves continuity below the
@@ -1251,7 +1275,7 @@ async def _select_with_stickiness(
                 if pinned_result.account is not None:
                     return finish_selection(
                         pinned_result,
-                        persist_account_id=pinned.account_id if sticky_max_age_seconds is not None else None,
+                        persist_account_id=pinned_refresh_account_id,
                     )
             else:
                 # Reallocate only when a burn-first target exists and can
@@ -1305,7 +1329,7 @@ async def _select_with_stickiness(
                         if pinned_result.account is not None:
                             return finish_selection(
                                 pinned_result,
-                                persist_account_id=(pinned.account_id if sticky_max_age_seconds is not None else None),
+                                persist_account_id=pinned_refresh_account_id,
                             )
                 reallocate_sticky = True
             # Grace period: if the pinned account is rate-limited with a
@@ -1332,7 +1356,7 @@ async def _select_with_stickiness(
                 if grace_result.account is not None:
                     return finish_selection(
                         grace_result,
-                        persist_account_id=pinned.account_id if sticky_max_age_seconds is not None else None,
+                        persist_account_id=pinned_refresh_account_id,
                     )
             if reallocate_sticky:
                 pending_mutation = _StickyMutation(account_id=None)

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1635,7 +1635,7 @@ class LoadBalancer:
         ignore_standard_quota: bool = False,
         allow_usage_exhaustion_error: bool = True,
         usage_exhaustion_states: Iterable[AccountState] | None = None,
-        sticky_refresh_skippable: bool = False,
+        sticky_refresh_skip_deadline: datetime | None = None,
     ) -> _StickySelectionOutcome:
         return await _run_select_with_stickiness(
             states=states,
@@ -1660,7 +1660,7 @@ class LoadBalancer:
             ignore_standard_quota=ignore_standard_quota,
             allow_usage_exhaustion_error=allow_usage_exhaustion_error,
             usage_exhaustion_states=usage_exhaustion_states,
-            sticky_refresh_skippable=sticky_refresh_skippable,
+            sticky_refresh_skip_deadline=sticky_refresh_skip_deadline,
         )
 
     _persist_sticky_mutation = staticmethod(_persist_sticky_mutation)

--- a/app/modules/proxy/load_balancer.py
+++ b/app/modules/proxy/load_balancer.py
@@ -1635,6 +1635,7 @@ class LoadBalancer:
         ignore_standard_quota: bool = False,
         allow_usage_exhaustion_error: bool = True,
         usage_exhaustion_states: Iterable[AccountState] | None = None,
+        sticky_refresh_skippable: bool = False,
     ) -> _StickySelectionOutcome:
         return await _run_select_with_stickiness(
             states=states,
@@ -1659,6 +1660,7 @@ class LoadBalancer:
             ignore_standard_quota=ignore_standard_quota,
             allow_usage_exhaustion_error=allow_usage_exhaustion_error,
             usage_exhaustion_states=usage_exhaustion_states,
+            sticky_refresh_skippable=sticky_refresh_skippable,
         )
 
     _persist_sticky_mutation = staticmethod(_persist_sticky_mutation)

--- a/app/modules/proxy/sticky_repository.py
+++ b/app/modules/proxy/sticky_repository.py
@@ -28,6 +28,17 @@ _DELETE_ENTRIES_CHUNK_SIZE = 250
 _ContinuitySource = Literal["session_header", "thread_header", "turn_state"]
 _SESSION_HEADER_ABANDONMENT_SCOPE = "session_header"
 
+# A same-owner TTL refresh upsert only rewrites ``updated_at``. On hot
+# (key, kind) rows, concurrent requests serialize on that row lock, so the
+# selection path skips the rewrite entirely while the row is younger than
+# this window. The window is bounded to at most 1% of the mapping TTL (so
+# expiry moves by at most 1% of the window it protects) and to a small
+# absolute ceiling; a rebind to a different owner or a row carrying any
+# abandonment marker is never skippable because those writes change state
+# beyond freshness.
+_REFRESH_SKIP_TTL_FRACTION = 0.01
+_REFRESH_SKIP_MAX_SECONDS = 15.0
+
 # Only the Live-call ownership namespace is reserved. Other LF-prefixed keys
 # (e.g. the pre-existing "\ncodex-lb-affinity-v1" selection affinities) remain
 # ordinary operator-manageable sessions.
@@ -58,6 +69,13 @@ class StickyOwnerLookup:
     # was retired. Global stale-hard tombstones leave this unset because their
     # established recovery path may legitimately reselect a recovered owner.
     abandoned_account_id: str | None = None
+    # True only when the row was observed in this lookup with a fresh
+    # ``updated_at`` (within the refresh-skip window derived from
+    # ``max_age_seconds``) and no abandonment marker, so a same-owner TTL
+    # refresh upsert would be a pure ``updated_at`` rewrite. Consumers must
+    # compare with ``is True`` (test doubles may auto-vivify attributes) and
+    # must never skip a write that changes the owner account.
+    refresh_can_be_skipped: bool = False
 
 
 def _continuity_is_abandoned_for_source(
@@ -90,6 +108,7 @@ def _owner_lookup_from_row(
     row: StickySession,
     *,
     continuity_source: _ContinuitySource | None,
+    refresh_can_be_skipped: bool = False,
 ) -> StickyOwnerLookup:
     if _continuity_is_abandoned_for_source(
         row.continuity_abandoned_at,
@@ -105,7 +124,31 @@ def _owner_lookup_from_row(
                 continuity_source,
             ),
         )
-    return StickyOwnerLookup(account_id=row.account_id, continuity_abandoned=False)
+    return StickyOwnerLookup(
+        account_id=row.account_id,
+        continuity_abandoned=False,
+        refresh_can_be_skipped=refresh_can_be_skipped,
+    )
+
+
+def _same_owner_refresh_can_be_skipped(
+    row: StickySession,
+    *,
+    observed_updated_at: datetime,
+    now: datetime,
+    max_age_seconds: int,
+) -> bool:
+    """Whether a same-owner upsert of this row would be a pure freshness rewrite.
+
+    Any abandonment marker disqualifies the skip: an upsert re-establishes
+    ownership by clearing both marker columns, so that write is semantic even
+    when the owner account is unchanged.
+    """
+
+    if row.continuity_abandoned_at is not None or row.continuity_abandonment_scope is not None:
+        return False
+    skip_window_seconds = min(_REFRESH_SKIP_MAX_SECONDS, max_age_seconds * _REFRESH_SKIP_TTL_FRACTION)
+    return (now - observed_updated_at).total_seconds() <= skip_window_seconds
 
 
 class StickySessionsRepository:
@@ -150,10 +193,20 @@ class StickySessionsRepository:
             return StickyOwnerLookup(account_id=None, continuity_abandoned=False)
         if max_age_seconds is None:
             return _owner_lookup_from_row(row, continuity_source=continuity_source)
-        cutoff = utcnow() - timedelta(seconds=max_age_seconds)
+        now = utcnow()
+        cutoff = now - timedelta(seconds=max_age_seconds)
         observed_updated_at = to_utc_naive(row.updated_at)
         if observed_updated_at >= cutoff:
-            return _owner_lookup_from_row(row, continuity_source=continuity_source)
+            return _owner_lookup_from_row(
+                row,
+                continuity_source=continuity_source,
+                refresh_can_be_skipped=_same_owner_refresh_can_be_skipped(
+                    row,
+                    observed_updated_at=observed_updated_at,
+                    now=now,
+                    max_age_seconds=max_age_seconds,
+                ),
+            )
 
         # Release the read snapshot before attempting a SQLite write upgrade.
         # The DELETE remains safe because every value observed above participates

--- a/app/modules/proxy/sticky_repository.py
+++ b/app/modules/proxy/sticky_repository.py
@@ -30,12 +30,13 @@ _SESSION_HEADER_ABANDONMENT_SCOPE = "session_header"
 
 # A same-owner TTL refresh upsert only rewrites ``updated_at``. On hot
 # (key, kind) rows, concurrent requests serialize on that row lock, so the
-# selection path skips the rewrite entirely while the row is younger than
-# this window. The window is bounded to at most 1% of the mapping TTL (so
-# expiry moves by at most 1% of the window it protects) and to a small
-# absolute ceiling; a rebind to a different owner or a row carrying any
-# abandonment marker is never skippable because those writes change state
-# beyond freshness.
+# selection path may skip the rewrite while the row is younger than this
+# window, revalidating the observed deadline at write time. The window is
+# bounded to at most 1% of the mapping TTL (so expiry moves by at most 1% of
+# the window it protects) and to a small absolute ceiling; a rebind to a
+# different owner, a row carrying any abandonment marker, or a row stamped in
+# the future is never skippable because those writes change state beyond
+# freshness (or the observation itself is untrustworthy).
 _REFRESH_SKIP_TTL_FRACTION = 0.01
 _REFRESH_SKIP_MAX_SECONDS = 15.0
 
@@ -69,13 +70,16 @@ class StickyOwnerLookup:
     # was retired. Global stale-hard tombstones leave this unset because their
     # established recovery path may legitimately reselect a recovered owner.
     abandoned_account_id: str | None = None
-    # True only when the row was observed in this lookup with a fresh
+    # Set only when the row was observed in this lookup with a fresh
     # ``updated_at`` (within the refresh-skip window derived from
     # ``max_age_seconds``) and no abandonment marker, so a same-owner TTL
-    # refresh upsert would be a pure ``updated_at`` rewrite. Consumers must
-    # compare with ``is True`` (test doubles may auto-vivify attributes) and
-    # must never skip a write that changes the owner account.
-    refresh_can_be_skipped: bool = False
+    # refresh upsert would be a pure ``updated_at`` rewrite. The value is the
+    # naive-UTC instant (``observed_updated_at`` + skip window) after which
+    # the skip is no longer valid; consumers must isinstance-check
+    # ``datetime`` (test doubles may auto-vivify attributes), must revalidate
+    # the deadline against the clock immediately before omitting the write,
+    # and must never skip a write that changes the owner account.
+    refresh_skip_deadline: datetime | None = None
 
 
 def _continuity_is_abandoned_for_source(
@@ -108,7 +112,7 @@ def _owner_lookup_from_row(
     row: StickySession,
     *,
     continuity_source: _ContinuitySource | None,
-    refresh_can_be_skipped: bool = False,
+    refresh_skip_deadline: datetime | None = None,
 ) -> StickyOwnerLookup:
     if _continuity_is_abandoned_for_source(
         row.continuity_abandoned_at,
@@ -127,28 +131,36 @@ def _owner_lookup_from_row(
     return StickyOwnerLookup(
         account_id=row.account_id,
         continuity_abandoned=False,
-        refresh_can_be_skipped=refresh_can_be_skipped,
+        refresh_skip_deadline=refresh_skip_deadline,
     )
 
 
-def _same_owner_refresh_can_be_skipped(
+def _same_owner_refresh_skip_deadline(
     row: StickySession,
     *,
     observed_updated_at: datetime,
     now: datetime,
     max_age_seconds: int,
-) -> bool:
-    """Whether a same-owner upsert of this row would be a pure freshness rewrite.
+) -> datetime | None:
+    """Deadline until which a same-owner upsert of this row stays skippable.
 
     Any abandonment marker disqualifies the skip: an upsert re-establishes
     ownership by clearing both marker columns, so that write is semantic even
-    when the owner account is unchanged.
+    when the owner account is unchanged. A row whose ``updated_at`` sits in
+    the future (database clock ahead of this process, or a restored row) is
+    also never skippable: an upper-bound-only age comparison would let such a
+    row satisfy the window for longer than the documented bound.
     """
 
     if row.continuity_abandoned_at is not None or row.continuity_abandonment_scope is not None:
-        return False
+        return None
+    age_seconds = (now - observed_updated_at).total_seconds()
+    if age_seconds < 0:
+        return None
     skip_window_seconds = min(_REFRESH_SKIP_MAX_SECONDS, max_age_seconds * _REFRESH_SKIP_TTL_FRACTION)
-    return (now - observed_updated_at).total_seconds() <= skip_window_seconds
+    if age_seconds > skip_window_seconds:
+        return None
+    return observed_updated_at + timedelta(seconds=skip_window_seconds)
 
 
 class StickySessionsRepository:
@@ -200,7 +212,7 @@ class StickySessionsRepository:
             return _owner_lookup_from_row(
                 row,
                 continuity_source=continuity_source,
-                refresh_can_be_skipped=_same_owner_refresh_can_be_skipped(
+                refresh_skip_deadline=_same_owner_refresh_skip_deadline(
                     row,
                     observed_updated_at=observed_updated_at,
                     now=now,

--- a/openspec/changes/coalesce-sticky-same-owner-refresh/proposal.md
+++ b/openspec/changes/coalesce-sticky-same-owner-refresh/proposal.md
@@ -17,21 +17,28 @@ the TTFT-critical selection path.
 ## What Changes
 
 - The owner lookup that selection already performs per request now also reports
-  whether the row was observed fresh: `updated_at` within
-  `min(15s, 1% of the mapping TTL)` AND no abandonment marker in either
-  `continuity_abandoned_at` or `continuity_abandonment_scope`.
-- When selection retains the same pinned owner and that flag is set, the
-  same-owner refresh upsert is skipped entirely — no statement, no row lock.
-  The next request after the window closes performs the normal write-through
-  refresh.
+  a refresh-skip deadline when the row was observed fresh: `updated_at` within
+  `min(15s, 1% of the mapping TTL)`, not stamped in the future, AND no
+  abandonment marker in either `continuity_abandoned_at` or
+  `continuity_abandonment_scope`. The deadline is
+  `observed_updated_at + skip window`.
+- When selection retains the same pinned owner, the mutation carries that
+  deadline to the persist site, which revalidates it against the clock at the
+  moment the statement would be issued and only then omits the same-owner
+  refresh upsert — no statement, no row lock. A deadline that lapsed during
+  admission or account-state persistence writes through, so the mapping's
+  effective expiry never moves earlier by more than the skip window. The next
+  request after the window closes performs the normal write-through refresh.
 - Every state-changing write is unaffected and still immediate: rebinding to a
   different account, deleting a mapping, restoring after failed admission,
-  clearing an abandonment tombstone, seeding a new mapping, and the raw legacy
-  owner paths. A row carrying any abandonment marker is never skippable because
-  the upsert also clears those marker columns.
-- The flag is DB-observed within the same request (no cross-request cache), so
-  it is correct with any number of workers or replicas: a replica can only skip
-  a write whose freshness it just read from the shared database.
+  clearing an abandonment tombstone, seeding a new mapping (including a thread
+  retention that must initialize a missing process seed — that write is the
+  seed-initialization carrier and is never skipped), and the raw legacy owner
+  paths. A row carrying any abandonment marker is never skippable because the
+  upsert also clears those marker columns.
+- The deadline is DB-observed within the same request (no cross-request cache),
+  so it is correct with any number of workers or replicas: a replica can only
+  skip a write whose freshness it just read from the shared database.
 
 ## Freshness window rationale
 

--- a/openspec/changes/coalesce-sticky-same-owner-refresh/proposal.md
+++ b/openspec/changes/coalesce-sticky-same-owner-refresh/proposal.md
@@ -1,0 +1,58 @@
+# Coalesce same-owner sticky refresh writes
+
+## Why
+
+The sticky-session upsert is the single most expensive statement in a production
+deployment: over 10 days of `pg_stat_statements` it accounted for 44% of total
+database execution time (1,203,934 calls, mean 32.1ms, stddev 259.9ms, max 23.2s,
+zero I/O time). The table itself is small (26MB / 27k rows) and healthy; the cost
+is row-lock serialization. Every request that retains its pinned owner on a
+TTL-based mapping (`prompt_cache`) re-executes
+`INSERT ... ON CONFLICT (key, kind) DO UPDATE SET account_id = ..., updated_at = now(), ...`
+purely to advance `updated_at`. Concurrent requests of one hot session hit the
+same `(key, kind)` row and queue on its row lock through each other's commits,
+which produces the heavy tail (stddev 8x the mean) and burns wall-clock time on
+the TTFT-critical selection path.
+
+## What Changes
+
+- The owner lookup that selection already performs per request now also reports
+  whether the row was observed fresh: `updated_at` within
+  `min(15s, 1% of the mapping TTL)` AND no abandonment marker in either
+  `continuity_abandoned_at` or `continuity_abandonment_scope`.
+- When selection retains the same pinned owner and that flag is set, the
+  same-owner refresh upsert is skipped entirely — no statement, no row lock.
+  The next request after the window closes performs the normal write-through
+  refresh.
+- Every state-changing write is unaffected and still immediate: rebinding to a
+  different account, deleting a mapping, restoring after failed admission,
+  clearing an abandonment tombstone, seeding a new mapping, and the raw legacy
+  owner paths. A row carrying any abandonment marker is never skippable because
+  the upsert also clears those marker columns.
+- The flag is DB-observed within the same request (no cross-request cache), so
+  it is correct with any number of workers or replicas: a replica can only skip
+  a write whose freshness it just read from the shared database.
+
+## Freshness window rationale
+
+`updated_at` on `prompt_cache` mappings is consumed by two TTL clocks, both
+driven by `openai_cache_affinity_max_age_seconds` (default 1800s): the read-path
+expiry in the owner lookup and the background cleanup loop. Skipping a refresh
+while the row is younger than `min(15s, TTL * 0.01)` means a mapping's effective
+expiry can move at most that window earlier — at most 1% of the TTL it protects,
+and never more than 15 seconds. Sessions with request gaps longer than the
+window (the overwhelming majority) still refresh on every request; only bursts
+faster than the window coalesce, and those bursts re-refresh within the window
+by construction. Durable kinds (`codex_session`, `sticky_thread` without TTL)
+never used the refresh-on-retention write and are untouched.
+
+## Impact
+
+- Affected specs: `sticky-session-operations`
+- Affected code: `app/modules/proxy/sticky_repository.py`,
+  `app/modules/proxy/_load_balancer/sticky_selection.py`,
+  `app/modules/proxy/load_balancer.py`
+- No new settings, no migration, no dashboard surface. Routing decisions are
+  byte-identical; only the redundant same-owner freshness write is coalesced.
+- Operators see `updated_at` in the dashboard sticky-session list advance in
+  steps of up to the skip window on hot sessions instead of per request.

--- a/openspec/changes/coalesce-sticky-same-owner-refresh/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/coalesce-sticky-same-owner-refresh/specs/sticky-session-operations/spec.md
@@ -15,14 +15,22 @@ write-per-request behavior.
 
 The skip decision MUST be derived from row state observed in the current request's
 database lookup, not from cross-request in-process state, so any number of workers or
-replicas remain correct.
+replicas remain correct. The lookup MUST report the skip as a deadline (the observed
+freshness timestamp plus the skip window), and the write path MUST revalidate that
+deadline against the clock at the moment the write would otherwise be issued — a
+deadline that lapsed while the request was being admitted no longer authorizes a
+skip. A row whose observed freshness timestamp lies in the future (clock skew or a
+restored row) MUST NOT be skippable at all.
 
 A skip MUST apply only to a pure freshness rewrite. The following writes MUST remain
 immediate and unconditional: rebinding the mapping to a different account, deleting
 the mapping, restoring a provisional owner after failed admission, initializing a
 seed mapping, and any upsert against a row carrying an abandonment marker (whose
-write also clears the marker columns). A raw legacy owner that shadows the namespaced
-row MUST NOT inherit the namespaced row's freshness observation.
+write also clears the marker columns). In particular, a retention write that would
+initialize a missing seed mapping MUST NOT be skipped even when the retained row
+itself was observed fresh, because the seed initialization piggybacks on that write.
+A raw legacy owner that shadows the namespaced row MUST NOT inherit the namespaced
+row's freshness observation.
 
 #### Scenario: Hot same-owner retention skips the redundant refresh write
 
@@ -52,3 +60,23 @@ row MUST NOT inherit the namespaced row's freshness observation.
 - **AND** a concurrent request rebinds the same mapping to another account
 - **WHEN** both requests complete
 - **THEN** the mapping's owner is the rebind target
+
+#### Scenario: A retention that must initialize a missing seed is never skipped
+
+- **GIVEN** a thread mapping observed fresher than the skip window
+- **AND** the corresponding process seed mapping does not exist
+- **WHEN** selection retains the thread mapping's pinned account
+- **THEN** the retention write is issued and the seed mapping is initialized
+
+#### Scenario: A deadline that lapsed during admission writes through
+
+- **GIVEN** a request whose lookup observed the row inside the skip window
+- **AND** admission latency carried the request past the observed skip deadline
+- **WHEN** the retention write would be issued
+- **THEN** the deadline is revalidated and the freshness write is performed
+
+#### Scenario: A future freshness timestamp is never skippable
+
+- **GIVEN** a mapping whose freshness timestamp lies ahead of the current clock
+- **WHEN** the owner lookup evaluates the skip window
+- **THEN** no skip deadline is reported and retention writes through

--- a/openspec/changes/coalesce-sticky-same-owner-refresh/specs/sticky-session-operations/spec.md
+++ b/openspec/changes/coalesce-sticky-same-owner-refresh/specs/sticky-session-operations/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Same-owner sticky refresh writes are coalesced
+
+When selection retains the existing pinned owner of a TTL-based sticky mapping, the
+mapping write exists only to advance the mapping's freshness timestamp. The system
+MUST skip that write when the same request's owner lookup already observed the row
+with a freshness timestamp younger than a bounded skip window, so concurrent requests
+of one hot session do not serialize on the same row's lock.
+
+The skip window MUST NOT exceed 1% of the mapping's configured TTL and MUST NOT
+exceed 15 seconds, so a mapping's effective expiry — on both the read-path TTL check
+and the background cleanup loop — moves at most that window earlier than today's
+write-per-request behavior.
+
+The skip decision MUST be derived from row state observed in the current request's
+database lookup, not from cross-request in-process state, so any number of workers or
+replicas remain correct.
+
+A skip MUST apply only to a pure freshness rewrite. The following writes MUST remain
+immediate and unconditional: rebinding the mapping to a different account, deleting
+the mapping, restoring a provisional owner after failed admission, initializing a
+seed mapping, and any upsert against a row carrying an abandonment marker (whose
+write also clears the marker columns). A raw legacy owner that shadows the namespaced
+row MUST NOT inherit the namespaced row's freshness observation.
+
+#### Scenario: Hot same-owner retention skips the redundant refresh write
+
+- **GIVEN** a `prompt_cache` mapping pinned to an eligible account
+- **AND** the request's owner lookup observed the row fresher than the skip window
+  with no abandonment marker
+- **WHEN** selection retains the pinned account
+- **THEN** the request routes to the pinned account
+- **AND** no sticky-session write is issued for the retention
+
+#### Scenario: Retention outside the skip window refreshes write-through
+
+- **GIVEN** a `prompt_cache` mapping pinned to an eligible account
+- **AND** the row's freshness timestamp is older than the skip window but inside the TTL
+- **WHEN** selection retains the pinned account
+- **THEN** the mapping's freshness timestamp is advanced by a write
+
+#### Scenario: Rebind is never coalesced
+
+- **GIVEN** a soft mapping whose row was observed fresher than the skip window
+- **WHEN** selection rebinds the mapping to a different account
+- **THEN** the rebind is persisted immediately
+
+#### Scenario: A skipped refresh does not clobber a concurrent rebind
+
+- **GIVEN** a request that observed a fresh same-owner row and skipped its refresh write
+- **AND** a concurrent request rebinds the same mapping to another account
+- **WHEN** both requests complete
+- **THEN** the mapping's owner is the rebind target

--- a/openspec/changes/coalesce-sticky-same-owner-refresh/tasks.md
+++ b/openspec/changes/coalesce-sticky-same-owner-refresh/tasks.md
@@ -2,30 +2,41 @@
 
 ## 1. Repository freshness observation
 
-- [x] 1.1 Extend `StickyOwnerLookup` with `refresh_can_be_skipped`, computed only on
-      the fresh-row TTL lookup path: `updated_at` within `min(15s, 1% of TTL)` and
-      both abandonment marker columns NULL
-- [x] 1.2 Keep the flag False on the stale-delete recovery path, on lookups without a
-      TTL, and on rows carrying any abandonment marker
+- [x] 1.1 Extend `StickyOwnerLookup` with `refresh_skip_deadline`
+      (`observed_updated_at + skip window`), computed only on the fresh-row TTL
+      lookup path: `updated_at` within `min(15s, 1% of TTL)`, not in the future,
+      and both abandonment marker columns NULL
+- [x] 1.2 Keep the deadline unset on the stale-delete recovery path, on lookups
+      without a TTL, on rows carrying any abandonment marker, and on rows whose
+      `updated_at` is ahead of the clock
 
 ## 2. Selection wiring
 
-- [x] 2.1 Thread the flag from `run_sticky_selection_path`'s per-attempt owner lookup
-      through `_select_with_stickiness`; reset it when the raw legacy owner shadows
-      the namespaced row and when the inner helper re-resolves the owner itself
-- [x] 2.2 Skip only the three same-owner pinned-retention refresh persists; rebinds,
-      deletes, restores, and seed initialization keep writing immediately
+- [x] 2.1 Thread the deadline from `run_sticky_selection_path`'s per-attempt owner
+      lookup through `_select_with_stickiness` onto the retention mutation; reset it
+      when the raw legacy owner shadows the namespaced row, when the inner helper
+      re-resolves the owner itself, and when the process seed is still missing
+      (seed initialization piggybacks on the retention write)
+- [x] 2.2 Revalidate the deadline at the persist site (`_sticky_refresh_write_skippable`)
+      and only then omit the same-owner refresh statement; rebinds, deletes,
+      restores, and seed-initializing writes keep writing immediately
 
 ## 3. Verification
 
-- [x] 3.1 Unit tests: skip on fresh same-owner retention, write-through when the flag
-      is unset, rebind/departed-owner writes never suppressed, grace-period retention
-      honors the window, internal re-resolution resets the flag
-- [x] 3.2 Integration tests: flag conditions against the real repository (fresh row,
-      TTL-scaled window, marker disqualification, no-TTL lookup), concurrent upserts
-      on one `(key, kind)` keep RETURNING/self-write and single-row semantics, a
-      skipped refresh never clobbers a concurrent rebind
-- [x] 3.3 `uv run pytest tests/unit/test_select_with_stickiness.py
+- [x] 3.1 Unit tests: skip on fresh same-owner retention, write-through when the
+      deadline is unset or lapsed at persist time, rebind/departed-owner writes never
+      suppressed, grace-period retention honors the window, internal re-resolution
+      resets the deadline, persist-time gate guards deletes/seed writes/non-datetime
+      deadlines
+- [x] 3.2 Balancer-level tests: fresh same-owner retention issues no write when the
+      seed exists, a fresh thread row with a missing seed still writes and initializes
+      the seed, an expired deadline writes through
+- [x] 3.3 Integration tests: deadline conditions against the real repository (fresh
+      row, TTL-scaled window, marker disqualification, future timestamp, no-TTL
+      lookup), concurrent upserts on one `(key, kind)` keep RETURNING/self-write and
+      single-row semantics, a skipped refresh never clobbers a concurrent rebind
+- [x] 3.4 `uv run pytest tests/unit/test_select_with_stickiness.py
+      tests/unit/test_load_balancer_concurrency.py
       tests/integration/test_proxy_sticky_sessions.py`, `uv run ruff check`,
       `uv run ruff format --check`, `make typecheck`
-- [x] 3.4 `openspec validate coalesce-sticky-same-owner-refresh --strict`
+- [x] 3.5 `openspec validate coalesce-sticky-same-owner-refresh --strict`

--- a/openspec/changes/coalesce-sticky-same-owner-refresh/tasks.md
+++ b/openspec/changes/coalesce-sticky-same-owner-refresh/tasks.md
@@ -18,8 +18,11 @@
       re-resolves the owner itself, and when the process seed is still missing
       (seed initialization piggybacks on the retention write)
 - [x] 2.2 Revalidate the deadline at the persist site (`_sticky_refresh_write_skippable`)
-      and only then omit the same-owner refresh statement; rebinds, deletes,
-      restores, and seed-initializing writes keep writing immediately
+      and only then omit the same-owner refresh statement — on both the non-probe
+      persist path and the recovery-probe admission path (whose compensating
+      restores are skipped symmetrically when nothing was written); rebinds,
+      deletes, restores of actually-written rows, and seed-initializing writes
+      keep writing immediately
 
 ## 3. Verification
 
@@ -30,7 +33,9 @@
       deadlines
 - [x] 3.2 Balancer-level tests: fresh same-owner retention issues no write when the
       seed exists, a fresh thread row with a missing seed still writes and initializes
-      the seed, an expired deadline writes through
+      the seed, an expired deadline writes through, and a fresh retention of a
+      due-probing pinned owner skips the write on the probe admission path while
+      the probe reservation still commits
 - [x] 3.3 Integration tests: deadline conditions against the real repository (fresh
       row, TTL-scaled window, marker disqualification, future timestamp, no-TTL
       lookup), concurrent upserts on one `(key, kind)` keep RETURNING/self-write and

--- a/openspec/changes/coalesce-sticky-same-owner-refresh/tasks.md
+++ b/openspec/changes/coalesce-sticky-same-owner-refresh/tasks.md
@@ -1,0 +1,31 @@
+# Tasks
+
+## 1. Repository freshness observation
+
+- [x] 1.1 Extend `StickyOwnerLookup` with `refresh_can_be_skipped`, computed only on
+      the fresh-row TTL lookup path: `updated_at` within `min(15s, 1% of TTL)` and
+      both abandonment marker columns NULL
+- [x] 1.2 Keep the flag False on the stale-delete recovery path, on lookups without a
+      TTL, and on rows carrying any abandonment marker
+
+## 2. Selection wiring
+
+- [x] 2.1 Thread the flag from `run_sticky_selection_path`'s per-attempt owner lookup
+      through `_select_with_stickiness`; reset it when the raw legacy owner shadows
+      the namespaced row and when the inner helper re-resolves the owner itself
+- [x] 2.2 Skip only the three same-owner pinned-retention refresh persists; rebinds,
+      deletes, restores, and seed initialization keep writing immediately
+
+## 3. Verification
+
+- [x] 3.1 Unit tests: skip on fresh same-owner retention, write-through when the flag
+      is unset, rebind/departed-owner writes never suppressed, grace-period retention
+      honors the window, internal re-resolution resets the flag
+- [x] 3.2 Integration tests: flag conditions against the real repository (fresh row,
+      TTL-scaled window, marker disqualification, no-TTL lookup), concurrent upserts
+      on one `(key, kind)` keep RETURNING/self-write and single-row semantics, a
+      skipped refresh never clobbers a concurrent rebind
+- [x] 3.3 `uv run pytest tests/unit/test_select_with_stickiness.py
+      tests/integration/test_proxy_sticky_sessions.py`, `uv run ruff check`,
+      `uv run ruff format --check`, `make typecheck`
+- [x] 3.4 `openspec validate coalesce-sticky-same-owner-refresh --strict`

--- a/tests/integration/test_proxy_sticky_sessions.py
+++ b/tests/integration/test_proxy_sticky_sessions.py
@@ -2926,3 +2926,181 @@ async def test_seed_hard_sticky_outage_grace_on_startup_refreshes_only_unavailab
             entry = await repo.get_entry(f"turn_{account_id}", kind=StickySessionKind.CODEX_SESSION)
             assert entry is not None
             assert entry.updated_at == long_ago
+
+
+async def _create_account(account_id: str) -> None:
+    encryptor = TokenEncryptor()
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(
+            Account(
+                id=account_id,
+                email=f"{account_id}@example.com",
+                plan_type="plus",
+                access_token_encrypted=encryptor.encrypt("access"),
+                refresh_token_encrypted=encryptor.encrypt("refresh"),
+                id_token_encrypted=encryptor.encrypt("id"),
+                last_refresh=utcnow(),
+                status=AccountStatus.ACTIVE,
+                deactivation_reason=None,
+            )
+        )
+
+
+async def _backdate_sticky_row(key: str, kind: StickySessionKind, *, age_seconds: float) -> None:
+    from app.db.models import StickySession
+
+    async with SessionLocal() as session:
+        await session.execute(
+            update(StickySession)
+            .where(StickySession.key == key, StickySession.kind == kind)
+            .values(updated_at=utcnow() - timedelta(seconds=age_seconds))
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_sticky_lookup_refresh_skippable_only_for_fresh_unmarked_rows(db_setup):
+    """refresh_can_be_skipped is set only when a same-owner upsert would be a
+    pure updated_at rewrite: fresh within min(15s, 1% of TTL) and free of any
+    abandonment marker."""
+    from app.db.models import StickySession
+    from app.modules.proxy.sticky_repository import StickySessionsRepository
+
+    await _create_account("acc_refresh_skip")
+    key = "key_refresh_skip"
+
+    async with SessionLocal() as session:
+        repo = StickySessionsRepository(session)
+        await repo.upsert(key, "acc_refresh_skip", kind=StickySessionKind.PROMPT_CACHE)
+
+        fresh = await repo.get_account_id_and_abandonment(
+            key,
+            kind=StickySessionKind.PROMPT_CACHE,
+            max_age_seconds=1800,
+        )
+        assert fresh.account_id == "acc_refresh_skip"
+        assert fresh.refresh_can_be_skipped is True
+
+        # Without a TTL there is no refresh write to skip.
+        durable = await repo.get_account_id_and_abandonment(key, kind=StickySessionKind.PROMPT_CACHE)
+        assert durable.account_id == "acc_refresh_skip"
+        assert durable.refresh_can_be_skipped is False
+
+    # 10s old: inside the 15s cap for an 1800s TTL, but outside 1% of a 600s
+    # TTL (6s) — the window scales with the TTL it protects.
+    await _backdate_sticky_row(key, StickySessionKind.PROMPT_CACHE, age_seconds=10.0)
+    async with SessionLocal() as session:
+        repo = StickySessionsRepository(session)
+        within_cap = await repo.get_account_id_and_abandonment(
+            key,
+            kind=StickySessionKind.PROMPT_CACHE,
+            max_age_seconds=1800,
+        )
+        assert within_cap.account_id == "acc_refresh_skip"
+        assert within_cap.refresh_can_be_skipped is True
+        beyond_fraction = await repo.get_account_id_and_abandonment(
+            key,
+            kind=StickySessionKind.PROMPT_CACHE,
+            max_age_seconds=600,
+        )
+        assert beyond_fraction.account_id == "acc_refresh_skip"
+        assert beyond_fraction.refresh_can_be_skipped is False
+
+    # An abandonment marker disqualifies the skip even on a fresh row: the
+    # upsert that would be skipped also clears the marker columns.
+    async with SessionLocal() as session:
+        await session.execute(
+            update(StickySession)
+            .where(StickySession.key == key, StickySession.kind == StickySessionKind.PROMPT_CACHE)
+            .values(updated_at=utcnow(), continuity_abandonment_scope="session_header")
+        )
+        await session.commit()
+    async with SessionLocal() as session:
+        repo = StickySessionsRepository(session)
+        marked = await repo.get_account_id_and_abandonment(
+            key,
+            kind=StickySessionKind.PROMPT_CACHE,
+            max_age_seconds=1800,
+            continuity_source="turn_state",
+        )
+        # Non-matching source keeps the owner, but the marker still makes a
+        # same-owner upsert semantic (it would clear the scope).
+        assert marked.account_id == "acc_refresh_skip"
+        assert marked.refresh_can_be_skipped is False
+
+
+@pytest.mark.asyncio
+async def test_sticky_upsert_concurrent_same_key_semantics(db_setup):
+    """Concurrent upserts on one (key, kind) must each observe their own
+    write in RETURNING, keep exactly one row, and settle on one of the
+    written owners."""
+    from sqlalchemy import func as sa_func
+    from sqlalchemy import select
+
+    from app.db.models import StickySession
+    from app.modules.proxy.sticky_repository import StickySessionsRepository
+
+    await _create_account("acc_conc_a")
+    await _create_account("acc_conc_b")
+    key = "key_concurrent_upsert"
+    started_at = utcnow()
+
+    async def _one_upsert(index: int) -> str:
+        account_id = "acc_conc_a" if index % 2 == 0 else "acc_conc_b"
+        async with SessionLocal() as session:
+            repo = StickySessionsRepository(session)
+            row = await repo.upsert(key, account_id, kind=StickySessionKind.PROMPT_CACHE)
+            assert row.key == key
+            # RETURNING must reflect this statement's own write, not a
+            # concurrent winner's row.
+            assert row.account_id == account_id
+            assert row.continuity_abandoned_at is None
+            return row.account_id
+
+    results = await asyncio.gather(*(_one_upsert(index) for index in range(12)))
+    assert set(results) == {"acc_conc_a", "acc_conc_b"}
+
+    async with SessionLocal() as session:
+        row_count = await session.scalar(
+            select(sa_func.count())
+            .select_from(StickySession)
+            .where(StickySession.key == key, StickySession.kind == StickySessionKind.PROMPT_CACHE)
+        )
+        assert row_count == 1
+        final = await StickySessionsRepository(session).get_entry(key, kind=StickySessionKind.PROMPT_CACHE)
+        assert final is not None
+        assert final.account_id in {"acc_conc_a", "acc_conc_b"}
+        # Backend timestamps may carry second precision only.
+        assert final.updated_at >= started_at.replace(microsecond=0)
+
+
+@pytest.mark.asyncio
+async def test_sticky_refresh_skip_never_clobbers_concurrent_rebind(db_setup):
+    """A request that observed a fresh same-owner row and skipped its refresh
+    write must leave a concurrent rebind to another account intact."""
+    from app.modules.proxy.sticky_repository import StickySessionsRepository
+
+    await _create_account("acc_skip_old")
+    await _create_account("acc_skip_new")
+    key = "key_skip_vs_rebind"
+
+    async with SessionLocal() as session:
+        repo = StickySessionsRepository(session)
+        await repo.upsert(key, "acc_skip_old", kind=StickySessionKind.PROMPT_CACHE)
+        lookup = await repo.get_account_id_and_abandonment(
+            key,
+            kind=StickySessionKind.PROMPT_CACHE,
+            max_age_seconds=1800,
+        )
+        assert lookup.account_id == "acc_skip_old"
+        # The selection layer would skip its same-owner refresh here.
+        assert lookup.refresh_can_be_skipped is True
+
+    # Concurrent request rebinds the mapping while the first request is still
+    # in flight; the first request performs no compensating write.
+    async with SessionLocal() as session:
+        await StickySessionsRepository(session).upsert(key, "acc_skip_new", kind=StickySessionKind.PROMPT_CACHE)
+
+    async with SessionLocal() as session:
+        final = await StickySessionsRepository(session).get_account_id(key, kind=StickySessionKind.PROMPT_CACHE)
+        assert final == "acc_skip_new"

--- a/tests/integration/test_proxy_sticky_sessions.py
+++ b/tests/integration/test_proxy_sticky_sessions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-from datetime import timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import cast
 
@@ -2960,9 +2960,9 @@ async def _backdate_sticky_row(key: str, kind: StickySessionKind, *, age_seconds
 
 @pytest.mark.asyncio
 async def test_sticky_lookup_refresh_skippable_only_for_fresh_unmarked_rows(db_setup):
-    """refresh_can_be_skipped is set only when a same-owner upsert would be a
-    pure updated_at rewrite: fresh within min(15s, 1% of TTL) and free of any
-    abandonment marker."""
+    """refresh_skip_deadline is set only when a same-owner upsert would be a
+    pure updated_at rewrite: fresh within min(15s, 1% of TTL), not stamped in
+    the future, and free of any abandonment marker."""
     from app.db.models import StickySession
     from app.modules.proxy.sticky_repository import StickySessionsRepository
 
@@ -2979,12 +2979,15 @@ async def test_sticky_lookup_refresh_skippable_only_for_fresh_unmarked_rows(db_s
             max_age_seconds=1800,
         )
         assert fresh.account_id == "acc_refresh_skip"
-        assert fresh.refresh_can_be_skipped is True
+        assert isinstance(fresh.refresh_skip_deadline, datetime)
+        # The deadline is observed_updated_at + window: never further out
+        # than the full window from now.
+        assert fresh.refresh_skip_deadline <= utcnow() + timedelta(seconds=15.0)
 
         # Without a TTL there is no refresh write to skip.
         durable = await repo.get_account_id_and_abandonment(key, kind=StickySessionKind.PROMPT_CACHE)
         assert durable.account_id == "acc_refresh_skip"
-        assert durable.refresh_can_be_skipped is False
+        assert durable.refresh_skip_deadline is None
 
     # 10s old: inside the 15s cap for an 1800s TTL, but outside 1% of a 600s
     # TTL (6s) — the window scales with the TTL it protects.
@@ -2997,14 +3000,28 @@ async def test_sticky_lookup_refresh_skippable_only_for_fresh_unmarked_rows(db_s
             max_age_seconds=1800,
         )
         assert within_cap.account_id == "acc_refresh_skip"
-        assert within_cap.refresh_can_be_skipped is True
+        assert isinstance(within_cap.refresh_skip_deadline, datetime)
         beyond_fraction = await repo.get_account_id_and_abandonment(
             key,
             kind=StickySessionKind.PROMPT_CACHE,
             max_age_seconds=600,
         )
         assert beyond_fraction.account_id == "acc_refresh_skip"
-        assert beyond_fraction.refresh_can_be_skipped is False
+        assert beyond_fraction.refresh_skip_deadline is None
+
+    # A future updated_at (database clock ahead of the application, or a
+    # restored row) is never skippable: an upper-bound-only age check would
+    # otherwise satisfy the window for longer than the documented bound.
+    await _backdate_sticky_row(key, StickySessionKind.PROMPT_CACHE, age_seconds=-30.0)
+    async with SessionLocal() as session:
+        repo = StickySessionsRepository(session)
+        future_stamped = await repo.get_account_id_and_abandonment(
+            key,
+            kind=StickySessionKind.PROMPT_CACHE,
+            max_age_seconds=1800,
+        )
+        assert future_stamped.account_id == "acc_refresh_skip"
+        assert future_stamped.refresh_skip_deadline is None
 
     # An abandonment marker disqualifies the skip even on a fresh row: the
     # upsert that would be skipped also clears the marker columns.
@@ -3026,7 +3043,7 @@ async def test_sticky_lookup_refresh_skippable_only_for_fresh_unmarked_rows(db_s
         # Non-matching source keeps the owner, but the marker still makes a
         # same-owner upsert semantic (it would clear the scope).
         assert marked.account_id == "acc_refresh_skip"
-        assert marked.refresh_can_be_skipped is False
+        assert marked.refresh_skip_deadline is None
 
 
 @pytest.mark.asyncio
@@ -3094,7 +3111,7 @@ async def test_sticky_refresh_skip_never_clobbers_concurrent_rebind(db_setup):
         )
         assert lookup.account_id == "acc_skip_old"
         # The selection layer would skip its same-owner refresh here.
-        assert lookup.refresh_can_be_skipped is True
+        assert isinstance(lookup.refresh_skip_deadline, datetime)
 
     # Concurrent request rebinds the mapping while the first request is still
     # in flight; the first request performs no compensating write.

--- a/tests/unit/test_load_balancer_concurrency.py
+++ b/tests/unit/test_load_balancer_concurrency.py
@@ -4639,3 +4639,31 @@ async def test_fresh_same_owner_retention_skips_refresh_write_on_probe_admission
     assert probing_runtime.last_selected_at is not None
     assert probing_runtime.last_selected_at > 0.0
     await skip_balancer.release_account_lease(selected.lease)
+
+
+@pytest.mark.asyncio
+async def test_fresh_thread_only_retention_without_seed_key_skips_refresh_write() -> None:
+    """Thread-only affinity (no process seed key at all) has nothing to
+    initialize, so a fresh same-owner retention skips its refresh write."""
+    balancer, owner, alternate, sticky_repo = _make_cap_spillover_balancer("thread-skip-no-seedkey")
+    assert alternate is not None
+    thread_key = _codex_backend_identity({"thread-id": "thread-only-skip"}).thread_selection_key
+    assert thread_key is not None
+    sticky_repo.account_ids_by_key = {thread_key: owner.id}
+    sticky_repo.refresh_skip_deadlines_by_key[thread_key] = datetime.now(tz=timezone.utc).replace(
+        tzinfo=None
+    ) + timedelta(seconds=10)
+
+    selected = await balancer.select_account(
+        sticky_key=thread_key,
+        sticky_kind=StickySessionKind.PROMPT_CACHE,
+        sticky_source="thread_header",
+        sticky_max_age_seconds=300,
+        routing_strategy="usage_weighted",
+    )
+
+    assert selected.account is not None
+    assert selected.account.id == owner.id
+    assert sticky_repo.upserts == []
+    assert sticky_repo.seeded_upserts == []
+    assert sticky_repo.deleted == []

--- a/tests/unit/test_load_balancer_concurrency.py
+++ b/tests/unit/test_load_balancer_concurrency.py
@@ -5,7 +5,7 @@ import logging
 import time
 from collections.abc import AsyncIterator, Collection
 from contextlib import asynccontextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any, Literal, cast
 from unittest.mock import AsyncMock
@@ -227,6 +227,9 @@ class _StubStickySessionsRepository:
         # ambiguous-owner check for them.
         self.abandoned_keys: set[str] = set()
         self.scoped_abandoned_account_ids_by_key: dict[str, str] = {}
+        # Refresh-skip deadlines reported alongside the owner lookup, keyed by
+        # sticky key (see StickyOwnerLookup.refresh_skip_deadline).
+        self.refresh_skip_deadlines_by_key: dict[str, datetime] = {}
         self.deleted: list[tuple[str, StickySessionKind | None]] = []
         self.upserts: list[tuple[str, str, StickySessionKind | None]] = []
         self.insert_if_absent_calls: list[tuple[str, str, StickySessionKind]] = []
@@ -248,9 +251,17 @@ class _StubStickySessionsRepository:
         if key in self.abandoned_keys:
             return StickyOwnerLookup(account_id=None, continuity_abandoned=True)
         if self.account_ids_by_key is not None:
-            return StickyOwnerLookup(account_id=self.account_ids_by_key.get(key), continuity_abandoned=False)
+            return StickyOwnerLookup(
+                account_id=self.account_ids_by_key.get(key),
+                continuity_abandoned=False,
+                refresh_skip_deadline=self.refresh_skip_deadlines_by_key.get(key),
+            )
         del kwargs
-        return StickyOwnerLookup(account_id=self.account_id, continuity_abandoned=False)
+        return StickyOwnerLookup(
+            account_id=self.account_id,
+            continuity_abandoned=False,
+            refresh_skip_deadline=self.refresh_skip_deadlines_by_key.get(key),
+        )
 
     async def upsert(self, *args: Any, **kwargs: Any) -> Any:
         sticky_key = cast(str, args[0])
@@ -3025,6 +3036,116 @@ async def test_first_codex_thread_initializes_process_preference_once_for_later_
         (first_thread_key, first_account_id, StickySessionKind.PROMPT_CACHE),
         (sibling_thread_key, first_account_id, StickySessionKind.PROMPT_CACHE),
     ]
+
+
+@pytest.mark.asyncio
+async def test_fresh_same_owner_retention_skips_refresh_write_when_seed_exists() -> None:
+    """A hot same-owner retention whose lookup observed the row inside the
+    refresh-skip window issues no sticky write at all."""
+    balancer, owner, alternate, sticky_repo = _make_cap_spillover_balancer("thread-skip-refresh")
+    assert alternate is not None
+    process_session = "process-skip-refresh"
+    process_key = _codex_session_selection_key(process_session)
+    thread_key = _codex_backend_identity(
+        {"session-id": process_session, "thread-id": "thread-skip"}
+    ).thread_selection_key
+    assert thread_key is not None
+    sticky_repo.account_ids_by_key = {process_key: owner.id, thread_key: owner.id}
+    sticky_repo.refresh_skip_deadlines_by_key[thread_key] = datetime.now(tz=timezone.utc).replace(
+        tzinfo=None
+    ) + timedelta(seconds=10)
+
+    selected = await balancer.select_account(
+        sticky_key=thread_key,
+        sticky_kind=StickySessionKind.PROMPT_CACHE,
+        sticky_source="thread_header",
+        legacy_sticky_key=process_session,
+        sticky_seed_key=process_key,
+        sticky_seed_kind=StickySessionKind.CODEX_SESSION,
+        sticky_max_age_seconds=300,
+        routing_strategy="usage_weighted",
+    )
+
+    assert selected.account is not None
+    assert selected.account.id == owner.id
+    assert sticky_repo.upserts == []
+    assert sticky_repo.seeded_upserts == []
+    assert sticky_repo.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_fresh_thread_row_with_missing_seed_still_writes_and_initializes_seed() -> None:
+    """Seed initialization piggybacks on the thread retention write; a fresh
+    thread row must not suppress it while the process seed is absent."""
+    balancer, owner, alternate, sticky_repo = _make_cap_spillover_balancer("thread-skip-seedless")
+    assert alternate is not None
+    process_session = "process-skip-seedless"
+    process_key = _codex_session_selection_key(process_session)
+    thread_key = _codex_backend_identity(
+        {"session-id": process_session, "thread-id": "thread-seedless"}
+    ).thread_selection_key
+    assert thread_key is not None
+    sticky_repo.account_ids_by_key = {thread_key: owner.id}
+    sticky_repo.refresh_skip_deadlines_by_key[thread_key] = datetime.now(tz=timezone.utc).replace(
+        tzinfo=None
+    ) + timedelta(seconds=10)
+
+    selected = await balancer.select_account(
+        sticky_key=thread_key,
+        sticky_kind=StickySessionKind.PROMPT_CACHE,
+        sticky_source="thread_header",
+        legacy_sticky_key=process_session,
+        sticky_seed_key=process_key,
+        sticky_seed_kind=StickySessionKind.CODEX_SESSION,
+        sticky_max_age_seconds=300,
+        routing_strategy="usage_weighted",
+    )
+
+    assert selected.account is not None
+    assert selected.account.id == owner.id
+    assert sticky_repo.account_ids_by_key[process_key] == owner.id
+    assert sticky_repo.seeded_upserts == [
+        (
+            thread_key,
+            owner.id,
+            StickySessionKind.PROMPT_CACHE,
+            process_key,
+            StickySessionKind.CODEX_SESSION,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_expired_refresh_skip_deadline_still_writes_through() -> None:
+    """A deadline that lapsed between lookup and persist must not suppress the
+    refresh: the skip window is revalidated at write time."""
+    balancer, owner, alternate, sticky_repo = _make_cap_spillover_balancer("thread-skip-expired")
+    assert alternate is not None
+    process_session = "process-skip-expired"
+    process_key = _codex_session_selection_key(process_session)
+    thread_key = _codex_backend_identity(
+        {"session-id": process_session, "thread-id": "thread-expired"}
+    ).thread_selection_key
+    assert thread_key is not None
+    sticky_repo.account_ids_by_key = {process_key: owner.id, thread_key: owner.id}
+    sticky_repo.refresh_skip_deadlines_by_key[thread_key] = datetime.now(tz=timezone.utc).replace(
+        tzinfo=None
+    ) - timedelta(seconds=1)
+
+    selected = await balancer.select_account(
+        sticky_key=thread_key,
+        sticky_kind=StickySessionKind.PROMPT_CACHE,
+        sticky_source="thread_header",
+        legacy_sticky_key=process_session,
+        sticky_seed_key=process_key,
+        sticky_seed_kind=StickySessionKind.CODEX_SESSION,
+        sticky_max_age_seconds=300,
+        routing_strategy="usage_weighted",
+    )
+
+    assert selected.account is not None
+    assert selected.account.id == owner.id
+    assert sticky_repo.upserts == [(thread_key, owner.id, StickySessionKind.PROMPT_CACHE)]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_load_balancer_concurrency.py
+++ b/tests/unit/test_load_balancer_concurrency.py
@@ -4560,3 +4560,82 @@ async def test_api_key_fair_share_concurrent_sticky_selections_cannot_overshoot_
     # The commit re-check kept heavy at exactly its share across both paths.
     heavy_total = sum((runtime.stream_key_inflight or {}).get("heavy", 0) for runtime in balancer._runtime.values())
     assert heavy_total == 2
+
+
+@pytest.mark.asyncio
+async def test_fresh_same_owner_retention_skips_refresh_write_on_probe_admission() -> None:
+    """The recovery-probe admission path honors the refresh-skip deadline the
+    same way the non-probe persist site does: a fresh same-owner retention of
+    a due-probing pinned owner issues no sticky write."""
+    now_epoch = int(datetime.now(tz=timezone.utc).timestamp())
+    healthy = _make_account("acc-probe-skip-healthy")
+    probing = _make_account("acc-probe-skip-probing")
+    key = "probe-skip-session"
+
+    def _build(sticky_repo: _StubStickySessionsRepository) -> LoadBalancer:
+        accounts_repo = _StubAccountsRepository([healthy, probing])
+        usage_repo = _StubUsageRepository(
+            primary={
+                healthy.id: _usage_row_with_percent(
+                    150,
+                    healthy.id,
+                    used_percent=30.0,
+                    reset_at=now_epoch + 300,
+                ),
+                probing.id: _usage_row_with_percent(
+                    151,
+                    probing.id,
+                    used_percent=10.0,
+                    reset_at=now_epoch + 300,
+                ),
+            },
+            secondary={},
+        )
+        balancer = LoadBalancer(lambda: _repo_factory(accounts_repo, usage_repo, sticky_repo))
+        balancer._runtime[probing.id] = RuntimeState(
+            health_tier=HEALTH_TIER_PROBING,
+            last_selected_at=0.0,
+            version=17,
+        )
+        return balancer
+
+    # Control: without a freshness observation the probe admission persists
+    # the retention write, proving this scenario exercises the probe branch.
+    control_repo = _StubStickySessionsRepository()
+    control_repo.account_ids_by_key = {key: probing.id}
+    control_balancer = _build(control_repo)
+    control = await control_balancer.select_account(
+        sticky_key=key,
+        sticky_kind=StickySessionKind.PROMPT_CACHE,
+        sticky_max_age_seconds=300,
+        routing_strategy="usage_weighted",
+        lease_kind="stream",
+    )
+    assert control.account is not None
+    assert control.account.id == probing.id
+    assert control_repo.upserts == [(key, probing.id, StickySessionKind.PROMPT_CACHE)]
+    await control_balancer.release_account_lease(control.lease)
+
+    skip_repo = _StubStickySessionsRepository()
+    skip_repo.account_ids_by_key = {key: probing.id}
+    skip_repo.refresh_skip_deadlines_by_key[key] = datetime.now(tz=timezone.utc).replace(tzinfo=None) + timedelta(
+        seconds=10
+    )
+    skip_balancer = _build(skip_repo)
+    selected = await skip_balancer.select_account(
+        sticky_key=key,
+        sticky_kind=StickySessionKind.PROMPT_CACHE,
+        sticky_max_age_seconds=300,
+        routing_strategy="usage_weighted",
+        lease_kind="stream",
+    )
+    assert selected.account is not None
+    assert selected.account.id == probing.id
+    assert skip_repo.upserts == []
+    assert skip_repo.deleted == []
+    # The probe reservation itself still committed: runtime advanced.
+    probing_runtime = skip_balancer._runtime[probing.id]
+    assert probing_runtime.version > 17
+    assert probing_runtime.last_selected_at is not None
+    assert probing_runtime.last_selected_at > 0.0
+    await skip_balancer.release_account_lease(selected.lease)

--- a/tests/unit/test_select_with_stickiness.py
+++ b/tests/unit/test_select_with_stickiness.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import time
 from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
 from typing import cast
 from unittest.mock import AsyncMock
 
@@ -16,7 +17,10 @@ import pytest
 
 from app.core.balancer import AccountState, RoutingCost, RoutingCostsByAccount, RoutingStrategy
 from app.db.models import Account, AccountStatus, StickySessionKind
-from app.modules.proxy._load_balancer.sticky_selection import _STICKY_EXISTING_UNSET
+from app.modules.proxy._load_balancer.sticky_selection import (
+    _STICKY_EXISTING_UNSET,
+    _sticky_refresh_write_skippable,
+)
 from app.modules.proxy.load_balancer import LoadBalancer
 
 pytestmark = pytest.mark.unit
@@ -78,7 +82,7 @@ async def _invoke_stickiness(
     relative_availability_power: float = 2.0,
     relative_availability_top_k: int = 5,
     routing_costs_by_account_id: RoutingCostsByAccount | None = None,
-    sticky_refresh_skippable: bool = False,
+    sticky_refresh_skip_deadline: datetime | None = None,
     sticky_existing_account_id: str | None | object = _STICKY_EXISTING_UNSET,
 ):
     """Wrapper that calls production LoadBalancer._select_with_stickiness.
@@ -110,10 +114,16 @@ async def _invoke_stickiness(
         relative_availability_top_k=relative_availability_top_k,
         sticky_repo=sticky_repo,
         routing_costs_by_account_id=routing_costs_by_account_id,
-        sticky_refresh_skippable=sticky_refresh_skippable,
+        sticky_refresh_skip_deadline=sticky_refresh_skip_deadline,
         sticky_existing_account_id=sticky_existing_account_id,
     )
-    if outcome.mutation is not None:
+    # Mirror the production persist site (run_sticky_selection_path): a pure
+    # same-owner freshness rewrite is omitted only after revalidating its
+    # observed skip deadline at write time.
+    if outcome.mutation is not None and not _sticky_refresh_write_skippable(
+        outcome.mutation,
+        initialize_seed_key=None,
+    ):
         await lb._persist_sticky_mutation(
             sticky_repo=sticky_repo,
             sticky_key=sticky_key,
@@ -121,6 +131,10 @@ async def _invoke_stickiness(
             mutation=outcome.mutation,
         )
     return outcome.selection
+
+
+def _future_deadline(seconds: float = 10.0) -> datetime:
+    return datetime.now(tz=timezone.utc).replace(tzinfo=None) + timedelta(seconds=seconds)
 
 
 # ---------------------------------------------------------------------------
@@ -1110,7 +1124,7 @@ async def test_refresh_skippable_pinned_retention_skips_upsert():
         [acc_a, acc_b],
         "key1",
         repo,
-        sticky_refresh_skippable=True,
+        sticky_refresh_skip_deadline=_future_deadline(),
         sticky_existing_account_id="a",
     )
 
@@ -1132,7 +1146,7 @@ async def test_refresh_skippable_false_pinned_retention_still_refreshes():
         [acc_a, acc_b],
         "key1",
         repo,
-        sticky_refresh_skippable=False,
+        sticky_refresh_skip_deadline=None,
         sticky_existing_account_id="a",
     )
 
@@ -1153,7 +1167,7 @@ async def test_refresh_skippable_never_suppresses_reallocation_write():
         [acc_a, acc_b],
         "key1",
         repo,
-        sticky_refresh_skippable=True,
+        sticky_refresh_skip_deadline=_future_deadline(),
         sticky_existing_account_id="a",
     )
 
@@ -1173,7 +1187,7 @@ async def test_refresh_skippable_never_suppresses_departed_owner_rebind():
         [acc_b],
         "key1",
         repo,
-        sticky_refresh_skippable=True,
+        sticky_refresh_skip_deadline=_future_deadline(),
         sticky_existing_account_id="a",
     )
 
@@ -1194,7 +1208,7 @@ async def test_refresh_skippable_grace_period_retention_skips_upsert():
         [pinned, acc_b],
         "key1",
         repo,
-        sticky_refresh_skippable=True,
+        sticky_refresh_skip_deadline=_future_deadline(),
         sticky_existing_account_id="a",
     )
 
@@ -1214,9 +1228,50 @@ async def test_refresh_skippable_reset_when_existing_owner_not_prefetched():
         [acc_a],
         "key1",
         repo,
-        sticky_refresh_skippable=True,
+        sticky_refresh_skip_deadline=_future_deadline(),
     )
 
     assert result.account is not None
     assert result.account.account_id == "a"
     repo.upsert.assert_called_once_with("key1", "a", kind=StickySessionKind.PROMPT_CACHE)
+
+
+@pytest.mark.asyncio
+async def test_refresh_skip_deadline_expired_at_persist_time_still_refreshes():
+    """The skip deadline is revalidated at write time: a deadline that lapsed
+    between lookup and persist must not suppress the refresh, keeping the
+    mapping's effective expiry within the documented skip-window bound."""
+    acc_a = _active("a", used_percent=10.0)
+    repo = _make_sticky_repo(existing_account_id="a")
+
+    result = await _invoke_stickiness(
+        [acc_a],
+        "key1",
+        repo,
+        sticky_refresh_skip_deadline=_future_deadline(-0.5),
+        sticky_existing_account_id="a",
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "a"
+    repo.upsert.assert_called_once_with("key1", "a", kind=StickySessionKind.PROMPT_CACHE)
+
+
+def test_refresh_write_skippable_guards_seed_and_delete_and_deadline():
+    """The persist-time gate never skips deletes, seed-initializing writes,
+    non-datetime deadlines (auto-vivified test doubles), or lapsed deadlines."""
+    from app.modules.proxy._load_balancer.sticky_selection import _StickyMutation
+
+    refresh = _StickyMutation(account_id="a", refresh_skip_deadline=_future_deadline())
+    assert _sticky_refresh_write_skippable(refresh, initialize_seed_key=None) is True
+    # Seed initialization piggybacks on this write and must never be skipped.
+    assert _sticky_refresh_write_skippable(refresh, initialize_seed_key="seed-key") is False
+    # Deletes are never skippable.
+    delete = _StickyMutation(account_id=None, refresh_skip_deadline=_future_deadline())
+    assert _sticky_refresh_write_skippable(delete, initialize_seed_key=None) is False
+    # A lapsed deadline fails revalidation.
+    expired = _StickyMutation(account_id="a", refresh_skip_deadline=_future_deadline(-0.5))
+    assert _sticky_refresh_write_skippable(expired, initialize_seed_key=None) is False
+    # Mutations without an observed deadline always write through.
+    plain = _StickyMutation(account_id="a")
+    assert _sticky_refresh_write_skippable(plain, initialize_seed_key=None) is False

--- a/tests/unit/test_select_with_stickiness.py
+++ b/tests/unit/test_select_with_stickiness.py
@@ -16,6 +16,7 @@ import pytest
 
 from app.core.balancer import AccountState, RoutingCost, RoutingCostsByAccount, RoutingStrategy
 from app.db.models import Account, AccountStatus, StickySessionKind
+from app.modules.proxy._load_balancer.sticky_selection import _STICKY_EXISTING_UNSET
 from app.modules.proxy.load_balancer import LoadBalancer
 
 pytestmark = pytest.mark.unit
@@ -77,6 +78,8 @@ async def _invoke_stickiness(
     relative_availability_power: float = 2.0,
     relative_availability_top_k: int = 5,
     routing_costs_by_account_id: RoutingCostsByAccount | None = None,
+    sticky_refresh_skippable: bool = False,
+    sticky_existing_account_id: str | None | object = _STICKY_EXISTING_UNSET,
 ):
     """Wrapper that calls production LoadBalancer._select_with_stickiness.
 
@@ -107,6 +110,8 @@ async def _invoke_stickiness(
         relative_availability_top_k=relative_availability_top_k,
         sticky_repo=sticky_repo,
         routing_costs_by_account_id=routing_costs_by_account_id,
+        sticky_refresh_skippable=sticky_refresh_skippable,
+        sticky_existing_account_id=sticky_existing_account_id,
     )
     if outcome.mutation is not None:
         await lb._persist_sticky_mutation(
@@ -1084,4 +1089,134 @@ async def test_burn_first_reallocation_only_when_burn_first_is_selectable():
     assert result.account is not None
     assert result.account.account_id == "a"
     repo.delete.assert_not_called()
+    repo.upsert.assert_called_once_with("key1", "a", kind=StickySessionKind.PROMPT_CACHE)
+
+
+# ---------------------------------------------------------------------------
+# Same-owner refresh skip: hot (key, kind) rows must not be rewritten on every
+# request when the lookup already observed a fresh row.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_skippable_pinned_retention_skips_upsert():
+    """A healthy pinned owner within the refresh-skip window routes to the
+    pinned account without any sticky write."""
+    acc_a = _active("a", used_percent=10.0)
+    acc_b = _active("b", used_percent=50.0)
+    repo = _make_sticky_repo(existing_account_id="a")
+
+    result = await _invoke_stickiness(
+        [acc_a, acc_b],
+        "key1",
+        repo,
+        sticky_refresh_skippable=True,
+        sticky_existing_account_id="a",
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "a"
+    repo.upsert.assert_not_called()
+    repo.delete.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_skippable_false_pinned_retention_still_refreshes():
+    """Without the freshness observation the pinned retention keeps its
+    write-through updated_at refresh."""
+    acc_a = _active("a", used_percent=10.0)
+    acc_b = _active("b", used_percent=50.0)
+    repo = _make_sticky_repo(existing_account_id="a")
+
+    result = await _invoke_stickiness(
+        [acc_a, acc_b],
+        "key1",
+        repo,
+        sticky_refresh_skippable=False,
+        sticky_existing_account_id="a",
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "a"
+    repo.upsert.assert_called_once_with("key1", "a", kind=StickySessionKind.PROMPT_CACHE)
+
+
+@pytest.mark.asyncio
+async def test_refresh_skippable_never_suppresses_reallocation_write():
+    """Budget-pressure rebind to a different owner must persist immediately
+    even when the old row was observed fresh."""
+    acc_a = _active("a", used_percent=96.0)
+    acc_b = _active("b", used_percent=50.0)
+    repo = _make_sticky_repo(existing_account_id="a")
+
+    result = await _invoke_stickiness(
+        [acc_a, acc_b],
+        "key1",
+        repo,
+        sticky_refresh_skippable=True,
+        sticky_existing_account_id="a",
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "b"
+    repo.upsert.assert_called_once_with("key1", "b", kind=StickySessionKind.PROMPT_CACHE)
+
+
+@pytest.mark.asyncio
+async def test_refresh_skippable_never_suppresses_departed_owner_rebind():
+    """A pinned owner that left the pool is still rebound with an immediate
+    write even when the old row was observed fresh."""
+    acc_b = _active("b", used_percent=50.0)
+    repo = _make_sticky_repo(existing_account_id="a")
+
+    result = await _invoke_stickiness(
+        [acc_b],
+        "key1",
+        repo,
+        sticky_refresh_skippable=True,
+        sticky_existing_account_id="a",
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "b"
+    repo.upsert.assert_called_once_with("key1", "b", kind=StickySessionKind.PROMPT_CACHE)
+
+
+@pytest.mark.asyncio
+async def test_refresh_skippable_grace_period_retention_skips_upsert():
+    """The grace-period pinned retention also honors the skip window."""
+    now = time.time()
+    pinned = _rate_limited("a", reset_at=now + 10)
+    acc_b = _active("b", used_percent=50.0)
+    repo = _make_sticky_repo(existing_account_id="a")
+
+    result = await _invoke_stickiness(
+        [pinned, acc_b],
+        "key1",
+        repo,
+        sticky_refresh_skippable=True,
+        sticky_existing_account_id="a",
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "a"
+    repo.upsert.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_skippable_reset_when_existing_owner_not_prefetched():
+    """The freshness observation belongs to the caller-provided lookup; an
+    internal owner lookup must fall back to write-through refresh."""
+    acc_a = _active("a", used_percent=10.0)
+    repo = _make_sticky_repo(existing_account_id="a")
+
+    result = await _invoke_stickiness(
+        [acc_a],
+        "key1",
+        repo,
+        sticky_refresh_skippable=True,
+    )
+
+    assert result.account is not None
+    assert result.account.account_id == "a"
     repo.upsert.assert_called_once_with("key1", "a", kind=StickySessionKind.PROMPT_CACHE)


### PR DESCRIPTION
## Problem

Production DB profiling shows the sticky_sessions upsert — a same-owner TTL refresh of the hot `(key, kind)` row on every request — accounts for **44% of DB time**. Under concurrency this write also contends on the same hot row, since every request through a pinned session re-upserts the identical owner just to bump `updated_at`.

## Root cause

The pinned-retention path unconditionally persists a refresh upsert on every request, even when the row was just refreshed milliseconds ago by another request on the same session. The write carries no new information (same owner, same markers) — only a fresher timestamp.

## Fix

Coalesce the refresh in the request path, using the DB observation the request already makes:

- The per-request owner lookup (`get_account_id_and_abandonment`) now also reports row freshness via a new `refresh_can_be_skipped` flag on `StickyOwnerLookup`. Condition: `updated_at` within `min(15s, 1% of TTL)` of now AND both abandonment marker columns NULL.
- The flag is threaded through `run_sticky_selection_path` → `_select_with_stickiness`, and only the **refresh persist at the 3 pinned-retention sites** is skipped. The persist-time gate (`_sticky_refresh_write_skippable`) revalidates the deadline.
- Everything else writes through unchanged: re-pin (account_id change), delete, restore, seed initialization, tombstone clear, and the legacy raw-owner path. Routing semantics are unchanged.

Because the skip decision comes from the same request's DB read, there is no in-memory cache — this is safe across multiple workers and replicas. A SQL `WHERE`-guarded upsert was considered and rejected: `RETURNING` returns 0 rows on skip (ambiguous with conflict-loss) and the row lock is still taken, so contention would remain.

TTL impact: expiry can arrive up to the skip window early (1% of TTL, capped at 15s absolute). Rationale recorded in the OpenSpec proposal (`openspec/changes/coalesce-sticky-same-owner-refresh/proposal.md`); change folder included, `openspec validate --strict` passes.

## Evidence

- Skipped write is strictly the refresh upsert on already-fresh rows; the SELECT lookup remains per-request. Of the 44% DB time, the removable portion is the upsert write share (estimated ~74% of it), not the whole 44%.
- Concurrency semantics covered by an integration test running 12 concurrent upsert tasks on the same `(key, kind)`: `RETURNING` = own write, single row, final owner consistent; plus a test that a skip cannot clobber a concurrent re-pin.

## Testing

- `uv run pytest tests/unit/test_select_with_stickiness.py` — 47 passed (6 new: skip / write-through / re-pin & abandoning-owner immediate write / grace skip / flag reset on internal re-lookup)
- `tests/integration/test_proxy_sticky_sessions.py` — 42 passed, 3 consecutive runs (3 new: freshness flag conditions incl. TTL scaling, marker disqualification, no-TTL; 12-task concurrent same-key upsert semantics; skip does not clobber concurrent re-pin)
- Related unit modules (6): 293 passed; sticky/load_balancer/proxy_service keyword sweep: 550 passed
- `uv run ruff check` + `ruff format --check` — pass
- `make typecheck` (ty) — pass; `make architecture-check` — pass
- `openspec validate coalesce-sticky-same-owner-refresh --strict` + `openspec validate --specs` (57 passed) — pass
- No deploys; no production DB writes. Local codex review, 4 rounds, clean.

## Follow-ups / non-blocking notes

- Pre-existing flake: `test_codex_goal_restart_cannot_retire_owner_outside_api_key_scope` fails 1/16 on clean origin/main vs 3/16 on this branch (serial runs; Fisher p≈0.6, not significant). Failure mode is the 0.05s `proxy_request_budget_seconds` test budget tripping `upstream_request_timeout` (service.py:1990). The hard-sticky path it exercises does pass through this diff's (negligible-cost) lookup deadline computation — worth watching frequency in CI after merge.
- `tests/unit/test_select_with_stickiness.py`'s `_invoke_stickiness` harness mirrors the persist-site gate directly, so that file alone would not catch a wiring bug in `run_sticky_selection_path`; the 5 new tests in `tests/unit/test_load_balancer_concurrency.py` exercise the full `balancer.select_account` path (with a write-through control on the probe path), and the integration tests validate the repository deadline math (15s cap, 1% TTL scaling, future-stamp, marker disqualification) against a real DB.
- Cosmetic: dashboard sticky-session `updated_at` on hot sessions now advances in steps of up to 15s (documented in proposal.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)