### PR TITLE
perf(accounts): bound the account-listing live tail with a 2h fold lag and a 30s summary cache

### DIFF
--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import time
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
@@ -65,6 +66,50 @@ class AccountRequestUsageSummary:
     total_cost_usd: float
 
 
+# The account-listing request-usage summary dedupes and re-aggregates the
+# un-folded raw tail on every dashboard accounts load, and the displayed
+# lifetime totals tolerate short staleness. Cache the merged summaries per
+# account-id signature for a small fixed TTL, mirroring the request-log
+# COUNT cache (issue #1340 / PRINCIPLES.md P2); the test suite patches the
+# TTL to 0 so summaries stay exact within a test. Account deletion and
+# duplicate-identity consolidation clear the cache because they re-attribute
+# usage rather than merely append to it.
+_SUMMARY_CACHE_TTL_SECONDS = 30.0
+_SUMMARY_CACHE_MAX_ENTRIES = 64
+_request_usage_summary_cache: dict[tuple[str, ...] | None, tuple[dict[str, AccountRequestUsageSummary], float]] = {}
+
+
+def _clear_request_usage_summary_cache() -> None:
+    _request_usage_summary_cache.clear()
+
+
+def _cached_request_usage_summaries(
+    key: tuple[str, ...] | None,
+) -> dict[str, AccountRequestUsageSummary] | None:
+    entry = _request_usage_summary_cache.get(key)
+    if entry is None:
+        return None
+    summaries, expires_at = entry
+    if time.monotonic() >= expires_at:
+        _request_usage_summary_cache.pop(key, None)
+        return None
+    return summaries
+
+
+def _store_request_usage_summaries(
+    key: tuple[str, ...] | None,
+    summaries: dict[str, AccountRequestUsageSummary],
+    ttl_seconds: float,
+) -> None:
+    if len(_request_usage_summary_cache) >= _SUMMARY_CACHE_MAX_ENTRIES:
+        oldest = min(
+            _request_usage_summary_cache,
+            key=lambda existing: _request_usage_summary_cache[existing][1],
+        )
+        _request_usage_summary_cache.pop(oldest, None)
+    _request_usage_summary_cache[key] = (summaries, time.monotonic() + ttl_seconds)
+
+
 class AccountIdentityConflictError(Exception):
     def __init__(self, email: str) -> None:
         self.email = email
@@ -122,6 +167,12 @@ class AccountsRepository:
         self,
         account_ids: list[str] | None = None,
     ) -> dict[str, AccountRequestUsageSummary]:
+        ttl_seconds = _SUMMARY_CACHE_TTL_SECONDS
+        cache_key = tuple(sorted(account_ids)) if account_ids is not None else None
+        if ttl_seconds > 0:
+            cached = _cached_request_usage_summaries(cache_key)
+            if cached is not None:
+                return dict(cached)
         rollup_repo = AccountUsageRollupRepository(self._session)
         folded, watermark = await rollup_repo.read_state(account_ids)
 
@@ -165,6 +216,9 @@ class AccountsRepository:
                 cached_input_tokens=cached_total,
                 total_cost_usd=round(float(total_cost_usd), 6),
             )
+        if ttl_seconds > 0:
+            _store_request_usage_summaries(cache_key, summaries, ttl_seconds)
+            return dict(summaries)
         return summaries
 
     async def exists_active_chatgpt_account_id(self, chatgpt_account_id: str) -> bool:
@@ -274,6 +328,10 @@ class AccountsRepository:
                 await self._session.commit()
                 if usage_cache_dirty:
                     _clear_bulk_history_since_sqlite_cache()
+                    # Consolidation re-attributes request logs and rollup sums
+                    # to the canonical account; cached listing summaries would
+                    # keep reporting the deleted duplicates until TTL expiry.
+                    _clear_request_usage_summary_cache()
                     # Duplicate reconciliation deletes Account rows, cascading
                     # any account_proxy_bindings they owned. The route cache is
                     # keyed by deterministic account id, so stale duplicate-id
@@ -852,6 +910,10 @@ class AccountsRepository:
             await self._session.commit()
             if deleted_id is not None:
                 _clear_bulk_history_since_sqlite_cache()
+                # Deletion drops the account's rollup row and detaches or
+                # deletes its request logs; cached listing summaries would
+                # keep reporting the account until TTL expiry.
+                _clear_request_usage_summary_cache()
             return deleted_id is not None
 
     async def rotate_tokens(

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -77,9 +77,18 @@ class AccountRequestUsageSummary:
 _SUMMARY_CACHE_TTL_SECONDS = 30.0
 _SUMMARY_CACHE_MAX_ENTRIES = 64
 _request_usage_summary_cache: dict[tuple[str, ...] | None, tuple[dict[str, AccountRequestUsageSummary], float]] = {}
+# Invalidation generation: a fill that was already computing when a clear
+# happened must not re-populate the cache with its pre-clear result. Fills
+# capture the generation before their first await and stores are discarded
+# on mismatch. Deletion/consolidation clear synchronously right after their
+# commit (no await in between), so every store either precedes the commit
+# (its stale data is wiped by the clear) or observes the bumped generation.
+_summary_cache_generation = 0
 
 
 def _clear_request_usage_summary_cache() -> None:
+    global _summary_cache_generation
+    _summary_cache_generation += 1
     _request_usage_summary_cache.clear()
 
 
@@ -100,7 +109,10 @@ def _store_request_usage_summaries(
     key: tuple[str, ...] | None,
     summaries: dict[str, AccountRequestUsageSummary],
     ttl_seconds: float,
+    generation: int,
 ) -> None:
+    if generation != _summary_cache_generation:
+        return
     if len(_request_usage_summary_cache) >= _SUMMARY_CACHE_MAX_ENTRIES:
         oldest = min(
             _request_usage_summary_cache,
@@ -169,6 +181,7 @@ class AccountsRepository:
     ) -> dict[str, AccountRequestUsageSummary]:
         ttl_seconds = _SUMMARY_CACHE_TTL_SECONDS
         cache_key = tuple(sorted(account_ids)) if account_ids is not None else None
+        generation = _summary_cache_generation
         if ttl_seconds > 0:
             cached = _cached_request_usage_summaries(cache_key)
             if cached is not None:
@@ -217,7 +230,7 @@ class AccountsRepository:
                 total_cost_usd=round(float(total_cost_usd), 6),
             )
         if ttl_seconds > 0:
-            _store_request_usage_summaries(cache_key, summaries, ttl_seconds)
+            _store_request_usage_summaries(cache_key, summaries, ttl_seconds, generation)
             return dict(summaries)
         return summaries
 

--- a/app/modules/accounts/usage_rollup.py
+++ b/app/modules/accounts/usage_rollup.py
@@ -18,13 +18,34 @@ logger = logging.getLogger(__name__)
 
 # Rows younger than the lag stay on the live side of the fold boundary.
 # The lag MUST exceed the maximum possible distance between a log row's
-# requested_at and its actual insertion time: requested_at is the request
-# START, but the row is written at stream END, so a long-running stream
-# inserts a row dated its full duration in the past — if that lands below an
-# already-advanced watermark it is neither folded nor in the live tail and
-# vanishes from totals. 24h dwarfs any survivable stream duration and the
-# post-stream duplicate/model/cost rewrite paths (which settle in seconds).
-FOLD_LAG = timedelta(hours=24)
+# requested_at and the moment its insert becomes visible: a row landing below
+# an already-advanced watermark is neither folded nor in the live tail and
+# vanishes from totals. Every insert path stamps requested_at inside
+# ``RequestLogsRepository.add_log`` at write time (``requested_at or
+# utcnow()``; no live caller passes an explicit value — the parameter exists
+# for tests), so the distance is only clock skew between replicas plus the
+# single-row insert transaction's commit latency, NOT the request duration:
+# a stream-end log write is dated at the write, not at the request start.
+# Measured over one full production history (6.0M rows) the worst insert
+# landed 7.9s below the requested_at frontier (p99.9 = 30ms). Post-insert
+# mutators need no allowance here either: ``update_model_for_request``
+# skips rows at/below the watermarks, and consolidation/deletion reassign
+# logs under the fold-state lock while mirroring the folded sums.
+#
+# 2h keeps a ~900x margin over the observed worst case (covering scheduler
+# stalls, NTP drift, paused VMs) while bounding the raw tail every account
+# and API-key summary read must dedupe and re-aggregate; the previous 24h
+# lag — sized for a stream-start dating scheme this codebase never actually
+# had — left an always-rescanned tail of ~660k rows (11% of the table) on
+# the reference deployment and degraded the listing aggregate to a full
+# seq-scan hash join (measured 60s cold / 2.1s warm vs 63ms at 2h).
+#
+# This lag is a shared visibility contract: the hourly/conversation fold
+# targets and the retention min-gate (``now - 2 * FOLD_LAG`` freshness,
+# ``watermark - FOLD_LAG`` prune floor) derive from the same constant.
+# A fold pass after an upgrade from the 24h lag absorbs the watermark jump
+# as one ordinary backfill slice (FOLD_SLICE bounds it).
+FOLD_LAG = timedelta(hours=2)
 # Historical backfill folds at most this much history per transaction.
 FOLD_SLICE = timedelta(days=7)
 

--- a/openspec/changes/bound-account-summary-live-tail/context.md
+++ b/openspec/changes/bound-account-summary-live-tail/context.md
@@ -26,6 +26,18 @@ is computed over every row. 2h ≈ 900x the all-history worst case, with room
 for replica clock skew, paused VMs, and event-loop stalls far beyond
 anything observed.
 
+Operational bound made explicit by this change: writer-replica wall clocks
+(the `utcnow()` used by `add_log`) must stay within one fold lag of the fold
+leader's clock, and no insert transaction may stay open that long. This
+requirement is not new — it existed at 24h and only its margin changed. All
+replicas share one database and one NTP discipline; a clock trailing by two
+hours implies TLS/OAuth breakage long before rollup drift, and the DB pool
+recycles connections far below the lag. The residual exposure (a 2–24h
+trailing clock that the old lag absorbed) is accepted; deployments that
+cannot bound clock skew should not shorten further. A hard fence (stamping
+`requested_at` from the database clock) would cost the write path's
+no-refresh optimization and is left as a follow-up if ever needed.
+
 Post-insert mutators are fenced independently of the lag:
 
 - `update_model_for_request` selects only rows strictly above the lifetime
@@ -33,6 +45,18 @@ Post-insert mutators are fenced independently of the lag:
 - Account deletion and duplicate-identity consolidation reassign request
   logs under the fold-state lock and mirror folded sums
   (`merge_rollups_into`, time-rollup mirrors).
+
+## Cache invalidation race (generation fence)
+
+A summary fill that is between its two statements when deletion or
+consolidation commits could otherwise store its pre-commit result *after*
+the lifecycle clear, serving stale attribution for a full TTL. Fills capture
+a generation counter before their first await; `_clear_...` bumps it and
+stores are discarded on mismatch. The clear runs synchronously right after
+the lifecycle commit (no await between them), so on the single event loop
+every store either precedes the commit (wiped by the clear) or observes the
+bumped generation. Regression:
+`test_summary_cache_fill_discarded_when_invalidated_mid_flight`.
 
 ## Read-path cost of the 24h tail
 

--- a/openspec/changes/bound-account-summary-live-tail/context.md
+++ b/openspec/changes/bound-account-summary-live-tail/context.md
@@ -1,0 +1,83 @@
+# Context: measurements behind the 2h fold lag
+
+All numbers from the reference production deployment (PostgreSQL 18,
+2 vCPU), 2026-08-16, read-only.
+
+## Insert-visibility skew (what the lag must actually cover)
+
+`requested_at` is assigned inside `RequestLogsRepository.add_log` as
+`requested_at or utcnow()`; a repo-wide audit found **no live caller passing
+an explicit value** (the parameter exists for tests; the
+`limit_warmup` Protocol declares it but its call site does not use it). The
+log write happens at stream end and is dated at the write, so the
+stream-start-dating threat the original 24h comment guarded against does not
+exist — and has not existed since the initial commit.
+
+Frontier-lag measurement (how far below the running `max(requested_at)` by
+insert order — `id` — a row lands at insert):
+
+| window | rows | p99 | p99.9 | max |
+|---|---|---|---|---|
+| last 2M rows (~3.6 days) | 1,999,999 | 4.6ms | 46ms | 5.36s |
+| full history | 5,992,511 | — | 30ms | **7.89s** |
+
+This bound covers every insert path (normal, warmup, duplicates), because it
+is computed over every row. 2h ≈ 900x the all-history worst case, with room
+for replica clock skew, paused VMs, and event-loop stalls far beyond
+anything observed.
+
+Post-insert mutators are fenced independently of the lag:
+
+- `update_model_for_request` selects only rows strictly above the lifetime
+  watermark and at/above the hourly watermark, under the fold-state lock.
+- Account deletion and duplicate-identity consolidation reassign request
+  logs under the fold-state lock and mirror folded sums
+  (`merge_rollups_into`, time-rollup mirrors).
+
+## Read-path cost of the 24h tail
+
+- Tail at measurement time: 655,804 of 5,992,447 rows (11%).
+- Listing aggregate (`deduped_usage_aggregate_stmt` above the watermark),
+  production `EXPLAIN (ANALYZE, BUFFERS)`:
+  - **24h watermark (actual)**: 59.96s cold — the planner abandons the
+    covering index at ~656k tail rows and degrades to a parallel seq scan
+    (external-merge sort, 28MB spill) hash-joined against a hash of the
+    entire 5.99M-row table (46,474kB hash memory, 16 batches, 75k temp
+    pages). Warm-cache production average for the same call family: 2.1s
+    over 1,459 calls, max 131s.
+  - **2h parameter, same query shape**: 63ms — index scan on
+    `idx_logs_dash_usage_covering` (9,124 rows), hash-agg dedupe, nested
+    loop over `request_logs_pkey`.
+  - **1h parameter**: 18ms.
+- No index or query-shape change is needed once the tail is bounded; the
+  existing covering index already serves the bounded range. The residual
+  per-render cost is then amortized by the 30s summary cache.
+
+## Upgrade path
+
+`run_fold_pass` folds toward `now - FOLD_LAG` in bounded `FOLD_SLICE` (7d)
+transactions, so the one-time 22h watermark jump after this change lands in
+a single ordinary slice; `test_fold_absorbs_widened_watermark_gap` pins the
+totals across the jump. The watermark only advances, so a rollback to the
+24h constant simply pauses folding until `now - 24h` catches up with the
+already-advanced watermark — reads stay correct throughout (rows above the
+watermark are always live-tail-served).
+
+## Retention interaction
+
+The retention job's raw-prune floor (`watermark - FOLD_LAG`) and freshness
+gate (`watermark` within `2 * FOLD_LAG` of now) tighten with the constant.
+The floor exists so no rollup is robbed of raw it has not folded and so
+concurrent readers holding a slightly older watermark lose nothing; both
+need seconds. Consequence for retention-enabled deployments: raw becomes
+physically prunable at ~4h age instead of ~48h when the configured retention
+period is that short; sub-hour partial-window reads (non-hour-aligned
+`since`/`until`) over pruned history hit their documented raw-degrade path
+sooner. Hour-aligned reads are rollup-served and unaffected.
+
+The rollup/retention parity corpus
+(`tests/integration/test_request_usage_rollup_parity.py`) was authored
+against the 24h lag (TARGET_W at BASE+9d, prune floor at BASE+8d, unaligned
+windows and boundary rows placed between them); it now pins
+`CORPUS_FOLD_LAG = 24h` explicitly because the parity semantics it proves
+are lag-independent.

--- a/openspec/changes/bound-account-summary-live-tail/proposal.md
+++ b/openspec/changes/bound-account-summary-live-tail/proposal.md
@@ -1,0 +1,68 @@
+# Bound the account-summary live tail: 2h fold lag + short summary TTL cache
+
+## Why
+
+The account listing recomputes its request-usage summaries by deduping and
+re-aggregating every raw `request_logs` row above the lifetime fold watermark
+on each dashboard accounts load. The watermark trails `now` by the fold lag,
+so the lag directly sizes that always-rescanned tail.
+
+The lag has been 24h since the rollup shipped, justified by a premise the
+write path never had: the sizing comment (and the fold spec scenario) claim a
+log row is *dated at request start but inserted at stream end*, so the lag
+must exceed the maximum request duration. In this codebase `requested_at` is
+stamped **inside `RequestLogsRepository.add_log` at write time**
+(`requested_at or utcnow()`, and no live caller passes an explicit value —
+the parameter exists for tests). A row can land below the `requested_at`
+frontier only through replica clock skew, the single-row insert transaction's
+commit latency, or a process stall. Measured over one full production history
+(6.0M rows), the worst insert landed 7.9s below the frontier (p99.9 = 30ms).
+Post-insert mutators need no lag allowance either: `update_model_for_request`
+skips rows at/below the watermarks, and account consolidation/deletion
+reassign logs under the fold-state lock while mirroring the folded sums.
+
+The oversized lag is expensive: on the reference deployment the 24h tail is
+~660k rows (11% of the table), the listing aggregate was measured at 1,459
+calls averaging 2.1s (max 131s), and the cold plan degrades to a full
+seq-scan hash join over the whole table (measured 60s). With a 2h bound the
+identical query runs in 63ms via the covering-index nested-loop plan.
+
+Independently, the listing recomputes the summaries on every accounts load
+even though the displayed lifetime totals tolerate short staleness — the same
+shape the request-log COUNT cache already addresses (issue #1340).
+
+## What Changes
+
+- `FOLD_LAG` drops from 24h to 2h. 2h keeps a ~900x margin over the worst
+  insert-visibility skew ever observed while bounding the raw tail every
+  account and API-key summary read must re-aggregate. The hourly and
+  conversation fold targets and the retention min-gate derive from the same
+  constant and tighten with it; the retention floor's purpose (protect raw
+  the folds have not consumed and concurrent readers holding a slightly
+  older watermark) needs seconds, not hours.
+- On upgrade, the first fold pass absorbs the 22h watermark jump as ordinary
+  bounded backfill slices; totals are unchanged (fold moves rows from the
+  live tail into the persisted sums).
+- The fold-lag spec scenario is corrected to state the real invariant
+  (insert-visibility skew), replacing the false stream-start-dating premise.
+- Account request-usage summaries gain a process-local fixed-TTL (30s) cache
+  keyed by the account-id signature, mirroring the request-log COUNT cache.
+  Account deletion and duplicate-identity consolidation clear it because they
+  re-attribute usage rather than merely append; a non-positive TTL bypasses
+  the cache (the test suite runs with TTL 0).
+
+No schema change, no new settings, no API change.
+
+## Impact
+
+- Affected specs: `query-caching` (fold safety-lag requirement, account
+  summary read requirement).
+- Affected code: `app/modules/accounts/usage_rollup.py` (constant + sizing
+  rationale), `app/modules/accounts/repository.py` (summary TTL cache +
+  invalidation hooks), `tests/`.
+- Behavior visible to operators: account/API-key summary reads get a 2h raw
+  tail instead of 24h; listing summaries may be up to 30s stale (matching the
+  dashboard's 30s poll cadence); with retention enabled, raw rows become
+  physically prunable once they are one fold lag (now 2h) below the
+  watermark, so sub-hour partial-window raw reads over pruned history reach
+  their documented degrade path sooner.

--- a/openspec/changes/bound-account-summary-live-tail/specs/query-caching/spec.md
+++ b/openspec/changes/bound-account-summary-live-tail/specs/query-caching/spec.md
@@ -49,6 +49,7 @@ The merged summaries MAY be served from a process-local cache keyed by the reque
 - **GIVEN** cached summaries that include an account
 - **WHEN** that account is deleted, or a duplicate-identity consolidation removes it
 - **THEN** the cache MUST be cleared so the next read reflects the new attribution
+- **AND** a summary computation already in flight when the invalidation happens MUST NOT re-populate the cache with its pre-invalidation result
 
 ### Requirement: A background fold job advances the account usage rollup safely
 

--- a/openspec/changes/bound-account-summary-live-tail/specs/query-caching/spec.md
+++ b/openspec/changes/bound-account-summary-live-tail/specs/query-caching/spec.md
@@ -1,0 +1,90 @@
+# query-caching (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Account request usage summaries combine a persistent rollup with a bounded live tail
+
+Account request-usage summaries MUST NOT aggregate the full `request_logs` history per read. The read MUST combine persisted per-account rollup sums with a live aggregate constrained to rows newer than the rollup watermark, while preserving existing dedupe semantics (latest row id per `(account_id, request_id, requested_at)`) and existing filters (warmup kinds and soft-deleted rows excluded) on the live portion.
+
+The merged summaries MAY be served from a process-local cache keyed by the requested account-id signature for a small fixed TTL, because the displayed lifetime totals tolerate short staleness. Account deletion and duplicate-identity consolidation MUST clear the cache in the process that performed them (they re-attribute or remove usage rather than append to it). A non-positive TTL MUST bypass the cache entirely so tests and precision-sensitive callers observe exact totals.
+
+#### Scenario: Summary read does not scan folded history
+
+- **GIVEN** rollup rows exist with watermark `folded_through = T`
+- **WHEN** account request-usage summaries are loaded
+- **THEN** the live request-log aggregate MUST constrain to `requested_at > T`
+- **AND** the returned totals MUST equal the persisted rollup sums plus the live-tail aggregate per account
+- **AND** the cached-input clamp (`cached_input_tokens ≤ input_tokens`) MUST apply to the merged totals
+
+#### Scenario: Summary before the first fold matches legacy behavior
+
+- **GIVEN** no rollup rows exist yet
+- **WHEN** account request-usage summaries are loaded
+- **THEN** the live aggregate MUST cover all non-deleted, non-warmup request-log history
+- **AND** the returned totals MUST equal the pre-rollup query results
+
+#### Scenario: Folding does not change reported totals
+
+- **GIVEN** a set of request-log rows including duplicate rows sharing `(account_id, request_id, requested_at)`
+- **WHEN** a fold pass folds part of that history and summaries are read afterwards
+- **THEN** the totals MUST equal the totals the legacy full-history dedupe aggregate would report for the same rows
+
+#### Scenario: Summary read is snapshot-consistent with a concurrent fold commit
+
+- **GIVEN** a fold slice may commit at any point during a summary read
+- **WHEN** the read fetches rollup sums and the watermark
+- **THEN** both MUST come from a single database snapshot (one statement)
+- **AND** no qualifying request-log row's contribution may be absent from both the rollup sums and the live-tail aggregate of that read
+
+#### Scenario: Cached summaries are served within the TTL per signature
+
+- **GIVEN** a positive summary cache TTL
+- **AND** summaries were computed for one account-id signature
+- **WHEN** the same signature is requested again within the TTL
+- **THEN** the cached summaries MAY be returned without touching the database
+- **AND** a different account-id signature MUST NOT be served from that entry
+
+#### Scenario: Account deletion invalidates cached summaries
+
+- **GIVEN** cached summaries that include an account
+- **WHEN** that account is deleted, or a duplicate-identity consolidation removes it
+- **THEN** the cache MUST be cleared so the next read reflects the new attribution
+
+### Requirement: A background fold job advances the account usage rollup safely
+
+A periodic background job MUST fold request-log rows into `account_usage_rollups` and advance the watermark. Folding MUST be restricted to rows older than a safety lag, MUST apply the dedupe and filtering semantics of the summary query within the folded window, MUST run on at most one instance at a time, and MUST be idempotent under repeated or concurrent invocation.
+
+#### Scenario: Fold boundary respects the safety lag
+
+- **WHEN** a fold pass runs at time `now`
+- **THEN** it MUST NOT fold any row with `requested_at > now − lag`
+- **AND** rows younger than the lag remain covered by the live-tail aggregate
+- **AND** the lag MUST exceed the maximum possible distance between a row's `requested_at` and the moment its insert becomes visible — `requested_at` is stamped at write time inside the log insert path, so this distance is bounded by replica clock skew, insert-commit latency, and process stalls, not by request duration — because a row landing below the watermark would otherwise vanish from totals
+- **AND** post-insert mutations of folded rows MUST NOT rely on the lag: they are fenced by the watermark (skipped below it) or run under the fold-state lock while mirroring the folded sums
+
+#### Scenario: Widening the lag gap is absorbed as ordinary backfill
+
+- **GIVEN** a deployment whose persisted watermark trails `now − lag` by more than one fold cadence (for example after the lag constant is shortened)
+- **WHEN** the next fold passes run
+- **THEN** the gap MUST be folded in the bounded backfill slices with reported totals unchanged
+
+#### Scenario: Duplicate rows never split across the fold boundary
+
+- **GIVEN** duplicate request-log rows sharing the same `(account_id, request_id, requested_at)`
+- **WHEN** a fold pass selects its window by `requested_at`
+- **THEN** all rows of the duplicate group MUST land on the same side of the boundary
+- **AND** only the latest row id of the group MUST contribute to the folded sums
+
+#### Scenario: Fold is idempotent and single-writer
+
+- **GIVEN** a fold pass has committed sums through watermark `T`
+- **WHEN** another fold pass runs for the same window (repeat invocation or a second instance)
+- **THEN** it MUST observe watermark `T` inside its transaction and fold no row at or before `T`
+- **AND** no request-log row's contribution appears twice in the rollup
+
+#### Scenario: Historical backfill is sliced and non-blocking
+
+- **GIVEN** a deployment with existing request-log history and no rollup rows
+- **WHEN** the first fold passes run
+- **THEN** history MUST be folded in bounded time slices, each committed in its own transaction
+- **AND** summary reads issued during backfill MUST return correct totals (rollup so far plus remaining live tail)

--- a/openspec/changes/bound-account-summary-live-tail/tasks.md
+++ b/openspec/changes/bound-account-summary-live-tail/tasks.md
@@ -1,0 +1,42 @@
+# Tasks
+
+## 1. Fold lag
+
+- [x] 1.1 Shorten `FOLD_LAG` to 2h and rewrite the sizing comment around the
+      actual invariant: `requested_at` is stamped at insert time inside
+      `add_log`, so the lag bounds insert-visibility skew (clock skew +
+      commit latency + stalls), not request duration; note the measured
+      production worst case (7.9s over 6.0M rows) and the fenced post-insert
+      mutators
+- [x] 1.2 Verify the watermark jump after the lag change is absorbed by the
+      ordinary backfill path with totals unchanged (regression test
+      `test_fold_absorbs_widened_watermark_gap`)
+
+## 2. Summary TTL cache
+
+- [x] 2.1 Cache `list_request_usage_summary_by_account` results per
+      account-id signature for a fixed 30s TTL with a bounded entry count,
+      mirroring the request-log COUNT cache; non-positive TTL bypasses
+- [x] 2.2 Clear the cache on account deletion and on duplicate-identity
+      consolidation (both re-attribute usage), alongside the existing
+      `_clear_bulk_history_since_sqlite_cache()` call sites
+- [x] 2.3 Zero the TTL for the test suite via an autouse conftest fixture so
+      summaries stay exact within a test (same pattern as the COUNT cache)
+
+## 3. Tests
+
+- [x] 3.1 Cache behavior: staleness within TTL, per-signature keying,
+      invalidation on delete and on consolidation
+- [x] 3.2 Re-anchor the rollup/retention parity corpus on an explicit
+      `CORPUS_FOLD_LAG = 24h` pin — its 10-day geometry (TARGET_W, prune
+      floor, unaligned windows) was authored against the old lag and the
+      parity semantics are lag-independent
+- [x] 3.3 Fix the lag-coupled backdated insert in
+      `test_account_delete_removes_rollup_row` (`now - FOLD_LAG / 2`)
+- [x] 3.4 `uv run pytest`, `uv run ruff check`, `uv run ruff format --check`
+
+## 4. Spec
+
+- [x] 4.1 Correct the fold safety-lag scenario in `query-caching` and add the
+      summary-cache allowance to the account summary requirement
+- [x] 4.2 `openspec validate bound-account-summary-live-tail --strict`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,6 +143,17 @@ def _disable_request_log_count_cache(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _disable_account_usage_summary_cache(monkeypatch):
+    """Zero the account request-usage summary cache TTL so listing summaries
+    stay exact within a test. The TTL is a fixed constant in production;
+    cache-behavior tests patch it back to a positive value."""
+    import app.modules.accounts.repository as accounts_repository_module
+
+    accounts_repository_module._clear_request_usage_summary_cache()
+    monkeypatch.setattr(accounts_repository_module, "_SUMMARY_CACHE_TTL_SECONDS", 0.0)
+
+
+@pytest.fixture(autouse=True)
 def _disable_rate_limit_reset_credits_scheduler_startup(monkeypatch):
     import app.main as main_module
 

--- a/tests/integration/test_account_usage_rollup.py
+++ b/tests/integration/test_account_usage_rollup.py
@@ -396,7 +396,7 @@ async def test_account_delete_removes_rollup_row(db_setup):
             logs_repo,
             account_id="acc_del2",
             request_id="req_2",
-            requested_at=now - timedelta(hours=12),
+            requested_at=now - FOLD_LAG / 2,
         )
     await run_fold_pass(now=now + timedelta(days=1))
     assert len(await _rollup_rows()) == 1
@@ -444,3 +444,132 @@ async def test_backfill_start_skips_excluded_prefix(db_setup):
 
     summaries = await _summaries()
     assert summaries["acc_prefix"].request_count == 1
+
+
+@pytest.mark.asyncio
+async def test_fold_absorbs_widened_watermark_gap(db_setup):
+    """Upgrading from the previous 24h fold lag leaves the watermark far
+    behind the new ``now - FOLD_LAG`` target; the next pass must absorb the
+    gap as ordinary backfill slices with reported totals unchanged."""
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_gap", "gap@example.com"))
+        await _add_log(
+            logs_repo, account_id="acc_gap", request_id="req_gap_old", requested_at=now - timedelta(hours=30)
+        )
+        await _add_log(
+            logs_repo, account_id="acc_gap", request_id="req_gap_mid", requested_at=now - timedelta(hours=12)
+        )
+        await _add_log(
+            logs_repo, account_id="acc_gap", request_id="req_gap_young", requested_at=now - timedelta(minutes=10)
+        )
+
+    # Simulate the pre-upgrade deployment: a fold pass whose target lands a
+    # day back, leaving rows between the old and new targets unfolded.
+    await run_fold_pass(now=now - timedelta(hours=24) + FOLD_LAG)
+    assert await _watermark() == now - timedelta(hours=24)
+    before = await _summaries()
+    assert before["acc_gap"].request_count == 3
+
+    await run_fold_pass(now=now)
+    assert await _watermark() == now - FOLD_LAG
+    rows = await _rollup_rows()
+    assert len(rows) == 1
+    assert rows[0].request_count == 2  # old + mid folded, young stays live
+
+    assert await _summaries() == before
+
+
+@pytest.mark.asyncio
+async def test_summary_cache_serves_within_ttl_per_signature(db_setup, monkeypatch):
+    import app.modules.accounts.repository as accounts_repository_module
+
+    monkeypatch.setattr(accounts_repository_module, "_SUMMARY_CACHE_TTL_SECONDS", 30.0)
+    accounts_repository_module._clear_request_usage_summary_cache()
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_ttl", "ttl@example.com"))
+        await _add_log(logs_repo, account_id="acc_ttl", request_id="req_ttl_1", requested_at=now - timedelta(minutes=5))
+
+    first = await _summaries()
+    assert first["acc_ttl"].request_count == 1
+
+    async with SessionLocal() as session:
+        await _add_log(
+            RequestLogsRepository(session),
+            account_id="acc_ttl",
+            request_id="req_ttl_2",
+            requested_at=now - timedelta(minutes=1),
+        )
+
+    # Same signature within the TTL: served from cache, staleness tolerated.
+    assert (await _summaries())["acc_ttl"].request_count == 1
+    # A different account-id signature is a different cache entry.
+    scoped = await _summaries(["acc_ttl"])
+    assert scoped["acc_ttl"].request_count == 2
+
+    accounts_repository_module._clear_request_usage_summary_cache()
+    assert (await _summaries())["acc_ttl"].request_count == 2
+
+
+@pytest.mark.asyncio
+async def test_summary_cache_cleared_on_account_delete(db_setup, monkeypatch):
+    import app.modules.accounts.repository as accounts_repository_module
+
+    monkeypatch.setattr(accounts_repository_module, "_SUMMARY_CACHE_TTL_SECONDS", 30.0)
+    accounts_repository_module._clear_request_usage_summary_cache()
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_keep", "keep@example.com"))
+        await accounts_repo.upsert(_make_account("acc_gone", "gone@example.com"))
+        await _add_log(logs_repo, account_id="acc_keep", request_id="req_keep", requested_at=now - timedelta(minutes=5))
+        await _add_log(logs_repo, account_id="acc_gone", request_id="req_gone", requested_at=now - timedelta(minutes=5))
+
+    first = await _summaries()
+    assert "acc_gone" in first
+
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).delete("acc_gone")
+
+    after = await _summaries()
+    assert "acc_gone" not in after
+    assert after["acc_keep"].request_count == 1
+
+
+@pytest.mark.asyncio
+async def test_summary_cache_cleared_on_identity_consolidation(db_setup, monkeypatch):
+    import app.modules.accounts.repository as accounts_repository_module
+
+    monkeypatch.setattr(accounts_repository_module, "_SUMMARY_CACHE_TTL_SECONDS", 30.0)
+    accounts_repository_module._clear_request_usage_summary_cache()
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        canonical = _make_account("acc_cc", "cc@example.com", chatgpt_account_id="chatgpt_cc")
+        duplicate = _make_account("acc_cc__copy", "cc@example.com", chatgpt_account_id="chatgpt_cc")
+        await accounts_repo.upsert(canonical, merge_by_email=False)
+        await accounts_repo.upsert(duplicate, merge_by_email=False)
+        await _add_log(logs_repo, account_id="acc_cc", request_id="req_cc_1", requested_at=now - timedelta(minutes=5))
+        await _add_log(
+            logs_repo, account_id="acc_cc__copy", request_id="req_cc_2", requested_at=now - timedelta(minutes=5)
+        )
+
+    first = await _summaries()
+    assert first["acc_cc"].request_count == 1
+    assert first["acc_cc__copy"].request_count == 1
+
+    async with SessionLocal() as session:
+        reauth = _make_account("acc_cc", "cc@example.com", chatgpt_account_id="chatgpt_cc")
+        saved = await AccountsRepository(session).upsert(reauth, merge_by_email=False, merge_by_chatgpt_identity=True)
+        assert saved.id == "acc_cc"
+
+    after = await _summaries()
+    assert "acc_cc__copy" not in after
+    assert after["acc_cc"].request_count == 2

--- a/tests/integration/test_account_usage_rollup.py
+++ b/tests/integration/test_account_usage_rollup.py
@@ -573,3 +573,38 @@ async def test_summary_cache_cleared_on_identity_consolidation(db_setup, monkeyp
     after = await _summaries()
     assert "acc_cc__copy" not in after
     assert after["acc_cc"].request_count == 2
+
+
+@pytest.mark.asyncio
+async def test_summary_cache_fill_discarded_when_invalidated_mid_flight(db_setup, monkeypatch):
+    """A fill already computing when deletion/consolidation clears the cache
+    must not re-populate it with its pre-clear result (generation fence)."""
+    import app.modules.accounts.repository as accounts_repository_module
+
+    monkeypatch.setattr(accounts_repository_module, "_SUMMARY_CACHE_TTL_SECONDS", 30.0)
+    accounts_repository_module._clear_request_usage_summary_cache()
+    now = utcnow()
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        await accounts_repo.upsert(_make_account("acc_racefill", "racefill@example.com"))
+        await _add_log(
+            logs_repo, account_id="acc_racefill", request_id="req_rf", requested_at=now - timedelta(minutes=5)
+        )
+
+    real_read_state = accounts_repository_module.AccountUsageRollupRepository.read_state
+
+    async def _read_state_with_racing_clear(self, account_ids=None):
+        result = await real_read_state(self, account_ids)
+        # Simulate a consolidation/deletion committing and clearing while
+        # this fill is still between its two statements.
+        accounts_repository_module._clear_request_usage_summary_cache()
+        return result
+
+    monkeypatch.setattr(
+        accounts_repository_module.AccountUsageRollupRepository, "read_state", _read_state_with_racing_clear
+    )
+    first = await _summaries()
+    assert first["acc_racefill"].request_count == 1
+    # The interleaved clear must have won: nothing was cached.
+    assert accounts_repository_module._request_usage_summary_cache == {}

--- a/tests/integration/test_request_usage_rollup_parity.py
+++ b/tests/integration/test_request_usage_rollup_parity.py
@@ -35,7 +35,6 @@ from app.db.models import (
 )
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
-from app.modules.accounts.usage_rollup import FOLD_LAG
 from app.modules.accounts.usage_time_rollup import (
     floor_to_hour,
     run_conversation_fold_pass,
@@ -50,10 +49,24 @@ pytestmark = pytest.mark.integration
 
 _EPOCH = datetime(1970, 1, 1)
 
+# The 10-day corpus geometry below (TARGET_W at BASE + 9d, prune floor at
+# BASE + 8d, unaligned windows and boundary rows placed between them) was
+# authored against a 24h fold lag. The parity semantics under test are
+# lag-independent, so the lag is pinned here to keep the corpus exercising
+# every boundary it was designed around; the production FOLD_LAG's own
+# tail/absorption behavior is covered in test_account_usage_rollup.py.
+CORPUS_FOLD_LAG = timedelta(hours=24)
+
+
+@pytest.fixture(autouse=True)
+def _pin_corpus_fold_lag(monkeypatch):
+    monkeypatch.setattr("app.modules.accounts.usage_time_rollup.FOLD_LAG", CORPUS_FOLD_LAG)
+
+
 # Fixed 10-day corpus timeline (all naive UTC, matching requested_at).
 BASE = datetime(2025, 7, 1)
 NOW = BASE + timedelta(days=10, minutes=37)
-TARGET_W = floor_to_hour(NOW - FOLD_LAG)  # BASE + 9d
+TARGET_W = floor_to_hour(NOW - CORPUS_FOLD_LAG)  # BASE + 9d
 MID_W = BASE + timedelta(days=5, hours=3)  # whole hour mid-history
 
 SINCE_ALIGNED = BASE + timedelta(days=2)
@@ -462,10 +475,10 @@ async def test_switched_readers_match_legacy_across_watermark_states(db_setup):
     # Watermark state 2 — mid-history whole hour. The hourly and conversation
     # folds advance separately (mixed-watermark states in between must hold
     # parity too: each satellite degrades on its own watermark).
-    await run_hourly_fold_pass(now=MID_W + FOLD_LAG)
+    await run_hourly_fold_pass(now=MID_W + CORPUS_FOLD_LAG)
     assert await _watermark() == MID_W
     _assert_snapshots_equal(await _snapshot(), reference)
-    await run_conversation_fold_pass(now=MID_W + FOLD_LAG)
+    await run_conversation_fold_pass(now=MID_W + CORPUS_FOLD_LAG)
     assert await _conversation_watermark() == MID_W
     _assert_snapshots_equal(await _snapshot(), reference)
 
@@ -486,8 +499,8 @@ async def test_reader_is_consistent_under_concurrent_fold_commit(db_setup, monke
     came from, and folding never deletes raw rows."""
     await _seed_corpus()
     reference = await _snapshot()
-    await run_hourly_fold_pass(now=MID_W + FOLD_LAG)
-    await run_conversation_fold_pass(now=MID_W + FOLD_LAG)
+    await run_hourly_fold_pass(now=MID_W + CORPUS_FOLD_LAG)
+    await run_conversation_fold_pass(now=MID_W + CORPUS_FOLD_LAG)
 
     real_read_hourly_window = request_logs_repository_module.read_hourly_window
     fold_injections = {"count": 0}
@@ -568,7 +581,7 @@ async def test_escape_hatch_reset_degrades_to_legacy_then_rebackfills(db_setup):
 @pytest.mark.asyncio
 async def test_statistics_survive_retention_pruning_folded_raw(db_setup, monkeypatch):
     """The headline guarantee: after raw rows below the retention gate
-    (watermark - FOLD_LAG) are physically deleted, every rollup-served
+    (watermark - fold lag) are physically deleted, every rollup-served
     statistic is unchanged — INCLUDING the distinct-conversation metrics,
     which the conversation presence satellite now serves for folded history
     (they used to be raw-bound and shrink here). earliest_activity_at falls
@@ -584,7 +597,7 @@ async def test_statistics_survive_retention_pruning_folded_raw(db_setup, monkeyp
     lead_ceil = floor_to_hour(SINCE_UNALIGNED) + timedelta(hours=1)
     leadless = await _snapshot(lead_since=lead_ceil)
 
-    prune_cutoff = TARGET_W - FOLD_LAG
+    prune_cutoff = TARGET_W - CORPUS_FOLD_LAG
     async with SessionLocal() as session:
         await session.execute(delete(RequestLog).where(RequestLog.requested_at < prune_cutoff))
         await session.commit()
@@ -693,7 +706,7 @@ async def test_dashboard_overview_json_is_identical_before_and_after_fold(async_
     before = await async_client.get("/api/dashboard/overview?timeframe=7d")
     assert before.status_code == 200
 
-    folded_slices = await run_hourly_fold_pass()  # real now: rows are > FOLD_LAG old
+    folded_slices = await run_hourly_fold_pass()  # real now: rows are > fold lag old
     assert folded_slices > 0
     assert await run_conversation_fold_pass() > 0
     async with SessionLocal() as session:


### PR DESCRIPTION
## Problem

The account listing endpoint aggregates a raw `request_logs` "live tail" on every call, bounded by `FOLD_LAG = 24h`. On production data (5,992,447 rows), that tail covers 655,804 rows (~11%). At that size the planner abandons the covering index (`idx_logs_dash_usage_covering`) and falls back to a parallel seq scan over all 5.99M rows plus a hash join (temp ~75k pages): **59.96s cold** at the real 24h watermark, ~2.1s warm average. The same query with a 2h parameter runs in **63ms** (nested loop over the covering index); 1h runs in 18ms.

## Root cause

`FOLD_LAG = 24h` was introduced in f8d4beab (#1238) on the premise that rows are inserted at stream end while `requested_at` is stamped at request start, so the lag had to exceed the maximum stream duration. That premise was never true: `add_log` (`app/modules/request_logs/repository.py`) stamps `requested_at or utcnow()` at **insert time**, and no live caller ever passes an explicit `requested_at` (the parameter is test-only; the `limit_warmup` Protocol declaration never forwards one; the websocket mixin call is a metrics path, not `add_log`). There are also no post-insert mutations that could land behind the watermark: `update_model_for_request` skips below-watermark rows, and account consolidation/deletion run under the fold-state lock with rollup mirroring.

Production frontier measurement (insert delay vs. running max of `requested_at` in id order, all 5,992,511 rows): **max 7.89s, p99.9 30ms** — covering every insert path.

## Fix

1. **`FOLD_LAG` 24h → 2h** (~900x margin over the measured 7.89s max). At 2h the covering-index plan holds, so no query-shape or index changes are needed, and no migration. The one-time 22h watermark jump is absorbed by the existing `FOLD_SLICE` backfill path as a single slice (pinned by a regression test).
2. **30s TTL process-local cache** for `list_request_usage_summary_by_account`, keyed by the account-id signature (mirrors the existing `_COUNT_CACHE` precedent; capped at 64 entries; `TTL <= 0` bypasses, and an autouse conftest fixture zeroes it in tests). The cache is cleared on account deletion and duplicate consolidation, with a generation-counter fence so an in-flight fill cannot store a stale result after an invalidation.

Fold math, dedup semantics, and the deletion/consolidation rollup mirroring are unchanged.

## Evidence (production, read-only)

- Frontier insert delay over full history (5,992,511 rows): max 7.89s, p99.9 30ms.
- Live tail at 24h watermark: 655,804 rows → seq-scan/hash-join plan, 59.96s cold / ~2.1s warm.
- Same aggregation at 2h: 63ms (covering-index nested loop); 1h: 18ms.

## Testing

- Full suite: 8,272 passed / 31 skipped / 1 failed (`test_responses_websocket_route_drain_interrupts_blocked_idle_receive` — timing flake under 10-way parallel pytest at loadavg 6; passes in isolation in 0.88s; unrelated to this change).
- Affected suites re-run after rebase onto 5d27f7f0: `test_account_usage_rollup` (16) + parity (7) + `accounts_api` + `data_retention` + `time_rollup` + `repository_locks` = 111 passed.
- New tests: watermark-gap absorption (`test_fold_absorbs_widened_watermark_gap`), cache TTL/signature keying, deletion invalidation, consolidation invalidation, in-flight invalidation fence (`test_summary_cache_fill_discarded_when_invalidated_mid_flight`).
- Two existing tests were coupled to the 24h constant and adjusted: the parity corpus pins `CORPUS_FOLD_LAG = 24h` explicitly (its geometry was authored against the old lag; semantics are lag-independent), and the deletion test's backdated insert now uses `now - FOLD_LAG/2`.
- `ruff check` / `ruff format` clean; `openspec validate bound-account-summary-live-tail --strict` and `--specs` (57/57) pass.
- Two adversarial-review rounds with codex converged clean ("no actionable correctness issues").

## Follow-ups / operational notes

- The one-time 22h absorption slice scans a ~584k-row window twice inside one transaction while holding the fold-state row lock (~60s cold on pg; on sqlite it blocks the writer section for the slice duration). Deploying in a low-traffic window is recommended; data safety is unaffected (atomic commit, monotonic watermark).
- Cache invalidation is process-local, matching the `workers=1` topology contract and the `_COUNT_CACHE` precedent; a multi-worker deployment would need shared invalidation.
- With a 2h lag, the retention freshness gate (`now - 2*FOLD_LAG`) becomes more conservative under fold-scheduler stalls, which is the safe direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)