### PR TITLE
perf(accounts): make account deletion a fast mark + background batch drain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ POSTGRES_PYTEST_TARGETS := \
 	tests/integration/test_db_commit_durability.py \
 	tests/test_request_logs_options_api.py \
 	tests/integration/test_account_usage_rollup.py \
+	tests/integration/test_account_deletion_background.py \
 	tests/integration/test_request_usage_time_rollup.py \
 	tests/integration/test_request_usage_rollup_parity.py \
 	tests/integration/test_migrations.py::test_request_usage_time_rollups_migration_upgrade_and_downgrade \

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ POSTGRES_PYTEST_TARGETS := \
 	tests/integration/test_repositories.py::test_replace_reauthorized_discards_pending_downgrade_evidence \
 	tests/integration/test_repositories.py::test_upsert_account_slot_discards_pending_downgrade_evidence_on_reimport \
 	tests/integration/test_migrations.py::test_account_plan_downgrade_observations_migration_upgrade_and_downgrade \
+	tests/integration/test_migrations.py::test_account_pending_deletion_migration_upgrade_and_downgrade \
 	tests/integration/test_usage_repository.py::test_bulk_history_since_primary_query_plan_is_index_only_postgresql \
 	tests/integration/test_usage_repository.py::test_bulk_history_since_cutoff_query_plan_is_index_only_postgresql \
 	tests/integration/test_usage_repository.py::test_bulk_history_since_secondary_query_plan_is_index_only_postgresql \

--- a/app/db/alembic/versions/20260816_000000_add_account_pending_deletion.py
+++ b/app/db/alembic/versions/20260816_000000_add_account_pending_deletion.py
@@ -56,9 +56,25 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     bind = op.get_bind()
+    columns = _columns(bind)
+    if "delete_requested_at" in columns:
+        # The marker columns are the deletion queue's only durable state:
+        # dropping them while deletions are queued would silently abandon
+        # acknowledged deletions and hand the parent build unusable
+        # (credential-wiped, partially drained) account rows it would list
+        # again. Refuse instead — let the worker finish (or supersede the
+        # deletions via re-import/reauth) before downgrading.
+        pending = bind.execute(
+            sa.text(f"SELECT COUNT(*) FROM {_TABLE} WHERE delete_requested_at IS NOT NULL")  # noqa: S608
+        ).scalar()
+        if pending:
+            raise RuntimeError(
+                f"cannot downgrade {revision}: {pending} account(s) are still queued for "
+                "background deletion; wait for the deletion worker to finish (or supersede "
+                "the deletions with a credential re-import) before downgrading"
+            )
     if _INDEX in _indexes(bind):
         op.drop_index(_INDEX, table_name=_TABLE)
-    columns = _columns(bind)
     if "delete_history_requested" in columns:
         op.drop_column(_TABLE, "delete_history_requested")
     if "delete_requested_at" in columns:

--- a/app/db/alembic/versions/20260816_000000_add_account_pending_deletion.py
+++ b/app/db/alembic/versions/20260816_000000_add_account_pending_deletion.py
@@ -16,10 +16,15 @@ branch_labels = None
 depends_on = None
 
 _TABLE = "accounts"
+_INDEX = "idx_accounts_delete_requested_at"
 
 
 def _columns(bind) -> set[str]:
     return {column["name"] for column in sa.inspect(bind).get_columns(_TABLE)}
+
+
+def _indexes(bind) -> set[str]:
+    return {index["name"] for index in sa.inspect(bind).get_indexes(_TABLE)}
 
 
 def upgrade() -> None:
@@ -37,10 +42,22 @@ def upgrade() -> None:
                 server_default=sa.false(),
             ),
         )
+    if _INDEX not in _indexes(bind):
+        # Pending-deletion queue probe/order support; partial so it is empty
+        # (and free) in the steady state with no pending deletions.
+        op.create_index(
+            _INDEX,
+            _TABLE,
+            ["delete_requested_at", "id"],
+            postgresql_where=sa.text("delete_requested_at IS NOT NULL"),
+            sqlite_where=sa.text("delete_requested_at IS NOT NULL"),
+        )
 
 
 def downgrade() -> None:
     bind = op.get_bind()
+    if _INDEX in _indexes(bind):
+        op.drop_index(_INDEX, table_name=_TABLE)
     columns = _columns(bind)
     if "delete_history_requested" in columns:
         op.drop_column(_TABLE, "delete_history_requested")

--- a/app/db/alembic/versions/20260816_000000_add_account_pending_deletion.py
+++ b/app/db/alembic/versions/20260816_000000_add_account_pending_deletion.py
@@ -1,0 +1,48 @@
+"""add account pending-deletion marker columns
+
+Revision ID: 20260816_000000_add_account_pending_deletion
+Revises: 20260812_120000_add_sticky_abandonment_scope
+Create Date: 2026-08-16
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260816_000000_add_account_pending_deletion"
+down_revision = "20260812_120000_add_sticky_abandonment_scope"
+branch_labels = None
+depends_on = None
+
+_TABLE = "accounts"
+
+
+def _columns(bind) -> set[str]:
+    return {column["name"] for column in sa.inspect(bind).get_columns(_TABLE)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    columns = _columns(bind)
+    if "delete_requested_at" not in columns:
+        op.add_column(_TABLE, sa.Column("delete_requested_at", sa.DateTime(), nullable=True))
+    if "delete_history_requested" not in columns:
+        op.add_column(
+            _TABLE,
+            sa.Column(
+                "delete_history_requested",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    columns = _columns(bind)
+    if "delete_history_requested" in columns:
+        op.drop_column(_TABLE, "delete_history_requested")
+    if "delete_requested_at" in columns:
+        op.drop_column(_TABLE, "delete_requested_at")

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -137,6 +137,20 @@ class Account(Base):
         server_default=false(),
         nullable=False,
     )
+    # Pending-deletion marker: set by the fast DELETE path, consumed by the
+    # background deletion worker, cleared only by a credential replacement
+    # (re-import/reauth) that supersedes the deletion. Non-NULL rows are
+    # hidden from account listings and are already unroutable (the fast path
+    # also sets status=DEACTIVATED).
+    delete_requested_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    # Frozen at the first delete request (repeat requests do not escalate):
+    # True selects the history-deleting variant in the background worker.
+    delete_history_requested: Mapped[bool] = mapped_column(
+        Boolean,
+        default=False,
+        server_default=false(),
+        nullable=False,
+    )
 
     api_key_assignments: Mapped[list["ApiKeyAccountAssignment"]] = relationship(
         "ApiKeyAccountAssignment",

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -2135,6 +2135,17 @@ Index(
     postgresql_include=["used_percent", "reset_at", "window_minutes", "id"],
 )
 Index("idx_accounts_email", Account.email)
+# Pending-deletion queue: every replica probes ``delete_requested_at IS NOT
+# NULL LIMIT 1`` each worker interval and the leader orders the queue by
+# (delete_requested_at, id); the partial index keeps both reads off the full
+# accounts table and is empty in the steady state (no pending deletions).
+Index(
+    "idx_accounts_delete_requested_at",
+    Account.delete_requested_at,
+    Account.id,
+    postgresql_where=text("delete_requested_at IS NOT NULL"),
+    sqlite_where=text("delete_requested_at IS NOT NULL"),
+)
 Index("idx_api_keys_name", ApiKey.name)
 Index("idx_logs_account_time", RequestLog.account_id, RequestLog.requested_at)
 Index("idx_logs_model_source_time", RequestLog.model_source_id, RequestLog.requested_at)

--- a/app/main.py
+++ b/app/main.py
@@ -63,6 +63,7 @@ from app.core.usage.reset_credits_refresh_scheduler import build_rate_limit_rese
 from app.core.utils.time import utcnow
 from app.db.session import SessionLocal, close_db, close_session, init_background_db, init_db
 from app.modules.accounts import api as accounts_api
+from app.modules.accounts.deletion import build_account_deletion_scheduler
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.accounts.usage_rollup_scheduler import build_account_usage_rollup_scheduler
 from app.modules.api_keys import api as api_keys_api
@@ -488,6 +489,7 @@ async def lifespan(app: FastAPI):
     automations_scheduler = build_automations_scheduler()
     rate_limit_reset_credits_scheduler = build_rate_limit_reset_credits_scheduler()
     account_usage_rollup_scheduler = build_account_usage_rollup_scheduler()
+    account_deletion_scheduler = build_account_deletion_scheduler()
     data_retention_scheduler = build_data_retention_scheduler()
     telemetry_scheduler = build_telemetry_scheduler()
     start_live_usage_ingestor()
@@ -501,6 +503,7 @@ async def lifespan(app: FastAPI):
     await automations_scheduler.start()
     await rate_limit_reset_credits_scheduler.start()
     await account_usage_rollup_scheduler.start()
+    await account_deletion_scheduler.start()
     await data_retention_scheduler.start()
     await telemetry_scheduler.start()
     if settings.metrics_enabled and PROMETHEUS_AVAILABLE:
@@ -718,6 +721,7 @@ async def lifespan(app: FastAPI):
         await stop_live_usage_ingestor()
         await rate_limit_reset_credits_scheduler.stop()
         await account_usage_rollup_scheduler.stop()
+        await account_deletion_scheduler.stop()
         await data_retention_scheduler.stop()
         await telemetry_scheduler.stop()
         # Release the scheduler leader lease only after every leader-gated

--- a/app/modules/accounts/deletion.py
+++ b/app/modules/accounts/deletion.py
@@ -79,7 +79,11 @@ from app.modules.accounts.repository import (
     AccountsRepository,
     credentials_replaced_since_wipe,
 )
-from app.modules.proxy.account_cache import get_account_selection_cache, propagate_account_routing_change
+from app.modules.proxy.account_cache import (
+    get_account_selection_cache,
+    mark_account_routing_unavailable,
+    propagate_account_routing_change,
+)
 from app.modules.usage.repository import _clear_bulk_history_since_sqlite_cache
 
 logger = logging.getLogger(__name__)
@@ -196,19 +200,29 @@ _ChunkFn = Callable[..., Awaitable[int]]
 async def _run_chunk(chunk_fn: _ChunkFn, account_id: str, *, batch_size: int) -> int | None:
     """Run one chunk transaction; None when the pending marker disappeared
     (deletion superseded)."""
+    drift_repaired = False
     async with get_background_session() as session:
         async with sqlite_writer_section():
-            delete_history = await _pending_state(session, account_id)
-            if delete_history is None:
+            state = await _pending_state(session, account_id)
+            if state is None:
                 await session.rollback()
                 return None
+            delete_history, drift_repaired = state
             affected = await chunk_fn(session, account_id, delete_history=delete_history, batch_size=batch_size)
             await session.commit()
+    if drift_repaired:
+        # The drift a pre-upgrade replica wrote may already be cached in
+        # selection/API-key snapshots on this or peer replicas; repairing the
+        # database alone would leave those caches selecting the wiped account
+        # (or honoring a stale assignment) until expiry. Same invalidation
+        # fan-out as the delete request itself.
+        mark_account_routing_unavailable(account_id)
+        await _invalidate_account_caches()
     return affected
 
 
-async def _pending_state(session: AsyncSession, account_id: str) -> bool | None:
-    """The frozen ``delete_history`` choice, or None when no longer pending.
+async def _pending_state(session: AsyncSession, account_id: str) -> tuple[bool, bool] | None:
+    """``(delete_history, drift_repaired)``, or None when no longer pending.
 
     On PostgreSQL the read locks the account row (``FOR NO KEY UPDATE``) for
     the rest of the chunk transaction, so a credential replacement cannot
@@ -251,8 +265,11 @@ async def _pending_state(session: AsyncSession, account_id: str) -> bool | None:
     # API-key assignment begin_delete removed. Re-fence both under the row
     # lock held above; any drift is bounded by one chunk transaction. The
     # credentials check above already excluded genuine replacements, so a
-    # non-DEACTIVATED status here can only be such drift.
+    # non-DEACTIVATED status here can only be such drift. The caller
+    # propagates cache invalidation after commit when drift was repaired.
+    drift_repaired = False
     if row[5] is not AccountStatus.DEACTIVATED or row[6] != ACCOUNT_PENDING_DELETION_REASON:
+        drift_repaired = True
         await session.execute(
             update(Account)
             .where(Account.id == account_id)
@@ -263,8 +280,14 @@ async def _pending_state(session: AsyncSession, account_id: str) -> bool | None:
                 blocked_at=None,
             )
         )
-    await session.execute(delete(ApiKeyAccountAssignment).where(ApiKeyAccountAssignment.account_id == account_id))
-    return bool(row[1])
+    assignment_rows = await session.execute(
+        delete(ApiKeyAccountAssignment)
+        .where(ApiKeyAccountAssignment.account_id == account_id)
+        .returning(ApiKeyAccountAssignment.account_id)
+    )
+    if assignment_rows.scalars().first() is not None:
+        drift_repaired = True
+    return bool(row[1]), drift_repaired
 
 
 async def _usage_history_chunk(session: AsyncSession, account_id: str, *, delete_history: bool, batch_size: int) -> int:

--- a/app/modules/accounts/deletion.py
+++ b/app/modules/accounts/deletion.py
@@ -214,14 +214,16 @@ async def _pending_state(session: AsyncSession, account_id: str) -> bool | None:
     stmt = select(
         Account.delete_requested_at,
         Account.delete_history_requested,
+        Account.access_token_encrypted,
         Account.refresh_token_encrypted,
+        Account.id_token_encrypted,
     ).where(Account.id == account_id)
     if session.get_bind().dialect.name == "postgresql":
         stmt = stmt.with_for_update(key_share=True)
     row = (await session.execute(stmt)).first()
     if row is None or row[0] is None:
         return None
-    if credentials_replaced_since_wipe(row[2]):
+    if credentials_replaced_since_wipe(row[2], row[3], row[4]):
         await session.execute(
             update(Account)
             .where(Account.id == account_id)

--- a/app/modules/accounts/deletion.py
+++ b/app/modules/accounts/deletion.py
@@ -100,9 +100,10 @@ async def run_account_deletion_pass(*, batch_size: int = DELETE_BATCH_SIZE) -> d
     """Drain and finalize every account marked for deletion.
 
     Round-robin fairness: each round advances every pending account by at
-    most one full chunk, and the pending set is re-scanned between rounds, so
-    a newly marked account starts draining within one chunk transaction of
-    its request even while another account's long drain is in progress.
+    most one nonempty chunk, and the pending set is re-scanned between
+    rounds, so a newly marked account starts draining within one chunk
+    transaction of its request even while another account's long drain is in
+    progress.
 
     Returns an outcome per account id: ``finalized`` (rows drained, account
     row removed), ``superseded`` (marker cleared mid-drain by a credential
@@ -148,9 +149,10 @@ async def _advance_account(account_id: str, *, batch_size: int) -> str:
 
     Runs the drain tables in order (usage snapshots first — not
     fold-governed — then the raw request logs) but stops after the first
-    FULL chunk so the caller can round-robin other pending accounts:
-    ``draining`` means more chunks remain. Tables whose chunk came up short
-    are drained; when every table is, finalize.
+    NONEMPTY chunk so the caller can round-robin other pending accounts —
+    each round commits at most one row-touching transaction per account:
+    ``draining`` means more work may remain. Only tables whose chunk came up
+    empty are known drained; when every table is, finalize.
     """
     for chunk_fn in (_usage_history_chunk, _additional_usage_history_chunk, _request_logs_chunk):
         affected = await _run_chunk(chunk_fn, account_id, batch_size=batch_size)
@@ -160,7 +162,7 @@ async def _advance_account(account_id: str, *, batch_size: int) -> str:
             # Same hygiene as retention pruning: bulk usage-history reads are
             # cached on SQLite and must not serve the drained account.
             _clear_bulk_history_since_sqlite_cache()
-        if affected >= batch_size:
+        if affected:
             return "draining"
     # Finalization: residual rows (streams that settled a log row mid-drain),
     # folded-bucket mirrors, sticky/rollup rows, and the account row itself —

--- a/app/modules/accounts/deletion.py
+++ b/app/modules/accounts/deletion.py
@@ -67,7 +67,7 @@ from app.core.upstream_proxy.cache import get_upstream_route_cache
 from app.core.utils.time import utcnow
 from app.db.models import Account, AdditionalUsageHistory, RequestLog, UsageHistory
 from app.db.session import get_background_session, sqlite_writer_section
-from app.modules.accounts.repository import AccountsRepository
+from app.modules.accounts.repository import AccountsRepository, credentials_replaced_since_wipe
 from app.modules.proxy.account_cache import get_account_selection_cache, propagate_account_routing_change
 from app.modules.usage.repository import _clear_bulk_history_since_sqlite_cache
 
@@ -205,12 +205,29 @@ async def _pending_state(session: AsyncSession, account_id: str) -> bool | None:
     replacement blocks until the chunk commits, then the next chunk observes
     the cleared marker and stops. On SQLite the writer section already
     serializes this transaction against every other writer.
+
+    A replacement handled by a pre-upgrade replica (rolling deploy) writes
+    fresh credentials but cannot clear marker columns its ORM does not know;
+    fresh non-wiped ciphertext on a marked row is therefore itself the
+    supersede signal — the marker is cleared here, under the same lock.
     """
-    stmt = select(Account.delete_requested_at, Account.delete_history_requested).where(Account.id == account_id)
+    stmt = select(
+        Account.delete_requested_at,
+        Account.delete_history_requested,
+        Account.refresh_token_encrypted,
+    ).where(Account.id == account_id)
     if session.get_bind().dialect.name == "postgresql":
         stmt = stmt.with_for_update(key_share=True)
     row = (await session.execute(stmt)).first()
     if row is None or row[0] is None:
+        return None
+    if credentials_replaced_since_wipe(row[2]):
+        await session.execute(
+            update(Account)
+            .where(Account.id == account_id)
+            .values(delete_requested_at=None, delete_history_requested=False)
+        )
+        await session.commit()
         return None
     return bool(row[1])
 

--- a/app/modules/accounts/deletion.py
+++ b/app/modules/accounts/deletion.py
@@ -58,7 +58,7 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Protocol, TypeVar, cast
 
-from sqlalchemy import delete, select, update
+from sqlalchemy import Select, delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth.api_key_cache import get_api_key_cache
@@ -93,11 +93,19 @@ logger = logging.getLogger(__name__)
 # draining immediately and the tick only covers follower-received requests
 # and restart resume.
 DELETION_INTERVAL_SECONDS = 30
-# Rows per chunk transaction. Bounded so no chunk holds a long transaction:
-# measured production deletes ran ~1.2s/10k usage_history rows and ~23s/10k
-# request_logs detaches (18 indexes, non-HOT updates), so 5k keeps every
-# transaction comfortably short on both tables.
-DELETE_BATCH_SIZE = 5_000
+# Rows per chunk transaction. Every chunk holds the account row lock
+# (``FOR NO KEY UPDATE``) for its full duration, so a supersede
+# (``replace_reauthorized``) or a fenced settlement write can wait for at most
+# one chunk. Measured production rates: ~1.2s/10k usage_history deletes and
+# ~23s/10k request_logs detaches (18 indexes, non-HOT updates) — 1k bounds the
+# worst table at ~2.3s per transaction (5k would have been ~11.5s there).
+DELETE_BATCH_SIZE = 1_000
+# Between consecutive row-touching rounds the pass sleeps a fraction of the
+# round's own duration (capped), so a multi-hundred-chunk drain leaves the
+# 2-vCPU database headroom for foreground traffic instead of running chunk
+# transactions back-to-back.
+INTER_ROUND_PAUSE_RATIO = 0.25
+INTER_ROUND_PAUSE_CAP_SECONDS = 2.0
 
 _T = TypeVar("_T")
 
@@ -126,18 +134,31 @@ async def run_account_deletion_pass(*, batch_size: int = DELETE_BATCH_SIZE) -> d
     next tick).
     """
     outcomes: dict[str, str] = {}
+    # Tables observed empty for an account earlier in THIS pass are not
+    # re-probed on later rounds: a drained table stays drained for the rest of
+    # the drain (rows that land afterwards — e.g. a stream settling a log row
+    # mid-drain — are swept by finalization's residual pass), and re-probing
+    # would cost one account-row-locking transaction per table per round.
+    drained: dict[str, set[str]] = {}
+    loop = asyncio.get_running_loop()
     while True:
         runnable = [
             account_id for account_id in await _pending_deletion_ids() if outcomes.get(account_id) in (None, "draining")
         ]
         if not runnable:
             break
+        round_started = loop.time()
         for account_id in runnable:
             try:
-                outcomes[account_id] = await _advance_account(account_id, batch_size=batch_size)
+                outcomes[account_id] = await _advance_account(
+                    account_id, batch_size=batch_size, drained=drained.setdefault(account_id, set())
+                )
             except Exception:
                 logger.exception("Background account deletion failed account_id=%s", account_id)
                 outcomes[account_id] = "error"
+        if any(outcomes.get(account_id) == "draining" for account_id in runnable):
+            elapsed = loop.time() - round_started
+            await asyncio.sleep(min(INTER_ROUND_PAUSE_CAP_SECONDS, elapsed * INTER_ROUND_PAUSE_RATIO))
     # ``draining`` cannot survive the loop: an account leaves the runnable
     # set only through a terminal outcome or by vanishing from the pending
     # scan (its marker was cleared — a supersede that raced the scan).
@@ -159,7 +180,7 @@ async def _pending_deletion_ids() -> list[str]:
         return list(rows.scalars().all())
 
 
-async def _advance_account(account_id: str, *, batch_size: int) -> str:
+async def _advance_account(account_id: str, *, batch_size: int, drained: set[str] | None = None) -> str:
     """One bounded round of work for one account.
 
     Runs the drain tables in order (usage snapshots first — not
@@ -167,18 +188,30 @@ async def _advance_account(account_id: str, *, batch_size: int) -> str:
     NONEMPTY chunk so the caller can round-robin other pending accounts —
     each round commits at most one row-touching transaction per account:
     ``draining`` means more work may remain. Only tables whose chunk came up
-    empty are known drained; when every table is, finalize.
+    empty are known drained; when every table is, finalize. ``drained``
+    (caller-owned, per pass) records those tables so later rounds skip their
+    probes instead of re-running one locking transaction per table per round.
     """
-    for chunk_fn in (_usage_history_chunk, _additional_usage_history_chunk, _request_logs_chunk):
+    if drained is None:
+        drained = set()
+    for label, chunk_fn in (
+        ("usage_history", _usage_history_chunk),
+        ("additional_usage_history", _additional_usage_history_chunk),
+        ("request_logs", _request_logs_chunk),
+    ):
+        if label in drained:
+            continue
         affected = await _run_chunk(chunk_fn, account_id, batch_size=batch_size)
         if affected is None:
             return "superseded"
-        if affected and chunk_fn is _usage_history_chunk:
+        if not affected:
+            drained.add(label)
+            continue
+        if label == "usage_history":
             # Same hygiene as retention pruning: bulk usage-history reads are
             # cached on SQLite and must not serve the drained account.
             _clear_bulk_history_since_sqlite_cache()
-        if affected:
-            return "draining"
+        return "draining"
     # Finalization: residual rows (streams that settled a log row mid-drain),
     # folded-bucket mirrors, sticky/rollup rows, and the account row itself —
     # one fold-state-locked transaction, identical in shape to the historical
@@ -290,8 +323,84 @@ async def _pending_state(session: AsyncSession, account_id: str) -> tuple[bool, 
     return bool(row[1]), drift_repaired
 
 
+# Chunk batch shape — why a RANGE predicate plus an index-matching ORDER BY
+# instead of plain ``account_id = :id LIMIT n``:
+#
+# With an equality predicate the PostgreSQL planner folds ``account_id`` into
+# a constant, drops it from the sort pathkeys, and — whenever the per-account
+# row estimate is large (exactly the accounts this drain exists for) — plans
+# the LIMIT subquery as an early-terminating Seq Scan (or a scan of an
+# unrelated time index with a filter), betting on uniformly interleaved
+# matches. That bet loses precisely mid-drain: detached/deleted rows no
+# longer match, so each chunk re-scans a growing dead prefix, and once the
+# table is drained but statistics are stale, every empty probe is a FULL heap
+# scan (0 matches → no early termination). Verified against the production
+# planner (606,970-row account): Seq Scans on all three tables.
+#
+# ``account_id >= :id AND account_id <= :id`` selects the same rows but keeps
+# ``account_id`` out of the constant-equivalence class, so it survives as the
+# leading ORDER BY pathkey; the ORDER BY then lists the target index's exact
+# column order, making that account-leading index the only sort-free plan:
+#
+#   usage_history            → idx_usage_account_time (account_id, recorded_at)
+#   additional_usage_history → ix_additional_usage_distinct_labels
+#                              (account_id, quota_key, limit_name, metered_feature)
+#   request_logs             → idx_logs_account_kind_deleted_latest
+#                              (account_id, request_kind, deleted_at,
+#                               requested_at, id) — covering: Index Only Scan
+#
+# Verified on the production planner: all three plan as index (or index-only)
+# scans with the account range as the Index Cond, and a drained-table probe
+# costs one index descent (~8 cost units) instead of a heap scan. Chunk scan
+# work is therefore bounded by the account's own remaining rows regardless of
+# statistics staleness, and detached rows leave the scanned key range
+# immediately. Row order is irrelevant to correctness (every row is drained);
+# the ORDER BY exists purely to pin the plan.
+
+
+def _usage_history_batch(account_id: str, batch_size: int) -> Select[tuple[int]]:
+    return (
+        select(UsageHistory.id)
+        .where(UsageHistory.account_id >= account_id, UsageHistory.account_id <= account_id)
+        .order_by(UsageHistory.account_id, UsageHistory.recorded_at)
+        .limit(batch_size)
+    )
+
+
+def _additional_usage_history_batch(account_id: str, batch_size: int) -> Select[tuple[int]]:
+    return (
+        select(AdditionalUsageHistory.id)
+        .where(
+            AdditionalUsageHistory.account_id >= account_id,
+            AdditionalUsageHistory.account_id <= account_id,
+        )
+        .order_by(
+            AdditionalUsageHistory.account_id,
+            AdditionalUsageHistory.quota_key,
+            AdditionalUsageHistory.limit_name,
+            AdditionalUsageHistory.metered_feature,
+        )
+        .limit(batch_size)
+    )
+
+
+def _request_logs_batch(account_id: str, batch_size: int) -> Select[tuple[int]]:
+    return (
+        select(RequestLog.id)
+        .where(RequestLog.account_id >= account_id, RequestLog.account_id <= account_id)
+        .order_by(
+            RequestLog.account_id,
+            RequestLog.request_kind,
+            RequestLog.deleted_at,
+            RequestLog.requested_at,
+            RequestLog.id,
+        )
+        .limit(batch_size)
+    )
+
+
 async def _usage_history_chunk(session: AsyncSession, account_id: str, *, delete_history: bool, batch_size: int) -> int:
-    batch = select(UsageHistory.id).where(UsageHistory.account_id == account_id).limit(batch_size).scalar_subquery()
+    batch = _usage_history_batch(account_id, batch_size).scalar_subquery()
     result = await session.execute(delete(UsageHistory).where(UsageHistory.id.in_(batch)).returning(UsageHistory.id))
     return len(result.scalars().all())
 
@@ -299,12 +408,7 @@ async def _usage_history_chunk(session: AsyncSession, account_id: str, *, delete
 async def _additional_usage_history_chunk(
     session: AsyncSession, account_id: str, *, delete_history: bool, batch_size: int
 ) -> int:
-    batch = (
-        select(AdditionalUsageHistory.id)
-        .where(AdditionalUsageHistory.account_id == account_id)
-        .limit(batch_size)
-        .scalar_subquery()
-    )
+    batch = _additional_usage_history_batch(account_id, batch_size).scalar_subquery()
     result = await session.execute(
         delete(AdditionalUsageHistory).where(AdditionalUsageHistory.id.in_(batch)).returning(AdditionalUsageHistory.id)
     )
@@ -317,7 +421,7 @@ async def _request_logs_chunk(session: AsyncSession, account_id: str, *, delete_
     Deliberately NOT fold-state-locked and NOT mirrored: see the module
     docstring for why interleaved fold slices converge at finalization.
     """
-    batch = select(RequestLog.id).where(RequestLog.account_id == account_id).limit(batch_size).scalar_subquery()
+    batch = _request_logs_batch(account_id, batch_size).scalar_subquery()
     if delete_history:
         result = await session.execute(delete(RequestLog).where(RequestLog.id.in_(batch)).returning(RequestLog.id))
     else:

--- a/app/modules/accounts/deletion.py
+++ b/app/modules/accounts/deletion.py
@@ -1,0 +1,315 @@
+"""Background account deletion: fast-marked accounts drained in bounded chunks.
+
+``DELETE /api/accounts/{id}`` used to detach (or delete) the account's entire
+raw history in ONE transaction while holding the fold-state lock: for a
+long-lived account that is hundreds of thousands of rows across ``request_logs``
+(18 indexes) and ``usage_history``, minutes of fold blockage, one pinned pool
+connection, and an HTTP client timeout. The API now only stamps the
+pending-deletion marker (``AccountsRepository.begin_delete``); this module
+drains the bulk rows afterwards, ``DELETE_BATCH_SIZE`` rows per transaction,
+and finalizes with the exact transaction shape the synchronous path used.
+
+Fold-safety argument — why the chunk transactions do NOT take the fold-state
+lock, yet a deleted account's folded rows can never resurrect:
+
+1. Chunk transactions touch only raw rows (``usage_history``,
+   ``additional_usage_history``, ``request_logs``); they never write a rollup
+   table and never move a watermark. ``usage_history`` tables are not
+   fold-governed at all.
+2. A fold slice that interleaves between chunks may aggregate rows still
+   attributed to the account (adding folded rows under the account dimension)
+   or rows a chunk already detached (adding them under the orphaned-deleted
+   dimension — exactly the soft-path end state). Both are converged by the
+   finalization transaction: it takes ``lock_fold_state()`` and only then
+   detaches/deletes the residual raw rows and runs the lifecycle mirrors,
+   which move or remove EVERY folded row carrying the account dimension,
+   including rows folded mid-drain.
+3. Every fold slice holds the fold-state row lock from before it reads raw
+   rows until its commit. A slice therefore commits either before
+   finalization (its account-attributed output exists when the mirrors run
+   and is moved/removed by them) or after (it observes the post-finalization
+   raw state, which carries no attribution to the account). No slice can
+   commit pre-deletion attribution after the mirrors ran — the exact
+   resurrection the single-transaction path guarded against.
+
+Restart safety and idempotency: all progress lives in the database (the
+marker columns plus the shrinking predicate ``WHERE account_id = :id``), so a
+leader restart resumes mid-drain, and re-running any chunk is a no-op.
+A credential replacement (re-import/reauth) clears the marker and supersedes
+the deletion: chunks re-check the marker per transaction and finalization
+re-checks it under the account row lock, so a superseded account is never
+finalized.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import importlib
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Protocol, TypeVar, cast
+
+from sqlalchemy import delete, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth.api_key_cache import get_api_key_cache
+from app.core.cache.invalidation import NAMESPACE_API_KEY, get_cache_invalidation_poller
+from app.core.upstream_proxy.cache import get_upstream_route_cache
+from app.core.utils.time import utcnow
+from app.db.models import Account, AdditionalUsageHistory, RequestLog, UsageHistory
+from app.db.session import get_background_session, sqlite_writer_section
+from app.modules.accounts.repository import AccountsRepository
+from app.modules.proxy.account_cache import get_account_selection_cache, propagate_account_routing_change
+from app.modules.usage.repository import _clear_bulk_history_since_sqlite_cache
+
+logger = logging.getLogger(__name__)
+
+# Worker tick; the fast delete path additionally wakes the local worker, so a
+# single-replica deployment (or a delete that lands on the leader) starts
+# draining immediately and the tick only covers follower-received requests
+# and restart resume.
+DELETION_INTERVAL_SECONDS = 30
+# Rows per chunk transaction. Bounded so no chunk holds a long transaction:
+# measured production deletes ran ~1.2s/10k usage_history rows and ~23s/10k
+# request_logs detaches (18 indexes, non-HOT updates), so 5k keeps every
+# transaction comfortably short on both tables.
+DELETE_BATCH_SIZE = 5_000
+
+_T = TypeVar("_T")
+
+
+class _LeaderElectionLike(Protocol):
+    async def run_if_leader(self, fn: Callable[[], Awaitable[_T]]) -> _T | None: ...
+
+
+def _get_leader_election() -> _LeaderElectionLike:
+    module = importlib.import_module("app.core.scheduling.leader_election")
+    return cast(_LeaderElectionLike, module.get_leader_election())
+
+
+async def run_account_deletion_pass(*, batch_size: int = DELETE_BATCH_SIZE) -> dict[str, str]:
+    """Drain and finalize every account marked for deletion.
+
+    Returns an outcome per account id: ``finalized`` (rows drained, account
+    row removed), ``superseded`` (marker cleared mid-drain by a credential
+    replacement — deletion abandoned), or ``error`` (logged; retried on the
+    next tick).
+    """
+    outcomes: dict[str, str] = {}
+    for account_id in await _pending_deletion_ids():
+        try:
+            outcomes[account_id] = await _drain_and_finalize(account_id, batch_size=batch_size)
+        except Exception:
+            logger.exception("Background account deletion failed account_id=%s", account_id)
+            outcomes[account_id] = "error"
+    if any(outcome == "finalized" for outcome in outcomes.values()):
+        await _invalidate_account_caches()
+    if outcomes:
+        logger.info("Account deletion pass outcomes=%s", outcomes)
+    return outcomes
+
+
+async def _pending_deletion_ids() -> list[str]:
+    async with get_background_session() as session:
+        rows = await session.execute(
+            select(Account.id)
+            .where(Account.delete_requested_at.is_not(None))
+            .order_by(Account.delete_requested_at.asc(), Account.id.asc())
+        )
+        return list(rows.scalars().all())
+
+
+async def _drain_and_finalize(account_id: str, *, batch_size: int) -> str:
+    # Usage snapshots first (not fold-governed), then the raw request logs.
+    for chunk_fn in (_usage_history_chunk, _additional_usage_history_chunk, _request_logs_chunk):
+        drained = await _drain_chunks(chunk_fn, account_id, batch_size=batch_size)
+        if chunk_fn is _usage_history_chunk:
+            # Same hygiene as retention pruning: bulk usage-history reads are
+            # cached on SQLite and must not serve the drained account.
+            _clear_bulk_history_since_sqlite_cache()
+        if not drained:
+            return "superseded"
+    # Finalization: residual rows (streams that settled a log row mid-drain),
+    # folded-bucket mirrors, sticky/rollup rows, and the account row itself —
+    # one fold-state-locked transaction, identical in shape to the historical
+    # synchronous delete but over a residual row set instead of full history.
+    async with get_background_session() as session:
+        finalized = await AccountsRepository(session).delete(account_id, only_pending=True)
+    return "finalized" if finalized else "superseded"
+
+
+_ChunkFn = Callable[..., Awaitable[int]]
+
+
+async def _drain_chunks(chunk_fn: _ChunkFn, account_id: str, *, batch_size: int) -> bool:
+    """Run ``chunk_fn`` in per-transaction chunks until it drains; False when
+    the pending marker disappeared (deletion superseded)."""
+    while True:
+        async with get_background_session() as session:
+            async with sqlite_writer_section():
+                delete_history = await _pending_state(session, account_id)
+                if delete_history is None:
+                    return False
+                affected = await chunk_fn(session, account_id, delete_history=delete_history, batch_size=batch_size)
+                await session.commit()
+        if affected < batch_size:
+            return True
+
+
+async def _pending_state(session: AsyncSession, account_id: str) -> bool | None:
+    """The frozen ``delete_history`` choice, or None when no longer pending."""
+    row = (
+        await session.execute(
+            select(Account.delete_requested_at, Account.delete_history_requested).where(Account.id == account_id)
+        )
+    ).first()
+    if row is None or row[0] is None:
+        return None
+    return bool(row[1])
+
+
+async def _usage_history_chunk(session: AsyncSession, account_id: str, *, delete_history: bool, batch_size: int) -> int:
+    batch = select(UsageHistory.id).where(UsageHistory.account_id == account_id).limit(batch_size).scalar_subquery()
+    result = await session.execute(delete(UsageHistory).where(UsageHistory.id.in_(batch)).returning(UsageHistory.id))
+    return len(result.scalars().all())
+
+
+async def _additional_usage_history_chunk(
+    session: AsyncSession, account_id: str, *, delete_history: bool, batch_size: int
+) -> int:
+    batch = (
+        select(AdditionalUsageHistory.id)
+        .where(AdditionalUsageHistory.account_id == account_id)
+        .limit(batch_size)
+        .scalar_subquery()
+    )
+    result = await session.execute(
+        delete(AdditionalUsageHistory).where(AdditionalUsageHistory.id.in_(batch)).returning(AdditionalUsageHistory.id)
+    )
+    return len(result.scalars().all())
+
+
+async def _request_logs_chunk(session: AsyncSession, account_id: str, *, delete_history: bool, batch_size: int) -> int:
+    """Detach (soft) or delete (hard) one chunk of the account's raw logs.
+
+    Deliberately NOT fold-state-locked and NOT mirrored: see the module
+    docstring for why interleaved fold slices converge at finalization.
+    """
+    batch = select(RequestLog.id).where(RequestLog.account_id == account_id).limit(batch_size).scalar_subquery()
+    if delete_history:
+        result = await session.execute(delete(RequestLog).where(RequestLog.id.in_(batch)).returning(RequestLog.id))
+    else:
+        result = await session.execute(
+            update(RequestLog)
+            .where(RequestLog.id.in_(batch))
+            .values(account_id=None, deleted_at=utcnow())
+            .returning(RequestLog.id)
+        )
+    return len(result.scalars().all())
+
+
+async def _invalidate_account_caches() -> None:
+    """Post-finalization invalidation, mirroring the synchronous delete path.
+
+    Account ids are deterministic (delete-then-re-import regenerates the same
+    id), so cached route outcomes and API-key assignment snapshots must not
+    survive the account row's removal.
+    """
+    get_account_selection_cache().invalidate()
+    get_api_key_cache().clear()
+    await get_upstream_route_cache().invalidate()
+    await propagate_account_routing_change()
+    poller = get_cache_invalidation_poller()
+    if poller is not None:
+        await poller.bump(NAMESPACE_API_KEY)
+
+
+@dataclass(slots=True)
+class AccountDeletionScheduler:
+    """Leader-gated worker tick with a local wake signal.
+
+    Each tick first checks — with one cheap indexed-table read, before any
+    leader-election work — whether any account is pending deletion, so the
+    steady state (no pending deletions) costs one SELECT per interval.
+    """
+
+    interval_seconds: int
+    _task: asyncio.Task[None] | None = None
+    _stop: asyncio.Event = field(default_factory=asyncio.Event)
+    _wake: asyncio.Event = field(default_factory=asyncio.Event)
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    async def start(self) -> None:
+        if self._task and not self._task.done():
+            return
+        self._stop.clear()
+        self._task = asyncio.create_task(self._run_loop())
+
+    async def stop(self) -> None:
+        if not self._task:
+            return
+        self._stop.set()
+        self._task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._task
+        self._task = None
+
+    def wake(self) -> None:
+        """Start the next pass immediately (fast delete path just committed)."""
+        self._wake.set()
+
+    async def _run_loop(self) -> None:
+        while not self._stop.is_set():
+            # Clear BEFORE running so a wake that lands mid-pass (a second
+            # delete request) schedules another pass instead of being lost.
+            self._wake.clear()
+            await self._run_once()
+            try:
+                await asyncio.wait_for(self._wake.wait(), timeout=self.interval_seconds)
+            except asyncio.TimeoutError:
+                continue
+
+    async def _run_once(self) -> None:
+        try:
+            if not await _any_pending_deletion():
+                return
+        except Exception:
+            logger.exception("Failed to check for pending account deletions")
+            return
+        await _get_leader_election().run_if_leader(self._run_as_leader)
+
+    async def _run_as_leader(self) -> None:
+        async with self._lock:
+            try:
+                await run_account_deletion_pass()
+            except Exception:
+                logger.exception("Account deletion pass failed")
+
+
+async def _any_pending_deletion() -> bool:
+    async with get_background_session() as session:
+        row = await session.execute(select(Account.id).where(Account.delete_requested_at.is_not(None)).limit(1))
+        return row.scalar_one_or_none() is not None
+
+
+_scheduler: AccountDeletionScheduler | None = None
+
+
+def build_account_deletion_scheduler() -> AccountDeletionScheduler:
+    global _scheduler
+    _scheduler = AccountDeletionScheduler(interval_seconds=DELETION_INTERVAL_SECONDS)
+    return _scheduler
+
+
+def request_account_deletion_run() -> None:
+    """Nudge the local worker after a delete request commits.
+
+    A follower's nudge is a no-op (``run_if_leader`` declines) and the
+    leader's periodic tick picks the request up within the interval; when the
+    receiving replica IS the leader — the common single-replica case — the
+    drain starts immediately.
+    """
+    if _scheduler is not None:
+        _scheduler.wake()

--- a/app/modules/accounts/deletion.py
+++ b/app/modules/accounts/deletion.py
@@ -36,9 +36,16 @@ Restart safety and idempotency: all progress lives in the database (the
 marker columns plus the shrinking predicate ``WHERE account_id = :id``), so a
 leader restart resumes mid-drain, and re-running any chunk is a no-op.
 A credential replacement (re-import/reauth) clears the marker and supersedes
-the deletion: chunks re-check the marker per transaction and finalization
-re-checks it under the account row lock, so a superseded account is never
-finalized.
+the deletion: every chunk transaction re-reads the marker under the account
+row lock (PostgreSQL ``FOR NO KEY UPDATE``; the SQLite writer section
+serializes writers) before touching rows, and finalization re-checks it the
+same way, so no chunk can commit row work after a replacement committed and
+a superseded account is never finalized.
+
+Fairness: a deletion pass round-robins one chunk per pending account and
+re-scans for newly marked accounts between rounds, so one account's
+multi-minute drain can neither starve another marked account nor delay a
+delete request that arrives mid-pass.
 """
 
 from __future__ import annotations
@@ -92,20 +99,35 @@ def _get_leader_election() -> _LeaderElectionLike:
 async def run_account_deletion_pass(*, batch_size: int = DELETE_BATCH_SIZE) -> dict[str, str]:
     """Drain and finalize every account marked for deletion.
 
+    Round-robin fairness: each round advances every pending account by at
+    most one full chunk, and the pending set is re-scanned between rounds, so
+    a newly marked account starts draining within one chunk transaction of
+    its request even while another account's long drain is in progress.
+
     Returns an outcome per account id: ``finalized`` (rows drained, account
     row removed), ``superseded`` (marker cleared mid-drain by a credential
     replacement — deletion abandoned), or ``error`` (logged; retried on the
     next tick).
     """
     outcomes: dict[str, str] = {}
-    for account_id in await _pending_deletion_ids():
-        try:
-            outcomes[account_id] = await _drain_and_finalize(account_id, batch_size=batch_size)
-        except Exception:
-            logger.exception("Background account deletion failed account_id=%s", account_id)
-            outcomes[account_id] = "error"
-    if any(outcome == "finalized" for outcome in outcomes.values()):
-        await _invalidate_account_caches()
+    while True:
+        runnable = [
+            account_id for account_id in await _pending_deletion_ids() if outcomes.get(account_id) in (None, "draining")
+        ]
+        if not runnable:
+            break
+        for account_id in runnable:
+            try:
+                outcomes[account_id] = await _advance_account(account_id, batch_size=batch_size)
+            except Exception:
+                logger.exception("Background account deletion failed account_id=%s", account_id)
+                outcomes[account_id] = "error"
+    # ``draining`` cannot survive the loop: an account leaves the runnable
+    # set only through a terminal outcome or by vanishing from the pending
+    # scan (its marker was cleared — a supersede that raced the scan).
+    for account_id, outcome in outcomes.items():
+        if outcome == "draining":
+            outcomes[account_id] = "superseded"
     if outcomes:
         logger.info("Account deletion pass outcomes=%s", outcomes)
     return outcomes
@@ -121,50 +143,71 @@ async def _pending_deletion_ids() -> list[str]:
         return list(rows.scalars().all())
 
 
-async def _drain_and_finalize(account_id: str, *, batch_size: int) -> str:
-    # Usage snapshots first (not fold-governed), then the raw request logs.
+async def _advance_account(account_id: str, *, batch_size: int) -> str:
+    """One bounded round of work for one account.
+
+    Runs the drain tables in order (usage snapshots first — not
+    fold-governed — then the raw request logs) but stops after the first
+    FULL chunk so the caller can round-robin other pending accounts:
+    ``draining`` means more chunks remain. Tables whose chunk came up short
+    are drained; when every table is, finalize.
+    """
     for chunk_fn in (_usage_history_chunk, _additional_usage_history_chunk, _request_logs_chunk):
-        drained = await _drain_chunks(chunk_fn, account_id, batch_size=batch_size)
-        if chunk_fn is _usage_history_chunk:
+        affected = await _run_chunk(chunk_fn, account_id, batch_size=batch_size)
+        if affected is None:
+            return "superseded"
+        if affected and chunk_fn is _usage_history_chunk:
             # Same hygiene as retention pruning: bulk usage-history reads are
             # cached on SQLite and must not serve the drained account.
             _clear_bulk_history_since_sqlite_cache()
-        if not drained:
-            return "superseded"
+        if affected >= batch_size:
+            return "draining"
     # Finalization: residual rows (streams that settled a log row mid-drain),
     # folded-bucket mirrors, sticky/rollup rows, and the account row itself —
     # one fold-state-locked transaction, identical in shape to the historical
     # synchronous delete but over a residual row set instead of full history.
     async with get_background_session() as session:
         finalized = await AccountsRepository(session).delete(account_id, only_pending=True)
-    return "finalized" if finalized else "superseded"
+    if not finalized:
+        return "superseded"
+    # Invalidate immediately (not at end of pass): the account row is gone
+    # and ids are deterministic, so cached routing/API-key snapshots must not
+    # outlive it while the pass keeps draining other accounts.
+    await _invalidate_account_caches()
+    return "finalized"
 
 
 _ChunkFn = Callable[..., Awaitable[int]]
 
 
-async def _drain_chunks(chunk_fn: _ChunkFn, account_id: str, *, batch_size: int) -> bool:
-    """Run ``chunk_fn`` in per-transaction chunks until it drains; False when
-    the pending marker disappeared (deletion superseded)."""
-    while True:
-        async with get_background_session() as session:
-            async with sqlite_writer_section():
-                delete_history = await _pending_state(session, account_id)
-                if delete_history is None:
-                    return False
-                affected = await chunk_fn(session, account_id, delete_history=delete_history, batch_size=batch_size)
-                await session.commit()
-        if affected < batch_size:
-            return True
+async def _run_chunk(chunk_fn: _ChunkFn, account_id: str, *, batch_size: int) -> int | None:
+    """Run one chunk transaction; None when the pending marker disappeared
+    (deletion superseded)."""
+    async with get_background_session() as session:
+        async with sqlite_writer_section():
+            delete_history = await _pending_state(session, account_id)
+            if delete_history is None:
+                await session.rollback()
+                return None
+            affected = await chunk_fn(session, account_id, delete_history=delete_history, batch_size=batch_size)
+            await session.commit()
+    return affected
 
 
 async def _pending_state(session: AsyncSession, account_id: str) -> bool | None:
-    """The frozen ``delete_history`` choice, or None when no longer pending."""
-    row = (
-        await session.execute(
-            select(Account.delete_requested_at, Account.delete_history_requested).where(Account.id == account_id)
-        )
-    ).first()
+    """The frozen ``delete_history`` choice, or None when no longer pending.
+
+    On PostgreSQL the read locks the account row (``FOR NO KEY UPDATE``) for
+    the rest of the chunk transaction, so a credential replacement cannot
+    clear the marker between this read and the chunk's row mutations — the
+    replacement blocks until the chunk commits, then the next chunk observes
+    the cleared marker and stops. On SQLite the writer section already
+    serializes this transaction against every other writer.
+    """
+    stmt = select(Account.delete_requested_at, Account.delete_history_requested).where(Account.id == account_id)
+    if session.get_bind().dialect.name == "postgresql":
+        stmt = stmt.with_for_update(key_share=True)
+    row = (await session.execute(stmt)).first()
     if row is None or row[0] is None:
         return None
     return bool(row[1])

--- a/app/modules/accounts/deletion.py
+++ b/app/modules/accounts/deletion.py
@@ -65,9 +65,20 @@ from app.core.auth.api_key_cache import get_api_key_cache
 from app.core.cache.invalidation import NAMESPACE_API_KEY, get_cache_invalidation_poller
 from app.core.upstream_proxy.cache import get_upstream_route_cache
 from app.core.utils.time import utcnow
-from app.db.models import Account, AdditionalUsageHistory, RequestLog, UsageHistory
+from app.db.models import (
+    Account,
+    AccountStatus,
+    AdditionalUsageHistory,
+    ApiKeyAccountAssignment,
+    RequestLog,
+    UsageHistory,
+)
 from app.db.session import get_background_session, sqlite_writer_section
-from app.modules.accounts.repository import AccountsRepository, credentials_replaced_since_wipe
+from app.modules.accounts.repository import (
+    ACCOUNT_PENDING_DELETION_REASON,
+    AccountsRepository,
+    credentials_replaced_since_wipe,
+)
 from app.modules.proxy.account_cache import get_account_selection_cache, propagate_account_routing_change
 from app.modules.usage.repository import _clear_bulk_history_since_sqlite_cache
 
@@ -217,6 +228,8 @@ async def _pending_state(session: AsyncSession, account_id: str) -> bool | None:
         Account.access_token_encrypted,
         Account.refresh_token_encrypted,
         Account.id_token_encrypted,
+        Account.status,
+        Account.deactivation_reason,
     ).where(Account.id == account_id)
     if session.get_bind().dialect.name == "postgresql":
         stmt = stmt.with_for_update(key_share=True)
@@ -231,6 +244,26 @@ async def _pending_state(session: AsyncSession, account_id: str) -> bool | None:
         )
         await session.commit()
         return None
+    # Self-heal drift written by pre-upgrade replicas during a rolling
+    # deploy (their writers are unfenced): a late settlement may have
+    # replaced the terminal status — making the wiped account selectable
+    # again — and an unconditional assignment insert may have recreated an
+    # API-key assignment begin_delete removed. Re-fence both under the row
+    # lock held above; any drift is bounded by one chunk transaction. The
+    # credentials check above already excluded genuine replacements, so a
+    # non-DEACTIVATED status here can only be such drift.
+    if row[5] is not AccountStatus.DEACTIVATED or row[6] != ACCOUNT_PENDING_DELETION_REASON:
+        await session.execute(
+            update(Account)
+            .where(Account.id == account_id)
+            .values(
+                status=AccountStatus.DEACTIVATED,
+                deactivation_reason=ACCOUNT_PENDING_DELETION_REASON,
+                reset_at=None,
+                blocked_at=None,
+            )
+        )
+    await session.execute(delete(ApiKeyAccountAssignment).where(ApiKeyAccountAssignment.account_id == account_id))
     return bool(row[1])
 
 

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import delete, or_, select, text, update
+from sqlalchemy import case, delete, func, or_, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import OperationalError
@@ -50,6 +50,10 @@ from app.modules.usage.repository import _clear_bulk_history_since_sqlite_cache
 
 _SETTINGS_ROW_ID = 1
 _DUPLICATE_ACCOUNT_SUFFIX = "__copy"
+# deactivation_reason stamped by the fast DELETE path while the background
+# worker drains the account's rows. The authoritative pending marker is
+# accounts.delete_requested_at; the reason string is operator-facing only.
+ACCOUNT_PENDING_DELETION_REASON = "pending_deletion"
 _UNSET = object()
 _HARD_STICKY_UNAVAILABLE_STATUSES = frozenset(
     (AccountStatus.PAUSED, AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED)
@@ -103,7 +107,11 @@ class AccountsRepository:
         return result.scalar_one_or_none()
 
     async def list_accounts(self, *, refresh_existing: bool = False) -> list[Account]:
-        stmt = select(Account).order_by(Account.email)
+        # Accounts marked for background deletion are already deleted from the
+        # operator's point of view: they never appear in listings (dashboard,
+        # usage refresh, automations) even though their rows survive until the
+        # deletion worker finishes draining them.
+        stmt = select(Account).where(Account.delete_requested_at.is_(None)).order_by(Account.email)
         if refresh_existing:
             stmt = stmt.execution_options(populate_existing=True)
         result = await self._session.execute(stmt)
@@ -112,7 +120,12 @@ class AccountsRepository:
     async def list_accounts_by_ids(self, account_ids: list[str], *, refresh_existing: bool = False) -> list[Account]:
         if not account_ids:
             return []
-        stmt = select(Account).where(Account.id.in_(account_ids)).order_by(Account.email)
+        stmt = (
+            select(Account)
+            .where(Account.id.in_(account_ids))
+            .where(Account.delete_requested_at.is_(None))
+            .order_by(Account.email)
+        )
         if refresh_existing:
             stmt = stmt.execution_options(populate_existing=True)
         result = await self._session.execute(stmt)
@@ -816,12 +829,84 @@ class AccountsRepository:
             await self._session.commit()
             return result.scalar_one_or_none() is not None
 
-    async def delete(self, account_id: str, *, delete_history: bool = False) -> bool:
+    async def begin_delete(self, account_id: str, *, delete_history: bool = False) -> bool:
+        """Mark an account for background deletion; commits in milliseconds.
+
+        Fast path of ``DELETE /api/accounts/{id}``: the account becomes
+        terminal (``DEACTIVATED`` — every serving path already excludes it)
+        and carries the pending-deletion marker that hides it from listings
+        and enqueues it for the deletion worker, which drains its bulk rows
+        in chunks and finalizes via :meth:`delete` with ``only_pending=True``.
+
+        Idempotent: a repeat request on an already-marked account succeeds
+        without changing the frozen ``delete_history`` choice (first request
+        wins — matching the synchronous behavior, where a second DELETE after
+        the first completed found nothing left to escalate).
+        """
+        async with sqlite_writer_section():
+            result = await self._session.execute(
+                update(Account)
+                .where(Account.id == account_id)
+                .values(
+                    status=AccountStatus.DEACTIVATED,
+                    deactivation_reason=ACCOUNT_PENDING_DELETION_REASON,
+                    reset_at=None,
+                    blocked_at=None,
+                    delete_requested_at=func.coalesce(Account.delete_requested_at, utcnow()),
+                    delete_history_requested=case(
+                        (Account.delete_requested_at.is_(None), delete_history),
+                        else_=Account.delete_history_requested,
+                    ),
+                )
+                .returning(Account.id)
+            )
+            updated_id = result.scalar_one_or_none()
+            if updated_id is not None:
+                # Same immediate cleanup the DEACTIVATED transition performs:
+                # sticky mappings and bridge sessions must not outlive the
+                # account's routability.
+                await self._session.execute(delete(StickySession).where(StickySession.account_id == account_id))
+                await self._close_http_bridge_sessions_for_account(account_id)
+            await self._session.commit()
+            return updated_id is not None
+
+    async def delete(
+        self,
+        account_id: str,
+        *,
+        delete_history: bool = False,
+        only_pending: bool = False,
+    ) -> bool:
         async with sqlite_writer_section():
             if self._dialect_name() == "postgresql":
                 # Identity membership precedes the fold-state lock so live
                 # settlement and deletion cannot form an identity/fold cycle.
-                await self._lock_postgresql_account_identity_membership(account_id, None)
+                locked_account = await self._lock_postgresql_account_identity_membership(account_id, None)
+                pending_state = (
+                    None
+                    if locked_account is None
+                    else (locked_account.delete_requested_at, locked_account.delete_history_requested)
+                )
+            else:
+                pending_state = (
+                    await self._session.execute(
+                        select(Account.delete_requested_at, Account.delete_history_requested).where(
+                            Account.id == account_id
+                        )
+                    )
+                ).first()
+            if only_pending:
+                # Background finalization: a credential replacement
+                # (re-import/reauth) that cleared the marker supersedes the
+                # deletion, so touch nothing. The variant comes from the
+                # persisted flag frozen at request time, never the caller.
+                # On PostgreSQL the identity-membership row lock held above
+                # keeps the marker stable through this transaction; on SQLite
+                # the writer section serializes all writers.
+                if pending_state is None or pending_state[0] is None:
+                    await self._session.rollback()
+                    return False
+                delete_history = bool(pending_state[1])
             # Serialize against fold passes before touching the account's
             # request logs: without the fold-state lock an in-flight hourly
             # slice could aggregate the pre-delete attribution but commit
@@ -1213,6 +1298,12 @@ def _apply_account_updates(target: Account, source: Account) -> None:
     target.deactivation_reason = source.deactivation_reason
     target.reset_at = source.reset_at
     target.blocked_at = source.blocked_at
+    # A credential replacement (re-import/reauth) supersedes a pending
+    # background deletion: clearing the marker makes the deletion worker
+    # abandon the account before finalizing (rows already drained stay
+    # detached — history loss was requested by the earlier delete).
+    target.delete_requested_at = None
+    target.delete_history_requested = False
 
 
 def _slot_lock_key(account: Account, *, preserve_unknown_workspace_duplicates: bool = True) -> str:

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -680,6 +680,10 @@ class AccountsRepository:
             result = await self._session.execute(
                 update(Account)
                 .where(Account.id == account_id)
+                # Marked-for-deletion rows are gone from the operator's
+                # perspective: ID-based mutations must report not-found, as the
+                # synchronous delete did once the row was removed.
+                .where(Account.delete_requested_at.is_(None))
                 .values(security_work_authorized=enabled)
                 .returning(Account.id)
             )
@@ -849,7 +853,14 @@ class AccountsRepository:
     async def update_alias(self, account_id: str, alias: str | None) -> bool:
         async with sqlite_writer_section():
             result = await self._session.execute(
-                update(Account).where(Account.id == account_id).values(alias=alias).returning(Account.id)
+                update(Account)
+                .where(Account.id == account_id)
+                # Marked-for-deletion rows are gone from the operator's
+                # perspective: ID-based mutations must report not-found, as the
+                # synchronous delete did once the row was removed.
+                .where(Account.delete_requested_at.is_(None))
+                .values(alias=alias)
+                .returning(Account.id)
             )
             await self._session.commit()
             return result.scalar_one_or_none() is not None
@@ -859,6 +870,10 @@ class AccountsRepository:
             result = await self._session.execute(
                 update(Account)
                 .where(Account.id == account_id)
+                # Marked-for-deletion rows are gone from the operator's
+                # perspective: ID-based mutations must report not-found, as the
+                # synchronous delete did once the row was removed.
+                .where(Account.delete_requested_at.is_(None))
                 .values(limit_warmup_enabled=enabled)
                 .returning(Account.id)
             )
@@ -870,6 +885,10 @@ class AccountsRepository:
             result = await self._session.execute(
                 update(Account)
                 .where(Account.id == account_id)
+                # Marked-for-deletion rows are gone from the operator's
+                # perspective: ID-based mutations must report not-found, as the
+                # synchronous delete did once the row was removed.
+                .where(Account.delete_requested_at.is_(None))
                 .values(routing_policy=routing_policy)
                 .returning(Account.id)
             )

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -56,6 +56,27 @@ _DUPLICATE_ACCOUNT_SUFFIX = "__copy"
 # worker drains the account's rows. The authoritative pending marker is
 # accounts.delete_requested_at; the reason string is operator-facing only.
 ACCOUNT_PENDING_DELETION_REASON = "pending_deletion"
+
+
+def credentials_replaced_since_wipe(refresh_token_encrypted: bytes) -> bool:
+    """True when a marked account's refresh ciphertext is no longer the
+    empty-credential wipe stamped by :meth:`AccountsRepository.begin_delete`.
+
+    New-code credential replacements clear the pending-deletion marker in the
+    same transaction, but a replacement handled by a PRE-UPGRADE replica
+    during a rolling deploy writes fresh ciphertext without knowing the
+    marker columns. Fresh (non-wiped) credentials on a still-marked row are
+    therefore themselves the supersede signal; the caller must clear the
+    marker and abandon the deletion. Undecryptable material also counts as
+    replaced — never finalize a row whose credentials we cannot attribute to
+    our own wipe.
+    """
+    try:
+        return TokenEncryptor().decrypt(refresh_token_encrypted) != ""
+    except Exception:
+        return True
+
+
 _UNSET = object()
 _HARD_STICKY_UNAVAILABLE_STATUSES = frozenset(
     (AccountStatus.PAUSED, AccountStatus.RATE_LIMITED, AccountStatus.QUOTA_EXCEEDED)
@@ -946,14 +967,20 @@ class AccountsRepository:
                 pending_state = (
                     None
                     if locked_account is None
-                    else (locked_account.delete_requested_at, locked_account.delete_history_requested)
+                    else (
+                        locked_account.delete_requested_at,
+                        locked_account.delete_history_requested,
+                        locked_account.refresh_token_encrypted,
+                    )
                 )
             else:
                 pending_state = (
                     await self._session.execute(
-                        select(Account.delete_requested_at, Account.delete_history_requested).where(
-                            Account.id == account_id
-                        )
+                        select(
+                            Account.delete_requested_at,
+                            Account.delete_history_requested,
+                            Account.refresh_token_encrypted,
+                        ).where(Account.id == account_id)
                     )
                 ).first()
             if only_pending:
@@ -966,6 +993,18 @@ class AccountsRepository:
                 # the writer section serializes all writers.
                 if pending_state is None or pending_state[0] is None:
                     await self._session.rollback()
+                    return False
+                if credentials_replaced_since_wipe(pending_state[2]):
+                    # A pre-upgrade replica replaced the credentials without
+                    # being able to clear marker columns its ORM does not
+                    # know. That replacement supersedes the deletion: clear
+                    # the marker (we hold the row lock) and abandon.
+                    await self._session.execute(
+                        update(Account)
+                        .where(Account.id == account_id)
+                        .values(delete_requested_at=None, delete_history_requested=False)
+                    )
+                    await self._session.commit()
                     return False
                 delete_history = bool(pending_state[1])
             # Serialize against fold passes before touching the account's

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -12,6 +12,7 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.auth import extract_id_token_claims, resolve_seat_identity
 from app.core.crypto import TokenEncryptor
 from app.core.upstream_proxy.cache import get_upstream_route_cache
 from app.core.utils.time import utcnow
@@ -860,7 +861,13 @@ class AccountsRepository:
         credentials from it. A credential replacement (the only supersede
         path) writes fresh ciphertext, and token rotation is CAS-guarded on
         the pre-wipe refresh ciphertext, so a stale in-flight rotation
-        misses rather than resurrecting the old material.
+        misses rather than resurrecting the old material. Before the wipe,
+        the non-secret seat identity is preserved: legacy rows whose
+        ``chatgpt_user_id`` was never backfilled carry it only inside the
+        id-token claims, and targeted reauthentication — the promised
+        supersede path — verifies the seat against exactly those two
+        sources, so ``chatgpt_user_id`` is backfilled from the claims when
+        absent.
 
         API-key account assignments are removed here as well (the FK cascade
         used to do this when the synchronous delete removed the row), so key
@@ -873,26 +880,43 @@ class AccountsRepository:
         wins — matching the synchronous behavior, where a second DELETE after
         the first completed found nothing left to escalate).
         """
-        wiped_token = TokenEncryptor().encrypt("")
+        encryptor = TokenEncryptor()
+        wiped_token = encryptor.encrypt("")
         async with sqlite_writer_section():
+            seat_stmt = select(Account.chatgpt_user_id, Account.id_token_encrypted).where(Account.id == account_id)
+            if self._dialect_name() == "postgresql":
+                # Hold the row through the mark so the derived seat identity
+                # cannot go stale between this read and the update below.
+                seat_stmt = seat_stmt.with_for_update(key_share=True)
+            seat_row = (await self._session.execute(seat_stmt)).first()
+            if seat_row is None:
+                await self._session.rollback()
+                return False
+            seat_user_id: str | None = seat_row[0]
+            if seat_user_id is None:
+                try:
+                    claims = extract_id_token_claims(encryptor.decrypt(seat_row[1]))
+                    seat_user_id = resolve_seat_identity(claims, claims.auth)
+                except Exception:
+                    seat_user_id = None
+            values: dict[str, Any] = {
+                "status": AccountStatus.DEACTIVATED,
+                "deactivation_reason": ACCOUNT_PENDING_DELETION_REASON,
+                "reset_at": None,
+                "blocked_at": None,
+                "access_token_encrypted": wiped_token,
+                "refresh_token_encrypted": wiped_token,
+                "id_token_encrypted": wiped_token,
+                "delete_requested_at": func.coalesce(Account.delete_requested_at, utcnow()),
+                "delete_history_requested": case(
+                    (Account.delete_requested_at.is_(None), delete_history),
+                    else_=Account.delete_history_requested,
+                ),
+            }
+            if seat_user_id is not None:
+                values["chatgpt_user_id"] = seat_user_id
             result = await self._session.execute(
-                update(Account)
-                .where(Account.id == account_id)
-                .values(
-                    status=AccountStatus.DEACTIVATED,
-                    deactivation_reason=ACCOUNT_PENDING_DELETION_REASON,
-                    reset_at=None,
-                    blocked_at=None,
-                    access_token_encrypted=wiped_token,
-                    refresh_token_encrypted=wiped_token,
-                    id_token_encrypted=wiped_token,
-                    delete_requested_at=func.coalesce(Account.delete_requested_at, utcnow()),
-                    delete_history_requested=case(
-                        (Account.delete_requested_at.is_(None), delete_history),
-                        else_=Account.delete_history_requested,
-                    ),
-                )
-                .returning(Account.id)
+                update(Account).where(Account.id == account_id).values(**values).returning(Account.id)
             )
             updated_id = result.scalar_one_or_none()
             if updated_id is not None:

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -12,6 +12,7 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.crypto import TokenEncryptor
 from app.core.upstream_proxy.cache import get_upstream_route_cache
 from app.core.utils.time import utcnow
 from app.db.account_identity_lock import advisory_lock_key, lock_postgresql_account_identities
@@ -620,7 +621,17 @@ class AccountsRepository:
             if blocked_at is not _UNSET:
                 values["blocked_at"] = blocked_at
             result = await self._session.execute(
-                update(Account).where(Account.id == account_id).values(**values).returning(Account.id)
+                update(Account)
+                .where(Account.id == account_id)
+                # An account marked for background deletion is terminal: a
+                # stale in-flight settlement (e.g. a 429 from a request that
+                # was selected before the DELETE) must not replace the
+                # DEACTIVATED/pending_deletion state and make the account
+                # selectable again mid-drain. Only a credential replacement
+                # (which clears the marker) may resurrect the row.
+                .where(Account.delete_requested_at.is_(None))
+                .values(**values)
+                .returning(Account.id)
             )
             updated_id = result.scalar_one_or_none()
             if updated_id is not None and self._hard_sticky_outage_started(previous_status, status):
@@ -668,6 +679,9 @@ class AccountsRepository:
                 update(Account)
                 .where(Account.id == account_id)
                 .where(Account.status == expected_status)
+                # Same pending-deletion fence as ``update_status``: marked
+                # rows are terminal for ordinary status writers.
+                .where(Account.delete_requested_at.is_(None))
                 .values(**values)
                 .returning(Account.id)
             )
@@ -838,11 +852,28 @@ class AccountsRepository:
         and enqueues it for the deletion worker, which drains its bulk rows
         in chunks and finalizes via :meth:`delete` with ``only_pending=True``.
 
+        The stored token ciphertext is overwritten with empty-credential
+        ciphertext in the same transaction: the row outlives the DELETE
+        response by the drain duration, and no reader — including a
+        pre-upgrade replica during a rolling deploy, whose export endpoints
+        do not know the marker — may still be able to produce usable
+        credentials from it. A credential replacement (the only supersede
+        path) writes fresh ciphertext, and token rotation is CAS-guarded on
+        the pre-wipe refresh ciphertext, so a stale in-flight rotation
+        misses rather than resurrecting the old material.
+
+        API-key account assignments are removed here as well (the FK cascade
+        used to do this when the synchronous delete removed the row), so key
+        listings and pooled-usage projections exclude the account
+        immediately; the key's ``account_assignment_scope_enabled`` flag is
+        persisted separately and keeps the key scoped.
+
         Idempotent: a repeat request on an already-marked account succeeds
         without changing the frozen ``delete_history`` choice (first request
         wins — matching the synchronous behavior, where a second DELETE after
         the first completed found nothing left to escalate).
         """
+        wiped_token = TokenEncryptor().encrypt("")
         async with sqlite_writer_section():
             result = await self._session.execute(
                 update(Account)
@@ -852,6 +883,9 @@ class AccountsRepository:
                     deactivation_reason=ACCOUNT_PENDING_DELETION_REASON,
                     reset_at=None,
                     blocked_at=None,
+                    access_token_encrypted=wiped_token,
+                    refresh_token_encrypted=wiped_token,
+                    id_token_encrypted=wiped_token,
                     delete_requested_at=func.coalesce(Account.delete_requested_at, utcnow()),
                     delete_history_requested=case(
                         (Account.delete_requested_at.is_(None), delete_history),
@@ -867,6 +901,9 @@ class AccountsRepository:
                 # account's routability.
                 await self._session.execute(delete(StickySession).where(StickySession.account_id == account_id))
                 await self._close_http_bridge_sessions_for_account(account_id)
+                await self._session.execute(
+                    delete(ApiKeyAccountAssignment).where(ApiKeyAccountAssignment.account_id == account_id)
+                )
             await self._session.commit()
             return updated_id is not None
 

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -912,6 +912,32 @@ class AccountsRepository:
         wins — matching the synchronous behavior, where a second DELETE after
         the first completed found nothing left to escalate).
         """
+        # Repeat requests short-circuit BEFORE the writer section / row lock:
+        # a drain chunk holds the account row (and, on SQLite, the writer
+        # section) for up to a few seconds, and the fast-path contract is a
+        # millisecond-scale response. The unlocked read is safe because the
+        # repeat changes nothing — the first request froze the variant and
+        # the wipe/cleanup already ran — and a replacement racing this read
+        # supersedes the deletion exactly as if it landed after this
+        # response. When credentials were replaced WITHOUT clearing the
+        # marker (a pre-upgrade replica's replacement), fall through to the
+        # full path so an explicit re-delete re-wipes and re-arms.
+        marked_row = (
+            await self._session.execute(
+                select(
+                    Account.delete_requested_at,
+                    Account.access_token_encrypted,
+                    Account.refresh_token_encrypted,
+                    Account.id_token_encrypted,
+                ).where(Account.id == account_id)
+            )
+        ).first()
+        if (
+            marked_row is not None
+            and marked_row[0] is not None
+            and not credentials_replaced_since_wipe(marked_row[1], marked_row[2], marked_row[3])
+        ):
+            return True
         encryptor = TokenEncryptor()
         wiped_token = encryptor.encrypt("")
         async with sqlite_writer_section():

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -1013,6 +1013,23 @@ class AccountsRepository:
             # after this transaction, resurrecting the account's folded rows
             # the mirrors below just moved or removed.
             await lock_fold_state(self._session)
+            if self._dialect_name() == "postgresql":
+                # Upgrade the account row to a full FOR UPDATE lock BEFORE the
+                # raw sweeps. FOR UPDATE conflicts with the KEY SHARE taken by
+                # concurrent request-log FK inserts, so every in-flight
+                # stream's log row either commits before this point (and the
+                # sweeps below see it) or its insert blocks until this
+                # transaction commits and then fails its FK against the
+                # deleted row — the same outcome a post-delete insert always
+                # had. Without the upgrade, an insert could commit between
+                # the sweep and the account-row delete: the FK's ON DELETE
+                # SET NULL would leave a live (deleted_at IS NULL) orphan on
+                # the soft path, or surviving raw history under
+                # delete_history. Lock order (identity -> fold -> row
+                # exclusive) matches the historical transaction, where the
+                # final DELETE acquired this same exclusive lock after the
+                # fold lock.
+                await self._session.execute(select(Account.id).where(Account.id == account_id).with_for_update())
             await self._session.execute(delete(UsageHistory).where(UsageHistory.account_id == account_id))
             if delete_history:
                 await self._session.execute(delete(RequestLog).where(RequestLog.account_id == account_id))

--- a/app/modules/accounts/repository.py
+++ b/app/modules/accounts/repository.py
@@ -58,8 +58,12 @@ _DUPLICATE_ACCOUNT_SUFFIX = "__copy"
 ACCOUNT_PENDING_DELETION_REASON = "pending_deletion"
 
 
-def credentials_replaced_since_wipe(refresh_token_encrypted: bytes) -> bool:
-    """True when a marked account's refresh ciphertext is no longer the
+def credentials_replaced_since_wipe(
+    access_token_encrypted: bytes,
+    refresh_token_encrypted: bytes,
+    id_token_encrypted: bytes,
+) -> bool:
+    """True when a marked account's token ciphertext is no longer the
     empty-credential wipe stamped by :meth:`AccountsRepository.begin_delete`.
 
     New-code credential replacements clear the pending-deletion marker in the
@@ -67,14 +71,21 @@ def credentials_replaced_since_wipe(refresh_token_encrypted: bytes) -> bool:
     during a rolling deploy writes fresh ciphertext without knowing the
     marker columns. Fresh (non-wiped) credentials on a still-marked row are
     therefore themselves the supersede signal; the caller must clear the
-    marker and abandon the deletion. Undecryptable material also counts as
+    marker and abandon the deletion. ALL THREE token fields are inspected: a
+    legal replacement may carry an empty refresh token while providing fresh
+    access/id material, and mistaking it for the wipe would finalize a
+    freshly replaced account. Undecryptable material also counts as
     replaced — never finalize a row whose credentials we cannot attribute to
     our own wipe.
     """
-    try:
-        return TokenEncryptor().decrypt(refresh_token_encrypted) != ""
-    except Exception:
-        return True
+    encryptor = TokenEncryptor()
+    for ciphertext in (access_token_encrypted, refresh_token_encrypted, id_token_encrypted):
+        try:
+            if encryptor.decrypt(ciphertext) != "":
+                return True
+        except Exception:
+            return True
+    return False
 
 
 _UNSET = object()
@@ -970,7 +981,9 @@ class AccountsRepository:
                     else (
                         locked_account.delete_requested_at,
                         locked_account.delete_history_requested,
+                        locked_account.access_token_encrypted,
                         locked_account.refresh_token_encrypted,
+                        locked_account.id_token_encrypted,
                     )
                 )
             else:
@@ -979,7 +992,9 @@ class AccountsRepository:
                         select(
                             Account.delete_requested_at,
                             Account.delete_history_requested,
+                            Account.access_token_encrypted,
                             Account.refresh_token_encrypted,
+                            Account.id_token_encrypted,
                         ).where(Account.id == account_id)
                     )
                 ).first()
@@ -994,7 +1009,7 @@ class AccountsRepository:
                 if pending_state is None or pending_state[0] is None:
                     await self._session.rollback()
                     return False
-                if credentials_replaced_since_wipe(pending_state[2]):
+                if credentials_replaced_since_wipe(pending_state[2], pending_state[3], pending_state[4]):
                     # A pre-upgrade replica replaced the credentials without
                     # being able to clear marker columns its ORM does not
                     # know. That replacement supersedes the deletion: clear

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -234,7 +234,7 @@ class AccountsService:
         )
 
     async def get_account_trends(self, account_id: str) -> AccountTrendsResponse | None:
-        account = await self._repo.get_by_id(account_id)
+        account = await self._get_visible_account(account_id)
         if not account or not self._usage_repo:
             return None
         now = utcnow()
@@ -256,7 +256,7 @@ class AccountsService:
         )
 
     async def get_usage_reset_credits(self, account_id: str) -> AccountUsageResetCreditsResponse | None:
-        account = await self._repo.get_by_id(account_id)
+        account = await self._get_visible_account(account_id)
         if account is None:
             return None
         if account.status in (AccountStatus.PAUSED, AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
@@ -319,7 +319,7 @@ class AccountsService:
         *,
         redeem_request_id: str | None = None,
     ) -> AccountUsageResetConsumeResponse | None:
-        account = await self._repo.get_by_id(account_id)
+        account = await self._get_visible_account(account_id)
         if account is None:
             return None
         if account.status in (AccountStatus.PAUSED, AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
@@ -424,18 +424,19 @@ class AccountsService:
                 encryptor=self._encryptor,
             )
 
-    async def _get_exportable_account(self, account_id: str) -> Account | None:
-        """Account for credential-export endpoints; marked-for-deletion rows
-        are gone from the operator's perspective (the synchronous delete
-        returned 404 here) and MUST NOT keep serving decrypted tokens during
-        the background drain window."""
+    async def _get_visible_account(self, account_id: str) -> Account | None:
+        """Account fetch for ID-based operator routes; marked-for-deletion
+        rows are gone from the operator's perspective (the synchronous delete
+        returned 404 on every one of these routes once the row was removed)
+        and MUST NOT keep serving reads, mutations, or decrypted tokens
+        during the background drain window."""
         account = await self._repo.get_by_id(account_id)
         if account is None or account.delete_requested_at is not None:
             return None
         return account
 
     async def export_opencode_auth(self, account_id: str) -> AccountOpenCodeAuthExportResponse | None:
-        account = await self._get_exportable_account(account_id)
+        account = await self._get_visible_account(account_id)
         if account is None:
             return None
 
@@ -460,7 +461,7 @@ class AccountsService:
         )
 
     async def export_auth(self, account_id: str) -> AccountAuthExportResponse | None:
-        account = await self._get_exportable_account(account_id)
+        account = await self._get_visible_account(account_id)
         if account is None:
             return None
 
@@ -630,7 +631,7 @@ class AccountsService:
         return result
 
     async def pause_account(self, account_id: str) -> bool:
-        account = await self._repo.get_by_id(account_id)
+        account = await self._get_visible_account(account_id)
         if account is None:
             return False
         if account.status in (AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):
@@ -703,7 +704,7 @@ class AccountsService:
         return await self._repo.update_alias(account_id, normalized)
 
     async def export_account(self, account_id: str) -> AccountExportResponse | None:
-        account = await self._get_exportable_account(account_id)
+        account = await self._get_visible_account(account_id)
         if not account:
             return None
         access_token = self._encryptor.decrypt(account.access_token_encrypted)
@@ -744,7 +745,7 @@ class AccountsService:
         before/after snapshot so the operator can see whether the upstream
         state changed.
         """
-        account = await self._repo.get_by_id(account_id)
+        account = await self._get_visible_account(account_id)
         if account is None:
             return None
         if account.status in (AccountStatus.PAUSED, AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED):

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -40,6 +40,7 @@ from app.core.utils.time import naive_utc_to_epoch, to_utc_naive, utcnow
 from app.db.models import Account, AccountStatus, DashboardSettings
 from app.db.session import get_background_session
 from app.modules.accounts.auth_manager import AuthManager
+from app.modules.accounts.deletion import request_account_deletion_run
 from app.modules.accounts.mappers import build_account_summaries, build_account_usage_trends
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.accounts.schemas import (
@@ -592,6 +593,11 @@ class AccountsService:
         account = await self._repo.get_by_id(account_id)
         if account is None:
             return False
+        if account.delete_requested_at is not None:
+            # Marked for background deletion: already invisible in listings
+            # and about to be removed — report it as gone rather than racing
+            # the deletion worker back to ACTIVE.
+            return False
         if account.status == AccountStatus.REAUTH_REQUIRED:
             raise AccountStateTransitionError("Account requires re-authentication and cannot be reactivated directly")
         result = await self._repo.update_status_if_current(
@@ -659,19 +665,25 @@ class AccountsService:
         return result
 
     async def delete_account(self, account_id: str, *, delete_history: bool = False) -> bool:
-        result = await self._repo.delete(account_id, delete_history=delete_history)
+        # Fast path: stamp the pending-deletion marker (terminal status, hidden
+        # from listings, sticky/bridge cleanup) and return in milliseconds; the
+        # background deletion worker drains the bulk rows and removes the
+        # account row afterwards (see app.modules.accounts.deletion).
+        result = await self._repo.begin_delete(account_id, delete_history=delete_history)
         if result:
             mark_account_routing_unavailable(account_id)
             get_account_selection_cache().invalidate()
             get_api_key_cache().clear()
-            # Deletion cascades the account_proxy_bindings row away, and account
-            # ids are deterministic (delete-then-re-import regenerates the same
-            # id), so the cached route outcome must not survive the deletion.
+            # Finalization cascades the account_proxy_bindings row away, and
+            # account ids are deterministic (delete-then-re-import regenerates
+            # the same id), so the cached route outcome must not survive the
+            # delete request; the worker invalidates again after finalizing.
             await get_upstream_route_cache().invalidate()
             await propagate_account_routing_change()
             poller = get_cache_invalidation_poller()
             if poller is not None:
                 await poller.bump(NAMESPACE_API_KEY)
+            request_account_deletion_run()
         return result
 
     async def set_account_alias(self, account_id: str, alias: str | None) -> bool:

--- a/app/modules/accounts/service.py
+++ b/app/modules/accounts/service.py
@@ -424,8 +424,18 @@ class AccountsService:
                 encryptor=self._encryptor,
             )
 
-    async def export_opencode_auth(self, account_id: str) -> AccountOpenCodeAuthExportResponse | None:
+    async def _get_exportable_account(self, account_id: str) -> Account | None:
+        """Account for credential-export endpoints; marked-for-deletion rows
+        are gone from the operator's perspective (the synchronous delete
+        returned 404 here) and MUST NOT keep serving decrypted tokens during
+        the background drain window."""
         account = await self._repo.get_by_id(account_id)
+        if account is None or account.delete_requested_at is not None:
+            return None
+        return account
+
+    async def export_opencode_auth(self, account_id: str) -> AccountOpenCodeAuthExportResponse | None:
+        account = await self._get_exportable_account(account_id)
         if account is None:
             return None
 
@@ -450,7 +460,7 @@ class AccountsService:
         )
 
     async def export_auth(self, account_id: str) -> AccountAuthExportResponse | None:
-        account = await self._repo.get_by_id(account_id)
+        account = await self._get_exportable_account(account_id)
         if account is None:
             return None
 
@@ -693,7 +703,7 @@ class AccountsService:
         return await self._repo.update_alias(account_id, normalized)
 
     async def export_account(self, account_id: str) -> AccountExportResponse | None:
-        account = await self._repo.get_by_id(account_id)
+        account = await self._get_exportable_account(account_id)
         if not account:
             return None
         access_token = self._encryptor.decrypt(account.access_token_encrypted)

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -204,6 +204,11 @@ class ApiKeysRepository:
             .where(
                 ~Account.status.in_((AccountStatus.REAUTH_REQUIRED, AccountStatus.DEACTIVATED, AccountStatus.PAUSED))
             )
+            # Status alone is not enough: an unfenced pre-upgrade replica can
+            # briefly replace a marked account's terminal status during a
+            # rolling deploy, and a deleted account must never re-enter the
+            # unscoped pooled-usage projections.
+            .where(Account.delete_requested_at.is_(None))
         )
         return list(result.scalars().all())
 

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -441,25 +441,30 @@ class ApiKeysRepository:
         return await self.get_limits_by_key(key_id)
 
     async def replace_account_assignments(self, key_id: str, account_ids: list[str], *, commit: bool = True) -> None:
+        # Re-check the pending-deletion marker atomically with the write:
+        # validation ran in an earlier transaction, and an account DELETE can
+        # commit in between — the marked row still exists (background drain),
+        # so a plain FK insert would succeed and resurrect an assignment
+        # begin_delete just removed. The FOR SHARE lock (PostgreSQL)
+        # conflicts with begin_delete's row update, so either this
+        # transaction commits first (and begin_delete's assignment cleanup
+        # removes its rows) or the marker is visible below and the account is
+        # skipped. The account locks are taken BEFORE the assignment-row
+        # delete to match begin_delete's order (account row, then assignment
+        # rows) — taking them after would form a lock cycle with a
+        # concurrent begin_delete and deadlock. SQLite serializes writers,
+        # so the marker predicate alone is race-free there.
+        if account_ids and self._session.get_bind().dialect.name == "postgresql":
+            await self._session.execute(
+                select(Account.id).where(Account.id.in_(account_ids)).with_for_update(read=True)
+            )
         await self._session.execute(delete(ApiKeyAccountAssignment).where(ApiKeyAccountAssignment.api_key_id == key_id))
         if account_ids:
-            # Re-check the pending-deletion marker atomically with the
-            # insert: validation ran in an earlier transaction, and an
-            # account DELETE can commit in between — the marked row still
-            # exists (background drain), so a plain FK insert would succeed
-            # and resurrect an assignment begin_delete just removed. The
-            # FOR SHARE lock (PostgreSQL) conflicts with begin_delete's row
-            # update, so either this insert commits first (and begin_delete's
-            # assignment cleanup removes it) or the marker is visible here
-            # and the account is skipped. SQLite serializes writers, so the
-            # marker predicate alone is race-free there.
             assignment_source = (
                 select(literal(key_id), Account.id)
                 .where(Account.id.in_(account_ids))
                 .where(Account.delete_requested_at.is_(None))
             )
-            if self._session.get_bind().dialect.name == "postgresql":
-                assignment_source = assignment_source.with_for_update(read=True)
             await self._session.execute(
                 insert(ApiKeyAccountAssignment).from_select(["api_key_id", "account_id"], assignment_source)
             )

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
-from sqlalchemy import BigInteger, Integer, cast, delete, func, or_, select, true, update
+from sqlalchemy import BigInteger, Integer, cast, delete, func, insert, literal, or_, select, true, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import load_only, selectinload
 
@@ -442,8 +442,27 @@ class ApiKeysRepository:
 
     async def replace_account_assignments(self, key_id: str, account_ids: list[str], *, commit: bool = True) -> None:
         await self._session.execute(delete(ApiKeyAccountAssignment).where(ApiKeyAccountAssignment.api_key_id == key_id))
-        for account_id in account_ids:
-            self._session.add(ApiKeyAccountAssignment(api_key_id=key_id, account_id=account_id))
+        if account_ids:
+            # Re-check the pending-deletion marker atomically with the
+            # insert: validation ran in an earlier transaction, and an
+            # account DELETE can commit in between — the marked row still
+            # exists (background drain), so a plain FK insert would succeed
+            # and resurrect an assignment begin_delete just removed. The
+            # FOR SHARE lock (PostgreSQL) conflicts with begin_delete's row
+            # update, so either this insert commits first (and begin_delete's
+            # assignment cleanup removes it) or the marker is visible here
+            # and the account is skipped. SQLite serializes writers, so the
+            # marker predicate alone is race-free there.
+            assignment_source = (
+                select(literal(key_id), Account.id)
+                .where(Account.id.in_(account_ids))
+                .where(Account.delete_requested_at.is_(None))
+            )
+            if self._session.get_bind().dialect.name == "postgresql":
+                assignment_source = assignment_source.with_for_update(read=True)
+            await self._session.execute(
+                insert(ApiKeyAccountAssignment).from_select(["api_key_id", "account_id"], assignment_source)
+            )
         if commit:
             await self._session.commit()
         parent = await self._session.get(ApiKey, key_id)

--- a/app/modules/api_keys/repository.py
+++ b/app/modules/api_keys/repository.py
@@ -183,6 +183,11 @@ class ApiKeysRepository:
             select(Account)
             .options(load_only(Account.id, Account.plan_type, Account.status))
             .where(Account.id.in_(account_ids))
+            # An account marked for background deletion is already deleted
+            # from the operator's point of view: assignment validation must
+            # reject it (the synchronous delete removed the row outright) and
+            # pooled-usage projections must not count it while its rows drain.
+            .where(Account.delete_requested_at.is_(None))
         )
         return list(result.scalars().all())
 

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -1706,7 +1706,9 @@ async def _ensure_v1_reset_credit_account_fresh(account_id: str) -> _V1ResetCred
     async with get_background_session() as session:
         repo = AccountsRepository(session)
         account = await repo.get_by_id(account_id)
-        if account is None:
+        # An account marked for background deletion is already deleted from
+        # every consumer's point of view (its credentials are wiped).
+        if account is None or account.delete_requested_at is not None:
             raise HTTPException(status_code=404, detail="Account not found")
         auth_manager = AuthManager(
             repo,
@@ -1747,6 +1749,11 @@ async def v1_redeem_reset_credit(
         return capability_transport_denial
     async with get_background_session() as session:
         account = await AccountsRepository(session).get_by_id(payload.account_id)
+        # A pending-deletion account is gone (credentials wiped): treat it
+        # exactly like an account outside the pool. ``getattr`` because pool
+        # membership tests stub the account with plain namespaces.
+        if account is not None and getattr(account, "delete_requested_at", None) is not None:
+            account = None
         if not _is_reset_credit_account_in_api_key_pool(account, api_key):
             raise HTTPException(status_code=403, detail="Account is outside the API key pool")
         if account is None:

--- a/app/modules/rate_limit_reset_credits/api.py
+++ b/app/modules/rate_limit_reset_credits/api.py
@@ -132,7 +132,8 @@ async def get_rate_limit_reset_credits(
 ) -> RateLimitResetCreditsSnapshotResponse | None:
     store = get_rate_limit_reset_credits_store()
     account = await context.repository.get_by_id(account_id)
-    if account is None:
+    # A pending-deletion account is gone from the operator's point of view.
+    if account is None or account.delete_requested_at is not None:
         await store.invalidate(account_id)
         return None
     if account.status in _NON_REDEEMABLE_STATUSES or not account.chatgpt_account_id:
@@ -158,7 +159,9 @@ async def consume_rate_limit_reset_credit(
     context: AccountsContext = Depends(get_accounts_context),
 ) -> ConsumeResetCreditResponseSchema:
     account = await context.repository.get_by_id(account_id)
-    if account is None:
+    # A pending-deletion account is gone from the operator's point of view:
+    # the synchronous delete 404'd here once the row was removed.
+    if account is None or account.delete_requested_at is not None:
         raise DashboardNotFoundError("Account not found", code="account_not_found")
 
     store = get_rate_limit_reset_credits_store()

--- a/app/modules/settings/api.py
+++ b/app/modules/settings/api.py
@@ -413,7 +413,10 @@ async def _validate_proxy_pool_id(context: SettingsContext, pool_id: str | None)
 
 async def _get_account_or_error(context: SettingsContext, account_id: str) -> Account:
     account = await context.session.get(Account, account_id)
-    if account is None:
+    # An account marked for background deletion is already deleted from the
+    # operator's point of view: binding mutations must report not-found, as
+    # the synchronous delete did once the row was removed.
+    if account is None or account.delete_requested_at is not None:
         raise DashboardBadRequestError("Account not found", code="account_not_found")
     return account
 

--- a/openspec/changes/background-account-deletion/design.md
+++ b/openspec/changes/background-account-deletion/design.md
@@ -72,7 +72,12 @@ The wipe is what keeps the rolling upgrade honest: a pre-upgrade replica's
 export endpoints read the row without knowing the marker, and must not be
 able to hand out usable credentials during the drain window. Token rotation
 is CAS-guarded on the pre-wipe refresh ciphertext (a stale rotation misses),
-and every supersede path writes complete fresh ciphertext.
+and every supersede path writes complete fresh ciphertext. The wipe must
+not break the reauth supersede path itself: targeted reauthentication
+verifies the seat against `chatgpt_user_id` or — on legacy rows where it
+was never backfilled — the stored id-token claims, so `begin_delete`
+backfills `chatgpt_user_id` from those claims (non-secret identity) in the
+same transaction before destroying them.
 
 ### D2: The account row is the queue (no new table)
 

--- a/openspec/changes/background-account-deletion/design.md
+++ b/openspec/changes/background-account-deletion/design.md
@@ -139,10 +139,26 @@ The letter of the history-rewrite discipline in `usage_time_rollup.py`
 mirror or skip **in the same transaction**") is relaxed for this one path:
 mid-drain, folded buckets may still attribute to an account whose raw rows a
 chunk already detached. That intermediate state never double- or
-under-counts a read (folded side serves below-watermark, raw tail above) and
-is bounded by drain duration; the end state is byte-identical to the
-synchronous path. The module docstring of `deletion.py` documents this as
-the single sanctioned exception, converged by finalization.
+under-counts a read (folded side serves below-watermark, raw tail above;
+the watermark folds each raw row exactly once, and already-folded rows are
+never re-read), and on the deletion path it is bounded by drain duration:
+the end state is byte-identical to the synchronous path, with the module
+docstring of `deletion.py` documenting this as the single sanctioned
+exception, converged by finalization.
+
+When a supersede lands after a partial drain, finalization never runs and
+the divergence for rows drained before the supersede is the PERMANENT,
+intended end state: folded buckets keep attributing that traffic to the
+revived account (it is the account's true pre-delete history — nothing is
+added or inflated), while the raw rows stay detached (soft) or deleted
+(`delete_history`), exactly as the "rows already drained stay detached"
+trade-off promises. Reads stay consistent for the same reason as mid-drain:
+below-watermark reads are folded-only, drained rows below the watermark are
+never re-folded, and drained rows above the watermark fold once under the
+orphaned dimension. Reconciling instead (running the lifecycle mirrors at
+supersede time) was rejected: it would drag the fold lock and per-row delta
+mirroring into every credential-replacement path to "fix" attribution that
+is already historically correct.
 
 ### D4: Finalization reuses `AccountsRepository.delete()` with a marker guard
 
@@ -239,8 +255,13 @@ re-import) once the API returns. The spec states row purge is asynchronous.
   too); the account side is removed by the mirrors, and API-key folded sums
   keeping settled traffic is the documented behavior for folded history.
 - **Supersede after partial drain**: a re-import that lands mid-drain keeps
-  the account but its already-detached rows stay detached. Documented; the
-  operator asked for deletion first.
+  the account but its already-detached rows stay detached (and
+  already-deleted rows stay deleted), while folded buckets keep attributing
+  the pre-supersede-drained traffic to the revived account — permanently,
+  since finalization's mirrors never run. This is historically correct
+  attribution (the folded numbers pre-existed the delete), never double- or
+  under-counts a read (see D3), and is the documented consequence of the
+  operator asking for deletion first.
 - **Alembic head races**: the revision sits on the current single head;
   parallel PRs adding revisions require the usual head merge.
 

--- a/openspec/changes/background-account-deletion/design.md
+++ b/openspec/changes/background-account-deletion/design.md
@@ -116,25 +116,44 @@ request-log row at stream end, possibly after every chunk ran.
 `_apply_account_updates` (every credential replacement: re-import, reauth,
 slot reuse) clears the marker: account ids are deterministic, so
 delete-then-reimport lands on the marked row, and letting the worker delete
-a just-reimported account would be data loss. Chunks re-check the marker per
-transaction and finalization re-checks under the row lock, so a superseded
+a just-reimported account would be data loss. Every chunk transaction and
+finalization re-read the marker under the account row lock (PostgreSQL
+`FOR NO KEY UPDATE`, compatible with the `KEY SHARE` taken by concurrent
+rollup FK inserts; on SQLite the writer section serializes writers), so a
+replacement either commits before the marker read (the chunk sees the
+cleared marker and stops) or blocks until the chunk commits — no chunk can
+mutate rows after a replacement has successfully returned, and a superseded
 account is never finalized (rows already drained stay detached — history
-loss was requested by the earlier delete). Repeat DELETE requests return
+loss was requested by the earlier delete). The chunk takes only the account
+row lock and touches only that account's child rows, so no new lock ordering
+is introduced. Marked accounts are also absent from the credential-export
+endpoints: the synchronous delete made exports 404 immediately, and the
+asynchronous drain window must not keep decrypted tokens retrievable after
+a successful DELETE. Repeat DELETE requests return
 success without escalating `delete_history` (first request wins), matching
 the synchronous world where a second DELETE arrived after the account was
 already gone. `reactivate_account` treats a marked account as not found
 rather than racing the worker back to ACTIVE.
 
-### D6: Worker = leader-gated 30 s tick + local wake, cheap pre-check
+### D6: Worker = leader-gated 30 s tick + local wake, cheap pre-check, round-robin pass
 
-Same scheduler shape as retention. Each tick runs one indexed `LIMIT 1`
-existence probe *before* leader election, so the steady state costs one tiny
-SELECT per interval. `delete_account` wakes the local worker after commit:
-on the leader (the single-replica common case) draining starts immediately;
-a follower's wake is a no-op and the leader's tick picks the request up
-within 30 s. Batch size 5k: measured ~1.2 s/10k `usage_history` deletes and
-~23 s/10k `request_logs` detaches put 5k comfortably under a few seconds per
-transaction on the worst table.
+Same scheduler shape as retention. Each tick runs one `LIMIT 1` existence
+probe *before* leader election — served by the partial index
+`idx_accounts_delete_requested_at` (`WHERE delete_requested_at IS NOT
+NULL`), which is empty in the steady state — so a tick with nothing to do
+costs one tiny index probe. `delete_account` wakes the local worker after
+commit: on the leader (the single-replica common case) draining starts
+immediately; a follower's wake is a no-op and the leader's tick picks the
+request up within 30 s. Batch size 5k: measured ~1.2 s/10k `usage_history`
+deletes and ~23 s/10k `request_logs` detaches put 5k comfortably under a few
+seconds per transaction on the worst table.
+
+A deletion pass round-robins: each round advances every pending account by
+at most one full chunk and the pending set is re-scanned between rounds.
+A multi-minute drain (the measured 133k-row account is ~27 chunks) therefore
+cannot starve another marked account, and a DELETE that lands mid-pass is
+picked up by the next round's re-scan rather than waiting for the whole pass
+to finish.
 
 ### D7: API contract unchanged (`{"status": "deleted"}`)
 
@@ -166,9 +185,11 @@ re-import) once the API returns. The spec states row purge is asynchronous.
 ## Migration
 
 `20260816_000000_add_account_pending_deletion`: adds
-`accounts.delete_requested_at` (nullable DateTime) and
-`accounts.delete_history_requested` (Boolean, `server_default false`), with
-column-existence guards and a symmetric downgrade. Existing rows are
+`accounts.delete_requested_at` (nullable DateTime),
+`accounts.delete_history_requested` (Boolean, `server_default false`), and
+the partial queue index `idx_accounts_delete_requested_at`
+(`(delete_requested_at, id) WHERE delete_requested_at IS NOT NULL`), with
+existence guards and a symmetric downgrade. Existing rows are
 untouched (no pending deletions can predate the feature). Rolling upgrade: an
 old replica neither sets nor reads the marker; a delete handled by an old
 replica is simply the old synchronous delete.

--- a/openspec/changes/background-account-deletion/design.md
+++ b/openspec/changes/background-account-deletion/design.md
@@ -60,7 +60,21 @@ would otherwise replace `DEACTIVATED` with `RATE_LIMITED` and make the
 account selectable again for direct-by-id paths mid-drain. Credential
 replacement does not go through these writers (it writes fields directly and
 clears the marker in the same transaction), so the supersede path is
-unaffected.
+unaffected. Pre-upgrade replicas' writers are unfenced during a rolling
+deploy, so every drain chunk additionally self-heals: when the marked row
+drifted (non-terminal status or a recreated API-key assignment) without a
+credential replacement, the chunk re-asserts the terminal status and
+re-removes the assignments under the row lock it already holds — a DB
+trigger was rejected as disproportionate machinery for a drift window that
+is already bounded to one chunk transaction (seconds).
+
+Repeat DELETE requests short-circuit on an unlocked marker+wipe read before
+entering the writer section / row lock: a drain chunk holds the account row
+(and, on SQLite, the writer section) for seconds at a time, and the
+fast-path contract must hold throughout the drain. The short-circuit falls
+through to the full path when the credentials were replaced without
+clearing the marker, so an explicit re-delete after a legacy replacement
+re-wipes and re-arms the deletion.
 
 `begin_delete` additionally produces the two projections the synchronous
 delete's row removal produced instantly: it deletes the account's

--- a/openspec/changes/background-account-deletion/design.md
+++ b/openspec/changes/background-account-deletion/design.md
@@ -87,8 +87,13 @@ or undecryptable material on a marked row means a replacement happened, and
 the worker clears the marker itself (under the row lock) instead of
 draining further or finalizing. API-key assignment validation
 (`ApiKeysRepository.list_accounts_by_ids`) likewise rejects marked
-accounts, so a key create/update racing the DELETE cannot recreate an
-assignment that would re-surface the account in key listings.
+accounts, and `replace_account_assignments` inserts through a conditional
+`INSERT … SELECT … WHERE delete_requested_at IS NULL` (with `FOR SHARE` on
+PostgreSQL, which conflicts with `begin_delete`'s row update) — so a key
+create/update whose validation raced the DELETE cannot recreate an
+assignment that would re-surface the account in key listings: either the
+insert commits first and `begin_delete`'s assignment cleanup removes it, or
+the marker is visible to the insert and the account is skipped.
 
 ### D2: The account row is the queue (no new table)
 
@@ -147,6 +152,19 @@ writer section serializes writers. Lock order (identity → fold) matches
 consolidation, so no new deadlock ordering is introduced. Residual rows also
 cover stragglers: a stream that started before the mark settles its
 request-log row at stream end, possibly after every chunk ran.
+
+After the fold lock, finalization upgrades the account row to a full
+`FOR UPDATE` lock (PostgreSQL) before the residual sweeps. `FOR UPDATE`
+conflicts with the `KEY SHARE` a request-log FK insert takes, so an
+in-flight stream's insert either commits before the sweep (and is swept) or
+blocks until the transaction commits and then fails its FK against the
+deleted row — the same outcome a post-delete insert always had. Without the
+upgrade, an insert could commit between the sweep and the account-row
+delete, where `ON DELETE SET NULL` would leave a live (`deleted_at IS
+NULL`) orphan on the soft path or surviving raw history under
+`delete_history`. The lock order (identity → fold → row exclusive) matches
+the historical transaction, whose final `DELETE` acquired the same
+exclusive lock after the fold lock.
 
 ### D5: Supersede-by-replacement, first-request-wins idempotency
 

--- a/openspec/changes/background-account-deletion/design.md
+++ b/openspec/changes/background-account-deletion/design.md
@@ -295,3 +295,17 @@ token ciphertext, so old export/read paths that do not know the marker can
 only produce empty credentials until finalization removes the row (old
 replicas may transiently show the account in listings during the mixed
 window; it is unroutable via the terminal status either way).
+
+One mixed-window caveat follows directly from "old replica = old delete": a
+repeat DELETE routed to a pre-upgrade replica while the row is still marked
+runs the legacy synchronous delete with its caller-provided
+`delete_history` variant, which can differ from the frozen first-request
+choice (either direction). The legacy delete is still a complete,
+fold-locked, mirror-correct deletion — only the history-policy choice
+diverges, only inside the deploy window, and only when the operator issues
+contradictory repeat requests inside it. Fencing was rejected: new code
+cannot retrofit a fence into binaries that predate the marker columns, a
+database trigger is disproportionate machinery for the window, and a
+"defer background marks until the fleet is upgraded" gate would add a
+permanent setting for a transient condition (single-replica deployments —
+the production topology — have no mixed window at all).

--- a/openspec/changes/background-account-deletion/design.md
+++ b/openspec/changes/background-account-deletion/design.md
@@ -79,6 +79,17 @@ was never backfilled — the stored id-token claims, so `begin_delete`
 backfills `chatgpt_user_id` from those claims (non-secret identity) in the
 same transaction before destroying them.
 
+The wipe doubles as the supersede signal for pre-upgrade replicas: a
+replacement handled by old code writes fresh ciphertext but cannot clear
+marker columns its ORM does not know. Every marker re-check (chunk and
+finalization) therefore also inspects the refresh ciphertext — non-wiped
+or undecryptable material on a marked row means a replacement happened, and
+the worker clears the marker itself (under the row lock) instead of
+draining further or finalizing. API-key assignment validation
+(`ApiKeysRepository.list_accounts_by_ids`) likewise rejects marked
+accounts, so a key create/update racing the DELETE cannot recreate an
+assignment that would re-surface the account in key listings.
+
 ### D2: The account row is the queue (no new table)
 
 The marker columns make the `accounts` row its own durable work item: the

--- a/openspec/changes/background-account-deletion/design.md
+++ b/openspec/changes/background-account-deletion/design.md
@@ -53,6 +53,27 @@ pending-deletion state itself lives in `accounts.delete_requested_at`
 (variant, frozen at request time); `deactivation_reason="pending_deletion"`
 is operator-facing only.
 
+The marker also fences ordinary status writers (`update_status`,
+`update_status_if_current` gain `delete_requested_at IS NULL`): a stale
+in-flight settlement — e.g. a 429 for a request selected before the DELETE —
+would otherwise replace `DEACTIVATED` with `RATE_LIMITED` and make the
+account selectable again for direct-by-id paths mid-drain. Credential
+replacement does not go through these writers (it writes fields directly and
+clears the marker in the same transaction), so the supersede path is
+unaffected.
+
+`begin_delete` additionally produces the two projections the synchronous
+delete's row removal produced instantly: it deletes the account's
+`ApiKeyAccountAssignment` rows (key listings and pooled-usage reads exclude
+the account immediately; the key's persisted `account_assignment_scope_enabled`
+flag keeps the key scoped, exactly as after the FK cascade) and overwrites
+the access/refresh/id token ciphertext with empty-credential ciphertext.
+The wipe is what keeps the rolling upgrade honest: a pre-upgrade replica's
+export endpoints read the row without knowing the marker, and must not be
+able to hand out usable credentials during the drain window. Token rotation
+is CAS-guarded on the pre-wipe refresh ciphertext (a stale rotation misses),
+and every supersede path writes complete fresh ciphertext.
+
 ### D2: The account row is the queue (no new table)
 
 The marker columns make the `accounts` row its own durable work item: the
@@ -149,11 +170,13 @@ deletes and ~23 s/10k `request_logs` detaches put 5k comfortably under a few
 seconds per transaction on the worst table.
 
 A deletion pass round-robins: each round advances every pending account by
-at most one full chunk and the pending set is re-scanned between rounds.
-A multi-minute drain (the measured 133k-row account is ~27 chunks) therefore
-cannot starve another marked account, and a DELETE that lands mid-pass is
-picked up by the next round's re-scan rather than waiting for the whole pass
-to finish.
+at most one NONEMPTY chunk transaction (a round stops at the first chunk
+that touched rows, not the first batch-size-full one, so small tables cannot
+stack several row-touching transactions into one round) and the pending set
+is re-scanned between rounds. A multi-minute drain (the measured 133k-row
+account is ~27 chunks) therefore cannot starve another marked account, and a
+DELETE that lands mid-pass is picked up by the next round's re-scan rather
+than waiting for the whole pass to finish.
 
 ### D7: API contract unchanged (`{"status": "deleted"}`)
 
@@ -192,4 +215,9 @@ the partial queue index `idx_accounts_delete_requested_at`
 existence guards and a symmetric downgrade. Existing rows are
 untouched (no pending deletions can predate the feature). Rolling upgrade: an
 old replica neither sets nor reads the marker; a delete handled by an old
-replica is simply the old synchronous delete.
+replica is simply the old synchronous delete, and a delete handled by a new
+replica leaves old replicas nothing exploitable — the fast path wipes the
+token ciphertext, so old export/read paths that do not know the marker can
+only produce empty credentials until finalization removes the row (old
+replicas may transiently show the account in listings during the mixed
+window; it is unroutable via the terminal status either way).

--- a/openspec/changes/background-account-deletion/design.md
+++ b/openspec/changes/background-account-deletion/design.md
@@ -82,18 +82,23 @@ same transaction before destroying them.
 The wipe doubles as the supersede signal for pre-upgrade replicas: a
 replacement handled by old code writes fresh ciphertext but cannot clear
 marker columns its ORM does not know. Every marker re-check (chunk and
-finalization) therefore also inspects the refresh ciphertext — non-wiped
-or undecryptable material on a marked row means a replacement happened, and
-the worker clears the marker itself (under the row lock) instead of
-draining further or finalizing. API-key assignment validation
+finalization) therefore also inspects ALL THREE token ciphertexts —
+non-wiped or undecryptable material in any field of a marked row means a
+replacement happened (a legal replacement may carry an empty refresh token
+while providing fresh access/id material, so a refresh-only check would
+finalize a freshly replaced account), and the worker clears the marker
+itself (under the row lock) instead of draining further or finalizing. API-key assignment validation
 (`ApiKeysRepository.list_accounts_by_ids`) likewise rejects marked
-accounts, and `replace_account_assignments` inserts through a conditional
-`INSERT … SELECT … WHERE delete_requested_at IS NULL` (with `FOR SHARE` on
-PostgreSQL, which conflicts with `begin_delete`'s row update) — so a key
-create/update whose validation raced the DELETE cannot recreate an
-assignment that would re-surface the account in key listings: either the
-insert commits first and `begin_delete`'s assignment cleanup removes it, or
-the marker is visible to the insert and the account is skipped.
+accounts, and `replace_account_assignments` locks the target account rows (`FOR SHARE`
+on PostgreSQL, which conflicts with `begin_delete`'s row update) BEFORE
+touching any assignment row — the same account-then-assignment order
+`begin_delete` uses, so the race serializes instead of deadlocking — and
+then inserts through a conditional `INSERT … SELECT … WHERE
+delete_requested_at IS NULL`. A key create/update whose validation raced
+the DELETE therefore cannot recreate an assignment that would re-surface
+the account in key listings: either it commits first and `begin_delete`'s
+assignment cleanup removes its rows, or the marker is visible to the
+insert and the account is skipped.
 
 ### D2: The account row is the queue (no new table)
 

--- a/openspec/changes/background-account-deletion/design.md
+++ b/openspec/changes/background-account-deletion/design.md
@@ -1,0 +1,174 @@
+## Context
+
+Reference commit: `origin/main` 0c8d9219. Verified surfaces:
+`AccountsRepository.delete()` and its fold-state lock comment,
+`app/modules/accounts/usage_rollup.py` (lifetime fold, `lock_fold_state`),
+`app/modules/accounts/usage_time_rollup.py` (hourly/demand/error/conversation
+folds, lifecycle mirrors, history-rewrite discipline), `app/core/retention/`
+(chunked prune precedent, BATCH_SIZE=10k), duplicate-account consolidation
+(`_reconcile_chatgpt_identity_duplicates`, same fold lock), scheduler + leader
+election pattern, Alembic single head `20260812_120000_add_sticky_abandonment_scope`.
+
+Production measurements (10.0.0.113): account deletion = single transaction
+holding the fold-state lock for the whole drain; ~93k `usage_history` rows ≈
+11.6 s each for two accounts; ~133k `request_logs` soft-detach = 313 s (18
+indexes ≈ 8.3 GB, every row non-HOT); fold blocked; 73 pool timeouts in 36 h;
+HTTP client timeout on the DELETE call.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- DELETE API returns in milliseconds; the account is immediately invisible to
+  listings and unroutable.
+- Bulk row work proceeds in bounded background transactions (5k rows each) so
+  the fold, the pool, and vacuum are never blocked for minutes.
+- Same end state as the synchronous delete for both `delete_history`
+  variants, including the folded-bucket lifecycle mirrors and the
+  "rollup row deleted with the account row" invariant.
+- Restart-safe resume, idempotent repeat requests, explicit supersede path.
+
+**Non-Goals:**
+
+- No change to duplicate-account consolidation (still synchronous under the
+  fold lock; its row volume is bounded by the duplicate's history and it must
+  stay atomic with the identity swap).
+- No change to retention, fold cadence, or watermark semantics.
+- No new settings; no dashboard UI for drain progress (the account is simply
+  gone; the worker logs outcomes).
+
+## Decisions
+
+### D1: Terminal mark = existing `DEACTIVATED` status + marker columns, not a new enum value
+
+Serving-path exclusion lists are written as denylists
+(`status not in (REAUTH_REQUIRED, DEACTIVATED, PAUSED)` in
+`proxy/helpers.py`, `load_balancer.py`, `account_cache.py`, `proxy/api.py`,
+`realtime_live.py`): a new `DELETING` enum value would be *routable* until
+every denylist was found and extended, and would require a PostgreSQL enum
+migration. Reusing `DEACTIVATED` inherits every existing exclusion (sticky
+purge, bridge close, selection caches) with zero new status handling. The
+pending-deletion state itself lives in `accounts.delete_requested_at`
+(authoritative marker + queue ordering) and `delete_history_requested`
+(variant, frozen at request time); `deactivation_reason="pending_deletion"`
+is operator-facing only.
+
+### D2: The account row is the queue (no new table)
+
+The marker columns make the `accounts` row its own durable work item: the
+worker scans `delete_requested_at IS NOT NULL`, progress is the shrinking
+`WHERE account_id = :id` predicates, and finalization's row delete is the
+dequeue. Restart resume and idempotency need no extra state machine; a
+crash between any two chunk transactions loses nothing.
+
+### D3: Chunks do NOT take the fold-state lock; only finalization does
+
+The single-transaction delete held the fold lock to prevent an in-flight
+fold slice from committing pre-delete attribution after the mirrors ran
+(resurrecting folded rows). The chunked drain preserves that invariant with
+lock-free chunks because:
+
+1. Chunk transactions touch only raw rows; they never write a rollup table
+   or move a watermark (`usage_history` tables are not fold-governed at all).
+2. An interleaved fold slice aggregates either still-attached rows (folded
+   under the account dimension) or already-detached rows (folded under the
+   orphaned-deleted dimension — the soft-path end state). Both converge at
+   finalization: it takes `lock_fold_state()`, detaches/deletes residual raw
+   rows, and runs the lifecycle mirrors, which move or remove EVERY folded
+   row carrying the account dimension — including rows folded mid-drain.
+3. Every fold slice holds the fold-state row lock (`FOR UPDATE` on the
+   `account_usage_rollup_state` row) from before it reads raw rows until its
+   commit. A slice therefore commits strictly before finalization (its
+   output is mirrored) or strictly after (it sees no attributed raw rows).
+   Post-finalization resurrection is impossible.
+
+Per-chunk fold-lock acquisition was considered and rejected: it adds fold
+stalls proportional to drain length while providing nothing the finalization
+lock does not already guarantee (the mirrors are a pure dimension move over
+whatever is folded at mirror time).
+
+The letter of the history-rewrite discipline in `usage_time_rollup.py`
+("mutations of folded dimensions below the watermark take the fold lock and
+mirror or skip **in the same transaction**") is relaxed for this one path:
+mid-drain, folded buckets may still attribute to an account whose raw rows a
+chunk already detached. That intermediate state never double- or
+under-counts a read (folded side serves below-watermark, raw tail above) and
+is bounded by drain duration; the end state is byte-identical to the
+synchronous path. The module docstring of `deletion.py` documents this as
+the single sanctioned exception, converged by finalization.
+
+### D4: Finalization reuses `AccountsRepository.delete()` with a marker guard
+
+`delete(only_pending=True)` is the historical transaction verbatim —
+identity-membership lock (PostgreSQL), fold-state lock, residual
+usage-history delete, residual detach/delete + mirrors, sticky + rollup +
+account row — plus: it aborts (touching nothing) unless the marker is still
+set, and it reads the `delete_history` variant from the persisted flag
+rather than the caller. The identity-membership `FOR NO KEY UPDATE` row lock
+(PostgreSQL) keeps the marker stable through the transaction; on SQLite the
+writer section serializes writers. Lock order (identity → fold) matches
+consolidation, so no new deadlock ordering is introduced. Residual rows also
+cover stragglers: a stream that started before the mark settles its
+request-log row at stream end, possibly after every chunk ran.
+
+### D5: Supersede-by-replacement, first-request-wins idempotency
+
+`_apply_account_updates` (every credential replacement: re-import, reauth,
+slot reuse) clears the marker: account ids are deterministic, so
+delete-then-reimport lands on the marked row, and letting the worker delete
+a just-reimported account would be data loss. Chunks re-check the marker per
+transaction and finalization re-checks under the row lock, so a superseded
+account is never finalized (rows already drained stay detached — history
+loss was requested by the earlier delete). Repeat DELETE requests return
+success without escalating `delete_history` (first request wins), matching
+the synchronous world where a second DELETE arrived after the account was
+already gone. `reactivate_account` treats a marked account as not found
+rather than racing the worker back to ACTIVE.
+
+### D6: Worker = leader-gated 30 s tick + local wake, cheap pre-check
+
+Same scheduler shape as retention. Each tick runs one indexed `LIMIT 1`
+existence probe *before* leader election, so the steady state costs one tiny
+SELECT per interval. `delete_account` wakes the local worker after commit:
+on the leader (the single-replica common case) draining starts immediately;
+a follower's wake is a no-op and the leader's tick picks the request up
+within 30 s. Batch size 5k: measured ~1.2 s/10k `usage_history` deletes and
+~23 s/10k `request_logs` detaches put 5k comfortably under a few seconds per
+transaction on the worst table.
+
+### D7: API contract unchanged (`{"status": "deleted"}`)
+
+The dashboard's delete mutation only toasts and refetches the listing, which
+already excludes the marked account — the operator-visible contract ("after
+DELETE, the account is gone from the list") holds exactly. Returning a new
+`"deleting"` status would break any consumer comparing against "deleted"
+while conveying nothing actionable: the deletion is irrevocable (modulo
+re-import) once the API returns. The spec states row purge is asynchronous.
+
+## Risks / Trade-offs
+
+- **Mid-drain visibility**: statistics pages may briefly attribute folded
+  history to the (invisible) account while raw rows are already detached.
+  Bounded by drain duration; strictly better than the previous minutes-long
+  fold outage.
+- **Interleaved folds vs hard delete**: a fold slice between hard-delete
+  chunks may fold rows (account and API-key aggregates) that the
+  single-transaction path would have deleted first. This is inherent fold
+  timing (a fold 1 s before the DELETE captured them under the old code
+  too); the account side is removed by the mirrors, and API-key folded sums
+  keeping settled traffic is the documented behavior for folded history.
+- **Supersede after partial drain**: a re-import that lands mid-drain keeps
+  the account but its already-detached rows stay detached. Documented; the
+  operator asked for deletion first.
+- **Alembic head races**: the revision sits on the current single head;
+  parallel PRs adding revisions require the usual head merge.
+
+## Migration
+
+`20260816_000000_add_account_pending_deletion`: adds
+`accounts.delete_requested_at` (nullable DateTime) and
+`accounts.delete_history_requested` (Boolean, `server_default false`), with
+column-existence guards and a symmetric downgrade. Existing rows are
+untouched (no pending deletions can predate the feature). Rolling upgrade: an
+old replica neither sets nor reads the marker; a delete handled by an old
+replica is simply the old synchronous delete.

--- a/openspec/changes/background-account-deletion/design.md
+++ b/openspec/changes/background-account-deletion/design.md
@@ -21,8 +21,9 @@ HTTP client timeout on the DELETE call.
 
 - DELETE API returns in milliseconds; the account is immediately invisible to
   listings and unroutable.
-- Bulk row work proceeds in bounded background transactions (5k rows each) so
-  the fold, the pool, and vacuum are never blocked for minutes.
+- Bulk row work proceeds in bounded background transactions (1k rows each,
+  batch selection pinned to account-leading indexes) so the fold, the pool,
+  and vacuum are never blocked for minutes.
 - Same end state as the synchronous delete for both `delete_history`
   variants, including the folded-bucket lifecycle mirrors and the
   "rollup row deleted with the account row" invariant.
@@ -234,17 +235,39 @@ NULL`), which is empty in the steady state — so a tick with nothing to do
 costs one tiny index probe. `delete_account` wakes the local worker after
 commit: on the leader (the single-replica common case) draining starts
 immediately; a follower's wake is a no-op and the leader's tick picks the
-request up within 30 s. Batch size 5k: measured ~1.2 s/10k `usage_history`
-deletes and ~23 s/10k `request_logs` detaches put 5k comfortably under a few
-seconds per transaction on the worst table.
+request up within 30 s. Batch size 1k: measured ~1.2 s/10k `usage_history`
+deletes and ~23 s/10k `request_logs` detaches (18 indexes, non-HOT updates)
+bound the worst table at ~2.3 s per transaction — and every chunk holds the
+account row lock (`FOR NO KEY UPDATE`) for its full duration, so a supersede
+or fenced settlement waits for at most one chunk. Between row-touching
+rounds the pass sleeps a fraction of the round's own duration (capped), so
+a multi-hundred-chunk drain leaves the 2-vCPU database headroom instead of
+running chunk transactions back-to-back.
+
+Chunk batch selection is planner-pinned to the account-leading indexes
+(`idx_usage_account_time`, `ix_additional_usage_distinct_labels`,
+`idx_logs_account_kind_deleted_latest` — the last one covering, so the
+request-log batch is an index-only scan): the batch subquery selects with an
+`account_id >= :id AND account_id <= :id` range (equivalent rows, but the
+range keeps `account_id` out of the constant-equivalence class and thus in
+the sort pathkeys) ordered by the target index's exact column order, making
+that index the only sort-free plan. A plain `account_id = :id LIMIT n` shape
+was verified on the production planner to run as a LIMIT-terminated Seq
+Scan for exactly the large accounts this change targets — with an unbounded
+dead-prefix re-scan mid-drain and a guaranteed full heap scan for every
+empty probe once per-account statistics go stale. With the pinned shape,
+chunk scan work is bounded by the account's own remaining rows and a
+drained-table probe is a single index descent. Within one pass, a table
+observed empty is not re-probed on later rounds (rows settling mid-drain
+are converged by finalization's residual sweep anyway).
 
 A deletion pass round-robins: each round advances every pending account by
 at most one NONEMPTY chunk transaction (a round stops at the first chunk
 that touched rows, not the first batch-size-full one, so small tables cannot
 stack several row-touching transactions into one round) and the pending set
 is re-scanned between rounds. A multi-minute drain (the measured 133k-row
-account is ~27 chunks) therefore cannot starve another marked account, and a
-DELETE that lands mid-pass is picked up by the next round's re-scan rather
+account is ~133 chunks) therefore cannot starve another marked account, and
+a DELETE that lands mid-pass is picked up by the next round's re-scan rather
 than waiting for the whole pass to finish.
 
 ### D7: API contract unchanged (`{"status": "deleted"}`)

--- a/openspec/changes/background-account-deletion/proposal.md
+++ b/openspec/changes/background-account-deletion/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+`DELETE /api/accounts/{id}` detaches (or deletes) the account's entire raw
+history in one transaction while holding the fold-state lock. Measured on
+production: ~11.6 s to delete ~93k `usage_history` rows and **313 s** to
+soft-detach ~133k `request_logs` rows (18 indexes, every row non-HOT). For
+those minutes the fold is blocked, one pool connection is pinned (contributing
+to `QueuePool` timeouts), the HTTP client times out, and the long transaction
+delays vacuum.
+
+## What Changes
+
+- `DELETE /api/accounts/{id}` becomes a fast mark: the account turns terminal
+  (`DEACTIVATED` + a pending-deletion marker), disappears from listings and
+  serving immediately, and the API returns within milliseconds with the
+  existing `{"status": "deleted"}` contract.
+- A new leader-gated background worker drains the account's bulk rows
+  (`usage_history`, `additional_usage_history`, `request_logs`) in bounded
+  chunks (5k rows per transaction, no fold-state lock), then finalizes in one
+  fold-state-locked transaction with the exact shape of the old synchronous
+  delete: residual rows, folded-bucket lifecycle mirrors, sticky/rollup rows,
+  account row.
+- Deletion is restart-safe (all progress in the database), idempotent
+  (repeat DELETE requests succeed without escalating the frozen
+  `delete_history` choice), supports both `delete_history` variants, and is
+  superseded by a credential replacement (re-import/reauth) that clears the
+  marker.
+- Schema: two new nullable-safe columns on `accounts`
+  (`delete_requested_at`, `delete_history_requested`), Alembic revision
+  `20260816_000000_add_account_pending_deletion` on the current single head.
+
+## Capabilities
+
+### New Capabilities
+
+- `account-deletion`: asynchronous account deletion lifecycle — fast terminal
+  mark, immediate listing/serving exclusion, chunked background drain with
+  fold-interleave safety, restart-safe finalization, idempotency, and
+  supersede-by-replacement semantics.
+
+### Modified Capabilities
+
+(none — the query-caching lifecycle requirement "rollup row deleted in the
+same transaction as the account deletion" continues to hold: the finalization
+transaction removes both together.)
+
+## Impact
+
+- `app/modules/accounts/repository.py` (`begin_delete`, marker-guarded
+  `delete(only_pending=True)`, listing filters, replacement clears marker),
+  `app/modules/accounts/deletion.py` (new worker + scheduler),
+  `app/modules/accounts/service.py`, `app/main.py` (scheduler wiring),
+  `app/db/models.py`, one Alembic revision.
+- No API schema change (`AccountDeleteResponse` unchanged), no frontend
+  change (the listing refetch after delete already sees the account gone),
+  no new settings.

--- a/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
+++ b/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
@@ -17,9 +17,13 @@ untouched), and an overwrite of the stored access/refresh/id token
 ciphertext with empty-credential ciphertext so that NO reader of the
 surviving row — including a pre-upgrade replica during a rolling deploy,
 whose export endpoints do not know the marker — can produce usable
-credentials during the drain window. The response contract remains
-`{"status": "deleted"}` with 200 for an existing account and 404 otherwise;
-row purge is asynchronous.
+credentials during the drain window. Because targeted reauthentication (a
+supersede path) verifies the seat against `chatgpt_user_id` or, on legacy
+rows where it was never backfilled, the stored id-token claims, the fast
+path MUST preserve the non-secret seat identity before the wipe by
+backfilling `chatgpt_user_id` from those claims when it is absent. The
+response contract remains `{"status": "deleted"}` with 200 for an existing
+account and 404 otherwise; row purge is asynchronous.
 
 Accounts carrying the pending-deletion marker MUST be excluded from account
 listings (`GET /api/accounts` and every listing-derived read) and MUST be
@@ -57,6 +61,16 @@ which clears the marker — may change a marked account's state.
 - **THEN** the response is 404 and no token material is returned
 - **AND** the row's stored token ciphertext decrypts to empty credentials
   (nothing usable remains for readers that do not know the marker)
+
+#### Scenario: Seat identity survives the token wipe for reauth supersede
+
+- **GIVEN** a legacy account whose `chatgpt_user_id` is unset (seat identity
+  lives only in the stored id-token claims)
+- **WHEN** `DELETE /api/accounts/{id}` marks the account and wipes the token
+  ciphertext
+- **THEN** `chatgpt_user_id` is backfilled from the id-token claims in the
+  same transaction, so a targeted reauthentication can still verify the
+  seat and supersede the deletion
 
 #### Scenario: Deleted account leaves API-key listings immediately
 

--- a/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
+++ b/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
@@ -231,7 +231,15 @@ orphaned-deleted dimension MUST preserve the account's full folded history.
 All drain progress MUST live in the database so a worker restart resumes an
 interrupted deletion with no separate recovery step. Repeat DELETE requests
 for a marked account MUST succeed idempotently and MUST NOT change the
-frozen `delete_history` choice (first request wins). A credential
+frozen `delete_history` choice (first request wins). The first-request-wins
+invariant is scoped to replicas running this revision: during a rolling
+deploy, a repeat DELETE routed to a pre-upgrade replica performs the legacy
+synchronous delete with its caller-provided variant (exactly the pre-change
+behavior — a complete, mirror-correct deletion whose variant choice may
+differ from the frozen one). This window is bounded by the deploy itself,
+requires the operator to issue contradictory repeat requests inside it, and
+is accepted: new code cannot fence binaries that predate the marker, and a
+deployment gate would add permanent configuration for a transient window. A credential
 replacement (re-import or reauthentication landing on the marked row) MUST
 clear the marker and supersede the deletion: every drain chunk and the
 finalization transaction MUST re-check the marker under the account row lock

--- a/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
+++ b/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
@@ -9,9 +9,17 @@ work (raw request-log detach/delete, usage-history removal) on the request
 path. The request MUST only stamp a durable pending-deletion marker in a
 short transaction: terminal `DEACTIVATED` status, the pending-deletion
 marker (`delete_requested_at`), the frozen `delete_history` choice
-(`delete_history_requested`), sticky-session removal, and bridge-session
-closure. The response contract remains `{"status": "deleted"}` with 200 for
-an existing account and 404 otherwise; row purge is asynchronous.
+(`delete_history_requested`), sticky-session removal, bridge-session
+closure, API-key account-assignment removal (the projection the synchronous
+delete's FK cascade produced — key listings and pooled-usage reads exclude
+the account immediately while the key's persisted assignment-scope flag is
+untouched), and an overwrite of the stored access/refresh/id token
+ciphertext with empty-credential ciphertext so that NO reader of the
+surviving row — including a pre-upgrade replica during a rolling deploy,
+whose export endpoints do not know the marker — can produce usable
+credentials during the drain window. The response contract remains
+`{"status": "deleted"}` with 200 for an existing account and 404 otherwise;
+row purge is asynchronous.
 
 Accounts carrying the pending-deletion marker MUST be excluded from account
 listings (`GET /api/accounts` and every listing-derived read) and MUST be
@@ -20,6 +28,12 @@ marked account MUST report the account as not found, and the
 credential-export endpoints (account export, auth export, opencode auth
 export) MUST likewise report it as not found — a successful DELETE MUST NOT
 leave decrypted tokens retrievable during the background drain window.
+
+Ordinary status writes MUST NOT modify a marked account: a stale in-flight
+settlement (for example a 429 landing after the DELETE for a request
+selected before it) must not replace the terminal `DEACTIVATED` state and
+make the account selectable mid-drain. Only a credential replacement —
+which clears the marker — may change a marked account's state.
 
 #### Scenario: Delete responds without draining rows
 
@@ -41,6 +55,23 @@ leave decrypted tokens retrievable during the background drain window.
   drained
 - **WHEN** any credential-export endpoint is called for the account
 - **THEN** the response is 404 and no token material is returned
+- **AND** the row's stored token ciphertext decrypts to empty credentials
+  (nothing usable remains for readers that do not know the marker)
+
+#### Scenario: Deleted account leaves API-key listings immediately
+
+- **GIVEN** an account assigned to an API key
+- **WHEN** `DELETE /api/accounts/{id}` returns
+- **THEN** the key's listed assigned-account ids no longer contain the
+  account and its pooled-usage projection excludes it
+- **AND** the key's assignment-scope flag remains enabled
+
+#### Scenario: Stale settlement cannot resurrect a marked account
+
+- **GIVEN** an account marked for background deletion
+- **WHEN** an ordinary status write (e.g. a late rate-limit settlement)
+  targets the account
+- **THEN** the write is rejected and the account stays terminal and marked
 
 ### Requirement: Background worker drains marked accounts in bounded chunks
 
@@ -55,9 +86,11 @@ and account rows together. The soft variant MUST detach raw rows
 (`account_id=NULL, deleted_at` set); the `delete_history` variant MUST
 delete them. The worker MUST start a drain promptly after a delete request
 on the leader replica and within one worker interval otherwise. A deletion
-pass MUST round-robin chunk work across pending accounts and re-scan for
-newly marked accounts between rounds, so one account's long drain cannot
-delay another marked account's drain start by more than one chunk round.
+pass MUST round-robin across pending accounts — at most one nonempty chunk
+transaction per account per round — and re-scan for newly marked accounts
+between rounds, so one account's long drain cannot delay another marked
+account's drain start by more than one chunk transaction per pending
+account.
 
 #### Scenario: Chunked drain reaches the synchronous end state (soft)
 

--- a/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
+++ b/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
@@ -1,0 +1,117 @@
+# account-deletion Delta
+
+## ADDED Requirements
+
+### Requirement: Account deletion requests return fast and hide the account immediately
+
+`DELETE /api/accounts/{account_id}` MUST NOT perform the account's bulk row
+work (raw request-log detach/delete, usage-history removal) on the request
+path. The request MUST only stamp a durable pending-deletion marker in a
+short transaction: terminal `DEACTIVATED` status, the pending-deletion
+marker (`delete_requested_at`), the frozen `delete_history` choice
+(`delete_history_requested`), sticky-session removal, and bridge-session
+closure. The response contract remains `{"status": "deleted"}` with 200 for
+an existing account and 404 otherwise; row purge is asynchronous.
+
+Accounts carrying the pending-deletion marker MUST be excluded from account
+listings (`GET /api/accounts` and every listing-derived read) and MUST be
+excluded from proxy serving via the terminal status. Reactivation of a
+marked account MUST report the account as not found.
+
+#### Scenario: Delete responds without draining rows
+
+- **GIVEN** an account with raw request-log and usage-history rows
+- **WHEN** `DELETE /api/accounts/{id}` returns 200 `{"status": "deleted"}`
+- **THEN** the account no longer appears in `GET /api/accounts`
+- **AND** the account row still exists, terminal and marked, with its raw
+  rows untouched until the background worker drains them
+
+#### Scenario: Marked account cannot be reactivated
+
+- **GIVEN** an account marked for background deletion
+- **WHEN** `POST /api/accounts/{id}/reactivate` is called
+- **THEN** the response is 404 `account_not_found`
+
+### Requirement: Background worker drains marked accounts in bounded chunks
+
+A leader-gated background worker MUST drain each marked account's
+`usage_history`, `additional_usage_history`, and `request_logs` rows in
+bounded per-transaction chunks (at most `DELETE_BATCH_SIZE` rows per
+transaction) without holding the fold-state lock, and MUST then finalize in
+ONE fold-state-locked transaction that detaches or deletes residual raw rows
+(including request-log rows settled mid-drain by in-flight streams), runs
+the folded-bucket lifecycle mirrors, and removes the sticky, lifetime-rollup,
+and account rows together. The soft variant MUST detach raw rows
+(`account_id=NULL, deleted_at` set); the `delete_history` variant MUST
+delete them. The worker MUST start a drain promptly after a delete request
+on the leader replica and within one worker interval otherwise.
+
+#### Scenario: Chunked drain reaches the synchronous end state (soft)
+
+- **GIVEN** a marked account whose raw rows exceed one chunk
+- **WHEN** the worker completes the drain and finalization
+- **THEN** every raw request-log row is detached and soft-deleted, usage
+  snapshots are removed, and the sticky, lifetime-rollup, and account rows
+  are deleted in the finalization transaction
+
+#### Scenario: Chunked drain reaches the synchronous end state (delete_history)
+
+- **GIVEN** an account marked with the `delete_history` variant
+- **WHEN** the worker completes the drain and finalization
+- **THEN** the account's raw request-log rows are deleted and its folded
+  time-axis buckets are removed
+
+### Requirement: Interleaved fold slices never resurrect a deleted account's folded rows
+
+Fold passes MUST remain able to run between drain chunks. Because every fold
+slice holds the fold-state row lock from before reading raw rows until its
+commit, and finalization takes the same lock before running the lifecycle
+mirrors over whatever is folded at that moment, a fold slice MUST either
+commit before finalization (its account-attributed output is moved or
+removed by the mirrors) or after (it observes no raw rows attributed to the
+account). After finalization commits, no folded row in any rollup table may
+carry the deleted account's dimension, and under the soft variant the
+orphaned-deleted dimension MUST preserve the account's full folded history.
+
+#### Scenario: Fold between chunks is converged by finalization
+
+- **GIVEN** a marked account with part of its raw history already detached
+  by drain chunks and part still attached
+- **WHEN** a fold pass commits between chunks (attributing the still-attached
+  rows to the account) and the worker then completes finalization
+- **THEN** no rollup table contains rows under the account's dimension
+- **AND** (soft variant) the orphaned-deleted dimension carries the account's
+  complete folded history
+- **AND** fold passes run after finalization add nothing under the account's
+  dimension
+
+### Requirement: Deletion is restart-safe, idempotent, and superseded by credential replacement
+
+All drain progress MUST live in the database so a worker restart resumes an
+interrupted deletion with no separate recovery step. Repeat DELETE requests
+for a marked account MUST succeed idempotently and MUST NOT change the
+frozen `delete_history` choice (first request wins). A credential
+replacement (re-import or reauthentication landing on the marked row) MUST
+clear the marker and supersede the deletion: drain chunks re-check the
+marker per transaction and finalization re-checks it under the account row
+lock, so a superseded account is never finalized (rows already drained stay
+detached).
+
+#### Scenario: Restart resumes a partial drain
+
+- **GIVEN** a marked account whose drain was interrupted after some chunks
+- **WHEN** a fresh worker pass runs
+- **THEN** the drain resumes from the database state and finalizes normally
+
+#### Scenario: Repeat delete does not escalate the variant
+
+- **GIVEN** an account marked by a request without `delete_history`
+- **WHEN** a second `DELETE` request arrives with `delete_history=true`
+- **THEN** the request succeeds and the frozen choice remains the soft variant
+
+#### Scenario: Re-import supersedes a pending deletion
+
+- **GIVEN** a marked account mid-drain
+- **WHEN** a credential replacement lands on the row and clears the marker
+- **THEN** the worker abandons the deletion without removing the account row
+- **AND** rows detached before the replacement remain detached

--- a/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
+++ b/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
@@ -197,6 +197,14 @@ finalization transaction MUST re-check the marker under the account row lock
 rows, so no chunk commits row work after a replacement committed and a
 superseded account is never finalized (rows already drained stay detached).
 
+After a supersede that followed a partial drain, rows drained before the
+replacement keep their drained end state (detached under the soft variant,
+deleted under `delete_history`), and folded rollups keep attributing the
+pre-supersede-drained traffic to the revived account: it is the account's
+true pre-delete history, and reads MUST NOT double- or under-count as a
+result (below-watermark reads are folded-only; drained rows above the
+watermark fold exactly once, under the orphaned dimension).
+
 A credential replacement handled by a pre-upgrade replica during a rolling
 deploy writes fresh credentials but cannot clear marker columns unknown to
 its ORM. The worker MUST therefore treat non-wiped (or undecryptable)

--- a/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
+++ b/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
@@ -169,7 +169,18 @@ pass MUST round-robin across pending accounts — at most one nonempty chunk
 transaction per account per round — and re-scan for newly marked accounts
 between rounds, so one account's long drain cannot delay another marked
 account's drain start by more than one chunk transaction per pending
-account.
+account. Chunk batch selection MUST be served by an account-leading index
+on every drain table (on PostgreSQL: `idx_usage_account_time`,
+`ix_additional_usage_distinct_labels`, and the covering
+`idx_logs_account_kind_deleted_latest`), so per-chunk scan work is bounded
+by the account's own remaining rows: it MUST NOT degrade to sequential
+scans when per-account statistics are large or stale mid-drain, and a probe
+of an already-drained table MUST terminate on the index without scanning
+the heap. Within one pass, the worker MUST NOT re-probe a drain table it
+already observed empty for an account (rows that land after that
+observation are swept by finalization's residual pass), and it MUST pause
+between consecutive row-touching rounds in proportion to the round's
+duration so a long drain does not run chunk transactions back-to-back.
 
 #### Scenario: Chunked drain reaches the synchronous end state (soft)
 
@@ -201,6 +212,24 @@ account.
 - **WHEN** another account is marked for deletion (before or during the pass)
 - **THEN** the second account's drain starts within one chunk round and both
   accounts finalize
+
+#### Scenario: Chunk selection stays on the account index
+
+- **GIVEN** a marked account whose per-account row estimate is large (or
+  stale after a partial drain)
+- **WHEN** a drain chunk selects its batch on PostgreSQL
+- **THEN** the batch subquery is planned as a scan of the account-leading
+  index on each drain table (index-only for `request_logs`), not a
+  sequential scan, and an empty probe terminates on the index
+
+#### Scenario: Drained tables are not re-probed within a pass
+
+- **GIVEN** a marked account whose usage tables drained while its request
+  logs still span further chunks
+- **WHEN** subsequent rounds of the same pass advance the account
+- **THEN** the drained tables' chunk transactions do not run again and
+  finalization still sweeps any rows that landed after the empty
+  observation
 
 ### Requirement: Interleaved fold slices never resurrect a deleted account's folded rows
 

--- a/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
+++ b/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
@@ -17,7 +17,10 @@ untouched), and an overwrite of the stored access/refresh/id token
 ciphertext with empty-credential ciphertext so that NO reader of the
 surviving row — including a pre-upgrade replica during a rolling deploy,
 whose export endpoints do not know the marker — can produce usable
-credentials during the drain window. Because targeted reauthentication (a
+credentials during the drain window. Repeat DELETE requests MUST
+short-circuit before taking the account row lock or the SQLite writer
+section, so the millisecond contract holds even while a drain chunk
+transaction is holding the row. Because targeted reauthentication (a
 supersede path) verifies the seat against `chatgpt_user_id` or, on legacy
 rows where it was never backfilled, the stored id-token claims, the fast
 path MUST preserve the non-secret seat identity before the wipe by
@@ -37,7 +40,12 @@ Ordinary status writes MUST NOT modify a marked account: a stale in-flight
 settlement (for example a 429 landing after the DELETE for a request
 selected before it) must not replace the terminal `DEACTIVATED` state and
 make the account selectable mid-drain. Only a credential replacement —
-which clears the marker — may change a marked account's state.
+which clears the marker — may change a marked account's state. Because
+pre-upgrade replicas' status writers are unfenced during a rolling deploy,
+every drain chunk transaction MUST re-assert the terminal status (and
+re-remove any recreated API-key assignments) under the account row lock
+when the marked row has drifted without a credential replacement, bounding
+such drift to one chunk transaction.
 
 Marked accounts MUST be rejected by API-key account-assignment validation
 and excluded from API-key pooled-usage projections, and assignment
@@ -103,6 +111,22 @@ account in key listings before finalization.
 - **WHEN** an ordinary status write (e.g. a late rate-limit settlement)
   targets the account
 - **THEN** the write is rejected and the account stays terminal and marked
+
+#### Scenario: Drift written by an unfenced pre-upgrade replica is re-fenced
+
+- **GIVEN** a marked account whose status was replaced (or whose API-key
+  assignment was recreated) by a pre-upgrade replica's unfenced writer,
+  with the token ciphertext still wiped
+- **WHEN** the next drain chunk transaction runs
+- **THEN** the terminal status and reason are re-asserted and the recreated
+  assignment is removed, in the same chunk transaction
+
+#### Scenario: Repeat delete stays fast during an active drain
+
+- **GIVEN** a marked account whose drain chunk transaction currently holds
+  the account row lock
+- **WHEN** a repeat `DELETE /api/accounts/{id}` arrives
+- **THEN** it returns success without waiting for the chunk transaction
 
 ### Requirement: Background worker drains marked accounts in bounded chunks
 

--- a/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
+++ b/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
@@ -43,9 +43,11 @@ Marked accounts MUST be rejected by API-key account-assignment validation
 and excluded from API-key pooled-usage projections, and assignment
 insertion MUST re-check the marker atomically with the write (a conditional
 insert; on PostgreSQL additionally serialized against the delete mark by a
-`FOR SHARE` lock on the account rows), so an assignment created or updated
-after — or racing — the DELETE cannot re-surface the account in key
-listings before finalization.
+`FOR SHARE` lock on the account rows, acquired BEFORE any assignment-row
+mutation so the lock order matches the delete path's account-then-assignment
+order and the race serializes instead of deadlocking), so an assignment
+created or updated after — or racing — the DELETE cannot re-surface the
+account in key listings before finalization.
 
 #### Scenario: Delete responds without draining rows
 
@@ -198,9 +200,11 @@ superseded account is never finalized (rows already drained stay detached).
 A credential replacement handled by a pre-upgrade replica during a rolling
 deploy writes fresh credentials but cannot clear marker columns unknown to
 its ORM. The worker MUST therefore treat non-wiped (or undecryptable)
-credential ciphertext on a marked row as a credential replacement: it MUST
-clear the marker itself under the account row lock and abandon the deletion
-without mutating any further rows.
+ciphertext in ANY of the access/refresh/id token fields of a marked row as
+a credential replacement (a legal replacement may carry an empty refresh
+token while providing fresh access/id material): it MUST clear the marker
+itself under the account row lock and abandon the deletion without mutating
+any further rows.
 
 #### Scenario: Restart resumes a partial drain
 

--- a/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
+++ b/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
@@ -39,6 +39,11 @@ selected before it) must not replace the terminal `DEACTIVATED` state and
 make the account selectable mid-drain. Only a credential replacement —
 which clears the marker — may change a marked account's state.
 
+Marked accounts MUST be rejected by API-key account-assignment validation
+and excluded from API-key pooled-usage projections, so an assignment
+created or updated after the DELETE cannot re-surface the account in key
+listings before finalization.
+
 #### Scenario: Delete responds without draining rows
 
 - **GIVEN** an account with raw request-log and usage-history rows
@@ -79,6 +84,13 @@ which clears the marker — may change a marked account's state.
 - **THEN** the key's listed assigned-account ids no longer contain the
   account and its pooled-usage projection excludes it
 - **AND** the key's assignment-scope flag remains enabled
+
+#### Scenario: Marked account cannot be assigned to an API key
+
+- **GIVEN** an account marked for background deletion
+- **WHEN** an API-key create or update names the account in its assigned
+  account ids
+- **THEN** the request is rejected as referencing an unknown account
 
 #### Scenario: Stale settlement cannot resurrect a marked account
 
@@ -165,6 +177,13 @@ finalization transaction MUST re-check the marker under the account row lock
 rows, so no chunk commits row work after a replacement committed and a
 superseded account is never finalized (rows already drained stay detached).
 
+A credential replacement handled by a pre-upgrade replica during a rolling
+deploy writes fresh credentials but cannot clear marker columns unknown to
+its ORM. The worker MUST therefore treat non-wiped (or undecryptable)
+credential ciphertext on a marked row as a credential replacement: it MUST
+clear the marker itself under the account row lock and abandon the deletion
+without mutating any further rows.
+
 #### Scenario: Restart resumes a partial drain
 
 - **GIVEN** a marked account whose drain was interrupted after some chunks
@@ -183,3 +202,11 @@ superseded account is never finalized (rows already drained stay detached).
 - **WHEN** a credential replacement lands on the row and clears the marker
 - **THEN** the worker abandons the deletion without removing the account row
 - **AND** rows detached before the replacement remain detached
+
+#### Scenario: Legacy-replica replacement supersedes without clearing the marker
+
+- **GIVEN** a marked account mid-drain whose credentials were replaced by a
+  pre-upgrade replica (fresh ciphertext, marker still set)
+- **WHEN** the worker's next chunk or finalization re-checks the row
+- **THEN** the worker clears the marker, abandons the deletion, and the
+  fresh credentials survive

--- a/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
+++ b/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
@@ -16,7 +16,10 @@ an existing account and 404 otherwise; row purge is asynchronous.
 Accounts carrying the pending-deletion marker MUST be excluded from account
 listings (`GET /api/accounts` and every listing-derived read) and MUST be
 excluded from proxy serving via the terminal status. Reactivation of a
-marked account MUST report the account as not found.
+marked account MUST report the account as not found, and the
+credential-export endpoints (account export, auth export, opencode auth
+export) MUST likewise report it as not found — a successful DELETE MUST NOT
+leave decrypted tokens retrievable during the background drain window.
 
 #### Scenario: Delete responds without draining rows
 
@@ -32,6 +35,13 @@ marked account MUST report the account as not found.
 - **WHEN** `POST /api/accounts/{id}/reactivate` is called
 - **THEN** the response is 404 `account_not_found`
 
+#### Scenario: Marked account no longer serves credential exports
+
+- **GIVEN** an account marked for background deletion whose rows are not yet
+  drained
+- **WHEN** any credential-export endpoint is called for the account
+- **THEN** the response is 404 and no token material is returned
+
 ### Requirement: Background worker drains marked accounts in bounded chunks
 
 A leader-gated background worker MUST drain each marked account's
@@ -44,7 +54,10 @@ the folded-bucket lifecycle mirrors, and removes the sticky, lifetime-rollup,
 and account rows together. The soft variant MUST detach raw rows
 (`account_id=NULL, deleted_at` set); the `delete_history` variant MUST
 delete them. The worker MUST start a drain promptly after a delete request
-on the leader replica and within one worker interval otherwise.
+on the leader replica and within one worker interval otherwise. A deletion
+pass MUST round-robin chunk work across pending accounts and re-scan for
+newly marked accounts between rounds, so one account's long drain cannot
+delay another marked account's drain start by more than one chunk round.
 
 #### Scenario: Chunked drain reaches the synchronous end state (soft)
 
@@ -60,6 +73,13 @@ on the leader replica and within one worker interval otherwise.
 - **WHEN** the worker completes the drain and finalization
 - **THEN** the account's raw request-log rows are deleted and its folded
   time-axis buckets are removed
+
+#### Scenario: A long drain does not starve other marked accounts
+
+- **GIVEN** one marked account whose drain spans many chunks
+- **WHEN** another account is marked for deletion (before or during the pass)
+- **THEN** the second account's drain starts within one chunk round and both
+  accounts finalize
 
 ### Requirement: Interleaved fold slices never resurrect a deleted account's folded rows
 
@@ -92,10 +112,11 @@ interrupted deletion with no separate recovery step. Repeat DELETE requests
 for a marked account MUST succeed idempotently and MUST NOT change the
 frozen `delete_history` choice (first request wins). A credential
 replacement (re-import or reauthentication landing on the marked row) MUST
-clear the marker and supersede the deletion: drain chunks re-check the
-marker per transaction and finalization re-checks it under the account row
-lock, so a superseded account is never finalized (rows already drained stay
-detached).
+clear the marker and supersede the deletion: every drain chunk and the
+finalization transaction MUST re-check the marker under the account row lock
+(PostgreSQL `FOR NO KEY UPDATE`; the SQLite writer section) before mutating
+rows, so no chunk commits row work after a replacement committed and a
+superseded account is never finalized (rows already drained stay detached).
 
 #### Scenario: Restart resumes a partial drain
 

--- a/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
+++ b/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
@@ -30,11 +30,16 @@ account and 404 otherwise; row purge is asynchronous.
 
 Accounts carrying the pending-deletion marker MUST be excluded from account
 listings (`GET /api/accounts` and every listing-derived read) and MUST be
-excluded from proxy serving via the terminal status. Reactivation of a
-marked account MUST report the account as not found, and the
-credential-export endpoints (account export, auth export, opencode auth
-export) MUST likewise report it as not found — a successful DELETE MUST NOT
-leave decrypted tokens retrievable during the background drain window.
+excluded from proxy serving via the terminal status. EVERY ID-based account
+route MUST report a marked account as not found — reads (trends,
+reset-credit views), mutations (account update, alias, limit-warmup,
+routing policy), action routes (pause, probe, reset-credit consumption,
+reactivation), and the credential-export endpoints (account export, auth
+export, opencode auth export) — because the synchronous delete returned 404
+on all of them once the row was removed, and a successful DELETE MUST NOT
+leave decrypted tokens retrievable during the background drain window. Only
+credential-replacement paths (re-import, reauthentication) may address the
+marked row.
 
 Ordinary status writes MUST NOT modify a marked account: a stale in-flight
 settlement (for example a 429 landing after the DELETE for a request
@@ -69,6 +74,14 @@ account in key listings before finalization.
 
 - **GIVEN** an account marked for background deletion
 - **WHEN** `POST /api/accounts/{id}/reactivate` is called
+- **THEN** the response is 404 `account_not_found`
+
+#### Scenario: All ID-based routes report the marked account as gone
+
+- **GIVEN** an account marked for background deletion whose rows are not yet
+  drained
+- **WHEN** any ID-based account route (trends, reset-credit read/consume,
+  probe, pause, update, alias, limit-warmup, routing policy) is called
 - **THEN** the response is 404 `account_not_found`
 
 #### Scenario: Marked account no longer serves credential exports

--- a/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
+++ b/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
@@ -31,13 +31,15 @@ account and 404 otherwise; row purge is asynchronous.
 Accounts carrying the pending-deletion marker MUST be excluded from account
 listings (`GET /api/accounts` and every listing-derived read) and MUST be
 excluded from proxy serving via the terminal status. EVERY ID-based account
-route MUST report a marked account as not found — reads (trends,
-reset-credit views), mutations (account update, alias, limit-warmup,
-routing policy), action routes (pause, probe, reset-credit consumption,
-reactivation), and the credential-export endpoints (account export, auth
-export, opencode auth export) — because the synchronous delete returned 404
-on all of them once the row was removed, and a successful DELETE MUST NOT
-leave decrypted tokens retrievable during the background drain window. Only
+surface MUST report a marked account as not found (or absent) — reads
+(trends, reset-credit views), mutations (account update, alias,
+limit-warmup, routing policy, upstream-proxy binding), action routes
+(pause, probe, reset-credit consumption on both the dashboard and
+rate-limit route families, `/v1` reset-credit redemption, reactivation),
+and the credential-export endpoints (account export, auth export, opencode
+auth export) — because the synchronous delete returned 404 on all of them
+once the row was removed, and a successful DELETE MUST NOT leave decrypted
+tokens retrievable during the background drain window. Only
 credential-replacement paths (re-import, reauthentication) may address the
 marked row.
 
@@ -50,7 +52,10 @@ pre-upgrade replicas' status writers are unfenced during a rolling deploy,
 every drain chunk transaction MUST re-assert the terminal status (and
 re-remove any recreated API-key assignments) under the account row lock
 when the marked row has drifted without a credential replacement, bounding
-such drift to one chunk transaction.
+such drift to one chunk transaction; after the repairing chunk commits, the
+worker MUST propagate the same cache invalidation as the delete request
+(routing unavailability, selection/API-key snapshots, routing-change bump)
+so replicas that cached the drift stop serving it.
 
 Marked accounts MUST be rejected by API-key account-assignment validation
 and excluded from API-key pooled-usage projections, and assignment

--- a/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
+++ b/openspec/changes/background-account-deletion/specs/account-deletion/spec.md
@@ -40,8 +40,11 @@ make the account selectable mid-drain. Only a credential replacement —
 which clears the marker — may change a marked account's state.
 
 Marked accounts MUST be rejected by API-key account-assignment validation
-and excluded from API-key pooled-usage projections, so an assignment
-created or updated after the DELETE cannot re-surface the account in key
+and excluded from API-key pooled-usage projections, and assignment
+insertion MUST re-check the marker atomically with the write (a conditional
+insert; on PostgreSQL additionally serialized against the delete mark by a
+`FOR SHARE` lock on the account rows), so an assignment created or updated
+after — or racing — the DELETE cannot re-surface the account in key
 listings before finalization.
 
 #### Scenario: Delete responds without draining rows
@@ -108,7 +111,13 @@ transaction) without holding the fold-state lock, and MUST then finalize in
 ONE fold-state-locked transaction that detaches or deletes residual raw rows
 (including request-log rows settled mid-drain by in-flight streams), runs
 the folded-bucket lifecycle mirrors, and removes the sticky, lifetime-rollup,
-and account rows together. The soft variant MUST detach raw rows
+and account rows together. Finalization MUST serialize against in-flight
+raw-row inserts (on PostgreSQL by upgrading the account row to a full lock
+that conflicts with the FK's `KEY SHARE` before the residual sweep), so a
+log row committed by an in-flight stream is either swept by finalization or
+its insert fails against the already-deleted account — finalization may
+leave behind neither a live orphan row (soft variant) nor surviving raw
+history (`delete_history` variant). The soft variant MUST detach raw rows
 (`account_id=NULL, deleted_at` set); the `delete_history` variant MUST
 delete them. The worker MUST start a drain promptly after a delete request
 on the leader replica and within one worker interval otherwise. A deletion
@@ -132,6 +141,15 @@ account.
 - **WHEN** the worker completes the drain and finalization
 - **THEN** the account's raw request-log rows are deleted and its folded
   time-axis buckets are removed
+
+#### Scenario: In-flight log insert cannot escape finalization
+
+- **GIVEN** a marked account whose drain is complete and an in-flight stream
+  holding an uncommitted request-log insert for it
+- **WHEN** finalization runs
+- **THEN** finalization waits for the insert to commit and sweeps the late
+  row (or the insert fails against the deleted account), leaving no live
+  orphan and no surviving history
 
 #### Scenario: A long drain does not starve other marked accounts
 

--- a/openspec/changes/background-account-deletion/tasks.md
+++ b/openspec/changes/background-account-deletion/tasks.md
@@ -39,6 +39,12 @@
 - [x] 2.9 Reject marked accounts in API-key assignment validation
       (`ApiKeysRepository.list_accounts_by_ids`) so post-DELETE key updates
       cannot recreate assignments for the account.
+- [x] 2.10 Atomic marker re-check in `replace_account_assignments`
+      (conditional INSERT…SELECT, `FOR SHARE` on PostgreSQL) so validation
+      that raced the DELETE cannot recreate an assignment.
+- [x] 2.11 Finalization upgrades the account row to `FOR UPDATE` before the
+      residual sweeps (PostgreSQL) so in-flight FK inserts are either swept
+      or fail post-delete — no live orphans, no surviving history.
 
 ## 3. Background worker
 

--- a/openspec/changes/background-account-deletion/tasks.md
+++ b/openspec/changes/background-account-deletion/tasks.md
@@ -63,11 +63,18 @@
 ## 3. Background worker
 
 - [x] 3.1 `app/modules/accounts/deletion.py`: chunked drain
-      (usage_history, additional_usage_history, request_logs; 5k rows per
+      (usage_history, additional_usage_history, request_logs; 1k rows per
       transaction, marker re-check under the account row lock per chunk, no
       fold-state lock) for both variants; round-robin at most one nonempty
       chunk per pending account per round with a pending re-scan between
       rounds.
+- [x] 3.1a Pin chunk batch selection to the account-leading indexes
+      (`account_id` range predicate + index-order ORDER BY →
+      `idx_usage_account_time`, `ix_additional_usage_distinct_labels`,
+      covering `idx_logs_account_kind_deleted_latest`), verified against the
+      production planner; skip re-probing tables observed empty within a
+      pass; pause between row-touching rounds proportionally to round
+      duration.
 - [x] 3.2 Finalization via `AccountsRepository.delete(only_pending=True)`:
       historical transaction shape (identity lock → fold-state lock →
       residual rows → mirrors → sticky/rollup/account) plus marker guard and

--- a/openspec/changes/background-account-deletion/tasks.md
+++ b/openspec/changes/background-account-deletion/tasks.md
@@ -24,7 +24,9 @@
       window, matching the synchronous delete's contract.
 - [x] 2.5 Wipe the stored token ciphertext in `begin_delete` so readers that
       do not know the marker (pre-upgrade replicas during a rolling deploy)
-      cannot export usable credentials mid-drain.
+      cannot export usable credentials mid-drain; backfill the non-secret
+      seat identity (`chatgpt_user_id`) from the id-token claims first so
+      targeted reauthentication can still verify and supersede.
 - [x] 2.6 Remove the account's API-key assignments in `begin_delete` (the
       projection the synchronous FK cascade produced): key listings and
       pooled-usage reads exclude the account immediately, scope flag intact.

--- a/openspec/changes/background-account-deletion/tasks.md
+++ b/openspec/changes/background-account-deletion/tasks.md
@@ -22,14 +22,24 @@
 - [x] 2.4 Hide marked accounts from the credential-export endpoints (account
       export, auth export, opencode auth export): 404 during the drain
       window, matching the synchronous delete's contract.
+- [x] 2.5 Wipe the stored token ciphertext in `begin_delete` so readers that
+      do not know the marker (pre-upgrade replicas during a rolling deploy)
+      cannot export usable credentials mid-drain.
+- [x] 2.6 Remove the account's API-key assignments in `begin_delete` (the
+      projection the synchronous FK cascade produced): key listings and
+      pooled-usage reads exclude the account immediately, scope flag intact.
+- [x] 2.7 Fence ordinary status writers (`update_status`,
+      `update_status_if_current`) on `delete_requested_at IS NULL` so stale
+      in-flight settlements cannot resurrect a marked account.
 
 ## 3. Background worker
 
 - [x] 3.1 `app/modules/accounts/deletion.py`: chunked drain
       (usage_history, additional_usage_history, request_logs; 5k rows per
       transaction, marker re-check under the account row lock per chunk, no
-      fold-state lock) for both variants; round-robin one chunk per pending
-      account per round with a pending re-scan between rounds.
+      fold-state lock) for both variants; round-robin at most one nonempty
+      chunk per pending account per round with a pending re-scan between
+      rounds.
 - [x] 3.2 Finalization via `AccountsRepository.delete(only_pending=True)`:
       historical transaction shape (identity lock → fold-state lock →
       residual rows → mirrors → sticky/rollup/account) plus marker guard and

--- a/openspec/changes/background-account-deletion/tasks.md
+++ b/openspec/changes/background-account-deletion/tasks.md
@@ -45,6 +45,12 @@
 - [x] 2.11 Finalization upgrades the account row to `FOR UPDATE` before the
       residual sweeps (PostgreSQL) so in-flight FK inserts are either swept
       or fail post-delete — no live orphans, no surviving history.
+- [x] 2.12 Per-chunk self-heal of drift written by unfenced pre-upgrade
+      replicas: re-assert terminal status and re-remove recreated API-key
+      assignments under the chunk's row lock.
+- [x] 2.13 Repeat DELETE short-circuits on an unlocked marker+wipe read so
+      the millisecond contract holds while a drain chunk holds the account
+      row lock / SQLite writer section.
 
 ## 3. Background worker
 

--- a/openspec/changes/background-account-deletion/tasks.md
+++ b/openspec/changes/background-account-deletion/tasks.md
@@ -33,6 +33,12 @@
 - [x] 2.7 Fence ordinary status writers (`update_status`,
       `update_status_if_current`) on `delete_requested_at IS NULL` so stale
       in-flight settlements cannot resurrect a marked account.
+- [x] 2.8 Treat non-wiped credential ciphertext on a marked row as a
+      supersede (replacement by a pre-upgrade replica that cannot clear the
+      marker): chunks and finalization clear the marker and abandon.
+- [x] 2.9 Reject marked accounts in API-key assignment validation
+      (`ApiKeysRepository.list_accounts_by_ids`) so post-DELETE key updates
+      cannot recreate assignments for the account.
 
 ## 3. Background worker
 

--- a/openspec/changes/background-account-deletion/tasks.md
+++ b/openspec/changes/background-account-deletion/tasks.md
@@ -51,11 +51,14 @@
 - [x] 2.13 Repeat DELETE short-circuits on an unlocked marker+wipe read so
       the millisecond contract holds while a drain chunk holds the account
       row lock / SQLite writer section.
-- [x] 2.14 Treat marked accounts as absent on every ID-based account route
-      (trends, reset-credit read/consume, probe, pause, update, alias,
-      limit-warmup, routing policy) via a marker-aware fetch or an atomic
-      write predicate; filter the marker in the unscoped API-key pool query
-      (`list_all_accounts`) as well.
+- [x] 2.14 Treat marked accounts as absent on every ID-based account surface
+      (trends, reset-credit read/consume on both route families, probe,
+      pause, update, alias, limit-warmup, routing policy, upstream-proxy
+      binding, `/v1` reset-credit redemption) via a marker-aware fetch or an
+      atomic write predicate; filter the marker in the unscoped API-key pool
+      query (`list_all_accounts`) as well.
+- [x] 2.15 Propagate the delete-request cache invalidation after a chunk
+      repairs pre-upgrade-replica drift, so cached drift stops being served.
 
 ## 3. Background worker
 
@@ -87,3 +90,7 @@
       keep the direct synchronous `AccountsRepository.delete` coverage.
 - [x] 4.3 `ruff check` + `ruff format` + architecture checks + focused
       account/rollup/migration test suites + strict OpenSpec validation.
+- [x] 4.4 Alembic round-trip coverage for
+      `20260816_000000_add_account_pending_deletion` (parent -> revision ->
+      downgrade -> guarded upgrade -> head), wired into the PostgreSQL CI
+      target list.

--- a/openspec/changes/background-account-deletion/tasks.md
+++ b/openspec/changes/background-account-deletion/tasks.md
@@ -4,6 +4,10 @@
       `accounts.delete_history_requested` columns (model + Alembic revision
       `20260816_000000_add_account_pending_deletion` on the current head,
       guarded upgrade/downgrade).
+- [x] 1.2 Partial queue index `idx_accounts_delete_requested_at`
+      (`(delete_requested_at, id) WHERE delete_requested_at IS NOT NULL`) so
+      the per-interval pending probe and the queue-order scan never touch the
+      full accounts table.
 
 ## 2. Fast delete path
 
@@ -15,13 +19,17 @@
       contract (`{"status": "deleted"}`).
 - [x] 2.3 Clear the marker in `_apply_account_updates` so credential
       replacement supersedes a pending deletion.
+- [x] 2.4 Hide marked accounts from the credential-export endpoints (account
+      export, auth export, opencode auth export): 404 during the drain
+      window, matching the synchronous delete's contract.
 
 ## 3. Background worker
 
 - [x] 3.1 `app/modules/accounts/deletion.py`: chunked drain
       (usage_history, additional_usage_history, request_logs; 5k rows per
-      transaction, marker re-check per chunk, no fold-state lock) for both
-      variants.
+      transaction, marker re-check under the account row lock per chunk, no
+      fold-state lock) for both variants; round-robin one chunk per pending
+      account per round with a pending re-scan between rounds.
 - [x] 3.2 Finalization via `AccountsRepository.delete(only_pending=True)`:
       historical transaction shape (identity lock → fold-state lock →
       residual rows → mirrors → sticky/rollup/account) plus marker guard and
@@ -38,7 +46,8 @@
       dimension preserves history), restart resume, straggler row settled
       mid-drain, repeat-request idempotency without variant escalation,
       supersede by replacement (including the drain/finalize race), fast-path
-      API contract (immediate hide, 404 reactivate).
+      API contract (immediate hide, 404 reactivate, 404 credential exports),
+      round-robin interleave and mid-pass pickup of newly marked accounts.
 - [x] 4.2 Update the existing delete API tests to drive the worker pass;
       keep the direct synchronous `AccountsRepository.delete` coverage.
 - [x] 4.3 `ruff check` + `ruff format` + architecture checks + focused

--- a/openspec/changes/background-account-deletion/tasks.md
+++ b/openspec/changes/background-account-deletion/tasks.md
@@ -51,6 +51,11 @@
 - [x] 2.13 Repeat DELETE short-circuits on an unlocked marker+wipe read so
       the millisecond contract holds while a drain chunk holds the account
       row lock / SQLite writer section.
+- [x] 2.14 Treat marked accounts as absent on every ID-based account route
+      (trends, reset-credit read/consume, probe, pause, update, alias,
+      limit-warmup, routing policy) via a marker-aware fetch or an atomic
+      write predicate; filter the marker in the unscoped API-key pool query
+      (`list_all_accounts`) as well.
 
 ## 3. Background worker
 

--- a/openspec/changes/background-account-deletion/tasks.md
+++ b/openspec/changes/background-account-deletion/tasks.md
@@ -93,4 +93,6 @@
 - [x] 4.4 Alembic round-trip coverage for
       `20260816_000000_add_account_pending_deletion` (parent -> revision ->
       downgrade -> guarded upgrade -> head), wired into the PostgreSQL CI
-      target list.
+      target list; downgrade REFUSES while any deletion is queued (the
+      marker columns are the queue's only durable state) and the refusal is
+      covered by the round-trip test.

--- a/openspec/changes/background-account-deletion/tasks.md
+++ b/openspec/changes/background-account-deletion/tasks.md
@@ -1,0 +1,45 @@
+## 1. Schema
+
+- [x] 1.1 Add `accounts.delete_requested_at` and
+      `accounts.delete_history_requested` columns (model + Alembic revision
+      `20260816_000000_add_account_pending_deletion` on the current head,
+      guarded upgrade/downgrade).
+
+## 2. Fast delete path
+
+- [x] 2.1 `AccountsRepository.begin_delete`: terminal `DEACTIVATED` mark +
+      pending marker + sticky/bridge cleanup in one short transaction;
+      idempotent, first request freezes the `delete_history` choice.
+- [x] 2.2 Hide marked accounts from `list_accounts` / `list_accounts_by_ids`;
+      block reactivation of marked accounts; keep the DELETE response
+      contract (`{"status": "deleted"}`).
+- [x] 2.3 Clear the marker in `_apply_account_updates` so credential
+      replacement supersedes a pending deletion.
+
+## 3. Background worker
+
+- [x] 3.1 `app/modules/accounts/deletion.py`: chunked drain
+      (usage_history, additional_usage_history, request_logs; 5k rows per
+      transaction, marker re-check per chunk, no fold-state lock) for both
+      variants.
+- [x] 3.2 Finalization via `AccountsRepository.delete(only_pending=True)`:
+      historical transaction shape (identity lock → fold-state lock →
+      residual rows → mirrors → sticky/rollup/account) plus marker guard and
+      persisted-variant read.
+- [x] 3.3 Leader-gated scheduler (30 s tick, cheap pending pre-check before
+      leader election, local wake from the delete path), wired into the app
+      lifespan; post-finalization cache invalidation mirroring the old
+      synchronous path.
+
+## 4. Validation
+
+- [x] 4.1 Integration coverage: chunk-boundary drain (both variants), fold
+      pass interleaved between chunks (no folded-row resurrection, orphaned
+      dimension preserves history), restart resume, straggler row settled
+      mid-drain, repeat-request idempotency without variant escalation,
+      supersede by replacement (including the drain/finalize race), fast-path
+      API contract (immediate hide, 404 reactivate).
+- [x] 4.2 Update the existing delete API tests to drive the worker pass;
+      keep the direct synchronous `AccountsRepository.delete` coverage.
+- [x] 4.3 `ruff check` + `ruff format` + architecture checks + focused
+      account/rollup/migration test suites + strict OpenSpec validation.

--- a/tests/integration/test_account_deletion_background.py
+++ b/tests/integration/test_account_deletion_background.py
@@ -547,6 +547,88 @@ async def test_credential_replacement_supersedes_pending_deletion(db_setup):
     assert await _attached_log_count("acc_bg_super") == 2
 
 
+async def _legacy_replace_credentials(account_id: str, encryptor: TokenEncryptor) -> None:
+    """Mimic a credential replacement by a pre-upgrade replica: fresh
+    ciphertext and status, but the marker columns its ORM does not know stay
+    untouched."""
+    async with SessionLocal() as session:
+        await session.execute(
+            update(Account)
+            .where(Account.id == account_id)
+            .values(
+                access_token_encrypted=encryptor.encrypt("fresh-access"),
+                refresh_token_encrypted=encryptor.encrypt("fresh-refresh"),
+                id_token_encrypted=encryptor.encrypt("fresh-id"),
+                status=AccountStatus.ACTIVE,
+                deactivation_reason=None,
+            )
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_legacy_replica_replacement_supersedes_mid_drain(db_setup):
+    """A replacement handled by a pre-upgrade replica cannot clear the marker;
+    fresh (non-wiped) ciphertext on a marked row must itself supersede."""
+    encryptor = TokenEncryptor()
+    await _seed_account("acc_bg_legacy", log_count=3)
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_legacy")
+    assert await _run_one_detach_chunk("acc_bg_legacy", batch_size=2) == 2
+
+    await _legacy_replace_credentials("acc_bg_legacy", encryptor)
+
+    outcomes = await run_account_deletion_pass(batch_size=2)
+    assert outcomes == {"acc_bg_legacy": "superseded"}
+    row = await _account_row("acc_bg_legacy")
+    assert row is not None
+    # The worker cleared the marker itself and preserved the fresh material.
+    assert row.delete_requested_at is None
+    assert encryptor.decrypt(row.refresh_token_encrypted) == "fresh-refresh"
+    # Rows detached before the replacement stay detached; the rest survive.
+    assert await _attached_log_count("acc_bg_legacy") == 1
+    # The account is no longer rescanned on later passes.
+    assert await run_account_deletion_pass(batch_size=2) == {}
+
+
+@pytest.mark.asyncio
+async def test_legacy_replica_replacement_before_finalize_is_abandoned(db_setup):
+    encryptor = TokenEncryptor()
+    await _seed_account("acc_bg_legacy_fin", log_count=1)
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_legacy_fin")
+    assert await _run_one_detach_chunk("acc_bg_legacy_fin", batch_size=10) == 1
+
+    await _legacy_replace_credentials("acc_bg_legacy_fin", encryptor)
+
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).delete("acc_bg_legacy_fin", only_pending=True) is False
+    row = await _account_row("acc_bg_legacy_fin")
+    assert row is not None
+    assert row.delete_requested_at is None
+    assert encryptor.decrypt(row.refresh_token_encrypted) == "fresh-refresh"
+
+
+@pytest.mark.asyncio
+async def test_marked_account_cannot_be_assigned_to_api_key(async_client, db_setup):
+    await _seed_account("acc_bg_assign", log_count=1)
+
+    delete = await async_client.delete("/api/accounts/acc_bg_assign")
+    assert delete.status_code == 200
+
+    # A key update racing (or following) the DELETE must not recreate an
+    # assignment that would re-surface the deleted account in key listings.
+    create = await async_client.post("/api/api-keys/", json={"name": "post-delete-key"})
+    assert create.status_code == 200
+    key_id = create.json()["id"]
+    update_resp = await async_client.patch(
+        f"/api/api-keys/{key_id}",
+        json={"assignedAccountIds": ["acc_bg_assign"]},
+    )
+    assert update_resp.status_code == 400
+    assert update_resp.json()["error"]["code"] == "invalid_api_key_payload"
+
+
 @pytest.mark.asyncio
 async def test_supersede_between_drain_and_finalize_is_abandoned(db_setup):
     await _seed_account("acc_bg_race", log_count=2)

--- a/tests/integration/test_account_deletion_background.py
+++ b/tests/integration/test_account_deletion_background.py
@@ -1,0 +1,424 @@
+"""Background (chunked) account deletion: drain, fold interleave, restart,
+idempotency, and supersede semantics for both delete_history variants."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from sqlalchemy import func, select, update
+
+from app.core.crypto import TokenEncryptor
+from app.core.utils.time import utcnow
+from app.db.models import (
+    Account,
+    AccountStatus,
+    AccountUsageRollup,
+    RequestDemandQuarterRollup,
+    RequestLog,
+    RequestUsageHourlyRollup,
+    StickySession,
+    StickySessionKind,
+    UsageHistory,
+)
+from app.db.session import SessionLocal, get_background_session, sqlite_writer_section
+from app.modules.accounts.deletion import _request_logs_chunk, run_account_deletion_pass
+from app.modules.accounts.repository import ACCOUNT_PENDING_DELETION_REASON, AccountsRepository
+from app.modules.accounts.usage_rollup import run_fold_pass
+from app.modules.accounts.usage_time_rollup import run_hourly_fold_pass, to_dimension
+from app.modules.request_logs.repository import RequestLogsRepository
+from app.modules.usage.repository import UsageRepository
+
+pytestmark = pytest.mark.integration
+
+_ORPHAN_DIMENSION = to_dimension(None)
+
+
+@pytest.fixture(autouse=True)
+def _no_background_wake(monkeypatch):
+    """Keep the drain under explicit test control.
+
+    The suite's stand-in leader election runs scheduler bodies inline, so the
+    delete API's worker wake would drain accounts concurrently with (and race)
+    the passes these tests drive step by step.
+    """
+    monkeypatch.setattr("app.modules.accounts.service.request_account_deletion_run", lambda: None)
+
+
+def _make_account(account_id: str, email: str) -> Account:
+    encryptor = TokenEncryptor()
+    return Account(
+        id=account_id,
+        email=email,
+        plan_type="plus",
+        access_token_encrypted=encryptor.encrypt("access"),
+        refresh_token_encrypted=encryptor.encrypt("refresh"),
+        id_token_encrypted=encryptor.encrypt("id"),
+        last_refresh=utcnow(),
+        status=AccountStatus.ACTIVE,
+        deactivation_reason=None,
+    )
+
+
+async def _add_log(logs_repo: RequestLogsRepository, *, account_id: str, request_id: str, requested_at) -> None:
+    await logs_repo.add_log(
+        account_id=account_id,
+        request_id=request_id,
+        model="gpt-5.1-codex",
+        input_tokens=100,
+        output_tokens=50,
+        latency_ms=100,
+        status="success",
+        error_code=None,
+        requested_at=requested_at,
+        cost_usd=0.01,
+    )
+
+
+async def _seed_account(account_id: str, *, log_count: int, usage_count: int = 0, requested_at=None) -> None:
+    requested_at = requested_at or (utcnow() - timedelta(days=2))
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        logs_repo = RequestLogsRepository(session)
+        usage_repo = UsageRepository(session)
+        await accounts_repo.upsert(_make_account(account_id, f"{account_id}@example.com"))
+        for index in range(log_count):
+            await _add_log(
+                logs_repo,
+                account_id=account_id,
+                request_id=f"req_{account_id}_{index}",
+                requested_at=requested_at,
+            )
+        for index in range(usage_count):
+            await usage_repo.add_entry(account_id, float(index), window="primary")
+
+
+async def _account_row(account_id: str) -> Account | None:
+    async with SessionLocal() as session:
+        return await session.get(Account, account_id)
+
+
+async def _attached_log_count(account_id: str) -> int:
+    async with SessionLocal() as session:
+        return (
+            await session.execute(select(func.count(RequestLog.id)).where(RequestLog.account_id == account_id))
+        ).scalar_one()
+
+
+async def _log_rows(prefix: str) -> list[RequestLog]:
+    async with SessionLocal() as session:
+        return list(
+            (await session.execute(select(RequestLog).where(RequestLog.request_id.like(f"req_{prefix}%"))))
+            .scalars()
+            .all()
+        )
+
+
+async def _hourly_rows_for_dimension(dimension: str) -> list[RequestUsageHourlyRollup]:
+    async with SessionLocal() as session:
+        return list(
+            (
+                await session.execute(
+                    select(RequestUsageHourlyRollup).where(RequestUsageHourlyRollup.account_id == dimension)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+
+async def _demand_rows_for_dimension(dimension: str) -> list[RequestDemandQuarterRollup]:
+    async with SessionLocal() as session:
+        return list(
+            (
+                await session.execute(
+                    select(RequestDemandQuarterRollup).where(RequestDemandQuarterRollup.account_id == dimension)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+
+async def _lifetime_rollup(account_id: str) -> AccountUsageRollup | None:
+    async with SessionLocal() as session:
+        return await session.get(AccountUsageRollup, account_id)
+
+
+async def _run_one_detach_chunk(account_id: str, *, batch_size: int, delete_history: bool = False) -> int:
+    async with get_background_session() as session:
+        async with sqlite_writer_section():
+            affected = await _request_logs_chunk(
+                session, account_id, delete_history=delete_history, batch_size=batch_size
+            )
+            await session.commit()
+    return affected
+
+
+@pytest.mark.asyncio
+async def test_delete_api_marks_and_hides_immediately(async_client, db_setup):
+    await _seed_account("acc_bg_mark", log_count=2, usage_count=2)
+
+    delete = await async_client.delete("/api/accounts/acc_bg_mark")
+    assert delete.status_code == 200
+    assert delete.json()["status"] == "deleted"
+
+    # Hidden from the listing immediately, before any background work ran.
+    accounts = await async_client.get("/api/accounts")
+    assert accounts.status_code == 200
+    assert all(entry["accountId"] != "acc_bg_mark" for entry in accounts.json()["accounts"])
+
+    # The row itself survives, terminal and marked, until the worker drains it.
+    row = await _account_row("acc_bg_mark")
+    assert row is not None
+    assert row.status is AccountStatus.DEACTIVATED
+    assert row.deactivation_reason == ACCOUNT_PENDING_DELETION_REASON
+    assert row.delete_requested_at is not None
+    assert await _attached_log_count("acc_bg_mark") == 2
+
+    # Repeat request is idempotent and does not escalate the frozen variant.
+    repeat = await async_client.delete("/api/accounts/acc_bg_mark?delete_history=true")
+    assert repeat.status_code == 200
+    row = await _account_row("acc_bg_mark")
+    assert row is not None
+    assert row.delete_history_requested is False
+
+    # A marked account is gone from the operator's perspective: reactivation
+    # reports not-found instead of racing the deletion worker.
+    reactivate = await async_client.post("/api/accounts/acc_bg_mark/reactivate")
+    assert reactivate.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_chunked_soft_delete_drains_across_chunk_boundaries(db_setup):
+    await _seed_account("acc_bg_soft", log_count=7, usage_count=5)
+    async with SessionLocal() as session:
+        session.add(
+            StickySession(
+                key="sticky_bg_soft",
+                kind=StickySessionKind.CODEX_SESSION,
+                account_id="acc_bg_soft",
+            )
+        )
+        await session.commit()
+
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_soft")
+
+    outcomes = await run_account_deletion_pass(batch_size=3)
+    assert outcomes == {"acc_bg_soft": "finalized"}
+
+    assert await _account_row("acc_bg_soft") is None
+    logs = await _log_rows("acc_bg_soft")
+    assert len(logs) == 7
+    assert all(row.account_id is None and row.deleted_at is not None for row in logs)
+    async with SessionLocal() as session:
+        usage_left = (
+            await session.execute(select(func.count(UsageHistory.id)).where(UsageHistory.account_id == "acc_bg_soft"))
+        ).scalar_one()
+        sticky_left = (
+            await session.execute(
+                select(func.count(StickySession.key)).where(StickySession.account_id == "acc_bg_soft")
+            )
+        ).scalar_one()
+    assert usage_left == 0
+    assert sticky_left == 0
+    assert await _lifetime_rollup("acc_bg_soft") is None
+
+    # Idempotent: a second pass finds nothing to do.
+    assert await run_account_deletion_pass(batch_size=3) == {}
+
+
+@pytest.mark.asyncio
+async def test_chunked_hard_delete_removes_history(db_setup):
+    await _seed_account("acc_bg_hard", log_count=5, usage_count=2)
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_hard", delete_history=True)
+
+    outcomes = await run_account_deletion_pass(batch_size=2)
+    assert outcomes == {"acc_bg_hard": "finalized"}
+
+    assert await _account_row("acc_bg_hard") is None
+    assert await _log_rows("acc_bg_hard") == []
+
+
+@pytest.mark.asyncio
+async def test_fold_interleaved_between_chunks_does_not_resurrect_soft(db_setup):
+    """A fold slice committing between detach chunks re-attributes still-
+    attached rows to the account; finalization's fold-locked mirrors must
+    move ALL of it to the orphaned-deleted dimension."""
+    now = utcnow()
+    account_dimension = to_dimension("acc_bg_fold")
+    # Group A (2 rows) old enough for the first fold; group B (2 rows) folded
+    # only by the interleaved fold below.
+    await _seed_account("acc_bg_fold", log_count=2, requested_at=now - timedelta(days=5))
+    async with SessionLocal() as session:
+        logs_repo = RequestLogsRepository(session)
+        for index in range(2):
+            await _add_log(
+                logs_repo,
+                account_id="acc_bg_fold",
+                request_id=f"req_acc_bg_fold_b{index}",
+                requested_at=now - timedelta(days=2),
+            )
+
+    # First fold covers only group A (target = now-3d - FOLD_LAG).
+    await run_fold_pass(now=now - timedelta(days=3))
+    await run_hourly_fold_pass(now=now - timedelta(days=3))
+    assert await _hourly_rows_for_dimension(account_dimension) != []
+
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_fold")
+
+    # One chunk detaches the two oldest (group A) rows; group B stays attached.
+    assert await _run_one_detach_chunk("acc_bg_fold", batch_size=2) == 2
+    assert await _attached_log_count("acc_bg_fold") == 2
+
+    # Interleaved folds aggregate group B while it is still attributed.
+    await run_fold_pass(now=now)
+    await run_hourly_fold_pass(now=now)
+    assert await _lifetime_rollup("acc_bg_fold") is not None
+    interleaved_hourly = await _hourly_rows_for_dimension(account_dimension)
+    assert sum(row.request_count for row in interleaved_hourly if not row.is_deleted) >= 2
+
+    # Resume and finish the deletion.
+    outcomes = await run_account_deletion_pass(batch_size=2)
+    assert outcomes == {"acc_bg_fold": "finalized"}
+
+    # No folded row anywhere still carries the account dimension...
+    assert await _hourly_rows_for_dimension(account_dimension) == []
+    assert await _demand_rows_for_dimension(account_dimension) == []
+    assert await _lifetime_rollup("acc_bg_fold") is None
+    # ...and the orphaned-deleted dimension preserves the full folded history.
+    orphan_hourly = await _hourly_rows_for_dimension(_ORPHAN_DIMENSION)
+    assert sum(row.request_count for row in orphan_hourly if row.is_deleted) == 4
+    logs = await _log_rows("acc_bg_fold")
+    assert len(logs) == 4
+    assert all(row.account_id is None and row.deleted_at is not None for row in logs)
+
+    # Folds after finalization see only detached raw rows: nothing new may
+    # appear under the account dimension.
+    await run_hourly_fold_pass(now=now + timedelta(days=1))
+    await run_fold_pass(now=now + timedelta(days=1))
+    assert await _hourly_rows_for_dimension(account_dimension) == []
+    assert await _lifetime_rollup("acc_bg_fold") is None
+
+
+@pytest.mark.asyncio
+async def test_fold_interleaved_between_chunks_does_not_resurrect_hard(db_setup):
+    now = utcnow()
+    account_dimension = to_dimension("acc_bg_fhard")
+    await _seed_account("acc_bg_fhard", log_count=2, requested_at=now - timedelta(days=5))
+    async with SessionLocal() as session:
+        logs_repo = RequestLogsRepository(session)
+        for index in range(2):
+            await _add_log(
+                logs_repo,
+                account_id="acc_bg_fhard",
+                request_id=f"req_acc_bg_fhard_b{index}",
+                requested_at=now - timedelta(days=2),
+            )
+    await run_hourly_fold_pass(now=now - timedelta(days=3))
+
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_fhard", delete_history=True)
+
+    assert await _run_one_detach_chunk("acc_bg_fhard", batch_size=2, delete_history=True) == 2
+    await run_hourly_fold_pass(now=now)
+
+    outcomes = await run_account_deletion_pass(batch_size=2)
+    assert outcomes == {"acc_bg_fhard": "finalized"}
+
+    assert await _hourly_rows_for_dimension(account_dimension) == []
+    assert await _demand_rows_for_dimension(account_dimension) == []
+    assert await _log_rows("acc_bg_fhard") == []
+
+
+@pytest.mark.asyncio
+async def test_restart_resumes_partial_drain(db_setup):
+    await _seed_account("acc_bg_resume", log_count=5, usage_count=3)
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_resume")
+
+    # Simulate a crash after one detach chunk: progress lives in the rows.
+    assert await _run_one_detach_chunk("acc_bg_resume", batch_size=2) == 2
+    assert await _attached_log_count("acc_bg_resume") == 3
+
+    # A fresh pass (restarted leader) resumes from the database state.
+    outcomes = await run_account_deletion_pass(batch_size=2)
+    assert outcomes == {"acc_bg_resume": "finalized"}
+    assert await _account_row("acc_bg_resume") is None
+    logs = await _log_rows("acc_bg_resume")
+    assert len(logs) == 5
+    assert all(row.account_id is None for row in logs)
+
+
+@pytest.mark.asyncio
+async def test_straggler_row_settled_mid_drain_is_finalized(db_setup):
+    """A stream that settles its request-log row after the drain chunks ran
+    is caught by finalization's residual sweep."""
+    await _seed_account("acc_bg_late", log_count=3)
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_late")
+    assert await _run_one_detach_chunk("acc_bg_late", batch_size=10) == 3
+
+    async with SessionLocal() as session:
+        await _add_log(
+            RequestLogsRepository(session),
+            account_id="acc_bg_late",
+            request_id="req_acc_bg_late_straggler",
+            requested_at=utcnow() - timedelta(hours=1),
+        )
+
+    outcomes = await run_account_deletion_pass(batch_size=10)
+    assert outcomes == {"acc_bg_late": "finalized"}
+    logs = await _log_rows("acc_bg_late")
+    assert len(logs) == 4
+    assert all(row.account_id is None and row.deleted_at is not None for row in logs)
+
+
+@pytest.mark.asyncio
+async def test_credential_replacement_supersedes_pending_deletion(db_setup):
+    await _seed_account("acc_bg_super", log_count=4)
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_super")
+    assert await _run_one_detach_chunk("acc_bg_super", batch_size=2) == 2
+
+    # Re-import lands on the same row via the slot-identity path and clears
+    # the marker (credential replacement supersedes the deletion).
+    async with SessionLocal() as session:
+        replacement = _make_account("acc_bg_super", "acc_bg_super@example.com")
+        saved = await AccountsRepository(session).upsert(replacement, merge_by_email=True)
+        assert saved.id == "acc_bg_super"
+
+    row = await _account_row("acc_bg_super")
+    assert row is not None
+    assert row.delete_requested_at is None
+    assert row.status is AccountStatus.ACTIVE
+
+    outcomes = await run_account_deletion_pass(batch_size=2)
+    assert outcomes == {}
+    assert await _account_row("acc_bg_super") is not None
+    # Rows detached before the supersede stay detached; the rest survive.
+    assert await _attached_log_count("acc_bg_super") == 2
+
+
+@pytest.mark.asyncio
+async def test_supersede_between_drain_and_finalize_is_abandoned(db_setup):
+    await _seed_account("acc_bg_race", log_count=2)
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_race")
+    assert await _run_one_detach_chunk("acc_bg_race", batch_size=10) == 2
+
+    # Marker cleared right before finalization (replacement won the race).
+    async with SessionLocal() as session:
+        await session.execute(
+            update(Account)
+            .where(Account.id == "acc_bg_race")
+            .values(delete_requested_at=None, delete_history_requested=False)
+        )
+        await session.commit()
+
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).delete("acc_bg_race", only_pending=True) is False
+    assert await _account_row("acc_bg_race") is not None

--- a/tests/integration/test_account_deletion_background.py
+++ b/tests/integration/test_account_deletion_background.py
@@ -610,6 +610,94 @@ async def test_legacy_replica_replacement_before_finalize_is_abandoned(db_setup)
 
 
 @pytest.mark.asyncio
+async def test_finalization_serializes_against_inflight_log_insert(db_setup):
+    """PostgreSQL: an in-flight stream's request-log insert holds the FK KEY
+    SHARE on the account row; finalization's FOR UPDATE row upgrade must wait
+    for it, so the late row is swept instead of surviving as a live orphan
+    via ON DELETE SET NULL."""
+    import asyncio
+
+    async with SessionLocal() as probe:
+        if probe.get_bind().dialect.name != "postgresql":
+            pytest.skip("FK KEY SHARE / FOR UPDATE interleaving is PostgreSQL-specific")
+
+    await _seed_account("acc_bg_inflight", log_count=1)
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_inflight")
+    assert await _run_one_detach_chunk("acc_bg_inflight", batch_size=10) == 1
+
+    async with SessionLocal() as inflight:
+        # In-flight stream: the insert takes (and holds) FK KEY SHARE on the
+        # account row until commit.
+        inflight.add(
+            RequestLog(
+                account_id="acc_bg_inflight",
+                request_id="req_acc_bg_inflight_late",
+                requested_at=utcnow(),
+                model="gpt-5.1-codex",
+                status="success",
+                input_tokens=1,
+                output_tokens=1,
+                cost_usd=0.0,
+            )
+        )
+        await inflight.flush()
+
+        pass_task = asyncio.create_task(run_account_deletion_pass(batch_size=10))
+        # Finalization must block on the row upgrade while the insert is open.
+        done, _ = await asyncio.wait({pass_task}, timeout=1.0)
+        commit_first = not done
+        await inflight.commit()
+        outcomes = await pass_task
+
+    assert commit_first, "finalization finished while an uncommitted FK insert held KEY SHARE"
+    assert outcomes == {"acc_bg_inflight": "finalized"}
+    assert await _account_row("acc_bg_inflight") is None
+    logs = await _log_rows("acc_bg_inflight")
+    assert len(logs) == 2
+    # The late row was swept by the residual sweep, not orphaned live.
+    assert all(row.account_id is None and row.deleted_at is not None for row in logs)
+
+
+@pytest.mark.asyncio
+async def test_assignment_insert_rechecks_marker_atomically(db_setup):
+    """replace_account_assignments must skip marked accounts even when an
+    earlier validation (different transaction) still believed they existed."""
+    from app.db.models import ApiKey, ApiKeyAccountAssignment
+    from app.modules.api_keys.repository import ApiKeysRepository
+
+    await _seed_account("acc_bg_atomic", log_count=0)
+    async with SessionLocal() as session:
+        session.add(
+            ApiKey(
+                id="key_bg_atomic",
+                name="atomic-recheck-key",
+                key_hash="hash_bg_atomic",
+                key_prefix="sk-atomic",
+                account_assignment_scope_enabled=True,
+            )
+        )
+        await session.commit()
+
+    # DELETE lands after validation would have passed.
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_atomic")
+
+    async with SessionLocal() as session:
+        await ApiKeysRepository(session).replace_account_assignments("key_bg_atomic", ["acc_bg_atomic"])
+
+    async with SessionLocal() as session:
+        assigned = (
+            await session.execute(
+                select(func.count())
+                .select_from(ApiKeyAccountAssignment)
+                .where(ApiKeyAccountAssignment.api_key_id == "key_bg_atomic")
+            )
+        ).scalar_one()
+    assert assigned == 0
+
+
+@pytest.mark.asyncio
 async def test_marked_account_cannot_be_assigned_to_api_key(async_client, db_setup):
     await _seed_account("acc_bg_assign", log_count=1)
 

--- a/tests/integration/test_account_deletion_background.py
+++ b/tests/integration/test_account_deletion_background.py
@@ -751,6 +751,46 @@ async def test_marked_account_cannot_be_assigned_to_api_key(async_client, db_set
 
 
 @pytest.mark.asyncio
+async def test_supersede_after_partial_drain_preserves_folded_attribution(db_setup):
+    """Rows drained before a supersede stay drained, and folded rollups keep
+    attributing that traffic to the revived account — with no double count
+    from later folds (drained below-watermark rows are never re-folded)."""
+    now = utcnow()
+    account_dimension = to_dimension("acc_bg_sfold")
+    await _seed_account("acc_bg_sfold", log_count=2, requested_at=now - timedelta(days=5))
+
+    # Fold the two rows under the account dimension first.
+    await run_fold_pass(now=now - timedelta(days=3))
+    await run_hourly_fold_pass(now=now - timedelta(days=3))
+    folded_before = sum(row.request_count for row in await _hourly_rows_for_dimension(account_dimension))
+    assert folded_before == 2
+
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_sfold")
+    # One chunk detaches both already-folded rows.
+    assert await _run_one_detach_chunk("acc_bg_sfold", batch_size=10) == 2
+
+    # Re-import supersedes before finalization ever runs.
+    async with SessionLocal() as session:
+        saved = await AccountsRepository(session).upsert(
+            _make_account("acc_bg_sfold", "acc_bg_sfold@example.com"), merge_by_email=True
+        )
+        assert saved.id == "acc_bg_sfold"
+    assert await run_account_deletion_pass(batch_size=10) == {}
+
+    # Folded attribution is the permanent end state: unchanged by later
+    # folds (no loss, no double count), while raw rows stay detached.
+    await run_fold_pass(now=now)
+    await run_hourly_fold_pass(now=now)
+    folded_after = sum(row.request_count for row in await _hourly_rows_for_dimension(account_dimension))
+    assert folded_after == folded_before
+    assert await _lifetime_rollup("acc_bg_sfold") is not None
+    logs = await _log_rows("acc_bg_sfold")
+    assert len(logs) == 2
+    assert all(row.account_id is None and row.deleted_at is not None for row in logs)
+
+
+@pytest.mark.asyncio
 async def test_supersede_between_drain_and_finalize_is_abandoned(db_setup):
     await _seed_account("acc_bg_race", log_count=2)
     async with SessionLocal() as session:

--- a/tests/integration/test_account_deletion_background.py
+++ b/tests/integration/test_account_deletion_background.py
@@ -8,7 +8,7 @@ import json
 from datetime import timedelta
 
 import pytest
-from sqlalchemy import func, select, update
+from sqlalchemy import func, select, text, update
 
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
@@ -484,13 +484,13 @@ async def test_pass_picks_up_account_marked_mid_pass(db_setup, monkeypatch):
     original_advance = deletion._advance_account
     marked_second = False
 
-    async def advance_and_mark(account_id, *, batch_size):
+    async def advance_and_mark(account_id, *, batch_size, drained=None):
         nonlocal marked_second
         if not marked_second:
             marked_second = True
             async with SessionLocal() as session:
                 assert await AccountsRepository(session).begin_delete("acc_bg_mid_b")
-        return await original_advance(account_id, batch_size=batch_size)
+        return await original_advance(account_id, batch_size=batch_size, drained=drained)
 
     monkeypatch.setattr(deletion, "_advance_account", advance_and_mark)
 
@@ -907,3 +907,124 @@ async def test_supersede_between_drain_and_finalize_is_abandoned(db_setup):
     async with SessionLocal() as session:
         assert await AccountsRepository(session).delete("acc_bg_race", only_pending=True) is False
     assert await _account_row("acc_bg_race") is not None
+
+
+def _batch_pinning_cases() -> tuple[tuple[object, object, str], ...]:
+    from app.db.models import AdditionalUsageHistory
+    from app.modules.accounts import deletion
+
+    return (
+        (deletion._usage_history_batch, UsageHistory.__table__, "idx_usage_account_time"),
+        (
+            deletion._additional_usage_history_batch,
+            AdditionalUsageHistory.__table__,
+            "ix_additional_usage_distinct_labels",
+        ),
+        (deletion._request_logs_batch, RequestLog.__table__, "idx_logs_account_kind_deleted_latest"),
+    )
+
+
+def test_chunk_batch_statements_pin_account_leading_index_order():
+    """The chunk batch shape is what keeps the planner off sequential scans.
+
+    An ``account_id = :id LIMIT n`` subquery plans as a LIMIT-terminated Seq
+    Scan on the production planner for exactly the large accounts the drain
+    targets (equality folds account_id out of the sort pathkeys). The batch
+    builders must keep (a) the range predicate pair (never plain equality)
+    and (b) an ORDER BY that lists the target account-leading index's exact
+    column order, so that index is the only sort-free plan.
+    """
+    from sqlalchemy.dialects import postgresql as postgresql_dialect
+
+    for batch_fn, table, index_name in _batch_pinning_cases():
+        index = next(idx for idx in table.indexes if idx.name == index_name)
+        sql = str(batch_fn("acc_bg_pin", 50).compile(dialect=postgresql_dialect.dialect()))
+        expected_order = ", ".join(f"{table.name}.{column.name}" for column in index.expressions)
+        assert f"ORDER BY {expected_order}" in sql, sql
+        assert f"{table.name}.account_id >= " in sql, sql
+        assert f"{table.name}.account_id <= " in sql, sql
+        assert f"{table.name}.account_id = " not in sql, sql
+
+
+@pytest.mark.asyncio
+async def test_chunk_batch_query_plan_uses_account_leading_indexes_postgresql(db_setup):
+    """The batch ORDER BY must be served by the pinned index, not a sort.
+
+    Sequential/bitmap scans and (incremental) sorts are disabled so the
+    planner has to surface an ordered index path for the batch shape; the
+    only index that can provide the ORDER BY after the leading account_id
+    range is the pinned account-leading index. A drained (or missing)
+    account's probe must terminate on the same index instead of falling
+    back to a heap scan.
+    """
+    await _seed_account("acc_bg_plan", log_count=8, usage_count=8)
+    async with SessionLocal() as session:
+        if session.get_bind().dialect.name != "postgresql":
+            pytest.skip("PostgreSQL-only query plan test")
+
+        from app.db.models import AdditionalUsageHistory
+
+        session.add_all(
+            AdditionalUsageHistory(
+                account_id="acc_bg_plan",
+                quota_key="codex_spark",
+                limit_name="GPT-5.3-Codex-Spark",
+                metered_feature="codex_bengalfox",
+                window="primary",
+                used_percent=float(index),
+            )
+            for index in range(8)
+        )
+        await session.commit()
+
+        await session.execute(text("SET enable_seqscan = off"))
+        await session.execute(text("SET enable_bitmapscan = off"))
+        await session.execute(text("SET enable_sort = off"))
+        await session.execute(text("SET enable_incremental_sort = off"))
+        for batch_fn, _table, index_name in _batch_pinning_cases():
+            for account_id in ("acc_bg_plan", "acc_bg_plan_drained_probe"):
+                compiled = batch_fn(account_id, 5).compile(
+                    dialect=session.get_bind().dialect, compile_kwargs={"literal_binds": True}
+                )
+                plan = (await session.execute(text(f"EXPLAIN (FORMAT JSON) {compiled}"))).scalar_one()
+                plan_json = json.dumps(plan)
+                assert index_name in plan_json, (account_id, plan_json)
+                assert "Seq Scan" not in plan_json, (account_id, plan_json)
+                assert "Sort Key" not in plan_json, (account_id, plan_json)
+
+
+@pytest.mark.asyncio
+async def test_pass_probes_drained_tables_once_per_pass(db_setup, monkeypatch):
+    """A table observed empty for an account is not re-probed on later rounds
+    of the same pass: each probe is a full account-row-locking transaction,
+    and per-account statistics can go stale exactly during the churn window."""
+    from app.modules.accounts import deletion
+
+    await _seed_account("acc_bg_memo", log_count=3)
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_memo")
+
+    calls = {"usage_history": 0, "additional_usage_history": 0, "request_logs": 0}
+    for attr, key in (
+        ("_usage_history_chunk", "usage_history"),
+        ("_additional_usage_history_chunk", "additional_usage_history"),
+        ("_request_logs_chunk", "request_logs"),
+    ):
+        original = getattr(deletion, attr)
+
+        def _make_spy(original=original, key=key):
+            async def spy(session, account_id, *, delete_history, batch_size):
+                calls[key] += 1
+                return await original(session, account_id, delete_history=delete_history, batch_size=batch_size)
+
+            return spy
+
+        monkeypatch.setattr(deletion, attr, _make_spy())
+
+    outcomes = await run_account_deletion_pass(batch_size=1)
+    assert outcomes == {"acc_bg_memo": "finalized"}
+    # usage tables: exactly one (empty) probe in round 1, then skipped while
+    # rounds 2-4 drain the logs; request_logs: three one-row chunks plus the
+    # final empty probe that lets the pass finalize.
+    assert calls == {"usage_history": 1, "additional_usage_history": 1, "request_logs": 4}
+    assert await _account_row("acc_bg_memo") is None

--- a/tests/integration/test_account_deletion_background.py
+++ b/tests/integration/test_account_deletion_background.py
@@ -592,6 +592,39 @@ async def test_legacy_replica_replacement_supersedes_mid_drain(db_setup):
 
 
 @pytest.mark.asyncio
+async def test_legacy_replacement_with_empty_refresh_token_supersedes(db_setup):
+    """A legal replacement may carry an empty refresh token while providing
+    fresh access/id material; a refresh-only wipe check would mistake it for
+    the original wipe and finalize the freshly replaced account."""
+    encryptor = TokenEncryptor()
+    await _seed_account("acc_bg_legacy_er", log_count=1)
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_legacy_er")
+    assert await _run_one_detach_chunk("acc_bg_legacy_er", batch_size=10) == 1
+
+    async with SessionLocal() as session:
+        await session.execute(
+            update(Account)
+            .where(Account.id == "acc_bg_legacy_er")
+            .values(
+                access_token_encrypted=encryptor.encrypt("fresh-access"),
+                refresh_token_encrypted=encryptor.encrypt(""),
+                id_token_encrypted=encryptor.encrypt("fresh-id"),
+                status=AccountStatus.ACTIVE,
+                deactivation_reason=None,
+            )
+        )
+        await session.commit()
+
+    outcomes = await run_account_deletion_pass(batch_size=10)
+    assert outcomes == {"acc_bg_legacy_er": "superseded"}
+    row = await _account_row("acc_bg_legacy_er")
+    assert row is not None
+    assert row.delete_requested_at is None
+    assert encryptor.decrypt(row.access_token_encrypted) == "fresh-access"
+
+
+@pytest.mark.asyncio
 async def test_legacy_replica_replacement_before_finalize_is_abandoned(db_setup):
     encryptor = TokenEncryptor()
     await _seed_account("acc_bg_legacy_fin", log_count=1)

--- a/tests/integration/test_account_deletion_background.py
+++ b/tests/integration/test_account_deletion_background.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 
 import base64
 import json
+from collections.abc import Callable
 from datetime import timedelta
+from typing import cast
 
 import pytest
-from sqlalchemy import func, select, text, update
+from sqlalchemy import Table, func, select, text, update
+from sqlalchemy.sql import Select
 
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import utcnow
@@ -909,18 +912,18 @@ async def test_supersede_between_drain_and_finalize_is_abandoned(db_setup):
     assert await _account_row("acc_bg_race") is not None
 
 
-def _batch_pinning_cases() -> tuple[tuple[object, object, str], ...]:
+def _batch_pinning_cases() -> tuple[tuple[Callable[[str, int], Select[tuple[int]]], Table, str], ...]:
     from app.db.models import AdditionalUsageHistory
     from app.modules.accounts import deletion
 
     return (
-        (deletion._usage_history_batch, UsageHistory.__table__, "idx_usage_account_time"),
+        (deletion._usage_history_batch, cast("Table", UsageHistory.__table__), "idx_usage_account_time"),
         (
             deletion._additional_usage_history_batch,
-            AdditionalUsageHistory.__table__,
+            cast("Table", AdditionalUsageHistory.__table__),
             "ix_additional_usage_distinct_labels",
         ),
-        (deletion._request_logs_batch, RequestLog.__table__, "idx_logs_account_kind_deleted_latest"),
+        (deletion._request_logs_batch, cast("Table", RequestLog.__table__), "idx_logs_account_kind_deleted_latest"),
     )
 
 
@@ -939,7 +942,7 @@ def test_chunk_batch_statements_pin_account_leading_index_order():
     for batch_fn, table, index_name in _batch_pinning_cases():
         index = next(idx for idx in table.indexes if idx.name == index_name)
         sql = str(batch_fn("acc_bg_pin", 50).compile(dialect=postgresql_dialect.dialect()))
-        expected_order = ", ".join(f"{table.name}.{column.name}" for column in index.expressions)
+        expected_order = ", ".join(f"{table.name}.{column.name}" for column in index.columns)
         assert f"ORDER BY {expected_order}" in sql, sql
         assert f"{table.name}.account_id >= " in sql, sql
         assert f"{table.name}.account_id <= " in sql, sql

--- a/tests/integration/test_account_deletion_background.py
+++ b/tests/integration/test_account_deletion_background.py
@@ -3,6 +3,8 @@ idempotency, and supersede semantics for both delete_history variants."""
 
 from __future__ import annotations
 
+import base64
+import json
 from datetime import timedelta
 
 import pytest
@@ -193,6 +195,35 @@ async def test_delete_api_marks_and_hides_immediately(async_client, db_setup):
     for export_path in ("export", "export/auth", "export/opencode-auth"):
         export = await async_client.post(f"/api/accounts/acc_bg_mark/{export_path}")
         assert export.status_code == 404, export_path
+
+
+def _fake_id_token(payload: dict) -> str:
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
+    return f"header.{encoded}.signature"
+
+
+@pytest.mark.asyncio
+async def test_begin_delete_preserves_seat_identity_before_token_wipe(db_setup):
+    """Legacy rows carry their seat identity only inside the id-token claims;
+    targeted reauthentication (a supersede path) verifies the seat against
+    chatgpt_user_id or those claims, so the wipe must backfill the non-secret
+    identity first."""
+    encryptor = TokenEncryptor()
+    async with SessionLocal() as session:
+        account = _make_account("acc_bg_seat", "acc_bg_seat@example.com")
+        assert account.chatgpt_user_id is None
+        account.id_token_encrypted = encryptor.encrypt(_fake_id_token({"sub": "user-legacy-seat"}))
+        await AccountsRepository(session).upsert(account)
+
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_seat")
+
+    row = await _account_row("acc_bg_seat")
+    assert row is not None
+    # The ciphertext is wiped (no usable credentials remain on the row)...
+    assert encryptor.decrypt(row.id_token_encrypted) == ""
+    # ...but the seat identity survives in the non-secret column.
+    assert row.chatgpt_user_id == "user-legacy-seat"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_account_deletion_background.py
+++ b/tests/integration/test_account_deletion_background.py
@@ -188,6 +188,12 @@ async def test_delete_api_marks_and_hides_immediately(async_client, db_setup):
     reactivate = await async_client.post("/api/accounts/acc_bg_mark/reactivate")
     assert reactivate.status_code == 404
 
+    # Credential exports must not keep serving decrypted tokens during the
+    # drain window: the synchronous delete 404'd here immediately.
+    for export_path in ("export", "export/auth", "export/opencode-auth"):
+        export = await async_client.post(f"/api/accounts/acc_bg_mark/{export_path}")
+        assert export.status_code == 404, export_path
+
 
 @pytest.mark.asyncio
 async def test_chunked_soft_delete_drains_across_chunk_boundaries(db_setup):
@@ -332,6 +338,74 @@ async def test_fold_interleaved_between_chunks_does_not_resurrect_hard(db_setup)
     assert await _hourly_rows_for_dimension(account_dimension) == []
     assert await _demand_rows_for_dimension(account_dimension) == []
     assert await _log_rows("acc_bg_fhard") == []
+
+
+@pytest.mark.asyncio
+async def test_pass_round_robins_chunks_across_pending_accounts(db_setup, monkeypatch):
+    """One account's long drain must not starve another: each round advances
+    every pending account by at most one full chunk."""
+    from app.modules.accounts import deletion
+
+    await _seed_account("acc_bg_rr_a", log_count=3)
+    await _seed_account("acc_bg_rr_b", log_count=3)
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        assert await repo.begin_delete("acc_bg_rr_a")
+        assert await repo.begin_delete("acc_bg_rr_b")
+
+    chunk_calls: list[str] = []
+    original_chunk = deletion._request_logs_chunk
+
+    async def spy_chunk(session, account_id, *, delete_history, batch_size):
+        chunk_calls.append(account_id)
+        return await original_chunk(session, account_id, delete_history=delete_history, batch_size=batch_size)
+
+    monkeypatch.setattr(deletion, "_request_logs_chunk", spy_chunk)
+
+    outcomes = await run_account_deletion_pass(batch_size=1)
+    assert outcomes == {"acc_bg_rr_a": "finalized", "acc_bg_rr_b": "finalized"}
+    # Full chunks alternate between the two accounts instead of draining one
+    # account to completion first.
+    assert chunk_calls[:6] == [
+        "acc_bg_rr_a",
+        "acc_bg_rr_b",
+        "acc_bg_rr_a",
+        "acc_bg_rr_b",
+        "acc_bg_rr_a",
+        "acc_bg_rr_b",
+    ]
+    assert await _account_row("acc_bg_rr_a") is None
+    assert await _account_row("acc_bg_rr_b") is None
+
+
+@pytest.mark.asyncio
+async def test_pass_picks_up_account_marked_mid_pass(db_setup, monkeypatch):
+    """A DELETE that lands while a pass is draining another account is picked
+    up by the between-rounds re-scan, not deferred to the next tick."""
+    from app.modules.accounts import deletion
+
+    await _seed_account("acc_bg_mid_a", log_count=2)
+    await _seed_account("acc_bg_mid_b", log_count=1)
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_mid_a")
+
+    original_advance = deletion._advance_account
+    marked_second = False
+
+    async def advance_and_mark(account_id, *, batch_size):
+        nonlocal marked_second
+        if not marked_second:
+            marked_second = True
+            async with SessionLocal() as session:
+                assert await AccountsRepository(session).begin_delete("acc_bg_mid_b")
+        return await original_advance(account_id, batch_size=batch_size)
+
+    monkeypatch.setattr(deletion, "_advance_account", advance_and_mark)
+
+    outcomes = await run_account_deletion_pass(batch_size=1)
+    assert outcomes == {"acc_bg_mid_a": "finalized", "acc_bg_mid_b": "finalized"}
+    assert await _account_row("acc_bg_mid_a") is None
+    assert await _account_row("acc_bg_mid_b") is None
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_account_deletion_background.py
+++ b/tests/integration/test_account_deletion_background.py
@@ -42,9 +42,17 @@ def _no_background_wake(monkeypatch):
 
     The suite's stand-in leader election runs scheduler bodies inline, so the
     delete API's worker wake would drain accounts concurrently with (and race)
-    the passes these tests drive step by step.
+    the passes these tests drive step by step. The scheduler's own tick (one
+    pass at startup plus every interval) is neutralized as well: a tick firing
+    between a DELETE and the assertions would drain the account these tests
+    expect to still be marked.
     """
     monkeypatch.setattr("app.modules.accounts.service.request_account_deletion_run", lambda: None)
+
+    async def _no_tick(self) -> None:
+        return None
+
+    monkeypatch.setattr("app.modules.accounts.deletion.AccountDeletionScheduler._run_once", _no_tick)
 
 
 def _make_account(account_id: str, email: str) -> Account:
@@ -640,6 +648,82 @@ async def test_legacy_replica_replacement_before_finalize_is_abandoned(db_setup)
     assert row is not None
     assert row.delete_requested_at is None
     assert encryptor.decrypt(row.refresh_token_encrypted) == "fresh-refresh"
+
+
+@pytest.mark.asyncio
+async def test_repeat_delete_short_circuits_without_waiting_on_chunk_lock(db_setup):
+    """A repeat DELETE must keep the millisecond contract even while a drain
+    chunk transaction holds the account row lock."""
+    import asyncio
+
+    async with SessionLocal() as probe:
+        if probe.get_bind().dialect.name != "postgresql":
+            pytest.skip("row-lock wait behavior is PostgreSQL-specific")
+
+    await _seed_account("acc_bg_repeat", log_count=1)
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_repeat")
+
+    async with SessionLocal() as locker:
+        # Hold the same lock a drain chunk holds for its whole transaction.
+        await locker.execute(select(Account.id).where(Account.id == "acc_bg_repeat").with_for_update(key_share=True))
+        async with SessionLocal() as session:
+            repeat = await asyncio.wait_for(AccountsRepository(session).begin_delete("acc_bg_repeat"), timeout=2.0)
+        assert repeat is True
+        await locker.rollback()
+
+
+@pytest.mark.asyncio
+async def test_chunk_self_heals_drift_from_unfenced_replicas(db_setup):
+    """During a rolling deploy, pre-upgrade replicas' unfenced writers can
+    replace the terminal status or recreate API-key assignments on a marked
+    row; the next chunk transaction must re-fence both."""
+    from app.db.models import ApiKey, ApiKeyAccountAssignment
+    from app.modules.accounts import deletion
+
+    await _seed_account("acc_bg_heal", log_count=2)
+    async with SessionLocal() as session:
+        session.add(
+            ApiKey(
+                id="key_bg_heal",
+                name="heal-key",
+                key_hash="hash_bg_heal",
+                key_prefix="sk-heal",
+                account_assignment_scope_enabled=True,
+            )
+        )
+        await session.commit()
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_heal")
+
+    # Old-replica drift: unfenced status write + unconditional assignment
+    # insert (tokens stay wiped, so this is NOT a credential replacement).
+    async with SessionLocal() as session:
+        await session.execute(
+            update(Account)
+            .where(Account.id == "acc_bg_heal")
+            .values(status=AccountStatus.RATE_LIMITED, deactivation_reason="rate_limited")
+        )
+        session.add(ApiKeyAccountAssignment(api_key_id="key_bg_heal", account_id="acc_bg_heal"))
+        await session.commit()
+
+    affected = await deletion._run_chunk(deletion._usage_history_chunk, "acc_bg_heal", batch_size=10)
+    assert affected is not None
+
+    row = await _account_row("acc_bg_heal")
+    assert row is not None
+    assert row.status is AccountStatus.DEACTIVATED
+    assert row.deactivation_reason == ACCOUNT_PENDING_DELETION_REASON
+    assert row.delete_requested_at is not None
+    async with SessionLocal() as session:
+        assigned = (
+            await session.execute(
+                select(func.count())
+                .select_from(ApiKeyAccountAssignment)
+                .where(ApiKeyAccountAssignment.account_id == "acc_bg_heal")
+            )
+        ).scalar_one()
+    assert assigned == 0
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_account_deletion_background.py
+++ b/tests/integration/test_account_deletion_background.py
@@ -204,6 +204,20 @@ async def test_delete_api_marks_and_hides_immediately(async_client, db_setup):
         export = await async_client.post(f"/api/accounts/acc_bg_mark/{export_path}")
         assert export.status_code == 404, export_path
 
+    # Every other ID-based account route treats the marked row as gone too —
+    # the synchronous delete returned 404 on all of them once the row was
+    # removed.
+    base = "/api/accounts/acc_bg_mark"
+    assert (await async_client.get(f"{base}/trends")).status_code == 404
+    assert (await async_client.get(f"{base}/usage-reset-credits")).status_code == 404
+    assert (await async_client.post(f"{base}/usage-reset-credits/consume")).status_code == 404
+    assert (await async_client.post(f"{base}/probe")).status_code == 404
+    assert (await async_client.post(f"{base}/pause")).status_code == 404
+    assert (await async_client.patch(base, json={"securityWorkAuthorized": True})).status_code == 404
+    assert (await async_client.put(f"{base}/alias", json={"alias": "ghost"})).status_code == 404
+    assert (await async_client.put(f"{base}/limit-warmup", json={"enabled": True})).status_code == 404
+    assert (await async_client.put(f"{base}/routing-policy", json={"routingPolicy": "preserve"})).status_code == 404
+
 
 def _fake_id_token(payload: dict) -> str:
     encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")

--- a/tests/integration/test_account_deletion_background.py
+++ b/tests/integration/test_account_deletion_background.py
@@ -196,6 +196,45 @@ async def test_delete_api_marks_and_hides_immediately(async_client, db_setup):
 
 
 @pytest.mark.asyncio
+async def test_marked_account_wipes_tokens_and_rejects_stale_status_writes(db_setup):
+    await _seed_account("acc_bg_fence", log_count=1)
+    async with SessionLocal() as session:
+        assert await AccountsRepository(session).begin_delete("acc_bg_fence")
+
+    # The surviving row must not carry usable credentials: readers that do
+    # not know the marker (pre-upgrade replicas during a rolling deploy) can
+    # only produce empty credentials from it.
+    row = await _account_row("acc_bg_fence")
+    assert row is not None
+    encryptor = TokenEncryptor()
+    assert encryptor.decrypt(row.access_token_encrypted) == ""
+    assert encryptor.decrypt(row.refresh_token_encrypted) == ""
+    assert encryptor.decrypt(row.id_token_encrypted) == ""
+
+    # Stale in-flight settlements (e.g. a late 429 for a request selected
+    # before the DELETE) must not replace the terminal state and make the
+    # account selectable again mid-drain.
+    async with SessionLocal() as session:
+        repo = AccountsRepository(session)
+        assert await repo.update_status("acc_bg_fence", AccountStatus.RATE_LIMITED, "rate_limited") is False
+        assert (
+            await repo.update_status_if_current(
+                "acc_bg_fence",
+                AccountStatus.RATE_LIMITED,
+                "rate_limited",
+                expected_status=AccountStatus.DEACTIVATED,
+                expected_deactivation_reason=ACCOUNT_PENDING_DELETION_REASON,
+            )
+            is False
+        )
+    row = await _account_row("acc_bg_fence")
+    assert row is not None
+    assert row.status is AccountStatus.DEACTIVATED
+    assert row.deactivation_reason == ACCOUNT_PENDING_DELETION_REASON
+    assert row.delete_requested_at is not None
+
+
+@pytest.mark.asyncio
 async def test_chunked_soft_delete_drains_across_chunk_boundaries(db_setup):
     await _seed_account("acc_bg_soft", log_count=7, usage_count=5)
     async with SessionLocal() as session:

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -595,8 +595,15 @@ async def test_delete_account_removes_from_list(async_client):
 @pytest.mark.asyncio
 async def test_delete_account_soft_deletes_request_logs(async_client, db_setup, monkeypatch):
     # The suite's inline leader election would let the API's worker wake race
-    # the explicit pass below; keep the drain under test control.
+    # the explicit pass below; keep the drain under test control. The
+    # scheduler's own startup/interval tick is neutralized for the same
+    # reason.
     monkeypatch.setattr("app.modules.accounts.service.request_account_deletion_run", lambda: None)
+
+    async def _no_tick(self) -> None:
+        return None
+
+    monkeypatch.setattr("app.modules.accounts.deletion.AccountDeletionScheduler._run_once", _no_tick)
     async with SessionLocal() as session:
         accounts_repo = AccountsRepository(session)
         logs_repo = RequestLogsRepository(session)
@@ -639,8 +646,15 @@ async def test_delete_account_soft_deletes_request_logs(async_client, db_setup, 
 @pytest.mark.asyncio
 async def test_delete_account_with_delete_history_hard_deletes_request_logs(async_client, db_setup, monkeypatch):
     # The suite's inline leader election would let the API's worker wake race
-    # the explicit pass below; keep the drain under test control.
+    # the explicit pass below; keep the drain under test control. The
+    # scheduler's own startup/interval tick is neutralized for the same
+    # reason.
     monkeypatch.setattr("app.modules.accounts.service.request_account_deletion_run", lambda: None)
+
+    async def _no_tick(self) -> None:
+        return None
+
+    monkeypatch.setattr("app.modules.accounts.deletion.AccountDeletionScheduler._run_once", _no_tick)
     async with SessionLocal() as session:
         accounts_repo = AccountsRepository(session)
         logs_repo = RequestLogsRepository(session)

--- a/tests/integration/test_accounts_api_extended.py
+++ b/tests/integration/test_accounts_api_extended.py
@@ -13,6 +13,7 @@ from app.core.usage.refresh_scheduler import reconcile_recoverable_account_statu
 from app.core.utils.time import naive_utc_to_epoch, utcnow
 from app.db.models import Account, AccountStatus, RequestLog
 from app.db.session import SessionLocal
+from app.modules.accounts.deletion import run_account_deletion_pass
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.proxy.account_cache import clear_account_routing_unavailable, is_account_routing_unavailable
 from app.modules.request_logs.repository import RequestLogsRepository
@@ -592,7 +593,10 @@ async def test_delete_account_removes_from_list(async_client):
 
 
 @pytest.mark.asyncio
-async def test_delete_account_soft_deletes_request_logs(async_client, db_setup):
+async def test_delete_account_soft_deletes_request_logs(async_client, db_setup, monkeypatch):
+    # The suite's inline leader election would let the API's worker wake race
+    # the explicit pass below; keep the drain under test control.
+    monkeypatch.setattr("app.modules.accounts.service.request_account_deletion_run", lambda: None)
     async with SessionLocal() as session:
         accounts_repo = AccountsRepository(session)
         logs_repo = RequestLogsRepository(session)
@@ -612,6 +616,10 @@ async def test_delete_account_soft_deletes_request_logs(async_client, db_setup):
     delete = await async_client.delete("/api/accounts/acc_delete_logs")
     assert delete.status_code == 200
 
+    # The API only marks the account; the background worker drains the rows.
+    outcomes = await run_account_deletion_pass()
+    assert outcomes["acc_delete_logs"] == "finalized"
+
     async with SessionLocal() as session:
         row = (
             await session.execute(select(RequestLog).where(RequestLog.request_id == "req_delete_logs_1"))
@@ -629,7 +637,10 @@ async def test_delete_account_soft_deletes_request_logs(async_client, db_setup):
 
 
 @pytest.mark.asyncio
-async def test_delete_account_with_delete_history_hard_deletes_request_logs(async_client, db_setup):
+async def test_delete_account_with_delete_history_hard_deletes_request_logs(async_client, db_setup, monkeypatch):
+    # The suite's inline leader election would let the API's worker wake race
+    # the explicit pass below; keep the drain under test control.
+    monkeypatch.setattr("app.modules.accounts.service.request_account_deletion_run", lambda: None)
     async with SessionLocal() as session:
         accounts_repo = AccountsRepository(session)
         logs_repo = RequestLogsRepository(session)
@@ -649,6 +660,10 @@ async def test_delete_account_with_delete_history_hard_deletes_request_logs(asyn
     delete = await async_client.delete("/api/accounts/acc_hard_delete?delete_history=true")
     assert delete.status_code == 200
     assert delete.json()["status"] == "deleted"
+
+    # The API only marks the account; the background worker drains the rows.
+    outcomes = await run_account_deletion_pass()
+    assert outcomes["acc_hard_delete"] == "finalized"
 
     async with SessionLocal() as session:
         result = await session.execute(select(RequestLog).where(RequestLog.request_id == "req_hard_delete_1"))

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -1388,6 +1388,28 @@ async def test_account_pending_deletion_migration_upgrade_and_downgrade(tmp_path
             state = await conn.run_sync(_schema_state)
         assert state == {"columns": marker_columns, "index_present": True}
 
+        # Downgrade refuses while a deletion is queued: the marker columns are
+        # the queue's only durable state, and dropping them would silently
+        # abandon an acknowledged deletion.
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO accounts (id, codex_installation_id, email, plan_type, "
+                    "access_token_encrypted, refresh_token_encrypted, id_token_encrypted, "
+                    "last_refresh, status, delete_requested_at, delete_history_requested) "
+                    "VALUES ('acc_mig_pending', 'install-mig-pending', 'mig@example.com', 'plus', "
+                    "X'00', X'00', X'00', '2026-08-16 00:00:00', 'deactivated', "
+                    "'2026-08-16 00:00:00', 0)"
+                )
+            )
+        with pytest.raises(Exception, match="queued for"):
+            await to_thread.run_sync(lambda: command.downgrade(_build_alembic_config(db_url), parent_revision))
+        async with engine.connect() as conn:
+            state = await conn.run_sync(_schema_state)
+        assert state == {"columns": marker_columns, "index_present": True}
+        async with engine.begin() as conn:
+            await conn.execute(text("DELETE FROM accounts WHERE id = 'acc_mig_pending'"))
+
         await to_thread.run_sync(lambda: command.downgrade(_build_alembic_config(db_url), parent_revision))
         async with engine.connect() as conn:
             state = await conn.run_sync(_schema_state)

--- a/tests/integration/test_migrations.py
+++ b/tests/integration/test_migrations.py
@@ -1353,6 +1353,67 @@ async def test_usage_history_autovacuum_tuning_migration_sets_and_resets_relopti
 
 
 @pytest.mark.asyncio
+async def test_account_pending_deletion_migration_upgrade_and_downgrade(tmp_path):
+    """Round-trip the pending-deletion marker migration through Alembic:
+    parent -> revision adds the two guarded marker columns and the partial
+    queue index, downgrade removes all three, the guarded upgrade tolerates
+    pre-existing columns, and an upgrade to head proves the revision sits on
+    the single-head path."""
+    from alembic import command
+    from sqlalchemy import inspect as sa_inspect
+
+    from app.db.migrate import _build_alembic_config
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'account-pending-deletion.sqlite'}"
+    parent_revision = "20260812_120000_add_sticky_abandonment_scope"
+    pending_deletion_revision = "20260816_000000_add_account_pending_deletion"
+    marker_columns = {"delete_requested_at", "delete_history_requested"}
+    index_name = "idx_accounts_delete_requested_at"
+
+    def _schema_state(sync_conn):
+        inspector = sa_inspect(sync_conn)
+        columns = {column["name"] for column in inspector.get_columns("accounts")}
+        indexes = {index["name"] for index in inspector.get_indexes("accounts")}
+        return {"columns": columns & marker_columns, "index_present": index_name in indexes}
+
+    await to_thread.run_sync(lambda: run_upgrade(db_url, parent_revision, bootstrap_legacy=False))
+    engine = create_async_engine(db_url, future=True)
+    try:
+        async with engine.connect() as conn:
+            state = await conn.run_sync(_schema_state)
+        assert state == {"columns": set(), "index_present": False}
+
+        await to_thread.run_sync(lambda: run_upgrade(db_url, pending_deletion_revision, bootstrap_legacy=False))
+        async with engine.connect() as conn:
+            state = await conn.run_sync(_schema_state)
+        assert state == {"columns": marker_columns, "index_present": True}
+
+        await to_thread.run_sync(lambda: command.downgrade(_build_alembic_config(db_url), parent_revision))
+        async with engine.connect() as conn:
+            state = await conn.run_sync(_schema_state)
+        assert state == {"columns": set(), "index_present": False}
+
+        # Guarded upgrade: a database where the columns already exist (e.g. a
+        # pre-merge build of this revision) must upgrade cleanly and still
+        # create the missing index.
+        async with engine.begin() as conn:
+            await conn.execute(text("ALTER TABLE accounts ADD COLUMN delete_requested_at DATETIME"))
+        await to_thread.run_sync(lambda: run_upgrade(db_url, pending_deletion_revision, bootstrap_legacy=False))
+        async with engine.connect() as conn:
+            state = await conn.run_sync(_schema_state)
+        assert state == {"columns": marker_columns, "index_present": True}
+
+        # Single-head path: upgrading to head from here must succeed and keep
+        # the marker schema in place.
+        await to_thread.run_sync(lambda: run_upgrade(db_url, "head", bootstrap_legacy=False))
+        async with engine.connect() as conn:
+            state = await conn.run_sync(_schema_state)
+        assert state == {"columns": marker_columns, "index_present": True}
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_account_plan_downgrade_observations_migration_upgrade_and_downgrade(tmp_path):
     """Round-trip the plan-downgrade evidence migration through Alembic itself.
 

--- a/tests/unit/test_accounts_service_transitions.py
+++ b/tests/unit/test_accounts_service_transitions.py
@@ -26,6 +26,7 @@ def _account(
         deactivation_reason=deactivation_reason,
         reset_at=reset_at,
         blocked_at=blocked_at,
+        delete_requested_at=None,
     )
 
 


### PR DESCRIPTION
## Problem

Account deletion is a single synchronous transaction that detaches/deletes every raw row for the account while holding the fold-state lock. Measured on prod (10.0.0.113, read-only):

- Soft delete of a 133k-row account: **313 s** detaching `usage_history` in one transaction.
- `delete_history=true` on a 93k-row account: **11.6 s** of `usage_history` deletes alone.
- During that window the fold pipeline is blocked (~5 min of fold blockage on the large account), the HTTP request hangs, and on the 2vCPU host the whole app is starved.

## Root cause

`AccountsRepository.delete()` does everything — identity-membership lock, fold-state lock, full raw detach/delete across `usage_history`, `additional_usage_history`, `request_logs`, lifecycle mirrors, rollup/sticky/account-row deletes — in one transaction sized by the account's entire history. Deletion cost scales with row count, and it all happens inline in the DELETE request under the fold lock.

## Fix

Deletion becomes a **fast mark + background batch drain**:

**Fast path** — `DELETE /api/accounts/{id}` → `begin_delete()`: one millisecond-scale txn setting `status=DEACTIVATED` (inherits every existing serving-path denylist exclusion; no new enum value), `deactivation_reason="pending_deletion"`, new `accounts.delete_requested_at` (authoritative marker + queue ordering) and `delete_history_requested` (frozen at first request; repeats are idempotent and never escalate), plus sticky delete + bridge-session close. `list_accounts`/`list_accounts_by_ids` filter marked rows, so the dashboard refetch never sees the account; the response stays `{"status":"deleted"}` (no schema/UI change). `reactivate` on a marked account → 404.

**Background** — new `app/modules/accounts/deletion.py`: leader-gated scheduler (30 s tick with a cheap LIMIT-1 pending pre-check before leader election, plus a local wake from the delete path so the single-replica case starts instantly). `run_account_deletion_pass()` drains `usage_history`, `additional_usage_history`, then `request_logs` in 1k-row transactions (detach for soft, DELETE for `delete_history`), re-checking the marker per chunk. The account row itself is the queue: restart resume and chunk idempotency fall out of the shrinking `WHERE account_id` predicate — no new table, no phase column.

**Planner pinning** — verified on the prod planner: naive chunk subqueries plan as LIMIT-terminated Seq Scans (`request_logs` est 613k rows), and a naive `ORDER BY recorded_at` picks the *wrong* index because equality on `account_id` folds it out of the sort pathkeys. Chunk selection therefore uses an `account_id >= :id AND account_id <= :id` range predicate (same rows, but `account_id` survives as the leading pathkey) + ORDER BY matching each target index's exact column order: `usage_history` → `idx_usage_account_time`, `additional_usage_history` → `ix_additional_usage_distinct_labels`, `request_logs` → covering `idx_logs_account_kind_deleted_latest` (Index Only Scan). A drained/nonexistent-account probe costs one index descent (cost ~8.6) instead of a heap scan. Tables observed empty within a pass are memoized and not re-probed (~122+ redundant account-row-locking txns eliminated for the top account), and an inter-round throttle (`min(2.0s, 0.25 × round duration)`) keeps a multi-hundred-chunk drain from running back-to-back on the 2vCPU host.

**Fold safety** (documented in the module docstring + openspec design.md D3): chunk txns deliberately do NOT take the fold-state lock — they touch only raw rows, never rollups or watermarks. An interleaved fold slice folds still-attached rows under the account dimension or already-detached rows under the orphaned-deleted dimension (the soft-path end state). Finalization = `AccountsRepository.delete(only_pending=True)`: identity-membership lock → `lock_fold_state()` → residual detach/delete (catches straggler rows settled by in-flight streams) → lifecycle mirrors → sticky/lifetime-rollup/account row delete, one txn, historically identical shape but over a residual row set. Since every fold slice holds the fold-state FOR UPDATE lock from before reading raw until commit, a slice commits either before finalization (its account-attributed output is moved/removed by the mirrors) or after (sees no attributed raw) — post-finalization resurrection is impossible. Lock order (identity → fold) matches consolidation. The query-caching requirement "rollup row deleted in the same transaction as the account row" still holds.

**Supersede** — `_apply_account_updates` (every credential replacement: re-import/reauth/slot reuse) clears the marker; chunks and finalization (under the pg FOR NO KEY UPDATE row lock / sqlite writer section) re-check it, so a re-imported account is never finalized away; rows already drained stay detached (documented trade-off).

**Schema** — migration `20260816_000000_add_account_pending_deletion` on the current single head `20260812_120000_add_sticky_abandonment_scope` (guarded add/drop of the two columns). Old replicas during a rolling upgrade just perform the old synchronous delete. Downgrade is fail-closed: it refuses while any deletion is queued (ops note: an emergency rollback mid-drain waits for the drain or requires re-importing queued accounts).

**Openspec** — `openspec/changes/background-account-deletion/` (proposal, design D1–D7 with prod measurements, tasks, new `account-deletion` capability delta: 4 requirements / 10 scenarios, including normative index-pinning / no-heap-scan-probe / no-re-probe / inter-round-pause requirements). `openspec validate background-account-deletion --strict` passes.

## Evidence

- Prod-measured 313 s / 133k-row detach and 11.6 s / 93k `usage_history` deletes become ~133 background chunk txns bounded at ~2.3 s each (measured ~23 s per 10k request_logs detach ⇒ 1k chunk ≈ 2.3 s); supersede and fenced settlement writers wait at most one chunk.
- Fold blockage drops from ~5 min to the finalization txn over residual rows only.
- Prod planner verification (read-only EXPLAIN on the 606,970-row account): all three chunk shapes are Index / Index Only Scans with the account range as Index Cond; no Seq Scan, no Sort.

## Testing

New `tests/integration/test_account_deletion_background.py`:
- Fast-path API contract: immediate hide, marker state, idempotent repeat without variant escalation, reactivate 404.
- Chunk-boundary drain, soft + hard; fold pass interleaved between detach chunks for BOTH variants (no rollup row under the account dimension afterwards; orphaned-deleted dimension preserves full folded history; post-finalization folds add nothing).
- Restart resume from partial drain; straggler log settled mid-drain caught by finalization's residual sweep; supersede via real upsert replacement and via the drain/finalize race (`delete(only_pending=True)` returns False, row survives).
- Structural test pinning each batch builder's range predicate + ORDER BY column order against the actual model Index definitions; PostgreSQL EXPLAIN plan test (seqscan/bitmapscan/sort off, repo's existing plan-test pattern) asserting each batch — including the drained probe — is served by the pinned index; pass-level test asserting drained tables are probed exactly once per pass.

Existing two delete API tests updated to drive `run_account_deletion_pass()` explicitly (worker wake monkeypatched off — the suite's inline NoopLeaderElection otherwise races explicit passes; discovered on pg).

Results: full unit suite 6100 passed; deletion suite 22 passed / 3 skipped on sqlite and 25/25 on disposable PostgreSQL (prod untouched, read-only EXPLAIN only); sqlite integration green for accounts api/extended/rollup, repositories, migrations, time-rollup, rollup parity, cache-invalidation bus, dashboard overview; pg green for deletion, extended, overview, migration contract/drift + empty-upgrade, fold suites, retention. `ruff check`/`format`, `ty check`, proxy architecture check, `openspec --strict` all green. New test file added to Makefile `POSTGRES_PYTEST_TARGETS`.

## Follow-ups

- Supersede after a partial drain leaves a rollup/raw divergence for already-drained rows (documented trade-off in design.md); the trailing-48h upgrade-repair refold can shift attribution of those below-watermark buckets across restarts — a reconciliation sweep could close this.
- `AccountDeletionScheduler._run_once` guards the pending pre-check but not `run_if_leader` itself (mirrors the existing rollup scheduler pattern); a broad guard would make the loop unkillable.
- Mid-drain, raw-scanning surfaces (recent-requests) still show not-yet-detached rows for the drain duration; converges at finalization.
- Repeat DELETE during the drain window returns 200 and silently keeps the first request's `delete_history` variant — no API signal that an escalation was dropped (first-request-wins is in the spec).
- Per-chunk drift-repair `ApiKeyAccountAssignment` DELETE runs every chunk though drift is only possible during rolling deploys; could be hoisted.
- Soft-deleted rows carry per-chunk `deleted_at` timestamps instead of one uniform value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous account deletion with immediate deactivation and background cleanup.
  * Accounts pending deletion are hidden from listings, actions, assignments, and related credit or proxy operations.
  * Credential replacement can cancel a pending deletion.
  * Supports soft or permanent history removal with restart-safe processing.
  * Added migration support for tracking pending deletions.

* **Bug Fixes**
  * Prevented stale updates and new assignments from restoring or targeting accounts pending deletion.

* **Tests**
  * Added comprehensive integration coverage for deletion processing, migrations, recovery, locking, and data cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->