### PR TITLE
fix(docker): upgrade util-linux family in runtime image for CVE-2026-53615

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ WORKDIR /app
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --only-upgrade \
-        libc-bin libc6 libcap2 libssl3t64 libsystemd0 libudev1 openssl sed \
+        bsdutils libblkid1 libc-bin libc6 libcap2 libmount1 libsmartcols1 libssl3t64 \
+        libsystemd0 libudev1 libuuid1 openssl sed util-linux \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         openssl-provider-legacy \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Problem

Main CI went red on the **Docker build → Trivy high-severity gate** starting with the overnight vulnerability-feed update: CVE-2026-53615 (HIGH, util-linux/bsdutils) against the `python:3.14-slim` base image. Unrelated to any code change — the same image built green yesterday (e.g. PR #1795 CI at 22:12 UTC).

## Fix

Debian ships the fix in `2.41.5-0+deb13u1`. This adds the util-linux binary family (`bsdutils util-linux libblkid1 libmount1 libsmartcols1 libuuid1`) to the runtime stage's existing `--only-upgrade` remediation list, same pattern as the prior libc/openssl entries. `--only-upgrade` skips family members not installed in slim.

## Testing

- Verified the failing gate output names only CVE-2026-53615 (bsdutils, fix available).
- Docker build + Trivy gate in this PR's CI is the authoritative verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runtime environment to receive security and maintenance upgrades for additional system packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->