### PR TITLE
feat(dashboard): weekly runway model + per-key burn attribution

### DIFF
--- a/app/modules/dashboard/repository.py
+++ b/app/modules/dashboard/repository.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Collection
+from collections.abc import Collection, Mapping
+from dataclasses import dataclass
 from datetime import datetime
 
+from sqlalchemy import case, func, select, union_all
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.usage.types import BucketConversationAggregate, BucketModelAggregate, RequestActivityAggregate
@@ -10,6 +12,7 @@ from app.db.models import (
     Account,
     AccountLimitWarmup,
     AdditionalUsageHistory,
+    ApiKey,
     DashboardSettings,
     RequestLog,
     UsageHistory,
@@ -18,11 +21,27 @@ from app.modules.accounts.repository import AccountsRepository
 from app.modules.limit_warmup.repository import LimitWarmupRepository
 from app.modules.request_logs.repository import RequestLogsRepository
 from app.modules.settings.repository import SettingsRepository
-from app.modules.usage.repository import AdditionalUsageRepository, UsageHistorySnapshot, UsageRepository
+from app.modules.usage.repository import (
+    AdditionalUsageRepository,
+    NormalizedUsageWindow,
+    UsageHistorySnapshot,
+    UsageRepository,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ApiKeyAttributionRow:
+    api_key_id: str | None
+    name: str
+    requests: int
+    billable_tokens: int
+    cached_tokens: int
+    dominant_model: str
 
 
 class DashboardRepository:
     def __init__(self, session: AsyncSession) -> None:
+        self._session = session
         self._accounts_repo = AccountsRepository(session)
         self._usage_repo = UsageRepository(session)
         self._logs_repo = RequestLogsRepository(session)
@@ -66,6 +85,19 @@ class DashboardRepository:
     async def latest_window_minutes(self, window: str) -> int | None:
         return await self._usage_repo.latest_window_minutes(window)
 
+    async def positive_used_percent_deltas_by_account(
+        self,
+        account_windows: Mapping[str, NormalizedUsageWindow],
+        *,
+        since: datetime,
+        until: datetime,
+    ) -> dict[str, float]:
+        return await self._usage_repo.positive_used_percent_deltas_by_account(
+            account_windows,
+            since=since,
+            until=until,
+        )
+
     async def list_logs_since(self, since: datetime) -> list[RequestLog]:
         return await self._logs_repo.list_since(since)
 
@@ -101,6 +133,123 @@ class DashboardRepository:
 
     async def earliest_activity_at(self) -> datetime | None:
         return await self._logs_repo.earliest_activity_at()
+
+    async def top_api_key_attribution_since(
+        self,
+        since: datetime,
+        *,
+        now: datetime,
+        per_metric_limit: int = 3,
+    ) -> list[ApiKeyAttributionRow]:
+        key_name = func.coalesce(func.nullif(ApiKey.name, ""), "(unnamed)")
+        billable_tokens = func.coalesce(RequestLog.input_tokens, 0) + func.coalesce(
+            RequestLog.output_tokens, RequestLog.reasoning_tokens, 0
+        )
+        grouped_models = (
+            select(
+                RequestLog.api_key_id.label("api_key_id"),
+                key_name.label("name"),
+                RequestLog.model.label("model"),
+                func.count(RequestLog.id).label("requests"),
+                func.coalesce(func.sum(billable_tokens), 0).label("billable_tokens"),
+                func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("cached_tokens"),
+            )
+            .select_from(RequestLog)
+            .outerjoin(ApiKey, ApiKey.id == RequestLog.api_key_id)
+            .where(
+                RequestLog.requested_at >= since,
+                RequestLog.requested_at <= now,
+                RequestLog.deleted_at.is_(None),
+                # Warmup probes are internal traffic and must not surface as
+                # top consumers, matching the request-log usage queries.
+                RequestLogsRepository._exclude_warmup_clause(),
+            )
+            .group_by(RequestLog.api_key_id, key_name, RequestLog.model)
+            .cte("weekly_pace_key_models")
+        )
+        ranked_models = select(
+            grouped_models,
+            func.row_number()
+            .over(
+                partition_by=grouped_models.c.api_key_id,
+                order_by=(
+                    grouped_models.c.requests.desc(),
+                    grouped_models.c.billable_tokens.desc(),
+                    grouped_models.c.model.asc(),
+                ),
+            )
+            .label("model_rank"),
+        ).cte("weekly_pace_ranked_models")
+        key_totals = (
+            select(
+                ranked_models.c.api_key_id,
+                func.max(ranked_models.c.name).label("name"),
+                func.sum(ranked_models.c.requests).label("requests"),
+                func.sum(ranked_models.c.billable_tokens).label("billable_tokens"),
+                func.sum(ranked_models.c.cached_tokens).label("cached_tokens"),
+                func.max(
+                    case(
+                        (ranked_models.c.model_rank == 1, ranked_models.c.model),
+                        else_=None,
+                    )
+                ).label("dominant_model"),
+            )
+            .group_by(ranked_models.c.api_key_id)
+            .cte("weekly_pace_key_totals")
+        )
+        top_by_requests = (
+            select(key_totals)
+            .order_by(
+                key_totals.c.requests.desc(),
+                key_totals.c.billable_tokens.desc(),
+                key_totals.c.api_key_id.asc(),
+            )
+            .limit(per_metric_limit)
+            .subquery("weekly_pace_top_requests")
+        )
+        top_by_billable = (
+            select(key_totals)
+            .order_by(
+                key_totals.c.billable_tokens.desc(),
+                key_totals.c.requests.desc(),
+                key_totals.c.api_key_id.asc(),
+            )
+            .limit(per_metric_limit)
+            .subquery("weekly_pace_top_billable")
+        )
+        candidates = union_all(
+            select(top_by_requests),
+            select(top_by_billable),
+        ).cte("weekly_pace_key_candidates")
+        statement = (
+            select(
+                candidates.c.api_key_id,
+                func.max(candidates.c.name).label("name"),
+                func.max(candidates.c.requests).label("requests"),
+                func.max(candidates.c.billable_tokens).label("billable_tokens"),
+                func.max(candidates.c.cached_tokens).label("cached_tokens"),
+                func.max(candidates.c.dominant_model).label("dominant_model"),
+            )
+            .group_by(candidates.c.api_key_id)
+            .order_by(
+                func.max(candidates.c.requests).desc(),
+                func.max(candidates.c.billable_tokens).desc(),
+                candidates.c.api_key_id.asc(),
+            )
+            .limit(per_metric_limit * 2)
+        )
+        rows = (await self._session.execute(statement)).all()
+        return [
+            ApiKeyAttributionRow(
+                api_key_id=str(row.api_key_id) if row.api_key_id is not None else None,
+                name=str(row.name),
+                requests=int(row.requests),
+                billable_tokens=int(row.billable_tokens),
+                cached_tokens=int(row.cached_tokens),
+                dominant_model=str(row.dominant_model),
+            )
+            for row in rows
+        ]
 
     async def list_additional_quota_keys(
         self,

--- a/app/modules/dashboard/repository.py
+++ b/app/modules/dashboard/repository.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Collection
+from collections.abc import Collection, Mapping
+from dataclasses import dataclass
 from datetime import datetime
 
+from sqlalchemy import case, func, select, union_all
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.usage.types import BucketConversationAggregate, BucketModelAggregate, RequestActivityAggregate
@@ -10,6 +12,7 @@ from app.db.models import (
     Account,
     AccountLimitWarmup,
     AdditionalUsageHistory,
+    ApiKey,
     DashboardSettings,
     RequestLog,
     UsageHistory,
@@ -21,8 +24,18 @@ from app.modules.settings.repository import SettingsRepository
 from app.modules.usage.repository import AdditionalUsageRepository, UsageHistorySnapshot, UsageRepository
 
 
+@dataclass(frozen=True, slots=True)
+class ApiKeyAttributionRow:
+    name: str
+    requests: int
+    billable_tokens: int
+    cached_tokens: int
+    dominant_model: str
+
+
 class DashboardRepository:
     def __init__(self, session: AsyncSession) -> None:
+        self._session = session
         self._accounts_repo = AccountsRepository(session)
         self._usage_repo = UsageRepository(session)
         self._logs_repo = RequestLogsRepository(session)
@@ -66,6 +79,19 @@ class DashboardRepository:
     async def latest_window_minutes(self, window: str) -> int | None:
         return await self._usage_repo.latest_window_minutes(window)
 
+    async def positive_used_percent_deltas_by_account(
+        self,
+        account_windows: Mapping[str, str],
+        *,
+        since: datetime,
+        until: datetime,
+    ) -> dict[str, float]:
+        return await self._usage_repo.positive_used_percent_deltas_by_account(
+            account_windows,
+            since=since,
+            until=until,
+        )
+
     async def list_logs_since(self, since: datetime) -> list[RequestLog]:
         return await self._logs_repo.list_since(since)
 
@@ -101,6 +127,119 @@ class DashboardRepository:
 
     async def earliest_activity_at(self) -> datetime | None:
         return await self._logs_repo.earliest_activity_at()
+
+    async def top_api_key_attribution_since(
+        self,
+        since: datetime,
+        *,
+        per_metric_limit: int = 3,
+    ) -> list[ApiKeyAttributionRow]:
+        key_name = func.coalesce(func.nullif(ApiKey.name, ""), "(unnamed)")
+        billable_tokens = (
+            func.coalesce(RequestLog.input_tokens, 0)
+            + func.coalesce(RequestLog.output_tokens, 0)
+            + func.coalesce(RequestLog.reasoning_tokens, 0)
+        )
+        grouped_models = (
+            select(
+                RequestLog.api_key_id.label("api_key_id"),
+                key_name.label("name"),
+                RequestLog.model.label("model"),
+                func.count(RequestLog.id).label("requests"),
+                func.coalesce(func.sum(billable_tokens), 0).label("billable_tokens"),
+                func.coalesce(func.sum(RequestLog.cached_input_tokens), 0).label("cached_tokens"),
+            )
+            .select_from(RequestLog)
+            .outerjoin(ApiKey, ApiKey.id == RequestLog.api_key_id)
+            .where(
+                RequestLog.requested_at >= since,
+                RequestLog.deleted_at.is_(None),
+            )
+            .group_by(RequestLog.api_key_id, key_name, RequestLog.model)
+            .cte("weekly_pace_key_models")
+        )
+        ranked_models = select(
+            grouped_models,
+            func.row_number()
+            .over(
+                partition_by=grouped_models.c.api_key_id,
+                order_by=(
+                    grouped_models.c.requests.desc(),
+                    grouped_models.c.billable_tokens.desc(),
+                    grouped_models.c.model.asc(),
+                ),
+            )
+            .label("model_rank"),
+        ).cte("weekly_pace_ranked_models")
+        key_totals = (
+            select(
+                ranked_models.c.api_key_id,
+                func.max(ranked_models.c.name).label("name"),
+                func.sum(ranked_models.c.requests).label("requests"),
+                func.sum(ranked_models.c.billable_tokens).label("billable_tokens"),
+                func.sum(ranked_models.c.cached_tokens).label("cached_tokens"),
+                func.max(
+                    case(
+                        (ranked_models.c.model_rank == 1, ranked_models.c.model),
+                        else_=None,
+                    )
+                ).label("dominant_model"),
+            )
+            .group_by(ranked_models.c.api_key_id)
+            .cte("weekly_pace_key_totals")
+        )
+        top_by_requests = (
+            select(key_totals)
+            .order_by(
+                key_totals.c.requests.desc(),
+                key_totals.c.billable_tokens.desc(),
+                key_totals.c.api_key_id.asc(),
+            )
+            .limit(per_metric_limit)
+            .subquery("weekly_pace_top_requests")
+        )
+        top_by_billable = (
+            select(key_totals)
+            .order_by(
+                key_totals.c.billable_tokens.desc(),
+                key_totals.c.requests.desc(),
+                key_totals.c.api_key_id.asc(),
+            )
+            .limit(per_metric_limit)
+            .subquery("weekly_pace_top_billable")
+        )
+        candidates = union_all(
+            select(top_by_requests),
+            select(top_by_billable),
+        ).cte("weekly_pace_key_candidates")
+        statement = (
+            select(
+                candidates.c.api_key_id,
+                func.max(candidates.c.name).label("name"),
+                func.max(candidates.c.requests).label("requests"),
+                func.max(candidates.c.billable_tokens).label("billable_tokens"),
+                func.max(candidates.c.cached_tokens).label("cached_tokens"),
+                func.max(candidates.c.dominant_model).label("dominant_model"),
+            )
+            .group_by(candidates.c.api_key_id)
+            .order_by(
+                func.max(candidates.c.requests).desc(),
+                func.max(candidates.c.billable_tokens).desc(),
+                candidates.c.api_key_id.asc(),
+            )
+            .limit(per_metric_limit * 2)
+        )
+        rows = (await self._session.execute(statement)).all()
+        return [
+            ApiKeyAttributionRow(
+                name=str(row.name),
+                requests=int(row.requests),
+                billable_tokens=int(row.billable_tokens),
+                cached_tokens=int(row.cached_tokens),
+                dominant_model=str(row.dominant_model),
+            )
+            for row in rows
+        ]
 
     async def list_additional_quota_keys(
         self,

--- a/app/modules/dashboard/repository.py
+++ b/app/modules/dashboard/repository.py
@@ -21,11 +21,17 @@ from app.modules.accounts.repository import AccountsRepository
 from app.modules.limit_warmup.repository import LimitWarmupRepository
 from app.modules.request_logs.repository import RequestLogsRepository
 from app.modules.settings.repository import SettingsRepository
-from app.modules.usage.repository import AdditionalUsageRepository, UsageHistorySnapshot, UsageRepository
+from app.modules.usage.repository import (
+    AdditionalUsageRepository,
+    NormalizedUsageWindow,
+    UsageHistorySnapshot,
+    UsageRepository,
+)
 
 
 @dataclass(frozen=True, slots=True)
 class ApiKeyAttributionRow:
+    api_key_id: str | None
     name: str
     requests: int
     billable_tokens: int
@@ -81,7 +87,7 @@ class DashboardRepository:
 
     async def positive_used_percent_deltas_by_account(
         self,
-        account_windows: Mapping[str, str],
+        account_windows: Mapping[str, NormalizedUsageWindow],
         *,
         since: datetime,
         until: datetime,
@@ -132,13 +138,12 @@ class DashboardRepository:
         self,
         since: datetime,
         *,
+        now: datetime,
         per_metric_limit: int = 3,
     ) -> list[ApiKeyAttributionRow]:
         key_name = func.coalesce(func.nullif(ApiKey.name, ""), "(unnamed)")
-        billable_tokens = (
-            func.coalesce(RequestLog.input_tokens, 0)
-            + func.coalesce(RequestLog.output_tokens, 0)
-            + func.coalesce(RequestLog.reasoning_tokens, 0)
+        billable_tokens = func.coalesce(RequestLog.input_tokens, 0) + func.coalesce(
+            RequestLog.output_tokens, RequestLog.reasoning_tokens, 0
         )
         grouped_models = (
             select(
@@ -153,6 +158,7 @@ class DashboardRepository:
             .outerjoin(ApiKey, ApiKey.id == RequestLog.api_key_id)
             .where(
                 RequestLog.requested_at >= since,
+                RequestLog.requested_at <= now,
                 RequestLog.deleted_at.is_(None),
             )
             .group_by(RequestLog.api_key_id, key_name, RequestLog.model)
@@ -232,6 +238,7 @@ class DashboardRepository:
         rows = (await self._session.execute(statement)).all()
         return [
             ApiKeyAttributionRow(
+                api_key_id=str(row.api_key_id) if row.api_key_id is not None else None,
                 name=str(row.name),
                 requests=int(row.requests),
                 billable_tokens=int(row.billable_tokens),

--- a/app/modules/dashboard/schemas.py
+++ b/app/modules/dashboard/schemas.py
@@ -71,6 +71,21 @@ class DepletionResponse(DashboardModel):
 
 WeeklyCreditPaceStatus = Literal["behind", "on_track", "ahead", "danger"]
 WeeklyCreditPaceConfidence = Literal["high", "medium", "low"]
+WeeklyCreditRunwayStatus = Literal["safe", "tight", "runs_dry"]
+
+
+class WeeklyCreditResetEvent(DashboardModel):
+    at: datetime
+    credits_returned: float
+
+
+class WeeklyCreditApiKeyAttribution(DashboardModel):
+    api_key_id: str | None = None
+    name: str
+    requests: int
+    billable_tokens: int
+    cached_tokens: int
+    dominant_model: str
 
 
 class WeeklyCreditPaceResponse(DashboardModel):
@@ -97,6 +112,17 @@ class WeeklyCreditPaceResponse(DashboardModel):
     projected_minimum_remaining_credits: float | None = None
     forecast_burn_rate_credits_per_hour: float | None = None
     scheduled_burn_rate_credits_per_hour: float
+    headroom_percent: float
+    headroom_credits: float
+    burn_rate_recent_credits_per_hour: float | None = None
+    depletion_eta_hours: float | None = None
+    next_relief_in_hours: float
+    next_relief_credits: float
+    reset_events: list[WeeklyCreditResetEvent] = Field(default_factory=list)
+    runway_status: WeeklyCreditRunwayStatus
+    saturated_account_count: int
+    top_api_keys: list[WeeklyCreditApiKeyAttribution] = Field(default_factory=list)
+    add_pro_accounts: int | None = None
     status: WeeklyCreditPaceStatus
     account_count: int
     stale_account_count: int = 0

--- a/app/modules/dashboard/schemas.py
+++ b/app/modules/dashboard/schemas.py
@@ -71,6 +71,20 @@ class DepletionResponse(DashboardModel):
 
 WeeklyCreditPaceStatus = Literal["behind", "on_track", "ahead", "danger"]
 WeeklyCreditPaceConfidence = Literal["high", "medium", "low"]
+WeeklyCreditRunwayStatus = Literal["safe", "tight", "runs_dry"]
+
+
+class WeeklyCreditResetEvent(DashboardModel):
+    at: datetime
+    credits_returned: float
+
+
+class WeeklyCreditApiKeyAttribution(DashboardModel):
+    name: str
+    requests: int
+    billable_tokens: int
+    cached_tokens: int
+    dominant_model: str
 
 
 class WeeklyCreditPaceResponse(DashboardModel):
@@ -97,6 +111,17 @@ class WeeklyCreditPaceResponse(DashboardModel):
     projected_minimum_remaining_credits: float | None = None
     forecast_burn_rate_credits_per_hour: float | None = None
     scheduled_burn_rate_credits_per_hour: float
+    headroom_percent: float
+    headroom_credits: float
+    burn_rate_recent_credits_per_hour: float | None = None
+    depletion_eta_hours: float | None = None
+    next_relief_in_hours: float
+    next_relief_credits: float
+    reset_events: list[WeeklyCreditResetEvent] = Field(default_factory=list)
+    runway_status: WeeklyCreditRunwayStatus
+    saturated_account_count: int
+    top_api_keys: list[WeeklyCreditApiKeyAttribution] = Field(default_factory=list)
+    add_pro_accounts: int | None = None
     status: WeeklyCreditPaceStatus
     account_count: int
     stale_account_count: int = 0

--- a/app/modules/dashboard/schemas.py
+++ b/app/modules/dashboard/schemas.py
@@ -80,6 +80,7 @@ class WeeklyCreditResetEvent(DashboardModel):
 
 
 class WeeklyCreditApiKeyAttribution(DashboardModel):
+    api_key_id: str | None = None
     name: str
     requests: int
     billable_tokens: int

--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -23,8 +23,10 @@ from app.modules.dashboard.schemas import (
     DashboardProjectionsResponse,
     DashboardUsageWindows,
     DepletionResponse,
+    WeeklyCreditApiKeyAttribution,
+    WeeklyCreditPaceResponse,
 )
-from app.modules.dashboard.weekly_pace import build_weekly_credit_pace
+from app.modules.dashboard.weekly_pace import DEMAND_WINDOW, build_weekly_credit_pace
 from app.modules.usage.builders import (
     align_bucket_window_start,
     build_activity_summaries,
@@ -38,6 +40,7 @@ from app.modules.usage.depletion_service import (
     prune_depletion_cache,
 )
 from app.modules.usage.mappers import usage_history_to_window_row
+from app.modules.usage.repository import NormalizedUsageWindow
 
 # Newest-first per-account row bound for the projections history fetch
 # (PostgreSQL; the SQLite snapshot cache keeps the shared floor). Live
@@ -173,6 +176,33 @@ class DashboardService:
             ),
         )
 
+        dashboard_settings = await self._repo.get_settings()
+        _, secondary_history = await _load_projection_histories(
+            self._repo,
+            primary_usage,
+            secondary_usage,
+            now,
+            smoothing_window_minutes=dashboard_settings.weekly_pace_smoothing_minutes,
+            include_primary=False,
+        )
+        settings = get_settings()
+        trailing_demand = await self._repo.positive_used_percent_deltas_by_account(
+            _weekly_history_windows(primary_usage, secondary_usage),
+            since=now - DEMAND_WINDOW,
+            until=now,
+        )
+        weekly_credit_pace = build_weekly_credit_pace(
+            accounts=accounts,
+            account_summaries=account_summaries,
+            secondary_history=secondary_history,
+            now=now,
+            usage_refresh_interval_seconds=settings.usage_refresh_interval_seconds,
+            trailing_demand_used_percent_by_account=trailing_demand,
+            working_days=_parse_weekly_pace_working_days(dashboard_settings.weekly_pace_working_days),
+            smoothing_window_minutes=dashboard_settings.weekly_pace_smoothing_minutes,
+        )
+        await _attach_top_api_keys(self._repo, weekly_credit_pace, now)
+
         additional_ts = await self._repo.latest_additional_recorded_at()
         return DashboardOverviewResponse(
             last_sync_at=_latest_recorded_at(primary_usage, secondary_usage, monthly_usage, additional_ts),
@@ -181,6 +211,7 @@ class DashboardService:
             summary=summary,
             windows=windows,
             trends=trends,
+            weekly_credit_pace=weekly_credit_pace,
         )
 
     async def get_projections(self) -> DashboardProjectionsResponse:
@@ -207,20 +238,48 @@ class DashboardService:
         )
         pri_depletion, sec_depletion = _build_depletion_by_window(primary_history, secondary_history, now)
         settings = get_settings()
+        trailing_demand = await self._repo.positive_used_percent_deltas_by_account(
+            _weekly_history_windows(primary_usage, secondary_usage),
+            since=now - DEMAND_WINDOW,
+            until=now,
+        )
         weekly_credit_pace = build_weekly_credit_pace(
             accounts=accounts,
             account_summaries=account_summaries,
             secondary_history=secondary_history,
             now=now,
             usage_refresh_interval_seconds=settings.usage_refresh_interval_seconds,
+            trailing_demand_used_percent_by_account=trailing_demand,
             working_days=_parse_weekly_pace_working_days(dashboard_settings.weekly_pace_working_days),
             smoothing_window_minutes=dashboard_settings.weekly_pace_smoothing_minutes,
         )
+        await _attach_top_api_keys(self._repo, weekly_credit_pace, now)
         return DashboardProjectionsResponse(
             depletion_primary=pri_depletion,
             depletion_secondary=sec_depletion,
             weekly_credit_pace=weekly_credit_pace,
         )
+
+
+async def _attach_top_api_keys(
+    repo: DashboardRepository,
+    weekly_credit_pace: WeeklyCreditPaceResponse | None,
+    now: datetime,
+) -> None:
+    if weekly_credit_pace is None:
+        return
+    rows = await repo.top_api_key_attribution_since(now - timedelta(hours=2), now=now)
+    weekly_credit_pace.top_api_keys = [
+        WeeklyCreditApiKeyAttribution(
+            api_key_id=row.api_key_id,
+            name=row.name,
+            requests=row.requests,
+            billable_tokens=row.billable_tokens,
+            cached_tokens=row.cached_tokens,
+            dominant_model=row.dominant_model,
+        )
+        for row in rows
+    ]
 
 
 async def _load_projection_histories(
@@ -230,9 +289,14 @@ async def _load_projection_histories(
     now: datetime,
     *,
     smoothing_window_minutes: int,
+    include_primary: bool = True,
 ) -> tuple[dict[str, list[UsageHistory]], dict[str, list[UsageHistory]]]:
     # Compute depletion separately for primary-window and secondary-window
     # accounts so the aggregate is not skewed by mixing different window durations.
+    # Callers that only consume the secondary half (the overview weekly pace)
+    # pass include_primary=False to skip the primary bulk fetch; weekly-only
+    # accounts whose history source is the primary stream are still fetched
+    # because their rows feed secondary_history.
     primary_rows_raw = _rows_from_latest(primary_usage)
     secondary_rows_raw = _rows_from_latest(secondary_usage)
     primary_rows, _ = usage_core.normalize_weekly_only_rows(
@@ -255,13 +319,14 @@ async def _load_projection_histories(
 
     for account_id in all_account_ids:
         if account_id in normalized_primary_ids:
-            usage_entry = primary_usage[account_id]
-            acct_window = usage_entry.window_minutes if usage_entry.window_minutes else 300
-            acct_since = now - timedelta(minutes=acct_window)
-            pri_fetch_ids.append(account_id)
-            pri_cutoffs[account_id] = acct_since
-            if acct_since < pri_since:
-                pri_since = acct_since
+            if include_primary:
+                usage_entry = primary_usage[account_id]
+                acct_window = usage_entry.window_minutes if usage_entry.window_minutes else 300
+                acct_since = now - timedelta(minutes=acct_window)
+                pri_fetch_ids.append(account_id)
+                pri_cutoffs[account_id] = acct_since
+                if acct_since < pri_since:
+                    pri_since = acct_since
             if account_id in secondary_usage:
                 sec_entry = secondary_usage[account_id]
                 sec_window = sec_entry.window_minutes if sec_entry.window_minutes else 10080
@@ -333,10 +398,11 @@ async def _load_projection_histories(
 
     for account_id in all_account_ids:
         if account_id in normalized_primary_ids:
-            cutoff = pri_cutoffs[account_id]
-            rows = filter_depletion_history_since(all_pri_rows.get(account_id, []), cutoff)
-            if rows:
-                primary_history[account_id] = rows
+            if include_primary:
+                cutoff = pri_cutoffs[account_id]
+                rows = filter_depletion_history_since(all_pri_rows.get(account_id, []), cutoff)
+                if rows:
+                    primary_history[account_id] = rows
             if account_id in sec_cutoffs:
                 s_cutoff = sec_cutoffs[account_id]
                 s_rows = filter_depletion_history_since(all_sec_rows.get(account_id, []), s_cutoff)
@@ -411,6 +477,31 @@ def _should_use_weekly_primary_history(
         usage_history_to_window_row(primary_entry),
         usage_history_to_window_row(secondary_entry) if secondary_entry is not None else None,
     )
+
+
+def _weekly_history_windows(
+    primary_usage: dict[str, UsageHistory],
+    secondary_usage: dict[str, UsageHistory],
+) -> dict[str, NormalizedUsageWindow]:
+    primary_rows, _ = usage_core.normalize_weekly_only_rows(
+        _rows_from_latest(primary_usage),
+        _rows_from_latest(secondary_usage),
+    )
+    normalized_primary_ids = {row.account_id for row in primary_rows}
+    windows: dict[str, NormalizedUsageWindow] = {}
+    for account_id in set(primary_usage) | set(secondary_usage):
+        if account_id in normalized_primary_ids:
+            if account_id in secondary_usage:
+                windows[account_id] = "secondary"
+        elif account_id in primary_usage:
+            windows[account_id] = (
+                "primary"
+                if _should_use_weekly_primary_history(primary_usage[account_id], secondary_usage.get(account_id))
+                else "secondary"
+            )
+        else:
+            windows[account_id] = "secondary"
+    return windows
 
 
 def _latest_recorded_at(

--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -26,7 +26,7 @@ from app.modules.dashboard.schemas import (
     WeeklyCreditApiKeyAttribution,
     WeeklyCreditPaceResponse,
 )
-from app.modules.dashboard.weekly_pace import build_weekly_credit_pace
+from app.modules.dashboard.weekly_pace import DEMAND_WINDOW, build_weekly_credit_pace
 from app.modules.usage.builders import (
     align_bucket_window_start,
     build_activity_summaries,
@@ -40,6 +40,7 @@ from app.modules.usage.depletion_service import (
     prune_depletion_cache,
 )
 from app.modules.usage.mappers import usage_history_to_window_row
+from app.modules.usage.repository import NormalizedUsageWindow
 
 # Newest-first per-account row bound for the projections history fetch
 # (PostgreSQL; the SQLite snapshot cache keeps the shared floor). Live
@@ -186,7 +187,7 @@ class DashboardService:
         settings = get_settings()
         trailing_demand = await self._repo.positive_used_percent_deltas_by_account(
             _weekly_history_windows(primary_usage, secondary_usage),
-            since=now - timedelta(days=7),
+            since=now - DEMAND_WINDOW,
             until=now,
         )
         weekly_credit_pace = build_weekly_credit_pace(
@@ -238,7 +239,7 @@ class DashboardService:
         settings = get_settings()
         trailing_demand = await self._repo.positive_used_percent_deltas_by_account(
             _weekly_history_windows(primary_usage, secondary_usage),
-            since=now - timedelta(days=7),
+            since=now - DEMAND_WINDOW,
             until=now,
         )
         weekly_credit_pace = build_weekly_credit_pace(
@@ -266,9 +267,10 @@ async def _attach_top_api_keys(
 ) -> None:
     if weekly_credit_pace is None:
         return
-    rows = await repo.top_api_key_attribution_since(now - timedelta(hours=2))
+    rows = await repo.top_api_key_attribution_since(now - timedelta(hours=2), now=now)
     weekly_credit_pace.top_api_keys = [
         WeeklyCreditApiKeyAttribution(
+            api_key_id=row.api_key_id,
             name=row.name,
             requests=row.requests,
             billable_tokens=row.billable_tokens,
@@ -472,13 +474,13 @@ def _should_use_weekly_primary_history(
 def _weekly_history_windows(
     primary_usage: dict[str, UsageHistory],
     secondary_usage: dict[str, UsageHistory],
-) -> dict[str, str]:
+) -> dict[str, NormalizedUsageWindow]:
     primary_rows, _ = usage_core.normalize_weekly_only_rows(
         _rows_from_latest(primary_usage),
         _rows_from_latest(secondary_usage),
     )
     normalized_primary_ids = {row.account_id for row in primary_rows}
-    windows: dict[str, str] = {}
+    windows: dict[str, NormalizedUsageWindow] = {}
     for account_id in set(primary_usage) | set(secondary_usage):
         if account_id in normalized_primary_ids:
             if account_id in secondary_usage:

--- a/app/modules/dashboard/service.py
+++ b/app/modules/dashboard/service.py
@@ -23,6 +23,8 @@ from app.modules.dashboard.schemas import (
     DashboardProjectionsResponse,
     DashboardUsageWindows,
     DepletionResponse,
+    WeeklyCreditApiKeyAttribution,
+    WeeklyCreditPaceResponse,
 )
 from app.modules.dashboard.weekly_pace import build_weekly_credit_pace
 from app.modules.usage.builders import (
@@ -173,6 +175,32 @@ class DashboardService:
             ),
         )
 
+        dashboard_settings = await self._repo.get_settings()
+        _, secondary_history = await _load_projection_histories(
+            self._repo,
+            primary_usage,
+            secondary_usage,
+            now,
+            smoothing_window_minutes=dashboard_settings.weekly_pace_smoothing_minutes,
+        )
+        settings = get_settings()
+        trailing_demand = await self._repo.positive_used_percent_deltas_by_account(
+            _weekly_history_windows(primary_usage, secondary_usage),
+            since=now - timedelta(days=7),
+            until=now,
+        )
+        weekly_credit_pace = build_weekly_credit_pace(
+            accounts=accounts,
+            account_summaries=account_summaries,
+            secondary_history=secondary_history,
+            now=now,
+            usage_refresh_interval_seconds=settings.usage_refresh_interval_seconds,
+            trailing_demand_used_percent_by_account=trailing_demand,
+            working_days=_parse_weekly_pace_working_days(dashboard_settings.weekly_pace_working_days),
+            smoothing_window_minutes=dashboard_settings.weekly_pace_smoothing_minutes,
+        )
+        await _attach_top_api_keys(self._repo, weekly_credit_pace, now)
+
         additional_ts = await self._repo.latest_additional_recorded_at()
         return DashboardOverviewResponse(
             last_sync_at=_latest_recorded_at(primary_usage, secondary_usage, monthly_usage, additional_ts),
@@ -181,6 +209,7 @@ class DashboardService:
             summary=summary,
             windows=windows,
             trends=trends,
+            weekly_credit_pace=weekly_credit_pace,
         )
 
     async def get_projections(self) -> DashboardProjectionsResponse:
@@ -207,20 +236,47 @@ class DashboardService:
         )
         pri_depletion, sec_depletion = _build_depletion_by_window(primary_history, secondary_history, now)
         settings = get_settings()
+        trailing_demand = await self._repo.positive_used_percent_deltas_by_account(
+            _weekly_history_windows(primary_usage, secondary_usage),
+            since=now - timedelta(days=7),
+            until=now,
+        )
         weekly_credit_pace = build_weekly_credit_pace(
             accounts=accounts,
             account_summaries=account_summaries,
             secondary_history=secondary_history,
             now=now,
             usage_refresh_interval_seconds=settings.usage_refresh_interval_seconds,
+            trailing_demand_used_percent_by_account=trailing_demand,
             working_days=_parse_weekly_pace_working_days(dashboard_settings.weekly_pace_working_days),
             smoothing_window_minutes=dashboard_settings.weekly_pace_smoothing_minutes,
         )
+        await _attach_top_api_keys(self._repo, weekly_credit_pace, now)
         return DashboardProjectionsResponse(
             depletion_primary=pri_depletion,
             depletion_secondary=sec_depletion,
             weekly_credit_pace=weekly_credit_pace,
         )
+
+
+async def _attach_top_api_keys(
+    repo: DashboardRepository,
+    weekly_credit_pace: WeeklyCreditPaceResponse | None,
+    now: datetime,
+) -> None:
+    if weekly_credit_pace is None:
+        return
+    rows = await repo.top_api_key_attribution_since(now - timedelta(hours=2))
+    weekly_credit_pace.top_api_keys = [
+        WeeklyCreditApiKeyAttribution(
+            name=row.name,
+            requests=row.requests,
+            billable_tokens=row.billable_tokens,
+            cached_tokens=row.cached_tokens,
+            dominant_model=row.dominant_model,
+        )
+        for row in rows
+    ]
 
 
 async def _load_projection_histories(
@@ -411,6 +467,31 @@ def _should_use_weekly_primary_history(
         usage_history_to_window_row(primary_entry),
         usage_history_to_window_row(secondary_entry) if secondary_entry is not None else None,
     )
+
+
+def _weekly_history_windows(
+    primary_usage: dict[str, UsageHistory],
+    secondary_usage: dict[str, UsageHistory],
+) -> dict[str, str]:
+    primary_rows, _ = usage_core.normalize_weekly_only_rows(
+        _rows_from_latest(primary_usage),
+        _rows_from_latest(secondary_usage),
+    )
+    normalized_primary_ids = {row.account_id for row in primary_rows}
+    windows: dict[str, str] = {}
+    for account_id in set(primary_usage) | set(secondary_usage):
+        if account_id in normalized_primary_ids:
+            if account_id in secondary_usage:
+                windows[account_id] = "secondary"
+        elif account_id in primary_usage:
+            windows[account_id] = (
+                "primary"
+                if _should_use_weekly_primary_history(primary_usage[account_id], secondary_usage.get(account_id))
+                else "secondary"
+            )
+        else:
+            windows[account_id] = "secondary"
+    return windows
 
 
 def _latest_recorded_at(

--- a/app/modules/dashboard/weekly_pace.py
+++ b/app/modules/dashboard/weekly_pace.py
@@ -1,18 +1,33 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from math import ceil, isfinite
 from typing import Literal
 
+from app.core.usage import PLAN_CAPACITY_CREDITS_SECONDARY
 from app.core.usage.depletion import EWMAState, ewma_update
 from app.core.utils.time import naive_utc_to_epoch
 from app.db.models import Account, AccountStatus, UsageHistory
 from app.modules.accounts.schemas import AccountSummary
-from app.modules.dashboard.schemas import WeeklyCreditPaceResponse, WeeklyCreditPaceStatus
+from app.modules.dashboard.schemas import (
+    WeeklyCreditApiKeyAttribution,
+    WeeklyCreditPaceResponse,
+    WeeklyCreditPaceStatus,
+    WeeklyCreditResetEvent,
+    WeeklyCreditRunwayStatus,
+)
 
-PRO_WEEKLY_CAPACITY_CREDITS = 50_400.0
+PRO_WEEKLY_CAPACITY_CREDITS = PLAN_CAPACITY_CREDITS_SECONDARY["pro"]
 RECENT_BURN_WINDOW = timedelta(hours=6)
+FLEET_BURN_WINDOW = timedelta(hours=3)
+DEMAND_WINDOW = timedelta(days=7)
+RELIEF_COHORT_USED_PERCENT = 95.0
+RELIEF_CLUSTER_WINDOW = timedelta(hours=1)
+SATURATED_USED_PERCENT = 99.5
+TIGHT_MARGIN_HOURS = 24.0
+TIGHT_HEADROOM_PERCENT = 12.0
 MIN_FRESHNESS_SECONDS = 300.0
 FRESHNESS_MISSED_REFRESH_CYCLES = 3.0
 PACE_ELIGIBLE_ACCOUNT_STATUSES = frozenset(
@@ -57,6 +72,8 @@ def build_weekly_credit_pace(
     secondary_history: dict[str, list[UsageHistory]],
     now: datetime,
     usage_refresh_interval_seconds: int,
+    top_api_keys: list[WeeklyCreditApiKeyAttribution] | None = None,
+    trailing_demand_used_percent_by_account: Mapping[str, float] | None = None,
     working_days: set[int] | None = None,
     smoothing_window_minutes: int = 30,
 ) -> WeeklyCreditPaceResponse | None:
@@ -184,6 +201,37 @@ def build_weekly_credit_pace(
     )
     pro_accounts = ceil(pro_equivalent) if pro_equivalent is not None else None
 
+    headroom_credits = total_actual_remaining_credits
+    headroom_percent = 100.0 * headroom_credits / total_full_credits
+    recent_burn_rate = _fleet_recent_burn_rate_credits_per_hour(
+        pace_accounts,
+        secondary_history,
+        now,
+    )
+    depletion_eta_hours = (
+        headroom_credits / recent_burn_rate if recent_burn_rate is not None and recent_burn_rate > 0 else None
+    )
+    next_relief_in_hours, next_relief_credits = _next_relief(pace_accounts, now_ms)
+    runway_status = _runway_status(
+        depletion_eta_hours=depletion_eta_hours,
+        next_relief_in_hours=next_relief_in_hours,
+        headroom_percent=headroom_percent,
+    )
+    saturated_account_count = sum(_used_percent(account) >= SATURATED_USED_PERCENT for account in pace_accounts)
+    add_pro_accounts = None
+    if trailing_demand_used_percent_by_account is not None:
+        trailing_demand_credits = sum(
+            account.full_credits
+            * max(0.0, trailing_demand_used_percent_by_account.get(account.account_id, 0.0))
+            / 100.0
+            for account in pace_accounts
+        )
+        demand_quota_weeks = trailing_demand_credits / PRO_WEEKLY_CAPACITY_CREDITS
+        fleet_capacity_quota_weeks = total_full_credits / PRO_WEEKLY_CAPACITY_CREDITS
+        demand_surplus_accounts = demand_quota_weeks - fleet_capacity_quota_weeks
+        if demand_surplus_accounts > 0 and (runway_status == "runs_dry" or saturated_account_count > 0):
+            add_pro_accounts = ceil(demand_surplus_accounts)
+
     return WeeklyCreditPaceResponse(
         total_full_credits=total_full_credits,
         total_actual_remaining_credits=total_actual_remaining_credits,
@@ -207,12 +255,99 @@ def build_weekly_credit_pace(
         projected_minimum_remaining_credits=projection.projected_minimum_remaining_credits,
         forecast_burn_rate_credits_per_hour=forecast_rate,
         scheduled_burn_rate_credits_per_hour=scheduled_burn_rate_credits_per_hour,
-        status=_weekly_pace_status(smoothed_delta_percent, projected_shortfall_credits),
+        headroom_percent=headroom_percent,
+        headroom_credits=headroom_credits,
+        burn_rate_recent_credits_per_hour=recent_burn_rate,
+        depletion_eta_hours=depletion_eta_hours,
+        next_relief_in_hours=next_relief_in_hours,
+        next_relief_credits=next_relief_credits,
+        reset_events=_reset_events(pace_accounts, now_ms),
+        runway_status=runway_status,
+        saturated_account_count=saturated_account_count,
+        top_api_keys=top_api_keys or [],
+        add_pro_accounts=add_pro_accounts,
+        status=_legacy_status(runway_status),
         account_count=len(pace_accounts),
         stale_account_count=stale_account_count,
         inactive_account_count=inactive_account_count,
         confidence=_confidence(len(pace_accounts), rate_sample_count, stale_account_count),
     )
+
+
+def _fleet_recent_burn_rate_credits_per_hour(
+    accounts: list[_PaceAccount],
+    secondary_history: dict[str, list[UsageHistory]],
+    now: datetime,
+) -> float | None:
+    window_start = now - FLEET_BURN_WINDOW
+    total_burn_credits = 0.0
+    considered_recorded_at: list[datetime] = []
+
+    for account in accounts:
+        rows = sorted(
+            (row for row in secondary_history.get(account.account_id, []) if window_start <= row.recorded_at <= now),
+            key=lambda row: row.recorded_at,
+        )
+        if len(rows) < 2:
+            continue
+
+        considered_recorded_at.extend(row.recorded_at for row in rows)
+        for previous, current in zip(rows, rows[1:]):
+            delta_percent = current.used_percent - previous.used_percent
+            if delta_percent > 0:
+                total_burn_credits += account.full_credits * delta_percent / 100.0
+
+    if not considered_recorded_at:
+        return None
+
+    observed_span_hours = (max(considered_recorded_at) - min(considered_recorded_at)).total_seconds() / 3600.0
+    return total_burn_credits / max(0.5, observed_span_hours)
+
+
+def _next_relief(accounts: list[_PaceAccount], now_ms: float) -> tuple[float, float]:
+    cohort = [account for account in accounts if _used_percent(account) >= RELIEF_COHORT_USED_PERCENT]
+    if not cohort:
+        cohort = accounts
+
+    soonest_reset_ms = min(account.reset_at_ms for account in cohort)
+    cluster_end_ms = soonest_reset_ms + RELIEF_CLUSTER_WINDOW.total_seconds() * 1000.0
+    relief_credits = sum(
+        account.full_credits * _used_percent(account) / 100.0
+        for account in cohort
+        if account.reset_at_ms <= cluster_end_ms
+    )
+    return max(0.0, (soonest_reset_ms - now_ms) / 3_600_000.0), relief_credits
+
+
+def _reset_events(accounts: list[_PaceAccount], now_ms: float) -> list[WeeklyCreditResetEvent]:
+    horizon_ms = now_ms + DEMAND_WINDOW.total_seconds() * 1000.0
+    return [
+        WeeklyCreditResetEvent(
+            at=datetime.fromtimestamp(account.reset_at_ms / 1000.0, UTC),
+            credits_returned=account.full_credits * _used_percent(account) / 100.0,
+        )
+        for account in sorted(accounts, key=lambda item: item.reset_at_ms)
+        if account.reset_at_ms <= horizon_ms
+    ]
+
+
+def _runway_status(
+    *,
+    depletion_eta_hours: float | None,
+    next_relief_in_hours: float,
+    headroom_percent: float,
+) -> WeeklyCreditRunwayStatus:
+    if depletion_eta_hours is not None and depletion_eta_hours < next_relief_in_hours:
+        return "runs_dry"
+    if (
+        depletion_eta_hours is not None and depletion_eta_hours - next_relief_in_hours < TIGHT_MARGIN_HOURS
+    ) or headroom_percent < TIGHT_HEADROOM_PERCENT:
+        return "tight"
+    return "safe"
+
+
+def _used_percent(account: _PaceAccount) -> float:
+    return 100.0 * (account.full_credits - account.remaining_credits) / account.full_credits
 
 
 def _weekly_timing(summary: AccountSummary, now_ms: float) -> tuple[float, float, float, float] | None:
@@ -450,12 +585,10 @@ def _weekday(epoch_ms: float) -> int:
     return datetime.fromtimestamp(epoch_ms / 1000.0, UTC).weekday()
 
 
-def _weekly_pace_status(delta_percent: float, projected_shortfall_credits: float) -> WeeklyCreditPaceStatus:
-    if projected_shortfall_credits > 0:
+def _legacy_status(runway_status: WeeklyCreditRunwayStatus) -> WeeklyCreditPaceStatus:
+    if runway_status == "runs_dry":
         return "danger"
-    if delta_percent < -5:
-        return "behind"
-    if delta_percent > 5:
+    if runway_status == "tight":
         return "ahead"
     return "on_track"
 

--- a/app/modules/dashboard/weekly_pace.py
+++ b/app/modules/dashboard/weekly_pace.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from math import ceil, isfinite
 from typing import Literal
 
+from app.core.usage import PLAN_CAPACITY_CREDITS_SECONDARY
 from app.core.usage.depletion import EWMAState, ewma_update
 from app.core.utils.time import naive_utc_to_epoch
 from app.db.models import Account, AccountStatus, UsageHistory
@@ -17,7 +19,7 @@ from app.modules.dashboard.schemas import (
     WeeklyCreditRunwayStatus,
 )
 
-PRO_WEEKLY_CAPACITY_CREDITS = 50_400.0
+PRO_WEEKLY_CAPACITY_CREDITS = PLAN_CAPACITY_CREDITS_SECONDARY["pro"]
 RECENT_BURN_WINDOW = timedelta(hours=6)
 FLEET_BURN_WINDOW = timedelta(hours=3)
 DEMAND_WINDOW = timedelta(days=7)
@@ -70,7 +72,7 @@ def build_weekly_credit_pace(
     now: datetime,
     usage_refresh_interval_seconds: int,
     top_api_keys: list[WeeklyCreditApiKeyAttribution] | None = None,
-    trailing_demand_used_percent_by_account: dict[str, float] | None = None,
+    trailing_demand_used_percent_by_account: Mapping[str, float] | None = None,
     working_days: set[int] | None = None,
     smoothing_window_minutes: int = 30,
 ) -> WeeklyCreditPaceResponse | None:
@@ -215,23 +217,18 @@ def build_weekly_credit_pace(
         headroom_percent=headroom_percent,
     )
     saturated_account_count = sum(_used_percent(account) >= SATURATED_USED_PERCENT for account in pace_accounts)
-    trailing_demand_credits = (
-        _trailing_demand_credits(pace_accounts, secondary_history, now)
-        if trailing_demand_used_percent_by_account is None
-        else sum(
+    add_pro_accounts = None
+    if trailing_demand_used_percent_by_account is not None:
+        trailing_demand_credits = sum(
             account.full_credits
             * max(0.0, trailing_demand_used_percent_by_account.get(account.account_id, 0.0))
             / 100.0
             for account in pace_accounts
         )
-    )
-    demand_quota_weeks = trailing_demand_credits / PRO_WEEKLY_CAPACITY_CREDITS
-    demand_surplus_accounts = demand_quota_weeks - len(pace_accounts)
-    add_pro_accounts = (
-        ceil(demand_surplus_accounts)
-        if demand_surplus_accounts > 0 and (runway_status == "runs_dry" or saturated_account_count > 0)
-        else None
-    )
+        demand_quota_weeks = trailing_demand_credits / PRO_WEEKLY_CAPACITY_CREDITS
+        demand_surplus_accounts = demand_quota_weeks - len(pace_accounts)
+        if demand_surplus_accounts > 0 and (runway_status == "runs_dry" or saturated_account_count > 0):
+            add_pro_accounts = ceil(demand_surplus_accounts)
 
     return WeeklyCreditPaceResponse(
         total_full_credits=total_full_credits,
@@ -282,32 +279,27 @@ def _fleet_recent_burn_rate_credits_per_hour(
 ) -> float | None:
     window_start = now - FLEET_BURN_WINDOW
     total_burn_credits = 0.0
-    has_delta_sample = False
+    considered_recorded_at: list[datetime] = []
 
     for account in accounts:
-        buckets: list[list[UsageHistory]] = [[], [], []]
-        for row in secondary_history.get(account.account_id, []):
-            if row.recorded_at < window_start or row.recorded_at > now:
-                continue
-            bucket_index = min(
-                2,
-                int((row.recorded_at - window_start).total_seconds() // 3600),
-            )
-            buckets[bucket_index].append(row)
+        rows = sorted(
+            (row for row in secondary_history.get(account.account_id, []) if window_start <= row.recorded_at <= now),
+            key=lambda row: row.recorded_at,
+        )
+        if len(rows) < 2:
+            continue
 
-        for bucket in buckets:
-            bucket.sort(key=lambda row: row.recorded_at)
-            if len(bucket) < 2:
-                continue
-            has_delta_sample = True
-            for previous, current in zip(bucket, bucket[1:]):
-                delta_percent = current.used_percent - previous.used_percent
-                if delta_percent > 0:
-                    total_burn_credits += account.full_credits * delta_percent / 100.0
+        considered_recorded_at.extend(row.recorded_at for row in rows)
+        for previous, current in zip(rows, rows[1:]):
+            delta_percent = current.used_percent - previous.used_percent
+            if delta_percent > 0:
+                total_burn_credits += account.full_credits * delta_percent / 100.0
 
-    if not has_delta_sample:
+    if not considered_recorded_at:
         return None
-    return total_burn_credits / (FLEET_BURN_WINDOW.total_seconds() / 3600.0)
+
+    observed_span_hours = (max(considered_recorded_at) - min(considered_recorded_at)).total_seconds() / 3600.0
+    return total_burn_credits / max(0.5, observed_span_hours)
 
 
 def _next_relief(accounts: list[_PaceAccount], now_ms: float) -> tuple[float, float]:
@@ -350,25 +342,6 @@ def _runway_status(
     ) or headroom_percent < TIGHT_HEADROOM_PERCENT:
         return "tight"
     return "safe"
-
-
-def _trailing_demand_credits(
-    accounts: list[_PaceAccount],
-    secondary_history: dict[str, list[UsageHistory]],
-    now: datetime,
-) -> float:
-    window_start = now - DEMAND_WINDOW
-    total_demand_credits = 0.0
-    for account in accounts:
-        rows = sorted(
-            (row for row in secondary_history.get(account.account_id, []) if window_start <= row.recorded_at <= now),
-            key=lambda row: row.recorded_at,
-        )
-        for previous, current in zip(rows, rows[1:]):
-            delta_percent = current.used_percent - previous.used_percent
-            if delta_percent > 0:
-                total_demand_credits += account.full_credits * delta_percent / 100.0
-    return total_demand_credits
 
 
 def _used_percent(account: _PaceAccount) -> float:

--- a/app/modules/dashboard/weekly_pace.py
+++ b/app/modules/dashboard/weekly_pace.py
@@ -9,10 +9,23 @@ from app.core.usage.depletion import EWMAState, ewma_update
 from app.core.utils.time import naive_utc_to_epoch
 from app.db.models import Account, AccountStatus, UsageHistory
 from app.modules.accounts.schemas import AccountSummary
-from app.modules.dashboard.schemas import WeeklyCreditPaceResponse, WeeklyCreditPaceStatus
+from app.modules.dashboard.schemas import (
+    WeeklyCreditApiKeyAttribution,
+    WeeklyCreditPaceResponse,
+    WeeklyCreditPaceStatus,
+    WeeklyCreditResetEvent,
+    WeeklyCreditRunwayStatus,
+)
 
 PRO_WEEKLY_CAPACITY_CREDITS = 50_400.0
 RECENT_BURN_WINDOW = timedelta(hours=6)
+FLEET_BURN_WINDOW = timedelta(hours=3)
+DEMAND_WINDOW = timedelta(days=7)
+RELIEF_COHORT_USED_PERCENT = 95.0
+RELIEF_CLUSTER_WINDOW = timedelta(hours=1)
+SATURATED_USED_PERCENT = 99.5
+TIGHT_MARGIN_HOURS = 24.0
+TIGHT_HEADROOM_PERCENT = 12.0
 MIN_FRESHNESS_SECONDS = 300.0
 FRESHNESS_MISSED_REFRESH_CYCLES = 3.0
 PACE_ELIGIBLE_ACCOUNT_STATUSES = frozenset(
@@ -56,6 +69,8 @@ def build_weekly_credit_pace(
     secondary_history: dict[str, list[UsageHistory]],
     now: datetime,
     usage_refresh_interval_seconds: int,
+    top_api_keys: list[WeeklyCreditApiKeyAttribution] | None = None,
+    trailing_demand_used_percent_by_account: dict[str, float] | None = None,
     working_days: set[int] | None = None,
     smoothing_window_minutes: int = 30,
 ) -> WeeklyCreditPaceResponse | None:
@@ -183,6 +198,41 @@ def build_weekly_credit_pace(
     )
     pro_accounts = ceil(pro_equivalent) if pro_equivalent is not None else None
 
+    headroom_credits = total_actual_remaining_credits
+    headroom_percent = 100.0 * headroom_credits / total_full_credits
+    recent_burn_rate = _fleet_recent_burn_rate_credits_per_hour(
+        pace_accounts,
+        secondary_history,
+        now,
+    )
+    depletion_eta_hours = (
+        headroom_credits / recent_burn_rate if recent_burn_rate is not None and recent_burn_rate > 0 else None
+    )
+    next_relief_in_hours, next_relief_credits = _next_relief(pace_accounts, now_ms)
+    runway_status = _runway_status(
+        depletion_eta_hours=depletion_eta_hours,
+        next_relief_in_hours=next_relief_in_hours,
+        headroom_percent=headroom_percent,
+    )
+    saturated_account_count = sum(_used_percent(account) >= SATURATED_USED_PERCENT for account in pace_accounts)
+    trailing_demand_credits = (
+        _trailing_demand_credits(pace_accounts, secondary_history, now)
+        if trailing_demand_used_percent_by_account is None
+        else sum(
+            account.full_credits
+            * max(0.0, trailing_demand_used_percent_by_account.get(account.account_id, 0.0))
+            / 100.0
+            for account in pace_accounts
+        )
+    )
+    demand_quota_weeks = trailing_demand_credits / PRO_WEEKLY_CAPACITY_CREDITS
+    demand_surplus_accounts = demand_quota_weeks - len(pace_accounts)
+    add_pro_accounts = (
+        ceil(demand_surplus_accounts)
+        if demand_surplus_accounts > 0 and (runway_status == "runs_dry" or saturated_account_count > 0)
+        else None
+    )
+
     return WeeklyCreditPaceResponse(
         total_full_credits=total_full_credits,
         total_actual_remaining_credits=total_actual_remaining_credits,
@@ -206,12 +256,123 @@ def build_weekly_credit_pace(
         projected_minimum_remaining_credits=projection.projected_minimum_remaining_credits,
         forecast_burn_rate_credits_per_hour=forecast_rate,
         scheduled_burn_rate_credits_per_hour=scheduled_burn_rate_credits_per_hour,
-        status=_weekly_pace_status(smoothed_delta_percent, projected_shortfall_credits),
+        headroom_percent=headroom_percent,
+        headroom_credits=headroom_credits,
+        burn_rate_recent_credits_per_hour=recent_burn_rate,
+        depletion_eta_hours=depletion_eta_hours,
+        next_relief_in_hours=next_relief_in_hours,
+        next_relief_credits=next_relief_credits,
+        reset_events=_reset_events(pace_accounts, now_ms),
+        runway_status=runway_status,
+        saturated_account_count=saturated_account_count,
+        top_api_keys=top_api_keys or [],
+        add_pro_accounts=add_pro_accounts,
+        status=_legacy_status(runway_status),
         account_count=len(pace_accounts),
         stale_account_count=stale_account_count,
         inactive_account_count=inactive_account_count,
         confidence=_confidence(len(pace_accounts), rate_sample_count, stale_account_count),
     )
+
+
+def _fleet_recent_burn_rate_credits_per_hour(
+    accounts: list[_PaceAccount],
+    secondary_history: dict[str, list[UsageHistory]],
+    now: datetime,
+) -> float | None:
+    window_start = now - FLEET_BURN_WINDOW
+    total_burn_credits = 0.0
+    has_delta_sample = False
+
+    for account in accounts:
+        buckets: list[list[UsageHistory]] = [[], [], []]
+        for row in secondary_history.get(account.account_id, []):
+            if row.recorded_at < window_start or row.recorded_at > now:
+                continue
+            bucket_index = min(
+                2,
+                int((row.recorded_at - window_start).total_seconds() // 3600),
+            )
+            buckets[bucket_index].append(row)
+
+        for bucket in buckets:
+            bucket.sort(key=lambda row: row.recorded_at)
+            if len(bucket) < 2:
+                continue
+            has_delta_sample = True
+            for previous, current in zip(bucket, bucket[1:]):
+                delta_percent = current.used_percent - previous.used_percent
+                if delta_percent > 0:
+                    total_burn_credits += account.full_credits * delta_percent / 100.0
+
+    if not has_delta_sample:
+        return None
+    return total_burn_credits / (FLEET_BURN_WINDOW.total_seconds() / 3600.0)
+
+
+def _next_relief(accounts: list[_PaceAccount], now_ms: float) -> tuple[float, float]:
+    cohort = [account for account in accounts if _used_percent(account) >= RELIEF_COHORT_USED_PERCENT]
+    if not cohort:
+        cohort = accounts
+
+    soonest_reset_ms = min(account.reset_at_ms for account in cohort)
+    cluster_end_ms = soonest_reset_ms + RELIEF_CLUSTER_WINDOW.total_seconds() * 1000.0
+    relief_credits = sum(
+        account.full_credits * _used_percent(account) / 100.0
+        for account in cohort
+        if account.reset_at_ms <= cluster_end_ms
+    )
+    return max(0.0, (soonest_reset_ms - now_ms) / 3_600_000.0), relief_credits
+
+
+def _reset_events(accounts: list[_PaceAccount], now_ms: float) -> list[WeeklyCreditResetEvent]:
+    horizon_ms = now_ms + DEMAND_WINDOW.total_seconds() * 1000.0
+    return [
+        WeeklyCreditResetEvent(
+            at=datetime.fromtimestamp(account.reset_at_ms / 1000.0, UTC),
+            credits_returned=account.full_credits * _used_percent(account) / 100.0,
+        )
+        for account in sorted(accounts, key=lambda item: item.reset_at_ms)
+        if account.reset_at_ms <= horizon_ms
+    ]
+
+
+def _runway_status(
+    *,
+    depletion_eta_hours: float | None,
+    next_relief_in_hours: float,
+    headroom_percent: float,
+) -> WeeklyCreditRunwayStatus:
+    if depletion_eta_hours is not None and depletion_eta_hours < next_relief_in_hours:
+        return "runs_dry"
+    if (
+        depletion_eta_hours is not None and depletion_eta_hours - next_relief_in_hours < TIGHT_MARGIN_HOURS
+    ) or headroom_percent < TIGHT_HEADROOM_PERCENT:
+        return "tight"
+    return "safe"
+
+
+def _trailing_demand_credits(
+    accounts: list[_PaceAccount],
+    secondary_history: dict[str, list[UsageHistory]],
+    now: datetime,
+) -> float:
+    window_start = now - DEMAND_WINDOW
+    total_demand_credits = 0.0
+    for account in accounts:
+        rows = sorted(
+            (row for row in secondary_history.get(account.account_id, []) if window_start <= row.recorded_at <= now),
+            key=lambda row: row.recorded_at,
+        )
+        for previous, current in zip(rows, rows[1:]):
+            delta_percent = current.used_percent - previous.used_percent
+            if delta_percent > 0:
+                total_demand_credits += account.full_credits * delta_percent / 100.0
+    return total_demand_credits
+
+
+def _used_percent(account: _PaceAccount) -> float:
+    return 100.0 * (account.full_credits - account.remaining_credits) / account.full_credits
 
 
 def _weekly_timing(summary: AccountSummary, now_ms: float) -> tuple[float, float, float, float] | None:
@@ -449,12 +610,10 @@ def _weekday(epoch_ms: float) -> int:
     return datetime.fromtimestamp(epoch_ms / 1000.0, UTC).weekday()
 
 
-def _weekly_pace_status(delta_percent: float, projected_shortfall_credits: float) -> WeeklyCreditPaceStatus:
-    if projected_shortfall_credits > 0:
+def _legacy_status(runway_status: WeeklyCreditRunwayStatus) -> WeeklyCreditPaceStatus:
+    if runway_status == "runs_dry":
         return "danger"
-    if delta_percent < -5:
-        return "behind"
-    if delta_percent > 5:
+    if runway_status == "tight":
         return "ahead"
     return "on_track"
 

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
 import sqlite3
-from collections.abc import Collection
+from collections.abc import Collection, Mapping
 from contextlib import closing
 from dataclasses import dataclass
 from datetime import datetime
 from hashlib import sha256
 from threading import RLock
-from typing import Any, Callable, cast
+from typing import Any, Callable, Literal, cast
 
 from anyio import to_thread
 from sqlalchemy import (
     Integer,
     String,
     and_,
+    case,
     column,
     delete,
     func,
@@ -43,6 +44,7 @@ from app.modules.usage.additional_quota_keys import (
 )
 
 _PRIMARY_WINDOW_LITERAL = literal_column("'primary'")
+NormalizedUsageWindow = Literal["primary", "secondary"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -857,6 +859,45 @@ class UsageRepository:
             )
             for row in rows
         ]
+
+    async def positive_used_percent_deltas_by_account(
+        self,
+        account_windows: Mapping[str, NormalizedUsageWindow],
+        *,
+        since: datetime,
+        until: datetime,
+    ) -> dict[str, float]:
+        if not account_windows:
+            return {}
+        account_window_pairs = tuple(account_windows.items())
+        samples = (
+            select(
+                UsageHistory.account_id.label("account_id"),
+                UsageHistory.used_percent.label("used_percent"),
+                func.lag(UsageHistory.used_percent)
+                .over(
+                    partition_by=UsageHistory.account_id,
+                    order_by=(UsageHistory.recorded_at, UsageHistory.id),
+                )
+                .label("previous_used_percent"),
+            )
+            .where(
+                tuple_(UsageHistory.account_id, _normalized_window_expr()).in_(account_window_pairs),
+                UsageHistory.recorded_at >= since,
+                UsageHistory.recorded_at <= until,
+            )
+            .subquery("weekly_demand_samples")
+        )
+        delta = samples.c.used_percent - samples.c.previous_used_percent
+        statement = select(
+            samples.c.account_id,
+            func.coalesce(
+                func.sum(case((delta > 0, delta), else_=0.0)),
+                0.0,
+            ).label("positive_delta"),
+        ).group_by(samples.c.account_id)
+        rows = (await self._session.execute(statement)).all()
+        return {str(row.account_id): float(row.positive_delta) for row in rows}
 
     async def latest_by_account(
         self,

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from hashlib import sha256
 from threading import RLock
-from typing import Any, Callable, cast
+from typing import Any, Callable, Literal, cast
 
 from anyio import to_thread
 from sqlalchemy import (
@@ -44,6 +44,7 @@ from app.modules.usage.additional_quota_keys import (
 )
 
 _PRIMARY_WINDOW_LITERAL = literal_column("'primary'")
+NormalizedUsageWindow = Literal["primary", "secondary"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -861,7 +862,7 @@ class UsageRepository:
 
     async def positive_used_percent_deltas_by_account(
         self,
-        account_windows: Mapping[str, str],
+        account_windows: Mapping[str, NormalizedUsageWindow],
         *,
         since: datetime,
         until: datetime,

--- a/app/modules/usage/repository.py
+++ b/app/modules/usage/repository.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
-from collections.abc import Collection
+from collections.abc import Collection, Mapping
 from contextlib import closing
 from dataclasses import dataclass
 from datetime import datetime
@@ -14,6 +14,7 @@ from sqlalchemy import (
     Integer,
     String,
     and_,
+    case,
     column,
     delete,
     func,
@@ -857,6 +858,45 @@ class UsageRepository:
             )
             for row in rows
         ]
+
+    async def positive_used_percent_deltas_by_account(
+        self,
+        account_windows: Mapping[str, str],
+        *,
+        since: datetime,
+        until: datetime,
+    ) -> dict[str, float]:
+        if not account_windows:
+            return {}
+        account_window_pairs = tuple(account_windows.items())
+        samples = (
+            select(
+                UsageHistory.account_id.label("account_id"),
+                UsageHistory.used_percent.label("used_percent"),
+                func.lag(UsageHistory.used_percent)
+                .over(
+                    partition_by=UsageHistory.account_id,
+                    order_by=(UsageHistory.recorded_at, UsageHistory.id),
+                )
+                .label("previous_used_percent"),
+            )
+            .where(
+                tuple_(UsageHistory.account_id, _normalized_window_expr()).in_(account_window_pairs),
+                UsageHistory.recorded_at >= since,
+                UsageHistory.recorded_at <= until,
+            )
+            .subquery("weekly_demand_samples")
+        )
+        delta = samples.c.used_percent - samples.c.previous_used_percent
+        statement = select(
+            samples.c.account_id,
+            func.coalesce(
+                func.sum(case((delta > 0, delta), else_=0.0)),
+                0.0,
+            ).label("positive_delta"),
+        ).group_by(samples.c.account_id)
+        rows = (await self._session.execute(statement)).all()
+        return {str(row.account_id): float(row.positive_delta) for row in rows}
 
     async def latest_by_account(
         self,

--- a/openspec/changes/redesign-weekly-pace-runway/design.md
+++ b/openspec/changes/redesign-weekly-pace-runway/design.md
@@ -1,0 +1,90 @@
+# Design: weekly pace runway model
+
+## Rationale for the model change
+
+The card must answer four operator questions, in order:
+
+1. How much is left? → `headroom_percent`, `headroom_credits`
+2. When does it run out at the current pace? → `depletion_eta_hours`
+3. Does the next reset save us? → `next_relief_in_hours`,
+   `next_relief_credits`, and the relief-gated verdict (`runway_status`)
+4. Who is burning it? → `top_api_keys[]`
+
+These thresholds and the relief-gated verdict were validated by backtesting the
+2026-08-16 incident: a headroom/ETA rule fired 21h (warn) and 5h (crit) before
+user-visible failure, while the linear-schedule delta and `accounts.status`
+gave no usable signal at any point. The same math already runs in the ops
+watchdog (`codex_lb_quota_watch.py`); this change makes the dashboard card and
+the alerting share one truth.
+
+## Calculation details
+
+- **Burn rate**: keep the per-account 6h EWMA (`_recent_burn_rate_credits_per_hour`)
+  for the fleet forecast, but expose the fleet trailing 3h mean as
+  `burn_rate_recent_credits_per_hour` — it is what the ETA headline uses.
+  Rationale: 3h mean is responsive without single-hour jitter, and matched the
+  incident timeline in backtest. EWMA remains an input to the reset-aware
+  simulation.
+- **ETA**: `headroom_credits / burn_rate_recent` (no burn → null). The
+  reset-aware simulation (`_project_weekly_pool`) is retained and still
+  produces `projected_depletion_hours` / `projected_minimum_remaining_credits`;
+  the two answers differ when a reset lands first, which is exactly what the
+  relief verdict presents.
+- **Relief**: soonest `reset_at` among accounts ≥95% used (they return the
+  most credits); `next_relief_credits` sums `used_percent/100 × capacity` for
+  accounts whose reset falls within 1h of that soonest reset (reset-day
+  clustering, same rule as the ops tooling). `reset_events[]` lists per-account
+  `{at, credits_returned}` for the timeline bar, capped to the next 7 days.
+- **Verdict** (`runway_status`):
+  - `runs_dry`: ETA < time-to-relief (finite ETA)
+  - `tight`: survives, but `eta − relief` is less than 24h or headroom is
+    less than 12%
+  - `safe`: otherwise
+  Legacy `status` is derived for one release: `runs_dry→danger`,
+  `tight→ahead`, `safe→on_track` (`behind` retired).
+- **Censoring guard**: `saturated_account_count` (≥99.5%). When
+  `saturated == account_count`, demand-derived numbers are floors; the card
+  labels them as such.
+- **Attribution**: per-key trailing 2h from `request_logs`: requests, billable
+  tokens (input+output+reasoning), cached tokens, dominant model. No per-key
+  credit estimate in v1 — credits-per-request varies ~5x by workload shape and
+  a wrong number is worse than none; naming the key is the actionable part.
+  Top 3 by requests + top 3 by billable tokens, merged, deduped.
+- **Recommendation**:
+  - First remedy: existing `throttle_to_percent` (already computed, now
+    surfaced) — shown only when `runs_dry`.
+  - `add_pro_accounts`: from trailing-7d fleet demand in quota-weeks
+    (`Σ positive weekly burn / 50,400`) minus current fleet capacity in
+    quota-weeks (`Σ full_credits / 50,400`), ceil,
+    shown only when demand exceeds capacity AND (`runs_dry` or
+    `saturated_account_count > 0`). This is stable across hours and matches
+    the capacity-sizing methodology used for actual purchase decisions.
+
+## Perf / loading
+
+`weekly_credit_pace` is already computed inside `GET /api/dashboard/overview`;
+the card currently waits for the projections query before painting in some
+states. Frontend requirement: paint from the overview payload immediately,
+treat `projections.weeklyCreditPace` as a refinement, and reserve layout with a
+fixed-size skeleton so the card neither pops in late nor shifts.
+
+## Attribution query cost
+
+One aggregate over `request_logs` bounded to 2h (indexed on `requested_at`),
+grouped by `api_key_id`, LIMIT'd. Runs inside the overview handler; measured
+row counts at incident peak (~32K/h) keep this well under the endpoint budget.
+If overview latency regresses, the fallback is moving attribution to the
+projections endpoint — decided at review time with numbers, not preemptively.
+
+## Wire compatibility
+
+All current `WeeklyCreditPaceResponse` fields remain populated for one release
+(the linear-schedule fields keep their current math). New fields are additive.
+Frontend Zod schemas mark new fields optional so older backends parse.
+
+## PR split
+
+1. **Backend**: calc rewrite + schemas + attribution query + unit/integration
+   tests. Reviewable without UI.
+2. **Frontend**: card redesign + utils/schema updates + tests + before/after
+   screenshots (repo rule for dashboard-visible PRs).

--- a/openspec/changes/redesign-weekly-pace-runway/design.md
+++ b/openspec/changes/redesign-weekly-pace-runway/design.md
@@ -1,0 +1,89 @@
+# Design: weekly pace runway model
+
+## Rationale for the model change
+
+The card must answer four operator questions, in order:
+
+1. How much is left? → `headroom_percent`, `headroom_credits`
+2. When does it run out at the current pace? → `depletion_eta_hours`
+3. Does the next reset save us? → `next_relief_in_hours`,
+   `next_relief_credits`, `survives_to_relief`
+4. Who is burning it? → `top_api_keys[]`
+
+These thresholds and the relief-gated verdict were validated by backtesting the
+2026-08-16 incident: a headroom/ETA rule fired 21h (warn) and 5h (crit) before
+user-visible failure, while the linear-schedule delta and `accounts.status`
+gave no usable signal at any point. The same math already runs in the ops
+watchdog (`codex_lb_quota_watch.py`); this change makes the dashboard card and
+the alerting share one truth.
+
+## Calculation details
+
+- **Burn rate**: keep the per-account 6h EWMA (`_recent_burn_rate_credits_per_hour`)
+  for the fleet forecast, but expose the fleet trailing 3h mean as
+  `burn_rate_recent_credits_per_hour` — it is what the ETA headline uses.
+  Rationale: 3h mean is responsive without single-hour jitter, and matched the
+  incident timeline in backtest. EWMA remains an input to the reset-aware
+  simulation.
+- **ETA**: `headroom_credits / burn_rate_recent` (no burn → null). The
+  reset-aware simulation (`_project_weekly_pool`) is retained and still
+  produces `projected_depletion_hours` / `projected_minimum_remaining_credits`;
+  the two answers differ when a reset lands first, which is exactly what the
+  relief verdict presents.
+- **Relief**: soonest `reset_at` among accounts ≥95% used (they return the
+  most credits); `next_relief_credits` sums `used_percent/100 × capacity` for
+  accounts whose reset falls within 1h of that soonest reset (reset-day
+  clustering, same rule as the ops tooling). `reset_events[]` lists per-account
+  `{at, credits_returned}` for the timeline bar, capped to the next 7 days.
+- **Verdict** (`runway_status`):
+  - `runs_dry`: ETA < time-to-relief (finite ETA)
+  - `tight`: survives, but margin (relief − ETA... expressed as
+    `eta − relief`) < 24h or headroom < 12%
+  - `safe`: otherwise
+  Legacy `status` is derived for one release: `runs_dry→danger`,
+  `tight→ahead`, `safe→on_track` (`behind` retired).
+- **Censoring guard**: `saturated_account_count` (≥99.5%). When
+  `saturated == account_count`, demand-derived numbers are floors; the card
+  labels them as such.
+- **Attribution**: per-key trailing 2h from `request_logs`: requests, billable
+  tokens (input+output+reasoning), cached tokens, dominant model. No per-key
+  credit estimate in v1 — credits-per-request varies ~5x by workload shape and
+  a wrong number is worse than none; naming the key is the actionable part.
+  Top 3 by requests + top 3 by billable tokens, merged, deduped.
+- **Recommendation**:
+  - First remedy: existing `throttle_to_percent` (already computed, now
+    surfaced) — shown only when `runs_dry`.
+  - `add_pro_accounts`: from trailing-7d fleet demand in quota-weeks
+    (`Σ positive weekly burn / 50,400`) minus current account count, ceil,
+    shown only when demand exceeds capacity AND (`runs_dry` or
+    `saturated_account_count > 0`). This is stable across hours and matches
+    the capacity-sizing methodology used for actual purchase decisions.
+
+## Perf / loading
+
+`weekly_credit_pace` is already computed inside `GET /api/dashboard/overview`;
+the card currently waits for the projections query before painting in some
+states. Frontend requirement: paint from the overview payload immediately,
+treat `projections.weeklyCreditPace` as a refinement, and reserve layout with a
+fixed-size skeleton so the card neither pops in late nor shifts.
+
+## Attribution query cost
+
+One aggregate over `request_logs` bounded to 2h (indexed on `requested_at`),
+grouped by `api_key_id`, LIMIT'd. Runs inside the overview handler; measured
+row counts at incident peak (~32K/h) keep this well under the endpoint budget.
+If overview latency regresses, the fallback is moving attribution to the
+projections endpoint — decided at review time with numbers, not preemptively.
+
+## Wire compatibility
+
+All current `WeeklyCreditPaceResponse` fields remain populated for one release
+(the linear-schedule fields keep their current math). New fields are additive.
+Frontend Zod schemas mark new fields optional so older backends parse.
+
+## PR split
+
+1. **Backend**: calc rewrite + schemas + attribution query + unit/integration
+   tests. Reviewable without UI.
+2. **Frontend**: card redesign + utils/schema updates + tests + before/after
+   screenshots (repo rule for dashboard-visible PRs).

--- a/openspec/changes/redesign-weekly-pace-runway/proposal.md
+++ b/openspec/changes/redesign-weekly-pace-runway/proposal.md
@@ -1,0 +1,61 @@
+# Redesign weekly pace card: runway vs relief
+
+## Why
+
+The 2026-08-16 pool-exhaustion incident proved the current "Weekly credits pace"
+card answers the wrong question. It compares actual burn against a synthetic
+linear schedule nobody follows, so it reads "31% over planned usage" during
+normal bursty operation and stayed uninformative while the fleet was actually
+running dry. Operators treat it as noise.
+
+Diagnosed defects (verified against `app/modules/dashboard/weekly_pace.py` and
+incident data):
+
+1. **Fictional baseline** — `scheduled_used_percent` assumes uniform linear
+   burn across the window. Real usage is bursty; a gap vs an imaginary plan is
+   not actionable, and the ±5% status thresholds keep the card permanently in
+   a warning state (alarm fatigue).
+2. **The operative question is missing** — "do we run dry BEFORE the next
+   reset returns capacity?" The internal simulation already models resets but
+   the card never surfaces when relief arrives or how much it returns.
+3. **Noisy recommendation** — "add ~N accounts" divides an instantaneous
+   6h-EWMA shortfall by 50,400, so it swings wildly day to day. Account
+   purchases are weekly decisions; an hourly-volatile number destroys trust.
+4. **No attribution** — fleet totals only. During the incident the actionable
+   unit was a single API key (73% of requests); the card gave no way to see it.
+5. **Censoring ignored** — `used_percent` saturates at 100, so demand-derived
+   claims understate need exactly when the fleet is clipped.
+
+## What Changes
+
+- Replace the card's model: linear-schedule pace comparison → **runway vs
+  relief** (headroom, depletion ETA, next reset relief, survives-to-relief
+  verdict).
+- Status semantics change from schedule-gap thresholds to the relief verdict
+  (`safe` / `tight` / `runs_dry`); legacy fields stay populated for one release.
+- Add per-API-key burn attribution (trailing 2h) to the overview payload and
+  card.
+- Rebase the add-capacity recommendation on trailing-7d demand in
+  quota-weeks (stable), gated behind a persistent shortfall; keep
+  `throttle_to_percent` as the first remedy.
+- Frontend card redesign: timeline bar (now → ETA → reset ticks), instant
+  paint from the overview payload (no projections-fetch gate), shared
+  dashboard design primitives.
+
+## Impact
+
+- Affected specs: `frontend-architecture` (Dashboard weekly credits pace
+  requirement)
+- Affected code:
+  - `app/modules/dashboard/weekly_pace.py` (calculation rewrite)
+  - `app/modules/dashboard/schemas.py`, `service.py` (new fields, attribution
+    query wiring)
+  - `app/modules/usage/repository.py` or dashboard repository (per-key 2h
+    rollup query)
+  - `frontend/src/features/dashboard/components/weekly-credits-pace-card.tsx`,
+    `schemas.ts`, `utils.ts` (+ tests)
+- Two stacked PRs: backend (calc + API), frontend (card). One OpenSpec change
+  governs both.
+- Wire compat: all existing response fields remain for one release; new fields
+  are additive. `GET /api/dashboard/overview` and `/projections` shapes stay
+  backward-compatible.

--- a/openspec/changes/redesign-weekly-pace-runway/specs/frontend-architecture/spec.md
+++ b/openspec/changes/redesign-weekly-pace-runway/specs/frontend-architecture/spec.md
@@ -1,0 +1,112 @@
+# frontend-architecture delta
+
+## MODIFIED Requirements
+
+### Requirement: Dashboard weekly credits pace
+
+The dashboard SHALL show weekly quota runway when account weekly capacity credits, remaining credits, reset time, and window length are available. The card MUST present, in priority order: fleet headroom (percent and credits), depletion ETA at the recent burn rate, the next reset relief (arrival time and credits returned), a survives-to-relief verdict, and per-API-key burn attribution for the trailing two hours. The runway calculation MUST use credit totals rather than averaging per-account percentages. The dashboard MUST render the card immediately from the `weeklyCreditPace` object in `GET /api/dashboard/overview` without waiting for any other request, and MAY refine it when the projections payload arrives. Card status MUST derive from the relief verdict (`safe`, `tight`, `runs_dry`) rather than from deviation against a linear schedule. Linear-schedule pace fields SHALL remain populated in the response for one release for wire compatibility.
+
+#### Scenario: Weekly credits pace uses account reset deadlines
+
+- **WHEN** multiple accounts have weekly quota data with different `resetAtSecondary` values
+- **THEN** the system computes depletion, relief, and expected remaining weekly credits from each account's own reset time and window length before summing fleet totals
+
+#### Scenario: Weekly credits pace excludes hard-blocked or stale usage rows
+
+- **WHEN** an account is `reauth_required`, paused, deactivated, missing from the account table, or its latest weekly usage sample is older than the freshness window derived from the usage refresh interval
+- **THEN** the account is not included in weekly runway totals or forecasts
+- **AND** the response reports the excluded stale account count separately from the included account count
+
+#### Scenario: Exhausted accounts still count in weekly credits pace
+
+- **WHEN** an account is `rate_limited` or `quota_exceeded`
+- **AND** it has complete, fresh weekly capacity, remaining credits, reset time, and window length
+- **THEN** the account is included in weekly runway totals and forecasts
+
+#### Scenario: Current schedule gap is separate from forecast shortfall
+
+- **WHEN** actual remaining weekly credits are lower than scheduled remaining weekly credits
+- **THEN** the response reports `scheduleGapCredits` for the current deficit against the linear schedule
+- **AND** the response reports `projectedShortfallCredits` only for a future shortfall forecast based on recent burn
+- **AND** any surface that presents the linear-schedule deficit describes it as over planned usage, fewer credits remaining than scheduled, or equivalent over-consumption wording rather than "behind schedule"
+
+#### Scenario: Displayed pace gap uses configured smoothing
+
+- **GIVEN** the weekly pace gap smoothing window is configured
+- **WHEN** recent weekly usage samples are available for the current weekly reset/window segment
+- **THEN** the response includes `smoothedDeltaPercent`, `smoothedScheduleGapCredits`, and `paceGapSmoothingMinutes`
+- **AND** `actualUsedPercent` remains the live current value
+
+#### Scenario: Weekly pace smoothing resets with quota window
+
+- **GIVEN** a smoothing time window contains samples from before and after a weekly quota reset
+- **WHEN** the latest sample belongs to the new reset/window segment
+- **THEN** the smoothed pace gap excludes the samples from the previous reset/window segment
+
+#### Scenario: Forecast burn uses recent weekly usage slope
+
+- **WHEN** an account has high cumulative weekly usage from earlier in the window but no recent increase in weekly used percent
+- **THEN** the depletion forecast is based on the recent slope and does not assume the earlier full-window average continues
+
+#### Scenario: Near-reset depletion is not a false alarm
+
+- **WHEN** an account has consumed 99% of its weekly quota and 99% of its weekly window has elapsed
+- **THEN** the runway verdict treats that account's imminent reset as relief rather than reporting it as over plan
+
+#### Scenario: Missing weekly credit data is omitted
+
+- **WHEN** an account is missing weekly capacity credits, remaining credits, reset time, or window length
+- **THEN** that account is omitted from weekly runway calculation
+
+#### Scenario: No valid weekly credit data hides pace
+
+- **WHEN** no account has complete, fresh weekly credits pace data for an `active`, `rate_limited`, or `quota_exceeded` account
+- **THEN** the dashboard does not render a fake weekly runway value
+
+#### Scenario: Relief falls back to the full fleet when no account is near exhaustion
+
+- **WHEN** no included account is at or above 95 percent weekly usage
+- **THEN** the next relief time is the soonest reset among all included accounts
+- **AND** the relief credits sum the used credits of included accounts whose reset falls within one hour of that soonest reset
+
+#### Scenario: Verdict reflects whether relief arrives before depletion
+
+- **WHEN** the depletion ETA at the recent burn rate falls before the soonest reset among accounts at or above 95% weekly usage
+- **THEN** the response reports `runwayStatus` as `runs_dry`
+- **AND** the card presents the depletion time and the missed relief time together
+
+#### Scenario: Surviving to relief is not an incident
+
+- **WHEN** the depletion ETA falls after the soonest relief reset
+- **AND** the margin between them is at least 24 hours and fleet headroom is at least 12 percent
+- **THEN** the response reports `runwayStatus` as `safe`
+- **AND** the card renders without warning emphasis
+
+#### Scenario: Per-key attribution names the burn source
+
+- **WHEN** request logs exist in the trailing two hours
+- **THEN** the response lists the top API keys by requests and by billable tokens with request count, billable tokens, and dominant model
+- **AND** the card renders them so an operator can identify the consumer without leaving the dashboard
+
+#### Scenario: Saturated fleet labels demand as a floor
+
+- **WHEN** every included account is at or above 99.5 percent weekly usage
+- **THEN** demand-derived figures are labeled as at-least floors rather than exact demand
+
+#### Scenario: Add-capacity recommendation is stable and gated
+
+- **WHEN** trailing seven-day fleet demand in quota-weeks exceeds current fleet weekly capacity
+- **AND** the runway verdict is `runs_dry` or at least one account is saturated
+- **THEN** the response recommends additional Pro accounts computed from the weekly demand surplus
+- **AND** the recommendation does not change materially from hour to hour under steady traffic
+
+#### Scenario: Throttle guidance precedes purchase guidance
+
+- **WHEN** the runway verdict is `runs_dry`
+- **AND** `throttleToPercent` is available
+- **THEN** the card presents throttling to the sustainable rate as the first remedy before any add-capacity suggestion
+
+#### Scenario: Card paints without the projections request
+
+- **WHEN** the overview response has arrived and the projections request is still in flight or failed
+- **THEN** the weekly runway card renders its full content from the overview payload with a stable layout footprint

--- a/openspec/changes/redesign-weekly-pace-runway/specs/frontend-architecture/spec.md
+++ b/openspec/changes/redesign-weekly-pace-runway/specs/frontend-architecture/spec.md
@@ -1,0 +1,106 @@
+# frontend-architecture delta
+
+## MODIFIED Requirements
+
+### Requirement: Dashboard weekly credits pace
+
+The dashboard SHALL show weekly quota runway when account weekly capacity credits, remaining credits, reset time, and window length are available. The card MUST present, in priority order: fleet headroom (percent and credits), depletion ETA at the recent burn rate, the next reset relief (arrival time and credits returned), a survives-to-relief verdict, and per-API-key burn attribution for the trailing two hours. The runway calculation MUST use credit totals rather than averaging per-account percentages. The dashboard MUST render the card immediately from the `weeklyCreditPace` object in `GET /api/dashboard/overview` without waiting for any other request, and MAY refine it when the projections payload arrives. Card status MUST derive from the relief verdict (`safe`, `tight`, `runs_dry`) rather than from deviation against a linear schedule. Linear-schedule pace fields SHALL remain populated in the response for one release for wire compatibility.
+
+#### Scenario: Weekly credits pace uses account reset deadlines
+
+- **WHEN** multiple accounts have weekly quota data with different `resetAtSecondary` values
+- **THEN** the system computes depletion, relief, and expected remaining weekly credits from each account's own reset time and window length before summing fleet totals
+
+#### Scenario: Weekly credits pace excludes hard-blocked or stale usage rows
+
+- **WHEN** an account is `reauth_required`, paused, deactivated, missing from the account table, or its latest weekly usage sample is older than the freshness window derived from the usage refresh interval
+- **THEN** the account is not included in weekly runway totals or forecasts
+- **AND** the response reports the excluded stale account count separately from the included account count
+
+#### Scenario: Exhausted accounts still count in weekly credits pace
+
+- **WHEN** an account is `rate_limited` or `quota_exceeded`
+- **AND** it has complete, fresh weekly capacity, remaining credits, reset time, and window length
+- **THEN** the account is included in weekly runway totals and forecasts
+
+#### Scenario: Current schedule gap is separate from forecast shortfall
+
+- **WHEN** actual remaining weekly credits are lower than scheduled remaining weekly credits
+- **THEN** the response reports `scheduleGapCredits` for the current deficit against the linear schedule
+- **AND** the response reports `projectedShortfallCredits` only for a future shortfall forecast based on recent burn
+- **AND** any surface that presents the linear-schedule deficit describes it as over planned usage, fewer credits remaining than scheduled, or equivalent over-consumption wording rather than "behind schedule"
+
+#### Scenario: Displayed pace gap uses configured smoothing
+
+- **GIVEN** the weekly pace gap smoothing window is configured
+- **WHEN** recent weekly usage samples are available for the current weekly reset/window segment
+- **THEN** the response includes `smoothedDeltaPercent`, `smoothedScheduleGapCredits`, and `paceGapSmoothingMinutes`
+- **AND** `actualUsedPercent` remains the live current value
+
+#### Scenario: Weekly pace smoothing resets with quota window
+
+- **GIVEN** a smoothing time window contains samples from before and after a weekly quota reset
+- **WHEN** the latest sample belongs to the new reset/window segment
+- **THEN** the smoothed pace gap excludes the samples from the previous reset/window segment
+
+#### Scenario: Forecast burn uses recent weekly usage slope
+
+- **WHEN** an account has high cumulative weekly usage from earlier in the window but no recent increase in weekly used percent
+- **THEN** the depletion forecast is based on the recent slope and does not assume the earlier full-window average continues
+
+#### Scenario: Near-reset depletion is not a false alarm
+
+- **WHEN** an account has consumed 99% of its weekly quota and 99% of its weekly window has elapsed
+- **THEN** the runway verdict treats that account's imminent reset as relief rather than reporting it as over plan
+
+#### Scenario: Missing weekly credit data is omitted
+
+- **WHEN** an account is missing weekly capacity credits, remaining credits, reset time, or window length
+- **THEN** that account is omitted from weekly runway calculation
+
+#### Scenario: No valid weekly credit data hides pace
+
+- **WHEN** no account has complete, fresh weekly credits pace data for an `active`, `rate_limited`, or `quota_exceeded` account
+- **THEN** the dashboard does not render a fake weekly runway value
+
+#### Scenario: Verdict reflects whether relief arrives before depletion
+
+- **WHEN** the depletion ETA at the recent burn rate falls before the soonest reset among accounts at or above 95% weekly usage
+- **THEN** the response reports `runwayStatus` as `runs_dry`
+- **AND** the card presents the depletion time and the missed relief time together
+
+#### Scenario: Surviving to relief is not an incident
+
+- **WHEN** the depletion ETA falls after the soonest relief reset
+- **AND** the margin between them is at least 24 hours and fleet headroom is at least 12 percent
+- **THEN** the response reports `runwayStatus` as `safe`
+- **AND** the card renders without warning emphasis
+
+#### Scenario: Per-key attribution names the burn source
+
+- **WHEN** request logs exist in the trailing two hours
+- **THEN** the response lists the top API keys by requests and by billable tokens with request count, billable tokens, and dominant model
+- **AND** the card renders them so an operator can identify the consumer without leaving the dashboard
+
+#### Scenario: Saturated fleet labels demand as a floor
+
+- **WHEN** every included account is at or above 99.5 percent weekly usage
+- **THEN** demand-derived figures are labeled as at-least floors rather than exact demand
+
+#### Scenario: Add-capacity recommendation is stable and gated
+
+- **WHEN** trailing seven-day fleet demand in quota-weeks exceeds current fleet weekly capacity
+- **AND** the runway verdict is `runs_dry` or at least one account is saturated
+- **THEN** the response recommends additional Pro accounts computed from the weekly demand surplus
+- **AND** the recommendation does not change materially from hour to hour under steady traffic
+
+#### Scenario: Throttle guidance precedes purchase guidance
+
+- **WHEN** the runway verdict is `runs_dry`
+- **AND** `throttleToPercent` is available
+- **THEN** the card presents throttling to the sustainable rate as the first remedy before any add-capacity suggestion
+
+#### Scenario: Card paints without the projections request
+
+- **WHEN** the overview response has arrived and the projections request is still in flight or failed
+- **THEN** the weekly runway card renders its full content from the overview payload with a stable layout footprint

--- a/openspec/changes/redesign-weekly-pace-runway/tasks.md
+++ b/openspec/changes/redesign-weekly-pace-runway/tasks.md
@@ -1,0 +1,28 @@
+# Tasks
+
+## 1. Backend — runway calculation + attribution (PR 1)
+
+- [ ] 1.1 Add runway fields to `WeeklyCreditPaceResponse` (additive): `headroom_percent`, `headroom_credits`, `burn_rate_recent_credits_per_hour`, `depletion_eta_hours`, `next_relief_in_hours`, `next_relief_credits`, `reset_events`, `runway_status`, `saturated_account_count`, `top_api_keys`, `add_pro_accounts`
+- [ ] 1.2 Implement runway math in `weekly_pace.py`: trailing-3h fleet burn, ETA, relief clustering (≥95% cohort, 1h reset-day cluster), verdict per design.md; keep legacy fields populated with current math
+- [ ] 1.3 Map legacy `status` from `runway_status` (`runs_dry→danger`, `tight→ahead`, `safe→on_track`)
+- [ ] 1.4 Per-key trailing-2h attribution query (repository) + wire into overview service; LIMIT + index check on `request_logs(requested_at)`
+- [ ] 1.5 Stable `add_pro_accounts` from trailing-7d quota-weeks demand, gated per spec
+- [ ] 1.6 Unit tests: verdict branches (runs_dry/tight/safe), relief clustering, censoring label, attribution merge/dedupe, legacy status mapping
+- [ ] 1.7 Integration test: overview payload carries new fields; older-shape compatibility
+- [ ] 1.8 `make lint` + `uv run ty check` + unfiltered `tests/unit`
+
+## 2. Frontend — card redesign (PR 2, after PR 1 merges)
+
+- [ ] 2.1 Zod schema additions (optional fields, older-backend tolerant)
+- [ ] 2.2 Card rewrite: header verdict badge, four-question layout (headroom / ETA / relief / attribution), timeline bar (now → ETA marker → reset ticks)
+- [ ] 2.3 Instant paint from overview; projections as refinement; fixed-footprint skeleton
+- [ ] 2.4 Design alignment with existing dashboard primitives (tokens, spacing, muted palette; no bespoke one-off styles)
+- [ ] 2.5 Conditional remedies: throttle-first when runs_dry; add-capacity only when gated on
+- [ ] 2.6 i18n: en/ko/zh-CN strings
+- [ ] 2.7 Component tests: verdict rendering, attribution list, no-projections paint, saturated floor label
+- [ ] 2.8 Frontend gates (typecheck/lint/build/vitest) + before/after screenshots
+
+## 3. Spec sync & archive
+
+- [ ] 3.1 `openspec validate redesign-weekly-pace-runway` clean
+- [ ] 3.2 After both PRs merge: `/opsx:sync` then `/opsx:archive`

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -8,7 +8,7 @@ import pytest
 
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import naive_utc_to_epoch, utcnow
-from app.db.models import Account, AccountStatus, RequestLog
+from app.db.models import Account, AccountStatus, ApiKey, RequestLog
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.accounts.schemas import AccountSummary
@@ -151,6 +151,96 @@ async def test_dashboard_overview_combines_data(async_client, db_setup):
     assert any(v > 0 for v in request_values)
     conversation_values = [p["v"] for p in trends["conversations"]]
     assert any(v > 0 for v in conversation_values)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_overview_carries_weekly_runway_fields_and_attribution(
+    async_client,
+    db_setup,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fixed_now = datetime(2026, 8, 17, 12, 0, 0)
+    monkeypatch.setattr("app.modules.dashboard.service.utcnow", lambda: fixed_now)
+    reset_at = int(naive_utc_to_epoch(fixed_now + timedelta(hours=4)))
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+        await accounts_repo.upsert(_make_account("acc-runway", "runway@example.com", plan_type="pro"))
+        for minutes_ago, used_percent in (
+            (170, 70.0),
+            (130, 80.0),
+            (110, 80.0),
+            (70, 90.0),
+            (50, 90.0),
+            (1, 95.0),
+        ):
+            await usage_repo.add_entry(
+                "acc-runway",
+                used_percent,
+                window="secondary",
+                window_minutes=10_080,
+                reset_at=reset_at,
+                recorded_at=fixed_now - timedelta(minutes=minutes_ago),
+            )
+        session.add(ApiKey(id="key-runway", name="Runway key", key_hash="hash-runway", key_prefix="run"))
+        session.add(
+            RequestLog(
+                account_id="acc-runway",
+                api_key_id="key-runway",
+                request_id="runway-request",
+                requested_at=fixed_now - timedelta(minutes=10),
+                model="gpt-5.1",
+                status="success",
+                input_tokens=100,
+                output_tokens=25,
+                reasoning_tokens=10,
+                cached_input_tokens=20,
+            )
+        )
+        await session.commit()
+
+    response = await async_client.get("/api/dashboard/overview")
+
+    assert response.status_code == 200
+    pace = response.json()["weeklyCreditPace"]
+    assert pace is not None
+    assert pace["headroomPercent"] == pytest.approx(5.0)
+    assert pace["headroomCredits"] == pytest.approx(2_520.0)
+    assert pace["burnRateRecentCreditsPerHour"] == pytest.approx(4_473.3727810651)
+    assert pace["depletionEtaHours"] == pytest.approx(0.5633333333)
+    assert pace["nextReliefInHours"] == pytest.approx(4.0)
+    assert pace["nextReliefCredits"] == pytest.approx(47_880.0)
+    assert pace["runwayStatus"] == "runs_dry"
+    assert pace["status"] == "danger"
+    assert pace["saturatedAccountCount"] == 0
+    assert pace["addProAccounts"] is None
+    assert len(pace["resetEvents"]) == 1
+    assert pace["topApiKeys"] == [
+        {
+            "apiKeyId": "key-runway",
+            "name": "Runway key",
+            "requests": 1,
+            "billableTokens": 125,
+            "cachedTokens": 20,
+            "dominantModel": "gpt-5.1",
+        }
+    ]
+    assert pace["scheduledUsedPercent"] == pytest.approx(97.619, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_overview_omits_weekly_pace_value_without_weekly_data(
+    async_client,
+    db_setup,
+):
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(_make_account("acc-no-weekly", "no-weekly@example.com"))
+
+    response = await async_client.get("/api/dashboard/overview")
+
+    assert response.status_code == 200
+    assert response.json()["weeklyCreditPace"] is None
 
 
 @pytest.mark.asyncio
@@ -669,7 +759,10 @@ async def test_dashboard_projections_weekly_credit_pace_excludes_inactive_and_st
     assert pace["actualUsedPercent"] == pytest.approx(73.333, abs=0.01)
     assert pace["scheduledUsedPercent"] == pytest.approx(42.857, abs=0.01)
     assert pace["scheduleGapCredits"] == pytest.approx(46_080.0, abs=1.0)
-    assert pace["status"] == "ahead"
+    # No account has two fresh samples, so burn is unmeasured and headroom is
+    # ~26.7%: the runway verdict is safe, which maps to legacy on_track.
+    assert pace["runwayStatus"] == "safe"
+    assert pace["status"] == "on_track"
 
 
 @pytest.mark.asyncio
@@ -725,7 +818,7 @@ async def test_dashboard_projections_weekly_credit_pace_forecast_uses_recent_slo
     assert pace["forecastBurnRateCreditsPerHour"] == pytest.approx(0.0)
     assert pace["paceMultiplier"] == pytest.approx(0.0)
     assert pace["pauseForBreakEvenHours"] is None
-    assert pace["status"] == "ahead"
+    assert pace["status"] == "on_track"
 
 
 @pytest.mark.asyncio
@@ -859,7 +952,7 @@ async def test_dashboard_projections_weekly_credit_pace_uses_configured_working_
     assert pace["actualUsedPercent"] == pytest.approx(80.0)
     assert pace["scheduledUsedPercent"] == pytest.approx(100.0)
     assert pace["scheduleGapCredits"] == 0
-    assert pace["status"] == "behind"
+    assert pace["status"] == "on_track"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -8,7 +8,7 @@ import pytest
 
 from app.core.crypto import TokenEncryptor
 from app.core.utils.time import naive_utc_to_epoch, utcnow
-from app.db.models import Account, AccountStatus, RequestLog
+from app.db.models import Account, AccountStatus, ApiKey, RequestLog
 from app.db.session import SessionLocal
 from app.modules.accounts.repository import AccountsRepository
 from app.modules.accounts.schemas import AccountSummary
@@ -151,6 +151,95 @@ async def test_dashboard_overview_combines_data(async_client, db_setup):
     assert any(v > 0 for v in request_values)
     conversation_values = [p["v"] for p in trends["conversations"]]
     assert any(v > 0 for v in conversation_values)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_overview_carries_weekly_runway_fields_and_attribution(
+    async_client,
+    db_setup,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    fixed_now = datetime(2026, 8, 17, 12, 0, 0)
+    monkeypatch.setattr("app.modules.dashboard.service.utcnow", lambda: fixed_now)
+    reset_at = int(naive_utc_to_epoch(fixed_now + timedelta(hours=4)))
+
+    async with SessionLocal() as session:
+        accounts_repo = AccountsRepository(session)
+        usage_repo = UsageRepository(session)
+        await accounts_repo.upsert(_make_account("acc-runway", "runway@example.com", plan_type="pro"))
+        for minutes_ago, used_percent in (
+            (170, 70.0),
+            (130, 80.0),
+            (110, 80.0),
+            (70, 90.0),
+            (50, 90.0),
+            (1, 95.0),
+        ):
+            await usage_repo.add_entry(
+                "acc-runway",
+                used_percent,
+                window="secondary",
+                window_minutes=10_080,
+                reset_at=reset_at,
+                recorded_at=fixed_now - timedelta(minutes=minutes_ago),
+            )
+        session.add(ApiKey(id="key-runway", name="Runway key", key_hash="hash-runway", key_prefix="run"))
+        session.add(
+            RequestLog(
+                account_id="acc-runway",
+                api_key_id="key-runway",
+                request_id="runway-request",
+                requested_at=fixed_now - timedelta(minutes=10),
+                model="gpt-5.1",
+                status="success",
+                input_tokens=100,
+                output_tokens=25,
+                reasoning_tokens=10,
+                cached_input_tokens=20,
+            )
+        )
+        await session.commit()
+
+    response = await async_client.get("/api/dashboard/overview")
+
+    assert response.status_code == 200
+    pace = response.json()["weeklyCreditPace"]
+    assert pace is not None
+    assert pace["headroomPercent"] == pytest.approx(5.0)
+    assert pace["headroomCredits"] == pytest.approx(2_520.0)
+    assert pace["burnRateRecentCreditsPerHour"] == pytest.approx(4_200.0)
+    assert pace["depletionEtaHours"] == pytest.approx(0.6)
+    assert pace["nextReliefInHours"] == pytest.approx(4.0)
+    assert pace["nextReliefCredits"] == pytest.approx(47_880.0)
+    assert pace["runwayStatus"] == "runs_dry"
+    assert pace["status"] == "danger"
+    assert pace["saturatedAccountCount"] == 0
+    assert pace["addProAccounts"] is None
+    assert len(pace["resetEvents"]) == 1
+    assert pace["topApiKeys"] == [
+        {
+            "name": "Runway key",
+            "requests": 1,
+            "billableTokens": 135,
+            "cachedTokens": 20,
+            "dominantModel": "gpt-5.1",
+        }
+    ]
+    assert pace["scheduledUsedPercent"] == pytest.approx(97.619, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_dashboard_overview_omits_weekly_pace_value_without_weekly_data(
+    async_client,
+    db_setup,
+):
+    async with SessionLocal() as session:
+        await AccountsRepository(session).upsert(_make_account("acc-no-weekly", "no-weekly@example.com"))
+
+    response = await async_client.get("/api/dashboard/overview")
+
+    assert response.status_code == 200
+    assert response.json()["weeklyCreditPace"] is None
 
 
 @pytest.mark.asyncio
@@ -669,7 +758,7 @@ async def test_dashboard_projections_weekly_credit_pace_excludes_inactive_and_st
     assert pace["actualUsedPercent"] == pytest.approx(60.0)
     assert pace["scheduledUsedPercent"] == pytest.approx(42.857, abs=0.01)
     assert pace["scheduleGapCredits"] == pytest.approx(17_280.0, abs=1.0)
-    assert pace["status"] == "ahead"
+    assert pace["status"] == "on_track"
 
 
 @pytest.mark.asyncio
@@ -725,7 +814,7 @@ async def test_dashboard_projections_weekly_credit_pace_forecast_uses_recent_slo
     assert pace["forecastBurnRateCreditsPerHour"] == pytest.approx(0.0)
     assert pace["paceMultiplier"] == pytest.approx(0.0)
     assert pace["pauseForBreakEvenHours"] is None
-    assert pace["status"] == "ahead"
+    assert pace["status"] == "on_track"
 
 
 @pytest.mark.asyncio
@@ -859,7 +948,7 @@ async def test_dashboard_projections_weekly_credit_pace_uses_configured_working_
     assert pace["actualUsedPercent"] == pytest.approx(80.0)
     assert pace["scheduledUsedPercent"] == pytest.approx(100.0)
     assert pace["scheduleGapCredits"] == 0
-    assert pace["status"] == "behind"
+    assert pace["status"] == "on_track"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_dashboard_overview.py
+++ b/tests/integration/test_dashboard_overview.py
@@ -207,8 +207,8 @@ async def test_dashboard_overview_carries_weekly_runway_fields_and_attribution(
     assert pace is not None
     assert pace["headroomPercent"] == pytest.approx(5.0)
     assert pace["headroomCredits"] == pytest.approx(2_520.0)
-    assert pace["burnRateRecentCreditsPerHour"] == pytest.approx(4_200.0)
-    assert pace["depletionEtaHours"] == pytest.approx(0.6)
+    assert pace["burnRateRecentCreditsPerHour"] == pytest.approx(4_473.3727810651)
+    assert pace["depletionEtaHours"] == pytest.approx(0.5633333333)
     assert pace["nextReliefInHours"] == pytest.approx(4.0)
     assert pace["nextReliefCredits"] == pytest.approx(47_880.0)
     assert pace["runwayStatus"] == "runs_dry"
@@ -218,9 +218,10 @@ async def test_dashboard_overview_carries_weekly_runway_fields_and_attribution(
     assert len(pace["resetEvents"]) == 1
     assert pace["topApiKeys"] == [
         {
+            "apiKeyId": "key-runway",
             "name": "Runway key",
             "requests": 1,
-            "billableTokens": 135,
+            "billableTokens": 125,
             "cachedTokens": 20,
             "dominantModel": "gpt-5.1",
         }

--- a/tests/unit/test_dashboard_weekly_pace.py
+++ b/tests/unit/test_dashboard_weekly_pace.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import cast
+
+import pytest
+from sqlalchemy import Table
+
+from app.core.utils.time import naive_utc_to_epoch
+from app.db.models import Account, AccountStatus, ApiKey, RequestLog, UsageHistory
+from app.db.session import SessionLocal
+from app.modules.accounts.schemas import AccountSummary
+from app.modules.dashboard.repository import DashboardRepository
+from app.modules.dashboard.weekly_pace import PRO_WEEKLY_CAPACITY_CREDITS, build_weekly_credit_pace
+
+NOW = datetime(2026, 8, 17, 12, 0, 0)
+
+
+def _account(account_id: str) -> Account:
+    return Account(id=account_id, status=AccountStatus.ACTIVE)
+
+
+def _summary(
+    account_id: str,
+    *,
+    used_percent: float,
+    reset_in_hours: float,
+    capacity: float = PRO_WEEKLY_CAPACITY_CREDITS,
+) -> AccountSummary:
+    return AccountSummary(
+        account_id=account_id,
+        email=f"{account_id}@example.com",
+        display_name=account_id,
+        plan_type="pro",
+        status="active",
+        reset_at_secondary=NOW + timedelta(hours=reset_in_hours),
+        window_minutes_secondary=10_080,
+        capacity_credits_secondary=capacity,
+        remaining_credits_secondary=capacity * (1.0 - used_percent / 100.0),
+    )
+
+
+def _row(account_id: str, used_percent: float, recorded_at: datetime) -> UsageHistory:
+    return UsageHistory(
+        account_id=account_id,
+        used_percent=used_percent,
+        recorded_at=recorded_at,
+        window="secondary",
+        reset_at=int(naive_utc_to_epoch(NOW + timedelta(days=1))),
+        window_minutes=10_080,
+    )
+
+
+def _three_hour_history(account_id: str, *, final_used_percent: float, hourly_delta: float) -> list[UsageHistory]:
+    values = [
+        final_used_percent - 3 * hourly_delta,
+        final_used_percent - 2 * hourly_delta,
+        final_used_percent - 2 * hourly_delta,
+        final_used_percent - hourly_delta,
+        final_used_percent - hourly_delta,
+        final_used_percent,
+    ]
+    offsets = [170, 130, 110, 70, 50, 1]
+    return [_row(account_id, value, NOW - timedelta(minutes=offset)) for value, offset in zip(values, offsets)]
+
+
+def _build(
+    summaries: list[AccountSummary],
+    histories: dict[str, list[UsageHistory]],
+    *,
+    trailing_demand_used_percent_by_account: dict[str, float] | None = None,
+):
+    pace = build_weekly_credit_pace(
+        accounts=[_account(summary.account_id) for summary in summaries],
+        account_summaries=summaries,
+        secondary_history=histories,
+        now=NOW,
+        usage_refresh_interval_seconds=60,
+        trailing_demand_used_percent_by_account=trailing_demand_used_percent_by_account,
+    )
+    assert pace is not None
+    return pace
+
+
+@pytest.mark.parametrize(
+    ("used_percent", "reset_in_hours", "hourly_delta", "runway_status", "legacy_status"),
+    [
+        (90.0, 5.0, 10.0, "runs_dry", "danger"),
+        (80.0, 1.0, 10.0, "tight", "ahead"),
+        (20.0, 1.0, 1.0, "safe", "on_track"),
+    ],
+)
+def test_weekly_pace_verdict_branches_and_legacy_status_mapping(
+    used_percent: float,
+    reset_in_hours: float,
+    hourly_delta: float,
+    runway_status: str,
+    legacy_status: str,
+) -> None:
+    account_id = f"acc-{runway_status}"
+    pace = _build(
+        [_summary(account_id, used_percent=used_percent, reset_in_hours=reset_in_hours)],
+        {account_id: _three_hour_history(account_id, final_used_percent=used_percent, hourly_delta=hourly_delta)},
+    )
+
+    assert pace.runway_status == runway_status
+    assert pace.status == legacy_status
+    assert pace.burn_rate_recent_credits_per_hour is not None
+    assert pace.depletion_eta_hours is not None
+
+
+def test_weekly_pace_relief_clusters_resets_within_one_hour() -> None:
+    summaries = [
+        _summary("acc-first", used_percent=96.0, reset_in_hours=2.0),
+        _summary("acc-clustered", used_percent=97.0, reset_in_hours=2.5),
+        _summary("acc-later", used_percent=98.0, reset_in_hours=5.0),
+    ]
+    histories = {
+        summary.account_id: [_row(summary.account_id, used, NOW - timedelta(minutes=1))]
+        for summary, used in zip(summaries, (96.0, 97.0, 98.0))
+    }
+
+    pace = _build(summaries, histories)
+
+    assert pace.next_relief_in_hours == pytest.approx(2.0)
+    assert pace.next_relief_credits == pytest.approx(PRO_WEEKLY_CAPACITY_CREDITS * 1.93)
+    assert len(pace.reset_events) == 3
+
+
+def test_weekly_pace_relief_falls_back_to_all_accounts_below_cohort_threshold() -> None:
+    summaries = [
+        _summary("acc-low-a", used_percent=40.0, reset_in_hours=3.0),
+        _summary("acc-low-b", used_percent=20.0, reset_in_hours=6.0),
+    ]
+    histories = {
+        summary.account_id: [_row(summary.account_id, used, NOW - timedelta(minutes=1))]
+        for summary, used in zip(summaries, (40.0, 20.0))
+    }
+
+    pace = _build(summaries, histories)
+
+    assert pace.next_relief_in_hours == pytest.approx(3.0)
+    assert pace.next_relief_credits == pytest.approx(PRO_WEEKLY_CAPACITY_CREDITS * 0.4)
+
+
+def test_weekly_pace_recent_burn_counts_delta_across_hour_boundary() -> None:
+    account_id = "acc-cross-hour"
+    pace = _build(
+        [_summary(account_id, used_percent=80.0, reset_in_hours=2.0)],
+        {
+            account_id: [
+                _row(account_id, 70.0, NOW - timedelta(minutes=61)),
+                _row(account_id, 80.0, NOW - timedelta(minutes=59)),
+                _row(account_id, 80.0, NOW - timedelta(minutes=1)),
+            ]
+        },
+    )
+
+    assert pace.burn_rate_recent_credits_per_hour == pytest.approx(5_040.0)
+
+
+def test_weekly_pace_recent_burn_uses_floored_observed_span() -> None:
+    account_id = "acc-short-span"
+    pace = _build(
+        [_summary(account_id, used_percent=80.0, reset_in_hours=2.0)],
+        {
+            account_id: [
+                _row(account_id, 70.0, NOW - timedelta(minutes=6)),
+                _row(account_id, 80.0, NOW - timedelta(minutes=1)),
+            ]
+        },
+    )
+
+    assert pace.burn_rate_recent_credits_per_hour == pytest.approx(10_080.0)
+
+
+def test_weekly_pace_recent_burn_skips_reset_delta() -> None:
+    account_id = "acc-reset"
+    pace = _build(
+        [_summary(account_id, used_percent=10.0, reset_in_hours=2.0)],
+        {
+            account_id: [
+                _row(account_id, 80.0, NOW - timedelta(minutes=6)),
+                _row(account_id, 10.0, NOW - timedelta(minutes=1)),
+            ]
+        },
+    )
+
+    assert pace.burn_rate_recent_credits_per_hour == pytest.approx(0.0)
+
+
+def test_weekly_pace_recent_burn_ignores_single_sample_accounts() -> None:
+    summaries = [
+        _summary("acc-single-a", used_percent=70.0, reset_in_hours=2.0),
+        _summary("acc-single-b", used_percent=80.0, reset_in_hours=3.0),
+    ]
+    pace = _build(
+        summaries,
+        {
+            summary.account_id: [_row(summary.account_id, used, NOW - timedelta(minutes=1))]
+            for summary, used in zip(summaries, (70.0, 80.0))
+        },
+    )
+
+    assert pace.burn_rate_recent_credits_per_hour is None
+
+
+def test_weekly_pace_near_reset_is_relief_not_runs_dry() -> None:
+    summary = _summary("acc-near-reset", used_percent=99.0, reset_in_hours=1.68)
+    pace = _build(
+        [summary],
+        {
+            summary.account_id: _three_hour_history(
+                summary.account_id,
+                final_used_percent=99.0,
+                hourly_delta=0.0,
+            )
+        },
+    )
+
+    assert pace.next_relief_in_hours == pytest.approx(1.68)
+    assert pace.next_relief_credits == pytest.approx(PRO_WEEKLY_CAPACITY_CREDITS * 0.99)
+    assert pace.depletion_eta_hours is None
+    assert pace.runway_status == "tight"
+    assert pace.status == "ahead"
+
+
+def test_weekly_pace_counts_saturated_accounts() -> None:
+    summaries = [
+        _summary("acc-saturated", used_percent=99.5, reset_in_hours=2.0),
+        _summary("acc-not-saturated", used_percent=99.49, reset_in_hours=2.0),
+    ]
+    histories = {
+        summary.account_id: [_row(summary.account_id, used, NOW - timedelta(minutes=1))]
+        for summary, used in zip(summaries, (99.5, 99.49))
+    }
+
+    pace = _build(summaries, histories)
+
+    assert pace.saturated_account_count == 1
+
+
+def _multi_window_history(account_id: str, final_used_percent: float) -> list[UsageHistory]:
+    points = [
+        (timedelta(days=6, hours=20), 0.0),
+        (timedelta(days=6), 90.0),
+        (timedelta(days=5), 1.0),
+        (timedelta(days=4), 91.0),
+        (timedelta(days=3), 2.0),
+        (timedelta(days=2), 92.0),
+        (timedelta(minutes=1), final_used_percent),
+    ]
+    return [_row(account_id, used, NOW - age) for age, used in points]
+
+
+def test_weekly_pace_add_pro_accounts_is_gated_on_for_saturation() -> None:
+    account_id = "acc-demand-saturated"
+    pace = _build(
+        [_summary(account_id, used_percent=99.5, reset_in_hours=2.0)],
+        {account_id: _multi_window_history(account_id, 99.5)},
+        trailing_demand_used_percent_by_account={account_id: 277.5},
+    )
+
+    assert pace.saturated_account_count == 1
+    assert pace.add_pro_accounts == 2
+
+
+def test_weekly_pace_add_pro_accounts_uses_fleet_capacity_on_mixed_fleets() -> None:
+    pro_id = "acc-mixed-pro"
+    plus_id = "acc-mixed-plus"
+    summaries = [
+        _summary(pro_id, used_percent=99.5, reset_in_hours=2.0),
+        _summary(plus_id, used_percent=99.5, reset_in_hours=2.0, capacity=7_560.0),
+    ]
+    histories = {
+        summary.account_id: [_row(summary.account_id, 99.5, NOW - timedelta(minutes=1))] for summary in summaries
+    }
+
+    pace = _build(
+        summaries,
+        histories,
+        trailing_demand_used_percent_by_account={pro_id: 110.0, plus_id: 300.0},
+    )
+
+    # Demand is 78,120 credits (1.55 Pro-weeks) against 57,960 credits of fleet
+    # capacity (1.15 Pro-weeks). A seat-count basis would treat the Plus account
+    # as a full Pro seat (1.55 - 2 < 0) and suppress the recommendation; the
+    # capacity basis recommends one extra Pro account.
+    assert pace.saturated_account_count == 2
+    assert pace.add_pro_accounts == 1
+
+
+def test_weekly_pace_add_pro_accounts_is_gated_off_without_distress() -> None:
+    account_id = "acc-demand-safe"
+    pace = _build(
+        [_summary(account_id, used_percent=20.0, reset_in_hours=1.0)],
+        {account_id: _multi_window_history(account_id, 20.0)},
+    )
+
+    assert pace.runway_status == "safe"
+    assert pace.saturated_account_count == 0
+    assert pace.add_pro_accounts is None
+
+
+def test_weekly_pace_add_pro_accounts_is_none_without_demand_surplus() -> None:
+    account_id = "acc-no-surplus"
+    pace = _build(
+        [_summary(account_id, used_percent=99.5, reset_in_hours=2.0)],
+        {account_id: [_row(account_id, 99.5, NOW - timedelta(minutes=1))]},
+        trailing_demand_used_percent_by_account={account_id: 100.0},
+    )
+
+    assert pace.saturated_account_count == 1
+    assert pace.add_pro_accounts is None
+
+
+def test_weekly_pace_add_pro_accounts_is_none_without_sql_demand_mapping() -> None:
+    account_id = "acc-demand-without-mapping"
+    pace = _build(
+        [_summary(account_id, used_percent=99.5, reset_in_hours=2.0)],
+        {account_id: _multi_window_history(account_id, 99.5)},
+        trailing_demand_used_percent_by_account=None,
+    )
+
+    assert pace.saturated_account_count == 1
+    assert pace.add_pro_accounts is None
+
+
+@pytest.mark.asyncio
+async def test_weekly_pace_attribution_merges_rankings_and_dedupes_unnamed_key(db_setup) -> None:
+    del db_setup
+    async with SessionLocal() as session:
+        session.add(ApiKey(id="key-alpha", name="Alpha", key_hash="hash-alpha", key_prefix="alpha"))
+        session.add_all(
+            [
+                RequestLog(
+                    api_key_id="key-alpha",
+                    request_id=f"alpha-{index}",
+                    requested_at=NOW - timedelta(minutes=index + 1),
+                    model="gpt-alpha" if index < 3 else "gpt-other",
+                    status="success",
+                    input_tokens=10,
+                    output_tokens=5,
+                    reasoning_tokens=2,
+                    cached_input_tokens=3,
+                )
+                for index in range(4)
+            ]
+        )
+        session.add_all(
+            [
+                RequestLog(
+                    api_key_id="missing-key",
+                    request_id=f"unnamed-{index}",
+                    requested_at=NOW - timedelta(minutes=10 + index),
+                    model="gpt-unnamed",
+                    status="success",
+                    input_tokens=20,
+                    output_tokens=1,
+                    reasoning_tokens=0,
+                    cached_input_tokens=4,
+                )
+                for index in range(3)
+            ]
+        )
+        session.add(
+            RequestLog(
+                api_key_id="key-token-heavy",
+                request_id="token-heavy",
+                requested_at=NOW - timedelta(minutes=20),
+                model="gpt-heavy",
+                status="success",
+                input_tokens=1_000,
+                output_tokens=500,
+                reasoning_tokens=250,
+                cached_input_tokens=100,
+            )
+        )
+        session.add(
+            RequestLog(
+                api_key_id="key-alpha",
+                request_id="deleted-alpha",
+                requested_at=NOW - timedelta(minutes=1),
+                deleted_at=NOW,
+                model="gpt-deleted",
+                status="success",
+                input_tokens=50_000,
+            )
+        )
+        session.add(
+            RequestLog(
+                api_key_id="key-alpha",
+                request_id="future-alpha",
+                requested_at=NOW + timedelta(minutes=1),
+                model="gpt-future",
+                status="success",
+                input_tokens=50_000,
+            )
+        )
+        session.add_all(
+            [
+                RequestLog(
+                    api_key_id="key-warmup-only",
+                    request_id=f"warmup-{kind}",
+                    requested_at=NOW - timedelta(minutes=5),
+                    request_kind=kind,
+                    model="gpt-warmup",
+                    status="success",
+                    input_tokens=900_000,
+                    output_tokens=900_000,
+                )
+                for kind in ("warmup", "limit_warmup")
+            ]
+        )
+        await session.commit()
+
+        rows = await DashboardRepository(session).top_api_key_attribution_since(
+            NOW - timedelta(hours=2),
+            now=NOW,
+        )
+
+    assert [row.name for row in rows] == ["Alpha", "(unnamed)", "(unnamed)"]
+    assert [row.api_key_id for row in rows] == ["key-alpha", "missing-key", "key-token-heavy"]
+    # Warmup probes are internal traffic and never rank, even with dominant volume.
+    assert all(row.api_key_id != "key-warmup-only" for row in rows)
+    assert sum(row.name == "Alpha" for row in rows) == 1
+    alpha = rows[0]
+    assert alpha.requests == 4
+    assert alpha.billable_tokens == 60
+    assert alpha.cached_tokens == 12
+    assert alpha.dominant_model == "gpt-alpha"
+    assert any(row.billable_tokens == 1_500 for row in rows)
+    request_logs_table = cast(Table, RequestLog.__table__)
+    assert "idx_logs_dash_usage_covering" in {index.name for index in request_logs_table.indexes}

--- a/tests/unit/test_dashboard_weekly_pace.py
+++ b/tests/unit/test_dashboard_weekly_pace.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import cast
+
+import pytest
+from sqlalchemy import Table
+
+from app.core.utils.time import naive_utc_to_epoch
+from app.db.models import Account, AccountStatus, ApiKey, RequestLog, UsageHistory
+from app.db.session import SessionLocal
+from app.modules.accounts.schemas import AccountSummary
+from app.modules.dashboard.repository import DashboardRepository
+from app.modules.dashboard.weekly_pace import PRO_WEEKLY_CAPACITY_CREDITS, build_weekly_credit_pace
+
+NOW = datetime(2026, 8, 17, 12, 0, 0)
+
+
+def _account(account_id: str) -> Account:
+    return Account(id=account_id, status=AccountStatus.ACTIVE)
+
+
+def _summary(
+    account_id: str,
+    *,
+    used_percent: float,
+    reset_in_hours: float,
+    capacity: float = PRO_WEEKLY_CAPACITY_CREDITS,
+) -> AccountSummary:
+    return AccountSummary(
+        account_id=account_id,
+        email=f"{account_id}@example.com",
+        display_name=account_id,
+        plan_type="pro",
+        status="active",
+        reset_at_secondary=NOW + timedelta(hours=reset_in_hours),
+        window_minutes_secondary=10_080,
+        capacity_credits_secondary=capacity,
+        remaining_credits_secondary=capacity * (1.0 - used_percent / 100.0),
+    )
+
+
+def _row(account_id: str, used_percent: float, recorded_at: datetime) -> UsageHistory:
+    return UsageHistory(
+        account_id=account_id,
+        used_percent=used_percent,
+        recorded_at=recorded_at,
+        window="secondary",
+        reset_at=int(naive_utc_to_epoch(NOW + timedelta(days=1))),
+        window_minutes=10_080,
+    )
+
+
+def _three_hour_history(account_id: str, *, final_used_percent: float, hourly_delta: float) -> list[UsageHistory]:
+    values = [
+        final_used_percent - 3 * hourly_delta,
+        final_used_percent - 2 * hourly_delta,
+        final_used_percent - 2 * hourly_delta,
+        final_used_percent - hourly_delta,
+        final_used_percent - hourly_delta,
+        final_used_percent,
+    ]
+    offsets = [170, 130, 110, 70, 50, 1]
+    return [_row(account_id, value, NOW - timedelta(minutes=offset)) for value, offset in zip(values, offsets)]
+
+
+def _build(
+    summaries: list[AccountSummary],
+    histories: dict[str, list[UsageHistory]],
+):
+    pace = build_weekly_credit_pace(
+        accounts=[_account(summary.account_id) for summary in summaries],
+        account_summaries=summaries,
+        secondary_history=histories,
+        now=NOW,
+        usage_refresh_interval_seconds=60,
+    )
+    assert pace is not None
+    return pace
+
+
+@pytest.mark.parametrize(
+    ("used_percent", "reset_in_hours", "hourly_delta", "runway_status", "legacy_status"),
+    [
+        (90.0, 5.0, 10.0, "runs_dry", "danger"),
+        (80.0, 1.0, 10.0, "tight", "ahead"),
+        (20.0, 1.0, 1.0, "safe", "on_track"),
+    ],
+)
+def test_weekly_pace_verdict_branches_and_legacy_status_mapping(
+    used_percent: float,
+    reset_in_hours: float,
+    hourly_delta: float,
+    runway_status: str,
+    legacy_status: str,
+) -> None:
+    account_id = f"acc-{runway_status}"
+    pace = _build(
+        [_summary(account_id, used_percent=used_percent, reset_in_hours=reset_in_hours)],
+        {account_id: _three_hour_history(account_id, final_used_percent=used_percent, hourly_delta=hourly_delta)},
+    )
+
+    assert pace.runway_status == runway_status
+    assert pace.status == legacy_status
+    assert pace.burn_rate_recent_credits_per_hour is not None
+    assert pace.depletion_eta_hours is not None
+
+
+def test_weekly_pace_relief_clusters_resets_within_one_hour() -> None:
+    summaries = [
+        _summary("acc-first", used_percent=96.0, reset_in_hours=2.0),
+        _summary("acc-clustered", used_percent=97.0, reset_in_hours=2.5),
+        _summary("acc-later", used_percent=98.0, reset_in_hours=5.0),
+    ]
+    histories = {
+        summary.account_id: [_row(summary.account_id, used, NOW - timedelta(minutes=1))]
+        for summary, used in zip(summaries, (96.0, 97.0, 98.0))
+    }
+
+    pace = _build(summaries, histories)
+
+    assert pace.next_relief_in_hours == pytest.approx(2.0)
+    assert pace.next_relief_credits == pytest.approx(PRO_WEEKLY_CAPACITY_CREDITS * 1.93)
+    assert len(pace.reset_events) == 3
+
+
+def test_weekly_pace_near_reset_is_relief_not_runs_dry() -> None:
+    summary = _summary("acc-near-reset", used_percent=99.0, reset_in_hours=1.68)
+    pace = _build(
+        [summary],
+        {
+            summary.account_id: _three_hour_history(
+                summary.account_id,
+                final_used_percent=99.0,
+                hourly_delta=0.0,
+            )
+        },
+    )
+
+    assert pace.next_relief_in_hours == pytest.approx(1.68)
+    assert pace.next_relief_credits == pytest.approx(PRO_WEEKLY_CAPACITY_CREDITS * 0.99)
+    assert pace.depletion_eta_hours is None
+    assert pace.runway_status == "tight"
+    assert pace.status == "ahead"
+
+
+def test_weekly_pace_counts_saturated_accounts() -> None:
+    summaries = [
+        _summary("acc-saturated", used_percent=99.5, reset_in_hours=2.0),
+        _summary("acc-not-saturated", used_percent=99.49, reset_in_hours=2.0),
+    ]
+    histories = {
+        summary.account_id: [_row(summary.account_id, used, NOW - timedelta(minutes=1))]
+        for summary, used in zip(summaries, (99.5, 99.49))
+    }
+
+    pace = _build(summaries, histories)
+
+    assert pace.saturated_account_count == 1
+
+
+def _multi_window_history(account_id: str, final_used_percent: float) -> list[UsageHistory]:
+    points = [
+        (timedelta(days=6, hours=20), 0.0),
+        (timedelta(days=6), 90.0),
+        (timedelta(days=5), 1.0),
+        (timedelta(days=4), 91.0),
+        (timedelta(days=3), 2.0),
+        (timedelta(days=2), 92.0),
+        (timedelta(minutes=1), final_used_percent),
+    ]
+    return [_row(account_id, used, NOW - age) for age, used in points]
+
+
+def test_weekly_pace_add_pro_accounts_is_gated_on_for_saturation() -> None:
+    account_id = "acc-demand-saturated"
+    pace = _build(
+        [_summary(account_id, used_percent=99.5, reset_in_hours=2.0)],
+        {account_id: _multi_window_history(account_id, 99.5)},
+    )
+
+    assert pace.saturated_account_count == 1
+    assert pace.add_pro_accounts == 2
+
+
+def test_weekly_pace_add_pro_accounts_is_gated_off_without_distress() -> None:
+    account_id = "acc-demand-safe"
+    pace = _build(
+        [_summary(account_id, used_percent=20.0, reset_in_hours=1.0)],
+        {account_id: _multi_window_history(account_id, 20.0)},
+    )
+
+    assert pace.runway_status == "safe"
+    assert pace.saturated_account_count == 0
+    assert pace.add_pro_accounts is None
+
+
+def test_weekly_pace_add_pro_accounts_is_none_without_demand_surplus() -> None:
+    account_id = "acc-no-surplus"
+    pace = _build(
+        [_summary(account_id, used_percent=99.5, reset_in_hours=2.0)],
+        {account_id: [_row(account_id, 99.5, NOW - timedelta(minutes=1))]},
+    )
+
+    assert pace.saturated_account_count == 1
+    assert pace.add_pro_accounts is None
+
+
+@pytest.mark.asyncio
+async def test_weekly_pace_attribution_merges_rankings_and_dedupes_unnamed_key(db_setup) -> None:
+    del db_setup
+    async with SessionLocal() as session:
+        session.add(ApiKey(id="key-alpha", name="Alpha", key_hash="hash-alpha", key_prefix="alpha"))
+        session.add_all(
+            [
+                RequestLog(
+                    api_key_id="key-alpha",
+                    request_id=f"alpha-{index}",
+                    requested_at=NOW - timedelta(minutes=index + 1),
+                    model="gpt-alpha" if index < 3 else "gpt-other",
+                    status="success",
+                    input_tokens=10,
+                    output_tokens=5,
+                    reasoning_tokens=2,
+                    cached_input_tokens=3,
+                )
+                for index in range(4)
+            ]
+        )
+        session.add_all(
+            [
+                RequestLog(
+                    api_key_id="missing-key",
+                    request_id=f"unnamed-{index}",
+                    requested_at=NOW - timedelta(minutes=10 + index),
+                    model="gpt-unnamed",
+                    status="success",
+                    input_tokens=20,
+                    output_tokens=1,
+                    reasoning_tokens=0,
+                    cached_input_tokens=4,
+                )
+                for index in range(3)
+            ]
+        )
+        session.add(
+            RequestLog(
+                api_key_id="key-token-heavy",
+                request_id="token-heavy",
+                requested_at=NOW - timedelta(minutes=20),
+                model="gpt-heavy",
+                status="success",
+                input_tokens=1_000,
+                output_tokens=500,
+                reasoning_tokens=250,
+                cached_input_tokens=100,
+            )
+        )
+        session.add(
+            RequestLog(
+                api_key_id="key-alpha",
+                request_id="deleted-alpha",
+                requested_at=NOW - timedelta(minutes=1),
+                deleted_at=NOW,
+                model="gpt-deleted",
+                status="success",
+                input_tokens=50_000,
+            )
+        )
+        await session.commit()
+
+        rows = await DashboardRepository(session).top_api_key_attribution_since(NOW - timedelta(hours=2))
+
+    assert [row.name for row in rows] == ["Alpha", "(unnamed)", "(unnamed)"]
+    assert sum(row.name == "Alpha" for row in rows) == 1
+    alpha = rows[0]
+    assert alpha.requests == 4
+    assert alpha.billable_tokens == 68
+    assert alpha.cached_tokens == 12
+    assert alpha.dominant_model == "gpt-alpha"
+    assert any(row.billable_tokens == 1_750 for row in rows)
+    request_logs_table = cast(Table, RequestLog.__table__)
+    assert "idx_logs_dash_usage_covering" in {index.name for index in request_logs_table.indexes}

--- a/tests/unit/test_dashboard_weekly_pace.py
+++ b/tests/unit/test_dashboard_weekly_pace.py
@@ -67,6 +67,8 @@ def _three_hour_history(account_id: str, *, final_used_percent: float, hourly_de
 def _build(
     summaries: list[AccountSummary],
     histories: dict[str, list[UsageHistory]],
+    *,
+    trailing_demand_used_percent_by_account: dict[str, float] | None = None,
 ):
     pace = build_weekly_credit_pace(
         accounts=[_account(summary.account_id) for summary in summaries],
@@ -74,6 +76,7 @@ def _build(
         secondary_history=histories,
         now=NOW,
         usage_refresh_interval_seconds=60,
+        trailing_demand_used_percent_by_account=trailing_demand_used_percent_by_account,
     )
     assert pace is not None
     return pace
@@ -122,6 +125,68 @@ def test_weekly_pace_relief_clusters_resets_within_one_hour() -> None:
     assert pace.next_relief_in_hours == pytest.approx(2.0)
     assert pace.next_relief_credits == pytest.approx(PRO_WEEKLY_CAPACITY_CREDITS * 1.93)
     assert len(pace.reset_events) == 3
+
+
+def test_weekly_pace_recent_burn_counts_delta_across_hour_boundary() -> None:
+    account_id = "acc-cross-hour"
+    pace = _build(
+        [_summary(account_id, used_percent=80.0, reset_in_hours=2.0)],
+        {
+            account_id: [
+                _row(account_id, 70.0, NOW - timedelta(minutes=61)),
+                _row(account_id, 80.0, NOW - timedelta(minutes=59)),
+                _row(account_id, 80.0, NOW - timedelta(minutes=1)),
+            ]
+        },
+    )
+
+    assert pace.burn_rate_recent_credits_per_hour == pytest.approx(5_040.0)
+
+
+def test_weekly_pace_recent_burn_uses_floored_observed_span() -> None:
+    account_id = "acc-short-span"
+    pace = _build(
+        [_summary(account_id, used_percent=80.0, reset_in_hours=2.0)],
+        {
+            account_id: [
+                _row(account_id, 70.0, NOW - timedelta(minutes=6)),
+                _row(account_id, 80.0, NOW - timedelta(minutes=1)),
+            ]
+        },
+    )
+
+    assert pace.burn_rate_recent_credits_per_hour == pytest.approx(10_080.0)
+
+
+def test_weekly_pace_recent_burn_skips_reset_delta() -> None:
+    account_id = "acc-reset"
+    pace = _build(
+        [_summary(account_id, used_percent=10.0, reset_in_hours=2.0)],
+        {
+            account_id: [
+                _row(account_id, 80.0, NOW - timedelta(minutes=6)),
+                _row(account_id, 10.0, NOW - timedelta(minutes=1)),
+            ]
+        },
+    )
+
+    assert pace.burn_rate_recent_credits_per_hour == pytest.approx(0.0)
+
+
+def test_weekly_pace_recent_burn_ignores_single_sample_accounts() -> None:
+    summaries = [
+        _summary("acc-single-a", used_percent=70.0, reset_in_hours=2.0),
+        _summary("acc-single-b", used_percent=80.0, reset_in_hours=3.0),
+    ]
+    pace = _build(
+        summaries,
+        {
+            summary.account_id: [_row(summary.account_id, used, NOW - timedelta(minutes=1))]
+            for summary, used in zip(summaries, (70.0, 80.0))
+        },
+    )
+
+    assert pace.burn_rate_recent_credits_per_hour is None
 
 
 def test_weekly_pace_near_reset_is_relief_not_runs_dry() -> None:
@@ -177,6 +242,7 @@ def test_weekly_pace_add_pro_accounts_is_gated_on_for_saturation() -> None:
     pace = _build(
         [_summary(account_id, used_percent=99.5, reset_in_hours=2.0)],
         {account_id: _multi_window_history(account_id, 99.5)},
+        trailing_demand_used_percent_by_account={account_id: 277.5},
     )
 
     assert pace.saturated_account_count == 1
@@ -200,6 +266,19 @@ def test_weekly_pace_add_pro_accounts_is_none_without_demand_surplus() -> None:
     pace = _build(
         [_summary(account_id, used_percent=99.5, reset_in_hours=2.0)],
         {account_id: [_row(account_id, 99.5, NOW - timedelta(minutes=1))]},
+        trailing_demand_used_percent_by_account={account_id: 100.0},
+    )
+
+    assert pace.saturated_account_count == 1
+    assert pace.add_pro_accounts is None
+
+
+def test_weekly_pace_add_pro_accounts_is_none_without_sql_demand_mapping() -> None:
+    account_id = "acc-demand-without-mapping"
+    pace = _build(
+        [_summary(account_id, used_percent=99.5, reset_in_hours=2.0)],
+        {account_id: _multi_window_history(account_id, 99.5)},
+        trailing_demand_used_percent_by_account=None,
     )
 
     assert pace.saturated_account_count == 1
@@ -267,17 +346,31 @@ async def test_weekly_pace_attribution_merges_rankings_and_dedupes_unnamed_key(d
                 input_tokens=50_000,
             )
         )
+        session.add(
+            RequestLog(
+                api_key_id="key-alpha",
+                request_id="future-alpha",
+                requested_at=NOW + timedelta(minutes=1),
+                model="gpt-future",
+                status="success",
+                input_tokens=50_000,
+            )
+        )
         await session.commit()
 
-        rows = await DashboardRepository(session).top_api_key_attribution_since(NOW - timedelta(hours=2))
+        rows = await DashboardRepository(session).top_api_key_attribution_since(
+            NOW - timedelta(hours=2),
+            now=NOW,
+        )
 
     assert [row.name for row in rows] == ["Alpha", "(unnamed)", "(unnamed)"]
+    assert [row.api_key_id for row in rows] == ["key-alpha", "missing-key", "key-token-heavy"]
     assert sum(row.name == "Alpha" for row in rows) == 1
     alpha = rows[0]
     assert alpha.requests == 4
-    assert alpha.billable_tokens == 68
+    assert alpha.billable_tokens == 60
     assert alpha.cached_tokens == 12
     assert alpha.dominant_model == "gpt-alpha"
-    assert any(row.billable_tokens == 1_750 for row in rows)
+    assert any(row.billable_tokens == 1_500 for row in rows)
     request_logs_table = cast(Table, RequestLog.__table__)
     assert "idx_logs_dash_usage_covering" in {index.name for index in request_logs_table.indexes}


### PR DESCRIPTION
## Summary

Backend half of OpenSpec change `redesign-weekly-pace-runway` (frontend card PR follows).

The 2026-08-16 pool-exhaustion incident showed the weekly pace card's linear-schedule comparison gives no usable signal: the ±5% schedule-gap status kept the card in a permanent warning state during normal bursty traffic, yet produced no distinct signal while the fleet was actually running dry. This PR adds a runway model that answers the operative question — **does the pool run dry before the next reset returns capacity?**

### New (additive) `WeeklyCreditPaceResponse` fields

- `headroom_percent`, `headroom_credits` — fleet remaining
- `burn_rate_recent_credits_per_hour` — trailing-3h fleet burn
- `depletion_eta_hours` — headroom / recent burn
- `next_relief_in_hours`, `next_relief_credits`, `reset_events` — soonest reset among the ≥95%-used cohort (1h reset clustering), credits it returns, per-account reset ticks (7d cap)
- `runway_status` — `safe` / `tight` / `runs_dry`; `runs_dry` = finite ETA before relief
- `saturated_account_count` — censoring guard (≥99.5% accounts; demand figures are floors when all are saturated)
- `top_api_keys` — trailing-2h per-key attribution (requests, billable tokens, dominant model), single bounded aggregate
- `add_pro_accounts` — stable purchase hint from trailing-7d demand in quota-weeks, gated behind `runs_dry`/saturation

### Wire compatibility

All existing fields keep their current math (legacy linear-schedule fields included). Legacy `status` is derived: `runs_dry→danger`, `tight→ahead`, `safe→on_track`. No removals.

### Model validation

The same headroom/ETA/relief math was backtested hourly against the 08-16 incident: warn threshold fired 21h before user-visible failure, crit 5h before, while `accounts.status` and the schedule-gap delta never moved. The dashboard card and the ops watchdog now share one model.

## Verification

- `tests/unit` full suite: 6195 passed, 3 skipped
- targeted: 187 passed; overview integration: 27 passed
- `make lint`, `uv run ty check` clean
- OpenSpec: `openspec validate redesign-weekly-pace-runway` → valid

## Simplicity gates

- Zero-config: no new settings, env vars, or README sections; all fields additive on an existing endpoint (P1)
- One concern: backend calculation + attribution only; UI lands in the follow-up PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added weekly credit runway insights, including headroom, burn rate, depletion estimates, reset relief, and safe/tight/runs-dry statuses.
  * Added top API key usage attribution with request, token, cached-token, and model details.
  * Added saturated-account counts and capacity recommendations based on recent demand.
  * Enhanced dashboard overview and projection responses with these insights.

* **Documentation**
  * Added specifications and implementation planning for the redesigned weekly credits pace experience.

* **Tests**
  * Added coverage for runway calculations, reset handling, attribution, recommendations, and dashboard responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->