### PR TITLE
chore: release v1.24.0-beta.2

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.24.0-beta.1"  # x-release-please-version
+__version__ = "1.24.0-beta.2"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.24.0-beta.1
-appVersion: 1.24.0-beta.1
+version: 1.24.0-beta.2
+appVersion: 1.24.0-beta.2
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.24.0-beta.1",
+  "version": "1.24.0-beta.2",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.24.0-beta.1"
+version = "1.24.0-beta.2"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.24.0b1"
+version = "1.24.0-beta.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.24.0-beta.2 for the 1.24.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.24.0-beta.2 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1692; no manual beta workflow dispatch is required.

## Changes since v1.24.0-beta.1
- feat(api-keys): allow per-key reasoning effort policies (#1642) (
ed31b7)
-  feat(reports): Add API Key Filtering to Reports Dashboard (#1728) (
1f65f8)
- fix(proxy): compact transport switch + trigger canonicalization (supersedes #1749) (#1809) (
0481ed)
- feat(proxy): support Ultrafast service tier (#1734) (
d522a4)
- feat(ui): surface reasoning token usage (#1801) (
8e7589)
- fix(models): raise GPT-5.6 bootstrap max_context_window to 872k (#1813) (
1add10)
- fix(proxy): drop malformed compact item ids (#1815) (
812265)
- fix(proxy): classify parameterless previous response errors (#1818) (
eeab46)

## Release-candidate validation
Validated candidate: 011b7ff1f1bd9131b838af0e08316fc43bfc3d3a

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates — CI green at 011b7ff1 (run 32247777949: pytest unit, integration-core 3 shards + bridge + e2e, pytest PostgreSQL, migration checks sqlite+postgres, ruff, ty)
- [x] Frontend tests/build — CI green at 011b7ff1 (vitest + coverage, tsc, eslint, vite build)
- [x] Wheel/package validation — CI `Package (build)` green at 011b7ff1
- [x] Docker/container smoke — image built locally from 011b7ff1 (sha256:6ba6ba7440dc); booted against a scratch postgres:18-alpine on an isolated network: alembic head `20260806_030000_add_api_key_allowed_reasoning_efforts` applied (matches script head verified from the candidate tree; the only new migration in this train, from #1642), `GET /health/ready` 200, unauthenticated `GET /api/dashboard/overview` 401 bootstrap_required, `POST /v1/responses` and `/v1/chat/completions` without key 401 invalid_api_key, 0 genuine error signatures in app+postgres logs (only probe-induced 401 warnings)
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required — this train is proxy/UI fixes verified by their suites (#1642 #1728 #1734 #1801 #1809 #1813 #1815 #1818 #1819); the openai 2.53.0→3.0.0 major bump is dev-group only (zero `openai` imports in `app/`, not shipped in wheel or container) and the e2e SDK-compat suite exercised the 3.0.0 client against this exact candidate in CI; the single schema delta (additive, #1642) was applied and verified in the container smoke. Live-path validation proceeds on the internal 113 pool after publish with the previous beta staged for one-line rollback

## Install after publish
```bash
uvx --from "codex-lb==1.24.0b2" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.24.0-beta.2
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.24.0-beta.2 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.24.0.