### PR TITLE
fix(models): raise GPT-5.6 bootstrap max_context_window to 872k

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1291,6 +1291,17 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "zenasharp",
+      "name": "zenasharp",
+      "avatar_url": "https://avatars.githubusercontent.com/u/170236008?v=4",
+      "profile": "https://github.com/zenasharp",
+      "contributions": [
+        "code",
+        "test",
+        "doc"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -293,6 +293,9 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/e
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/evan-choi"><img src="https://avatars.githubusercontent.com/u/9690415?v=4?s=100" width="100px;" alt="Evan"/><br /><sub><b>Evan</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=evan-choi" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://chaoxu.prof/"><img src="https://avatars.githubusercontent.com/u/18860?v=4?s=100" width="100px;" alt="Chao Xu"/><br /><sub><b>Chao Xu</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=chaoxu" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=chaoxu" title="Tests">⚠️</a></td>
     </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/zenasharp"><img src="https://avatars.githubusercontent.com/u/170236008?v=4?s=100" width="100px;" alt="zenasharp"/><br /><sub><b>zenasharp</b></sub></a><br /><a href="https://github.com/Soju06/codex-lb/commits?author=zenasharp" title="Code">💻</a> <a href="https://github.com/Soju06/codex-lb/commits?author=zenasharp" title="Tests">⚠️</a> <a href="https://github.com/Soju06/codex-lb/commits?author=zenasharp" title="Documentation">📖</a></td>
+    </tr>
   </tbody>
 </table>
 

--- a/app/core/openai/model_registry.py
+++ b/app/core/openai/model_registry.py
@@ -220,7 +220,9 @@ def _gpt56_raw(
 ) -> dict[str, JsonValue]:
     """Raw catalog fields for the GPT-5.6 family, mirroring the upstream
     bundled catalog (codex-rs/models-manager/models.json at rust-v0.145.0)
-    field-for-field. The ~16.5 KB ``base_instructions`` string and the
+    field-for-field, with one tracked exception: ``max_context_window``, which
+    upstream later raised from 272,000 to 872,000 (see the field comment
+    below). The ~16.5 KB ``base_instructions`` string and the
     personality-templated ``model_messages`` object are deliberately not
     bundled; the live upstream registry supplies them on the first refresh.
     """
@@ -237,6 +239,16 @@ def _gpt56_raw(
         "use_responses_lite": True,
         "include_skills_usage_instructions": False,
         "auto_review_model_override": None,
+        # Upstream raised only the ceiling: ``max_context_window`` 272000 ->
+        # 872000 with ``context_window`` unchanged at 272000. ``_bootstrap_model``
+        # synthesizes ``max_context_window == context_window``, so the family
+        # ceiling has to override it here, the same decoupling ``gpt-5.4`` uses.
+        # Pinned evidence: openai/codex commit
+        # 2eee483e49f88b868f67364134a658b3298e6c14 -- "Raise the GPT-5.6 maximum
+        # context window" (openai/codex#39102). Not yet in a ``rust-v*`` release
+        # tag; ``rust-v0.148.0-alpha.21`` still ships 272000. Re-pin to the tag
+        # once one carries it.
+        "max_context_window": 872_000,
         "auto_compact_token_limit": None,
         "comp_hash": "3000",
         "reasoning_summary_format": "experimental",

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -4,7 +4,7 @@ Point any OpenAI-compatible client at codex-lb. If [API key auth](api-keys.md) i
 
 Model availability is discovered from the upstream Codex model catalog and can vary by account plan, workspace, rollout, and upstream deprecation state. Prefer the live `GET /v1/models` or `GET /backend-api/codex/models` response over a copied static table when configuring clients or API-key model allowlists.
 
-The examples below use the current frontier lineup: **`gpt-5.6-sol`** (strongest), **`gpt-5.6-terra`** (balanced), and **`gpt-5.6-luna`** (fast) — all 272k context. `gpt-5.5` and `gpt-5.4` are still served for older pinned clients; retired slugs such as `gpt-5.3-codex`, `gpt-5.3-codex-spark`, and `gpt-5.1-codex-mini` were dropped from the upstream bundled catalog and should no longer be used in new configs.
+The examples below use the current frontier lineup: **`gpt-5.6-sol`** (strongest), **`gpt-5.6-terra`** (balanced), and **`gpt-5.6-luna`** (fast) — all with a 272k default input budget and an 872k upstream maximum ([opt-in, Codex CLI only](#opting-into-the-872k-context-window)). `gpt-5.5` and `gpt-5.4` are still served for older pinned clients; retired slugs such as `gpt-5.3-codex`, `gpt-5.3-codex-spark`, and `gpt-5.1-codex-mini` were dropped from the upstream bundled catalog and should no longer be used in new configs.
 
 | Client | Endpoint | Config |
 |--------|----------|--------|
@@ -30,6 +30,31 @@ wire_api = "responses"
 supports_websockets = true
 requires_openai_auth = true # required for codex app
 ```
+
+### Opting into the 872k context window
+
+GPT-5.6 ships a 272,000-token default input budget with an 872,000-token
+maximum. codex-lb advertises both — `context_window` and `max_context_window`
+on `GET /backend-api/codex/models` — and the Codex CLI stays on the default
+until you raise it in `~/.codex/config.toml` (top level, before any
+`[section]` header):
+
+```toml
+model_context_window = 872000
+```
+
+- Values above `max_context_window` are clamped to it: `model_context_window =
+  1000000` resolves to 872,000 and does not unlock a 1M window.
+- Leave `model_auto_compact_token_limit` unset. Codex auto-compacts at 90% of
+  the resolved window — 784,800 tokens here — and clamps any larger configured
+  value down to that, so setting `900000` is a no-op. Set it only to compact
+  *earlier*.
+- Cost: input beyond the 272,000-token threshold is metered at the upstream
+  long-context rate. That threshold is why 272,000 stays the default.
+
+These keys are Codex-CLI-only. The OpenCode / OpenClaw / SDK examples below
+stay at 272000 because `/v1/models` reports the default input budget, not the
+ceiling.
 
 ### Daybreak Blue profile (Trusted Access)
 

--- a/openspec/changes/raise-gpt56-max-context-window/proposal.md
+++ b/openspec/changes/raise-gpt56-max-context-window/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+Upstream raised the GPT-5.6 maximum context window from 272,000 to 872,000
+tokens while leaving the default input budget at 272,000
+(`codex-rs/models-manager/models.json`, openai/codex commit
+`2eee483e49f88b868f67364134a658b3298e6c14`, "Raise the GPT-5.6 maximum context
+window", openai/codex#39102). codex-lb's bootstrap catalog synthesizes
+`max_context_window` as a copy of `context_window`
+(`app/core/openai/model_registry.py`), so it advertises a 272,000 ceiling for
+Sol, Terra, and Luna. A Codex client pointed at codex-lb before the first live
+registry refresh therefore has its `model_context_window` opt-in clamped to
+272,000 and cannot reach the window upstream actually serves.
+
+## What Changes
+
+- Decouple `max_context_window` from `context_window` for the GPT-5.6
+  bootstrap family: `max_context_window` becomes 872,000; `context_window`
+  stays 272,000.
+- Keep the GPT-5.6 base provenance pinned at Codex `rust-v0.145.0`, with a
+  single tracked exception for `max_context_window`, pinned to the upstream
+  commit that raised it (no `rust-v*` release tag carries it yet as of
+  `rust-v0.148.0-alpha.21`).
+- Document the Codex CLI opt-in, including the clamp semantics that make
+  `model_context_window = 1000000` resolve to 872,000 and
+  `model_auto_compact_token_limit = 900000` a no-op (Codex clamps the
+  auto-compact limit to 90% of the resolved window).
+
+## Non-goals
+
+- `context_window` stays 272,000. It is the tuned default input budget and the
+  upstream long-context pricing threshold.
+- The other post-`rust-v0.145.0` upstream deltas to these entries
+  (`include_apps_usage_instructions`, `include_plugin_usage_instructions`, the
+  `base_instructions` relocation to `prompt.md`, `supports_parallel_tool_calls`
+  now serde-defaulted) are out of scope and need their own compatibility
+  review.
+- No clamp or override logic changes; `/v1` input budget fields keep reporting
+  the default input budget (see PR #1808 for override plumbing work).
+
+## Impact
+
+- No schema, route, or database migration change.
+- Before a live registry refresh, `GET /backend-api/codex/models` changes the
+  GPT-5.6 advertised `max_context_window` from 272,000 to 872,000 tokens;
+  `context_window` is unchanged.
+- `GET /v1/models` is unchanged: it reports the default input budget and does
+  not promote `raw["max_context_window"]`.
+- Operator `CODEX_LB_MODEL_CONTEXT_WINDOW_OVERRIDES` entries and persisted
+  registry snapshots continue to take precedence over bootstrap values.
+- The delta restates the `model-catalog-compat` GPT-5.6 requirement in full,
+  so it is order-insensitive with respect to the still-unarchived
+  `fix-gpt56-context-window` delta (issue #1714): applied before or after it,
+  the merged requirement text is identical.
+- Revert cost is one line if upstream reverts before tagging a release.

--- a/openspec/changes/raise-gpt56-max-context-window/specs/model-catalog-compat/spec.md
+++ b/openspec/changes/raise-gpt56-max-context-window/specs/model-catalog-compat/spec.md
@@ -1,0 +1,77 @@
+## MODIFIED Requirements
+
+### Requirement: GPT-5.6 bootstrap metadata matches the upstream bundled catalog
+
+The GPT-5.6 bootstrap catalog entries (`gpt-5.6-sol`, `gpt-5.6-terra`,
+`gpt-5.6-luna`) MUST mirror the upstream bundled catalog
+(`codex-rs/models-manager/models.json` at Codex release `rust-v0.145.0`)
+field-for-field for every metadata field codex-lb serves, with one tracked
+exception: `max_context_window`, which upstream raised from `272000` to
+`872000` in openai/codex commit
+`2eee483e49f88b868f67364134a658b3298e6c14` (openai/codex#39102) and which no
+`rust-v*` release tag carries as of `rust-v0.148.0-alpha.21`. In particular
+each entry MUST carry: `context_window` of `272000` and `max_context_window`
+of `872000`; `minimal_client_version` `"0.144.0"`; `tool_mode`
+`"code_mode_only"`; `use_responses_lite` `true`; `apply_patch_tool_type`
+`"freeform"`; `web_search_tool_type` `"text_and_image"`;
+`supports_image_detail_original` `true`; `truncation_policy` `{ "mode":
+"tokens", "limit": 10000 }`; `comp_hash` `"3000"`; `reasoning_summary_format`
+`"experimental"`; `default_reasoning_summary` `"none"`;
+`include_skills_usage_instructions` `false`; `experimental_supported_tools`
+`[]` (a field the Codex client's deserializer requires); `supports_search_tool`
+`true`; `additional_speed_tiers` `["fast"]`; the `priority`/`Fast` service tier
+entry; `shell_type` `"shell_command"`; `prefer_websockets` `true`; and the
+21-plan `available_in_plans` list upstream advertises (including `edu_plus`,
+`edu_pro`, `enterprise_cbp_automation`, and `sci`). `multi_agent_version` MUST
+be `"v2"` for Sol and Terra and `"v1"` for Luna. Sol MUST carry the upstream
+`availability_nux` message while Terra and Luna carry `null`. Default reasoning
+levels MUST be `low` for Sol and `medium` for Terra and Luna, and
+reasoning-level descriptions MUST be the verbatim upstream strings.
+
+`context_window` is the default input budget and `max_context_window` is the
+ceiling a client may opt into; the two MUST NOT be collapsed into one value
+for these entries.
+
+The ~16.5 KB upstream `base_instructions` prompt and the personality-templated
+`model_messages` object are deliberately NOT bundled in the bootstrap catalog;
+the first successful live registry refresh supplies them. This is the only
+sanctioned divergence from the upstream GPT-5.6 entries beyond the
+`max_context_window` exception above.
+
+#### Scenario: GPT-5.6 bootstrap entries advertise the raised upstream ceiling
+
+- **GIVEN** the model registry has no refreshed upstream snapshot
+- **AND** no persisted snapshot is loaded
+- **AND** no `CODEX_LB_MODEL_CONTEXT_WINDOW_OVERRIDES` entry applies to these slugs
+- **WHEN** a client calls `GET /backend-api/codex/models`
+- **THEN** `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` report
+  `context_window=272000`
+- **AND** each reports `max_context_window=872000`
+
+#### Scenario: OpenAI-compatible metadata keeps the default input budget
+
+- **GIVEN** the model registry has no refreshed upstream snapshot
+- **AND** no persisted snapshot is loaded
+- **AND** no `CODEX_LB_MODEL_CONTEXT_WINDOW_OVERRIDES` entry applies to these slugs
+- **WHEN** a client calls `GET /v1/models`
+- **THEN** each GPT-5.6 entry reports `context_window=272000` and
+  `input_context_window=272000`
+- **AND** the raised Codex-native ceiling is not promoted into the
+  OpenAI-compatible input budget fields
+
+#### Scenario: GPT-5.6 entries expose upstream tool and multi-agent metadata
+
+- **GIVEN** the model registry has no refreshed upstream snapshot
+- **AND** no persisted snapshot is loaded
+- **WHEN** a client calls `GET /backend-api/codex/models`
+- **THEN** `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` carry `tool_mode: "code_mode_only"`, `use_responses_lite: true`, `experimental_supported_tools: []`, and `minimal_client_version: "0.144.0"`
+- **AND** `multi_agent_version` is `"v2"` for Sol and Terra and `"v1"` for Luna
+
+#### Scenario: GPT-5.6 entries expose upstream reasoning-summary and plan metadata
+
+- **GIVEN** the model registry has no refreshed upstream snapshot
+- **AND** no persisted snapshot is loaded
+- **WHEN** a client calls `GET /backend-api/codex/models`
+- **THEN** each GPT-5.6 entry carries `default_reasoning_summary: "none"`, `reasoning_summary_format: "experimental"`, and `comp_hash: "3000"`
+- **AND** each GPT-5.6 entry's `available_in_plans` includes `edu_plus`, `edu_pro`, `enterprise_cbp_automation`, and `sci`
+- **AND** only `gpt-5.6-sol` carries a non-null `availability_nux` message

--- a/openspec/changes/raise-gpt56-max-context-window/tasks.md
+++ b/openspec/changes/raise-gpt56-max-context-window/tasks.md
@@ -1,0 +1,49 @@
+## 1. Bootstrap catalog
+
+- [x] 1.1 Add `max_context_window: 872_000` to `_gpt56_raw()` so it overrides
+      the `_bootstrap_model` synthesis for all three GPT-5.6 slugs at once.
+- [x] 1.2 Leave `context_window` at 272,000 for Sol, Terra, and Luna.
+- [x] 1.3 Amend the `_gpt56_raw()` docstring to record `max_context_window` as
+      the one tracked divergence from the `rust-v0.145.0` base pin, citing the
+      upstream commit.
+
+## 2. Regression coverage
+
+- [x] 2.1 Assert `max_context_window == 872_000` and `context_window ==
+      272_000` for every GPT-5.6 entry in the shared unit-test loop.
+- [x] 2.2 Assert the same pair through `GET /backend-api/codex/models` in the
+      shared integration-test loop.
+- [x] 2.3 Assert `max_context_window > context_window` in both loops so a
+      future re-unification of the two fields fails loudly.
+- [x] 2.4 Assert `GET /v1/models` still reports 272,000 for the GPT-5.6 input
+      budget fields on the bootstrap path.
+- [x] 2.5 Re-pin both evidence comments to `rust-v0.145.0` plus the upstream
+      commit for `max_context_window`.
+
+## 3. Documentation
+
+- [x] 3.1 Distinguish the 272k default budget from the 872k maximum in the
+      client-setup model lineup summary.
+- [x] 3.2 Document the Codex CLI opt-in with correct clamp semantics: values
+      above `max_context_window` are clamped, and the auto-compact limit
+      resolves to 90% of the window, so larger values are no-ops.
+- [x] 3.3 Leave the OpenCode and OpenClaw examples at 272,000, matching what
+      `/v1/models` advertises.
+
+## 4. Specification
+
+- [x] 4.1 Add a `model-catalog-compat` delta requiring `context_window`
+      272,000 and `max_context_window` 872,000 for the GPT-5.6 bootstrap
+      entries.
+- [x] 4.2 Restate the requirement and surviving scenarios in full so the delta
+      is order-insensitive against the unarchived `fix-gpt56-context-window`
+      delta.
+- [x] 4.3 Carry GIVEN clauses on context-budget scenarios excluding refreshed
+      snapshots, persisted snapshots, and operator context-window overrides.
+
+## 5. Validation
+
+- [x] 5.1 `openspec validate raise-gpt56-max-context-window --strict`
+- [x] 5.2 `openspec validate --specs`
+- [x] 5.3 Focused unit + integration model-catalog tests, ruff, and
+      `mkdocs build --strict`.

--- a/tests/integration/test_v1_models.py
+++ b/tests/integration/test_v1_models.py
@@ -261,6 +261,18 @@ async def test_v1_models_uses_bootstrap_models_when_registry_not_populated(async
     assert ids == BOOTSTRAP_MODEL_SLUGS
     assert "gpt-5.5-pro" not in ids
 
+    # The raised GPT-5.6 ceiling is a Codex-native field. /v1 input budgets
+    # stay on ``context_window`` so OpenAI-compatible clients keep packing to
+    # the 272k default instead of the 872k ``max_context_window`` ceiling.
+    entries = {item["id"]: item for item in payload["data"]}
+    for slug in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
+        entry = entries[slug]
+        assert entry["metadata"]["context_window"] == 272_000
+        assert entry["metadata"]["input_context_window"] == 272_000
+        assert entry["capabilities"]["context_length"] == 272_000
+        assert entry["context_length"] == 272_000
+        assert entry["contextLength"] == 272_000
+
 
 @pytest.mark.asyncio
 async def test_backend_codex_models_uses_bootstrap_upstream_metadata(async_client):
@@ -315,7 +327,10 @@ async def test_backend_codex_models_uses_bootstrap_upstream_metadata(async_clien
     }
 
     # Reproducible upstream catalog evidence:
-    # codex-rs/models-manager/models.json at rust-v0.145.0.
+    # codex-rs/models-manager/models.json at rust-v0.145.0, except
+    # ``max_context_window``: raised to 872000 in openai/codex commit
+    # 2eee483e49f88b868f67364134a658b3298e6c14 (openai/codex#39102), which no
+    # rust-v* release tag carries yet.
     for gpt56 in (sol, terra, luna):
         assert gpt56["minimal_client_version"] == "0.144.0"
         assert gpt56["context_window"] == 272_000
@@ -328,7 +343,8 @@ async def test_backend_codex_models_uses_bootstrap_upstream_metadata(async_clien
         assert gpt56["reasoning_summary_format"] == "experimental"
         assert gpt56["comp_hash"] == "3000"
         assert gpt56["experimental_supported_tools"] == []
-        assert gpt56["max_context_window"] == 272_000
+        assert gpt56["max_context_window"] == 872_000
+        assert gpt56["max_context_window"] > gpt56["context_window"]
         assert gpt56["service_tiers"] == [
             {"id": "priority", "name": "Fast", "description": "1.5x speed, increased usage"}
         ]

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -273,7 +273,10 @@ def test_bootstrap_models_include_representative_upstream_metadata():
     assert [level.effort for level in luna.supported_reasoning_levels] == ["low", "medium", "high", "xhigh", "max"]
 
     # Reproducible upstream catalog evidence:
-    # codex-rs/models-manager/models.json at rust-v0.145.0.
+    # codex-rs/models-manager/models.json at rust-v0.145.0, except
+    # ``max_context_window``: raised to 872000 in openai/codex commit
+    # 2eee483e49f88b868f67364134a658b3298e6c14 (openai/codex#39102), which no
+    # rust-v* release tag carries yet.
     for gpt56 in (sol, terra, luna):
         assert gpt56.minimal_client_version == "0.144.0"
         assert gpt56.context_window == 272_000
@@ -289,7 +292,13 @@ def test_bootstrap_models_include_representative_upstream_metadata():
         assert gpt56.raw["include_skills_usage_instructions"] is False
         assert gpt56.raw["experimental_supported_tools"] == []
         assert gpt56.raw["supports_search_tool"] is True
-        assert gpt56.raw["max_context_window"] == 272_000
+        # The upstream ceiling is decoupled from the default input budget, so
+        # the ``_bootstrap_model`` synthesis (max == context_window) must not
+        # win for these entries.
+        max_context_window = gpt56.raw["max_context_window"]
+        assert isinstance(max_context_window, int)
+        assert max_context_window == 872_000
+        assert max_context_window > gpt56.context_window
         assert gpt56.raw["service_tiers"] == [
             {"id": "priority", "name": "Fast", "description": "1.5x speed, increased usage"}
         ]


### PR DESCRIPTION
## Summary

Upstream raised the GPT-5.6 maximum context window to 872,000 while keeping the 272,000 default input budget (openai/codex#39102). The bootstrap catalog synthesizes `max_context_window == context_window`, so clients pointed at codex-lb before the first live registry refresh get their `model_context_window` opt-in clamped to 272,000. This decouples the two for Sol/Terra/Luna — the same pattern `gpt-5.4` already uses.

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)

Linked issue: Fixes #1812

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [x] This PR touches a codex-faithful path (Codex model catalog shape) and preserves upstream-equivalent behavior

Change directory: `openspec/changes/raise-gpt56-max-context-window/`

## Changes

- `app/core/openai/model_registry.py`: add `"max_context_window": 872_000` to `_gpt56_raw()`; docstring records it as the one tracked divergence from the `rust-v0.145.0` base pin. `context_window` stays 272,000.
- Tests: the shared three-model loops assert `context_window == 272_000`, `max_context_window == 872_000`, and `max > context_window`; the bootstrap `/v1/models` test asserts all input-budget fields stay 272,000 (the ceiling is Codex-native only).
- `docs/client-setup.md`: lineup now says 272k default / 872k maximum, plus an opt-in subsection: `model_context_window = 872000`, larger values are clamped, and the auto-compact limit is clamped to 90% of the resolved window, so raising it past that is a no-op. OpenCode/OpenClaw examples stay at 272,000, matching `/v1/models`.
- No overlap with #1808 (no clamp/override logic changed); the `_make_upstream_model()`-based override tests never hit bootstrap and need no edits.

## Upstream evidence

- [`codex-rs/models-manager/models.json` @ `2eee483e`](https://github.com/openai/codex/blob/2eee483e49f88b868f67364134a658b3298e6c14/codex-rs/models-manager/models.json): `context_window: 272000`, `max_context_window: 872000` for all three slugs ([commit](https://github.com/openai/codex/commit/2eee483e49f88b868f67364134a658b3298e6c14), openai/codex#39102).
- Upstream's regression test in that commit (`manager_tests.rs::get_model_info_applies_long_context_override_to_bundled_gpt_5_6_models`) resolves a configured `1_000_000` to `872_000`.
- Negative control: [`rust-v0.148.0-alpha.21`](https://github.com/openai/codex/blob/rust-v0.148.0-alpha.21/codex-rs/models-manager/models.json) still ships 272,000 — no release tag carries the raise yet, hence the immutable commit-SHA pin with a re-pin note in the code comment. Happy to hold the merge until a `rust-v*` tag ships it if preferred.
- Base provenance stays on `rust-v0.145.0`: the entries gained other post-0.145.0 deltas codex-lb does not ship (`include_apps_usage_instructions`, `include_plugin_usage_instructions`, `base_instructions` relocation, `supports_parallel_tool_calls` serde default) — out of scope, listed in the proposal's Non-goals.

## Test plan

```
uv run pytest -q tests/unit/test_model_registry.py tests/integration/test_v1_models.py   # 104 passed
uv run pytest -q tests/unit tests/test_request_logs_options_api.py                       # 6232 passed; remaining failures are Windows-host-only and identical on clean main
uv run ruff check . && uv run ruff format --check .                                      # clean
uv run ty check                                                                          # 5 diagnostics, identical set on clean main
uv run mkdocs build --strict                                                             # built
openspec validate raise-gpt56-max-context-window --strict && openspec validate --specs   # valid; 57 passed
```

## Screenshots / output

Bootstrap `GET /backend-api/codex/models`, all three GPT-5.6 slugs, before → after:

```
context_window=272000  max_context_window=272000  →  context_window=272000  max_context_window=872000
```

`/v1/models` input-budget fields unchanged at 272,000 (asserted in `test_v1_models_uses_bootstrap_models_when_registry_not_populated`).

## Checklist

- [x] Title is in Conventional Commits format (`<type>(<scope>)?: <subject>`).
- [x] Linked the related issue / discussion above.
- [x] Added or updated tests covering the change.
- [x] Ran the relevant `make` subset locally (see test plan).
- [x] If touching specs: `openspec validate --specs` passes (delta restates the requirement in full, so it is order-insensitive with the unarchived `fix-gpt56-context-window` delta — see #1714).
- [x] Simplicity gates reviewed: the five simplicity rules (PRINCIPLES.md P1-P5).
- [x] CHANGELOG is **not** edited by hand (release-please handles it).
