### PR TITLE
fix(proxy): drop malformed compact item ids

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -58,7 +58,7 @@ from app.core.errors import (
 )
 from app.core.openai.exceptions import ClientPayloadError
 from app.core.openai.model_registry import get_model_registry
-from app.core.openai.models import CompactResponsePayload, OpenAIError
+from app.core.openai.models import CompactResponsePayload, OpenAIError, normalize_compaction_item_id
 from app.core.openai.parsing import (
     classify_event_type,
     parse_compact_response_payload,
@@ -1245,6 +1245,7 @@ async def _compact_response_payload_from_sse(
 ) -> JsonValue:
     last_payload: dict[str, JsonValue] | None = None
     output_items: dict[int, dict[str, JsonValue]] = {}
+    unindexed_output_items: list[dict[str, JsonValue]] = []
     async for event_block in _iter_sse_events(resp, idle_timeout_seconds, max_event_bytes):
         payload = parse_sse_data_json(event_block)
         if payload is None:
@@ -1254,15 +1255,26 @@ async def _compact_response_payload_from_sse(
         if event_type in {"response.output_item.added", "response.output_item.done"}:
             output_index = payload.get("output_index")
             item = payload.get("item")
-            if isinstance(output_index, int) and isinstance(item, dict):
+            if not isinstance(item, dict):
+                continue
+            if isinstance(output_index, int):
                 output_items[output_index] = dict(item)
+            elif event_type == "response.output_item.done":
+                # Some compatible upstream responses omit output_index on the
+                # terminal item even though response.completed has no output.
+                unindexed_output_items.append(dict(item))
         if event_type == "response.completed":
             response = payload.get("response")
             if isinstance(response, dict):
                 existing_output = response.get("output")
-                if output_items and not (isinstance(existing_output, list) and existing_output):
+                if (output_items or unindexed_output_items) and not (
+                    isinstance(existing_output, list) and existing_output
+                ):
                     merged_response = dict(response)
-                    merged_response["output"] = [item for _, item in sorted(output_items.items())]
+                    merged_response["output"] = [
+                        *[item for _, item in sorted(output_items.items())],
+                        *unindexed_output_items,
+                    ]
                     return merged_response
                 return response
             raise ValueError("response.completed event missing response object")
@@ -1355,10 +1367,12 @@ def _compact_output_item_from_message(item: Mapping[str, JsonValue]) -> dict[str
         "type": "compaction",
         "encrypted_content": text,
     }
-    for key in ("id", "status"):
-        value = item.get(key)
-        if isinstance(value, str) and value.strip():
-            normalized[key] = value
+    item_id = normalize_compaction_item_id(item.get("id"))
+    if item_id is not None:
+        normalized["id"] = item_id
+    status = item.get("status")
+    if isinstance(status, str) and status.strip():
+        normalized["status"] = status
     return normalized
 
 
@@ -1392,10 +1406,12 @@ def _normalize_compact_output_item(item: Mapping[str, JsonValue]) -> dict[str, J
         "type": "compaction",
         "encrypted_content": encrypted_content,
     }
-    for key in ("id", "status"):
-        value = item.get(key)
-        if isinstance(value, str) and value.strip():
-            normalized[key] = value
+    item_id = normalize_compaction_item_id(item.get("id"))
+    if item_id is not None:
+        normalized["id"] = item_id
+    status = item.get("status")
+    if isinstance(status, str) and status.strip():
+        normalized["status"] = status
     return normalized
 
 

--- a/app/core/openai/models.py
+++ b/app/core/openai/models.py
@@ -142,5 +142,17 @@ class CompactResponsePayload(BaseModel):
         return _normalize_model_value(ResponseUsage, value)
 
 
+def normalize_compaction_item_id(item_id: object) -> str | None:
+    """Return an ID compatible with the Responses API compaction item type."""
+    if not isinstance(item_id, str):
+        return None
+    normalized = item_id.strip()
+    if not normalized:
+        return None
+    if normalized.startswith("cmp"):
+        return normalized
+    return f"cmp_{normalized}"
+
+
 OpenAIResponseResult: TypeAlias = OpenAIResponsePayload | OpenAIErrorEnvelope
 CompactResponseResult: TypeAlias = CompactResponsePayload | OpenAIErrorEnvelope

--- a/app/core/openai/models.py
+++ b/app/core/openai/models.py
@@ -143,15 +143,12 @@ class CompactResponsePayload(BaseModel):
 
 
 def normalize_compaction_item_id(item_id: object) -> str | None:
-    """Return an ID compatible with the Responses API compaction item type."""
+    """Return a valid compaction ID without changing opaque upstream identity."""
     if not isinstance(item_id, str):
         return None
-    normalized = item_id.strip()
-    if not normalized:
-        return None
-    if normalized.startswith("cmp"):
-        return normalized
-    return f"cmp_{normalized}"
+    if item_id.startswith("cmp_"):
+        return item_id
+    return None
 
 
 OpenAIResponseResult: TypeAlias = OpenAIResponsePayload | OpenAIErrorEnvelope

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -123,6 +123,7 @@ from app.core.openai.models import (
     OpenAIError,
     OpenAIResponsePayload,
     OpenAIResponseResult,
+    normalize_compaction_item_id,
 )
 from app.core.openai.models import (
     OpenAIErrorEnvelope as OpenAIErrorEnvelopeModel,
@@ -6201,8 +6202,8 @@ def _normalize_compaction_output_item(item: Mapping[str, JsonValue]) -> dict[str
         "type": "compaction",
         "encrypted_content": encrypted_content,
     }
-    item_id = item.get("id")
-    if isinstance(item_id, str) and item_id.strip():
+    item_id = normalize_compaction_item_id(item.get("id"))
+    if item_id is not None:
         normalized["id"] = item_id
     status = item.get("status")
     if isinstance(status, str) and status.strip():

--- a/openspec/changes/document-compact-trigger-proxy-contract/proposal.md
+++ b/openspec/changes/document-compact-trigger-proxy-contract/proposal.md
@@ -18,9 +18,9 @@ implementation detail that contradicts the existing context notes.
 - Document that Codex compact transport uses streamed `POST
   /backend-api/codex/responses` with `stream=true` and `store=false`, and
   reconstructs the compact response from the terminal SSE lifecycle.
-- Document that legacy message-shaped compact output is converted to a valid
-  `compaction` item ID beginning with `cmp`, while valid upstream IDs remain
-  unchanged.
+- Document that legacy message-shaped compact output is converted to a
+  `compaction` item while only valid opaque `cmp_` IDs are preserved; malformed
+  IDs are omitted rather than rewritten.
 - Document that the standalone Codex `/backend-api/codex/responses/compact`
   route remains a compatibility endpoint, while `/v1/responses/compact`
   preserves duplicate-trigger normalization for existing OpenAI-compatible

--- a/openspec/changes/document-compact-trigger-proxy-contract/proposal.md
+++ b/openspec/changes/document-compact-trigger-proxy-contract/proposal.md
@@ -18,6 +18,9 @@ implementation detail that contradicts the existing context notes.
 - Document that Codex compact transport uses streamed `POST
   /backend-api/codex/responses` with `stream=true` and `store=false`, and
   reconstructs the compact response from the terminal SSE lifecycle.
+- Document that legacy message-shaped compact output is converted to a valid
+  `compaction` item ID beginning with `cmp`, while valid upstream IDs remain
+  unchanged.
 - Document that the standalone Codex `/backend-api/codex/responses/compact`
   route remains a compatibility endpoint, while `/v1/responses/compact`
   preserves duplicate-trigger normalization for existing OpenAI-compatible

--- a/openspec/changes/document-compact-trigger-proxy-contract/specs/responses-api-compat/spec.md
+++ b/openspec/changes/document-compact-trigger-proxy-contract/specs/responses-api-compat/spec.md
@@ -54,6 +54,16 @@ OpenAI-style `/v1/responses/compact` is otherwise unchanged by this requirement;
 - **AND** it does not require the legacy `/backend-api/codex/responses/compact`
   upstream route to be available
 
+#### Scenario: Legacy message-shaped compact output gets a valid item ID
+
+- **WHEN** the upstream compact response exposes the encrypted compact payload
+  as a legacy `message` item with a non-empty ID that does not begin with `cmp`
+- **THEN** the proxy converts that item to `type="compaction"` and prefixes
+  the ID with `cmp_` while preserving its suffix
+- **AND** an existing ID that already begins with `cmp` is preserved unchanged
+- **AND** ordinary message items outside the compact-output conversion remain
+  unchanged
+
 #### Scenario: Standalone Codex compact remains a compatibility endpoint
 
 - **WHEN** a client calls `POST /backend-api/codex/responses/compact`

--- a/openspec/changes/document-compact-trigger-proxy-contract/specs/responses-api-compat/spec.md
+++ b/openspec/changes/document-compact-trigger-proxy-contract/specs/responses-api-compat/spec.md
@@ -78,7 +78,7 @@ OpenAI-style `/v1/responses/compact` is otherwise unchanged by this requirement;
 
 - **WHEN** a Codex-affinity `POST /backend-api/codex/responses/compact` request receives upstream output that contains historical message items and one compaction summary item
 - **THEN** the JSON response body contains exactly one `output` item for that compaction summary
-- **AND** the normalized item preserves the compaction summary's non-empty upstream ID and status
+- **AND** the normalized item preserves the compaction summary's valid `cmp_`-prefixed upstream ID and status
 - **AND** it does not expose historical message items as standalone compact output
 
 #### Scenario: OpenAI-compatible compact normalizes duplicate triggers

--- a/openspec/changes/document-compact-trigger-proxy-contract/specs/responses-api-compat/spec.md
+++ b/openspec/changes/document-compact-trigger-proxy-contract/specs/responses-api-compat/spec.md
@@ -4,11 +4,11 @@
 
 When `POST /backend-api/codex/responses` receives a request whose top-level `input` array contains exactly one `{"type":"compaction_trigger"}` item as its final element, the proxy SHALL remove that trigger before calling upstream compaction handling and SHALL emit a raw SSE stream that contains exactly one compaction output item. The internal compact request built for that flow MUST contain exactly one terminal `compaction_trigger` item on the compact wire, and the proxy MUST reject duplicate or non-terminal top-level `compaction_trigger` placement locally with HTTP 400 `invalid_request_error` before any upstream compact handling.
 
-The stream MUST emit `response.created`, `response.output_item.added`, `response.output_item.done`, and `response.completed` in that order with monotonically increasing sequence numbers. The added event MUST expose the selected compaction item as in progress. The done event and terminal completed response MUST carry the same terminal `compaction` item. When the selected encrypted upstream compaction item carries a non-empty `id` or `status`, the synthetic stream MUST preserve those values with its `encrypted_content`; it MUST NOT generate a replacement item ID.
+The stream MUST emit `response.created`, `response.output_item.added`, `response.output_item.done`, and `response.completed` in that order with monotonically increasing sequence numbers. The added event MUST expose the selected compaction item as in progress. The done event and terminal completed response MUST carry the same terminal `compaction` item. When the selected encrypted upstream compaction item carries a valid `cmp_` ID or status, the synthetic stream MUST preserve those values with its `encrypted_content`; it MUST NOT generate or rewrite a replacement item ID. A malformed, empty, or non-`cmp_` ID MUST be omitted while the opaque encrypted content remains unchanged.
 
 Codex compact flows SHALL send the upstream compact request to `POST /backend-api/codex/responses` with `stream=true` and `store=false`, accept the upstream SSE response, and reconstruct one normalized compact response item from the terminal response lifecycle; they MUST NOT require the legacy `/backend-api/codex/responses/compact` upstream route to be available.
 
-For Codex-affinity standalone compact requests, `POST /backend-api/codex/responses/compact` SHALL remain available as a compatibility endpoint with its subscription-backed compact routing contract, and SHALL normalize an upstream remote-compaction-v2 response that includes historical message output plus a compaction summary into the single compact output item required by Codex clients. A non-empty upstream compaction item `id` or `status` MUST be preserved in that normalized output item.
+For Codex-affinity standalone compact requests, `POST /backend-api/codex/responses/compact` SHALL remain available as a compatibility endpoint with its subscription-backed compact routing contract, and SHALL normalize an upstream remote-compaction-v2 response that includes historical message output plus a compaction summary into the single compact output item required by Codex clients. A valid upstream `cmp_` compaction item `id` and any non-empty `status` MUST be preserved in that normalized output item. An empty, non-string, or non-`cmp_` ID MUST be omitted rather than rewritten; encrypted content MUST remain unchanged.
 
 OpenAI-style `/v1/responses/compact` is otherwise unchanged by this requirement; when it receives duplicate top-level `compaction_trigger` items, codex-lb preserves the existing compatibility behavior and the forwarded compact input contains one terminal trigger.
 
@@ -54,13 +54,15 @@ OpenAI-style `/v1/responses/compact` is otherwise unchanged by this requirement;
 - **AND** it does not require the legacy `/backend-api/codex/responses/compact`
   upstream route to be available
 
-#### Scenario: Legacy message-shaped compact output gets a valid item ID
+#### Scenario: Legacy message-shaped compact output does not get a rewritten item ID
 
 - **WHEN** the upstream compact response exposes the encrypted compact payload
-  as a legacy `message` item with a non-empty ID that does not begin with `cmp`
-- **THEN** the proxy converts that item to `type="compaction"` and prefixes
-  the ID with `cmp_` while preserving its suffix
-- **AND** an existing ID that already begins with `cmp` is preserved unchanged
+  as a legacy `message` item with a non-empty ID that does not begin with `cmp_`
+- **THEN** the proxy converts that item to `type="compaction"` and omits the
+  malformed ID
+- **AND** the proxy preserves the encrypted content unchanged
+- **AND** an existing ID that begins with `cmp_` is preserved byte-for-byte
+- **AND** the proxy does not synthesize a `cmp_msg_...` ID
 - **AND** ordinary message items outside the compact-output conversion remain
   unchanged
 

--- a/openspec/changes/document-compact-trigger-proxy-contract/tasks.md
+++ b/openspec/changes/document-compact-trigger-proxy-contract/tasks.md
@@ -7,7 +7,7 @@
 - [x] 1.3 Record the streamed `/backend-api/codex/responses` compact transport,
   the standalone Codex compatibility endpoint, and the `/v1` normalization
   asymmetry.
-- [x] 1.4 Record the legacy message-shaped compact ID normalization contract.
+- [x] 1.4 Record the legacy message-shaped compact ID filtering contract.
 
 ## 2. Validate the change
 

--- a/openspec/changes/document-compact-trigger-proxy-contract/tasks.md
+++ b/openspec/changes/document-compact-trigger-proxy-contract/tasks.md
@@ -7,6 +7,7 @@
 - [x] 1.3 Record the streamed `/backend-api/codex/responses` compact transport,
   the standalone Codex compatibility endpoint, and the `/v1` normalization
   asymmetry.
+- [x] 1.4 Record the legacy message-shaped compact ID normalization contract.
 
 ## 2. Validate the change
 

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -794,7 +794,7 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
     assert body["id"] == "resp_compact_summary_1"
     assert body["output"] == [
         {
-            "id": "msg_compact_summary_1",
+            "id": "cmp_msg_compact_summary_1",
             "type": "compaction",
             "status": "completed",
             "encrypted_content": "enc_compact_summary_1",
@@ -1629,14 +1629,19 @@ async def test_proxy_compact_output_round_trips_into_followup_responses_without_
         "object": "response.compaction",
         "output": [
             {
-                "type": "message",
+                "type": "compaction",
                 "id": "msg_compact_round_trip",
-                "role": "assistant",
-                "content": [{"type": "output_text", "text": "preserve me exactly"}],
+                "encrypted_content": "preserve me exactly",
             },
             {"type": "reasoning", "encrypted_content": "enc_round_trip_state"},
         ],
         "retained_items": [{"type": "item_reference", "id": "msg_original_round_trip"}],
+    }
+    expected_compact_window = {
+        **compact_window,
+        "output": [
+            {**compact_window["output"][0], "id": "cmp_msg_compact_round_trip"},
+        ],
     }
     seen_inputs: list[object] = []
 
@@ -1653,7 +1658,7 @@ async def test_proxy_compact_output_round_trips_into_followup_responses_without_
     compact_payload = {"model": "gpt-5.1", "instructions": "compact", "input": []}
     compact_response = await async_client.post("/backend-api/codex/responses/compact", json=compact_payload)
     assert compact_response.status_code == 200
-    assert compact_response.json() == compact_window
+    assert compact_response.json() == expected_compact_window
 
     stream_payload = {
         "model": "gpt-5.1",
@@ -1664,7 +1669,7 @@ async def test_proxy_compact_output_round_trips_into_followup_responses_without_
     response = await async_client.post("/backend-api/codex/responses", json=stream_payload)
 
     assert response.status_code == 200
-    assert seen_inputs == [compact_window["output"]]
+    assert seen_inputs == [expected_compact_window["output"]]
 
 
 _NEUTRAL_FULL_RESEND_INPUT: list[dict[str, object]] = [

--- a/tests/integration/test_proxy_compact.py
+++ b/tests/integration/test_proxy_compact.py
@@ -794,7 +794,6 @@ async def test_proxy_compact_success_preserves_compaction_payload(async_client, 
     assert body["id"] == "resp_compact_summary_1"
     assert body["output"] == [
         {
-            "id": "cmp_msg_compact_summary_1",
             "type": "compaction",
             "status": "completed",
             "encrypted_content": "enc_compact_summary_1",
@@ -1639,9 +1638,7 @@ async def test_proxy_compact_output_round_trips_into_followup_responses_without_
     }
     expected_compact_window = {
         **compact_window,
-        "output": [
-            {**compact_window["output"][0], "id": "cmp_msg_compact_round_trip"},
-        ],
+        "output": [{"type": "compaction", "encrypted_content": "preserve me exactly"}],
     }
     seen_inputs: list[object] = []
 

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -445,7 +445,7 @@ async def test_compact_responses_uses_codex_client_when_route_is_resolved(route:
     assert response.id == "resp_compact_1"
     assert response.model_extra is not None
     assert response.model_extra["output"] == [
-        {"id": "cmp_msg_compact_1", "type": "compaction", "status": "completed", "encrypted_content": "enc_compact_1"}
+        {"type": "compaction", "status": "completed", "encrypted_content": "enc_compact_1"}
     ]
     assert client.calls[0]["url"].endswith("/backend-api/codex/responses")
     assert client.calls[0]["route"] is route
@@ -476,7 +476,6 @@ async def test_compact_responses_recovers_terminal_item_without_output_index(
     assert response.model_extra is not None
     assert response.model_extra["output"] == [
         {
-            "id": "cmp_msg_compact_without_index",
             "type": "compaction",
             "status": "completed",
             "encrypted_content": "enc_compact_without_index",
@@ -552,7 +551,7 @@ async def test_compact_responses_message_fallback_selects_last_message(
     assert response.id == "resp_compact_messages"
     assert response.model_extra is not None
     assert response.model_extra["output"] == [
-        {"id": "msg_summary", "type": "compaction", "status": "completed", "encrypted_content": "enc_summary"}
+        {"type": "compaction", "status": "completed", "encrypted_content": "enc_summary"}
     ]
 
 

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -96,10 +96,30 @@ class _CompactStreamContent:
         )
 
 
+class _CompactStreamWithoutOutputIndexContent:
+    async def iter_chunked(self, size: int):
+        del size
+        yield (
+            b'data: {"type":"response.output_item.done",'
+            b'"item":{"id":"msg_compact_without_index","type":"message",'
+            b'"status":"completed","content":[{"type":"output_text",'
+            b'"text":"enc_compact_without_index"}]}}\n\n'
+            b'data: {"type":"response.completed","response":'
+            b'{"object":"response","id":"resp_compact_without_index",'
+            b'"status":"completed","output":[]}}\n\n'
+        )
+
+
 class _CompactStreamResponse:
     status_code = 200
     headers: dict[str, str] = {}
     content = _CompactStreamContent()
+
+
+class _CompactStreamWithoutOutputIndexResponse:
+    status_code = 200
+    headers: dict[str, str] = {}
+    content = _CompactStreamWithoutOutputIndexContent()
 
 
 class _BufferedCompactStreamResponse:
@@ -425,7 +445,7 @@ async def test_compact_responses_uses_codex_client_when_route_is_resolved(route:
     assert response.id == "resp_compact_1"
     assert response.model_extra is not None
     assert response.model_extra["output"] == [
-        {"id": "msg_compact_1", "type": "compaction", "status": "completed", "encrypted_content": "enc_compact_1"}
+        {"id": "cmp_msg_compact_1", "type": "compaction", "status": "completed", "encrypted_content": "enc_compact_1"}
     ]
     assert client.calls[0]["url"].endswith("/backend-api/codex/responses")
     assert client.calls[0]["route"] is route
@@ -434,6 +454,34 @@ async def test_compact_responses_uses_codex_client_when_route_is_resolved(route:
     assert client.calls[0]["json"]["stream"] is True
     assert client.calls[0]["headers"]["Accept"] == "text/event-stream"
     assert trace.endpoint_id == "ep_1"
+
+
+@pytest.mark.asyncio
+async def test_compact_responses_recovers_terminal_item_without_output_index(
+    route: ResolvedUpstreamRoute,
+) -> None:
+    client = _RouteMetadataCodexClient(_CompactStreamWithoutOutputIndexResponse())
+    payload = ResponsesCompactRequest(model="gpt-5.2", instructions="Summarize.", input="hello")
+
+    response = await compact_responses(
+        payload,
+        {"user-agent": "codex"},
+        "access",
+        "chatgpt_account",
+        session=cast(Any, object()),
+        route=route,
+        codex_client=cast(Any, client),
+    )
+
+    assert response.model_extra is not None
+    assert response.model_extra["output"] == [
+        {
+            "id": "cmp_msg_compact_without_index",
+            "type": "compaction",
+            "status": "completed",
+            "encrypted_content": "enc_compact_without_index",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -423,7 +423,7 @@ def test_compact_response_output_item_preserves_summary_item_id() -> None:
     }
 
 
-def test_compact_response_output_item_normalizes_invalid_id_prefix() -> None:
+def test_compact_response_output_item_drops_invalid_id_prefix() -> None:
     payload = CompactResponsePayload.model_validate(
         {
             "object": "response.compaction",
@@ -438,7 +438,6 @@ def test_compact_response_output_item_normalizes_invalid_id_prefix() -> None:
     )
 
     assert proxy_api_module._compact_response_output_item(payload) == {
-        "id": "cmp_msg_compact_context",
         "type": "compaction",
         "encrypted_content": "COMPACT_CONTEXT",
     }

--- a/tests/unit/test_proxy_api_responses_contract.py
+++ b/tests/unit/test_proxy_api_responses_contract.py
@@ -423,6 +423,27 @@ def test_compact_response_output_item_preserves_summary_item_id() -> None:
     }
 
 
+def test_compact_response_output_item_normalizes_invalid_id_prefix() -> None:
+    payload = CompactResponsePayload.model_validate(
+        {
+            "object": "response.compaction",
+            "output": [
+                {
+                    "id": "msg_compact_context",
+                    "type": "compaction",
+                    "encrypted_content": "COMPACT_CONTEXT",
+                }
+            ],
+        }
+    )
+
+    assert proxy_api_module._compact_response_output_item(payload) == {
+        "id": "cmp_msg_compact_context",
+        "type": "compaction",
+        "encrypted_content": "COMPACT_CONTEXT",
+    }
+
+
 def test_compact_response_id_generates_unique_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(proxy_api_module, "get_request_id", lambda: None)
     payload = CompactResponsePayload.model_validate({"object": "response.compaction"})


### PR DESCRIPTION
## What changed

After upstream PR #1809, a compact response in the legacy message-shaped format could be converted to a `type="compaction"` item while retaining its original `msg_...` ID. The next Codex request replays that item, and the upstream API rejects it with `Expected an ID that begins with cmp`.

This follow-up:

- preserves a valid upstream `cmp_...` ID byte-for-byte;
- removes malformed, empty, or non-`cmp_` IDs from normalized compaction items;
- avoids the unsafe conversion of `msg_...` to `cmp_msg_...`;
- leaves `encrypted_content` unchanged so the opaque payload remains associated with its original identity;
- preserves the Responses stream transport from PR #1809 and covers the fallback path when `output_index` is missing.

When the ID is absent, the Codex client can assign a new valid `cmp_...` ID later. This is consistent with the official Compaction documentation and the current OpenAI Codex client models.

## Validation

- `uv run pytest -q tests/unit/test_codex_upstream_paths.py tests/unit/test_proxy_api_responses_contract.py tests/integration/test_proxy_compact.py` -> 145 passed
- `uv run pytest -q tests/unit` -> 6248 passed, 70 skipped
- `make lint` -> passed
- `uv run ty check` -> passed
- `npx -y @fission-ai/openspec@1.8.0 validate --strict document-compact-trigger-proxy-contract` -> valid
- `make test-unit` could not start because `bun` is not installed in the environment; the complete Python unit test suite passed when run directly.

## References

- https://developers.openai.com/api/docs/guides/compaction
- https://github.com/Soju06/codex-lb/pull/1809
- https://github.com/openai/codex/blob/main/codex-rs/core/src/client.rs
- https://github.com/openai/codex/blob/main/codex-rs/protocol/src/models.rs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compact-response handling for terminal events that lack an output index.
  - Valid compact item IDs are preserved and normalized consistently.
  - Invalid IDs are omitted without altering encrypted content.
  - Legacy message-shaped responses are converted to the standardized `compaction` format.
  - Follow-up streamed responses now preserve normalized compaction output reliably.

- **Documentation**
  - Clarified compact-response compatibility requirements and legacy response conversion behavior.

- **Tests**
  - Added coverage for missing output indexes, invalid IDs, response normalization, and round-trip streaming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->