### PR TITLE
fix(proxy): recognize the terse upstream previous_response_id rejection

### DIFF
--- a/app/core/errors.py
+++ b/app/core/errors.py
@@ -76,7 +76,14 @@ def is_previous_response_not_found_message(message: str | None) -> bool:
     if message is None:
         return False
     normalized = " ".join(message.lower().split())
-    return "previous response" in normalized and "not found" in normalized
+    if "previous response" in normalized and "not found" in normalized:
+        return True
+    # The Codex backend also rejects an unresolvable anchor with a terse
+    # ``Invalid `previous_response_id`.`` that carries neither "not found" nor an
+    # error ``param``. Recognize that shape too: the recovery (retry with full
+    # input and no anchor) is the correct response to any upstream rejection of
+    # the anchor itself, including a malformed one.
+    return "previous_response_id" in normalized and ("invalid" in normalized or "not found" in normalized)
 
 
 def previous_response_id_from_not_found_message(message: str | None) -> str | None:
@@ -102,7 +109,11 @@ def is_previous_response_not_found_error(
 ) -> bool:
     if code == PREVIOUS_RESPONSE_NOT_FOUND_CODE:
         return True
-    if code != "invalid_request_error" or param != "previous_response_id":
+    if code != "invalid_request_error":
+        return False
+    # ``param`` is absent on the terse rejection shape; only a *different* param
+    # rules the anchor out as the cause.
+    if param is not None and param != "previous_response_id":
         return False
     return is_previous_response_not_found_message(message)
 

--- a/openspec/changes/recognize-terse-previous-response-rejection/proposal.md
+++ b/openspec/changes/recognize-terse-previous-response-rejection/proposal.md
@@ -1,0 +1,19 @@
+## Why
+
+Upstream detection of an unresolvable `previous_response_id` is string-shaped: `is_previous_response_not_found_error` requires `code=previous_response_not_found`, or `code=invalid_request_error` **with** `param=previous_response_id` **and** a message containing "previous response … not found".
+
+The Codex backend now rejects an unresolvable anchor with a terse `Invalid \`previous_response_id\`.` that carries neither the `param` nor the "not found" wording. The predicate stops matching, and every recovery site gated on it — the WebSocket full-resend retry, the HTTP bridge anchor rewrite, and the public-error masking — is skipped, so the raw upstream 400 reaches the client as a failed turn the user has to abandon.
+
+Observed on a production deployment: anchor recoveries ran 1–8/hour and were invisible to users until the message shape changed, after which recoveries dropped to zero and raw 400s rose to 17/hour across 10 API keys and both transports (56 HTTP / 15 WebSocket in 24 hours).
+
+## What Changes
+
+- `is_previous_response_not_found_message` also matches a message that names `previous_response_id` alongside "invalid" (in addition to the existing "previous response … not found" wording).
+- A missing error `param` is treated as inconclusive rather than disqualifying: only a *different* `param` rules the anchor out as the cause. `code` must still be `invalid_request_error` (or the canonical `previous_response_not_found`).
+- No change to what recovery does. Retrying with full input and no anchor is already the correct response to any upstream rejection of the anchor itself, including a malformed one.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: upstream previous-response misses are detected from the terse rejection shape as well, so recovery and public-error masking keep engaging.

--- a/openspec/changes/recognize-terse-previous-response-rejection/specs/responses-api-compat/spec.md
+++ b/openspec/changes/recognize-terse-previous-response-rejection/specs/responses-api-compat/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: Public Responses errors mask previous-response misses
+
+Public Responses endpoints MUST NOT return an OpenAI-shaped `previous_response_not_found` error to clients. If a lower layer still raises or collects that error, the API layer MUST rewrite it to a retryable `stream_incomplete` continuity failure and remove the missing response id from the public payload. An upstream rejection of the anchor MUST be recognized from its wording as well as its canonical code: an `invalid_request_error` whose message names `previous_response_id` as invalid or not found is a previous-response miss even when the error carries no `param`. An error whose `param` names a different field MUST NOT be treated as a previous-response miss.
+
+#### Scenario: API layer receives an upstream previous-response miss
+
+- **WHEN** a public `/responses`, `/v1/responses`, `/responses/compact`, or `/v1/responses/compact` handler receives an error with `code=previous_response_not_found`
+- **OR** it receives `code=invalid_request_error` with `param=previous_response_id` and a message saying the previous response was not found
+- **THEN** the response status is retryable
+- **AND** the public error code is `stream_incomplete`
+- **AND** the missing `previous_response_id` is not exposed in the response body
+
+#### Scenario: Upstream rejects the anchor without a param or "not found" wording
+
+- **WHEN** a public Responses handler receives `code=invalid_request_error` with no `param` and a message of ``Invalid `previous_response_id`.``
+- **THEN** it is treated as a previous-response miss
+- **AND** the public error code is `stream_incomplete` rather than the raw upstream `invalid_request_error`
+
+#### Scenario: An error naming a different param is not a previous-response miss
+
+- **WHEN** a public Responses handler receives `code=invalid_request_error` whose `param` names a field other than `previous_response_id`
+- **THEN** it is not treated as a previous-response miss, whatever its message says

--- a/openspec/changes/recognize-terse-previous-response-rejection/tasks.md
+++ b/openspec/changes/recognize-terse-previous-response-rejection/tasks.md
@@ -1,0 +1,10 @@
+## 1. Detection
+
+- [x] 1.1 Match a terse upstream rejection that names `previous_response_id` alongside "invalid", in addition to the existing "previous response … not found" wording
+- [x] 1.2 Treat an absent error `param` as inconclusive; only a different `param` disqualifies the anchor as the cause
+
+## 2. Tests
+
+- [x] 2.1 The terse shape (`code=invalid_request_error`, no `param`, message ``Invalid `previous_response_id`.``) is classified as a previous-response miss
+- [x] 2.2 The pre-existing shapes (canonical code, and `param=previous_response_id` with "not found") still classify
+- [x] 2.3 A different `param`, an unrelated `invalid_request_error` message, and a non-400 code that merely mentions the anchor are all left unmatched

--- a/tests/unit/test_openai_errors.py
+++ b/tests/unit/test_openai_errors.py
@@ -59,6 +59,40 @@ def test_previous_response_not_found_classifier_covers_openai_shapes():
     )
 
 
+def test_is_previous_response_not_found_error_terse_upstream_shape():
+    # The Codex backend rejects an unresolvable anchor with a terse message that
+    # carries neither "not found" nor an error ``param``; the recovery must still
+    # engage, otherwise the raw 400 reaches the client.
+    assert is_previous_response_not_found_error(
+        code="invalid_request_error",
+        param=None,
+        message="Invalid `previous_response_id`.",
+    )
+    assert is_previous_response_not_found_error(
+        code="invalid_request_error",
+        param="previous_response_id",
+        message="Invalid previous_response_id",
+    )
+    # A different param still rules the anchor out as the cause.
+    assert not is_previous_response_not_found_error(
+        code="invalid_request_error",
+        param="model",
+        message="Invalid `previous_response_id`.",
+    )
+    # An unrelated 400 that never mentions the anchor is untouched.
+    assert not is_previous_response_not_found_error(
+        code="invalid_request_error",
+        param=None,
+        message="Invalid value for 'temperature'.",
+    )
+    # A non-400 code that happens to mention the anchor is untouched.
+    assert not is_previous_response_not_found_error(
+        code="rate_limit_exceeded",
+        param=None,
+        message="Invalid `previous_response_id`.",
+    )
+
+
 def test_previous_response_id_from_not_found_message_extracts_anchor():
     assert (
         previous_response_id_from_not_found_message(


### PR DESCRIPTION
## Why

Detection of an unresolvable `previous_response_id` is string-shaped. `is_previous_response_not_found_error` matches only:

- `code=previous_response_not_found`, or
- `code=invalid_request_error` **with** `param=previous_response_id` **and** a message containing "previous response … not found"

The Codex backend now rejects an unresolvable anchor like this instead:

```json
{"error":{"message":"Invalid `previous_response_id`.","type":"invalid_request_error","code":"invalid_request_error"}}
```

No `param`, no "not found". The predicate returns `False`, and every recovery site gated on it is skipped — the WebSocket full-resend retry, the HTTP bridge anchor rewrite, and the public-error masking that is supposed to turn this into a retryable `stream_incomplete`. The raw upstream 400 reaches the client, and the user's turn dies with `Invalid previous_response_id.` on a thread they then have to abandon.

## Observed impact

On a production deployment (~8k successful requests/hour), the changeover is unmistakable in the request log:

| hour (UTC) | recoveries (`codex_previous_response_stale`) | raw 400s reaching clients |
|---|---|---|
| 08-18 04:00 → 16:00 | 1–8 per hour | 0 |
| 08-18 22:00 | 0 | 1 |
| 08-19 04:00 | 0 | 13 |
| 08-19 06:00 | 0 | 17 |

24-hour totals: **71 raw 400s across 10 API keys**, on both transports (56 HTTP bridge, 15 WebSocket). Recoveries: zero since the wording changed. Before it changed, users never saw this error at all — the retry absorbed it.

## What changes

- `is_previous_response_not_found_message` also matches a message that names `previous_response_id` alongside "invalid".
- A missing `param` becomes inconclusive rather than disqualifying — only a *different* `param` rules the anchor out. `code` must still be `invalid_request_error` (or the canonical `previous_response_not_found`).

What recovery *does* is unchanged. Retrying with full input and no anchor is already the right response to any upstream rejection of the anchor itself, including a malformed one, so widening detection cannot produce a wrong recovery — at worst one extra full-context retry on a 400 that mentions the anchor.

## Spec

`openspec/changes/recognize-terse-previous-response-rejection/` modifies the `responses-api-compat` requirement "Public Responses errors mask previous-response misses" to state that the miss is recognized from wording as well as canonical code, and that a different `param` still disqualifies.

## Tests

`tests/unit/test_openai_errors.py::test_is_previous_response_not_found_error_terse_upstream_shape` covers the terse shape, the two pre-existing shapes, a different `param`, an unrelated `invalid_request_error` message, and a non-400 code that merely mentions the anchor. `ruff check`, `ruff format --check`, and `ty check` clean; unit suite 4,299 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when a previous response cannot be found or is rejected by the service.
  * Recognizes both detailed and terse error messages, including cases where parameter details are omitted.
  * Prevents unrelated parameter errors from being incorrectly treated as recoverable.
  * Continues masking missing response identifiers from public error messages.

* **Tests**
  * Added coverage for valid recovery scenarios and unrelated or mismatched errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->