### PR TITLE
fix(proxy): retain image reservation recovery ownership

### DIFF
--- a/app/modules/proxy/_service/api_key_usage.py
+++ b/app/modules/proxy/_service/api_key_usage.py
@@ -359,6 +359,34 @@ class _ApiKeyUsageMixin:
             finally:
                 _signal_propagated_responses_service_cleanup_ready()
 
+    async def settle_image_api_key_usage(
+        self,
+        api_key: ApiKeyData | None,
+        reservation: ApiKeyUsageReservationData | None,
+        *,
+        model: str,
+        input_tokens: int | None,
+        output_tokens: int | None,
+        cached_input_tokens: int | None,
+        request_id: str,
+    ) -> bool:
+        """Transfer captured image usage to tracked reservation settlement."""
+        has_usage = bool(input_tokens) or bool(output_tokens)
+        settlement = _StreamSettlement(
+            status="success" if has_usage else "failed",
+            model=model,
+            input_tokens=int(input_tokens or 0) if has_usage else None,
+            output_tokens=int(output_tokens or 0) if has_usage else None,
+            cached_input_tokens=int(cached_input_tokens or 0) if has_usage else None,
+            service_tier=None,
+        )
+        return await self._settle_stream_api_key_usage(
+            api_key,
+            reservation,
+            settlement,
+            request_id=request_id,
+        )
+
     async def _settle_stream_api_key_usage(
         self,
         api_key: ApiKeyData | None,

--- a/app/modules/proxy/_service/api_key_usage.py
+++ b/app/modules/proxy/_service/api_key_usage.py
@@ -371,7 +371,7 @@ class _ApiKeyUsageMixin:
         request_id: str,
     ) -> bool:
         """Transfer captured image usage to tracked reservation settlement."""
-        has_usage = bool(input_tokens) or bool(output_tokens)
+        has_usage = input_tokens is not None or output_tokens is not None
         settlement = _StreamSettlement(
             status="success" if has_usage else "failed",
             model=model,

--- a/app/modules/proxy/api.py
+++ b/app/modules/proxy/api.py
@@ -3179,6 +3179,8 @@ async def _proxy_images_generation_request(
                 _output = captured.get("image_output_tokens")
                 _cached = captured.get("image_cached_input_tokens")
                 await _finalize_image_reservation(
+                    context.service,
+                    api_key,
                     reservation,
                     model=public_model,
                     input_tokens=_input if isinstance(_input, int) else None,
@@ -3232,6 +3234,8 @@ async def _proxy_images_generation_request(
     _output = captured.get("image_output_tokens")
     _cached = captured.get("image_cached_input_tokens")
     await _finalize_image_reservation(
+        context.service,
+        api_key,
         reservation,
         model=public_model,
         input_tokens=_input if isinstance(_input, int) else None,
@@ -3474,6 +3478,8 @@ async def _proxy_images_edit_request(
                 _output = captured.get("image_output_tokens")
                 _cached = captured.get("image_cached_input_tokens")
                 await _finalize_image_reservation(
+                    context.service,
+                    api_key,
                     reservation,
                     model=public_model,
                     input_tokens=_input if isinstance(_input, int) else None,
@@ -3527,6 +3533,8 @@ async def _proxy_images_edit_request(
     _output = captured.get("image_output_tokens")
     _cached = captured.get("image_cached_input_tokens")
     await _finalize_image_reservation(
+        context.service,
+        api_key,
         reservation,
         model=public_model,
         input_tokens=_input if isinstance(_input, int) else None,
@@ -7651,6 +7659,8 @@ async def _release_reservation_best_effort(
 
 
 async def _finalize_image_reservation(
+    service: proxy_service_module.ProxyService,
+    api_key: ApiKeyData | None,
     reservation: ApiKeyUsageReservationData | None,
     *,
     model: str,
@@ -7658,47 +7668,18 @@ async def _finalize_image_reservation(
     output_tokens: int | None,
     cached_input_tokens: int | None = None,
 ) -> None:
-    """Finalize the API-key usage reservation for a ``/v1/images/*`` call.
-
-    The image adapter bypasses the standard stream settlement (``stream_responses``
-    is invoked with ``api_key_reservation=None``) because the ``image_generation``
-    tool path typically leaves ``response.usage`` empty; charging from
-    ``tool_usage.image_gen`` is the only source of truth. This helper
-    finalizes the reservation with the captured image tokens when present,
-    otherwise releases it. Calling this exactly once per request prevents
-    the double-billing scenario where both the standard settlement and
-    the post-hoc image record_usage path increment limits.
-
-    Persistence errors are caught and logged so a transient DB/session
-    failure during the tail accounting cannot turn a successfully
-    generated image into a user-facing 500 (non-streaming) or an
-    abrupt stream termination (streaming). This mirrors the
-    best-effort accounting policy used by
-    ``ProxyService._settle_stream_api_key_usage``.
-    """
+    """Transfer image-token settlement to tracked persistence ownership."""
     if reservation is None:
         return
-    try:
-        if not input_tokens and not output_tokens:
-            await _release_reservation(reservation)
-            return
-        async with get_background_session() as session:
-            service = ApiKeysService(ApiKeysRepository(session))
-            await service.finalize_usage_reservation(
-                reservation.reservation_id,
-                model=model,
-                input_tokens=int(input_tokens or 0),
-                output_tokens=int(output_tokens or 0),
-                cached_input_tokens=int(cached_input_tokens or 0),
-                service_tier=None,
-            )
-    except Exception:
-        logger.warning(
-            "failed to finalize image reservation reservation_id=%s model=%s",
-            reservation.reservation_id,
-            model,
-            exc_info=True,
-        )
+    await service.settle_image_api_key_usage(
+        api_key,
+        reservation,
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cached_input_tokens=cached_input_tokens,
+        request_id=get_request_id() or reservation.reservation_id,
+    )
 
 
 async def _settle_source_reservation(

--- a/openspec/changes/archive/2026-08-19-fix-images-finalize-reservation-release/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-19-fix-images-finalize-reservation-release/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/archive/2026-08-19-fix-images-finalize-reservation-release/design.md
+++ b/openspec/changes/archive/2026-08-19-fix-images-finalize-reservation-release/design.md
@@ -1,0 +1,89 @@
+## Context
+
+Image generation and edit reserve limited API-key quota before invoking the
+internal Responses pipeline. They intentionally pass no reservation into that
+pipeline because image usage comes from `tool_usage.image_gen`, not
+`response.usage`. The image adapter therefore owns final settlement.
+
+The current adapter performs finalization inline after it has already produced
+the public image result. A persistence failure rolls the reservation back to
+`reserved`; the adapter logs and returns, so no request-scoped owner remains.
+The standard Responses settlement path already provides detached task tracking,
+cancellation handoff, retrying release, bounded repository concurrency, and
+graceful persistence drain.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Transfer image reservation ownership exactly once to the existing tracked
+  settlement machinery.
+- Finalize captured image tokens when persistence succeeds.
+- Preserve the completed public response while failed or cancelled settlement
+  transfers ownership to the existing retrying release fallback.
+- Keep generation/edit and streaming/non-streaming behavior aligned.
+
+**Non-Goals**
+
+- Define image-only retries of authoritative token finalization.
+- Change repository states, retry timings, concurrency limits, stale-reset
+  policy, database schema, settings, or external response shapes.
+- Give the internal Responses stream a second settlement owner.
+- Broaden pre-terminal image cancellation cleanup.
+
+## Decisions
+
+### Reuse tracked stream settlement ownership
+
+Add one image-facing adapter on the API-key usage mixin. The adapter constructs
+the existing settlement value from the public image model, captured image
+tokens, API-key data, reservation, service tier `None`, and request id, then
+delegates to the existing tracked settlement entrypoint.
+
+This keeps task registration, cancellation callbacks, retrying release, and
+persistence drain in one implementation rather than copying lifecycle logic
+into the route module.
+
+### Preserve image-token authority
+
+When at least one captured image token field is usable, the adapter records a
+successful settlement and normalizes missing token fields to zero. When no
+captured image usage is usable, it selects the existing non-success settlement
+path so the reservation releases instead of recording fabricated usage.
+
+The internal Responses call continues receiving `api_key_reservation=None`.
+
+### Transfer ownership before returning the completed result
+
+All four image completion paths call the same adapter exactly once. The adapter
+returns after the settlement task is registered; the public response does not
+wait for persistence. If tracked finalization fails or is cancelled, its done
+callback transfers ownership synchronously to the retrying release task.
+
+Exactly-once refers to the terminal database mutation. Retried release attempts
+remain safe because repository transitions claim only a still-reserved row.
+
+## Risks / Trade-offs
+
+- A failed finalization falls back to release, so successful image usage can be
+  omitted under persistence failure. This matches existing standard stream
+  policy and is preferable to keeping quota ownerless. Retrying authoritative
+  finalization is a broader accounting-policy change and remains separate.
+- Reusing a private settlement value couples the adapter to existing settlement
+  internals. Keeping construction inside the mixin limits that coupling and
+  avoids route-level task lifecycle duplication.
+- Permanent release failure leaves quota conservatively reserved, but the task
+  remains visible to persistence drain and the stale reaper remains a final
+  process-restart fallback.
+
+## Migration Plan
+
+No migration or rollout setting is required. Existing terminal reservations are
+unchanged; new image completions use tracked settlement after deployment.
+
+Rollback restores inline image finalization behavior without data conversion.
+
+## Open Questions
+
+None for this change. Stronger retries of authoritative image finalization are
+explicit follow-up scope.

--- a/openspec/changes/archive/2026-08-19-fix-images-finalize-reservation-release/proposal.md
+++ b/openspec/changes/archive/2026-08-19-fix-images-finalize-reservation-release/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Image generation and edit routes reserve limited API-key quota but deliberately
+exclude that reservation from the internal Responses stream settlement path.
+Their image-specific finalizer currently logs and abandons the reservation when
+persistence fails, leaving quota charged until stale cleanup and leaving
+graceful persistence drain unaware of the unresolved work.
+
+## What Changes
+
+- Transfer image reservation settlement to the existing tracked,
+  cancellation-safe stream settlement machinery while preserving captured
+  `tool_usage.image_gen` tokens as the authoritative usage source.
+- Preserve successful public Images JSON and SSE responses when settlement
+  fails or is cancelled.
+- Transfer failed or cancelled finalization to the existing tracked,
+  retrying release fallback so persistence drain remains aware of unresolved
+  ownership.
+- Keep the internal Responses stream reservation-free to prevent duplicate
+  settlement across image and standard response paths.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `images-api-compat`: require successful image generation and edit paths to
+  retain tracked reservation ownership through finalization or fallback release.
+
+## Impact
+
+- Affects the image generation/edit settlement handoff in
+  `app/modules/proxy/api.py` and the reusable API-key settlement seam in
+  `app/modules/proxy/_service/api_key_usage.py`.
+- Adds event-driven integration coverage for finalization failure,
+  cancellation, release retry, persistence drain, and all four image response
+  modes.
+- Does not change database schema, API-key repository transitions, retry
+  constants, scheduler policy, external response schemas, or settings.

--- a/openspec/changes/archive/2026-08-19-fix-images-finalize-reservation-release/specs/images-api-compat/spec.md
+++ b/openspec/changes/archive/2026-08-19-fix-images-finalize-reservation-release/specs/images-api-compat/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Image routes participate in usage accounting and policy
+
+The system SHALL apply API-key allowed-model policy and model-scoped usage
+limits to `/v1/images/*` using the publicly-requested `gpt-image-*` value as the
+effective model. The system SHALL record the publicly-requested `gpt-image-*`
+value (not the internal host model) in the request log's `model` column once the
+upstream response id becomes known. A successful image generation or edit that
+owns a limited API-key reservation SHALL transfer that reservation exactly once
+to persistence-drained settlement using captured `tool_usage.image_gen` tokens,
+while the internal Responses stream SHALL NOT receive a second settlement
+owner. Failed or cancelled finalization SHALL preserve the completed public
+image response and transfer ownership to the tracked retrying release fallback.
+
+#### Scenario: API key allowed-model policy blocks gpt-image-2
+
+- **WHEN** an API key's `allowed_models` list does not include `gpt-image-2`
+- **THEN** requests to `/v1/images/generations` or `/v1/images/edits` with `model=gpt-image-2` return 403 `model_not_allowed`
+
+#### Scenario: Request log surfaces the publicly requested image model
+
+- **WHEN** an `/v1/images/*` request completes successfully against an internal host Responses model (for example `gpt-5.5`)
+- **THEN** the resulting `request_logs` row has `model` equal to the publicly requested value (for example `gpt-image-2`) so dashboards and usage views surface the user-visible model rather than the internal host model
+
+#### Scenario: Failed image-token settlement retains tracked release ownership
+
+- **GIVEN** a limited API key owns a reservation for a successful image generation or edit request
+- **AND** the internal Responses stream receives no API-key reservation
+- **AND** the image adapter captures authoritative `tool_usage.image_gen` tokens
+- **WHEN** tracked finalization fails or is cancelled while the reservation remains `reserved`
+- **THEN** the completed public Images JSON response or SSE completion remains available
+- **AND** settlement ownership transfers to a persistence-drained fallback release task
+- **AND** transient release failures keep that task tracked and retrying until release succeeds or graceful persistence drain reports timeout
+- **AND** a successful fallback restores pre-reserved quota exactly once without recording `response.usage` or starting a second image settlement

--- a/openspec/changes/archive/2026-08-19-fix-images-finalize-reservation-release/tasks.md
+++ b/openspec/changes/archive/2026-08-19-fix-images-finalize-reservation-release/tasks.md
@@ -1,0 +1,16 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Replace the unkeyed finalization-failure case with a limited-key integration that proves the completed image response transfers an unresolved reservation to tracked release ownership
+- [x] 1.2 Add event-driven coverage for settlement cancellation and retrying release while persistence drain remains pending
+- [x] 1.3 Cover generation and edit, streaming and non-streaming, to prove exactly one image settlement handoff and no internal Responses reservation owner
+
+## 2. Tracked Image Settlement
+
+- [x] 2.1 Add an image-facing API-key usage adapter that delegates captured image tokens to the existing tracked stream settlement lifecycle
+- [x] 2.2 Route all four image completion paths through the adapter while preserving public response availability and public model attribution
+
+## 3. Verification
+
+- [x] 3.1 Run focused image and settlement tests, Ruff, type checking, proxy architecture checks, and strict affected OpenSpec validation
+- [x] 3.2 Exercise the isolated HTTP image surface with a limited key, gated release retry, persistence drain, and real SQLite state assertions
+- [x] 3.3 Verify implementation against this change, synchronize the delta, and archive the verified OpenSpec change

--- a/openspec/specs/images-api-compat/spec.md
+++ b/openspec/specs/images-api-compat/spec.md
@@ -89,7 +89,16 @@ When a client requests `stream=true` on `/v1/images/generations` or `/v1/images/
 
 ### Requirement: Image routes participate in usage accounting and policy
 
-The system SHALL apply API-key allowed-model policy and model-scoped usage limits to `/v1/images/*` using the publicly-requested `gpt-image-*` value as the effective model. The system SHALL record the publicly-requested `gpt-image-*` value (not the internal host model) in the request log's `model` column once the upstream response id becomes known.
+The system SHALL apply API-key allowed-model policy and model-scoped usage
+limits to `/v1/images/*` using the publicly-requested `gpt-image-*` value as the
+effective model. The system SHALL record the publicly-requested `gpt-image-*`
+value (not the internal host model) in the request log's `model` column once the
+upstream response id becomes known. A successful image generation or edit that
+owns a limited API-key reservation SHALL transfer that reservation exactly once
+to persistence-drained settlement using captured `tool_usage.image_gen` tokens,
+while the internal Responses stream SHALL NOT receive a second settlement
+owner. Failed or cancelled finalization SHALL preserve the completed public
+image response and transfer ownership to the tracked retrying release fallback.
 
 #### Scenario: API key allowed-model policy blocks gpt-image-2
 
@@ -100,6 +109,17 @@ The system SHALL apply API-key allowed-model policy and model-scoped usage limit
 
 - **WHEN** an `/v1/images/*` request completes successfully against an internal host Responses model (for example `gpt-5.5`)
 - **THEN** the resulting `request_logs` row has `model` equal to the publicly requested value (for example `gpt-image-2`) so dashboards and usage views surface the user-visible model rather than the internal host model
+
+#### Scenario: Failed image-token settlement retains tracked release ownership
+
+- **GIVEN** a limited API key owns a reservation for a successful image generation or edit request
+- **AND** the internal Responses stream receives no API-key reservation
+- **AND** the image adapter captures authoritative `tool_usage.image_gen` tokens
+- **WHEN** tracked finalization fails or is cancelled while the reservation remains `reserved`
+- **THEN** the completed public Images JSON response or SSE completion remains available
+- **AND** settlement ownership transfers to a persistence-drained fallback release task
+- **AND** transient release failures keep that task tracked and retrying until release succeeds or graceful persistence drain reports timeout
+- **AND** a successful fallback restores pre-reserved quota exactly once without recording `response.usage` or starting a second image settlement
 
 ### Requirement: Image routes expose bounded operational observability
 

--- a/tests/integration/test_proxy_images.py
+++ b/tests/integration/test_proxy_images.py
@@ -9,6 +9,7 @@ translation -> public response shape pipeline.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import logging
@@ -17,6 +18,7 @@ from typing import Any, cast
 
 import pytest
 from httpx import AsyncByteStream
+from sqlalchemy import select
 from starlette.datastructures import UploadFile
 from starlette.responses import JSONResponse
 
@@ -25,7 +27,9 @@ import app.modules.proxy.service as proxy_module
 from app.core.config.settings import Settings
 from app.core.exceptions import ProxyModelNotAllowed, ProxyRateLimitError
 from app.core.multipart import MultipartPolicy
-from app.db.models import DashboardSettings
+from app.db.models import ApiKeyUsageReservation, DashboardSettings
+from app.db.session import SessionLocal
+from app.modules.api_keys.repository import ApiKeysRepository
 
 pytestmark = pytest.mark.integration
 
@@ -1608,12 +1612,30 @@ async def test_images_edits_accepts_image_brackets_form_key(async_client, monkey
 
 
 @pytest.mark.asyncio
-async def test_images_generations_succeeds_when_reservation_finalize_fails(async_client, monkeypatch):
-    """A successful image generation must NOT 500 when the post-hoc
-    API-key reservation finalize raises (e.g. transient DB failure).
-    The accounting failure is swallowed and logged; the client still
-    receives the image envelope.
-    """
+async def test_images_generations_finalize_failure_tracks_release_recovery(
+    async_client,
+    monkeypatch,
+):
+    """A successful image keeps tracked ownership after finalization fails."""
+    await _enable_api_key_auth(async_client)
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": "images-finalize-release-recovery",
+            "limits": [
+                {
+                    "limitType": "total_tokens",
+                    "limitWindow": "weekly",
+                    "maxValue": 1_000_000,
+                },
+            ],
+        },
+    )
+    assert created.status_code == 200, created.text
+    key_payload = created.json()
+    api_key = key_payload["key"]
+    api_key_id = key_payload["id"]
+
     await _import_account(async_client, "acc_images_finalize_fail", "img-fin-fail@example.com")
 
     async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False, **kwargs):
@@ -1650,14 +1672,23 @@ async def test_images_generations_succeeds_when_reservation_finalize_fails(async
     # Patch finalize to blow up so we can confirm the route still 200s.
     from app.modules.api_keys.service import ApiKeysService
 
+    release_completed = asyncio.Event()
+    original_release = ApiKeysService.release_usage_reservation
+
     async def fake_finalize(self, *args, **kwargs):
         del self, args, kwargs
         raise RuntimeError("simulated DB failure during finalize")
 
+    async def tracked_release(self, reservation_id):
+        await original_release(self, reservation_id)
+        release_completed.set()
+
     monkeypatch.setattr(ApiKeysService, "finalize_usage_reservation", fake_finalize)
+    monkeypatch.setattr(ApiKeysService, "release_usage_reservation", tracked_release)
 
     response = await async_client.post(
         "/v1/images/generations",
+        headers={"Authorization": f"Bearer {api_key}"},
         json={
             "model": "gpt-image-2",
             "prompt": "x",
@@ -1669,3 +1700,185 @@ async def test_images_generations_succeeds_when_reservation_finalize_fails(async
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["data"] == [{"b64_json": "B64_FINFAIL"}]
+    await asyncio.wait_for(release_completed.wait(), timeout=1.0)
+
+    async with SessionLocal() as session:
+        reservations = (
+            (
+                await session.execute(
+                    select(ApiKeyUsageReservation).where(ApiKeyUsageReservation.api_key_id == api_key_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert [reservation.status for reservation in reservations] == ["released"]
+
+        limits = await ApiKeysRepository(session).get_limits_by_key(api_key_id)
+        assert len(limits) == 1
+        assert limits[0].current_value == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("route", "stream"),
+    [
+        ("generations", False),
+        ("generations", True),
+        ("edits", False),
+        ("edits", True),
+    ],
+)
+async def test_image_routes_handoff_captured_usage_exactly_once(
+    async_client,
+    monkeypatch,
+    route,
+    stream,
+):
+    await _enable_api_key_auth(async_client)
+    created = await async_client.post(
+        "/api/api-keys/",
+        json={
+            "name": f"images-{route}-{'stream' if stream else 'json'}-handoff",
+            "limits": [
+                {
+                    "limitType": "total_tokens",
+                    "limitWindow": "weekly",
+                    "maxValue": 1_000_000,
+                },
+            ],
+        },
+    )
+    assert created.status_code == 200, created.text
+    api_key = created.json()["key"]
+
+    await _import_account(
+        async_client,
+        f"acc_images_{route}_{stream}",
+        f"img-{route}-{stream}@example.com",
+    )
+
+    async def fake_stream(
+        payload,
+        headers,
+        access_token,
+        account_id,
+        base_url=None,
+        raise_for_status=False,
+        **kwargs,
+    ):
+        del payload, headers, access_token, account_id, base_url, raise_for_status, kwargs
+        yield _sse(
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    "type": "image_generation_call",
+                    "id": f"ig_{route}_{stream}",
+                    "status": "completed",
+                    "result": "B64_HANDOFF",
+                },
+            }
+        )
+        yield _sse(
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": f"resp_{route}_{stream}",
+                    "tool_usage": {
+                        "image_gen": {
+                            "input_tokens": 3,
+                            "output_tokens": 4,
+                        }
+                    },
+                },
+            }
+        )
+
+    async def fake_ensure_fresh(self, account, **kwargs):
+        del self, kwargs
+        return account
+
+    internal_reservations: list[object] = []
+    original_stream_responses = proxy_module.ProxyService.stream_responses
+
+    async def tracked_stream_responses(self, *args, **kwargs):
+        internal_reservations.append(kwargs.get("api_key_reservation"))
+        async for chunk in original_stream_responses(self, *args, **kwargs):
+            yield chunk
+
+    handoffs: list[dict[str, object]] = []
+    original_settle_image = proxy_module.ProxyService.settle_image_api_key_usage
+
+    async def tracked_settle_image(
+        self,
+        api_key_arg,
+        reservation_arg,
+        **kwargs,
+    ):
+        handoffs.append(
+            {
+                "api_key": api_key_arg,
+                "reservation": reservation_arg,
+                **kwargs,
+            }
+        )
+        return await original_settle_image(
+            self,
+            api_key_arg,
+            reservation_arg,
+            **kwargs,
+        )
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+    monkeypatch.setattr(proxy_module.ProxyService, "_ensure_fresh_with_budget", fake_ensure_fresh)
+    monkeypatch.setattr(proxy_module.ProxyService, "stream_responses", tracked_stream_responses)
+    monkeypatch.setattr(
+        proxy_module.ProxyService,
+        "settle_image_api_key_usage",
+        tracked_settle_image,
+    )
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    if route == "generations":
+        response = await async_client.post(
+            "/v1/images/generations",
+            headers=headers,
+            json={
+                "model": "gpt-image-2",
+                "prompt": "handoff",
+                "stream": stream,
+                "size": "1024x1024",
+                "quality": "low",
+            },
+        )
+    else:
+        response = await async_client.post(
+            "/v1/images/edits",
+            headers=headers,
+            data={
+                "model": "gpt-image-2",
+                "prompt": "handoff",
+                "stream": str(stream).lower(),
+                "size": "1024x1024",
+                "quality": "low",
+            },
+            files={
+                "image": (
+                    "source.png",
+                    b"\x89PNG\r\n\x1a\n" + b"\x00" * 16,
+                    "image/png",
+                ),
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert internal_reservations == [None]
+    assert len(handoffs) == 1
+    handoff = handoffs[0]
+    assert handoff["api_key"] is not None
+    assert handoff["reservation"] is not None
+    assert handoff["model"] == "gpt-image-2"
+    assert handoff["input_tokens"] == 3
+    assert handoff["output_tokens"] == 4
+    assert handoff["cached_input_tokens"] is None

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -30020,7 +30020,12 @@ async def test_stream_api_key_cancelled_settlement_transfers_to_release(monkeypa
 
 
 @pytest.mark.asyncio
-async def test_image_api_key_settlement_maps_captured_usage_once(monkeypatch):
+@pytest.mark.parametrize(("input_tokens", "output_tokens"), [(3, 4), (0, 0)])
+async def test_image_api_key_settlement_maps_captured_usage_once(
+    monkeypatch,
+    input_tokens,
+    output_tokens,
+):
     repo = SimpleNamespace(api_keys=object())
 
     @asynccontextmanager
@@ -30082,8 +30087,8 @@ async def test_image_api_key_settlement_maps_captured_usage_once(monkeypatch):
         api_key,
         reservation,
         model="gpt-image-2",
-        input_tokens=3,
-        output_tokens=4,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
         cached_input_tokens=None,
         request_id="req_image_handoff",
     )
@@ -30100,8 +30105,8 @@ async def test_image_api_key_settlement_maps_captured_usage_once(monkeypatch):
     assert captured_reservation is reservation
     assert settlement.status == "success"
     assert settlement.model == "gpt-image-2"
-    assert settlement.input_tokens == 3
-    assert settlement.output_tokens == 4
+    assert settlement.input_tokens == input_tokens
+    assert settlement.output_tokens == output_tokens
     assert settlement.cached_input_tokens == 0
     assert settlement.service_tier is None
     assert settlement.usage_settlement_transferred

--- a/tests/unit/test_proxy_utils.py
+++ b/tests/unit/test_proxy_utils.py
@@ -29951,6 +29951,165 @@ async def test_stream_api_key_background_settlement_failure_falls_back_to_releas
 
 
 @pytest.mark.asyncio
+async def test_stream_api_key_cancelled_settlement_transfers_to_release(monkeypatch):
+    finalize_started = asyncio.Event()
+    release_completed = asyncio.Event()
+    repo = SimpleNamespace(api_keys=object())
+
+    @asynccontextmanager
+    async def repo_factory() -> AsyncIterator[SimpleNamespace]:
+        yield repo
+
+    class FakeApiKeysService:
+        def __init__(self, api_keys_repository: object) -> None:
+            assert api_keys_repository is repo.api_keys
+
+        async def finalize_usage_reservation(self, reservation_id: str, **kwargs: object) -> None:
+            del reservation_id, kwargs
+            finalize_started.set()
+            await asyncio.Event().wait()
+
+        async def release_usage_reservation(self, reservation_id: str) -> None:
+            assert reservation_id == "resv_image_cancel"
+            release_completed.set()
+
+    monkeypatch.setattr(proxy_service, "ApiKeysService", FakeApiKeysService)
+
+    service = proxy_service.ProxyService(cast(proxy_service.ProxyRepoFactory, repo_factory))
+    api_key = ApiKeyData(
+        id="key_image_cancel",
+        name="image cancel",
+        key_prefix="sk-image-cancel",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_image_cancel",
+        key_id=api_key.id,
+        model="gpt-image-2",
+    )
+    settlement = proxy_service._StreamSettlement(
+        status="success",
+        model="gpt-image-2",
+        input_tokens=3,
+        output_tokens=4,
+    )
+
+    assert await service._settle_stream_api_key_usage(
+        api_key,
+        reservation,
+        settlement,
+        request_id="req_image_cancel",
+    )
+    await asyncio.wait_for(finalize_started.wait(), timeout=1.0)
+
+    settlement_task = next(iter(service._background_cleanup_tasks))
+    settlement_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await settlement_task
+
+    await asyncio.wait_for(release_completed.wait(), timeout=1.0)
+    assert await service.drain_persistence_tasks(timeout_seconds=1)
+    assert service._background_cleanup_tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_image_api_key_settlement_maps_captured_usage_once(monkeypatch):
+    repo = SimpleNamespace(api_keys=object())
+
+    @asynccontextmanager
+    async def repo_factory() -> AsyncIterator[SimpleNamespace]:
+        yield repo
+
+    service = proxy_service.ProxyService(cast(proxy_service.ProxyRepoFactory, repo_factory))
+    api_key = ApiKeyData(
+        id="key_image_handoff",
+        name="image handoff",
+        key_prefix="sk-image-handoff",
+        allowed_models=None,
+        enforced_model=None,
+        enforced_reasoning_effort=None,
+        enforced_service_tier=None,
+        expires_at=None,
+        is_active=True,
+        created_at=utcnow(),
+        last_used_at=None,
+    )
+    reservation = proxy_service.ApiKeyUsageReservationData(
+        reservation_id="resv_image_handoff",
+        key_id=api_key.id,
+        model="gpt-image-2",
+    )
+    captured: list[
+        tuple[
+            ApiKeyData | None,
+            proxy_service.ApiKeyUsageReservationData | None,
+            proxy_service._StreamSettlement,
+            str,
+            bool,
+        ]
+    ] = []
+
+    async def settle_spy(
+        api_key_arg: ApiKeyData | None,
+        reservation_arg: proxy_service.ApiKeyUsageReservationData | None,
+        settlement: proxy_service._StreamSettlement,
+        request_id: str,
+        *,
+        wait_for_settlement: bool = False,
+    ) -> bool:
+        settlement.usage_settlement_transferred = True
+        captured.append(
+            (
+                api_key_arg,
+                reservation_arg,
+                settlement,
+                request_id,
+                wait_for_settlement,
+            )
+        )
+        return True
+
+    monkeypatch.setattr(service, "_settle_stream_api_key_usage", settle_spy)
+
+    assert await service.settle_image_api_key_usage(
+        api_key,
+        reservation,
+        model="gpt-image-2",
+        input_tokens=3,
+        output_tokens=4,
+        cached_input_tokens=None,
+        request_id="req_image_handoff",
+    )
+
+    assert len(captured) == 1
+    (
+        captured_api_key,
+        captured_reservation,
+        settlement,
+        request_id,
+        wait_for_settlement,
+    ) = captured[0]
+    assert captured_api_key is api_key
+    assert captured_reservation is reservation
+    assert settlement.status == "success"
+    assert settlement.model == "gpt-image-2"
+    assert settlement.input_tokens == 3
+    assert settlement.output_tokens == 4
+    assert settlement.cached_input_tokens == 0
+    assert settlement.service_tier is None
+    assert settlement.usage_settlement_transferred
+    assert request_id == "req_image_handoff"
+    assert wait_for_settlement is False
+
+
+@pytest.mark.asyncio
 async def test_stream_api_key_release_retries_bound_concurrent_repository_attempts(monkeypatch):
     retry_concurrency = proxy_service._STREAM_API_KEY_RELEASE_RETRY_MAX_CONCURRENCY
     task_count = retry_concurrency + 1


### PR DESCRIPTION
## Summary

- transfer image generation/edit API-key reservations to the existing tracked settlement lifecycle
- preserve successful Images JSON/SSE responses while failed or cancelled finalization hands ownership to retrying release
- keep internal Responses settlement reservation-free and prove exactly one handoff across generation/edit and streaming/non-streaming

## Why

Image routes charge from authoritative `tool_usage.image_gen` tokens and deliberately bypass standard internal Responses settlement. A post-hoc finalization failure previously rolled the reservation back to `reserved`, logged, and returned without a request-scoped settlement or release owner. Reserved quota could remain charged until stale cleanup.

## OpenSpec

Archived and synced:

- `openspec/changes/archive/2026-08-19-fix-images-finalize-reservation-release/`
- `openspec/specs/images-api-compat/spec.md`

`openspec validate images-api-compat --strict` passes. Repository-wide `openspec validate --specs` retains the same eight pre-existing main-branch failures and introduces no new failure.

## Validation

- RED: keyed image request returned HTTP 200 but reservation assertion failed with `reserved != released`
- GREEN: complete image integration file — `59 passed`
- focused settlement ownership/retry tests — `11 passed`
- post-rebase focused image/settlement matrix — `7 passed`
- complete unit suite — `6250 passed, 70 skipped` (67 Helm skips because Helm is unavailable; 3 documented load-balancer skips)
- Ruff check + format — passed
- ty — passed
- proxy architecture checks — passed
- changed-file diagnostics — clean

## Real-surface QA

An isolated FastAPI + SQLite + fake-upstream instance was exercised with literal `curl -i` against `/v1/images/generations` using a limited API key.

- client received HTTP 200 and `B64_QA_IMAGE` before recovery completed
- gated state: reservation `reserved`, quota `10240`, pending owner `1`, finalize calls `1`, release calls `1`
- after opening the exact release event: reservation `released`, quota `0`, pending owners `0`
- QA server, port 33101, SQLite DB, and temp harness were removed

## Security and scope

- reuses the existing bounded-concurrency tracked release lifecycle from #1545
- no authorization, repository transition, retry policy, schema, migration, setting, dependency, or public response-shape change
- no deployment or dashboard changes

Fixes #1821
Refs #498
Refs #1545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved usage accounting for image generation and editing in streaming and non-streaming requests.
  - Reservations now settle exactly once using captured image token usage.
  - Completed image responses are preserved when settlement fails or is cancelled, with quota release retried automatically.
  - Standardized API-key model usage tracking for image requests.

- **Tests**
  - Added coverage for cancellation, persistence failures, retries, and reservation recovery.

- **Documentation**
  - Updated image API compatibility and settlement behavior requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Exact named regression proof

```bash
uv run pytest -q tests/integration/test_proxy_images.py::test_images_generations_finalize_failure_tracks_release_recovery
# 1 passed
```

During the gated real-surface run, the public HTTP 200 image body arrived first; the persistence drain remained pending while release was blocked, then the reservation released exactly once and quota was restored.