### PR TITLE
fix(proxy): preserve compact terminal error type

### DIFF
--- a/app/core/clients/proxy.py
+++ b/app/core/clients/proxy.py
@@ -1469,10 +1469,13 @@ def _compact_sse_terminal_error_payload(
         error_code = payload.get("code")
         error_message = payload.get("message")
         if isinstance(error_code, str) and error_code and isinstance(error_message, str) and error_message:
+            error_type = payload.get("error_type")
+            if not isinstance(error_type, str) or not error_type.strip():
+                error_type = "server_error"
             detail: OpenAIErrorDetail = {
                 "code": error_code,
                 "message": error_message,
-                "type": "server_error",
+                "type": error_type,
             }
             param = payload.get("param")
             if isinstance(param, str) and param:

--- a/openspec/changes/archive/2026-08-19-preserve-compact-top-level-error-type/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-19-preserve-compact-top-level-error-type/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/archive/2026-08-19-preserve-compact-top-level-error-type/design.md
+++ b/openspec/changes/archive/2026-08-19-preserve-compact-top-level-error-type/design.md
@@ -1,0 +1,58 @@
+## Context
+
+Compact Responses receives an upstream HTTP response whose body can terminate
+with an SSE event. Nested OpenAI-style error objects are parsed through the
+shared error parser and preserve their type. A top-level event shaped as
+`{"type":"error","error_type":...,"code":...,"message":...}` instead uses a
+fallback converter.
+
+The status-code helper already reads top-level `error_type`, so it can infer
+HTTP 400/401/403/429 correctly. The fallback envelope independently hard-codes
+`server_error`, producing an internally inconsistent public response.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Preserve a supplied non-blank top-level `error_type`.
+- Retain `server_error` when the field is absent, non-string, or blank.
+- Leave nested envelopes and all other mapped fields/statuses unchanged.
+
+**Non-Goals**
+
+- Change compact request routing, retries, account selection, or health.
+- Infer new status codes or normalize arbitrary upstream error types.
+- Change non-compact Responses or nested error parsing.
+
+## Decisions
+
+### Fix only the top-level fallback
+
+The fallback converter reads `payload["error_type"]`. A string containing at
+least one non-whitespace character becomes the OpenAI detail `type`; otherwise
+the existing `server_error` value remains.
+
+This keeps the fix at the data-loss seam and avoids changing the shared parser
+or status inference that already behave correctly.
+
+### Preserve supplied type text
+
+Whitespace is used only to decide whether a value is blank. A non-blank string
+is forwarded verbatim, matching the existing field-preservation behavior for
+top-level `code`, `message`, and `param`.
+
+## Risks / Trade-offs
+
+- Upstream can supply an unfamiliar type. Preserving it is preferable to
+  fabricating `server_error` and matches OpenAI-compatible passthrough behavior.
+- The fallback remains intentionally conservative for absent, non-string, or
+  whitespace-only values.
+
+## Migration Plan
+
+No migration, setting, or rollout step is required. Rollback restores the
+previous top-level type substitution.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-19-preserve-compact-top-level-error-type/proposal.md
+++ b/openspec/changes/archive/2026-08-19-preserve-compact-top-level-error-type/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The compact Responses transport derives the correct HTTP status from a
+top-level terminal SSE frame's `error_type`, but its fallback OpenAI envelope
+replaces that supplied type with `server_error`. Clients therefore receive a
+contradictory response such as HTTP 400 with `error.type=server_error` even
+though the upstream classified the failure as `invalid_request_error`.
+
+## What Changes
+
+- Preserve a non-empty top-level compact SSE `error_type` in the emitted OpenAI
+  error envelope.
+- Keep `server_error` as the compatibility fallback when the top-level field is
+  absent or blank.
+- Preserve existing nested error-envelope behavior and status, code, message,
+  and parameter mapping.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `responses-api-compat`: define compact terminal error-envelope behavior for
+  top-level `type=error` SSE frames.
+
+## Impact
+
+- Affects the compact SSE terminal-error converter in
+  `app/core/clients/proxy.py`.
+- Adds focused routed transport tests and fallback/nested controls.
+- Does not change request routing, retry behavior, account health, schemas,
+  settings, dependencies, or non-compact Responses behavior.

--- a/openspec/changes/archive/2026-08-19-preserve-compact-top-level-error-type/specs/responses-api-compat/spec.md
+++ b/openspec/changes/archive/2026-08-19-preserve-compact-top-level-error-type/specs/responses-api-compat/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Compact terminal SSE errors preserve top-level error type
+
+When the compact Responses upstream terminates with a top-level SSE `type=error` frame, the proxy MUST preserve a supplied non-blank `error_type` in the emitted OpenAI error envelope. If `error_type` is absent, non-string, or blank, the proxy MUST use `server_error`. The proxy MUST preserve existing status, code, message, and parameter mapping, and MUST NOT alter nested OpenAI-style error-envelope behavior.
+
+#### Scenario: Top-level invalid request type is preserved
+
+- **WHEN** compact upstream terminates with a top-level `type=error` frame whose `error_type` is `invalid_request_error`
+- **THEN** the proxy returns HTTP 400 with `error.type=invalid_request_error`
+- **AND** preserves the frame's code, message, and parameter
+
+#### Scenario: Missing or blank top-level type uses compatibility fallback
+
+- **WHEN** compact upstream terminates with a top-level `type=error` frame whose `error_type` is absent or blank
+- **THEN** the emitted OpenAI error envelope uses `error.type=server_error`
+- **AND** existing status, code, message, and parameter mapping remains unchanged
+
+#### Scenario: Nested compact error envelope remains unchanged
+
+- **WHEN** compact upstream terminates with a nested OpenAI-style error envelope
+- **THEN** the proxy preserves the nested type and all other mapped fields using the existing parser

--- a/openspec/changes/archive/2026-08-19-preserve-compact-top-level-error-type/tasks.md
+++ b/openspec/changes/archive/2026-08-19-preserve-compact-top-level-error-type/tasks.md
@@ -1,0 +1,15 @@
+## 1. Regression Coverage
+
+- [x] 1.1 Add a routed compact top-level terminal SSE regression that preserves `invalid_request_error`
+- [x] 1.2 Add missing and blank `error_type` fallback controls and retain the nested-envelope control
+
+## 2. Compact Error Conversion
+
+- [x] 2.1 Preserve a supplied non-blank top-level `error_type` in the OpenAI error detail
+- [x] 2.2 Keep status, code, message, parameter, nested-envelope, and `server_error` fallback behavior unchanged
+
+## 3. Verification
+
+- [x] 3.1 Run focused compact tests, Ruff, type checking, proxy architecture checks, and strict affected OpenSpec validation
+- [x] 3.2 Exercise the live compact HTTP route with top-level invalid-request and missing-type upstream terminal frames
+- [x] 3.3 Verify implementation against this change, synchronize the delta, and archive the verified OpenSpec change

--- a/openspec/specs/responses-api-compat/spec.md
+++ b/openspec/specs/responses-api-compat/spec.md
@@ -5342,3 +5342,24 @@ Responses-compatible routes MUST accept the canonical `ultrafast` service tier a
 
 - **WHEN** upstream completes a request with `response.service_tier: "ultrafast"`
 - **THEN** the actual and billable request-log tiers are `ultrafast`
+
+### Requirement: Compact terminal SSE errors preserve top-level error type
+
+When the compact Responses upstream terminates with a top-level SSE `type=error` frame, the proxy MUST preserve a supplied non-blank `error_type` in the emitted OpenAI error envelope. If `error_type` is absent, non-string, or blank, the proxy MUST use `server_error`. The proxy MUST preserve existing status, code, message, and parameter mapping, and MUST NOT alter nested OpenAI-style error-envelope behavior.
+
+#### Scenario: Top-level invalid request type is preserved
+
+- **WHEN** compact upstream terminates with a top-level `type=error` frame whose `error_type` is `invalid_request_error`
+- **THEN** the proxy returns HTTP 400 with `error.type=invalid_request_error`
+- **AND** preserves the frame's code, message, and parameter
+
+#### Scenario: Missing or blank top-level type uses compatibility fallback
+
+- **WHEN** compact upstream terminates with a top-level `type=error` frame whose `error_type` is absent or blank
+- **THEN** the emitted OpenAI error envelope uses `error.type=server_error`
+- **AND** existing status, code, message, and parameter mapping remains unchanged
+
+#### Scenario: Nested compact error envelope remains unchanged
+
+- **WHEN** compact upstream terminates with a nested OpenAI-style error envelope
+- **THEN** the proxy preserves the nested type and all other mapped fields using the existing parser

--- a/tests/unit/test_codex_upstream_paths.py
+++ b/tests/unit/test_codex_upstream_paths.py
@@ -164,10 +164,15 @@ class _CompactTerminalErrorStreamResponse:
     status = 200
     status_code = 200
     headers = {"content-type": "text/event-stream"}
-    content = (
-        b'data: {"type":"error","code":"rate_limit_exceeded","message":"quota closed",'
-        b'"param":"previous_response_id"}\n\n'
-    )
+
+    def __init__(self, error_type: str, error_code: str) -> None:
+        self.content = (
+            b'data: {"type":"error","error_type":"'
+            + error_type.encode("utf-8")
+            + b'","code":"'
+            + error_code.encode("utf-8")
+            + b'","message":"compact rejected","param":"previous_response_id"}\n\n'
+        )
 
 
 class _CompactTerminalFailedStreamResponse:
@@ -621,10 +626,20 @@ async def test_compact_responses_terminal_sse_error_infers_status_from_error_det
 
 
 @pytest.mark.asyncio
-async def test_compact_responses_routed_top_level_sse_error_preserves_fields(
+@pytest.mark.parametrize(
+    ("error_type", "error_code", "expected_status"),
+    [
+        ("invalid_request_error", "invalid_request_error", 400),
+        ("rate_limit_error", "rate_limit_exceeded", 429),
+    ],
+)
+async def test_compact_responses_routed_top_level_sse_error_preserves_type(
     route: ResolvedUpstreamRoute,
+    error_type: str,
+    error_code: str,
+    expected_status: int,
 ) -> None:
-    client = _RouteMetadataCodexClient(_CompactTerminalErrorStreamResponse())
+    client = _RouteMetadataCodexClient(_CompactTerminalErrorStreamResponse(error_type, error_code))
     payload = ResponsesCompactRequest(model="gpt-5.2", instructions="Summarize.", input="hello")
 
     with pytest.raises(ProxyResponseError) as exc_info:
@@ -638,11 +653,29 @@ async def test_compact_responses_routed_top_level_sse_error_preserves_fields(
             codex_client=cast(Any, client),
         )
 
-    assert exc_info.value.status_code == 429
+    assert exc_info.value.status_code == expected_status
     error = exc_info.value.payload["error"]
-    assert error["code"] == "rate_limit_exceeded"
-    assert error["message"] == "quota closed"
+    assert error["type"] == error_type
+    assert error["code"] == error_code
+    assert error["message"] == "compact rejected"
     assert error["param"] == "previous_response_id"
+
+
+@pytest.mark.parametrize("error_type", [None, "", "   ", 123])
+def test_compact_top_level_sse_error_type_uses_server_error_fallback(
+    error_type: object,
+) -> None:
+    payload: dict[str, Any] = {
+        "type": "error",
+        "code": "upstream_error",
+        "message": "compact failed",
+    }
+    if error_type is not None:
+        payload["error_type"] = error_type
+
+    detail = proxy_module._compact_sse_terminal_error_payload(payload, "error")
+
+    assert detail["error"]["type"] == "server_error"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- preserve non-blank top-level compact SSE `error_type` in the public OpenAI error envelope
- retain `server_error` for absent, blank, or non-string values
- keep nested envelopes and status/code/message/param mapping unchanged

## Why

Compact terminal SSE status inference already reads top-level `error_type`, but the fallback envelope hard-coded `server_error`. Clients could therefore receive HTTP 400 with `error.type=server_error` for an upstream `invalid_request_error`.

## OpenSpec

Archived:

- `openspec/changes/archive/2026-08-19-preserve-compact-top-level-error-type/`

Synced:

- `openspec/specs/responses-api-compat/spec.md`

The change delta validated strictly before archive. Normal archive could not rebuild the already-invalid source capability, so the exact requirement was synced manually and archive used `--skip-specs`. Structured comparison confirms the worktree and clean main retain the same ten pre-existing MUST/SHALL errors; this PR adds none.

## Validation

- RED: routed invalid-request and rate-limit cases both returned `server_error`; `2 failed, 4 fallback controls passed`
- GREEN: focused preservation/fallback/nested matrix — `7 passed`
- complete compact upstream-path file plus nested control — `37 passed` (independent review later ran current file as `48 passed`)
- Ruff check + format — passed
- ty — passed
- proxy architecture — passed
- changed-file diagnostics — clean
- `git diff --check` — passed

## Real-surface QA

An isolated FastAPI + SQLite instance served the actual worktree route at `/backend-api/codex/responses/compact`, with only upstream terminal SSE semantics faked.

- top-level `invalid_request_error` → HTTP 400 and `error.type=invalid_request_error`
- missing top-level type → existing HTTP 502 status and `error.type=server_error`
- code, message, and `previous_response_id` param were preserved
- server, port 33102, SQLite DB, and temp harness were removed

## Security and scope

- no new fields are exposed; the same type already drives status inference and nested envelopes
- no routing, retry, account-health, schema, migration, setting, dependency, or non-compact behavior change

Fixes #1823
Refs #1809

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compact Responses errors now preserve valid, non-empty error types from upstream responses.
  * Missing, blank, or invalid error types continue to use `server_error`.
  * Existing status, code, message, parameter, and nested error handling remain unchanged.
  * Error responses now provide more accurate error classification while maintaining compatibility with existing behavior.

* **Tests**
  * Added coverage for invalid-request, rate-limit, nested, and fallback error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Exact named regression proof

```bash
uv run pytest -q tests/unit/test_codex_upstream_paths.py::test_compact_responses_routed_top_level_sse_error_preserves_type
# 1 passed
```

Fallback and nested controls remained green: absent/blank top-level type uses `server_error`, while nested status/code/message/param behavior is unchanged.