### PR TITLE
fix(helm): bind TTFT dashboard SQL datasource

### DIFF
--- a/deploy/helm/codex-lb/README.md
+++ b/deploy/helm/codex-lb/README.md
@@ -424,6 +424,13 @@ externalSecrets:
   enabled: true                    # Use External Secrets Operator
 ```
 
+The Grafana sidecar imports the dashboard JSON but does not provision
+datasources or database credentials. In the **codex-lb TTFT Breakdown**
+dashboard, select the Grafana PostgreSQL datasource that points to the
+codex-lb database from the visible **PostgreSQL** (`DS_SQL`) dropdown. All
+four SQL panels follow that one runtime selection. The owning contract is in
+[proxy runtime observability](../../../openspec/specs/proxy-runtime-observability/).
+
 Install with:
 
 ```bash

--- a/deploy/helm/codex-lb/dashboards/ttft-breakdown.json
+++ b/deploy/helm/codex-lb/dashboards/ttft-breakdown.json
@@ -5,7 +5,10 @@
   "editable": true,
   "panels": [
     {
-      "datasource": "${DS_SQL}",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${DS_SQL}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "ms"
@@ -29,7 +32,10 @@
       "type": "table"
     },
     {
-      "datasource": "${DS_SQL}",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${DS_SQL}"
+      },
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -51,7 +57,10 @@
       "type": "table"
     },
     {
-      "datasource": "${DS_SQL}",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${DS_SQL}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "ms"
@@ -75,7 +84,10 @@
       "type": "table"
     },
     {
-      "datasource": "${DS_SQL}",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "${DS_SQL}"
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "ms"
@@ -106,7 +118,20 @@
     "ttft"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "hide": 0,
+        "includeAll": false,
+        "label": "PostgreSQL",
+        "multi": false,
+        "name": "DS_SQL",
+        "options": [],
+        "query": "grafana-postgresql-datasource",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-24h",

--- a/openspec/changes/archive/2026-08-19-bind-ttft-dashboard-sql-datasource/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-19-bind-ttft-dashboard-sql-datasource/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/archive/2026-08-19-bind-ttft-dashboard-sql-datasource/context.md
+++ b/openspec/changes/archive/2026-08-19-bind-ttft-dashboard-sql-datasource/context.md
@@ -1,0 +1,54 @@
+# Context: TTFT dashboard SQL datasource binding
+
+## Purpose
+
+Make the sidecar-provisioned TTFT dashboard immediately bindable to an
+operator's PostgreSQL datasource without baking a cluster-specific UID into
+the chart.
+
+## Decisions
+
+- `DS_SQL` remains a runtime dashboard variable because datasource UIDs differ
+  across Grafana installations.
+- The variable is visible and single-select so operators can inspect and
+  change the active PostgreSQL datasource without editing dashboard JSON.
+- Every panel uses Grafana's typed datasource object with PostgreSQL plugin
+  type and `${DS_SQL}` UID. One dashboard variable remains the single source
+  of truth for all four panels.
+- The dashboard stays in `dashboards/*.json`; the existing Helm template,
+  sidecar labels, folder annotation, and optional title override remain
+  unchanged.
+
+## Constraints
+
+- Do not add a Helm value for a datasource UID: datasource selection is a
+  Grafana runtime concern and a new chart setting would duplicate the
+  dashboard variable.
+- Do not provision PostgreSQL credentials or a Grafana datasource from this
+  chart.
+- Preserve each panel's SQL, layout, IDs, titles, and visualization type.
+
+## Failure Modes
+
+- A scalar `"datasource": "${DS_SQL}"` is ambiguous to modern Grafana and can
+  be resolved as a literal missing UID.
+- A hidden, multi-value, or include-all variable can make panel execution
+  non-deterministic or leave operators unable to repair a stale selection.
+- A variable that accepts non-PostgreSQL plugins can select a datasource that
+  cannot execute the dashboard's SQL.
+
+## Example
+
+After the Grafana sidecar imports `ttft-breakdown.json`, an operator opens the
+dashboard and selects datasource UID `codex-lb-postgres` from the `DS_SQL`
+dropdown. All four panels resolve to:
+
+```json
+{
+  "type": "grafana-postgresql-datasource",
+  "uid": "${DS_SQL}"
+}
+```
+
+Grafana substitutes `codex-lb-postgres` at runtime and executes every TTFT
+query against that datasource.

--- a/openspec/changes/archive/2026-08-19-bind-ttft-dashboard-sql-datasource/design.md
+++ b/openspec/changes/archive/2026-08-19-bind-ttft-dashboard-sql-datasource/design.md
@@ -1,0 +1,98 @@
+## Context
+
+The Helm chart packages `ttft-breakdown.json` unchanged in a
+sidecar-discoverable ConfigMap. The dashboard's four SQL panels currently use
+the legacy scalar `"${DS_SQL}"` datasource form while `templating.list` is
+empty. Grafana 12.4.4 therefore has no runtime value to interpolate and can
+resolve the placeholder as a missing UID.
+
+Datasource UIDs and credentials are installation-specific. The chart must
+remain portable and must not take ownership of provisioning an operator's
+Grafana PostgreSQL datasource.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the selected PostgreSQL datasource explicit, visible, and deterministic
+  at dashboard runtime.
+- Route all four panels through the same selected UID using Grafana 12.4.4's
+  typed datasource-reference schema.
+- Preserve current SQL, layout, sidecar packaging, title overrides, and chart
+  values.
+
+**Non-Goals:**
+
+- Provisioning a Grafana datasource, PostgreSQL credentials, or database
+  permissions.
+- Adding a Helm value for a cluster-specific datasource UID.
+- Changing TTFT queries, visualizations, panel layout, navigation, or
+  application runtime behavior.
+
+## Decisions
+
+### Use a classic datasource template variable
+
+Declare `DS_SQL` with `type: datasource` and plugin query
+`grafana-postgresql-datasource`. Keep it visible, single-select, and without
+an all-datasources option.
+
+Alternative: hard-code a datasource UID in Helm. Rejected because UIDs are
+installation-specific and would require another chart setting for a Grafana
+runtime concern.
+
+### Use typed panel datasource references
+
+Each panel uses:
+
+```json
+{
+  "type": "grafana-postgresql-datasource",
+  "uid": "${DS_SQL}"
+}
+```
+
+Grafana 12.4.4 defines panel datasources as `{type, uid}` references and
+interpolates variables in the UID field. The existing scalar form is legacy
+input and does not satisfy the current schema.
+
+Alternative: leave panel references scalar and only add the variable.
+Rejected because it preserves the ambiguous representation that produced the
+missing-datasource state.
+
+### Preserve the existing Helm packaging seam
+
+Keep dashboard JSON under `dashboards/` and let
+`templates/grafana-dashboard.yaml` package it unchanged. A rendered ConfigMap
+test proves the runtime variable and typed panel references survive Helm.
+
+Alternative: generate the variable in the template. Rejected because it
+duplicates dashboard structure in Go templates and makes standalone dashboard
+validation harder.
+
+## Risks / Trade-offs
+
+- **No PostgreSQL datasource exists** → The dropdown has no valid selection;
+  chart documentation states that operators must provision and select one.
+- **A saved selection becomes stale** → The variable remains visible so the
+  operator can select another ordinary PostgreSQL datasource.
+- **A datasource connects but lacks request-log access** → Grafana reports the
+  database/query error normally; this change only owns datasource resolution.
+- **Grafana schema behavior changes** → Focused artifact tests and a real
+  Grafana 12.4.4 API/browser scenario lock the supported contract.
+
+## Migration Plan
+
+1. Upgrade or redeploy the chart with Grafana dashboard sidecar support
+   enabled.
+2. Let the sidecar replace the dashboard ConfigMap payload.
+3. Open the TTFT dashboard and select the PostgreSQL datasource that points to
+   the codex-lb database.
+
+Rollback is a chart rollback to the previous dashboard JSON. No database,
+application, secret, or chart-value migration is involved.
+
+## Open Questions
+
+None. Grafana 12.4.4 documentation and source confirm the plugin ID,
+datasource-variable flags, typed panel reference, and UID interpolation path.

--- a/openspec/changes/archive/2026-08-19-bind-ttft-dashboard-sql-datasource/proposal.md
+++ b/openspec/changes/archive/2026-08-19-bind-ttft-dashboard-sql-datasource/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+The shipped TTFT breakdown dashboard references `${DS_SQL}` on every panel,
+but it does not declare that runtime variable. Grafana therefore treats the
+literal placeholder as a datasource UID and renders
+`Datasource ${DS_SQL} was not found` instead of executing the PostgreSQL
+queries.
+
+## What Changes
+
+- Declare `DS_SQL` as a visible, single-select runtime datasource variable
+  restricted to the PostgreSQL datasource plugin.
+- Bind all four TTFT panels through typed datasource objects whose UID is the
+  selected `DS_SQL` value.
+- Preserve Helm sidecar ConfigMap packaging and title overrides.
+- Document that operators select the PostgreSQL datasource after the sidecar
+  provisions the dashboard.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `proxy-runtime-observability`: The shipped TTFT dashboard MUST resolve its
+  SQL panels through an operator-selected PostgreSQL datasource.
+
+## Impact
+
+- `deploy/helm/codex-lb/dashboards/ttft-breakdown.json`
+- `deploy/helm/codex-lb/README.md`
+- focused dashboard-artifact and rendered-ConfigMap tests
+
+There is no application runtime, API, database schema, chart value, sidecar
+label, or navigation change.

--- a/openspec/changes/archive/2026-08-19-bind-ttft-dashboard-sql-datasource/specs/proxy-runtime-observability/spec.md
+++ b/openspec/changes/archive/2026-08-19-bind-ttft-dashboard-sql-datasource/specs/proxy-runtime-observability/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: 24-hour TTFT breakdown queries are available
+
+Operators MUST have an OpenSpec context runbook or dashboard artifact with
+24-hour TTFT breakdown queries by user agent group, upstream transport,
+model/cache ratio, session gap cohort, prompt size cohort, and prewarm
+status/outcome.
+
+The shipped Grafana TTFT dashboard MUST declare a visible, single-select
+runtime datasource variable named `DS_SQL` that is restricted to PostgreSQL.
+Every SQL panel MUST bind to the selected UID through a typed PostgreSQL
+datasource object. The Helm chart MUST preserve the dashboard in its existing
+sidecar-discoverable ConfigMap, and chart documentation MUST tell operators to
+select the PostgreSQL datasource in Grafana.
+
+#### Scenario: Operator investigates TTFT regression
+
+- **WHEN** an operator needs to inspect the last 24 hours of request-log
+  latency
+- **THEN** the repository provides SQL that reports p50, p90, p95 TTFT and
+  total latency for the requested breakdowns
+
+#### Scenario: Sidecar-provisioned dashboard resolves the selected database
+
+- **GIVEN** the Helm chart renders the Grafana dashboard ConfigMap
+- **AND** Grafana has a PostgreSQL datasource available
+- **WHEN** the operator selects that datasource through `DS_SQL`
+- **THEN** all four TTFT panels resolve to the selected datasource UID
+- **AND** no panel reports `Datasource ${DS_SQL} was not found`
+
+#### Scenario: Datasource choice remains explicit and deterministic
+
+- **WHEN** Grafana loads the TTFT dashboard
+- **THEN** `DS_SQL` is visible to the operator
+- **AND** it permits exactly one PostgreSQL datasource selection
+- **AND** it does not offer an all-datasources selection

--- a/openspec/changes/archive/2026-08-19-bind-ttft-dashboard-sql-datasource/tasks.md
+++ b/openspec/changes/archive/2026-08-19-bind-ttft-dashboard-sql-datasource/tasks.md
@@ -1,0 +1,26 @@
+## 1. Regression coverage
+
+- [x] 1.1 Add dashboard JSON assertions for the visible single-select
+      PostgreSQL `DS_SQL` variable and all four typed panel bindings.
+- [x] 1.2 Add a rendered ConfigMap assertion proving Helm preserves the
+      runtime datasource contract.
+
+## 2. Dashboard and operator documentation
+
+- [x] 2.1 Declare `DS_SQL` and convert all TTFT panels to typed PostgreSQL
+      datasource objects without changing SQL or layout.
+- [x] 2.2 Document Grafana-side PostgreSQL datasource selection while
+      preserving the existing sidecar deployment model.
+
+## 3. Verification
+
+- [x] 3.1 Capture focused RED, implement the minimal artifact fix, and run the
+      focused tests GREEN.
+- [x] 3.2 Run changed-file diagnostics, Ruff, typecheck, Helm architecture and
+      rendering gates, strict affected OpenSpec validation, and final diff
+      review.
+- [x] 3.3 Provision the exact rendered dashboard into isolated Grafana 12.4.4
+      with a synthetic PostgreSQL datasource; inspect the API and 1440x900
+      browser surface and capture evidence.
+- [x] 3.4 Sync the verified delta into the owning capability and archive the
+      completed change before publication.

--- a/openspec/specs/proxy-runtime-observability/context.md
+++ b/openspec/specs/proxy-runtime-observability/context.md
@@ -12,9 +12,18 @@ See `openspec/specs/proxy-runtime-observability/spec.md` for normative requireme
 - **Request tracing is opt-in:** outbound request summary and payload tracing remain configurable because payload logs can be noisy or sensitive. Since issue #1340 phase 1 the switch is the single `CODEX_LB_TRACE` comma-separated channel list (`shape`, `shape_raw_cache_key`, `payload`, `service_tier`, `upstream_summary`, `upstream_payload`); empty default = all off. It is an incident-debugging knob for interactive use only.
 - **Error logs must be correlated:** request id, endpoint, status, code, and message are the minimum useful fields for debugging 4xx/5xx failures.
 - **Prewarm observability is outcome-only:** the Codex HTTP-bridge prewarm canary experiment finished, so its bucket/cohort dimensions were retired (issue #1340 phase 4). The `codex_lb_http_bridge_prewarm_total` counter is labelled by `outcome` only, request logs record `prewarm_status` / `prewarm_latency_ms` (statuses: `not_applicable`, `skipped`, `success`, `timeout`, `error` — `canary_miss` no longer occurs), and the legacy `prewarm_canary_bucket` / `prewarm_eligible_reason` request-log columns stay declared but unwritten for one release for rolling-upgrade safety; the Alembic drop revision ships next release (see the next-release queue in `openspec/specs/deployment-installation/context.md`).
+- **TTFT datasource selection stays in Grafana:** the Helm chart packages the
+  TTFT dashboard but does not provision a PostgreSQL datasource or its
+  credentials. The visible, single-select `DS_SQL` variable keeps
+  installation-specific datasource UIDs out of chart values while routing all
+  four SQL panels through one explicit selection.
 
 ## Operational Notes
 
 - Use request ids to correlate inbound proxy logs, outbound upstream traces, and client-visible failures.
 - Prefer summary tracing in normal debugging sessions; enable payload tracing only when the exact normalized outbound request matters.
 - For direct compact `5xx` failures, look for `proxy_compact_failure` alongside `upstream_request_complete`; together they show the compact failure phase, failure detail, exception type, retry metadata, and affinity source.
+- After the Grafana sidecar imports the TTFT dashboard, select the ordinary
+  PostgreSQL datasource that points to the codex-lb database from the visible
+  **PostgreSQL** dropdown. A datasource registered only as a frontend runtime
+  plugin is not listed by Grafana's datasource variable.

--- a/openspec/specs/proxy-runtime-observability/spec.md
+++ b/openspec/specs/proxy-runtime-observability/spec.md
@@ -478,12 +478,34 @@ Operators MUST have an OpenSpec context runbook or dashboard artifact with
 model/cache ratio, session gap cohort, prompt size cohort, and prewarm
 status/outcome.
 
+The shipped Grafana TTFT dashboard MUST declare a visible, single-select
+runtime datasource variable named `DS_SQL` that is restricted to PostgreSQL.
+Every SQL panel MUST bind to the selected UID through a typed PostgreSQL
+datasource object. The Helm chart MUST preserve the dashboard in its existing
+sidecar-discoverable ConfigMap, and chart documentation MUST tell operators to
+select the PostgreSQL datasource in Grafana.
+
 #### Scenario: Operator investigates TTFT regression
 
 - **WHEN** an operator needs to inspect the last 24 hours of request-log
   latency
 - **THEN** the repository provides SQL that reports p50, p90, p95 TTFT and
   total latency for the requested breakdowns
+
+#### Scenario: Sidecar-provisioned dashboard resolves the selected database
+
+- **GIVEN** the Helm chart renders the Grafana dashboard ConfigMap
+- **AND** Grafana has a PostgreSQL datasource available
+- **WHEN** the operator selects that datasource through `DS_SQL`
+- **THEN** all four TTFT panels resolve to the selected datasource UID
+- **AND** no panel reports `Datasource ${DS_SQL} was not found`
+
+#### Scenario: Datasource choice remains explicit and deterministic
+
+- **WHEN** Grafana loads the TTFT dashboard
+- **THEN** `DS_SQL` is visible to the operator
+- **AND** it permits exactly one PostgreSQL datasource selection
+- **AND** it does not offer an all-datasources selection
 
 ### Requirement: Dashboard request logs show generation speed
 

--- a/tests/unit/test_helm_monitoring_artifacts.py
+++ b/tests/unit/test_helm_monitoring_artifacts.py
@@ -12,6 +12,48 @@ pytestmark = pytest.mark.unit
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _CHART_DIR = _REPO_ROOT / "deploy" / "helm" / "codex-lb"
+_POSTGRES_DATASOURCE_TYPE = "grafana-postgresql-datasource"
+
+
+def _ttft_dashboard() -> dict:
+    return json.loads((_CHART_DIR / "dashboards" / "ttft-breakdown.json").read_text())
+
+
+def test_ttft_dashboard_declares_visible_single_select_postgres_datasource() -> None:
+    dashboard = _ttft_dashboard()
+    (datasource,) = dashboard["templating"]["list"]
+
+    assert {
+        "name": datasource["name"],
+        "label": datasource["label"],
+        "type": datasource["type"],
+        "query": datasource["query"],
+        "hide": datasource["hide"],
+        "multi": datasource["multi"],
+        "includeAll": datasource["includeAll"],
+    } == {
+        "name": "DS_SQL",
+        "label": "PostgreSQL",
+        "type": "datasource",
+        "query": _POSTGRES_DATASOURCE_TYPE,
+        "hide": 0,
+        "multi": False,
+        "includeAll": False,
+    }
+
+
+def test_ttft_dashboard_panels_bind_selected_postgres_datasource_uid() -> None:
+    dashboard = _ttft_dashboard()
+
+    assert len(dashboard["panels"]) == 4
+    assert all(
+        panel["datasource"]
+        == {
+            "type": _POSTGRES_DATASOURCE_TYPE,
+            "uid": "${DS_SQL}",
+        }
+        for panel in dashboard["panels"]
+    )
 
 
 def test_high_error_rate_alert_aggregates_request_series_before_division() -> None:

--- a/tests/unit/test_helm_replica_artifacts.py
+++ b/tests/unit/test_helm_replica_artifacts.py
@@ -164,6 +164,33 @@ def test_grafana_dashboard_titles_can_be_overridden() -> None:
     assert dashboard_config["data"]["ttft-breakdown.json"] == raw_dashboard_values["ttft-breakdown.json"]
 
 
+def test_rendered_ttft_dashboard_keeps_runtime_postgres_datasource_binding() -> None:
+    rendered = _helm_template(
+        "--set",
+        "metrics.grafanaDashboard.enabled=true",
+        "--show-only",
+        "templates/grafana-dashboard.yaml",
+    )
+    (dashboard_config,) = _helm_documents(rendered)
+    dashboard = json.loads(dashboard_config["data"]["ttft-breakdown.json"])
+    (datasource,) = dashboard["templating"]["list"]
+
+    assert datasource["name"] == "DS_SQL"
+    assert datasource["type"] == "datasource"
+    assert datasource["query"] == "grafana-postgresql-datasource"
+    assert datasource["hide"] == 0
+    assert datasource["multi"] is False
+    assert datasource["includeAll"] is False
+    assert all(
+        panel["datasource"]
+        == {
+            "type": "grafana-postgresql-datasource",
+            "uid": "${DS_SQL}",
+        }
+        for panel in dashboard["panels"]
+    )
+
+
 def _prod_overlay_args(*args: str) -> tuple[str, ...]:
     return (
         "-f",


### PR DESCRIPTION
## Summary

The Helm-shipped **codex-lb TTFT Breakdown** dashboard referenced an undeclared `${DS_SQL}` placeholder on all four panels, so Grafana 12.4.4 resolved it as a missing datasource UID. This PR declares a visible, single-select PostgreSQL datasource variable and binds every panel through Grafana's typed `{type, uid}` datasource reference.

Fixes #1826

## Type of change

- [x] `fix:` — bug fix (no behavior change beyond the bug)
- [ ] Breaking change

## OpenSpec

- [x] This PR includes / updates an OpenSpec change
- [ ] This PR touches a codex-faithful path

Archived change directory:

- `openspec/changes/archive/2026-08-19-bind-ttft-dashboard-sql-datasource/`

Owning capability:

- `openspec/specs/proxy-runtime-observability/`

## Changes

- declare visible `DS_SQL` with `type: datasource`, PostgreSQL plugin ID, single selection, and no **All** option
- convert all four panel datasource fields from the legacy scalar placeholder to typed `{type, uid}` objects
- preserve every SQL query, panel ID/title/layout/type, title override, sidecar label, folder annotation, and ConfigMap packaging seam
- document that operators select an existing Grafana PostgreSQL datasource; the chart does not provision datasource credentials or add a chart setting
- add direct dashboard JSON and rendered ConfigMap regressions

No application runtime, API, database schema, chart value, credential, navigation, dependency, or SQL-query change is included.

## Simplicity

- [x] Works without a new setting or environment variable
- [x] Adds no required base-install setup step; the optional dashboard uses an existing Grafana PostgreSQL datasource
- New settings: none
- [x] Root README / `.env.example` / dashboard core navigation budgets are unchanged
- [x] P1-P5 reviewed; no `simplicity-budget-approved` label is required

## Test plan

### Genuine RED → GREEN

RED on the base artifact:

```text
2 failed, 1 skipped
```

The source assertions failed because `templating.list` was empty and the four panel datasources were scalar strings. The rendered seam initially skipped only because Helm was not installed locally. After installing Helm 3 and applying the fix:

```bash
PATH=/opt/homebrew/opt/helm@3/bin:$PATH uv run pytest -q \
  tests/unit/test_helm_monitoring_artifacts.py::test_ttft_dashboard_declares_visible_single_select_postgres_datasource \
  tests/unit/test_helm_monitoring_artifacts.py::test_ttft_dashboard_panels_bind_selected_postgres_datasource_uid \
  tests/unit/test_helm_replica_artifacts.py::test_rendered_ttft_dashboard_keeps_runtime_postgres_datasource_binding
# 3 passed
```

Complete affected files:

```bash
PATH=/opt/homebrew/opt/helm@3/bin:$PATH uv run pytest -q \
  tests/unit/test_helm_monitoring_artifacts.py \
  tests/unit/test_helm_replica_artifacts.py
# 30 passed
```

### Local gates

- `make lint` — proxy architecture passed; Ruff passed; 947 files formatted
- `make typecheck` — ty passed
- `make helm-lint helm-template` — seven chart profiles passed
- `make helm-kubeconform` — Kubernetes 1.32 and 1.35: 18 valid, 0 invalid/errors each
- `openspec validate proxy-runtime-observability --strict` — passed
- `git diff --check` — passed
- changed Python files/directories — no LSP diagnostics

Repo-wide `openspec validate --specs` retains the same eight pre-existing failures in untouched capabilities; the changed owning capability and archived delta validate strictly.

### Real Grafana 12.4.4 surface

An isolated Docker network served:

- Grafana `12.4.4` / commit `42cdc391`
- PostgreSQL 16 with one synthetic `request_logs` row
- ordinary datasource UID `synthetic-postgres` with `Database Connection OK`
- the exact dashboard extracted from the Helm-rendered ConfigMap

API inspection confirmed one visible `DS_SQL` variable and four typed `${DS_SQL}` panel bindings. All four `/api/ds/query` calls returned status 200, one frame, and one row. At 1440x900 the selected datasource and all four populated panels rendered; browser assertions reported no missing-datasource, panel-error, or query-error state.

Five independent review lanes passed: requirement/OpenSpec, code quality, security, hands-on QA, and GitHub/simplicity/overlap context.

## Screenshots / output

### Before — exact base SHA `812265d1`

The first-load panel status reports `Datasource ${DS_SQL} was not found`.

![TTFT dashboard before: missing DS_SQL datasource](https://github.com/user-attachments/assets/f6daa933-b9f5-40d0-a143-41a01092630e)

### After — exact Helm-rendered fix

The visible PostgreSQL selector resolves `Synthetic TTFT PostgreSQL`; all four panels render seeded data.

![TTFT dashboard after: selected PostgreSQL datasource and four populated panels](https://github.com/user-attachments/assets/aa4ded1c-cf1a-4082-96f5-6dc5e80e3739)

## Checklist

- [x] Title is in Conventional Commits format
- [x] Linked the related issue
- [x] Added source and rendered regression tests
- [x] Ran the relevant local `make` targets
- [x] Affected OpenSpec change/spec validate strictly; archived change is synced
- [x] Simplicity gates P1-P5 reviewed
- [x] `CHANGELOG.md` was not edited
- [x] No self-merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible PostgreSQL datasource selector to the TTFT Breakdown dashboard.
  * All SQL panels now use the selected datasource consistently.

* **Documentation**
  * Added guidance explaining how to select the PostgreSQL datasource after dashboard import.

* **Tests**
  * Added regression coverage for datasource selection and panel binding in packaged and rendered dashboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->