### PR TITLE
fix(proxy): reject truncated chat completion streams

### DIFF
--- a/app/core/openai/chat_responses.py
+++ b/app/core/openai/chat_responses.py
@@ -353,11 +353,11 @@ def iter_chat_chunks(
                 response = payload.get("response")
                 if isinstance(response, dict):
                     maybe_error = response.get("error")
-                    if isinstance(maybe_error, dict):
+                    if isinstance(maybe_error, dict) and maybe_error:
                         error = maybe_error
             else:
                 maybe_error = payload.get("error")
-                if isinstance(maybe_error, dict):
+                if isinstance(maybe_error, dict) and maybe_error:
                     error = maybe_error
             if error is not None:
                 error_payload: dict[str, JsonValue] = {"error": error}

--- a/app/core/openai/chat_responses.py
+++ b/app/core/openai/chat_responses.py
@@ -361,9 +361,11 @@ def iter_chat_chunks(
                     error = maybe_error
             if error is not None:
                 error_payload: dict[str, JsonValue] = {"error": error}
-                yield _dump_sse(error_payload)
-                yield "data: [DONE]\n\n"
-                return
+            else:
+                error_payload = _default_error_envelope().model_dump(mode="json", exclude_none=True)
+            yield _dump_sse(error_payload)
+            yield "data: [DONE]\n\n"
+            return
         if event_type in ("response.completed", "response.incomplete"):
             for tool_state in state.tool_calls:
                 stream_delta = tool_state.build_stream_delta()

--- a/app/core/openai/chat_responses.py
+++ b/app/core/openai/chat_responses.py
@@ -448,6 +448,9 @@ async def stream_chat_chunks(
             if chunk.strip() == "data: [DONE]":
                 terminal_chunk_sent = True
                 break
+    if not terminal_chunk_sent:
+        yield _dump_sse(_upstream_stream_truncated_error_payload())
+        yield "data: [DONE]\n\n"
 
 
 async def collect_chat_completion(stream: AsyncIterator[str], model: str) -> ChatCompletionResult:
@@ -460,6 +463,7 @@ async def collect_chat_completion(stream: AsyncIterator[str], model: str) -> Cha
     tool_index = ToolCallIndex()
     tool_calls: list[ToolCallState] = []
     terminal_error: ChatCompletionResult | None = None
+    terminal_event_seen = False
 
     async for line in stream:
         payload = _parse_data(line)
@@ -496,6 +500,7 @@ async def collect_chat_completion(stream: AsyncIterator[str], model: str) -> Cha
         if terminal_error is not None:
             continue
         if event_type in ("response.completed", "response.incomplete"):
+            terminal_event_seen = True
             response = payload.get("response")
             if isinstance(response, dict):
                 response_id_value = response.get("id")
@@ -507,6 +512,8 @@ async def collect_chat_completion(stream: AsyncIterator[str], model: str) -> Cha
 
     if terminal_error is not None:
         return terminal_error
+    if not terminal_event_seen:
+        return _upstream_stream_truncated_error()
 
     message_content: str | None = "".join(content_parts)
     message_refusal = "".join(refusal_parts) or None
@@ -580,6 +587,20 @@ def _dump_chunk(chunk: ChatCompletionChunk, *, include_usage: bool = False) -> s
 
 def _dump_sse(payload: dict[str, JsonValue]) -> str:
     return format_sse_data(payload)
+
+
+def _upstream_stream_truncated_error_payload() -> dict[str, JsonValue]:
+    return {
+        "error": {
+            "message": "Responses stream ended before a terminal event",
+            "type": "server_error",
+            "code": "upstream_stream_truncated",
+        }
+    }
+
+
+def _upstream_stream_truncated_error() -> OpenAIErrorEnvelope:
+    return OpenAIErrorEnvelope.model_validate(_upstream_stream_truncated_error_payload())
 
 
 def _finish_reason_from_incomplete(response: JsonValue | None) -> str:

--- a/openspec/changes/reject-truncated-chat-completions/.openspec.yaml
+++ b/openspec/changes/reject-truncated-chat-completions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/reject-truncated-chat-completions/design.md
+++ b/openspec/changes/reject-truncated-chat-completions/design.md
@@ -1,0 +1,79 @@
+## Context
+
+`POST /v1/chat/completions` always asks the upstream Responses client for an SSE
+iterator. The adapter converts that iterator either into Chat Completions SSE or
+into a collected JSON response. Explicit terminal events are already mapped,
+but natural iterator exhaustion is not tracked. This leaves the streaming
+protocol unterminated and lets the collected path synthesize
+`finish_reason=stop`.
+
+The public `/v1/responses` path already uses `upstream_stream_truncated`,
+`server_error`, and HTTP 502 for EOF before a terminal event. The Chat adapter
+must match those machine-consumed semantics without depending on the proxy API
+module.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detect whether a terminal upstream Responses event was observed.
+- Use the canonical `upstream_stream_truncated` code and `server_error` type.
+- Finish streaming Chat errors with `data: [DONE]`.
+- Keep explicit completion, incomplete, failure, and generator-cleanup behavior
+  unchanged.
+
+**Non-Goals:**
+
+- Change public `/v1/responses` normalization.
+- Change retry, account selection, keepalive, or reservation policy.
+- Convert explicit `response.incomplete` into a transport error.
+- Refactor unrelated Chat payload or tool-call mapping.
+
+## Decisions
+
+### Decision: detect truncation at the Chat adapter boundary
+
+The adapter is the first layer that knows whether it observed a Chat-relevant
+terminal Responses event. `stream_chat_chunks` will synthesize the error chunk
+and `[DONE]` only when its mapped iterator exhausts without a terminal marker.
+`collect_chat_completion` will return the equivalent error envelope before it
+assembles a `ChatCompletion`.
+
+This keeps the behavior correct for both the subscription route and any other
+caller of the adapter without changing the public Responses pipeline.
+
+### Decision: preserve canonical machine semantics
+
+The synthesized error uses:
+
+- code: `upstream_stream_truncated`
+- type: `server_error`
+- message: `Responses stream ended before a terminal event`
+
+The existing route-level `_status_for_error` fallback maps that envelope to
+HTTP 502. No Chat-specific status policy is added.
+
+### Decision: leave explicit incomplete events successful
+
+`response.incomplete` is a terminal event with a meaningful finish reason such
+as `length` or `content_filter`. It remains a Chat completion. Only EOF without
+any terminal event is classified as transport truncation.
+
+## Risks / Trade-offs
+
+- A caller that previously relied on partial EOF content will now receive a
+  retriable error. That is intentional because presenting partial output as
+  complete is contract-breaking and suppresses retries.
+- Streaming may already have emitted partial content before the error. The
+  terminal error chunk and `[DONE]` make that state explicit without retracting
+  bytes already delivered.
+
+## Test Strategy
+
+- Unit-test streaming delta-then-EOF for error + `[DONE]`.
+- Unit-test collected delta-then-EOF for the canonical error envelope.
+- Route-test non-streaming HTTP status and error code.
+- Manually drive streaming and non-streaming ASGI requests with an inert
+  delta-then-EOF upstream.
+- Keep existing explicit completion, incomplete, error, usage, tool-call, and
+  generator-close tests green.

--- a/openspec/changes/reject-truncated-chat-completions/proposal.md
+++ b/openspec/changes/reject-truncated-chat-completions/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The Chat Completions adapter currently treats an upstream Responses iterator
+that reaches EOF without a terminal event as success. Streaming callers receive
+content without the required `data: [DONE]` marker, while non-streaming callers
+receive a successful `chat.completion` whose partial text has
+`finish_reason=stop`. The public Responses adapter already classifies the same
+condition as `upstream_stream_truncated`.
+
+## What Changes
+
+- Detect upstream EOF before any `response.completed`,
+  `response.incomplete`, `response.failed`, or `error` event.
+- Emit an OpenAI error chunk followed by `data: [DONE]` for streaming Chat
+  Completions.
+- Return an OpenAI error envelope that maps to HTTP 502 for non-streaming Chat
+  Completions.
+- Preserve explicit terminal/error handling, usage/tool-call finalization, and
+  upstream generator cleanup.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `chat-completions-compat`: define deterministic truncation behavior for
+  streaming and collected Chat Completions.
+
+## Impact
+
+- Affected code: `app/core/openai/chat_responses.py`
+- Affected route: `POST /v1/chat/completions`
+- Affected tests: Chat response mapping and proxy Chat Completions integration
+- Compatibility: malformed upstream termination changes from false success to a
+  stable OpenAI server-error envelope

--- a/openspec/changes/reject-truncated-chat-completions/specs/chat-completions-compat/spec.md
+++ b/openspec/changes/reject-truncated-chat-completions/specs/chat-completions-compat/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Chat Completions reject truncated upstream Responses streams
+
+`POST /v1/chat/completions` MUST classify upstream Responses iterator
+exhaustion before a terminal `response.completed`, `response.incomplete`,
+`response.failed`, or `error` event as `upstream_stream_truncated`. The error
+MUST use OpenAI error type `server_error`. Partial content received before the
+exhaustion MUST NOT be presented as a successfully completed non-streaming Chat
+Completion.
+
+#### Scenario: Streaming upstream EOF emits error and done
+
+- **WHEN** a streaming Chat Completions request receives zero or more
+  non-terminal upstream Responses events
+- **AND** the upstream iterator reaches EOF before a terminal event
+- **THEN** the proxy MUST emit an OpenAI error chunk with code
+  `upstream_stream_truncated`
+- **AND** the proxy MUST terminate the stream with `data: [DONE]`
+
+#### Scenario: Collected upstream EOF returns an error envelope
+
+- **WHEN** a non-streaming Chat Completions request receives zero or more
+  non-terminal upstream Responses events
+- **AND** the upstream iterator reaches EOF before a terminal event
+- **THEN** the proxy MUST return HTTP 502
+- **AND** the response body MUST be an OpenAI error envelope with code
+  `upstream_stream_truncated` and type `server_error`
+- **AND** the proxy MUST NOT return a `chat.completion` success object
+
+#### Scenario: Explicit terminal events retain existing behavior
+
+- **WHEN** the upstream iterator emits `response.completed`,
+  `response.incomplete`, `response.failed`, or `error`
+- **THEN** the proxy MUST preserve the existing Chat Completions mapping for
+  that event
+- **AND** the proxy MUST preserve existing usage, tool-call, and upstream
+  generator cleanup behavior

--- a/openspec/changes/reject-truncated-chat-completions/tasks.md
+++ b/openspec/changes/reject-truncated-chat-completions/tasks.md
@@ -1,0 +1,23 @@
+## 1. Specification
+
+- [x] 1.1 Define streaming and non-streaming EOF truncation requirements.
+- [x] 1.2 Validate the scoped OpenSpec change.
+
+## 2. Regression Coverage
+
+- [x] 2.1 Add a streaming adapter regression for error chunk plus `[DONE]`.
+- [x] 2.2 Add a collected adapter regression for the canonical error envelope.
+- [x] 2.3 Add a non-streaming route regression for HTTP 502 and
+  `upstream_stream_truncated`.
+
+## 3. Implementation
+
+- [x] 3.1 Track terminal event observation in the Chat adapter.
+- [x] 3.2 Synthesize canonical truncation errors without changing explicit
+  terminal behavior.
+
+## 4. Verification
+
+- [x] 4.1 Run focused Chat adapter and route tests.
+- [x] 4.2 Manually verify streaming and non-streaming HTTP surfaces.
+- [x] 4.3 Run lint, type, diagnostic, and strict OpenSpec gates.

--- a/tests/integration/test_proxy_chat_completions.py
+++ b/tests/integration/test_proxy_chat_completions.py
@@ -88,6 +88,34 @@ async def test_v1_chat_completions_stream_truncated_eof_emits_error_and_done(asy
 
 
 @pytest.mark.asyncio
+async def test_v1_chat_completions_stream_terminal_error_without_payload_uses_default_error(
+    async_client,
+    monkeypatch,
+):
+    email = "chat-stream-terminal-error@example.com"
+    raw_account_id = "acc_chat_stream_terminal_error"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    imported = await async_client.post("/api/accounts/import", files=files)
+    assert imported.status_code == 200
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        del payload, headers, access_token, account_id, base_url, raise_for_status
+        yield 'data: {"type":"response.output_text.delta","delta":"partial"}\n\n'
+        yield 'data: {"type":"response.failed","response":{"id":"r1","status":"failed"}}\n\n'
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    payload = {"model": "gpt-5.2", "messages": [{"role": "user", "content": "hi"}], "stream": True}
+    async with async_client.stream("POST", "/v1/chat/completions", json=payload) as response:
+        assert response.status_code == 200
+        lines = [line async for line in response.aiter_lines() if line]
+
+    assert json.loads(lines[-2][len("data: ") :])["error"]["code"] == "upstream_error"
+    assert lines[-1] == "data: [DONE]"
+
+
+@pytest.mark.asyncio
 async def test_v1_chat_completions_omits_synthesized_tools(async_client, monkeypatch):
     email = "chatnotools@example.com"
     raw_account_id = "acc_chatnotools"

--- a/tests/integration/test_proxy_chat_completions.py
+++ b/tests/integration/test_proxy_chat_completions.py
@@ -61,6 +61,33 @@ async def test_v1_chat_completions_stream(async_client, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_v1_chat_completions_stream_truncated_eof_emits_error_and_done(async_client, monkeypatch):
+    # #given
+    email = "chat-stream-truncated@example.com"
+    raw_account_id = "acc_chat_stream_truncated"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    imported = await async_client.post("/api/accounts/import", files=files)
+    assert imported.status_code == 200
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        del payload, headers, access_token, account_id, base_url, raise_for_status
+        yield 'data: {"type":"response.output_text.delta","delta":"hi"}\n\n'
+
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    # #when
+    payload = {"model": "gpt-5.2", "messages": [{"role": "user", "content": "hi"}], "stream": True}
+    async with async_client.stream("POST", "/v1/chat/completions", json=payload) as response:
+        assert response.status_code == 200
+        lines = [line async for line in response.aiter_lines() if line]
+
+    # #then
+    assert json.loads(lines[-2][len("data: ") :])["error"]["code"] == "upstream_stream_truncated"
+    assert lines[-1] == "data: [DONE]"
+
+
+@pytest.mark.asyncio
 async def test_v1_chat_completions_omits_synthesized_tools(async_client, monkeypatch):
     email = "chatnotools@example.com"
     raw_account_id = "acc_chatnotools"
@@ -209,6 +236,39 @@ async def test_v1_chat_completions_non_stream_forces_stream(async_client, monkey
 
     assert observed_stream["value"] is True
     assert body["object"] == "chat.completion"
+
+
+@pytest.mark.asyncio
+async def test_v1_chat_completions_non_stream_truncated_eof_returns_502(async_client, monkeypatch):
+    # #given
+    email = "chat-nonstr-truncated@example.com"
+    raw_account_id = "acc_chat_nonstr_truncated"
+    auth_json = _make_auth_json(raw_account_id, email)
+    files = {"auth_json": ("auth.json", json.dumps(auth_json), "application/json")}
+    imported = await async_client.post("/api/accounts/import", files=files)
+    assert imported.status_code == 200
+
+    async def passthrough_probe(stream, **_kwargs):
+        return stream, None
+
+    async def fake_stream(payload, headers, access_token, account_id, base_url=None, raise_for_status=False):
+        del payload, headers, access_token, account_id, base_url, raise_for_status
+        yield 'data: {"type":"response.output_text.delta","delta":"hi"}\n\n'
+
+    monkeypatch.setattr(proxy_api, "_probe_chat_stream_startup_error", passthrough_probe)
+    monkeypatch.setattr(proxy_module, "core_stream_responses", fake_stream)
+
+    # #when
+    response = await async_client.post(
+        "/v1/chat/completions",
+        json={"model": "gpt-5.2", "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    # #then
+    assert response.status_code == 502
+    body = response.json()
+    assert body["error"]["code"] == "upstream_stream_truncated"
+    assert body["error"]["type"] == "server_error"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_chat_response_mapping.py
+++ b/tests/unit/test_chat_response_mapping.py
@@ -75,6 +75,22 @@ def test_error_event_emits_done_chunk():
 
 
 @pytest.mark.asyncio
+async def test_stream_chat_chunks_emits_error_and_done_when_upstream_ends_without_terminal_event():
+    # #given
+    async def _stream():
+        yield 'data: {"type":"response.output_text.delta","delta":"hi"}\n\n'
+
+    # #when
+    chunks = [chunk async for chunk in stream_chat_chunks(_stream(), model="gpt-5.2")]
+
+    # #then
+    assert chunks[-1].strip() == "data: [DONE]"
+    error_chunk = json.loads(chunks[-2][5:].strip())
+    assert error_chunk["error"]["code"] == "upstream_stream_truncated"
+    assert error_chunk["error"]["type"] == "server_error"
+
+
+@pytest.mark.asyncio
 async def test_collect_completion_parses_event_prefixed_sse_block():
     lines = [
         (
@@ -92,6 +108,22 @@ async def test_collect_completion_parses_event_prefixed_sse_block():
     assert isinstance(result, OpenAIErrorEnvelope)
     assert result.error is not None
     assert result.error.code == "no_accounts"
+
+
+@pytest.mark.asyncio
+async def test_collect_chat_completion_returns_error_when_upstream_ends_without_terminal_event():
+    # #given
+    async def _stream():
+        yield 'data: {"type":"response.output_text.delta","delta":"hi"}\n\n'
+
+    # #when
+    result = await collect_chat_completion(_stream(), model="gpt-5.2")
+
+    # #then
+    assert isinstance(result, OpenAIErrorEnvelope)
+    assert result.error is not None
+    assert result.error.code == "upstream_stream_truncated"
+    assert result.error.type == "server_error"
 
 
 def test_tool_call_delta_is_emitted():

--- a/tests/unit/test_chat_response_mapping.py
+++ b/tests/unit/test_chat_response_mapping.py
@@ -74,6 +74,29 @@ def test_error_event_emits_done_chunk():
     assert chunks[-1].strip() == "data: [DONE]"
 
 
+@pytest.mark.parametrize(
+    "event_line",
+    [
+        'data: {"type":"response.failed","response":{"id":"r1","status":"failed"}}\n\n',
+        'data: {"type":"error"}\n\n',
+    ],
+)
+@pytest.mark.asyncio
+async def test_stream_chat_chunks_preserves_terminal_error_without_payload(event_line: str):
+    async def _stream():
+        yield event_line
+
+    chunks = [chunk async for chunk in stream_chat_chunks(_stream(), model="gpt-5.2")]
+
+    error_payload = json.loads(chunks[-2][5:].strip())
+    assert error_payload["error"] == {
+        "message": "Upstream error",
+        "type": "server_error",
+        "code": "upstream_error",
+    }
+    assert chunks[-1].strip() == "data: [DONE]"
+
+
 @pytest.mark.asyncio
 async def test_stream_chat_chunks_emits_error_and_done_when_upstream_ends_without_terminal_event():
     # #given

--- a/tests/unit/test_chat_response_mapping.py
+++ b/tests/unit/test_chat_response_mapping.py
@@ -78,7 +78,9 @@ def test_error_event_emits_done_chunk():
     "event_line",
     [
         'data: {"type":"response.failed","response":{"id":"r1","status":"failed"}}\n\n',
+        'data: {"type":"response.failed","response":{"error":{}}}\n\n',
         'data: {"type":"error"}\n\n',
+        'data: {"type":"error","error":{}}\n\n',
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
## Why

`POST /v1/chat/completions` treated a Responses iterator that reached EOF before a terminal event as success. Streaming callers received an unterminated partial response, while non-streaming callers received a successful `chat.completion` with partial content.

## What

- detect EOF before `response.completed`, `response.incomplete`, `response.failed`, or `error`
- emit a stable `upstream_stream_truncated` error chunk followed by `data: [DONE]` for streaming requests
- return the canonical `server_error` envelope, mapped to HTTP 502, for non-streaming requests
- preserve explicit terminal/error mapping, usage and tool-call finalization, generator cleanup, and `/v1/responses` behavior
- document the public compatibility contract in OpenSpec

## Validation

- `29 passed` — focused Chat response-mapping unit suite
- `16 passed` — focused Chat Completions integration suite
- Ruff check and format: clean
- Ty type check: clean
- LSP diagnostics on changed Python files: clean
- scoped OpenSpec change and owning capability: strict validation clean
- manual ASGI QA: streaming error + `[DONE]`; non-streaming HTTP 502 canonical envelope

The repository-wide `openspec validate --specs` command still reports the same eight unrelated baseline specification failures present on `main`; this change introduces no new OpenSpec failure.

## OpenSpec

Change: `reject-truncated-chat-completions` (10/10 tasks complete).

## Simplicity

No new setting, dependency, route, navigation item, README section, or compatibility shim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detects truncated upstream responses instead of returning partial completions.
  * Streaming responses now report a standardized server error and finish with `[DONE]`.
  * Non-streaming requests now return HTTP 502 with a clear truncation error.
  * Provides a consistent server error when upstream failures omit error details.
  * Preserves existing handling for explicitly completed responses.

* **Tests**
  * Added coverage for truncated streams, terminal failures, missing error details, and proper response termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->