### PR TITLE
chore: release v1.24.0-beta.3

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.24.0-beta.2"  # x-release-please-version
+__version__ = "1.24.0-beta.3"  # x-release-please-version
 __all__ = ["app", "__version__"]
 
 

--- a/deploy/helm/codex-lb/Chart.yaml
+++ b/deploy/helm/codex-lb/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Production-grade Helm chart for codex-lb — OpenAI API load balancer with usage
   tracking, account pooling, and observability
 type: application
-version: 1.24.0-beta.2
-appVersion: 1.24.0-beta.2
+version: 1.24.0-beta.3
+appVersion: 1.24.0-beta.3
 kubeVersion: '>=1.32.0-0'
 home: https://github.com/soju06/codex-lb
 sources:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "1.24.0-beta.2",
+  "version": "1.24.0-beta.3",
   "type": "module",
   "packageManager": "bun@1.3.14",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "codex-lb"
-version = "1.24.0-beta.2"
+version = "1.24.0-beta.3"
 description = "Codex load balancer and proxy for ChatGPT accounts with usage dashboard"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ wheels = [
 
 [[package]]
 name = "codex-lb"
-version = "1.24.0-beta.2"
+version = "1.24.0-beta.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- Prepares beta release v1.24.0-beta.3 for the 1.24.0 stable train.
- Updates release-managed version files only; release-please remains the stable release owner.
- Merging this PR will publish v1.24.0-beta.3 only after the release-candidate validation checklist below is completed for this exact candidate SHA.
- Synced automatically from release-please PR #1692; no manual beta workflow dispatch is required.

## Changes since v1.24.0-beta.2
- fix(proxy): bind account-bound retries to dispatch owner (#1829) (3381938)
- fix(proxy): reject truncated chat completion streams (#1833) (
6ba083)
- fix(proxy): retain image reservation recovery ownership (#1822) (
bd67c6)
- fix(warmup): warm paid-to-free transitions (#1825) (
68892e)
- feat(model-sources): embeddings source capability (#1776) (
4d0f0f)
- fix(helm): bind TTFT dashboard SQL datasource (#1827) (
8abd50)
- fix(reports): format full Cost values with grouping separators (#1814) (
028a75)
- fix(proxy): preserve compact terminal error type (#1824) (
78d63e)
- feat(config): timeout-invariant linter — validate deadline/TTL inequalities at startup and in CI (#1622) (
d148dd)
- fix(models): apply context-window overrides to /v1 input context fields (#1808) (
c750dc)
- fix(http-bridge): classify recovery error frames and poison same-anchor eventless failures (#1841) (
01f089)
- fix(proxy): O(1) shared-future admission waits + event-loop lag watchdog (#1842) (
ed2c94)
- feat(telemetry): report consent state and send a decision-time opt-out signal (#1835) (
1541ee)

## Release-candidate validation
Validated candidate: 4c4acb9f6f836f4b888e809a26212e23ff52476f

Complete these checks on the exact candidate SHA above before merging. The beta release guard and publish workflow fail while any item remains unchecked or the SHA is stale.

- [x] Backend/unit/integration gates — PR CI green on 9bbe3dfe: unit, PostgreSQL, e2e, integration-bridge, integration-core 1-3, alembic (sqlite+pg)
- [x] Frontend tests/build — PR CI green: vitest+coverage, vite build, tsc, eslint, Playwright dashboard smoke
- [x] Wheel/package validation — CI Package (build) green + local `uv build` at 9bbe3dfe → codex_lb-1.24.0b3 wheel, isolated import of app/shared_future/loop_lag_monitor OK
- [x] Docker/container smoke — image built locally from 9bbe3dfe and booted (sqlite): /health/live + /health/ready 200, unauthenticated /v1/chat/completions 401 contract, loop-lag watchdog default 0.5s confirmed, startup log clean
- [ ] Live upstream/account smoke
- [x] Live upstream/account smoke not required — no upstream-contract change in this train beyond already-live beta.2 paths; prod cutover uses zdt-deploy.sh with 180s observation + auto-rollback

## Install after publish
```bash
uvx --from "codex-lb==1.24.0b3" codex-lb
docker pull ghcr.io/Soju06/codex-lb:1.24.0-beta.3
helm install codex-lb oci://ghcr.io/soju06/charts/codex-lb --version 1.24.0-beta.3 --devel
```

## Promotion
Merge the normal release-please PR to promote this beta-tested train to 1.24.0.

